### PR TITLE
fix: export composite action outputs

### DIFF
--- a/action/action.yml
+++ b/action/action.yml
@@ -79,16 +79,22 @@ inputs:
 outputs:
   score:
     description: "The numeric score (0-100)"
+    value: ${{ steps.scan.outputs.score }}
   grade:
     description: "The letter grade (A-F)"
+    value: ${{ steps.scan.outputs.grade }}
   submission_eligible:
     description: "Whether the plugin met the submission threshold and passed the configured severity gate"
+    value: ${{ steps.scan.outputs.submission_eligible }}
   submission_performed:
     description: "Whether a submission issue was created or reused"
+    value: ${{ steps.scan.outputs.submission_performed }}
   submission_issue_urls:
     description: "Comma-separated URLs for submission issues created or reused"
+    value: ${{ steps.scan.outputs.submission_issue_urls }}
   submission_issue_numbers:
     description: "Comma-separated issue numbers for submission issues created or reused"
+    value: ${{ steps.scan.outputs.submission_issue_numbers }}
 
 branding:
   icon: "check-circle"

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -20,6 +20,10 @@ def test_action_metadata_includes_marketplace_branding_and_fallback_install() ->
     assert "python3 -m codex_plugin_scanner.action_runner" in action_text
     assert "value: ${{ steps.scan.outputs.score }}" in action_text
     assert "value: ${{ steps.scan.outputs.grade }}" in action_text
+    assert "value: ${{ steps.scan.outputs.submission_eligible }}" in action_text
+    assert "value: ${{ steps.scan.outputs.submission_performed }}" in action_text
+    assert "value: ${{ steps.scan.outputs.submission_issue_urls }}" in action_text
+    assert "value: ${{ steps.scan.outputs.submission_issue_numbers }}" in action_text
 
 
 def test_publish_workflow_attaches_marketplace_action_bundle() -> None:

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -13,11 +13,13 @@ def test_action_metadata_includes_marketplace_branding_and_fallback_install() ->
     assert 'icon: "check-circle"' in action_text
     assert 'color: "blue"' in action_text
     assert "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065" in action_text
-    assert 'pip install codex-plugin-scanner' in action_text
+    assert "pip install codex-plugin-scanner" in action_text
     assert 'pip install "$LOCAL_SOURCE"' in action_text
     assert "submission_enabled:" in action_text
     assert "submission_issue_urls:" in action_text
     assert "python3 -m codex_plugin_scanner.action_runner" in action_text
+    assert "value: ${{ steps.scan.outputs.score }}" in action_text
+    assert "value: ${{ steps.scan.outputs.grade }}" in action_text
 
 
 def test_publish_workflow_attaches_marketplace_action_bundle() -> None:
@@ -35,14 +37,14 @@ def test_publish_action_repo_workflow_syncs_action_repository() -> None:
     assert "ACTION_REPO_TOKEN" in workflow_text
     assert "hashgraph-online/hol-codex-plugin-scanner-action" in workflow_text
     assert "Validate publication credentials" in workflow_text
-    assert 'if: secrets.ACTION_REPO_TOKEN != \'\'' not in workflow_text
+    assert "if: secrets.ACTION_REPO_TOKEN != ''" not in workflow_text
     assert "inputs.create_repository && 'true' || 'false'" in workflow_text
     assert "SOURCE_REF" in workflow_text
     assert 'gh repo create "${ACTION_REPOSITORY}"' in workflow_text
     assert 'cp "${GITHUB_WORKSPACE}/action/action.yml" action.yml' in workflow_text
-    assert 'git push origin refs/tags/v1 --force' in workflow_text
+    assert "git push origin refs/tags/v1 --force" in workflow_text
     assert 'gh release create "${TAG}"' in workflow_text
-    assert 'Published automatically from ${SOURCE_SERVER_URL}/${SOURCE_REPOSITORY}/tree/${SOURCE_REF}' in workflow_text
+    assert "Published automatically from ${SOURCE_SERVER_URL}/${SOURCE_REPOSITORY}/tree/${SOURCE_REF}" in workflow_text
 
 
 def test_action_bundle_docs_live_in_action_readme() -> None:

