### PR TITLE
chore: harden OpenSSF repo practices

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,49 @@
+name: Bug report
+description: Report a defect in hol-guard, plugin-scanner, packaging, or automation.
+title: "[bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for reproducible defects in `hol-guard`, `plugin-scanner`, release packaging, or the GitHub Action.
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      options:
+        - hol-guard
+        - plugin-scanner
+        - GitHub Action
+        - container image
+        - release workflow
+        - documentation
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Include expected behavior and actual behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Provide commands, config, or sample inputs that reproduce the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include OS, Python version, package version, and relevant runner or harness details.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Paste any relevant logs, stack traces, or screenshots.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability reporting
+    url: https://github.com/hashgraph-online/ai-plugin-scanner/blob/main/SECURITY.md
+    about: Report vulnerabilities privately via the process documented in SECURITY.md.
+  - name: Project discussions
+    url: https://github.com/hashgraph-online/ai-plugin-scanner/discussions
+    about: Use discussions for design questions, proposals, and broader product feedback.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,29 @@
+name: Feature request
+description: Propose a new capability or improvement.
+title: "[enhancement] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for scanner, Guard, GitHub Action, release, or ecosystem-support improvements.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: Describe the current limitation or pain point.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: Describe the behavior or interface you want.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Note any workaround or alternative approach you already tried.

--- a/.github/workflows/dependabot-uv-lock.yml
+++ b/.github/workflows/dependabot-uv-lock.yml
@@ -1,30 +1,30 @@
 name: Dependabot Lockfile Sync
 
 on:
-  pull_request_target:
-    types:
-      - opened
-      - synchronize
-      - reopened
+  push:
+    branches:
+      - "dependabot/**"
     paths:
       - "pyproject.toml"
       - "requirements.txt"
       - "docker-requirements.txt"
       - ".github/dependabot.yml"
+  workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   sync-lockfile:
-    if: github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - name: Checkout PR branch
+      - name: Checkout Dependabot branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.ref }}
           fetch-depth: 0
 
       - name: Set up Python

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,37 +1,68 @@
-# Contributing to Codex Plugin Scanner
+# Contributing to AI Plugin Scanner
 
