### PR TITLE
feat(action): native sticky PR comments with final gate enforcement

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -60,6 +60,13 @@ Advanced distribution paths are available when you need them:
 | `submission_plugin_url` | Override the plugin repository URL used in the submission issue | `""` |
 | `submission_plugin_description` | Override the plugin description used in the submission issue | `""` |
 | `submission_author` | Override the plugin author used in the submission issue | `""` |
+| `pr_comment` | Sticky PR summary comment mode: `off`, `auto`, `always` | `off` |
+| `pr_comment_style` | PR comment detail level: `concise` or `full` | `concise` |
+| `pr_comment_header` | Optional sticky comment header override | `""` |
+| `pr_comment_max_findings` | Maximum top findings listed in the comment | `3` |
+| `pr_comment_token` | Optional token for comments; defaults to `github.token` | `""` |
+| `pr_comment_skip_if_unchanged` | Skip updates when rendered comment body did not change | `true` |
+| `pr_comment_compare_to_previous` | Include metric deltas vs previous scanner comment on the same PR | `true` |
 
 ## Outputs
 
@@ -78,6 +85,12 @@ Advanced distribution paths are available when you need them:
 | `submission_performed` | `true` when a submission issue was created or an existing one was reused |
 | `submission_issue_urls` | Comma-separated submission issue URLs |
 | `submission_issue_numbers` | Comma-separated submission issue numbers |
+| `pr_comment_status` | PR comment status: `disabled`, `skipped`, `created`, `updated`, `unchanged`, or `failed` |
+| `pr_comment_url` | URL of the sticky PR comment when available |
+| `pr_comment_id` | Numeric GitHub issue-comment ID when available |
+| `pr_comment_reason` | Reason for skipped/failed comment operations |
+| `action_exit_code` | Final scanner exit code after report/comment handling |
+| `action_exit_reason` | Human-readable reason for non-zero exit |
 
 The action also writes a concise summary to `GITHUB_STEP_SUMMARY` by default. The full report is written to the job log for `text` output, or to the file you pass through `output` for `json`, `markdown`, or `sarif`.
 
@@ -86,7 +99,7 @@ Mode notes:
 - `scan` and `lint` respect `profile`, `config`, and `baseline`.
 - `verify` respects `online` and writes a human-readable report for `format: text`.
 - `submit` writes the plugin-quality artifact to `output` when provided, otherwise `plugin-quality.json`. `registry_payload_output` remains dedicated to the separate HOL registry payload.
-- `online`, `submission_enabled`, and `upload_sarif` are the only common paths that intentionally reach beyond the runner after the scanner package itself has been installed.
+- `online`, `submission_enabled`, `upload_sarif`, and `pr_comment` are the common paths that intentionally reach beyond the runner after the scanner package itself has been installed.
 
 ## Examples
 
@@ -196,29 +209,56 @@ jobs:
 
 Use a fine-grained token with `issues:write` on `hashgraph-online/awesome-codex-plugins`. `submission_token` is required when `submission_enabled: true`. The action deduplicates by an exact hidden plugin URL marker in the issue body, so repeated pushes reuse the open submission issue instead of opening duplicates.
 
-### Markdown report as PR comment
+### Native sticky PR summary comment
 
 ```yaml
 - uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
   id: scan
   with:
     plugin_dir: "."
-    format: markdown
-    output: scan-report.md
-
-- name: Comment PR
-  uses: actions/github-script@v7
-  with:
-    script: |
-      const fs = require('fs');
-      const report = fs.readFileSync('scan-report.md', 'utf8');
-      github.rest.issues.createComment({
-        issue_number: context.issue.number,
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        body: report
-      });
+    mode: scan
+    format: json
+    output: scanner-report.json
+    pr_comment: auto
+    pr_comment_style: concise
+    pr_comment_max_findings: 5
 ```
+
+`pr_comment: auto` updates a single sticky comment when the workflow runs on a PR and quietly skips on non-PR events. Use `pr_comment: always` when PR comments are required for policy; that mode fails the action if comment publication fails.
+
+### Advanced sticky comment configuration
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+  security-events: write
+
+- uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+  with:
+    plugin_dir: "."
+    mode: scan
+    format: sarif
+    upload_sarif: true
+    pr_comment: always
+    pr_comment_style: full
+    pr_comment_header: scanner-main-scan
+    pr_comment_token: ${{ secrets.SCANNER_PR_COMMENT_TOKEN }}
+```
+
+Recommended minimum permissions for PR-comment workflows:
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+  security-events: write
+```
+
+Fork PR note:
+
+- On forked PR events, `github.token` may not have permission to create comments. In `pr_comment: auto`, the action reports `pr_comment_status=skipped` without failing the run.
+- `pull_request_target` is not the default recommendation because it changes the threat model for untrusted PR content.
 
 ## Release Management
 
@@ -253,6 +293,31 @@ Set `mode` to one of `scan`, `lint`, `verify`, or `submit`.
 For `submit` mode, point `plugin_dir` at one concrete plugin directory. Repository-mode discovery is supported for `scan`, `lint`, and `verify`, but `submit` intentionally remains single-plugin.
 
 For `scan` mode, set `upload_sarif: true` to emit and upload SARIF automatically instead of wiring a separate upload step by hand.
+
+## Troubleshooting
+
+### Why didn't I get a PR comment?
+
+- Check `pr_comment_status` and `pr_comment_reason` outputs.
+- Verify the run was a PR event and token permissions include `pull-requests: write` or `issues: write`.
+- With `pr_comment: auto`, permission failures are non-fatal and reported as `skipped`.
+
+### Why did the action fail after posting a comment?
+
+- The action emits `action_exit_code` and `action_exit_reason`.
+- The final enforcement step fails the job when score/severity/policy gates fail, even if report/comment publication succeeded.
+
+### Why is there only one scanner comment for multiple runs?
+
+- Sticky mode updates one marker comment per mode/profile/target by design.
+- Change `pr_comment_header` if you intentionally want separate independent scanner comments.
+
+### How do summary, PR comment, SARIF, and submission issues differ?
+
+- Job summary: quick run recap in Actions UI.
+- PR comment: reviewer-visible sticky summary in the PR conversation.
+- SARIF: code scanning ingestion and security tab surfacing.
+- Submission issue: optional cross-repo ecosystem submission workflow.
 
 ## Container Distribution
 

--- a/action/action.yml
+++ b/action/action.yml
@@ -115,6 +115,34 @@ inputs:
     description: "Override the plugin author used in the submission issue"
     required: false
     default: ""
+  pr_comment:
+    description: "Publish a sticky PR summary comment: off, auto, or always"
+    required: false
+    default: "off"
+  pr_comment_style:
+    description: "PR comment detail level: concise or full"
+    required: false
+    default: "concise"
+  pr_comment_header:
+    description: "Optional sticky comment header override; defaults to a deterministic mode/profile/plugin hash"
+    required: false
+    default: ""
+  pr_comment_max_findings:
+    description: "Maximum number of top findings shown in the PR comment"
+    required: false
+    default: "3"
+  pr_comment_token:
+    description: "Optional token for PR comments. Defaults to github.token; requires pull-requests:write or issues:write."
+    required: false
+    default: ""
+  pr_comment_skip_if_unchanged:
+    description: "Skip updating the sticky PR comment when the rendered body is unchanged"
+    required: false
+    default: "true"
+  pr_comment_compare_to_previous:
+    description: "Include metric deltas versus the previous scanner comment on this PR"
+    required: false
+    default: "true"
 
 outputs:
   score:
@@ -156,6 +184,24 @@ outputs:
   submission_issue_numbers:
     description: "Comma-separated issue numbers for submission issues created or reused"
     value: ${{ steps.scan.outputs.submission_issue_numbers }}
+  pr_comment_status:
+    description: "PR comment result: disabled, skipped, created, updated, unchanged, or failed"
+    value: ${{ steps.scan.outputs.pr_comment_status }}
+  pr_comment_url:
+    description: "URL of the sticky PR comment when created/updated/found"
+    value: ${{ steps.scan.outputs.pr_comment_url }}
+  pr_comment_id:
+    description: "Numeric GitHub issue-comment ID when available"
+    value: ${{ steps.scan.outputs.pr_comment_id }}
+  pr_comment_reason:
+    description: "Reason for a skipped/failed PR comment operation"
+    value: ${{ steps.scan.outputs.pr_comment_reason }}
+  action_exit_code:
+    description: "Scanner exit code computed after reports/comments/SARIF handling"
+    value: ${{ steps.scan.outputs.action_exit_code }}
+  action_exit_reason:
+    description: "Human-readable reason for a non-zero scanner exit code"
+    value: ${{ steps.scan.outputs.action_exit_reason }}
 
 branding:
   icon: "check-circle"
@@ -234,6 +280,7 @@ runs:
 
     - name: Run scanner
       id: scan
+      continue-on-error: true
       shell: bash
       env:
         MODE: ${{ inputs.mode }}
@@ -261,12 +308,36 @@ runs:
         SUBMISSION_PLUGIN_URL: ${{ inputs.submission_plugin_url }}
         SUBMISSION_PLUGIN_DESCRIPTION: ${{ inputs.submission_plugin_description }}
         SUBMISSION_AUTHOR: ${{ inputs.submission_author }}
