### PR TITLE
chore: align scorecard workflow with official action

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,6 +10,8 @@ jobs:
   scorecard:
     runs-on: ubuntu-latest
     permissions:
+      actions: read
+      contents: read
       id-token: write
       security-events: write
     steps:
@@ -33,3 +35,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13
         with:
           sarif_file: results.sarif
+        if: always()

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -31,6 +31,7 @@ jobs:
           name: SARIF file
           path: results.sarif
           retention-days: 5
+        if: always()
       - name: Upload to code-scanning
         uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,8 +4,8 @@ on:
     - cron: '0 0 * * 0'
   push:
     branches: [main]
-permissions:
-  contents: read
+permissions: read-all
+
 jobs:
   scorecard:
     runs-on: ubuntu-latest
@@ -13,15 +13,23 @@ jobs:
       id-token: write
       security-events: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
-      - uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13
+      - name: Upload artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13
         with:
           sarif_file: results.sarif
-        if: always()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ cisco = []
 dev = [
     "build>=1.2.2",
     "jsonschema>=4.23.0",
+    "pyyaml>=6.0",
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "ruff>=0.4.0",

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import yaml
+
 ROOT = Path(__file__).resolve().parent.parent
 
 
@@ -136,10 +138,13 @@ def test_ci_workflow_covers_cross_platform_runtime() -> None:
 
 def test_scorecard_workflow_matches_official_install_pattern() -> None:
     workflow_text = (ROOT / ".github" / "workflows" / "scorecard.yml").read_text(encoding="utf-8")
+    workflow = yaml.safe_load(workflow_text)
 
     assert "name: OpenSSF Scorecard" in workflow_text
     assert "permissions: read-all" in workflow_text
     assert "branches: [main]" in workflow_text
+    assert workflow["jobs"]["scorecard"]["permissions"]["actions"] == "read"
+    assert workflow["jobs"]["scorecard"]["permissions"]["contents"] == "read"
     assert "id-token: write" in workflow_text
     assert "security-events: write" in workflow_text
     assert 'uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' in workflow_text
@@ -148,9 +153,12 @@ def test_scorecard_workflow_matches_official_install_pattern() -> None:
     assert "results_format: sarif" in workflow_text
     assert "publish_results: true" in workflow_text
     assert 'uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f' in workflow_text
+    assert "persist-credentials: false" in workflow_text
+    assert "path: results.sarif" in workflow_text
     assert "retention-days: 5" in workflow_text
     assert 'uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13' in workflow_text
     assert "sarif_file: results.sarif" in workflow_text
+    assert "if: always()" in workflow_text
 
 
 def test_harness_smoke_workflow_covers_nightly_self_hosted_release_gate() -> None:

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -156,6 +156,7 @@ def test_scorecard_workflow_matches_official_install_pattern() -> None:
     assert "persist-credentials: false" in workflow_text
     assert "path: results.sarif" in workflow_text
     assert "retention-days: 5" in workflow_text
+    assert workflow_text.count("if: always()") == 2
     assert 'uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13' in workflow_text
     assert "sarif_file: results.sarif" in workflow_text
     assert "if: always()" in workflow_text

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -134,6 +134,25 @@ def test_ci_workflow_covers_cross_platform_runtime() -> None:
     assert "macos-latest" in workflow_text
 
 
+def test_scorecard_workflow_matches_official_install_pattern() -> None:
+    workflow_text = (ROOT / ".github" / "workflows" / "scorecard.yml").read_text(encoding="utf-8")
+
+    assert "name: OpenSSF Scorecard" in workflow_text
+    assert "permissions: read-all" in workflow_text
+    assert "branches: [main]" in workflow_text
+    assert "id-token: write" in workflow_text
+    assert "security-events: write" in workflow_text
+    assert 'uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' in workflow_text
+    assert 'uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a' in workflow_text
+    assert "results_file: results.sarif" in workflow_text
+    assert "results_format: sarif" in workflow_text
+    assert "publish_results: true" in workflow_text
+    assert 'uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f' in workflow_text
+    assert "retention-days: 5" in workflow_text
+    assert 'uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13' in workflow_text
+    assert "sarif_file: results.sarif" in workflow_text
+
+
 def test_harness_smoke_workflow_covers_nightly_self_hosted_release_gate() -> None:
     workflow_text = (ROOT / ".github" / "workflows" / "harness-smoke.yml").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- align the existing OpenSSF Scorecard workflow to the official action pattern
- add SARIF artifact upload alongside code scanning upload
- lock the workflow shape in the action bundle regression tests

## Verification
- python3 - <<'PY' ... yaml.safe_load(.github/workflows/scorecard.yml)
- uv run --no-sync pytest tests/test_action_bundle.py