### PR TITLE
fix: simplify hol guard package and cli

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: plugin-scanner-publish-${{ github.ref }}
+  group: hol-guard-publish-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -70,9 +70,15 @@ jobs:
         run: |
           sed -i "1,/^version = /{s/^version = .*/version = \"$VERSION\"/}" pyproject.toml
           sed -i "1,/^__version__ = /{s/^__version__ = .*/__version__ = \"$VERSION\"/}" src/codex_plugin_scanner/version.py
-      - name: Build primary package (plugin-scanner)
+      - name: Build primary package (hol-guard)
         run: uv run --no-sync python -m build
-      - name: Build legacy compatibility package (codex-plugin-scanner)
+      - name: Build compatibility package (plugin-scanner)
+        run: |
+          cp pyproject.toml pyproject.toml.bak
+          sed -i "1,/^name = /{s/^name = .*/name = \"plugin-scanner\"/}" pyproject.toml
+          uv run --no-sync python -m build
+          mv pyproject.toml.bak pyproject.toml
+      - name: Build compatibility package (codex-plugin-scanner)
         run: |
           cp pyproject.toml pyproject.toml.bak
           sed -i "1,/^name = /{s/^name = .*/name = \"codex-plugin-scanner\"/}" pyproject.toml
@@ -171,6 +177,10 @@ jobs:
           ${LOG}
 
           ### Installation
+          \`\`\`bash
+          uv tool install hol-guard==${VERSION}
+          \`\`\`
+
           \`\`\`bash
           uv tool install plugin-scanner==${VERSION}
           \`\`\`

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# HOL Plugin Ecosystem Scanner
+# HOL Guard
 
-[![PyPI Version](https://img.shields.io/pypi/v/plugin-scanner.svg?logo=pypi&logoColor=white&cacheSeconds=300)](https://pypi.org/project/plugin-scanner/)
-[![Legacy Namespace](https://img.shields.io/badge/legacy-codex--plugin--scanner-6b7280?logo=pypi&logoColor=white)](https://pypi.org/project/codex-plugin-scanner/)
-[![Python Versions](https://img.shields.io/pypi/pyversions/plugin-scanner)](https://pypi.org/project/plugin-scanner/)
-[![PyPI Downloads](https://img.shields.io/pypi/dm/plugin-scanner)](https://pypistats.org/packages/plugin-scanner)
+[![PyPI Version](https://img.shields.io/pypi/v/hol-guard.svg?logo=pypi&logoColor=white&cacheSeconds=300)](https://pypi.org/project/hol-guard/)
+[![Legacy Namespace](https://img.shields.io/badge/legacy-plugin--scanner_and_codex--plugin--scanner-6b7280?logo=pypi&logoColor=white)](https://pypi.org/project/plugin-scanner/)
+[![Python Versions](https://img.shields.io/pypi/pyversions/hol-guard)](https://pypi.org/project/hol-guard/)
+[![PyPI Downloads](https://img.shields.io/pypi/dm/hol-guard)](https://pypistats.org/packages/hol-guard)
 [![CI](https://github.com/hashgraph-online/ai-plugin-scanner/actions/workflows/ci.yml/badge.svg)](https://github.com/hashgraph-online/ai-plugin-scanner/actions/workflows/ci.yml)
 [![Publish](https://github.com/hashgraph-online/ai-plugin-scanner/actions/workflows/publish.yml/badge.svg)](https://github.com/hashgraph-online/ai-plugin-scanner/actions/workflows/publish.yml)
 [![Container Image](https://img.shields.io/badge/ghcr-ai--plugin--scanner-2496ED?logo=docker&logoColor=white)](https://github.com/hashgraph-online/ai-plugin-scanner/pkgs/container/ai-plugin-scanner)
@@ -12,52 +12,56 @@
 [![GitHub Stars](https://img.shields.io/github/stars/hashgraph-online/ai-plugin-scanner?style=social)](https://github.com/hashgraph-online/ai-plugin-scanner/stargazers)
 [![Lint: ruff](https://img.shields.io/badge/lint-ruff-D7FF64.svg)](https://github.com/astral-sh/ruff)
 
-| ![Hashgraph Online Logo](https://hol.org/brand/Logo_Whole_Dark.png) | **HOL Guard for local harness protection, plus the scanner CI gate for plugin ecosystems**. Protect Codex, Claude Code, Cursor, Gemini, and OpenCode before local tools run, then lint locally, verify in CI, and ship publish-ready bundles for manifests, skills, MCP, and marketplace metadata.<br><br>Use Guard when you want a local safety loop. Use the scanner when you want publishing and CI confidence.<br><br>[PyPI Package (`plugin-scanner`)](https://pypi.org/project/plugin-scanner/)<br>[Legacy Namespace (`codex-plugin-scanner`)](https://pypi.org/project/codex-plugin-scanner/)<br>[HOL Plugin Registry](https://hol.org/registry/plugins)<br>[HOL GitHub Organization](https://github.com/hashgraph-online)<br>[Report an Issue](https://github.com/hashgraph-online/ai-plugin-scanner/issues) |
+| ![Hashgraph Online Logo](https://hol.org/brand/Logo_Whole_Dark.png) | **Protect Codex, Claude Code, Cursor, Gemini, and OpenCode before local tools run.** HOL Guard watches the tools wired into your harness, shows you what changed, and records what you approved or blocked. The scanner commands stay available for teams that also want linting and CI checks for plugin, skill, MCP, and marketplace packages.<br><br>Start with `hol-guard` if you want local protection. Add the scanner commands later if you also publish or review packages in CI.<br><br>[PyPI Package (`hol-guard`)](https://pypi.org/project/hol-guard/)<br>[Legacy Namespace (`plugin-scanner`)](https://pypi.org/project/plugin-scanner/)<br>[Legacy Namespace (`codex-plugin-scanner`)](https://pypi.org/project/codex-plugin-scanner/)<br>[HOL Plugin Registry](https://hol.org/registry/plugins)<br>[HOL GitHub Organization](https://github.com/hashgraph-online)<br>[Report an Issue](https://github.com/hashgraph-online/ai-plugin-scanner/issues) |
 | :--- | :--- |
 
-## Guard Start In 60 Seconds
+## Protect A Harness In 60 Seconds
 
 ```bash
