### PR TITLE
feat: add Cisco skill scanning and security ops reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,7 @@ Add to your plugin's CI:
 - name: Install scanner
   run: pip install codex-plugin-scanner
 - name: Scan plugin
-  run: codex-plugin-scanner ./my-plugin --fail-on-severity high
-- name: Upload SARIF
-  run: codex-plugin-scanner ./my-plugin --format sarif --output codex-plugin-scanner.sarif
+  run: codex-plugin-scanner ./my-plugin --fail-on-severity high --format sarif --output codex-plugin-scanner.sarif
 ```
 
 ## Use as a pre-commit hook

--- a/README.md
+++ b/README.md
@@ -6,12 +6,18 @@
 [![CI](https://github.com/hashgraph-online/codex-plugin-scanner/actions/workflows/ci.yml/badge.svg)](https://github.com/hashgraph-online/codex-plugin-scanner/actions/workflows/ci.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/hashgraph-online/codex-plugin-scanner/badge)](https://scorecard.dev/viewer/?uri=github.com/hashgraph-online/codex-plugin-scanner)
 
-A security and best-practices scanner for [Codex CLI plugins](https://developers.openai.com/codex/plugins). Scans plugin directories and outputs a score from 0-100.
+A security and security-ops scanner for [Codex plugins](https://developers.openai.com/codex/plugins). It scores the applicable plugin surface from 0-100, emits structured findings, and can run Cisco's `skill-scanner` against plugin skills for deeper analysis.
 
 ## Installation
 
 ```bash
 pip install codex-plugin-scanner
+```
+
+To enable Cisco-backed skill scanning:
+
+```bash
+pip install "codex-plugin-scanner[cisco]"
 ```
 
 Or run directly without installing:
@@ -29,57 +35,61 @@ codex-plugin-scanner ./my-plugin
 # Output as JSON
 codex-plugin-scanner ./my-plugin --json
 
-# Write report to file
-codex-plugin-scanner ./my-plugin --output report.json
+# Write a SARIF report for GitHub code scanning
+codex-plugin-scanner ./my-plugin --format sarif --output report.sarif
+
+# Fail CI on high-severity findings
+codex-plugin-scanner ./my-plugin --fail-on-severity high
+
+# Require Cisco skill scanning with a strict policy
+codex-plugin-scanner ./my-plugin --cisco-skill-scan on --cisco-policy strict
 ```
 
 ### Example Output
 
 ```
-🔗 Codex Plugin Scanner v1.0.0
+🔗 Codex Plugin Scanner v1.1.0
 Scanning: ./my-plugin
 
 ── Manifest Validation (25/25) ──
-  ✅ plugin.json exists                          +5
-  ✅ Valid JSON                                   +5
-  ✅ Required fields present                      +8
-  ✅ Version follows semver                       +4
-  ✅ Name is kebab-case                           +3
+  ✅ plugin.json exists                          +4
+  ✅ Valid JSON                                  +4
+  ✅ Required fields present                     +5
+  ✅ Version follows semver                      +3
+  ✅ Name is kebab-case                          +2
+  ✅ Recommended metadata present                +4
+  ✅ Declared paths are safe                     +3
 
-── Security (30/30) ──
-  ✅ SECURITY.md found                           +5
-  ✅ LICENSE found (Apache-2.0)                  +5
-  ✅ No hardcoded secrets detected               +10
-  ✅ No dangerous MCP commands                   +10
+── Security (16/16) ──
+  ✅ SECURITY.md found                           +3
+  ✅ LICENSE found                               +3
+  ✅ No hardcoded secrets                        +7
+  ✅ No dangerous MCP commands                   +0
+  ✅ No approval bypass defaults                 +3
 
-── Best Practices (25/25) ──
-  ✅ README.md found                             +5
-  ✅ Skills directory exists if declared          +5
-  ✅ SKILL.md frontmatter                        +5
-  ✅ No .env files committed                     +5
-  ✅ .codexignore found                          +5
+── Skill Security (15/15) ──
+  ✅ Cisco skill scan completed                  +3
+  ✅ No elevated Cisco skill findings            +8
+  ✅ Skills analyzable                           +4
 
-── Marketplace (10/10) ──
-  ✅ marketplace.json valid                      +5
-  ✅ Policy fields present                       +5
-
-── Code Quality (10/10) ──
-  ✅ No eval or Function constructor             +5
-  ✅ No shell injection patterns                 +5
+Findings: critical:0, high:0, medium:0, low:0, info:0
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Final Score: 100/100 (A - Excellent)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-## Scoring Breakdown
+Optional surfaces such as `marketplace.json`, `.mcp.json`, and plugin skills are treated as not-applicable when they are not present. The final score is normalized over the applicable maximum so plugins are not rewarded or penalized for surfaces they do not expose.
+
+## Checks
 
 | Category | Max Points | Checks |
 |----------|-----------|--------|
-| Manifest Validation | 25 | plugin.json exists, valid JSON, required fields, semver version, kebab-case name |
-| Security | 30 | SECURITY.md, LICENSE, no hardcoded secrets, no dangerous MCP commands |
-| Best Practices | 25 | README.md, skills directory, SKILL.md frontmatter, no .env files, .codexignore |
-| Marketplace | 10 | marketplace.json valid, policy fields present |
+| Manifest Validation | 25 | plugin.json, required fields, semver, kebab-case, recommended metadata, safe declared paths |
+| Security | 20 | SECURITY.md, LICENSE, no hardcoded secrets, no dangerous MCP commands, no approval bypass defaults |
+| Best Practices | 15 | README.md, skills directory, SKILL.md frontmatter, no committed `.env`, `.codexignore` |
+| Marketplace | 15 | marketplace.json validity, policy fields, safe source paths |
+| Skill Security | 15 | Cisco scan availability, elevated skill findings, analyzability |
 | Code Quality | 10 | no eval/Function, no shell injection |
 
 ### Grade Scale
@@ -98,8 +108,17 @@ The scanner detects:
 
 - **Hardcoded secrets**: AWS keys, GitHub tokens, OpenAI keys, Slack tokens, GitLab tokens, generic password/secret/token patterns
 - **Dangerous MCP commands**: `rm -rf`, `sudo`, `curl|sh`, `wget|sh`, `eval`, `exec`, `powershell -c`
+- **Risky Codex defaults**: approval bypass and unrestricted sandbox defaults in plugin-shipped config/docs
 - **Shell injection**: template literals with unsanitized interpolation in exec/spawn calls
 - **Unsafe code**: `eval()` and `new Function()` usage
+- **Cisco skill threats**: policy violations and risky behaviors detected by Cisco `skill-scanner`
+
+## Report Formats
+
+- `text`: human-readable terminal summary with findings and category scores
+- `json`: structured findings, integration status, and per-check details
+- `markdown`: review-ready report for issues and pull requests
+- `sarif`: GitHub code scanning compatible output
 
 ## Use as a GitHub Action
 
@@ -109,7 +128,9 @@ Add to your plugin's CI:
 - name: Install scanner
   run: pip install codex-plugin-scanner
 - name: Scan plugin
-  run: codex-plugin-scanner ./my-plugin
+  run: codex-plugin-scanner ./my-plugin --fail-on-severity high
+- name: Upload SARIF
+  run: codex-plugin-scanner ./my-plugin --format sarif --output codex-plugin-scanner.sarif
 ```
 
 ## Use as a pre-commit hook

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "codex-plugin-scanner"
-version = "1.0.0"
-description = "Security and best-practices scanner for Codex CLI plugins. Scores plugins 0-100."
+version = "1.1.0"
+description = "Security and security-ops scanner for Codex plugins with Cisco-backed skill analysis."
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10"
@@ -31,6 +31,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+cisco = [
+    "cisco-ai-skill-scanner>=2.0.6,<3",
+]
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",

--- a/src/codex_plugin_scanner/__init__.py
+++ b/src/codex_plugin_scanner/__init__.py
@@ -1,14 +1,17 @@
 """Codex Plugin Scanner - security and best-practices scanner for Codex CLI plugins."""
 
-from .models import GRADE_LABELS, CategoryResult, CheckResult, ScanResult, get_grade
+from .models import GRADE_LABELS, CategoryResult, CheckResult, Finding, ScanOptions, ScanResult, Severity, get_grade
 from .scanner import scan_plugin
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 __all__ = [
     "GRADE_LABELS",
     "CategoryResult",
     "CheckResult",
+    "Finding",
+    "ScanOptions",
     "ScanResult",
+    "Severity",
     "get_grade",
     "scan_plugin",
 ]

