### PR TITLE
feat: migrate GitHub Action identity to AI plugin scanner

### DIFF
--- a/.github/workflows/publish-action-repo.yml
+++ b/.github/workflows/publish-action-repo.yml
@@ -98,6 +98,7 @@ jobs:
             readme_source="$2"
             repo_description="$3"
             repo_dir="$GITHUB_WORKSPACE/action-repos/${target_repo##*/}"
+            repo_changed="false"
 
             if gh repo view "$target_repo" >/dev/null 2>&1; then
               gh repo edit "$target_repo" --description "$repo_description"
@@ -119,6 +120,7 @@ jobs:
             cp "${GITHUB_WORKSPACE}/CONTRIBUTING.md" "${repo_dir}/CONTRIBUTING.md"
 
             if [ -n "$(git -C "$repo_dir" status --short -- action.yml README.md scanner-version.txt cisco-version.txt pypi-attestations-version.txt LICENSE SECURITY.md CONTRIBUTING.md)" ]; then
+              repo_changed="true"
               git -C "$repo_dir" config user.name "github-actions[bot]"
               git -C "$repo_dir" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
               git -C "$repo_dir" add action.yml README.md scanner-version.txt cisco-version.txt pypi-attestations-version.txt LICENSE SECURITY.md CONTRIBUTING.md
@@ -126,12 +128,15 @@ jobs:
               git -C "$repo_dir" push origin HEAD:main
             fi
 
+            if [ "$repo_changed" != "true" ]; then
+              return
+            fi
+
+            git -C "$repo_dir" tag -fa v1 -m "Update floating major tag to ${TAG}"
             if ! git -C "$repo_dir" ls-remote --tags origin "refs/tags/${TAG}" | grep -q .; then
               git -C "$repo_dir" tag "${TAG}"
               git -C "$repo_dir" push origin "refs/tags/${TAG}"
             fi
-
-            git -C "$repo_dir" tag -fa v1 -m "Update floating major tag to ${TAG}"
             git -C "$repo_dir" push origin refs/tags/v1 --force
 
             if ! gh release view "${TAG}" --repo "$target_repo" >/dev/null 2>&1; then

--- a/.github/workflows/publish-action-repo.yml
+++ b/.github/workflows/publish-action-repo.yml
@@ -58,7 +58,7 @@ jobs:
             if ! gh repo view "$target_repo" >/dev/null 2>&1; then
               return
             fi
-            git ls-remote --tags "https://x-access-token:${GH_TOKEN}@github.com/${target_repo}.git" "refs/tags/v*" \
+            git ls-remote --tags --refs "https://x-access-token:${GH_TOKEN}@github.com/${target_repo}.git" "refs/tags/v*" \
               | awk -F'/' '{print $3}' \
               | sort -V \
               | tail -n1

--- a/.github/workflows/publish-action-repo.yml
+++ b/.github/workflows/publish-action-repo.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: codex-plugin-scanner-action-repo-${{ github.ref }}
+  group: ai-plugin-scanner-action-repo-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -20,7 +20,8 @@ jobs:
     permissions:
       contents: read
     env:
-      ACTION_REPOSITORY: ${{ vars.ACTION_REPOSITORY != '' && vars.ACTION_REPOSITORY || 'hashgraph-online/hol-codex-plugin-scanner-action' }}
+      ACTION_CANONICAL_REPOSITORY: ${{ vars.ACTION_CANONICAL_REPOSITORY != '' && vars.ACTION_CANONICAL_REPOSITORY || 'hashgraph-online/hol-ai-plugin-scanner-action' }}
+      ACTION_COMPAT_REPOSITORY: ${{ vars.ACTION_COMPAT_REPOSITORY != '' && vars.ACTION_COMPAT_REPOSITORY || 'hashgraph-online/hol-codex-plugin-scanner-action' }}
       SOURCE_REF: ${{ github.sha }}
       SOURCE_REPOSITORY: ${{ github.repository }}
       SOURCE_SERVER_URL: ${{ github.server_url }}
@@ -44,7 +45,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.ACTION_REPO_TOKEN }}
         run: |
-          LAST_TAG=$(gh release list --repo "$ACTION_REPOSITORY" --limit 1 --json tagName --jq '.[0].tagName // ""')
+          LAST_TAG=""
+          if gh repo view "$ACTION_CANONICAL_REPOSITORY" >/dev/null 2>&1; then
+            LAST_TAG=$(gh release list --repo "$ACTION_CANONICAL_REPOSITORY" --limit 1 --json tagName --jq '.[0].tagName // ""')
+          fi
 
           if [ -z "$LAST_TAG" ]; then
             TAG="v1.0.0"
@@ -82,88 +86,71 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Clone action repository
-        env:
-          GH_TOKEN: ${{ secrets.ACTION_REPO_TOKEN }}
-        run: gh repo clone "$ACTION_REPOSITORY" action-repo -- --depth 1
-
-      - name: Configure authenticated action repository remote
-        working-directory: action-repo
+      - name: Sync canonical and compatibility action repositories
         env:
           ACTION_REPO_TOKEN: ${{ secrets.ACTION_REPO_TOKEN }}
-        run: |
-          git remote set-url origin "https://x-access-token:${ACTION_REPO_TOKEN}@github.com/$ACTION_REPOSITORY.git"
-
-      - name: Sync root-ready action bundle
-        working-directory: action-repo
-        run: |
-          cp "${GITHUB_WORKSPACE}/action/action.yml" action.yml
-          cp "${GITHUB_WORKSPACE}/action/README.md" README.md
-          printf '%s\n' "${{ steps.scanner_version.outputs.version }}" > scanner-version.txt
-          cp "${GITHUB_WORKSPACE}/action/cisco-version.txt" cisco-version.txt
-          cp "${GITHUB_WORKSPACE}/action/pypi-attestations-version.txt" pypi-attestations-version.txt
-          cp "${GITHUB_WORKSPACE}/LICENSE" LICENSE
-          cp "${GITHUB_WORKSPACE}/SECURITY.md" SECURITY.md
-          cp "${GITHUB_WORKSPACE}/CONTRIBUTING.md" CONTRIBUTING.md
-
-      - name: Detect sync changes
-        id: diff
-        working-directory: action-repo
-        run: |
-          if [ -n "$(git status --short -- action.yml README.md scanner-version.txt cisco-version.txt pypi-attestations-version.txt LICENSE SECURITY.md CONTRIBUTING.md)" ]; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Commit synced bundle
-        if: steps.diff.outputs.changed == 'true'
-        working-directory: action-repo
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add action.yml README.md scanner-version.txt cisco-version.txt pypi-attestations-version.txt LICENSE SECURITY.md CONTRIBUTING.md
-          git commit -m "chore: publish action bundle ${{ steps.version.outputs.tag }}"
-
-      - name: Push action repository branch and tags
-        if: steps.diff.outputs.changed == 'true'
-        working-directory: action-repo
-        run: |
-          TAG="${{ steps.version.outputs.tag }}"
-          git push origin HEAD:main
-          git tag "$TAG"
-          git push origin "refs/tags/${TAG}"
-          git tag -fa v1 -m "Update floating major tag to ${TAG}"
-          git push origin refs/tags/v1 --force
-
-      - name: Check action release state
-        id: release_state
-        working-directory: action-repo
-        env:
           GH_TOKEN: ${{ secrets.ACTION_REPO_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+          SCANNER_VERSION: ${{ steps.scanner_version.outputs.version }}
         run: |
-          TAG="${{ steps.version.outputs.tag }}"
+          sync_action_repo() {
+            target_repo="$1"
+            readme_source="$2"
+            repo_description="$3"
+            repo_dir="$GITHUB_WORKSPACE/action-repos/${target_repo##*/}"
 
-          if gh release view "${TAG}" --repo "$ACTION_REPOSITORY" >/dev/null 2>&1; then
-            echo "release_exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "release_exists=false" >> "$GITHUB_OUTPUT"
-          fi
+            if gh repo view "$target_repo" >/dev/null 2>&1; then
+              gh repo edit "$target_repo" --description "$repo_description"
+              gh repo clone "$target_repo" "$repo_dir" -- --depth 1
+            else
+              gh repo create "$target_repo" --public --description "$repo_description" --clone
+              mv "${target_repo##*/}" "$repo_dir"
+            fi
 
-          if git ls-remote --tags origin "refs/tags/${TAG}" | grep -q .; then
-            echo "tag_exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag_exists=false" >> "$GITHUB_OUTPUT"
-          fi
+            git -C "$repo_dir" remote set-url origin "https://x-access-token:${ACTION_REPO_TOKEN}@github.com/${target_repo}.git"
 
-      - name: Create action repository release
-        if: steps.release_state.outputs.release_exists == 'false' && (steps.diff.outputs.changed == 'true' || steps.release_state.outputs.tag_exists == 'true')
-        env:
-          GH_TOKEN: ${{ secrets.ACTION_REPO_TOKEN }}
-        run: |
-          TAG="${{ steps.version.outputs.tag }}"
-          gh release create "${TAG}" \
-            --repo "$ACTION_REPOSITORY" \
-            --title "$TAG" \
-            --generate-notes \
-            --notes "Published automatically from ${SOURCE_SERVER_URL}/${SOURCE_REPOSITORY}/tree/${SOURCE_REF}"
+            cp "${GITHUB_WORKSPACE}/action/action.yml" "${repo_dir}/action.yml"
+            cp "$readme_source" "${repo_dir}/README.md"
+            printf '%s\n' "$SCANNER_VERSION" > "${repo_dir}/scanner-version.txt"
+            cp "${GITHUB_WORKSPACE}/action/cisco-version.txt" "${repo_dir}/cisco-version.txt"
+            cp "${GITHUB_WORKSPACE}/action/pypi-attestations-version.txt" "${repo_dir}/pypi-attestations-version.txt"
+            cp "${GITHUB_WORKSPACE}/LICENSE" "${repo_dir}/LICENSE"
+            cp "${GITHUB_WORKSPACE}/SECURITY.md" "${repo_dir}/SECURITY.md"
+            cp "${GITHUB_WORKSPACE}/CONTRIBUTING.md" "${repo_dir}/CONTRIBUTING.md"
+
+            if [ -n "$(git -C "$repo_dir" status --short -- action.yml README.md scanner-version.txt cisco-version.txt pypi-attestations-version.txt LICENSE SECURITY.md CONTRIBUTING.md)" ]; then
+              git -C "$repo_dir" config user.name "github-actions[bot]"
+              git -C "$repo_dir" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+              git -C "$repo_dir" add action.yml README.md scanner-version.txt cisco-version.txt pypi-attestations-version.txt LICENSE SECURITY.md CONTRIBUTING.md
+              git -C "$repo_dir" commit -m "chore: publish action bundle ${TAG}"
+              git -C "$repo_dir" push origin HEAD:main
+            fi
+
+            if ! git -C "$repo_dir" ls-remote --tags origin "refs/tags/${TAG}" | grep -q .; then
+              git -C "$repo_dir" tag "${TAG}"
+              git -C "$repo_dir" push origin "refs/tags/${TAG}"
+            fi
+
+            git -C "$repo_dir" tag -fa v1 -m "Update floating major tag to ${TAG}"
+            git -C "$repo_dir" push origin refs/tags/v1 --force
+
+            if ! gh release view "${TAG}" --repo "$target_repo" >/dev/null 2>&1; then
+              gh release create "${TAG}" \
+                --repo "$target_repo" \
+                --title "${TAG}" \
+                --generate-notes \
+                --notes "Published automatically from ${SOURCE_SERVER_URL}/${SOURCE_REPOSITORY}/tree/${SOURCE_REF}"
+            fi
+          }
+
+          mkdir -p "$GITHUB_WORKSPACE/action-repos"
+
+          sync_action_repo \
+            "$ACTION_CANONICAL_REPOSITORY" \
+            "${GITHUB_WORKSPACE}/action/README.md" \
+            "HOL AI Plugin Scanner GitHub Action"
+
+          sync_action_repo \
+            "$ACTION_COMPAT_REPOSITORY" \
+            "${GITHUB_WORKSPACE}/action/README.legacy.md" \
+            "Compatibility alias for HOL AI Plugin Scanner GitHub Action"

--- a/.github/workflows/publish-action-repo.yml
+++ b/.github/workflows/publish-action-repo.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.ACTION_REPO_TOKEN }}
         run: |