-# See what Guard can protect on this machine
-pipx run plugin-guard guard start
+# See what Guard found on this machine
+pipx run hol-guard start
 
 # Install Guard in front of Codex
-pipx run plugin-guard guard install codex
+pipx run hol-guard install codex
 
-# Review the current tool state before launch
-pipx run plugin-guard guard run codex
+# Record the current tool state once
+pipx run hol-guard run codex --dry-run
 
-# Inspect local receipts later
-pipx run plugin-guard guard receipts
+# Launch through Guard after that
+pipx run hol-guard run codex
+
+# Check what Guard approved or blocked
+pipx run hol-guard receipts
 ```
 
-Guard is local-first:
+How Guard works:
 
-1. detect your harnesses
-2. install a Guard launcher
-3. run the harness through Guard
-4. approve or block changes
-5. inspect receipts locally
-6. connect sync only if you want shared history later
+1. find the harnesses on your machine
+2. install a Guard launcher in front of the one you use
+3. record the current tool state once
+4. let Guard stop and review new or changed tools before launch
+5. check receipts locally
+6. connect sync later only if you want shared history
 
-Guard commands that matter most:
+Start here if you are trying to stay safe inside a harness:
 
-- `plugin-scanner guard start` for the first-run path
-- `plugin-scanner guard status` for the current protection state
-- `plugin-scanner guard install <harness>` to create a local Guard launcher
-- `plugin-scanner guard run <harness> --dry-run` to record the current state before launch
-- `plugin-scanner guard run <harness>` to review and approve changed tools before launch
-- `plugin-scanner guard diff <harness>` when Guard says something changed
-- `plugin-scanner guard receipts` for local history
+- `hol-guard start` shows the first steps
+- `hol-guard status` shows what Guard is watching now
+- `hol-guard install <harness>` creates the launcher
+- `hol-guard run <harness> --dry-run` records the current state
+- `hol-guard run <harness>` reviews changes before launch
+- `hol-guard diff <harness>` shows what changed
+- `hol-guard receipts` shows local history
 
 See [docs/guard/get-started.md](docs/guard/get-started.md) for the full local flow.
 
-## Scanner Start In 30 Seconds
+## Use The Scanner In CI
 
 ```bash
-# Local preflight
-pipx run plugin-scanner lint .
-pipx run plugin-scanner verify .
+# Install the package once, then use the scanner commands in your shell
+pipx install hol-guard
+plugin-scanner lint .
+plugin-scanner verify .
 ```
 
 ```yaml
@@ -72,38 +76,30 @@ pipx run plugin-scanner verify .
 
 If your repository uses a Codex marketplace root like `.agents/plugins/marketplace.json`, keep `plugin_dir: "."`. The scanner will discover local `./plugins/...` entries automatically, scan each local plugin manifest, and skip remote marketplace entries instead of treating the repo root as a single plugin.
 
-## Two Product Modes
+## Start With Guard, Add CI Later
 
-### HOL Guard
+If you use Codex, Claude Code, Cursor, Gemini, or OpenCode every day, start with Guard.
 
-Use Guard when the problem is local runtime safety inside a harness:
+- Guard is the part that protects your local harness before tools run.
+- It helps when a new MCP server appears, when a tool changes after you trusted it, or when you want a receipt for what was approved or blocked.
 
-- a new MCP server showed up in local config
-- an existing tool changed after you trusted it
-- you want receipts for what was approved or blocked
-- you want to review changes before Codex, Claude Code, Cursor, Gemini, or OpenCode launches
+If you publish plugins, skills, or marketplace packages, add the scanner in CI too.
 
-### Scanner CI Gate
-
-Use the scanner when the problem is authoring, CI, and publish readiness:
-
-- lint manifests and metadata
-- verify runtime and install surfaces
-- block PRs with policy gates
-- emit artifacts before submission or publishing
+- The scanner checks manifests, metadata, runtime surfaces, and policy rules before a release or CI gate passes.
+- It is the publishing and repo review side of this package, not the first thing a local Guard user needs to learn.
 
 ## Use Scanner After `$plugin-creator`
 
-`plugin-scanner` is designed as the quality gate between plugin creation and distribution:
+If you are building and shipping packages, the scanner fits after `$plugin-creator`:
 
 1. Scaffold with `$plugin-creator`.
 2. Run `lint` locally to catch structure, metadata, and security issues early.
 3. Run `verify` in CI to block regressions and enforce quality policy.
 4. Ship or submit with confidence, backed by scanner artifacts and trust signals.
 
-The score remains available as a trust and triage signal, but the primary workflow is **preflight + CI gating + publish readiness**.
+The score stays available as a trust and triage signal, but the day-to-day workflow is simple: check locally, verify in CI, then release.
 
-## Trust Score Provenance
+## How Trust Scoring Works
 
 The scanner now emits explicit trust provenance alongside the quality grade:
 
