### PR TITLE
fix: harden action publication workflow

### DIFF
--- a/.github/workflows/publish-action-repo.yml
+++ b/.github/workflows/publish-action-repo.yml
@@ -34,7 +34,8 @@ jobs:
       GH_TOKEN: ${{ secrets.ACTION_REPO_TOKEN }}
       ACTION_REPOSITORY: ${{ inputs.action_repository != '' && inputs.action_repository || vars.ACTION_REPOSITORY != '' && vars.ACTION_REPOSITORY || 'hashgraph-online/hol-codex-plugin-scanner-action' }}
       RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
-      CREATE_REPOSITORY: ${{ github.event_name == 'workflow_dispatch' && inputs.create_repository || 'true' }}
+      CREATE_REPOSITORY: ${{ github.event_name == 'workflow_dispatch' && (inputs.create_repository && 'true' || 'false') || 'true' }}
+      SOURCE_REF: ${{ github.event.release.tag_name || inputs.release_tag || github.ref_name }}
       SOURCE_REPOSITORY: ${{ github.repository }}
       SOURCE_SERVER_URL: ${{ github.server_url }}
     steps:
@@ -121,7 +122,11 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           TAG="${{ steps.version.outputs.tag }}"
-          NOTES="Published automatically from ${SOURCE_SERVER_URL}/${SOURCE_REPOSITORY}/releases/tag/${TAG}"
+          if [ -n "${RELEASE_TAG}" ]; then
+            NOTES="Published automatically from ${SOURCE_SERVER_URL}/${SOURCE_REPOSITORY}/releases/tag/${TAG}"
+          else
+            NOTES="Published automatically from ${SOURCE_SERVER_URL}/${SOURCE_REPOSITORY}/tree/${SOURCE_REF}"
+          fi
 
           if gh release view "${TAG}" --repo "${ACTION_REPOSITORY}" >/dev/null 2>&1; then
             gh release edit "${TAG}" \

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -36,10 +36,13 @@ def test_publish_action_repo_workflow_syncs_action_repository() -> None:
     assert "hashgraph-online/hol-codex-plugin-scanner-action" in workflow_text
     assert "Validate publication credentials" in workflow_text
     assert 'if: secrets.ACTION_REPO_TOKEN != \'\'' not in workflow_text
+    assert "inputs.create_repository && 'true' || 'false'" in workflow_text
+    assert "SOURCE_REF" in workflow_text
     assert 'gh repo create "${ACTION_REPOSITORY}"' in workflow_text
     assert 'cp "${GITHUB_WORKSPACE}/action/action.yml" action.yml' in workflow_text
     assert 'git push origin refs/tags/v1 --force' in workflow_text
     assert 'gh release create "${TAG}"' in workflow_text
+    assert 'Published automatically from ${SOURCE_SERVER_URL}/${SOURCE_REPOSITORY}/tree/${SOURCE_REF}' in workflow_text
 
 
 def test_action_bundle_docs_live_in_action_readme() -> None:


### PR DESCRIPTION
## Summary
- make `create_repository=false` work correctly on workflow dispatch
- link manual action-repo publishes back to the correct source ref instead of an unrelated release tag
- extend regression coverage for both cases

## Verification
- `.venv/bin/python -m pytest tests/test_action_bundle.py -q`
- `.venv/bin/python -m pytest -q`
- `yq . .github/workflows/publish-action-repo.yml >/dev/null`