### PR TITLE
[codex] tighten guard runtime and release bar

### DIFF
--- a/.github/workflows/harness-smoke.yml
+++ b/.github/workflows/harness-smoke.yml
@@ -1,0 +1,114 @@
+name: Guard Harness Smoke
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 7 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  codex-release-gate:
+    name: Codex release gate
+    runs-on:
+      - self-hosted
+      - linux
+      - guard
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
+        with:
+          enable-cache: true
+      - name: Prepare Guard environment
+        run: |
+          uv sync --frozen --extra dev
+          mkdir -p .guard-ci/codex-home/.codex .guard-ci/codex-workspace/.codex
+          cat > .guard-ci/codex-home/.codex/config.toml <<'EOF'
+          [mcp_servers.global_tools]
+          command = "python3"
+          args = ["-m", "http.server", "9000"]
+          EOF
+          cat > .guard-ci/codex-workspace/.codex/config.toml <<'EOF'
+          [mcp_servers.workspace_skill]
+          command = "node"
+          args = ["workspace-skill.js"]
+          EOF
+      - name: Guard detect and install for Codex
+        run: |
+          uv run hol-guard detect codex --home .guard-ci/codex-home --workspace .guard-ci/codex-workspace --json
+          uv run hol-guard install codex --home .guard-ci/codex-home --workspace .guard-ci/codex-workspace --json
+          uv run hol-guard run codex --home .guard-ci/codex-home --workspace .guard-ci/codex-workspace --dry-run --default-action allow --json
+      - name: Verify Codex runtime is available
+        run: |
+          command -v codex
+          codex mcp list
+
+  macos-release-gate:
+    name: Claude or Cursor release gate
+    runs-on:
+      - self-hosted
+      - macOS
+      - guard
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
+        with:
+          enable-cache: true
+      - name: Prepare Guard environment
+        run: uv sync --frozen --extra dev
+      - name: Guard detect for Claude Code
+        run: uv run hol-guard detect claude-code --json
+      - name: Guard detect for Cursor
+        run: uv run hol-guard detect cursor --json
+      - name: Verify Claude Code or Cursor runtime
+        run: |
+          if command -v claude >/dev/null 2>&1; then
+            claude --help >/dev/null
+            exit 0
+          fi
+          command -v cursor-agent
+          cursor-agent mcp list
+
+  windows-release-gate:
+    name: Gemini or OpenCode release gate
+    runs-on:
+      - self-hosted
+      - windows
+      - guard
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
+        with:
+          enable-cache: true
+      - name: Prepare Guard environment
+        shell: pwsh
+        run: uv sync --frozen --extra dev
+      - name: Guard detect for Gemini
+        shell: pwsh
+        run: uv run hol-guard detect gemini --json
+      - name: Guard detect for OpenCode
+        shell: pwsh
+        run: uv run hol-guard detect opencode --json
+      - name: Verify Gemini or OpenCode runtime
+        shell: pwsh
+        run: |
+          $gemini = Get-Command gemini -ErrorAction SilentlyContinue
+          if ($null -ne $gemini) {
+            gemini --help | Out-Null
+            exit 0
+          }
+          $opencode = Get-Command opencode -ErrorAction SilentlyContinue
+          if ($null -eq $opencode) {
+            throw "Expected gemini or opencode on the Windows Guard runner."
+          }
+          opencode --help | Out-Null

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,18 +70,75 @@ jobs:
         run: |
           sed -i "1,/^version = /{s/^version = .*/version = \"$VERSION\"/}" pyproject.toml
           sed -i "1,/^__version__ = /{s/^__version__ = .*/__version__ = \"$VERSION\"/}" src/codex_plugin_scanner/version.py
-      - name: Build primary package (hol-guard)
-        run: uv run --no-sync python -m build
-      - name: Build compatibility package (plugin-scanner)
+      - name: Build Guard package (hol-guard)
         run: |
           cp pyproject.toml pyproject.toml.bak
-          sed -i "1,/^name = /{s/^name = .*/name = \"plugin-scanner\"/}" pyproject.toml
+          python3 - <<'PY'
+          from pathlib import Path
+
+          path = Path("pyproject.toml")
+          text = path.read_text(encoding="utf-8")
+          text = text.replace('name = "hol-guard"', 'name = "hol-guard"', 1)
+          text = text.replace(
+              'description = "Protect local AI harnesses with HOL Guard and run scanner checks for Codex, Claude, Cursor, Gemini, and OpenCode."',
+              'description = "Protect local AI harnesses with HOL Guard before tools run in Codex, Claude Code, Cursor, Gemini, and OpenCode."',
+              1,
+          )
+          start = text.index("[project.scripts]")
+          end = text.index("\n\n[project.urls]")
+          scripts = '''[project.scripts]
+hol-guard = "codex_plugin_scanner.cli:main"
+plugin-guard = "codex_plugin_scanner.cli:main"'''
+          text = text[:start] + scripts + text[end:]
+          path.write_text(text, encoding="utf-8")
+          PY
           uv run --no-sync python -m build
           mv pyproject.toml.bak pyproject.toml
-      - name: Build compatibility package (codex-plugin-scanner)
+      - name: Build scanner package (plugin-scanner)
         run: |
           cp pyproject.toml pyproject.toml.bak
-          sed -i "1,/^name = /{s/^name = .*/name = \"codex-plugin-scanner\"/}" pyproject.toml
+          python3 - <<'PY'
+          from pathlib import Path
+
+          path = Path("pyproject.toml")
+          text = path.read_text(encoding="utf-8")
+          text = text.replace('name = "hol-guard"', 'name = "plugin-scanner"', 1)
+          text = text.replace(
+              'description = "Protect local AI harnesses with HOL Guard and run scanner checks for Codex, Claude, Cursor, Gemini, and OpenCode."',
+              'description = "Lint, verify, and gate plugin ecosystems for maintainers, CI, and publish workflows."',
+              1,
+          )
+          start = text.index("[project.scripts]")
+          end = text.index("\n\n[project.urls]")
+          scripts = '''[project.scripts]
+plugin-scanner = "codex_plugin_scanner.cli:main"
+plugin-ecosystem-scanner = "codex_plugin_scanner.cli:main"'''
+          text = text[:start] + scripts + text[end:]
+          path.write_text(text, encoding="utf-8")
+          PY
+          uv run --no-sync python -m build
+          mv pyproject.toml.bak pyproject.toml
+      - name: Build codex compatibility alias (codex-plugin-scanner)
+        run: |
+          cp pyproject.toml pyproject.toml.bak
+          python3 - <<'PY'
+          from pathlib import Path
+
+          path = Path("pyproject.toml")
+          text = path.read_text(encoding="utf-8")
+          text = text.replace('name = "hol-guard"', 'name = "codex-plugin-scanner"', 1)
+          text = text.replace(
+              'description = "Protect local AI harnesses with HOL Guard and run scanner checks for Codex, Claude, Cursor, Gemini, and OpenCode."',
+              'description = "Compatibility alias for teams still pinned to the codex-plugin-scanner package name."',
+              1,
+          )
+          start = text.index("[project.scripts]")
+          end = text.index("\n\n[project.urls]")
+          scripts = '''[project.scripts]
+codex-plugin-scanner = "codex_plugin_scanner.cli:main"'''
+          text = text[:start] + scripts + text[end:]
+          path.write_text(text, encoding="utf-8")
+          PY
           uv run --no-sync python -m build
           mv pyproject.toml.bak pyproject.toml
       - name: Verify distributions

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # HOL Guard
 