@@ -133,21 +129,23 @@ pytest -q
 ## Install
 
 ```bash
-pip install plugin-scanner
+pip install hol-guard
 ```
 
 Cisco-backed skill scanning is optional:
 
 ```bash
-pip install "plugin-scanner[cisco]"
+pip install "hol-guard[cisco]"
 ```
 
 The `cisco` extra installs the published `cisco-ai-skill-scanner` package from PyPI so the scanner remains publishable on PyPI and the optional Cisco analysis path works with standard package metadata.
 
-You can also run the scanner without a local install:
+You can also install once and use both Guard and scanner commands:
 
 ```bash
-pipx run plugin-scanner ./my-plugin
+pipx install hol-guard
+hol-guard start
+plugin-scanner ./my-plugin
 ```
 
 Container-first environments can use the published image instead:
@@ -162,8 +160,16 @@ docker run --rm \
 Backward compatibility remains available for teams still pinned to the historical package namespace:
 
 ```bash
+pip install plugin-scanner
 pip install codex-plugin-scanner
-pipx run codex-plugin-scanner verify .
+```
+
+Compatibility command names also stay available:
+
+```bash
+plugin-guard start
+plugin-scanner verify .
+codex-plugin-scanner verify .
 ```
 
 ## Ecosystem Support
@@ -177,11 +183,11 @@ pipx run codex-plugin-scanner verify .
 
 Use `--ecosystem auto` (default) to scan all detected packages in a repository, or select a single ecosystem explicitly.
 
-## What The Scanner Covers
+## What The Scanner Checks
 
 `plugin-scanner` supports a full quality suite:
 
-- `scan` for full-surface security and publishability analysis
+- `scan` for full-surface security and release analysis
 - `lint` for rule-oriented authoring feedback
 - `verify` for runtime and install-surface readiness checks
 - `submit` for artifact-backed submission gating

--- a/docs/guard/architecture.md
+++ b/docs/guard/architecture.md
@@ -24,10 +24,10 @@ Guard evaluates local artifacts in this order:
 
 The local product loop is:
 
-1. `guard start` detects supported harnesses and suggests the next step
-2. `guard install <harness>` creates a local launcher shim
-3. `guard run <harness>` evaluates changes before the harness launches
-4. `guard receipts` and `guard status` let users inspect local decisions
-5. `guard login` and `guard sync` stay optional
+1. `hol-guard start` detects supported harnesses and suggests the next step
+2. `hol-guard install <harness>` creates a local launcher shim
+3. `hol-guard run <harness>` evaluates changes before the harness launches
+4. `hol-guard receipts` and `hol-guard status` let users inspect local decisions
+5. `hol-guard login` and `hol-guard sync` stay optional
 
 Wrapper mode is still the core execution strategy in this phase. Config mutation is limited to the Claude Code hook helper, where Guard can add and remove its own hook entry in workspace-local settings.

--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -1,56 +1,56 @@
 # Guard Get Started
 
-Guard is the local product inside `plugin-scanner`.
-If you want the shortest entrypoint, install and run the dedicated `plugin-guard` console script.
+Guard ships as the `hol-guard` package and command.
+The scanner commands stay available in the same install for CI and package checks.
 
 Use it when you want to protect a harness before local MCP servers, skills, hooks, or plugin surfaces run.
 
-## The local loop
+## The everyday flow
 
-1. Detect your harnesses:
+1. See what Guard found:
 
    ```bash
-   plugin-guard guard start
+   hol-guard start
    ```
 
 2. Install Guard in front of the harness you use most:
 
    ```bash
-   plugin-guard guard install codex
+   hol-guard install codex
    ```
 
 3. Run one dry pass so Guard records the current state:
 
    ```bash
-   plugin-guard guard run codex --dry-run
+   hol-guard run codex --dry-run
    ```
 
-4. Launch through Guard after that. Guard will prompt you if a tool is new or changed:
+4. Launch through Guard after that. Guard will stop and ask if a tool is new or changed:
 
    ```bash
-   plugin-guard guard run codex
+   hol-guard run codex
    ```
 
 5. Review changes when Guard blocks or asks for another look:
 
    ```bash
-   plugin-scanner guard diff codex
-   plugin-scanner guard allow codex --scope artifact --artifact-id codex:project:workspace_skill
-   plugin-scanner guard deny codex --scope artifact --artifact-id codex:project:workspace_skill
+   hol-guard diff codex
+   hol-guard allow codex --scope artifact --artifact-id codex:project:workspace_skill
+   hol-guard deny codex --scope artifact --artifact-id codex:project:workspace_skill
    ```
 
-6. Inspect receipts:
+6. Check receipts and current status:
 
    ```bash
-   plugin-guard guard receipts
-   plugin-guard guard status
+   hol-guard receipts
+   hol-guard status
    ```
 
-7. Connect sync only if you want shared history later:
+7. Sign in later only if you want shared history:
 
    ```bash
-   plugin-scanner guard login --sync-url <url> --token <token>
-   plugin-scanner guard sync
+   hol-guard login --sync-url <url> --token <token>
+   hol-guard sync
    ```
 
 ## What `install` does
@@ -72,11 +72,11 @@ Use these local repos to prove Guard against real first-party surfaces:
 Suggested local validation:
 
 ```bash
-plugin-scanner guard detect codex --json
-plugin-scanner guard install codex
-plugin-scanner guard status
-plugin-scanner guard run codex --dry-run
-plugin-scanner guard receipts
+hol-guard detect codex --json
+hol-guard install codex
+hol-guard status
+hol-guard run codex --dry-run
+hol-guard receipts
 ```
 
 For a real Codex canary, point `~/.codex/config.toml` or `<workspace>/.codex/config.toml` at a local `hashnet-mcp` command, then repeat the Guard loop above.

