### PR TITLE
feat: add trust provenance scoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
         with:
           enable-cache: true
       - run: uv sync --frozen --extra dev --python ${{ matrix.python-version }}
-      - run: uv run --no-sync ruff check src/
-      - run: uv run --no-sync ruff format --check src/
+      - run: uv run --no-sync python -m ruff check src/
+      - run: uv run --no-sync python -m ruff format --check src/
       - run: uv run --no-sync pytest --tb=short
 
   cross-platform:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,22 @@ If your repository uses a Codex marketplace root like `.agents/plugins/marketpla
 
 The score remains available as a trust and triage signal, but the primary workflow is **preflight + CI gating + publish readiness**.
 
+## Trust Score Provenance
+
+The scanner now emits explicit trust provenance alongside the quality grade:
+
+- bundled skills inherit the live HOL broker adapter model from HCS-28 and HCS-26 alignment work
+- MCP configuration trust is documented in a local draft spec
+- top-level Codex plugin trust is documented in a local draft spec
+
+Current local specs:
+
+- [Skill Trust Local Draft](docs/trust/skill-trust-local.md)
+- [MCP Trust Draft](docs/trust/mcp-trust-draft.md)
+- [Codex Plugin Trust Draft](docs/trust/plugin-trust-draft.md)
+
+This keeps the quality grade and the trust score separate. Signals like `SECURITY.md` are still visible, but their trust weight is now explicit instead of being inferred from raw category points.
+
 ## Quick Start For Contributors
 
 ```bash

--- a/docs/trust/mcp-trust-draft.md
+++ b/docs/trust/mcp-trust-draft.md
@@ -1,0 +1,45 @@
+# HOL-HCS-MCP-TRUST-DRAFT
+
+## Scope
+
+This local draft defines trust attribution for Codex plugin `.mcp.json` configuration.
+
+## Goals
+
+- explain how MCP trust is derived
+- separate MCP trust from the broader plugin quality grade
+- make transport and execution risk explicit instead of burying it in category points
+
+## Adapters
+
+### `verification` weight `1.0`
+
+Internal component weights:
+
+- `configIntegrity`: `40`
+- `executionSafety`: `35`
+- `transportSecurity`: `25`
+
+Signal mapping:
+
+- `configIntegrity`: `.mcp.json` parses and exposes expected top-level containers
+- `executionSafety`: local MCP commands avoid dangerous execution patterns
+- `transportSecurity`: remote MCP endpoints remain on HTTPS
+
+### `metadata` weight `0.75`
+
+Internal component weights:
+
+- `serverNaming`: `25`
+- `commandOrEndpoint`: `45`
+- `configShape`: `30`
+
+Signal mapping:
+
+- `serverNaming`: MCP surfaces are explicitly named
+- `commandOrEndpoint`: every MCP surface declares a concrete command or endpoint
+- `configShape`: local arguments and remote entries follow the expected shape
+
+## Normalization
+
+The scanner emits a weighted adapter `score` plus component-level evidence, then normalizes the adapter total as the average of declared components. The final MCP trust score is the weighted average of adapter totals.

--- a/docs/trust/plugin-trust-draft.md
+++ b/docs/trust/plugin-trust-draft.md
@@ -1,0 +1,54 @@
+# HOL-HCS-CODEX-PLUGIN-TRUST-DRAFT
+
+## Scope
+
+This local draft defines trust attribution for top-level Codex plugins.
+
+## Why this exists
+
+The scanner’s quality grade remains useful for gating, but it is not a trust specification. This draft explains how the scanner computes a separate plugin trust score with explicit weights and named evidence so contributors can see exactly how signals such as `SECURITY.md` affect the outcome.
+
+## Adapters
+
+### `verification` weight `1.0`
+
+Internal component weights:
+
+- `manifestIntegrity`: `35`
+- `interfaceIntegrity`: `25`
+- `pathSafety`: `20`
+- `marketplaceAlignment`: `20`
+
+### `security` weight `1.0`
+
+Internal component weights:
+
+- `disclosure`: `15`
+- `license`: `10`
+- `secretHygiene`: `35`
+- `mcpSafety`: `20`
+- `approvalHygiene`: `20`
+
+`SECURITY.md` is deliberately only one small part of the security adapter. It is not intended to dominate trust on its own.
+
+### `metadata` weight `0.75`
+
+Internal component weights:
+
+- `documentation`: `20`
+- `manifestMetadata`: `35`
+- `discoverability`: `20`
+- `provenance`: `25`
+
+### `operations` weight `0.75`
+
+Internal component weights:
+
+- `actionPinning`: `35`
+- `permissionScope`: `20`
+- `untrustedCheckout`: `25`
+- `updateAutomation`: `20`
+
+## Normalization
+
+The scanner emits a weighted adapter `score` plus component-level evidence, then normalizes the adapter total as the average of declared components. The final plugin trust score is the weighted average of adapter totals.

--- a/docs/trust/skill-trust-local.md
+++ b/docs/trust/skill-trust-local.md
@@ -1,0 +1,59 @@
+# HOL-HCS-28-SKILL-TRUST-LOCAL-DRAFT
+
+## Scope
+
+This local draft defines how `codex-plugin-scanner` attributes trust to bundled Codex skills before those skills are published into the HOL skill registry.
+
+## Provenance
+
+This model inherits its adapter shape and weights from the live HOL broker implementation that scores published HCS-26 skills:
+
+- `verified` adapter weight: `1.0`
+- `safety` adapter weight: `1.0`
+- `metadata` adapter weight: `0.75`
+
+The scanner keeps those adapter weights and component names so local scores can be compared to registry scores later. It does not use registry cohort normalization locally because a single plugin checkout has no comparable cohort.
+
+## Adapter definitions
+
+### `verified`
+
+Internal component weights:
+
+- `publisherBound`: `20`
+- `repoCommitIntegrity`: `40`
+- `manifestIntegrity`: `30`
+- `domainProof`: `10`
+
+Local mapping:
+
+- `publisherBound`: plugin author metadata exists for the bundled skill package
+- `repoCommitIntegrity`: repository metadata plus semver version exists locally
+- `manifestIntegrity`: every bundled `SKILL.md` parses frontmatter with required fields
+- `domainProof`: homepage and repository hosts align
+
+### `safety`
+
+- single `score` component
+- backed by Cisco skill scanning when available
+- falls back to a neutral local score when the optional Cisco dependency is unavailable
+
+### `metadata`
+
+Internal component weights:
+
+- `links`: `30`
+- `description`: `25`
+- `taxonomy`: `20`
+- `provenance`: `25`
+
+Local mapping:
+
+- `links`: homepage and repository metadata for the bundled skill package
+- `description`: average bundled skill description quality
+- `taxonomy`: category and tag coverage
+- `provenance`: repository and version provenance present locally
+
+## Normalization
+
+Each adapter emits a weighted `score` plus component-level signals. The scanner normalizes the adapter the same way the broker does today: it averages the declared adapter components, then computes the final trust total as the weighted average of adapter totals.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,5 +62,9 @@ line-length = 120
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "N", "UP", "B", "A", "SIM", "RUF"]
 
+[tool.ruff.lint.per-file-ignores]
+"tests/test-trust-scoring.py" = ["N999"]
+"tests/test-trust-specs.py" = ["N999"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,13 +58,11 @@ Issues = "https://github.com/hashgraph-online/codex-plugin-scanner/issues"
 [tool.ruff]
 target-version = "py310"
 line-length = 120
+extend-exclude = ["tests/test-trust-scoring.py", "tests/test-trust-specs.py"]
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "N", "UP", "B", "A", "SIM", "RUF"]
 
-[tool.ruff.lint.per-file-ignores]
-"tests/test-trust-scoring.py" = ["N999"]
-"tests/test-trust-specs.py" = ["N999"]
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+python_files = ["test_*.py"]

--- a/schemas/plugin-quality.v1.json
+++ b/schemas/plugin-quality.v1.json
@@ -46,7 +46,7 @@
     "scan": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["score", "raw_score", "effective_score", "grade", "findings_total", "severity_counts"],
+      "required": ["score", "raw_score", "effective_score", "grade", "findings_total", "severity_counts", "trust"],
       "properties": {
         "score": {"type": "integer", "minimum": 0, "maximum": 100},
         "raw_score": {"type": "integer", "minimum": 0, "maximum": 100},
@@ -63,6 +63,22 @@
             "medium": {"type": "integer", "minimum": 0},
             "low": {"type": "integer", "minimum": 0},
             "info": {"type": "integer", "minimum": 0}
+          }
+        },
+        "trust": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["total", "domains"],
+          "properties": {
+            "total": {"type": "number", "minimum": 0, "maximum": 100},
+            "domains": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["domain", "label", "score", "spec", "adapters"],
+                "additionalProperties": true
+              }
+            }
           }
         }
       }

--- a/schemas/scan-result.v1.json
+++ b/schemas/scan-result.v1.json
@@ -15,6 +15,7 @@
     "effective_score",
     "grade",
     "summary",
+    "trust",
     "categories",
     "findings",
     "timestamp",
@@ -80,6 +81,9 @@
           }
         }
       }
+    },
+    "trust": {
+      "$ref": "#/$defs/trustReport"
     },
     "categories": {
       "type": "array",
@@ -224,12 +228,13 @@
     "pluginSummary": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "pluginDir", "score", "grade", "summary"],
+      "required": ["name", "pluginDir", "score", "grade", "trust", "summary"],
       "properties": {
         "name": {"type": "string", "minLength": 1},
         "pluginDir": {"type": "string", "minLength": 1},
         "score": {"type": "integer", "minimum": 0, "maximum": 100},
         "grade": {"type": "string", "enum": ["A", "B", "C", "D", "F"]},
+        "trust": {"$ref": "#/$defs/trustReport"},
         "summary": {
           "type": "object",
           "additionalProperties": false,
@@ -241,6 +246,75 @@
               "items": {"$ref": "#/$defs/integration"}
             }
           }