-Thank you for your interest in contributing!
+Thanks for contributing to `ai-plugin-scanner`.
+
+This repository ships:
+
+- `hol-guard` for local harness protection
+- `plugin-scanner` for CI and maintainer checks across supported AI plugin ecosystems
+- `codex-plugin-scanner` as a compatibility package alias
+
+## Before You Start
+
+- Search existing [issues](https://github.com/hashgraph-online/ai-plugin-scanner/issues) before opening a new report.
+- Use [discussions](https://github.com/hashgraph-online/ai-plugin-scanner/discussions) for design questions, proposals, and broader feedback.
+- Open a pull request for code or documentation changes. PRs against `main` are the normal contribution path.
 
 ## Development Setup
 
 ```bash
-git clone https://github.com/hashgraph-online/codex-plugin-scanner.git
-cd codex-plugin-scanner
-pip install -e ".[dev]"
-pytest
+git clone https://github.com/hashgraph-online/ai-plugin-scanner.git
+cd ai-plugin-scanner
+uv sync --frozen --extra dev
 ```
 
-## Adding New Checks
+If you prefer a virtualenv-first workflow, the repository can also be installed in editable mode:
 
-1. Create a new check function in the appropriate file under `src/codex_plugin_scanner/checks/`.
-2. Add it to the corresponding `run_*_checks()` function.
-3. Write tests in `tests/`.
-4. Update the README's checks table.
-5. Submit a PR.
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+```
 
-## Code Style
+## Validation Requirements
 
-- Python 3.10+
-- Ruff for linting and formatting
-- All checks must return a `CheckResult` with accurate point values
+All non-trivial changes should include or update automated tests.
 
-## Pull Request Process
+Run the standard validation commands before opening or updating a pull request:
 
-1. Fork the repo
-2. Create a feature branch
-3. Write tests for new functionality
-4. Ensure `pytest` passes and `ruff check` is clean
-5. Submit PR against `main`
+```bash
+uv run --no-sync python -m ruff check src tests
+uv run --no-sync python -m ruff format --check src tests
+uv run --no-sync pytest --tb=short
+```
+
+If you changed packaging or release logic, also verify the build:
+
+```bash
+uv run --no-sync python -m build
+```
+
+## Contribution Process
+
+1. Fork the repository.
+2. Create a feature branch from `main`.
+3. Make the smallest coherent change that fixes the issue or adds the feature.
+4. Add or update tests for new functionality and changed behavior.
+5. Run the validation commands above.
+6. Open a pull request against `main` with a clear summary of what changed and why.
+
+## Contribution Expectations
+
+- Python code should remain compatible with the versions declared in `pyproject.toml`.
+- Keep command examples and package names aligned with the current product names: `hol-guard`, `plugin-scanner`, and `ai-plugin-scanner`.
+- Update user-facing docs when the CLI surface, GitHub Action contract, trust scoring behavior, or published workflows change.
+- Do not commit secrets, credentials, or local environment files.
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ This repository ships:
 ```bash
 git clone https://github.com/hashgraph-online/ai-plugin-scanner.git
 cd ai-plugin-scanner
-uv sync --frozen --extra dev
+uv sync --extra dev
 ```
 
 If you prefer a virtualenv-first workflow, the repository can also be installed in editable mode:
@@ -37,15 +37,25 @@ All non-trivial changes should include or update automated tests.
 Run the standard validation commands before opening or updating a pull request:
 
 ```bash
-uv run --no-sync python -m ruff check src tests
-uv run --no-sync python -m ruff format --check src tests
-uv run --no-sync pytest --tb=short
+# If using uv:
+uv run python -m ruff check src tests
+uv run python -m ruff format --check src tests
+uv run pytest --tb=short
+
+# If using pip (with the virtualenv activated):
+python -m ruff check src tests
+python -m ruff format --check src tests
+pytest --tb=short
 ```
 
 If you changed packaging or release logic, also verify the build:
 
 ```bash
-uv run --no-sync python -m build
+# If using uv:
+uv run python -m build
+
+# If using pip:
+python -m build
 ```
 
 ## Contribution Process

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,31 +4,40 @@
 
 | Version | Supported |
 |---------|-----------|
-| 1.x     | Yes       |
+| 2.x     | Yes       |
+| 1.x     | No        |
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in this project, please report it responsibly:
+If you discover a security vulnerability in `ai-plugin-scanner`, please report it privately:
 
-1. Do not open a public issue.
-2. Email us at security@hol.org with details.
-3. Include steps to reproduce, expected vs actual behavior, and potential impact.
-4. We will acknowledge within 48 hours and aim to resolve within 7 days.
+1. Do not open a public issue for the vulnerability.
+2. Email `security@hol.org`.
+3. Include the affected package or surface (`hol-guard`, `plugin-scanner`, GitHub Action, container image, or release workflow).
+4. Include reproduction steps, impact, and any known mitigations.
 
-## Security Best Practices
+We aim to:
 
-This tool helps you follow security best practices for Codex plugins. For the latest guidance, see the [Codex Security documentation](https://developers.openai.com/codex/security).
+- acknowledge vulnerability reports within 48 hours
+- provide an initial triage response within 14 days
+- resolve confirmed issues as quickly as practical based on severity and release risk
 
-### For Plugin Authors
+## Scope
 
-- Never commit API keys, tokens, or secrets to your repository.
-- Use environment variables for sensitive configuration.
-- Avoid dangerous shell commands in `.mcp.json` configurations.
-- Include a `SECURITY.md` in your plugin repository.
-- Use permissive licenses (Apache-2.0 or MIT) for clarity.
+This policy covers:
 
-### For Scanner Users
+- the Python packages published from this repository
+- the reviewed container image
+- the GitHub Action bundle sourced from this repository
+- release and automation workflows maintained in this repository
 
-- This scanner checks for common patterns but does not guarantee security.
-- Always review plugin code manually before installation.
-- Keep this tool updated for the latest check definitions.
+## Secure Use Guidance
+
+For users of the project:
+
+- keep the scanner and Guard packages updated to the latest supported release line
+- review plugin code and MCP configuration before enabling it in a local harness
+- avoid committing secrets, API keys, or local environment files into plugin repositories
+- prefer HTTPS-only remote endpoints and pinned GitHub Actions in plugin repositories
+
+The scanner and Guard help identify risky patterns, but they are not a substitute for manual review or a full secure development lifecycle.


### PR DESCRIPTION
## Summary
- refresh stale contribution and security documentation so badge evidence matches the current `ai-plugin-scanner` repo and release line
- replace the unsafe `pull_request_target` Dependabot lockfile sync with a branch-push workflow for Dependabot-owned branches
- add structured issue templates and contact links for bug reports, feature requests, discussions, and private security reporting

## Verification
- validated all new and changed YAML files with Python YAML parsing
- reviewed the updated contribution and security docs end to end
- confirmed the lockfile sync workflow no longer checks out PR head refs from `pull_request_target`
