### PR TITLE
chore: bump version to 1.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "codex-plugin-scanner"
-version = "1.3.0"
+version = "1.4.0"
 description = "Security, operational-security, and publishability scanner for Codex plugins with Cisco-backed skill analysis."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/codex_plugin_scanner/version.py
+++ b/src/codex_plugin_scanner/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for tool version."""
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"


### PR DESCRIPTION
Bumps to 1.4.0 to clear past the stale .post/.dev versions on PyPI.