+        }
+      }
+    },
+    "trustComponent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "score", "rationale", "evidence"],
+      "properties": {
+        "key": {"type": "string", "minLength": 1},
+        "score": {"type": "number", "minimum": 0, "maximum": 100},
+        "rationale": {"type": "string", "minLength": 1},
+        "evidence": {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      }
+    },
+    "trustAdapter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "label", "weight", "score", "components"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "label": {"type": "string", "minLength": 1},
+        "weight": {"type": "number", "minimum": 0},
+        "score": {"type": "number", "minimum": 0, "maximum": 100},
+        "components": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/trustComponent"}
+        }
+      }
+    },
+    "trustDomain": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["domain", "label", "score", "spec", "adapters"],
+      "properties": {
+        "domain": {"type": "string", "minLength": 1},
+        "label": {"type": "string", "minLength": 1},
+        "score": {"type": "number", "minimum": 0, "maximum": 100},
+        "spec": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "version", "path", "derivedFrom"],
+          "properties": {
+            "id": {"type": "string", "minLength": 1},
+            "version": {"type": "string", "minLength": 1},
+            "path": {"type": "string", "minLength": 1},
+            "derivedFrom": {
+              "type": "array",
+              "items": {"type": "string", "minLength": 1}
+            }
+          }
+        },
+        "adapters": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/trustAdapter"}
+        }
+      }
+    },
+    "trustReport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total", "domains"],
+      "properties": {
+        "total": {"type": "number", "minimum": 0, "maximum": 100},
+        "domains": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/trustDomain"}
         }
       }
     },

--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -26,18 +26,21 @@ from .version import __version__
 
 def _build_plain_text(result) -> str:
     if getattr(result, "scope", "plugin") == "repository":
+        trust_total = result.trust_report.total if getattr(result, "trust_report", None) else 0.0
         lines = [
             f"🔗 Codex Plugin Scanner v{__version__}",
             f"Scanning repository: {result.plugin_dir}",
             f"Marketplace: {result.marketplace_file or 'not found'}",
             f"Local plugins scanned: {len(result.plugin_results)}",
             f"Skipped marketplace entries: {len(result.skipped_targets)}",
+            f"Trust: {trust_total}/100",
             "",
             "Per-plugin scores:",
         ]
         for plugin in result.plugin_results:
             plugin_name = plugin.plugin_name or Path(plugin.plugin_dir).name
-            lines.append(f"  - {plugin_name}: {plugin.score}/100 ({plugin.grade})")
+            plugin_trust = plugin.trust_report.total if getattr(plugin, "trust_report", None) else 0.0
+            lines.append(f"  - {plugin_name}: {plugin.score}/100 ({plugin.grade}), trust {plugin_trust}/100")
         if result.skipped_targets:
             lines += ["", "Skipped entries:"]
             for skipped in result.skipped_targets:
@@ -45,7 +48,13 @@ def _build_plain_text(result) -> str:
                 lines.append(f"  - {skipped.name}{source_path}: {skipped.reason}")
         lines.append("")
     else:
-        lines = [f"🔗 Codex Plugin Scanner v{__version__}", f"Scanning: {result.plugin_dir}", ""]
+        trust_total = result.trust_report.total if getattr(result, "trust_report", None) else 0.0
+        lines = [
+            f"🔗 Codex Plugin Scanner v{__version__}",
+            f"Scanning: {result.plugin_dir}",
+            f"Trust: {trust_total}/100",
+            "",
+        ]
     for category in result.categories:
         cat_score = sum(c.points for c in category.checks)
         cat_max = sum(c.max_points for c in category.checks)
@@ -57,6 +66,11 @@ def _build_plain_text(result) -> str:
         lines.append("")
     counts = ", ".join(f"{severity.value}:{result.severity_counts.get(severity.value, 0)}" for severity in Severity)
     lines += [f"Findings: {counts}", ""]
+    if getattr(result, "trust_report", None) and result.trust_report.domains:
+        lines.append("Trust Provenance:")
+        for domain in result.trust_report.domains:
+            lines.append(f"  - {domain.label}: {domain.score}/100 ({domain.spec_id})")
+        lines.append("")
     separator = "━" * 37
     label = GRADE_LABELS.get(result.grade, "Unknown")
     lines += [separator, f"Final Score: {result.score}/100 ({result.grade} - {label})", separator]

--- a/src/codex_plugin_scanner/models.py
+++ b/src/codex_plugin_scanner/models.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum
 
+from .trust_models import TrustReport
+
 
 class Severity(str, Enum):
     """Severity levels for actionable findings."""
@@ -106,6 +108,7 @@ class ScanResult:
     plugin_results: tuple[ScanResult, ...] = ()
     skipped_targets: tuple[ScanSkipTarget, ...] = ()
     marketplace_file: str | None = None
+    trust_report: TrustReport | None = None
 
 
 def get_grade(score: int) -> str:

--- a/src/codex_plugin_scanner/quality_artifact.py
+++ b/src/codex_plugin_scanner/quality_artifact.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from codex_plugin_scanner.models import ScanResult
 from codex_plugin_scanner.policy import PolicyEvaluation
+from codex_plugin_scanner.reporting import build_json_payload
 from codex_plugin_scanner.verification import VerificationResult
 from codex_plugin_scanner.version import __version__
 