--- a/tests/test_action_runner.py
+++ b/tests/test_action_runner.py
@@ -1,0 +1,44 @@
+"""Behavior checks for the GitHub Action runner output contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_plugin_scanner.action_runner import main
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_action_runner_writes_score_and_grade_outputs(monkeypatch, tmp_path, capsys) -> None:
+    output_path = tmp_path / "github-output.txt"
+
+    monkeypatch.setenv("PLUGIN_DIR", str(FIXTURES / "good-plugin"))
+    monkeypatch.setenv("FORMAT", "json")
+    monkeypatch.setenv("OUTPUT", "")
+    monkeypatch.setenv("MIN_SCORE", "0")
+    monkeypatch.setenv("FAIL_ON", "none")
+    monkeypatch.setenv("CISCO_SCAN", "off")
+    monkeypatch.setenv("CISCO_POLICY", "balanced")
+    monkeypatch.setenv("SUBMISSION_ENABLED", "false")
+    monkeypatch.setenv("SUBMISSION_SCORE_THRESHOLD", "80")
+    monkeypatch.setenv("SUBMISSION_REPOS", "hashgraph-online/awesome-codex-plugins")
+    monkeypatch.setenv("SUBMISSION_TOKEN", "")
+    monkeypatch.setenv("SUBMISSION_LABELS", "plugin-submission")
+    monkeypatch.setenv("SUBMISSION_CATEGORY", "Community Plugins")
+    monkeypatch.setenv("SUBMISSION_PLUGIN_NAME", "")
+    monkeypatch.setenv("SUBMISSION_PLUGIN_URL", "")
+    monkeypatch.setenv("SUBMISSION_PLUGIN_DESCRIPTION", "")
+    monkeypatch.setenv("SUBMISSION_AUTHOR", "")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
+
+    exit_code = main()
+
+    assert exit_code == 0
+    output_lines = output_path.read_text(encoding="utf-8").splitlines()
+    assert "score=100" in output_lines
+    assert "grade=A" in output_lines
+    assert "submission_eligible=false" in output_lines
+    assert "submission_performed=false" in output_lines
+
+    stdout = capsys.readouterr().out
+    assert '"score": 100' in stdout

--- a/tests/test_action_runner.py
+++ b/tests/test_action_runner.py
@@ -9,7 +9,7 @@ from codex_plugin_scanner.action_runner import main
 FIXTURES = Path(__file__).parent / "fixtures"
 
 
-def test_action_runner_writes_score_and_grade_outputs(monkeypatch, tmp_path, capsys) -> None:
+def test_action_runner_writes_all_outputs(monkeypatch, tmp_path, capsys) -> None:
     output_path = tmp_path / "github-output.txt"
 
     monkeypatch.setenv("PLUGIN_DIR", str(FIXTURES / "good-plugin"))
@@ -39,6 +39,8 @@ def test_action_runner_writes_score_and_grade_outputs(monkeypatch, tmp_path, cap
     assert "grade=A" in output_lines
     assert "submission_eligible=false" in output_lines
     assert "submission_performed=false" in output_lines
+    assert "submission_issue_urls=" in output_lines
+    assert "submission_issue_numbers=" in output_lines
 
     stdout = capsys.readouterr().out
     assert '"score": 100' in stdout

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -131,9 +131,7 @@ class TestMcpTransportSecurity:
         with tempfile.TemporaryDirectory() as tmpdir:
             mcp = Path(tmpdir) / ".mcp.json"
             mcp.write_text(
-                (
-                    '{"mcpServers":{"safe":{"command":"echo","metadata":{"homepage":{"url":"http://example.com"}}}}}'
-                ),
+                ('{"mcpServers":{"safe":{"command":"echo","metadata":{"homepage":{"url":"http://example.com"}}}}}'),
                 encoding="utf-8",
             )
             r = check_mcp_transport_security(Path(tmpdir))


### PR DESCRIPTION
## Summary
- map composite action outputs to the scan step outputs so downstream workflows can read score and grade
- add an action runner regression test that verifies GITHUB_OUTPUT receives score and grade
- extend bundle regression checks to assert the manifest-level output mapping

## Verification
- uv run --no-sync ruff check src tests
- uv run --no-sync ruff format --check src tests
- uv run --no-sync pytest tests/test_action_bundle.py tests/test_action_runner.py -q
- uv run --no-sync pytest -q
- uv run --no-sync python -m build