+        PR_COMMENT: ${{ inputs.pr_comment }}
+        PR_COMMENT_STYLE: ${{ inputs.pr_comment_style }}
+        PR_COMMENT_HEADER: ${{ inputs.pr_comment_header }}
+        PR_COMMENT_MAX_FINDINGS: ${{ inputs.pr_comment_max_findings }}
+        PR_COMMENT_TOKEN: ${{ inputs.pr_comment_token }}
+        PR_COMMENT_SKIP_IF_UNCHANGED: ${{ inputs.pr_comment_skip_if_unchanged }}
+        PR_COMMENT_COMPARE_TO_PREVIOUS: ${{ inputs.pr_comment_compare_to_previous }}
+        GITHUB_TOKEN: ${{ github.token }}
         GITHUB_STEP_SUMMARY: ${{ env.GITHUB_STEP_SUMMARY }}
       run: python3 -m codex_plugin_scanner.action_runner
 
     - name: Upload SARIF
-      if: ${{ inputs.upload_sarif == 'true' && inputs.mode == 'scan' && steps.scan.outputs.report_path != '' }}
+      if: ${{ always() && inputs.upload_sarif == 'true' && inputs.mode == 'scan' && steps.scan.outputs.report_path != '' }}
       uses: github/codeql-action/upload-sarif@51f77329afa6477de8c49fc9c7046c15b9a4e79d
       with:
         sarif_file: ${{ steps.scan.outputs.report_path }}
         category: ${{ inputs.sarif_category }}
+
+    - name: Enforce scanner execution
+      if: ${{ steps.scan.outcome == 'failure' && steps.scan.outputs.action_exit_code == '' }}
+      shell: bash
+      run: |
+        echo "Scanner execution failed before writing action outputs." >&2
+        exit 1
+
+    - name: Enforce scanner outcome
+      if: ${{ steps.scan.outputs.action_exit_code != '' && steps.scan.outputs.action_exit_code != '0' }}
+      shell: bash
+      run: |
+        if [ -n "${{ steps.scan.outputs.action_exit_reason }}" ]; then
+          echo "${{ steps.scan.outputs.action_exit_reason }}" >&2
+        fi
+        exit "${{ steps.scan.outputs.action_exit_code }}"

--- a/src/codex_plugin_scanner/action_runner.py
+++ b/src/codex_plugin_scanner/action_runner.py
@@ -10,7 +10,15 @@ from pathlib import Path
 
 from . import __version__
 from .cli import _build_plain_text, _build_verification_text, _scan_with_policy
-from .models import GRADE_LABELS, max_severity
+from .models import GRADE_LABELS, SEVERITY_ORDER, max_severity
+from .pr_comments import (
+    PRCommentCategory,
+    PRCommentConfig,
+    PRCommentFinding,
+    PRCommentIntegration,
+    PRCommentSnapshot,
+    publish_pr_comment,
+)
 from .quality_artifact import build_quality_artifact, write_quality_artifact
 from .reporting import build_json_payload, format_markdown, format_sarif, should_fail_for_severity
 from .submission import (
@@ -38,6 +46,16 @@ def _read_bool_env(name: str, *, default: bool = False) -> bool:
 
 def _read_env(name: str, default: str = "") -> str:
     return os.environ.get(name, default)
+
+
+def _read_int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw.strip())
+    except ValueError:
+        return default
 
 
 def _write_outputs(path: str, values: dict[str, str]) -> None:
@@ -144,6 +162,9 @@ def _build_step_summary_lines(
     scope: str = "plugin",
     local_plugin_count: int | None = None,
     skipped_target_count: int | None = None,
+    pr_comment_status: str = "",
+    pr_comment_url: str = "",
+    pr_comment_reason: str = "",
 ) -> tuple[str, ...]:
     lines = ["## HOL Codex Plugin Scanner", "", f"- Mode: {mode}"]
     lines.append(f"- Scope: {scope}")
