### PR TITLE
fix: publish version from pyproject.toml directly, no suffix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,8 +50,6 @@ jobs:
           VERSION="$BASE_VERSION"
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
-          elif [ "$GITHUB_REF" = "refs/heads/main" ]; then
-            VERSION="${BASE_VERSION}.post${GITHUB_RUN_NUMBER}"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Computed version: $VERSION"


### PR DESCRIPTION
Strips the .post suffix. Publishes the exact version in pyproject.toml (currently 1.3.0) to PyPI. skip-existing handles re-pushes. Tags override with their version.