### PR TITLE
[codex] Add Guard approval center flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ pipx run hol-guard start
 pipx run hol-guard install codex
 pipx run hol-guard run codex --dry-run
 pipx run hol-guard run codex
+pipx run hol-guard approvals
 pipx run hol-guard receipts
 ```
 
@@ -37,7 +38,8 @@ What you get from Guard:
 
 - Detects local harness config on your machine
 - Records a baseline before you trust a tool
-- Stops on new or changed artifacts before launch
+- Pauses cleanly on new or changed artifacts before launch
+- Queues blocked changes in a localhost approval center when the harness cannot prompt inline
 - Stores receipts locally so you can review decisions later
 - Keeps sync optional until you actually want shared history
 
@@ -55,11 +57,27 @@ See [docs/guard/get-started.md](docs/guard/get-started.md) for the full local fl
 - `hol-guard run <harness> --dry-run`
   Records the current state once before you trust it.
 - `hol-guard run <harness>`
-  Reviews changes before launch.
-- `hol-guard diff <harness>`
-  Shows what changed.
+  Reviews changes before launch and hands blocked sessions to the approval center when needed.
+- `hol-guard approvals`
+  Lists pending approvals or resolves them from the terminal.
 - `hol-guard receipts`
   Shows local approval and block history.
+
+</details>
+
+<details>
+<summary>Harness approval strategy</summary>
+
+- `claude-code`
+  Guard prefers Claude hooks first, then the local approval center when the shell cannot prompt.
+- `codex`
+  Guard owns artifact approval today through the local approval center. App Server is the future path for richer in-client approvals.
+- `cursor`
+  Guard respects Cursor’s native tool approval and focuses on artifact trust before launch.
+- `opencode`
+  Guard authors package-level policy while OpenCode keeps native allow or deny rules.
+- `gemini`
+  Guard scans extensions and falls back to the local approval center for blocked changes.
 
 </details>
 

--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -31,22 +31,28 @@ Use it when you want to protect a harness before local MCP servers, skills, hook
    hol-guard run codex
    ```
 
-5. Review changes when Guard blocks or asks for another look:
+5. If the shell is interactive, approve inline. If the shell cannot prompt, Guard queues the change in the local approval center instead of ending the session with a dead stop:
 
    ```bash
-   hol-guard diff codex
-   hol-guard allow codex --scope artifact --artifact-id codex:project:workspace_skill
-   hol-guard deny codex --scope artifact --artifact-id codex:project:workspace_skill
+   hol-guard approvals
    ```
 
-6. Check receipts and current status:
+6. Review or resolve changes from the terminal when you want a text-only path:
+
+   ```bash
+   hol-guard approvals approve <request-id>
+   hol-guard approvals deny <request-id>
+   hol-guard diff codex
+   ```
+
+7. Check receipts and current status:
 
    ```bash
    hol-guard receipts
    hol-guard status
    ```
 