@@ -168,7 +189,195 @@ def _build_step_summary_lines(
         lines.append(f"- Registry payload: `{registry_payload_path}`")
     if submission_issues:
         lines.append(f"- Submission issues: {', '.join(issue.url for issue in submission_issues)}")
+    if pr_comment_status:
+        status_line = f"- PR comment: {pr_comment_status}"
+        if pr_comment_url:
+            status_line += f" ({pr_comment_url})"
+        lines.append(status_line)
+        if pr_comment_reason:
+            lines.append(f"- PR comment reason: {pr_comment_reason}")
     return tuple(lines)
+
+
+def _normalize_pr_comment_mode(value: str) -> str:
+    normalized = value.strip().lower()
+    if normalized in {"off", "auto", "always"}:
+        return normalized
+    return "off"
+
+
+def _normalize_pr_comment_style(value: str) -> str:
+    normalized = value.strip().lower()
+    if normalized in {"concise", "full"}:
+        return normalized
+    return "concise"
+
+
+def _sorted_findings(result) -> list:
+    return sorted(
+        result.findings,
+        key=lambda finding: (
+            -SEVERITY_ORDER[finding.severity],
+            finding.category,
+            finding.title,
+            finding.file_path or "",
+            finding.line_number or 0,
+        ),
+    )
+
+
+def _build_pr_comment_snapshot_for_scan(
+    *,
+    mode: str,
+    profile: str,
+    plugin_dir: str,
+    result,
+    policy_pass: bool,
+    verify_pass: bool | None,
+    gate_pass: bool,
+    gate_reasons: tuple[str, ...],
+    min_score: int,
+    fail_on_severity: str,
+    score_gate_pass: bool,
+    severity_gate_pass: bool,
+    submission_eligible: bool,
+    submission_issues: list[SubmissionIssue],
+    workflow_url: str,
+    full_report_markdown: str,
+) -> PRCommentSnapshot:
+    deduped: list[PRCommentFinding] = []
+    seen: set[tuple[str, str, str, str, int | None]] = set()
+    for finding in _sorted_findings(result):
+        key = (
+            finding.rule_id,
+            finding.severity.value,
+            finding.title,
+            finding.file_path or "",
+            finding.line_number,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(
+            PRCommentFinding(
+                severity=finding.severity.value,
+                title=finding.title,
+                file_path=finding.file_path or "",
+                line_number=finding.line_number,
+                remediation=finding.remediation or "",
+            )
+        )
+    top_findings = tuple(deduped[:10])
+    categories = tuple(
+        PRCommentCategory(
+            name=category.name,
+            score=sum(check.points for check in category.checks),
+            max_score=sum(check.max_points for check in category.checks),
+        )
+        for category in result.categories
+    )
+    integrations = tuple(
+        PRCommentIntegration(
+            name=integration.name,
+            status=integration.status,
+            message=integration.message,
+        )
+        for integration in result.integrations
+    )
+    return PRCommentSnapshot(
+        mode=mode,
+        profile=profile,
+        plugin_dir=plugin_dir,
+        scope=getattr(result, "scope", "plugin"),
+        score=result.score,
+        grade=result.grade,
+        grade_label=GRADE_LABELS.get(result.grade, "Unknown"),
+        max_severity=max_severity(result.findings).value if result.findings else "none",
+        findings_total=sum(result.severity_counts.values()),
+        severity_counts={key: int(value) for key, value in result.severity_counts.items()},
+        min_score=min_score,
+        fail_on_severity=fail_on_severity,
+        score_gate_pass=score_gate_pass,
+        severity_gate_pass=severity_gate_pass,
+        policy_pass=policy_pass,
+        verify_pass=verify_pass,
+        gate_pass=gate_pass,
+        gate_reasons=gate_reasons,
+        top_findings=top_findings,
+        categories=categories,
+        integrations=integrations,
+        submission_eligible=submission_eligible,
+        submission_issues=tuple(issue.url for issue in submission_issues),
+        workflow_url=workflow_url,
+        full_report_markdown=full_report_markdown,
+    )
+
+
+def _case_severity_label(classification: str) -> str:
+    if classification in {"protocol", "spawn-failure", "timeout", "transport", "tls"}:
+        return "high"
+    if classification in {"schema", "asset-missing", "invalid-json", "missing-manifest"}:
+        return "medium"
+    return "info"
+
+
+def _build_pr_comment_snapshot_for_verify(
+    *,
+    mode: str,
+    profile: str,
+    plugin_dir: str,
+    verification,
+    gate_pass: bool,
+    gate_reasons: tuple[str, ...],
+    fail_on_severity: str,
+    workflow_url: str,
+    full_report_markdown: str,
+) -> PRCommentSnapshot:
+    failed_cases = [case for case in verification.cases if not case.passed]
+    severity_counts = {severity: 0 for severity in ("critical", "high", "medium", "low", "info")}
+    top_findings: list[PRCommentFinding] = []
+    for case in failed_cases:
+        severity = _case_severity_label(case.classification)
+        severity_counts[severity] = severity_counts.get(severity, 0) + 1
+        top_findings.append(
+            PRCommentFinding(
+                severity=severity,
+                title=f"{case.component}: {case.name}",
+                remediation=case.message,
+            )
+        )
+    max_severity_value = "none"
+    for severity in ("critical", "high", "medium", "low", "info"):
+        if severity_counts.get(severity, 0) > 0:
+            max_severity_value = severity
+            break
+    return PRCommentSnapshot(
+        mode=mode,
+        profile=profile,
+        plugin_dir=plugin_dir,
+        scope=getattr(verification, "scope", "plugin"),
+        score=None,
+        grade="",
+        grade_label="",
+        max_severity=max_severity_value,
+        findings_total=len(failed_cases),
+        severity_counts=severity_counts,
+        min_score=None,
+        fail_on_severity=fail_on_severity,
+        score_gate_pass=None,
+        severity_gate_pass=None,
+        policy_pass=None,
+        verify_pass=verification.verify_pass,
+        gate_pass=gate_pass,
+        gate_reasons=gate_reasons,
+        top_findings=tuple(top_findings),
+        categories=(),
+        integrations=(),
+        submission_eligible=None,
+        submission_issues=(),
+        workflow_url=workflow_url,
+        full_report_markdown=full_report_markdown,
+    )
 
 
 def main() -> int:
@@ -183,12 +392,12 @@ def main() -> int:
     config = _read_env("CONFIG")
     baseline = _read_env("BASELINE")
     online = _read_bool_env("ONLINE")
-    min_score = int(_read_env("MIN_SCORE", "0"))
+    min_score = _read_int_env("MIN_SCORE", 0)
     fail_on = _read_env("FAIL_ON", "none")
     cisco_scan = _read_env("CISCO_SCAN", "auto")
     cisco_policy = _read_env("CISCO_POLICY", "balanced")
     submission_enabled = _read_bool_env("SUBMISSION_ENABLED")
-    submission_threshold = int(_read_env("SUBMISSION_SCORE_THRESHOLD", "80"))
+    submission_threshold = _read_int_env("SUBMISSION_SCORE_THRESHOLD", 80)
     submission_repos = _parse_csv(_read_env("SUBMISSION_REPOS"))
     submission_token = _read_env("SUBMISSION_TOKEN").strip()
     submission_labels = _parse_csv(_read_env("SUBMISSION_LABELS"))
@@ -202,6 +411,16 @@ def main() -> int:
     github_sha = _read_env("GITHUB_SHA")
     github_run_id = _read_env("GITHUB_RUN_ID")
     github_api_url = _read_env("GITHUB_API_URL", "https://api.github.com")
+    github_event_name = _read_env("GITHUB_EVENT_NAME")
+    github_event_path = _read_env("GITHUB_EVENT_PATH")
+    github_ref = _read_env("GITHUB_REF")
+    pr_comment_mode = _normalize_pr_comment_mode(_read_env("PR_COMMENT", "off"))
+    pr_comment_style = _normalize_pr_comment_style(_read_env("PR_COMMENT_STYLE", "concise"))
+    pr_comment_header = _read_env("PR_COMMENT_HEADER")
+    pr_comment_max_findings = max(0, _read_int_env("PR_COMMENT_MAX_FINDINGS", 3))
+    pr_comment_skip_if_unchanged = _read_bool_env("PR_COMMENT_SKIP_IF_UNCHANGED", default=True)
+    pr_comment_compare_to_previous = _read_bool_env("PR_COMMENT_COMPARE_TO_PREVIOUS", default=True)
+    pr_comment_token = _read_env("PR_COMMENT_TOKEN").strip() or _read_env("GITHUB_TOKEN").strip()
 
     workflow_url = ""
     if github_repository and github_run_id:
@@ -226,11 +445,20 @@ def main() -> int:
         "submission_performed": "false",
         "submission_issue_urls": "",
         "submission_issue_numbers": "",
+        "pr_comment_status": "",
+        "pr_comment_url": "",
+        "pr_comment_id": "",
+        "pr_comment_reason": "",
+        "action_exit_code": "0",
+        "action_exit_reason": "",
     }
     verify_pass_for_summary: bool | None = None
+    verify_pass_for_comment: bool | None = None
     scan_scope = "plugin"
     local_plugin_count: int | None = None
     skipped_target_count: int | None = None
+    gate_reasons: list[str] = []
+    snapshot: PRCommentSnapshot | None = None
 
     if mode in {"scan", "lint", "submit"}:
         args = _build_scan_args(
@@ -252,13 +480,12 @@ def main() -> int:
             local_plugin_count = len(result.plugin_results)
             skipped_target_count = len(result.skipped_targets)
         rendered = ""
-        artifact_path = ""
         verification = None
+        artifact_path = ""
         if mode == "scan":
             if upload_sarif:
                 if output_format != "sarif":
-                    print("upload_sarif requires format=sarif.", file=sys.stderr)
-                    return 1
+                    gate_reasons.append("upload_sarif requires format=sarif")
                 if not output_path:
                     output_path = "codex-plugin-scanner.sarif"
             rendered = _render_scan_output(
@@ -277,26 +504,32 @@ def main() -> int:
             )
         else:
             if scan_scope != "plugin":
-                print(
-                    "Submission mode requires a single plugin directory. "
-                    "Point plugin_dir at one plugin instead of a repo marketplace root.",
-                    file=sys.stderr,
+                gate_reasons.append(
+                    "submission mode requires plugin_dir to point at a single plugin directory"
                 )
-                return 1
-            verification = verify_plugin(Path(plugin_dir).resolve(), online=online)
-            artifact_path = output_path or "plugin-quality.json"
-            artifact = build_quality_artifact(
-                Path(plugin_dir).resolve(),
-                result,
-                verification,
-                policy_eval,
-                resolved_profile,
-                raw_score=raw_result.score,
-            )
-            write_quality_artifact(Path(artifact_path), artifact)
-            rendered = json.dumps(artifact, indent=2)
-            print(f"Submission artifact written to {artifact_path}")
-            verify_pass_for_summary = verification.verify_pass
+                rendered = _render_scan_output(
+                    result,
+                    output_format="json" if output_format == "json" else "text",
+                    profile=resolved_profile,
+                    policy_pass=policy_eval.policy_pass,
+                    raw_score=raw_result.score,
+                )
+            else:
+                verification = verify_plugin(Path(plugin_dir).resolve(), online=online)
+                artifact_path = output_path or "plugin-quality.json"
+                artifact = build_quality_artifact(
+                    Path(plugin_dir).resolve(),
+                    result,
+                    verification,
+                    policy_eval,
+                    resolved_profile,
+                    raw_score=raw_result.score,
+                )
+                write_quality_artifact(Path(artifact_path), artifact)
+                rendered = json.dumps(artifact, indent=2)
+                print(f"Submission artifact written to {artifact_path}")
+                verify_pass_for_summary = verification.verify_pass
+                verify_pass_for_comment = verification.verify_pass
 
         if output_path and mode != "submit":
             target = Path(output_path)
@@ -308,6 +541,7 @@ def main() -> int:
         else:
             print(rendered)
 
+        score_failed = result.score < min_score
         severity_failed = should_fail_for_severity(result, fail_on)
         output_values.update(
             {
@@ -320,6 +554,7 @@ def main() -> int:
                 "findings_total": str(sum(result.severity_counts.values())),
             }
         )
+        verify_pass_for_comment = verification.verify_pass if verification is not None else None
 
         if submission_enabled or registry_payload_output:
             metadata = resolve_submission_metadata(
@@ -357,59 +592,73 @@ def main() -> int:
 
             if submission_eligible:
                 if not submission_repos:
-                    print("Submission is enabled but no submission repositories were configured.", file=sys.stderr)
-                    return 1
-                if not submission_token:
-                    print("Submission is enabled but no submission token was provided.", file=sys.stderr)
-                    return 1
-                if not metadata.plugin_url:
-                    print("Submission metadata is missing a plugin repository URL.", file=sys.stderr)
-                    return 1
-                title = build_submission_issue_title(metadata)
-                body = build_submission_issue_body(
-                    metadata,
-                    result,
-                    payload=registry_payload,
-                    workflow_url=workflow_url,
-                )
-                for submission_repo in submission_repos:
-                    existing = find_existing_submission_issue(
-                        submission_repo,
-                        metadata.plugin_url,
-                        submission_token,
-                        api_base_url=github_api_url,
+                    gate_reasons.append("submission is enabled but no submission repositories were configured")
+                elif not submission_token:
+                    gate_reasons.append("submission is enabled but no submission token was provided")
+                elif not metadata.plugin_url:
+                    gate_reasons.append("submission metadata is missing a plugin repository URL")
+                else:
+                    title = build_submission_issue_title(metadata)
+                    body = build_submission_issue_body(
+                        metadata,
+                        result,
+                        payload=registry_payload,
+                        workflow_url=workflow_url,
                     )
-                    if existing is not None:
-                        submission_issues.append(existing)
-                        continue
-                    submission_issues.append(
-                        create_submission_issue(
+                    for submission_repo in submission_repos:
+                        existing = find_existing_submission_issue(
                             submission_repo,
-                            title,
-                            body,
+                            metadata.plugin_url,
                             submission_token,
-                            labels=submission_labels,
                             api_base_url=github_api_url,
                         )
-                    )
+                        if existing is not None:
+                            submission_issues.append(existing)
+                            continue
+                        submission_issues.append(
+                            create_submission_issue(
+                                submission_repo,
+                                title,
+                                body,
+                                submission_token,
+                                labels=submission_labels,
+                                api_base_url=github_api_url,
+                            )
+                        )
 
         output_values["submission_eligible"] = "true" if submission_eligible else "false"
         output_values["submission_performed"] = "true" if submission_issues else "false"
         output_values["submission_issue_urls"] = ",".join(issue.url for issue in submission_issues)
         output_values["submission_issue_numbers"] = ",".join(str(issue.number) for issue in submission_issues)
 
-        if result.score < min_score:
-            print(f"Score {result.score} is below minimum threshold {min_score}", file=sys.stderr)
-            return 1
-        if should_fail_for_severity(result, fail_on):
-            print(f'Findings met or exceeded the "{fail_on}" severity threshold.', file=sys.stderr)
-            return 1
+        if score_failed:
+            gate_reasons.append(f"score {result.score} is below minimum threshold {min_score}")
+        if severity_failed:
+            gate_reasons.append(f'findings met or exceeded the "{fail_on}" severity threshold')
         if not policy_eval.policy_pass:
-            print(f'Policy profile "{resolved_profile}" failed.', file=sys.stderr)
-            return 1
+            gate_reasons.append(f'policy profile "{resolved_profile}" failed')
         if mode == "submit" and verification is not None and not verification.verify_pass:
-            print("Submission blocked: runtime verification failed.", file=sys.stderr)
-            return 1
+            gate_reasons.append("submission blocked because runtime verification failed")
+
+        gate_pass = not gate_reasons
+        snapshot = _build_pr_comment_snapshot_for_scan(
+            mode=mode,
+            profile=resolved_profile,
+            plugin_dir=str(Path(plugin_dir).resolve()),
+            result=result,
+            policy_pass=policy_eval.policy_pass,
+            verify_pass=verify_pass_for_comment,
+            gate_pass=gate_pass,
+            gate_reasons=tuple(gate_reasons),
+            min_score=min_score,
+            fail_on_severity=fail_on,
+            score_gate_pass=not score_failed,
+            severity_gate_pass=not severity_failed,
+            submission_eligible=submission_eligible,
+            submission_issues=submission_issues,
+            workflow_url=workflow_url,
+            full_report_markdown=format_markdown(result),
+        )
 
     elif mode == "verify":
         verification = verify_plugin(Path(plugin_dir).resolve(), online=online)
@@ -426,14 +675,90 @@ def main() -> int:
             report_path_value = str(target)
         else:
             print(rendered)
-        return_code = 1 if not verification.verify_pass else 0
         output_values["verify_pass"] = "true" if verification.verify_pass else "false"
+        verify_pass_for_summary = verification.verify_pass
+        verify_pass_for_comment = verification.verify_pass
+        if not verification.verify_pass:
+            gate_reasons.append("runtime verification failed")
+        snapshot = _build_pr_comment_snapshot_for_verify(
+            mode=mode,
+            profile=profile,
+            plugin_dir=str(Path(plugin_dir).resolve()),
+            verification=verification,
+            gate_pass=verification.verify_pass,
+            gate_reasons=tuple(gate_reasons),
+            fail_on_severity=fail_on,
+            workflow_url=workflow_url,
+            full_report_markdown=rendered,
+        )
     else:
         print(f"Unsupported mode: {mode}", file=sys.stderr)
         return 1
 
     output_values["report_path"] = report_path_value
     output_values["registry_payload_path"] = registry_payload_path_value
+    action_exit_code = 0 if not gate_reasons else 1
+    action_exit_reason = "; ".join(dict.fromkeys(gate_reasons))
+
+    pr_comment_outcome = publish_pr_comment(
+        config=PRCommentConfig(
+            mode=pr_comment_mode,
+            style=pr_comment_style,
+            header=pr_comment_header,
+            max_findings=pr_comment_max_findings,
+            token=pr_comment_token,
+            skip_if_unchanged=pr_comment_skip_if_unchanged,
+            compare_to_previous=pr_comment_compare_to_previous,
+            api_base_url=github_api_url,
+        ),
+        snapshot=snapshot
+        if snapshot is not None
+        else PRCommentSnapshot(
+            mode=mode,
+            profile=profile,
+            plugin_dir=str(Path(plugin_dir).resolve()),
+            scope=scan_scope,
+            score=None,
+            grade="",
+            grade_label="",
+            max_severity=output_values["max_severity"] or "none",
+            findings_total=None,
+            severity_counts={severity: 0 for severity in ("critical", "high", "medium", "low", "info")},
+            min_score=min_score,
+            fail_on_severity=fail_on,
+            score_gate_pass=None,
+            severity_gate_pass=None,
+            policy_pass=True if output_values["policy_pass"] == "true" else None,
+            verify_pass=verify_pass_for_comment,
+            gate_pass=not gate_reasons,
+            gate_reasons=tuple(gate_reasons),
+            top_findings=(),
+            categories=(),
+            integrations=(),
+            submission_eligible=submission_eligible,
+            submission_issues=tuple(issue.url for issue in submission_issues),
+            workflow_url=workflow_url,
+            full_report_markdown="",
+        ),
+        event_name=github_event_name,
+        event_path=github_event_path,
+        ref=github_ref,
+        repository=github_repository,
+        head_sha=github_sha,
+    )
+    output_values["pr_comment_status"] = pr_comment_outcome.status
+    output_values["pr_comment_url"] = pr_comment_outcome.url
+    output_values["pr_comment_id"] = "" if pr_comment_outcome.comment_id is None else str(pr_comment_outcome.comment_id)
+    output_values["pr_comment_reason"] = pr_comment_outcome.reason
+    if pr_comment_outcome.status == "failed":
+        reason = f"pull request comment failed: {pr_comment_outcome.reason or 'unknown error'}"
+        if reason not in gate_reasons:
+            gate_reasons.append(reason)
+        action_exit_code = 1
+        action_exit_reason = "; ".join(dict.fromkeys(gate_reasons))
+
+    output_values["action_exit_code"] = str(action_exit_code)
+    output_values["action_exit_reason"] = action_exit_reason
 
     step_summary_path = _read_env("GITHUB_STEP_SUMMARY")
     if write_step_summary and step_summary_path:
@@ -454,6 +779,9 @@ def main() -> int:
                 scope=scan_scope,
                 local_plugin_count=local_plugin_count,
                 skipped_target_count=skipped_target_count,
+                pr_comment_status=output_values["pr_comment_status"],
+                pr_comment_url=output_values["pr_comment_url"],
+                pr_comment_reason=output_values["pr_comment_reason"],
             ),
         )
 
@@ -461,9 +789,9 @@ def main() -> int:
     if github_output:
         _write_outputs(github_output, output_values)
 
-    if mode == "verify":
-        return return_code
-    return 0
+    if action_exit_code != 0 and action_exit_reason:
+        print(action_exit_reason, file=sys.stderr)
+    return action_exit_code
 
 
 if __name__ == "__main__":

--- a/src/codex_plugin_scanner/action_runner.py
+++ b/src/codex_plugin_scanner/action_runner.py
@@ -504,9 +504,7 @@ def main() -> int:
             )
         else:
             if scan_scope != "plugin":
-                gate_reasons.append(
-                    "submission mode requires plugin_dir to point at a single plugin directory"
-                )
+                gate_reasons.append("submission mode requires plugin_dir to point at a single plugin directory")
                 rendered = _render_scan_output(
                     result,
                     output_format="json" if output_format == "json" else "text",

--- a/src/codex_plugin_scanner/pr_comments.py
+++ b/src/codex_plugin_scanner/pr_comments.py
@@ -633,8 +633,8 @@ def publish_pr_comment(
         return PRCommentOutcome(status="updated", url=updated.url, comment_id=updated.comment_id)
     except HTTPError as error:
         reason = f"GitHub API {error.code} while writing PR comment"
-    except OSError as error:
-        reason = f"network error while writing PR comment: {error}"
+    except (OSError, ValueError) as error:
+        reason = f"network error or invalid response while writing PR comment: {error}"
     except RuntimeError as error:
         reason = str(error)
     if config.mode == "always":

--- a/src/codex_plugin_scanner/pr_comments.py
+++ b/src/codex_plugin_scanner/pr_comments.py
@@ -1,0 +1,642 @@
+"""Native sticky pull request comments for the scanner GitHub Action."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+REQUEST_TIMEOUT_SECONDS = 30
+COMMENT_MARKER_PREFIX = "<!-- hol-codex-plugin-scanner:"
+COMMENT_MARKER_SUFFIX = " -->"
+COMMENT_DATA_PREFIX = "<!-- hol-codex-plugin-scanner-data:"
+COMMENT_DATA_SUFFIX = " -->"
+SEVERITY_ORDER = ("critical", "high", "medium", "low", "info")
+
+
+@dataclass(frozen=True, slots=True)
+class PullRequestContext:
+    owner: str
+    repo: str
+    number: int
+    event_name: str
+    head_sha: str
+    workflow_url: str
+
+
+@dataclass(frozen=True, slots=True)
+class PRCommentConfig:
+    mode: str
+    style: str
+    header: str
+    max_findings: int
+    token: str
+    skip_if_unchanged: bool
+    compare_to_previous: bool
+    api_base_url: str = "https://api.github.com"
+
+
+@dataclass(frozen=True, slots=True)
+class PRCommentFinding:
+    severity: str
+    title: str
+    file_path: str = ""
+    line_number: int | None = None
+    remediation: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class PRCommentCategory:
+    name: str
+    score: int
+    max_score: int
+
+
+@dataclass(frozen=True, slots=True)
+class PRCommentIntegration:
+    name: str
+    status: str
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class PRCommentSnapshot:
+    mode: str
+    profile: str
+    plugin_dir: str
+    scope: str
+    score: int | None
+    grade: str
+    grade_label: str
+    max_severity: str
+    findings_total: int | None
+    severity_counts: dict[str, int]
+    min_score: int | None
+    fail_on_severity: str
+    score_gate_pass: bool | None
+    severity_gate_pass: bool | None
+    policy_pass: bool | None
+    verify_pass: bool | None
+    gate_pass: bool
+    gate_reasons: tuple[str, ...]
+    top_findings: tuple[PRCommentFinding, ...]
+    categories: tuple[PRCommentCategory, ...]
+    integrations: tuple[PRCommentIntegration, ...]
+    submission_eligible: bool | None
+    submission_issues: tuple[str, ...]
+    workflow_url: str
+    full_report_markdown: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class PRCommentOutcome:
+    status: str
+    reason: str = ""
+    url: str = ""
+    comment_id: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _ExistingComment:
+    comment_id: int
+    body: str
+    url: str
+    updated_at: str
+
+
+def _repo_api_path(owner: str, repo: str) -> str:
+    return f"{quote(owner, safe='')}/{quote(repo, safe='')}"
+
+
+def _request_json(
+    method: str,
+    url: str,
+    token: str,
+    payload: dict[str, object] | None = None,
+) -> dict[str, object] | list[dict[str, object]]:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = Request(url, data=data, method=method)
+    request.add_header("Accept", "application/vnd.github+json")
+    request.add_header("Authorization", f"Bearer {token}")
+    request.add_header("User-Agent", "codex-plugin-scanner")
+    if data is not None:
+        request.add_header("Content-Type", "application/json")
+    with urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _list_issue_comments(
+    *,
+    context: PullRequestContext,
+    token: str,
+    api_base_url: str,
+) -> list[_ExistingComment]:
+    encoded_repo = _repo_api_path(context.owner, context.repo)
+    base_url = api_base_url.rstrip("/")
+    comments: list[_ExistingComment] = []
+    page = 1
+    while True:
+        response = _request_json(
+            "GET",
+            f"{base_url}/repos/{encoded_repo}/issues/{context.number}/comments?per_page=100&page={page}",
+            token,
+        )
+        if not isinstance(response, list) or not response:
+            return comments
+        for item in response:
+            comment_id = item.get("id")
+            body = item.get("body")
+            url = item.get("html_url")
+            updated_at = item.get("updated_at")
+            if not isinstance(comment_id, int):
+                continue
+            if not isinstance(body, str):
+                continue
+            if not isinstance(url, str) or not url:
+                continue
+            if not isinstance(updated_at, str):
+                updated_at = ""
+            comments.append(
+                _ExistingComment(
+                    comment_id=comment_id,
+                    body=body,
+                    url=url,
+                    updated_at=updated_at,
+                )
+            )
+        if len(response) < 100:
+            return comments
+        page += 1
+
+
+def _create_issue_comment(
+    *,
+    context: PullRequestContext,
+    token: str,
+    body: str,
+    api_base_url: str,
+) -> _ExistingComment:
+    encoded_repo = _repo_api_path(context.owner, context.repo)
+    response = _request_json(
+        "POST",
+        f"{api_base_url.rstrip('/')}/repos/{encoded_repo}/issues/{context.number}/comments",
+        token,
+        {"body": body},
+    )
+    if not isinstance(response, dict):
+        raise RuntimeError("GitHub comment response had unexpected shape.")
+    comment_id = response.get("id")
+    url = response.get("html_url")
+    updated_at = response.get("updated_at")
+    if not isinstance(comment_id, int) or not isinstance(url, str) or not isinstance(updated_at, str):
+        raise RuntimeError("GitHub comment response is missing required fields.")
+    return _ExistingComment(comment_id=comment_id, body=body, url=url, updated_at=updated_at)
+
+
+def _update_issue_comment(
+    *,
+    context: PullRequestContext,
+    token: str,
+    comment_id: int,
+    body: str,
+    api_base_url: str,
+) -> _ExistingComment:
+    encoded_repo = _repo_api_path(context.owner, context.repo)
+    response = _request_json(
+        "PATCH",
+        f"{api_base_url.rstrip('/')}/repos/{encoded_repo}/issues/comments/{comment_id}",
+        token,
+        {"body": body},
+    )
+    if not isinstance(response, dict):
+        raise RuntimeError("GitHub comment response had unexpected shape.")
+    url = response.get("html_url")
+    updated_at = response.get("updated_at")
+    if not isinstance(url, str) or not isinstance(updated_at, str):
+        raise RuntimeError("GitHub comment response is missing required fields.")
+    return _ExistingComment(comment_id=comment_id, body=body, url=url, updated_at=updated_at)
+
+
+def _extract_pr_number_from_ref(ref: str) -> int | None:
+    match = re.match(r"^refs/pull/(\d+)/(?:merge|head)$", ref)
+    if match is None:
+        return None
+    try:
+        return int(match.group(1))
+    except ValueError:
+        return None
+
+
+def resolve_pr_context(
+    *,
+    event_name: str,
+    event_path: str,
+    ref: str,
+    repository: str,
+    head_sha: str,
+    workflow_url: str,
+) -> PullRequestContext | None:
+    repository = repository.strip()
+    if "/" not in repository:
+        return None
+    owner, repo = repository.split("/", 1)
+    pr_number: int | None = None
+    if event_path:
+        event_file = Path(event_path)
+        if event_file.exists():
+            try:
+                payload = json.loads(event_file.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                payload = None
+            if isinstance(payload, dict):
+                pull_request = payload.get("pull_request")
+                if isinstance(pull_request, dict):
+                    number = pull_request.get("number")
+                    if isinstance(number, int):
+                        pr_number = number
+                    head = pull_request.get("head")
+                    if isinstance(head, dict):
+                        sha = head.get("sha")
+                        if isinstance(sha, str) and sha:
+                            head_sha = sha
+    if pr_number is None:
+        pr_number = _extract_pr_number_from_ref(ref)
+    if pr_number is None:
+        return None
+    return PullRequestContext(
+        owner=owner,
+        repo=repo,
+        number=pr_number,
+        event_name=event_name,
+        head_sha=head_sha,
+        workflow_url=workflow_url,
+    )
+
+
+def compute_comment_header(*, mode: str, profile: str, plugin_dir: str, configured_header: str) -> str:
+    header = configured_header.strip()
+    if header:
+        return header
+    digest = hashlib.sha256(f"{mode}|{profile}|{plugin_dir}".encode()).hexdigest()[:12]
+    return f"mode={mode};profile={profile};target={digest}"
+
+
+def _comment_marker(header: str) -> str:
+    return f"{COMMENT_MARKER_PREFIX}{header}{COMMENT_MARKER_SUFFIX}"
+
+
+def _encode_metadata(snapshot: PRCommentSnapshot) -> str:
+    metadata = {
+        "score": snapshot.score,
+        "findings_total": snapshot.findings_total,
+        "severity_counts": snapshot.severity_counts,
+        "policy_pass": snapshot.policy_pass,
+        "verify_pass": snapshot.verify_pass,
+        "max_severity": snapshot.max_severity,
+    }
+    encoded = base64.urlsafe_b64encode(json.dumps(metadata, separators=(",", ":")).encode("utf-8"))
+    return encoded.decode("utf-8").rstrip("=")
+
+
+def _decode_metadata(body: str) -> dict[str, object] | None:
+    match = re.search(
+        re.escape(COMMENT_DATA_PREFIX) + r"([A-Za-z0-9_-]+)" + re.escape(COMMENT_DATA_SUFFIX),
+        body,
+    )
+    if match is None:
+        return None
+    encoded = match.group(1)
+    padded = encoded + "=" * ((4 - (len(encoded) % 4)) % 4)
+    try:
+        decoded = base64.urlsafe_b64decode(padded.encode("utf-8"))
+        payload = json.loads(decoded.decode("utf-8"))
+    except (ValueError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _normalize_body(body: str) -> str:
+    return "\n".join(line.rstrip() for line in body.strip().splitlines())
+
+
+def _bool_label(value: bool | None) -> str:
+    if value is None:
+        return "n/a"
+    return "yes" if value else "no"
+
+
+def _gate_label(*, passed: bool | None, descriptor: str) -> str:
+    if passed is None:
+        return "n/a"
+    return f"{descriptor} {'✅' if passed else '❌'}"
+
+
+def _severity_breakdown(severity_counts: dict[str, int]) -> str:
+    parts = [f"{severity}: {severity_counts.get(severity, 0)}" for severity in SEVERITY_ORDER]
+    return ", ".join(parts)
+
+
+def _truncate(text: str, limit: int = 240) -> str:
+    normalized = " ".join(text.split())
+    if len(normalized) <= limit:
+        return normalized
+    return f"{normalized[: limit - 1]}…"
+
+
+def _format_path(file_path: str, line_number: int | None) -> str:
+    if not file_path:
+        return ""
+    if line_number is None:
+        return file_path
+    return f"{file_path}:{line_number}"
+
+
+def _format_top_findings(snapshot: PRCommentSnapshot, *, max_findings: int) -> list[str]:
+    findings = list(snapshot.top_findings)[: max(max_findings, 0)]
+    if not findings:
+        return ["- No actionable findings."]
+    lines: list[str] = []
+    for finding in findings:
+        location = _format_path(finding.file_path, finding.line_number)
+        location_suffix = f" ({location})" if location else ""
+        remediation = _truncate(finding.remediation) if finding.remediation else "Review scanner output details."
+        lines.append(f"- **{finding.severity.upper()}** {finding.title}{location_suffix}")
+        lines.append(f"  - {_truncate(remediation)}")
+    return lines
+
+
+def _format_categories(snapshot: PRCommentSnapshot, *, style: str) -> list[str]:
+    if not snapshot.categories:
+        return ["- No category details captured for this mode."]
+    order = {
+        "Manifest Validation": 0,
+        "Security": 1,
+        "Operational Security": 2,
+        "Best Practices": 3,
+        "Marketplace": 4,
+        "Skill Security": 5,
+        "Code Quality": 6,
+    }
+    categories = sorted(snapshot.categories, key=lambda category: order.get(category.name, 99))
+    lines: list[str] = []
+    for category in categories:
+        if category.max_score == 0 and style == "concise":
+            continue
+        if category.max_score == 0:
+            lines.append(f"- {category.name}: n/a")
+            continue
+        lines.append(f"- {category.name}: {category.score}/{category.max_score}")
+    return lines or ["- No scored categories for this run."]
+
+
+def _format_integrations(snapshot: PRCommentSnapshot) -> list[str]:
+    if not snapshot.integrations:
+        return ["- No optional integrations were active."]
+    return [f"- {item.name}: `{item.status}` - {item.message}" for item in snapshot.integrations]
+
+
+def _parse_previous_bool(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    return None
+
+
+def _parse_previous_int(value: object) -> int | None:
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _parse_previous_severity_counts(value: object) -> dict[str, int]:
+    if not isinstance(value, dict):
+        return {}
+    parsed: dict[str, int] = {}
+    for key, raw in value.items():
+        if not isinstance(key, str):
+            continue
+        if isinstance(raw, int):
+            parsed[key] = raw
+    return parsed
+
+
+def _build_delta_line(previous: dict[str, object] | None, snapshot: PRCommentSnapshot) -> str:
+    if previous is None:
+        return "Compared with the previous scan on this PR: no prior scanner comment metadata was found."
+    delta_parts: list[str] = []
+    previous_score = _parse_previous_int(previous.get("score"))
+    if snapshot.score is not None and previous_score is not None:
+        score_delta = snapshot.score - previous_score
+        delta_parts.append(f"score {'+' if score_delta >= 0 else ''}{score_delta}")
+    previous_findings_total = _parse_previous_int(previous.get("findings_total"))
+    if snapshot.findings_total is not None and previous_findings_total is not None:
+        findings_delta = snapshot.findings_total - previous_findings_total
+        delta_parts.append(f"findings {'+' if findings_delta >= 0 else ''}{findings_delta}")
+    previous_counts = _parse_previous_severity_counts(previous.get("severity_counts"))
+    for severity in SEVERITY_ORDER:
+        if severity not in snapshot.severity_counts and severity not in previous_counts:
+            continue
+        delta = snapshot.severity_counts.get(severity, 0) - previous_counts.get(severity, 0)
+        if delta != 0:
+            delta_parts.append(f"{severity} {'+' if delta >= 0 else ''}{delta}")
+    previous_policy = _parse_previous_bool(previous.get("policy_pass"))
+    if snapshot.policy_pass is not None and previous_policy is not None:
+        policy_state = "changed" if snapshot.policy_pass != previous_policy else "unchanged"
+        delta_parts.append(f"policy {policy_state}")
+    previous_verify = _parse_previous_bool(previous.get("verify_pass"))
+    if snapshot.verify_pass is not None and previous_verify is not None:
+        verify_state = "changed" if snapshot.verify_pass != previous_verify else "unchanged"
+        delta_parts.append(f"verify {verify_state}")
+    if not delta_parts:
+        return "Compared with the previous scan on this PR: no measurable metric changes."
+    return f"Compared with the previous scan on this PR: {', '.join(delta_parts)}."
+
+
+def _render_pr_comment(
+    *,
+    marker: str,
+    snapshot: PRCommentSnapshot,
+    style: str,
+    max_findings: int,
+    compare_to_previous: bool,
+    previous_metadata: dict[str, object] | None,
+) -> str:
+    verdict = "✅ Passed" if snapshot.gate_pass else "❌ Gate failed"
+    min_score_value = "n/a" if snapshot.min_score is None else str(snapshot.min_score)
+    score_gate_descriptor = f"min_score={min_score_value}"
+    severity_gate_value = snapshot.fail_on_severity or "none"
+    severity_gate_descriptor = f"fail_on_severity={severity_gate_value}"
+    lines = [
+        f"## HOL Codex Plugin Scanner · {verdict}",
+        "",
+        "_Checks run: manifest, security posture, operational security, marketplace integrity, "
+        "skill safety, and code quality._",
+        "",
+        "| Metric | Value |",
+        "| --- | --- |",
+        f"| Mode | `{snapshot.mode}` |",
+        f"| Profile | `{snapshot.profile}` |",
+        f"| Scope | `{snapshot.scope}` |",
+    ]
+    if snapshot.score is not None:
+        lines.append(f"| Score | `{snapshot.score}/100` |")
+    if snapshot.grade:
+        lines.append(f"| Grade | `{snapshot.grade}` ({snapshot.grade_label}) |")
+    lines += [
+        f"| Highest severity | `{snapshot.max_severity}` |",
+        f"| Findings | `{snapshot.findings_total if snapshot.findings_total is not None else 'n/a'}` |",
+        f"| Severity breakdown | `{_severity_breakdown(snapshot.severity_counts)}` |",
+        f"| Score gate | `{_gate_label(passed=snapshot.score_gate_pass, descriptor=score_gate_descriptor)}` |",
+        f"| Severity gate | `{_gate_label(passed=snapshot.severity_gate_pass, descriptor=severity_gate_descriptor)}` |",
+        f"| Policy pass | `{_bool_label(snapshot.policy_pass)}` |",
+        f"| Verify pass | `{_bool_label(snapshot.verify_pass)}` |",
+    ]
+    if snapshot.submission_eligible is not None:
+        lines.append(f"| Submission eligible | `{_bool_label(snapshot.submission_eligible)}` |")
+
+    if snapshot.gate_reasons:
+        lines += ["", "**Blocking reasons**", ""]
+        lines.extend(f"- {reason}" for reason in snapshot.gate_reasons)
+
+    if compare_to_previous:
+        lines += ["", _build_delta_line(previous_metadata, snapshot), ""]
+
+    lines += ["**Top findings**", ""]
+    lines.extend(_format_top_findings(snapshot, max_findings=max_findings))
+
+    lines += ["", "<details>", "<summary>Category breakdown</summary>", ""]
+    lines.extend(_format_categories(snapshot, style=style))
+    lines += ["", "</details>", "", "<details>", "<summary>Integration and submission status</summary>", ""]
+    lines.extend(_format_integrations(snapshot))
+    if snapshot.submission_issues:
+        lines += ["", f"- Submission issues: {', '.join(snapshot.submission_issues)}"]
+    if snapshot.workflow_url:
+        lines += ["", f"- Workflow run: {snapshot.workflow_url}"]
+    lines += ["", "</details>"]
+
+    if style == "full":
+        lines += ["", f"- Plugin target: `{snapshot.plugin_dir}`"]
+        if snapshot.verify_pass is False:
+            lines += ["- Runtime verification reported at least one failing case."]
+        if snapshot.full_report_markdown:
+            lines += [
+                "",
+                "<details>",
+                "<summary>Full scanner report</summary>",
+                "",
+                snapshot.full_report_markdown,
+                "",
+                "</details>",
+            ]
+
+    lines += [
+        "",
+        marker,
+        f"{COMMENT_DATA_PREFIX}{_encode_metadata(snapshot)}{COMMENT_DATA_SUFFIX}",
+    ]
+    return "\n".join(lines)
+
+
+def _find_existing_marker_comment(comments: list[_ExistingComment], marker: str) -> _ExistingComment | None:
+    matching = [comment for comment in comments if marker in comment.body]
+    if not matching:
+        return None
+    matching.sort(key=lambda item: (item.updated_at, item.comment_id))
+    return matching[-1]
+
+
+def publish_pr_comment(
+    *,
+    config: PRCommentConfig,
+    snapshot: PRCommentSnapshot,
+    event_name: str,
+    event_path: str,
+    ref: str,
+    repository: str,
+    head_sha: str,
+) -> PRCommentOutcome:
+    if config.mode == "off":
+        return PRCommentOutcome(status="disabled")
+
+    context = resolve_pr_context(
+        event_name=event_name,
+        event_path=event_path,
+        ref=ref,
+        repository=repository,
+        head_sha=head_sha,
+        workflow_url=snapshot.workflow_url,
+    )
+    if context is None:
+        if config.mode == "always":
+            return PRCommentOutcome(
+                status="failed",
+                reason="pr-comment is required, but this run is not associated with a pull request",
+            )
+        return PRCommentOutcome(status="skipped", reason="not a pull request event")
+
+    if not config.token:
+        if config.mode == "always":
+            return PRCommentOutcome(status="failed", reason="pr-comment is required, but no comment token was provided")
+        return PRCommentOutcome(status="skipped", reason="no comment token provided")
+
+    try:
+        header = compute_comment_header(
+            mode=snapshot.mode,
+            profile=snapshot.profile,
+            plugin_dir=snapshot.plugin_dir,
+            configured_header=config.header,
+        )
+        marker = _comment_marker(header)
+        comments = _list_issue_comments(context=context, token=config.token, api_base_url=config.api_base_url)
+        existing = _find_existing_marker_comment(comments, marker)
+        previous_metadata = _decode_metadata(existing.body) if existing is not None else None
+        body = _render_pr_comment(
+            marker=marker,
+            snapshot=snapshot,
+            style=config.style,
+            max_findings=config.max_findings,
+            compare_to_previous=config.compare_to_previous,
+            previous_metadata=previous_metadata,
+        )
+        should_skip = (
+            existing is not None
+            and config.skip_if_unchanged
+            and _normalize_body(existing.body) == _normalize_body(body)
+        )
+        if should_skip:
+            return PRCommentOutcome(
+                status="unchanged",
+                reason="comment body unchanged",
+                url=existing.url,
+                comment_id=existing.comment_id,
+            )
+        if existing is None:
+            created = _create_issue_comment(
+                context=context,
+                token=config.token,
+                body=body,
+                api_base_url=config.api_base_url,
+            )
+            return PRCommentOutcome(status="created", url=created.url, comment_id=created.comment_id)
+        updated = _update_issue_comment(
+            context=context,
+            token=config.token,
+            comment_id=existing.comment_id,
+            body=body,
+            api_base_url=config.api_base_url,
+        )
+        return PRCommentOutcome(status="updated", url=updated.url, comment_id=updated.comment_id)
+    except HTTPError as error:
+        reason = f"GitHub API {error.code} while writing PR comment"
+    except OSError as error:
+        reason = f"network error while writing PR comment: {error}"
+    except RuntimeError as error:
+        reason = str(error)
+    if config.mode == "always":
+        return PRCommentOutcome(status="failed", reason=reason)
+    return PRCommentOutcome(status="skipped", reason=reason)

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -43,6 +43,13 @@ def test_action_metadata_includes_marketplace_branding_and_fallback_install() ->
     assert "sarif_category:" in action_text
     assert "registry_payload_output:" in action_text
     assert "submission_enabled:" in action_text
+    assert "pr_comment:" in action_text
+    assert "pr_comment_style:" in action_text
+    assert "pr_comment_header:" in action_text
+    assert "pr_comment_max_findings:" in action_text
+    assert "pr_comment_token:" in action_text
+    assert "pr_comment_skip_if_unchanged:" in action_text
+    assert "pr_comment_compare_to_previous:" in action_text
     assert "policy_pass:" in action_text
     assert "verify_pass:" in action_text
     assert "grade_label:" in action_text
@@ -51,12 +58,27 @@ def test_action_metadata_includes_marketplace_branding_and_fallback_install() ->
     assert "report_path:" in action_text
     assert "registry_payload_path:" in action_text
     assert "submission_issue_urls:" in action_text
+    assert "pr_comment_status:" in action_text
+    assert "pr_comment_url:" in action_text
+    assert "pr_comment_id:" in action_text
+    assert "pr_comment_reason:" in action_text
+    assert "action_exit_code:" in action_text
+    assert "action_exit_reason:" in action_text
     assert "python3 -m codex_plugin_scanner.action_runner" in action_text
+    assert "continue-on-error: true" in action_text
     assert "MODE: ${{ inputs.mode }}" in action_text
     assert "PROFILE: ${{ inputs.profile }}" in action_text
     assert "CONFIG: ${{ inputs.config }}" in action_text
     assert "BASELINE: ${{ inputs.baseline }}" in action_text
     assert "ONLINE: ${{ inputs.online }}" in action_text
+    assert "PR_COMMENT: ${{ inputs.pr_comment }}" in action_text
+    assert "PR_COMMENT_STYLE: ${{ inputs.pr_comment_style }}" in action_text
+    assert "PR_COMMENT_HEADER: ${{ inputs.pr_comment_header }}" in action_text
+    assert "PR_COMMENT_MAX_FINDINGS: ${{ inputs.pr_comment_max_findings }}" in action_text
+    assert "PR_COMMENT_TOKEN: ${{ inputs.pr_comment_token }}" in action_text
+    assert "PR_COMMENT_SKIP_IF_UNCHANGED: ${{ inputs.pr_comment_skip_if_unchanged }}" in action_text
+    assert "PR_COMMENT_COMPARE_TO_PREVIOUS: ${{ inputs.pr_comment_compare_to_previous }}" in action_text
+    assert "GITHUB_TOKEN: ${{ github.token }}" in action_text
     assert "value: ${{ steps.scan.outputs.score }}" in action_text
     assert "value: ${{ steps.scan.outputs.grade }}" in action_text
     assert "value: ${{ steps.scan.outputs.policy_pass }}" in action_text
@@ -70,8 +92,16 @@ def test_action_metadata_includes_marketplace_branding_and_fallback_install() ->
     assert "value: ${{ steps.scan.outputs.submission_performed }}" in action_text
     assert "value: ${{ steps.scan.outputs.submission_issue_urls }}" in action_text
     assert "value: ${{ steps.scan.outputs.submission_issue_numbers }}" in action_text
+    assert "value: ${{ steps.scan.outputs.pr_comment_status }}" in action_text
+    assert "value: ${{ steps.scan.outputs.pr_comment_url }}" in action_text
+    assert "value: ${{ steps.scan.outputs.pr_comment_id }}" in action_text
+    assert "value: ${{ steps.scan.outputs.pr_comment_reason }}" in action_text
+    assert "value: ${{ steps.scan.outputs.action_exit_code }}" in action_text
+    assert "value: ${{ steps.scan.outputs.action_exit_reason }}" in action_text
     assert "GITHUB_STEP_SUMMARY" in action_text
     assert "github/codeql-action/upload-sarif@" in action_text
+    assert "if: ${{ always() && inputs.upload_sarif == 'true'" in action_text
+    assert "Enforce scanner outcome" in action_text
 
 
 def test_publish_workflow_attaches_marketplace_action_bundle() -> None:
@@ -164,7 +194,7 @@ def test_action_bundle_docs_live_in_action_readme() -> None:
     assert "install_source: local" in action_readme
     assert "uses: ./action" in action_readme
     assert "ghcr.io/hashgraph-online/codex-plugin-scanner:<version>" in action_readme
-    assert "online`, `submission_enabled`, and `upload_sarif`" in action_readme
+    assert "online`, `submission_enabled`, `upload_sarif`, and `pr_comment`" in action_readme
     assert "registry_payload_output" in action_readme
     assert "grade_label" in action_readme
     assert "max_severity" in action_readme
@@ -173,8 +203,18 @@ def test_action_bundle_docs_live_in_action_readme() -> None:
     assert "publish-action-repo.yml" in action_readme
     assert "hashgraph-online/hol-codex-plugin-scanner-action@v1" in action_readme
     assert "actions/checkout@v4" in action_readme
-    assert "actions/github-script@v7" in action_readme
     assert "opt-in Cisco skill-scanner dependency used by this repo" in action_readme
+    assert "Native sticky PR summary comment" in action_readme
+    assert "pr_comment: auto" in action_readme
+    assert "pr_comment: always" in action_readme
+    assert "Advanced sticky comment configuration" in action_readme
+    assert "pull-requests: write" in action_readme
+    assert "pr_comment_style: full" in action_readme
+    assert "pr_comment_header: scanner-main-scan" in action_readme
+    assert "Fork PR note:" in action_readme
+    assert "Troubleshooting" in action_readme
+    assert "pr_comment_status" in action_readme
+    assert "action_exit_reason" in action_readme
 
 
 def test_readme_uses_stable_apache_license_badge() -> None:

--- a/tests/test_action_runner.py
+++ b/tests/test_action_runner.py
@@ -6,6 +6,7 @@ import socket
 from pathlib import Path
 
 from codex_plugin_scanner.action_runner import main
+from codex_plugin_scanner.pr_comments import PRCommentOutcome
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -51,6 +52,12 @@ def test_action_runner_writes_all_outputs(monkeypatch, tmp_path, capsys) -> None
     assert "submission_performed=false" in output_lines
     assert "submission_issue_urls=" in output_lines
     assert "submission_issue_numbers=" in output_lines
+    assert "pr_comment_status=disabled" in output_lines
+    assert "pr_comment_url=" in output_lines
+    assert "pr_comment_id=" in output_lines
+    assert "pr_comment_reason=" in output_lines
+    assert "action_exit_code=0" in output_lines
+    assert "action_exit_reason=" in output_lines
 
     stdout = capsys.readouterr().out
     assert '"score": 100' in stdout
@@ -142,6 +149,7 @@ def test_action_runner_verify_mode_writes_human_report(monkeypatch, tmp_path, ca
     assert "Verification: PASS" in output_path.read_text(encoding="utf-8")
     assert "mode=verify" in github_output.read_text(encoding="utf-8")
     assert "verify_pass=true" in github_output.read_text(encoding="utf-8")
+    assert "action_exit_code=0" in github_output.read_text(encoding="utf-8")
     assert "Report written to" in capsys.readouterr().out
 
 
@@ -174,12 +182,64 @@ def test_action_runner_repository_scan_defaults_to_marketplace_root(monkeypatch,
     exit_code = main()
 
     assert exit_code == 0
-    summary_text = summary_path.read_text(encoding="utf-8")
-    assert "- Scope: repository" in summary_text
-    assert "- Local plugins scanned: 2" in summary_text
-    assert "- Skipped marketplace entries: 1" in summary_text
-    output_lines = output_path.read_text(encoding="utf-8").splitlines()
-    assert any(line.startswith("score=") for line in output_lines)
+
+
+def test_action_runner_failed_gate_still_writes_outputs(monkeypatch, tmp_path) -> None:
+    output_path = tmp_path / "github-output.txt"
+
+    monkeypatch.setenv("PLUGIN_DIR", str(FIXTURES / "good-plugin"))
+    monkeypatch.setenv("FORMAT", "json")
+    monkeypatch.setenv("OUTPUT", "")
+    monkeypatch.setenv("MIN_SCORE", "101")
+    monkeypatch.setenv("FAIL_ON", "none")
+    monkeypatch.setenv("CISCO_SCAN", "off")
+    monkeypatch.setenv("CISCO_POLICY", "balanced")
+    monkeypatch.setenv("SUBMISSION_ENABLED", "false")
+    monkeypatch.setenv("WRITE_STEP_SUMMARY", "false")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
+
+    exit_code = main()
+
+    assert exit_code == 1
+    output_text = output_path.read_text(encoding="utf-8")
+    assert "score=100" in output_text
+    assert "action_exit_code=1" in output_text
+    assert "action_exit_reason=score 100 is below minimum threshold 101" in output_text
+
+
+def test_action_runner_pr_comment_always_failure_blocks_run(monkeypatch, tmp_path) -> None:
+    output_path = tmp_path / "github-output.txt"
+
+    monkeypatch.setenv("PLUGIN_DIR", str(FIXTURES / "good-plugin"))
+    monkeypatch.setenv("FORMAT", "json")
+    monkeypatch.setenv("OUTPUT", "")
+    monkeypatch.setenv("MIN_SCORE", "0")
+    monkeypatch.setenv("FAIL_ON", "none")
+    monkeypatch.setenv("CISCO_SCAN", "off")
+    monkeypatch.setenv("CISCO_POLICY", "balanced")
+    monkeypatch.setenv("SUBMISSION_ENABLED", "false")
+    monkeypatch.setenv("WRITE_STEP_SUMMARY", "false")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
+    monkeypatch.setenv("PR_COMMENT", "always")
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(tmp_path / "event.json"))
+    monkeypatch.setenv("GITHUB_REPOSITORY", "hashgraph-online/codex-plugin-scanner")
+    monkeypatch.setenv("GITHUB_REF", "refs/pull/123/merge")
+    monkeypatch.setenv("PR_COMMENT_TOKEN", "token")
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.action_runner.publish_pr_comment",
+        lambda **_: PRCommentOutcome(status="failed", reason="boom"),
+    )
+
+    exit_code = main()
+
+    assert exit_code == 1
+    output_text = output_path.read_text(encoding="utf-8")
+    assert "pr_comment_status=failed" in output_text
+    assert "pr_comment_reason=boom" in output_text
+    assert "action_exit_code=1" in output_text
+    assert "action_exit_reason=pull request comment failed: boom" in output_text
 
 
 def test_action_runner_default_scan_does_not_open_network_connections(monkeypatch, tmp_path) -> None:
@@ -215,3 +275,38 @@ def test_action_runner_default_scan_does_not_open_network_connections(monkeypatc
     exit_code = main()
 
     assert exit_code == 0
+
+
+def test_action_runner_step_summary_includes_pr_comment_status(monkeypatch, tmp_path) -> None:
+    output_path = tmp_path / "github-output.txt"
+    summary_path = tmp_path / "step-summary.md"
+
+    monkeypatch.setenv("PLUGIN_DIR", str(FIXTURES / "good-plugin"))
+    monkeypatch.setenv("FORMAT", "json")
+    monkeypatch.setenv("OUTPUT", "")
+    monkeypatch.setenv("MIN_SCORE", "0")
+    monkeypatch.setenv("FAIL_ON", "none")
+    monkeypatch.setenv("CISCO_SCAN", "off")
+    monkeypatch.setenv("CISCO_POLICY", "balanced")
+    monkeypatch.setenv("SUBMISSION_ENABLED", "false")
+    monkeypatch.setenv("WRITE_STEP_SUMMARY", "true")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary_path))
+    monkeypatch.setattr(
+        "codex_plugin_scanner.action_runner.publish_pr_comment",
+        lambda **_: PRCommentOutcome(
+            status="created",
+            url="https://github.com/hashgraph-online/codex-plugin-scanner/pull/1#issuecomment-1",
+            comment_id=1,
+        ),
+    )
+
+    exit_code = main()
+
+    assert exit_code == 0
+    summary_text = summary_path.read_text(encoding="utf-8")
+    assert (
+        "- PR comment: created "
+        "(https://github.com/hashgraph-online/codex-plugin-scanner/pull/1#issuecomment-1)"
+        in summary_text
+    )

--- a/tests/test_pr_comments.py
+++ b/tests/test_pr_comments.py
@@ -153,3 +153,31 @@ def test_publish_pr_comment_creates_new_comment(monkeypatch) -> None:
     assert "Compared with the previous scan on this PR" in create_calls[0][1]
     assert "| Score gate | `min_score=80 ✅` |" in create_calls[0][1]
     assert "| Severity gate | `fail_on_severity=high ✅` |" in create_calls[0][1]
+
+
+def test_publish_pr_comment_handles_invalid_api_response_in_auto_mode(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "codex_plugin_scanner.pr_comments._list_issue_comments",
+        lambda **_: (_ for _ in ()).throw(ValueError("bad json")),
+    )
+
+    outcome = publish_pr_comment(
+        config=PRCommentConfig(
+            mode="auto",
+            style="concise",
+            header="",
+            max_findings=3,
+            token="token",
+            skip_if_unchanged=True,
+            compare_to_previous=True,
+        ),
+        snapshot=_build_snapshot(),
+        event_name="pull_request",
+        event_path="",
+        ref="refs/pull/123/merge",
+        repository="hashgraph-online/codex-plugin-scanner",
+        head_sha="abc123",
+    )
+
+    assert outcome.status == "skipped"
+    assert "invalid response" in outcome.reason

--- a/tests/test_pr_comments.py
+++ b/tests/test_pr_comments.py
@@ -1,0 +1,155 @@
+"""Tests for native sticky pull request comment support."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from codex_plugin_scanner.pr_comments import (
+    PRCommentConfig,
+    PRCommentSnapshot,
+    PullRequestContext,
+    compute_comment_header,
+    publish_pr_comment,
+    resolve_pr_context,
+)
+
+
+def _build_snapshot(*, gate_pass: bool = True) -> PRCommentSnapshot:
+    return PRCommentSnapshot(
+        mode="scan",
+        profile="default",
+        plugin_dir="/repo",
+        scope="plugin",
+        score=92,
+        grade="A",
+        grade_label="Excellent",
+        max_severity="medium",
+        findings_total=2,
+        severity_counts={"critical": 0, "high": 0, "medium": 2, "low": 0, "info": 0},
+        min_score=80,
+        fail_on_severity="high",
+        score_gate_pass=True,
+        severity_gate_pass=True,
+        policy_pass=True,
+        verify_pass=True,
+        gate_pass=gate_pass,
+        gate_reasons=() if gate_pass else ("policy profile failed",),
+        top_findings=(),
+        categories=(),
+        integrations=(),
+        submission_eligible=False,
+        submission_issues=(),
+        workflow_url="https://github.com/hashgraph-online/codex-plugin-scanner/actions/runs/1",
+        full_report_markdown="",
+    )
+
+
+def test_compute_comment_header_is_stable() -> None:
+    header_a = compute_comment_header(
+        mode="scan",
+        profile="default",
+        plugin_dir="/repo",
+        configured_header="",
+    )
+    header_b = compute_comment_header(
+        mode="scan",
+        profile="default",
+        plugin_dir="/repo",
+        configured_header="",
+    )
+    assert header_a == header_b
+    assert header_a.startswith("mode=scan;profile=default;target=")
+
+
+def test_resolve_pr_context_reads_event_payload(tmp_path: Path) -> None:
+    event_payload = {
+        "pull_request": {
+            "number": 45,
+            "head": {"sha": "abc123"},
+        }
+    }
+    event_file = tmp_path / "event.json"
+    event_file.write_text(json.dumps(event_payload), encoding="utf-8")
+
+    context = resolve_pr_context(
+        event_name="pull_request",
+        event_path=str(event_file),
+        ref="refs/pull/45/merge",
+        repository="hashgraph-online/codex-plugin-scanner",
+        head_sha="fallback",
+        workflow_url="",
+    )
+
+    assert context is not None
+    assert context.owner == "hashgraph-online"
+    assert context.repo == "codex-plugin-scanner"
+    assert context.number == 45
+    assert context.head_sha == "abc123"
+
+
+def test_publish_pr_comment_auto_skips_when_not_pr_event() -> None:
+    outcome = publish_pr_comment(
+        config=PRCommentConfig(
+            mode="auto",
+            style="concise",
+            header="",
+            max_findings=3,
+            token="token",
+            skip_if_unchanged=True,
+            compare_to_previous=True,
+        ),
+        snapshot=_build_snapshot(),
+        event_name="push",
+        event_path="",
+        ref="refs/heads/main",
+        repository="hashgraph-online/codex-plugin-scanner",
+        head_sha="abc123",
+    )
+
+    assert outcome.status == "skipped"
+    assert outcome.reason == "not a pull request event"
+
+
+def test_publish_pr_comment_creates_new_comment(monkeypatch) -> None:
+    create_calls: list[tuple[PullRequestContext, str]] = []
+
+    monkeypatch.setattr("codex_plugin_scanner.pr_comments._list_issue_comments", lambda **_: [])
+
+    def _create_stub(*, context, token, body, api_base_url):
+        create_calls.append((context, body))
+        return SimpleNamespace(
+            comment_id=10,
+            url="https://github.com/comment/10",
+            body=body,
+            updated_at="",
+        )
+
+    monkeypatch.setattr("codex_plugin_scanner.pr_comments._create_issue_comment", _create_stub)
+
+    outcome = publish_pr_comment(
+        config=PRCommentConfig(
+            mode="auto",
+            style="concise",
+            header="",
+            max_findings=3,
+            token="token",
+            skip_if_unchanged=True,
+            compare_to_previous=True,
+        ),
+        snapshot=_build_snapshot(),
+        event_name="pull_request",
+        event_path="",
+        ref="refs/pull/123/merge",
+        repository="hashgraph-online/codex-plugin-scanner",
+        head_sha="abc123",
+    )
+
+    assert outcome.status == "created"
+    assert outcome.comment_id == 10
+    assert outcome.url == "https://github.com/comment/10"
+    assert len(create_calls) == 1
+    assert "Compared with the previous scan on this PR" in create_calls[0][1]
+    assert "| Score gate | `min_score=80 ✅` |" in create_calls[0][1]
+    assert "| Severity gate | `fail_on_severity=high ✅` |" in create_calls[0][1]


### PR DESCRIPTION
## Summary
- add native sticky PR comments to the scanner action (off/auto/always) with deterministic header matching
- add PR comment outputs (pr_comment_*) and final gate outputs (action_exit_code/action_exit_reason)
- refactor action orchestration so policy-style failures still allow report/summary/comment/SARIF flow before final enforcement
- add PR comment renderer details from the PRD/todo: gate table, blocking reasons, previous-run delta, top findings, category breakdown, submission/integration section
- update action docs with native comment usage, advanced config, permissions guidance, and troubleshooting

## Verification
- uv run --extra dev ruff check .
- uv run --extra dev pytest -q
- uv run --extra dev python -m build
- end-to-end integration run of action_runner against a local mock GitHub API covering sticky lifecycle and gate behavior:
  - first run: comment created
  - second run: comment updated
  - third run: unchanged skip
  - failing gate run: comment updated + non-zero action exit

## Notes
- per request, pr-comment-prd.md and scanner-todo.md were not included in this PR