--- a/src/codex_plugin_scanner/checks/best_practices.py
+++ b/src/codex_plugin_scanner/checks/best_practices.py
@@ -1,10 +1,10 @@
-"""Best practice checks (25 points)."""
+"""Best practice checks (15 points)."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
-from ..models import CheckResult
+from ..models import CheckResult, Finding, Severity
 from .manifest import load_manifest
 
 ENV_FILES = {".env", ".env.local", ".env.production"}
@@ -15,9 +15,22 @@ def check_readme(plugin_dir: Path) -> CheckResult:
     return CheckResult(
         name="README.md found",
         passed=exists,
-        points=5 if exists else 0,
-        max_points=5,
+        points=3 if exists else 0,
+        max_points=3,
         message="README.md found" if exists else "README.md not found",
+        findings=()
+        if exists
+        else (
+            Finding(
+                rule_id="README_MISSING",
+                severity=Severity.LOW,
+                category="best-practices",
+                title="README.md is missing",
+                description="Plugins should document installation, usage, and security expectations in README.md.",
+                remediation="Add a README.md that explains setup, usage, and operational constraints.",
+                file_path="README.md",
+            ),
+        ),
     )
 
 
@@ -27,34 +40,47 @@ def check_skills_directory(plugin_dir: Path) -> CheckResult:
         return CheckResult(
             name="Skills directory exists if declared",
             passed=True,
-            points=5,
-            max_points=5,
+            points=0,
+            max_points=0,
             message="Cannot parse manifest, skipping check",
+            applicable=False,
         )
     skills = manifest.get("skills")
     if not skills:
         return CheckResult(
             name="Skills directory exists if declared",
             passed=True,
-            points=5,
-            max_points=5,
+            points=0,
+            max_points=0,
             message="No skills field declared, check not applicable",
+            applicable=False,
         )
     skills_path = plugin_dir / skills
     if skills_path.is_dir():
         return CheckResult(
             name="Skills directory exists if declared",
             passed=True,
-            points=5,
-            max_points=5,
+            points=3,
+            max_points=3,
             message=f'Skills directory "{skills}" exists',
         )
     return CheckResult(
         name="Skills directory exists if declared",
         passed=False,
         points=0,
-        max_points=5,
+        max_points=3,
         message=f'Skills directory "{skills}" declared but not found',
+        findings=(
+            Finding(
+                rule_id="SKILLS_DIR_MISSING",
+                severity=Severity.MEDIUM,
+                category="best-practices",
+                title="Declared skills directory is missing",
+                description=f'The manifest declares "{skills}" as the skills directory, but it does not exist.',
+                remediation="Create the skills directory or correct the manifest path.",
+                file_path=".codex-plugin/plugin.json",
+            ),
+        ),
     )
 
 
@@ -64,27 +90,30 @@ def check_skill_frontmatter(plugin_dir: Path) -> CheckResult:
         return CheckResult(
             name="SKILL.md frontmatter",
             passed=True,
-            points=5,
-            max_points=5,
+            points=0,
+            max_points=0,
             message="Cannot parse manifest, skipping check",
+            applicable=False,
         )
     skills = manifest.get("skills")
     if not skills:
         return CheckResult(
             name="SKILL.md frontmatter",
             passed=True,
-            points=5,
-            max_points=5,
+            points=0,
+            max_points=0,
             message="No skills field declared, check not applicable",
+            applicable=False,
         )
     skills_path = plugin_dir / skills
     if not skills_path.is_dir():
         return CheckResult(
             name="SKILL.md frontmatter",
             passed=True,
-            points=5,
-            max_points=5,
+            points=0,
+            max_points=0,
             message="Skills directory not found, skipping check",
+            applicable=False,
         )
 
     skill_files = list(skills_path.glob("*/SKILL.md"))
@@ -92,9 +121,10 @@ def check_skill_frontmatter(plugin_dir: Path) -> CheckResult:
         return CheckResult(
             name="SKILL.md frontmatter",
             passed=True,
-            points=5,
-            max_points=5,
+            points=0,
+            max_points=0,
             message="No SKILL.md files found, nothing to check",
+            applicable=False,
         )
 
     issues: list[str] = []
@@ -118,16 +148,28 @@ def check_skill_frontmatter(plugin_dir: Path) -> CheckResult:
         return CheckResult(
             name="SKILL.md frontmatter",
             passed=True,
-            points=5,
-            max_points=5,
+            points=3,
+            max_points=3,
             message="All SKILL.md files have valid frontmatter",
         )
     return CheckResult(
         name="SKILL.md frontmatter",
         passed=False,
         points=0,
-        max_points=5,
+        max_points=3,
         message=f"SKILL.md missing valid frontmatter in: {', '.join(issues)}",
+        findings=tuple(
+            Finding(
+                rule_id="SKILL_FRONTMATTER_INVALID",
+                severity=Severity.MEDIUM,
+                category="best-practices",
+                title="Skill frontmatter is invalid",
+                description=f"{path} is missing valid skill frontmatter.",
+                remediation="Add YAML frontmatter with at least name and description fields.",
+                file_path=path,
+            )
+            for path in issues
+        ),
     )
 
 
@@ -137,16 +179,28 @@ def check_no_env_files(plugin_dir: Path) -> CheckResult:
         return CheckResult(
             name="No .env files committed",
             passed=True,
-            points=5,
-            max_points=5,
+            points=3,
+            max_points=3,
             message="No .env files found",
         )
     return CheckResult(
         name="No .env files committed",
         passed=False,
         points=0,
-        max_points=5,
+        max_points=3,
         message=f".env files found: {', '.join(found)}",
+        findings=tuple(
+            Finding(
+                rule_id="ENV_FILE_COMMITTED",
+                severity=Severity.HIGH,
+                category="best-practices",
+                title="Environment file is committed",
+                description=f'The file "{path}" is present in the plugin directory.',
+                remediation="Remove committed environment files and rely on local, ignored configuration.",
+                file_path=path,
+            )
+            for path in found
+        ),
     )
 
 
@@ -155,9 +209,22 @@ def check_codexignore(plugin_dir: Path) -> CheckResult:
     return CheckResult(
         name=".codexignore found",
         passed=exists,
-        points=5 if exists else 0,
-        max_points=5,
+        points=3 if exists else 0,
+        max_points=3,
         message=".codexignore found" if exists else ".codexignore not found",
+        findings=()
+        if exists
+        else (
+            Finding(
+                rule_id="CODEXIGNORE_MISSING",
+                severity=Severity.INFO,
+                category="best-practices",
+                title=".codexignore is missing",
+                description="A .codexignore file helps prevent accidental inclusion of local artifacts and secrets.",
+                remediation="Add a .codexignore file with generated assets, local state, and secret paths.",
+                file_path=".codexignore",
+            ),
+        ),
     )
 
 

--- a/src/codex_plugin_scanner/checks/code_quality.py
+++ b/src/codex_plugin_scanner/checks/code_quality.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from ..models import CheckResult
+from ..models import CheckResult, Finding, Severity
 
 CODE_EXTS = {".py", ".js", ".ts", ".jsx", ".tsx", ".mjs", ".cjs"}
 EXCLUDED_DIRS = {"node_modules", ".git", "dist", ".next", "coverage", "__pycache__", ".venv", "venv"}
@@ -55,6 +55,18 @@ def check_no_eval(plugin_dir: Path) -> CheckResult:
         points=0,
         max_points=5,
         message=f"Found: {', '.join(findings[:3])}",
+        findings=tuple(
+            Finding(
+                rule_id="DANGEROUS_DYNAMIC_EXECUTION",
+                severity=Severity.HIGH,
+                category="code-quality",
+                title="Dynamic code execution detected",
+                description=f"{entry} uses eval() or new Function().",
+                remediation="Remove dynamic code evaluation and replace it with explicit control flow.",
+                file_path=entry.split(":")[0],
+            )
+            for entry in findings
+        ),
     )
 
 
@@ -81,6 +93,18 @@ def check_no_shell_injection(plugin_dir: Path) -> CheckResult:
         points=0,
         max_points=5,
         message=f"Shell injection patterns in: {', '.join(findings)}",
+        findings=tuple(
+            Finding(
+                rule_id="SHELL_INJECTION_PATTERN",
+                severity=Severity.HIGH,
+                category="code-quality",
+                title="Potential shell injection pattern detected",
+                description=f"{path} interpolates untrusted values into a shell execution call.",
+                remediation="Pass arguments as structured arrays and validate user-controlled input before execution.",
+                file_path=path,
+            )
+            for path in findings
+        ),
     )
 
 

--- a/src/codex_plugin_scanner/checks/manifest.py
+++ b/src/codex_plugin_scanner/checks/manifest.py
@@ -6,43 +6,96 @@ import json
 import re
 from pathlib import Path
 
-from ..models import CheckResult
+from ..models import CheckResult, Finding, Severity
 
-SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+")
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
 KEBAB_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+RECOMMENDED_FIELDS = ("author", "homepage", "repository", "license", "keywords")
 
 
 def load_manifest(plugin_dir: Path) -> dict | None:
-    p = plugin_dir / ".codex-plugin" / "plugin.json"
-    if not p.exists():
+    path = plugin_dir / ".codex-plugin" / "plugin.json"
+    if not path.exists():
         return None
     try:
-        return json.loads(p.read_text(encoding="utf-8"))
+        return json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return None
 
 
+def _manifest_finding(
+    rule_id: str,
+    title: str,
+    description: str,
+    remediation: str,
+    *,
+    severity: Severity = Severity.MEDIUM,
+) -> Finding:
+    return Finding(
+        rule_id=rule_id,
+        severity=severity,
+        category="manifest-validation",
+        title=title,
+        description=description,
+        remediation=remediation,
+        file_path=".codex-plugin/plugin.json",
+    )
+
+
+def _is_safe_relative_path(plugin_dir: Path, value: str) -> bool:
+    candidate = Path(value)
+    if candidate.is_absolute():
+        return False
+    resolved = (plugin_dir / candidate).resolve()
+    try:
+        resolved.relative_to(plugin_dir.resolve())
+    except ValueError:
+        return False
+    return True
+
+
 def check_plugin_json_exists(plugin_dir: Path) -> CheckResult:
-    p = plugin_dir / ".codex-plugin" / "plugin.json"
-    exists = p.exists()
+    exists = (plugin_dir / ".codex-plugin" / "plugin.json").exists()
+    findings = ()
+    if not exists:
+        findings = (
+            _manifest_finding(
+                "PLUGIN_JSON_MISSING",
+                "plugin.json is missing",
+                "Codex plugins must declare .codex-plugin/plugin.json.",
+                "Add .codex-plugin/plugin.json with the documented plugin fields.",
+            ),
+        )
     return CheckResult(
         name="plugin.json exists",
         passed=exists,
-        points=5 if exists else 0,
-        max_points=5,
+        points=4 if exists else 0,
+        max_points=4,
         message="plugin.json found" if exists else "plugin.json not found at .codex-plugin/plugin.json",
+        findings=findings,
     )
 
 
 def check_valid_json(plugin_dir: Path) -> CheckResult:
-    p = plugin_dir / ".codex-plugin" / "plugin.json"
+    path = plugin_dir / ".codex-plugin" / "plugin.json"
     try:
-        content = p.read_text(encoding="utf-8")
-        json.loads(content)
-        return CheckResult(name="Valid JSON", passed=True, points=5, max_points=5, message="plugin.json is valid JSON")
+        json.loads(path.read_text(encoding="utf-8"))
+        return CheckResult(name="Valid JSON", passed=True, points=4, max_points=4, message="plugin.json is valid JSON")
     except Exception:
         return CheckResult(
-            name="Valid JSON", passed=False, points=0, max_points=5, message="plugin.json is not valid JSON"
+            name="Valid JSON",
+            passed=False,
+            points=0,
+            max_points=4,
+            message="plugin.json is not valid JSON",
+            findings=(
+                _manifest_finding(
+                    "PLUGIN_JSON_INVALID",
+                    "plugin.json is invalid JSON",
+                    "The plugin manifest could not be parsed.",
+                    "Fix the JSON syntax in .codex-plugin/plugin.json.",
+                ),
+            ),
         )
 
 
@@ -50,24 +103,46 @@ def check_required_fields(plugin_dir: Path) -> CheckResult:
     manifest = load_manifest(plugin_dir)
     if manifest is None:
         return CheckResult(
-            name="Required fields present", passed=False, points=0, max_points=8, message="Cannot parse plugin.json"
+            name="Required fields present",
+            passed=False,
+            points=0,
+            max_points=5,
+            message="Cannot parse plugin.json",
+            findings=(
+                _manifest_finding(
+                    "PLUGIN_JSON_REQUIRED_FIELDS_UNCHECKED",
+                    "Required fields could not be validated",
+                    "Required manifest fields cannot be validated until plugin.json parses cleanly.",
+                    "Fix the manifest format and include name, version, and description.",
+                ),
+            ),
         )
     required = ["name", "version", "description"]
-    missing = [f for f in required if not manifest.get(f) or not isinstance(manifest.get(f), str)]
+    missing = [field for field in required if not manifest.get(field) or not isinstance(manifest.get(field), str)]
     if not missing:
         return CheckResult(
             name="Required fields present",
             passed=True,
-            points=8,
-            max_points=8,
-            message="All required fields (name, version, description) present",
+            points=5,
+            max_points=5,
+            message="All required fields (name, version, description) are present.",
         )
+    findings = tuple(
+        _manifest_finding(
+            f"PLUGIN_JSON_MISSING_{field.upper()}",
+            f'Manifest field "{field}" is missing',
+            f'The manifest does not define a valid string for "{field}".',
+            f'Add a non-empty string value for "{field}" in plugin.json.',
+        )
+        for field in missing
+    )
     return CheckResult(
         name="Required fields present",
         passed=False,
         points=0,
-        max_points=8,
+        max_points=5,
         message=f"Missing required fields: {', '.join(missing)}",
+        findings=findings,
     )
 
 
@@ -75,23 +150,36 @@ def check_semver(plugin_dir: Path) -> CheckResult:
     manifest = load_manifest(plugin_dir)
     if manifest is None:
         return CheckResult(
-            name="Version follows semver", passed=False, points=0, max_points=4, message="Cannot parse plugin.json"
+            name="Version follows semver",
+            passed=False,
+            points=0,
+            max_points=3,
+            message="Cannot parse plugin.json",
         )
-    version = manifest.get("version", "")
-    if version and SEMVER_RE.match(str(version)):
+    version = str(manifest.get("version", ""))
+    if version and SEMVER_RE.match(version):
         return CheckResult(
             name="Version follows semver",
             passed=True,
-            points=4,
-            max_points=4,
-            message=f'Version "{version}" follows semver',
+            points=3,
+            max_points=3,
+            message=f'Version "{version}" follows semver.',
         )
     return CheckResult(
         name="Version follows semver",
         passed=False,
         points=0,
-        max_points=4,
-        message=f'Version "{version}" does not follow semver (expected X.Y.Z)',
+        max_points=3,
+        message=f'Version "{version}" does not follow semver (expected X.Y.Z).',
+        findings=(
+            _manifest_finding(
+                "PLUGIN_JSON_BAD_SEMVER",
+                "Manifest version is not semver",
+                f'The version "{version}" does not match the documented semver format.',
+                "Use a version like 1.2.3 in plugin.json.",
+                severity=Severity.LOW,
+            ),
+        ),
     )
 
 
@@ -99,15 +187,140 @@ def check_kebab_case(plugin_dir: Path) -> CheckResult:
     manifest = load_manifest(plugin_dir)
     if manifest is None:
         return CheckResult(
-            name="Name is kebab-case", passed=False, points=0, max_points=3, message="Cannot parse plugin.json"
+            name="Name is kebab-case",
+            passed=False,
+            points=0,
+            max_points=2,
+            message="Cannot parse plugin.json",
         )
-    name = manifest.get("name", "")
-    if name and KEBAB_RE.match(str(name)):
+    name = str(manifest.get("name", ""))
+    if name and KEBAB_RE.match(name):
         return CheckResult(
-            name="Name is kebab-case", passed=True, points=3, max_points=3, message=f'Name "{name}" is kebab-case'
+            name="Name is kebab-case",
+            passed=True,
+            points=2,
+            max_points=2,
+            message=f'Name "{name}" is kebab-case.',
         )
     return CheckResult(
-        name="Name is kebab-case", passed=False, points=0, max_points=3, message=f'Name "{name}" should be kebab-case'
+        name="Name is kebab-case",
+        passed=False,
+        points=0,
+        max_points=2,
+        message=f'Name "{name}" should be kebab-case.',
+        findings=(
+            _manifest_finding(
+                "PLUGIN_JSON_BAD_NAME",
+                "Manifest name is not kebab-case",
+                f'The plugin name "{name}" does not follow the recommended kebab-case style.',
+                "Rename the plugin to use lowercase words separated by hyphens.",
+                severity=Severity.LOW,
+            ),
+        ),
+    )
+
+
+def check_recommended_metadata(plugin_dir: Path) -> CheckResult:
+    manifest = load_manifest(plugin_dir)
+    if manifest is None:
+        return CheckResult(
+            name="Recommended metadata present",
+            passed=False,
+            points=0,
+            max_points=4,
+            message="Cannot parse plugin.json",
+        )
+
+    missing: list[str] = []
+    for field in RECOMMENDED_FIELDS:
+        value = manifest.get(field)
+        if field == "author":
+            if not isinstance(value, dict) or not isinstance(value.get("name"), str) or not value.get("name"):
+                missing.append(field)
+            continue
+        if field == "keywords":
+            if not isinstance(value, list) or not value or not all(isinstance(item, str) and item for item in value):
+                missing.append(field)
+            continue
+        if not isinstance(value, str) or not value:
+            missing.append(field)
+
+    if not missing:
+        return CheckResult(
+            name="Recommended metadata present",
+            passed=True,
+            points=4,
+            max_points=4,
+            message="Recommended plugin metadata is present.",
+        )
+
+    findings = tuple(
+        _manifest_finding(
+            f"PLUGIN_JSON_RECOMMENDED_{field.upper()}",
+            f'Recommended field "{field}" is missing',
+            f'The manifest is missing the documented recommended field "{field}".',
+            f'Add "{field}" to strengthen the plugin manifest metadata.',
+            severity=Severity.INFO,
+        )
+        for field in missing
+    )
+    return CheckResult(
+        name="Recommended metadata present",
+        passed=False,
+        points=0,
+        max_points=4,
+        message=f"Missing recommended metadata: {', '.join(missing)}",
+        findings=findings,
+    )
+
+
+def check_declared_paths_safe(plugin_dir: Path) -> CheckResult:
+    manifest = load_manifest(plugin_dir)
+    if manifest is None:
+        return CheckResult(
+            name="Declared paths are safe",
+            passed=False,
+            points=0,
+            max_points=3,
+            message="Cannot parse plugin.json",
+        )
+
+    unsafe: list[str] = []
+    skills_path = manifest.get("skills")
+    if isinstance(skills_path, str) and not _is_safe_relative_path(plugin_dir, skills_path):
+        unsafe.append(f"skills={skills_path}")
+
+    apps = manifest.get("apps")
+    if isinstance(apps, list):
+        for app in apps:
+            if isinstance(app, str) and not _is_safe_relative_path(plugin_dir, app):
+                unsafe.append(f"apps={app}")
+
+    if not unsafe:
+        return CheckResult(
+            name="Declared paths are safe",
+            passed=True,
+            points=3,
+            max_points=3,
+            message="Declared manifest paths stay within the plugin directory.",
+        )
+
+    findings = tuple(
+        _manifest_finding(
+            "PLUGIN_JSON_UNSAFE_PATH",
+            "Manifest declares an unsafe path",
+            f'The manifest path "{entry}" resolves outside the plugin directory or is absolute.',
+            "Use only relative paths that stay within the plugin repository.",
+        )
+        for entry in unsafe
+    )
+    return CheckResult(
+        name="Declared paths are safe",
+        passed=False,
+        points=0,
+        max_points=3,
+        message=f"Unsafe manifest paths detected: {', '.join(unsafe)}",
+        findings=findings,
     )
 
 
@@ -118,4 +331,6 @@ def run_manifest_checks(plugin_dir: Path) -> tuple[CheckResult, ...]:
         check_required_fields(plugin_dir),
         check_semver(plugin_dir),
         check_kebab_case(plugin_dir),
+        check_recommended_metadata(plugin_dir),
+        check_declared_paths_safe(plugin_dir),
     )

--- a/src/codex_plugin_scanner/checks/marketplace.py
+++ b/src/codex_plugin_scanner/checks/marketplace.py
@@ -1,11 +1,25 @@
-"""Marketplace validation checks (10 points)."""
+"""Marketplace validation checks (15 points)."""
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
 
-from ..models import CheckResult
+from ..models import CheckResult, Finding, Severity
+
+
+def _is_safe_source(plugin_dir: Path, source: str) -> bool:
+    if source.startswith(("http://", "https://", "git+", "github://")):
+        return True
+    candidate = Path(source)
+    if candidate.is_absolute():
+        return False
+    resolved = (plugin_dir / candidate).resolve()
+    try:
+        resolved.relative_to(plugin_dir.resolve())
+    except ValueError:
+        return False
+    return True
 
 
 def check_marketplace_json(plugin_dir: Path) -> CheckResult:
@@ -14,9 +28,10 @@ def check_marketplace_json(plugin_dir: Path) -> CheckResult:
         return CheckResult(
             name="marketplace.json valid",
             passed=True,
-            points=5,
-            max_points=5,
+            points=0,
+            max_points=0,
             message="No marketplace.json found, check not applicable",
+            applicable=False,
         )
     try:
         data = json.loads(mp.read_text(encoding="utf-8"))
@@ -27,6 +42,17 @@ def check_marketplace_json(plugin_dir: Path) -> CheckResult:
             points=0,
             max_points=5,
             message="marketplace.json is not valid JSON",
+            findings=(
+                Finding(
+                    rule_id="MARKETPLACE_JSON_INVALID",
+                    severity=Severity.MEDIUM,
+                    category="marketplace",
+                    title="marketplace.json is invalid JSON",
+                    description="The marketplace manifest could not be parsed.",
+                    remediation="Fix the JSON syntax in marketplace.json.",
+                    file_path="marketplace.json",
+                ),
+            ),
         )
 
     if not data.get("name") or not isinstance(data.get("name"), str):
@@ -36,6 +62,17 @@ def check_marketplace_json(plugin_dir: Path) -> CheckResult:
             points=0,
             max_points=5,
             message='marketplace.json missing "name" field',
+            findings=(
+                Finding(
+                    rule_id="MARKETPLACE_NAME_MISSING",
+                    severity=Severity.LOW,
+                    category="marketplace",
+                    title='marketplace.json is missing "name"',
+                    description='The marketplace manifest must define a "name" field.',
+                    remediation='Add a string "name" field to marketplace.json.',
+                    file_path="marketplace.json",
+                ),
+            ),
         )
     if not isinstance(data.get("plugins"), list):
         return CheckResult(
@@ -44,6 +81,17 @@ def check_marketplace_json(plugin_dir: Path) -> CheckResult:
             points=0,
             max_points=5,
             message='marketplace.json missing "plugins" array',
+            findings=(
+                Finding(
+                    rule_id="MARKETPLACE_PLUGINS_MISSING",
+                    severity=Severity.MEDIUM,
+                    category="marketplace",
+                    title='marketplace.json is missing the "plugins" array',
+                    description='The marketplace manifest must declare its plugin list in a "plugins" array.',
+                    remediation='Add a "plugins" array to marketplace.json.',
+                    file_path="marketplace.json",
+                ),
+            ),
         )
     for i, plugin in enumerate(data["plugins"]):
         if not plugin.get("source") or not isinstance(plugin.get("source"), str):
@@ -53,6 +101,17 @@ def check_marketplace_json(plugin_dir: Path) -> CheckResult:
                 points=0,
                 max_points=5,
                 message=f'marketplace.json plugin[{i}] missing "source" field',
+                findings=(
+                    Finding(
+                        rule_id="MARKETPLACE_SOURCE_MISSING",
+                        severity=Severity.MEDIUM,
+                        category="marketplace",
+                        title="Marketplace plugin source is missing",
+                        description=f'plugin[{i}] in marketplace.json is missing a "source" field.',
+                        remediation='Add a "source" string for each marketplace entry.',
+                        file_path="marketplace.json",
+                    ),
+                ),
             )
         if not plugin.get("policy") or not isinstance(plugin.get("policy"), dict):
             return CheckResult(
@@ -61,6 +120,17 @@ def check_marketplace_json(plugin_dir: Path) -> CheckResult:
                 points=0,
                 max_points=5,
                 message=f'marketplace.json plugin[{i}] missing "policy" field',
+                findings=(
+                    Finding(
+                        rule_id="MARKETPLACE_POLICY_MISSING",
+                        severity=Severity.MEDIUM,
+                        category="marketplace",
+                        title="Marketplace policy is missing",
+                        description=f'plugin[{i}] in marketplace.json is missing a "policy" object.',
+                        remediation='Add a "policy" object for each marketplace entry.',
+                        file_path="marketplace.json",
+                    ),
+                ),
             )
     return CheckResult(
         name="marketplace.json valid", passed=True, points=5, max_points=5, message="marketplace.json is valid"
@@ -73,9 +143,10 @@ def check_policy_fields(plugin_dir: Path) -> CheckResult:
         return CheckResult(
             name="Policy fields present",
             passed=True,
-            points=5,
-            max_points=5,
+            points=0,
+            max_points=0,
             message="No marketplace.json found, check not applicable",
+            applicable=False,
         )
     try:
         data = json.loads(mp.read_text(encoding="utf-8"))
@@ -120,6 +191,78 @@ def check_policy_fields(plugin_dir: Path) -> CheckResult:
         points=0,
         max_points=5,
         message=f"Policy issues: {', '.join(issues[:3])}",
+        findings=tuple(
+            Finding(
+                rule_id="MARKETPLACE_POLICY_FIELDS_MISSING",
+                severity=Severity.MEDIUM,
+                category="marketplace",
+                title="Marketplace policy fields are incomplete",
+                description=issue,
+                remediation="Add both policy.installation and policy.authentication for each marketplace entry.",
+                file_path="marketplace.json",
+            )
+            for issue in issues
+        ),
+    )
+
+
+def check_sources_safe(plugin_dir: Path) -> CheckResult:
+    mp = plugin_dir / "marketplace.json"
+    if not mp.exists():
+        return CheckResult(
+            name="Marketplace sources are safe",
+            passed=True,
+            points=0,
+            max_points=0,
+            message="No marketplace.json found, check not applicable",
+            applicable=False,
+        )
+
+    try:
+        data = json.loads(mp.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return CheckResult(
+            name="Marketplace sources are safe",
+            passed=True,
+            points=0,
+            max_points=0,
+            message="Cannot parse marketplace.json, skipping source safety checks",
+            applicable=False,
+        )
+
+    unsafe: list[str] = []
+    for index, plugin in enumerate(data.get("plugins", [])):
+        source = plugin.get("source")
+        if isinstance(source, str) and not _is_safe_source(plugin_dir, source):
+            unsafe.append(f"plugin[{index}]={source}")
+
+    if not unsafe:
+        return CheckResult(
+            name="Marketplace sources are safe",
+            passed=True,
+            points=5,
+            max_points=5,
+            message="Marketplace sources are relative-safe or remote URLs.",
+        )
+
+    return CheckResult(
+        name="Marketplace sources are safe",
+        passed=False,
+        points=0,
+        max_points=5,
+        message=f"Unsafe marketplace sources detected: {', '.join(unsafe)}",
+        findings=tuple(
+            Finding(
+                rule_id="MARKETPLACE_UNSAFE_SOURCE",
+                severity=Severity.MEDIUM,
+                category="marketplace",
+                title="Marketplace source escapes the plugin directory",
+                description=f'The marketplace source "{entry}" is absolute or resolves outside the plugin directory.',
+                remediation="Use a relative in-repo path or an explicit remote URL for marketplace sources.",
+                file_path="marketplace.json",
+            )
+            for entry in unsafe
+        ),
     )
 
 
@@ -127,4 +270,5 @@ def run_marketplace_checks(plugin_dir: Path) -> tuple[CheckResult, ...]:
     return (
         check_marketplace_json(plugin_dir),
         check_policy_fields(plugin_dir),
+        check_sources_safe(plugin_dir),
     )

--- a/src/codex_plugin_scanner/checks/marketplace.py
+++ b/src/codex_plugin_scanner/checks/marketplace.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from urllib.parse import urlparse
 
 from ..models import CheckResult, Finding, Severity
 
 
 def _is_safe_source(plugin_dir: Path, source: str) -> bool:
-    if source.startswith(("http://", "https://", "git+", "github://")):
+    if source.startswith(("https://", "git+", "github://")):
         return True
+    if urlparse(source).scheme:
+        return False
     candidate = Path(source)
     if candidate.is_absolute():
         return False

--- a/src/codex_plugin_scanner/checks/security.py
+++ b/src/codex_plugin_scanner/checks/security.py
@@ -1,11 +1,11 @@
-"""Security checks (30 points)."""
+"""Security checks (20 points)."""
 
 from __future__ import annotations
 
 import re
 from pathlib import Path
 
-from ..models import CheckResult
+from ..models import CheckResult, Finding, Severity
 
 # Patterns for hardcoded secrets
 SECRET_PATTERNS: list[re.Pattern[str]] = [
@@ -66,6 +66,12 @@ DANGEROUS_MCP_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"cmd\s*/c", re.I),
 ]
 
+RISKY_APPROVAL_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"danger-full-access"),
+    re.compile(r'approval[_ -]?policy["\']?\s*[:=]\s*["\']never["\']', re.I),
+    re.compile(r'approvalMode["\']?\s*[:=]\s*["\']bypass["\']', re.I),
+]
+
 
 def _scan_all_files(plugin_dir: Path) -> list[Path]:
     """Recursively find all files, skipping excluded dirs."""
@@ -86,30 +92,62 @@ def check_security_md(plugin_dir: Path) -> CheckResult:
     return CheckResult(
         name="SECURITY.md found",
         passed=exists,
-        points=5 if exists else 0,
-        max_points=5,
+        points=3 if exists else 0,
+        max_points=3,
         message="SECURITY.md found" if exists else "SECURITY.md not found",
+        findings=()
+        if exists
+        else (
+            Finding(
+                rule_id="SECURITY_MD_MISSING",
+                severity=Severity.LOW,
+                category="security",
+                title="SECURITY.md is missing",
+                description=(
+                    "Plugins should publish a SECURITY.md file for responsible disclosure and support guidance."
+                ),
+                remediation="Add a SECURITY.md file with reporting guidance and supported versions.",
+                file_path="SECURITY.md",
+            ),
+        ),
     )
 
 
 def check_license(plugin_dir: Path) -> CheckResult:
     lp = plugin_dir / "LICENSE"
     if not lp.exists():
-        return CheckResult(name="LICENSE found", passed=False, points=0, max_points=5, message="LICENSE file not found")
+        return CheckResult(
+            name="LICENSE found",
+            passed=False,
+            points=0,
+            max_points=3,
+            message="LICENSE file not found",
+            findings=(
+                Finding(
+                    rule_id="LICENSE_MISSING",
+                    severity=Severity.LOW,
+                    category="security",
+                    title="LICENSE file is missing",
+                    description="Plugins should ship a LICENSE file so consumers can review usage rights.",
+                    remediation="Add a LICENSE file that matches the manifest license metadata.",
+                    file_path="LICENSE",
+                ),
+            ),
+        )
     try:
         content = lp.read_text(encoding="utf-8", errors="ignore")
         if "Apache" in content and ("2.0" in content or "www.apache.org" in content):
             return CheckResult(
-                name="LICENSE found", passed=True, points=5, max_points=5, message="LICENSE found (Apache-2.0)"
+                name="LICENSE found", passed=True, points=3, max_points=3, message="LICENSE found (Apache-2.0)"
             )
         if "MIT" in content and "Permission is hereby granted" in content:
-            return CheckResult(name="LICENSE found", passed=True, points=5, max_points=5, message="LICENSE found (MIT)")
+            return CheckResult(name="LICENSE found", passed=True, points=3, max_points=3, message="LICENSE found (MIT)")
         return CheckResult(
-            name="LICENSE found", passed=True, points=5, max_points=5, message="LICENSE found (not Apache-2.0 or MIT)"
+            name="LICENSE found", passed=True, points=3, max_points=3, message="LICENSE found"
         )
     except OSError:
         return CheckResult(
-            name="LICENSE found", passed=False, points=0, max_points=5, message="LICENSE exists but could not be read"
+            name="LICENSE found", passed=False, points=0, max_points=3, message="LICENSE exists but could not be read"
         )
 
 
@@ -126,7 +164,7 @@ def check_no_hardcoded_secrets(plugin_dir: Path) -> CheckResult:
                 break
     if not findings:
         return CheckResult(
-            name="No hardcoded secrets", passed=True, points=10, max_points=10, message="No hardcoded secrets detected"
+            name="No hardcoded secrets", passed=True, points=7, max_points=7, message="No hardcoded secrets detected"
         )
     shown = findings[:5]
     suffix = f" and {len(findings) - 5} more" if len(findings) > 5 else ""
@@ -134,8 +172,20 @@ def check_no_hardcoded_secrets(plugin_dir: Path) -> CheckResult:
         name="No hardcoded secrets",
         passed=False,
         points=0,
-        max_points=10,
+        max_points=7,
         message=f"Hardcoded secrets found in: {', '.join(shown)}{suffix}",
+        findings=tuple(
+            Finding(
+                rule_id="HARDCODED_SECRET",
+                severity=Severity.HIGH,
+                category="security",
+                title="Hardcoded secret detected",
+                description=f"Potential secret material was detected in {path}.",
+                remediation="Remove the secret from source control and load it securely at runtime.",
+                file_path=path,
+            )
+            for path in findings
+        ),
     )
 
 
@@ -145,15 +195,21 @@ def check_no_dangerous_mcp(plugin_dir: Path) -> CheckResult:
         return CheckResult(
             name="No dangerous MCP commands",
             passed=True,
-            points=10,
-            max_points=10,
+            points=0,
+            max_points=0,
             message="No .mcp.json found, skipping check",
+            applicable=False,
         )
     try:
         content = mcp_path.read_text(encoding="utf-8")
     except OSError:
         return CheckResult(
-            name="No dangerous MCP commands", passed=True, points=10, max_points=10, message="Could not read .mcp.json"
+            name="No dangerous MCP commands",
+            passed=True,
+            points=0,
+            max_points=0,
+            message="Could not read .mcp.json",
+            applicable=False,
         )
     found: list[str] = []
     for pattern in DANGEROUS_MCP_PATTERNS:
@@ -163,16 +219,72 @@ def check_no_dangerous_mcp(plugin_dir: Path) -> CheckResult:
         return CheckResult(
             name="No dangerous MCP commands",
             passed=True,
-            points=10,
-            max_points=10,
+            points=4,
+            max_points=4,
             message="No dangerous commands found in .mcp.json",
         )
     return CheckResult(
         name="No dangerous MCP commands",
         passed=False,
         points=0,
-        max_points=10,
+        max_points=4,
         message=f"Dangerous patterns in .mcp.json: {', '.join(found)}",
+        findings=tuple(
+            Finding(
+                rule_id="DANGEROUS_MCP_COMMAND",
+                severity=Severity.HIGH,
+                category="security",
+                title="Dangerous MCP command pattern detected",
+                description=f'The MCP configuration matches the risky pattern "{pattern}".',
+                remediation="Remove destructive commands and require explicit user approval before high-risk actions.",
+                file_path=".mcp.json",
+            )
+            for pattern in found
+        ),
+    )
+
+
+def check_no_approval_bypass_defaults(plugin_dir: Path) -> CheckResult:
+    findings: list[str] = []
+    for file_path in _scan_all_files(plugin_dir):
+        try:
+            content = file_path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        if not file_path.name.endswith((".json", ".md", ".yaml", ".yml", ".toml")):
+            continue
+        if any(pattern.search(content) for pattern in RISKY_APPROVAL_PATTERNS):
+            findings.append(str(file_path.relative_to(plugin_dir)))
+
+    if not findings:
+        return CheckResult(
+            name="No approval bypass defaults",
+            passed=True,
+            points=3,
+            max_points=3,
+            message="No risky approval or sandbox defaults detected.",
+        )
+
+    return CheckResult(
+        name="No approval bypass defaults",
+        passed=False,
+        points=0,
+        max_points=3,
+        message=f"Risky approval defaults found in: {', '.join(findings)}",
+        findings=tuple(
+            Finding(
+                rule_id="RISKY_APPROVAL_DEFAULT",
+                severity=Severity.MEDIUM,
+                category="security",
+                title="Risky approval or sandbox default detected",
+                description=f"{path} contains a dangerous approval or sandbox default.",
+                remediation=(
+                    "Avoid shipping configurations that default to bypassed approvals or unrestricted sandboxes."
+                ),
+                file_path=path,
+            )
+            for path in findings
+        ),
     )
 
 
@@ -182,4 +294,5 @@ def run_security_checks(plugin_dir: Path) -> tuple[CheckResult, ...]:
         check_license(plugin_dir),
         check_no_hardcoded_secrets(plugin_dir),
         check_no_dangerous_mcp(plugin_dir),
+        check_no_approval_bypass_defaults(plugin_dir),
     )

--- a/src/codex_plugin_scanner/checks/skill_security.py
+++ b/src/codex_plugin_scanner/checks/skill_security.py
@@ -1,0 +1,203 @@
+"""Skill security checks powered by Cisco skill-scanner."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..integrations.cisco_skill_scanner import (
+    CiscoIntegrationStatus,
+    CiscoSkillScanSummary,
+    run_cisco_skill_scan,
+)
+from ..models import SEVERITY_ORDER, CheckResult, Finding, ScanOptions, Severity, max_severity
+from .manifest import load_manifest
+
+
+def _not_applicable_results(message: str) -> tuple[CheckResult, ...]:
+    return (
+        CheckResult(
+            name="Cisco skill scan completed",
+            passed=True,
+            points=0,
+            max_points=0,
+            message=message,
+            applicable=False,
+        ),
+        CheckResult(
+            name="No elevated Cisco skill findings",
+            passed=True,
+            points=0,
+            max_points=0,
+            message=message,
+            applicable=False,
+        ),
+        CheckResult(
+            name="Skills analyzable",
+            passed=True,
+            points=0,
+            max_points=0,
+            message=message,
+            applicable=False,
+        ),
+    )
+
+
+def _elevated_findings(findings: tuple[Finding, ...]) -> tuple[Finding, ...]:
+    return tuple(
+        finding
+        for finding in findings
+        if SEVERITY_ORDER[finding.severity] >= SEVERITY_ORDER[Severity.MEDIUM]
+    )
+
+
+def _availability_check(summary: CiscoSkillScanSummary, mode: str) -> CheckResult:
+    if summary.status in {CiscoIntegrationStatus.ENABLED, CiscoIntegrationStatus.SKIPPED}:
+        return CheckResult(
+            name="Cisco skill scan completed",
+            passed=True,
+            points=3 if summary.status == CiscoIntegrationStatus.ENABLED else 0,
+            max_points=3 if summary.status == CiscoIntegrationStatus.ENABLED else 0,
+            message=summary.message,
+            applicable=summary.status == CiscoIntegrationStatus.ENABLED,
+        )
+
+    findings = ()
+    if mode == "on":
+        findings = (
+            Finding(
+                rule_id="CISCO-SCANNER-UNAVAILABLE",
+                severity=Severity.LOW,
+                category="skill-security",
+                title="Cisco skill scanner unavailable",
+                description=summary.message,
+                remediation="Install the cisco extra or disable the Cisco scan requirement for this run.",
+                source="cisco-skill-scanner",
+            ),
+        )
+        return CheckResult(
+            name="Cisco skill scan completed",
+            passed=False,
+            points=0,
+            max_points=3,
+            message=summary.message,
+            findings=findings,
+        )
+
+    return CheckResult(
+        name="Cisco skill scan completed",
+        passed=True,
+        points=3,
+        max_points=3,
+        message=summary.message,
+    )
+
+
+def _findings_check(summary: CiscoSkillScanSummary) -> CheckResult:
+    if summary.status != CiscoIntegrationStatus.ENABLED:
+        return CheckResult(
+            name="No elevated Cisco skill findings",
+            passed=True,
+            points=0,
+            max_points=0,
+            message="Cisco scan not executed; elevated findings check not applicable.",
+            applicable=False,
+        )
+
+    elevated = _elevated_findings(summary.findings)
+    if not elevated:
+        advisory_count = summary.total_findings
+        if advisory_count:
+            return CheckResult(
+                name="No elevated Cisco skill findings",
+                passed=True,
+                points=8,
+                max_points=8,
+                message=f"Cisco scan found only advisory-level findings ({advisory_count}).",
+                findings=summary.findings,
+            )
+        return CheckResult(
+            name="No elevated Cisco skill findings",
+            passed=True,
+            points=8,
+            max_points=8,
+            message="Cisco scan found no elevated skill findings.",
+        )
+
+    severity = max_severity(elevated)
+    top_titles = ", ".join(finding.title for finding in elevated[:3])
+    return CheckResult(
+        name="No elevated Cisco skill findings",
+        passed=False,
+        points=0,
+        max_points=8,
+        message=f"Elevated Cisco findings detected ({severity.value if severity else 'unknown'}): {top_titles}",
+        findings=elevated,
+    )
+
+
+def _analyzability_check(summary: CiscoSkillScanSummary) -> CheckResult:
+    if summary.status != CiscoIntegrationStatus.ENABLED:
+        return CheckResult(
+            name="Skills analyzable",
+            passed=True,
+            points=0,
+            max_points=0,
+            message="Cisco scan not executed; analyzability not applicable.",
+            applicable=False,
+        )
+
+    if summary.skills_skipped:
+        skipped = ", ".join(summary.skills_skipped[:3])
+        return CheckResult(
+            name="Skills analyzable",
+            passed=False,
+            points=0,
+            max_points=4,
+            message=f"Cisco skipped skills: {skipped}",
+        )
+
+    if summary.skills_scanned > 0:
+        return CheckResult(
+            name="Skills analyzable",
+            passed=True,
+            points=4,
+            max_points=4,
+            message=f"Cisco analyzed {summary.skills_scanned} skill(s).",
+        )
+
+    return CheckResult(
+        name="Skills analyzable",
+        passed=False,
+        points=0,
+        max_points=4,
+        message="Cisco scan ran but did not analyze any skills.",
+    )
+
+
+def run_skill_security_checks(plugin_dir: Path, options: ScanOptions | None = None) -> tuple[CheckResult, ...]:
+    """Run Cisco-backed skill security checks when the plugin declares skills."""
+
+    scan_options = options or ScanOptions()
+    manifest = load_manifest(plugin_dir)
+    if manifest is None:
+        return _not_applicable_results("plugin.json is unavailable; skill security checks skipped.")
+
+    skills_path_value = manifest.get("skills")
+    if not isinstance(skills_path_value, str) or not skills_path_value.strip():
+        return _not_applicable_results("No skills declared in plugin.json.")
+
+    skills_dir = (plugin_dir / skills_path_value).resolve()
+    if not skills_dir.is_dir():
+        return _not_applicable_results(f'Skills directory "{skills_path_value}" is missing; see best-practice checks.')
+
+    summary = run_cisco_skill_scan(
+        skills_dir=skills_dir,
+        mode=scan_options.cisco_skill_scan,
+        policy_name=scan_options.cisco_policy,
+    )
+
+    return (
+        _availability_check(summary, scan_options.cisco_skill_scan),
+        _findings_check(summary),
+        _analyzability_check(summary),
+    )