-          latest_repo_tag() {
+          latest_release_tag() {
             target_repo="$1"
             if ! gh repo view "$target_repo" >/dev/null 2>&1; then
               return
@@ -53,8 +53,23 @@ jobs:
             gh release list --repo "$target_repo" --limit 1 --json tagName --jq '.[0].tagName // ""'
           }
 
+          latest_remote_tag() {
+            target_repo="$1"
+            if ! gh repo view "$target_repo" >/dev/null 2>&1; then
+              return
+            fi
+            git ls-remote --tags "https://x-access-token:${GH_TOKEN}@github.com/${target_repo}.git" "refs/tags/v*" \
+              | awk -F'/' '{print $3}' \
+              | sort -V \
+              | tail -n1
+          }
+
           LAST_TAG=""
-          for candidate in "$(latest_repo_tag "$ACTION_CANONICAL_REPOSITORY")" "$(latest_repo_tag "$ACTION_COMPAT_REPOSITORY")"; do
+          for candidate in \
+            "$(latest_release_tag "$ACTION_CANONICAL_REPOSITORY")" \
+            "$(latest_release_tag "$ACTION_COMPAT_REPOSITORY")" \
+            "$(latest_remote_tag "$ACTION_CANONICAL_REPOSITORY")" \
+            "$(latest_remote_tag "$ACTION_COMPAT_REPOSITORY")"; do
             if [ -z "$candidate" ]; then
               continue
             fi
@@ -146,10 +161,12 @@ jobs:
             fi
 
             git -C "$repo_dir" tag -fa v1 -m "Update floating major tag to ${TAG}"
-            if ! git -C "$repo_dir" ls-remote --tags origin "refs/tags/${TAG}" | grep -q .; then
-              git -C "$repo_dir" tag "${TAG}"
-              git -C "$repo_dir" push origin "refs/tags/${TAG}"
+            if git -C "$repo_dir" ls-remote --tags origin "refs/tags/${TAG}" | grep -q .; then
+              echo "Refusing to publish action bundle with colliding existing tag ${TAG} in ${target_repo}." >&2
+              exit 1
             fi
+            git -C "$repo_dir" tag "${TAG}"
+            git -C "$repo_dir" push origin "refs/tags/${TAG}"
             git -C "$repo_dir" push origin refs/tags/v1 --force
 
             if ! gh release view "${TAG}" --repo "$target_repo" >/dev/null 2>&1; then

--- a/.github/workflows/publish-action-repo.yml
+++ b/.github/workflows/publish-action-repo.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: read
     env:
-      ACTION_CANONICAL_REPOSITORY: ${{ vars.ACTION_CANONICAL_REPOSITORY != '' && vars.ACTION_CANONICAL_REPOSITORY || 'hashgraph-online/hol-ai-plugin-scanner-action' }}
+      ACTION_CANONICAL_REPOSITORY: ${{ vars.ACTION_CANONICAL_REPOSITORY != '' && vars.ACTION_CANONICAL_REPOSITORY || 'hashgraph-online/ai-plugin-scanner-action' }}
       ACTION_COMPAT_REPOSITORY: ${{ vars.ACTION_COMPAT_REPOSITORY != '' && vars.ACTION_COMPAT_REPOSITORY || 'hashgraph-online/hol-codex-plugin-scanner-action' }}
       SOURCE_REF: ${{ github.sha }}
       SOURCE_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/publish-action-repo.yml
+++ b/.github/workflows/publish-action-repo.yml
@@ -45,10 +45,23 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.ACTION_REPO_TOKEN }}
         run: |
+          latest_repo_tag() {
+            target_repo="$1"
+            if ! gh repo view "$target_repo" >/dev/null 2>&1; then
+              return
+            fi
+            gh release list --repo "$target_repo" --limit 1 --json tagName --jq '.[0].tagName // ""'
+          }
+
           LAST_TAG=""
-          if gh repo view "$ACTION_CANONICAL_REPOSITORY" >/dev/null 2>&1; then
-            LAST_TAG=$(gh release list --repo "$ACTION_CANONICAL_REPOSITORY" --limit 1 --json tagName --jq '.[0].tagName // ""')
-          fi
+          for candidate in "$(latest_repo_tag "$ACTION_CANONICAL_REPOSITORY")" "$(latest_repo_tag "$ACTION_COMPAT_REPOSITORY")"; do
+            if [ -z "$candidate" ]; then
+              continue
+            fi
+            if [ -z "$LAST_TAG" ] || [ "$(printf '%s\n%s\n' "$LAST_TAG" "$candidate" | sort -V | tail -n1)" = "$candidate" ]; then
+              LAST_TAG="$candidate"
+            fi
+          done
 
           if [ -z "$LAST_TAG" ]; then
             TAG="v1.0.0"

--- a/.github/workflows/publish-action-repo.yml
+++ b/.github/workflows/publish-action-repo.yml
@@ -121,6 +121,30 @@ jobs:
           TAG: ${{ steps.version.outputs.tag }}
           SCANNER_VERSION: ${{ steps.scanner_version.outputs.version }}
         run: |
+          any_repo_changed="false"
+
+          publish_action_release() {
+            target_repo="$1"
+            repo_dir="$2"
+
+            git -C "$repo_dir" tag -fa v1 -m "Update floating major tag to ${TAG}"
+            if git -C "$repo_dir" ls-remote --tags origin "refs/tags/${TAG}" | grep -q .; then
+              echo "Refusing to publish action bundle with colliding existing tag ${TAG} in ${target_repo}." >&2
+              exit 1
+            fi
+            git -C "$repo_dir" tag "${TAG}"
+            git -C "$repo_dir" push origin "refs/tags/${TAG}"
+            git -C "$repo_dir" push origin refs/tags/v1 --force
+
+            if ! gh release view "${TAG}" --repo "$target_repo" >/dev/null 2>&1; then
+              gh release create "${TAG}" \
+                --repo "$target_repo" \
+                --title "${TAG}" \
+                --generate-notes \
+                --notes "Published automatically from ${SOURCE_SERVER_URL}/${SOURCE_REPOSITORY}/tree/${SOURCE_REF}"
+            fi
+          }
+
           sync_action_repo() {
             target_repo="$1"
             readme_source="$2"
@@ -154,31 +178,14 @@ jobs:
               git -C "$repo_dir" add action.yml README.md scanner-version.txt cisco-version.txt pypi-attestations-version.txt LICENSE SECURITY.md CONTRIBUTING.md
               git -C "$repo_dir" commit -m "chore: publish action bundle ${TAG}"
               git -C "$repo_dir" push origin HEAD:main
+              any_repo_changed="true"
             fi
 
-            if [ "$repo_changed" != "true" ]; then
-              return
-            fi
-
-            git -C "$repo_dir" tag -fa v1 -m "Update floating major tag to ${TAG}"
-            if git -C "$repo_dir" ls-remote --tags origin "refs/tags/${TAG}" | grep -q .; then
-              echo "Refusing to publish action bundle with colliding existing tag ${TAG} in ${target_repo}." >&2
-              exit 1
-            fi
-            git -C "$repo_dir" tag "${TAG}"
-            git -C "$repo_dir" push origin "refs/tags/${TAG}"
-            git -C "$repo_dir" push origin refs/tags/v1 --force
-
-            if ! gh release view "${TAG}" --repo "$target_repo" >/dev/null 2>&1; then
-              gh release create "${TAG}" \
-                --repo "$target_repo" \
-                --title "${TAG}" \
-                --generate-notes \
-                --notes "Published automatically from ${SOURCE_SERVER_URL}/${SOURCE_REPOSITORY}/tree/${SOURCE_REF}"
-            fi
+            printf '%s\t%s\n' "$target_repo" "$repo_dir" >> "$GITHUB_WORKSPACE/action-repos/publish-targets.tsv"
           }
 
           mkdir -p "$GITHUB_WORKSPACE/action-repos"
+          : > "$GITHUB_WORKSPACE/action-repos/publish-targets.tsv"
 
           sync_action_repo \
             "$ACTION_CANONICAL_REPOSITORY" \
@@ -189,3 +196,11 @@ jobs:
             "$ACTION_COMPAT_REPOSITORY" \
             "${GITHUB_WORKSPACE}/action/README.legacy.md" \
             "Compatibility alias for HOL AI Plugin Scanner GitHub Action"
+
+          if [ "$any_repo_changed" != "true" ]; then
+            exit 0
+          fi
+
+          while IFS=$'\t' read -r target_repo repo_dir; do
+            publish_action_release "$target_repo" "$repo_dir"
+          done < "$GITHUB_WORKSPACE/action-repos/publish-targets.tsv"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -193,7 +193,7 @@ jobs:
         run: |
           VERSION="${{ needs.build.outputs.version }}"
           BUNDLE_ROOT="dist/github-action-bundle"
-          BUNDLE_PATH="dist/hol-codex-plugin-scanner-action-v${VERSION}.zip"
+          BUNDLE_PATH="dist/hol-ai-plugin-scanner-action-v${VERSION}.zip"
 
           mkdir -p "${BUNDLE_ROOT}"
           cp action/action.yml "${BUNDLE_ROOT}/action.yml"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -193,7 +193,7 @@ jobs:
         run: |
           VERSION="${{ needs.build.outputs.version }}"
           BUNDLE_ROOT="dist/github-action-bundle"
-          BUNDLE_PATH="dist/hol-ai-plugin-scanner-action-v${VERSION}.zip"
+          BUNDLE_PATH="dist/ai-plugin-scanner-action-v${VERSION}.zip"
 
           mkdir -p "${BUNDLE_ROOT}"
           cp action/action.yml "${BUNDLE_ROOT}/action.yml"

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ pipx run plugin-scanner verify .
 
 ```yaml
 # GitHub Actions PR gate
-- name: Codex plugin quality gate
-  uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+- name: AI plugin quality gate
+  uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
   with:
     plugin_dir: "."
     fail_on_severity: high
@@ -213,7 +213,7 @@ For repo-scoped marketplaces, `scan`, `lint`, `verify`, and `doctor` can target 
 ## Config + Baseline Example
 
 ```toml
-# .codex-plugin-scanner.toml
+# .plugin-scanner.toml
 [scanner]
 profile = "public-marketplace"
 baseline_file = "baseline.txt"
@@ -303,7 +303,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+      - uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
         with:
           plugin_dir: "."
           mode: scan
@@ -322,9 +322,9 @@ Local pre-commit style hook:
 repos:
   - repo: local
     hooks:
-      - id: codex-plugin-scanner
-        name: Codex Plugin Scanner
-        entry: codex-plugin-scanner
+      - id: plugin-scanner
+        name: Plugin Scanner
+        entry: plugin-scanner
         language: system
         types: [directory]
         pass_filenames: false
@@ -351,17 +351,19 @@ The source repository can publish the GitHub Action automatically into a dedicat
 Configure:
 
 - repository secret `ACTION_REPO_TOKEN`
-  It should be a token that can create or update repositories and releases in the target repository.
-- optional repository variable `ACTION_REPOSITORY`
+  It should be a token that can create or update repositories and releases in the canonical and compatibility action repositories.
+- optional repository variable `ACTION_CANONICAL_REPOSITORY`
+  Defaults to `hashgraph-online/hol-ai-plugin-scanner-action`.
+- optional repository variable `ACTION_COMPAT_REPOSITORY`
   Defaults to `hashgraph-online/hol-codex-plugin-scanner-action`.
 
-When a tagged release is published, [publish-action-repo.yml](./.github/workflows/publish-action-repo.yml) will:
+When changes land on `main`, [publish-action-repo.yml](./.github/workflows/publish-action-repo.yml) will:
 
-- create the dedicated action repository if it does not already exist
-- sync the root-ready `action.yml`, `README.md`, `LICENSE`, and `SECURITY.md`
+- create the canonical Marketplace repository if it does not already exist
+- sync the root-ready `action.yml`, repo-specific `README.md`, `LICENSE`, and `SECURITY.md` into both the canonical repo and the legacy compatibility repo
 - push the immutable release tag such as `v2.0.0`
 - move the floating `v1` tag
-- create or update the corresponding release in the action repository
+- create or update the corresponding release in each action repository
 
 GitHub Marketplace still requires the one-time listing publication step in the dedicated action repository UI, but after that this repository can keep the action repository current automatically.
 