--- a/docs/guard/local-vs-cloud.md
+++ b/docs/guard/local-vs-cloud.md
@@ -1,6 +1,6 @@
-# Local vs Cloud
+# Works Locally First
 
-Guard is local-first.
+Guard works on your machine before you sign in anywhere.
 
 Local features available without sign-in:
 
@@ -19,4 +19,4 @@ Optional cloud features:
 - billing and entitlements
 - shared team policy
 
-The local runtime does not require any hosted service. `guard login` and `guard sync` exist to layer optional cloud features on top of the local product, not to unlock the core safety workflow.
+The local runtime does not require any hosted service. `hol-guard login` and `hol-guard sync` add optional cloud features later. They do not unlock the core safety workflow.

--- a/docs/guard/testing-matrix.md
+++ b/docs/guard/testing-matrix.md
@@ -3,22 +3,22 @@
 Automated coverage in this phase includes:
 
 - Guard CLI behavior tests for detect, scan, run, diff, receipts, install, uninstall, login, and sync
-- Guard product-flow tests for `guard start`, `guard status`, and launcher shim creation
+- Guard product-flow tests for `hol-guard start`, `hol-guard status`, and launcher shim creation
 - SQLite persistence through real command execution in temporary homes and workspaces
 - consumer-mode JSON contract generation against scanner fixtures
 - local HTTP sync against a live in-process server instead of mocked transport
 
 Manual verification should include:
 
-- `guard start`
-- `guard status`
-- `guard detect codex --json`
-- `guard detect cursor --json`
-- `guard detect gemini --json`
-- `guard detect opencode --json`
-- `guard install codex`
-- `guard run codex --dry-run --default-action allow --json`
-- `guard receipts`
+- `hol-guard start`
+- `hol-guard status`
+- `hol-guard detect codex --json`
+- `hol-guard detect cursor --json`
+- `hol-guard detect gemini --json`
+- `hol-guard detect opencode --json`
+- `hol-guard install codex`
+- `hol-guard run codex --dry-run --default-action allow --json`
+- `hol-guard receipts`
 - `codex mcp list`
 - `cursor-agent mcp list`
 - `gemini --help`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "plugin-scanner"
+name = "hol-guard"
 version = "2.0.0"
-description = "Local Guard runtime plus security and publishability scanning for Codex, Claude, Cursor, Gemini, and OpenCode."
+description = "Protect local AI harnesses with HOL Guard and run scanner checks for Codex, Claude, Cursor, Gemini, and OpenCode."
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10"
@@ -49,6 +49,7 @@ publish = [
 ]
 
 [project.scripts]
+hol-guard = "codex_plugin_scanner.cli:main"
 plugin-scanner = "codex_plugin_scanner.cli:main"
 plugin-guard = "codex_plugin_scanner.cli:main"
 codex-plugin-scanner = "codex_plugin_scanner.cli:main"

--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from .config import ConfigError, load_baseline_rule_ids, load_scanner_config
 from .ecosystems.registry import list_supported_ecosystems
-from .guard.cli import add_guard_parser, run_guard_command
+from .guard.cli import add_guard_parser, add_guard_root_parser, run_guard_command
 from .lint_fixes import apply_safe_autofixes
 from .models import GRADE_LABELS, ScanOptions, Severity, get_grade
 from .policy import POLICY_PROFILES, build_rule_inventory, evaluate_policy, resolve_profile
