### PR TITLE
fix: simplify dependabot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,6 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
-      - "python"
     commit-message:
       prefix: "deps(pip)"
     groups:
@@ -50,7 +49,6 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
-      - "docker"
     commit-message:
       prefix: "deps(docker)"
     groups:


### PR DESCRIPTION
## Summary
- remove custom `python` and `docker` Dependabot labels from the scanner repo
- keep only the stable shared labels `dependencies` and `github-actions` in config
- avoid future Dependabot failures when repo-specific labels drift or are missing

## Verification
- created the missing labels live on the affected repos so current PRs stop erroring immediately
- validated `.github/dependabot.yml` parses successfully with Python YAML
