### PR TITLE
fix: refresh PyPI version references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HOL Codex Plugin Scanner
 
-[![PyPI Version](https://img.shields.io/pypi/v/codex-plugin-scanner?logo=pypi&logoColor=white)](https://pypi.org/project/codex-plugin-scanner/)
+[![PyPI Version](https://img.shields.io/pypi/v/codex-plugin-scanner.svg?logo=pypi&logoColor=white&cacheSeconds=300)](https://pypi.org/project/codex-plugin-scanner/)
 [![Python Versions](https://img.shields.io/pypi/pyversions/codex-plugin-scanner)](https://pypi.org/project/codex-plugin-scanner/)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/codex-plugin-scanner)](https://pypistats.org/packages/codex-plugin-scanner)
 [![CI](https://github.com/hashgraph-online/codex-plugin-scanner/actions/workflows/ci.yml/badge.svg)](https://github.com/hashgraph-online/codex-plugin-scanner/actions/workflows/ci.yml)
@@ -268,7 +268,7 @@ When a tagged release is published, [publish-action-repo.yml](./.github/workflow
 
 - create the dedicated action repository if it does not already exist
 - sync the root-ready `action.yml`, `README.md`, `LICENSE`, and `SECURITY.md`
-- push the immutable release tag such as `v1.2.0`
+- push the immutable release tag such as `v1.4.0`
 - move the floating `v1` tag
 - create or update the corresponding release in the action repository
 
@@ -468,4 +468,3 @@ Plugins that pass the scanner with a high score are candidates for listing in th
 ## License
 
 Apache-2.0
-

--- a/action/README.md
+++ b/action/README.md
@@ -179,7 +179,7 @@ Use a fine-grained token with `issues:write` on `hashgraph-online/awesome-codex-
 
 ## Release Management
 
-- Publish immutable releases such as `v1.2.0`.
+- Publish immutable releases such as `v1.4.0`.
 - Move the floating major tag `v1` to the latest compatible release.
 - Keep this action in its own public repository for GitHub Marketplace publication.
 - Configure `ACTION_REPO_TOKEN` in the source repository so `publish-action-repo.yml` can sync this root-ready bundle automatically.

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -64,7 +64,7 @@ def test_submission_payload_and_issue_body_include_registry_data() -> None:
         source_repository="hashgraph-online/example-good-plugin",
         source_sha="abc123",
         workflow_url="https://github.com/hashgraph-online/example-good-plugin/actions/runs/1",
-        scanner_version="1.2.0",
+        scanner_version="1.4.0",
     )
     body = build_submission_issue_body(
         metadata,


### PR DESCRIPTION
## Summary
- cache-bust the PyPI version badge so GitHub fetches the current Shields response
- update stale 1.2.0 README/action release examples to 1.4.0
- align the submission helper test fixture with the current scanner release version

## Verification
- `gh api https://pypi.org/pypi/codex-plugin-scanner/json --jq .info.version` -> `1.4.0`
- `gh api https://img.shields.io/pypi/v/codex-plugin-scanner.svg?logo=pypi&logoColor=white&cacheSeconds=300` returns an SVG with `aria-label="pypi: v1.4.0"`
- `/Users/michaelkantor/CascadeProjects/codex-plugin-scanner/.venv/bin/python -c import sys, pytest; sys.path.insert(0, "src"); raise SystemExit(pytest.main(["tests/test_submission.py", "-q"]))`
