### PR TITLE
feat: surface Cisco evidence in Guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ pip install "plugin-scanner[cisco]"
 
 `cisco-ai-mcp-scanner` stays in the optional `cisco` extra because it is Python 3.11+ only and adds a heavier YARA-backed install surface than the lean baseline should require.
 
+On Guard surfaces, the Cisco extra adds optional offline evidence to `hol-guard scan`, `hol-guard preflight`, and `hol-guard explain <path>`. Use `--cisco-mode {auto,on,off}` to control that consumer-mode evidence path for local artifact scans. `hol-guard run` and Guard runtime prompt/file-read protection remain native Guard behavior in this pass.
+
 ### Cisco package status
 
 Credit to [Cisco AI Defense](https://github.com/cisco-ai-defense) for open-sourcing the packages below.

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -9,6 +9,7 @@ import webbrowser
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from ...models import ScanOptions
 from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
 from ..approvals import approval_center_hint, queue_blocked_approvals, wait_for_approval_requests
@@ -145,11 +146,13 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     preflight_parser.add_argument("--harness")
     preflight_parser.add_argument("--enforce", action="store_true")
     preflight_parser.add_argument("--json", action="store_true")
+    _add_guard_cisco_mode_arg(preflight_parser)
 
     scan_parser = guard_subparsers.add_parser("scan", help="Run a consumer-mode scan for a local artifact")
     scan_parser.add_argument("target", nargs="?", default=".")
     scan_parser.add_argument("--consumer-mode", action="store_true")
     scan_parser.add_argument("--json", action="store_true")
+    _add_guard_cisco_mode_arg(scan_parser)
 
     diff_parser = guard_subparsers.add_parser("diff", help="Compare current harness artifacts to stored snapshots")
     diff_parser.add_argument("harness")
@@ -171,10 +174,16 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
 
     add_approval_parser(guard_subparsers, _add_guard_common_args)
 
-    explain_parser = guard_subparsers.add_parser("explain", help="Show the latest evidence for a local artifact")
+    explain_parser = guard_subparsers.add_parser(
+        "explain",
+        help=(
+            "Show the latest evidence for a local artifact or local path with offline Cisco MCP evidence when available"
+        ),
+    )
     explain_parser.add_argument("target")
     _add_guard_common_args(explain_parser)
     explain_parser.add_argument("--json", action="store_true")
+    _add_guard_cisco_mode_arg(explain_parser)
 
     for name, action in (("allow", "allow"), ("deny", "block")):
         policy_parser = guard_subparsers.add_parser(name, help=f"{name.title()} a harness artifact")
@@ -257,16 +266,33 @@ def _add_guard_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--workspace")
 
 
+def _add_guard_cisco_mode_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--cisco-mode",
+        choices=("auto", "on", "off"),
+        default="auto",
+        help="Control optional Cisco scanner evidence for local consumer-mode artifact scans.",
+    )
+
+
+def _build_cisco_scan_options(mode: str) -> ScanOptions:
+    return ScanOptions(cisco_skill_scan=mode, cisco_mcp_scan=mode)
+
+
 def run_guard_command(args: argparse.Namespace) -> int:
     """Execute a Guard subcommand."""
 
     if args.guard_command == "scan":
-        payload = run_consumer_scan(Path(args.target).resolve())
+        payload = run_consumer_scan(Path(args.target).resolve(), options=_build_cisco_scan_options(args.cisco_mode))
         _emit("scan", payload, args.json or args.consumer_mode)
         return 0
 
     if args.guard_command == "preflight":
-        payload = run_consumer_scan(Path(args.target).resolve(), intended_harness=getattr(args, "harness", None))
+        payload = run_consumer_scan(
+            Path(args.target).resolve(),
+            intended_harness=getattr(args, "harness", None),
+            options=_build_cisco_scan_options(args.cisco_mode),
+        )
         _emit("preflight", payload, getattr(args, "json", False))
         if getattr(args, "enforce", False):
             install_verdict = payload.get("install_verdict")
@@ -478,7 +504,7 @@ def run_guard_command(args: argparse.Namespace) -> int:
         return 0
 
     if args.guard_command == "explain":
-        payload = _build_explain_payload(store, args.target)
+        payload = _build_explain_payload(store, args.target, options=_build_cisco_scan_options(args.cisco_mode))
         _emit("explain", payload, getattr(args, "json", False))
         return 0
 
@@ -954,10 +980,14 @@ def _build_abom_payload(store: GuardStore) -> dict[str, object]:
     }
 
 