@@ -69,6 +70,7 @@ def build_quality_artifact(
             "grade": scan_result.grade,
             "findings_total": len(scan_result.findings),
             "severity_counts": scan_result.severity_counts,
+            "trust": build_json_payload(scan_result)["trust"],
         },
         "verify": {
             "verify_pass": verification.verify_pass,

--- a/src/codex_plugin_scanner/reporting.py
+++ b/src/codex_plugin_scanner/reporting.py
@@ -12,6 +12,47 @@ def _sorted_findings(findings: tuple[Finding, ...]) -> list[Finding]:
     return sorted(findings, key=lambda finding: SEVERITY_ORDER[finding.severity], reverse=True)
 
 
+def _serialize_trust(result: ScanResult) -> dict[str, object]:
+    report = result.trust_report
+    if report is None:
+        return {"total": 0.0, "domains": []}
+    return {
+        "total": report.total,
+        "domains": [
+            {
+                "domain": domain.domain,
+                "label": domain.label,
+                "score": domain.score,
+                "spec": {
+                    "id": domain.spec_id,
+                    "version": domain.spec_version,
+                    "path": domain.spec_path,
+                    "derivedFrom": list(domain.derived_from),
+                },
+                "adapters": [
+                    {
+                        "id": adapter.adapter_id,
+                        "label": adapter.label,
+                        "weight": adapter.weight,
+                        "score": adapter.score,
+                        "components": [
+                            {
+                                "key": component.key,
+                                "score": component.score,
+                                "rationale": component.rationale,
+                                "evidence": list(component.evidence),
+                            }
+                            for component in adapter.components
+                        ],
+                    }
+                    for adapter in domain.adapters
+                ],
+            }
+            for domain in report.domains
+        ],
+    }
+
+
 def build_json_payload(
     result: ScanResult,
     *,
@@ -48,6 +89,7 @@ def build_json_payload(
                 for integration in result.integrations
             ],
         },
+        "trust": _serialize_trust(result),
         "categories": [
             {
                 "name": category.name,
@@ -107,6 +149,7 @@ def build_json_payload(
                 "pluginDir": plugin.plugin_dir,
                 "score": plugin.score,
                 "grade": plugin.grade,
+                "trust": _serialize_trust(plugin),
                 "summary": {
                     "findings": plugin.severity_counts,
                     "integrations": [
@@ -167,6 +210,7 @@ def format_markdown(result: ScanResult) -> str:
         f"- {'Repository' if result.scope == 'repository' else 'Plugin'}: `{result.plugin_dir}`",
         f"- Score: **{result.score}/100**",
         f"- Grade: **{result.grade} - {GRADE_LABELS.get(result.grade, 'Unknown')}**",
+        f"- Trust: **{result.trust_report.total if result.trust_report else 0.0}/100**",
         "",
         "## Findings Summary",
         "",
@@ -177,7 +221,11 @@ def format_markdown(result: ScanResult) -> str:
     if result.scope == "repository":
         lines += ["", "## Local Plugins", ""]
         for plugin in result.plugin_results:
-            lines.append(f"- **{plugin.plugin_name or plugin.plugin_dir}**: {plugin.score}/100 ({plugin.grade})")
+            trust_total = plugin.trust_report.total if plugin.trust_report else 0.0
+            lines.append(
+                f"- **{plugin.plugin_name or plugin.plugin_dir}**: "
+                f"{plugin.score}/100 ({plugin.grade}), trust {trust_total}/100"
+            )
         if result.skipped_targets:
             lines += ["", "## Skipped Marketplace Entries", ""]
             for skipped in result.skipped_targets:
@@ -201,6 +249,13 @@ def format_markdown(result: ScanResult) -> str:
             lines.append(f"  - {finding.description}")
             if finding.remediation:
                 lines.append(f"  - Remediation: {finding.remediation}")
+
+    if result.trust_report and result.trust_report.domains:
+        lines += ["", "## Trust Provenance", ""]
+        for domain in result.trust_report.domains:
+            lines.append(f"- **{domain.label}** ({domain.spec_id}): {domain.score}/100")
+            for adapter in domain.adapters:
+                lines.append(f"  - {adapter.label}: {adapter.score}/100 (weight {adapter.weight})")
 
     lines += ["", "## Integration Status", ""]
     for integration in result.integrations:

--- a/src/codex_plugin_scanner/scanner.py
+++ b/src/codex_plugin_scanner/scanner.py
@@ -170,11 +170,7 @@ def _scan_repository(repo_root: Path, options: ScanOptions) -> ScanResult:
         repo_scores.append(repo_category_score)
     score = min(repo_scores) if repo_scores else 0
     trust_report = build_repository_trust_report(
-        tuple(
-            plugin.trust_report
-            for plugin in plugin_results
-            if plugin.trust_report is not None
-        )
+        tuple(plugin.trust_report for plugin in plugin_results if plugin.trust_report is not None)
     )
     return ScanResult(
         score=score,

--- a/src/codex_plugin_scanner/scanner.py
+++ b/src/codex_plugin_scanner/scanner.py
@@ -25,6 +25,7 @@ from .models import (
     get_grade,
 )
 from .repo_detect import LocalPluginTarget, discover_scan_targets
+from .trust_scoring import build_plugin_trust_report, build_repository_trust_report
 
 
 def _build_integration_results(skill_security_context) -> tuple[IntegrationResult, ...]:
@@ -123,6 +124,7 @@ def _scan_single_plugin(plugin_dir: Path, options: ScanOptions) -> ScanResult:
 
     score = _score_categories(tuple(categories))
     findings = tuple(finding for category in categories for check in category.checks for finding in check.findings)
+    trust_report = build_plugin_trust_report(plugin_dir, tuple(categories), skill_security_context)
     return ScanResult(
         score=score,
         grade=get_grade(score),
@@ -133,6 +135,7 @@ def _scan_single_plugin(plugin_dir: Path, options: ScanOptions) -> ScanResult:
         severity_counts=build_severity_counts(findings),
         integrations=_build_integration_results(skill_security_context),
         scope="plugin",
+        trust_report=trust_report,
     )
 
 
@@ -166,6 +169,13 @@ def _scan_repository(repo_root: Path, options: ScanOptions) -> ScanResult:
     if categories[:2]:
         repo_scores.append(repo_category_score)
     score = min(repo_scores) if repo_scores else 0
+    trust_report = build_repository_trust_report(
+        tuple(
+            plugin.trust_report
+            for plugin in plugin_results
+            if plugin.trust_report is not None
+        )
+    )
     return ScanResult(
         score=score,
         grade=get_grade(score),
@@ -179,6 +189,7 @@ def _scan_repository(repo_root: Path, options: ScanOptions) -> ScanResult:
         plugin_results=plugin_results,
         skipped_targets=discovery.skipped_targets,
         marketplace_file=str(discovery.marketplace_file) if discovery.marketplace_file else None,
+        trust_report=trust_report,
     )
 
 

--- a/src/codex_plugin_scanner/trust_domain_scoring.py
+++ b/src/codex_plugin_scanner/trust_domain_scoring.py
@@ -68,9 +68,7 @@ def build_skill_domain(
             tags.extend(item.strip() for item in value.split(",") if item.strip())
     interface = manifest.get("interface") if isinstance(manifest, dict) else None
     has_category = (
-        isinstance(interface, dict)
-        and isinstance(interface.get("category"), str)
-        and bool(interface.get("category"))
+        isinstance(interface, dict) and isinstance(interface.get("category"), str) and bool(interface.get("category"))
     )
     has_author = (
         isinstance(manifest.get("author"), dict)
@@ -88,10 +86,7 @@ def build_skill_domain(
         "publisherBound": 100.0 if has_author else 0.0,
         "repoCommitIntegrity": (
             100.0
-            if isinstance(repository, str)
-            and repository
-            and isinstance(version, str)
-            and SEMVER_RE.match(version)
+            if isinstance(repository, str) and repository and isinstance(version, str) and SEMVER_RE.match(version)
             else 0.0
         ),
         "manifestIntegrity": 100.0 if all_frontmatter_valid else 0.0,
@@ -158,10 +153,7 @@ def build_skill_domain(
     safety_score = 50.0
     safety_message = "Cisco skill scanning unavailable; using neutral local safety score."
     if context.summary is not None and context.summary.status == CiscoIntegrationStatus.ENABLED:
-        unique_findings = {
-            f"{finding.rule_id}:{finding.severity.value}"
-            for finding in context.summary.findings
-        }
+        unique_findings = {f"{finding.rule_id}:{finding.severity.value}" for finding in context.summary.findings}
         safety_score = 100.0
         for finding_key in unique_findings:
             if finding_key.endswith(":high"):
@@ -230,9 +222,7 @@ def build_skill_domain(
             ),
         ),
     )
-    total = round_trust_score(
-        (adapters[0].score * 1.0 + adapters[1].score * 1.0 + adapters[2].score * 0.75) / 2.75
-    )
+    total = round_trust_score((adapters[0].score * 1.0 + adapters[1].score * 1.0 + adapters[2].score * 0.75) / 2.75)
     return TrustDomainScore(
         domain="skills",
         label=SKILL_TRUST_SPEC.label,
@@ -256,26 +246,29 @@ def build_mcp_domain(plugin_dir: Path, categories: tuple[CategoryResult, ...]) -
     remote_entries = remotes if isinstance(remotes, list) else []
     local_servers = servers if isinstance(servers, dict) else {}
     has_named_surfaces = bool(remote_entries) or bool(local_servers)
-    secure_remote_urls = all(
-        isinstance(entry, dict) and is_https_url(str(entry.get("url", "")))
-        for entry in remote_entries
-    ) if remote_entries else True
-    local_commands_valid = all(
-        isinstance(config, dict)
-        and isinstance(config.get("command"), str)
-        and bool(config.get("command"))
-        and (
-            "args" not in config
-            or (
-                isinstance(config.get("args"), list)
-                and all(isinstance(value, str) for value in config.get("args"))
+    secure_remote_urls = (
+        all(isinstance(entry, dict) and is_https_url(str(entry.get("url", ""))) for entry in remote_entries)
+        if remote_entries
+        else True
+    )
+    local_commands_valid = (
+        all(
+            isinstance(config, dict)
+            and isinstance(config.get("command"), str)
+            and bool(config.get("command"))
+            and (
+                "args" not in config
+                or (
+                    isinstance(config.get("args"), list) and all(isinstance(value, str) for value in config.get("args"))
+                )
             )
+            for config in local_servers.values()
         )
-        for config in local_servers.values()
-    ) if local_servers else True
+        if local_servers
+        else True
+    )
     config_shape = (not payload) or (
-        (remotes is None or isinstance(remotes, list))
-        and (servers is None or isinstance(servers, dict))
+        (remotes is None or isinstance(remotes, list)) and (servers is None or isinstance(servers, dict))
     )
 
     verification_components = {
@@ -373,9 +366,7 @@ def build_plugin_domain(plugin_dir: Path, categories: tuple[CategoryResult, ...]
     best_checks = category_checks(categories, "Best Practices")
     marketplace_checks = category_checks(categories, "Marketplace")
     interface = (
-        manifest.get("interface")
-        if isinstance(manifest, dict) and isinstance(manifest.get("interface"), dict)
-        else {}
+        manifest.get("interface") if isinstance(manifest, dict) and isinstance(manifest.get("interface"), dict) else {}
     )
     author = manifest.get("author") if isinstance(manifest, dict) and isinstance(manifest.get("author"), dict) else {}
     has_author = isinstance(author.get("name"), str) and bool(author.get("name"))

--- a/src/codex_plugin_scanner/trust_domain_scoring.py
+++ b/src/codex_plugin_scanner/trust_domain_scoring.py
@@ -1,0 +1,634 @@
+"""Domain-specific trust scoring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .checks.manifest import SEMVER_RE, load_manifest
+from .checks.skill_security import SkillSecurityContext
+from .integrations.cisco_skill_scanner import CiscoIntegrationStatus
+from .models import CategoryResult
+from .trust_helpers import (
+    category_checks,
+    check_percent,
+    is_https_url,
+    load_mcp_payload,
+    normalize_adapter_total,
+    parse_skill_frontmatter,
+    round_trust_score,
+    url_host,
+    weighted_score,
+)
+from .trust_models import TrustAdapterScore, TrustComponentScore, TrustDomainScore
+from .trust_specs import MCP_TRUST_SPEC, PLUGIN_TRUST_SPEC, SKILL_TRUST_SPEC
+
+
+def _component(
+    key: str,
+    values: dict[str, float],
+    rationale: str,
+) -> TrustComponentScore:
+    return TrustComponentScore(key, values[key], rationale)
+
+
+def _skill_files(plugin_dir: Path, manifest: dict[str, object] | None) -> tuple[Path, ...]:
+    if manifest is None:
+        return ()
+    skills_root = manifest.get("skills")
+    if not isinstance(skills_root, str) or not skills_root.strip():
+        return ()
+    skills_dir = plugin_dir / skills_root
+    if not skills_dir.is_dir():
+        return ()
+    return tuple(sorted(skills_dir.rglob("SKILL.md")))
+
+
+def build_skill_domain(
+    plugin_dir: Path,
+    manifest: dict[str, object] | None,
+    context: SkillSecurityContext,
+) -> TrustDomainScore | None:
+    skill_files = _skill_files(plugin_dir, manifest)
+    if not skill_files:
+        return None
+
+    frontmatters = [payload for payload in (parse_skill_frontmatter(path) for path in skill_files) if payload]
+    frontmatter_count = len(frontmatters)
+    all_frontmatter_valid = frontmatter_count == len(skill_files)
+    descriptions = [str(payload.get("description", "")).strip() for payload in frontmatters]
+    average_description_length = (
+        sum(len(description) for description in descriptions) / len(descriptions) if descriptions else 0
+    )
+    tags: list[str] = []
+    for payload in frontmatters:
+        value = payload.get("tags")
+        if isinstance(value, list):
+            tags.extend(item for item in value if isinstance(item, str) and item.strip())
+        elif isinstance(value, str) and value.strip():
+            tags.extend(item.strip() for item in value.split(",") if item.strip())
+    interface = manifest.get("interface") if isinstance(manifest, dict) else None
+    has_category = (
+        isinstance(interface, dict)
+        and isinstance(interface.get("category"), str)
+        and bool(interface.get("category"))
+    )
+    has_author = (
+        isinstance(manifest.get("author"), dict)
+        and isinstance(manifest["author"].get("name"), str)
+        and bool(manifest["author"].get("name"))
+    )
+    repository = manifest.get("repository") if isinstance(manifest, dict) else None
+    homepage = manifest.get("homepage") if isinstance(manifest, dict) else None
+    version = manifest.get("version") if isinstance(manifest, dict) else None
+    same_host = url_host(repository if isinstance(repository, str) else None) and url_host(
+        repository if isinstance(repository, str) else None
+    ) == url_host(homepage if isinstance(homepage, str) else None)
+
+    verified_components = {
+        "publisherBound": 100.0 if has_author else 0.0,
+        "repoCommitIntegrity": (
+            100.0
+            if isinstance(repository, str)
+            and repository
+            and isinstance(version, str)
+            and SEMVER_RE.match(version)
+            else 0.0
+        ),
+        "manifestIntegrity": 100.0 if all_frontmatter_valid else 0.0,
+        "domainProof": 100.0 if same_host else 0.0,
+    }
+    verified_components["score"] = weighted_score(
+        verified_components,
+        {
+            "publisherBound": 20.0,
+            "repoCommitIntegrity": 40.0,
+            "manifestIntegrity": 30.0,
+            "domainProof": 10.0,
+        },
+    )
+
+    has_links = isinstance(homepage, str) and homepage.strip()
+    has_repo = isinstance(repository, str) and repository.strip()
+    links = 100.0 if has_links and has_repo else 60.0 if has_links or has_repo else 0.0
+    if average_description_length >= 160:
+        description_score = 100.0
+    elif average_description_length >= 80:
+        description_score = 85.0
+    elif average_description_length >= 30:
+        description_score = 65.0
+    elif average_description_length >= 10:
+        description_score = 40.0
+    else:
+        description_score = 0.0
+    tag_count = len(tags)
+    if has_category and tag_count >= 3:
+        taxonomy = 100.0
+    elif has_category and tag_count >= 1:
+        taxonomy = 85.0
+    elif has_category or tag_count >= 3:
+        taxonomy = 70.0
+    elif tag_count >= 1:
+        taxonomy = 55.0
+    else:
+        taxonomy = 0.0
+    if has_repo and isinstance(version, str) and SEMVER_RE.match(version):
+        provenance = 100.0
+    elif has_repo:
+        provenance = 70.0
+    elif isinstance(version, str) and SEMVER_RE.match(version):
+        provenance = 40.0
+    else:
+        provenance = 0.0
+    metadata_components = {
+        "links": links,
+        "description": description_score,
+        "taxonomy": taxonomy,
+        "provenance": provenance,
+    }
+    metadata_components["score"] = weighted_score(
+        metadata_components,
+        {
+            "links": 30.0,
+            "description": 25.0,
+            "taxonomy": 20.0,
+            "provenance": 25.0,
+        },
+    )
+
+    safety_score = 50.0
+    safety_message = "Cisco skill scanning unavailable; using neutral local safety score."
+    if context.summary is not None and context.summary.status == CiscoIntegrationStatus.ENABLED:
+        unique_findings = {
+            f"{finding.rule_id}:{finding.severity.value}"
+            for finding in context.summary.findings
+        }
+        safety_score = 100.0
+        for finding_key in unique_findings:
+            if finding_key.endswith(":high"):
+                safety_score -= 25.0
+            elif finding_key.endswith(":medium"):
+                safety_score -= 12.0
+            elif finding_key.endswith(":low"):
+                safety_score -= 6.0
+        safety_score = round_trust_score(safety_score)
+        safety_message = context.summary.message
+    elif context.summary is not None and context.summary.status == CiscoIntegrationStatus.SKIPPED:
+        safety_message = context.summary.message
+
+    adapters = (
+        TrustAdapterScore(
+            adapter_id="verified",
+            label="Verification Signals",
+            weight=1.0,
+            score=normalize_adapter_total(SKILL_TRUST_SPEC.adapters[0].component_keys, verified_components),
+            components=(
+                _component("score", verified_components, "Broker-aligned weighted verification subtotal."),
+                _component("publisherBound", verified_components, "Manifest author is present for bundled skills."),
+                _component(
+                    "repoCommitIntegrity",
+                    verified_components,
+                    "Repository and semver version are present for local provenance.",
+                ),
+                _component(
+                    "manifestIntegrity",
+                    verified_components,
+                    "All bundled skills parse frontmatter with required fields.",
+                ),
+                _component("domainProof", verified_components, "Homepage and repository hosts align."),
+            ),
+        ),
+        TrustAdapterScore(
+            adapter_id="safety",
+            label="Safety Signals",
+            weight=1.0,
+            score=normalize_adapter_total(SKILL_TRUST_SPEC.adapters[1].component_keys, {"score": safety_score}),
+            components=(TrustComponentScore("score", safety_score, safety_message),),
+        ),
+        TrustAdapterScore(
+            adapter_id="metadata",
+            label="Metadata Completeness",
+            weight=0.75,
+            score=normalize_adapter_total(SKILL_TRUST_SPEC.adapters[2].component_keys, metadata_components),
+            components=(
+                _component("score", metadata_components, "Broker-aligned weighted metadata subtotal."),
+                _component(
+                    "links",
+                    metadata_components,
+                    "Homepage and repository links are declared for the bundled skill package.",
+                ),
+                _component(
+                    "description",
+                    metadata_components,
+                    "Skill descriptions are substantive enough for discovery.",
+                ),
+                _component("taxonomy", metadata_components, "Skills expose category and tag signals for discovery."),
+                _component(
+                    "provenance",
+                    metadata_components,
+                    "Repository and version provenance are declared locally.",
+                ),
+            ),
+        ),
+    )
+    total = round_trust_score(
+        (adapters[0].score * 1.0 + adapters[1].score * 1.0 + adapters[2].score * 0.75) / 2.75
+    )
+    return TrustDomainScore(
+        domain="skills",
+        label=SKILL_TRUST_SPEC.label,
+        spec_id=SKILL_TRUST_SPEC.spec_id,
+        spec_version=SKILL_TRUST_SPEC.version,
+        spec_path=SKILL_TRUST_SPEC.spec_path,
+        derived_from=SKILL_TRUST_SPEC.derived_from,
+        score=total,
+        adapters=adapters,
+    )
+
+
+def build_mcp_domain(plugin_dir: Path, categories: tuple[CategoryResult, ...]) -> TrustDomainScore | None:
+    payload = load_mcp_payload(plugin_dir)
+    if payload is None:
+        return None
+
+    security_checks = category_checks(categories, "Security")
+    remotes = payload.get("remotes")
+    servers = payload.get("mcpServers")
+    remote_entries = remotes if isinstance(remotes, list) else []
+    local_servers = servers if isinstance(servers, dict) else {}
+    has_named_surfaces = bool(remote_entries) or bool(local_servers)
+    secure_remote_urls = all(
+        isinstance(entry, dict) and is_https_url(str(entry.get("url", "")))
+        for entry in remote_entries
+    ) if remote_entries else True
+    local_commands_valid = all(
+        isinstance(config, dict)
+        and isinstance(config.get("command"), str)
+        and bool(config.get("command"))
+        and (
+            "args" not in config
+            or (
+                isinstance(config.get("args"), list)
+                and all(isinstance(value, str) for value in config.get("args"))
+            )
+        )
+        for config in local_servers.values()
+    ) if local_servers else True
+    config_shape = (not payload) or (
+        (remotes is None or isinstance(remotes, list))
+        and (servers is None or isinstance(servers, dict))
+    )
+
+    verification_components = {
+        "configIntegrity": 100.0 if config_shape else 0.0,
+        "executionSafety": check_percent(security_checks, "No dangerous MCP commands"),
+        "transportSecurity": check_percent(security_checks, "MCP remote transports are hardened"),
+    }
+    verification_components["score"] = weighted_score(
+        verification_components,
+        {
+            "configIntegrity": 40.0,
+            "executionSafety": 35.0,
+            "transportSecurity": 25.0,
+        },
+    )
+
+    metadata_components = {
+        "serverNaming": 100.0 if has_named_surfaces else 0.0,
+        "commandOrEndpoint": 100.0 if secure_remote_urls and local_commands_valid and has_named_surfaces else 0.0,
+        "configShape": 100.0 if config_shape else 0.0,
+    }
+    metadata_components["score"] = weighted_score(
+        metadata_components,
+        {
+            "serverNaming": 25.0,
+            "commandOrEndpoint": 45.0,
+            "configShape": 30.0,
+        },
+    )
+
+    adapters = (
+        TrustAdapterScore(
+            adapter_id="verification",
+            label="Verification Signals",
+            weight=1.0,
+            score=normalize_adapter_total(MCP_TRUST_SPEC.adapters[0].component_keys, verification_components),
+            components=(
+                _component("score", verification_components, "Weighted MCP verification subtotal."),
+                _component(
+                    "configIntegrity",
+                    verification_components,
+                    "The .mcp.json surface parses and matches the expected container shape.",
+                ),
+                _component(
+                    "executionSafety",
+                    verification_components,
+                    "Local MCP commands avoid dangerous execution patterns.",
+                ),
+                _component(
+                    "transportSecurity",
+                    verification_components,
+                    "Remote MCP transports stay on HTTPS when present.",
+                ),
+            ),
+        ),
+        TrustAdapterScore(
+            adapter_id="metadata",
+            label="Configuration Completeness",
+            weight=0.75,
+            score=normalize_adapter_total(MCP_TRUST_SPEC.adapters[1].component_keys, metadata_components),
+            components=(
+                _component("score", metadata_components, "Weighted MCP metadata subtotal."),
+                _component(
+                    "serverNaming",
+                    metadata_components,
+                    "MCP surfaces are explicitly named for operators and reviewers.",
+                ),
+                _component(
+                    "commandOrEndpoint",
+                    metadata_components,
+                    "Every MCP surface declares a concrete local command or remote endpoint.",
+                ),
+                _component("configShape", metadata_components, "The top-level MCP configuration shape is valid."),
+            ),
+        ),
+    )
+    total = round_trust_score((adapters[0].score * 1.0 + adapters[1].score * 0.75) / 1.75)
+    return TrustDomainScore(
+        domain="mcp",
+        label=MCP_TRUST_SPEC.label,
+        spec_id=MCP_TRUST_SPEC.spec_id,
+        spec_version=MCP_TRUST_SPEC.version,
+        spec_path=MCP_TRUST_SPEC.spec_path,
+        derived_from=MCP_TRUST_SPEC.derived_from,
+        score=total,
+        adapters=adapters,
+    )
+
+
+def build_plugin_domain(plugin_dir: Path, categories: tuple[CategoryResult, ...]) -> TrustDomainScore:
+    manifest = load_manifest(plugin_dir)
+    manifest_checks = category_checks(categories, "Manifest Validation")
+    security_checks = category_checks(categories, "Security")
+    operational_checks = category_checks(categories, "Operational Security")
+    best_checks = category_checks(categories, "Best Practices")
+    marketplace_checks = category_checks(categories, "Marketplace")
+    interface = (
+        manifest.get("interface")
+        if isinstance(manifest, dict) and isinstance(manifest.get("interface"), dict)
+        else {}
+    )
+    author = manifest.get("author") if isinstance(manifest, dict) and isinstance(manifest.get("author"), dict) else {}
+    has_author = isinstance(author.get("name"), str) and bool(author.get("name"))
+    has_homepage = is_https_url(manifest.get("homepage") if isinstance(manifest, dict) else None)
+    has_repository = is_https_url(manifest.get("repository") if isinstance(manifest, dict) else None)
+    keywords = manifest.get("keywords") if isinstance(manifest, dict) else None
+    keyword_count = len(keywords) if isinstance(keywords, list) else 0
+    has_interface_category = isinstance(interface.get("category"), str) and bool(interface.get("category"))
+    discoverability = (
+        100.0
+        if has_interface_category and keyword_count >= 3
+        else 75.0
+        if has_interface_category or keyword_count >= 1
+        else 0.0
+    )
+    provenance = (
+        100.0
+        if has_author and has_homepage and has_repository
+        else 70.0
+        if has_author and (has_homepage or has_repository)
+        else 40.0
+        if has_author or has_repository or has_homepage
+        else 0.0
+    )
+
+    verification_components = {
+        "manifestIntegrity": weighted_score(
+            {
+                "exists": check_percent(manifest_checks, "plugin.json exists"),
+                "json": check_percent(manifest_checks, "Valid JSON"),
+                "required": check_percent(manifest_checks, "Required fields present"),
+                "version": check_percent(manifest_checks, "Version follows semver"),
+            },
+            {"exists": 20.0, "json": 20.0, "required": 35.0, "version": 25.0},
+        ),
+        "interfaceIntegrity": weighted_score(
+            {
+                "metadata": check_percent(manifest_checks, "Interface metadata complete if declared"),
+                "links": check_percent(manifest_checks, "Interface links and assets valid if declared"),
+            },
+            {"metadata": 60.0, "links": 40.0},
+        ),
+        "pathSafety": check_percent(manifest_checks, "Declared paths are safe"),
+        "marketplaceAlignment": weighted_score(
+            {
+                "valid": check_percent(marketplace_checks, "marketplace.json valid"),
+                "policy": check_percent(marketplace_checks, "Policy fields present"),
+                "sources": check_percent(marketplace_checks, "Marketplace sources are safe"),
+            },
+            {"valid": 35.0, "policy": 35.0, "sources": 30.0},
+        ),
+    }
+    verification_components["score"] = weighted_score(
+        verification_components,
+        {
+            "manifestIntegrity": 35.0,
+            "interfaceIntegrity": 25.0,
+            "pathSafety": 20.0,
+            "marketplaceAlignment": 20.0,
+        },
+    )
+
+    security_components = {
+        "disclosure": check_percent(security_checks, "SECURITY.md found"),
+        "license": check_percent(security_checks, "LICENSE found"),
+        "secretHygiene": check_percent(security_checks, "No hardcoded secrets"),
+        "mcpSafety": weighted_score(
+            {
+                "commands": check_percent(security_checks, "No dangerous MCP commands"),
+                "transport": check_percent(security_checks, "MCP remote transports are hardened"),
+            },
+            {"commands": 50.0, "transport": 50.0},
+        ),
+        "approvalHygiene": check_percent(security_checks, "No approval bypass defaults"),
+    }
+    security_components["score"] = weighted_score(
+        security_components,
+        {
+            "disclosure": 15.0,
+            "license": 10.0,
+            "secretHygiene": 35.0,
+            "mcpSafety": 20.0,
+            "approvalHygiene": 20.0,
+        },
+    )
+
+    metadata_components = {
+        "documentation": check_percent(best_checks, "README.md found"),
+        "manifestMetadata": check_percent(manifest_checks, "Recommended metadata present"),
+        "discoverability": discoverability,
+        "provenance": provenance,
+    }
+    metadata_components["score"] = weighted_score(
+        metadata_components,
+        {
+            "documentation": 20.0,
+            "manifestMetadata": 35.0,
+            "discoverability": 20.0,
+            "provenance": 25.0,
+        },
+    )
+
+    operations_components = {
+        "actionPinning": check_percent(operational_checks, "Third-party GitHub Actions pinned to SHAs"),
+        "permissionScope": check_percent(operational_checks, "No write-all GitHub Actions permissions"),
+        "untrustedCheckout": check_percent(operational_checks, "No privileged untrusted checkout patterns"),
+        "updateAutomation": weighted_score(
+            {
+                "dependabot": check_percent(operational_checks, "Dependabot configured for automation surfaces"),
+                "lockfiles": check_percent(operational_checks, "Dependency manifests have lockfiles"),
+            },
+            {"dependabot": 50.0, "lockfiles": 50.0},
+        ),
+    }
+    operations_components["score"] = weighted_score(
+        operations_components,
+        {
+            "actionPinning": 35.0,
+            "permissionScope": 20.0,
+            "untrustedCheckout": 25.0,
+            "updateAutomation": 20.0,
+        },
+    )
+
+    adapters = (
+        TrustAdapterScore(
+            adapter_id="verification",
+            label="Manifest And Surface Integrity",
+            weight=1.0,
+            score=normalize_adapter_total(PLUGIN_TRUST_SPEC.adapters[0].component_keys, verification_components),
+            components=(
+                _component("score", verification_components, "Weighted plugin verification subtotal."),
+                _component(
+                    "manifestIntegrity",
+                    verification_components,
+                    "Manifest presence, syntax, required fields, and versioning stay intact.",
+                ),
+                _component(
+                    "interfaceIntegrity",
+                    verification_components,
+                    "Interface metadata and assets are complete when declared.",
+                ),
+                _component(
+                    "pathSafety",
+                    verification_components,
+                    "Declared plugin paths stay within the package root.",
+                ),
+                _component(
+                    "marketplaceAlignment",
+                    verification_components,
+                    "Marketplace metadata remains structurally aligned when present.",
+                ),
+            ),
+        ),
+        TrustAdapterScore(
+            adapter_id="security",
+            label="Security Posture",
+            weight=1.0,
+            score=normalize_adapter_total(PLUGIN_TRUST_SPEC.adapters[1].component_keys, security_components),
+            components=(
+                _component("score", security_components, "Weighted plugin security subtotal."),
+                _component(
+                    "disclosure",
+                    security_components,
+                    "SECURITY.md is only one documented disclosure signal, not the whole trust score.",
+                ),
+                _component("license", security_components, "License clarity is present for downstream consumers."),
+                _component(
+                    "secretHygiene",
+                    security_components,
+                    "The source tree is free from hardcoded secret patterns.",
+                ),
+                _component(
+                    "mcpSafety",
+                    security_components,
+                    "MCP surfaces avoid dangerous commands and insecure remotes.",
+                ),
+                _component(
+                    "approvalHygiene",
+                    security_components,
+                    "The plugin avoids bypass-style approval defaults.",
+                ),
+            ),
+        ),
+        TrustAdapterScore(
+            adapter_id="metadata",
+            label="Metadata Completeness",
+            weight=0.75,
+            score=normalize_adapter_total(PLUGIN_TRUST_SPEC.adapters[2].component_keys, metadata_components),
+            components=(
+                _component("score", metadata_components, "Weighted plugin metadata subtotal."),
+                _component(
+                    "documentation",
+                    metadata_components,
+                    "README coverage is present for operators and contributors.",
+                ),
+                _component(
+                    "manifestMetadata",
+                    metadata_components,
+                    "Recommended manifest metadata is complete.",
+                ),
+                _component(
+                    "discoverability",
+                    metadata_components,
+                    "Category and keyword signals support marketplace discovery.",
+                ),
+                _component(
+                    "provenance",
+                    metadata_components,
+                    "Author, homepage, and repository metadata establish provenance.",
+                ),
+            ),
+        ),
+        TrustAdapterScore(
+            adapter_id="operations",
+            label="Operational Hygiene",
+            weight=0.75,
+            score=normalize_adapter_total(PLUGIN_TRUST_SPEC.adapters[3].component_keys, operations_components),
+            components=(
+                _component("score", operations_components, "Weighted operational hygiene subtotal."),
+                _component(
+                    "actionPinning",
+                    operations_components,
+                    "Third-party actions are pinned to immutable revisions.",
+                ),
+                _component(
+                    "permissionScope",
+                    operations_components,
+                    "Workflows avoid broad GitHub token scopes.",
+                ),
+                _component(
+                    "untrustedCheckout",
+                    operations_components,
+                    "Privileged workflows do not check out untrusted pull request code.",
+                ),
+                _component(
+                    "updateAutomation",
+                    operations_components,
+                    "Dependabot and lockfiles keep automation surfaces current.",
+                ),
+            ),
+        ),
+    )
+    total = round_trust_score(
+        (adapters[0].score + adapters[1].score + adapters[2].score * 0.75 + adapters[3].score * 0.75) / 3.5
+    )
+    return TrustDomainScore(
+        domain="plugin",
+        label=PLUGIN_TRUST_SPEC.label,
+        spec_id=PLUGIN_TRUST_SPEC.spec_id,
+        spec_version=PLUGIN_TRUST_SPEC.version,
+        spec_path=PLUGIN_TRUST_SPEC.spec_path,
+        derived_from=PLUGIN_TRUST_SPEC.derived_from,
+        score=total,
+        adapters=adapters,
+    )

--- a/src/codex_plugin_scanner/trust_domain_scoring.py
+++ b/src/codex_plugin_scanner/trust_domain_scoring.py
@@ -11,6 +11,7 @@ from .models import CategoryResult
 from .trust_helpers import (
     category_checks,
     check_percent,
+    has_required_skill_frontmatter,
     is_https_url,
     load_mcp_payload,
     normalize_adapter_total,
@@ -53,8 +54,8 @@ def build_skill_domain(
         return None
 
     frontmatters = [payload for payload in (parse_skill_frontmatter(path) for path in skill_files) if payload]
-    frontmatter_count = len(frontmatters)
-    all_frontmatter_valid = frontmatter_count == len(skill_files)
+    valid_frontmatters = [payload for payload in frontmatters if has_required_skill_frontmatter(payload)]
+    all_frontmatter_valid = len(valid_frontmatters) == len(skill_files)
     descriptions = [str(payload.get("description", "")).strip() for payload in frontmatters]
     average_description_length = (
         sum(len(description) for description in descriptions) / len(descriptions) if descriptions else 0
@@ -238,9 +239,10 @@ def build_skill_domain(
 
 
 def build_mcp_domain(plugin_dir: Path, categories: tuple[CategoryResult, ...]) -> TrustDomainScore | None:
-    payload = load_mcp_payload(plugin_dir)
-    if payload is None:
+    payload_state = load_mcp_payload(plugin_dir)
+    if payload_state is None:
         return None
+    payload = payload_state.payload
 
     security_checks = category_checks(categories, "Security")
     remotes = payload.get("remotes")
@@ -269,7 +271,7 @@ def build_mcp_domain(plugin_dir: Path, categories: tuple[CategoryResult, ...]) -
         if local_servers
         else True
     )
-    config_shape = (not payload) or (
+    config_shape = payload_state.parse_valid and (
         (remotes is None or isinstance(remotes, list)) and (servers is None or isinstance(servers, dict))
     )
 

--- a/src/codex_plugin_scanner/trust_domain_scoring.py
+++ b/src/codex_plugin_scanner/trust_domain_scoring.py
@@ -78,9 +78,9 @@ def build_skill_domain(
     repository = manifest.get("repository") if isinstance(manifest, dict) else None
     homepage = manifest.get("homepage") if isinstance(manifest, dict) else None
     version = manifest.get("version") if isinstance(manifest, dict) else None
-    same_host = url_host(repository if isinstance(repository, str) else None) and url_host(
-        repository if isinstance(repository, str) else None
-    ) == url_host(homepage if isinstance(homepage, str) else None)
+    repo_host = url_host(repository if isinstance(repository, str) else None)
+    home_host = url_host(homepage if isinstance(homepage, str) else None)
+    same_host = bool(repo_host) and repo_host == home_host
 
     verified_components = {
         "publisherBound": 100.0 if has_author else 0.0,
@@ -156,7 +156,9 @@ def build_skill_domain(
         unique_findings = {f"{finding.rule_id}:{finding.severity.value}" for finding in context.summary.findings}
         safety_score = 100.0
         for finding_key in unique_findings:
-            if finding_key.endswith(":high"):
+            if finding_key.endswith(":critical"):
+                safety_score -= 50.0
+            elif finding_key.endswith(":high"):
                 safety_score -= 25.0
             elif finding_key.endswith(":medium"):
                 safety_score -= 12.0

--- a/src/codex_plugin_scanner/trust_helpers.py
+++ b/src/codex_plugin_scanner/trust_helpers.py
@@ -1,0 +1,117 @@
+"""Shared helpers for trust scoring."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from urllib.parse import urlparse
+
+from .models import CategoryResult
+
+
+def round_trust_score(value: float) -> float:
+    return round(max(0.0, min(100.0, value)) * 100) / 100
+
+
+def weighted_score(components: dict[str, float], weights: dict[str, float]) -> float:
+    total_weight = sum(weight for weight in weights.values() if weight > 0)
+    if total_weight <= 0:
+        return 0.0
+    return round_trust_score(sum(components[key] * weights[key] for key in weights) / total_weight)
+
+
+def normalize_adapter_total(component_keys: tuple[str, ...], contributions: dict[str, float]) -> float:
+    values = [round_trust_score(contributions.get(key, 0.0)) for key in component_keys]
+    if not values:
+        return 0.0
+    return round_trust_score(sum(values) / len(values))
+
+
+def normalize_report_total(scores: tuple[float, ...]) -> float:
+    if not scores:
+        return 0.0
+    return round_trust_score(sum(scores) / len(scores))
+
+
+def category_checks(categories: tuple[CategoryResult, ...], name: str) -> dict[str, object]:
+    for category in categories:
+        if category.name == name:
+            return {check.name: check for check in category.checks}
+    return {}
+
+
+def check_percent(checks: dict[str, object], name: str) -> float:
+    check = checks.get(name)
+    if check is None:
+        return 100.0
+    max_points = getattr(check, "max_points", 0)
+    if max_points == 0:
+        return 100.0
+    return round_trust_score(getattr(check, "points", 0) * 100 / max_points)
+
+
+def is_https_url(value: str | None) -> bool:
+    if not value:
+        return False
+    parsed = urlparse(value)
+    return parsed.scheme == "https" and bool(parsed.netloc)
+
+
+def url_host(value: str | None) -> str:
+    if not value:
+        return ""
+    return (urlparse(value).hostname or "").lower()
+
+
+def parse_skill_frontmatter(skill_file: Path) -> dict[str, object] | None:
+    try:
+        content = skill_file.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    if not content.startswith("---"):
+        return None
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return None
+    payload: dict[str, object] = {}
+    current_list_key: str | None = None
+    for raw_line in parts[1].splitlines():
+        line = raw_line.rstrip()
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("- ") and current_list_key:
+            existing = payload.setdefault(current_list_key, [])
+            if isinstance(existing, list):
+                existing.append(stripped[2:].strip())
+            continue
+        current_list_key = None
+        if ":" not in stripped:
+            continue
+        key, raw_value = stripped.split(":", 1)
+        normalized_key = key.strip()
+        value = raw_value.strip()
+        if value.startswith("[") and value.endswith("]"):
+            payload[normalized_key] = [
+                item.strip().strip("'\"")
+                for item in value[1:-1].split(",")
+                if item.strip()
+            ]
+            continue
+        if value:
+            payload[normalized_key] = value.strip("'\"")
+            continue
+        payload[normalized_key] = []
+        current_list_key = normalized_key
+    return payload
+
+
+def load_mcp_payload(plugin_dir: Path) -> dict[str, object] | None:
+    path = plugin_dir / ".mcp.json"
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}

--- a/src/codex_plugin_scanner/trust_helpers.py
+++ b/src/codex_plugin_scanner/trust_helpers.py
@@ -92,11 +92,7 @@ def parse_skill_frontmatter(skill_file: Path) -> dict[str, object] | None:
         normalized_key = key.strip()
         value = raw_value.strip()
         if value.startswith("[") and value.endswith("]"):
-            payload[normalized_key] = [
-                item.strip().strip("'\"")
-                for item in value[1:-1].split(",")
-                if item.strip()
-            ]
+            payload[normalized_key] = [item.strip().strip("'\"") for item in value[1:-1].split(",") if item.strip()]
             continue
         if value:
             payload[normalized_key] = value.strip("'\"")

--- a/src/codex_plugin_scanner/trust_helpers.py
+++ b/src/codex_plugin_scanner/trust_helpers.py
@@ -3,10 +3,17 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlparse
 
 from .models import CategoryResult
+
+
+@dataclass(frozen=True)
+class McpPayloadState:
+    payload: dict[str, object]
+    parse_valid: bool
 
 
 def round_trust_score(value: float) -> float:
@@ -102,12 +109,22 @@ def parse_skill_frontmatter(skill_file: Path) -> dict[str, object] | None:
     return payload
 
 
-def load_mcp_payload(plugin_dir: Path) -> dict[str, object] | None:
+def has_required_skill_frontmatter(payload: dict[str, object]) -> bool:
+    for field in ("name", "description"):
+        value = payload.get(field)
+        if not isinstance(value, str) or not value.strip():
+            return False
+    return True
+
+
+def load_mcp_payload(plugin_dir: Path) -> McpPayloadState | None:
     path = plugin_dir / ".mcp.json"
     if not path.exists():
         return None
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        return {}
-    return payload if isinstance(payload, dict) else {}
+        return McpPayloadState(payload={}, parse_valid=False)
+    if not isinstance(payload, dict):
+        return McpPayloadState(payload={}, parse_valid=False)
+    return McpPayloadState(payload=payload, parse_valid=True)

--- a/src/codex_plugin_scanner/trust_models.py
+++ b/src/codex_plugin_scanner/trust_models.py
@@ -1,0 +1,71 @@
+"""Trust provenance data models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True, slots=True)
+class TrustComponentScore:
+    """One scored trust component inside an adapter."""
+
+    key: str
+    score: float
+    rationale: str
+    evidence: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class TrustAdapterScore:
+    """Weighted adapter score inside a trust domain."""
+
+    adapter_id: str
+    label: str
+    weight: float
+    score: float
+    components: tuple[TrustComponentScore, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class TrustDomainScore:
+    """One trust domain such as plugin, skills, or MCP."""
+
+    domain: str
+    label: str
+    spec_id: str
+    spec_version: str
+    spec_path: str
+    derived_from: tuple[str, ...]
+    score: float
+    adapters: tuple[TrustAdapterScore, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class TrustReport:
+    """Overall trust report emitted alongside scan results."""
+
+    total: float
+    domains: tuple[TrustDomainScore, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class TrustAdapterSpec:
+    """Definition of a trust adapter and its components."""
+
+    adapter_id: str
+    label: str
+    weight: float
+    component_keys: tuple[str, ...]
+    default_component_key: str = "score"
+
+
+@dataclass(frozen=True, slots=True)
+class TrustSpecDefinition:
+    """Definition of a trust scoring specification."""
+
+    spec_id: str
+    version: str
+    label: str
+    spec_path: str
+    derived_from: tuple[str, ...]
+    adapters: tuple[TrustAdapterSpec, ...] = field(default_factory=tuple)

--- a/src/codex_plugin_scanner/trust_scoring.py
+++ b/src/codex_plugin_scanner/trust_scoring.py
@@ -1,0 +1,37 @@
+"""Trust scoring and provenance formatting for scan results."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .checks.manifest import load_manifest
+from .checks.skill_security import SkillSecurityContext
+from .models import CategoryResult
+from .trust_domain_scoring import build_mcp_domain, build_plugin_domain, build_skill_domain
+from .trust_helpers import normalize_report_total, round_trust_score
+from .trust_models import TrustReport
+
+
+def build_plugin_trust_report(
+    plugin_dir: Path,
+    categories: tuple[CategoryResult, ...],
+    skill_security_context: SkillSecurityContext,
+) -> TrustReport:
+    manifest = load_manifest(plugin_dir)
+    domains = [
+        domain
+        for domain in (
+            build_plugin_domain(plugin_dir, categories),
+            build_skill_domain(plugin_dir, manifest, skill_security_context),
+            build_mcp_domain(plugin_dir, categories),
+        )
+        if domain is not None
+    ]
+    scores = tuple(domain.score for domain in domains)
+    return TrustReport(total=normalize_report_total(scores), domains=tuple(domains))
+
+
+def build_repository_trust_report(plugin_reports: tuple[TrustReport, ...]) -> TrustReport:
+    if not plugin_reports:
+        return TrustReport(total=0.0, domains=())
+    return TrustReport(total=round_trust_score(min(report.total for report in plugin_reports)), domains=())

--- a/src/codex_plugin_scanner/trust_specs.py
+++ b/src/codex_plugin_scanner/trust_specs.py
@@ -1,0 +1,99 @@
+"""Local trust specifications used by the scanner."""
+
+from __future__ import annotations
+
+from .trust_models import TrustAdapterSpec, TrustSpecDefinition
+
+SKILL_TRUST_SPEC = TrustSpecDefinition(
+    spec_id="HOL-HCS-28-SKILL-TRUST-LOCAL-DRAFT",
+    version="0.1.0",
+    label="Skill Trust",
+    spec_path="docs/trust/skill-trust-local.md",
+    derived_from=(
+        "HCS-28",
+        "HCS-26",
+        "registry-broker skill trust service",
+    ),
+    adapters=(
+        TrustAdapterSpec(
+            adapter_id="verified",
+            label="Verification Signals",
+            weight=1.0,
+            component_keys=(
+                "score",
+                "publisherBound",
+                "repoCommitIntegrity",
+                "manifestIntegrity",
+                "domainProof",
+            ),
+        ),
+        TrustAdapterSpec(
+            adapter_id="safety",
+            label="Safety Signals",
+            weight=1.0,
+            component_keys=("score",),
+        ),
+        TrustAdapterSpec(
+            adapter_id="metadata",
+            label="Metadata Completeness",
+            weight=0.75,
+            component_keys=("score", "links", "description", "taxonomy", "provenance"),
+        ),
+    ),
+)
+
+MCP_TRUST_SPEC = TrustSpecDefinition(
+    spec_id="HOL-HCS-MCP-TRUST-DRAFT",
+    version="0.1.0",
+    label="MCP Server Trust",
+    spec_path="docs/trust/mcp-trust-draft.md",
+    derived_from=("HCS-26", "HCS-28", "Codex MCP verification model"),
+    adapters=(
+        TrustAdapterSpec(
+            adapter_id="verification",
+            label="Verification Signals",
+            weight=1.0,
+            component_keys=("score", "configIntegrity", "executionSafety", "transportSecurity"),
+        ),
+        TrustAdapterSpec(
+            adapter_id="metadata",
+            label="Configuration Completeness",
+            weight=0.75,
+            component_keys=("score", "serverNaming", "commandOrEndpoint", "configShape"),
+        ),
+    ),
+)
+
+PLUGIN_TRUST_SPEC = TrustSpecDefinition(
+    spec_id="HOL-HCS-CODEX-PLUGIN-TRUST-DRAFT",
+    version="0.1.0",
+    label="Codex Plugin Trust",
+    spec_path="docs/trust/plugin-trust-draft.md",
+    derived_from=("HCS-26", "HCS-28", "scanner quality gate"),
+    adapters=(
+        TrustAdapterSpec(
+            adapter_id="verification",
+            label="Manifest And Surface Integrity",
+            weight=1.0,
+            component_keys=("score", "manifestIntegrity", "interfaceIntegrity", "pathSafety", "marketplaceAlignment"),
+        ),
+        TrustAdapterSpec(
+            adapter_id="security",
+            label="Security Posture",
+            weight=1.0,
+            component_keys=("score", "disclosure", "license", "secretHygiene", "mcpSafety", "approvalHygiene"),
+        ),
+        TrustAdapterSpec(
+            adapter_id="metadata",
+            label="Metadata Completeness",
+            weight=0.75,
+            component_keys=("score", "documentation", "manifestMetadata", "discoverability", "provenance"),
+        ),
+        TrustAdapterSpec(
+            adapter_id="operations",
+            label="Operational Hygiene",
+            weight=0.75,
+            component_keys=("score", "actionPinning", "permissionScope", "untrustedCheckout", "updateAutomation"),
+        ),
+    ),
+)

--- a/tests/test-trust-scoring.py
+++ b/tests/test-trust-scoring.py
@@ -1,0 +1,88 @@
+"""Trust scoring integration tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_plugin_scanner.reporting import build_json_payload
+from codex_plugin_scanner.scanner import scan_plugin
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_good_plugin_emits_skill_and_plugin_trust_domains():
+    result = scan_plugin(FIXTURES / "good-plugin")
+
+    assert result.trust_report is not None
+    assert result.trust_report.total > 0
+
+    domains = {domain.domain: domain for domain in result.trust_report.domains}
+    assert set(domains) >= {"plugin", "skills"}
+
+    plugin_domain = domains["plugin"]
+    assert plugin_domain.spec_id == "HOL-HCS-CODEX-PLUGIN-TRUST-DRAFT"
+    security_adapter = next(adapter for adapter in plugin_domain.adapters if adapter.adapter_id == "security")
+    disclosure_component = next(
+        component for component in security_adapter.components if component.key == "disclosure"
+    )
+    assert disclosure_component.score == 100
+
+    skill_domain = domains["skills"]
+    assert skill_domain.spec_id == "HOL-HCS-28-SKILL-TRUST-LOCAL-DRAFT"
+    assert {adapter.adapter_id for adapter in skill_domain.adapters} == {"verified", "safety", "metadata"}
+
+
+def test_safe_mcp_config_emits_mcp_trust_domain(tmp_path: Path):
+    plugin_dir = tmp_path
+    manifest_dir = plugin_dir / ".codex-plugin"
+    manifest_dir.mkdir()
+    (manifest_dir / "plugin.json").write_text(
+        json.dumps(
+            {
+                "name": "mcp-trust-demo",
+                "version": "1.0.0",
+                "description": "MCP trust demo plugin",
+                "author": {"name": "Hashgraph Online"},
+                "homepage": "https://example.com/plugin",
+                "repository": "https://github.com/hashgraph-online/codex-plugin-scanner",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (plugin_dir / "README.md").write_text("# Demo\n", encoding="utf-8")
+    (plugin_dir / "SECURITY.md").write_text("Report issues privately.\n", encoding="utf-8")
+    (plugin_dir / "LICENSE").write_text("MIT\nPermission is hereby granted\n", encoding="utf-8")
+    (plugin_dir / ".codexignore").write_text("dist/\n", encoding="utf-8")
+    (plugin_dir / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "local-demo": {
+                        "command": "python",
+                        "args": ["-m", "demo_server"],
+                    }
+                },
+                "remotes": [{"url": "https://example.com/mcp"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = scan_plugin(plugin_dir)
+
+    assert result.trust_report is not None
+    domains = {domain.domain: domain for domain in result.trust_report.domains}
+    assert "mcp" in domains
+    verification_adapter = next(adapter for adapter in domains["mcp"].adapters if adapter.adapter_id == "verification")
+    assert verification_adapter.score > 0
+
+
+def test_json_payload_includes_trust_provenance():
+    result = scan_plugin(FIXTURES / "good-plugin")
+
+    payload = build_json_payload(result)
+
+    assert payload["trust"]["total"] == result.trust_report.total
+    plugin_domain = next(domain for domain in payload["trust"]["domains"] if domain["domain"] == "plugin")
+    assert plugin_domain["spec"]["id"] == "HOL-HCS-CODEX-PLUGIN-TRUST-DRAFT"

--- a/tests/test-trust-specs.py
+++ b/tests/test-trust-specs.py
@@ -1,0 +1,31 @@
+"""Trust specification coverage."""
+
+from pathlib import Path
+
+from codex_plugin_scanner.trust_specs import MCP_TRUST_SPEC, PLUGIN_TRUST_SPEC, SKILL_TRUST_SPEC
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _adapter_weight_map(spec) -> dict[str, float]:
+    return {adapter.adapter_id: adapter.weight for adapter in spec.adapters}
+
+
+def test_skill_trust_spec_inherits_broker_weights():
+    assert SKILL_TRUST_SPEC.spec_id == "HOL-HCS-28-SKILL-TRUST-LOCAL-DRAFT"
+    assert "HCS-28" in SKILL_TRUST_SPEC.derived_from
+    assert "HCS-26" in SKILL_TRUST_SPEC.derived_from
+    assert "registry-broker skill trust service" in SKILL_TRUST_SPEC.derived_from
+    assert _adapter_weight_map(SKILL_TRUST_SPEC) == {
+        "verified": 1.0,
+        "safety": 1.0,
+        "metadata": 0.75,
+    }
+    assert (ROOT / SKILL_TRUST_SPEC.spec_path).exists()
+
+
+def test_mcp_and_plugin_specs_exist_locally():
+    assert MCP_TRUST_SPEC.spec_id == "HOL-HCS-MCP-TRUST-DRAFT"
+    assert PLUGIN_TRUST_SPEC.spec_id == "HOL-HCS-CODEX-PLUGIN-TRUST-DRAFT"
+    assert (ROOT / MCP_TRUST_SPEC.spec_path).exists()
+    assert (ROOT / PLUGIN_TRUST_SPEC.spec_path).exists()

--- a/tests/test_trust_scoring.py
+++ b/tests/test_trust_scoring.py
@@ -1,0 +1,88 @@
+"""Trust scoring integration tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_plugin_scanner.reporting import build_json_payload
+from codex_plugin_scanner.scanner import scan_plugin
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_good_plugin_emits_skill_and_plugin_trust_domains():
+    result = scan_plugin(FIXTURES / "good-plugin")
+
+    assert result.trust_report is not None
+    assert result.trust_report.total > 0
+
+    domains = {domain.domain: domain for domain in result.trust_report.domains}
+    assert set(domains) >= {"plugin", "skills"}
+
+    plugin_domain = domains["plugin"]
+    assert plugin_domain.spec_id == "HOL-HCS-CODEX-PLUGIN-TRUST-DRAFT"
+    security_adapter = next(adapter for adapter in plugin_domain.adapters if adapter.adapter_id == "security")
+    disclosure_component = next(
+        component for component in security_adapter.components if component.key == "disclosure"
+    )
+    assert disclosure_component.score == 100
+
+    skill_domain = domains["skills"]
+    assert skill_domain.spec_id == "HOL-HCS-28-SKILL-TRUST-LOCAL-DRAFT"
+    assert {adapter.adapter_id for adapter in skill_domain.adapters} == {"verified", "safety", "metadata"}
+
+
+def test_safe_mcp_config_emits_mcp_trust_domain(tmp_path: Path):
+    plugin_dir = tmp_path
+    manifest_dir = plugin_dir / ".codex-plugin"
+    manifest_dir.mkdir()
+    (manifest_dir / "plugin.json").write_text(
+        json.dumps(
+            {
+                "name": "mcp-trust-demo",
+                "version": "1.0.0",
+                "description": "MCP trust demo plugin",
+                "author": {"name": "Hashgraph Online"},
+                "homepage": "https://example.com/plugin",
+                "repository": "https://github.com/hashgraph-online/codex-plugin-scanner",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (plugin_dir / "README.md").write_text("# Demo\n", encoding="utf-8")
+    (plugin_dir / "SECURITY.md").write_text("Report issues privately.\n", encoding="utf-8")
+    (plugin_dir / "LICENSE").write_text("MIT\nPermission is hereby granted\n", encoding="utf-8")
+    (plugin_dir / ".codexignore").write_text("dist/\n", encoding="utf-8")
+    (plugin_dir / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "local-demo": {
+                        "command": "python",
+                        "args": ["-m", "demo_server"],
+                    }
+                },
+                "remotes": [{"url": "https://example.com/mcp"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = scan_plugin(plugin_dir)
+
+    assert result.trust_report is not None
+    domains = {domain.domain: domain for domain in result.trust_report.domains}
+    assert "mcp" in domains
+    verification_adapter = next(adapter for adapter in domains["mcp"].adapters if adapter.adapter_id == "verification")
+    assert verification_adapter.score > 0
+
+
+def test_json_payload_includes_trust_provenance():
+    result = scan_plugin(FIXTURES / "good-plugin")
+
+    payload = build_json_payload(result)
+
+    assert payload["trust"]["total"] == result.trust_report.total
+    plugin_domain = next(domain for domain in payload["trust"]["domains"] if domain["domain"] == "plugin")
+    assert plugin_domain["spec"]["id"] == "HOL-HCS-CODEX-PLUGIN-TRUST-DRAFT"

--- a/tests/test_trust_scoring.py
+++ b/tests/test_trust_scoring.py
@@ -11,6 +11,28 @@ from codex_plugin_scanner.scanner import scan_plugin
 FIXTURES = Path(__file__).parent / "fixtures"
 
 
+def write_minimal_plugin(plugin_dir: Path) -> None:
+    manifest_dir = plugin_dir / ".codex-plugin"
+    manifest_dir.mkdir()
+    (manifest_dir / "plugin.json").write_text(
+        json.dumps(
+            {
+                "name": "trust-demo",
+                "version": "1.0.0",
+                "description": "Trust scoring demo plugin",
+                "author": {"name": "Hashgraph Online"},
+                "homepage": "https://example.com/plugin",
+                "repository": "https://github.com/hashgraph-online/codex-plugin-scanner",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (plugin_dir / "README.md").write_text("# Demo\n", encoding="utf-8")
+    (plugin_dir / "SECURITY.md").write_text("Report issues privately.\n", encoding="utf-8")
+    (plugin_dir / "LICENSE").write_text("MIT\nPermission is hereby granted\n", encoding="utf-8")
+    (plugin_dir / ".codexignore").write_text("dist/\n", encoding="utf-8")
+
+
 def test_good_plugin_emits_skill_and_plugin_trust_domains():
     result = scan_plugin(FIXTURES / "good-plugin")
 
@@ -35,25 +57,7 @@ def test_good_plugin_emits_skill_and_plugin_trust_domains():
 
 def test_safe_mcp_config_emits_mcp_trust_domain(tmp_path: Path):
     plugin_dir = tmp_path
-    manifest_dir = plugin_dir / ".codex-plugin"
-    manifest_dir.mkdir()
-    (manifest_dir / "plugin.json").write_text(
-        json.dumps(
-            {
-                "name": "mcp-trust-demo",
-                "version": "1.0.0",
-                "description": "MCP trust demo plugin",
-                "author": {"name": "Hashgraph Online"},
-                "homepage": "https://example.com/plugin",
-                "repository": "https://github.com/hashgraph-online/codex-plugin-scanner",
-            }
-        ),
-        encoding="utf-8",
-    )
-    (plugin_dir / "README.md").write_text("# Demo\n", encoding="utf-8")
-    (plugin_dir / "SECURITY.md").write_text("Report issues privately.\n", encoding="utf-8")
-    (plugin_dir / "LICENSE").write_text("MIT\nPermission is hereby granted\n", encoding="utf-8")
-    (plugin_dir / ".codexignore").write_text("dist/\n", encoding="utf-8")
+    write_minimal_plugin(plugin_dir)
     (plugin_dir / ".mcp.json").write_text(
         json.dumps(
             {
@@ -76,6 +80,64 @@ def test_safe_mcp_config_emits_mcp_trust_domain(tmp_path: Path):
     assert "mcp" in domains
     verification_adapter = next(adapter for adapter in domains["mcp"].adapters if adapter.adapter_id == "verification")
     assert verification_adapter.score > 0
+
+
+def test_invalid_skill_frontmatter_reduces_manifest_integrity(tmp_path: Path):
+    plugin_dir = tmp_path
+    write_minimal_plugin(plugin_dir)
+    skills_dir = plugin_dir / "skills" / "demo-skill"
+    skills_dir.mkdir(parents=True)
+    (plugin_dir / ".codex-plugin" / "plugin.json").write_text(
+        json.dumps(
+            {
+                "name": "trust-demo",
+                "version": "1.0.0",
+                "description": "Trust scoring demo plugin",
+                "skills": "skills",
+                "author": {"name": "Hashgraph Online"},
+                "homepage": "https://example.com/plugin",
+                "repository": "https://github.com/hashgraph-online/codex-plugin-scanner",
+                "interface": {"category": "developer-tools"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (skills_dir / "SKILL.md").write_text(
+        "---\nname: Demo Skill\n---\n\nMissing description field.\n",
+        encoding="utf-8",
+    )
+
+    result = scan_plugin(plugin_dir)
+
+    skill_domain = next(domain for domain in result.trust_report.domains if domain.domain == "skills")
+    verified_adapter = next(adapter for adapter in skill_domain.adapters if adapter.adapter_id == "verified")
+    manifest_integrity = next(
+        component for component in verified_adapter.components if component.key == "manifestIntegrity"
+    )
+    assert manifest_integrity.score == 0
+
+
+def test_invalid_mcp_json_zeroes_config_integrity(tmp_path: Path):
+    plugin_dir = tmp_path
+    write_minimal_plugin(plugin_dir)
+    (plugin_dir / ".mcp.json").write_text("{invalid json\n", encoding="utf-8")
+
+    result = scan_plugin(plugin_dir)
+
+    mcp_domain = next(domain for domain in result.trust_report.domains if domain.domain == "mcp")
+    verification_adapter = next(adapter for adapter in mcp_domain.adapters if adapter.adapter_id == "verification")
+    config_integrity = next(
+        component for component in verification_adapter.components if component.key == "configIntegrity"
+    )
+    config_shape = next(
+        component
+        for adapter in mcp_domain.adapters
+        if adapter.adapter_id == "metadata"
+        for component in adapter.components
+        if component.key == "configShape"
+    )
+    assert config_integrity.score == 0
+    assert config_shape.score == 0
 
 
 def test_json_payload_includes_trust_provenance():

--- a/tests/test_trust_specs.py
+++ b/tests/test_trust_specs.py
@@ -1,0 +1,31 @@
+"""Trust specification coverage."""
+
+from pathlib import Path
+
+from codex_plugin_scanner.trust_specs import MCP_TRUST_SPEC, PLUGIN_TRUST_SPEC, SKILL_TRUST_SPEC
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _adapter_weight_map(spec) -> dict[str, float]:
+    return {adapter.adapter_id: adapter.weight for adapter in spec.adapters}
+
+
+def test_skill_trust_spec_inherits_broker_weights():
+    assert SKILL_TRUST_SPEC.spec_id == "HOL-HCS-28-SKILL-TRUST-LOCAL-DRAFT"
+    assert "HCS-28" in SKILL_TRUST_SPEC.derived_from
+    assert "HCS-26" in SKILL_TRUST_SPEC.derived_from
+    assert "registry-broker skill trust service" in SKILL_TRUST_SPEC.derived_from
+    assert _adapter_weight_map(SKILL_TRUST_SPEC) == {
+        "verified": 1.0,
+        "safety": 1.0,
+        "metadata": 0.75,
+    }
+    assert (ROOT / SKILL_TRUST_SPEC.spec_path).exists()
+
+
+def test_mcp_and_plugin_specs_exist_locally():
+    assert MCP_TRUST_SPEC.spec_id == "HOL-HCS-MCP-TRUST-DRAFT"
+    assert PLUGIN_TRUST_SPEC.spec_id == "HOL-HCS-CODEX-PLUGIN-TRUST-DRAFT"
+    assert (ROOT / MCP_TRUST_SPEC.spec_path).exists()
+    assert (ROOT / PLUGIN_TRUST_SPEC.spec_path).exists()


### PR DESCRIPTION
## Summary
- add explicit local trust specifications for bundled skills, MCP configuration, and top-level Codex plugins
- inherit the live HOL broker skill trust adapter weights and surface trust provenance in scan JSON, text, markdown, and submission artifacts
- document the new trust specs and add regression coverage for trust payloads and schema contracts

## Verification
- `uv run --extra dev ruff check .`
- `uv run --extra dev pytest -q`
- `uv run --extra dev python -m build`
- `uv run --extra dev codex-plugin-scanner scan tests/fixtures/good-plugin --format json`
