### PR TITLE
fix: make action publication workflow dispatchable

### DIFF
--- a/.github/workflows/publish-action-repo.yml
+++ b/.github/workflows/publish-action-repo.yml
@@ -29,7 +29,6 @@ concurrency:
 jobs:
   publish-action-repo:
     name: Publish GitHub Action Repository
-    if: secrets.ACTION_REPO_TOKEN != ''
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.ACTION_REPO_TOKEN }}
@@ -43,6 +42,13 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name || inputs.release_tag || github.ref }}
           fetch-depth: 0
+
+      - name: Validate publication credentials
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "ACTION_REPO_TOKEN is required to publish the GitHub Action repository." >&2
+            exit 1
+          fi
 
       - name: Resolve version
         id: version

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -34,6 +34,8 @@ def test_publish_action_repo_workflow_syncs_action_repository() -> None:
     assert "Publish GitHub Action Repository" in workflow_text
     assert "ACTION_REPO_TOKEN" in workflow_text
     assert "hashgraph-online/hol-codex-plugin-scanner-action" in workflow_text
+    assert "Validate publication credentials" in workflow_text
+    assert 'if: secrets.ACTION_REPO_TOKEN != \'\'' not in workflow_text
     assert 'gh repo create "${ACTION_REPOSITORY}"' in workflow_text
     assert 'cp "${GITHUB_WORKSPACE}/action/action.yml" action.yml' in workflow_text
     assert 'git push origin refs/tags/v1 --force' in workflow_text


### PR DESCRIPTION
## Summary
- remove the invalid job-level secrets expression from the action publication workflow
- validate ACTION_REPO_TOKEN inside the job so workflow dispatches succeed
- add regression coverage for the dispatch-safe workflow shape

## Verification
- `.venv/bin/python -m pytest tests/test_action_bundle.py -q`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m build`