### PR TITLE
Allow publishing to TestPyPI on push to main in CI workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -122,7 +122,7 @@ jobs:
 
   publish-testpypi:
     name: Publish to TestPyPI
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'testpypi'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'testpypi')
     needs: build
     runs-on: ubuntu-latest
     environment: testpypi
@@ -192,6 +192,7 @@ pip install codex-plugin-scanner==${VERSION}
 
 **Full Changelog**: ${COMPARE_URL}
 EOF
+
 
           echo "notes_path=release-notes.md" >> "$GITHUB_OUTPUT"
       - name: Build GitHub Action bundle


### PR DESCRIPTION
### Motivation
- Enable automated publishing to TestPyPI on direct `push` to the `main` branch in addition to manual `workflow_dispatch` runs with `publish_target == 'testpypi'`.

### Description
- Update the `publish-testpypi` job condition in `.github/workflows/publish.yml` to `if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'testpypi')` and apply a small whitespace adjustment around the release-notes output.

### Testing
- No automated tests were run as part of this change; the modification is limited to the CI workflow file and will be validated by GitHub Actions on the next run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd0c5aa3ec832d8af4eb008767f7ed)