### PR TITLE
feat: polish scanner CLI UX

### DIFF
--- a/src/codex_plugin_scanner/action_runner.py
+++ b/src/codex_plugin_scanner/action_runner.py
@@ -360,12 +360,15 @@ def main() -> int:
             cisco_mcp_scan=cisco_mcp_scan,
             cisco_policy=cisco_policy,
         )
-        raw_result, result, resolved_profile, policy_eval, _effective_score, _config_path, _baseline_path = (
-            _scan_with_policy(
-            args,
-            Path(plugin_dir).resolve(),
-            )
-        )
+        (
+            raw_result,
+            result,
+            resolved_profile,
+            policy_eval,
+            _effective_score,
+            _config_path,
+            _baseline_path,
+        ) = _scan_with_policy(args, Path(plugin_dir).resolve())
         scan_scope = getattr(result, "scope", "plugin")
         if scan_scope == "repository":
             local_plugin_count = len(result.plugin_results)

--- a/src/codex_plugin_scanner/action_runner.py
+++ b/src/codex_plugin_scanner/action_runner.py
@@ -10,7 +10,8 @@ from pathlib import Path
 from urllib.error import HTTPError, URLError
 
 from . import __version__
-from .cli import _build_plain_text, _build_verification_text, _scan_with_policy
+from .cli import _scan_with_policy
+from .cli_ui import build_plain_text, build_verification_text
 from .config import ConfigError, load_scanner_config
 from .github_reporting import (
     build_scan_pr_comment_body,
@@ -139,14 +140,14 @@ def _render_scan_output(result, *, output_format: str, profile: str, policy_pass
         return format_markdown(result)
     if output_format == "sarif":
         return format_sarif(result)
-    return _build_plain_text(result)
+    return build_plain_text(result)
 
 
 def _render_verify_output(verification, *, output_format: str) -> str:
     payload = build_verification_payload(verification)
     if output_format == "json":
         return json.dumps(payload, indent=2)
-    return _build_verification_text(payload)
+    return build_verification_text(payload)
 
 
 def _render_lint_output(result, *, output_format: str, profile: str, policy_pass: bool) -> str:
@@ -359,9 +360,11 @@ def main() -> int:
             cisco_mcp_scan=cisco_mcp_scan,
             cisco_policy=cisco_policy,
         )
-        raw_result, result, resolved_profile, policy_eval, _effective_score = _scan_with_policy(
+        raw_result, result, resolved_profile, policy_eval, _effective_score, _config_path, _baseline_path = (
+            _scan_with_policy(
             args,
             Path(plugin_dir).resolve(),
+            )
         )
         scan_scope = getattr(result, "scope", "plugin")
         if scan_scope == "repository":

--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -10,11 +10,19 @@ import zipfile
 from dataclasses import asdict, replace
 from pathlib import Path
 
-from .config import ConfigError, load_baseline_rule_ids, load_scanner_config
+from .cli_ui import (
+    build_cli_epilog,
+    build_plain_text,
+    build_scan_help_epilog,
+    build_verification_text,
+    emit_hint,
+    emit_scan_provenance,
+)
+from .config import DEFAULT_CONFIG_FILES, ConfigError, load_baseline_rule_ids, load_scanner_config
 from .ecosystems.registry import list_supported_ecosystems
 from .guard.cli import add_guard_parser, add_guard_root_parser, run_guard_command
 from .lint_fixes import apply_safe_autofixes
-from .models import GRADE_LABELS, ScanOptions, Severity, get_grade
+from .models import ScanOptions, get_grade
 from .policy import POLICY_PROFILES, build_rule_inventory, evaluate_policy, resolve_profile
 from .quality_artifact import build_quality_artifact, write_quality_artifact
 from .reporting import format_json as render_json
@@ -26,92 +34,8 @@ from .verification import build_doctor_report, build_verification_payload, verif
 from .version import __version__
 
 
-def _build_plain_text(result) -> str:
-    if getattr(result, "scope", "plugin") == "repository":
-        trust_total = result.trust_report.total if getattr(result, "trust_report", None) else 0.0
-        lines = [
-            f"🔗 Codex Plugin Scanner v{__version__}",
-            f"Scanning repository: {result.plugin_dir}",
-            f"Marketplace: {result.marketplace_file or 'not found'}",
-            f"Local plugins scanned: {len(result.plugin_results)}",
-            f"Skipped marketplace entries: {len(result.skipped_targets)}",
-            f"Trust: {trust_total}/100",
-            "",
-            "Per-plugin scores:",
-        ]
-        for plugin in result.plugin_results:
-            plugin_name = plugin.plugin_name or Path(plugin.plugin_dir).name
-            plugin_trust = plugin.trust_report.total if getattr(plugin, "trust_report", None) else 0.0
-            lines.append(f"  - {plugin_name}: {plugin.score}/100 ({plugin.grade}), trust {plugin_trust}/100")
-        if result.skipped_targets:
-            lines += ["", "Skipped entries:"]
-            for skipped in result.skipped_targets:
-                source_path = f" [{skipped.source_path}]" if skipped.source_path else ""
-                lines.append(f"  - {skipped.name}{source_path}: {skipped.reason}")
-        lines.append("")
-    else:
-        trust_total = result.trust_report.total if getattr(result, "trust_report", None) else 0.0
-        lines = [
-            f"🔗 Codex Plugin Scanner v{__version__}",
-            f"Scanning: {result.plugin_dir}",
-            f"Trust: {trust_total}/100",
-            "",
-        ]
-        ecosystems = getattr(result, "ecosystems", ())
-        packages = getattr(result, "packages", ())
-        if ecosystems:
-            lines.append(f"Ecosystems: {', '.join(ecosystems)}")
-        if packages:
-            lines.append(f"Detected packages: {len(packages)}")
-        if ecosystems or packages:
-            lines.append("")
-    for category in result.categories:
-        cat_score = sum(c.points for c in category.checks)
-        cat_max = sum(c.max_points for c in category.checks)
-        lines.append(f"── {category.name} ({cat_score}/{cat_max}) ──")
-        for check in category.checks:
-            icon = "✅" if check.passed else "⚠️"
-            pts = f"+{check.points}" if check.passed else "+0"
-            lines.append(f"  {icon} {check.name:<42} {pts}")
-        lines.append("")
-    counts = ", ".join(f"{severity.value}:{result.severity_counts.get(severity.value, 0)}" for severity in Severity)
-    lines += [f"Findings: {counts}", ""]
-    if getattr(result, "trust_report", None) and result.trust_report.domains:
-        lines.append("Trust Provenance:")
-        for domain in result.trust_report.domains:
-            lines.append(f"  - {domain.label}: {domain.score}/100 ({domain.spec_id})")
-        lines.append("")
-    if result.integrations:
-        lines.append("Integration Status:")
-        for integration in result.integrations:
-            lines.append(f"  - {integration.name}: {integration.status} - {integration.message}")
-        lines.append("")
-    separator = "━" * 37
-    label = GRADE_LABELS.get(result.grade, "Unknown")
-    lines += [separator, f"Final Score: {result.score}/100 ({result.grade} - {label})", separator]
-    return "\n".join(lines)
-
-
 def format_text(result) -> str:
-    return _build_plain_text(result)
-
-
-def _build_verification_text(payload: dict[str, object]) -> str:
-    verify_pass = bool(payload.get("verify_pass"))
-    status = "PASS" if verify_pass else "FAIL"
-    lines = [f"Verification: {status}", ""]
-    cases = payload.get("cases", [])
-    if not isinstance(cases, list):
-        return "\n".join(lines)
-    for case in cases:
-        if not isinstance(case, dict):
-            continue
-        icon = "✅" if case.get("passed") else "⚠️"
-        component = case.get("component", "unknown")
-        name = case.get("name", "unnamed")
-        message = case.get("message", "")
-        lines.append(f"{icon} {component}: {name} - {message}")
-    return "\n".join(lines)
+    return build_plain_text(result)
 
 
 def format_json(
@@ -153,7 +77,12 @@ def _is_scanner_program(program_name: str) -> bool:
 
 def _build_parser(program_name: str, *, program_mode: str) -> argparse.ArgumentParser:
     if program_mode == "guard":
-        parser = argparse.ArgumentParser(prog=program_name, description="Protect local harnesses before tools run.")
+        parser = argparse.ArgumentParser(
+            prog=program_name,
+            description="Protect local harnesses before tools run.",
+            epilog=build_cli_epilog(program_name, include_guard=False),
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+        )
         parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
         add_guard_root_parser(parser)
         return parser
@@ -165,12 +94,19 @@ def _build_parser(program_name: str, *, program_mode: str) -> argparse.ArgumentP
     parser = argparse.ArgumentParser(
         prog=program_name,
         description=description,
+        epilog=build_cli_epilog(program_name, include_guard=program_mode == "combined"),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     parser.add_argument("--list-ecosystems", action="store_true", help="List supported plugin ecosystems and exit")
     subparsers = parser.add_subparsers(dest="command")
 
-    scan_parser = subparsers.add_parser("scan", help="Run full weighted scan")
+    scan_parser = subparsers.add_parser(
+        "scan",
+        help="Run full weighted scan",
+        epilog=build_scan_help_epilog(program_name),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     scan_parser.add_argument("plugin_dir")
     scan_parser.add_argument("--json", action="store_true")
     scan_parser.add_argument("--format", choices=("text", "json", "markdown", "sarif"), default="text")
@@ -277,12 +213,32 @@ def _print_lint_explain(rule_id: str) -> int:
     spec = get_rule_spec(rule_id)
     if spec is None:
         print(f"Unknown rule id: {rule_id}", file=sys.stderr)
+        emit_hint("run `lint --list-rules` to inspect the available rule identifiers.")
         return 1
     print(json.dumps(asdict(spec), indent=2, default=str))
     return 0
 
 
+def _resolve_scanner_config_path(plugin_dir: Path, config_path: str | None) -> Path | None:
+    if config_path:
+        candidate = Path(config_path)
+        return candidate if candidate.is_absolute() else (plugin_dir / candidate)
+    for name in DEFAULT_CONFIG_FILES:
+        candidate = plugin_dir / name
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _resolve_baseline_path(plugin_dir: Path, baseline_path: str | None) -> Path | None:
+    if not baseline_path:
+        return None
+    candidate = Path(baseline_path)
+    return candidate if candidate.is_absolute() else (plugin_dir / candidate)
+
+
 def _resolve_policy_profile(args: argparse.Namespace, plugin_dir: Path):
+    config_path = _resolve_scanner_config_path(plugin_dir, getattr(args, "config", None))
     try:
         config = load_scanner_config(plugin_dir, getattr(args, "config", None))
         baseline_path = getattr(args, "baseline", None) or config.baseline_file
@@ -292,11 +248,11 @@ def _resolve_policy_profile(args: argparse.Namespace, plugin_dir: Path):
         raise
 
     profile = resolve_profile(getattr(args, "profile", None) or config.profile)
-    return profile, config, baseline_ids
+    return profile, config, baseline_ids, config_path, _resolve_baseline_path(plugin_dir, baseline_path)
 
 
 def _scan_with_policy(args: argparse.Namespace, plugin_dir: Path):
-    profile, config, baseline_ids = _resolve_policy_profile(args, plugin_dir)
+    profile, config, baseline_ids, config_path, baseline_path = _resolve_policy_profile(args, plugin_dir)
     raw_result = scan_plugin(
         plugin_dir,
         ScanOptions(
@@ -322,7 +278,7 @@ def _scan_with_policy(args: argparse.Namespace, plugin_dir: Path):
     policy_eval = evaluate_policy(result.findings, profile, rule_inventory=inventory)
     effective_score = compute_effective_score(result)
     result = replace(result, score=effective_score, grade=get_grade(effective_score))
-    return raw_result, result, profile, policy_eval, effective_score
+    return raw_result, result, profile, policy_eval, effective_score, config_path, baseline_path
 
 
 def _run_scan(args: argparse.Namespace) -> int:
@@ -331,11 +287,16 @@ def _run_scan(args: argparse.Namespace) -> int:
         print(f'Error: "{resolved}" is not a directory.', file=sys.stderr)
         return 1
     try:
-        raw_result, result, profile, policy_eval, effective_score = _scan_with_policy(args, resolved)
+        raw_result, result, profile, policy_eval, effective_score, config_path, baseline_path = _scan_with_policy(
+            args,
+            resolved,
+        )
     except ConfigError:
         return 1
 
     output_format = "json" if args.json else args.format
+    if output_format == "text":
+        emit_scan_provenance(profile=profile, config_path=config_path, baseline_path=baseline_path)
     if output_format == "json":
         output = format_json(
             result,
@@ -350,7 +311,7 @@ def _run_scan(args: argparse.Namespace) -> int:
     elif output_format == "sarif":
         output = format_sarif(result)
     else:
-        output = _build_plain_text(result)
+        output = build_plain_text(result)
         print(output)
 
     if args.output:
@@ -362,18 +323,22 @@ def _run_scan(args: argparse.Namespace) -> int:
     min_score = args.min_score
     if result.score < min_score:
         print(f"Score {result.score} is below threshold {min_score}", file=sys.stderr)
+        emit_hint("review the highest-severity findings above, then rerun with --format json if you need automation.")
         return 1
     if should_fail_for_severity(result, args.fail_on_severity):
         print(
             f'Findings met or exceeded the "{args.fail_on_severity}" severity threshold.',
             file=sys.stderr,
         )
+        emit_hint("adjust --fail-on-severity only if your policy allows reporting without a blocking gate.")
         return 1
     if args.strict and result.findings:
         print("Strict mode failed because findings were present.", file=sys.stderr)
+        emit_hint("rerun without --strict to inspect findings without turning the report into a failing gate.")
         return 1
     if not policy_eval.policy_pass:
         print(f'Policy profile "{profile}" failed.', file=sys.stderr)
+        emit_hint("use a different --profile only when that matches your documented review policy.")
         return 1
     return 0
 
@@ -394,7 +359,10 @@ def _run_lint(args: argparse.Namespace) -> int:
             print(f"- {change}")
 
     try:
-        _raw, result, profile, policy_eval, effective_score = _scan_with_policy(args, resolved)
+        _raw, result, profile, policy_eval, effective_score, _config_path, _baseline_path = _scan_with_policy(
+            args,
+            resolved,
+        )
     except ConfigError:
         return 1
 
@@ -436,7 +404,7 @@ def _run_verify(args: argparse.Namespace) -> int:
     if args.format == "json":
         print(json.dumps(payload, indent=2))
     else:
-        print(_build_verification_text(payload))
+        print(build_verification_text(payload))
     return 0 if verification.verify_pass else 1
 
 
@@ -446,7 +414,10 @@ def _run_submit(args: argparse.Namespace) -> int:
         print(f'Error: "{resolved}" is not a directory.', file=sys.stderr)
         return 1
     try:
-        raw_result, result, profile, policy_eval, _effective_score = _scan_with_policy(args, resolved)
+        raw_result, result, profile, policy_eval, _effective_score, _config_path, _baseline_path = _scan_with_policy(
+            args,
+            resolved,
+        )
     except ConfigError:
         return 1
     if getattr(result, "scope", "plugin") != "plugin":

--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -323,7 +323,10 @@ def _run_scan(args: argparse.Namespace) -> int:
     min_score = args.min_score
     if result.score < min_score:
         print(f"Score {result.score} is below threshold {min_score}", file=sys.stderr)
-        emit_hint("review the highest-severity findings above, then rerun with --format json if you need automation.")
+        if output_format == "text":
+            emit_hint(
+                "review the highest-severity findings above, then rerun with --format json if you need automation."
+            )
         return 1
     if should_fail_for_severity(result, args.fail_on_severity):
         print(

--- a/src/codex_plugin_scanner/cli_ui.py
+++ b/src/codex_plugin_scanner/cli_ui.py
@@ -1,0 +1,157 @@
+"""Human-friendly CLI rendering helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from .models import GRADE_LABELS, Severity
+from .version import __version__
+
+
+def build_plain_text(result) -> str:
+    """Render a scan result as human-readable text."""
+
+    if getattr(result, "scope", "plugin") == "repository":
+        trust_total = result.trust_report.total if getattr(result, "trust_report", None) else 0.0
+        lines = [
+            f"🔗 Codex Plugin Scanner v{__version__}",
+            f"Scanning repository: {result.plugin_dir}",
+            f"Marketplace: {result.marketplace_file or 'not found'}",
+            f"Local plugins scanned: {len(result.plugin_results)}",
+            f"Skipped marketplace entries: {len(result.skipped_targets)}",
+            f"Trust: {trust_total}/100",
+            "",
+            "Per-plugin scores:",
+        ]
+        for plugin in result.plugin_results:
+            plugin_name = plugin.plugin_name or Path(plugin.plugin_dir).name
+            plugin_trust = plugin.trust_report.total if getattr(plugin, "trust_report", None) else 0.0
+            lines.append(f"  - {plugin_name}: {plugin.score}/100 ({plugin.grade}), trust {plugin_trust}/100")
+        if result.skipped_targets:
+            lines += ["", "Skipped entries:"]
+            for skipped in result.skipped_targets:
+                source_path = f" [{skipped.source_path}]" if skipped.source_path else ""
+                lines.append(f"  - {skipped.name}{source_path}: {skipped.reason}")
+        lines.append("")
+    else:
+        trust_total = result.trust_report.total if getattr(result, "trust_report", None) else 0.0
+        lines = [
+            f"🔗 Codex Plugin Scanner v{__version__}",
+            f"Scanning: {result.plugin_dir}",
+            f"Trust: {trust_total}/100",
+            "",
+        ]
+        ecosystems = getattr(result, "ecosystems", ())
+        packages = getattr(result, "packages", ())
+        if ecosystems:
+            lines.append(f"Ecosystems: {', '.join(ecosystems)}")
+        if packages:
+            lines.append(f"Detected packages: {len(packages)}")
+        if ecosystems or packages:
+            lines.append("")
+    for category in result.categories:
+        cat_score = sum(check.points for check in category.checks)
+        cat_max = sum(check.max_points for check in category.checks)
+        lines.append(f"── {category.name} ({cat_score}/{cat_max}) ──")
+        for check in category.checks:
+            icon = "✅" if check.passed else "⚠️"
+            points = f"+{check.points}" if check.passed else "+0"
+            lines.append(f"  {icon} {check.name:<42} {points}")
+        lines.append("")
+    counts = ", ".join(f"{severity.value}:{result.severity_counts.get(severity.value, 0)}" for severity in Severity)
+    lines += [f"Findings: {counts}", ""]
+    if getattr(result, "trust_report", None) and result.trust_report.domains:
+        lines.append("Trust Provenance:")
+        for domain in result.trust_report.domains:
+            lines.append(f"  - {domain.label}: {domain.score}/100 ({domain.spec_id})")
+        lines.append("")
+    if result.integrations:
+        lines.append("Integration Status:")
+        for integration in result.integrations:
+            lines.append(f"  - {integration.name}: {integration.status} - {integration.message}")
+        lines.append("")
+    separator = "━" * 37
+    label = GRADE_LABELS.get(result.grade, "Unknown")
+    lines += [separator, f"Final Score: {result.score}/100 ({result.grade} - {label})", separator]
+    return "\n".join(lines)
+
+
+def build_verification_text(payload: dict[str, object]) -> str:
+    """Render verification payloads in a human-readable format."""
+
+    verify_pass = bool(payload.get("verify_pass"))
+    status = "PASS" if verify_pass else "FAIL"
+    lines = [f"Verification: {status}", ""]
+    cases = payload.get("cases", [])
+    if not isinstance(cases, list):
+        return "\n".join(lines)
+    for case in cases:
+        if not isinstance(case, dict):
+            continue
+        icon = "✅" if case.get("passed") else "⚠️"
+        component = case.get("component", "unknown")
+        name = case.get("name", "unnamed")
+        message = case.get("message", "")
+        lines.append(f"{icon} {component}: {name} - {message}")
+    return "\n".join(lines)
+
+
+def build_cli_epilog(program_name: str, *, include_guard: bool) -> str:
+    """Return shared top-level help examples."""
+
+    lines = [
+        "Common workflows:",
+        f"  {program_name} scan ./my-plugin",
+        f"  {program_name} scan ./my-plugin --format json --output report.json",
+        f"  {program_name} lint ./my-plugin --fix",
+        f"  {program_name} verify ./my-plugin --online",
+    ]
+    if include_guard:
+        lines.extend(
+            [
+                f"  {program_name} guard start",
+                f"  {program_name} guard bootstrap codex",
+            ]
+        )
+    lines.extend(
+        [
+            "",
+            "Automation:",
+            "  Use --format json or --json in CI when another tool will parse stdout.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_scan_help_epilog(program_name: str) -> str:
+    """Return scan-specific help examples."""
+
+    return "\n".join(
+        [
+            "Common workflows:",
+            f"  {program_name} scan ./my-plugin",
+            f"  {program_name} scan ./my-plugin --format json --output report.json",
+            f"  {program_name} scan ./plugins --ecosystem codex",
+            "",
+            "Automation:",
+            "  Use --format json or --json in CI when another tool will parse stdout.",
+        ]
+    )
+
+
+def emit_scan_provenance(*, profile: str, config_path: Path | None, baseline_path: Path | None) -> None:
+    """Emit lightweight provenance for human-readable scan flows."""
+
+    lines = [f"Policy profile: {profile}"]
+    if config_path is not None:
+        lines.append(f"Using config: {config_path}")
+    if baseline_path is not None:
+        lines.append(f"Using baseline: {baseline_path}")
+    print("\n".join(lines), file=sys.stderr)
+
+
+def emit_hint(message: str) -> None:
+    """Emit a single hint line to stderr."""
+
+    print(f"hint: {message}", file=sys.stderr)

--- a/src/codex_plugin_scanner/cli_ui.py
+++ b/src/codex_plugin_scanner/cli_ui.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from .models import GRADE_LABELS, Severity
+from .models import GRADE_LABELS, ScanResult, Severity
 from .version import __version__
 
 
-def build_plain_text(result) -> str:
+def build_plain_text(result: ScanResult) -> str:
     """Render a scan result as human-readable text."""
 
     if getattr(result, "scope", "plugin") == "repository":
@@ -146,8 +146,10 @@ def emit_scan_provenance(*, profile: str, config_path: Path | None, baseline_pat
     lines = [f"Policy profile: {profile}"]
     if config_path is not None:
         lines.append(f"Using config: {config_path}")
-    if baseline_path is not None:
+    if baseline_path is not None and baseline_path.exists():
         lines.append(f"Using baseline: {baseline_path}")
+    elif baseline_path is not None:
+        lines.append(f"Baseline not found: {baseline_path}")
     print("\n".join(lines), file=sys.stderr)
 
 

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -463,30 +463,85 @@ def _render_cisco_evidence(console: Console, payload: dict[str, object]) -> None
     console.print(Panel(body, title="Cisco static scan evidence", border_style="blue"))
 
 
-def _render_scan(console: Console, payload: dict[str, object]) -> None:
+def _build_consumer_summary_table(payload: dict[str, object]) -> Table:
     recommendation = payload.get("policy_recommendation")
-    ecosystems = []
-    if isinstance(payload.get("capability_manifest"), dict):
-        ecosystems = _coerce_string_list(payload["capability_manifest"].get("ecosystems"))
+    manifest = payload.get("capability_manifest")
+    threat_intelligence = payload.get("threat_intelligence")
+    evidence_bundle = payload.get("trust_evidence_bundle")
+    provenance_record = payload.get("provenance_record")
     artifact_snapshot = payload.get("artifact_snapshot")
     artifact_path = "."
     if isinstance(artifact_snapshot, dict):
         artifact_path = str(artifact_snapshot.get("path") or artifact_snapshot.get("artifact_path") or ".")
+    artifact_name = Path(artifact_path).name or artifact_path
+    ecosystems = _coerce_string_list(manifest.get("ecosystems")) if isinstance(manifest, dict) else []
+    categories = _coerce_string_list(manifest.get("category_names")) if isinstance(manifest, dict) else []
+    packages = _coerce_dict_list(manifest.get("packages")) if isinstance(manifest, dict) else []
+    severity_counts = (
+        evidence_bundle.get("severity_counts")
+        if isinstance(evidence_bundle, dict) and isinstance(evidence_bundle.get("severity_counts"), dict)
+        else {}
+    )
     body = Table.grid(padding=(0, 1))
+    body.add_row("Name", artifact_name)
     body.add_row("Artifact", artifact_path)
     body.add_row("Ecosystems", ", ".join(ecosystems) or "unknown")
+    if categories:
+        body.add_row("Categories", ", ".join(categories))
+    if packages:
+        body.add_row("Packages", str(len(packages)))
     if isinstance(recommendation, dict):
         body.add_row("Recommended action", _action_text(str(recommendation.get("action", "review"))))
-    console.print(Panel(body, title="Consumer scan", border_style="cyan"))
-    _render_cisco_evidence(console, payload)
-    console.print(
-        Syntax(
-            json.dumps(payload, indent=2),
-            "json",
-            theme="ansi_dark",
-            word_wrap=True,
+        body.add_row("Reason", str(recommendation.get("reason") or "No recommendation detail provided."))
+    if isinstance(threat_intelligence, dict):
+        body.add_row("Highest severity", str(threat_intelligence.get("highest_severity") or "info"))
+        body.add_row("Finding count", str(threat_intelligence.get("finding_count") or 0))
+    elif severity_counts:
+        body.add_row(
+            "Findings",
+            ", ".join(f"{key}:{value}" for key, value in severity_counts.items() if value) or "none",
         )
-    )
+    if isinstance(provenance_record, dict) and provenance_record.get("trust_score") is not None:
+        body.add_row("Trust score", str(provenance_record.get("trust_score")))
+    return body
+
+
+def _render_consumer_evidence_panels(console: Console, payload: dict[str, object]) -> None:
+    evidence_bundle = payload.get("trust_evidence_bundle")
+    if isinstance(evidence_bundle, dict):
+        severity_counts = evidence_bundle.get("severity_counts")
+        integrations = _coerce_dict_list(evidence_bundle.get("integrations"))
+        summary = Table.grid(padding=(0, 1))
+        if isinstance(severity_counts, dict):
+            summary.add_row(
+                "By severity",
+                ", ".join(f"{key}:{value}" for key, value in severity_counts.items() if value) or "none",
+            )
+        if integrations:
+            summary.add_row(
+                "Integrations",
+                ", ".join(
+                    str(item.get("name") or "integration") for item in integrations if item.get("name") is not None
+                )
+                or "none",
+            )
+        if summary.row_count > 0:
+            console.print(Panel(summary, title="Evidence summary", border_style="yellow"))
+        findings = _coerce_string_list(evidence_bundle.get("findings"))
+        if findings:
+            console.print(
+                Panel(
+                    "\n".join(f"• {item}" for item in findings[:5]),
+                    title="Evidence highlights",
+                    border_style="yellow",
+                )
+            )
+
+
+def _render_scan(console: Console, payload: dict[str, object]) -> None:
+    console.print(Panel(_build_consumer_summary_table(payload), title="Consumer scan", border_style="cyan"))
+    _render_consumer_evidence_panels(console, payload)
+    _render_cisco_evidence(console, payload)
 
 
 def _render_preflight(console: Console, payload: dict[str, object]) -> None:
@@ -506,7 +561,9 @@ def _render_preflight(console: Console, payload: dict[str, object]) -> None:
         body.add_row("Highest severity", str(threat_intelligence.get("highest_severity") or "info"))
         body.add_row("Findings", str(threat_intelligence.get("finding_count") or 0))
     console.print(Panel(body, title="Install-time preflight", border_style="cyan"))
-    _render_scan(console, payload)
+    console.print(Panel(_build_consumer_summary_table(payload), title="Artifact scan", border_style="blue"))
+    _render_consumer_evidence_panels(console, payload)
+    _render_cisco_evidence(console, payload)
 
 
 def _render_protect(console: Console, payload: dict[str, object]) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -123,6 +123,18 @@ class TestMain:
         assert "[cisco]" in output
         assert "Python 3.11+" in output
 
+    def test_scan_help_lists_common_workflows(self, capsys):
+        parser = cli_module._build_parser("plugin-scanner", program_mode="scanner")
+
+        with contextlib.suppress(SystemExit):
+            parser.parse_args(["scan", "--help"])
+
+        output = capsys.readouterr().out
+
+        assert "Common workflows:" in output
+        assert "plugin-scanner scan ./my-plugin" in output
+        assert "Use --format json or --json in CI" in output
+
     def test_returns_0_for_good_plugin(self):
         rc = main([str(FIXTURES / "good-plugin")])
         assert rc == 0
@@ -200,6 +212,29 @@ class TestMain:
         # Should still produce text output
         assert f"{expected_score}/100" in captured.out
 
+    def test_text_scan_emits_provenance_to_stderr(self, tmp_path, capsys):
+        plugin_dir = tmp_path / "good-plugin"
+        shutil.copytree(FIXTURES / "good-plugin", plugin_dir)
+        baseline_path = plugin_dir / "baseline.txt"
+        baseline_path.write_text("README_MISSING\n", encoding="utf-8")
+        (plugin_dir / ".plugin-scanner.toml").write_text(
+            """
+[scanner]
+profile = "default"
+baseline_file = "baseline.txt"
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        rc = main([str(plugin_dir)])
+        captured = capsys.readouterr()
+
+        assert rc == 0
+        assert "Policy profile: default" in captured.err
+        assert f"Using config: {plugin_dir / '.plugin-scanner.toml'}" in captured.err
+        assert f"Using baseline: {baseline_path}" in captured.err
+
     def test_min_score_exact_boundary(self):
         # At exact boundary should pass (>=)
         rc = main([str(FIXTURES / "good-plugin"), "--min-score", str(EXPECTED_GOOD_PLUGIN_SCORE)])
@@ -216,6 +251,14 @@ class TestMain:
         output = capsys.readouterr().out
         assert rc == 0
         assert '"rule_id": "CODEXIGNORE_MISSING"' in output
+
+    def test_lint_explain_unknown_rule_includes_hint(self, capsys):
+        rc = main(["lint", "--explain", "NOT_A_REAL_RULE"])
+        captured = capsys.readouterr()
+
+        assert rc == 1
+        assert "Unknown rule id: NOT_A_REAL_RULE" in captured.err
+        assert "lint --list-rules" in captured.err
 
     def test_lint_fails_for_strict_profile(self):
         rc = main(["lint", str(FIXTURES / "bad-plugin"), "--profile", "strict-security"])
@@ -294,6 +337,15 @@ class TestMain:
         captured = capsys.readouterr()
         assert rc == 1
         assert 'Policy profile "strict-security" failed.' in captured.err
+
+    def test_scan_reports_min_score_failures_with_hint(self, capsys):
+        rc = main(["scan", str(FIXTURES / "bad-plugin"), "--min-score", "50"])
+        captured = capsys.readouterr()
+        expected_score = scan_plugin(FIXTURES / "bad-plugin").score
+
+        assert rc == 1
+        assert f"Score {expected_score} is below threshold 50" in captured.err
+        assert "hint:" in captured.err
 
     def test_doctor_bundle(self, tmp_path):
         bundle = tmp_path / "doctor.json"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -235,6 +235,27 @@ baseline_file = "baseline.txt"
         assert f"Using config: {plugin_dir / '.plugin-scanner.toml'}" in captured.err
         assert f"Using baseline: {baseline_path}" in captured.err
 
+    def test_text_scan_reports_missing_baseline_in_provenance(self, tmp_path, capsys):
+        plugin_dir = tmp_path / "good-plugin"
+        shutil.copytree(FIXTURES / "good-plugin", plugin_dir)
+        baseline_path = plugin_dir / "baseline.txt"
+        (plugin_dir / ".plugin-scanner.toml").write_text(
+            """
+[scanner]
+profile = "default"
+baseline_file = "baseline.txt"
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+
+        rc = main([str(plugin_dir)])
+        captured = capsys.readouterr()
+
+        assert rc == 0
+        assert f"Baseline not found: {baseline_path}" in captured.err
+        assert f"Using baseline: {baseline_path}" not in captured.err
+
     def test_min_score_exact_boundary(self):
         # At exact boundary should pass (>=)
         rc = main([str(FIXTURES / "good-plugin"), "--min-score", str(EXPECTED_GOOD_PLUGIN_SCORE)])
@@ -346,6 +367,15 @@ baseline_file = "baseline.txt"
         assert rc == 1
         assert f"Score {expected_score} is below threshold 50" in captured.err
         assert "hint:" in captured.err
+
+    def test_json_min_score_failures_do_not_emit_text_hint(self, capsys):
+        rc = main(["scan", str(FIXTURES / "bad-plugin"), "--min-score", "50", "--format", "json"])
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+
+        assert rc == 1
+        assert parsed["score"] == scan_plugin(FIXTURES / "bad-plugin").score
+        assert "hint:" not in captured.err
 
     def test_doctor_bundle(self, tmp_path):
         bundle = tmp_path / "doctor.json"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -467,6 +467,8 @@ args = ["workspace-skill.js"]
         assert "Consumer scan" in output
         assert "Artifact" in output
         assert "good-plugin" in output
+        assert "Recommended action" in output
+        assert '"policy_recommendation"' not in output
 
     def test_guard_run_persists_receipts_and_policy(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -652,6 +654,81 @@ args = ["workspace-skill.js"]
         assert output["install_verdict"]["action"] == "review"
         assert output["install_target"]["intended_harness"] == "codex"
         assert output["threat_intelligence"]["verdict_source"] == "local-scan"
+
+    def test_guard_preflight_human_output_stays_summary_first(self, tmp_path, capsys, monkeypatch):
+        target = tmp_path / "incoming-plugin"
+        target.mkdir(parents=True)
+        payload = {
+            "schema_version": "guard-consumer.v2",
+            "generated_at": "2026-04-11T00:00:00+00:00",
+            "install_target": {
+                "path": str(target),
+                "intended_harness": "codex",
+            },
+            "artifact_snapshot": {
+                "path": str(target),
+                "artifact_hash": "abc123",
+            },
+            "capability_manifest": {
+                "ecosystems": ["codex"],
+                "packages": [],
+                "category_names": ["Security"],
+            },
+            "artifact_diff": {
+                "changed": False,
+                "changed_fields": [],
+            },
+            "provenance_record": {
+                "scope": "plugin",
+                "plugin_dir": str(target),
+                "trust_score": None,
+            },
+            "trust_evidence_bundle": {
+                "findings": ["Posts environment secrets to a remote host."],
+                "severity_counts": {"critical": 1, "high": 0, "medium": 0, "low": 0, "info": 0},
+                "integrations": [],
+            },
+            "policy_recommendation": {
+                "action": "review",
+                "reason": "Install-time scan found risky network and secret access behavior.",
+            },
+            "install_verdict": {
+                "action": "review",
+                "reason": "Install-time scan found risky network and secret access behavior.",
+                "can_install": False,
+            },
+            "abom_entry": {
+                "artifact_id": "preflight:incoming-plugin",
+                "artifact_type": "plugin",
+            },
+            "threat_intelligence": {
+                "verdict_source": "local-scan",
+                "highest_severity": "critical",
+                "finding_count": 1,
+            },
+        }
+        monkeypatch.setattr(
+            guard_commands_module,
+            "run_consumer_scan",
+            lambda path, intended_harness=None, options=None: payload,
+        )
+
+        rc = main(
+            [
+                "guard",
+                "preflight",
+                str(target),
+                "--harness",
+                "codex",
+            ]
+        )
+        output = capsys.readouterr().out
+
+        assert rc == 0
+        assert "Install-time preflight" in output
+        assert "Install verdict" in output
+        assert "Highest severity" in output
+        assert '"install_verdict"' not in output
 
     def test_guard_policies_and_exceptions_show_persisted_rules(self, tmp_path, capsys):
         home_dir = tmp_path / "home"


### PR DESCRIPTION
## Summary
- add a shared human-facing UX layer for scanner output, help examples, provenance, and actionable hints
- make Guard human scan/preflight output summary-first instead of dumping raw JSON
- add regression coverage for the new CLI and Guard rendering behavior

## Verification
- .venv/bin/ruff check src/codex_plugin_scanner/cli.py src/codex_plugin_scanner/cli_ui.py src/codex_plugin_scanner/action_runner.py src/codex_plugin_scanner/guard/cli/render.py tests/test_cli.py tests/test_guard_cli.py
- .venv/bin/pytest
- .venv/bin/python -m build
- .venv/bin/plugin-scanner scan tests/fixtures/good-plugin
- .venv/bin/plugin-scanner scan tests/fixtures/good-plugin --format json
- .venv/bin/plugin-scanner verify tests/fixtures/good-plugin --format json
- .venv/bin/hol-guard scan tests/fixtures/good-plugin --consumer-mode
- .venv/bin/hol-guard preflight tests/fixtures/good-plugin --harness codex