--- a/src/codex_plugin_scanner/checks/skill_security.py
+++ b/src/codex_plugin_scanner/checks/skill_security.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
 from ..integrations.cisco_skill_scanner import (
@@ -11,6 +12,12 @@ from ..integrations.cisco_skill_scanner import (
 )
 from ..models import SEVERITY_ORDER, CheckResult, Finding, ScanOptions, Severity, max_severity
 from .manifest import load_manifest
+
+
+@dataclass(frozen=True, slots=True)
+class SkillSecurityContext:
+    summary: CiscoSkillScanSummary | None
+    skip_message: str | None = None
 
 
 def _not_applicable_results(message: str) -> tuple[CheckResult, ...]:
@@ -51,14 +58,23 @@ def _elevated_findings(findings: tuple[Finding, ...]) -> tuple[Finding, ...]:
 
 
 def _availability_check(summary: CiscoSkillScanSummary, mode: str) -> CheckResult:
-    if summary.status in {CiscoIntegrationStatus.ENABLED, CiscoIntegrationStatus.SKIPPED}:
+    if summary.status == CiscoIntegrationStatus.ENABLED:
         return CheckResult(
             name="Cisco skill scan completed",
             passed=True,
-            points=3 if summary.status == CiscoIntegrationStatus.ENABLED else 0,
-            max_points=3 if summary.status == CiscoIntegrationStatus.ENABLED else 0,
+            points=3,
+            max_points=3,
             message=summary.message,
-            applicable=summary.status == CiscoIntegrationStatus.ENABLED,
+        )
+
+    if summary.status == CiscoIntegrationStatus.SKIPPED:
+        return CheckResult(
+            name="Cisco skill scan completed",
+            passed=True,
+            points=0,
+            max_points=0,
+            message=summary.message,
+            applicable=False,
         )
 
     findings = ()
@@ -86,9 +102,10 @@ def _availability_check(summary: CiscoSkillScanSummary, mode: str) -> CheckResul
     return CheckResult(
         name="Cisco skill scan completed",
         passed=True,
-        points=3,
-        max_points=3,
+        points=0,
+        max_points=0,
         message=summary.message,
+        applicable=False,
     )
 
 
@@ -174,28 +191,53 @@ def _analyzability_check(summary: CiscoSkillScanSummary) -> CheckResult:
     )
 
 