-def _build_explain_payload(store: GuardStore, target: str) -> dict[str, object]:
+def _build_explain_payload(
+    store: GuardStore,
+    target: str,
+    options: ScanOptions | None = None,
+) -> dict[str, object]:
     target_path = Path(target).expanduser()
     if target_path.exists():
-        return run_consumer_scan(target_path.resolve())
+        return run_consumer_scan(target_path.resolve(), options=options)
     inventory_item = store.find_inventory_item(target)
     if inventory_item is None:
         raise ValueError(f"Guard does not know artifact {target}.")

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -279,19 +279,37 @@ def _build_cisco_scan_options(mode: str) -> ScanOptions:
     return ScanOptions(cisco_skill_scan=mode, cisco_mcp_scan=mode)
 
 
+def _resolve_cisco_scan_options(mode: str) -> ScanOptions | None:
+    if mode == "auto":
+        return None
+    return _build_cisco_scan_options(mode)
+
+
+def _run_consumer_scan_with_mode(
+    target: Path,
+    *,
+    intended_harness: str | None = None,
+    cisco_mode: str,
+) -> dict[str, object]:
+    options = _resolve_cisco_scan_options(cisco_mode)
+    if options is None:
+        return run_consumer_scan(target, intended_harness=intended_harness)
+    return run_consumer_scan(target, intended_harness=intended_harness, options=options)
+
+
 def run_guard_command(args: argparse.Namespace) -> int:
     """Execute a Guard subcommand."""
 
     if args.guard_command == "scan":
-        payload = run_consumer_scan(Path(args.target).resolve(), options=_build_cisco_scan_options(args.cisco_mode))
+        payload = _run_consumer_scan_with_mode(Path(args.target).resolve(), cisco_mode=args.cisco_mode)
         _emit("scan", payload, args.json or args.consumer_mode)
         return 0
 
     if args.guard_command == "preflight":
