### PR TITLE
fix: use .post instead of .dev for stable versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
           elif [ "$GITHUB_REF" = "refs/heads/main" ]; then
-            VERSION="${BASE_VERSION}.dev${GITHUB_RUN_NUMBER}"
+            VERSION="${BASE_VERSION}.post${GITHUB_RUN_NUMBER}"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Computed version: $VERSION"


### PR DESCRIPTION
.dev = pre-release (hidden by pip, not shown as latest on GitHub). .post = stable post-release per PEP 440 (visible everywhere).