### PR TITLE
feat: improve scanner action ecosystem outputs

### DIFF
--- a/.github/workflows/publish-action-repo.yml
+++ b/.github/workflows/publish-action-repo.yml
@@ -35,6 +35,7 @@ jobs:
       ACTION_REPOSITORY: ${{ inputs.action_repository != '' && inputs.action_repository || vars.ACTION_REPOSITORY != '' && vars.ACTION_REPOSITORY || 'hashgraph-online/hol-codex-plugin-scanner-action' }}
       RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
       CREATE_REPOSITORY: ${{ github.event_name == 'workflow_dispatch' && (inputs.create_repository && 'true' || 'false') || 'true' }}
+      PUBLISH_IMMUTABLE_RELEASE: ${{ github.event_name == 'release' || inputs.release_tag != '' }}
       SOURCE_REF: ${{ github.event.release.tag_name || inputs.release_tag || github.ref_name }}
       SOURCE_REPOSITORY: ${{ github.repository }}
       SOURCE_SERVER_URL: ${{ github.server_url }}
@@ -113,12 +114,16 @@ jobs:
             git push origin HEAD:main
           fi
 
-          git tag -f "${TAG}"
-          git push origin "refs/tags/${TAG}" --force
           git tag -f v1
           git push origin refs/tags/v1 --force
 
+          if [ "${PUBLISH_IMMUTABLE_RELEASE}" = "true" ]; then
+            git tag -f "${TAG}"
+            git push origin "refs/tags/${TAG}" --force
+          fi
+
       - name: Create or update action repository release
+        if: env.PUBLISH_IMMUTABLE_RELEASE == 'true'
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           TAG="${{ steps.version.outputs.tag }}"

