### PR TITLE
fix: stop publishing mutable ghcr latest tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -278,7 +278,6 @@ jobs:
           {
             echo "value<<EOF"
             echo "${IMAGE_NAME}:${VERSION}"
-            echo "${IMAGE_NAME}:latest"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
       - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -108,7 +108,7 @@ def test_publish_workflow_attaches_marketplace_action_bundle() -> None:
     assert "docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567" in workflow_text
     assert "docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83" in workflow_text
     assert "ghcr.io/${{ github.repository }}" in workflow_text
-    assert "${IMAGE_NAME}:latest" in workflow_text
+    assert "${IMAGE_NAME}:latest" not in workflow_text
     assert "org.opencontainers.image.version=${{ needs.build.outputs.version }}" in workflow_text
     e2e_workflow_text = (ROOT / ".github" / "workflows" / "e2e-test.yml").read_text(encoding="utf-8")
     assert e2e_workflow_text.count("install_source: local") == 5


### PR DESCRIPTION
## Summary
- remove mutable latest-tag publish from GHCR workflow
- keep immutable versioned container tags only
- update workflow regression test accordingly

## Verification
- uv run --no-sync pytest -q
- uv run --no-sync pytest -q tests/test_action_bundle.py
- uv run --no-sync ruff check src tests

This fixes publish failures caused by a 403 when pushing the latest tag while preserving successful PyPI and versioned GHCR publication.