### PR TITLE
feat: harden scanner security and marketplace action packaging

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest
@@ -11,8 +15,8 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -15,7 +15,7 @@ jobs:
     name: Scanner (text format)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: ./action
         id: scan
         with:
@@ -26,7 +26,7 @@ jobs:
     name: Scanner (JSON format)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: ./action
         id: scan
         with:
@@ -47,10 +47,8 @@ jobs:
   scanner-sarif:
     name: Scanner (SARIF format)
     runs-on: ubuntu-latest
-    permissions:
-      security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: ./action
         id: scan
         with:
@@ -72,7 +70,7 @@ jobs:
     name: Scanner (fail on low score)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: ./action
         id: scan
         continue-on-error: true
@@ -92,7 +90,7 @@ jobs:
     name: Scanner (Markdown format)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: ./action
         id: scan
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       changed: ${{ steps.version.outputs.changed }}
       tag_exists: ${{ steps.tag.outputs.exists }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 2
       - id: version
@@ -61,8 +61,8 @@ jobs:
     if: needs.detect-version.outputs.changed == 'true' || startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
           cache: "pip"
@@ -76,7 +76,7 @@ jobs:
       - name: Verify distributions
         run: twine check dist/*
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: distributions
           path: dist/
@@ -90,11 +90,11 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: distributions
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -107,11 +107,11 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: distributions
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
 
   release:
     name: Create GitHub Release
@@ -121,7 +121,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
       - name: Generate changelog
@@ -153,6 +153,25 @@ jobs:
           EOF
 
           echo "notes_path=release-notes.md" >> $GITHUB_OUTPUT
+      - name: Build GitHub Action bundle
+        id: action_bundle
+        run: |
+          VERSION="${{ needs.detect-version.outputs.version }}"
+          BUNDLE_ROOT="dist/github-action-bundle"
+          BUNDLE_PATH="dist/hol-codex-plugin-scanner-action-v${VERSION}.zip"
+
+          mkdir -p "${BUNDLE_ROOT}"
+          cp action/action.yml "${BUNDLE_ROOT}/action.yml"
+          cp action/README.md "${BUNDLE_ROOT}/README.md"
+          cp LICENSE "${BUNDLE_ROOT}/LICENSE"
+          cp SECURITY.md "${BUNDLE_ROOT}/SECURITY.md"
+
+          (
+            cd "${BUNDLE_ROOT}"
+            zip -rq "../$(basename "${BUNDLE_PATH}")" .
+          )
+
+          echo "bundle_path=${BUNDLE_PATH}" >> $GITHUB_OUTPUT
       - name: Create tag and release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -165,4 +184,5 @@ jobs:
           fi
           gh release create "v${VERSION}" \
             --title "v${VERSION}" \
-            --notes-file ${{ steps.changelog.outputs.notes_path }}
+            --notes-file ${{ steps.changelog.outputs.notes_path }} \
+            "${{ steps.action_bundle.outputs.bundle_path }}#hol-codex-plugin-scanner-action-v${VERSION}.zip"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,15 +13,15 @@ jobs:
       id-token: write
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           persist-credentials: false
-      - uses: ossf/scorecard-action@v2.4.3
+      - uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
-      - uses: github/codeql-action/upload-sarif@v3.29.5
+      - uses: github/codeql-action/upload-sarif@2a2dd30f8030072d379eb0c9ea51789aa2ea9ca4
         with:
           sarif_file: results.sarif
         if: always()

--- a/README.md
+++ b/README.md
@@ -168,6 +168,19 @@ repos:
         args: ["./"]
 ```
 
+## GitHub Action
+
+The scanner ships with a composite GitHub Action source bundle in [action/action.yml](action/action.yml).
+
+GitHub Marketplace has two important constraints for actions:
+
+- the published action must live in a dedicated public repository with a single root `action.yml`
+- that repository cannot contain workflow files
+
+Because the scanner repository itself contains CI and release workflows, the Marketplace listing should be published from a separate action-only repository. The scanner release workflow now emits a root-ready bundle zip for that repository on every tagged release.
+
+The source README for that dedicated action repository lives in [action/README.md](action/README.md), and the full publication guide lives in [docs/github-action-marketplace.md](docs/github-action-marketplace.md).
+
 ## Development
 
 ```bash

--- a/action/README.md
+++ b/action/README.md
@@ -1,12 +1,14 @@
-# Codex Plugin Scanner GitHub Action
+# HOL Codex Plugin Scanner GitHub Action
 
-Scan your [Codex plugin](https://developers.openai.com/codex/plugins) for security issues and best practices. Outputs a 0-100 score with detailed findings.
+Scan your [Codex plugin](https://developers.openai.com/codex/plugins) for security, publishability, and best practices. The action emits a `0-100` score, a grade, and the requested report format.
+
+This README is intentionally root-ready for a dedicated GitHub Marketplace action repository. GitHub Marketplace requires that repository to contain a single root `action.yml` and no workflow files.
 
 ## Usage
 
 ```yaml
 - name: Scan Codex Plugin
-  uses: hashgraph-online/codex-plugin-scanner/action@v1
+  uses: your-org/hol-codex-plugin-scanner-action@v1
   with:
     plugin_dir: "./my-plugin"
     min_score: 70
@@ -24,7 +26,7 @@ Scan your [Codex plugin](https://developers.openai.com/codex/plugins) for securi
 | `fail_on_severity` | Fail on findings at or above this severity: `none`, `critical`, `high`, `medium`, `low`, `info` | `none` |
 | `cisco_skill_scan` | Cisco skill-scanner mode: `auto`, `on`, `off` | `auto` |
 | `cisco_policy` | Cisco policy preset: `permissive`, `balanced`, `strict` | `balanced` |
-| `install_cisco` | Install the cisco extra for skill scanning | `false` |
+| `install_cisco` | Install the Cisco skill-scanner dependency for live skill scanning | `false` |
 
 ## Outputs
 
@@ -32,14 +34,15 @@ Scan your [Codex plugin](https://developers.openai.com/codex/plugins) for securi
 |--------|-------------|
 | `score` | Numeric score (0-100) |
 | `grade` | Letter grade (A-F) |
-| `report` | Full report text |
+
+The report itself is written to the job log for `text` output, or to the file you pass through `output` for `json`, `markdown`, or `sarif`.
 
 ## Examples
 
 ### Basic scan with minimum score gate
 
 ```yaml
-- uses: hashgraph-online/codex-plugin-scanner/action@v1
+- uses: your-org/hol-codex-plugin-scanner-action@v1
   with:
     plugin_dir: "."
     min_score: 70
@@ -48,7 +51,7 @@ Scan your [Codex plugin](https://developers.openai.com/codex/plugins) for securi
 ### SARIF output for GitHub Code Scanning
 
 ```yaml
-- uses: hashgraph-online/codex-plugin-scanner/action@v1
+- uses: your-org/hol-codex-plugin-scanner-action@v1
   with:
     plugin_dir: "."
     format: sarif
@@ -59,7 +62,7 @@ Scan your [Codex plugin](https://developers.openai.com/codex/plugins) for securi
 ### With Cisco skill scanning
 
 ```yaml
-- uses: hashgraph-online/codex-plugin-scanner/action@v1
+- uses: your-org/hol-codex-plugin-scanner-action@v1
   with:
     plugin_dir: "."
     cisco_skill_scan: on
@@ -70,7 +73,7 @@ Scan your [Codex plugin](https://developers.openai.com/codex/plugins) for securi
 ### Markdown report as PR comment
 
 ```yaml
-- uses: hashgraph-online/codex-plugin-scanner/action@v1
+- uses: your-org/hol-codex-plugin-scanner-action@v1
   id: scan
   with:
     plugin_dir: "."
@@ -90,6 +93,16 @@ Scan your [Codex plugin](https://developers.openai.com/codex/plugins) for securi
         body: report
       });
 ```
+
+## Release Management
+
+- Publish immutable releases such as `v1.2.0`.
+- Move the floating major tag `v1` to the latest compatible release.
+- Keep this action in its own public repository for GitHub Marketplace publication.
+
+## Source Of Truth
+
+The source bundle for this action lives in the main scanner repository under `action/`. Release artifacts from that repository should export a root-ready action bundle for the dedicated Marketplace repository.
 
 ## License
 

--- a/action/action.yml
+++ b/action/action.yml
@@ -1,6 +1,6 @@
-name: "Codex Plugin Scanner"
-description: "Scan a Codex plugin directory for security and best practices. Scores from 0-100."
-author: "Hashgraph Online"
+name: "HOL Codex Plugin Scanner"
+description: "Scan a Codex plugin directory for security, publishability, and best practices. Scores from 0-100."
+author: "HOL"
 
 inputs:
   plugin_dir:
@@ -32,7 +32,7 @@ inputs:
     required: false
     default: "balanced"
   install_cisco:
-    description: "Install the cisco extra for skill scanning"
+    description: "Install the Cisco skill-scanner dependency for live skill scanning"
     required: false
     default: "false"
 
@@ -41,6 +41,10 @@ outputs:
     description: "The numeric score (0-100)"
   grade:
     description: "The letter grade (A-F)"
+
+branding:
+  icon: "check-circle"
+  color: "blue"
 
 runs:
   using: "composite"
@@ -52,10 +56,21 @@ runs:
 
     - name: Install scanner
       shell: bash
-      env:
-        ACTION_ROOT: ${{ github.action_path }}/..
       run: |
-        pip install "$ACTION_ROOT"
+        LOCAL_SOURCE=""
+        for candidate in "$GITHUB_ACTION_PATH" "$GITHUB_ACTION_PATH/.."; do
+          if [ -f "$candidate/pyproject.toml" ] && [ -d "$candidate/src/codex_plugin_scanner" ]; then
+            LOCAL_SOURCE="$candidate"
+            break
+          fi
+        done
+
+        if [ -n "$LOCAL_SOURCE" ]; then
+          pip install "$LOCAL_SOURCE"
+        else
+          pip install codex-plugin-scanner
+        fi
+
         if [ "${{ inputs.install_cisco }}" = "true" ]; then
           pip install "cisco-ai-skill-scanner>=2.0.6,<3"
         fi

--- a/docs/github-action-marketplace.md
+++ b/docs/github-action-marketplace.md
@@ -1,0 +1,91 @@
+# GitHub Action Marketplace Publishing
+
+## Why The Marketplace Action Needs A Separate Repository
+
+GitHub Marketplace action publication has repository-level constraints:
+
+- the action must be in a public repository
+- the repository must contain a single root `action.yml`
+- the repository must not contain any workflow files
+- the action `name` must be unique in GitHub Marketplace
+
+The scanner package repository intentionally contains CI, release, and scorecard workflows, so it should remain the source repository for the Python package and the action bundle, not the Marketplace listing itself.
+
+## Source Of Truth In This Repository
+
+These files are the canonical source for the Marketplace action:
+
+- `action/action.yml`
+- `action/README.md`
+- `LICENSE`
+- `SECURITY.md`
+
+Tagged releases from this repository also publish a root-ready bundle zip named like:
+
+- `hol-codex-plugin-scanner-action-v1.2.0.zip`
+
+That zip contains the exact file layout expected by the dedicated Marketplace repository root.
+
+## Recommended Publication Model
+
+Use two repositories:
+
+1. `hashgraph-online/codex-plugin-scanner`
+   - source of truth for the Python package
+   - source of truth for the action bundle
+   - owns CI, tests, docs, and package publishing
+2. a dedicated public action repository
+   - example slug: `hashgraph-online/hol-codex-plugin-scanner-action`
+   - contains only the Marketplace action files at the repository root
+   - publishes Marketplace releases and floating major tags like `v1`
+
+## Files To Place In The Dedicated Action Repository Root
+
+- `action.yml`
+- `README.md`
+- `LICENSE`
+- `SECURITY.md`
+
+Do not copy `.github/workflows` into that repository.
+
+## Action Metadata Choices
+
+The Marketplace-ready action metadata is configured as:
+
+- `name`: `HOL Codex Plugin Scanner`
+- `branding.icon`: `check-circle`
+- `branding.color`: `blue`
+
+Those values are chosen to reduce name-collision risk and give the listing a clear trust-and-validation visual treatment.
+
+## Release Strategy
+
+For the dedicated Marketplace repository:
+
+- publish immutable releases such as `v1.2.0`
+- move the floating major tag `v1` to the latest compatible release
+- keep the action README aligned with the scanner package release it wraps
+
+For the scanner package repository:
+
+- continue publishing PyPI releases from `publish.yml`
+- continue generating the Marketplace action zip asset on tagged releases
+
+## Validation Checklist Before Publishing
+
+- confirm the dedicated action repository is public
+- confirm `action.yml` is at the repository root
+- confirm the repository has no workflow files
+- confirm the release is tagged with a semantic version like `v1.2.0`
+- confirm the floating `v1` tag points to the current compatible release
+- confirm the publishing account has accepted the GitHub Marketplace developer agreement
+- confirm the Marketplace category selection is set during release publication
+
+## Runtime Behavior
+
+The action supports both source-repo and Marketplace-repo installs:
+
+- when the package source exists adjacent to the action, it installs the local checkout
+- otherwise, it installs `codex-plugin-scanner` from PyPI
+
+That lets the source repository test the action in CI while keeping the same `action.yml` portable to the dedicated Marketplace repository.

--- a/src/codex_plugin_scanner/checks/security.py
+++ b/src/codex_plugin_scanner/checks/security.py
@@ -75,6 +75,9 @@ RISKY_APPROVAL_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r'approvalMode["\']?\s*[:=]\s*["\']bypass["\']', re.I),
 ]
 
+APACHE_LICENSE_VERSION_RE = re.compile(r"apache\s+license\s*,?\s*version\s+2\.0", re.I)
+LICENSE_URL_RE = re.compile(r"https?://[^\s<>()\"']+")
+
 
 def _scan_all_files(plugin_dir: Path) -> list[Path]:
     """Recursively find all files, skipping excluded dirs."""
@@ -88,6 +91,16 @@ def _scan_all_files(plugin_dir: Path) -> list[Path]:
             continue
         files.append(p)
     return files
+
+
+def _has_canonical_apache_license_reference(content: str) -> bool:
+    for candidate in LICENSE_URL_RE.findall(content):
+        parsed = urlparse(candidate.rstrip(".,;:"))
+        hostname = (parsed.hostname or "").lower()
+        path = parsed.path.rstrip("/")
+        if hostname == "www.apache.org" and path == "/licenses/LICENSE-2.0":
+            return True
+    return False
 
 
 def check_security_md(plugin_dir: Path) -> CheckResult:
@@ -139,7 +152,9 @@ def check_license(plugin_dir: Path) -> CheckResult:
         )
     try:
         content = lp.read_text(encoding="utf-8", errors="ignore")
-        if "Apache" in content and ("2.0" in content or "www.apache.org" in content):
+        if "apache" in content.lower() and (
+            APACHE_LICENSE_VERSION_RE.search(content) or _has_canonical_apache_license_reference(content)
+        ):
             return CheckResult(
                 name="LICENSE found", passed=True, points=3, max_points=3, message="LICENSE found (Apache-2.0)"
             )

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -1,0 +1,33 @@
+"""Regression checks for the GitHub Action bundle and Marketplace packaging."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_action_metadata_includes_marketplace_branding_and_fallback_install() -> None:
+    action_text = (ROOT / "action" / "action.yml").read_text(encoding="utf-8")
+
+    assert 'name: "HOL Codex Plugin Scanner"' in action_text
+    assert "branding:" in action_text
+    assert 'icon: "check-circle"' in action_text
+    assert 'color: "blue"' in action_text
+    assert 'pip install codex-plugin-scanner' in action_text
+    assert 'pip install "$LOCAL_SOURCE"' in action_text
+
+
+def test_publish_workflow_attaches_marketplace_action_bundle() -> None:
+    workflow_text = (ROOT / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8")
+
+    assert "Build GitHub Action bundle" in workflow_text
+    assert "hol-codex-plugin-scanner-action-v${VERSION}.zip" in workflow_text
+    assert 'cp action/action.yml "${BUNDLE_ROOT}/action.yml"' in workflow_text
+
+
+def test_action_bundle_has_root_ready_readme_and_marketplace_guide() -> None:
+    action_readme = (ROOT / "action" / "README.md").read_text(encoding="utf-8")
+    guide = (ROOT / "docs" / "github-action-marketplace.md").read_text(encoding="utf-8")
+
+    assert "single root `action.yml`" in action_readme
+    assert "must not contain any workflow files" in guide
+    assert "dedicated public action repository" in guide

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -31,6 +31,24 @@ class TestLicense:
         r = check_license(FIXTURES / "good-plugin")
         assert r.passed and r.points == 3
 
+    def test_passes_for_apache_canonical_url(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            d = Path(tmpdir)
+            (d / "LICENSE").write_text(
+                "Apache License\nSee https://www.apache.org/licenses/LICENSE-2.0 for the full text.\n"
+            )
+            r = check_license(d)
+            assert r.passed and r.points == 3
+            assert r.message == "LICENSE found (Apache-2.0)"
+
+    def test_does_not_treat_arbitrary_apache_hostname_text_as_canonical_license(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            d = Path(tmpdir)
+            (d / "LICENSE").write_text("Apache project notes mentioning www.apache.org are included here.")
+            r = check_license(d)
+            assert r.passed and r.points == 3
+            assert r.message == "LICENSE found"
+
     def test_passes_for_mit(self):
         r = check_license(FIXTURES / "mit-license")
         assert r.passed and r.points == 3


### PR DESCRIPTION
## Purpose
- harden the scanner repo against the current code-scanning findings that can be fixed in-repo
- make the bundled GitHub Action ready for Marketplace publication through a dedicated action repo
- document and test the Marketplace bundle flow end to end

## Linked Issues
- none

## Affected Paths
- `.github/workflows/ci.yml`
- `.github/workflows/e2e-test.yml`
- `.github/workflows/publish.yml`
- `.github/workflows/scorecard.yml`
- `.github/dependabot.yml`
- `action/action.yml`
- `action/README.md`
- `docs/github-action-marketplace.md`
- `README.md`
- `src/codex_plugin_scanner/checks/security.py`
- `tests/test_security.py`
- `tests/test_action_bundle.py`

## What Changed
- pinned GitHub Actions workflows to immutable SHAs and added explicit permissions where missing
- removed the unnecessary `security-events: write` permission from the E2E SARIF validation job
- added Dependabot coverage for `github-actions` and `pip`
- tightened Apache 2.0 license detection to avoid the CodeQL substring-sanitization finding
- updated the bundled action metadata and docs for the dedicated Marketplace repository model
- added regression coverage for both the Marketplace bundle flow and the tightened license check

## Setup / Env Notes
- validated from the scanner worktree using the repository virtual environment
- no secret or environment file changes
- GitHub Marketplace still requires a separate public action repository with a root `action.yml`; this PR keeps `codex-plugin-scanner` as the source repo and release-bundle generator

## Verification
```bash
ruff check src tests
python -c 'import sys; sys.path.insert(0, "src"); import pytest; raise SystemExit(pytest.main(["-q"]))'
python -m build
yq '.' .github/workflows/ci.yml >/dev/null
yq '.' .github/workflows/e2e-test.yml >/dev/null
yq '.' .github/workflows/scorecard.yml >/dev/null
yq '.' .github/workflows/publish.yml >/dev/null
yq '.' .github/dependabot.yml >/dev/null
```

## Residual Security Notes
- branch protection, mandatory reviews, repository age, fuzzing, and CII badge status remain GitHub/repository-level concerns rather than code changes
- the release job keeps `contents: write` because it creates tags and releases
- direct `pip install ...` commands may continue to be flagged until the repo adopts a hash-pinned install strategy for CI and publishing
