### PR TITLE
feat: automate plugin submission workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,48 @@ Because the scanner repository itself contains CI and release workflows, the Mar
 
 The source README for that dedicated action repository lives in [action/README.md](action/README.md), and the full publication guide lives in [docs/github-action-marketplace.md](docs/github-action-marketplace.md).
 
+### Plugin Author Submission Flow
+
+The action can also handle submission intake. A plugin repository can wire the scanner into CI so a passing scan opens or reuses a submission issue in [awesome-codex-plugins](https://github.com/hashgraph-online/awesome-codex-plugins).
+
+The intended path is:
+
+1. Add the scanner action to plugin CI.
+2. Require `min_score: 80` and a severity gate such as `fail_on_severity: high`.
+3. Enable submission mode with a token that has `issues:write` on `hashgraph-online/awesome-codex-plugins`.
+4. When the plugin clears the threshold, the action opens or reuses a submission issue.
+5. The issue body includes machine-readable registry payload data, so registry automation can ingest the same submission event.
+
+Example:
+
+```yaml
+permissions:
+  contents: read
+
+jobs:
+  scan-plugin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Scan and submit if eligible
+        id: scan
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+        with:
+          plugin_dir: "."
+          min_score: 80
+          fail_on_severity: high
+          submission_enabled: true
+          submission_score_threshold: 80
+          submission_token: ${{ secrets.AWESOME_CODEX_PLUGINS_TOKEN }}
+
+      - name: Print submission issue
+        if: steps.scan.outputs.submission_performed == 'true'
+        run: echo "${{ steps.scan.outputs.submission_issue_urls }}"
+```
+
+`submission_token` is required when `submission_enabled: true`. This flow is idempotent. If the plugin repository was already submitted, the action reuses the existing open issue instead of opening duplicates by matching an exact hidden plugin URL marker in the existing issue body.
+
 ## Development
 
 ```bash

--- a/action/README.md
+++ b/action/README.md
@@ -27,6 +27,16 @@ This README is intentionally root-ready for a dedicated GitHub Marketplace actio
 | `cisco_skill_scan` | Cisco skill-scanner mode: `auto`, `on`, `off` | `auto` |
 | `cisco_policy` | Cisco policy preset: `permissive`, `balanced`, `strict` | `balanced` |
 | `install_cisco` | Install the Cisco skill-scanner dependency for live skill scanning | `false` |
+| `submission_enabled` | Open submission issues for awesome-list and registry automation when the plugin clears the submission threshold | `false` |
+| `submission_score_threshold` | Minimum score required before a submission issue is created | `80` |
+| `submission_repos` | Comma-separated GitHub repositories that should receive the submission issue | `hashgraph-online/awesome-codex-plugins` |
+| `submission_token` | Required when `submission_enabled` is `true`; use a token with `issues:write` access to the submission repositories | `""` |
+| `submission_labels` | Comma-separated labels to apply when creating submission issues | `plugin-submission` |
+| `submission_category` | Listing category included in the submission issue body | `Community Plugins` |
+| `submission_plugin_name` | Override the plugin name used in the submission issue | `""` |
+| `submission_plugin_url` | Override the plugin repository URL used in the submission issue | `""` |
+| `submission_plugin_description` | Override the plugin description used in the submission issue | `""` |
+| `submission_author` | Override the plugin author used in the submission issue | `""` |
 
 ## Outputs
 
@@ -34,6 +44,10 @@ This README is intentionally root-ready for a dedicated GitHub Marketplace actio
 |--------|-------------|
 | `score` | Numeric score (0-100) |
 | `grade` | Letter grade (A-F) |
+| `submission_eligible` | `true` when the plugin met the submission threshold and passed the configured severity gate |
+| `submission_performed` | `true` when a submission issue was created or an existing one was reused |
+| `submission_issue_urls` | Comma-separated submission issue URLs |
+| `submission_issue_numbers` | Comma-separated submission issue numbers |
 
 The report itself is written to the job log for `text` output, or to the file you pass through `output` for `json`, `markdown`, or `sarif`.
 
@@ -69,6 +83,38 @@ The report itself is written to the job log for `text` output, or to the file yo
     cisco_policy: strict
     install_cisco: true
 ```
+
+### Score 80+ and auto-file an awesome-list submission issue
+
+When the scan reaches `80+` and does not trip the configured severity gate, the action opens or reuses a submission issue in `hashgraph-online/awesome-codex-plugins`. The issue body includes a machine-readable registry payload so downstream registry automation can ingest the same submission event.
+
+```yaml
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Scan plugin and submit if eligible
+        id: scan
+        uses: your-org/hol-codex-plugin-scanner-action@v1
+        with:
+          plugin_dir: "."
+          min_score: 80
+          fail_on_severity: high
+          submission_enabled: true
+          submission_score_threshold: 80
+          submission_token: ${{ secrets.AWESOME_CODEX_PLUGINS_TOKEN }}
+
+      - name: Show submission issue
+        if: steps.scan.outputs.submission_performed == 'true'
+        run: echo "${{ steps.scan.outputs.submission_issue_urls }}"
+```
+
+Use a fine-grained token with `issues:write` on `hashgraph-online/awesome-codex-plugins`. `submission_token` is required when `submission_enabled: true`. The action deduplicates by an exact hidden plugin URL marker in the issue body, so repeated pushes reuse the open submission issue instead of opening duplicates.
 
 ### Markdown report as PR comment
 

--- a/action/action.yml
+++ b/action/action.yml
@@ -48,7 +48,7 @@ inputs:
     required: false
     default: "hashgraph-online/awesome-codex-plugins"
   submission_token:
-    description: "Token with issues:write access to the submission repositories"
+    description: "Required when submission_enabled is true; use a token with issues:write access to the submission repositories"
     required: false
     default: ""
   submission_labels:
@@ -102,7 +102,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
       with:
         python-version: "3.12"
 
@@ -149,176 +149,4 @@ runs:
         SUBMISSION_PLUGIN_DESCRIPTION: ${{ inputs.submission_plugin_description }}
         SUBMISSION_AUTHOR: ${{ inputs.submission_author }}
       run: |
-        python3 - <<'PY'
-        from __future__ import annotations
-
-        import os
-        import sys
-        from pathlib import Path
-
-        from codex_plugin_scanner import __version__
-        from codex_plugin_scanner.cli import format_text
-        from codex_plugin_scanner.models import ScanOptions
-        from codex_plugin_scanner.reporting import (
-            format_json,
-            format_markdown,
-            format_sarif,
-            should_fail_for_severity,
-        )
-        from codex_plugin_scanner.scanner import scan_plugin
-        from codex_plugin_scanner.submission import (
-            build_submission_issue_body,
-            build_submission_issue_title,
-            build_submission_payload,
-            create_submission_issue,
-            find_existing_submission_issue,
-            resolve_submission_metadata,
-        )
-
-        plugin_dir = os.environ["PLUGIN_DIR"]
-        output_format = os.environ["FORMAT"]
-        output_path = os.environ["OUTPUT"]
-        min_score = int(os.environ["MIN_SCORE"])
-        fail_on = os.environ["FAIL_ON"]
-        cisco_scan = os.environ["CISCO_SCAN"]
-        cisco_policy = os.environ["CISCO_POLICY"]
-        submission_enabled = os.environ["SUBMISSION_ENABLED"].strip().lower() == "true"
-        submission_threshold = int(os.environ["SUBMISSION_SCORE_THRESHOLD"])
-        submission_repos = tuple(
-            repo.strip() for repo in os.environ["SUBMISSION_REPOS"].split(",") if repo.strip()
-        )
-        submission_token = os.environ["SUBMISSION_TOKEN"].strip() or os.environ.get("GITHUB_TOKEN", "").strip()
-        submission_labels = tuple(
-            label.strip() for label in os.environ["SUBMISSION_LABELS"].split(",") if label.strip()
-        )
-        submission_category = os.environ["SUBMISSION_CATEGORY"]
-        submission_plugin_name = os.environ["SUBMISSION_PLUGIN_NAME"]
-        submission_plugin_url = os.environ["SUBMISSION_PLUGIN_URL"]
-        submission_plugin_description = os.environ["SUBMISSION_PLUGIN_DESCRIPTION"]
-        submission_author = os.environ["SUBMISSION_AUTHOR"]
-        github_repository = os.environ.get("GITHUB_REPOSITORY", "")
-        github_server_url = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
-        github_sha = os.environ.get("GITHUB_SHA", "")
-        github_run_id = os.environ.get("GITHUB_RUN_ID", "")
-        github_api_url = os.environ.get("GITHUB_API_URL", "https://api.github.com")
-
-        workflow_url = ""
-        if github_repository and github_run_id:
-            workflow_url = f"{github_server_url.rstrip('/')}/{github_repository}/actions/runs/{github_run_id}"
-
-        result = scan_plugin(
-            plugin_dir,
-            ScanOptions(
-                cisco_skill_scan=cisco_scan,
-                cisco_policy=cisco_policy,
-            ),
-        )
-
-        if output_format == "json":
-            rendered = format_json(result)
-        elif output_format == "markdown":
-            rendered = format_markdown(result)
-        elif output_format == "sarif":
-            rendered = format_sarif(result)
-        else:
-            rendered = format_text(result)
-
-        if output_path:
-            target = Path(output_path)
-            target.write_text(rendered, encoding="utf-8")
-            print(f"Report written to {target}")
-        else:
-            print(rendered)
-
-        severity_failed = should_fail_for_severity(result, fail_on)
-        submission_eligible = submission_enabled and result.score >= submission_threshold and not severity_failed
-        submission_issues = []
-
-        if submission_eligible:
-            if not submission_repos:
-                print("Submission is enabled but no submission repositories were configured.", file=sys.stderr)
-                raise SystemExit(1)
-            if not submission_token:
-                print("Submission is enabled but no submission token was provided.", file=sys.stderr)
-                raise SystemExit(1)
-
-            metadata = resolve_submission_metadata(
-                Path(plugin_dir).resolve(),
-                result,
-                plugin_name=submission_plugin_name,
-                plugin_url=submission_plugin_url,
-                description=submission_plugin_description,
-                author=submission_author,
-                category=submission_category,
-                github_repository=github_repository or None,
-                github_server_url=github_server_url,
-            )
-            if not metadata.plugin_url:
-                print("Submission metadata is missing a plugin repository URL.", file=sys.stderr)
-                raise SystemExit(1)
-
-            payload = build_submission_payload(
-                metadata,
-                result,
-                source_repository=github_repository,
-                source_sha=github_sha,
-                workflow_url=workflow_url,
-                scanner_version=__version__,
-            )
-            title = build_submission_issue_title(metadata)
-            body = build_submission_issue_body(
-                metadata,
-                result,
-                payload=payload,
-                workflow_url=workflow_url,
-            )
-
-            for submission_repo in submission_repos:
-                existing = find_existing_submission_issue(
-                    submission_repo,
-                    metadata.plugin_url,
-                    submission_token,
-                    api_base_url=github_api_url,
-                )
-                if existing is not None:
-                    submission_issues.append(existing)
-                    continue
-                submission_issues.append(
-                    create_submission_issue(
-                        submission_repo,
-                        title,
-                        body,
-                        submission_token,
-                        labels=submission_labels,
-                        api_base_url=github_api_url,
-                    )
-                )
-
-        github_output = os.environ.get("GITHUB_OUTPUT")
-        if github_output:
-            with Path(github_output).open("a", encoding="utf-8") as handle:
-                handle.write(f"score={result.score}\n")
-                handle.write(f"grade={result.grade}\n")
-                handle.write(f"submission_eligible={'true' if submission_eligible else 'false'}\n")
-                handle.write(f"submission_performed={'true' if submission_issues else 'false'}\n")
-                handle.write("submission_issue_urls=" + ",".join(issue.url for issue in submission_issues) + "\n")
-                handle.write(
-                    "submission_issue_numbers="
-                    + ",".join(str(issue.number) for issue in submission_issues)
-                    + "\n"
-                )
-
-        if result.score < min_score:
-            print(
-                f"Score {result.score} is below minimum threshold {min_score}",
-                file=sys.stderr,
-            )
-            raise SystemExit(1)
-
-        if severity_failed:
-            print(
-                f'Findings met or exceeded the "{fail_on}" severity threshold.',
-                file=sys.stderr,
-            )
-            raise SystemExit(1)
-        PY
+        python3 -m codex_plugin_scanner.action_runner

--- a/action/action.yml
+++ b/action/action.yml
@@ -94,10 +94,6 @@ branding:
   icon: "check-circle"
   color: "blue"
 
-branding:
-  icon: "check-circle"
-  color: "blue"
-
 runs:
   using: "composite"
   steps:

--- a/action/action.yml
+++ b/action/action.yml
@@ -35,12 +35,64 @@ inputs:
     description: "Install the Cisco skill-scanner dependency for live skill scanning"
     required: false
     default: "false"
+  submission_enabled:
+    description: "Open submission issues for awesome-list and registry automation when the plugin clears the submission threshold"
+    required: false
+    default: "false"
+  submission_score_threshold:
+    description: "Minimum score required before a submission issue is created"
+    required: false
+    default: "80"
+  submission_repos:
+    description: "Comma-separated GitHub repositories that should receive the submission issue"
+    required: false
+    default: "hashgraph-online/awesome-codex-plugins"
+  submission_token:
+    description: "Token with issues:write access to the submission repositories"
+    required: false
+    default: ""
+  submission_labels:
+    description: "Comma-separated labels to apply when creating submission issues"
+    required: false
+    default: "plugin-submission"
+  submission_category:
+    description: "Listing category to include in the submission issue body"
+    required: false
+    default: "Community Plugins"
+  submission_plugin_name:
+    description: "Override the plugin name used in the submission issue"
+    required: false
+    default: ""
+  submission_plugin_url:
+    description: "Override the plugin repository URL used in the submission issue"
+    required: false
+    default: ""
+  submission_plugin_description:
+    description: "Override the plugin description used in the submission issue"
+    required: false
+    default: ""
+  submission_author:
+    description: "Override the plugin author used in the submission issue"
+    required: false
+    default: ""
 
 outputs:
   score:
     description: "The numeric score (0-100)"
   grade:
     description: "The letter grade (A-F)"
+  submission_eligible:
+    description: "Whether the plugin met the submission threshold and passed the configured severity gate"
+  submission_performed:
+    description: "Whether a submission issue was created or reused"
+  submission_issue_urls:
+    description: "Comma-separated URLs for submission issues created or reused"
+  submission_issue_numbers:
+    description: "Comma-separated issue numbers for submission issues created or reused"
+
+branding:
+  icon: "check-circle"
+  color: "blue"
 
 branding:
   icon: "check-circle"
@@ -86,6 +138,16 @@ runs:
         FAIL_ON: ${{ inputs.fail_on_severity }}
         CISCO_SCAN: ${{ inputs.cisco_skill_scan }}
         CISCO_POLICY: ${{ inputs.cisco_policy }}
+        SUBMISSION_ENABLED: ${{ inputs.submission_enabled }}
+        SUBMISSION_SCORE_THRESHOLD: ${{ inputs.submission_score_threshold }}
+        SUBMISSION_REPOS: ${{ inputs.submission_repos }}
+        SUBMISSION_TOKEN: ${{ inputs.submission_token }}
+        SUBMISSION_LABELS: ${{ inputs.submission_labels }}
+        SUBMISSION_CATEGORY: ${{ inputs.submission_category }}
+        SUBMISSION_PLUGIN_NAME: ${{ inputs.submission_plugin_name }}
+        SUBMISSION_PLUGIN_URL: ${{ inputs.submission_plugin_url }}
+        SUBMISSION_PLUGIN_DESCRIPTION: ${{ inputs.submission_plugin_description }}
+        SUBMISSION_AUTHOR: ${{ inputs.submission_author }}
       run: |
         python3 - <<'PY'
         from __future__ import annotations
@@ -94,6 +156,7 @@ runs:
         import sys
         from pathlib import Path
 
+        from codex_plugin_scanner import __version__
         from codex_plugin_scanner.cli import format_text
         from codex_plugin_scanner.models import ScanOptions
         from codex_plugin_scanner.reporting import (
@@ -103,6 +166,14 @@ runs:
             should_fail_for_severity,
         )
         from codex_plugin_scanner.scanner import scan_plugin
+        from codex_plugin_scanner.submission import (
+            build_submission_issue_body,
+            build_submission_issue_title,
+            build_submission_payload,
+            create_submission_issue,
+            find_existing_submission_issue,
+            resolve_submission_metadata,
+        )
 
         plugin_dir = os.environ["PLUGIN_DIR"]
         output_format = os.environ["FORMAT"]
@@ -111,6 +182,29 @@ runs:
         fail_on = os.environ["FAIL_ON"]
         cisco_scan = os.environ["CISCO_SCAN"]
         cisco_policy = os.environ["CISCO_POLICY"]
+        submission_enabled = os.environ["SUBMISSION_ENABLED"].strip().lower() == "true"
+        submission_threshold = int(os.environ["SUBMISSION_SCORE_THRESHOLD"])
+        submission_repos = tuple(
+            repo.strip() for repo in os.environ["SUBMISSION_REPOS"].split(",") if repo.strip()
+        )
+        submission_token = os.environ["SUBMISSION_TOKEN"].strip() or os.environ.get("GITHUB_TOKEN", "").strip()
+        submission_labels = tuple(
+            label.strip() for label in os.environ["SUBMISSION_LABELS"].split(",") if label.strip()
+        )
+        submission_category = os.environ["SUBMISSION_CATEGORY"]
+        submission_plugin_name = os.environ["SUBMISSION_PLUGIN_NAME"]
+        submission_plugin_url = os.environ["SUBMISSION_PLUGIN_URL"]
+        submission_plugin_description = os.environ["SUBMISSION_PLUGIN_DESCRIPTION"]
+        submission_author = os.environ["SUBMISSION_AUTHOR"]
+        github_repository = os.environ.get("GITHUB_REPOSITORY", "")
+        github_server_url = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+        github_sha = os.environ.get("GITHUB_SHA", "")
+        github_run_id = os.environ.get("GITHUB_RUN_ID", "")
+        github_api_url = os.environ.get("GITHUB_API_URL", "https://api.github.com")
+
+        workflow_url = ""
+        if github_repository and github_run_id:
+            workflow_url = f"{github_server_url.rstrip('/')}/{github_repository}/actions/runs/{github_run_id}"
 
         result = scan_plugin(
             plugin_dir,
@@ -136,11 +230,83 @@ runs:
         else:
             print(rendered)
 
+        severity_failed = should_fail_for_severity(result, fail_on)
+        submission_eligible = submission_enabled and result.score >= submission_threshold and not severity_failed
+        submission_issues = []
+
+        if submission_eligible:
+            if not submission_repos:
+                print("Submission is enabled but no submission repositories were configured.", file=sys.stderr)
+                raise SystemExit(1)
+            if not submission_token:
+                print("Submission is enabled but no submission token was provided.", file=sys.stderr)
+                raise SystemExit(1)
+
+            metadata = resolve_submission_metadata(
+                Path(plugin_dir).resolve(),
+                result,
+                plugin_name=submission_plugin_name,
+                plugin_url=submission_plugin_url,
+                description=submission_plugin_description,
+                author=submission_author,
+                category=submission_category,
+                github_repository=github_repository or None,
+                github_server_url=github_server_url,
+            )
+            if not metadata.plugin_url:
+                print("Submission metadata is missing a plugin repository URL.", file=sys.stderr)
+                raise SystemExit(1)
+
+            payload = build_submission_payload(
+                metadata,
+                result,
+                source_repository=github_repository,
+                source_sha=github_sha,
+                workflow_url=workflow_url,
+                scanner_version=__version__,
+            )
+            title = build_submission_issue_title(metadata)
+            body = build_submission_issue_body(
+                metadata,
+                result,
+                payload=payload,
+                workflow_url=workflow_url,
+            )
+
+            for submission_repo in submission_repos:
+                existing = find_existing_submission_issue(
+                    submission_repo,
+                    metadata.plugin_url,
+                    submission_token,
+                    api_base_url=github_api_url,
+                )
+                if existing is not None:
+                    submission_issues.append(existing)
+                    continue
+                submission_issues.append(
+                    create_submission_issue(
+                        submission_repo,
+                        title,
+                        body,
+                        submission_token,
+                        labels=submission_labels,
+                        api_base_url=github_api_url,
+                    )
+                )
+
         github_output = os.environ.get("GITHUB_OUTPUT")
         if github_output:
             with Path(github_output).open("a", encoding="utf-8") as handle:
                 handle.write(f"score={result.score}\n")
                 handle.write(f"grade={result.grade}\n")
+                handle.write(f"submission_eligible={'true' if submission_eligible else 'false'}\n")
+                handle.write(f"submission_performed={'true' if submission_issues else 'false'}\n")
+                handle.write("submission_issue_urls=" + ",".join(issue.url for issue in submission_issues) + "\n")
+                handle.write(
+                    "submission_issue_numbers="
+                    + ",".join(str(issue.number) for issue in submission_issues)
+                    + "\n"
+                )
 
         if result.score < min_score:
             print(
@@ -149,7 +315,7 @@ runs:
             )
             raise SystemExit(1)
 
-        if should_fail_for_severity(result, fail_on):
+        if severity_failed:
             print(
                 f'Findings met or exceeded the "{fail_on}" severity threshold.',
                 file=sys.stderr,

--- a/docs/github-action-marketplace.md
+++ b/docs/github-action-marketplace.md
@@ -89,3 +89,14 @@ The action supports both source-repo and Marketplace-repo installs:
 - otherwise, it installs `codex-plugin-scanner` from PyPI
 
 That lets the source repository test the action in CI while keeping the same `action.yml` portable to the dedicated Marketplace repository.
+
+## Plugin Author Submission Workflow
+
+The Marketplace action also supports a plugin-author submission flow:
+
+- the plugin repository runs the scanner action in CI
+- the action enforces a score threshold such as `80`
+- if the plugin clears the threshold, passes the configured severity gate, and provides an explicit `submission_token`, the action opens or reuses a submission issue in `hashgraph-online/awesome-codex-plugins`
+- the issue body includes a machine-readable registry payload so registry automation can ingest the same submission signal
+
+This keeps the plugin-author path compact: scan, qualify, and submit from one workflow.

--- a/src/codex_plugin_scanner/action_runner.py
+++ b/src/codex_plugin_scanner/action_runner.py
@@ -1,0 +1,186 @@
+"""GitHub Action entry point for scan and submission workflows."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from . import __version__
+from .cli import format_text
+from .models import ScanOptions
+from .reporting import format_json, format_markdown, format_sarif, should_fail_for_severity
+from .scanner import scan_plugin
+from .submission import (
+    build_submission_issue_body,
+    build_submission_issue_title,
+    build_submission_payload,
+    create_submission_issue,
+    find_existing_submission_issue,
+    resolve_submission_metadata,
+)
+
+
+def _parse_csv(value: str) -> tuple[str, ...]:
+    return tuple(item.strip() for item in value.split(",") if item.strip())
+
+
+def _read_bool_env(name: str) -> bool:
+    return os.environ[name].strip().lower() == "true"
+
+
+def _write_outputs(path: str, values: dict[str, str]) -> None:
+    with Path(path).open("a", encoding="utf-8") as handle:
+        for key, value in values.items():
+            handle.write(f"{key}={value}\n")
+
+
+def main() -> int:
+    plugin_dir = os.environ["PLUGIN_DIR"]
+    output_format = os.environ["FORMAT"]
+    output_path = os.environ["OUTPUT"]
+    min_score = int(os.environ["MIN_SCORE"])
+    fail_on = os.environ["FAIL_ON"]
+    cisco_scan = os.environ["CISCO_SCAN"]
+    cisco_policy = os.environ["CISCO_POLICY"]
+    submission_enabled = _read_bool_env("SUBMISSION_ENABLED")
+    submission_threshold = int(os.environ["SUBMISSION_SCORE_THRESHOLD"])
+    submission_repos = _parse_csv(os.environ["SUBMISSION_REPOS"])
+    submission_token = os.environ["SUBMISSION_TOKEN"].strip()
+    submission_labels = _parse_csv(os.environ["SUBMISSION_LABELS"])
+    submission_category = os.environ["SUBMISSION_CATEGORY"]
+    submission_plugin_name = os.environ["SUBMISSION_PLUGIN_NAME"]
+    submission_plugin_url = os.environ["SUBMISSION_PLUGIN_URL"]
+    submission_plugin_description = os.environ["SUBMISSION_PLUGIN_DESCRIPTION"]
+    submission_author = os.environ["SUBMISSION_AUTHOR"]
+    github_repository = os.environ.get("GITHUB_REPOSITORY", "")
+    github_server_url = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+    github_sha = os.environ.get("GITHUB_SHA", "")
+    github_run_id = os.environ.get("GITHUB_RUN_ID", "")
+    github_api_url = os.environ.get("GITHUB_API_URL", "https://api.github.com")
+
+    workflow_url = ""
+    if github_repository and github_run_id:
+        workflow_url = f"{github_server_url.rstrip('/')}/{github_repository}/actions/runs/{github_run_id}"
+
+    result = scan_plugin(
+        plugin_dir,
+        ScanOptions(
+            cisco_skill_scan=cisco_scan,
+            cisco_policy=cisco_policy,
+        ),
+    )
+
+    if output_format == "json":
+        rendered = format_json(result)
+    elif output_format == "markdown":
+        rendered = format_markdown(result)
+    elif output_format == "sarif":
+        rendered = format_sarif(result)
+    else:
+        rendered = format_text(result)
+
+    if output_path:
+        target = Path(output_path)
+        target.write_text(rendered, encoding="utf-8")
+        print(f"Report written to {target}")
+    else:
+        print(rendered)
+
+    severity_failed = should_fail_for_severity(result, fail_on)
+    submission_eligible = submission_enabled and result.score >= submission_threshold and not severity_failed
+    submission_issues = []
+
+    if submission_eligible:
+        if not submission_repos:
+            print("Submission is enabled but no submission repositories were configured.", file=sys.stderr)
+            return 1
+        if not submission_token:
+            print("Submission is enabled but no submission token was provided.", file=sys.stderr)
+            return 1
+
+        metadata = resolve_submission_metadata(
+            Path(plugin_dir).resolve(),
+            result,
+            plugin_name=submission_plugin_name,
+            plugin_url=submission_plugin_url,
+            description=submission_plugin_description,
+            author=submission_author,
+            category=submission_category,
+            github_repository=github_repository or None,
+            github_server_url=github_server_url,
+        )
+        if not metadata.plugin_url:
+            print("Submission metadata is missing a plugin repository URL.", file=sys.stderr)
+            return 1
+
+        payload = build_submission_payload(
+            metadata,
+            result,
+            source_repository=github_repository,
+            source_sha=github_sha,
+            workflow_url=workflow_url,
+            scanner_version=__version__,
+        )
+        title = build_submission_issue_title(metadata)
+        body = build_submission_issue_body(
+            metadata,
+            result,
+            payload=payload,
+            workflow_url=workflow_url,
+        )
+
+        for submission_repo in submission_repos:
+            existing = find_existing_submission_issue(
+                submission_repo,
+                metadata.plugin_url,
+                submission_token,
+                api_base_url=github_api_url,
+            )
+            if existing is not None:
+                submission_issues.append(existing)
+                continue
+            submission_issues.append(
+                create_submission_issue(
+                    submission_repo,
+                    title,
+                    body,
+                    submission_token,
+                    labels=submission_labels,
+                    api_base_url=github_api_url,
+                )
+            )
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        _write_outputs(
+            github_output,
+            {
+                "score": str(result.score),
+                "grade": result.grade,
+                "submission_eligible": "true" if submission_eligible else "false",
+                "submission_performed": "true" if submission_issues else "false",
+                "submission_issue_urls": ",".join(issue.url for issue in submission_issues),
+                "submission_issue_numbers": ",".join(str(issue.number) for issue in submission_issues),
+            },
+        )
+
+    if result.score < min_score:
+        print(
+            f"Score {result.score} is below minimum threshold {min_score}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if severity_failed:
+        print(
+            f'Findings met or exceeded the "{fail_on}" severity threshold.',
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/codex_plugin_scanner/submission.py
+++ b/src/codex_plugin_scanner/submission.py
@@ -1,0 +1,254 @@
+"""Helpers for awesome-list and registry submission workflows."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+from .checks.manifest import load_manifest
+from .models import GRADE_LABELS, ScanResult
+
+
+def _repo_api_path(repo: str) -> str:
+    owner, name = repo.split("/", 1)
+    return f"{quote(owner, safe='')}/{quote(name, safe='')}"
+
+
+@dataclass(frozen=True, slots=True)
+class SubmissionMetadata:
+    """Resolved metadata for a plugin submission issue."""
+
+    plugin_name: str
+    plugin_url: str
+    description: str
+    author: str
+    category: str
+
+
+@dataclass(frozen=True, slots=True)
+class SubmissionIssue:
+    """A created or reused submission issue."""
+
+    repo: str
+    number: int
+    url: str
+    created: bool
+
+
+def _request_json(
+    method: str,
+    url: str,
+    token: str,
+    payload: dict[str, object] | None = None,
+) -> dict[str, object] | list[dict[str, object]]:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = Request(url, data=data, method=method)
+    request.add_header("Accept", "application/vnd.github+json")
+    request.add_header("Authorization", f"Bearer {token}")
+    request.add_header("User-Agent", "codex-plugin-scanner")
+    if data is not None:
+        request.add_header("Content-Type", "application/json")
+    with urlopen(request) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def resolve_submission_metadata(
+    plugin_dir: Path,
+    result: ScanResult,
+    *,
+    plugin_name: str | None = None,
+    plugin_url: str | None = None,
+    description: str | None = None,
+    author: str | None = None,
+    category: str = "Community Plugins",
+    github_repository: str | None = None,
+    github_server_url: str = "https://github.com",
+) -> SubmissionMetadata:
+    """Resolve submission fields from overrides, manifest metadata, and GitHub context."""
+
+    manifest = load_manifest(plugin_dir) or {}
+    interface = manifest.get("interface") if isinstance(manifest.get("interface"), dict) else {}
+    manifest_author = manifest.get("author") if isinstance(manifest.get("author"), dict) else {}
+
+    resolved_name = (
+        (plugin_name or "").strip()
+        or str(interface.get("displayName") or "").strip()
+        or str(manifest.get("name") or "").strip()
+        or (github_repository.split("/")[-1] if github_repository else plugin_dir.name)
+    )
+    resolved_url = (
+        (plugin_url or "").strip()
+        or str(manifest.get("repository") or "").strip()
+        or str(manifest.get("homepage") or "").strip()
+        or (f"{github_server_url.rstrip('/')}/{github_repository}" if github_repository else "")
+    )
+    resolved_description = (
+        (description or "").strip()
+        or str(interface.get("shortDescription") or "").strip()
+        or str(manifest.get("description") or "").strip()
+        or f"{resolved_name} scored {result.score}/100 with codex-plugin-scanner."
+    )
+    resolved_author = (
+        (author or "").strip()
+        or str(interface.get("developerName") or "").strip()
+        or str(manifest_author.get("name") or "").strip()
+        or (github_repository.split("/")[0] if github_repository else "")
+    )
+
+    return SubmissionMetadata(
+        plugin_name=resolved_name,
+        plugin_url=resolved_url,
+        description=resolved_description,
+        author=resolved_author,
+        category=category.strip() or "Community Plugins",
+    )
+
+
+def build_submission_payload(
+    metadata: SubmissionMetadata,
+    result: ScanResult,
+    *,
+    source_repository: str,
+    source_sha: str = "",
+    workflow_url: str = "",
+    scanner_version: str = "",
+) -> dict[str, object]:
+    """Build machine-readable submission metadata for downstream registry automation."""
+
+    return {
+        "pluginName": metadata.plugin_name,
+        "pluginUrl": metadata.plugin_url,
+        "description": metadata.description,
+        "author": metadata.author,
+        "category": metadata.category,
+        "score": result.score,
+        "grade": result.grade,
+        "gradeLabel": GRADE_LABELS.get(result.grade, "Unknown"),
+        "findings": result.severity_counts,
+        "sourceRepository": source_repository,
+        "sourceSha": source_sha,
+        "workflowUrl": workflow_url,
+        "scannerVersion": scanner_version,
+        "timestamp": result.timestamp,
+    }
+
+
+def build_submission_issue_title(metadata: SubmissionMetadata, prefix: str = "[Plugin]") -> str:
+    """Build the awesome-list submission issue title."""
+
+    normalized_prefix = prefix.strip() or "[Plugin]"
+    return f"{normalized_prefix} {metadata.plugin_name}".strip()
+
+
+def build_submission_issue_body(
+    metadata: SubmissionMetadata,
+    result: ScanResult,
+    *,
+    payload: dict[str, object],
+    workflow_url: str = "",
+) -> str:
+    """Render a human-readable and machine-readable submission issue body."""
+
+    lines = [
+        "## Plugin Submission",
+        "",
+        f"- Plugin Name: {metadata.plugin_name}",
+        f"- GitHub Repository URL: {metadata.plugin_url}",
+        f"- Description: {metadata.description}",
+        f"- Author: {metadata.author}",
+        f"- Category: {metadata.category}",
+        "",
+        "## Scanner Verification",
+        "",
+        f"- Score: {result.score}/100",
+        f"- Grade: {result.grade} - {GRADE_LABELS.get(result.grade, 'Unknown')}",
+    ]
+    if workflow_url:
+        lines.append(f"- Workflow Run: {workflow_url}")
+
+    lines += [
+        "",
+        "## Checklist",
+        "",
+        "- [x] Plugin has a valid `.codex-plugin/plugin.json` manifest",
+        "- [x] Plugin is functional and well-documented",
+        "- [x] Repository is public",
+        "",
+        "## Registry Payload",
+        "",
+        "```json",
+        json.dumps(payload, indent=2),
+        "```",
+    ]
+    return "\n".join(lines)
+
+
+def find_existing_submission_issue(
+    repo: str,
+    plugin_url: str,
+    token: str,
+    *,
+    api_base_url: str = "https://api.github.com",
+) -> SubmissionIssue | None:
+    """Find an existing open submission issue for the same plugin URL."""
+
+    encoded_repo = _repo_api_path(repo)
+    issues = _request_json(
+        "GET",
+        f"{api_base_url.rstrip('/')}/repos/{encoded_repo}/issues?state=open&per_page=100",
+        token,
+    )
+    if not isinstance(issues, list):
+        return None
+
+    for issue in issues:
+        body = str(issue.get("body") or "")
+        if issue.get("pull_request") or plugin_url not in body:
+            continue
+        return SubmissionIssue(
+            repo=repo,
+            number=int(issue["number"]),
+            url=str(issue["html_url"]),
+            created=False,
+        )
+    return None
+
+
+def create_submission_issue(
+    repo: str,
+    title: str,
+    body: str,
+    token: str,
+    *,
+    labels: tuple[str, ...] = (),
+    api_base_url: str = "https://api.github.com",
+) -> SubmissionIssue:
+    """Create a submission issue, retrying without labels when the label set is invalid."""
+
+    encoded_repo = _repo_api_path(repo)
+    issue_url = f"{api_base_url.rstrip('/')}/repos/{encoded_repo}/issues"
+    payload: dict[str, object] = {"title": title, "body": body}
+    cleaned_labels = [label for label in labels if label.strip()]
+    if cleaned_labels:
+        payload["labels"] = cleaned_labels
+
+    try:
+        issue = _request_json("POST", issue_url, token, payload)
+    except HTTPError as error:
+        if error.code != 422 or "labels" not in payload:
+            raise
+        issue = _request_json("POST", issue_url, token, {"title": title, "body": body})
+
+    if not isinstance(issue, dict):
+        raise RuntimeError("GitHub issue creation returned an unexpected response.")
+
+    return SubmissionIssue(
+        repo=repo,
+        number=int(issue["number"]),
+        url=str(issue["html_url"]),
+        created=True,
+    )

--- a/src/codex_plugin_scanner/submission.py
+++ b/src/codex_plugin_scanner/submission.py
@@ -6,11 +6,15 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.error import HTTPError
-from urllib.parse import quote
+from urllib.parse import quote, urlencode
 from urllib.request import Request, urlopen
 
 from .checks.manifest import load_manifest
 from .models import GRADE_LABELS, ScanResult
+
+REQUEST_TIMEOUT_SECONDS = 30
+SUBMISSION_URL_MARKER_PREFIX = "<!-- codex-plugin-scanner-plugin-url: "
+SUBMISSION_URL_MARKER_SUFFIX = " -->"
 
 
 def _repo_api_path(repo: str) -> str:
@@ -39,6 +43,28 @@ class SubmissionIssue:
     created: bool
 
 
+def _submission_url_marker(plugin_url: str) -> str:
+    return f"{SUBMISSION_URL_MARKER_PREFIX}{plugin_url}{SUBMISSION_URL_MARKER_SUFFIX}"
+
+
+def _parse_submission_issue(
+    issue: dict[str, object],
+    *,
+    repo: str,
+    created: bool,
+) -> SubmissionIssue:
+    number = issue.get("number")
+    url = issue.get("html_url")
+    if not isinstance(number, int) or not isinstance(url, str) or not url:
+        raise RuntimeError("GitHub issue response is missing required fields.")
+    return SubmissionIssue(
+        repo=repo,
+        number=number,
+        url=url,
+        created=created,
+    )
+
+
 def _request_json(
     method: str,
     url: str,
@@ -52,7 +78,7 @@ def _request_json(
     request.add_header("User-Agent", "codex-plugin-scanner")
     if data is not None:
         request.add_header("Content-Type", "application/json")
-    with urlopen(request) as response:
+    with urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
         return json.loads(response.read().decode("utf-8"))
 
 
@@ -156,6 +182,8 @@ def build_submission_issue_body(
     lines = [
         "## Plugin Submission",
         "",
+        _submission_url_marker(metadata.plugin_url),
+        "",
         f"- Plugin Name: {metadata.plugin_name}",
         f"- GitHub Repository URL: {metadata.plugin_url}",
         f"- Description: {metadata.description}",
@@ -196,25 +224,32 @@ def find_existing_submission_issue(
 ) -> SubmissionIssue | None:
     """Find an existing open submission issue for the same plugin URL."""
 
-    encoded_repo = _repo_api_path(repo)
+    marker = _submission_url_marker(plugin_url)
+    query = urlencode(
+        {
+            "q": f'repo:{repo} is:issue is:open "{marker}" in:body',
+            "per_page": "10",
+        }
+    )
     issues = _request_json(
         "GET",
-        f"{api_base_url.rstrip('/')}/repos/{encoded_repo}/issues?state=open&per_page=100",
+        f"{api_base_url.rstrip('/')}/search/issues?{query}",
         token,
     )
-    if not isinstance(issues, list):
+    if not isinstance(issues, dict):
         return None
 
-    for issue in issues:
-        body = str(issue.get("body") or "")
-        if issue.get("pull_request") or plugin_url not in body:
+    items = issues.get("items")
+    if not isinstance(items, list):
+        return None
+
+    for issue in items:
+        if not isinstance(issue, dict):
             continue
-        return SubmissionIssue(
-            repo=repo,
-            number=int(issue["number"]),
-            url=str(issue["html_url"]),
-            created=False,
-        )
+        body = str(issue.get("body") or "")
+        if issue.get("pull_request") or marker not in body:
+            continue
+        return _parse_submission_issue(issue, repo=repo, created=False)
     return None
 
 
@@ -246,9 +281,4 @@ def create_submission_issue(
     if not isinstance(issue, dict):
         raise RuntimeError("GitHub issue creation returned an unexpected response.")
 
-    return SubmissionIssue(
-        repo=repo,
-        number=int(issue["number"]),
-        url=str(issue["html_url"]),
-        created=True,
-    )
+    return _parse_submission_issue(issue, repo=repo, created=True)

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -12,6 +12,7 @@ def test_action_metadata_includes_marketplace_branding_and_fallback_install() ->
     assert "branding:" in action_text
     assert 'icon: "check-circle"' in action_text
     assert 'color: "blue"' in action_text
+    assert "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065" in action_text
     assert 'pip install codex-plugin-scanner' in action_text
     assert 'pip install "$LOCAL_SOURCE"' in action_text
     assert "submission_enabled:" in action_text

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -14,6 +14,10 @@ def test_action_metadata_includes_marketplace_branding_and_fallback_install() ->
     assert 'color: "blue"' in action_text
     assert 'pip install codex-plugin-scanner' in action_text
     assert 'pip install "$LOCAL_SOURCE"' in action_text
+    assert "submission_enabled:" in action_text
+    assert "submission_issue_urls:" in action_text
+    assert "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065" in action_text
+    assert "python3 -m codex_plugin_scanner.action_runner" in action_text
 
 
 def test_publish_workflow_attaches_marketplace_action_bundle() -> None:
@@ -31,3 +35,5 @@ def test_action_bundle_has_root_ready_readme_and_marketplace_guide() -> None:
     assert "single root `action.yml`" in action_readme
     assert "must not contain any workflow files" in guide
     assert "dedicated public action repository" in guide
+    assert "submission issue" in action_readme
+    assert "awesome-codex-plugins" in guide

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -1,6 +1,7 @@
 """Tests for awesome-list submission helpers."""
 
 from pathlib import Path
+from urllib.error import HTTPError
 
 from codex_plugin_scanner.scanner import scan_plugin
 from codex_plugin_scanner.submission import (
@@ -8,6 +9,8 @@ from codex_plugin_scanner.submission import (
     build_submission_issue_body,
     build_submission_issue_title,
     build_submission_payload,
+    create_submission_issue,
+    find_existing_submission_issue,
     resolve_submission_metadata,
 )
 
@@ -74,6 +77,7 @@ def test_submission_payload_and_issue_body_include_registry_data() -> None:
     assert payload["grade"] == "A"
     assert payload["pluginUrl"] == metadata.plugin_url
     assert "## Registry Payload" in body
+    assert "<!-- codex-plugin-scanner-plugin-url: https://github.com/hashgraph-online/example-good-plugin -->" in body
     assert '"pluginName": "Example Good Plugin"' in body
     assert metadata.plugin_url in body
 
@@ -89,3 +93,128 @@ def test_submission_issue_title_uses_plugin_prefix() -> None:
 
     assert build_submission_issue_title(metadata) == "[Plugin] Example Good Plugin"
     assert build_submission_issue_title(metadata, prefix="[Registry]") == "[Registry] Example Good Plugin"
+
+
+def test_find_existing_submission_issue_uses_search_api_and_exact_marker(monkeypatch) -> None:
+    captured: dict[str, str] = {}
+
+    def fake_request_json(method: str, url: str, token: str, payload=None):
+        captured["method"] = method
+        captured["url"] = url
+        captured["token"] = token
+        return {
+            "items": [
+                {
+                    "number": 42,
+                    "html_url": "https://github.com/hashgraph-online/awesome-codex-plugins/issues/42",
+                    "body": (
+                        "## Plugin Submission\n"
+                        "<!-- codex-plugin-scanner-plugin-url: "
+                        "https://github.com/hashgraph-online/example-good-plugin -->\n"
+                    ),
+                },
+                {
+                    "number": 99,
+                    "html_url": "https://github.com/hashgraph-online/awesome-codex-plugins/issues/99",
+                    "body": (
+                        "## Plugin Submission\n"
+                        "<!-- codex-plugin-scanner-plugin-url: "
+                        "https://github.com/hashgraph-online/example-good-plugin-extra -->\n"
+                    ),
+                },
+            ]
+        }
+
+    monkeypatch.setattr("codex_plugin_scanner.submission._request_json", fake_request_json)
+
+    issue = find_existing_submission_issue(
+        "hashgraph-online/awesome-codex-plugins",
+        "https://github.com/hashgraph-online/example-good-plugin",
+        "token-123",
+    )
+
+    assert issue is not None
+    assert issue.number == 42
+    assert issue.created is False
+    assert captured["method"] == "GET"
+    assert "/search/issues?" in captured["url"]
+    assert captured["token"] == "token-123"
+
+
+def test_create_submission_issue_retries_without_labels_on_invalid_labels(monkeypatch) -> None:
+    calls: list[dict[str, object | None]] = []
+
+    def fake_request_json(method: str, url: str, token: str, payload=None):
+        calls.append({"method": method, "url": url, "token": token, "payload": payload})
+        if len(calls) == 1:
+            raise HTTPError(
+                url=url,
+                code=422,
+                msg="Unprocessable Entity",
+                hdrs=None,
+                fp=None,
+            )
+        return {
+            "number": 17,
+            "html_url": "https://github.com/hashgraph-online/awesome-codex-plugins/issues/17",
+        }
+
+    monkeypatch.setattr("codex_plugin_scanner.submission._request_json", fake_request_json)
+
+    issue = create_submission_issue(
+        "hashgraph-online/awesome-codex-plugins",
+        "[Plugin] Example Good Plugin",
+        "Body",
+        "token-123",
+        labels=("plugin-submission",),
+    )
+
+    assert issue.number == 17
+    assert issue.created is True
+    assert calls[0]["payload"] == {
+        "title": "[Plugin] Example Good Plugin",
+        "body": "Body",
+        "labels": ["plugin-submission"],
+    }
+    assert calls[1]["payload"] == {
+        "title": "[Plugin] Example Good Plugin",
+        "body": "Body",
+    }
+
+
+def test_create_submission_issue_rejects_malformed_api_responses(monkeypatch) -> None:
+    def fake_request_json(method: str, url: str, token: str, payload=None):
+        return []
+
+    monkeypatch.setattr("codex_plugin_scanner.submission._request_json", fake_request_json)
+
+    try:
+        create_submission_issue(
+            "hashgraph-online/awesome-codex-plugins",
+            "[Plugin] Example Good Plugin",
+            "Body",
+            "token-123",
+        )
+    except RuntimeError as error:
+        assert "unexpected response" in str(error)
+    else:
+        raise AssertionError("Expected create_submission_issue to reject malformed responses.")
+
+
+def test_create_submission_issue_rejects_missing_issue_fields(monkeypatch) -> None:
+    def fake_request_json(method: str, url: str, token: str, payload=None):
+        return {"number": "17"}
+
+    monkeypatch.setattr("codex_plugin_scanner.submission._request_json", fake_request_json)
+
+    try:
+        create_submission_issue(
+            "hashgraph-online/awesome-codex-plugins",
+            "[Plugin] Example Good Plugin",
+            "Body",
+            "token-123",
+        )
+    except RuntimeError as error:
+        assert "required fields" in str(error)
+    else:
+        raise AssertionError("Expected create_submission_issue to reject incomplete responses.")

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -1,0 +1,91 @@
+"""Tests for awesome-list submission helpers."""
+
+from pathlib import Path
+
+from codex_plugin_scanner.scanner import scan_plugin
+from codex_plugin_scanner.submission import (
+    SubmissionMetadata,
+    build_submission_issue_body,
+    build_submission_issue_title,
+    build_submission_payload,
+    resolve_submission_metadata,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_resolve_submission_metadata_prefers_manifest_fields() -> None:
+    result = scan_plugin(FIXTURES / "good-plugin")
+
+    metadata = resolve_submission_metadata(
+        FIXTURES / "good-plugin",
+        result,
+        github_repository="hashgraph-online/example-good-plugin",
+    )
+
+    assert metadata.plugin_name == "Example Good Plugin"
+    assert metadata.plugin_url == "https://github.com/hashgraph-online/codex-plugin-scanner"
+    assert metadata.description == "Reusable security-first plugin fixture"
+    assert metadata.author == "Hashgraph Online"
+    assert metadata.category == "Community Plugins"
+
+
+def test_resolve_submission_metadata_falls_back_to_github_context() -> None:
+    result = scan_plugin(FIXTURES / "minimal-plugin")
+
+    metadata = resolve_submission_metadata(
+        FIXTURES / "minimal-plugin",
+        result,
+        github_repository="hashgraph-online/minimal-plugin",
+    )
+
+    assert metadata.plugin_name == "minimal-plugin"
+    assert metadata.plugin_url == "https://github.com/hashgraph-online/minimal-plugin"
+    assert metadata.author == "hashgraph-online"
+    assert metadata.description == "A minimal plugin"
+
+
+def test_submission_payload_and_issue_body_include_registry_data() -> None:
+    result = scan_plugin(FIXTURES / "good-plugin")
+    metadata = SubmissionMetadata(
+        plugin_name="Example Good Plugin",
+        plugin_url="https://github.com/hashgraph-online/example-good-plugin",
+        description="Reusable security-first plugin fixture",
+        author="Hashgraph Online",
+        category="Community Plugins",
+    )
+
+    payload = build_submission_payload(
+        metadata,
+        result,
+        source_repository="hashgraph-online/example-good-plugin",
+        source_sha="abc123",
+        workflow_url="https://github.com/hashgraph-online/example-good-plugin/actions/runs/1",
+        scanner_version="1.2.0",
+    )
+    body = build_submission_issue_body(
+        metadata,
+        result,
+        payload=payload,
+        workflow_url="https://github.com/hashgraph-online/example-good-plugin/actions/runs/1",
+    )
+
+    assert payload["score"] == 100
+    assert payload["grade"] == "A"
+    assert payload["pluginUrl"] == metadata.plugin_url
+    assert "## Registry Payload" in body
+    assert '"pluginName": "Example Good Plugin"' in body
+    assert metadata.plugin_url in body
+
+
+def test_submission_issue_title_uses_plugin_prefix() -> None:
+    metadata = SubmissionMetadata(
+        plugin_name="Example Good Plugin",
+        plugin_url="https://github.com/hashgraph-online/example-good-plugin",
+        description="Reusable security-first plugin fixture",
+        author="Hashgraph Online",
+        category="Community Plugins",
+    )
+
+    assert build_submission_issue_title(metadata) == "[Plugin] Example Good Plugin"
+    assert build_submission_issue_title(metadata, prefix="[Registry]") == "[Registry] Example Good Plugin"


### PR DESCRIPTION
## Purpose
- add a plugin-author submission flow to the GitHub Action
- auto-file or reuse submission issues in `awesome-codex-plugins` once a plugin clears the configured trust threshold
- align the publish workflow with the Marketplace action bundle documented in the repo

## Affected Paths
- `README.md`
- `action/README.md`
- `action/action.yml`
- `.github/workflows/publish.yml`
- `docs/github-action-marketplace.md`
- `src/codex_plugin_scanner/submission.py`
- `tests/test_action_bundle.py`
- `tests/test_submission.py`

## Notes
- submission issues are gated by score threshold and severity threshold
- the action emits submission outputs for downstream registry automation
- the publish workflow now attaches a root-ready GitHub Action bundle zip to releases
- verification used the live `awesome-codex-plugins` issue template only; no production issue was created

## Verification
- `./.venv/bin/ruff check src tests`
- `./.venv/bin/python -c 'import sys; sys.path.insert(0,"src"); import pytest; raise SystemExit(pytest.main(["tests/test_submission.py","tests/test_action_bundle.py","-q"]))'`
- `./.venv/bin/python -c 'import sys; sys.path.insert(0,"src"); import pytest; raise SystemExit(pytest.main(["-q"]))'`
- `./.venv/bin/python -m build`