--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ GitHub Marketplace still requires the one-time listing publication step in the d
 
 The action can also handle submission intake. A plugin repository can wire the scanner into CI so a passing scan opens or reuses a submission issue in [awesome-codex-plugins](https://github.com/hashgraph-online/awesome-codex-plugins).
 
+It also emits Codex-friendly machine outputs:
+
+- `score`, `grade`, `grade_label`, `max_severity`, and `findings_total` as GitHub Action outputs
+- a concise markdown summary in the job summary by default
+- an optional machine-readable registry payload file for downstream registry, badge, or awesome-list automation
+
 The intended path is:
 
 1. Add the scanner action to plugin CI.
@@ -243,6 +249,44 @@ jobs:
 ```
 
 `submission_token` is required when `submission_enabled: true`. This flow is idempotent. If the plugin repository was already submitted, the action reuses the existing open issue instead of opening duplicates by matching an exact hidden plugin URL marker in the existing issue body.
+
+### Registry Payload For Codex Ecosystem Automation
+
+If you want to feed the same scan into a registry, badge pipeline, or another Codex automation step, request a registry payload file directly from the action:
+
+```yaml
+permissions:
+  contents: read
+
+jobs:
+  scan-plugin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Scan plugin
+        id: scan
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+        with:
+          plugin_dir: "."
+          format: sarif
+          output: codex-plugin-scanner.sarif
+          registry_payload_output: codex-plugin-registry-payload.json
+
+      - name: Show trust signals
+        run: |
+          echo "Score: ${{ steps.scan.outputs.score }}"
+          echo "Grade: ${{ steps.scan.outputs.grade_label }}"
+          echo "Max severity: ${{ steps.scan.outputs.max_severity }}"
+
+      - name: Upload registry payload
+        uses: actions/upload-artifact@v6
+        with:
+          name: codex-plugin-registry-payload
+          path: ${{ steps.scan.outputs.registry_payload_path }}
+```
+
+The registry payload mirrors the submission data used by HOL ecosystem automation, so one scan can drive code scanning, review summaries, awesome-list intake, and registry trust ingestion.
 
 ## Development
 

--- a/action/README.md
+++ b/action/README.md
@@ -22,6 +22,8 @@ This README is intentionally root-ready for a dedicated GitHub Marketplace actio
 | `plugin_dir` | Path to the plugin directory to scan | `.` |
 | `format` | Output format: `text`, `json`, `markdown`, `sarif` | `text` |
 | `output` | Write report to this file path | `""` |
+| `write_step_summary` | Write a concise markdown summary to the GitHub Actions job summary | `true` |
+| `registry_payload_output` | Write a machine-readable Codex ecosystem payload JSON file for registry or awesome-list automation | `""` |
 | `min_score` | Fail if score is below this threshold (0-100) | `0` |
 | `fail_on_severity` | Fail on findings at or above this severity: `none`, `critical`, `high`, `medium`, `low`, `info` | `none` |
 | `cisco_skill_scan` | Cisco skill-scanner mode: `auto`, `on`, `off` | `auto` |
@@ -44,12 +46,17 @@ This README is intentionally root-ready for a dedicated GitHub Marketplace actio
 |--------|-------------|
 | `score` | Numeric score (0-100) |
 | `grade` | Letter grade (A-F) |
+| `grade_label` | Human-readable grade label |
+| `max_severity` | Highest finding severity, or `none` |
+| `findings_total` | Total number of findings across all severities |
+| `report_path` | Path to the rendered report file, if `output` was set |
+| `registry_payload_path` | Path to the machine-readable Codex ecosystem payload file, if requested |
 | `submission_eligible` | `true` when the plugin met the submission threshold and passed the configured severity gate |
 | `submission_performed` | `true` when a submission issue was created or an existing one was reused |
 | `submission_issue_urls` | Comma-separated submission issue URLs |
 | `submission_issue_numbers` | Comma-separated submission issue numbers |
 
-The report itself is written to the job log for `text` output, or to the file you pass through `output` for `json`, `markdown`, or `sarif`.
+The action also writes a concise summary to `GITHUB_STEP_SUMMARY` by default. The full report is written to the job log for `text` output, or to the file you pass through `output` for `json`, `markdown`, or `sarif`.
 
 ## Examples
 
@@ -83,6 +90,26 @@ The report itself is written to the job log for `text` output, or to the file yo
     cisco_policy: strict
     install_cisco: true
 ```
+
+### Export registry payload for Codex ecosystem automation
+
+```yaml
+- uses: your-org/hol-codex-plugin-scanner-action@v1
+  id: scan
+  with:
+    plugin_dir: "."
+    format: sarif
+    output: codex-plugin-scanner.sarif
+    registry_payload_output: codex-plugin-registry-payload.json
+
+- name: Show trust signals
+  run: |
+    echo "Score: ${{ steps.scan.outputs.score }}"
+    echo "Grade: ${{ steps.scan.outputs.grade_label }}"
+    echo "Max severity: ${{ steps.scan.outputs.max_severity }}"
+```
+
+The registry payload mirrors the submission metadata used by HOL ecosystem automation, so the same scan can feed trust scoring, registry ingestion, badges, or awesome-list processing without reparsing the terminal output.
 
 ### Score 80+ and auto-file an awesome-list submission issue
 
@@ -127,7 +154,7 @@ Use a fine-grained token with `issues:write` on `hashgraph-online/awesome-codex-
     output: scan-report.md
 
 - name: Comment PR
-  uses: actions/github-script@v7
+  uses: actions/github-script@v8
   with:
     script: |
       const fs = require('fs');

--- a/action/action.yml
+++ b/action/action.yml
@@ -15,6 +15,14 @@ inputs:
     description: "Write report to this file path"
     required: false
     default: ""
+  write_step_summary:
+    description: "Write a concise markdown summary to the GitHub Actions job summary"
+    required: false
+    default: "true"
+  registry_payload_output:
+    description: "Write a machine-readable Codex ecosystem payload JSON file for registry or awesome-list automation"
+    required: false
+    default: ""
   min_score:
     description: "Fail the job if the score is below this threshold (0-100)"
     required: false
@@ -83,6 +91,21 @@ outputs:
   grade:
     description: "The letter grade (A-F)"
     value: ${{ steps.scan.outputs.grade }}
+  grade_label:
+    description: "The human-readable grade label"
+    value: ${{ steps.scan.outputs.grade_label }}
+  max_severity:
+    description: "The most severe finding in the scan result, or none"
+    value: ${{ steps.scan.outputs.max_severity }}
+  findings_total:
+    description: "The total number of findings across all severities"
+    value: ${{ steps.scan.outputs.findings_total }}
+  report_path:
+    description: "The path to the rendered report file, if output was requested"
+    value: ${{ steps.scan.outputs.report_path }}
+  registry_payload_path:
+    description: "The path to the machine-readable Codex ecosystem payload file, if requested"
+    value: ${{ steps.scan.outputs.registry_payload_path }}
   submission_eligible:
     description: "Whether the plugin met the submission threshold and passed the configured severity gate"
     value: ${{ steps.scan.outputs.submission_eligible }}
@@ -104,7 +127,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
       with:
         python-version: "3.12"
 
@@ -136,6 +159,8 @@ runs:
         PLUGIN_DIR: ${{ inputs.plugin_dir }}
         FORMAT: ${{ inputs.format }}
         OUTPUT: ${{ inputs.output }}
+        WRITE_STEP_SUMMARY: ${{ inputs.write_step_summary }}
+        REGISTRY_PAYLOAD_OUTPUT: ${{ inputs.registry_payload_output }}
         MIN_SCORE: ${{ inputs.min_score }}
         FAIL_ON: ${{ inputs.fail_on_severity }}
         CISCO_SCAN: ${{ inputs.cisco_skill_scan }}
@@ -150,5 +175,6 @@ runs:
         SUBMISSION_PLUGIN_URL: ${{ inputs.submission_plugin_url }}
         SUBMISSION_PLUGIN_DESCRIPTION: ${{ inputs.submission_plugin_description }}
         SUBMISSION_AUTHOR: ${{ inputs.submission_author }}
+        GITHUB_STEP_SUMMARY: ${{ env.GITHUB_STEP_SUMMARY }}
       run: |
         python3 -m codex_plugin_scanner.action_runner

--- a/src/codex_plugin_scanner/action_runner.py
+++ b/src/codex_plugin_scanner/action_runner.py
@@ -2,16 +2,18 @@
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 from pathlib import Path
 
 from . import __version__
 from .cli import format_text
-from .models import ScanOptions
+from .models import GRADE_LABELS, ScanOptions, ScanResult, Severity, max_severity
 from .reporting import format_json, format_markdown, format_sarif, should_fail_for_severity
 from .scanner import scan_plugin
 from .submission import (
+    SubmissionIssue,
     build_submission_issue_body,
     build_submission_issue_title,
     build_submission_payload,
@@ -35,10 +37,46 @@ def _write_outputs(path: str, values: dict[str, str]) -> None:
             handle.write(f"{key}={value}\n")
 
 
+def _write_step_summary(path: str, lines: tuple[str, ...]) -> None:
+    with Path(path).open("a", encoding="utf-8") as handle:
+        handle.write("\n".join(lines))
+        handle.write("\n")
+
+
+def _build_step_summary_lines(
+    *,
+    result: ScanResult,
+    highest_severity: Severity | None,
+    report_path: str,
+    registry_payload_path: str,
+    submission_issues: list[SubmissionIssue],
+    submission_eligible: bool,
+) -> tuple[str, ...]:
+    lines = [
+        "## HOL Codex Plugin Scanner",
+        "",
+        f"- Score: {result.score}/100",
+        f"- Grade: {result.grade} - {GRADE_LABELS.get(result.grade, 'Unknown')}",
+        f"- Max severity: {(highest_severity.value if highest_severity else 'none')}",
+        f"- Findings: {sum(result.severity_counts.values())}",
+        f"- Submission eligible: {'yes' if submission_eligible else 'no'}",
+    ]
+    if report_path:
+        lines.append(f"- Report: `{report_path}`")
+    if registry_payload_path:
+        lines.append(f"- Registry payload: `{registry_payload_path}`")
+    if submission_issues:
+        issue_urls = ", ".join(issue.url for issue in submission_issues)
+        lines.append(f"- Submission issues: {issue_urls}")
+    return tuple(lines)
+
+
 def main() -> int:
     plugin_dir = os.environ["PLUGIN_DIR"]
     output_format = os.environ["FORMAT"]
     output_path = os.environ["OUTPUT"]
+    write_step_summary = _read_bool_env("WRITE_STEP_SUMMARY")
+    registry_payload_output = os.environ["REGISTRY_PAYLOAD_OUTPUT"]
     min_score = int(os.environ["MIN_SCORE"])
     fail_on = os.environ["FAIL_ON"]
     cisco_scan = os.environ["CISCO_SCAN"]
@@ -87,18 +125,19 @@ def main() -> int:
     else:
         print(rendered)
 
+    highest_severity = max_severity(result.findings)
     severity_failed = should_fail_for_severity(result, fail_on)
     submission_eligible = submission_enabled and result.score >= submission_threshold and not severity_failed
     submission_issues = []
+    registry_payload = None
+    metadata = None
+    report_path_value = ""
+    registry_payload_path_value = ""
 
-    if submission_eligible:
-        if not submission_repos:
-            print("Submission is enabled but no submission repositories were configured.", file=sys.stderr)
-            return 1
-        if not submission_token:
-            print("Submission is enabled but no submission token was provided.", file=sys.stderr)
-            return 1
+    if output_path:
+        report_path_value = str(Path(output_path))
 
+    if submission_enabled or registry_payload_output:
         metadata = resolve_submission_metadata(
             Path(plugin_dir).resolve(),
             result,
@@ -110,11 +149,7 @@ def main() -> int:
             github_repository=github_repository or None,
             github_server_url=github_server_url,
         )
-        if not metadata.plugin_url:
-            print("Submission metadata is missing a plugin repository URL.", file=sys.stderr)
-            return 1
-
-        payload = build_submission_payload(
+        registry_payload = build_submission_payload(
             metadata,
             result,
             source_repository=github_repository,
@@ -122,11 +157,32 @@ def main() -> int:
             workflow_url=workflow_url,
             scanner_version=__version__,
         )
+        if registry_payload_output:
+            registry_payload_path = Path(registry_payload_output)
+            registry_payload_path.write_text(
+                json.dumps(registry_payload, indent=2),
+                encoding="utf-8",
+            )
+            registry_payload_path_value = str(registry_payload_path)
+
+    if submission_eligible:
+        if not submission_repos:
+            print("Submission is enabled but no submission repositories were configured.", file=sys.stderr)
+            return 1
+        if not submission_token:
+            print("Submission is enabled but no submission token was provided.", file=sys.stderr)
+            return 1
+        if metadata is None or registry_payload is None:
+            print("Submission metadata could not be resolved.", file=sys.stderr)
+            return 1
+        if not metadata.plugin_url:
+            print("Submission metadata is missing a plugin repository URL.", file=sys.stderr)
+            return 1
         title = build_submission_issue_title(metadata)
         body = build_submission_issue_body(
             metadata,
             result,
-            payload=payload,
+            payload=registry_payload,
             workflow_url=workflow_url,
         )
 
@@ -151,6 +207,20 @@ def main() -> int:
                 )
             )
 
+    step_summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "")
+    if write_step_summary and step_summary_path:
+        _write_step_summary(
+            step_summary_path,
+            _build_step_summary_lines(
+                result=result,
+                highest_severity=highest_severity,
+                report_path=report_path_value,
+                registry_payload_path=registry_payload_path_value,
+                submission_issues=submission_issues,
+                submission_eligible=submission_eligible,
+            ),
+        )
+
     github_output = os.environ.get("GITHUB_OUTPUT")
     if github_output:
         _write_outputs(
@@ -158,6 +228,11 @@ def main() -> int:
             {
                 "score": str(result.score),
                 "grade": result.grade,
+                "grade_label": GRADE_LABELS.get(result.grade, "Unknown"),
+                "max_severity": highest_severity.value if highest_severity else "none",
+                "findings_total": str(sum(result.severity_counts.values())),
+                "report_path": report_path_value,
+                "registry_payload_path": registry_payload_path_value,
                 "submission_eligible": "true" if submission_eligible else "false",
                 "submission_performed": "true" if submission_issues else "false",
                 "submission_issue_urls": ",".join(issue.url for issue in submission_issues),

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -12,18 +12,31 @@ def test_action_metadata_includes_marketplace_branding_and_fallback_install() ->
     assert "branding:" in action_text
     assert 'icon: "check-circle"' in action_text
     assert 'color: "blue"' in action_text
-    assert "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065" in action_text
+    assert "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405" in action_text
     assert "pip install codex-plugin-scanner" in action_text
     assert 'pip install "$LOCAL_SOURCE"' in action_text
+    assert "write_step_summary:" in action_text
+    assert "registry_payload_output:" in action_text
     assert "submission_enabled:" in action_text
+    assert "grade_label:" in action_text
+    assert "max_severity:" in action_text
+    assert "findings_total:" in action_text
+    assert "report_path:" in action_text
+    assert "registry_payload_path:" in action_text
     assert "submission_issue_urls:" in action_text
     assert "python3 -m codex_plugin_scanner.action_runner" in action_text
     assert "value: ${{ steps.scan.outputs.score }}" in action_text
     assert "value: ${{ steps.scan.outputs.grade }}" in action_text
+    assert "value: ${{ steps.scan.outputs.grade_label }}" in action_text
+    assert "value: ${{ steps.scan.outputs.max_severity }}" in action_text
+    assert "value: ${{ steps.scan.outputs.findings_total }}" in action_text
+    assert "value: ${{ steps.scan.outputs.report_path }}" in action_text
+    assert "value: ${{ steps.scan.outputs.registry_payload_path }}" in action_text
     assert "value: ${{ steps.scan.outputs.submission_eligible }}" in action_text
     assert "value: ${{ steps.scan.outputs.submission_performed }}" in action_text
     assert "value: ${{ steps.scan.outputs.submission_issue_urls }}" in action_text
     assert "value: ${{ steps.scan.outputs.submission_issue_numbers }}" in action_text
+    assert "GITHUB_STEP_SUMMARY" in action_text
 
 
 def test_publish_workflow_attaches_marketplace_action_bundle() -> None:
@@ -44,8 +57,10 @@ def test_publish_action_repo_workflow_syncs_action_repository() -> None:
     assert "if: secrets.ACTION_REPO_TOKEN != ''" not in workflow_text
     assert "inputs.create_repository && 'true' || 'false'" in workflow_text
     assert "SOURCE_REF" in workflow_text
+    assert "PUBLISH_IMMUTABLE_RELEASE" in workflow_text
     assert 'gh repo create "${ACTION_REPOSITORY}"' in workflow_text
     assert 'cp "${GITHUB_WORKSPACE}/action/action.yml" action.yml' in workflow_text
+    assert 'if [ "${PUBLISH_IMMUTABLE_RELEASE}" = "true" ]; then' in workflow_text
     assert "git push origin refs/tags/v1 --force" in workflow_text
     assert 'gh release create "${TAG}"' in workflow_text
     assert "Published automatically from ${SOURCE_SERVER_URL}/${SOURCE_REPOSITORY}/tree/${SOURCE_REF}" in workflow_text
@@ -58,9 +73,13 @@ def test_action_bundle_docs_live_in_action_readme() -> None:
     assert "no workflow files" in action_readme
     assert "dedicated Marketplace repository" in action_readme
     assert "Source Of Truth" in action_readme
+    assert "registry_payload_output" in action_readme
+    assert "grade_label" in action_readme
+    assert "max_severity" in action_readme
     assert "submission issue" in action_readme
     assert "awesome-codex-plugins" in action_readme
     assert "publish-action-repo.yml" in action_readme
+    assert "actions/github-script@v8" in action_readme
 
 
 def test_readme_uses_stable_apache_license_badge() -> None:

--- a/tests/test_action_runner.py
+++ b/tests/test_action_runner.py
@@ -29,6 +29,8 @@ def test_action_runner_writes_all_outputs(monkeypatch, tmp_path, capsys) -> None
     monkeypatch.setenv("SUBMISSION_PLUGIN_URL", "")
     monkeypatch.setenv("SUBMISSION_PLUGIN_DESCRIPTION", "")
     monkeypatch.setenv("SUBMISSION_AUTHOR", "")
+    monkeypatch.setenv("WRITE_STEP_SUMMARY", "false")
+    monkeypatch.setenv("REGISTRY_PAYLOAD_OUTPUT", "")
     monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
 
     exit_code = main()
@@ -37,6 +39,11 @@ def test_action_runner_writes_all_outputs(monkeypatch, tmp_path, capsys) -> None
     output_lines = output_path.read_text(encoding="utf-8").splitlines()
     assert "score=100" in output_lines
     assert "grade=A" in output_lines
+    assert "grade_label=Excellent" in output_lines
+    assert "max_severity=none" in output_lines
+    assert "findings_total=0" in output_lines
+    assert "report_path=" in output_lines
+    assert "registry_payload_path=" in output_lines
     assert "submission_eligible=false" in output_lines
     assert "submission_performed=false" in output_lines
     assert "submission_issue_urls=" in output_lines
@@ -44,3 +51,53 @@ def test_action_runner_writes_all_outputs(monkeypatch, tmp_path, capsys) -> None
 
     stdout = capsys.readouterr().out
     assert '"score": 100' in stdout
+
+
+def test_action_runner_writes_step_summary_and_registry_payload(monkeypatch, tmp_path) -> None:
+    output_path = tmp_path / "github-output.txt"
+    report_path = tmp_path / "scan-report.json"
+    summary_path = tmp_path / "step-summary.md"
+    registry_payload_path = tmp_path / "registry-payload.json"
+
+    monkeypatch.setenv("PLUGIN_DIR", str(FIXTURES / "good-plugin"))
+    monkeypatch.setenv("FORMAT", "json")
+    monkeypatch.setenv("OUTPUT", str(report_path))
+    monkeypatch.setenv("MIN_SCORE", "0")
+    monkeypatch.setenv("FAIL_ON", "none")
+    monkeypatch.setenv("CISCO_SCAN", "off")
+    monkeypatch.setenv("CISCO_POLICY", "balanced")
+    monkeypatch.setenv("SUBMISSION_ENABLED", "false")
+    monkeypatch.setenv("SUBMISSION_SCORE_THRESHOLD", "80")
+    monkeypatch.setenv("SUBMISSION_REPOS", "hashgraph-online/awesome-codex-plugins")
+    monkeypatch.setenv("SUBMISSION_TOKEN", "")
+    monkeypatch.setenv("SUBMISSION_LABELS", "plugin-submission")
+    monkeypatch.setenv("SUBMISSION_CATEGORY", "Community Plugins")
+    monkeypatch.setenv("SUBMISSION_PLUGIN_NAME", "")
+    monkeypatch.setenv("SUBMISSION_PLUGIN_URL", "")
+    monkeypatch.setenv("SUBMISSION_PLUGIN_DESCRIPTION", "")
+    monkeypatch.setenv("SUBMISSION_AUTHOR", "")
+    monkeypatch.setenv("WRITE_STEP_SUMMARY", "true")
+    monkeypatch.setenv("REGISTRY_PAYLOAD_OUTPUT", str(registry_payload_path))
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_path))
+    monkeypatch.setenv("GITHUB_REPOSITORY", "hashgraph-online/example-good-plugin")
+    monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.com")
+    monkeypatch.setenv("GITHUB_SHA", "abc123")
+    monkeypatch.setenv("GITHUB_RUN_ID", "77")
+
+    exit_code = main()
+
+    assert exit_code == 0
+    output_lines = output_path.read_text(encoding="utf-8").splitlines()
+    assert f"report_path={report_path}" in output_lines
+    assert f"registry_payload_path={registry_payload_path}" in output_lines
+
+    payload_text = registry_payload_path.read_text(encoding="utf-8")
+    assert '"pluginName": "Example Good Plugin"' in payload_text
+    assert '"sourceRepository": "hashgraph-online/example-good-plugin"' in payload_text
+
+    summary_text = summary_path.read_text(encoding="utf-8")
+    assert "## HOL Codex Plugin Scanner" in summary_text
+    assert "- Score: 100/100" in summary_text
+    assert "- Grade: A - Excellent" in summary_text
+    assert f"- Registry payload: `{registry_payload_path}`" in summary_text


### PR DESCRIPTION
## Summary
- update the composite action to the Node 24-safe setup-python v6 runtime
- add richer action outputs, job summaries, and registry-payload export for Codex ecosystem automation
- make manual action-repo publication update v1 safely without rewriting immutable release tags

## Verification
- ./.venv/bin/ruff check src tests
- ./.venv/bin/ruff format --check src tests
- ./.venv/bin/python -m pytest -q
- ./.venv/bin/python -m build
- yq '.' .github/workflows/publish-action-repo.yml >/dev/null
- yq '.' action/action.yml >/dev/null