@@ -136,8 +136,17 @@ def _add_common_policy_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--diff-base", help="Reserved for future diff-aware gating")
 
 
-def _build_parser() -> argparse.ArgumentParser:
-    program_name = Path(sys.argv[0]).name or "plugin-scanner"
+def _is_guard_program(program_name: str) -> bool:
+    return program_name in {"hol-guard", "plugin-guard"}
+
+
+def _build_parser(program_name: str, *, guard_program: bool) -> argparse.ArgumentParser:
+    if guard_program:
+        parser = argparse.ArgumentParser(prog=program_name, description="Protect local harnesses before tools run.")
+        parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+        add_guard_root_parser(parser)
+        return parser
+
     parser = argparse.ArgumentParser(
         prog=program_name,
         description="Run HOL Guard locally or scan plugin ecosystems for CI and publish readiness.",
@@ -207,8 +216,12 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _resolve_legacy_args(argv: list[str] | None) -> list[str] | None:
+def _resolve_legacy_args(argv: list[str] | None, *, guard_program: bool) -> list[str] | None:
     if not argv:
+        return argv
+    if guard_program:
+        if argv[0] == "guard":
+            return argv[1:]
         return argv
     known_commands = {
         "scan",
@@ -462,8 +475,10 @@ def _run_doctor(args: argparse.Namespace) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = _build_parser()
-    args = parser.parse_args(_resolve_legacy_args(argv))
+    program_name = Path(sys.argv[0]).name or "plugin-scanner"
+    guard_program = _is_guard_program(program_name)
+    parser = _build_parser(program_name, guard_program=guard_program)
+    args = parser.parse_args(_resolve_legacy_args(argv, guard_program=guard_program))
     if getattr(args, "list_ecosystems", False):
         for ecosystem in list_supported_ecosystems():
             print(ecosystem)

--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -137,7 +137,8 @@ def _add_common_policy_args(parser: argparse.ArgumentParser) -> None:
 
 
 def _is_guard_program(program_name: str) -> bool:
-    return program_name in {"hol-guard", "plugin-guard"}
+    normalized_name = Path(program_name).stem.lower()
+    return normalized_name in {"hol-guard", "plugin-guard"}
 
 
 def _build_parser(program_name: str, *, guard_program: bool) -> argparse.ArgumentParser:

--- a/src/codex_plugin_scanner/guard/cli/__init__.py
+++ b/src/codex_plugin_scanner/guard/cli/__init__.py
@@ -1,5 +1,5 @@
 """Guard CLI entrypoints."""
 
-from .commands import add_guard_parser, run_guard_command
+from .commands import add_guard_parser, add_guard_root_parser, run_guard_command
 
-__all__ = ["add_guard_parser", "run_guard_command"]
+__all__ = ["add_guard_parser", "add_guard_root_parser", "run_guard_command"]

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -60,9 +60,9 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     """Attach Guard subcommands to a parser."""
     guard_subparsers = guard_parser.add_subparsers(
         dest="guard_command",
+        required=True,
         metavar="{start,status,detect,install,uninstall,run,scan,diff,receipts,explain,allow,deny,doctor,login,sync}",
     )
-    guard_subparsers.required = True
 
     start_parser = guard_subparsers.add_parser("start", help="Show the first Guard steps for a local harness")
     _add_guard_common_args(start_parser)

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -26,7 +26,7 @@ def _now() -> str:
 
 
 def add_guard_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
-    """Register the Guard command family."""
+    """Register Guard as a nested command family."""
 
     program_name = Path(sys.argv[0]).name or "plugin-scanner"
     guard_parser = subparsers.add_parser(
@@ -45,6 +45,19 @@ def add_guard_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPar
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    _configure_guard_parser(guard_parser)
+
+
+def add_guard_root_parser(parser: argparse.ArgumentParser) -> None:
+    """Register Guard as the top-level CLI surface."""
+
+    parser.description = "Protect local harnesses before new or changed tools run."
+    parser.set_defaults(command="guard")
+    _configure_guard_parser(parser)
+
+
+def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
+    """Attach Guard subcommands to a parser."""
     guard_subparsers = guard_parser.add_subparsers(
         dest="guard_command",
         metavar="{start,status,detect,install,uninstall,run,scan,diff,receipts,explain,allow,deny,doctor,login,sync}",
@@ -247,7 +260,7 @@ def run_guard_command(args: argparse.Namespace) -> int:
         ):
             payload["review_hint"] = (
                 f"Guard blocked {args.harness} because this shell is non-interactive. "
-                f"Run `plugin-guard guard diff {args.harness}` and allow or deny the changed artifacts first."
+                f"Run `hol-guard diff {args.harness}` and allow or deny the changed artifacts first."
             )
         _emit("run", payload, getattr(args, "json", False))
         if payload.get("blocked"):

--- a/src/codex_plugin_scanner/guard/cli/product.py
+++ b/src/codex_plugin_scanner/guard/cli/product.py
@@ -11,6 +11,7 @@ from ..models import HarnessDetection
 from ..store import GuardStore
 
 HARNESS_PRIORITY = ("codex", "claude-code", "cursor", "gemini", "opencode")
+GUARD_COMMAND = "hol-guard"
 
 
 def build_guard_start_payload(
@@ -86,10 +87,10 @@ def _summarize_harness(
         "shim_path": str(shim_path) if isinstance(shim_path, str) else None,
         "config_paths": list(detection.config_paths),
         "next_action": next_action,
-        "install_command": f"plugin-scanner guard install {detection.harness}",
-        "run_command": f"plugin-scanner guard run {detection.harness} --dry-run",
-        "review_command": f"plugin-scanner guard diff {detection.harness}",
-        "receipts_command": "plugin-scanner guard receipts",
+        "install_command": f"{GUARD_COMMAND} install {detection.harness}",
+        "run_command": f"{GUARD_COMMAND} run {detection.harness} --dry-run",
+        "review_command": f"{GUARD_COMMAND} diff {detection.harness}",
+        "receipts_command": f"{GUARD_COMMAND} receipts",
     }
 
 
@@ -122,7 +123,7 @@ def _build_next_steps(recommended: dict[str, object] | None) -> list[dict[str, s
         return [
             {
                 "title": "Install a supported harness",
-                "command": "plugin-scanner guard detect",
+                "command": f"{GUARD_COMMAND} detect",
                 "detail": (
                     "Guard did not find a local harness config yet. Start by installing "
                     "Codex, Claude Code, Cursor, Gemini, or OpenCode."
@@ -133,7 +134,7 @@ def _build_next_steps(recommended: dict[str, object] | None) -> list[dict[str, s
     steps.append(
         {
             "title": "Optional sync later",
-            "command": "plugin-scanner guard login --sync-url <url> --token <token>",
+            "command": f"{GUARD_COMMAND} login --sync-url <url> --token <token>",
             "detail": (
                 "Keep receipts local by default, then connect sync only when you want "
                 "shared history or premium trust checks."
@@ -155,7 +156,7 @@ def _install_or_review_step(recommended: dict[str, object]) -> dict[str, str]:
     if next_action == "install-harness":
         return {
             "title": f"Install {harness}",
-            "command": "plugin-scanner guard detect",
+            "command": f"{GUARD_COMMAND} detect",
             "detail": "Guard needs a local harness install before it can protect launches.",
         }
     return {
@@ -177,7 +178,7 @@ def _run_step(recommended: dict[str, object]) -> dict[str, str]:
 def _receipts_step() -> dict[str, str]:
     return {
         "title": "Inspect receipts",
-        "command": "plugin-scanner guard receipts",
+        "command": f"{GUARD_COMMAND} receipts",
         "detail": "See what Guard approved, blocked, or flagged after local runs.",
     }
 

--- a/src/codex_plugin_scanner/guard/cli/prompt.py
+++ b/src/codex_plugin_scanner/guard/cli/prompt.py
@@ -74,7 +74,7 @@ def resolve_interactive_decisions(
         except (EOFError, KeyboardInterrupt):
             evaluation["review_hint"] = (
                 "Guard needs an interactive terminal to approve changes. "
-                f"Run `plugin-guard guard diff {artifact.harness}` and allow or deny the artifact before launch."
+                f"Run `hol-guard diff {artifact.harness}` and allow or deny the artifact before launch."
             )
             evaluation["blocked"] = True
             return evaluation

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -45,7 +45,7 @@ def _render_detect(console: Console, payload: dict[str, object]) -> None:
         _render_harness_detail(console, detection)
     if attention_count > 0:
         console.print(
-            "[yellow]Run `codex-plugin-scanner guard doctor <harness>` "
+            "[yellow]Run `hol-guard doctor <harness>` "
             "for harness-specific drift and runtime diagnostics.[/yellow]"
         )
 

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -45,8 +45,7 @@ def _render_detect(console: Console, payload: dict[str, object]) -> None:
         _render_harness_detail(console, detection)
     if attention_count > 0:
         console.print(
-            "[yellow]Run `hol-guard doctor <harness>` "
-            "for harness-specific drift and runtime diagnostics.[/yellow]"
+            "[yellow]Run `hol-guard doctor <harness>` for harness-specific drift and runtime diagnostics.[/yellow]"
         )
 
 

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -102,10 +102,14 @@ def test_publish_workflow_attaches_marketplace_action_bundle() -> None:
     assert '"${RELEASE_ASSETS[@]}"' in workflow_text
     assert "subject-path: |" in workflow_text
     assert "dist/*" in workflow_text
-    assert "Build legacy compatibility package (codex-plugin-scanner)" in workflow_text
+    assert "Build primary package (hol-guard)" in workflow_text
+    assert "Build compatibility package (plugin-scanner)" in workflow_text
+    assert "Build compatibility package (codex-plugin-scanner)" in workflow_text
+    assert 'sed -i "1,/^name = /{s/^name = .*/name = \\"plugin-scanner\\"/}" pyproject.toml' in workflow_text
     assert "codex-plugin-scanner" in workflow_text
     assert "cp pyproject.toml pyproject.toml.bak" in workflow_text
     assert "mv pyproject.toml.bak pyproject.toml" in workflow_text
+    assert "uv tool install hol-guard==${VERSION}" in workflow_text
     assert "uv tool install plugin-scanner==${VERSION}" in workflow_text
     assert "uv tool install codex-plugin-scanner==${VERSION}" in workflow_text
     assert "docker pull ghcr.io/hashgraph-online/ai-plugin-scanner:${VERSION}" in workflow_text
@@ -254,6 +258,7 @@ def test_readme_uses_stable_apache_license_badge() -> None:
     assert "publish-action-repo.yml" in readme
     assert "docs/github-action-marketplace.md" not in readme
     assert "ghcr.io/hashgraph-online/ai-plugin-scanner:<version>" in readme
+    assert "https://pypi.org/project/hol-guard/" in readme
     assert "https://pypi.org/project/plugin-scanner/" in readme
     assert "https://pypi.org/project/codex-plugin-scanner/" in readme
     assert "Container Image" in readme

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -24,8 +24,7 @@ def test_action_metadata_includes_marketplace_branding_and_fallback_install() ->
     assert 'python3 -m pip install "$LOCAL_SOURCE[cisco]"' in action_text
     assert 'elif [ "$INSTALL_SOURCE" = "pypi" ]; then' in action_text
     assert (
-        'python3 -m pip download --only-binary=:all: --no-deps --dest "$DIST_DIR" '
-        '"plugin-scanner==${SCANNER_VERSION}"'
+        'python3 -m pip download --only-binary=:all: --no-deps --dest "$DIST_DIR" "plugin-scanner==${SCANNER_VERSION}"'
     ) in action_text
     assert "python3 -m pypi_attestations verify pypi \\" in action_text
     assert 'python3 -m pip install "$DIST_DIR/$DIST_BASENAME"' in action_text
@@ -98,7 +97,7 @@ def test_publish_workflow_attaches_marketplace_action_bundle() -> None:
     assert "dist/plugin-scanner-v${VERSION}.intoto.jsonl" in workflow_text
     assert "Collect release asset files" in workflow_text
     assert "find dist -maxdepth 1 -type f -print0 | sort -z" in workflow_text
-    assert 'mapfile -t RELEASE_ASSETS <<\'EOF\'' in workflow_text
+    assert "mapfile -t RELEASE_ASSETS <<'EOF'" in workflow_text
     assert '"${RELEASE_ASSETS[@]}"' in workflow_text
     assert "subject-path: |" in workflow_text
     assert "dist/*" in workflow_text
@@ -154,16 +153,13 @@ def test_publish_action_repo_workflow_syncs_action_repository() -> None:
     assert "if: secrets.ACTION_REPO_TOKEN != ''" not in workflow_text
     assert "ACTION_CANONICAL_REPOSITORY" in workflow_text
     assert "ACTION_COMPAT_REPOSITORY" in workflow_text
-    assert 'latest_release_tag() {' in workflow_text
-    assert 'latest_remote_tag() {' in workflow_text
+    assert "latest_release_tag() {" in workflow_text
+    assert "latest_remote_tag() {" in workflow_text
     assert (
-        'git ls-remote --tags --refs "https://x-access-token:${GH_TOKEN}@github.com/${target_repo}.git" '
-        '"refs/tags/v*"'
+        'git ls-remote --tags --refs "https://x-access-token:${GH_TOKEN}@github.com/${target_repo}.git" "refs/tags/v*"'
     ) in workflow_text
-    assert 'awk -F' in workflow_text
-    assert (
-        'for candidate in '
-    ) in workflow_text
+    assert "awk -F" in workflow_text
+    assert ("for candidate in ") in workflow_text
     assert '"$(latest_release_tag "$ACTION_CANONICAL_REPOSITORY")" \\' in workflow_text
     assert '"$(latest_release_tag "$ACTION_COMPAT_REPOSITORY")" \\' in workflow_text
     assert '"$(latest_remote_tag "$ACTION_CANONICAL_REPOSITORY")" \\' in workflow_text
@@ -185,16 +181,14 @@ def test_publish_action_repo_workflow_syncs_action_repository() -> None:
     assert """printf '%s\\n' "$SCANNER_VERSION" > "${repo_dir}/scanner-version.txt" """[:-1] in workflow_text
     assert 'cp "${GITHUB_WORKSPACE}/action/cisco-version.txt" "${repo_dir}/cisco-version.txt"' in workflow_text
     assert (
-        'cp "${GITHUB_WORKSPACE}/action/pypi-attestations-version.txt" '
-        '"${repo_dir}/pypi-attestations-version.txt"'
+        'cp "${GITHUB_WORKSPACE}/action/pypi-attestations-version.txt" "${repo_dir}/pypi-attestations-version.txt"'
     ) in workflow_text
     assert 'git -C "$repo_dir" push origin HEAD:main' in workflow_text
     assert 'any_repo_changed="false"' in workflow_text
     assert 'repo_changed="false"' in workflow_text
     assert 'repo_changed="true"' in workflow_text
     assert (
-        'printf \'%s\\t%s\\n\' "$target_repo" "$repo_dir" >> '
-        '"$GITHUB_WORKSPACE/action-repos/publish-targets.tsv"'
+        'printf \'%s\\t%s\\n\' "$target_repo" "$repo_dir" >> "$GITHUB_WORKSPACE/action-repos/publish-targets.tsv"'
     ) in workflow_text
     assert ': > "$GITHUB_WORKSPACE/action-repos/publish-targets.tsv"' in workflow_text
     assert 'if [ "$any_repo_changed" != "true" ]; then' in workflow_text
@@ -203,7 +197,7 @@ def test_publish_action_repo_workflow_syncs_action_repository() -> None:
     assert 'publish_action_release "$target_repo" "$repo_dir"' in workflow_text
     assert 'gh release view "${TAG}" --repo "$target_repo"' in workflow_text
     assert 'git -C "$repo_dir" ls-remote --tags origin "refs/tags/${TAG}"' in workflow_text
-    assert 'Refusing to publish action bundle with colliding existing tag ${TAG} in ${target_repo}.' in workflow_text
+    assert "Refusing to publish action bundle with colliding existing tag ${TAG} in ${target_repo}." in workflow_text
     assert 'git -C "$repo_dir" push origin refs/tags/v1 --force' in workflow_text
     assert 'gh release create "${TAG}"' in workflow_text
     assert "--generate-notes" in workflow_text
@@ -281,8 +275,8 @@ def test_container_files_exist_for_enterprise_distribution() -> None:
     assert dockerfile_text.index("RUN python3 -m pip install --require-hashes -r /app/docker-requirements.txt") < (
         dockerfile_text.index("COPY src /app/src")
     )
-    assert "SOURCE_ROOT = \"/app/src\"" in dockerfile_text
-    assert "WORKSPACE = \"/workspace\"" in dockerfile_text
+    assert 'SOURCE_ROOT = "/app/src"' in dockerfile_text
+    assert 'WORKSPACE = "/workspace"' in dockerfile_text
     assert "from codex_plugin_scanner.cli import main" in dockerfile_text
     assert "USER scanner" in dockerfile_text
     assert "rich==14.2.0" in docker_requirements_text

--- a/tests/test_ecosystems.py
+++ b/tests/test_ecosystems.py
@@ -170,9 +170,7 @@ def test_opencode_jsonc_keeps_block_comment_literals_inside_strings(tmp_path: Pa
     assert result.packages and result.packages[0].name == "a/*b*/c"
 
 
-def test_opencode_permission_error_sets_specific_parse_reason(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_opencode_permission_error_sets_specific_parse_reason(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     config_path = tmp_path / "opencode.json"
     config_path.write_text('{"name":"demo"}', encoding="utf-8")
 

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -413,7 +413,7 @@ args = ["workspace-skill.js"]
         assert rc == 0
         assert "HOL Guard local harness status" in output
         assert "global_tools" in output
-        assert "Run `codex-plugin-scanner guard doctor <harness>`" in output
+        assert "Run `hol-guard doctor <harness>`" in output
 
     def test_guard_scan_emits_consumer_contract(self, capsys):
         rc = main(

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -131,6 +131,13 @@ class _SyncRequestHandler(BaseHTTPRequestHandler):
 
 
 class TestGuardCli:
+    def test_guard_requires_a_subcommand(self, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            main(["guard"])
+
+        assert exc_info.value.code == 2
+        assert "the following arguments are required" in capsys.readouterr().err
+
     def test_guard_detect_reports_supported_harnesses(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_product_flow.py
+++ b/tests/test_guard_product_flow.py
@@ -123,6 +123,33 @@ class TestGuardProductFlow:
         assert output["recommended_harness"] == "codex"
         assert output["next_steps"][0]["command"] == "hol-guard install codex"
 
+    def test_hol_guard_windows_entrypoint_runs_without_nested_guard_command(
+        self,
+        tmp_path,
+        capsys,
+        monkeypatch,
+    ):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        monkeypatch.setattr(sys, "argv", ["hol-guard.exe"])
+
+        rc = main(
+            [
+                "start",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["recommended_harness"] == "codex"
+        assert output["next_steps"][0]["command"] == "hol-guard install codex"
+
     def test_guard_install_creates_wrapper_shim(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_product_flow.py
+++ b/tests/test_guard_product_flow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 from codex_plugin_scanner.cli import main
@@ -75,8 +76,8 @@ class TestGuardProductFlow:
         assert output["receipt_count"] == 0
         assert codex_summary["managed"] is False
         assert codex_summary["next_action"] == "install"
-        assert output["next_steps"][0]["command"] == "plugin-scanner guard install codex"
-        assert output["next_steps"][1]["command"] == "plugin-scanner guard run codex --dry-run"
+        assert output["next_steps"][0]["command"] == "hol-guard install codex"
+        assert output["next_steps"][1]["command"] == "hol-guard run codex --dry-run"
 
     def test_guard_start_human_output_highlights_guard_loop(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -99,6 +100,28 @@ class TestGuardProductFlow:
         assert "Install Guard for codex" in output
         assert "Run Guard before launch" in output
         assert "Optional sync later" in output
+
+    def test_hol_guard_direct_entrypoint_runs_without_nested_guard_command(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        monkeypatch.setattr(sys, "argv", ["hol-guard"])
+
+        rc = main(
+            [
+                "start",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["recommended_harness"] == "codex"
+        assert output["next_steps"][0]["command"] == "hol-guard install codex"
 
     def test_guard_install_creates_wrapper_shim(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_trust_scoring.py
+++ b/tests/test_trust_scoring.py
@@ -50,9 +50,7 @@ def test_good_plugin_emits_skill_and_plugin_trust_domains():
     security_adapter = next(
         adapter for adapter in plugin_domain.adapters if adapter.adapter_id == "security.disclosure"
     )
-    disclosure_component = next(
-        component for component in security_adapter.components if component.key == "score"
-    )
+    disclosure_component = next(component for component in security_adapter.components if component.key == "score")
     assert disclosure_component.score == 100
 
     skill_domain = domains["skills"]
@@ -122,9 +120,7 @@ def test_invalid_skill_frontmatter_reduces_manifest_integrity(tmp_path: Path):
     verified_adapter = next(
         adapter for adapter in skill_domain.adapters if adapter.adapter_id == "verification.manifest-integrity"
     )
-    manifest_integrity = next(
-        component for component in verified_adapter.components if component.key == "score"
-    )
+    manifest_integrity = next(component for component in verified_adapter.components if component.key == "score")
     assert manifest_integrity.score == 0
 
 
@@ -139,9 +135,7 @@ def test_invalid_mcp_json_zeroes_config_integrity(tmp_path: Path):
     verification_adapter = next(
         adapter for adapter in mcp_domain.adapters if adapter.adapter_id == "verification.config-integrity"
     )
-    config_integrity = next(
-        component for component in verification_adapter.components if component.key == "score"
-    )
+    config_integrity = next(component for component in verification_adapter.components if component.key == "score")
     config_shape = next(
         component
         for adapter in mcp_domain.adapters

--- a/uv.lock
+++ b/uv.lock
@@ -1019,6 +1019,48 @@ wheels = [
 ]
 
 [[package]]
+name = "hol-guard"
+version = "2.0.0"
+source = { editable = "." }
+dependencies = [
+    { name = "rich" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+
+[package.optional-dependencies]
+cisco = [
+    { name = "cisco-ai-skill-scanner" },
+]
+dev = [
+    { name = "build" },
+    { name = "jsonschema" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
+
+[package.dev-dependencies]
+publish = [
+    { name = "twine" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "build", marker = "extra == 'dev'", specifier = ">=1.2.2" },
+    { name = "cisco-ai-skill-scanner", marker = "extra == 'cisco'", specifier = "==2.0.8" },
+    { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.23.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
+    { name = "rich", specifier = ">=13.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
+]
+provides-extras = ["cisco", "dev"]
+
+[package.metadata.requires-dev]
+publish = [{ name = "twine", specifier = ">=6.1.0" }]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -2025,48 +2067,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
-
-[[package]]
-name = "plugin-scanner"
-version = "2.0.0"
-source = { editable = "." }
-dependencies = [
-    { name = "rich" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-]
-
-[package.optional-dependencies]
-cisco = [
-    { name = "cisco-ai-skill-scanner" },
-]
-dev = [
-    { name = "build" },
-    { name = "jsonschema" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "ruff" },
-]
-
-[package.dev-dependencies]
-publish = [
-    { name = "twine" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "build", marker = "extra == 'dev'", specifier = ">=1.2.2" },
-    { name = "cisco-ai-skill-scanner", marker = "extra == 'cisco'", specifier = "==2.0.8" },
-    { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.23.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
-    { name = "rich", specifier = ">=13.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
-    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
-]
-provides-extras = ["cisco", "dev"]
-
-[package.metadata.requires-dev]
-publish = [{ name = "twine", specifier = ">=6.1.0" }]
 
 [[package]]
 name = "propcache"


### PR DESCRIPTION
## Summary
- simplify the Guard package and command shape around hol-guard
- clean up Guard README/docs copy so it reads like a user product
- align release packaging so hol-guard is the primary package and old names stay as compatibility paths

## Verification
- uv run --with pytest pytest -q tests/test_guard_product_flow.py tests/test_guard_launch_env.py tests/test_guard_runtime.py tests/test_guard_cli.py tests/test_action_bundle.py tests/test_submission.py tests/test_security_ops.py tests/test_verification.py
- uv run --with ruff ruff check src tests
- uv run --with build python -m build
- uv run hol-guard --help