### PR TITLE
fix: restore publishable cisco extra metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Cisco-backed skill scanning is optional:
 pip install "codex-plugin-scanner[cisco]"
 ```
 
-The `cisco` extra is pinned to a patched `hashgraph-online/skill-scanner` fork while the upstream Cisco release still carries a vulnerable LiteLLM pin.
+The `cisco` extra installs the published `cisco-ai-skill-scanner` package from PyPI so the scanner remains publishable on PyPI and the optional Cisco analysis path works with standard package metadata.
 
 You can also run the scanner without a local install:
 

--- a/action/README.md
+++ b/action/README.md
@@ -35,7 +35,7 @@ This README is intentionally root-ready for a dedicated GitHub Marketplace actio
 | `fail_on_severity` | Fail on findings at or above this severity: `none`, `critical`, `high`, `medium`, `low`, `info` | `none` |
 | `cisco_skill_scan` | Cisco skill-scanner mode: `auto`, `on`, `off` | `auto` |
 | `cisco_policy` | Cisco policy preset: `permissive`, `balanced`, `strict` | `balanced` |
-| `install_cisco` | Install the Cisco skill-scanner dependency from the pinned patched fork used by this repo | `false` |
+| `install_cisco` | Install the published Cisco skill-scanner dependency used by this repo | `false` |
 | `submission_enabled` | Open submission issues for awesome-list and registry automation when the plugin clears the submission threshold | `false` |
 | `submission_score_threshold` | Minimum score required before a submission issue is created | `80` |
 | `submission_repos` | Comma-separated GitHub repositories that should receive the submission issue | `hashgraph-online/awesome-codex-plugins` |
@@ -115,7 +115,7 @@ jobs:
     cisco_policy: strict
     install_cisco: true
 ```
-The action installs the Cisco scanner from the same pinned patched fork used in the main scanner repo until upstream publishes a fixed LiteLLM dependency.
+The action installs the published `cisco-ai-skill-scanner` package from PyPI so the optional Cisco analysis path works without introducing direct URL dependency metadata into the main scanner package.
 
 ### Export registry payload for Codex ecosystem automation
 

--- a/action/README.md
+++ b/action/README.md
@@ -35,7 +35,7 @@ This README is intentionally root-ready for a dedicated GitHub Marketplace actio
 | `fail_on_severity` | Fail on findings at or above this severity: `none`, `critical`, `high`, `medium`, `low`, `info` | `none` |
 | `cisco_skill_scan` | Cisco skill-scanner mode: `auto`, `on`, `off` | `auto` |
 | `cisco_policy` | Cisco policy preset: `permissive`, `balanced`, `strict` | `balanced` |
-| `install_cisco` | Install the published Cisco skill-scanner dependency used by this repo | `false` |
+| `install_cisco` | Install the scanner with its `cisco` extra enabled | `false` |
 | `submission_enabled` | Open submission issues for awesome-list and registry automation when the plugin clears the submission threshold | `false` |
 | `submission_score_threshold` | Minimum score required before a submission issue is created | `80` |
 | `submission_repos` | Comma-separated GitHub repositories that should receive the submission issue | `hashgraph-online/awesome-codex-plugins` |