-        payload = run_consumer_scan(
+        payload = _run_consumer_scan_with_mode(
             Path(args.target).resolve(),
             intended_harness=getattr(args, "harness", None),
-            options=_build_cisco_scan_options(args.cisco_mode),
+            cisco_mode=args.cisco_mode,
         )
         _emit("preflight", payload, getattr(args, "json", False))
         if getattr(args, "enforce", False):
@@ -504,7 +522,7 @@ def run_guard_command(args: argparse.Namespace) -> int:
         return 0
 
     if args.guard_command == "explain":
-        payload = _build_explain_payload(store, args.target, options=_build_cisco_scan_options(args.cisco_mode))
+        payload = _build_explain_payload_with_mode(store, args.target, cisco_mode=args.cisco_mode)
         _emit("explain", payload, getattr(args, "json", False))
         return 0
 
@@ -1001,6 +1019,13 @@ def _build_explain_payload(
         "latest_diff": latest_diff,
         "advisories": advisories,
     }
+
+
+def _build_explain_payload_with_mode(store: GuardStore, target: str, cisco_mode: str) -> dict[str, object]:
+    options = _resolve_cisco_scan_options(cisco_mode)
+    if options is None:
+        return _build_explain_payload(store, target)
+    return _build_explain_payload(store, target, options=options)
 
 
 def _matching_advisories(store: GuardStore, publisher: object) -> list[dict[str, object]]:

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -435,6 +435,34 @@ def _render_hook(console: Console, payload: dict[str, object]) -> None:
     console.print(Panel(body, title="Guard hook event", border_style="cyan"))
 
 
+def _cisco_status_text(status: str) -> Text:
+    styles = {
+        "enabled": "green",
+        "skipped": "yellow",
+        "unavailable": "yellow",
+        "failed": "red",
+    }
+    return Text(status, style=styles.get(status, "white"))
+
+
+def _render_cisco_evidence(console: Console, payload: dict[str, object]) -> None:
+    cisco_evidence = payload.get("cisco_evidence")
+    if not isinstance(cisco_evidence, dict):
+        return
+    body = Table.grid(padding=(0, 1))
+    body.add_row("Mode", str(cisco_evidence.get("mode", "offline-only")).replace("-", " "))
+    body.add_row("Status", _cisco_status_text(str(cisco_evidence.get("status", "skipped"))))
+    body.add_row("Findings", str(cisco_evidence.get("finding_count", 0)))
+    body.add_row("Targets", str(cisco_evidence.get("target_count", 0)))
+    body.add_row("Summary", str(cisco_evidence.get("summary", "No Cisco MCP evidence collected.")))
+    for integration in _coerce_dict_list(cisco_evidence.get("integrations")):
+        body.add_row(
+            str(integration.get("name", "cisco-mcp-scanner")),
+            str(integration.get("message", "No Cisco MCP detail available.")),
+        )
+    console.print(Panel(body, title="Cisco static scan evidence", border_style="blue"))
+
+
 def _render_scan(console: Console, payload: dict[str, object]) -> None:
     recommendation = payload.get("policy_recommendation")
     ecosystems = []
@@ -450,6 +478,7 @@ def _render_scan(console: Console, payload: dict[str, object]) -> None:
     if isinstance(recommendation, dict):
         body.add_row("Recommended action", _action_text(str(recommendation.get("action", "review"))))
     console.print(Panel(body, title="Consumer scan", border_style="cyan"))
+    _render_cisco_evidence(console, payload)
     console.print(
         Syntax(
             json.dumps(payload, indent=2),

--- a/src/codex_plugin_scanner/guard/consumer/service.py
+++ b/src/codex_plugin_scanner/guard/consumer/service.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from ...models import ScanOptions
 from ..adapters import get_adapter, list_adapters
 from ..adapters.base import HarnessContext
 from ..config import GuardConfig
@@ -420,7 +421,11 @@ def _first_seen_changed_fields(artifact: GuardArtifact) -> list[str]:
     return ["first_seen"]
 
 
-def run_consumer_scan(target: Path, intended_harness: str | None = None) -> dict[str, object]:
+def run_consumer_scan(
+    target: Path,
+    intended_harness: str | None = None,
+    options: ScanOptions | None = None,
+) -> dict[str, object]:
     """Expose the consumer-mode scan contract."""
 
-    return build_consumer_mode_contract(target, intended_harness=intended_harness)
+    return build_consumer_mode_contract(target, intended_harness=intended_harness, options=options)

--- a/src/codex_plugin_scanner/guard/schemas/consumer_mode.py
+++ b/src/codex_plugin_scanner/guard/schemas/consumer_mode.py
@@ -7,7 +7,12 @@ import json
 from dataclasses import asdict
 from pathlib import Path
 
-from ...models import SEVERITY_ORDER, Severity
+from ...models import (
+    SEVERITY_ORDER,
+    IntegrationResult,
+    ScanOptions,
+    Severity,
+)
 from ...scanner import scan_plugin
 
 
@@ -29,10 +34,72 @@ def _install_recommendation(
     return ("allow", "Install-time scan found no blocking issues in the local artifact.")
 
 
-def build_consumer_mode_contract(target: Path, intended_harness: str | None = None) -> dict[str, object]:
+def _is_applicable_cisco_mcp_integration(integration: IntegrationResult) -> bool:
+    return integration.name.startswith("cisco-mcp-scanner") and not integration.message.startswith("No .mcp.json found")
+
+
+def _resolve_cisco_status(integrations: tuple[IntegrationResult, ...]) -> str:
+    statuses = {integration.status for integration in integrations}
+    for status in ("failed", "unavailable", "enabled", "skipped"):
+        if status in statuses:
+            return status
+    return "skipped"
+
+
+def _target_count(integrations: tuple[IntegrationResult, ...]) -> int:
+    total = 0
+    for integration in integrations:
+        raw_count = integration.metadata.get("targets_scanned")
+        if raw_count is None:
+            continue
+        try:
+            total += int(raw_count)
+        except ValueError:
+            continue
+    return total if total > 0 else len(integrations)
+
+
+def _build_cisco_summary(status: str, finding_count: int, target_count: int) -> str:
+    if status == "enabled":
+        return (
+            f"{finding_count} finding across {target_count} local MCP target(s)"
+            if finding_count == 1
+            else f"{finding_count} findings across {target_count} local MCP target(s)"
+        )
+    if status == "skipped":
+        return f"Cisco MCP scanning disabled for {target_count} local MCP target(s)"
+    if status == "unavailable":
+        return f"Cisco MCP scanner unavailable for {target_count} local MCP target(s)"
+    return f"Cisco MCP scan failed for {target_count} local MCP target(s)"
+
+
+def _extract_cisco_evidence(integrations: tuple[IntegrationResult, ...]) -> dict[str, object] | None:
+    applicable_integrations = tuple(
+        integration for integration in integrations if _is_applicable_cisco_mcp_integration(integration)
+    )
+    if not applicable_integrations:
+        return None
+    finding_count = sum(integration.findings_count for integration in applicable_integrations)
+    target_count = _target_count(applicable_integrations)
+    status = _resolve_cisco_status(applicable_integrations)
+    return {
+        "mode": "offline-only",
+        "status": status,
+        "finding_count": finding_count,
+        "target_count": target_count,
+        "summary": _build_cisco_summary(status, finding_count, target_count),
+        "integrations": [asdict(integration) for integration in applicable_integrations],
+    }
+
+
+def build_consumer_mode_contract(
+    target: Path,
+    intended_harness: str | None = None,
+    options: ScanOptions | None = None,
+) -> dict[str, object]:
     """Build the stable consumer-mode payload for a local artifact."""
 
-    scan_result = scan_plugin(target)
+    scan_result = scan_plugin(target, options=options)
     summary_payload = {
         "path": str(target),
         "score": scan_result.score,
@@ -63,7 +130,7 @@ def build_consumer_mode_contract(target: Path, intended_harness: str | None = No
         "ecosystems": list(scan_result.ecosystems),
         "packages": [asdict(package) for package in scan_result.packages],
     }
-    return {
+    payload = {
         "schema_version": "guard-consumer.v2",
         "generated_at": scan_result.timestamp,
         "install_target": {
@@ -111,3 +178,7 @@ def build_consumer_mode_contract(target: Path, intended_harness: str | None = No
             "finding_count": len(scan_result.findings),
         },
     }
+    cisco_evidence = _extract_cisco_evidence(scan_result.integrations)
+    if cisco_evidence is not None:
+        payload["cisco_evidence"] = cisco_evidence
+    return payload

--- a/src/codex_plugin_scanner/guard/schemas/consumer_mode.py
+++ b/src/codex_plugin_scanner/guard/schemas/consumer_mode.py
@@ -35,7 +35,9 @@ def _install_recommendation(
 
 
 def _is_applicable_cisco_mcp_integration(integration: IntegrationResult) -> bool:
-    return integration.name.startswith("cisco-mcp-scanner") and not integration.message.startswith("No .mcp.json found")
+    return "cisco-mcp-scanner" in integration.name and (
+        "targets_scanned" in integration.metadata or "scan_mode" in integration.metadata
+    )
 
 
 def _resolve_cisco_status(integrations: tuple[IntegrationResult, ...]) -> str:
@@ -56,7 +58,7 @@ def _target_count(integrations: tuple[IntegrationResult, ...]) -> int:
             total += int(raw_count)
         except ValueError:
             continue
-    return total if total > 0 else len(integrations)
+    return total
 
 
 def _build_cisco_summary(status: str, finding_count: int, target_count: int) -> str:

--- a/tests/test_guard_consumer_mode.py
+++ b/tests/test_guard_consumer_mode.py
@@ -12,7 +12,7 @@ from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
 from codex_plugin_scanner.guard.cli.render import emit_guard_payload
 from codex_plugin_scanner.guard.schemas.consumer_mode import build_consumer_mode_contract
-from codex_plugin_scanner.models import ScanOptions
+from codex_plugin_scanner.models import IntegrationResult, ScanOptions, ScanResult
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -103,6 +103,43 @@ def test_build_consumer_mode_contract_omits_cisco_evidence_without_local_mcp_art
     payload = build_consumer_mode_contract(FIXTURES / "good-plugin", options=_build_scan_options("on"))
 
     assert "cisco_evidence" not in payload
+
+
+def test_build_consumer_mode_contract_includes_rebased_cisco_mcp_integration(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "repo"
+    target.mkdir()
+
+    def fake_scan_plugin(path: Path, options: ScanOptions | None = None) -> ScanResult:
+        return ScanResult(
+            score=92,
+            grade="A",
+            categories=(),
+            timestamp="2026-04-13T00:00:00+00:00",
+            plugin_dir=str(path),
+            findings=(),
+            severity_counts={severity: 0 for severity in ("critical", "high", "medium", "low", "info")},
+            integrations=(
+                IntegrationResult(
+                    name="workspace / cisco-mcp-scanner",
+                    status="enabled",
+                    message="Cisco MCP scanner completed static analysis for 2 target(s) with no findings.",
+                    metadata={"scan_mode": "static", "targets_scanned": "2"},
+                ),
+            ),
+            scope="repository",
+            ecosystems=("codex",),
+            packages=(),
+        )
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.schemas.consumer_mode.scan_plugin", fake_scan_plugin)
+
+    payload = build_consumer_mode_contract(target)
+
+    assert payload["cisco_evidence"]["summary"] == "0 findings across 2 local MCP target(s)"
+    assert payload["cisco_evidence"]["integrations"][0]["name"] == "workspace / cisco-mcp-scanner"
 
 
 @pytest.mark.parametrize("command", ["scan", "preflight", "explain"])

--- a/tests/test_guard_consumer_mode.py
+++ b/tests/test_guard_consumer_mode.py
@@ -1,0 +1,227 @@
+"""Tests for Guard consumer-mode Cisco integration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+from codex_plugin_scanner.guard.cli.render import emit_guard_payload
+from codex_plugin_scanner.guard.schemas.consumer_mode import build_consumer_mode_contract
+from codex_plugin_scanner.models import ScanOptions
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+class FakeCiscoFinding:
+    def __init__(
+        self,
+        *,
+        severity: str,
+        summary: str,
+        analyzer: str,
+        threat_category: str,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        self.severity = severity
+        self.summary = summary
+        self.analyzer = analyzer
+        self.threat_category = threat_category
+        self.details = details or {}
+
+
+def _write_mcp_plugin(plugin_dir: Path) -> None:
+    (plugin_dir / ".codex-plugin").mkdir(parents=True)
+    (plugin_dir / ".codex-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "mcp-plugin", "version": "1.0.0", "description": "fixture"}),
+        encoding="utf-8",
+    )
+    (plugin_dir / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"demo": {"command": "python", "args": ["server.py"]}}}),
+        encoding="utf-8",
+    )
+    (plugin_dir / "server.py").write_text("print('hello')\n", encoding="utf-8")
+
+
+def _build_fake_cisco_components() -> dict[str, type]:
+    class FakeYaraAnalyzer:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        async def analyze(self, content: str, context: dict[str, Any] | None = None) -> list[FakeCiscoFinding]:
+            file_path = str((context or {}).get("file_path", ""))
+            if file_path.endswith(".mcp.json"):
+                return [
+                    FakeCiscoFinding(
+                        severity="HIGH",
+                        summary="Detected command injection",
+                        analyzer="YARA",
+                        threat_category="command_injection",
+                        details={"raw_response": {"rule": "MCP_COMMAND_INJECTION"}},
+                    )
+                ]
+            return []
+
+    return {"YaraAnalyzer": FakeYaraAnalyzer}
+
+
+def _build_scan_options(mode: str) -> ScanOptions:
+    return ScanOptions(cisco_skill_scan=mode, cisco_mcp_scan=mode)
+
+
+def test_build_consumer_mode_contract_includes_cisco_evidence_for_local_mcp_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plugin_dir = tmp_path / "plugin"
+    _write_mcp_plugin(plugin_dir)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.integrations.cisco_mcp_scanner._load_mcp_scanner_components",
+        _build_fake_cisco_components,
+    )
+
+    payload = build_consumer_mode_contract(plugin_dir, options=_build_scan_options("on"))
+
+    cisco_evidence = payload["cisco_evidence"]
+
+    assert cisco_evidence["mode"] == "offline-only"
+    assert cisco_evidence["status"] == "enabled"
+    assert cisco_evidence["finding_count"] == 1
+    assert cisco_evidence["target_count"] == 2
+    assert cisco_evidence["summary"] == "1 finding across 2 local MCP target(s)"
+    assert cisco_evidence["integrations"][0]["name"] == "cisco-mcp-scanner"
+    assert any(
+        integration["name"] == "cisco-mcp-scanner" for integration in payload["trust_evidence_bundle"]["integrations"]
+    )
+
+
+def test_build_consumer_mode_contract_omits_cisco_evidence_without_local_mcp_artifact() -> None:
+    payload = build_consumer_mode_contract(FIXTURES / "good-plugin", options=_build_scan_options("on"))
+
+    assert "cisco_evidence" not in payload
+
+
+@pytest.mark.parametrize("command", ["scan", "preflight", "explain"])
+def test_guard_render_surfaces_cisco_evidence_for_local_mcp_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    command: str,
+) -> None:
+    plugin_dir = tmp_path / "plugin"
+    _write_mcp_plugin(plugin_dir)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.integrations.cisco_mcp_scanner._load_mcp_scanner_components",
+        _build_fake_cisco_components,
+    )
+    payload = build_consumer_mode_contract(plugin_dir, options=_build_scan_options("on"))
+
+    emit_guard_payload(command, payload, as_json=False)
+    output = capsys.readouterr().out
+
+    assert "Cisco static scan evidence" in output
+    assert "offline only" in output
+    assert "1 finding across 2 local MCP target(s)" in output
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected_harness"),
+    [
+        (["guard", "scan", "TARGET", "--cisco-mode", "off", "--json"], None),
+        (["guard", "preflight", "TARGET", "--harness", "codex", "--cisco-mode", "on", "--json"], "codex"),
+    ],
+)
+def test_guard_commands_thread_cisco_mode_to_consumer_scan(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    argv: list[str],
+    expected_harness: str | None,
+) -> None:
+    captured: dict[str, object] = {}
+    target = tmp_path / "target"
+    target.mkdir()
+
+    def fake_run_consumer_scan(
+        path: Path,
+        intended_harness: str | None = None,
+        options: ScanOptions | None = None,
+    ) -> dict[str, object]:
+        captured["path"] = path
+        captured["intended_harness"] = intended_harness
+        captured["options"] = options
+        return {"ok": True}
+
+    monkeypatch.setattr(guard_commands_module, "run_consumer_scan", fake_run_consumer_scan)
+
+    resolved_argv = [str(target) if value == "TARGET" else value for value in argv]
+    rc = main(resolved_argv)
+    json.loads(capsys.readouterr().out)
+
+    options = captured["options"]
+
+    assert rc == 0
+    assert captured["path"] == target.resolve()
+    assert captured["intended_harness"] == expected_harness
+    assert isinstance(options, ScanOptions)
+    assert options.cisco_skill_scan == resolved_argv[resolved_argv.index("--cisco-mode") + 1]
+    assert options.cisco_mcp_scan == resolved_argv[resolved_argv.index("--cisco-mode") + 1]
+
+
+def test_guard_explain_threads_cisco_mode_for_local_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    captured: dict[str, object] = {}
+    target = tmp_path / "target"
+    target.mkdir()
+
+    def fake_run_consumer_scan(
+        path: Path,
+        intended_harness: str | None = None,
+        options: ScanOptions | None = None,
+    ) -> dict[str, object]:
+        captured["path"] = path
+        captured["intended_harness"] = intended_harness
+        captured["options"] = options
+        return {
+            "artifact_snapshot": {"path": str(path)},
+            "capability_manifest": {"ecosystems": ["codex"]},
+            "policy_recommendation": {"action": "allow"},
+            "cisco_evidence": {
+                "mode": "offline-only",
+                "status": "skipped",
+                "finding_count": 0,
+                "target_count": 1,
+                "summary": "Cisco MCP scanning disabled for 1 local MCP target(s)",
+                "integrations": [
+                    {
+                        "name": "cisco-mcp-scanner",
+                        "status": "skipped",
+                        "message": "Cisco MCP scanning disabled by configuration.",
+                        "findings_count": 0,
+                        "metadata": {},
+                    }
+                ],
+            },
+        }
+
+    monkeypatch.setattr(guard_commands_module, "run_consumer_scan", fake_run_consumer_scan)
+
+    rc = main(["guard", "explain", str(target), "--cisco-mode", "off"])
+    output = capsys.readouterr().out
+    options = captured["options"]
+
+    assert rc == 0
+    assert captured["path"] == target.resolve()
+    assert captured["intended_harness"] is None
+    assert isinstance(options, ScanOptions)
+    assert options.cisco_skill_scan == "off"
+    assert options.cisco_mcp_scan == "off"
+    assert "Cisco static scan evidence" in output
+    assert "Cisco MCP scanning disabled for 1 local MCP target(s)" in output


### PR DESCRIPTION
## Summary
- add explicit --cisco-mode control to Guard consumer-mode scan, preflight, and local-path explain flows
- surface concise Cisco MCP evidence in Guard consumer-mode contracts and render output for applicable local MCP artifacts
- document the Guard/Cisco boundary and add focused Guard consumer-mode regression coverage

## Verification
- uv run python -m ruff check src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/consumer/service.py src/codex_plugin_scanner/guard/schemas/consumer_mode.py src/codex_plugin_scanner/guard/cli/render.py tests/test_guard_consumer_mode.py
- uv run python -m ruff format --check src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/consumer/service.py src/codex_plugin_scanner/guard/schemas/consumer_mode.py src/codex_plugin_scanner/guard/cli/render.py tests/test_guard_consumer_mode.py
- uv run pytest tests/test_guard_consumer_mode.py tests/test_mcp_security.py tests/test_guard_risk.py -q
- uv run python -m build