### PR TITLE
feat: add Cisco MCP scanner integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,18 @@ Cisco-backed scanner analysis is optional:
 pip install "plugin-scanner[cisco]"
 ```
 
-The `cisco` extra installs the published `cisco-ai-skill-scanner` package from PyPI so the scanner remains publishable on PyPI and the optional Cisco analysis path works with standard package metadata.
+The base install already includes the published `cisco-ai-skill-scanner` package for
+skill analysis. The `cisco` extra adds the optional published
+`cisco-ai-mcp-scanner` package on Python 3.11+ so static MCP analysis stays opt-in
+and the scanner remains publishable on PyPI with standard package metadata.
+
+Credit to [Cisco AI Defense](https://github.com/cisco-ai-defense) for open-sourcing
+[skill-scanner](https://github.com/cisco-ai-defense/skill-scanner),
+[mcp-scanner](https://github.com/cisco-ai-defense/mcp-scanner),
+[a2a-scanner](https://github.com/cisco-ai-defense/a2a-scanner), and
+[aibom](https://github.com/cisco-ai-defense/aibom). This scanner now ships the
+published `cisco-ai-skill-scanner` integration plus an optional static
+`cisco-ai-mcp-scanner` integration, with A2A and AIBOM work left for follow-up PRs.
 
 If you want both tools in one shell during local development:
 
@@ -216,7 +227,7 @@ The scanner evaluates only the surfaces a plugin actually exposes, then normaliz
 | Category | Max Points | Coverage |
 | :--- | :--- | :--- |
 | Manifest Validation | 31 | `plugin.json`, required fields, semver, kebab-case, recommended metadata, interface metadata, interface links and assets, safe declared paths |
-| Security | 24 | `SECURITY.md`, `LICENSE`, hardcoded secret detection, dangerous MCP commands, MCP transport hardening, risky approval defaults |
+| Security | 36 | `SECURITY.md`, `LICENSE`, hardcoded secret detection, dangerous MCP commands, MCP transport hardening, risky approval defaults, Cisco MCP scan status, elevated MCP findings, MCP analyzability |
 | Operational Security | 20 | SHA-pinned GitHub Actions, `write-all`, privileged untrusted checkout patterns, Dependabot, dependency lockfiles |
 | Best Practices | 15 | `README.md`, skills directory, `SKILL.md` frontmatter, committed `.env`, `.codexignore` |
 | Marketplace | 15 | `.agents/plugins/marketplace.json` validity, legacy `marketplace.json` compatibility, policy fields, safe source paths |
@@ -249,6 +260,9 @@ plugin-scanner ./my-plugin --fail-on-severity high
 
 # Require Cisco skill scanning with a strict policy
 plugin-scanner ./my-plugin --cisco-skill-scan on --cisco-policy strict
+
+# Require optional Cisco MCP static analysis
+plugin-scanner ./my-plugin --cisco-mcp-scan on
 ```
 
 ## Quality Suite Commands
@@ -374,6 +388,7 @@ The scanner currently detects or validates:
 - Publishability issues in `interface` metadata, HTTPS links, and declared asset paths
 - Workflow hardening gaps including unpinned third-party actions, `write-all`, privileged checkout patterns, missing Dependabot, and missing lockfiles
 - Skill-level issues surfaced by Cisco `skill-scanner` when the optional integration is installed
+- Static MCP findings surfaced by Cisco `mcp-scanner` when the optional `cisco` extra is installed
 
 ## CI And Automation
 