-def run_skill_security_checks(plugin_dir: Path, options: ScanOptions | None = None) -> tuple[CheckResult, ...]:
-    """Run Cisco-backed skill security checks when the plugin declares skills."""
+def resolve_skill_security_context(plugin_dir: Path, options: ScanOptions | None = None) -> SkillSecurityContext:
+    """Resolve Cisco skill scanning context for a plugin directory."""
 
     scan_options = options or ScanOptions()
     manifest = load_manifest(plugin_dir)
     if manifest is None:
-        return _not_applicable_results("plugin.json is unavailable; skill security checks skipped.")
+        return SkillSecurityContext(
+            summary=None,
+            skip_message="plugin.json is unavailable; skill security checks skipped.",
+        )
 
     skills_path_value = manifest.get("skills")
     if not isinstance(skills_path_value, str) or not skills_path_value.strip():
-        return _not_applicable_results("No skills declared in plugin.json.")
+        return SkillSecurityContext(summary=None, skip_message="No skills declared in plugin.json.")
 
     skills_dir = (plugin_dir / skills_path_value).resolve()
     if not skills_dir.is_dir():
-        return _not_applicable_results(f'Skills directory "{skills_path_value}" is missing; see best-practice checks.')
+        return SkillSecurityContext(
+            summary=None,
+            skip_message=f'Skills directory "{skills_path_value}" is missing; see best-practice checks.',
+        )
 
