### PR TITLE
fix: fetch tags before auto-versioning releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,8 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"


### PR DESCRIPTION
## Summary
- fetch tags in the publish build job so auto-versioning can see the latest release tag on main pushes
- preserve the existing tag-based release behavior

## Verification
- yq '.' .github/workflows/publish.yml >/dev/null
- verified build checkout now uses fetch-depth: 0 before computing the next version