@@ -614,6 +629,7 @@ Plugins that pass the scanner with a high score are candidates for listing in th
 - [OpenAI Codex Plugin Documentation](https://developers.openai.com/codex/plugins)
 - [Model Context Protocol Documentation](https://modelcontextprotocol.io)
 - [Cisco AI Skill Scanner](https://pypi.org/project/cisco-ai-skill-scanner/)
+- [Cisco AI MCP Scanner](https://pypi.org/project/cisco-ai-mcp-scanner/)
 - [HOL GitHub Organization](https://github.com/hashgraph-online)
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-cisco = []
+cisco = [
+    "cisco-ai-mcp-scanner~=4.5; python_version >= '3.11'",
+]
 dev = [
     "build>=1.2.2",
     "jsonschema>=4.26.0",

--- a/src/codex_plugin_scanner/action_runner.py
+++ b/src/codex_plugin_scanner/action_runner.py
@@ -104,6 +104,7 @@ def _build_scan_args(
     min_score: int,
     fail_on_severity: str,
     cisco_scan: str,
+    cisco_mcp_scan: str,
     cisco_policy: str,
 ) -> argparse.Namespace:
     return argparse.Namespace(
@@ -116,6 +117,7 @@ def _build_scan_args(
         min_score=min_score,
         fail_on_severity=fail_on_severity,
         cisco_skill_scan=cisco_scan,
+        cisco_mcp_scan=cisco_mcp_scan,
         cisco_policy=cisco_policy,
     )
 
@@ -229,6 +231,7 @@ def main() -> int:
     min_score = int(_read_env("MIN_SCORE", "0"))
     fail_on = _read_env("FAIL_ON", "none")
     cisco_scan = _read_env("CISCO_SCAN", "auto")
+    cisco_mcp_scan = _read_env("CISCO_MCP_SCAN", "auto")
     cisco_policy = _read_env("CISCO_POLICY", "balanced")
     submission_enabled = _read_bool_env("SUBMISSION_ENABLED")
     submission_threshold = int(_read_env("SUBMISSION_SCORE_THRESHOLD", "80"))
@@ -353,6 +356,7 @@ def main() -> int:
             min_score=min_score,
             fail_on_severity=fail_on,
             cisco_scan=cisco_scan,
+            cisco_mcp_scan=cisco_mcp_scan,
             cisco_policy=cisco_policy,
         )
         raw_result, result, resolved_profile, policy_eval, _effective_score = _scan_with_policy(

--- a/src/codex_plugin_scanner/checks/mcp_security.py
+++ b/src/codex_plugin_scanner/checks/mcp_security.py
@@ -1,0 +1,216 @@
+"""Cisco MCP security checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..integrations.cisco_mcp_scanner import CiscoMcpScanSummary, run_cisco_mcp_scan
+from ..integrations.cisco_skill_scanner import CiscoIntegrationStatus
+from ..models import SEVERITY_ORDER, CheckResult, Finding, ScanOptions, Severity, max_severity
+
+
+@dataclass(frozen=True, slots=True)
+class McpSecurityContext:
+    """Resolved Cisco MCP scan context."""
+
+    summary: CiscoMcpScanSummary | None
+    skip_message: str | None = None
+    target_present: bool = False
+
+
+def _not_applicable_results(message: str) -> tuple[CheckResult, ...]:
+    return (
+        CheckResult(
+            name="Cisco MCP scan completed",
+            passed=True,
+            points=0,
+            max_points=0,
+            message=message,
+            applicable=False,
+        ),
+        CheckResult(
+            name="No elevated Cisco MCP findings",
+            passed=True,
+            points=0,
+            max_points=0,
+            message=message,
+            applicable=False,
+        ),
+        CheckResult(
+            name="MCP sources analyzable",
+            passed=True,
+            points=0,
+            max_points=0,
+            message=message,
+            applicable=False,
+        ),
+    )
+
+
+def _elevated_findings(findings: tuple[Finding, ...]) -> tuple[Finding, ...]:
+    threshold = SEVERITY_ORDER[Severity.MEDIUM]
+    return tuple(finding for finding in findings if SEVERITY_ORDER[finding.severity] >= threshold)
+
+
+def _availability_check(summary: CiscoMcpScanSummary, mode: str) -> CheckResult:
+    if summary.status == CiscoIntegrationStatus.ENABLED:
+        return CheckResult(
+            name="Cisco MCP scan completed",
+            passed=True,
+            points=3,
+            max_points=3,
+            message=summary.message,
+        )
+
+    if summary.status == CiscoIntegrationStatus.SKIPPED:
+        return CheckResult(
+            name="Cisco MCP scan completed",
+            passed=True,
+            points=0,
+            max_points=0,
+            message=summary.message,
+            applicable=False,
+        )
+
+    if mode == "on":
+        rule_id = (
+            "CISCO-MCP-SCANNER-FAILED"
+            if summary.status == CiscoIntegrationStatus.FAILED
+            else "CISCO-MCP-SCANNER-UNAVAILABLE"
+        )
+        findings = (
+            Finding(
+                rule_id=rule_id,
+                severity=Severity.LOW,
+                category="security",
+                title="Cisco MCP scanner unavailable",
+                description=summary.message,
+                remediation="Install scanner dependencies or disable the Cisco MCP scan requirement for this run.",
+                source="cisco-mcp-scanner",
+            ),
+        )
+        return CheckResult(
+            name="Cisco MCP scan completed",
+            passed=False,
+            points=0,
+            max_points=3,
+            message=summary.message,
+            findings=findings,
+        )
+
+    return CheckResult(
+        name="Cisco MCP scan completed",
+        passed=True,
+        points=0,
+        max_points=0,
+        message=summary.message,
+        applicable=False,
+    )
+
+
+def _findings_check(summary: CiscoMcpScanSummary) -> CheckResult:
+    if summary.status != CiscoIntegrationStatus.ENABLED:
+        return CheckResult(
+            name="No elevated Cisco MCP findings",
+            passed=True,
+            points=0,
+            max_points=0,
+            message="Cisco MCP scan not executed; elevated findings check not applicable.",
+            applicable=False,
+        )
+
+    elevated = _elevated_findings(summary.findings)
+    if not elevated:
+        if summary.total_findings:
+            return CheckResult(
+                name="No elevated Cisco MCP findings",
+                passed=True,
+                points=6,
+                max_points=6,
+                message=f"Cisco MCP scan found only advisory-level findings ({summary.total_findings}).",
+                findings=summary.findings,
+            )
+        return CheckResult(
+            name="No elevated Cisco MCP findings",
+            passed=True,
+            points=6,
+            max_points=6,
+            message="Cisco MCP scan found no elevated findings.",
+        )
+
+    severity = max_severity(elevated)
+    titles = ", ".join(finding.title for finding in elevated[:3])
+    return CheckResult(
+        name="No elevated Cisco MCP findings",
+        passed=False,
+        points=0,
+        max_points=6,
+        message=f"Elevated Cisco MCP findings detected ({severity.value if severity else 'unknown'}): {titles}",
+        findings=summary.findings,
+    )
+
+
+def _analyzability_check(summary: CiscoMcpScanSummary) -> CheckResult:
+    if summary.status != CiscoIntegrationStatus.ENABLED:
+        return CheckResult(
+            name="MCP sources analyzable",
+            passed=True,
+            points=0,
+            max_points=0,
+            message="Cisco MCP scan not executed; analyzability not applicable.",
+            applicable=False,
+        )
+
+    if summary.targets_scanned > 0:
+        return CheckResult(
+            name="MCP sources analyzable",
+            passed=True,
+            points=3,
+            max_points=3,
+            message=f"Cisco MCP scanner analyzed {summary.targets_scanned} target(s).",
+        )
+
+    return CheckResult(
+        name="MCP sources analyzable",
+        passed=False,
+        points=0,
+        max_points=3,
+        message="Cisco MCP scan ran but did not analyze any targets.",
+    )
+
+
+def resolve_mcp_security_context(plugin_dir: Path, options: ScanOptions | None = None) -> McpSecurityContext:
+    """Resolve Cisco MCP security scan context for a plugin directory."""
+
+    if not (plugin_dir / ".mcp.json").is_file():
+        return McpSecurityContext(summary=None, skip_message="No .mcp.json found.", target_present=False)
+
+    scan_options = options or ScanOptions()
+    return McpSecurityContext(
+        summary=run_cisco_mcp_scan(plugin_dir, scan_options.cisco_mcp_scan),
+        target_present=True,
+    )
+
+
+def run_mcp_security_checks(
+    plugin_dir: Path,
+    options: ScanOptions | None = None,
+    context: McpSecurityContext | None = None,
+) -> tuple[CheckResult, ...]:
+    """Run Cisco MCP checks for plugins that declare MCP configuration."""
+
+    resolved_context = context or resolve_mcp_security_context(plugin_dir, options)
+    if resolved_context.skip_message:
+        return _not_applicable_results(resolved_context.skip_message)
+
+    summary = resolved_context.summary
+    if summary is None:
+        return _not_applicable_results("Cisco MCP scan context unavailable.")
+
+    scan_options = options or ScanOptions()
+    return (
+        _availability_check(summary, scan_options.cisco_mcp_scan),
+        _findings_check(summary),
+        _analyzability_check(summary),
+    )

--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -81,6 +81,11 @@ def _build_plain_text(result) -> str:
         for domain in result.trust_report.domains:
             lines.append(f"  - {domain.label}: {domain.score}/100 ({domain.spec_id})")
         lines.append("")
+    if result.integrations:
+        lines.append("Integration Status:")
+        for integration in result.integrations:
+            lines.append(f"  - {integration.name}: {integration.status} - {integration.message}")
+        lines.append("")
     separator = "━" * 37
     label = GRADE_LABELS.get(result.grade, "Unknown")
     lines += [separator, f"Final Score: {result.score}/100 ({result.grade} - {label})", separator]
@@ -178,6 +183,7 @@ def _build_parser(program_name: str, *, program_mode: str) -> argparse.ArgumentP
         default="none",
     )
     scan_parser.add_argument("--cisco-skill-scan", choices=("auto", "on", "off"), default="auto")
+    scan_parser.add_argument("--cisco-mcp-scan", choices=("auto", "on", "off"), default="auto")
     scan_parser.add_argument("--cisco-policy", choices=("permissive", "balanced", "strict"), default="balanced")
     scan_parser.add_argument(
         "--ecosystem",
@@ -285,6 +291,7 @@ def _scan_with_policy(args: argparse.Namespace, plugin_dir: Path):
         plugin_dir,
         ScanOptions(
             cisco_skill_scan=getattr(args, "cisco_skill_scan", "auto"),
+            cisco_mcp_scan=getattr(args, "cisco_mcp_scan", "auto"),
             cisco_policy=getattr(args, "cisco_policy", "balanced"),
             ecosystem=getattr(args, "ecosystem", "auto"),
         ),

--- a/src/codex_plugin_scanner/integrations/__init__.py
+++ b/src/codex_plugin_scanner/integrations/__init__.py
@@ -1,5 +1,12 @@
 """Optional integrations for deeper plugin analysis."""
 
+from .cisco_mcp_scanner import CiscoMcpScanSummary, run_cisco_mcp_scan
 from .cisco_skill_scanner import CiscoIntegrationStatus, CiscoSkillScanSummary, run_cisco_skill_scan
 
-__all__ = ["CiscoIntegrationStatus", "CiscoSkillScanSummary", "run_cisco_skill_scan"]
+__all__ = [
+    "CiscoIntegrationStatus",
+    "CiscoMcpScanSummary",
+    "CiscoSkillScanSummary",
+    "run_cisco_mcp_scan",
+    "run_cisco_skill_scan",
+]

--- a/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
@@ -21,7 +21,6 @@ _EXCLUDED_DIRS = {
     ".venv",
     "__pycache__",
     "coverage",
-    "dist",
     "node_modules",
     "venv",
 }
@@ -230,6 +229,11 @@ def run_cisco_mcp_scan(plugin_dir: Path, mode: str = "auto") -> CiscoMcpScanSumm
         return _build_summary(
             status=CiscoIntegrationStatus.UNAVAILABLE,
             message="Cisco MCP scanner not installed; deep MCP scan skipped.",
+        )
+    except Exception as exc:
+        return _build_summary(
+            status=CiscoIntegrationStatus.FAILED,
+            message=f"Cisco MCP scanner failed to load: {exc}",
         )
 
     try:

--- a/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
@@ -1,0 +1,226 @@
+"""Cisco MCP scanner integration."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..models import Finding, Severity, severity_from_value
+from .cisco_skill_scanner import CiscoIntegrationStatus
+
+_EXCLUDED_DIRS = {
+    ".codex-plugin",
+    ".git",
+    ".next",
+    ".turbo",
+    ".venv",
+    "__pycache__",
+    "coverage",
+    "dist",
+    "node_modules",
+    "venv",
+}
+_SOURCE_SUFFIXES = {".cjs", ".js", ".json", ".jsx", ".mjs", ".py", ".ts", ".tsx"}
+_MAX_TARGET_SIZE_BYTES = 1_000_000
+
+
+@dataclass(frozen=True, slots=True)
+class CiscoMcpScanSummary:
+    """Normalized summary from a Cisco MCP scan run."""
+
+    status: CiscoIntegrationStatus
+    message: str
+    findings: tuple[Finding, ...]
+    targets_scanned: int
+    analyzers_used: tuple[str, ...]
+    total_findings: int
+    findings_by_severity: dict[str, int]
+    scan_mode: str = "static"
+
+
+def _empty_counts() -> dict[str, int]:
+    return {severity.value: 0 for severity in Severity}
+
+
+def _build_summary(
+    *,
+    status: CiscoIntegrationStatus,
+    message: str,
+    findings: tuple[Finding, ...] = (),
+    targets_scanned: int = 0,
+    analyzers_used: tuple[str, ...] = (),
+) -> CiscoMcpScanSummary:
+    counts = _empty_counts()
+    for finding in findings:
+        counts[finding.severity.value] += 1
+    return CiscoMcpScanSummary(
+        status=status,
+        message=message,
+        findings=findings,
+        targets_scanned=targets_scanned,
+        analyzers_used=analyzers_used,
+        total_findings=len(findings),
+        findings_by_severity=counts,
+    )
+
+
+def _load_mcp_scanner_components() -> dict[str, object]:
+    from mcpscanner import YaraAnalyzer
+
+    return {"YaraAnalyzer": YaraAnalyzer}
+
+
+def _relative_path(plugin_dir: Path, file_path: Path) -> str:
+    try:
+        return file_path.resolve().relative_to(plugin_dir.resolve()).as_posix()
+    except ValueError:
+        return file_path.as_posix()
+
+
+def _normalize_rule_fragment(value: str) -> str:
+    normalized = []
+    for character in value.upper():
+        normalized.append(character if character.isalnum() else "-")
+    return "".join(normalized).strip("-") or "FINDING"
+
+
+def _extract_rule_id(details: object, threat_category: str) -> str:
+    if isinstance(details, dict):
+        raw_response = details.get("raw_response")
+        if isinstance(raw_response, dict):
+            candidate = raw_response.get("rule")
+            if isinstance(candidate, str) and candidate.strip():
+                return f"CISCO-MCP-{_normalize_rule_fragment(candidate)}"
+        candidate = details.get("threat_type")
+        if isinstance(candidate, str) and candidate.strip():
+            return f"CISCO-MCP-{_normalize_rule_fragment(candidate)}"
+    return f"CISCO-MCP-{_normalize_rule_fragment(threat_category)}"
+
+
+def _extract_description(summary: str, details: object) -> str:
+    if isinstance(details, dict):
+        evidence = details.get("evidence")
+        if isinstance(evidence, str) and evidence.strip():
+            return evidence.strip()
+    return summary or "Cisco MCP scanner reported a potential issue."
+
+
+def _extract_title(summary: str, threat_category: str) -> str:
+    if summary:
+        return summary
+    return threat_category.replace("_", " ").title() or "Cisco MCP scanner finding"
+
+
+def _normalize_finding(plugin_dir: Path, file_path: Path, finding: object) -> Finding:
+    summary = str(getattr(finding, "summary", "") or "")
+    details = getattr(finding, "details", {})
+    threat_category = str(getattr(finding, "threat_category", "") or "mcp-security")
+    return Finding(
+        rule_id=_extract_rule_id(details, threat_category),
+        severity=severity_from_value(str(getattr(finding, "severity", "info") or "info")),
+        category="security",
+        title=_extract_title(summary, threat_category),
+        description=_extract_description(summary, details),
+        file_path=_relative_path(plugin_dir, file_path),
+        source="cisco-mcp-scanner",
+    )
+
+
+def _collect_static_targets(plugin_dir: Path) -> tuple[Path, ...]:
+    config_path = plugin_dir / ".mcp.json"
+    if not config_path.is_file():
+        return ()
+
+    targets = [config_path]
+    for file_path in sorted(plugin_dir.rglob("*")):
+        if not file_path.is_file() or file_path == config_path:
+            continue
+        if any(part in _EXCLUDED_DIRS for part in file_path.parts):
+            continue
+        if file_path.suffix.lower() not in _SOURCE_SUFFIXES:
+            continue
+        try:
+            if file_path.stat().st_size > _MAX_TARGET_SIZE_BYTES:
+                continue
+        except OSError:
+            continue
+        targets.append(file_path)
+    return tuple(targets)
+
+
+async def _scan_targets(plugin_dir: Path, targets: tuple[Path, ...], analyzer: object) -> tuple[Finding, ...]:
+    findings: list[Finding] = []
+    for target in targets:
+        try:
+            content = target.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        content_type = "mcp-config" if target.name == ".mcp.json" else "mcp-source"
+        external_findings = await analyzer.analyze(
+            content,
+            {
+                "tool_name": target.name,
+                "content_type": content_type,
+                "file_path": str(target),
+            },
+        )
+        for finding in external_findings:
+            findings.append(_normalize_finding(plugin_dir, target, finding))
+    return tuple(findings)
+
+
+def run_cisco_mcp_scan(plugin_dir: Path, mode: str = "auto") -> CiscoMcpScanSummary:
+    """Run Cisco MCP scanner static analysis when available."""
+
+    if mode == "off":
+        return _build_summary(
+            status=CiscoIntegrationStatus.SKIPPED,
+            message="Cisco MCP scanning disabled by configuration.",
+        )
+
+    if not (plugin_dir / ".mcp.json").is_file():
+        return _build_summary(
+            status=CiscoIntegrationStatus.SKIPPED,
+            message="No .mcp.json found; Cisco MCP scan skipped.",
+        )
+
+    try:
+        components = _load_mcp_scanner_components()
+    except ImportError:
+        if mode == "on":
+            return _build_summary(
+                status=CiscoIntegrationStatus.UNAVAILABLE,
+                message="Cisco MCP scanner is required but not installed. Ensure package dependencies are installed.",
+            )
+        return _build_summary(
+            status=CiscoIntegrationStatus.UNAVAILABLE,
+            message="Cisco MCP scanner not installed; deep MCP scan skipped.",
+        )
+
+    try:
+        analyzer_class = components["YaraAnalyzer"]
+        analyzer = analyzer_class()
+        targets = _collect_static_targets(plugin_dir)
+        findings = asyncio.run(_scan_targets(plugin_dir, targets, analyzer))
+    except Exception as exc:
+        return _build_summary(
+            status=CiscoIntegrationStatus.FAILED,
+            message=f"Cisco MCP scanner failed: {exc}",
+        )
+
+    targets_scanned = len(targets)
+    if findings:
+        message = (
+            f"Cisco MCP scanner completed static analysis for {targets_scanned} target(s) "
+            f"and reported {len(findings)} finding(s)."
+        )
+    else:
+        message = f"Cisco MCP scanner completed static analysis for {targets_scanned} target(s) with no findings."
+    return _build_summary(
+        status=CiscoIntegrationStatus.ENABLED,
+        message=message,
+        findings=findings,
+        targets_scanned=targets_scanned,
+        analyzers_used=("yara",),
+    )

--- a/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import os
+from collections.abc import Awaitable
 from dataclasses import dataclass
 from pathlib import Path
+from threading import Thread
+from typing import TypeVar
 
 from ..models import Finding, Severity, severity_from_value
 from .cisco_skill_scanner import CiscoIntegrationStatus
@@ -23,6 +27,7 @@ _EXCLUDED_DIRS = {
 }
 _SOURCE_SUFFIXES = {".cjs", ".js", ".json", ".jsx", ".mjs", ".py", ".ts", ".tsx"}
 _MAX_TARGET_SIZE_BYTES = 1_000_000
+T = TypeVar("T")
 
 
 @dataclass(frozen=True, slots=True)
@@ -133,24 +138,52 @@ def _collect_static_targets(plugin_dir: Path) -> tuple[Path, ...]:
         return ()
 
     targets = [config_path]
-    for file_path in sorted(plugin_dir.rglob("*")):
-        if not file_path.is_file() or file_path == config_path:
-            continue
-        if any(part in _EXCLUDED_DIRS for part in file_path.parts):
-            continue
-        if file_path.suffix.lower() not in _SOURCE_SUFFIXES:
-            continue
-        try:
-            if file_path.stat().st_size > _MAX_TARGET_SIZE_BYTES:
+    for root, dirs, files in os.walk(plugin_dir, topdown=True):
+        dirs[:] = sorted(dir_name for dir_name in dirs if dir_name not in _EXCLUDED_DIRS)
+        current_dir = Path(root)
+        for file_name in sorted(files):
+            file_path = current_dir / file_name
+            if file_path == config_path or file_path.suffix.lower() not in _SOURCE_SUFFIXES:
                 continue
-        except OSError:
-            continue
-        targets.append(file_path)
+            try:
+                if file_path.stat().st_size > _MAX_TARGET_SIZE_BYTES:
+                    continue
+            except OSError:
+                continue
+            targets.append(file_path)
     return tuple(targets)
 
 
-async def _scan_targets(plugin_dir: Path, targets: tuple[Path, ...], analyzer: object) -> tuple[Finding, ...]:
+def _run_awaitable(awaitable: Awaitable[T]) -> T:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(awaitable)
+
+    result: list[T] = []
+    errors: list[BaseException] = []
+
+    def _runner() -> None:
+        try:
+            result.append(asyncio.run(awaitable))
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = Thread(target=_runner)
+    thread.start()
+    thread.join()
+    if errors:
+        raise errors[0]
+    if result:
+        return result[0]
+    raise RuntimeError("Cisco MCP scanner completed without a result.")
+
+
+async def _scan_targets(
+    plugin_dir: Path, targets: tuple[Path, ...], analyzer: object
+) -> tuple[tuple[Finding, ...], int]:
     findings: list[Finding] = []
+    targets_scanned = 0
     for target in targets:
         try:
             content = target.read_text(encoding="utf-8", errors="ignore")
@@ -165,9 +198,10 @@ async def _scan_targets(plugin_dir: Path, targets: tuple[Path, ...], analyzer: o
                 "file_path": str(target),
             },
         )
+        targets_scanned += 1
         for finding in external_findings:
             findings.append(_normalize_finding(plugin_dir, target, finding))
-    return tuple(findings)
+    return tuple(findings), targets_scanned
 
 
 def run_cisco_mcp_scan(plugin_dir: Path, mode: str = "auto") -> CiscoMcpScanSummary:
@@ -202,14 +236,13 @@ def run_cisco_mcp_scan(plugin_dir: Path, mode: str = "auto") -> CiscoMcpScanSumm
         analyzer_class = components["YaraAnalyzer"]
         analyzer = analyzer_class()
         targets = _collect_static_targets(plugin_dir)
-        findings = asyncio.run(_scan_targets(plugin_dir, targets, analyzer))
+        findings, targets_scanned = _run_awaitable(_scan_targets(plugin_dir, targets, analyzer))
     except Exception as exc:
         return _build_summary(
             status=CiscoIntegrationStatus.FAILED,
             message=f"Cisco MCP scanner failed: {exc}",
         )
 
-    targets_scanned = len(targets)
     if findings:
         message = (
             f"Cisco MCP scanner completed static analysis for {targets_scanned} target(s) "

--- a/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
@@ -136,7 +136,12 @@ def _collect_static_targets(plugin_dir: Path) -> tuple[Path, ...]:
     if not config_path.is_file():
         return ()
 
-    targets = [config_path]
+    targets: list[Path] = []
+    try:
+        if config_path.stat().st_size <= _MAX_TARGET_SIZE_BYTES:
+            targets.append(config_path)
+    except OSError:
+        pass
     for root, dirs, files in os.walk(plugin_dir, topdown=True):
         dirs[:] = sorted(dir_name for dir_name in dirs if dir_name not in _EXCLUDED_DIRS)
         current_dir = Path(root)

--- a/src/codex_plugin_scanner/models.py
+++ b/src/codex_plugin_scanner/models.py
@@ -91,6 +91,7 @@ class ScanOptions:
     """Runtime options that change scanner behavior."""
 
     cisco_skill_scan: str = "auto"
+    cisco_mcp_scan: str = "auto"
     cisco_policy: str = "balanced"
     ecosystem: str = "auto"
 

--- a/src/codex_plugin_scanner/scanner.py
+++ b/src/codex_plugin_scanner/scanner.py
@@ -12,6 +12,7 @@ from .checks.code_quality import run_code_quality_checks
 from .checks.gemini import run_gemini_checks
 from .checks.manifest import run_manifest_checks
 from .checks.marketplace import run_marketplace_checks
+from .checks.mcp_security import resolve_mcp_security_context, run_mcp_security_checks
 from .checks.opencode import run_opencode_checks
 from .checks.operational_security import run_operational_security_checks
 from .checks.security import run_security_checks
@@ -35,7 +36,7 @@ from .repo_detect import LocalPluginTarget, discover_scan_targets
 from .trust_scoring import build_plugin_trust_report, build_repository_trust_report
 
 
-def _build_integration_results(skill_security_context, package_label: str = "") -> tuple[IntegrationResult, ...]:
+def _build_skill_integration_results(skill_security_context, package_label: str = "") -> tuple[IntegrationResult, ...]:
     integration_name = "cisco-skill-scanner" if not package_label else f"cisco-skill-scanner[{package_label}]"
     if skill_security_context.skip_message:
         return (
@@ -67,6 +68,58 @@ def _build_integration_results(skill_security_context, package_label: str = "") 
             findings_count=summary.total_findings,
             metadata=metadata,
         ),
+    )
+
+
+def _build_mcp_integration_results(mcp_security_context, package_label: str = "") -> tuple[IntegrationResult, ...]:
+    integration_name = "cisco-mcp-scanner" if not package_label else f"cisco-mcp-scanner[{package_label}]"
+    if mcp_security_context.skip_message:
+        return (
+            IntegrationResult(
+                name=integration_name,
+                status=CiscoIntegrationStatus.SKIPPED,
+                message=mcp_security_context.skip_message,
+            ),
+        )
+
+    summary = mcp_security_context.summary
+    if summary is None:
+        return (
+            IntegrationResult(
+                name=integration_name,
+                status=CiscoIntegrationStatus.SKIPPED,
+                message="Cisco MCP scan context unavailable.",
+            ),
+        )
+
+    metadata = {
+        "scan_mode": summary.scan_mode,
+        "targets_scanned": str(summary.targets_scanned),
+    }
+    if summary.analyzers_used:
+        metadata["analyzers"] = ",".join(summary.analyzers_used)
+    return (
+        IntegrationResult(
+            name=integration_name,
+            status=summary.status,
+            message=summary.message,
+            findings_count=summary.total_findings,
+            metadata=metadata,
+        ),
+    )
+
+
+def _build_integration_results(
+    skill_security_context,
+    mcp_security_context,
+    package_label: str = "",
+) -> tuple[IntegrationResult, ...]:
+    return _build_skill_integration_results(
+        skill_security_context,
+        package_label,
+    ) + _build_mcp_integration_results(
+        mcp_security_context,
+        package_label,
     )
 
 
@@ -190,9 +243,13 @@ def _rebase_plugin_result(plugin_result: ScanResult, plugin_target: LocalPluginT
 
 def _scan_single_plugin(plugin_dir: Path, options: ScanOptions) -> ScanResult:
     skill_security_context = resolve_skill_security_context(plugin_dir, options)
+    mcp_security_context = resolve_mcp_security_context(plugin_dir, options)
     categories: list[CategoryResult] = [
         CategoryResult(name="Manifest Validation", checks=run_manifest_checks(plugin_dir)),
-        CategoryResult(name="Security", checks=run_security_checks(plugin_dir)),
+        CategoryResult(
+            name="Security",
+            checks=run_security_checks(plugin_dir) + run_mcp_security_checks(plugin_dir, options, mcp_security_context),
+        ),
         CategoryResult(name="Operational Security", checks=run_operational_security_checks(plugin_dir)),
         CategoryResult(name="Best Practices", checks=run_best_practice_checks(plugin_dir)),
         CategoryResult(name="Marketplace", checks=run_marketplace_checks(plugin_dir)),
@@ -214,7 +271,7 @@ def _scan_single_plugin(plugin_dir: Path, options: ScanOptions) -> ScanResult:
         plugin_dir=str(plugin_dir),
         findings=findings,
         severity_counts=build_severity_counts(findings),
-        integrations=_build_integration_results(skill_security_context),
+        integrations=_build_integration_results(skill_security_context, mcp_security_context),
         scope="plugin",
         trust_report=trust_report,
         ecosystems=("codex",),

--- a/tests/test_action_runner.py
+++ b/tests/test_action_runner.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import ClassVar
 from urllib.parse import parse_qs, urlsplit
 
-from codex_plugin_scanner.action_runner import main
+from codex_plugin_scanner.action_runner import _build_scan_args, main
 from codex_plugin_scanner.github_reporting import GitHubPrCommentResult, upsert_pr_comment
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -150,6 +150,22 @@ def test_action_runner_writes_all_outputs(monkeypatch, tmp_path, capsys) -> None
 
     stdout = capsys.readouterr().out
     assert '"score": 100' in stdout
+
+
+def test_build_scan_args_propagates_cisco_mcp_scan() -> None:
+    args = _build_scan_args(
+        plugin_dir=str(FIXTURES / "good-plugin"),
+        profile="default",
+        config="",
+        baseline="",
+        min_score=0,
+        fail_on_severity="none",
+        cisco_scan="auto",
+        cisco_mcp_scan="on",
+        cisco_policy="balanced",
+    )
+
+    assert args.cisco_mcp_scan == "on"
 
 
 def test_action_runner_writes_step_summary_and_registry_payload(monkeypatch, tmp_path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,9 +17,6 @@ from codex_plugin_scanner.scanner import scan_plugin
 FIXTURES = Path(__file__).parent / "fixtures"
 NONEXISTENT_PLUGIN_DIR = Path("/nonexistent/plugin-dir").resolve()
 EXPECTED_GOOD_PLUGIN_SCORE = 91
-EXPECTED_BAD_PLUGIN_SCORE = 39
-
-
 class TestFormatJson:
     def test_valid_json_output(self):
         result = scan_plugin(FIXTURES / "good-plugin")
@@ -85,7 +82,7 @@ class TestFormatText:
     def test_bad_plugin_output(self):
         result = scan_plugin(FIXTURES / "bad-plugin")
         output = format_text(result)
-        assert f"{EXPECTED_BAD_PLUGIN_SCORE}/100" in output
+        assert f"{result.score}/100" in output
         assert "Failing" in output
 
     def test_integration_block_supports_multiple_integrations(self):
@@ -182,10 +179,11 @@ class TestMain:
         assert "opencode" in output
 
     def test_text_mode_with_min_score_failure(self, capsys):
+        expected_score = scan_plugin(FIXTURES / "bad-plugin").score
         main([str(FIXTURES / "bad-plugin"), "--min-score", "50"])
         captured = capsys.readouterr()
         # Should still produce text output
-        assert f"{EXPECTED_BAD_PLUGIN_SCORE}/100" in captured.out
+        assert f"{expected_score}/100" in captured.out
 
     def test_min_score_exact_boundary(self):
         # At exact boundary should pass (>=)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,17 +5,19 @@ import shutil
 import sys
 import tempfile
 import zipfile
+from dataclasses import replace
 from pathlib import Path
 
 from codex_plugin_scanner import cli as cli_module
 from codex_plugin_scanner.cli import format_json, format_text, main
+from codex_plugin_scanner.models import IntegrationResult
 from codex_plugin_scanner.rules import get_rule_spec as original_get_rule_spec
 from codex_plugin_scanner.scanner import scan_plugin
 
 FIXTURES = Path(__file__).parent / "fixtures"
 NONEXISTENT_PLUGIN_DIR = Path("/nonexistent/plugin-dir").resolve()
 EXPECTED_GOOD_PLUGIN_SCORE = 91
-EXPECTED_BAD_PLUGIN_SCORE = 38
+EXPECTED_BAD_PLUGIN_SCORE = 39
 
 
 class TestFormatJson:
@@ -86,8 +88,29 @@ class TestFormatText:
         assert f"{EXPECTED_BAD_PLUGIN_SCORE}/100" in output
         assert "Failing" in output
 
+    def test_integration_block_supports_multiple_integrations(self):
+        result = scan_plugin(FIXTURES / "good-plugin")
+        result = replace(
+            result,
+            integrations=(
+                IntegrationResult(name="cisco-skill-scanner", status="enabled", message="Skill scan complete"),
+                IntegrationResult(name="cisco-mcp-scanner", status="enabled", message="MCP scan complete"),
+            ),
+        )
+
+        output = format_text(result)
+
+        assert "cisco-skill-scanner" in output
+        assert "cisco-mcp-scanner" in output
+
 
 class TestMain:
+    def test_parser_accepts_cisco_mcp_scan(self):
+        parser = cli_module._build_parser("plugin-scanner", program_mode="scanner")
+        args = parser.parse_args(["scan", str(FIXTURES / "good-plugin"), "--cisco-mcp-scan", "on"])
+
+        assert args.cisco_mcp_scan == "on"
+
     def test_returns_0_for_good_plugin(self):
         rc = main([str(FIXTURES / "good-plugin")])
         assert rc == 0
@@ -140,7 +163,7 @@ class TestMain:
         assert rc == 0
 
     def test_min_score_just_above(self):
-        rc = main([str(FIXTURES / "bad-plugin"), "--min-score", "39"])
+        rc = main([str(FIXTURES / "bad-plugin"), "--min-score", "40"])
         assert rc == 1
 
     def test_version_flag(self, capsys):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,7 +9,7 @@ from codex_plugin_scanner.scanner import scan_plugin
 
 FIXTURES = Path(__file__).parent / "fixtures"
 EXPECTED_GOOD_PLUGIN_SCORE = 91
-EXPECTED_BAD_PLUGIN_SCORE = 38
+EXPECTED_BAD_PLUGIN_SCORE = 39
 
 
 def test_good_plugin_expected_score():
@@ -45,7 +45,7 @@ def test_json_output_is_parseable():
     assert parsed["score"] == EXPECTED_GOOD_PLUGIN_SCORE
     assert len(parsed["categories"]) == 7
     total_checks = sum(len(c["checks"]) for c in parsed["categories"])
-    assert total_checks == 34
+    assert total_checks == 37
 
 
 def test_text_output_is_readable():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,9 +9,6 @@ from codex_plugin_scanner.scanner import scan_plugin
 
 FIXTURES = Path(__file__).parent / "fixtures"
 EXPECTED_GOOD_PLUGIN_SCORE = 91
-EXPECTED_BAD_PLUGIN_SCORE = 39
-
-
 def test_good_plugin_expected_score():
     result = scan_plugin(FIXTURES / "good-plugin")
     assert result.score == EXPECTED_GOOD_PLUGIN_SCORE
@@ -22,7 +19,7 @@ def test_good_plugin_expected_score():
 
 def test_bad_plugin_catches_all_issues():
     result = scan_plugin(FIXTURES / "bad-plugin")
-    assert result.score == EXPECTED_BAD_PLUGIN_SCORE
+    assert result.score < 50
     assert result.grade == "F"
 
     cats = {c.name: c for c in result.categories}

--- a/tests/test_live_cisco_smoke.py
+++ b/tests/test_live_cisco_smoke.py
@@ -31,3 +31,16 @@ def test_live_cisco_scan_on_good_plugin() -> None:
     assert integration.findings_count == len(cisco_findings)
     assert checks_by_name["Cisco skill scan completed"].passed is True
     assert checks_by_name["No elevated Cisco skill findings"].applicable is True
+
+
+def test_live_cisco_mcp_scan_on_bad_plugin() -> None:
+    if importlib.util.find_spec("mcpscanner") is None:
+        pytest.skip("cisco-ai-mcp-scanner is not installed in this environment")
+
+    result = scan_plugin(FIXTURES / "bad-plugin", ScanOptions(cisco_mcp_scan="on"))
+
+    integration = next(item for item in result.integrations if item.name == "cisco-mcp-scanner")
+    cisco_findings = [finding for finding in result.findings if finding.source == "cisco-mcp-scanner"]
+
+    assert integration.status == CiscoIntegrationStatus.ENABLED
+    assert integration.findings_count == len(cisco_findings)

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -1,0 +1,167 @@
+"""Tests for Cisco MCP security integration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from codex_plugin_scanner.checks.mcp_security import resolve_mcp_security_context, run_mcp_security_checks
+from codex_plugin_scanner.integrations.cisco_mcp_scanner import run_cisco_mcp_scan
+from codex_plugin_scanner.integrations.cisco_skill_scanner import CiscoIntegrationStatus
+from codex_plugin_scanner.models import ScanOptions
+from codex_plugin_scanner.scanner import scan_plugin
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+class FakeCiscoFinding:
+    def __init__(
+        self,
+        *,
+        severity: str,
+        summary: str,
+        analyzer: str,
+        threat_category: str,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        self.severity = severity
+        self.summary = summary
+        self.analyzer = analyzer
+        self.threat_category = threat_category
+        self.details = details or {}
+
+
+def _write_plugin(plugin_dir: Path) -> None:
+    (plugin_dir / ".codex-plugin").mkdir(parents=True)
+    (plugin_dir / ".codex-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "mcp-plugin", "version": "1.0.0", "description": "fixture"}),
+        encoding="utf-8",
+    )
+    (plugin_dir / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"demo": {"command": "python", "args": ["server.py"]}}}),
+        encoding="utf-8",
+    )
+    (plugin_dir / "server.py").write_text("print('hello')\n", encoding="utf-8")
+
+
+def test_mcp_security_auto_mode_unavailable_is_not_applicable(monkeypatch, tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugin"
+    _write_plugin(plugin_dir)
+
+    def _raise_import_error() -> object:
+        raise ImportError("mcpscanner not installed")
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.integrations.cisco_mcp_scanner._load_mcp_scanner_components",
+        _raise_import_error,
+    )
+
+    summary = run_cisco_mcp_scan(plugin_dir, mode="auto")
+    checks = run_mcp_security_checks(plugin_dir, ScanOptions(cisco_mcp_scan="auto"))
+
+    availability = next(check for check in checks if check.name == "Cisco MCP scan completed")
+    assert summary.status == CiscoIntegrationStatus.UNAVAILABLE
+    assert availability.applicable is False
+    assert availability.max_points == 0
+
+
+def test_mcp_security_on_mode_requires_dependency(monkeypatch, tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugin"
+    _write_plugin(plugin_dir)
+
+    def _raise_import_error() -> object:
+        raise ImportError("mcpscanner not installed")
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.integrations.cisco_mcp_scanner._load_mcp_scanner_components",
+        _raise_import_error,
+    )
+
+    checks = run_mcp_security_checks(plugin_dir, ScanOptions(cisco_mcp_scan="on"))
+
+    availability = next(check for check in checks if check.name == "Cisco MCP scan completed")
+    assert availability.passed is False
+    assert availability.max_points > 0
+    assert availability.findings[0].rule_id == "CISCO-MCP-SCANNER-UNAVAILABLE"
+
+
+def test_scan_plugin_includes_cisco_mcp_findings(monkeypatch, tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugin"
+    _write_plugin(plugin_dir)
+
+    class FakeYaraAnalyzer:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        async def analyze(self, content: str, context: dict[str, Any] | None = None) -> list[FakeCiscoFinding]:
+            file_path = str((context or {}).get("file_path", ""))
+            if file_path.endswith(".mcp.json"):
+                return [
+                    FakeCiscoFinding(
+                        severity="HIGH",
+                        summary="Detected command injection",
+                        analyzer="YARA",
+                        threat_category="command_injection",
+                        details={"raw_response": {"rule": "MCP_COMMAND_INJECTION"}},
+                    )
+                ]
+            if file_path.endswith("server.py"):
+                return [
+                    FakeCiscoFinding(
+                        severity="LOW",
+                        summary="Detected permissive server behavior",
+                        analyzer="YARA",
+                        threat_category="behavior",
+                        details={"evidence": "server.py"},
+                    )
+                ]
+            return []
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.integrations.cisco_mcp_scanner._load_mcp_scanner_components",
+        lambda: {"YaraAnalyzer": FakeYaraAnalyzer},
+    )
+
+    result = scan_plugin(plugin_dir, ScanOptions(cisco_skill_scan="off", cisco_mcp_scan="on"))
+
+    integration = next(item for item in result.integrations if item.name == "cisco-mcp-scanner")
+    security = next(category for category in result.categories if category.name == "Security")
+    mcp_findings = [finding for finding in result.findings if finding.source == "cisco-mcp-scanner"]
+
+    assert integration.status == CiscoIntegrationStatus.ENABLED
+    assert integration.findings_count == len(mcp_findings)
+    assert integration.metadata["scan_mode"] == "static"
+    assert integration.metadata["targets_scanned"] == "2"
+    assert any(check.name == "Cisco MCP scan completed" for check in security.checks)
+    assert {finding.file_path for finding in mcp_findings} == {".mcp.json", "server.py"}
+
+
+def test_mcp_security_skips_plugins_without_mcp_config() -> None:
+    context = resolve_mcp_security_context(FIXTURES / "good-plugin", ScanOptions(cisco_mcp_scan="on"))
+    checks = run_mcp_security_checks(FIXTURES / "good-plugin", ScanOptions(cisco_mcp_scan="on"), context)
+
+    assert context.target_present is False
+    assert all(check.applicable is False for check in checks)
+
+
+def test_mcp_security_handles_scanner_failures(monkeypatch, tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugin"
+    _write_plugin(plugin_dir)
+
+    class ExplodingYaraAnalyzer:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        async def analyze(self, content: str, context: dict[str, Any] | None = None) -> list[FakeCiscoFinding]:
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.integrations.cisco_mcp_scanner._load_mcp_scanner_components",
+        lambda: {"YaraAnalyzer": ExplodingYaraAnalyzer},
+    )
+
+    summary = run_cisco_mcp_scan(plugin_dir, mode="on")
+
+    assert summary.status == CiscoIntegrationStatus.FAILED
+    assert "boom" in summary.message

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from typing import Any
@@ -43,6 +44,33 @@ def _write_plugin(plugin_dir: Path) -> None:
         encoding="utf-8",
     )
     (plugin_dir / "server.py").write_text("print('hello')\n", encoding="utf-8")
+
+
+def test_scan_ignores_excluded_descendants(monkeypatch, tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugin"
+    _write_plugin(plugin_dir)
+    (plugin_dir / "node_modules").mkdir()
+    (plugin_dir / "node_modules" / "ignored.py").write_text("print('ignored')\n", encoding="utf-8")
+    analyzed_paths: list[str] = []
+
+    class RecordingYaraAnalyzer:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        async def analyze(self, content: str, context: dict[str, Any] | None = None) -> list[FakeCiscoFinding]:
+            analyzed_paths.append(str((context or {}).get("file_path", "")))
+            return []
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.integrations.cisco_mcp_scanner._load_mcp_scanner_components",
+        lambda: {"YaraAnalyzer": RecordingYaraAnalyzer},
+    )
+
+    summary = run_cisco_mcp_scan(plugin_dir, mode="on")
+
+    assert summary.status == CiscoIntegrationStatus.ENABLED
+    assert summary.targets_scanned == 2
+    assert all("node_modules" not in path for path in analyzed_paths)
 
 
 def test_mcp_security_auto_mode_unavailable_is_not_applicable(monkeypatch, tmp_path: Path) -> None:
@@ -137,6 +165,53 @@ def test_scan_plugin_includes_cisco_mcp_findings(monkeypatch, tmp_path: Path) ->
     assert {finding.file_path for finding in mcp_findings} == {".mcp.json", "server.py"}
 
 
+def test_scan_uses_plugin_relative_exclusions(monkeypatch, tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "dist" / "plugin"
+    plugin_dir.mkdir(parents=True)
+    _write_plugin(plugin_dir)
+
+    class RecordingYaraAnalyzer:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        async def analyze(self, content: str, context: dict[str, Any] | None = None) -> list[FakeCiscoFinding]:
+            return []
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.integrations.cisco_mcp_scanner._load_mcp_scanner_components",
+        lambda: {"YaraAnalyzer": RecordingYaraAnalyzer},
+    )
+
+    summary = run_cisco_mcp_scan(plugin_dir, mode="on")
+
+    assert summary.status == CiscoIntegrationStatus.ENABLED
+    assert summary.targets_scanned == 2
+
+
+def test_scan_runs_safely_inside_running_event_loop(monkeypatch, tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugin"
+    _write_plugin(plugin_dir)
+
+    class RecordingYaraAnalyzer:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        async def analyze(self, content: str, context: dict[str, Any] | None = None) -> list[FakeCiscoFinding]:
+            return []
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.integrations.cisco_mcp_scanner._load_mcp_scanner_components",
+        lambda: {"YaraAnalyzer": RecordingYaraAnalyzer},
+    )
+
+    async def _run_scan() -> CiscoIntegrationStatus:
+        return run_cisco_mcp_scan(plugin_dir, mode="on").status
+
+    status = asyncio.run(_run_scan())
+
+    assert status == CiscoIntegrationStatus.ENABLED
+
+
 def test_mcp_security_skips_plugins_without_mcp_config() -> None:
     context = resolve_mcp_security_context(FIXTURES / "good-plugin", ScanOptions(cisco_mcp_scan="on"))
     checks = run_mcp_security_checks(FIXTURES / "good-plugin", ScanOptions(cisco_mcp_scan="on"), context)
@@ -165,3 +240,32 @@ def test_mcp_security_handles_scanner_failures(monkeypatch, tmp_path: Path) -> N
 
     assert summary.status == CiscoIntegrationStatus.FAILED
     assert "boom" in summary.message
+
+
+def test_targets_scanned_counts_only_processed_targets(monkeypatch, tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugin"
+    _write_plugin(plugin_dir)
+    original_read_text = Path.read_text
+
+    class RecordingYaraAnalyzer:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        async def analyze(self, content: str, context: dict[str, Any] | None = None) -> list[FakeCiscoFinding]:
+            return []
+
+    def _read_text(self: Path, *args: object, **kwargs: object) -> str:
+        if self.name == "server.py":
+            raise OSError("unreadable")
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _read_text)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.integrations.cisco_mcp_scanner._load_mcp_scanner_components",
+        lambda: {"YaraAnalyzer": RecordingYaraAnalyzer},
+    )
+
+    summary = run_cisco_mcp_scan(plugin_dir, mode="on")
+
+    assert summary.status == CiscoIntegrationStatus.ENABLED
+    assert summary.targets_scanned == 1

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -314,3 +314,30 @@ def test_targets_scanned_counts_only_processed_targets(monkeypatch, tmp_path: Pa
 
     assert summary.status == CiscoIntegrationStatus.ENABLED
     assert summary.targets_scanned == 1
+
+
+def test_scan_skips_oversized_mcp_config(monkeypatch, tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugin"
+    _write_plugin(plugin_dir)
+    config_path = plugin_dir / ".mcp.json"
+    config_path.write_text("x" * 1_100_000, encoding="utf-8")
+    analyzed_paths: list[str] = []
+
+    class RecordingYaraAnalyzer:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        async def analyze(self, content: str, context: dict[str, Any] | None = None) -> list[FakeCiscoFinding]:
+            analyzed_paths.append(str((context or {}).get("file_path", "")))
+            return []
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.integrations.cisco_mcp_scanner._load_mcp_scanner_components",
+        lambda: {"YaraAnalyzer": RecordingYaraAnalyzer},
+    )
+
+    summary = run_cisco_mcp_scan(plugin_dir, mode="on")
+
+    assert summary.status == CiscoIntegrationStatus.ENABLED
+    assert summary.targets_scanned == 1
+    assert all(not path.endswith(".mcp.json") for path in analyzed_paths)

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -73,6 +73,33 @@ def test_scan_ignores_excluded_descendants(monkeypatch, tmp_path: Path) -> None:
     assert all("node_modules" not in path for path in analyzed_paths)
 
 
+def test_scan_includes_dist_descendants(monkeypatch, tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugin"
+    _write_plugin(plugin_dir)
+    (plugin_dir / "dist").mkdir()
+    (plugin_dir / "dist" / "server.js").write_text("console.log('dist')\n", encoding="utf-8")
+    analyzed_paths: list[str] = []
+
+    class RecordingYaraAnalyzer:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        async def analyze(self, content: str, context: dict[str, Any] | None = None) -> list[FakeCiscoFinding]:
+            analyzed_paths.append(str((context or {}).get("file_path", "")))
+            return []
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.integrations.cisco_mcp_scanner._load_mcp_scanner_components",
+        lambda: {"YaraAnalyzer": RecordingYaraAnalyzer},
+    )
+
+    summary = run_cisco_mcp_scan(plugin_dir, mode="on")
+
+    assert summary.status == CiscoIntegrationStatus.ENABLED
+    assert summary.targets_scanned == 3
+    assert any(path.endswith("dist/server.js") for path in analyzed_paths)
+
+
 def test_mcp_security_auto_mode_unavailable_is_not_applicable(monkeypatch, tmp_path: Path) -> None:
     plugin_dir = tmp_path / "plugin"
     _write_plugin(plugin_dir)
@@ -112,6 +139,24 @@ def test_mcp_security_on_mode_requires_dependency(monkeypatch, tmp_path: Path) -
     assert availability.passed is False
     assert availability.max_points > 0
     assert availability.findings[0].rule_id == "CISCO-MCP-SCANNER-UNAVAILABLE"
+
+
+def test_mcp_security_handles_loader_failures(monkeypatch, tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugin"
+    _write_plugin(plugin_dir)
+
+    def _raise_runtime_error() -> object:
+        raise RuntimeError("loader boom")
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.integrations.cisco_mcp_scanner._load_mcp_scanner_components",
+        _raise_runtime_error,
+    )
+
+    summary = run_cisco_mcp_scan(plugin_dir, mode="auto")
+
+    assert summary.status == CiscoIntegrationStatus.FAILED
+    assert "loader boom" in summary.message
 
 
 def test_scan_plugin_includes_cisco_mcp_findings(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_schema_contracts.py
+++ b/tests/test_schema_contracts.py
@@ -1,11 +1,15 @@
 """Schema contract smoke tests."""
 
 import json
+from dataclasses import replace
 from pathlib import Path
 
 from jsonschema import validate
 
 from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.models import IntegrationResult
+from codex_plugin_scanner.reporting import build_json_payload
+from codex_plugin_scanner.scanner import scan_plugin
 
 ROOT = Path(__file__).resolve().parents[1]
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -29,6 +33,27 @@ def test_repository_scan_output_matches_schema_required_keys(capsys):
     rc = main(["scan", str(FIXTURES / "multi-plugin-repo"), "--format", "json"])
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
+    schema = json.loads((ROOT / "schemas" / "scan-result.v1.json").read_text(encoding="utf-8"))
+    validate(instance=payload, schema=schema)
+
+
+def test_scan_output_with_multiple_integrations_matches_schema() -> None:
+    result = scan_plugin(FIXTURES / "good-plugin")
+    result = replace(
+        result,
+        integrations=(
+            IntegrationResult(name="cisco-skill-scanner", status="enabled", message="Skill scan complete"),
+            IntegrationResult(
+                name="cisco-mcp-scanner",
+                status="enabled",
+                message="MCP scan complete",
+                findings_count=1,
+                metadata={"scan_mode": "static", "targets_scanned": "2"},
+            ),
+        ),
+    )
+
+    payload = build_json_payload(result)
     schema = json.loads((ROOT / "schemas" / "scan-result.v1.json").read_text(encoding="utf-8"))
     validate(instance=payload, schema=schema)
 

--- a/uv.lock
+++ b/uv.lock
@@ -445,6 +445,28 @@ wheels = [
 ]
 
 [[package]]
+name = "cisco-ai-mcp-scanner"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "expandvars", marker = "python_full_version >= '3.11'" },
+    { name = "fastapi", marker = "python_full_version >= '3.11'" },
+    { name = "httpx", marker = "python_full_version >= '3.11'" },
+    { name = "litellm", marker = "python_full_version >= '3.11'" },
+    { name = "mcp", extra = ["cli"], marker = "python_full_version >= '3.11'" },
+    { name = "puremagic", version = "1.30", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "puremagic", version = "2.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.11'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.11'" },
+    { name = "uvicorn", marker = "python_full_version >= '3.11'" },
+    { name = "yara-python", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/f0/33332b096d50db255cebcf7861c4f9aef73dc70734499cffd52cc38a0765/cisco_ai_mcp_scanner-4.5.0.tar.gz", hash = "sha256:392d87b63ae2c86b0fdea7b1c08b015617f823ab0ef015c9087f9b902b2c6192", size = 273648, upload-time = "2026-04-06T23:35:13.729Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/a5/2e1279739347b63e4475d1249042fc3c1191ef280e912a6c67d903766a46/cisco_ai_mcp_scanner-4.5.0-py3-none-any.whl", hash = "sha256:b1fe61a54330a8318b459369203517b431329c5a6cf127633a1a9efd0b7e3777", size = 287102, upload-time = "2026-04-06T23:35:12.086Z" },
+]
+
+[[package]]
 name = "cisco-ai-skill-scanner"
 version = "2.0.8"
 source = { registry = "https://pypi.org/simple" }
@@ -753,6 +775,15 @@ wheels = [
 ]
 
 [[package]]
+name = "expandvars"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/64/a9d8ea289d663a44b346203a24bf798507463db1e76679eaa72ee6de1c7a/expandvars-1.1.2.tar.gz", hash = "sha256:6c5822b7b756a99a356b915dd1267f52ab8a4efaa135963bd7f4bd5d368f71d7", size = 70842, upload-time = "2025-09-12T10:55:20.929Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/e6/79c43f7a55264e479a9fbf21ddba6a73530b3ea8439a8bb7fa5a281721af/expandvars-1.1.2-py3-none-any.whl", hash = "sha256:d1652fe4e61914f5b88ada93aaedb396446f55ae4621de45c8cb9f66e5712526", size = 7526, upload-time = "2025-09-12T10:55:18.779Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.128.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1029,11 +1060,15 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+cisco = [
+    { name = "cisco-ai-mcp-scanner", marker = "python_full_version >= '3.11'" },
+]
 dev = [
     { name = "build" },
     { name = "jsonschema" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pyyaml" },
     { name = "ruff" },
 ]
 publish = [
@@ -1043,14 +1078,16 @@ publish = [
 [package.metadata]
 requires-dist = [
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2.2" },
+    { name = "cisco-ai-mcp-scanner", marker = "python_full_version >= '3.11' and extra == 'cisco'", specifier = "~=4.5" },
     { name = "cisco-ai-skill-scanner", specifier = "~=2.0.8" },
-    { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.23.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
+    { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.26.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
+    { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.3" },
     { name = "rich", specifier = ">=13.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.10" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
-    { name = "twine", marker = "extra == 'publish'", specifier = ">=6.1.0" },
+    { name = "twine", marker = "extra == 'publish'", specifier = ">=6.2.0" },
 ]
 provides-extras = ["cisco", "dev", "publish"]
 
@@ -1123,6 +1160,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
 ]
 
 [[package]]
@@ -1552,6 +1598,37 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "python_full_version >= '3.11'" },
+    { name = "httpx", marker = "python_full_version >= '3.11'" },
+    { name = "httpx-sse", marker = "python_full_version >= '3.11'" },
+    { name = "jsonschema", marker = "python_full_version >= '3.11'" },
+    { name = "pydantic", marker = "python_full_version >= '3.11'" },
+    { name = "pydantic-settings", marker = "python_full_version >= '3.11'" },
+    { name = "pyjwt", extra = ["crypto"], marker = "python_full_version >= '3.11'" },
+    { name = "python-multipart", marker = "python_full_version >= '3.11'" },
+    { name = "pywin32", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "sse-starlette", marker = "python_full_version >= '3.11'" },
+    { name = "starlette", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+    { name = "typing-inspection", marker = "python_full_version >= '3.11'" },
+    { name = "uvicorn", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+]
+
+[package.optional-dependencies]
+cli = [
+    { name = "python-dotenv", marker = "python_full_version >= '3.11'" },
+    { name = "typer", marker = "python_full_version >= '3.11'" },
 ]
 
 [[package]]
@@ -2192,6 +2269,34 @@ wheels = [
 ]
 
 [[package]]
+name = "puremagic"
+version = "1.30"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/7f/9998706bc516bdd664ccf929a1da6c6e5ee06e48f723ce45aae7cf3ff36e/puremagic-1.30.tar.gz", hash = "sha256:f9ff7ac157d54e9cf3bff1addfd97233548e75e685282d84ae11e7ffee1614c9", size = 314785, upload-time = "2025-07-04T18:48:36.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/ed/1e347d85d05b37a8b9a039ca832e5747e1e5248d0bd66042783ef48b4a37/puremagic-1.30-py3-none-any.whl", hash = "sha256:5eeeb2dd86f335b9cfe8e205346612197af3500c6872dffebf26929f56e9d3c1", size = 43304, upload-time = "2025-07-04T18:48:34.801Z" },
+]
+
+[[package]]
+name = "puremagic"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/74/ce5987ab9b8aec4ced06e2723ebb604205c9eb58abdad91453da93166380/puremagic-2.2.0.tar.gz", hash = "sha256:eb4bddf07c177c4b434554b92165b67449f5a51e152b976202d6254498810eef", size = 1189752, upload-time = "2026-04-08T01:39:55.562Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/81/314320aeffd88dadeac553ff9eb10f54507ab41deccd0c69f6221d254a0a/puremagic-2.2.0-py3-none-any.whl", hash = "sha256:c4f7ed7307f056c787199acfda839555921be1df13abba61e8e6db0c787ae1d0", size = 71971, upload-time = "2026-04-08T01:39:54.169Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2334,12 +2439,40 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic", marker = "python_full_version >= '3.11'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.11'" },
+    { name = "typing-inspection", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography", marker = "python_full_version >= '3.11'" },
 ]
 
 [[package]]
@@ -2371,7 +2504,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -2382,9 +2515,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -2429,6 +2562,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/40/44efbb0dfbd33aca6a6483191dae0716070ed99e2ecb0c53683f400a0b4f/pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3", size = 8760432, upload-time = "2025-07-14T20:13:05.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/bf/360243b1e953bd254a82f12653974be395ba880e7ec23e3731d9f73921cc/pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b", size = 9590103, upload-time = "2025-07-14T20:13:07.698Z" },
+    { url = "https://files.pythonhosted.org/packages/57/38/d290720e6f138086fb3d5ffe0b6caa019a791dd57866940c82e4eeaf2012/pywin32-311-cp310-cp310-win_arm64.whl", hash = "sha256:0502d1facf1fed4839a9a51ccbcc63d952cf318f78ffc00a7e78528ac27d7a2b", size = 8778557, upload-time = "2025-07-14T20:13:11.11Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
+    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
 ]
 
 [[package]]
@@ -2826,27 +2981,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.9"
+version = "0.15.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e6/97/e9f1ca355108ef7194e38c812ef40ba98c7208f47b13ad78d023caa583da/ruff-0.15.9.tar.gz", hash = "sha256:29cbb1255a9797903f6dde5ba0188c707907ff44a9006eb273b5a17bfa0739a2", size = 4617361, upload-time = "2026-04-02T18:17:20.829Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/d9/aa3f7d59a10ef6b14fe3431706f854dbf03c5976be614a9796d36326810c/ruff-0.15.10.tar.gz", hash = "sha256:d1f86e67ebfdef88e00faefa1552b5e510e1d35f3be7d423dc7e84e63788c94e", size = 4631728, upload-time = "2026-04-09T14:06:09.884Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/1f/9cdfd0ac4b9d1e5a6cf09bedabdf0b56306ab5e333c85c87281273e7b041/ruff-0.15.9-py3-none-linux_armv6l.whl", hash = "sha256:6efbe303983441c51975c243e26dff328aca11f94b70992f35b093c2e71801e1", size = 10511206, upload-time = "2026-04-02T18:16:41.574Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/f6/32bfe3e9c136b35f02e489778d94384118bb80fd92c6d92e7ccd97db12ce/ruff-0.15.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4965bac6ac9ea86772f4e23587746f0b7a395eccabb823eb8bfacc3fa06069f7", size = 10923307, upload-time = "2026-04-02T18:17:08.645Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/25/de55f52ab5535d12e7aaba1de37a84be6179fb20bddcbe71ec091b4a3243/ruff-0.15.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:eaf05aad70ca5b5a0a4b0e080df3a6b699803916d88f006efd1f5b46302daab8", size = 10316722, upload-time = "2026-04-02T18:16:44.206Z" },
-    { url = "https://files.pythonhosted.org/packages/48/11/690d75f3fd6278fe55fff7c9eb429c92d207e14b25d1cae4064a32677029/ruff-0.15.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9439a342adb8725f32f92732e2bafb6d5246bd7a5021101166b223d312e8fc59", size = 10623674, upload-time = "2026-04-02T18:16:50.951Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/ec/176f6987be248fc5404199255522f57af1b4a5a1b57727e942479fec98ad/ruff-0.15.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9c5e6faf9d97c8edc43877c3f406f47446fc48c40e1442d58cfcdaba2acea745", size = 10351516, upload-time = "2026-04-02T18:16:57.206Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/fc/51cffbd2b3f240accc380171d51446a32aa2ea43a40d4a45ada67368fbd2/ruff-0.15.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b34a9766aeec27a222373d0b055722900fbc0582b24f39661aa96f3fe6ad901", size = 11150202, upload-time = "2026-04-02T18:17:06.452Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/d4/25292a6dfc125f6b6528fe6af31f5e996e19bf73ca8e3ce6eb7fa5b95885/ruff-0.15.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:89dd695bc72ae76ff484ae54b7e8b0f6b50f49046e198355e44ea656e521fef9", size = 11988891, upload-time = "2026-04-02T18:17:18.575Z" },
-    { url = "https://files.pythonhosted.org/packages/13/e1/1eebcb885c10e19f969dcb93d8413dfee8172578709d7ee933640f5e7147/ruff-0.15.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ce187224ef1de1bd225bc9a152ac7102a6171107f026e81f317e4257052916d5", size = 11480576, upload-time = "2026-04-02T18:16:52.986Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/6b/a1548ac378a78332a4c3dcf4a134c2475a36d2a22ddfa272acd574140b50/ruff-0.15.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b0c7c341f68adb01c488c3b7d4b49aa8ea97409eae6462d860a79cf55f431b6", size = 11254525, upload-time = "2026-04-02T18:17:02.041Z" },
-    { url = "https://files.pythonhosted.org/packages/42/aa/4bb3af8e61acd9b1281db2ab77e8b2c3c5e5599bf2a29d4a942f1c62b8d6/ruff-0.15.9-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:55cc15eee27dc0eebdfcb0d185a6153420efbedc15eb1d38fe5e685657b0f840", size = 11204072, upload-time = "2026-04-02T18:17:13.581Z" },
-    { url = "https://files.pythonhosted.org/packages/69/48/d550dc2aa6e423ea0bcc1d0ff0699325ffe8a811e2dba156bd80750b86dc/ruff-0.15.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6537f6eed5cda688c81073d46ffdfb962a5f29ecb6f7e770b2dc920598997ed", size = 10594998, upload-time = "2026-04-02T18:16:46.369Z" },
-    { url = "https://files.pythonhosted.org/packages/63/47/321167e17f5344ed5ec6b0aa2cff64efef5f9e985af8f5622cfa6536043f/ruff-0.15.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6d3fcbca7388b066139c523bda744c822258ebdcfbba7d24410c3f454cc9af71", size = 10359769, upload-time = "2026-04-02T18:17:10.994Z" },
-    { url = "https://files.pythonhosted.org/packages/67/5e/074f00b9785d1d2c6f8c22a21e023d0c2c1817838cfca4c8243200a1fa87/ruff-0.15.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:058d8e99e1bfe79d8a0def0b481c56059ee6716214f7e425d8e737e412d69677", size = 10850236, upload-time = "2026-04-02T18:16:48.749Z" },
-    { url = "https://files.pythonhosted.org/packages/76/37/804c4135a2a2caf042925d30d5f68181bdbd4461fd0d7739da28305df593/ruff-0.15.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8e1ddb11dbd61d5983fa2d7d6370ef3eb210951e443cace19594c01c72abab4c", size = 11358343, upload-time = "2026-04-02T18:16:55.068Z" },
-    { url = "https://files.pythonhosted.org/packages/88/3d/1364fcde8656962782aa9ea93c92d98682b1ecec2f184e625a965ad3b4a6/ruff-0.15.9-py3-none-win32.whl", hash = "sha256:bde6ff36eaf72b700f32b7196088970bf8fdb2b917b7accd8c371bfc0fd573ec", size = 10583382, upload-time = "2026-04-02T18:17:04.261Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/56/5c7084299bd2cacaa07ae63a91c6f4ba66edc08bf28f356b24f6b717c799/ruff-0.15.9-py3-none-win_amd64.whl", hash = "sha256:45a70921b80e1c10cf0b734ef09421f71b5aa11d27404edc89d7e8a69505e43d", size = 11744969, upload-time = "2026-04-02T18:16:59.611Z" },
-    { url = "https://files.pythonhosted.org/packages/03/36/76704c4f312257d6dbaae3c959add2a622f63fcca9d864659ce6d8d97d3d/ruff-0.15.9-py3-none-win_arm64.whl", hash = "sha256:0694e601c028fd97dc5c6ee244675bc241aeefced7ef80cd9c6935a871078f53", size = 11005870, upload-time = "2026-04-02T18:17:15.773Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/00/a1c2fdc9939b2c03691edbda290afcd297f1f389196172826b03d6b6a595/ruff-0.15.10-py3-none-linux_armv6l.whl", hash = "sha256:0744e31482f8f7d0d10a11fcbf897af272fefdfcb10f5af907b18c2813ff4d5f", size = 10563362, upload-time = "2026-04-09T14:06:21.189Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/15/006990029aea0bebe9d33c73c3e28c80c391ebdba408d1b08496f00d422d/ruff-0.15.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b1e7c16ea0ff5a53b7c2df52d947e685973049be1cdfe2b59a9c43601897b22e", size = 10951122, upload-time = "2026-04-09T14:06:02.236Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c0/4ac978fe874d0618c7da647862afe697b281c2806f13ce904ad652fa87e4/ruff-0.15.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:93cc06a19e5155b4441dd72808fdf84290d84ad8a39ca3b0f994363ade4cebb1", size = 10314005, upload-time = "2026-04-09T14:06:00.026Z" },
+    { url = "https://files.pythonhosted.org/packages/da/73/c209138a5c98c0d321266372fc4e33ad43d506d7e5dd817dd89b60a8548f/ruff-0.15.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83e1dd04312997c99ea6965df66a14fb4f03ba978564574ffc68b0d61fd3989e", size = 10643450, upload-time = "2026-04-09T14:05:42.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/76/0deec355d8ec10709653635b1f90856735302cb8e149acfdf6f82a5feb70/ruff-0.15.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8154d43684e4333360fedd11aaa40b1b08a4e37d8ffa9d95fee6fa5b37b6fab1", size = 10379597, upload-time = "2026-04-09T14:05:49.984Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/be/86bba8fc8798c081e28a4b3bb6d143ccad3fd5f6f024f02002b8f08a9fa3/ruff-0.15.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ab88715f3a6deb6bde6c227f3a123410bec7b855c3ae331b4c006189e895cef", size = 11146645, upload-time = "2026-04-09T14:06:12.246Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/89/140025e65911b281c57be1d385ba1d932c2366ca88ae6663685aed8d4881/ruff-0.15.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a768ff5969b4f44c349d48edf4ab4f91eddb27fd9d77799598e130fb628aa158", size = 12030289, upload-time = "2026-04-09T14:06:04.776Z" },
+    { url = "https://files.pythonhosted.org/packages/88/de/ddacca9545a5e01332567db01d44bd8cf725f2db3b3d61a80550b48308ea/ruff-0.15.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ee3ef42dab7078bda5ff6a1bcba8539e9857deb447132ad5566a038674540d0", size = 11496266, upload-time = "2026-04-09T14:05:55.485Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/bb/7ddb00a83760ff4a83c4e2fc231fd63937cc7317c10c82f583302e0f6586/ruff-0.15.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51cb8cc943e891ba99989dd92d61e29b1d231e14811db9be6440ecf25d5c1609", size = 11256418, upload-time = "2026-04-09T14:05:57.69Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8d/55de0d35aacf6cd50b6ee91ee0f291672080021896543776f4170fc5c454/ruff-0.15.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e59c9bdc056a320fb9ea1700a8d591718b8faf78af065484e801258d3a76bc3f", size = 11288416, upload-time = "2026-04-09T14:05:44.695Z" },
+    { url = "https://files.pythonhosted.org/packages/68/cf/9438b1a27426ec46a80e0a718093c7f958ef72f43eb3111862949ead3cc1/ruff-0.15.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:136c00ca2f47b0018b073f28cb5c1506642a830ea941a60354b0e8bc8076b151", size = 10621053, upload-time = "2026-04-09T14:05:52.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/50/e29be6e2c135e9cd4cb15fbade49d6a2717e009dff3766dd080fcb82e251/ruff-0.15.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8b80a2f3c9c8a950d6237f2ca12b206bccff626139be9fa005f14feb881a1ae8", size = 10378302, upload-time = "2026-04-09T14:06:14.361Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2f/e0b36a6f99c51bb89f3a30239bc7bf97e87a37ae80aa2d6542d6e5150364/ruff-0.15.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e3e53c588164dc025b671c9df2462429d60357ea91af7e92e9d56c565a9f1b07", size = 10850074, upload-time = "2026-04-09T14:06:16.581Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/874da392558ce087a0f9b709dc6ec0d60cbc694c1c772dab8d5f31efe8cb/ruff-0.15.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b0c52744cf9f143a393e284125d2576140b68264a93c6716464e129a3e9adb48", size = 11358051, upload-time = "2026-04-09T14:06:18.948Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
+    { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
 ]
 
 [[package]]
@@ -2878,6 +3033,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "python_full_version >= '3.11'" },
+    { name = "starlette", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79badbc010f067cd769d6601ec11a57d78569c683fb4dd87/sse_starlette-3.3.4.tar.gz", hash = "sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1", size = 32427, upload-time = "2026-03-29T09:00:23.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/7f/3de5402f39890ac5660b86bcf5c03f9d855dad5c4ed764866d7b592b46fd/sse_starlette-3.3.4-py3-none-any.whl", hash = "sha256:84bb06e58939a8b38d8341f1bc9792f06c2b53f48c608dd207582b664fc8f3c1", size = 14330, upload-time = "2026-03-29T09:00:21.846Z" },
 ]
 
 [[package]]
@@ -3407,6 +3575,62 @@ name = "win-unicode-console"
 version = "0.5"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/89/8d/7aad74930380c8972ab282304a2ff45f3d4927108bb6693cabcc9fc6a099/win_unicode_console-0.5.zip", hash = "sha256:d4142d4d56d46f449d6f00536a73625a871cba040f0bc1a2e305a04578f07d1e", size = 31420, upload-time = "2016-06-25T19:48:54.05Z" }
+
+[[package]]
+name = "yara-python"
+version = "4.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/38/347d1fcde4edabd338d5872ca5759ccfb95ff1cf5207dafded981fd08c4f/yara_python-4.5.4.tar.gz", hash = "sha256:4c682170f3d5cb3a73aa1bd0dc9ab1c0957437b937b7a83ff6d7ffd366415b9c", size = 551142, upload-time = "2025-05-27T14:15:49.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/7f/5767870ecdde75b7991f67caa5d78d692d30239529b66262a33bb6ab12e3/yara_python-4.5.4-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:721d341bd2013fbada4df5aba0eb79a9e4e21c4b86441f7f111ab8c31671f125", size = 2471734, upload-time = "2025-05-27T14:14:03.034Z" },
+    { url = "https://files.pythonhosted.org/packages/13/01/c7253b9cbeb9058deff46e332d98d8a76ecdc07235a41f1a3050348b035e/yara_python-4.5.4-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:c785fd16475f2a3191cd4fae0cd608b1ba6271f495ec86fa26a3c5ac53f5f2e1", size = 208858, upload-time = "2025-05-27T14:14:04.728Z" },
+    { url = "https://files.pythonhosted.org/packages/02/09/cbe63e02a7b2448cd84b78918c1d765ce17038f1e7f0a6ae25e942bdca22/yara_python-4.5.4-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:5eefa3b157cd5f4454a317907bab334036f61385324b70cb61dbc656c44168d5", size = 2478392, upload-time = "2025-05-27T14:14:06.404Z" },
+    { url = "https://files.pythonhosted.org/packages/01/02/c5f2953a7dfd3055fd67581fe740c46c7b678d3760faced24674080019c8/yara_python-4.5.4-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:bbc0c5a2ee67e6043e4c2622093ebfc7d2c173dc643dd089742aedbdea48d6a4", size = 209306, upload-time = "2025-05-27T14:14:07.876Z" },
+    { url = "https://files.pythonhosted.org/packages/be/70/a7bd03cbf1ac7e9fcfe292b3dfad181d7fb7eabf6d0ee493f7c5b2386238/yara_python-4.5.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1b091f1bd6c5d2a9b5c0c682ba67ba31b87bb71b27876430775998b71c8e3f97", size = 2240111, upload-time = "2025-05-27T14:14:09.246Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/3d/0b0eadc8b39aa61cc04337d60b15fdebccaf662877a30604baadf760a4f5/yara_python-4.5.4-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:91276c90bb5e148e10050015fec8a1d4009a95eee9eb832d154f80355d0b4080", size = 2323286, upload-time = "2025-05-27T14:14:10.688Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/30/aab92c73b02bdda575f9507108c9617708f8d6812647a0654bc44447fc20/yara_python-4.5.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e20e1f69b6239fe4f4da97e9ff361d9be25d6f1d747589ea44b8a9ec412a12d", size = 2327981, upload-time = "2025-05-27T14:14:13.044Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/40/461d76a5ec526679e58efca35383d3511cade8c8fc8868ad9f97bea21a1a/yara_python-4.5.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a83773b561727fc360f7a6874f7fac1409bc9c391134dc3e070f1c2515c0db98", size = 2946194, upload-time = "2025-05-27T14:14:14.717Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d2/656319472612d821d224ef2a79dc5b8339332aa03e4586e5fd9ec0c45f4e/yara_python-4.5.4-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:14f203bd9fb33ad591e046429560133127fa4a6201dac28c525fa7c6c7ca36a7", size = 2416600, upload-time = "2025-05-27T14:14:16.269Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/76/5ec476aa39e81d4dd5e26071f6b2c763c4a7d7f628dff3370fe6053ba9ac/yara_python-4.5.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e632daf9f38f8d4b433f08f798b07a45756e6c396e9e0ec54aac10045f6d241d", size = 2636555, upload-time = "2025-05-27T14:14:18.082Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b5/26cdb3d13b91625dc35a68aca2db8cb62d6c6d5e7b83d97981b350163dd3/yara_python-4.5.4-cp310-cp310-win32.whl", hash = "sha256:a3866830f7f2d071f94cbce7c41d91444ac29e2cbbe279914abf518d57a2d41f", size = 1447301, upload-time = "2025-05-27T14:14:19.635Z" },
+    { url = "https://files.pythonhosted.org/packages/be/21/68f211559de12eac0cb0fd8dbda279cadb0cc681cc4dc6394f9e06dfd4e2/yara_python-4.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:135c1097ea0445a323038acd509162675ce6d5e21f848aa856779632d48dec42", size = 1825559, upload-time = "2025-05-27T14:14:21.508Z" },
+    { url = "https://files.pythonhosted.org/packages/17/17/f0bc4a643d8c3afb485c34b70fe1d161f3fe0459361d2eb3561d23cc16e1/yara_python-4.5.4-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:e3e2a5575d61adc2b4ff2007737590783a43d16386b061ac12e6e70a82e5d1de", size = 2471737, upload-time = "2025-05-27T14:14:23.876Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/11/39c74fc2732b89d4a5a6ad272b2b60ec84b3aae53b120a9eccc742eec802/yara_python-4.5.4-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:f79a27dbdafb79fc2dc03c7c3ba66751551e3e0b350ab69cc499870b78a6cb95", size = 208862, upload-time = "2025-05-27T14:14:25.941Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ef/ff38abffe3c5126da0b4f31471bc6df2e38f4f532a65941a1a8092cddb4f/yara_python-4.5.4-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:9d9acf6f8135bcee03f47b1096ad69f4a2788abe37dd070aab6e9dd816742ecc", size = 2478391, upload-time = "2025-05-27T14:14:27.802Z" },
+    { url = "https://files.pythonhosted.org/packages/69/97/638f0f6920250dd4cc202f05d2b931c4aeb8ea916ae185cd15b9dacf9ae4/yara_python-4.5.4-cp311-cp311-macosx_15_0_x86_64.whl", hash = "sha256:0e762e6c5b47ddf30b0128ba723da46fcc2aa7959a252748497492cb452d1c84", size = 209304, upload-time = "2025-05-27T14:14:29.663Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/08/e9396374b8d4348f71db28dabbcbde21ceb0e68c604a4de82ab4f1c286e9/yara_python-4.5.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:adcfac4b225e76ab6dcbeaf10101f0de2731fdbee51610dbc77b96e667e85a3a", size = 2242098, upload-time = "2025-05-27T14:14:31.001Z" },
+    { url = "https://files.pythonhosted.org/packages/58/fa/b159db2afedef12d5de32b6eb7c087a78c29dc51fc5111475bbd96759744/yara_python-4.5.4-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a82c87038f0da2d90051bfd6449cf9a4b977a15ee8372f3512ce0a413ef822fd", size = 2324289, upload-time = "2025-05-27T14:14:32.852Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1e/8846d6c37e3cc5328ac90d888ac60599ed62f1ffcb7d68054ad60954df4a/yara_python-4.5.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a1721b61ee4e625a143e8e5bf32fa6774797c06724c45067f3e8919a8e5f8f3", size = 2329563, upload-time = "2025-05-27T14:14:34.758Z" },
+    { url = "https://files.pythonhosted.org/packages/35/db/d6de595384e357366a8e7832876e5d9be56629e29e12d2a9325cc652e855/yara_python-4.5.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:57d80c7591bbc6d9e73934e0fa4cbbb35e3e733b2706c5fd6756edf495f42678", size = 2947661, upload-time = "2025-05-27T14:14:37.419Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/35d67095b0b000315545c59b2826166371d005f9815ca6c7c79a87e6c4cc/yara_python-4.5.4-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:3872b5f5575d6f5077f86e2b8bcdfe8688f859a50854334a4085399331167abc", size = 2417932, upload-time = "2025-05-27T14:14:40.402Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/28/760d114cea3f160e3f862d747208a09150974a668a49c0cee23a943006c4/yara_python-4.5.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:fd84af5b6da3429236b61f3ad8760fdc739d0e1d6a08b8f3d90cd375e71594df", size = 2638058, upload-time = "2025-05-27T14:14:42.141Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9d/e208dd3ffc38a163d18476d2f758c24de8ece67c9d59c654a6b5b400fd96/yara_python-4.5.4-cp311-cp311-win32.whl", hash = "sha256:491c9de854e4a47dfbef7b3a38686c574459779915be19dcf4421b65847a57ce", size = 1447300, upload-time = "2025-05-27T14:14:44.091Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ad/23ed18900f6024d5c1de567768c12a53c5759ac90d08624c87c816cd7249/yara_python-4.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:2a1bf52cb7b9178cc1ee2acd1697a0c8468af0c76aa1beffe22534bd4f62698b", size = 1825566, upload-time = "2025-05-27T14:14:45.879Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cc/deaf10b6b31ee81842176affce79d57c3b6df50e894cf6cdbb1f0eb12af2/yara_python-4.5.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:ade234700c492bce0efda96c1cdcd763425016e40df4a8d30c4c4e6897be5ace", size = 2471771, upload-time = "2025-05-27T14:14:47.381Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/47/9227c56450be00db6a3a50ccf88ba201945ae14a34b80b3aae4607954159/yara_python-4.5.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:e1dedd149be61992781f085b592d169d1d813f9b5ffc7c8c2b74e429b443414c", size = 208991, upload-time = "2025-05-27T14:14:48.832Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/0d/1f2e054f7ddf9fd4c873fccf63a08f2647b205398e11ea75cf44c161e702/yara_python-4.5.4-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:92b233aae320ee9e59728ee23f9faf4a423ae407d4768b47c8f0e472a34dbae2", size = 2478413, upload-time = "2025-05-27T14:14:50.205Z" },
+    { url = "https://files.pythonhosted.org/packages/10/ab/96e2d06c909ba07941d6d303f23624e46751a54d6fd358069275f982168c/yara_python-4.5.4-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:1f238f10d26e4701559f73a69b22e1e192a6fa20abdd76f57a7054566780aa89", size = 209401, upload-time = "2025-05-27T14:14:52.017Z" },
+    { url = "https://files.pythonhosted.org/packages/df/7d/e51ecb0db87094976904a52eb521e3faf9c18f7c889b9d5cf996ae3bb680/yara_python-4.5.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d29d0e137e0d77dd110186369276e88381f784bdc45b5932a2fb3463e2a1b1c7", size = 2245326, upload-time = "2025-05-27T14:14:53.338Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/5e/fe93d8609b8470148ebbae111f209c6f208bb834cee64046fce0532fcc70/yara_python-4.5.4-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e7d0039d734705b123494acad7a00b67df171dd5b1c16ff7b18ff07578efd4cd", size = 2327041, upload-time = "2025-05-27T14:14:54.915Z" },
+    { url = "https://files.pythonhosted.org/packages/52/06/104c4daa22e34a7edb49051798126c37f6280d4f1ea7e8888b043314e72d/yara_python-4.5.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e5eae935b05a9f8dc71df55a79c38f52abd93f8840310fe4e0d75fbd78284f24", size = 2332343, upload-time = "2025-05-27T14:14:56.424Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/38/4b788b8fe15faca08e4a52c0b3dc8787953115ce1811e7bf9439914b6a5b/yara_python-4.5.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:30fc7959394532c6e3f48faf59337f5da124f1630668258276b6cfa54e555a6e", size = 2949346, upload-time = "2025-05-27T14:14:57.924Z" },
+    { url = "https://files.pythonhosted.org/packages/53/3a/c1d97172aa9672f381df78b4d3a9f60378f35431ff48f4a6c45037057e07/yara_python-4.5.4-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e6d8c2acaf33931338fdb78aba8a68462b0151d833b2eeda712db87713ac2abf", size = 2421057, upload-time = "2025-05-27T14:15:00.118Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/cc/c6366d6d047f73594badd5444f6a32501e8b20ab1a7124837d305c08b42b/yara_python-4.5.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a3c7bc8cd0db5fb87ab579c755de83723030522f3c0cd5b3374044055a8ce6c6", size = 2639871, upload-time = "2025-05-27T14:15:02.63Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/5c/edacbd11db432ac04a37c9e3a7c569986256d9659d1859c6f828268dfeed/yara_python-4.5.4-cp312-cp312-win32.whl", hash = "sha256:d12e57101683e9270738a1bccf676747f93e86b5bc529e7a7fb7adf94f20bd77", size = 1447403, upload-time = "2025-05-27T14:15:04.193Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/e1/f6a72c155f3241360da890c218911d09bf63329eca9cfa1af64b1498339b/yara_python-4.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:bf14a8af06b2b980a889bdc3f9e8ccd6e703d2b3fa1c98da5fd3a1c3b551eb47", size = 1825743, upload-time = "2025-05-27T14:15:05.678Z" },
+    { url = "https://files.pythonhosted.org/packages/74/7f/9bf4864fee85f86302d78d373c93793419c080222b5e18badadebb959263/yara_python-4.5.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:fe8ad189843c729eae74be3b8447a4753fac2cebe705e5e2a7280badfcc7e3b4", size = 2471811, upload-time = "2025-05-27T14:15:07.55Z" },
+    { url = "https://files.pythonhosted.org/packages/44/58/dca36144c44b0613dbc39c70cc32ee0fc9db1ba9e5fa15f55657183f4229/yara_python-4.5.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:94e290d5035be23059d0475bff3eac8228acd51145bf0cabe355b1ddabab742b", size = 209044, upload-time = "2025-05-27T14:15:09.142Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/4c/997be6898cdda211cb601ae2af40a2dbd89a48ba9889168ddd3993636e97/yara_python-4.5.4-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:4537f8499d166d22a54739f440fb306f65b0438be2c6c4ecb2352ecb5adb5f1c", size = 2478416, upload-time = "2025-05-27T14:15:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/29/91d5911d6decdd8a96bb891cacd8922569480ff1d4b47e7947b5dfc7f1d6/yara_python-4.5.4-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:ab5133a16e466db6fe9c1a08d1b171013507896175010fb85fc1b92da32e558c", size = 209441, upload-time = "2025-05-27T14:15:12.173Z" },
+    { url = "https://files.pythonhosted.org/packages/87/9b/e21f534f33062f2e5f6dceec3cb4918f4923264b1609652adc0c83fe2bde/yara_python-4.5.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93f5f5aba88e2ed2aaebfbb697433a0c8020c6a6c6a711e900a29e9b512d5c3a", size = 2245135, upload-time = "2025-05-27T14:15:13.569Z" },
+    { url = "https://files.pythonhosted.org/packages/70/8e/3618d2473f1e97f3f91d13af5b1ed26381c74444f6cdebb849eb855b21ca/yara_python-4.5.4-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:473c52b53c39d5daedc1912bd8a82a1c88702a3e393688879d77f9ff5f396543", size = 2326864, upload-time = "2025-05-27T14:15:15.321Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/21477d4c83e7f267ff7d61a518eb1b2d3eb7877031c5c07bd1dc0a54eb95/yara_python-4.5.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9d9a58b7dc87411a2443d2e0382a111bd892aef9f6db2a1ebb4a9215eef0db71", size = 2331976, upload-time = "2025-05-27T14:15:17.138Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/5d/2680831aa43d181a0cc023ba89132ff6f03a0532f220cde27bccd60d54e2/yara_python-4.5.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0b9de86fbe8a646c0644df9e1396d6941dc6ed0f89be2807e6c52ab39161fd9f", size = 2949066, upload-time = "2025-05-27T14:15:18.822Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/76/e89ec354731b1872462fa9cfdfc6d4751c272b3f43fa55523a8f0fcdd48a/yara_python-4.5.4-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:973f0bc24470ac86b6009baf2800ad3eadfa4ab653b6546ba5c65e9239850f47", size = 2420758, upload-time = "2025-05-27T14:15:20.505Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/28/9499649cb2cb42592c13ca6a15163e0cbf132c2974394de171aa5f8b49e4/yara_python-4.5.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cb0f0e7183165426b09e2b1235e70909e540ac18e2c6be96070dfe17d7db4d78", size = 2639628, upload-time = "2025-05-27T14:15:22.142Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/37/e8f2b9a2287070f39fa6a5afbcf1ed6762f60ab3b1fb08018732838ccc25/yara_python-4.5.4-cp313-cp313-win32.whl", hash = "sha256:7707b144c8fcdb30c069ea57b94799cd7601f694ba01b696bbd1832721f37fd0", size = 1447395, upload-time = "2025-05-27T14:15:25.237Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a0/40b0291c8b24d13daf0e26538c9f3a0d843c38c6446dd17f36335bdd5b5f/yara_python-4.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:5f1288448991d63c1f6351c9f6d112916b0177ceefaa27d1419427a6ff09f829", size = 1825779, upload-time = "2025-05-27T14:15:26.802Z" },
+]
 
 [[package]]
 name = "yara-x"


### PR DESCRIPTION
## Summary
- add an optional static `cisco-ai-mcp-scanner` integration for MCP-aware plugin scans
- thread `--cisco-mcp-scan` / `CISCO_MCP_SCAN` through scan options, CLI, and action runner flows
- add MCP integration tests, schema/report coverage, and update README credit/docs

## What changed
- added `src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py` and `src/codex_plugin_scanner/checks/mcp_security.py`
- surfaced `cisco-mcp-scanner` results through existing findings and integration summaries without a schema bump
- kept the integration optional and lazily imported
- documented the broader Cisco AI Defense scanner relationship in the main README

## Verification
- `uv sync --extra dev --extra cisco`
- `uv run pytest -q tests/test_mcp_security.py tests/test_cli.py tests/test_action_runner.py tests/test_schema_contracts.py tests/test_live_cisco_smoke.py tests/test_integration.py`
- `uv run ruff check src tests`
- `uv run python -m build`