-[![PyPI Version](https://img.shields.io/pypi/v/hol-guard.svg?logo=pypi&logoColor=white&cacheSeconds=300)](https://pypi.org/project/hol-guard/)
-[![Legacy Namespace](https://img.shields.io/badge/legacy-plugin--scanner_and_codex--plugin--scanner-6b7280?logo=pypi&logoColor=white)](https://pypi.org/project/plugin-scanner/)
-[![Python Versions](https://img.shields.io/pypi/pyversions/hol-guard)](https://pypi.org/project/hol-guard/)
-[![PyPI Downloads](https://img.shields.io/pypi/dm/hol-guard)](https://pypistats.org/packages/hol-guard)
+[![Guard Package](https://img.shields.io/badge/package-hol--guard-1459C7?logo=pypi&logoColor=white)](#package-guide)
+[![Scanner Package](https://img.shields.io/badge/package-plugin--scanner-5B49D6?logo=pypi&logoColor=white)](#package-guide)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-3776AB?logo=python&logoColor=white)](#install-the-package-you-need)
 [![CI](https://github.com/hashgraph-online/ai-plugin-scanner/actions/workflows/ci.yml/badge.svg)](https://github.com/hashgraph-online/ai-plugin-scanner/actions/workflows/ci.yml)
 [![Publish](https://github.com/hashgraph-online/ai-plugin-scanner/actions/workflows/publish.yml/badge.svg)](https://github.com/hashgraph-online/ai-plugin-scanner/actions/workflows/publish.yml)
 [![Container Image](https://img.shields.io/badge/ghcr-ai--plugin--scanner-2496ED?logo=docker&logoColor=white)](https://github.com/hashgraph-online/ai-plugin-scanner/pkgs/container/ai-plugin-scanner)
@@ -12,8 +11,16 @@
 [![GitHub Stars](https://img.shields.io/github/stars/hashgraph-online/ai-plugin-scanner?style=social)](https://github.com/hashgraph-online/ai-plugin-scanner/stargazers)
 [![Lint: ruff](https://img.shields.io/badge/lint-ruff-D7FF64.svg)](https://github.com/astral-sh/ruff)
 
-| ![Hashgraph Online Logo](https://hol.org/brand/Logo_Whole_Dark.png) | **Protect Codex, Claude Code, Cursor, Gemini, and OpenCode before local tools run.** HOL Guard watches the tools wired into your harness, shows you what changed, and records what you approved or blocked. The scanner commands stay available for teams that also want linting and CI checks for plugin, skill, MCP, and marketplace packages.<br><br>Start with `hol-guard` if you want local protection. Add the scanner commands later if you also publish or review packages in CI.<br><br>[PyPI Package (`hol-guard`)](https://pypi.org/project/hol-guard/)<br>[Legacy Namespace (`plugin-scanner`)](https://pypi.org/project/plugin-scanner/)<br>[Legacy Namespace (`codex-plugin-scanner`)](https://pypi.org/project/codex-plugin-scanner/)<br>[HOL Plugin Registry](https://hol.org/registry/plugins)<br>[HOL GitHub Organization](https://github.com/hashgraph-online)<br>[Report an Issue](https://github.com/hashgraph-online/ai-plugin-scanner/issues) |
+| ![Hashgraph Online Logo](https://hol.org/brand/Logo_Whole_Dark.png) | **One repo, two first-class Python packages.** Use `hol-guard` to protect Codex, Claude Code, Cursor, Gemini, and OpenCode before local tools run. Use `plugin-scanner` to lint, verify, and gate plugin, skill, MCP, and marketplace packages in CI.<br><br>Install the package that matches your job. The repo houses both products, but users should not need to learn both on day one.<br><br>[PyPI Package (`hol-guard`)](https://pypi.org/project/hol-guard/)<br>[PyPI Package (`plugin-scanner`)](https://pypi.org/project/plugin-scanner/)<br>[Compatibility Alias (`codex-plugin-scanner`)](https://pypi.org/project/codex-plugin-scanner/)<br>[HOL Plugin Registry](https://hol.org/registry/plugins)<br>[HOL GitHub Organization](https://github.com/hashgraph-online)<br>[Report an Issue](https://github.com/hashgraph-online/ai-plugin-scanner/issues) |
 | :--- | :--- |
+
+## Package Guide
+
+| Install | Use it for | Main commands |
+| :--- | :--- | :--- |
+| `hol-guard` | local harness protection | `hol-guard start`, `hol-guard install codex`, `hol-guard run codex` |
+| `plugin-scanner` | maintainer and CI checks | `plugin-scanner lint`, `plugin-scanner verify`, `plugin-scanner submit` |
+| `codex-plugin-scanner` | compatibility alias for older automation | `codex-plugin-scanner verify` |
 
 ## Protect A Harness In 60 Seconds
 
@@ -58,8 +65,8 @@ See [docs/guard/get-started.md](docs/guard/get-started.md) for the full local fl
 ## Use The Scanner In CI
 
 ```bash
-# Install the package once, then use the scanner commands in your shell
-pipx install hol-guard
+# Install the scanner package for maintainer and CI workflows
+pipx install plugin-scanner
 plugin-scanner lint .
 plugin-scanner verify .
 ```
@@ -76,17 +83,17 @@ plugin-scanner verify .
 
 If your repository uses a Codex marketplace root like `.agents/plugins/marketplace.json`, keep `plugin_dir: "."`. The scanner will discover local `./plugins/...` entries automatically, scan each local plugin manifest, and skip remote marketplace entries instead of treating the repo root as a single plugin.
 
-## Start With Guard, Add CI Later
+## Start With Guard, Add Scanner When You Need It
 
 If you use Codex, Claude Code, Cursor, Gemini, or OpenCode every day, start with Guard.
 
 - Guard is the part that protects your local harness before tools run.
 - It helps when a new MCP server appears, when a tool changes after you trusted it, or when you want a receipt for what was approved or blocked.
 
-If you publish plugins, skills, or marketplace packages, add the scanner in CI too.
+If you publish plugins, skills, or marketplace packages, install the scanner package too.
 
 - The scanner checks manifests, metadata, runtime surfaces, and policy rules before a release or CI gate passes.
-- It is the publishing and repo review side of this package, not the first thing a local Guard user needs to learn.
+- It is the maintainer and repo review side of this repo, not something every Guard user needs on day one.
 
 ## Use Scanner After `$plugin-creator`
 
@@ -126,26 +133,33 @@ pip install -e ".[dev]"
 pytest -q
 ```
 
-## Install
+## Install The Package You Need
+
+Guard package:
 
 ```bash
 pip install hol-guard
 ```
 
-Cisco-backed skill scanning is optional:
+Scanner package:
 
 ```bash
-pip install "hol-guard[cisco]"
+pip install plugin-scanner
+```
+
+Cisco-backed scanner analysis is optional:
+
+```bash
+pip install "plugin-scanner[cisco]"
 ```
 
 The `cisco` extra installs the published `cisco-ai-skill-scanner` package from PyPI so the scanner remains publishable on PyPI and the optional Cisco analysis path works with standard package metadata.
 
-You can also install once and use both Guard and scanner commands:
+If you want both tools in one shell during local development:
 
 ```bash
 pipx install hol-guard
-hol-guard start
-plugin-scanner ./my-plugin
+pipx install plugin-scanner
 ```
 
 Container-first environments can use the published image instead:
@@ -157,16 +171,16 @@ docker run --rm \
   scan /workspace --format text
 ```
 
-Backward compatibility remains available for teams still pinned to the historical package namespace:
+The Codex-specific alias remains available for older automation that still expects the historical name:
 
 ```bash
-pip install plugin-scanner
 pip install codex-plugin-scanner
 ```
 
-Compatibility command names also stay available:
+Command names by package:
 
 ```bash
+hol-guard start
 plugin-guard start
 plugin-scanner verify .
 codex-plugin-scanner verify .

--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -1,7 +1,7 @@
 # Guard Get Started
 
-Guard ships as the `hol-guard` package and command.
-The scanner commands stay available in the same install for CI and package checks.
+Install `hol-guard` when you want local harness protection.
+Install `plugin-scanner` separately when you want maintainer or CI checks for plugin packages.
 
 Use it when you want to protect a harness before local MCP servers, skills, hooks, or plugin surfaces run.
 
@@ -52,6 +52,50 @@ Use it when you want to protect a harness before local MCP servers, skills, hook
    hol-guard login --sync-url <url> --token <token>
    hol-guard sync
    ```
+
+## Fine-tune local policy
+
+Guard works with local defaults first, then optional overrides for a harness, publisher, or artifact.
+
+Home config:
+
+```toml
+mode = "prompt"
+default_action = "warn"
+changed_hash_action = "require-reapproval"
+
+[harnesses.codex]
+default_action = "allow"
+
+[publishers.hashgraph-online]
+default_action = "allow"
+
+[artifacts."codex:project:workspace_tools"]
+default_action = "sandbox-required"
+```
+
+Optional project override:
+
+```toml
+# .ai-plugin-scanner-guard.toml
+[artifacts."codex:project:workspace_tools"]
+default_action = "block"
+```
+
+Guard resolves decisions in this order:
+
+1. saved decisions from `hol-guard allow` or `hol-guard deny`
+2. project override file
+3. home config
+4. Guard's built-in recommendation
+
+Use these actions in config or saved decisions:
+
+- `allow`
+- `warn`
+- `block`
+- `sandbox-required`
+- `require-reapproval`
 
 ## What `install` does
 

--- a/docs/guard/local-vs-cloud.md
+++ b/docs/guard/local-vs-cloud.md
@@ -10,6 +10,9 @@ Local features available without sign-in:
 - local policy decisions
 - wrapper-mode launch enforcement
 - local receipts and explain output
+- local policy overrides from home or workspace config
+
+Guard does not meter local safety features. You can detect harnesses, install launchers, diff changes, prompt for approval, and inspect receipts without signing in.
 
 Optional cloud features:
 

--- a/docs/guard/testing-matrix.md
+++ b/docs/guard/testing-matrix.md
@@ -7,6 +7,7 @@ Automated coverage in this phase includes:
 - SQLite persistence through real command execution in temporary homes and workspaces
 - consumer-mode JSON contract generation against scanner fixtures
 - local HTTP sync against a live in-process server instead of mocked transport
+- scheduled self-hosted harness smoke through `.github/workflows/harness-smoke.yml`
 
 Manual verification should include:
 
@@ -30,3 +31,10 @@ First-party canaries for local manual validation:
 - a local `registry-broker-skills` checkout for scanner fixtures and trust review
 
 Claude Code smoke tests remain conditional on the local `claude` binary being available.
+
+Nightly release-bar coverage should include:
+
+- Codex on a self-hosted Linux runner
+- Claude Code or Cursor on a self-hosted macOS runner
+- Gemini or OpenCode on a self-hosted Windows runner
+- a release gate that only passes when those harness families stay green

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,8 @@ packages = ["src/codex_plugin_scanner"]
 
 [tool.hatch.build]
 exclude = [
+    ".guard-live/**",
+    ".guard-package-venv/**",
     ".guard-e2e/**",
     ".guard-e2e-prod/**",
     ".guard-e2e-prod2/**",

--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -141,16 +141,25 @@ def _is_guard_program(program_name: str) -> bool:
     return normalized_name in {"hol-guard", "plugin-guard"}
 
 
-def _build_parser(program_name: str, *, guard_program: bool) -> argparse.ArgumentParser:
-    if guard_program:
+def _is_scanner_program(program_name: str) -> bool:
+    normalized_name = Path(program_name).stem.lower()
+    return normalized_name in {"plugin-scanner", "codex-plugin-scanner", "plugin-ecosystem-scanner"}
+
+
+def _build_parser(program_name: str, *, program_mode: str) -> argparse.ArgumentParser:
+    if program_mode == "guard":
         parser = argparse.ArgumentParser(prog=program_name, description="Protect local harnesses before tools run.")
         parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
         add_guard_root_parser(parser)
         return parser
 
+    description = "Scan plugin ecosystems for CI and publish readiness."
+    if program_mode == "combined":
+        description = "Run HOL Guard locally or scan plugin ecosystems for CI and publish readiness."
+
     parser = argparse.ArgumentParser(
         prog=program_name,
-        description="Run HOL Guard locally or scan plugin ecosystems for CI and publish readiness.",
+        description=description,
     )
     parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     parser.add_argument("--list-ecosystems", action="store_true", help="List supported plugin ecosystems and exit")
@@ -212,15 +221,16 @@ def _build_parser(program_name: str, *, guard_program: bool) -> argparse.Argumen
         default="all",
     )
     doctor_parser.add_argument("--bundle")
-    add_guard_parser(subparsers)
+    if program_mode == "combined":
+        add_guard_parser(subparsers)
 
     return parser
 
 
-def _resolve_legacy_args(argv: list[str] | None, *, guard_program: bool) -> list[str] | None:
+def _resolve_legacy_args(argv: list[str] | None, *, program_mode: str) -> list[str] | None:
     if not argv:
         return argv
-    if guard_program:
+    if program_mode == "guard":
         if argv[0] == "guard":
             return argv[1:]
         return argv
@@ -230,12 +240,13 @@ def _resolve_legacy_args(argv: list[str] | None, *, guard_program: bool) -> list
         "verify",
         "submit",
         "doctor",
-        "guard",
         "--version",
         "--list-ecosystems",
         "-h",
         "--help",
     }
+    if program_mode == "combined":
+        known_commands.add("guard")
     if argv[0] in known_commands:
         return argv
     return ["scan", *argv]
@@ -477,9 +488,14 @@ def _run_doctor(args: argparse.Namespace) -> int:
 
 def main(argv: list[str] | None = None) -> int:
     program_name = Path(sys.argv[0]).name or "plugin-scanner"
-    guard_program = _is_guard_program(program_name)
-    parser = _build_parser(program_name, guard_program=guard_program)
-    args = parser.parse_args(_resolve_legacy_args(argv, guard_program=guard_program))
+    if _is_guard_program(program_name):
+        program_mode = "guard"
+    elif _is_scanner_program(program_name):
+        program_mode = "scanner"
+    else:
+        program_mode = "combined"
+    parser = _build_parser(program_name, program_mode=program_mode)
+    args = parser.parse_args(_resolve_legacy_args(argv, program_mode=program_mode))
     if getattr(args, "list_ecosystems", False):
         for ecosystem in list_supported_ecosystems():
             print(ecosystem)

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -92,7 +92,10 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     _add_guard_common_args(run_parser)
     run_parser.add_argument("--json", action="store_true")
     run_parser.add_argument("--dry-run", action="store_true")
-    run_parser.add_argument("--default-action", choices=("allow", "warn", "review", "block", "require-reapproval"))
+    run_parser.add_argument(
+        "--default-action",
+        choices=("allow", "warn", "review", "block", "sandbox-required", "require-reapproval"),
+    )
     run_parser.add_argument("--arg", dest="passthrough_args", action="append", default=[])
 
     scan_parser = guard_subparsers.add_parser("scan", help="Run a consumer-mode scan for a local artifact")
@@ -150,7 +153,10 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     hook_parser.add_argument("--harness", default="claude-code")
     hook_parser.add_argument("--artifact-id")
     hook_parser.add_argument("--artifact-name")
-    hook_parser.add_argument("--policy-action", choices=("allow", "warn", "review", "block", "require-reapproval"))
+    hook_parser.add_argument(
+        "--policy-action",
+        choices=("allow", "warn", "review", "block", "sandbox-required", "require-reapproval"),
+    )
     hook_parser.add_argument("--event-file")
     hook_parser.add_argument("--json", action="store_true")
     guard_subparsers._choices_actions = [
@@ -352,6 +358,10 @@ def run_guard_command(args: argparse.Namespace) -> int:
             artifact_id=artifact_id,
             artifact_hash=str(payload.get("artifact_hash", f"hook:{artifact_id}")),
             policy_decision=policy_action,
+            capabilities_summary=_coalesce_string(
+                payload.get("capabilities_summary"),
+                f"hook artifact • {args.harness}",
+            ),
             changed_capabilities=changed_capabilities or ["hook"],
             provenance_summary=_coalesce_string(
                 payload.get("provenance_summary"),

--- a/src/codex_plugin_scanner/guard/cli/prompt.py
+++ b/src/codex_plugin_scanner/guard/cli/prompt.py
@@ -247,6 +247,7 @@ def _record_override_receipt(
         artifact_id=artifact.artifact_id,
         artifact_hash=artifact.artifact_hash,
         policy_decision=policy_decision,
+        capabilities_summary=_capabilities_summary(artifact),
         changed_capabilities=list(artifact.changed_fields),
         provenance_summary=artifact.provenance_summary,
         artifact_name=artifact.artifact_name,

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -170,6 +170,7 @@ def _render_receipts(console: Console, payload: dict[str, object]) -> None:
     table.add_column("Harness", style="cyan")
     table.add_column("Artifact", style="bold")
     table.add_column("Decision")
+    table.add_column("Capabilities", style="blue")
     table.add_column("Changed fields", style="magenta")
     for receipt in receipts:
         date_text, time_text = _timestamp_parts(receipt.get("timestamp"))
@@ -179,6 +180,7 @@ def _render_receipts(console: Console, payload: dict[str, object]) -> None:
             str(receipt.get("harness", "unknown")),
             str(receipt.get("artifact_name") or receipt.get("artifact_id") or "unknown"),
             _action_text(str(receipt.get("policy_decision", "warn"))),
+            str(receipt.get("capabilities_summary") or "unknown"),
             ", ".join(_coerce_string_list(receipt.get("changed_capabilities"))) or "none",
         )
     console.print(table)
@@ -252,11 +254,11 @@ def _render_scan(console: Console, payload: dict[str, object]) -> None:
     if isinstance(payload.get("capability_manifest"), dict):
         ecosystems = _coerce_string_list(payload["capability_manifest"].get("ecosystems"))
     artifact_snapshot = payload.get("artifact_snapshot")
+    artifact_path = "."
+    if isinstance(artifact_snapshot, dict):
+        artifact_path = str(artifact_snapshot.get("path") or artifact_snapshot.get("artifact_path") or ".")
     body = Table.grid(padding=(0, 1))
-    body.add_row(
-        "Artifact",
-        str(artifact_snapshot.get("artifact_path", ".")) if isinstance(artifact_snapshot, dict) else ".",
-    )
+    body.add_row("Artifact", artifact_path)
     body.add_row("Ecosystems", ", ".join(ecosystems) or "unknown")
     if isinstance(recommendation, dict):
         body.add_row("Recommended action", _action_text(str(recommendation.get("action", "review"))))
@@ -436,6 +438,7 @@ def _action_text(action: str) -> Text:
         "warn": "yellow",
         "review": "yellow",
         "require-reapproval": "magenta",
+        "sandbox-required": "cyan",
         "block": "red",
     }
     return Text(action, style=styles.get(action, "white"))

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -13,6 +13,20 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10
 from .models import GuardAction, GuardMode
 
 DEFAULT_GUARD_DIRNAME = ".ai-plugin-scanner-guard"
+VALID_GUARD_ACTIONS = {"allow", "warn", "review", "block", "sandbox-required", "require-reapproval"}
+
+
+def _coerce_action_map(payload: object) -> dict[str, GuardAction]:
+    if not isinstance(payload, dict):
+        return {}
+    action_map: dict[str, GuardAction] = {}
+    for key, value in payload.items():
+        if not isinstance(key, str):
+            continue
+        action = value if isinstance(value, str) else value.get("action") if isinstance(value, dict) else None
+        if isinstance(action, str) and action in VALID_GUARD_ACTIONS:
+            action_map[key] = action
+    return action_map
 
 
 @dataclass(frozen=True, slots=True)
@@ -30,6 +44,23 @@ class GuardConfig:
     telemetry: bool = False
     sync: bool = False
     billing: bool = False
+    harness_actions: dict[str, GuardAction] | None = None
+    publisher_actions: dict[str, GuardAction] | None = None
+    artifact_actions: dict[str, GuardAction] | None = None
+
+    def resolve_action_override(
+        self,
+        harness: str,
+        artifact_id: str | None,
+        publisher: str | None,
+    ) -> GuardAction | None:
+        if artifact_id is not None and self.artifact_actions is not None and artifact_id in self.artifact_actions:
+            return self.artifact_actions[artifact_id]
+        if publisher is not None and self.publisher_actions is not None and publisher in self.publisher_actions:
+            return self.publisher_actions[publisher]
+        if self.harness_actions is not None and harness in self.harness_actions:
+            return self.harness_actions[harness]
+        return None
 
 
 def resolve_guard_home(override: str | None = None) -> Path:
@@ -73,4 +104,7 @@ def load_guard_config(guard_home: Path, workspace: Path | None = None) -> GuardC
         telemetry=bool(merged.get("telemetry", False)),
         sync=bool(merged.get("sync", False)),
         billing=bool(merged.get("billing", False)),
+        harness_actions=_coerce_action_map(merged.get("harnesses")),
+        publisher_actions=_coerce_action_map(merged.get("publishers")),
+        artifact_actions=_coerce_action_map(merged.get("artifacts")),
     )

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -23,7 +23,13 @@ def _coerce_action_map(payload: object) -> dict[str, GuardAction]:
     for key, value in payload.items():
         if not isinstance(key, str):
             continue
-        action = value if isinstance(value, str) else value.get("action") if isinstance(value, dict) else None
+        action = (
+            value
+            if isinstance(value, str)
+            else (value.get("action") or value.get("default_action"))
+            if isinstance(value, dict)
+            else None
+        )
         if isinstance(action, str) and action in VALID_GUARD_ACTIONS:
             action_map[key] = action
     return action_map

--- a/src/codex_plugin_scanner/guard/consumer/service.py
+++ b/src/codex_plugin_scanner/guard/consumer/service.py
@@ -72,7 +72,7 @@ def diff_removed_artifact(previous: dict[str, object]) -> dict[str, object]:
 
 
 def _is_blocking_action(policy_action: str) -> bool:
-    return policy_action in {"block", "require-reapproval"}
+    return policy_action in {"block", "sandbox-required", "require-reapproval"}
 
 
 def _build_removed_provenance(previous: dict[str, object]) -> str:
@@ -81,6 +81,26 @@ def _build_removed_provenance(previous: dict[str, object]) -> str:
     scope_label = str(scope) if isinstance(scope, str) else "unknown"
     path_label = str(config_path) if isinstance(config_path, str) else "unknown config"
     return f"{scope_label} artifact removed from {path_label}"
+
+
+def _capabilities_summary(artifact: GuardArtifact) -> str:
+    parts = [artifact.artifact_type.replace("_", " ")]
+    if artifact.transport is not None:
+        parts.append(artifact.transport)
+    if artifact.command is not None:
+        parts.append(artifact.command)
+    return " • ".join(parts)
+
+
+def _removed_capabilities_summary(previous: dict[str, object]) -> str:
+    artifact_type = previous.get("artifact_type")
+    source_scope = previous.get("source_scope")
+    parts: list[str] = []
+    if isinstance(artifact_type, str):
+        parts.append(artifact_type.replace("_", " "))
+    if isinstance(source_scope, str):
+        parts.append(f"{source_scope} artifact")
+    return " • ".join(parts) if parts else "removed artifact"
 
 
 def detect_all(context: HarnessContext) -> list[HarnessDetection]:
@@ -115,17 +135,28 @@ def evaluate_detection(
         current_artifact_ids.add(artifact.artifact_id)
         previous = previous_snapshots.get(artifact.artifact_id)
         diff = diff_artifact(previous, artifact)
-        policy_action = decide_action(
-            configured_action=store.resolve_policy(
+        is_first_seen = diff["changed_fields"] == ["first_seen"]
+        configured_action = store.resolve_policy(
+            detection.harness,
+            artifact.artifact_id,
+            workspace,
+            artifact.publisher,
+        )
+        if configured_action is None:
+            configured_action = config.resolve_action_override(
                 detection.harness,
                 artifact.artifact_id,
-                workspace,
                 artifact.publisher,
-            ),
-            default_action=default_action,
-            config=config,
-            changed=bool(diff["changed"]),
-        )
+            )
+        if is_first_seen and configured_action is None and default_action is not None:
+            policy_action = default_action
+        else:
+            policy_action = decide_action(
+                configured_action=configured_action,
+                default_action=default_action,
+                config=config,
+                changed=bool(diff["changed"]),
+            )
         if _is_blocking_action(policy_action):
             blocked = True
         receipt = build_receipt(
@@ -133,6 +164,7 @@ def evaluate_detection(
             artifact_id=artifact.artifact_id,
             artifact_hash=str(diff["current_hash"]),
             policy_decision=policy_action,
+            capabilities_summary=_capabilities_summary(artifact),
             changed_capabilities=list(diff["changed_fields"]),
             provenance_summary=f"{artifact.source_scope} artifact defined at {artifact.config_path}",
             artifact_name=artifact.name,
@@ -189,6 +221,7 @@ def evaluate_detection(
             artifact_id=artifact_id,
             artifact_hash=previous_hash,
             policy_decision=policy_action,
+            capabilities_summary=_removed_capabilities_summary(previous),
             changed_capabilities=["removed"],
             provenance_summary=_build_removed_provenance(previous),
             artifact_name=str(artifact_name) if isinstance(artifact_name, str) else artifact_id,

--- a/src/codex_plugin_scanner/guard/models.py
+++ b/src/codex_plugin_scanner/guard/models.py
@@ -6,7 +6,7 @@ from dataclasses import asdict, dataclass, field
 from typing import Literal
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
-GuardAction = Literal["allow", "warn", "review", "block", "require-reapproval"]
+GuardAction = Literal["allow", "warn", "review", "block", "sandbox-required", "require-reapproval"]
 GuardMode = Literal["observe", "prompt", "enforce"]
 DecisionScope = Literal["global", "harness", "workspace", "artifact", "publisher"]
 
@@ -109,6 +109,7 @@ class GuardReceipt:
     artifact_id: str
     artifact_hash: str
     policy_decision: GuardAction
+    capabilities_summary: str
     changed_capabilities: tuple[str, ...]
     provenance_summary: str
     user_override: str | None = None

--- a/src/codex_plugin_scanner/guard/policy/engine.py
+++ b/src/codex_plugin_scanner/guard/policy/engine.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from ..config import GuardConfig
 from ..models import GuardAction
 
-VALID_GUARD_ACTIONS = {"allow", "warn", "review", "block", "require-reapproval"}
+VALID_GUARD_ACTIONS = {"allow", "warn", "review", "block", "sandbox-required", "require-reapproval"}
 SAFE_CHANGED_HASH_ACTION: GuardAction = "require-reapproval"
 SAFE_DEFAULT_ACTION: GuardAction = "require-reapproval"
 

--- a/src/codex_plugin_scanner/guard/receipts/manager.py
+++ b/src/codex_plugin_scanner/guard/receipts/manager.py
@@ -13,6 +13,7 @@ def build_receipt(
     artifact_id: str,
     artifact_hash: str,
     policy_decision: str,
+    capabilities_summary: str,
     changed_capabilities: list[str],
     provenance_summary: str,
     artifact_name: str | None,
@@ -28,6 +29,7 @@ def build_receipt(
         artifact_id=artifact_id,
         artifact_hash=artifact_hash,
         policy_decision=policy_decision,  # type: ignore[arg-type]
+        capabilities_summary=capabilities_summary,
         changed_capabilities=tuple(changed_capabilities),
         provenance_summary=provenance_summary,
         user_override=user_override,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -90,6 +90,7 @@ class GuardStore:
               artifact_id text not null,
               artifact_hash text not null,
               policy_decision text not null,
+              capabilities_summary text not null default '',
               changed_capabilities_json text not null,
               provenance_summary text not null,
               user_override text,
@@ -126,6 +127,7 @@ class GuardStore:
             for statement in statements:
                 connection.execute(statement)
             self._ensure_policy_column(connection, "publisher", "text")
+            self._ensure_runtime_receipts_column(connection, "capabilities_summary", "text not null default ''")
 
     @staticmethod
     def _ensure_policy_column(connection: sqlite3.Connection, column_name: str, column_type: str) -> None:
@@ -134,6 +136,14 @@ class GuardStore:
         if column_name in existing:
             return
         connection.execute(f"alter table policy_decisions add column {column_name} {column_type}")
+
+    @staticmethod
+    def _ensure_runtime_receipts_column(connection: sqlite3.Connection, column_name: str, column_type: str) -> None:
+        rows = connection.execute("pragma table_info(runtime_receipts)").fetchall()
+        existing = {str(row["name"]) for row in rows}
+        if column_name in existing:
+            return
+        connection.execute(f"alter table runtime_receipts add column {column_name} {column_type}")
 
     def list_table_names(self) -> list[str]:
         with self._connect() as connection:
@@ -279,10 +289,11 @@ class GuardStore:
             connection.execute(
                 """
                 insert into runtime_receipts (
-                  receipt_id, harness, artifact_id, artifact_hash, policy_decision, changed_capabilities_json,
+                  receipt_id, harness, artifact_id, artifact_hash, policy_decision, capabilities_summary,
+                  changed_capabilities_json,
                   provenance_summary, user_override, artifact_name, source_scope, timestamp
                 )
-                values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     receipt.receipt_id,
@@ -290,6 +301,7 @@ class GuardStore:
                     receipt.artifact_id,
                     receipt.artifact_hash,
                     receipt.policy_decision,
+                    receipt.capabilities_summary,
                     json.dumps(list(receipt.changed_capabilities)),
                     receipt.provenance_summary,
                     receipt.user_override,
@@ -303,7 +315,8 @@ class GuardStore:
         with self._connect() as connection:
             rows = connection.execute(
                 """
-                select receipt_id, harness, artifact_id, artifact_hash, policy_decision, changed_capabilities_json,
+                select receipt_id, harness, artifact_id, artifact_hash, policy_decision, capabilities_summary,
+                       changed_capabilities_json,
                        provenance_summary, user_override, artifact_name, source_scope, timestamp
                 from runtime_receipts
                 order by timestamp desc
@@ -318,6 +331,7 @@ class GuardStore:
                 "artifact_id": str(row["artifact_id"]),
                 "artifact_hash": str(row["artifact_hash"]),
                 "policy_decision": str(row["policy_decision"]),
+                "capabilities_summary": str(row["capabilities_summary"]),
                 "changed_capabilities": json.loads(str(row["changed_capabilities_json"])),
                 "provenance_summary": str(row["provenance_summary"]),
                 "user_override": row["user_override"],

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -101,10 +101,12 @@ def test_publish_workflow_attaches_marketplace_action_bundle() -> None:
     assert '"${RELEASE_ASSETS[@]}"' in workflow_text
     assert "subject-path: |" in workflow_text
     assert "dist/*" in workflow_text
-    assert "Build primary package (hol-guard)" in workflow_text
-    assert "Build compatibility package (plugin-scanner)" in workflow_text
-    assert "Build compatibility package (codex-plugin-scanner)" in workflow_text
-    assert 'sed -i "1,/^name = /{s/^name = .*/name = \\"plugin-scanner\\"/}" pyproject.toml' in workflow_text
+    assert "Build Guard package (hol-guard)" in workflow_text
+    assert "Build scanner package (plugin-scanner)" in workflow_text
+    assert "Build codex compatibility alias (codex-plugin-scanner)" in workflow_text
+    assert 'name = "plugin-scanner"' in workflow_text
+    assert 'plugin-ecosystem-scanner = "codex_plugin_scanner.cli:main"' in workflow_text
+    assert 'hol-guard = "codex_plugin_scanner.cli:main"' in workflow_text
     assert "codex-plugin-scanner" in workflow_text
     assert "cp pyproject.toml pyproject.toml.bak" in workflow_text
     assert "mv pyproject.toml.bak pyproject.toml" in workflow_text
@@ -130,6 +132,28 @@ def test_ci_workflow_covers_cross_platform_runtime() -> None:
 
     assert "windows-latest" in workflow_text
     assert "macos-latest" in workflow_text
+
+
+def test_harness_smoke_workflow_covers_nightly_self_hosted_release_gate() -> None:
+    workflow_text = (ROOT / ".github" / "workflows" / "harness-smoke.yml").read_text(encoding="utf-8")
+
+    assert "name: Guard Harness Smoke" in workflow_text
+    assert "schedule:" in workflow_text
+    assert "workflow_dispatch:" in workflow_text
+    assert "self-hosted" in workflow_text
+    assert "linux" in workflow_text
+    assert "macOS" in workflow_text
+    assert "windows" in workflow_text
+    assert "hol-guard detect codex" in workflow_text
+    assert "hol-guard run codex" in workflow_text
+    assert "--dry-run --default-action allow --json" in workflow_text
+    assert "codex mcp list" in workflow_text
+    assert "cursor-agent mcp list" in workflow_text
+    assert "gemini --help" in workflow_text
+    assert "opencode --help" in workflow_text
+    assert "Codex release gate" in workflow_text
+    assert "Claude or Cursor release gate" in workflow_text
+    assert "Gemini or OpenCode release gate" in workflow_text
 
 
 def test_codeql_workflow_has_stable_workspace_alias_and_source_root() -> None:
@@ -249,6 +273,13 @@ def test_readme_uses_stable_apache_license_badge() -> None:
 
     assert "https://img.shields.io/badge/license-Apache--2.0-blue.svg" in readme
     assert "https://img.shields.io/github/license/hashgraph-online/codex-plugin-scanner" not in readme
+    assert "https://img.shields.io/pypi/v/hol-guard" not in readme
+    assert "https://img.shields.io/pypi/v/plugin-scanner" not in readme
+    assert "https://img.shields.io/pypi/pyversions/hol-guard" not in readme
+    assert "https://img.shields.io/pypi/dm/hol-guard" not in readme
+    assert "https://img.shields.io/badge/package-hol--guard-" in readme
+    assert "https://img.shields.io/badge/package-plugin--scanner-" in readme
+    assert "https://img.shields.io/badge/python-3.10%2B-" in readme
     assert "publish-action-repo.yml" in readme
     assert "docs/github-action-marketplace.md" not in readme
     assert "ghcr.io/hashgraph-online/ai-plugin-scanner:<version>" in readme

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -15,6 +15,7 @@ import pytest
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.adapters import cursor as cursor_adapter_module
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+from codex_plugin_scanner.guard.cli.render import emit_guard_payload
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -441,6 +442,26 @@ args = ["workspace-skill.js"]
         assert output["policy_recommendation"]["action"] in {"allow", "review", "block"}
         assert "trust_evidence_bundle" in output
         assert "provenance_record" in output
+
+    def test_guard_scan_human_output_shows_artifact_path(self, capsys):
+        rc = main(
+            [
+                "guard",
+                "scan",
+                str(FIXTURES / "good-plugin"),
+                "--consumer-mode",
+                "--json",
+            ]
+        )
+        payload = json.loads(capsys.readouterr().out)
+
+        emit_guard_payload("scan", payload, as_json=False)
+        output = capsys.readouterr().out
+
+        assert rc == 0
+        assert "Consumer scan" in output
+        assert "Artifact" in output
+        assert "good-plugin" in output
 
     def test_guard_run_persists_receipts_and_policy(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_product_flow.py
+++ b/tests/test_guard_product_flow.py
@@ -8,6 +8,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from codex_plugin_scanner.cli import main
 
 
@@ -51,6 +53,31 @@ args = ["workspace-skill.js"]
 
 
 class TestGuardProductFlow:
+    def test_plugin_scanner_help_stays_scanner_only(self, capsys, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["plugin-scanner"])
+
+        with pytest.raises(SystemExit) as excinfo:
+            main(["--help"])
+
+        output = capsys.readouterr().out
+
+        assert excinfo.value.code == 0
+        assert "Scan plugin ecosystems for CI and publish readiness." in output
+        assert "{scan,lint,verify,submit,doctor}" in output
+        assert "guard" not in output
+
+    def test_python_module_entry_keeps_combined_surface(self, capsys, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["cli.py"])
+
+        with pytest.raises(SystemExit) as excinfo:
+            main(["--help"])
+
+        output = capsys.readouterr().out
+
+        assert excinfo.value.code == 0
+        assert "Run HOL Guard locally or scan plugin ecosystems for CI and publish readiness." in output
+        assert "{scan,lint,verify,submit,doctor,guard}" in output
+
     def test_guard_start_json_guides_first_run(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13,7 +13,7 @@ from typing import ClassVar
 
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
-from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.config import GuardConfig, load_guard_config
 from codex_plugin_scanner.guard.consumer import artifact_hash, evaluate_detection
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
@@ -92,6 +92,164 @@ class _RemoteProxyHandler(BaseHTTPRequestHandler):
 
 
 class TestGuardRuntime:
+    def test_guard_store_initializes_runtime_tables_and_receipt_columns(self, tmp_path):
+        store = GuardStore(tmp_path / "guard-home")
+
+        assert {
+            "artifact_diffs",
+            "artifact_hashes",
+            "artifact_snapshots",
+            "harness_installations",
+            "managed_installs",
+            "policy_decisions",
+            "publisher_cache",
+            "runtime_receipts",
+            "sync_state",
+        } <= set(store.list_table_names())
+
+        store.add_receipt(
+            build_receipt(
+                harness="codex",
+                artifact_id="codex:project:workspace-tools",
+                artifact_hash="hash-1",
+                policy_decision="allow",
+                capabilities_summary="mcp server • stdio • node",
+                changed_capabilities=["first_seen"],
+                provenance_summary="project artifact defined at .codex/config.toml",
+                artifact_name="workspace-tools",
+                source_scope="project",
+            )
+        )
+        receipts = store.list_receipts(limit=1)
+
+        assert receipts[0]["capabilities_summary"] == "mcp server • stdio • node"
+
+    def test_guard_load_config_parses_override_sections(self, tmp_path):
+        guard_home = tmp_path / "guard-home"
+        guard_home.mkdir(parents=True, exist_ok=True)
+        _write_text(
+            guard_home / "config.toml",
+            "\n".join(
+                [
+                    'default_action = "warn"',
+                    "[harnesses.codex]",
+                    'action = "allow"',
+                    '[publishers."hashgraph-online"]',
+                    'action = "sandbox-required"',
+                    '[artifacts."codex:project:workspace-tools"]',
+                    'action = "block"',
+                ]
+            )
+            + "\n",
+        )
+
+        config = load_guard_config(guard_home)
+
+        assert config.resolve_action_override("codex", None, None) == "allow"
+        assert config.resolve_action_override("codex", None, "hashgraph-online") == "sandbox-required"
+        assert config.resolve_action_override("codex", "codex:project:workspace-tools", None) == "block"
+
+    def test_guard_evaluate_detection_uses_config_action_overrides(self, tmp_path):
+        store = GuardStore(tmp_path / "guard-home")
+        config = GuardConfig(
+            guard_home=tmp_path / "guard-home",
+            workspace=None,
+            harness_actions={"codex": "allow"},
+            publisher_actions={"hashgraph-online": "sandbox-required"},
+            artifact_actions={"codex:project:workspace-tools": "block"},
+        )
+        artifact = GuardArtifact(
+            artifact_id="codex:project:workspace-tools",
+            name="workspace-tools",
+            harness="codex",
+            artifact_type="mcp_server",
+            source_scope="project",
+            config_path=str(tmp_path / "workspace" / ".codex" / "config.toml"),
+            command="node",
+            args=("workspace.js",),
+            transport="stdio",
+            publisher="hashgraph-online",
+        )
+        detection = HarnessDetection(
+            harness="codex",
+            installed=True,
+            command_available=True,
+            config_paths=(artifact.config_path,),
+            artifacts=(artifact,),
+        )
+
+        evaluation = evaluate_detection(detection, store, config, persist=True)
+        receipts = store.list_receipts(limit=1)
+
+        assert evaluation["blocked"] is True
+        assert evaluation["artifacts"][0]["policy_action"] == "block"
+        assert receipts[0]["capabilities_summary"] == "mcp server • stdio • node"
+
+    def test_guard_evaluate_detection_blocks_for_sandbox_required_override(self, tmp_path):
+        store = GuardStore(tmp_path / "guard-home")
+        config = GuardConfig(
+            guard_home=tmp_path / "guard-home",
+            workspace=None,
+            publisher_actions={"hashgraph-online": "sandbox-required"},
+        )
+        artifact = GuardArtifact(
+            artifact_id="codex:project:workspace-tools",
+            name="workspace-tools",
+            harness="codex",
+            artifact_type="mcp_server",
+            source_scope="project",
+            config_path=str(tmp_path / "workspace" / ".codex" / "config.toml"),
+            command="node",
+            args=("workspace.js",),
+            transport="stdio",
+            publisher="hashgraph-online",
+        )
+        detection = HarnessDetection(
+            harness="codex",
+            installed=True,
+            command_available=True,
+            config_paths=(artifact.config_path,),
+            artifacts=(artifact,),
+        )
+
+        evaluation = evaluate_detection(detection, store, config, persist=False)
+
+        assert evaluation["blocked"] is True
+        assert evaluation["artifacts"][0]["policy_action"] == "sandbox-required"
+
+    def test_guard_evaluate_detection_uses_default_action_for_first_seen_artifacts(self, tmp_path):
+        store = GuardStore(tmp_path / "guard-home")
+        config = GuardConfig(
+            guard_home=tmp_path / "guard-home",
+            workspace=None,
+            default_action="warn",
+            changed_hash_action="require-reapproval",
+        )
+        artifact = GuardArtifact(
+            artifact_id="codex:project:workspace-tools",
+            name="workspace-tools",
+            harness="codex",
+            artifact_type="mcp_server",
+            source_scope="project",
+            config_path=str(tmp_path / "workspace" / ".codex" / "config.toml"),
+            command="node",
+            args=("workspace.js",),
+            transport="stdio",
+        )
+        detection = HarnessDetection(
+            harness="codex",
+            installed=True,
+            command_available=True,
+            config_paths=(artifact.config_path,),
+            artifacts=(artifact,),
+        )
+
+        evaluation = evaluate_detection(detection, store, config, default_action="allow", persist=False)
+
+        assert evaluation["blocked"] is False
+        assert evaluation["artifacts"][0]["changed_fields"] == ["first_seen"]
+        assert evaluation["artifacts"][0]["policy_action"] == "allow"
+
     def test_guard_run_keeps_prior_snapshot_when_reapproval_blocks(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
         baseline = GuardArtifact(
@@ -604,6 +762,7 @@ class TestGuardRuntime:
                 artifact_id="codex:workspace_skill",
                 artifact_hash="hash-123",
                 policy_decision="allow",
+                capabilities_summary="mcp server • stdio • python",
                 changed_capabilities=["first_seen"],
                 provenance_summary="project artifact defined at .codex/config.toml",
                 artifact_name="workspace_skill",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -149,6 +149,30 @@ class TestGuardRuntime:
         assert config.resolve_action_override("codex", None, "hashgraph-online") == "sandbox-required"
         assert config.resolve_action_override("codex", "codex:project:workspace-tools", None) == "block"
 
+    def test_guard_load_config_accepts_default_action_inside_override_sections(self, tmp_path):
+        guard_home = tmp_path / "guard-home"
+        guard_home.mkdir(parents=True, exist_ok=True)
+        _write_text(
+            guard_home / "config.toml",
+            "\n".join(
+                [
+                    "[harnesses.codex]",
+                    'default_action = "allow"',
+                    '[publishers."hashgraph-online"]',
+                    'default_action = "sandbox-required"',
+                    '[artifacts."codex:project:workspace-tools"]',
+                    'default_action = "block"',
+                ]
+            )
+            + "\n",
+        )
+
+        config = load_guard_config(guard_home)
+
+        assert config.resolve_action_override("codex", None, None) == "allow"
+        assert config.resolve_action_override("codex", None, "hashgraph-online") == "sandbox-required"
+        assert config.resolve_action_override("codex", "codex:project:workspace-tools", None) == "block"
+
     def test_guard_evaluate_detection_uses_config_action_overrides(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
         config = GuardConfig(


### PR DESCRIPTION
## Summary
- tighten the local Guard product flow and docs
- fix README packaging/badge issues
- add nightly self-hosted harness smoke coverage for the release bar

## Validation
- uv run --with pytest pytest -q tests/test_guard_product_flow.py tests/test_guard_launch_env.py tests/test_guard_runtime.py tests/test_guard_cli.py tests/test_action_bundle.py tests/test_submission.py tests/test_security_ops.py tests/test_verification.py
- uv run --with ruff ruff check src tests
- uv run --with ruff ruff format --check src tests
- uv run --with build python -m build
- uv run hol-guard start --home .guard-final/home --workspace .guard-final/workspace --json
- uv run hol-guard install codex --home .guard-final/home --workspace .guard-final/workspace --json
- uv run hol-guard run codex --home .guard-final/home --workspace .guard-final/workspace --dry-run --default-action allow --json
- uv run hol-guard receipts --home .guard-final/home --json
- PATH="$PWD/.guard-final/home/bin:$PATH" guard-codex mcp list