@@ -115,7 +115,7 @@ jobs:
     cisco_policy: strict
     install_cisco: true
 ```
-The action installs the published `cisco-ai-skill-scanner` package from PyPI so the optional Cisco analysis path works without introducing direct URL dependency metadata into the main scanner package.
+The action installs the scanner with its published `cisco` extra enabled, so the optional Cisco analysis path stays aligned with the dependency declared in `pyproject.toml`.
 
 ### Export registry payload for Codex ecosystem automation
 

--- a/action/action.yml
+++ b/action/action.yml
@@ -177,13 +177,17 @@ runs:
         done
 
         if [ -n "$LOCAL_SOURCE" ]; then
-          pip install "$LOCAL_SOURCE"
+          if [ "${{ inputs.install_cisco }}" = "true" ]; then
+            pip install "$LOCAL_SOURCE[cisco]"
+          else
+            pip install "$LOCAL_SOURCE"
+          fi
         else
-          pip install codex-plugin-scanner
-        fi
-
-        if [ "${{ inputs.install_cisco }}" = "true" ]; then
-          pip install "cisco-ai-skill-scanner==2.0.7"
+          if [ "${{ inputs.install_cisco }}" = "true" ]; then
+            pip install "codex-plugin-scanner[cisco]"
+          else
+            pip install codex-plugin-scanner
+          fi
         fi
 
     - name: Run scanner

--- a/action/action.yml
+++ b/action/action.yml
@@ -68,7 +68,7 @@ inputs:
     required: false
     default: "balanced"
   install_cisco:
-    description: "Install the Cisco skill-scanner dependency from the pinned patched fork used by this repo"
+    description: "Install the published Cisco skill-scanner dependency used by this repo"
     required: false
     default: "false"
   submission_enabled:
@@ -183,8 +183,7 @@ runs:
         fi
 
         if [ "${{ inputs.install_cisco }}" = "true" ]; then
-          # Temporary fork pin until upstream cisco-ai-skill-scanner ships a LiteLLM fix.
-          pip install "cisco-ai-skill-scanner @ git+https://github.com/hashgraph-online/skill-scanner.git@9b0ea08111f9129abfdf7aedc47322615cda1164"
+          pip install "cisco-ai-skill-scanner==2.0.7"
         fi
 
     - name: Run scanner

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,7 @@ dependencies = [
 
 [project.optional-dependencies]
 cisco = [
-    # Temporary fork pin until upstream cisco-ai-skill-scanner ships a LiteLLM fix.
-    "cisco-ai-skill-scanner @ git+https://github.com/hashgraph-online/skill-scanner.git@9b0ea08111f9129abfdf7aedc47322615cda1164",
+    "cisco-ai-skill-scanner==2.0.7",
 ]
 dev = [
     "build>=1.2.2",
@@ -55,9 +54,6 @@ codex-plugin-scanner = "codex_plugin_scanner.cli:main"
 Homepage = "https://github.com/hashgraph-online/codex-plugin-scanner"
 Repository = "https://github.com/hashgraph-online/codex-plugin-scanner"
 Issues = "https://github.com/hashgraph-online/codex-plugin-scanner/issues"
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.ruff]
 target-version = "py310"

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -15,11 +15,7 @@ def test_action_metadata_includes_marketplace_branding_and_fallback_install() ->
     assert "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405" in action_text
     assert "pip install codex-plugin-scanner" in action_text
     assert 'pip install "$LOCAL_SOURCE"' in action_text
-    assert (
-        'pip install "cisco-ai-skill-scanner @ '
-        'git+https://github.com/hashgraph-online/skill-scanner.git@9b0ea08111f9129abfdf7aedc47322615cda1164"'
-        in action_text
-    )
+    assert 'pip install "cisco-ai-skill-scanner==2.0.7"' in action_text
     assert "write_step_summary:" in action_text
     assert "profile:" in action_text
     assert "config:" in action_text
@@ -108,7 +104,7 @@ def test_action_bundle_docs_live_in_action_readme() -> None:
     assert "awesome-codex-plugins" in action_readme
     assert "publish-action-repo.yml" in action_readme
     assert "actions/github-script@v8" in action_readme
-    assert "pinned patched fork" in action_readme
+    assert "published `cisco-ai-skill-scanner` package from PyPI" in action_readme
 
 
 def test_readme_uses_stable_apache_license_badge() -> None:

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -15,7 +15,8 @@ def test_action_metadata_includes_marketplace_branding_and_fallback_install() ->
     assert "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405" in action_text
     assert "pip install codex-plugin-scanner" in action_text
     assert 'pip install "$LOCAL_SOURCE"' in action_text
-    assert 'pip install "cisco-ai-skill-scanner==2.0.7"' in action_text
+    assert 'pip install "$LOCAL_SOURCE[cisco]"' in action_text
+    assert 'pip install "codex-plugin-scanner[cisco]"' in action_text
     assert "write_step_summary:" in action_text
     assert "profile:" in action_text
     assert "config:" in action_text
@@ -104,7 +105,7 @@ def test_action_bundle_docs_live_in_action_readme() -> None:
     assert "awesome-codex-plugins" in action_readme
     assert "publish-action-repo.yml" in action_readme
     assert "actions/github-script@v8" in action_readme
-    assert "published `cisco-ai-skill-scanner` package from PyPI" in action_readme
+    assert "scanner with its published `cisco` extra enabled" in action_readme
 
 
 def test_readme_uses_stable_apache_license_badge() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -446,8 +446,8 @@ wheels = [
 
 [[package]]
 name = "cisco-ai-skill-scanner"
-version = "2.0.8.dev6+g9b0ea0811"
-source = { git = "https://github.com/hashgraph-online/skill-scanner.git?rev=9b0ea08111f9129abfdf7aedc47322615cda1164#9b0ea08111f9129abfdf7aedc47322615cda1164" }
+version = "2.0.7"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
     { name = "click" },
@@ -469,6 +469,10 @@ dependencies = [
     { name = "textual" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "yara-x" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/3e/ce1a686422b56fd2b83e68b0494b1fbdf970d41785c8f0037fbc3530c035/cisco_ai_skill_scanner-2.0.7.tar.gz", hash = "sha256:a4b57e01f6c46361babd9893b77ecd20953a91e387bf38e92429bf32b95291ab", size = 929702, upload-time = "2026-04-02T13:45:45.403Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/af/237ab39f48e67d91f3577b18bc35a769e7ded8d6256e655867963c53c1fb/cisco_ai_skill_scanner-2.0.7-py3-none-any.whl", hash = "sha256:89ceaa9fabb55c4c6c01f5a4b05541a74e0958688021de16cf738f696d7e6f6f", size = 430077, upload-time = "2026-04-02T13:45:43.567Z" },
 ]
 
 [[package]]
@@ -511,7 +515,7 @@ publish = [
 [package.metadata]
 requires-dist = [
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2.2" },
-    { name = "cisco-ai-skill-scanner", marker = "extra == 'cisco'", git = "https://github.com/hashgraph-online/skill-scanner.git?rev=9b0ea08111f9129abfdf7aedc47322615cda1164" },
+    { name = "cisco-ai-skill-scanner", marker = "extra == 'cisco'", specifier = "==2.0.7" },
     { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.23.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
@@ -1412,7 +1416,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.83.0"
+version = "1.82.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1428,9 +1432,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/92/6ce9737554994ca8e536e5f4f6a87cc7c4774b656c9eb9add071caf7d54b/litellm-1.83.0.tar.gz", hash = "sha256:860bebc76c4bb27b4cf90b4a77acd66dba25aced37e3db98750de8a1766bfb7a", size = 17333062, upload-time = "2026-03-31T05:08:25.331Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/00/13993312e6d2fb29cd6d5ffceb293455ef747fe5675eaa9aa49b09184656/litellm-1.82.3.tar.gz", hash = "sha256:7215b95e7cc38a52b5ae778d67e8829dec86594c8b05d8431294e95c7d59937c", size = 17368754, upload-time = "2026-03-16T21:51:30.356Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/2c/a670cc050fcd6f45c6199eb99e259c73aea92edba8d5c2fc1b3686d36217/litellm-1.83.0-py3-none-any.whl", hash = "sha256:88c536d339248f3987571493015784671ba3f193a328e1ea6780dbebaa2094a8", size = 15610306, upload-time = "2026-03-31T05:08:21.987Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/3a/590d58dee65a238f7f3d5c37f8f9f9021ecaf27fe379a393b4259324b56e/litellm-1.82.3-py3-none-any.whl", hash = "sha256:609901f6c5a5cf8c24386e4e3f50738bb8a9db719709fd76b208c8ee6d00f7a7", size = 15551034, upload-time = "2026-03-16T21:51:26.747Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- replace the Cisco extra's direct Git dependency with the published `cisco-ai-skill-scanner==2.0.7` package
- align the Marketplace action install path and docs with the publishable PyPI contract
- regenerate `uv.lock` and keep the Cisco-enabled scan path covered by the existing action-bundle regression checks

## Verification
- `uv sync --frozen --extra dev --extra cisco --group publish`
- `./.venv/bin/ruff check .`
- `./.venv/bin/pytest -q`
- `./.venv/bin/python -m build`
- `./.venv/bin/python -m twine check dist/*`
- `./.venv/bin/codex-plugin-scanner scan tests/fixtures/good-plugin --format json --cisco-skill-scan on --cisco-policy balanced`
- inspected the built wheel metadata to confirm `Requires-Dist` now contains `cisco-ai-skill-scanner==2.0.7` instead of a direct Git URL