-    summary = run_cisco_skill_scan(
-        skills_dir=skills_dir,
-        mode=scan_options.cisco_skill_scan,
-        policy_name=scan_options.cisco_policy,
+    return SkillSecurityContext(
+        summary=run_cisco_skill_scan(
+            skills_dir=skills_dir,
+            mode=scan_options.cisco_skill_scan,
+            policy_name=scan_options.cisco_policy,
+        )
     )
 
+
+def run_skill_security_checks(
+    plugin_dir: Path,
+    options: ScanOptions | None = None,
+    context: SkillSecurityContext | None = None,
+) -> tuple[CheckResult, ...]:
+    """Run Cisco-backed skill security checks when the plugin declares skills."""
+
+    resolved_context = context or resolve_skill_security_context(plugin_dir, options)
+    if resolved_context.skip_message:
+        return _not_applicable_results(resolved_context.skip_message)
+
+    summary = resolved_context.summary
+    if summary is None:
+        return _not_applicable_results("Cisco scan context unavailable.")
+
+    scan_options = options or ScanOptions()
     return (
         _availability_check(summary, scan_options.cisco_skill_scan),
         _findings_check(summary),

--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -3,52 +3,19 @@
 from __future__ import annotations
 
 import argparse
-import json
 import sys
 from pathlib import Path
 
-from .models import GRADE_LABELS
+from .models import GRADE_LABELS, ScanOptions, Severity
+from .reporting import format_json as render_json
+from .reporting import format_markdown, format_sarif, should_fail_for_severity
 from .scanner import scan_plugin
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 
 def format_text(result) -> str:
-    """Format scan result as terminal output. Uses rich if available, falls back to plain text."""
-    try:
-        from rich.console import Console
-
-        console = Console()
-        console.print(f"[bold cyan]🔗 Codex Plugin Scanner v{__version__}[/bold cyan]")
-        console.print(f"Scanning: {result.plugin_dir}")
-        console.print()
-
-        for category in result.categories:
-            cat_score = sum(c.points for c in category.checks)
-            cat_max = sum(c.max_points for c in category.checks)
-            console.print(f"[bold yellow]── {category.name} ({cat_score}/{cat_max}) ──[/bold yellow]")
-
-            for check in category.checks:
-                icon = "✅" if check.passed else "⚠️"
-                name_style = "[green]" if check.passed else "[red]"
-                pts = f"[green]+{check.points}[/green]" if check.passed else "[red]+0[/red]"
-                console.print(f"  {icon} {name_style}{check.name:<42}[/]{pts}")
-            console.print()
-
-        separator = "━" * 37
-        grade = result.grade
-        grade_colors = {"A": "bold green", "B": "green", "C": "yellow", "D": "red", "F": "bold red"}
-        label = GRADE_LABELS.get(grade, "Unknown")
-        gc = grade_colors.get(grade, "red")
-
-        console.print(f"[bold]{separator}[/bold]")
-        console.print(f"Final Score: [bold]{result.score}[/bold]/100 ([{gc}]{grade} - {label}[/{gc}])")
-        console.print(f"[bold]{separator}[/bold]")
-        return ""
-    except ImportError:
-        pass
-
-    # Fallback: plain text output
+    """Format scan result as plain terminal output."""
     lines = [f"🔗 Codex Plugin Scanner v{__version__}", f"Scanning: {result.plugin_dir}", ""]
     for category in result.categories:
         cat_score = sum(c.points for c in category.checks)
@@ -59,6 +26,14 @@ def format_text(result) -> str:
             pts = f"+{check.points}" if check.passed else "+0"
             lines.append(f"  {icon} {check.name:<42} {pts}")
         lines.append("")
+    counts = ", ".join(f"{severity.value}:{result.severity_counts.get(severity.value, 0)}" for severity in Severity)
+    lines += [f"Findings: {counts}", ""]
+    if result.findings:
+        lines.append("Top Findings:")
+        for finding in result.findings[:5]:
+            location = f" ({finding.file_path})" if finding.file_path else ""
+            lines.append(f"  - {finding.severity.value.upper()} {finding.title}{location}")
+        lines.append("")
     separator = "━" * 37
     label = GRADE_LABELS.get(result.grade, "Unknown")
     lines += [separator, f"Final Score: {result.score}/100 ({result.grade} - {label})", separator]
@@ -67,31 +42,7 @@ def format_text(result) -> str:
 
 def format_json(result) -> str:
     """Format scan result as JSON."""
-    data = {
-        "score": result.score,
-        "grade": result.grade,
-        "categories": [
-            {
-                "name": cat.name,
-                "score": sum(c.points for c in cat.checks),
-                "max": sum(c.max_points for c in cat.checks),
-                "checks": [
-                    {
-                        "name": c.name,
-                        "passed": c.passed,
-                        "points": c.points,
-                        "maxPoints": c.max_points,
-                        "message": c.message,
-                    }
-                    for c in cat.checks
-                ],
-            }
-            for cat in result.categories
-        ],
-        "timestamp": result.timestamp,
-        "pluginDir": result.plugin_dir,
-    }
-    return json.dumps(data, indent=2)
+    return render_json(result)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -102,12 +53,36 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("plugin_dir", help="Path to the plugin directory to scan")
     parser.add_argument("--json", action="store_true", help="Output results as JSON")
-    parser.add_argument("--output", "-o", help="Write JSON report to file")
+    parser.add_argument(
+        "--format",
+        choices=("text", "json", "markdown", "sarif"),
+        default="text",
+        help="Output format (default: text)",
+    )
+    parser.add_argument("--output", "-o", help="Write the report to a file")
     parser.add_argument(
         "--min-score",
         type=int,
         default=0,
         help="Exit with code 1 if score is below this threshold (default: 0)",
+    )
+    parser.add_argument(
+        "--fail-on-severity",
+        choices=("none", "critical", "high", "medium", "low", "info"),
+        default="none",
+        help="Exit with code 1 if any finding is at or above the selected severity.",
+    )
+    parser.add_argument(
+        "--cisco-skill-scan",
+        choices=("auto", "on", "off"),
+        default="auto",
+        help="Run Cisco skill-scanner automatically when available, require it, or disable it.",
+    )
+    parser.add_argument(
+        "--cisco-policy",
+        choices=("permissive", "balanced", "strict"),
+        default="balanced",
+        help="Cisco skill-scanner policy preset to use when the integration runs.",
     )
     parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     args = parser.parse_args(argv)
@@ -117,24 +92,40 @@ def main(argv: list[str] | None = None) -> int:
         print(f'Error: "{resolved}" is not a directory.', file=sys.stderr)
         return 1
 
-    result = scan_plugin(args.plugin_dir)
+    output_format = "json" if args.json else args.format
+    if args.output and not args.json and args.format == "text":
+        output_format = "json"
+    result = scan_plugin(
+        args.plugin_dir,
+        ScanOptions(cisco_skill_scan=args.cisco_skill_scan, cisco_policy=args.cisco_policy),
+    )
 
-    if args.json or args.output:
+    if output_format == "json":
         output = format_json(result)
-        if args.output:
-            out_path = Path(args.output)
-            out_path.write_text(output, encoding="utf-8")
-            print(f"Report written to {out_path}")
-        else:
-            print(output)
+    elif output_format == "markdown":
+        output = format_markdown(result)
+    elif output_format == "sarif":
+        output = format_sarif(result)
     else:
-        text = format_text(result)
-        if text:
-            print(text)
+        output = format_text(result)
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.write_text(output, encoding="utf-8")
+        print(f"Report written to {out_path}")
+    elif output:
+        print(output)
 
     if result.score < args.min_score:
         print(
             f"Score {result.score} is below minimum threshold {args.min_score}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if should_fail_for_severity(result, args.fail_on_severity):
+        print(
+            f'Findings met or exceeded the "{args.fail_on_severity}" severity threshold.',
             file=sys.stderr,
         )
         return 1

--- a/src/codex_plugin_scanner/integrations/__init__.py
+++ b/src/codex_plugin_scanner/integrations/__init__.py
@@ -1,0 +1,5 @@
+"""Optional integrations for deeper plugin analysis."""
+
+from .cisco_skill_scanner import CiscoIntegrationStatus, CiscoSkillScanSummary, run_cisco_skill_scan
+
+__all__ = ["CiscoIntegrationStatus", "CiscoSkillScanSummary", "run_cisco_skill_scan"]

--- a/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
@@ -1,0 +1,150 @@
+"""Cisco skill-scanner integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+from ..models import Finding, Severity, severity_from_value
+
+
+class CiscoIntegrationStatus(StrEnum):
+    """State of the Cisco skill-scanner integration."""
+
+    ENABLED = "enabled"
+    SKIPPED = "skipped"
+    UNAVAILABLE = "unavailable"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True, slots=True)
+class CiscoSkillScanSummary:
+    """Normalized summary from a Cisco skill-scanner run."""
+
+    status: CiscoIntegrationStatus
+    message: str
+    findings: tuple[Finding, ...]
+    skills_scanned: int
+    skills_skipped: tuple[str, ...]
+    analyzers_used: tuple[str, ...]
+    policy_name: str
+    total_findings: int
+    findings_by_severity: dict[str, int]
+
+
+def _empty_counts() -> dict[str, int]:
+    return {severity.value: 0 for severity in Severity}
+
+
+def _build_unavailable_summary(message: str, *, status: CiscoIntegrationStatus) -> CiscoSkillScanSummary:
+    return CiscoSkillScanSummary(
+        status=status,
+        message=message,
+        findings=(),
+        skills_scanned=0,
+        skills_skipped=(),
+        analyzers_used=(),
+        policy_name="balanced",
+        total_findings=0,
+        findings_by_severity=_empty_counts(),
+    )
+
+
+def _to_local_finding(plugin_dir: Path, skill_result: dict[str, object], finding: dict[str, object]) -> Finding:
+    skill_path = Path(str(skill_result.get("skill_path", "")))
+    relative_skill_path = skill_path
+    if skill_path.is_absolute():
+        try:
+            relative_skill_path = skill_path.relative_to(plugin_dir)
+        except ValueError:
+            relative_skill_path = Path(skill_path.name)
+
+    finding_path = str(finding.get("file_path") or "").strip()
+    full_path = relative_skill_path / finding_path if finding_path else relative_skill_path
+    line_number = finding.get("line_number")
+
+    return Finding(
+        rule_id=str(finding.get("rule_id") or finding.get("id") or "CISCO-SKILL-SCANNER"),
+        severity=severity_from_value(str(finding.get("severity") or "info")),
+        category="skill-security",
+        title=str(finding.get("title") or "Cisco skill-scanner finding"),
+        description=str(finding.get("description") or "Cisco skill-scanner reported a potential issue."),
+        remediation=str(finding.get("remediation")) if finding.get("remediation") else None,
+        file_path=str(full_path),
+        line_number=int(line_number) if isinstance(line_number, int) else None,
+        source="cisco-skill-scanner",
+    )
+
+
+def run_cisco_skill_scan(skills_dir: Path, mode: str = "auto", policy_name: str = "balanced") -> CiscoSkillScanSummary:
+    """Run Cisco skill-scanner against a skills directory when available."""
+
+    if mode == "off":
+        return _build_unavailable_summary(
+            "Cisco skill scanning disabled by configuration.",
+            status=CiscoIntegrationStatus.SKIPPED,
+        )
+
+    try:
+        from skill_scanner import SkillScanner
+        from skill_scanner.core.scan_policy import ScanPolicy
+    except ImportError:
+        if mode == "on":
+            return _build_unavailable_summary(
+                "Cisco skill scanner is required but not installed. Install with the cisco extra.",
+                status=CiscoIntegrationStatus.UNAVAILABLE,
+            )
+        return _build_unavailable_summary(
+            "Cisco skill scanner not installed; deep skill scan skipped.",
+            status=CiscoIntegrationStatus.UNAVAILABLE,
+        )
+
+    try:
+        scanner = SkillScanner(policy=ScanPolicy(preset_base=policy_name))
+        report = scanner.scan_directory(skills_dir.resolve())
+        payload = report.to_dict()
+    except Exception as exc:  # pragma: no cover - defensive around third-party code
+        return _build_unavailable_summary(
+            f"Cisco skill scanner failed: {exc}",
+            status=CiscoIntegrationStatus.FAILED,
+        )
+
+    findings: list[Finding] = []
+    results = payload.get("results", [])
+    for result in results:
+        if not isinstance(result, dict):
+            continue
+        skill_findings = result.get("findings", [])
+        if not isinstance(skill_findings, list):
+            continue
+        for finding in skill_findings:
+            if isinstance(finding, dict):
+                findings.append(_to_local_finding(skills_dir.parent, result, finding))
+
+    summary = payload.get("summary", {})
+    counts = _empty_counts()
+    findings_by_severity = summary.get("findings_by_severity", {})
+    if isinstance(findings_by_severity, dict):
+        for key, value in findings_by_severity.items():
+            if key in counts and isinstance(value, int):
+                counts[key] = value
+
+    analyzers_used = []
+    skills_skipped: tuple[str, ...] = ()
+    if results and isinstance(results[0], dict):
+        analyzers = results[0].get("analyzers_used", [])
+        if isinstance(analyzers, list):
+            analyzers_used = [str(analyzer) for analyzer in analyzers]
+
+    return CiscoSkillScanSummary(
+        status=CiscoIntegrationStatus.ENABLED,
+        message=f"Cisco skill scanner completed using the {policy_name} policy preset.",
+        findings=tuple(findings),
+        skills_scanned=int(summary.get("total_skills_scanned", 0)),
+        skills_skipped=skills_skipped,
+        analyzers_used=tuple(analyzers_used),
+        policy_name=policy_name,
+        total_findings=int(summary.get("total_findings", len(findings))),
+        findings_by_severity=counts,
+    )

--- a/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
@@ -37,6 +37,24 @@ def _empty_counts() -> dict[str, int]:
     return {severity.value: 0 for severity in Severity}
 
 
+def _normalize_string_items(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list | tuple):
+        return ()
+
+    items: list[str] = []
+    for entry in value:
+        if isinstance(entry, str) and entry.strip():
+            items.append(entry.strip())
+            continue
+        if isinstance(entry, dict):
+            for key in ("skill_path", "path", "name", "skill_name"):
+                candidate = entry.get(key)
+                if isinstance(candidate, str) and candidate.strip():
+                    items.append(candidate.strip())
+                    break
+    return tuple(items)
+
+
 def _build_unavailable_summary(message: str, *, status: CiscoIntegrationStatus) -> CiscoSkillScanSummary:
     return CiscoSkillScanSummary(
         status=status,
@@ -75,6 +93,42 @@ def _to_local_finding(plugin_dir: Path, skill_result: dict[str, object], finding
         line_number=int(line_number) if isinstance(line_number, int) else None,
         source="cisco-skill-scanner",
     )
+
+
+def _extract_analyzers_used(results: object) -> tuple[str, ...]:
+    if not isinstance(results, list):
+        return ()
+
+    analyzers: list[str] = []
+    for result in results:
+        if not isinstance(result, dict):
+            continue
+        result_analyzers = result.get("analyzers_used", [])
+        if isinstance(result_analyzers, list):
+            analyzers.extend(str(analyzer) for analyzer in result_analyzers if str(analyzer).strip())
+    return tuple(dict.fromkeys(analyzers))
+
+
+def _extract_skipped_skills(summary: object, results: object) -> tuple[str, ...]:
+    skipped: list[str] = []
+
+    if isinstance(summary, dict):
+        for key in ("skills_skipped", "skipped_skills", "skipped_skill_paths"):
+            skipped.extend(_normalize_string_items(summary.get(key)))
+
+    if isinstance(results, list):
+        for result in results:
+            if not isinstance(result, dict):
+                continue
+            result_status = str(result.get("status") or "").strip().lower()
+            if result_status == "skipped" or result.get("skipped") is True:
+                skipped.extend(
+                    _normalize_string_items(
+                        [result.get("skill_path") or result.get("path") or result.get("skill_name")]
+                    )
+                )
+
+    return tuple(dict.fromkeys(skipped))
 
 
 def run_cisco_skill_scan(skills_dir: Path, mode: str = "auto", policy_name: str = "balanced") -> CiscoSkillScanSummary:
@@ -130,12 +184,8 @@ def run_cisco_skill_scan(skills_dir: Path, mode: str = "auto", policy_name: str 
             if key in counts and isinstance(value, int):
                 counts[key] = value
 
-    analyzers_used = []
-    skills_skipped: tuple[str, ...] = ()
-    if results and isinstance(results[0], dict):
-        analyzers = results[0].get("analyzers_used", [])
-        if isinstance(analyzers, list):
-            analyzers_used = [str(analyzer) for analyzer in analyzers]
+    analyzers_used = _extract_analyzers_used(results)
+    skills_skipped = _extract_skipped_skills(summary, results)
 
     return CiscoSkillScanSummary(
         status=CiscoIntegrationStatus.ENABLED,
@@ -143,7 +193,7 @@ def run_cisco_skill_scan(skills_dir: Path, mode: str = "auto", policy_name: str 
         findings=tuple(findings),
         skills_scanned=int(summary.get("total_skills_scanned", 0)),
         skills_skipped=skills_skipped,
-        analyzers_used=tuple(analyzers_used),
+        analyzers_used=analyzers_used,
         policy_name=policy_name,
         total_findings=int(summary.get("total_findings", len(findings))),
         findings_by_severity=counts,

--- a/src/codex_plugin_scanner/models.py
+++ b/src/codex_plugin_scanner/models.py
@@ -2,7 +2,42 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class Severity(StrEnum):
+    """Severity levels for actionable findings."""
+
+    CRITICAL = "critical"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+    INFO = "info"
+
+
+SEVERITY_ORDER: dict[Severity, int] = {
+    Severity.CRITICAL: 5,
+    Severity.HIGH: 4,
+    Severity.MEDIUM: 3,
+    Severity.LOW: 2,
+    Severity.INFO: 1,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class Finding:
+    """A structured finding emitted by a check or external scanner."""
+
+    rule_id: str
+    severity: Severity
+    category: str
+    title: str
+    description: str
+    remediation: str | None = None
+    file_path: str | None = None
+    line_number: int | None = None
+    source: str = "native"
 
 
 @dataclass(frozen=True, slots=True)
@@ -14,6 +49,8 @@ class CheckResult:
     points: int
     max_points: int
     message: str
+    findings: tuple[Finding, ...] = ()
+    applicable: bool = True
 
 
 @dataclass(frozen=True, slots=True)
@@ -25,6 +62,25 @@ class CategoryResult:
 
 
 @dataclass(frozen=True, slots=True)
+class IntegrationResult:
+    """Status of an optional scanning integration."""
+
+    name: str
+    status: str
+    message: str
+    findings_count: int = 0
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class ScanOptions:
+    """Runtime options that change scanner behavior."""
+
+    cisco_skill_scan: str = "auto"
+    cisco_policy: str = "balanced"
+
+
+@dataclass(frozen=True, slots=True)
 class ScanResult:
     """Full result of scanning a plugin directory."""
 
@@ -33,6 +89,9 @@ class ScanResult:
     categories: tuple[CategoryResult, ...]
     timestamp: str
     plugin_dir: str
+    findings: tuple[Finding, ...] = ()
+    severity_counts: dict[str, int] = field(default_factory=dict)
+    integrations: tuple[IntegrationResult, ...] = ()
 
 
 def get_grade(score: int) -> str:
@@ -46,6 +105,35 @@ def get_grade(score: int) -> str:
     if score >= 60:
         return "D"
     return "F"
+
+
+def severity_from_value(value: str | Severity) -> Severity:
+    """Normalize external severity strings into the local enum."""
+
+    if isinstance(value, Severity):
+        return value
+    normalized = value.strip().lower()
+    try:
+        return Severity(normalized)
+    except ValueError:
+        return Severity.INFO
+
+
+def build_severity_counts(findings: tuple[Finding, ...]) -> dict[str, int]:
+    """Count findings by severity."""
+
+    counts = {severity.value: 0 for severity in Severity}
+    for finding in findings:
+        counts[finding.severity.value] += 1
+    return counts
+
+
+def max_severity(findings: tuple[Finding, ...]) -> Severity | None:
+    """Return the most severe finding, if any."""
+
+    if not findings:
+        return None
+    return max(findings, key=lambda finding: SEVERITY_ORDER[finding.severity]).severity
 
 
 GRADE_LABELS: dict[str, str] = {

--- a/src/codex_plugin_scanner/reporting.py
+++ b/src/codex_plugin_scanner/reporting.py
@@ -1,0 +1,215 @@
+"""Structured report formatters for scan results."""
+
+from __future__ import annotations
+
+import json
+
+from .models import GRADE_LABELS, SEVERITY_ORDER, Finding, ScanResult, Severity, severity_from_value
+
+
+def _sorted_findings(findings: tuple[Finding, ...]) -> list[Finding]:
+    return sorted(findings, key=lambda finding: SEVERITY_ORDER[finding.severity], reverse=True)
+
+
+def build_json_payload(result: ScanResult) -> dict[str, object]:
+    """Convert a scan result into a JSON-serializable payload."""
+
+    return {
+        "score": result.score,
+        "grade": result.grade,
+        "summary": {
+            "gradeLabel": GRADE_LABELS.get(result.grade, "Unknown"),
+            "findings": result.severity_counts,
+            "integrations": [
+                {
+                    "name": integration.name,
+                    "status": integration.status,
+                    "message": integration.message,
+                    "findingsCount": integration.findings_count,
+                    "metadata": integration.metadata,
+                }
+                for integration in result.integrations
+            ],
+        },
+        "categories": [
+            {
+                "name": category.name,
+                "score": sum(check.points for check in category.checks),
+                "max": sum(check.max_points for check in category.checks),
+                "checks": [
+                    {
+                        "name": check.name,
+                        "passed": check.passed,
+                        "points": check.points,
+                        "maxPoints": check.max_points,
+                        "message": check.message,
+                        "findings": [
+                            {
+                                "ruleId": finding.rule_id,
+                                "severity": finding.severity.value,
+                                "title": finding.title,
+                                "description": finding.description,
+                                "remediation": finding.remediation,
+                                "filePath": finding.file_path,
+                                "lineNumber": finding.line_number,
+                                "source": finding.source,
+                            }
+                            for finding in check.findings
+                        ],
+                    }
+                    for check in category.checks
+                ],
+            }
+            for category in result.categories
+        ],
+        "findings": [
+            {
+                "ruleId": finding.rule_id,
+                "severity": finding.severity.value,
+                "category": finding.category,
+                "title": finding.title,
+                "description": finding.description,
+                "remediation": finding.remediation,
+                "filePath": finding.file_path,
+                "lineNumber": finding.line_number,
+                "source": finding.source,
+            }
+            for finding in _sorted_findings(result.findings)
+        ],
+        "timestamp": result.timestamp,
+        "pluginDir": result.plugin_dir,
+    }
+
+
+def format_json(result: ScanResult) -> str:
+    """Render a scan result as indented JSON."""
+
+    return json.dumps(build_json_payload(result), indent=2)
+
+
+def format_markdown(result: ScanResult) -> str:
+    """Render a scan result as a markdown report."""
+
+    lines = [
+        "# Codex Plugin Scanner Report",
+        "",
+        f"- Plugin: `{result.plugin_dir}`",
+        f"- Score: **{result.score}/100**",
+        f"- Grade: **{result.grade} - {GRADE_LABELS.get(result.grade, 'Unknown')}**",
+        "",
+        "## Findings Summary",
+        "",
+    ]
+    for severity in Severity:
+        lines.append(f"- {severity.value.title()}: {result.severity_counts.get(severity.value, 0)}")
+
+    lines += ["", "## Categories", ""]
+    for category in result.categories:
+        category_score = sum(check.points for check in category.checks)
+        category_max = sum(check.max_points for check in category.checks)
+        lines.append(
+            f"- **{category.name}**: {category_score}/{category_max}"
+        )
+
+    top_findings = _sorted_findings(result.findings)[:10]
+    lines += ["", "## Top Findings", ""]
+    if not top_findings:
+        lines.append("- No findings detected.")
+    else:
+        for finding in top_findings:
+            path = f" (`{finding.file_path}`)" if finding.file_path else ""
+            lines.append(f"- **{finding.severity.value.upper()}** {finding.title}{path}")
+            lines.append(f"  - {finding.description}")
+            if finding.remediation:
+                lines.append(f"  - Remediation: {finding.remediation}")
+
+    lines += ["", "## Integration Status", ""]
+    for integration in result.integrations:
+        lines.append(f"- **{integration.name}**: `{integration.status}` - {integration.message}")
+
+    return "\n".join(lines)
+
+
+def format_sarif(result: ScanResult) -> str:
+    """Render a scan result as SARIF 2.1.0 JSON."""
+
+    sorted_findings = _sorted_findings(result.findings)
+    rules = []
+    seen_rules: set[str] = set()
+    for finding in sorted_findings:
+        if finding.rule_id in seen_rules:
+            continue
+        rules.append(
+            {
+                "id": finding.rule_id,
+                "name": finding.title,
+                "shortDescription": {"text": finding.title},
+                "fullDescription": {"text": finding.description},
+                "help": {"text": finding.remediation or "Review and remediate this finding."},
+                "properties": {
+                    "tags": [finding.category, finding.source],
+                    "precision": "high",
+                    "problem.severity": finding.severity.value,
+                },
+            }
+        )
+        seen_rules.add(finding.rule_id)
+
+    results = []
+    for finding in sorted_findings:
+        level = "note"
+        if SEVERITY_ORDER[finding.severity] >= SEVERITY_ORDER[Severity.HIGH]:
+            level = "error"
+        elif SEVERITY_ORDER[finding.severity] >= SEVERITY_ORDER[Severity.MEDIUM]:
+            level = "warning"
+
+        result_entry: dict[str, object] = {
+            "ruleId": finding.rule_id,
+            "level": level,
+            "message": {"text": finding.description},
+            "properties": {
+                "severity": finding.severity.value,
+                "category": finding.category,
+                "source": finding.source,
+            },
+        }
+        if finding.file_path:
+            location = {
+                "physicalLocation": {
+                    "artifactLocation": {"uri": finding.file_path},
+                }
+            }
+            if finding.line_number:
+                location["physicalLocation"]["region"] = {"startLine": finding.line_number}
+            result_entry["locations"] = [location]
+        results.append(result_entry)
+
+    payload = {
+        "version": "2.1.0",
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "codex-plugin-scanner",
+                        "informationUri": "https://github.com/hashgraph-online/codex-plugin-scanner",
+                        "rules": rules,
+                    }
+                },
+                "results": results,
+            }
+        ],
+    }
+    return json.dumps(payload, indent=2)
+
+
+def should_fail_for_severity(result: ScanResult, threshold: str | None) -> bool:
+    """Return True when the result contains a finding at or above the threshold."""
+
+    if not threshold or threshold.lower() == "none":
+        return False
+    threshold_severity = severity_from_value(threshold)
+    return any(
+        SEVERITY_ORDER[finding.severity] >= SEVERITY_ORDER[threshold_severity]
+        for finding in result.findings
+    )

--- a/src/codex_plugin_scanner/scanner.py
+++ b/src/codex_plugin_scanner/scanner.py
@@ -10,10 +10,58 @@ from .checks.code_quality import run_code_quality_checks
 from .checks.manifest import run_manifest_checks
 from .checks.marketplace import run_marketplace_checks
 from .checks.security import run_security_checks
-from .models import CategoryResult, ScanResult, get_grade
+from .checks.skill_security import run_skill_security_checks
+from .integrations.cisco_skill_scanner import CiscoIntegrationStatus, run_cisco_skill_scan
+from .models import (
+    CategoryResult,
+    IntegrationResult,
+    ScanOptions,
+    ScanResult,
+    build_severity_counts,
+    get_grade,
+)
 
 
-def scan_plugin(plugin_dir: str | Path) -> ScanResult:
+def _build_integration_results(plugin_dir: Path, options: ScanOptions) -> tuple[IntegrationResult, ...]:
+    from .checks.manifest import load_manifest
+
+    manifest = load_manifest(plugin_dir)
+    skills_path = manifest.get("skills") if isinstance(manifest, dict) else None
+    if not isinstance(skills_path, str) or not skills_path.strip():
+        return (
+            IntegrationResult(
+                name="cisco-skill-scanner",
+                status=CiscoIntegrationStatus.SKIPPED,
+                message="No skills declared in plugin.json.",
+            ),
+        )
+
+    skills_dir = (plugin_dir / skills_path).resolve()
+    if not skills_dir.is_dir():
+        return (
+            IntegrationResult(
+                name="cisco-skill-scanner",
+                status=CiscoIntegrationStatus.SKIPPED,
+                message=f'Skills directory "{skills_path}" is missing.',
+            ),
+        )
+
+    summary = run_cisco_skill_scan(skills_dir, mode=options.cisco_skill_scan, policy_name=options.cisco_policy)
+    metadata = {"policy": summary.policy_name}
+    if summary.analyzers_used:
+        metadata["analyzers"] = ",".join(summary.analyzers_used)
+    return (
+        IntegrationResult(
+            name="cisco-skill-scanner",
+            status=summary.status,
+            message=summary.message,
+            findings_count=summary.total_findings,
+            metadata=metadata,
+        ),
+    )
+
+
+def scan_plugin(plugin_dir: str | Path, options: ScanOptions | None = None) -> ScanResult:
     """Scan a Codex plugin directory and return a scored result.
 
     Args:
@@ -23,17 +71,24 @@ def scan_plugin(plugin_dir: str | Path) -> ScanResult:
         ScanResult with score 0-100, grade A-F, and per-category breakdowns.
     """
     resolved = Path(plugin_dir).resolve()
+    scan_options = options or ScanOptions()
 
     categories: list[CategoryResult] = [
         CategoryResult(name="Manifest Validation", checks=run_manifest_checks(resolved)),
         CategoryResult(name="Security", checks=run_security_checks(resolved)),
         CategoryResult(name="Best Practices", checks=run_best_practice_checks(resolved)),
         CategoryResult(name="Marketplace", checks=run_marketplace_checks(resolved)),
+        CategoryResult(name="Skill Security", checks=run_skill_security_checks(resolved, scan_options)),
         CategoryResult(name="Code Quality", checks=run_code_quality_checks(resolved)),
     ]
 
-    score = sum(c.points for cat in categories for c in cat.checks)
+    earned_points = sum(check.points for category in categories for check in category.checks)
+    max_points = sum(check.max_points for category in categories for check in category.checks)
+    score = 100 if max_points == 0 else round((earned_points / max_points) * 100)
     grade = get_grade(score)
+    findings = tuple(finding for category in categories for check in category.checks for finding in check.findings)
+    severity_counts = build_severity_counts(findings)
+    integrations = _build_integration_results(resolved, scan_options)
 
     return ScanResult(
         score=score,
@@ -41,4 +96,7 @@ def scan_plugin(plugin_dir: str | Path) -> ScanResult:
         categories=tuple(categories),
         timestamp=datetime.now(timezone.utc).isoformat(),
         plugin_dir=str(resolved),
+        findings=findings,
+        severity_counts=severity_counts,
+        integrations=integrations,
     )

--- a/src/codex_plugin_scanner/scanner.py
+++ b/src/codex_plugin_scanner/scanner.py
@@ -10,8 +10,8 @@ from .checks.code_quality import run_code_quality_checks
 from .checks.manifest import run_manifest_checks
 from .checks.marketplace import run_marketplace_checks
 from .checks.security import run_security_checks
-from .checks.skill_security import run_skill_security_checks
-from .integrations.cisco_skill_scanner import CiscoIntegrationStatus, run_cisco_skill_scan
+from .checks.skill_security import resolve_skill_security_context, run_skill_security_checks
+from .integrations.cisco_skill_scanner import CiscoIntegrationStatus
 from .models import (
     CategoryResult,
     IntegrationResult,
@@ -22,31 +22,28 @@ from .models import (
 )
 
 
-def _build_integration_results(plugin_dir: Path, options: ScanOptions) -> tuple[IntegrationResult, ...]:
-    from .checks.manifest import load_manifest
-
-    manifest = load_manifest(plugin_dir)
-    skills_path = manifest.get("skills") if isinstance(manifest, dict) else None
-    if not isinstance(skills_path, str) or not skills_path.strip():
+def _build_integration_results(
+    skill_security_context,
+) -> tuple[IntegrationResult, ...]:
+    if skill_security_context.skip_message:
         return (
             IntegrationResult(
                 name="cisco-skill-scanner",
                 status=CiscoIntegrationStatus.SKIPPED,
-                message="No skills declared in plugin.json.",
+                message=skill_security_context.skip_message,
             ),
         )
 
-    skills_dir = (plugin_dir / skills_path).resolve()
-    if not skills_dir.is_dir():
+    summary = skill_security_context.summary
+    if summary is None:
         return (
             IntegrationResult(
                 name="cisco-skill-scanner",
                 status=CiscoIntegrationStatus.SKIPPED,
-                message=f'Skills directory "{skills_path}" is missing.',
+                message="Cisco scan context unavailable.",
             ),
         )
 
-    summary = run_cisco_skill_scan(skills_dir, mode=options.cisco_skill_scan, policy_name=options.cisco_policy)
     metadata = {"policy": summary.policy_name}
     if summary.analyzers_used:
         metadata["analyzers"] = ",".join(summary.analyzers_used)
@@ -72,13 +69,17 @@ def scan_plugin(plugin_dir: str | Path, options: ScanOptions | None = None) -> S
     """
     resolved = Path(plugin_dir).resolve()
     scan_options = options or ScanOptions()
+    skill_security_context = resolve_skill_security_context(resolved, scan_options)
 
     categories: list[CategoryResult] = [
         CategoryResult(name="Manifest Validation", checks=run_manifest_checks(resolved)),
         CategoryResult(name="Security", checks=run_security_checks(resolved)),
         CategoryResult(name="Best Practices", checks=run_best_practice_checks(resolved)),
         CategoryResult(name="Marketplace", checks=run_marketplace_checks(resolved)),
-        CategoryResult(name="Skill Security", checks=run_skill_security_checks(resolved, scan_options)),
+        CategoryResult(
+            name="Skill Security",
+            checks=run_skill_security_checks(resolved, scan_options, skill_security_context),
+        ),
         CategoryResult(name="Code Quality", checks=run_code_quality_checks(resolved)),
     ]
 
@@ -88,7 +89,7 @@ def scan_plugin(plugin_dir: str | Path, options: ScanOptions | None = None) -> S
     grade = get_grade(score)
     findings = tuple(finding for category in categories for check in category.checks for finding in check.findings)
     severity_counts = build_severity_counts(findings)
-    integrations = _build_integration_results(resolved, scan_options)
+    integrations = _build_integration_results(skill_security_context)
 
     return ScanResult(
         score=score,

--- a/tests/fixtures/good-plugin/.codex-plugin/plugin.json
+++ b/tests/fixtures/good-plugin/.codex-plugin/plugin.json
@@ -1,1 +1,18 @@
-{"name": "example-good-plugin", "version": "1.0.0", "description": "A well-structured example plugin", "skills": "skills"}
+{
+  "name": "example-good-plugin",
+  "version": "1.0.0",
+  "description": "A well-structured example plugin",
+  "author": {
+    "name": "Hashgraph Online",
+    "email": "dev@hol.org"
+  },
+  "homepage": "https://github.com/hashgraph-online/codex-plugin-scanner",
+  "repository": "https://github.com/hashgraph-online/codex-plugin-scanner",
+  "license": "Apache-2.0",
+  "keywords": ["codex", "plugin", "security"],
+  "interface": {
+    "type": "cli",
+    "displayName": "Example Good Plugin"
+  },
+  "skills": "skills"
+}

--- a/tests/fixtures/good-plugin/skills/example/SKILL.md
+++ b/tests/fixtures/good-plugin/skills/example/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: example
 description: An example skill that does things
+license: Apache-2.0
 ---
 This skill demonstrates best practices for Codex plugin skills.

--- a/tests/fixtures/mit-license/LICENSE
+++ b/tests/fixtures/mit-license/LICENSE
@@ -1,3 +1,5 @@
+MIT License
+
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.

--- a/tests/test_best_practices.py
+++ b/tests/test_best_practices.py
@@ -18,7 +18,7 @@ FIXTURES = Path(__file__).parent / "fixtures"
 class TestCheckReadme:
     def test_passes_when_found(self):
         r = check_readme(FIXTURES / "good-plugin")
-        assert r.passed and r.points == 5
+        assert r.passed and r.points == 3
 
     def test_fails_when_missing(self):
         r = check_readme(FIXTURES / "minimal-plugin")
@@ -28,11 +28,12 @@ class TestCheckReadme:
 class TestCheckSkillsDirectory:
     def test_passes_when_exists(self):
         r = check_skills_directory(FIXTURES / "good-plugin")
-        assert r.passed and r.points == 5
+        assert r.passed and r.points == 3
 
     def test_passes_when_no_skills_field(self):
         r = check_skills_directory(FIXTURES / "minimal-plugin")
-        assert r.passed and r.points == 5
+        assert r.passed and r.points == 0
+        assert not r.applicable
 
     def test_fails_when_declared_but_missing(self):
         r = check_skills_directory(FIXTURES / "skills-missing-dir")
@@ -42,17 +43,19 @@ class TestCheckSkillsDirectory:
     def test_passes_when_manifest_unreadable(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             r = check_skills_directory(Path(tmpdir))
-            assert r.passed and r.points == 5
+            assert r.passed and r.points == 0
+            assert not r.applicable
 
 
 class TestCheckSkillFrontmatter:
     def test_passes_with_valid_frontmatter(self):
         r = check_skill_frontmatter(FIXTURES / "good-plugin")
-        assert r.passed and r.points == 5
+        assert r.passed and r.points == 3
 
     def test_passes_when_no_skills_field(self):
         r = check_skill_frontmatter(FIXTURES / "minimal-plugin")
-        assert r.passed and r.points == 5
+        assert r.passed and r.points == 0
+        assert not r.applicable
 
     def test_fails_with_missing_frontmatter(self):
         r = check_skill_frontmatter(FIXTURES / "skills-no-frontmatter")
@@ -60,13 +63,14 @@ class TestCheckSkillFrontmatter:
 
     def test_passes_when_skills_dir_missing(self):
         r = check_skill_frontmatter(FIXTURES / "skills-missing-dir")
-        assert r.passed and r.points == 5
+        assert r.passed and r.points == 0
+        assert not r.applicable
 
 
 class TestCheckNoEnvFiles:
     def test_passes_when_clean(self):
         r = check_no_env_files(FIXTURES / "good-plugin")
-        assert r.passed and r.points == 5
+        assert r.passed and r.points == 3
 
     def test_fails_when_env_found(self):
         r = check_no_env_files(FIXTURES / "bad-plugin")
@@ -76,7 +80,7 @@ class TestCheckNoEnvFiles:
 class TestCheckCodexignore:
     def test_passes_when_found(self):
         r = check_codexignore(FIXTURES / "good-plugin")
-        assert r.passed and r.points == 5
+        assert r.passed and r.points == 3
 
     def test_fails_when_missing(self):
         r = check_codexignore(FIXTURES / "minimal-plugin")
@@ -84,19 +88,20 @@ class TestCheckCodexignore:
 
 
 class TestRunBestPracticeChecks:
-    def test_good_plugin_gets_25(self):
+    def test_good_plugin_gets_15(self):
         results = run_best_practice_checks(FIXTURES / "good-plugin")
-        assert sum(c.points for c in results) == 25
-
-    def test_minimal_plugin_gets_15(self):
-        # skills auto-pass(5+5), no-env pass(5), readme fail(0), codexignore fail(0)
-        results = run_best_practice_checks(FIXTURES / "minimal-plugin")
         assert sum(c.points for c in results) == 15
+        assert sum(c.max_points for c in results) == 15
 
-    def test_bad_plugin_gets_10(self):
-        # skills auto-pass(5+5), no-env fail(0), readme fail(0), codexignore fail(0)
+    def test_minimal_plugin_gets_3(self):
+        results = run_best_practice_checks(FIXTURES / "minimal-plugin")
+        assert sum(c.points for c in results) == 3
+        assert sum(c.max_points for c in results) == 9
+
+    def test_bad_plugin_gets_0(self):
         results = run_best_practice_checks(FIXTURES / "bad-plugin")
-        assert sum(c.points for c in results) == 10
+        assert sum(c.points for c in results) == 0
+        assert sum(c.max_points for c in results) == 9
 
     def test_returns_tuple_of_correct_length(self):
         results = run_best_practice_checks(FIXTURES / "good-plugin")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,9 +17,11 @@ class TestFormatJson:
         parsed = json.loads(output)
         assert parsed["score"] == 100
         assert parsed["grade"] == "A"
-        assert len(parsed["categories"]) == 5
+        assert len(parsed["categories"]) == 6
         assert "timestamp" in parsed
         assert "pluginDir" in parsed
+        assert "summary" in parsed
+        assert "findings" in parsed
 
     def test_categories_have_correct_structure(self):
         result = scan_plugin(FIXTURES / "good-plugin")
@@ -36,14 +38,14 @@ class TestFormatJson:
         assert "points" in check
         assert "maxPoints" in check
         assert "message" in check
+        assert "findings" in check
 
     def test_bad_plugin_json(self):
         result = scan_plugin(FIXTURES / "bad-plugin")
         output = format_json(result)
         parsed = json.loads(output)
         assert parsed["score"] < 60
-        security = next(c for c in parsed["categories"] if c["name"] == "Security")
-        assert security["score"] < security["max"]
+        assert parsed["summary"]["findings"]["high"] >= 1
 
 
 class TestFormatText:
@@ -68,7 +70,7 @@ class TestFormatText:
     def test_bad_plugin_output(self):
         result = scan_plugin(FIXTURES / "bad-plugin")
         output = format_text(result)
-        assert "40/100" in output
+        assert "38/100" in output
         assert "Failing" in output
 
 
@@ -112,12 +114,11 @@ class TestMain:
             assert parsed["score"] == 100
 
     def test_min_score_boundary(self):
-        # bad-plugin scores 40, so min-score=40 should pass
-        rc = main([str(FIXTURES / "bad-plugin"), "--min-score", "40"])
+        rc = main([str(FIXTURES / "bad-plugin"), "--min-score", "38"])
         assert rc == 0
 
     def test_min_score_just_above(self):
-        rc = main([str(FIXTURES / "bad-plugin"), "--min-score", "41"])
+        rc = main([str(FIXTURES / "bad-plugin"), "--min-score", "39"])
         assert rc == 1
 
     def test_version_flag(self, capsys):
@@ -130,7 +131,7 @@ class TestMain:
         main([str(FIXTURES / "bad-plugin"), "--min-score", "50"])
         captured = capsys.readouterr()
         # Should still produce text output
-        assert "40/100" in captured.out
+        assert "38/100" in captured.out
 
     def test_min_score_exact_boundary(self):
         # At exact boundary should pass (>=)

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -2,7 +2,7 @@
 
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from codex_plugin_scanner.cli import format_text
 from codex_plugin_scanner.scanner import scan_plugin
@@ -11,21 +11,16 @@ FIXTURES = Path(__file__).parent / "fixtures"
 
 
 class TestRichOutputBranch:
-    """Test that the rich import path works when available."""
+    """Test plain text formatting output."""
 
-    def test_format_text_with_rich(self):
-        """Test rich Console path via mock."""
-        mock_console = MagicMock()
-        mock_console_class = MagicMock(return_value=mock_console)
+    def test_format_text_returns_string(self):
         result = scan_plugin(FIXTURES / "good-plugin")
-
-        with patch.dict("sys.modules", {"rich": MagicMock(), "rich.console": MagicMock(Console=mock_console_class)}):
-            output = format_text(result)
-            assert output == ""
-            assert mock_console.print.call_count > 0
+        output = format_text(result)
+        assert isinstance(output, str)
+        assert "100/100" in output
 
     def test_format_text_fallback(self):
-        """Test fallback path when rich is not available."""
+        """Formatting remains stable even if rich is unavailable."""
         result = scan_plugin(FIXTURES / "good-plugin")
         with patch.dict("sys.modules", {"rich": None}):
             output = format_text(result)
@@ -94,6 +89,7 @@ class TestOSErrorBranches:
             with patch("pathlib.Path.read_text", side_effect=OSError("Permission denied")):
                 r = check_no_dangerous_mcp(d)
                 assert r.passed
+                assert not r.applicable
 
 
 class TestSecurityEdgeCases:
@@ -116,7 +112,7 @@ class TestSecurityEdgeCases:
             (d / "LICENSE").write_text("Custom license text here.")
             r = check_license(d)
             assert r.passed
-            assert "not Apache-2.0 or MIT" in r.message
+            assert r.message == "LICENSE found"
 
     def test_safe_mcp(self):
         from codex_plugin_scanner.checks.security import check_no_dangerous_mcp

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -19,7 +19,7 @@ def test_good_plugin_full_score():
 
 def test_bad_plugin_catches_all_issues():
     result = scan_plugin(FIXTURES / "bad-plugin")
-    assert result.score == 40
+    assert result.score == 38
     assert result.grade == "F"
 
     cats = {c.name: c for c in result.categories}
@@ -40,9 +40,9 @@ def test_json_output_is_parseable():
     output = format_json(result)
     parsed = json.loads(output)
     assert parsed["score"] == 100
-    assert len(parsed["categories"]) == 5
+    assert len(parsed["categories"]) == 6
     total_checks = sum(len(c["checks"]) for c in parsed["categories"])
-    assert total_checks == 18
+    assert total_checks == 25
 
 
 def test_text_output_is_readable():
@@ -53,6 +53,7 @@ def test_text_output_is_readable():
     assert "Security" in output
     assert "Best Practices" in output
     assert "Marketplace" in output
+    assert "Skill Security" in output
     assert "Code Quality" in output
     # Should have score
     assert "100/100" in output
@@ -70,7 +71,7 @@ def test_all_check_names_unique():
 def test_max_points_total_100():
     result = scan_plugin(FIXTURES / "good-plugin")
     total_max = sum(c.max_points for cat in result.categories for c in cat.checks)
-    assert total_max == 100
+    assert total_max == 81
 
 
 def test_mit_license_plugin():
@@ -84,10 +85,11 @@ def test_mit_license_plugin():
 def test_with_marketplace_plugin():
     result = scan_plugin(FIXTURES / "with-marketplace")
     mp_cat = next(c for c in result.categories if c.name == "Marketplace")
-    assert sum(c.points for c in mp_cat.checks) == 10
+    assert sum(c.points for c in mp_cat.checks) == 15
     mp_names = {c.name: c.passed for c in mp_cat.checks}
     assert mp_names["marketplace.json valid"] is True
     assert mp_names["Policy fields present"] is True
+    assert mp_names["Marketplace sources are safe"] is True
 
 
 def test_malformed_json_manifest():

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -39,7 +39,7 @@ class TestLoadManifest:
 class TestCheckPluginJsonExists:
     def test_passes_when_exists(self):
         r = check_plugin_json_exists(FIXTURES / "good-plugin")
-        assert r.passed and r.points == 5
+        assert r.passed and r.points == 4
 
     def test_fails_when_missing(self):
         r = check_plugin_json_exists(FIXTURES / "empty-dir")
@@ -49,7 +49,7 @@ class TestCheckPluginJsonExists:
 class TestCheckValidJson:
     def test_passes_for_valid_json(self):
         r = check_valid_json(FIXTURES / "good-plugin")
-        assert r.passed and r.points == 5
+        assert r.passed and r.points == 4
 
     def test_fails_for_malformed(self):
         r = check_valid_json(FIXTURES / "malformed-json")
@@ -63,7 +63,7 @@ class TestCheckValidJson:
 class TestCheckRequiredFields:
     def test_passes_when_all_present(self):
         r = check_required_fields(FIXTURES / "good-plugin")
-        assert r.passed and r.points == 8
+        assert r.passed and r.points == 5
 
     def test_fails_for_missing_description(self):
         r = check_required_fields(FIXTURES / "missing-fields")
@@ -78,7 +78,7 @@ class TestCheckRequiredFields:
 class TestCheckSemver:
     def test_passes_for_valid_semver(self):
         r = check_semver(FIXTURES / "good-plugin")
-        assert r.passed and r.points == 4
+        assert r.passed and r.points == 3
 
     def test_fails_for_non_semver(self):
         r = check_semver(FIXTURES / "bad-plugin")
@@ -92,7 +92,7 @@ class TestCheckSemver:
 class TestCheckKebabCase:
     def test_passes_for_kebab_case(self):
         r = check_kebab_case(FIXTURES / "good-plugin")
-        assert r.passed and r.points == 3
+        assert r.passed and r.points == 2
 
     def test_fails_for_bad_name(self):
         r = check_kebab_case(FIXTURES / "bad-plugin")
@@ -111,13 +111,13 @@ class TestRunManifestChecks:
         assert names["Version follows semver"] is False
         assert names["Name is kebab-case"] is False
 
-    def test_minimal_plugin_gets_25(self):
+    def test_minimal_plugin_gets_21(self):
         results = run_manifest_checks(FIXTURES / "minimal-plugin")
-        assert sum(c.points for c in results) == 25
+        assert sum(c.points for c in results) == 21
 
-    def test_malformed_json_gets_5(self):
+    def test_malformed_json_gets_4(self):
         results = run_manifest_checks(FIXTURES / "malformed-json")
-        assert sum(c.points for c in results) == 5  # exists(5), everything else fails
+        assert sum(c.points for c in results) == 4
 
     def test_empty_dir_gets_0(self):
         results = run_manifest_checks(FIXTURES / "empty-dir")
@@ -126,4 +126,4 @@ class TestRunManifestChecks:
     def test_returns_tuple_of_correct_length(self):
         results = run_manifest_checks(FIXTURES / "good-plugin")
         assert isinstance(results, tuple)
-        assert len(results) == 5
+        assert len(results) == 7

--- a/tests/test_marketplace.py
+++ b/tests/test_marketplace.py
@@ -15,7 +15,8 @@ FIXTURES = Path(__file__).parent / "fixtures"
 class TestCheckMarketplaceJson:
     def test_passes_when_no_file(self):
         r = check_marketplace_json(FIXTURES / "good-plugin")
-        assert r.passed and r.points == 5
+        assert r.passed and r.points == 0
+        assert not r.applicable
 
     def test_passes_for_valid_marketplace(self):
         r = check_marketplace_json(FIXTURES / "with-marketplace")
@@ -60,7 +61,8 @@ class TestCheckMarketplaceJson:
 class TestCheckPolicyFields:
     def test_passes_when_no_file(self):
         r = check_policy_fields(FIXTURES / "good-plugin")
-        assert r.passed and r.points == 5
+        assert r.passed and r.points == 0
+        assert not r.applicable
 
     def test_passes_when_all_fields_present(self):
         r = check_policy_fields(FIXTURES / "with-marketplace")
@@ -96,15 +98,16 @@ class TestCheckPolicyFields:
 
 
 class TestRunMarketplaceChecks:
-    def test_good_plugin_gets_10(self):
+    def test_good_plugin_gets_0(self):
         results = run_marketplace_checks(FIXTURES / "good-plugin")
-        assert sum(c.points for c in results) == 10
+        assert sum(c.points for c in results) == 0
+        assert sum(c.max_points for c in results) == 0
 
-    def test_with_marketplace_gets_10(self):
+    def test_with_marketplace_gets_15(self):
         results = run_marketplace_checks(FIXTURES / "with-marketplace")
-        assert sum(c.points for c in results) == 10
+        assert sum(c.points for c in results) == 15
 
     def test_returns_tuple_of_correct_length(self):
         results = run_marketplace_checks(FIXTURES / "good-plugin")
         assert isinstance(results, tuple)
-        assert len(results) == 2
+        assert len(results) == 3

--- a/tests/test_marketplace.py
+++ b/tests/test_marketplace.py
@@ -111,3 +111,15 @@ class TestRunMarketplaceChecks:
         results = run_marketplace_checks(FIXTURES / "good-plugin")
         assert isinstance(results, tuple)
         assert len(results) == 3
+
+    def test_http_marketplace_source_is_unsafe(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mp = Path(tmpdir) / "marketplace.json"
+            mp.write_text(
+                '{"name": "test", "plugins": [{"source": "http://example.com/plugin", '
+                '"policy": {"installation": "manual", "authentication": "none"}}]}'
+            )
+            results = run_marketplace_checks(Path(tmpdir))
+            source_check = next(check for check in results if check.name == "Marketplace sources are safe")
+            assert source_check.passed is False
+            assert "http://example.com/plugin" in source_check.message

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -75,16 +75,15 @@ class TestScanPlugin:
         assert result.score < 60
         assert result.grade == "F"
 
-    def test_minimal_plugin_scores_80(self):
+    def test_minimal_plugin_scores_73(self):
         result = scan_plugin(FIXTURES / "minimal-plugin")
-        assert result.score == 80
-        assert result.grade == "B"
+        assert result.score == 73
+        assert result.grade == "C"
 
-    def test_empty_dir_scores_55(self):
-        # security(20) + best practices(15) + marketplace(10) + code quality(10) = 55
+    def test_empty_dir_scores_38(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             result = scan_plugin(tmpdir)
-            assert result.score == 55
+            assert result.score == 38
 
     def test_mit_license_detected(self):
         result = scan_plugin(FIXTURES / "mit-license")
@@ -97,17 +96,18 @@ class TestScanPlugin:
         r2 = scan_plugin(FIXTURES / "good-plugin")
         assert r1.score == r2.score
 
-    def test_returns_5_categories(self):
+    def test_returns_6_categories(self):
         result = scan_plugin(FIXTURES / "good-plugin")
-        assert len(result.categories) == 5
+        assert len(result.categories) == 6
         names = [c.name for c in result.categories]
         assert "Manifest Validation" in names
         assert "Security" in names
         assert "Best Practices" in names
         assert "Marketplace" in names
+        assert "Skill Security" in names
         assert "Code Quality" in names
 
     def test_with_marketplace_plugin(self):
         result = scan_plugin(FIXTURES / "with-marketplace")
         mp_cat = next(c for c in result.categories if c.name == "Marketplace")
-        assert sum(c.points for c in mp_cat.checks) == 10
+        assert sum(c.points for c in mp_cat.checks) == 15

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -18,7 +18,7 @@ FIXTURES = Path(__file__).parent / "fixtures"
 class TestSecurityMd:
     def test_passes_when_found(self):
         r = check_security_md(FIXTURES / "good-plugin")
-        assert r.passed and r.points == 5
+        assert r.passed and r.points == 3
 
     def test_fails_when_missing(self):
         r = check_security_md(FIXTURES / "minimal-plugin")
@@ -28,11 +28,11 @@ class TestSecurityMd:
 class TestLicense:
     def test_passes_for_apache(self):
         r = check_license(FIXTURES / "good-plugin")
-        assert r.passed and r.points == 5
+        assert r.passed and r.points == 3
 
     def test_passes_for_mit(self):
         r = check_license(FIXTURES / "mit-license")
-        assert r.passed and r.points == 5
+        assert r.passed and r.points == 3
         assert "MIT" in r.message
 
     def test_fails_when_missing(self):
@@ -43,7 +43,7 @@ class TestLicense:
 class TestNoHardcodedSecrets:
     def test_passes_clean_dir(self):
         r = check_no_hardcoded_secrets(FIXTURES / "good-plugin")
-        assert r.passed and r.points == 10
+        assert r.passed and r.points == 7
 
     def test_fails_with_secrets(self):
         r = check_no_hardcoded_secrets(FIXTURES / "bad-plugin")
@@ -57,13 +57,14 @@ class TestNoHardcodedSecrets:
     def test_handles_empty_dir(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             r = check_no_hardcoded_secrets(Path(tmpdir))
-            assert r.passed and r.points == 10
+            assert r.passed and r.points == 7
 
 
 class TestNoDangerousMcp:
     def test_passes_when_no_mcp(self):
         r = check_no_dangerous_mcp(FIXTURES / "good-plugin")
-        assert r.passed and r.points == 10
+        assert r.passed and r.points == 0
+        assert not r.applicable
 
     def test_fails_with_dangerous_commands(self):
         r = check_no_dangerous_mcp(FIXTURES / "bad-plugin")
@@ -74,7 +75,7 @@ class TestNoDangerousMcp:
             mcp = Path(tmpdir) / ".mcp.json"
             mcp.write_text('{"mcpServers":{"safe":{"command":"echo","args":["hello"]}}}')
             r = check_no_dangerous_mcp(Path(tmpdir))
-            assert r.passed and r.points == 10
+            assert r.passed and r.points == 4
 
 
 class TestScanAllFiles:
@@ -100,9 +101,10 @@ class TestScanAllFiles:
 
 
 class TestRunSecurityChecks:
-    def test_good_plugin_gets_30(self):
+    def test_good_plugin_gets_16(self):
         results = run_security_checks(FIXTURES / "good-plugin")
-        assert sum(c.points for c in results) == 30
+        assert sum(c.points for c in results) == 16
+        assert sum(c.max_points for c in results) == 16
 
     def test_bad_plugin_detects_issues(self):
         results = run_security_checks(FIXTURES / "bad-plugin")
@@ -113,9 +115,9 @@ class TestRunSecurityChecks:
     def test_minimal_plugin_partial(self):
         results = run_security_checks(FIXTURES / "minimal-plugin")
         total = sum(c.points for c in results)
-        assert 0 < total < 30
+        assert 0 < total < 16
 
     def test_returns_tuple_of_correct_length(self):
         results = run_security_checks(FIXTURES / "good-plugin")
         assert isinstance(results, tuple)
-        assert len(results) == 4
+        assert len(results) == 5

--- a/tests/test_security_ops.py
+++ b/tests/test_security_ops.py
@@ -1,0 +1,50 @@
+"""Tests for security-ops oriented outputs and gates."""
+
+import json
+from pathlib import Path
+
+from codex_plugin_scanner.cli import format_json, main
+from codex_plugin_scanner.reporting import format_markdown, format_sarif
+from codex_plugin_scanner.scanner import scan_plugin
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_json_output_contains_findings_summary():
+    result = scan_plugin(FIXTURES / "bad-plugin")
+    payload = json.loads(format_json(result))
+
+    assert "summary" in payload
+    assert "findings" in payload["summary"]
+    assert payload["summary"]["findings"]["high"] >= 1
+    assert payload["findings"]
+
+
+def test_markdown_output_contains_top_findings():
+    result = scan_plugin(FIXTURES / "bad-plugin")
+    output = format_markdown(result)
+
+    assert "# Codex Plugin Scanner Report" in output
+    assert "## Top Findings" in output
+    assert "Hardcoded secret detected" in output or "Dangerous MCP command pattern detected" in output
+
+
+def test_sarif_output_contains_results():
+    result = scan_plugin(FIXTURES / "bad-plugin")
+    sarif = json.loads(format_sarif(result))
+
+    assert sarif["version"] == "2.1.0"
+    assert sarif["runs"][0]["tool"]["driver"]["name"] == "codex-plugin-scanner"
+    assert sarif["runs"][0]["results"]
+
+
+def test_fail_on_severity_trips_exit_code():
+    exit_code = main([str(FIXTURES / "bad-plugin"), "--fail-on-severity", "high"])
+    assert exit_code == 1
+
+
+def test_sarif_cli_format_is_parseable(capsys):
+    exit_code = main([str(FIXTURES / "bad-plugin"), "--format", "sarif"])
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["version"] == "2.1.0"

--- a/tests/test_skill_security.py
+++ b/tests/test_skill_security.py
@@ -1,11 +1,14 @@
 """Tests for Cisco-backed skill security checks."""
 
+import sys
 from pathlib import Path
+from types import ModuleType
 
 from codex_plugin_scanner.checks.skill_security import run_skill_security_checks
 from codex_plugin_scanner.integrations.cisco_skill_scanner import (
     CiscoIntegrationStatus,
     CiscoSkillScanSummary,
+    run_cisco_skill_scan,
 )
 from codex_plugin_scanner.models import Finding, ScanOptions, Severity
 from codex_plugin_scanner.scanner import scan_plugin
@@ -38,6 +41,20 @@ def _high_risk_summary() -> CiscoSkillScanSummary:
     )
 
 
+def _summary_with_status(status: CiscoIntegrationStatus, message: str) -> CiscoSkillScanSummary:
+    return CiscoSkillScanSummary(
+        status=status,
+        message=message,
+        findings=(),
+        skills_scanned=0,
+        skills_skipped=(),
+        analyzers_used=(),
+        policy_name="balanced",
+        total_findings=0,
+        findings_by_severity={"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0},
+    )
+
+
 def test_skill_security_uses_cisco_summary(monkeypatch):
     monkeypatch.setattr(
         "codex_plugin_scanner.checks.skill_security.run_cisco_skill_scan",
@@ -55,6 +72,24 @@ def test_skill_security_uses_cisco_summary(monkeypatch):
     assert "Dangerous command execution in skill" in names["No elevated Cisco skill findings"].message
 
 
+def test_skill_security_auto_mode_unavailable_is_not_applicable(monkeypatch):
+    monkeypatch.setattr(
+        "codex_plugin_scanner.checks.skill_security.run_cisco_skill_scan",
+        lambda *args, **kwargs: _summary_with_status(
+            CiscoIntegrationStatus.UNAVAILABLE,
+            "Cisco skill scanner not installed; deep skill scan skipped.",
+        ),
+    )
+
+    checks = run_skill_security_checks(FIXTURES / "good-plugin", ScanOptions(cisco_skill_scan="auto"))
+
+    availability = next(check for check in checks if check.name == "Cisco skill scan completed")
+    assert availability.passed is True
+    assert availability.points == 0
+    assert availability.max_points == 0
+    assert availability.applicable is False
+
+
 def test_scan_plugin_includes_cisco_findings(monkeypatch):
     monkeypatch.setattr(
         "codex_plugin_scanner.checks.skill_security.run_cisco_skill_scan",
@@ -67,3 +102,59 @@ def test_scan_plugin_includes_cisco_findings(monkeypatch):
     assert result.severity_counts["high"] == 1
     assert any(finding.source == "cisco-skill-scanner" for finding in result.findings)
     assert result.integrations[0].status == CiscoIntegrationStatus.ENABLED
+
+
+def test_scan_plugin_runs_cisco_scan_once(monkeypatch):
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def fake_scan(*args, **kwargs):
+        calls.append((args, kwargs))
+        return _high_risk_summary()
+
+    monkeypatch.setattr("codex_plugin_scanner.checks.skill_security.run_cisco_skill_scan", fake_scan)
+    monkeypatch.setattr("codex_plugin_scanner.scanner.run_cisco_skill_scan", fake_scan, raising=False)
+
+    scan_plugin(FIXTURES / "good-plugin", ScanOptions(cisco_skill_scan="on", cisco_policy="strict"))
+
+    assert len(calls) == 1
+
+
+def test_run_cisco_skill_scan_populates_skipped_skills(monkeypatch):
+    skill_scanner_module = ModuleType("skill_scanner")
+    skill_scanner_core_module = ModuleType("skill_scanner.core")
+    scan_policy_module = ModuleType("skill_scanner.core.scan_policy")
+
+    class FakeScanPolicy:
+        def __init__(self, preset_base: str):
+            self.preset_base = preset_base
+
+    class FakeReport:
+        def to_dict(self) -> dict[str, object]:
+            return {
+                "summary": {
+                    "total_skills_scanned": 1,
+                    "total_findings": 0,
+                    "findings_by_severity": {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0},
+                    "skills_skipped": ["skills/skipped/SKILL.md"],
+                },
+                "results": [{"findings": [], "analyzers_used": ["pipeline"]}],
+            }
+
+    class FakeSkillScanner:
+        def __init__(self, policy: FakeScanPolicy):
+            self.policy = policy
+
+        def scan_directory(self, _skills_dir: Path) -> FakeReport:
+            return FakeReport()
+
+    skill_scanner_module.SkillScanner = FakeSkillScanner
+    scan_policy_module.ScanPolicy = FakeScanPolicy
+
+    monkeypatch.setitem(sys.modules, "skill_scanner", skill_scanner_module)
+    monkeypatch.setitem(sys.modules, "skill_scanner.core", skill_scanner_core_module)
+    monkeypatch.setitem(sys.modules, "skill_scanner.core.scan_policy", scan_policy_module)
+
+    summary = run_cisco_skill_scan(FIXTURES / "good-plugin" / "skills", mode="on", policy_name="strict")
+
+    assert summary.status == CiscoIntegrationStatus.ENABLED
+    assert summary.skills_skipped == ("skills/skipped/SKILL.md",)

--- a/tests/test_skill_security.py
+++ b/tests/test_skill_security.py
@@ -1,0 +1,69 @@
+"""Tests for Cisco-backed skill security checks."""
+
+from pathlib import Path
+
+from codex_plugin_scanner.checks.skill_security import run_skill_security_checks
+from codex_plugin_scanner.integrations.cisco_skill_scanner import (
+    CiscoIntegrationStatus,
+    CiscoSkillScanSummary,
+)
+from codex_plugin_scanner.models import Finding, ScanOptions, Severity
+from codex_plugin_scanner.scanner import scan_plugin
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _high_risk_summary() -> CiscoSkillScanSummary:
+    return CiscoSkillScanSummary(
+        status=CiscoIntegrationStatus.ENABLED,
+        message="Cisco scan completed",
+        findings=(
+            Finding(
+                rule_id="CISCO-BEHAVIOR-1",
+                severity=Severity.HIGH,
+                category="skill-security",
+                title="Dangerous command execution in skill",
+                description="The skill exposes a command execution path that can be abused.",
+                remediation="Restrict tool execution and validate arguments.",
+                file_path="skills/example/SKILL.md",
+                source="cisco-skill-scanner",
+            ),
+        ),
+        skills_scanned=1,
+        skills_skipped=(),
+        analyzers_used=("static_analyzer", "pipeline"),
+        policy_name="strict",
+        total_findings=1,
+        findings_by_severity={"critical": 0, "high": 1, "medium": 0, "low": 0, "info": 0},
+    )
+
+
+def test_skill_security_uses_cisco_summary(monkeypatch):
+    monkeypatch.setattr(
+        "codex_plugin_scanner.checks.skill_security.run_cisco_skill_scan",
+        lambda *args, **kwargs: _high_risk_summary(),
+    )
+
+    checks = run_skill_security_checks(
+        FIXTURES / "good-plugin",
+        ScanOptions(cisco_skill_scan="on", cisco_policy="strict"),
+    )
+
+    names = {check.name: check for check in checks}
+    assert names["Cisco skill scan completed"].passed is True
+    assert names["No elevated Cisco skill findings"].passed is False
+    assert "Dangerous command execution in skill" in names["No elevated Cisco skill findings"].message
+
+
+def test_scan_plugin_includes_cisco_findings(monkeypatch):
+    monkeypatch.setattr(
+        "codex_plugin_scanner.checks.skill_security.run_cisco_skill_scan",
+        lambda *args, **kwargs: _high_risk_summary(),
+    )
+
+    result = scan_plugin(FIXTURES / "good-plugin", ScanOptions(cisco_skill_scan="on", cisco_policy="strict"))
+
+    assert any(category.name == "Skill Security" for category in result.categories)
+    assert result.severity_counts["high"] == 1
+    assert any(finding.source == "cisco-skill-scanner" for finding in result.findings)
+    assert result.integrations[0].status == CiscoIntegrationStatus.ENABLED


### PR DESCRIPTION
## Summary
- expand the scanner to model structured findings, normalized scoring, and applicable-surface scoring for modern Codex plugin manifests
- integrate Cisco skill-scanner for plugin skill analysis with policy controls and expose a new Skill Security category
- add security-ops outputs and gates including markdown/SARIF reporting, severity-based CI failure thresholds, and richer README/package metadata

## Verification
- `./.venv/bin/python -m pytest`
- `./.venv/bin/ruff check src tests`
- `./.venv/bin/python -m build`

## Notes
- Cisco scanning is available through the new optional `cisco` extra and can be required per run with `--cisco-skill-scan on`.
- Local continuity notes under `.claude/` were intentionally not included in this PR.