-7. Sign in later only if you want shared history:
+8. Sign in later only if you want shared history:
 
    ```bash
    hol-guard login --sync-url <url> --token <token>
@@ -105,6 +111,27 @@ Use these actions in config or saved decisions:
 - Windows: `~/.config/.ai-plugin-scanner-guard/bin/guard-<harness>.cmd`
 
 Claude Code also gets Guard hook entries in `.claude/settings.local.json` when you install from a workspace.
+
+## Harness approval model
+
+Guard uses three approval tiers:
+
+1. native harness approval where the harness already has a strong tool permission model
+2. the local Guard approval center on `127.0.0.1` when Guard needs to pause a launch cleanly
+3. terminal resolution through `hol-guard approvals` when you do not want a browser surface
+
+Current strategy:
+
+- `claude-code`
+  prefers Claude hooks and can hand blocked work to the approval center cleanly
+- `codex`
+  uses the Guard approval center today; App Server is the long-term richer in-client path
+- `cursor`
+  keeps Cursor’s native tool approval and lets Guard own artifact trust before tool use
+- `opencode`
+  keeps OpenCode’s permission model and lets Guard manage package and provenance policy
+- `gemini`
+  scans extension manifests and routes blocked changes to the approval center
 
 ## First-party canaries
 

--- a/docs/guard/harness-support.md
+++ b/docs/guard/harness-support.md
@@ -6,17 +6,28 @@ Current Guard support in this repo:
   - detects global and project `config.toml`
   - parses configured MCP servers
   - supports wrapper-mode `guard run codex`
+  - uses the local approval center for blocked artifact changes today
 - `claude-code`
   - detects global and project settings, hooks, `.mcp.json`, and workspace agents
   - supports local hook install and uninstall in `.claude/settings.local.json`
+  - is the best current harness for graceful approval deferral
 - `cursor`
   - detects global and project `mcp.json`
   - supports wrapper-mode management state
+  - leaves native Cursor tool approval in place and focuses Guard on artifact trust
 - `gemini`
   - detects local extension manifests and embedded MCP server declarations
   - supports wrapper-mode management state
+  - falls back to the local approval center when Guard blocks a launch
 - `opencode`
   - detects global and project config plus workspace commands
   - supports wrapper-mode management state
+  - respects OpenCode permission rules and uses Guard for package-level policy
+
+Approval tiers:
+
+1. native harness approval when the harness already has strong permission controls
+2. local Guard approval center on `127.0.0.1`
+3. terminal approval resolution through `hol-guard approvals`
 
 The harness adapters are designed to prefer discovery and reversible overlay behavior over invasive config mutation.

--- a/src/codex_plugin_scanner/guard/adapters/base.py
+++ b/src/codex_plugin_scanner/guard/adapters/base.py
@@ -73,6 +73,9 @@ class HarnessAdapter:
 
     harness = ""
     executable = ""
+    approval_tier = "approval-center"
+    approval_summary = "Guard pauses the launch and routes approval through the local approval center."
+    fallback_hint = "Use `hol-guard approvals` if you want to resolve it from the terminal."
 
     def detect(self, context: HarnessContext) -> HarnessDetection:
         raise NotImplementedError
@@ -117,6 +120,13 @@ class HarnessAdapter:
         if runtime_probe is not None and runtime_probe.get("timed_out") is True:
             warnings.append(f"{self.executable} diagnostics timed out before Guard could confirm runtime state.")
         return warnings
+
+    def approval_flow(self) -> dict[str, str]:
+        return {
+            "tier": self.approval_tier,
+            "summary": self.approval_summary,
+            "fallback_hint": self.fallback_hint,
+        }
 
     def diagnostics(self, context: HarnessContext) -> dict[str, object]:
         detection = self.detect(context)

--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -29,6 +29,11 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
 
     harness = "claude-code"
     executable = "claude"
+    approval_tier = "native-or-center"
+    approval_summary = (
+        "Guard uses Claude hooks first and falls back to the local approval center when the shell cannot prompt."
+    )
+    fallback_hint = "Claude is the best current harness for deferred Guard approvals."
 
     @staticmethod
     def _scope_for(context: HarnessContext, path: Path) -> str:

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -29,6 +29,9 @@ class CodexHarnessAdapter(HarnessAdapter):
 
     harness = "codex"
     executable = "codex"
+    approval_tier = "approval-center"
+    approval_summary = "Guard owns artifact approval today and can hand blocked changes to the local approval center."
+    fallback_hint = "For richer in-client approvals later, move the session onto Codex App Server."
 
     @staticmethod
     def _scope_for(context: HarnessContext, path: Path) -> str:

--- a/src/codex_plugin_scanner/guard/adapters/cursor.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor.py
@@ -11,6 +11,11 @@ class CursorHarnessAdapter(HarnessAdapter):
 
     harness = "cursor"
     executable = "cursor-agent"
+    approval_tier = "native-harness"
+    approval_summary = (
+        "Cursor already owns tool approval, so Guard focuses on artifact trust, provenance, and preflight review."
+    )
+    fallback_hint = "Resolve package-level trust in Guard and let Cursor keep its built-in tool approval flow."
 
     @staticmethod
     def _scope_for(context: HarnessContext, path) -> str:

--- a/src/codex_plugin_scanner/guard/adapters/gemini.py
+++ b/src/codex_plugin_scanner/guard/adapters/gemini.py
@@ -11,6 +11,11 @@ class GeminiHarnessAdapter(HarnessAdapter):
 
     harness = "gemini"
     executable = "gemini"
+    approval_tier = "approval-center"
+    approval_summary = (
+        "Guard scans Gemini extensions before launch and sends blocked changes to the local approval center."
+    )
+    fallback_hint = "Gemini gets preflight approval through Guard until it exposes a richer native approval surface."
 
     @staticmethod
     def _scope_for(context: HarnessContext, path) -> str:

--- a/src/codex_plugin_scanner/guard/adapters/opencode.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode.py
@@ -12,6 +12,11 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
 
     harness = "opencode"
     executable = "opencode"
+    approval_tier = "native-harness"
+    approval_summary = (
+        "OpenCode already has tool permissions, so Guard authors policy and provenance rules before launch."
+    )
+    fallback_hint = "Use Guard for artifact-level trust and keep OpenCode's native allow or deny model intact."
 
     @staticmethod
     def _scope_for(context: HarnessContext, path) -> str:

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -1,0 +1,146 @@
+"""Approval queue orchestration for local Guard reviews."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .adapters import get_adapter
+from .adapters.base import HarnessContext
+from .models import GuardApprovalRequest, HarnessDetection, PolicyDecision
+from .store import GuardStore
+
+GUARD_COMMAND = "hol-guard"
+
+
+def queue_blocked_approvals(
+    *,
+    detection: HarnessDetection,
+    evaluation: dict[str, object],
+    store: GuardStore,
+    approval_center_url: str,
+    now: str | None = None,
+) -> list[dict[str, object]]:
+    timestamp = now or _now()
+    artifacts_by_id = {artifact.artifact_id: artifact for artifact in detection.artifacts}
+    queued: list[dict[str, object]] = []
+    for item in evaluation.get("artifacts", []):
+        if not isinstance(item, dict):
+            continue
+        policy_action = item.get("policy_action")
+        if policy_action not in {"block", "sandbox-required", "require-reapproval"}:
+            continue
+        artifact_id = str(item.get("artifact_id") or "")
+        if not artifact_id:
+            continue
+        artifact = artifacts_by_id.get(artifact_id)
+        request_id = uuid.uuid4().hex
+        request = GuardApprovalRequest(
+            request_id=request_id,
+            harness=detection.harness,
+            artifact_id=artifact_id,
+            artifact_name=_artifact_name(item, artifact_id),
+            artifact_hash=str(item.get("artifact_hash") or "unknown"),
+            policy_action=str(policy_action),
+            recommended_scope="publisher" if artifact is not None and artifact.publisher else "artifact",
+            changed_fields=tuple(_string_list(item.get("changed_fields"))),
+            source_scope=_source_scope(item, artifact),
+            config_path=_config_path(item, artifact),
+            review_command=f"{GUARD_COMMAND} approvals approve {request_id}",
+            approval_url=f"{approval_center_url.rstrip('/')}/approvals/{request_id}",
+            publisher=artifact.publisher if artifact is not None else None,
+        )
+        store.add_approval_request(request, timestamp)
+        queued.append(request.to_dict())
+    return queued
+
+
+def apply_approval_resolution(
+    *,
+    store: GuardStore,
+    request_id: str,
+    action: str,
+    scope: str,
+    workspace: str | None,
+    reason: str | None,
+    now: str | None = None,
+) -> dict[str, object]:
+    request = store.get_approval_request(request_id)
+    if request is None:
+        raise ValueError(f"Unknown approval request: {request_id}")
+    if request["status"] != "pending":
+        raise ValueError(f"Approval request already resolved: {request_id}")
+    if scope == "publisher" and not isinstance(request.get("publisher"), str):
+        raise ValueError(f"Approval request {request_id} has no publisher scope to approve.")
+    decision = PolicyDecision(
+        harness=str(request["harness"]),
+        scope=scope,
+        action="allow" if action == "allow" else "block",
+        artifact_id=str(request["artifact_id"]) if scope == "artifact" else None,
+        workspace=workspace if scope == "workspace" else None,
+        publisher=str(request["publisher"]) if scope == "publisher" else None,
+        reason=reason,
+    )
+    store.upsert_policy(decision, now or _now())
+    store.resolve_approval_request(
+        request_id,
+        resolution_action=action,
+        resolution_scope=scope,
+        reason=reason,
+        resolved_at=now or _now(),
+    )
+    updated = store.get_approval_request(request_id)
+    if updated is None:
+        raise ValueError(f"Approval request disappeared: {request_id}")
+    return updated
+
+
+def approval_center_hint(
+    *,
+    context: HarnessContext,
+    harness: str,
+    approval_center_url: str,
+    queued: list[dict[str, object]],
+) -> str:
+    adapter = get_adapter(harness)
+    flow = adapter.approval_flow()
+    count = len(queued)
+    return (
+        f"Guard queued {count} approval request{'s' if count != 1 else ''} for {harness}. "
+        f"Open {approval_center_url} to review them. "
+        f"{flow['fallback_hint']}"
+    )
+
+
+def _artifact_name(item: dict[str, object], artifact_id: str) -> str:
+    name = item.get("artifact_name")
+    return str(name) if isinstance(name, str) and name else artifact_id
+
+
+def _config_path(item: dict[str, object], artifact) -> str:
+    if artifact is not None:
+        return artifact.config_path
+    value = item.get("config_path")
+    if isinstance(value, str) and value:
+        return value
+    return str(Path.cwd())
+
+
+def _source_scope(item: dict[str, object], artifact) -> str:
+    if artifact is not None:
+        return artifact.source_scope
+    value = item.get("source_scope")
+    if isinstance(value, str) and value:
+        return value
+    return "project"
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if isinstance(item, str)]
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -71,6 +71,8 @@ def apply_approval_resolution(
         raise ValueError(f"Unknown approval request: {request_id}")
     if request["status"] != "pending":
         raise ValueError(f"Approval request already resolved: {request_id}")
+    if scope == "workspace" and not workspace:
+        raise ValueError(f"Approval request {request_id} requires --workspace for workspace scope.")
     if scope == "publisher" and not isinstance(request.get("publisher"), str):
         raise ValueError(f"Approval request {request_id} has no publisher scope to approve.")
     decision = PolicyDecision(

--- a/src/codex_plugin_scanner/guard/cli/approval_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/approval_commands.py
@@ -1,0 +1,63 @@
+"""CLI helpers for Guard approval queue workflows."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ..approvals import apply_approval_resolution
+from ..daemon import load_guard_daemon_url
+from ..store import GuardStore
+
+
+def add_approval_parser(
+    guard_subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+    add_common_args,
+) -> None:
+    approvals_parser = guard_subparsers.add_parser("approvals", help="List or resolve pending Guard approvals")
+    approvals_subparsers = approvals_parser.add_subparsers(dest="approvals_command")
+
+    add_common_args(approvals_parser)
+    approvals_parser.add_argument("--json", action="store_true")
+
+    for name, action in (("approve", "allow"), ("deny", "block")):
+        decision_parser = approvals_subparsers.add_parser(name, help=f"{name.title()} a pending approval request")
+        decision_parser.add_argument("request_id")
+        decision_parser.add_argument(
+            "--scope",
+            choices=("artifact", "publisher", "workspace", "harness", "global"),
+            default="artifact",
+        )
+        decision_parser.add_argument("--reason")
+        add_common_args(decision_parser)
+        decision_parser.add_argument("--json", action="store_true")
+        decision_parser.set_defaults(approval_action=action)
+
+
+def run_approval_command(
+    args: argparse.Namespace,
+    *,
+    store: GuardStore,
+    workspace: Path | None,
+) -> dict[str, object]:
+    if getattr(args, "approvals_command", None) is None:
+        return {
+            "generated_at": _now(),
+            "approval_center_url": load_guard_daemon_url(store.guard_home),
+            "items": store.list_approval_requests(limit=200),
+        }
+    item = apply_approval_resolution(
+        store=store,
+        request_id=args.request_id,
+        action=args.approval_action,
+        scope=args.scope,
+        workspace=str(workspace) if workspace is not None else None,
+        reason=args.reason,
+        now=_now(),
+    )
+    return {"resolved": True, "item": item}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -10,12 +10,15 @@ from pathlib import Path
 
 from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
+from ..approvals import approval_center_hint, queue_blocked_approvals
 from ..config import load_guard_config, resolve_guard_home
 from ..consumer import detect_all, detect_harness, evaluate_detection, record_policy, run_consumer_scan
+from ..daemon import GuardDaemonServer, ensure_guard_daemon
 from ..policy.engine import SAFE_CHANGED_HASH_ACTION, VALID_GUARD_ACTIONS
 from ..receipts import build_receipt
 from ..runtime import guard_run, sync_receipts
 from ..store import GuardStore
+from .approval_commands import add_approval_parser, run_approval_command
 from .product import build_guard_start_payload, build_guard_status_payload
 from .prompt import build_prompt_artifacts, resolve_interactive_decisions
 from .render import emit_guard_payload
@@ -61,7 +64,10 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     guard_subparsers = guard_parser.add_subparsers(
         dest="guard_command",
         required=True,
-        metavar="{start,status,detect,install,uninstall,run,scan,diff,receipts,explain,allow,deny,doctor,login,sync}",
+        metavar=(
+            "{start,status,detect,install,uninstall,run,scan,diff,receipts,approvals,explain,"
+            "allow,deny,doctor,login,sync}"
+        ),
     )
 
     start_parser = guard_subparsers.add_parser("start", help="Show the first Guard steps for a local harness")
@@ -112,6 +118,8 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     _add_guard_common_args(receipts_parser)
     receipts_parser.add_argument("--json", action="store_true")
 
+    add_approval_parser(guard_subparsers, _add_guard_common_args)
+
     explain_parser = guard_subparsers.add_parser("explain", help="Show the latest evidence for a local artifact")
     explain_parser.add_argument("target")
     explain_parser.add_argument("--json", action="store_true")
@@ -159,8 +167,13 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     )
     hook_parser.add_argument("--event-file")
     hook_parser.add_argument("--json", action="store_true")
+
+    daemon_parser = guard_subparsers.add_parser("daemon", help=argparse.SUPPRESS)
+    _add_guard_common_args(daemon_parser)
+    daemon_parser.add_argument("--serve", action="store_true")
+    daemon_parser.add_argument("--json", action="store_true")
     guard_subparsers._choices_actions = [
-        action for action in guard_subparsers._choices_actions if action.dest != "hook"
+        action for action in guard_subparsers._choices_actions if action.dest not in {"hook", "daemon"}
     ]
 
 
@@ -228,6 +241,7 @@ def run_guard_command(args: argparse.Namespace) -> int:
 
     if args.guard_command == "run":
         interactive_resolver = None
+        blocked_resolver = None
         if (
             not getattr(args, "json", False)
             and not bool(args.dry_run)
@@ -247,6 +261,8 @@ def run_guard_command(args: argparse.Namespace) -> int:
                     workspace=str(workspace) if workspace else None,
                     now=_now(),
                 )
+        elif not bool(args.dry_run) and config.mode == "prompt":
+            blocked_resolver = _headless_approval_resolver(args=args, context=context, store=store)
 
         payload = guard_run(
             args.harness,
@@ -257,17 +273,8 @@ def run_guard_command(args: argparse.Namespace) -> int:
             passthrough_args=list(args.passthrough_args),
             default_action=args.default_action,
             interactive_resolver=interactive_resolver,
+            blocked_resolver=blocked_resolver,
         )
-        if (
-            payload.get("blocked")
-            and config.mode == "prompt"
-            and not getattr(args, "json", False)
-            and not sys.stdin.isatty()
-        ):
-            payload["review_hint"] = (
-                f"Guard blocked {args.harness} because this shell is non-interactive. "
-                f"Run `hol-guard diff {args.harness}` and allow or deny the changed artifacts first."
-            )
         _emit("run", payload, getattr(args, "json", False))
         if payload.get("blocked"):
             return 1
@@ -285,6 +292,11 @@ def run_guard_command(args: argparse.Namespace) -> int:
 
     if args.guard_command == "receipts":
         _emit("receipts", {"generated_at": _now(), "items": store.list_receipts()}, getattr(args, "json", False))
+        return 0
+
+    if args.guard_command == "approvals":
+        payload = run_approval_command(args, store=store, workspace=workspace)
+        _emit("approvals", payload, getattr(args, "json", False))
         return 0
 
     if args.guard_command == "explain":
@@ -327,6 +339,14 @@ def run_guard_command(args: argparse.Namespace) -> int:
     if args.guard_command == "sync":
         payload = sync_receipts(store)
         _emit("sync", payload, getattr(args, "json", False))
+        return 0
+
+    if args.guard_command == "daemon":
+        daemon = GuardDaemonServer(store)
+        if args.serve:
+            daemon.serve()
+            return 0
+        _emit("doctor", {"daemon_url": f"http://127.0.0.1:{daemon.port}"}, getattr(args, "json", False))
         return 0
 
     if args.guard_command == "hook":
@@ -389,6 +409,34 @@ def run_guard_command(args: argparse.Namespace) -> int:
 
 def _emit(command: str, payload: dict[str, object], as_json: bool) -> None:
     emit_guard_payload(command, payload, as_json)
+
+
+def _headless_approval_resolver(
+    *,
+    args: argparse.Namespace,
+    context: HarnessContext,
+    store: GuardStore,
+):
+    def resolve(detection, payload):
+        approval_center_url = ensure_guard_daemon(context.guard_home)
+        queued = queue_blocked_approvals(
+            detection=detection,
+            evaluation=payload,
+            store=store,
+            approval_center_url=approval_center_url,
+            now=_now(),
+        )
+        payload["approval_requests"] = queued
+        payload["approval_center_url"] = approval_center_url
+        payload["review_hint"] = approval_center_hint(
+            context=context,
+            harness=args.harness,
+            approval_center_url=approval_center_url,
+            queued=queued,
+        )
+        return payload
+
+    return resolve
 
 
 def _load_hook_payload(event_file: str | None) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/cli/product.py
+++ b/src/codex_plugin_scanner/guard/cli/product.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
 from ..config import GuardConfig
 from ..consumer import detect_all, evaluate_detection
+from ..daemon import load_guard_daemon_url
 from ..models import HarnessDetection
 from ..store import GuardStore
 
@@ -52,6 +54,8 @@ def _build_guard_product_payload(
         "workspace": str(context.workspace_dir) if context.workspace_dir is not None else None,
         "sync_configured": store.get_sync_credentials() is not None,
         "receipt_count": receipt_count,
+        "pending_approvals": store.count_approval_requests(),
+        "approval_center_url": load_guard_daemon_url(context.guard_home),
         "managed_harnesses": managed_harnesses,
         "recommended_harness": recommended["harness"] if recommended is not None else None,
         "harnesses": harnesses,
@@ -67,6 +71,7 @@ def _summarize_harness(
     config: GuardConfig,
 ) -> dict[str, object]:
     evaluation = evaluate_detection(detection, store, config, default_action="allow", persist=False)
+    approval_flow = get_adapter(detection.harness).approval_flow()
     managed_install = store.get_managed_install(detection.harness)
     review_count = sum(1 for artifact in evaluation["artifacts"] if bool(artifact["changed"]))
     managed = bool(managed_install and managed_install.get("active"))
@@ -91,6 +96,7 @@ def _summarize_harness(
         "run_command": f"{GUARD_COMMAND} run {detection.harness} --dry-run",
         "review_command": f"{GUARD_COMMAND} diff {detection.harness}",
         "receipts_command": f"{GUARD_COMMAND} receipts",
+        "approval_flow": approval_flow,
     }
 
 
@@ -131,6 +137,7 @@ def _build_next_steps(recommended: dict[str, object] | None) -> list[dict[str, s
             }
         ]
     steps = [_install_or_review_step(recommended), _run_step(recommended), _receipts_step()]
+    steps.append(_approvals_step())
     steps.append(
         {
             "title": "Optional sync later",
@@ -180,6 +187,14 @@ def _receipts_step() -> dict[str, str]:
         "title": "Inspect receipts",
         "command": f"{GUARD_COMMAND} receipts",
         "detail": "See what Guard approved, blocked, or flagged after local runs.",
+    }
+
+
+def _approvals_step() -> dict[str, str]:
+    return {
+        "title": "Resolve queued approvals",
+        "command": f"{GUARD_COMMAND} approvals",
+        "detail": "Use the local approval center or the approvals queue when a harness session cannot prompt inline.",
     }
 
 

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -54,11 +54,14 @@ def _render_start(console: Console, payload: dict[str, object]) -> None:
     console.print(
         Panel.fit(
             f"[bold]HOL Guard first run[/bold]\n"
-            f"{len(harnesses)} harnesses detected • {payload.get('receipt_count', 0)} receipts recorded",
+            f"{len(harnesses)} harnesses detected • {payload.get('receipt_count', 0)} receipts recorded • "
+            f"{payload.get('pending_approvals', 0)} approvals waiting",
             border_style="cyan",
         )
     )
     console.print(_build_product_table(harnesses))
+    if payload.get("approval_center_url"):
+        console.print(f"Approval center: [bold]{payload.get('approval_center_url')}[/bold]")
     console.print(_build_steps_panel(_coerce_dict_list(payload.get("next_steps"))))
 
 
@@ -69,11 +72,14 @@ def _render_status(console: Console, payload: dict[str, object]) -> None:
             f"[bold]HOL Guard status[/bold]\n"
             f"{payload.get('managed_harnesses', 0)} managed harnesses • "
             f"{payload.get('receipt_count', 0)} receipts • "
+            f"{payload.get('pending_approvals', 0)} approvals • "
             f"sync {'connected' if payload.get('sync_configured') else 'local only'}",
             border_style="cyan",
         )
     )
     console.print(_build_product_table(harnesses))
+    if payload.get("approval_center_url"):
+        console.print(f"Approval center: [bold]{payload.get('approval_center_url')}[/bold]")
     review_items = [item for item in harnesses if int(item.get("review_count", 0)) > 0]
     if review_items:
         console.print(
@@ -135,12 +141,17 @@ def _render_run(console: Console, payload: dict[str, object]) -> None:
     body.add_row("Harness", f"[bold]{payload.get('harness', 'unknown')}[/bold]")
     body.add_row("Receipts", str(payload.get("receipts_recorded", 0)))
     body.add_row("Launched", _bool_label(launched))
+    if payload.get("approval_center_url"):
+        body.add_row("Approval center", str(payload.get("approval_center_url")))
     if payload.get("review_hint"):
         body.add_row("Review", str(payload.get("review_hint")))
     if launched:
         body.add_row("Command", _command_text(payload.get("launch_command")))
     console.print(Panel(body, title=title, border_style=border_style))
     console.print(_build_artifact_result_table(_coerce_dict_list(payload.get("artifacts"))))
+    approval_requests = _coerce_dict_list(payload.get("approval_requests"))
+    if approval_requests:
+        console.print(_build_approval_table(approval_requests, title="Queued approvals"))
 
 
 def _render_diff(console: Console, payload: dict[str, object]) -> None:
@@ -184,6 +195,29 @@ def _render_receipts(console: Console, payload: dict[str, object]) -> None:
             ", ".join(_coerce_string_list(receipt.get("changed_capabilities"))) or "none",
         )
     console.print(table)
+
+
+def _render_approvals(console: Console, payload: dict[str, object]) -> None:
+    if payload.get("resolved"):
+        item = payload.get("item")
+        if isinstance(item, dict):
+            body = Table.grid(padding=(0, 1))
+            body.add_row("Artifact", str(item.get("artifact_name") or item.get("artifact_id") or "unknown"))
+            body.add_row("Harness", str(item.get("harness") or "unknown"))
+            body.add_row("Action", _action_text(str(item.get("resolution_action") or "warn")))
+            body.add_row("Scope", str(item.get("resolution_scope") or "artifact"))
+            console.print(Panel(body, title="Approval resolved", border_style="green"))
+            return
+    items = _coerce_dict_list(payload.get("items"))
+    console.print(
+        Panel.fit(
+            f"[bold]Pending Guard approvals[/bold]\n{len(items)} item{'s' if len(items) != 1 else ''} waiting",
+            border_style="yellow" if items else "green",
+        )
+    )
+    if payload.get("approval_center_url"):
+        console.print(f"Approval center: [bold]{payload.get('approval_center_url')}[/bold]")
+    console.print(_build_approval_table(items, title=None))
 
 
 def _render_managed_install(console: Console, payload: dict[str, object]) -> None:
@@ -380,6 +414,29 @@ def _build_artifact_result_table(artifacts: list[dict[str, object]]) -> Table:
     return table
 
 
+def _build_approval_table(items: list[dict[str, object]], *, title: str | None) -> Table:
+    table = Table(title=title, box=box.SIMPLE_HEAVY, show_header=True)
+    table.add_column("Request", style="dim", no_wrap=True)
+    table.add_column("Harness", style="cyan")
+    table.add_column("Artifact", style="bold")
+    table.add_column("Changed", style="magenta")
+    table.add_column("Recommendation")
+    table.add_column("Resolve", style="blue")
+    if not items:
+        table.add_row("—", "—", "No pending approvals", "—", "—", "—")
+        return table
+    for item in items:
+        table.add_row(
+            str(item.get("request_id") or "unknown"),
+            str(item.get("harness") or "unknown"),
+            str(item.get("artifact_name") or item.get("artifact_id") or "unknown"),
+            ", ".join(_coerce_string_list(item.get("changed_fields"))) or "none",
+            _action_text(str(item.get("policy_action") or "warn")),
+            str(item.get("review_command") or "hol-guard approvals"),
+        )
+    return table
+
+
 def _build_runtime_probe_panel(runtime_probe: dict[str, object]) -> Panel:
     body = Table.grid(padding=(0, 1))
     body.add_row("Command", _command_text(runtime_probe.get("command")))
@@ -486,6 +543,7 @@ def _clean_terminal_output(value: str) -> str:
 
 
 _RENDERERS: dict[str, Any] = {
+    "approvals": _render_approvals,
     "start": _render_start,
     "status": _render_status,
     "detect": _render_detect,

--- a/src/codex_plugin_scanner/guard/daemon/__init__.py
+++ b/src/codex_plugin_scanner/guard/daemon/__init__.py
@@ -1,5 +1,6 @@
 """Guard daemon helpers."""
 
+from .manager import ensure_guard_daemon, load_guard_daemon_url
 from .server import GuardDaemonServer
 
-__all__ = ["GuardDaemonServer"]
+__all__ = ["GuardDaemonServer", "ensure_guard_daemon", "load_guard_daemon_url"]

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -1,0 +1,88 @@
+"""Guard daemon lifecycle helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+def ensure_guard_daemon(guard_home: Path) -> str:
+    state_path = _state_path(guard_home)
+    existing_url = load_guard_daemon_url(guard_home)
+    if existing_url is not None:
+        return existing_url
+    command = [
+        sys.executable,
+        "-m",
+        "codex_plugin_scanner.cli",
+        "guard",
+        "daemon",
+        "--serve",
+        "--guard-home",
+        str(guard_home),
+    ]
+    kwargs: dict[str, object] = {
+        "stdin": subprocess.DEVNULL,
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+    }
+    if os.name == "nt":
+        kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS
+    else:
+        kwargs["start_new_session"] = True
+    subprocess.Popen(command, **kwargs)
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        url = load_guard_daemon_url(guard_home)
+        if url is not None:
+            return url
+        time.sleep(0.1)
+    raise RuntimeError(f"Guard approval center did not start. Expected state file at {state_path}.")
+
+
+def load_guard_daemon_url(guard_home: Path) -> str | None:
+    payload = _load_state(guard_home)
+    if payload is None:
+        return None
+    port = payload.get("port")
+    if not isinstance(port, int):
+        return None
+    url = f"http://127.0.0.1:{port}"
+    try:
+        with urllib.request.urlopen(f"{url}/healthz", timeout=1) as response:
+            if response.status == 200:
+                return url
+    except (OSError, urllib.error.URLError):
+        return None
+    return None
+
+
+def write_guard_daemon_state(guard_home: Path, port: int) -> None:
+    state_path = _state_path(guard_home)
+    state_path.write_text(json.dumps({"port": port}, indent=2), encoding="utf-8")
+
+
+def clear_guard_daemon_state(guard_home: Path) -> None:
+    state_path = _state_path(guard_home)
+    state_path.write_text("{}", encoding="utf-8")
+
+
+def _load_state(guard_home: Path) -> dict[str, object] | None:
+    state_path = _state_path(guard_home)
+    if not state_path.is_file():
+        return None
+    try:
+        payload = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _state_path(guard_home: Path) -> Path:
+    return guard_home / "daemon-state.json"

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -6,8 +6,11 @@ import json
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
+from urllib.parse import parse_qs, urlparse
 
+from ..approvals import apply_approval_resolution
 from ..store import GuardStore
+from .manager import clear_guard_daemon_state, write_guard_daemon_state
 
 
 class _GuardDaemonHttpServer(ThreadingHTTPServer):
@@ -17,35 +20,98 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
 class _GuardDaemonHandler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:
         store = self.server.store  # type: ignore[attr-defined]
-        if self.path == "/healthz":
+        parsed = urlparse(self.path)
+        if parsed.path == "/":
+            self._write_html(_build_approval_center_html(store.list_approval_requests(limit=200)))
+            return
+        if parsed.path == "/healthz":
             self._write_json(
                 {
                     "ok": True,
                     "receipts": len(store.list_receipts(limit=500)),
+                    "approvals": store.count_approval_requests(),
                     "tables": store.list_table_names(),
                 }
             )
             return
-        if self.path == "/receipts":
+        if parsed.path == "/receipts":
             self._write_json({"items": store.list_receipts(limit=200)})
+            return
+        if parsed.path == "/approvals":
+            self._write_json({"items": store.list_approval_requests(limit=200)})
+            return
+        if parsed.path.startswith("/approvals/"):
+            request_id = parsed.path.removeprefix("/approvals/")
+            approval = store.get_approval_request(request_id)
+            if approval is None:
+                self._write_json({"error": "not_found"}, status=404)
+                return
+            self._write_json(approval)
             return
         self.send_response(404)
         self.end_headers()
 
+    def do_POST(self) -> None:
+        parsed = urlparse(self.path)
+        if not parsed.path.endswith("/decision") or not parsed.path.startswith("/approvals/"):
+            self.send_response(404)
+            self.end_headers()
+            return
+        request_id = parsed.path.removeprefix("/approvals/").removesuffix("/decision")
+        payload = self._load_request_body()
+        action = str(payload.get("action") or "allow")
+        scope = str(payload.get("scope") or "artifact")
+        reason = payload.get("reason")
+        if not isinstance(reason, str):
+            reason = None
+        try:
+            updated = apply_approval_resolution(
+                store=self.server.store,  # type: ignore[attr-defined]
+                request_id=request_id,
+                action=action,
+                scope=scope,
+                workspace=None,
+                reason=reason,
+            )
+        except ValueError as error:
+            self._write_json({"resolved": False, "error": str(error)}, status=400)
+            return
+        self._write_json({"resolved": True, "item": updated})
+
     def log_message(self, fmt: str, *args: Any) -> None:
         return
 
-    def _write_json(self, payload: dict[str, Any]) -> None:
+    def _load_request_body(self) -> dict[str, object]:
+        length = int(self.headers.get("Content-Length", "0"))
+        if length <= 0:
+            return {}
+        raw_body = self.rfile.read(length).decode("utf-8")
+        content_type = self.headers.get("Content-Type", "")
+        if "application/json" in content_type:
+            payload = json.loads(raw_body)
+            return payload if isinstance(payload, dict) else {}
+        form_payload = parse_qs(raw_body)
+        return {key: values[-1] for key, values in form_payload.items() if values}
+
+    def _write_json(self, payload: dict[str, Any], *, status: int = 200) -> None:
         body = json.dumps(payload).encode("utf-8")
-        self.send_response(200)
+        self.send_response(status)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
 
+    def _write_html(self, body: str) -> None:
+        encoded = body.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
 
 class GuardDaemonServer:
-    """Small local daemon for health and receipt introspection."""
+    """Small local daemon for health, receipts, and approval-center introspection."""
 
     def __init__(self, store: GuardStore, host: str = "127.0.0.1", port: int = 0) -> None:
         self._server = _GuardDaemonHttpServer((host, port), _GuardDaemonHandler)
@@ -56,12 +122,58 @@ class GuardDaemonServer:
     def start(self) -> None:
         if self._thread is not None:
             return
+        write_guard_daemon_state(self._server.store.guard_home, self.port)
         self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
         self._thread.start()
+
+    def serve(self) -> None:
+        write_guard_daemon_state(self._server.store.guard_home, self.port)
+        try:
+            self._server.serve_forever()
+        finally:
+            clear_guard_daemon_state(self._server.store.guard_home)
 
     def stop(self) -> None:
         self._server.shutdown()
         self._server.server_close()
+        clear_guard_daemon_state(self._server.store.guard_home)
         if self._thread is not None:
             self._thread.join(timeout=5)
             self._thread = None
+
+
+def _build_approval_center_html(items: list[dict[str, object]]) -> str:
+    rows = []
+    for item in items:
+        request_id = str(item.get("request_id") or "unknown")
+        changed_fields = (
+            ", ".join(str(value) for value in item.get("changed_fields", []) if isinstance(value, str)) or "none"
+        )
+        rows.append(
+            "\n".join(
+                [
+                    "<article style='border:1px solid #d9d9d9;border-radius:16px;padding:16px;margin:16px 0;'>",
+                    f"<h2 style='margin:0 0 8px 0'>{item.get('artifact_name') or item.get('artifact_id')}</h2>",
+                    f"<p><strong>Harness:</strong> {item.get('harness')}</p>",
+                    f"<p><strong>Changed fields:</strong> {changed_fields}</p>",
+                    f"<p><strong>Recommendation:</strong> {item.get('policy_action')}</p>",
+                    "<form method='post' action='/approvals/"
+                    f"{request_id}/decision' style='display:flex;gap:8px;flex-wrap:wrap;'>",
+                    "<input type='hidden' name='scope' value='artifact'>",
+                    "<input type='hidden' name='reason' value='approved in local approval center'>",
+                    "<button name='action' value='allow'>Allow artifact</button>",
+                    "<button name='action' value='block'>Keep blocked</button>",
+                    "</form>",
+                    "</article>",
+                ]
+            )
+        )
+    body = "\n".join(rows) or "<p>No pending approvals.</p>"
+    return (
+        "<!doctype html><html><head><meta charset='utf-8'><title>HOL Guard approval center</title></head>"
+        "<body style='font-family:ui-sans-serif,system-ui;padding:24px;max-width:900px;margin:0 auto;'>"
+        "<h1>HOL Guard approval center</h1>"
+        "<p>Approve blocked harness changes without losing the current session.</p>"
+        f"{body}"
+        "</body></html>"
+    )

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import html
 import json
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -59,8 +60,11 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         request_id = parsed.path.removeprefix("/approvals/").removesuffix("/decision")
         payload = self._load_request_body()
-        action = str(payload.get("action") or "allow")
-        scope = str(payload.get("scope") or "artifact")
+        action = payload.get("action")
+        scope = payload.get("scope")
+        if not isinstance(action, str) or not action.strip() or not isinstance(scope, str) or not scope.strip():
+            self._write_json({"resolved": False, "error": "missing_required_fields"}, status=400)
+            return
         reason = payload.get("reason")
         if not isinstance(reason, str):
             reason = None
@@ -68,8 +72,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             updated = apply_approval_resolution(
                 store=self.server.store,  # type: ignore[attr-defined]
                 request_id=request_id,
-                action=action,
-                scope=scope,
+                action=action.strip(),
+                scope=scope.strip(),
                 workspace=None,
                 reason=reason,
             )
@@ -88,7 +92,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         raw_body = self.rfile.read(length).decode("utf-8")
         content_type = self.headers.get("Content-Type", "")
         if "application/json" in content_type:
-            payload = json.loads(raw_body)
+            try:
+                payload = json.loads(raw_body)
+            except json.JSONDecodeError:
+                return {}
             return payload if isinstance(payload, dict) else {}
         form_payload = parse_qs(raw_body)
         return {key: values[-1] for key, values in form_payload.items() if values}
@@ -145,18 +152,21 @@ class GuardDaemonServer:
 def _build_approval_center_html(items: list[dict[str, object]]) -> str:
     rows = []
     for item in items:
-        request_id = str(item.get("request_id") or "unknown")
-        changed_fields = (
+        request_id = html.escape(str(item.get("request_id") or "unknown"), quote=True)
+        changed_fields = html.escape(
             ", ".join(str(value) for value in item.get("changed_fields", []) if isinstance(value, str)) or "none"
         )
+        artifact_label = html.escape(str(item.get("artifact_name") or item.get("artifact_id") or "unknown"))
+        harness_label = html.escape(str(item.get("harness") or "unknown"))
+        recommendation_label = html.escape(str(item.get("policy_action") or "warn"))
         rows.append(
             "\n".join(
                 [
                     "<article style='border:1px solid #d9d9d9;border-radius:16px;padding:16px;margin:16px 0;'>",
-                    f"<h2 style='margin:0 0 8px 0'>{item.get('artifact_name') or item.get('artifact_id')}</h2>",
-                    f"<p><strong>Harness:</strong> {item.get('harness')}</p>",
+                    f"<h2 style='margin:0 0 8px 0'>{artifact_label}</h2>",
+                    f"<p><strong>Harness:</strong> {harness_label}</p>",
                     f"<p><strong>Changed fields:</strong> {changed_fields}</p>",
-                    f"<p><strong>Recommendation:</strong> {item.get('policy_action')}</p>",
+                    f"<p><strong>Recommendation:</strong> {recommendation_label}</p>",
                     "<form method='post' action='/approvals/"
                     f"{request_id}/decision' style='display:flex;gap:8px;flex-wrap:wrap;'>",
                     "<input type='hidden' name='scope' value='artifact'>",

--- a/src/codex_plugin_scanner/guard/models.py
+++ b/src/codex_plugin_scanner/guard/models.py
@@ -120,3 +120,27 @@ class GuardReceipt:
         payload = asdict(self)
         payload["changed_capabilities"] = list(self.changed_capabilities)
         return payload
+
+
+@dataclass(frozen=True, slots=True)
+class GuardApprovalRequest:
+    """Pending approval request surfaced through the local approval center."""
+
+    request_id: str
+    harness: str
+    artifact_id: str
+    artifact_name: str
+    artifact_hash: str
+    policy_action: GuardAction
+    recommended_scope: DecisionScope
+    changed_fields: tuple[str, ...]
+    source_scope: str
+    config_path: str
+    review_command: str
+    approval_url: str
+    publisher: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        payload = asdict(self)
+        payload["changed_fields"] = list(self.changed_fields)
+        return payload

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -27,6 +27,7 @@ def guard_run(
     passthrough_args: list[str],
     default_action: str | None = None,
     interactive_resolver: Callable[[HarnessDetection, dict[str, Any]], dict[str, Any]] | None = None,
+    blocked_resolver: Callable[[HarnessDetection, dict[str, Any]], dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Evaluate local harness state and optionally launch the harness."""
 
@@ -34,6 +35,8 @@ def guard_run(
     evaluation = evaluate_detection(detection, store, config, default_action=default_action)
     if not dry_run and interactive_resolver is not None and evaluation["blocked"]:
         evaluation = interactive_resolver(detection, evaluation)
+    elif not dry_run and blocked_resolver is not None and evaluation["blocked"]:
+        evaluation = blocked_resolver(detection, evaluation)
     if evaluation["blocked"] or dry_run:
         evaluation["launched"] = False
         evaluation["launch_command"] = []

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -8,7 +8,25 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
-from .models import GuardReceipt, PolicyDecision
+from .models import GuardApprovalRequest, GuardReceipt, PolicyDecision
+from .store_approvals import (
+    add_approval_request as persist_approval_request,
+)
+from .store_approvals import (
+    approval_schema_statement,
+)
+from .store_approvals import (
+    count_approval_requests as count_pending_approval_requests,
+)
+from .store_approvals import (
+    get_approval_request as load_approval_request,
+)
+from .store_approvals import (
+    list_approval_requests as load_approval_requests,
+)
+from .store_approvals import (
+    resolve_approval_request as persist_approval_resolution,
+)
 
 
 class GuardStore:
@@ -122,6 +140,7 @@ class GuardStore:
               updated_at text not null
             )
             """,
+            approval_schema_statement(),
         )
         with self._connect() as connection:
             for statement in statements:
@@ -346,6 +365,47 @@ class GuardStore:
         with self._connect() as connection:
             row = connection.execute("select count(*) as total from runtime_receipts").fetchone()
         return int(row["total"]) if row is not None else 0
+
+    def add_approval_request(self, request: GuardApprovalRequest, now: str) -> None:
+        with self._connect() as connection:
+            persist_approval_request(connection, request, now)
+
+    def list_approval_requests(
+        self,
+        *,
+        status: str | None = "pending",
+        harness: str | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, object]]:
+        with self._connect() as connection:
+            return load_approval_requests(connection, status=status, harness=harness, limit=limit)
+
+    def get_approval_request(self, request_id: str) -> dict[str, object] | None:
+        with self._connect() as connection:
+            return load_approval_request(connection, request_id)
+
+    def resolve_approval_request(
+        self,
+        request_id: str,
+        *,
+        resolution_action: str,
+        resolution_scope: str,
+        reason: str | None,
+        resolved_at: str,
+    ) -> None:
+        with self._connect() as connection:
+            persist_approval_resolution(
+                connection,
+                request_id,
+                resolution_action=resolution_action,
+                resolution_scope=resolution_scope,
+                reason=reason,
+                resolved_at=resolved_at,
+            )
+
+    def count_approval_requests(self, *, status: str | None = "pending") -> int:
+        with self._connect() as connection:
+            return count_pending_approval_requests(connection, status=status)
 
     def set_managed_install(
         self,

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -1,0 +1,175 @@
+"""Approval queue persistence helpers for the local Guard store."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from .models import GuardApprovalRequest
+
+
+def approval_schema_statement() -> str:
+    return """
+        create table if not exists approval_requests (
+          request_id text primary key,
+          harness text not null,
+          artifact_id text not null,
+          artifact_name text not null,
+          artifact_hash text not null,
+          publisher text,
+          policy_action text not null,
+          recommended_scope text not null,
+          changed_fields_json text not null,
+          source_scope text not null,
+          config_path text not null,
+          review_command text not null,
+          approval_url text not null,
+          status text not null,
+          resolution_action text,
+          resolution_scope text,
+          reason text,
+          created_at text not null,
+          resolved_at text
+        )
+        """
+
+
+def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalRequest, now: str) -> None:
+    connection.execute(
+        """
+        delete from approval_requests
+        where harness = ? and artifact_id = ? and status = 'pending'
+        """,
+        (request.harness, request.artifact_id),
+    )
+    connection.execute(
+        """
+        insert into approval_requests (
+          request_id, harness, artifact_id, artifact_name, artifact_hash, publisher, policy_action,
+          recommended_scope, changed_fields_json, source_scope, config_path, review_command,
+          approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
+        )
+        values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', null, null, null, ?, null)
+        """,
+        (
+            request.request_id,
+            request.harness,
+            request.artifact_id,
+            request.artifact_name,
+            request.artifact_hash,
+            request.publisher,
+            request.policy_action,
+            request.recommended_scope,
+            json.dumps(list(request.changed_fields)),
+            request.source_scope,
+            request.config_path,
+            request.review_command,
+            request.approval_url,
+            now,
+        ),
+    )
+
+
+def list_approval_requests(
+    connection: sqlite3.Connection,
+    *,
+    status: str | None = "pending",
+    harness: str | None = None,
+    limit: int = 50,
+) -> list[dict[str, object]]:
+    clauses = []
+    params: list[object] = []
+    if status is not None:
+        clauses.append("status = ?")
+        params.append(status)
+    if harness is not None:
+        clauses.append("harness = ?")
+        params.append(harness)
+    where_clause = f"where {' and '.join(clauses)}" if clauses else ""
+    rows = connection.execute(
+        f"""
+        select request_id, harness, artifact_id, artifact_name, artifact_hash, publisher, policy_action,
+               recommended_scope, changed_fields_json, source_scope, config_path, review_command,
+               approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
+        from approval_requests
+        {where_clause}
+        order by created_at desc
+        limit ?
+        """,
+        (*params, limit),
+    ).fetchall()
+    return [_row_to_payload(row) for row in rows]
+
+
+def get_approval_request(connection: sqlite3.Connection, request_id: str) -> dict[str, object] | None:
+    row = connection.execute(
+        """
+        select request_id, harness, artifact_id, artifact_name, artifact_hash, publisher, policy_action,
+               recommended_scope, changed_fields_json, source_scope, config_path, review_command,
+               approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
+        from approval_requests
+        where request_id = ?
+        """,
+        (request_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    return _row_to_payload(row)
+
+
+def resolve_approval_request(
+    connection: sqlite3.Connection,
+    request_id: str,
+    *,
+    resolution_action: str,
+    resolution_scope: str,
+    reason: str | None,
+    resolved_at: str,
+) -> None:
+    connection.execute(
+        """
+        update approval_requests
+        set status = 'resolved',
+            resolution_action = ?,
+            resolution_scope = ?,
+            reason = ?,
+            resolved_at = ?
+        where request_id = ?
+        """,
+        (resolution_action, resolution_scope, reason, resolved_at, request_id),
+    )
+
+
+def count_approval_requests(connection: sqlite3.Connection, *, status: str | None = "pending") -> int:
+    if status is None:
+        row = connection.execute("select count(*) as total from approval_requests").fetchone()
+    else:
+        row = connection.execute(
+            "select count(*) as total from approval_requests where status = ?",
+            (status,),
+        ).fetchone()
+    return int(row["total"]) if row is not None else 0
+
+
+def _row_to_payload(row: sqlite3.Row) -> dict[str, object]:
+    return {
+        "request_id": str(row["request_id"]),
+        "harness": str(row["harness"]),
+        "artifact_id": str(row["artifact_id"]),
+        "artifact_name": str(row["artifact_name"]),
+        "artifact_hash": str(row["artifact_hash"]),
+        "publisher": row["publisher"],
+        "policy_action": str(row["policy_action"]),
+        "recommended_scope": str(row["recommended_scope"]),
+        "changed_fields": json.loads(str(row["changed_fields_json"])),
+        "source_scope": str(row["source_scope"]),
+        "config_path": str(row["config_path"]),
+        "review_command": str(row["review_command"]),
+        "approval_url": str(row["approval_url"]),
+        "status": str(row["status"]),
+        "resolution_action": row["resolution_action"],
+        "resolution_scope": row["resolution_scope"],
+        "reason": row["reason"],
+        "created_at": str(row["created_at"]),
+        "resolved_at": row["resolved_at"],
+    }

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -120,6 +120,106 @@ class TestGuardApprovals:
         assert decision_payload["resolved"] is True
         assert store.get_approval_request("req-456")["status"] == "resolved"
 
+    def test_guard_daemon_rejects_missing_decision_fields(self, tmp_path):
+        store = GuardStore(tmp_path / "guard-home")
+        store.add_approval_request(
+            GuardApprovalRequest(
+                request_id="req-400",
+                harness="codex",
+                artifact_id="codex:project:workspace_skill",
+                artifact_name="workspace_skill",
+                artifact_hash="hash-400",
+                policy_action="require-reapproval",
+                recommended_scope="artifact",
+                changed_fields=("args",),
+                source_scope="project",
+                config_path=str(tmp_path / "workspace" / ".codex" / "config.toml"),
+                review_command="hol-guard approvals approve req-400",
+                approval_url="http://127.0.0.1/pending",
+            ),
+            "2026-04-11T00:00:00+00:00",
+        )
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/approvals/req-400/decision",
+                data=json.dumps({"action": "allow"}).encode("utf-8"),
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            try:
+                urllib.request.urlopen(request, timeout=5)
+            except urllib.error.HTTPError as error:
+                payload = json.loads(error.read().decode("utf-8"))
+                status = error.code
+            else:
+                raise AssertionError("expected HTTPError for missing scope")
+        finally:
+            daemon.stop()
+
+        assert status == 400
+        assert payload["error"] == "missing_required_fields"
+
+    def test_guard_daemon_ignores_invalid_json_body(self, tmp_path):
+        store = GuardStore(tmp_path / "guard-home")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/approvals/missing/decision",
+                data=b"{not-json",
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            try:
+                urllib.request.urlopen(request, timeout=5)
+            except urllib.error.HTTPError as error:
+                payload = json.loads(error.read().decode("utf-8"))
+                status = error.code
+            else:
+                raise AssertionError("expected HTTPError for invalid JSON body")
+        finally:
+            daemon.stop()
+
+        assert status == 400
+        assert payload["error"] == "missing_required_fields"
+
+    def test_guard_daemon_escapes_html_values_in_approval_center(self, tmp_path):
+        store = GuardStore(tmp_path / "guard-home")
+        store.add_approval_request(
+            GuardApprovalRequest(
+                request_id='req-escape" onclick="alert(1)',
+                harness="codex<script>",
+                artifact_id="codex:project:workspace_skill",
+                artifact_name="<img src=x onerror=alert(1)>",
+                artifact_hash="hash-escape",
+                policy_action="require-reapproval",
+                recommended_scope="artifact",
+                changed_fields=("<script>",),
+                source_scope="project",
+                config_path=str(tmp_path / "workspace" / ".codex" / "config.toml"),
+                review_command="hol-guard approvals approve req-escape",
+                approval_url="http://127.0.0.1/pending",
+            ),
+            "2026-04-11T00:00:00+00:00",
+        )
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/", timeout=5) as response:
+                body = response.read().decode("utf-8")
+        finally:
+            daemon.stop()
+
+        assert "<img src=x onerror=alert(1)>" not in body
+        assert "<script>" not in body
+        assert "&lt;img src=x onerror=alert(1)&gt;" in body
+        assert "codex&lt;script&gt;" in body
+
     def test_guard_run_headless_enqueues_approval_request(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -293,6 +293,52 @@ class TestGuardApprovals:
         assert approve_output["resolved"] is True
         assert store.resolve_policy("codex", "codex:project:workspace_skill", None) == "allow"
 
+    def test_guard_approvals_cli_rejects_workspace_scope_without_workspace(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        store = GuardStore(home_dir)
+        store.add_approval_request(
+            GuardApprovalRequest(
+                request_id="req-workspace",
+                harness="codex",
+                artifact_id="codex:project:workspace_skill",
+                artifact_name="workspace_skill",
+                artifact_hash="hash-workspace",
+                policy_action="require-reapproval",
+                recommended_scope="workspace",
+                changed_fields=("args",),
+                source_scope="project",
+                config_path=str(tmp_path / "workspace" / ".codex" / "config.toml"),
+                review_command="hol-guard approvals approve req-workspace",
+                approval_url="http://127.0.0.1/pending",
+            ),
+            "2026-04-11T00:00:00+00:00",
+        )
+
+        try:
+            main(
+                [
+                    "guard",
+                    "approvals",
+                    "approve",
+                    "req-workspace",
+                    "--home",
+                    str(home_dir),
+                    "--scope",
+                    "workspace",
+                    "--json",
+                ]
+            )
+        except SystemExit as error:
+            rc = error.code
+        else:
+            raise AssertionError("expected argparse failure for missing workspace scope target")
+
+        captured = capsys.readouterr()
+
+        assert rc == 2
+        assert "requires --workspace" in captured.err
+        assert store.get_approval_request("req-workspace")["status"] == "pending"
+
     def test_guard_queue_blocked_approvals_creates_requests_for_changed_artifacts(self, tmp_path):
         guard_home = tmp_path / "guard-home"
         store = GuardStore(guard_home)

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -1,0 +1,248 @@
+"""Behavior tests for the Guard approval queue and approval center."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.approvals import queue_blocked_approvals
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.consumer import artifact_hash, evaluate_detection
+from codex_plugin_scanner.guard.daemon import GuardDaemonServer
+from codex_plugin_scanner.guard.models import GuardApprovalRequest, GuardArtifact, HarnessDetection
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _build_guard_fixture(home_dir: Path, workspace_dir: Path) -> None:
+    _write_text(
+        home_dir / ".codex" / "config.toml",
+        """
+approval_policy = "never"
+
+[mcp_servers.global_tools]
+command = "python"
+args = ["-m", "http.server", "9000"]
+""".strip()
+        + "\n",
+    )
+    _write_text(
+        workspace_dir / ".codex" / "config.toml",
+        """
+[mcp_servers.workspace_skill]
+command = "node"
+args = ["workspace-skill.js"]
+""".strip()
+        + "\n",
+    )
+
+
+class TestGuardApprovals:
+    def test_guard_store_persists_and_resolves_approval_requests(self, tmp_path):
+        store = GuardStore(tmp_path / "guard-home")
+        request = GuardApprovalRequest(
+            request_id="req-123",
+            harness="codex",
+            artifact_id="codex:project:workspace_skill",
+            artifact_name="workspace_skill",
+            artifact_hash="hash-123",
+            policy_action="require-reapproval",
+            recommended_scope="artifact",
+            changed_fields=("args",),
+            source_scope="project",
+            config_path=str(tmp_path / "workspace" / ".codex" / "config.toml"),
+            review_command="hol-guard approvals approve req-123",
+            approval_url="http://127.0.0.1:4455/approvals/req-123",
+        )
+
+        store.add_approval_request(request, "2026-04-11T00:00:00+00:00")
+        pending = store.list_approval_requests()
+        store.resolve_approval_request(
+            "req-123",
+            resolution_action="allow",
+            resolution_scope="artifact",
+            reason="reviewed",
+            resolved_at="2026-04-11T00:01:00+00:00",
+        )
+        resolved = store.get_approval_request("req-123")
+
+        assert pending[0]["status"] == "pending"
+        assert pending[0]["approval_url"] == "http://127.0.0.1:4455/approvals/req-123"
+        assert resolved is not None
+        assert resolved["status"] == "resolved"
+        assert resolved["resolution_action"] == "allow"
+        assert resolved["resolution_scope"] == "artifact"
+
+    def test_guard_daemon_serves_approval_queue_and_resolves_requests(self, tmp_path):
+        store = GuardStore(tmp_path / "guard-home")
+        store.add_approval_request(
+            GuardApprovalRequest(
+                request_id="req-456",
+                harness="codex",
+                artifact_id="codex:project:workspace_skill",
+                artifact_name="workspace_skill",
+                artifact_hash="hash-456",
+                policy_action="require-reapproval",
+                recommended_scope="artifact",
+                changed_fields=("args",),
+                source_scope="project",
+                config_path=str(tmp_path / "workspace" / ".codex" / "config.toml"),
+                review_command="hol-guard approvals approve req-456",
+                approval_url="http://127.0.0.1/pending",
+            ),
+            "2026-04-11T00:00:00+00:00",
+        )
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/approvals", timeout=5) as response:
+                approvals_payload = json.loads(response.read().decode("utf-8"))
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/approvals/req-456/decision",
+                data=json.dumps({"action": "allow", "scope": "artifact", "reason": "approved"}).encode("utf-8"),
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=5) as response:
+                decision_payload = json.loads(response.read().decode("utf-8"))
+        finally:
+            daemon.stop()
+
+        assert approvals_payload["items"][0]["request_id"] == "req-456"
+        assert decision_payload["resolved"] is True
+        assert store.get_approval_request("req-456")["status"] == "resolved"
+
+    def test_guard_run_headless_enqueues_approval_request(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+
+        rc = main(
+            [
+                "guard",
+                "run",
+                "codex",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        store = GuardStore(home_dir)
+        approvals = store.list_approval_requests()
+
+        assert rc == 1
+        assert output["blocked"] is True
+        assert output["approval_center_url"].startswith("http://127.0.0.1:")
+        assert approvals[0]["harness"] == "codex"
+        assert approvals[0]["status"] == "pending"
+
+    def test_guard_approvals_cli_lists_and_resolves_requests(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        store = GuardStore(home_dir)
+        store.add_approval_request(
+            GuardApprovalRequest(
+                request_id="req-789",
+                harness="codex",
+                artifact_id="codex:project:workspace_skill",
+                artifact_name="workspace_skill",
+                artifact_hash="hash-789",
+                policy_action="require-reapproval",
+                recommended_scope="artifact",
+                changed_fields=("args",),
+                source_scope="project",
+                config_path=str(tmp_path / "workspace" / ".codex" / "config.toml"),
+                review_command="hol-guard approvals approve req-789",
+                approval_url="http://127.0.0.1/pending",
+            ),
+            "2026-04-11T00:00:00+00:00",
+        )
+
+        list_rc = main(["guard", "approvals", "--home", str(home_dir), "--json"])
+        list_output = json.loads(capsys.readouterr().out)
+        approve_rc = main(
+            [
+                "guard",
+                "approvals",
+                "approve",
+                "req-789",
+                "--home",
+                str(home_dir),
+                "--scope",
+                "artifact",
+                "--reason",
+                "approved",
+                "--json",
+            ]
+        )
+        approve_output = json.loads(capsys.readouterr().out)
+
+        assert list_rc == 0
+        assert list_output["items"][0]["request_id"] == "req-789"
+        assert approve_rc == 0
+        assert approve_output["resolved"] is True
+        assert store.resolve_policy("codex", "codex:project:workspace_skill", None) == "allow"
+
+    def test_guard_queue_blocked_approvals_creates_requests_for_changed_artifacts(self, tmp_path):
+        guard_home = tmp_path / "guard-home"
+        store = GuardStore(guard_home)
+        baseline = GuardArtifact(
+            artifact_id="codex:project:workspace_skill",
+            name="workspace_skill",
+            harness="codex",
+            artifact_type="mcp_server",
+            source_scope="project",
+            config_path=str(tmp_path / "workspace" / ".codex" / "config.toml"),
+            command="node",
+            args=("server.js",),
+            transport="stdio",
+        )
+        baseline_hash = artifact_hash(baseline)
+        store.save_snapshot(
+            "codex",
+            baseline.artifact_id,
+            {**baseline.to_dict(), "artifact_hash": baseline_hash},
+            baseline_hash,
+            "2026-04-10T00:00:00+00:00",
+        )
+        changed = GuardArtifact(
+            artifact_id=baseline.artifact_id,
+            name=baseline.name,
+            harness=baseline.harness,
+            artifact_type=baseline.artifact_type,
+            source_scope=baseline.source_scope,
+            config_path=baseline.config_path,
+            command="node",
+            args=("server.js", "--changed"),
+            transport="stdio",
+        )
+        detection = HarnessDetection(
+            harness="codex",
+            installed=True,
+            command_available=True,
+            config_paths=(baseline.config_path,),
+            artifacts=(changed,),
+        )
+        config = GuardConfig(guard_home=guard_home, workspace=None)
+
+        evaluation = evaluate_detection(detection, store, config, persist=True)
+        approvals = queue_blocked_approvals(
+            detection=detection,
+            evaluation=evaluation,
+            store=store,
+            approval_center_url="http://127.0.0.1:4455",
+        )
+
+        assert evaluation["blocked"] is True
+        assert approvals[0]["artifact_id"] == "codex:project:workspace_skill"
+        assert "args" in approvals[0]["changed_fields"]

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -603,7 +603,8 @@ class TestGuardRuntime:
         output = capsys.readouterr().out
 
         assert rc == 1
-        assert "non-interactive" in output
+        assert "approval center" in output.lower()
+        assert "Queued approvals" in output
 
     def test_guard_invalid_changed_hash_action_falls_back_to_reapproval(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")


### PR DESCRIPTION
## Summary
- add a local approval queue and localhost approval center for blocked Guard launches
- route non-interactive Guard runs through approvals instead of ending on a diff-only fallback
- document harness approval strategy and cover the new flow with runtime and CLI tests

## Validation
- uv run --with pytest pytest -q tests/test_guard_product_flow.py tests/test_guard_launch_env.py tests/test_guard_runtime.py tests/test_guard_cli.py tests/test_guard_approvals.py tests/test_action_bundle.py tests/test_submission.py tests/test_security_ops.py tests/test_verification.py
- uv run --with ruff ruff check src tests
- uv run --with ruff ruff format --check src tests
- uv run --with build python -m build
- real local flow: blocked codex run -> approval center -> terminal approval -> allowed dry-run