### PR TITLE
fix: publish to PyPI and create release on every main push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,24 +71,6 @@ jobs:
           name: distributions
           path: dist/
 
-  publish-canary:
-    name: Publish Canary to TestPyPI
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: build
-    runs-on: ubuntu-latest
-    environment: testpypi
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: distributions
-          path: dist/
-      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
-
   publish-testpypi:
     name: Publish to TestPyPI (Manual)
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'testpypi'
@@ -109,7 +91,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'pypi')
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'pypi')
     needs: build
     runs-on: ubuntu-latest
     environment: pypi
@@ -126,7 +108,7 @@ jobs:
 
   release:
     name: Create GitHub Release
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     needs: [build, publish-pypi]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Publish-pypi and release jobs now run on main pushes too, not just tags. Removes the separate canary job since publish-pypi handles it.