### PR TITLE
fix: repair publish workflow parse failure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,9 +86,9 @@ jobs:
           )
           start = text.index("[project.scripts]")
           end = text.index("\n\n[project.urls]")
-          scripts = '''[project.scripts]
-hol-guard = "codex_plugin_scanner.cli:main"
-plugin-guard = "codex_plugin_scanner.cli:main"'''
+          scripts = "[project.scripts]\n" \
+              'hol-guard = "codex_plugin_scanner.cli:main"\n' \
+              'plugin-guard = "codex_plugin_scanner.cli:main"'
           text = text[:start] + scripts + text[end:]
           path.write_text(text, encoding="utf-8")
           PY
@@ -110,9 +110,9 @@ plugin-guard = "codex_plugin_scanner.cli:main"'''
           )
           start = text.index("[project.scripts]")
           end = text.index("\n\n[project.urls]")
-          scripts = '''[project.scripts]
-plugin-scanner = "codex_plugin_scanner.cli:main"
-plugin-ecosystem-scanner = "codex_plugin_scanner.cli:main"'''
+          scripts = "[project.scripts]\n" \
+              'plugin-scanner = "codex_plugin_scanner.cli:main"\n' \
+              'plugin-ecosystem-scanner = "codex_plugin_scanner.cli:main"'
           text = text[:start] + scripts + text[end:]
           path.write_text(text, encoding="utf-8")
           PY
@@ -134,8 +134,8 @@ plugin-ecosystem-scanner = "codex_plugin_scanner.cli:main"'''
           )
           start = text.index("[project.scripts]")
           end = text.index("\n\n[project.urls]")
-          scripts = '''[project.scripts]
-codex-plugin-scanner = "codex_plugin_scanner.cli:main"'''
+          scripts = "[project.scripts]\n" \
+              'codex-plugin-scanner = "codex_plugin_scanner.cli:main"'
           text = text[:start] + scripts + text[end:]
           path.write_text(text, encoding="utf-8")
           PY


### PR DESCRIPTION
## Summary
- fix invalid YAML in `.github/workflows/publish.yml` caused by unindented multiline Python string literals escaping the `run: |` block
- keep the script content equivalent while using escaped newline string construction
- restore workflow parseability so publish jobs can run

## Verification
- `python3 - <<'PY' ... yaml.safe_load('.github/workflows/publish.yml') ...`
- `uv sync --frozen --extra dev --extra publish`
- local publish build sequence for all three package variants + `uv run --no-sync twine check dist/*`
