### PR TITLE
fix: authenticate action repo release pushes

### DIFF
--- a/.github/workflows/publish-action-repo.yml
+++ b/.github/workflows/publish-action-repo.yml
@@ -73,7 +73,7 @@ jobs:
         env:
           ACTION_REPO_TOKEN: ${{ secrets.ACTION_REPO_TOKEN }}
         run: |
-          git remote set-url origin "https://x-access-token:${ACTION_REPO_TOKEN}@github.com/${ACTION_REPOSITORY}.git"
+          git remote set-url origin "https://x-access-token:${ACTION_REPO_TOKEN}@github.com/$ACTION_REPOSITORY.git"
 
       - name: Sync root-ready action bundle
         working-directory: action-repo

--- a/.github/workflows/publish-action-repo.yml
+++ b/.github/workflows/publish-action-repo.yml
@@ -68,6 +68,13 @@ jobs:
           GH_TOKEN: ${{ secrets.ACTION_REPO_TOKEN }}
         run: gh repo clone "$ACTION_REPOSITORY" action-repo -- --depth 1
 
+      - name: Configure authenticated action repository remote
+        working-directory: action-repo
+        env:
+          ACTION_REPO_TOKEN: ${{ secrets.ACTION_REPO_TOKEN }}
+        run: |
+          git remote set-url origin "https://x-access-token:${ACTION_REPO_TOKEN}@github.com/${ACTION_REPOSITORY}.git"
+
       - name: Sync root-ready action bundle
         working-directory: action-repo
         run: |

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -81,6 +81,7 @@ def test_publish_action_repo_workflow_syncs_action_repository() -> None:
     assert 'git status --short -- action.yml README.md LICENSE SECURITY.md CONTRIBUTING.md' in workflow_text
     assert "SOURCE_REF" in workflow_text
     assert 'gh repo clone "$ACTION_REPOSITORY" action-repo -- --depth 1' in workflow_text
+    assert 'git remote set-url origin "https://x-access-token:${ACTION_REPO_TOKEN}@github.com/${ACTION_REPOSITORY}.git"' in workflow_text
     assert 'cp "${GITHUB_WORKSPACE}/action/action.yml" action.yml' in workflow_text
     assert 'git push origin HEAD:main' in workflow_text
     assert 'gh release view "${TAG}" --repo "$ACTION_REPOSITORY"' in workflow_text

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -81,7 +81,7 @@ def test_publish_action_repo_workflow_syncs_action_repository() -> None:
     assert 'git status --short -- action.yml README.md LICENSE SECURITY.md CONTRIBUTING.md' in workflow_text
     assert "SOURCE_REF" in workflow_text
     assert 'gh repo clone "$ACTION_REPOSITORY" action-repo -- --depth 1' in workflow_text
-    assert 'git remote set-url origin "https://x-access-token:${ACTION_REPO_TOKEN}@github.com/${ACTION_REPOSITORY}.git"' in workflow_text
+    assert 'git remote set-url origin "https://x-access-token:${ACTION_REPO_TOKEN}@github.com/$ACTION_REPOSITORY.git"' in workflow_text
     assert 'cp "${GITHUB_WORKSPACE}/action/action.yml" action.yml' in workflow_text
     assert 'git push origin HEAD:main' in workflow_text
     assert 'gh release view "${TAG}" --repo "$ACTION_REPOSITORY"' in workflow_text


### PR DESCRIPTION
## Summary
- configure the cloned action repository remote with ACTION_REPO_TOKEN before raw git pushes
- keep the release-sync workflow behavior unchanged otherwise
- add a focused regression assertion so the publish workflow keeps authenticated push configuration

## Root cause
The Publish GitHub Action Repository workflow cloned the action repo through `gh repo clone`, but later used raw `git push` and tag pushes against an unauthenticated HTTPS remote. That made the main-branch workflow fail with `fatal: could not read Username for https://github.com`.

## Verification
- `/Users/michaelkantor/CascadeProjects/codex-plugin-scanner/.venv/bin/pytest tests/test_action_bundle.py -q`
- `yq . .github/workflows/publish-action-repo.yml >/dev/null`