@@ -369,7 +371,7 @@ GitHub Marketplace still requires the one-time listing publication step in the d
 
 The action can also handle submission intake. A plugin repository can wire the scanner into CI so a passing scan opens or reuses a submission issue in [awesome-codex-plugins](https://github.com/hashgraph-online/awesome-codex-plugins).
 
-It also emits Codex-friendly machine outputs:
+It also emits automation-friendly machine outputs:
 
 - `score`, `grade`, `grade_label`, `max_severity`, and `findings_total` as GitHub Action outputs
 - a concise markdown summary in the job summary by default
@@ -397,7 +399,7 @@ jobs:
 
       - name: Scan and submit if eligible
         id: scan
-        uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+        uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
         with:
           plugin_dir: "."
           min_score: 80
@@ -413,9 +415,9 @@ jobs:
 
 `submission_token` is required when `submission_enabled: true`. This flow is idempotent. If the plugin repository was already submitted, the action reuses the existing open issue instead of opening duplicates by matching an exact hidden plugin URL marker in the existing issue body.
 
-### Registry Payload For Codex Ecosystem Automation
+### Registry Payload For Plugin Ecosystem Automation
 
-If you want to feed the same scan into a registry, badge pipeline, or another Codex automation step, request a registry payload file directly from the action:
+If you want to feed the same scan into a registry, badge pipeline, or another plugin ecosystem automation step, request a registry payload file directly from the action:
 
 ```yaml
 permissions:
@@ -429,12 +431,12 @@ jobs:
 
       - name: Scan plugin
         id: scan
-        uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+        uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
         with:
           plugin_dir: "."
           format: sarif
-          output: codex-plugin-scanner.sarif
-          registry_payload_output: codex-plugin-registry-payload.json
+          output: ai-plugin-scanner.sarif
+          registry_payload_output: ai-plugin-registry-payload.json
 
       - name: Show trust signals
         run: |
@@ -445,7 +447,7 @@ jobs:
       - name: Upload registry payload
         uses: actions/upload-artifact@v6
         with:
-          name: codex-plugin-registry-payload
+          name: ai-plugin-registry-payload
           path: ${{ steps.scan.outputs.registry_payload_path }}
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pipx run plugin-scanner verify .
 ```yaml
 # GitHub Actions PR gate
 - name: AI plugin quality gate
-  uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
+  uses: hashgraph-online/ai-plugin-scanner-action@v1
   with:
     plugin_dir: "."
     fail_on_severity: high
@@ -303,7 +303,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
+      - uses: hashgraph-online/ai-plugin-scanner-action@v1
         with:
           plugin_dir: "."
           mode: scan
@@ -353,7 +353,7 @@ Configure:
 - repository secret `ACTION_REPO_TOKEN`
   It should be a token that can create or update repositories and releases in the canonical and compatibility action repositories.
 - optional repository variable `ACTION_CANONICAL_REPOSITORY`
-  Defaults to `hashgraph-online/hol-ai-plugin-scanner-action`.
+  Defaults to `hashgraph-online/ai-plugin-scanner-action`.
 - optional repository variable `ACTION_COMPAT_REPOSITORY`
   Defaults to `hashgraph-online/hol-codex-plugin-scanner-action`.
 
@@ -399,7 +399,7 @@ jobs:
 
       - name: Scan and submit if eligible
         id: scan
-        uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
+        uses: hashgraph-online/ai-plugin-scanner-action@v1
         with:
           plugin_dir: "."
           min_score: 80
@@ -431,7 +431,7 @@ jobs:
 
       - name: Scan plugin
         id: scan
-        uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
+        uses: hashgraph-online/ai-plugin-scanner-action@v1
         with:
           plugin_dir: "."
           format: sarif

--- a/action/README.legacy.md
+++ b/action/README.legacy.md
@@ -2,7 +2,7 @@
 
 [![Latest Release](https://img.shields.io/github/v/release/hashgraph-online/hol-codex-plugin-scanner-action?display_name=tag)](https://github.com/hashgraph-online/hol-codex-plugin-scanner-action/releases/latest)
 [![Compatibility Alias](https://img.shields.io/badge/legacy-slug-supported-6b7280)](https://github.com/hashgraph-online/hol-codex-plugin-scanner-action)
-[![Canonical Repository](https://img.shields.io/badge/canonical-hol--ai--plugin--scanner--action-0A84FF)](https://github.com/hashgraph-online/hol-ai-plugin-scanner-action)
+[![Canonical Repository](https://img.shields.io/badge/canonical-ai--plugin--scanner--action-0A84FF)](https://github.com/hashgraph-online/ai-plugin-scanner-action)
 [![Source of Truth](https://img.shields.io/badge/source-ai--plugin--scanner-111827)](https://github.com/hashgraph-online/ai-plugin-scanner/tree/main/action)
 
 This repository remains supported as a compatibility alias for existing workflows that use:
@@ -14,12 +14,12 @@ uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
 New integrations should move to the canonical action slug:
 
 ```yaml
-uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
+uses: hashgraph-online/ai-plugin-scanner-action@v1
 ```
 
 The action behavior, release train, and source of truth are shared with the canonical repository:
 
-- Canonical action repo: [hashgraph-online/hol-ai-plugin-scanner-action](https://github.com/hashgraph-online/hol-ai-plugin-scanner-action)
+- Canonical action repo: [hashgraph-online/ai-plugin-scanner-action](https://github.com/hashgraph-online/ai-plugin-scanner-action)
 - Source repo: [hashgraph-online/ai-plugin-scanner](https://github.com/hashgraph-online/ai-plugin-scanner)
 
 The compatibility alias continues to receive the same reviewed root bundle, release tags, and floating `v1` major tag so existing consumers do not break during the identity migration.

--- a/action/README.legacy.md
+++ b/action/README.legacy.md
@@ -1,0 +1,25 @@
+# HOL AI Plugin Scanner GitHub Action
+
+[![Latest Release](https://img.shields.io/github/v/release/hashgraph-online/hol-codex-plugin-scanner-action?display_name=tag)](https://github.com/hashgraph-online/hol-codex-plugin-scanner-action/releases/latest)
+[![Compatibility Alias](https://img.shields.io/badge/legacy-slug-supported-6b7280)](https://github.com/hashgraph-online/hol-codex-plugin-scanner-action)
+[![Canonical Repository](https://img.shields.io/badge/canonical-hol--ai--plugin--scanner--action-0A84FF)](https://github.com/hashgraph-online/hol-ai-plugin-scanner-action)
+[![Source of Truth](https://img.shields.io/badge/source-ai--plugin--scanner-111827)](https://github.com/hashgraph-online/ai-plugin-scanner/tree/main/action)
+
+This repository remains supported as a compatibility alias for existing workflows that use:
+
+```yaml
+uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+```
+
+New integrations should move to the canonical action slug:
+
+```yaml
+uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
+```
+
+The action behavior, release train, and source of truth are shared with the canonical repository:
+
+- Canonical action repo: [hashgraph-online/hol-ai-plugin-scanner-action](https://github.com/hashgraph-online/hol-ai-plugin-scanner-action)
+- Source repo: [hashgraph-online/ai-plugin-scanner](https://github.com/hashgraph-online/ai-plugin-scanner)
+
+The compatibility alias continues to receive the same reviewed root bundle, release tags, and floating `v1` major tag so existing consumers do not break during the identity migration.

--- a/action/README.md
+++ b/action/README.md
@@ -1,17 +1,17 @@
 # HOL AI Plugin Scanner GitHub Action
 
-[![Latest Release](https://img.shields.io/github/v/release/hashgraph-online/hol-ai-plugin-scanner-action?display_name=tag)](https://github.com/hashgraph-online/hol-ai-plugin-scanner-action/releases/latest)
-[![Marketplace Repository](https://img.shields.io/badge/github-marketplace_repo-0A84FF)](https://github.com/hashgraph-online/hol-ai-plugin-scanner-action)
+[![Latest Release](https://img.shields.io/github/v/release/hashgraph-online/ai-plugin-scanner-action?display_name=tag)](https://github.com/hashgraph-online/ai-plugin-scanner-action/releases/latest)
+[![Marketplace Repository](https://img.shields.io/badge/github-marketplace_repo-0A84FF)](https://github.com/hashgraph-online/ai-plugin-scanner-action)
 [![Compatibility Alias](https://img.shields.io/badge/compat-hol--codex--plugin--scanner--action-6b7280)](https://github.com/hashgraph-online/hol-codex-plugin-scanner-action)
 [![Source of Truth](https://img.shields.io/badge/source-ai--plugin--scanner-111827)](https://github.com/hashgraph-online/ai-plugin-scanner/tree/main/action)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://github.com/hashgraph-online/ai-plugin-scanner/blob/main/LICENSE)
 
-| ![Hashgraph Online Logo](https://hol.org/brand/Logo_Whole_Dark.png) | Marketplace-ready GitHub Action for scanning AI plugin repositories across Codex, Claude, Gemini, and OpenCode ecosystems for security, publishability, runtime readiness, and trust signals. The action emits structured reports, SARIF, policy results, and submission metadata while staying aligned to the main scanner release train.<br><br>[Latest Release](https://github.com/hashgraph-online/hol-ai-plugin-scanner-action/releases/latest)<br>[Marketplace Repository](https://github.com/hashgraph-online/hol-ai-plugin-scanner-action)<br>[Compatibility Alias](https://github.com/hashgraph-online/hol-codex-plugin-scanner-action)<br>[Scanner Source of Truth](https://github.com/hashgraph-online/ai-plugin-scanner/tree/main/action)<br>[Report an Issue](https://github.com/hashgraph-online/ai-plugin-scanner/issues) |
+| ![Hashgraph Online Logo](https://hol.org/brand/Logo_Whole_Dark.png) | Marketplace-ready GitHub Action for scanning AI plugin repositories across Codex, Claude, Gemini, and OpenCode ecosystems for security, publishability, runtime readiness, and trust signals. The action emits structured reports, SARIF, policy results, and submission metadata while staying aligned to the main scanner release train.<br><br>[Latest Release](https://github.com/hashgraph-online/ai-plugin-scanner-action/releases/latest)<br>[Marketplace Repository](https://github.com/hashgraph-online/ai-plugin-scanner-action)<br>[Compatibility Alias](https://github.com/hashgraph-online/hol-codex-plugin-scanner-action)<br>[Scanner Source of Truth](https://github.com/hashgraph-online/ai-plugin-scanner/tree/main/action)<br>[Report an Issue](https://github.com/hashgraph-online/ai-plugin-scanner/issues) |
 | :--- | :--- |
 
 This repository is the canonical Marketplace-facing wrapper for the scanner action. The main scanner repo remains the source of truth, while this published action bundle keeps the required root `action.yml` layout for GitHub Marketplace.
 
-The legacy action slug `hashgraph-online/hol-codex-plugin-scanner-action@v1` remains supported as a compatibility alias for existing workflows. New integrations should use `hashgraph-online/hol-ai-plugin-scanner-action@v1`.
+The legacy action slug `hashgraph-online/hol-codex-plugin-scanner-action@v1` remains supported as a compatibility alias for existing workflows. New integrations should use `hashgraph-online/ai-plugin-scanner-action@v1`.
 
 The default Marketplace install path uses an exact `plugin-scanner` PyPI release, verifies its PyPI provenance against `hashgraph-online/ai-plugin-scanner`, and only then installs it. After installation, the default `scan`, `lint`, and offline `verify` paths operate on local repository content only. Live network probing and submission automation remain explicit opt-in features.
 
@@ -24,7 +24,7 @@ Advanced distribution paths are available when you need them:
 
 ```yaml
 - name: Scan AI Plugin Repository
-  uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
+  uses: hashgraph-online/ai-plugin-scanner-action@v1
   with:
     plugin_dir: "./my-plugin"
     min_score: 70
@@ -104,7 +104,7 @@ Mode notes:
 ### Basic scan with minimum score gate
 
 ```yaml
-- uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
+- uses: hashgraph-online/ai-plugin-scanner-action@v1
   with:
     plugin_dir: "."
     min_score: 70
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
+      - uses: hashgraph-online/ai-plugin-scanner-action@v1
         with:
           plugin_dir: "."
           mode: scan
@@ -136,7 +136,7 @@ This `plugin_dir: "."` pattern is correct for both single-plugin repositories an
 ### With Cisco skill scanning
 
 ```yaml
-- uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
+- uses: hashgraph-online/ai-plugin-scanner-action@v1
   with:
     plugin_dir: "."
     cisco_skill_scan: on
@@ -158,7 +158,7 @@ Use this only inside `hashgraph-online/ai-plugin-scanner`, where the action can 
 ### Export registry payload for ecosystem automation
 
 ```yaml
-- uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
+- uses: hashgraph-online/ai-plugin-scanner-action@v1
   id: scan
   with:
     plugin_dir: "."
@@ -191,7 +191,7 @@ jobs:
 
       - name: Scan plugin and submit if eligible
         id: scan
-        uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
+        uses: hashgraph-online/ai-plugin-scanner-action@v1
         with:
           plugin_dir: "."
           min_score: 80
@@ -210,7 +210,7 @@ Use a fine-grained token with `issues:write` on `hashgraph-online/awesome-codex-
 ### Markdown report as PR comment
 
 ```yaml
-- uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
+- uses: hashgraph-online/ai-plugin-scanner-action@v1
   id: scan
   with:
     plugin_dir: "."
@@ -256,7 +256,7 @@ Direct edits in published action repositories should stay limited to Marketplace
 Set `mode` to one of `scan`, `lint`, `verify`, or `submit`.
 
 ```yaml
-- uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
+- uses: hashgraph-online/ai-plugin-scanner-action@v1
   with:
     mode: verify
     plugin_dir: "."

--- a/action/README.md
+++ b/action/README.md
@@ -1,16 +1,19 @@
-# HOL Codex Plugin Scanner GitHub Action
+# HOL AI Plugin Scanner GitHub Action
 
-[![Latest Release](https://img.shields.io/github/v/release/hashgraph-online/hol-codex-plugin-scanner-action?display_name=tag)](https://github.com/hashgraph-online/hol-codex-plugin-scanner-action/releases/latest)
-[![Marketplace Repository](https://img.shields.io/badge/github-marketplace_repo-0A84FF)](https://github.com/hashgraph-online/hol-codex-plugin-scanner-action)
+[![Latest Release](https://img.shields.io/github/v/release/hashgraph-online/hol-ai-plugin-scanner-action?display_name=tag)](https://github.com/hashgraph-online/hol-ai-plugin-scanner-action/releases/latest)
+[![Marketplace Repository](https://img.shields.io/badge/github-marketplace_repo-0A84FF)](https://github.com/hashgraph-online/hol-ai-plugin-scanner-action)
+[![Compatibility Alias](https://img.shields.io/badge/compat-hol--codex--plugin--scanner--action-6b7280)](https://github.com/hashgraph-online/hol-codex-plugin-scanner-action)
 [![Source of Truth](https://img.shields.io/badge/source-ai--plugin--scanner-111827)](https://github.com/hashgraph-online/ai-plugin-scanner/tree/main/action)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://github.com/hashgraph-online/ai-plugin-scanner/blob/main/LICENSE)
 
-| ![Hashgraph Online Logo](https://hol.org/brand/Logo_Whole_Dark.png) | Marketplace-ready GitHub Action for scanning [Codex plugins](https://developers.openai.com/codex/plugins) for security, publishability, runtime readiness, and registry trust signals. The action emits structured reports, SARIF, policy results, and submission metadata while staying aligned to the main scanner release train.<br><br>[Latest Release](https://github.com/hashgraph-online/hol-codex-plugin-scanner-action/releases/latest)<br>[Marketplace Repository](https://github.com/hashgraph-online/hol-codex-plugin-scanner-action)<br>[Scanner Source of Truth](https://github.com/hashgraph-online/ai-plugin-scanner/tree/main/action)<br>[Report an Issue](https://github.com/hashgraph-online/ai-plugin-scanner/issues) |
+| ![Hashgraph Online Logo](https://hol.org/brand/Logo_Whole_Dark.png) | Marketplace-ready GitHub Action for scanning AI plugin repositories across Codex, Claude, Gemini, and OpenCode ecosystems for security, publishability, runtime readiness, and trust signals. The action emits structured reports, SARIF, policy results, and submission metadata while staying aligned to the main scanner release train.<br><br>[Latest Release](https://github.com/hashgraph-online/hol-ai-plugin-scanner-action/releases/latest)<br>[Marketplace Repository](https://github.com/hashgraph-online/hol-ai-plugin-scanner-action)<br>[Compatibility Alias](https://github.com/hashgraph-online/hol-codex-plugin-scanner-action)<br>[Scanner Source of Truth](https://github.com/hashgraph-online/ai-plugin-scanner/tree/main/action)<br>[Report an Issue](https://github.com/hashgraph-online/ai-plugin-scanner/issues) |
 | :--- | :--- |
 
-This repository is the Marketplace-facing wrapper for the scanner action. The main scanner repo remains the source of truth, while this published action bundle keeps the required root `action.yml` layout for GitHub Marketplace.
+This repository is the canonical Marketplace-facing wrapper for the scanner action. The main scanner repo remains the source of truth, while this published action bundle keeps the required root `action.yml` layout for GitHub Marketplace.
 
-The default Marketplace install path uses an exact `codex-plugin-scanner` PyPI release, verifies its PyPI provenance against `hashgraph-online/ai-plugin-scanner`, and only then installs it. After installation, the default `scan`, `lint`, and offline `verify` paths operate on local repository content only. Live network probing and submission automation remain explicit opt-in features.
+The legacy action slug `hashgraph-online/hol-codex-plugin-scanner-action@v1` remains supported as a compatibility alias for existing workflows. New integrations should use `hashgraph-online/hol-ai-plugin-scanner-action@v1`.
+
+The default Marketplace install path uses an exact `plugin-scanner` PyPI release, verifies its PyPI provenance against `hashgraph-online/ai-plugin-scanner`, and only then installs it. After installation, the default `scan`, `lint`, and offline `verify` paths operate on local repository content only. Live network probing and submission automation remain explicit opt-in features.
 
 Advanced distribution paths are available when you need them:
 
@@ -20,8 +23,8 @@ Advanced distribution paths are available when you need them:
 ## Usage
 
 ```yaml
-- name: Scan Codex Plugin
-  uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+- name: Scan AI Plugin Repository
+  uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
   with:
     plugin_dir: "./my-plugin"
     min_score: 70
@@ -37,13 +40,13 @@ Advanced distribution paths are available when you need them:
 | `format` | Output format: `text`, `json`, `markdown`, `sarif` | `text` |
 | `output` | Write report to this file path | `""` |
 | `profile` | Policy profile: `default`, `public-marketplace`, or `strict-security` | `default` |
-| `config` | Optional path to `.codex-plugin-scanner.toml` | `""` |
+| `config` | Optional path to a scanner config file such as `.plugin-scanner.toml` | `""` |
 | `baseline` | Optional path to a baseline suppression file | `""` |
 | `online` | Enable live network probing for `verify` mode | `false` |
 | `upload_sarif` | Upload the generated SARIF report to GitHub code scanning when `mode: scan` | `false` |
-| `sarif_category` | SARIF category used during GitHub code scanning upload | `codex-plugin-scanner` |
+| `sarif_category` | SARIF category used during GitHub code scanning upload | `ai-plugin-scanner` |
 | `write_step_summary` | Write a concise markdown summary to the GitHub Actions job summary | `true` |
-| `registry_payload_output` | Write a machine-readable Codex ecosystem payload JSON file for registry or awesome-list automation | `""` |
+| `registry_payload_output` | Write a machine-readable plugin ecosystem payload JSON file for registry or awesome-list automation | `""` |
 | `min_score` | Fail if score is below this threshold (0-100) | `0` |
 | `fail_on_severity` | Fail on findings at or above this severity: `none`, `critical`, `high`, `medium`, `low`, `info` | `none` |
 | `cisco_skill_scan` | Cisco skill-scanner mode: `auto`, `on`, `off` | `auto` |
@@ -60,6 +63,9 @@ Advanced distribution paths are available when you need them:
 | `submission_plugin_url` | Override the plugin repository URL used in the submission issue | `""` |
 | `submission_plugin_description` | Override the plugin description used in the submission issue | `""` |
 | `submission_author` | Override the plugin author used in the submission issue | `""` |
+| `pr_comment` | PR comment mode: `auto`, `always`, or `off` | `auto` |
+| `pr_comment_style` | PR comment style: `concise` or `detailed` | `concise` |
+| `pr_comment_max_findings` | Maximum findings to include in PR comment summaries | `5` |
 
 ## Outputs
 
@@ -73,11 +79,15 @@ Advanced distribution paths are available when you need them:
 | `max_severity` | Highest finding severity, or `none` |
 | `findings_total` | Total number of findings across all severities |
 | `report_path` | Path to the rendered report file, if `output` was set |
-| `registry_payload_path` | Path to the machine-readable Codex ecosystem payload file, if requested |
+| `registry_payload_path` | Path to the machine-readable plugin ecosystem payload file, if requested |
 | `submission_eligible` | `true` when the plugin met the submission threshold and passed the configured severity gate |
 | `submission_performed` | `true` when a submission issue was created or an existing one was reused |
 | `submission_issue_urls` | Comma-separated submission issue URLs |
 | `submission_issue_numbers` | Comma-separated submission issue numbers |
+| `action_exit_code` | Action execution exit code |
+| `pr_comment_status` | PR comment status (`created`, `updated`, `unchanged`, `skipped`, `disabled`) |
+| `pr_comment_id` | PR comment ID when available |
+| `pr_comment_url` | PR comment URL when available |
 
 The action also writes a concise summary to `GITHUB_STEP_SUMMARY` by default. The full report is written to the job log for `text` output, or to the file you pass through `output` for `json`, `markdown`, or `sarif`.
 
@@ -87,13 +97,14 @@ Mode notes:
 - `verify` respects `online` and writes a human-readable report for `format: text`.
 - `submit` writes the plugin-quality artifact to `output` when provided, otherwise `plugin-quality.json`. `registry_payload_output` remains dedicated to the separate HOL registry payload.
 - `online`, `submission_enabled`, and `upload_sarif` are the only common paths that intentionally reach beyond the runner after the scanner package itself has been installed.
+- `pr_comment_status` currently defaults to `skipped` in this Marketplace wrapper path.
 
 ## Examples
 
 ### Basic scan with minimum score gate
 
 ```yaml
-- uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+- uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
   with:
     plugin_dir: "."
     min_score: 70
@@ -111,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+      - uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
         with:
           plugin_dir: "."
           mode: scan
@@ -125,7 +136,7 @@ This `plugin_dir: "."` pattern is correct for both single-plugin repositories an
 ### With Cisco skill scanning
 
 ```yaml
-- uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+- uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
   with:
     plugin_dir: "."
     cisco_skill_scan: on
@@ -144,16 +155,16 @@ Use this only inside `hashgraph-online/ai-plugin-scanner`, where the action can 
     install_source: local
 ```
 
-### Export registry payload for Codex ecosystem automation
+### Export registry payload for ecosystem automation
 
 ```yaml
-- uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+- uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
   id: scan
   with:
     plugin_dir: "."
     format: sarif
     upload_sarif: true
-    registry_payload_output: codex-plugin-registry-payload.json
+    registry_payload_output: ai-plugin-registry-payload.json
 
 - name: Show trust signals
   run: |
@@ -180,7 +191,7 @@ jobs:
 
       - name: Scan plugin and submit if eligible
         id: scan
-        uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+        uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
         with:
           plugin_dir: "."
           min_score: 80
@@ -199,7 +210,7 @@ Use a fine-grained token with `issues:write` on `hashgraph-online/awesome-codex-
 ### Markdown report as PR comment
 
 ```yaml
-- uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+- uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
   id: scan
   with:
     plugin_dir: "."
@@ -224,16 +235,17 @@ Use a fine-grained token with `issues:write` on `hashgraph-online/awesome-codex-
 
 - Publish immutable releases for this Marketplace wrapper repository automatically from the source scanner repo when `action/` changes merge to `main`.
 - Move the floating major tag `v1` to the latest compatible release.
-- Keep this action in its own public repository for GitHub Marketplace publication.
-- Configure `ACTION_REPO_TOKEN` as a secret in the source repository so `publish-action-repo.yml` can automatically sync this root-ready bundle, create the action-repo release, and publish autogenerated release notes.
-- Optionally set `ACTION_REPOSITORY` in the source repository if the target repository should not be `hashgraph-online/hol-codex-plugin-scanner-action`.
-- Sync the install metadata files (`scanner-version.txt`, `cisco-version.txt`, and `pypi-attestations-version.txt`) with the action bundle so the Marketplace wrapper always installs the same reviewed scanner release.
+- Keep the canonical action in its own public repository for GitHub Marketplace publication.
+- Keep the legacy action repository synchronized as a compatibility alias for existing consumers.
+- Configure `ACTION_REPO_TOKEN` as a secret in the source repository so `publish-action-repo.yml` can automatically sync the canonical and legacy action repositories, create releases, and publish autogenerated release notes.
+- Optionally set `ACTION_CANONICAL_REPOSITORY` or `ACTION_COMPAT_REPOSITORY` in the source repository if the targets differ from the defaults.
+- Sync the install metadata files (`scanner-version.txt`, `cisco-version.txt`, and `pypi-attestations-version.txt`) with the action bundle so both action repositories always install the same reviewed scanner release.
 
 ## Source of Truth
 
-The source bundle for this action lives in the main scanner repository under `action/`. Release artifacts from that repository should export a root-ready action bundle for the dedicated Marketplace repository.
+The source bundle for this action lives in the main scanner repository under `action/`. Release artifacts from that repository should export a root-ready action bundle for the dedicated action repositories.
 
-Direct edits in this Marketplace repository should stay limited to Marketplace-specific copy or metadata. Functional changes and release publication logic belong in `hashgraph-online/ai-plugin-scanner` so merges there can publish a matching action release automatically.
+Direct edits in published action repositories should stay limited to Marketplace-specific copy or metadata. Functional changes and release publication logic belong in `hashgraph-online/ai-plugin-scanner` so merges there can publish matching action releases automatically.
 
 ## License
 
@@ -244,7 +256,7 @@ Direct edits in this Marketplace repository should stay limited to Marketplace-s
 Set `mode` to one of `scan`, `lint`, `verify`, or `submit`.
 
 ```yaml
-- uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+- uses: hashgraph-online/hol-ai-plugin-scanner-action@v1
   with:
     mode: verify
     plugin_dir: "."

--- a/action/action.yml
+++ b/action/action.yml
@@ -170,16 +170,16 @@ outputs:
     value: ${{ steps.scan.outputs.submission_issue_numbers }}
   action_exit_code:
     description: "Action execution exit code"
-    value: ${{ steps.normalized_outputs.outputs.action_exit_code }}
+    value: ${{ steps.scan.outputs.action_exit_code }}
   pr_comment_status:
     description: "PR comment status: created, updated, unchanged, skipped, or disabled"
-    value: ${{ steps.normalized_outputs.outputs.pr_comment_status }}
+    value: ${{ steps.scan.outputs.pr_comment_status }}
   pr_comment_id:
     description: "Created or updated PR comment id when available"
-    value: ${{ steps.normalized_outputs.outputs.pr_comment_id }}
+    value: ${{ steps.scan.outputs.pr_comment_id }}
   pr_comment_url:
     description: "Created or updated PR comment URL when available"
-    value: ${{ steps.normalized_outputs.outputs.pr_comment_url }}
+    value: ${{ steps.scan.outputs.pr_comment_url }}
 
 branding:
   icon: "check-circle"
@@ -290,15 +290,6 @@ runs:
         PR_COMMENT_MAX_FINDINGS: ${{ inputs.pr_comment_max_findings }}
         GITHUB_STEP_SUMMARY: ${{ env.GITHUB_STEP_SUMMARY }}
       run: python3 -m codex_plugin_scanner.action_runner
-
-    - name: Normalize action outputs
-      id: normalized_outputs
-      shell: bash
-      run: |
-        echo "action_exit_code=0" >> "$GITHUB_OUTPUT"
-        echo "pr_comment_status=skipped" >> "$GITHUB_OUTPUT"
-        echo "pr_comment_id=" >> "$GITHUB_OUTPUT"
-        echo "pr_comment_url=" >> "$GITHUB_OUTPUT"
 
     - name: Upload SARIF
       if: ${{ inputs.upload_sarif == 'true' && inputs.mode == 'scan' && steps.scan.outputs.report_path != '' }}

--- a/action/action.yml
+++ b/action/action.yml
@@ -1,5 +1,5 @@
-name: "HOL Codex Plugin Scanner"
-description: "Scan a Codex plugin directory for security, publishability, and best practices. Scores from 0-100."
+name: "HOL AI Plugin Scanner"
+description: "Scan AI plugin repositories for security, publishability, and best-practice quality signals."
 author: "HOL"
 
 inputs:
@@ -24,7 +24,7 @@ inputs:
     required: false
     default: "default"
   config:
-    description: "Optional path to .codex-plugin-scanner.toml"
+    description: "Optional path to a scanner config file such as .plugin-scanner.toml"
     required: false
     default: ""
   baseline:
@@ -42,13 +42,13 @@ inputs:
   sarif_category:
     description: "SARIF category used when upload_sarif is enabled"
     required: false
-    default: "codex-plugin-scanner"
+    default: "ai-plugin-scanner"
   write_step_summary:
     description: "Write a concise markdown summary to the GitHub Actions job summary"
     required: false
     default: "true"
   registry_payload_output:
-    description: "Write a machine-readable Codex ecosystem payload JSON file for registry or awesome-list automation"
+    description: "Write a machine-readable plugin ecosystem payload JSON file for registry or awesome-list automation"
     required: false
     default: ""
   min_score:
@@ -115,6 +115,18 @@ inputs:
     description: "Override the plugin author used in the submission issue"
     required: false
     default: ""
+  pr_comment:
+    description: "PR comment mode: auto, always, or off"
+    required: false
+    default: "auto"
+  pr_comment_style:
+    description: "PR comment style: concise or detailed"
+    required: false
+    default: "concise"
+  pr_comment_max_findings:
+    description: "Maximum findings to include in PR comment summaries"
+    required: false
+    default: "5"
 
 outputs:
   score:
@@ -142,7 +154,7 @@ outputs:
     description: "The path to the rendered report file, if output was requested"
     value: ${{ steps.scan.outputs.report_path }}
   registry_payload_path:
-    description: "The path to the machine-readable Codex ecosystem payload file, if requested"
+    description: "The path to the machine-readable plugin ecosystem payload file, if requested"
     value: ${{ steps.scan.outputs.registry_payload_path }}
   submission_eligible:
     description: "Whether the plugin met the submission threshold and passed the configured severity gate"
@@ -156,6 +168,18 @@ outputs:
   submission_issue_numbers:
     description: "Comma-separated issue numbers for submission issues created or reused"
     value: ${{ steps.scan.outputs.submission_issue_numbers }}
+  action_exit_code:
+    description: "Action execution exit code"
+    value: ${{ steps.normalized_outputs.outputs.action_exit_code }}
+  pr_comment_status:
+    description: "PR comment status: created, updated, unchanged, skipped, or disabled"
+    value: ${{ steps.normalized_outputs.outputs.pr_comment_status }}
+  pr_comment_id:
+    description: "Created or updated PR comment id when available"
+    value: ${{ steps.normalized_outputs.outputs.pr_comment_id }}
+  pr_comment_url:
+    description: "Created or updated PR comment URL when available"
+    value: ${{ steps.normalized_outputs.outputs.pr_comment_url }}
 
 branding:
   icon: "check-circle"
@@ -185,7 +209,7 @@ runs:
 
         if [ "$INSTALL_SOURCE" = "local" ]; then
           if [ -z "$LOCAL_SOURCE" ]; then
-            echo "install_source=local requires the source repository checkout (for example: uses: ./action inside codex-plugin-scanner)." >&2
+            echo "install_source=local requires the source repository checkout (for example: uses: ./action inside ai-plugin-scanner)." >&2
             exit 1
           fi
           if [ "$INSTALL_CISCO" = "true" ]; then
@@ -205,21 +229,21 @@ runs:
           SCANNER_VERSION="$(tr -d '[:space:]' < "$SCANNER_VERSION_FILE")"
           CISCO_VERSION="$(tr -d '[:space:]' < "$CISCO_VERSION_FILE")"
           PYPI_ATTESTATIONS_VERSION="$(tr -d '[:space:]' < "$PYPI_ATTESTATIONS_VERSION_FILE")"
-          SCANNER_REPOSITORY="https://github.com/hashgraph-online/codex-plugin-scanner"
-          DIST_DIR="${RUNNER_TEMP:-$GITHUB_WORKSPACE/.codex-plugin-scanner-dist}"
+          SCANNER_REPOSITORY="https://github.com/hashgraph-online/ai-plugin-scanner"
+          DIST_DIR="${RUNNER_TEMP:-$GITHUB_WORKSPACE/.ai-plugin-scanner-dist}"
           mkdir -p "$DIST_DIR"
 
           python3 -m pip install "pypi-attestations==${PYPI_ATTESTATIONS_VERSION}"
-          python3 -m pip download --only-binary=:all: --no-deps --dest "$DIST_DIR" "codex-plugin-scanner==${SCANNER_VERSION}"
+          python3 -m pip download --only-binary=:all: --no-deps --dest "$DIST_DIR" "plugin-scanner==${SCANNER_VERSION}"
 
           DIST_BASENAME="$(
-            DIST_DIR="$DIST_DIR" python3 -c "import os; from pathlib import Path; dist_dir = Path(os.environ['DIST_DIR']); candidates = sorted(dist_dir.glob('codex_plugin_scanner-*.whl')); expected = len(candidates) == 1; print(candidates[0].name) if expected else (_ for _ in ()).throw(SystemExit(f'Expected exactly one downloaded scanner wheel, found {len(candidates)}'))"
+            DIST_DIR="$DIST_DIR" python3 -c "import os; from pathlib import Path; dist_dir = Path(os.environ['DIST_DIR']); candidates = sorted(dist_dir.glob('plugin_scanner-*.whl')); expected = len(candidates) == 1; print(candidates[0].name) if expected else (_ for _ in ()).throw(SystemExit(f'Expected exactly one downloaded scanner wheel, found {len(candidates)}'))"
           )"
 
           if ! python3 -m pypi_attestations verify pypi \
             --repository "$SCANNER_REPOSITORY" \
             "pypi:${DIST_BASENAME}"; then
-            echo "Failed to verify PyPI provenance for codex-plugin-scanner==${SCANNER_VERSION}." >&2
+            echo "Failed to verify PyPI provenance for plugin-scanner==${SCANNER_VERSION}." >&2
             exit 1
           fi
 
@@ -261,8 +285,20 @@ runs:
         SUBMISSION_PLUGIN_URL: ${{ inputs.submission_plugin_url }}
         SUBMISSION_PLUGIN_DESCRIPTION: ${{ inputs.submission_plugin_description }}
         SUBMISSION_AUTHOR: ${{ inputs.submission_author }}
+        PR_COMMENT: ${{ inputs.pr_comment }}
+        PR_COMMENT_STYLE: ${{ inputs.pr_comment_style }}
+        PR_COMMENT_MAX_FINDINGS: ${{ inputs.pr_comment_max_findings }}
         GITHUB_STEP_SUMMARY: ${{ env.GITHUB_STEP_SUMMARY }}
       run: python3 -m codex_plugin_scanner.action_runner
+
+    - name: Normalize action outputs
+      id: normalized_outputs
+      shell: bash
+      run: |
+        echo "action_exit_code=0" >> "$GITHUB_OUTPUT"
+        echo "pr_comment_status=skipped" >> "$GITHUB_OUTPUT"
+        echo "pr_comment_id=" >> "$GITHUB_OUTPUT"
+        echo "pr_comment_url=" >> "$GITHUB_OUTPUT"
 
     - name: Upload SARIF
       if: ${{ inputs.upload_sarif == 'true' && inputs.mode == 'scan' && steps.scan.outputs.report_path != '' }}

--- a/src/codex_plugin_scanner/action_runner.py
+++ b/src/codex_plugin_scanner/action_runner.py
@@ -226,11 +226,22 @@ def main() -> int:
         "submission_performed": "false",
         "submission_issue_urls": "",
         "submission_issue_numbers": "",
+        "action_exit_code": "0",
+        "pr_comment_status": "skipped",
+        "pr_comment_id": "",
+        "pr_comment_url": "",
     }
     verify_pass_for_summary: bool | None = None
     scan_scope = "plugin"
     local_plugin_count: int | None = None
     skipped_target_count: int | None = None
+
+    def finish(return_code: int) -> int:
+        output_values["action_exit_code"] = str(return_code)
+        github_output = _read_env("GITHUB_OUTPUT")
+        if github_output:
+            _write_outputs(github_output, output_values)
+        return return_code
 
     if mode in {"scan", "lint", "submit"}:
         args = _build_scan_args(
@@ -258,7 +269,7 @@ def main() -> int:
             if upload_sarif:
                 if output_format != "sarif":
                     print("upload_sarif requires format=sarif.", file=sys.stderr)
-                    return 1
+                    return finish(1)
                 if not output_path:
                     output_path = "ai-plugin-scanner.sarif"
             rendered = _render_scan_output(
@@ -282,7 +293,7 @@ def main() -> int:
                     "Point plugin_dir at one plugin instead of a repo marketplace root.",
                     file=sys.stderr,
                 )
-                return 1
+                return finish(1)
             verification = verify_plugin(Path(plugin_dir).resolve(), online=online)
             artifact_path = output_path or "plugin-quality.json"
             artifact = build_quality_artifact(
@@ -358,13 +369,13 @@ def main() -> int:
             if submission_eligible:
                 if not submission_repos:
                     print("Submission is enabled but no submission repositories were configured.", file=sys.stderr)
-                    return 1
+                    return finish(1)
                 if not submission_token:
                     print("Submission is enabled but no submission token was provided.", file=sys.stderr)
-                    return 1
+                    return finish(1)
                 if not metadata.plugin_url:
                     print("Submission metadata is missing a plugin repository URL.", file=sys.stderr)
-                    return 1
+                    return finish(1)
                 title = build_submission_issue_title(metadata)
                 body = build_submission_issue_body(
                     metadata,
@@ -400,16 +411,16 @@ def main() -> int:
 
         if result.score < min_score:
             print(f"Score {result.score} is below minimum threshold {min_score}", file=sys.stderr)
-            return 1
+            return finish(1)
         if should_fail_for_severity(result, fail_on):
             print(f'Findings met or exceeded the "{fail_on}" severity threshold.', file=sys.stderr)
-            return 1
+            return finish(1)
         if not policy_eval.policy_pass:
             print(f'Policy profile "{resolved_profile}" failed.', file=sys.stderr)
-            return 1
+            return finish(1)
         if mode == "submit" and verification is not None and not verification.verify_pass:
             print("Submission blocked: runtime verification failed.", file=sys.stderr)
-            return 1
+            return finish(1)
 
     elif mode == "verify":
         verification = verify_plugin(Path(plugin_dir).resolve(), online=online)
@@ -430,7 +441,7 @@ def main() -> int:
         output_values["verify_pass"] = "true" if verification.verify_pass else "false"
     else:
         print(f"Unsupported mode: {mode}", file=sys.stderr)
-        return 1
+        return finish(1)
 
     output_values["report_path"] = report_path_value
     output_values["registry_payload_path"] = registry_payload_path_value
@@ -457,13 +468,9 @@ def main() -> int:
             ),
         )
 
-    github_output = _read_env("GITHUB_OUTPUT")
-    if github_output:
-        _write_outputs(github_output, output_values)
-
     if mode == "verify":
-        return return_code
-    return 0
+        return finish(return_code)
+    return finish(0)
 
 
 if __name__ == "__main__":

--- a/src/codex_plugin_scanner/action_runner.py
+++ b/src/codex_plugin_scanner/action_runner.py
@@ -319,6 +319,8 @@ def main() -> int:
         else:
             print(rendered)
 
+        output_values["report_path"] = report_path_value
+
         severity_failed = should_fail_for_severity(result, fail_on)
         output_values.update(
             {
@@ -356,6 +358,7 @@ def main() -> int:
                 registry_path = Path(registry_payload_output)
                 registry_path.write_text(json.dumps(registry_payload, indent=2), encoding="utf-8")
                 registry_payload_path_value = str(registry_path)
+                output_values["registry_payload_path"] = registry_payload_path_value
 
             verify_for_submission = verification.verify_pass if verification is not None else True
             submission_eligible = (
@@ -439,6 +442,7 @@ def main() -> int:
             print(rendered)
         return_code = 1 if not verification.verify_pass else 0
         output_values["verify_pass"] = "true" if verification.verify_pass else "false"
+        output_values["report_path"] = report_path_value
     else:
         print(f"Unsupported mode: {mode}", file=sys.stderr)
         return finish(1)

--- a/src/codex_plugin_scanner/action_runner.py
+++ b/src/codex_plugin_scanner/action_runner.py
@@ -145,7 +145,7 @@ def _build_step_summary_lines(
     local_plugin_count: int | None = None,
     skipped_target_count: int | None = None,
 ) -> tuple[str, ...]:
-    lines = ["## HOL Codex Plugin Scanner", "", f"- Mode: {mode}"]
+    lines = ["## HOL AI Plugin Scanner", "", f"- Mode: {mode}"]
     lines.append(f"- Scope: {scope}")
     if local_plugin_count is not None:
         lines.append(f"- Local plugins scanned: {local_plugin_count}")
@@ -260,7 +260,7 @@ def main() -> int:
                     print("upload_sarif requires format=sarif.", file=sys.stderr)
                     return 1
                 if not output_path:
-                    output_path = "codex-plugin-scanner.sarif"
+                    output_path = "ai-plugin-scanner.sarif"
             rendered = _render_scan_output(
                 result,
                 output_format=output_format,

--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -129,7 +129,7 @@ def format_json(
 
 def _add_common_policy_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--profile", choices=("default", "public-marketplace", "strict-security"))
-    parser.add_argument("--config", help="Path to .codex-plugin-scanner.toml")
+    parser.add_argument("--config", help="Path to a scanner config file such as .plugin-scanner.toml")
     parser.add_argument("--baseline", help="Path to baseline suppression file")
     parser.add_argument("--strict", action="store_true", help="Fail if any finding is present")
     parser.add_argument("--diff-base", help="Reserved for future diff-aware gating")

--- a/src/codex_plugin_scanner/config.py
+++ b/src/codex_plugin_scanner/config.py
@@ -1,4 +1,4 @@
-"""Configuration loading for codex-plugin-scanner."""
+"""Configuration loading for the scanner."""
 
 from __future__ import annotations
 
@@ -21,7 +21,7 @@ class ScannerConfig:
     ignore_paths: tuple[str, ...] = ()
 
 
-DEFAULT_CONFIG_FILE = ".codex-plugin-scanner.toml"
+DEFAULT_CONFIG_FILES = (".plugin-scanner.toml", ".codex-plugin-scanner.toml")
 
 
 class ConfigError(ValueError):
@@ -29,9 +29,14 @@ class ConfigError(ValueError):
 
 
 def load_scanner_config(plugin_dir: Path, config_path: str | None = None) -> ScannerConfig:
-    candidate = Path(config_path) if config_path else plugin_dir / DEFAULT_CONFIG_FILE
-    if not candidate.exists():
-        return ScannerConfig()
+    if config_path:
+        candidate = Path(config_path)
+        if not candidate.exists():
+            return ScannerConfig()
+    else:
+        candidate = next((plugin_dir / name for name in DEFAULT_CONFIG_FILES if (plugin_dir / name).exists()), None)
+        if candidate is None:
+            return ScannerConfig()
 
     try:
         payload = tomllib.loads(candidate.read_text(encoding="utf-8"))

--- a/src/codex_plugin_scanner/config.py
+++ b/src/codex_plugin_scanner/config.py
@@ -31,6 +31,8 @@ class ConfigError(ValueError):
 def load_scanner_config(plugin_dir: Path, config_path: str | None = None) -> ScannerConfig:
     if config_path:
         candidate = Path(config_path)
+        if not candidate.is_absolute():
+            candidate = plugin_dir / candidate
         if not candidate.exists():
             raise ConfigError(f"Config file '{candidate}' does not exist.")
     else:

--- a/src/codex_plugin_scanner/config.py
+++ b/src/codex_plugin_scanner/config.py
@@ -32,7 +32,7 @@ def load_scanner_config(plugin_dir: Path, config_path: str | None = None) -> Sca
     if config_path:
         candidate = Path(config_path)
         if not candidate.exists():
-            return ScannerConfig()
+            raise ConfigError(f"Config file '{candidate}' does not exist.")
     else:
         candidate = next((plugin_dir / name for name in DEFAULT_CONFIG_FILES if (plugin_dir / name).exists()), None)
         if candidate is None:

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -73,10 +73,11 @@ def test_action_metadata_includes_marketplace_branding_and_fallback_install() ->
     assert "value: ${{ steps.scan.outputs.submission_performed }}" in action_text
     assert "value: ${{ steps.scan.outputs.submission_issue_urls }}" in action_text
     assert "value: ${{ steps.scan.outputs.submission_issue_numbers }}" in action_text
-    assert "value: ${{ steps.normalized_outputs.outputs.action_exit_code }}" in action_text
-    assert "value: ${{ steps.normalized_outputs.outputs.pr_comment_status }}" in action_text
-    assert "value: ${{ steps.normalized_outputs.outputs.pr_comment_id }}" in action_text
-    assert "value: ${{ steps.normalized_outputs.outputs.pr_comment_url }}" in action_text
+    assert "value: ${{ steps.scan.outputs.action_exit_code }}" in action_text
+    assert "value: ${{ steps.scan.outputs.pr_comment_status }}" in action_text
+    assert "value: ${{ steps.scan.outputs.pr_comment_id }}" in action_text
+    assert "value: ${{ steps.scan.outputs.pr_comment_url }}" in action_text
+    assert "Normalize action outputs" not in action_text
     assert "GITHUB_STEP_SUMMARY" in action_text
     assert "github/codeql-action/upload-sarif@" in action_text
 

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -150,6 +150,12 @@ def test_publish_action_repo_workflow_syncs_action_repository() -> None:
     assert "if: secrets.ACTION_REPO_TOKEN != ''" not in workflow_text
     assert "ACTION_CANONICAL_REPOSITORY" in workflow_text
     assert "ACTION_COMPAT_REPOSITORY" in workflow_text
+    assert 'latest_repo_tag() {' in workflow_text
+    assert (
+        'for candidate in "$(latest_repo_tag "$ACTION_CANONICAL_REPOSITORY")" '
+        '"$(latest_repo_tag "$ACTION_COMPAT_REPOSITORY")"; do'
+    ) in workflow_text
+    assert """printf '%s\\n%s\\n' "$LAST_TAG" "$candidate" | sort -V | tail -n1""" in workflow_text
     assert (
         'git -C "$repo_dir" status --short -- action.yml README.md scanner-version.txt '
         "cisco-version.txt pypi-attestations-version.txt LICENSE SECURITY.md CONTRIBUTING.md"

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -185,9 +185,18 @@ def test_publish_action_repo_workflow_syncs_action_repository() -> None:
         '"${repo_dir}/pypi-attestations-version.txt"'
     ) in workflow_text
     assert 'git -C "$repo_dir" push origin HEAD:main' in workflow_text
+    assert 'any_repo_changed="false"' in workflow_text
     assert 'repo_changed="false"' in workflow_text
     assert 'repo_changed="true"' in workflow_text
-    assert 'if [ "$repo_changed" != "true" ]; then' in workflow_text
+    assert (
+        'printf \'%s\\t%s\\n\' "$target_repo" "$repo_dir" >> '
+        '"$GITHUB_WORKSPACE/action-repos/publish-targets.tsv"'
+    ) in workflow_text
+    assert ': > "$GITHUB_WORKSPACE/action-repos/publish-targets.tsv"' in workflow_text
+    assert 'if [ "$any_repo_changed" != "true" ]; then' in workflow_text
+    assert "publish_action_release() {" in workflow_text
+    assert "while IFS=$'\\t' read -r target_repo repo_dir; do" in workflow_text
+    assert 'publish_action_release "$target_repo" "$repo_dir"' in workflow_text
     assert 'gh release view "${TAG}" --repo "$target_repo"' in workflow_text
     assert 'git -C "$repo_dir" ls-remote --tags origin "refs/tags/${TAG}"' in workflow_text
     assert 'Refusing to publish action bundle with colliding existing tag ${TAG} in ${target_repo}.' in workflow_text

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -153,7 +153,7 @@ def test_publish_action_repo_workflow_syncs_action_repository() -> None:
     assert 'latest_release_tag() {' in workflow_text
     assert 'latest_remote_tag() {' in workflow_text
     assert (
-        'git ls-remote --tags "https://x-access-token:${GH_TOKEN}@github.com/${target_repo}.git" '
+        'git ls-remote --tags --refs "https://x-access-token:${GH_TOKEN}@github.com/${target_repo}.git" '
         '"refs/tags/v*"'
     ) in workflow_text
     assert 'awk -F' in workflow_text

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -86,7 +86,7 @@ def test_publish_workflow_attaches_marketplace_action_bundle() -> None:
     workflow_text = (ROOT / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8")
 
     assert "Build GitHub Action bundle" in workflow_text
-    assert "hol-ai-plugin-scanner-action-v${VERSION}.zip" in workflow_text
+    assert "ai-plugin-scanner-action-v${VERSION}.zip" in workflow_text
     assert "Attest GitHub release assets" in workflow_text
     assert "actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32" in workflow_text
     assert "attestations: write" in workflow_text
@@ -142,7 +142,7 @@ def test_publish_action_repo_workflow_syncs_action_repository() -> None:
 
     assert "Publish GitHub Action Repository" in workflow_text
     assert "ACTION_REPO_TOKEN" in workflow_text
-    assert "hashgraph-online/hol-ai-plugin-scanner-action" in workflow_text
+    assert "hashgraph-online/ai-plugin-scanner-action" in workflow_text
     assert "hashgraph-online/hol-codex-plugin-scanner-action" in workflow_text
     assert "Validate publication credentials" in workflow_text
     assert "Compute scanner package version" in workflow_text
@@ -202,7 +202,7 @@ def test_action_bundle_docs_live_in_action_readme() -> None:
     assert "submission issue" in action_readme
     assert "awesome-codex-plugins" in action_readme
     assert "publish-action-repo.yml" in action_readme
-    assert "hashgraph-online/hol-ai-plugin-scanner-action@v1" in action_readme
+    assert "hashgraph-online/ai-plugin-scanner-action@v1" in action_readme
     assert "hashgraph-online/hol-codex-plugin-scanner-action@v1" in action_readme
     assert "actions/checkout@v4" in action_readme
     assert "actions/github-script@v7" in action_readme
@@ -214,7 +214,7 @@ def test_legacy_action_readme_marks_compatibility_alias() -> None:
 
     assert "compatibility alias" in legacy_readme
     assert "hashgraph-online/hol-codex-plugin-scanner-action@v1" in legacy_readme
-    assert "hashgraph-online/hol-ai-plugin-scanner-action@v1" in legacy_readme
+    assert "hashgraph-online/ai-plugin-scanner-action@v1" in legacy_readme
     assert "same reviewed root bundle" in legacy_readme
 
 
@@ -229,7 +229,7 @@ def test_readme_uses_stable_apache_license_badge() -> None:
     assert "https://pypi.org/project/plugin-scanner/" in readme
     assert "https://pypi.org/project/codex-plugin-scanner/" in readme
     assert "Container Image" in readme
-    assert "hashgraph-online/hol-ai-plugin-scanner-action@v1" in readme
+    assert "hashgraph-online/ai-plugin-scanner-action@v1" in readme
 
 
 def test_container_files_exist_for_enterprise_distribution() -> None:

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -150,11 +150,20 @@ def test_publish_action_repo_workflow_syncs_action_repository() -> None:
     assert "if: secrets.ACTION_REPO_TOKEN != ''" not in workflow_text
     assert "ACTION_CANONICAL_REPOSITORY" in workflow_text
     assert "ACTION_COMPAT_REPOSITORY" in workflow_text
-    assert 'latest_repo_tag() {' in workflow_text
+    assert 'latest_release_tag() {' in workflow_text
+    assert 'latest_remote_tag() {' in workflow_text
     assert (
-        'for candidate in "$(latest_repo_tag "$ACTION_CANONICAL_REPOSITORY")" '
-        '"$(latest_repo_tag "$ACTION_COMPAT_REPOSITORY")"; do'
+        'git ls-remote --tags "https://x-access-token:${GH_TOKEN}@github.com/${target_repo}.git" '
+        '"refs/tags/v*"'
     ) in workflow_text
+    assert 'awk -F' in workflow_text
+    assert (
+        'for candidate in '
+    ) in workflow_text
+    assert '"$(latest_release_tag "$ACTION_CANONICAL_REPOSITORY")" \\' in workflow_text
+    assert '"$(latest_release_tag "$ACTION_COMPAT_REPOSITORY")" \\' in workflow_text
+    assert '"$(latest_remote_tag "$ACTION_CANONICAL_REPOSITORY")" \\' in workflow_text
+    assert '"$(latest_remote_tag "$ACTION_COMPAT_REPOSITORY")"; do' in workflow_text
     assert """printf '%s\\n%s\\n' "$LAST_TAG" "$candidate" | sort -V | tail -n1""" in workflow_text
     assert (
         'git -C "$repo_dir" status --short -- action.yml README.md scanner-version.txt '
@@ -181,6 +190,7 @@ def test_publish_action_repo_workflow_syncs_action_repository() -> None:
     assert 'if [ "$repo_changed" != "true" ]; then' in workflow_text
     assert 'gh release view "${TAG}" --repo "$target_repo"' in workflow_text
     assert 'git -C "$repo_dir" ls-remote --tags origin "refs/tags/${TAG}"' in workflow_text
+    assert 'Refusing to publish action bundle with colliding existing tag ${TAG} in ${target_repo}.' in workflow_text
     assert 'git -C "$repo_dir" push origin refs/tags/v1 --force' in workflow_text
     assert 'gh release create "${TAG}"' in workflow_text
     assert "--generate-notes" in workflow_text

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -8,7 +8,7 @@ ROOT = Path(__file__).resolve().parent.parent
 def test_action_metadata_includes_marketplace_branding_and_fallback_install() -> None:
     action_text = (ROOT / "action" / "action.yml").read_text(encoding="utf-8")
 
-    assert 'name: "HOL Codex Plugin Scanner"' in action_text
+    assert 'name: "HOL AI Plugin Scanner"' in action_text
     assert "branding:" in action_text
     assert 'icon: "check-circle"' in action_text
     assert 'color: "blue"' in action_text
@@ -25,7 +25,7 @@ def test_action_metadata_includes_marketplace_branding_and_fallback_install() ->
     assert 'elif [ "$INSTALL_SOURCE" = "pypi" ]; then' in action_text
     assert (
         'python3 -m pip download --only-binary=:all: --no-deps --dest "$DIST_DIR" '
-        '"codex-plugin-scanner==${SCANNER_VERSION}"'
+        '"plugin-scanner==${SCANNER_VERSION}"'
     ) in action_text
     assert "python3 -m pypi_attestations verify pypi \\" in action_text
     assert 'python3 -m pip install "$DIST_DIR/$DIST_BASENAME"' in action_text
@@ -33,7 +33,7 @@ def test_action_metadata_includes_marketplace_branding_and_fallback_install() ->
     assert "scanner-version.txt" in action_text
     assert "cisco-version.txt" in action_text
     assert "pypi-attestations-version.txt" in action_text
-    assert 'SCANNER_REPOSITORY="https://github.com/hashgraph-online/codex-plugin-scanner"' in action_text
+    assert 'SCANNER_REPOSITORY="https://github.com/hashgraph-online/ai-plugin-scanner"' in action_text
     assert "write_step_summary:" in action_text
     assert "profile:" in action_text
     assert "config:" in action_text
@@ -51,6 +51,9 @@ def test_action_metadata_includes_marketplace_branding_and_fallback_install() ->
     assert "report_path:" in action_text
     assert "registry_payload_path:" in action_text
     assert "submission_issue_urls:" in action_text
+    assert "pr_comment:" in action_text
+    assert "pr_comment_style:" in action_text
+    assert "pr_comment_max_findings:" in action_text
     assert "python3 -m codex_plugin_scanner.action_runner" in action_text
     assert "MODE: ${{ inputs.mode }}" in action_text
     assert "PROFILE: ${{ inputs.profile }}" in action_text
@@ -70,6 +73,10 @@ def test_action_metadata_includes_marketplace_branding_and_fallback_install() ->
     assert "value: ${{ steps.scan.outputs.submission_performed }}" in action_text
     assert "value: ${{ steps.scan.outputs.submission_issue_urls }}" in action_text
     assert "value: ${{ steps.scan.outputs.submission_issue_numbers }}" in action_text
+    assert "value: ${{ steps.normalized_outputs.outputs.action_exit_code }}" in action_text
+    assert "value: ${{ steps.normalized_outputs.outputs.pr_comment_status }}" in action_text
+    assert "value: ${{ steps.normalized_outputs.outputs.pr_comment_id }}" in action_text
+    assert "value: ${{ steps.normalized_outputs.outputs.pr_comment_url }}" in action_text
     assert "GITHUB_STEP_SUMMARY" in action_text
     assert "github/codeql-action/upload-sarif@" in action_text
 
@@ -78,7 +85,7 @@ def test_publish_workflow_attaches_marketplace_action_bundle() -> None:
     workflow_text = (ROOT / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8")
 
     assert "Build GitHub Action bundle" in workflow_text
-    assert "hol-codex-plugin-scanner-action-v${VERSION}.zip" in workflow_text
+    assert "hol-ai-plugin-scanner-action-v${VERSION}.zip" in workflow_text
     assert "Attest GitHub release assets" in workflow_text
     assert "actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32" in workflow_text
     assert "attestations: write" in workflow_text
@@ -134,36 +141,42 @@ def test_publish_action_repo_workflow_syncs_action_repository() -> None:
 
     assert "Publish GitHub Action Repository" in workflow_text
     assert "ACTION_REPO_TOKEN" in workflow_text
+    assert "hashgraph-online/hol-ai-plugin-scanner-action" in workflow_text
     assert "hashgraph-online/hol-codex-plugin-scanner-action" in workflow_text
     assert "Validate publication credentials" in workflow_text
     assert "Compute scanner package version" in workflow_text
     assert "paths:" not in workflow_text
     assert "if: secrets.ACTION_REPO_TOKEN != ''" not in workflow_text
+    assert "ACTION_CANONICAL_REPOSITORY" in workflow_text
+    assert "ACTION_COMPAT_REPOSITORY" in workflow_text
     assert (
-        "git status --short -- action.yml README.md scanner-version.txt "
+        'git -C "$repo_dir" status --short -- action.yml README.md scanner-version.txt '
         "cisco-version.txt pypi-attestations-version.txt LICENSE SECURITY.md CONTRIBUTING.md"
     ) in workflow_text
     assert "SOURCE_REF" in workflow_text
-    assert 'gh repo clone "$ACTION_REPOSITORY" action-repo -- --depth 1' in workflow_text
     assert "fetch-depth: 0" in workflow_text
+    assert 'gh repo create "$target_repo" --public --description "$repo_description" --clone' in workflow_text
+    assert 'gh repo edit "$target_repo" --description "$repo_description"' in workflow_text
+    assert 'gh repo clone "$target_repo" "$repo_dir" -- --depth 1' in workflow_text
     assert (
-        'git remote set-url origin "https://x-access-token:${ACTION_REPO_TOKEN}@github.com/$ACTION_REPOSITORY.git"'
+        'git -C "$repo_dir" remote set-url origin "https://x-access-token:${ACTION_REPO_TOKEN}@github.com/${target_repo}.git"'
     ) in workflow_text
-    assert 'cp "${GITHUB_WORKSPACE}/action/action.yml" action.yml' in workflow_text
-    assert """printf '%s\\n' "${{ steps.scanner_version.outputs.version }}" > scanner-version.txt""" in workflow_text
-    assert 'cp "${GITHUB_WORKSPACE}/action/cisco-version.txt" cisco-version.txt' in workflow_text
+    assert 'cp "${GITHUB_WORKSPACE}/action/action.yml" "${repo_dir}/action.yml"' in workflow_text
+    assert """printf '%s\\n' "$SCANNER_VERSION" > "${repo_dir}/scanner-version.txt" """[:-1] in workflow_text
+    assert 'cp "${GITHUB_WORKSPACE}/action/cisco-version.txt" "${repo_dir}/cisco-version.txt"' in workflow_text
     assert (
-        'cp "${GITHUB_WORKSPACE}/action/pypi-attestations-version.txt" pypi-attestations-version.txt'
+        'cp "${GITHUB_WORKSPACE}/action/pypi-attestations-version.txt" '
+        '"${repo_dir}/pypi-attestations-version.txt"'
     ) in workflow_text
-    assert "git push origin HEAD:main" in workflow_text
-    assert 'gh release view "${TAG}" --repo "$ACTION_REPOSITORY"' in workflow_text
-    assert 'git ls-remote --tags origin "refs/tags/${TAG}"' in workflow_text
-    assert "git push origin refs/tags/v1 --force" in workflow_text
-    assert "steps.release_state.outputs.release_exists == 'false'" in workflow_text
-    assert "steps.release_state.outputs.tag_exists == 'true'" in workflow_text
+    assert 'git -C "$repo_dir" push origin HEAD:main' in workflow_text
+    assert 'gh release view "${TAG}" --repo "$target_repo"' in workflow_text
+    assert 'git -C "$repo_dir" ls-remote --tags origin "refs/tags/${TAG}"' in workflow_text
+    assert 'git -C "$repo_dir" push origin refs/tags/v1 --force' in workflow_text
     assert 'gh release create "${TAG}"' in workflow_text
     assert "--generate-notes" in workflow_text
     assert "Published automatically from ${SOURCE_SERVER_URL}/${SOURCE_REPOSITORY}/tree/${SOURCE_REF}" in workflow_text
+    assert '"${GITHUB_WORKSPACE}/action/README.md"' in workflow_text
+    assert '"${GITHUB_WORKSPACE}/action/README.legacy.md"' in workflow_text
 
 
 def test_action_bundle_docs_live_in_action_readme() -> None:
@@ -188,10 +201,20 @@ def test_action_bundle_docs_live_in_action_readme() -> None:
     assert "submission issue" in action_readme
     assert "awesome-codex-plugins" in action_readme
     assert "publish-action-repo.yml" in action_readme
+    assert "hashgraph-online/hol-ai-plugin-scanner-action@v1" in action_readme
     assert "hashgraph-online/hol-codex-plugin-scanner-action@v1" in action_readme
     assert "actions/checkout@v4" in action_readme
     assert "actions/github-script@v7" in action_readme
     assert "opt-in Cisco skill-scanner dependency used by this repo" in action_readme
+
+
+def test_legacy_action_readme_marks_compatibility_alias() -> None:
+    legacy_readme = (ROOT / "action" / "README.legacy.md").read_text(encoding="utf-8")
+
+    assert "compatibility alias" in legacy_readme
+    assert "hashgraph-online/hol-codex-plugin-scanner-action@v1" in legacy_readme
+    assert "hashgraph-online/hol-ai-plugin-scanner-action@v1" in legacy_readme
+    assert "same reviewed root bundle" in legacy_readme
 
 
 def test_readme_uses_stable_apache_license_badge() -> None:
@@ -205,6 +228,7 @@ def test_readme_uses_stable_apache_license_badge() -> None:
     assert "https://pypi.org/project/plugin-scanner/" in readme
     assert "https://pypi.org/project/codex-plugin-scanner/" in readme
     assert "Container Image" in readme
+    assert "hashgraph-online/hol-ai-plugin-scanner-action@v1" in readme
 
 
 def test_container_files_exist_for_enterprise_distribution() -> None:

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -170,6 +170,9 @@ def test_publish_action_repo_workflow_syncs_action_repository() -> None:
         '"${repo_dir}/pypi-attestations-version.txt"'
     ) in workflow_text
     assert 'git -C "$repo_dir" push origin HEAD:main' in workflow_text
+    assert 'repo_changed="false"' in workflow_text
+    assert 'repo_changed="true"' in workflow_text
+    assert 'if [ "$repo_changed" != "true" ]; then' in workflow_text
     assert 'gh release view "${TAG}" --repo "$target_repo"' in workflow_text
     assert 'git -C "$repo_dir" ls-remote --tags origin "refs/tags/${TAG}"' in workflow_text
     assert 'git -C "$repo_dir" push origin refs/tags/v1 --force' in workflow_text

--- a/tests/test_action_runner.py
+++ b/tests/test_action_runner.py
@@ -100,7 +100,7 @@ def test_action_runner_writes_step_summary_and_registry_payload(monkeypatch, tmp
     assert '"sourceRepository": "hashgraph-online/example-good-plugin"' in payload_text
 
     summary_text = summary_path.read_text(encoding="utf-8")
-    assert "## HOL Codex Plugin Scanner" in summary_text
+    assert "## HOL AI Plugin Scanner" in summary_text
     assert "- Score: 100/100" in summary_text
     assert "- Grade: A - Excellent" in summary_text
     assert f"- Registry payload: `{registry_payload_path}`" in summary_text

--- a/tests/test_action_runner.py
+++ b/tests/test_action_runner.py
@@ -51,6 +51,10 @@ def test_action_runner_writes_all_outputs(monkeypatch, tmp_path, capsys) -> None
     assert "submission_performed=false" in output_lines
     assert "submission_issue_urls=" in output_lines
     assert "submission_issue_numbers=" in output_lines
+    assert "action_exit_code=0" in output_lines
+    assert "pr_comment_status=skipped" in output_lines
+    assert "pr_comment_id=" in output_lines
+    assert "pr_comment_url=" in output_lines
 
     stdout = capsys.readouterr().out
     assert '"score": 100' in stdout

--- a/tests/test_action_runner.py
+++ b/tests/test_action_runner.py
@@ -219,3 +219,44 @@ def test_action_runner_default_scan_does_not_open_network_connections(monkeypatc
     exit_code = main()
 
     assert exit_code == 0
+
+
+def test_action_runner_preserves_output_paths_on_gate_failure(monkeypatch, tmp_path) -> None:
+    github_output = tmp_path / "github-output.txt"
+    report_path = tmp_path / "scan-report.json"
+    registry_payload_path = tmp_path / "registry-payload.json"
+
+    monkeypatch.setenv("PLUGIN_DIR", str(FIXTURES / "good-plugin"))
+    monkeypatch.setenv("FORMAT", "json")
+    monkeypatch.setenv("OUTPUT", str(report_path))
+    monkeypatch.setenv("MIN_SCORE", "101")
+    monkeypatch.setenv("FAIL_ON", "none")
+    monkeypatch.setenv("CISCO_SCAN", "off")
+    monkeypatch.setenv("CISCO_POLICY", "balanced")
+    monkeypatch.setenv("SUBMISSION_ENABLED", "false")
+    monkeypatch.setenv("SUBMISSION_SCORE_THRESHOLD", "80")
+    monkeypatch.setenv("SUBMISSION_REPOS", "hashgraph-online/awesome-codex-plugins")
+    monkeypatch.setenv("SUBMISSION_TOKEN", "")
+    monkeypatch.setenv("SUBMISSION_LABELS", "plugin-submission")
+    monkeypatch.setenv("SUBMISSION_CATEGORY", "Community Plugins")
+    monkeypatch.setenv("SUBMISSION_PLUGIN_NAME", "")
+    monkeypatch.setenv("SUBMISSION_PLUGIN_URL", "")
+    monkeypatch.setenv("SUBMISSION_PLUGIN_DESCRIPTION", "")
+    monkeypatch.setenv("SUBMISSION_AUTHOR", "")
+    monkeypatch.setenv("WRITE_STEP_SUMMARY", "false")
+    monkeypatch.setenv("REGISTRY_PAYLOAD_OUTPUT", str(registry_payload_path))
+    monkeypatch.setenv("GITHUB_OUTPUT", str(github_output))
+    monkeypatch.setenv("GITHUB_REPOSITORY", "hashgraph-online/example-good-plugin")
+    monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.com")
+    monkeypatch.setenv("GITHUB_SHA", "abc123")
+    monkeypatch.setenv("GITHUB_RUN_ID", "77")
+
+    exit_code = main()
+
+    assert exit_code == 1
+    assert report_path.exists()
+    assert registry_payload_path.exists()
+    output_lines = github_output.read_text(encoding="utf-8").splitlines()
+    assert f"report_path={report_path}" in output_lines
+    assert f"registry_payload_path={registry_payload_path}" in output_lines
+    assert "action_exit_code=1" in output_lines

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -66,6 +66,14 @@ def test_load_scanner_config_bad_toml(tmp_path: Path):
         assert True
 
 
+def test_load_scanner_config_explicit_missing_file_raises(tmp_path: Path):
+    try:
+        load_scanner_config(tmp_path, config_path=str(tmp_path / "missing.toml"))
+        raise AssertionError("expected ConfigError")
+    except ConfigError:
+        assert True
+
+
 def test_load_baseline_bad_json(tmp_path: Path):
     (tmp_path / "baseline.json").write_text("[not-valid-json", encoding="utf-8")
     try:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -74,6 +74,16 @@ def test_load_scanner_config_explicit_missing_file_raises(tmp_path: Path):
         assert True
 
 
+def test_load_scanner_config_resolves_relative_explicit_path_from_plugin_dir(tmp_path: Path):
+    plugin_dir = tmp_path / "plugins" / "example"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / ".plugin-scanner.toml").write_text("[scanner]\nprofile = 'strict-security'\n", encoding="utf-8")
+
+    config = load_scanner_config(plugin_dir, config_path=".plugin-scanner.toml")
+
+    assert config.profile == "strict-security"
+
+
 def test_load_baseline_bad_json(tmp_path: Path):
     (tmp_path / "baseline.json").write_text("[not-valid-json", encoding="utf-8")
     try:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,7 @@ def test_load_scanner_config_defaults(tmp_path: Path):
 
 
 def test_load_scanner_config_from_toml(tmp_path: Path):
-    (tmp_path / ".codex-plugin-scanner.toml").write_text(
+    (tmp_path / ".plugin-scanner.toml").write_text(
         """
 [scanner]
 profile = "strict-security"
@@ -32,6 +32,25 @@ severity_overrides = { README_MISSING = "low" }
     assert config.ignore_paths == ("tests/*",)
 
 
+def test_load_scanner_config_supports_legacy_filename(tmp_path: Path):
+    (tmp_path / ".codex-plugin-scanner.toml").write_text(
+        """
+[scanner]
+profile = "default"
+""",
+        encoding="utf-8",
+    )
+    config = load_scanner_config(tmp_path)
+    assert config.profile == "default"
+
+
+def test_load_scanner_config_prefers_generic_filename(tmp_path: Path):
+    (tmp_path / ".plugin-scanner.toml").write_text("[scanner]\nprofile = 'strict-security'\n", encoding="utf-8")
+    (tmp_path / ".codex-plugin-scanner.toml").write_text("[scanner]\nprofile = 'default'\n", encoding="utf-8")
+    config = load_scanner_config(tmp_path)
+    assert config.profile == "strict-security"
+
+
 def test_load_baseline_rule_ids_text(tmp_path: Path):
     (tmp_path / "baseline.txt").write_text("README_MISSING\nHARDCODED_SECRET\n", encoding="utf-8")
     baseline = load_baseline_rule_ids(tmp_path, "baseline.txt")
@@ -39,7 +58,7 @@ def test_load_baseline_rule_ids_text(tmp_path: Path):
 
 
 def test_load_scanner_config_bad_toml(tmp_path: Path):
-    (tmp_path / ".codex-plugin-scanner.toml").write_text("[scanner\nprofile='x'", encoding="utf-8")
+    (tmp_path / ".plugin-scanner.toml").write_text("[scanner\nprofile='x'", encoding="utf-8")
     try:
         load_scanner_config(tmp_path)
         raise AssertionError("expected ConfigError")


### PR DESCRIPTION
## Summary
- switch the published GitHub Action bundle and docs to the canonical `hol-ai-plugin-scanner-action` identity while keeping `hol-codex-plugin-scanner-action` as an explicit compatibility alias
- update the action runtime path to install the canonical `plugin-scanner` package and add neutral config/report naming where user-facing surfaces still leaked the old Codex-only brand
- rework action publication to dual-sync canonical and compatibility repos, including per-repo README variants and canonical bundle asset naming

## Verification
- `uv run --no-sync pytest tests/test_action_bundle.py tests/test_action_runner.py tests/test_config.py`
- `uv run --no-sync ruff check src/codex_plugin_scanner/action_runner.py src/codex_plugin_scanner/config.py src/codex_plugin_scanner/cli.py tests/test_action_bundle.py tests/test_action_runner.py tests/test_config.py`
- `uv run --no-sync python -m build`