### PR TITLE
feat: add HOL Guard Copilot adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 | If you want to... | Install | Start with |
 | :--- | :--- | :--- |
-| protect Codex, Claude Code, Cursor, Gemini, or OpenCode before tools run | `hol-guard` | `hol-guard start` |
+| protect Codex, Claude Code, Copilot CLI, Cursor, Gemini, or OpenCode before tools run | `hol-guard` | `hol-guard start` |
 | lint and verify packages in CI before release | `plugin-scanner` | `plugin-scanner verify .` |
 
 ## Guard Quickstart
@@ -71,6 +71,8 @@ See [docs/guard/get-started.md](docs/guard/get-started.md) for the full local fl
 
 - `claude-code`
   Guard prefers Claude hooks first, then the local approval center when the shell cannot prompt.
+- `copilot`
+  Guard can wrap the `copilot` CLI, detect `~/.copilot/config.json`, `~/.copilot/mcp-config.json`, workspace `.vscode/mcp.json`, and install repo-local `.github/hooks/hol-guard-copilot.json` hook entries for documented `preToolUse` and `postToolUse` events.
 - `codex`
   Guard owns artifact approval today through the local approval center. App Server is the future path for richer in-client approvals.
 - `cursor`
@@ -179,6 +181,8 @@ pip install "plugin-scanner[cisco]"
 
 On Guard surfaces, the Cisco extra adds optional offline evidence to `hol-guard scan`, `hol-guard preflight`, and `hol-guard explain <path>`. Use `--cisco-mode {auto,on,off}` to control that consumer-mode evidence path for local artifact scans. `hol-guard run` and Guard runtime prompt/file-read protection remain native Guard behavior in this pass.
 
+Guard does not add Cisco AIBOM runtime integration in this pass. If AIBOM support returns later, it should stay on evidence or export surfaces rather than Guard blocking or approval logic.
+
 ### Cisco package status
 
 Credit to [Cisco AI Defense](https://github.com/cisco-ai-defense) for open-sourcing the packages below.
@@ -188,7 +192,7 @@ Credit to [Cisco AI Defense](https://github.com/cisco-ai-defense) for open-sourc
 | `cisco-ai-skill-scanner` | shipped by default | Included in the lean baseline install. |
 | `cisco-ai-mcp-scanner` | shipped via `[cisco]` | Recommended for full Cisco coverage on Python 3.11+, including repo-controlled CI and Docker. |
 | `cisco-ai-a2a-scanner` | deferred | Requires live A2A endpoints and is not added in this pass. |
-| `cisco-aibom` | deferred | Artifact-oriented output with heavier deps and no scoring value in this pass. |
+| `cisco-aibom` | deferred | No Guard runtime integration in this pass. Revisit later only for evidence or export workflows. |
 
 If you want both tools in one shell during local development:
 

--- a/docs/guard/architecture.md
+++ b/docs/guard/architecture.md
@@ -4,7 +4,7 @@ Guard lives inside `codex_plugin_scanner` and is the local product surface for h
 
 The runtime is split into:
 
-- `guard/adapters`: harness discovery for Codex, Claude Code, Cursor, Gemini, and OpenCode
+- `guard/adapters`: harness discovery for Codex, Claude Code, Copilot CLI, Cursor, Gemini, and OpenCode
 - `guard/shims`: local launcher shims that route harness launches through Guard
 - `guard/consumer`: orchestration for detection, policy evaluation, and consumer-mode scan output
 - `guard/policy`: local action resolution for allow, review, warn, and block decisions
@@ -30,4 +30,13 @@ The local product loop is:
 4. `hol-guard receipts` and `hol-guard status` let users inspect local decisions
 5. `hol-guard login` and `hol-guard sync` stay optional
 
-Wrapper mode is still the core execution strategy in this phase. Config mutation is limited to the Claude Code hook helper, where Guard can add and remove its own hook entry in workspace-local settings.
+Wrapper mode is still the core execution strategy in this phase. Config mutation is limited to documented local hook helpers, where Guard can add and remove its own hook entries in workspace-local Claude settings or workspace-local Copilot CLI repo hooks.
+
+For Microsoft Copilot, Guard supports two real local boundaries only:
+
+1. the `copilot` CLI wrapper and repo-local `.github/hooks/*.json` hook surface
+2. MCP artifact detection from `~/.copilot/mcp-config.json` and workspace `.vscode/mcp.json`
+
+That does not extend to VS Code Copilot extension-host interception.
+
+Cisco AIBOM stays out of Guard runtime policy in this phase. If it returns later, it should attach to evidence or export paths rather than launch blocking or approval flow.

--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -112,6 +112,8 @@ Use these actions in config or saved decisions:
 
 Claude Code also gets Guard hook entries in `.claude/settings.local.json` when you install from a workspace.
 
+Copilot CLI gets a Guard-owned repo hook file at `.github/hooks/hol-guard-copilot.json` when you install from a workspace. Guard only reads `~/.copilot/config.json` and `~/.copilot/mcp-config.json`; it does not auto-write user-level Copilot config.
+
 ## Harness approval model
 
 Guard uses three approval tiers:
@@ -124,6 +126,8 @@ Current strategy:
 
 - `claude-code`
   prefers Claude hooks and can hand blocked work to the approval center cleanly
+- `copilot`
+  wraps the `copilot` CLI, watches documented repo hooks and MCP config, and treats workspace `.vscode/mcp.json` as MCP artifact detection only
 - `codex`
   uses the Guard approval center today; App Server is the long-term richer in-client path
 - `cursor`
@@ -132,6 +136,8 @@ Current strategy:
   keeps OpenCode’s permission model and lets Guard manage package and provenance policy
 - `gemini`
   scans extension manifests and routes blocked changes to the approval center
+
+Guard does not claim VS Code Copilot extension-host interception in this pass, and it does not add Cisco AIBOM runtime policy logic. AIBOM can come back later only as evidence or export.
 
 ## First-party canaries
 

--- a/docs/guard/harness-support.md
+++ b/docs/guard/harness-support.md
@@ -11,6 +11,12 @@ Current Guard support in this repo:
   - detects global and project settings, hooks, `.mcp.json`, and workspace agents
   - supports local hook install and uninstall in `.claude/settings.local.json`
   - is the best current harness for graceful approval deferral
+- `copilot`
+  - detects read-only user config in `~/.copilot/config.json` and `~/.copilot/mcp-config.json`
+  - detects workspace `.vscode/mcp.json` as documented MCP artifact input only
+  - detects repo-local Copilot CLI hooks from `.github/hooks/*.json`
+  - installs and removes Guard-owned repo hooks in `.github/hooks/hol-guard-copilot.json`
+  - supports wrapper-mode `guard run copilot`
 - `cursor`
   - detects global and project `mcp.json`
   - supports wrapper-mode management state
@@ -31,3 +37,10 @@ Approval tiers:
 3. terminal approval resolution through `hol-guard approvals`
 
 The harness adapters are designed to prefer discovery and reversible overlay behavior over invasive config mutation.
+
+Explicit non-support:
+
+- Guard does not claim VS Code Copilot extension-host interception.
+- Guard does not add `guard run vscode-copilot`.
+- Guard treats `~/.copilot/*` as read-only detection input and does not auto-write user-level Copilot config.
+- Guard does not add Cisco AIBOM runtime or policy integration in this pass. If revisited later, AIBOM belongs on evidence or export surfaces.

--- a/src/codex_plugin_scanner/guard/adapters/__init__.py
+++ b/src/codex_plugin_scanner/guard/adapters/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from .base import HarnessAdapter, HarnessContext
 from .claude_code import ClaudeCodeHarnessAdapter
 from .codex import CodexHarnessAdapter
+from .copilot import CopilotHarnessAdapter
 from .cursor import CursorHarnessAdapter
 from .gemini import GeminiHarnessAdapter
 from .hermes import HermesHarnessAdapter
@@ -13,6 +14,7 @@ from .opencode import OpenCodeHarnessAdapter
 ADAPTERS: tuple[HarnessAdapter, ...] = (
     CodexHarnessAdapter(),
     ClaudeCodeHarnessAdapter(),
+    CopilotHarnessAdapter(),
     CursorHarnessAdapter(),
     GeminiHarnessAdapter(),
     HermesHarnessAdapter(),

--- a/src/codex_plugin_scanner/guard/adapters/copilot.py
+++ b/src/codex_plugin_scanner/guard/adapters/copilot.py
@@ -90,6 +90,16 @@ def _hooks_payload(payload: dict[str, object]) -> dict[str, object]:
     return payload
 
 
+def _hook_command_variants(entry: dict[str, object]) -> tuple[tuple[str, str], ...]:
+    variants: list[tuple[str, str]] = []
+    for shell_name in ("command", "bash", "powershell"):
+        command = entry.get(shell_name)
+        if not isinstance(command, str):
+            continue
+        variants.append((shell_name, command))
+    return tuple(variants)
+
+
 def _managed_hook_payload(payload: dict[str, object]) -> dict[str, object]:
     normalized_payload: dict[str, object] = {"version": 1, "hooks": {}}
     version = payload.get("version")
@@ -319,20 +329,19 @@ class CopilotHarnessAdapter(HarnessAdapter):
             for index, entry in enumerate(entries):
                 if not isinstance(entry, dict):
                     continue
-                command = entry.get("command")
-                if not isinstance(command, str):
-                    command = entry.get("bash")
-                if not isinstance(command, str):
-                    command = entry.get("powershell")
-                artifacts.append(
-                    GuardArtifact(
-                        artifact_id=f"copilot:project:hook:{config_path.stem}:{hook_name.lower()}:{index}",
-                        name=hook_name,
-                        harness=self.harness,
-                        artifact_type="hook",
-                        source_scope="project",
-                        config_path=str(config_path),
-                        command=command if isinstance(command, str) else None,
+                for shell_name, command in _hook_command_variants(entry):
+                    artifacts.append(
+                        GuardArtifact(
+                            artifact_id=(
+                                f"copilot:project:hook:{config_path.stem}:{hook_name.lower()}:{index}:{shell_name}"
+                            ),
+                            name=hook_name,
+                            harness=self.harness,
+                            artifact_type="hook",
+                            source_scope="project",
+                            config_path=str(config_path),
+                            command=command,
+                            metadata={"shell": shell_name},
+                        )
                     )
-                )
         return artifacts

--- a/src/codex_plugin_scanner/guard/adapters/copilot.py
+++ b/src/codex_plugin_scanner/guard/adapters/copilot.py
@@ -12,7 +12,15 @@ from ..models import GuardArtifact, HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
 from .base import HarnessAdapter, HarnessContext, _command_available, _json_payload, _run_command_probe
 
-_HOOK_EVENTS = ("preToolUse", "postToolUse")
+_MANAGED_HOOK_EVENTS = ("preToolUse", "postToolUse")
+_DETECTABLE_HOOK_EVENTS = (
+    "sessionStart",
+    "sessionEnd",
+    "userPromptSubmitted",
+    "preToolUse",
+    "postToolUse",
+    "errorOccurred",
+)
 _MANAGED_HOOK_FILENAME = "hol-guard-copilot.json"
 
 
@@ -97,7 +105,7 @@ def _managed_hook_payload(payload: dict[str, object]) -> dict[str, object]:
     normalized_payload["hooks"] = {
         str(hook_name): list(entries)
         for hook_name, entries in payload.items()
-        if hook_name != "version" and hook_name not in _HOOK_EVENTS and isinstance(entries, list)
+        if hook_name != "version" and hook_name not in _MANAGED_HOOK_EVENTS and isinstance(entries, list)
     }
     return normalized_payload
 
@@ -196,7 +204,7 @@ class CopilotHarnessAdapter(HarnessAdapter):
         payload = _managed_hook_payload(_json_payload(hook_path))
         hooks_payload = payload["hooks"]
         hook_entry = _hook_entry(context)
-        for hook_name in _HOOK_EVENTS:
+        for hook_name in _MANAGED_HOOK_EVENTS:
             hooks_payload[hook_name] = _merge_hook_entries(hooks_payload.get(hook_name), hook_entry)
         hook_path.parent.mkdir(parents=True, exist_ok=True)
         hook_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
@@ -225,7 +233,7 @@ class CopilotHarnessAdapter(HarnessAdapter):
         payload = _managed_hook_payload(payload)
         hooks_payload = payload["hooks"]
         bash_command, powershell_command = _hook_shell_commands(context)
-        for hook_name in _HOOK_EVENTS:
+        for hook_name in _MANAGED_HOOK_EVENTS:
             updated_entries = _remove_hook_entries(hooks_payload.get(hook_name), bash_command, powershell_command)
             if len(updated_entries) > 0:
                 hooks_payload[hook_name] = updated_entries
@@ -304,7 +312,7 @@ class CopilotHarnessAdapter(HarnessAdapter):
     ) -> list[GuardArtifact]:
         artifacts: list[GuardArtifact] = []
         hooks_payload = _hooks_payload(payload)
-        for hook_name in _HOOK_EVENTS:
+        for hook_name in _DETECTABLE_HOOK_EVENTS:
             entries = hooks_payload.get(hook_name)
             if not isinstance(entries, list):
                 continue

--- a/src/codex_plugin_scanner/guard/adapters/copilot.py
+++ b/src/codex_plugin_scanner/guard/adapters/copilot.py
@@ -165,8 +165,11 @@ class CopilotHarnessAdapter(HarnessAdapter):
                     payload = _json_payload(hook_path)
                     if not payload:
                         continue
+                    hook_artifacts = self._hook_artifacts(hook_path, payload)
+                    if len(hook_artifacts) == 0:
+                        continue
                     found_paths.append(str(hook_path))
-                    artifacts.extend(self._hook_artifacts(hook_path, payload))
+                    artifacts.extend(hook_artifacts)
         return HarnessDetection(
             harness=self.harness,
             installed=bool(found_paths) or _command_available(self.executable),

--- a/src/codex_plugin_scanner/guard/adapters/copilot.py
+++ b/src/codex_plugin_scanner/guard/adapters/copilot.py
@@ -139,6 +139,16 @@ def _managed_hook_payload(payload: dict[str, object]) -> dict[str, object]:
     return normalized_payload
 
 
+def _mcp_servers_payload(payload: dict[str, object]) -> dict[str, object] | None:
+    servers = payload.get("servers")
+    if isinstance(servers, dict):
+        return servers
+    mcp_servers = payload.get("mcpServers")
+    if isinstance(mcp_servers, dict):
+        return mcp_servers
+    return None
+
+
 def _command_parts(server_config: dict[str, object]) -> tuple[str | None, tuple[str, ...]]:
     command = server_config.get("command")
     args = tuple(str(value) for value in server_config.get("args", []) if isinstance(value, str))
@@ -309,8 +319,8 @@ class CopilotHarnessAdapter(HarnessAdapter):
         payload: dict[str, object],
         scope: str,
     ) -> list[GuardArtifact]:
-        servers = payload.get("servers")
-        if not isinstance(servers, dict):
+        servers = _mcp_servers_payload(payload)
+        if servers is None:
             return []
         artifacts: list[GuardArtifact] = []
         for name, server_config in servers.items():

--- a/src/codex_plugin_scanner/guard/adapters/copilot.py
+++ b/src/codex_plugin_scanner/guard/adapters/copilot.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import shlex
 import subprocess
 import sys
@@ -22,6 +23,12 @@ _DETECTABLE_HOOK_EVENTS = (
     "errorOccurred",
 )
 _MANAGED_HOOK_FILENAME = "hol-guard-copilot.json"
+_MANAGED_HOOK_COMMAND_PATTERNS = (
+    re.compile(r'(^|["\s])-m["\s]+codex_plugin_scanner\.cli(["\s]|$)'),
+    re.compile(r'(^|["\s])guard(["\s]|$)'),
+    re.compile(r'(^|["\s])hook(["\s]|$)'),
+    re.compile(r'--harness(?:["\s=]+)copilot(["\s]|$)'),
+)
 
 
 def _hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
@@ -59,22 +66,34 @@ def _hook_entry(context: HarnessContext) -> dict[str, object]:
     }
 
 
+def _is_managed_hook_command(command: str) -> bool:
+    normalized_command = command.lower()
+    return all(pattern.search(normalized_command) is not None for pattern in _MANAGED_HOOK_COMMAND_PATTERNS)
+
+
 def _is_managed_hook_entry(entry: object, bash_command: str, powershell_command: str) -> bool:
     if not isinstance(entry, dict):
         return False
     if entry.get("bash") == bash_command and entry.get("powershell") == powershell_command:
         return True
-    command = entry.get("command")
-    return isinstance(command, str) and command in {bash_command, powershell_command}
+    for command in (entry.get("command"), entry.get("bash"), entry.get("powershell")):
+        if not isinstance(command, str):
+            continue
+        if command in {bash_command, powershell_command}:
+            return True
+        if _is_managed_hook_command(command):
+            return True
+    return False
 
 
 def _merge_hook_entries(entries: object, hook_entry: dict[str, object]) -> list[object]:
     normalized = list(entries) if isinstance(entries, list) else []
     bash_command = str(hook_entry["bash"])
     powershell_command = str(hook_entry["powershell"])
-    if any(_is_managed_hook_entry(entry, bash_command, powershell_command) for entry in normalized):
-        return normalized
-    return [*normalized, hook_entry]
+    preserved_entries = [
+        entry for entry in normalized if not _is_managed_hook_entry(entry, bash_command, powershell_command)
+    ]
+    return [*preserved_entries, hook_entry]
 
 
 def _remove_hook_entries(entries: object, bash_command: str, powershell_command: str) -> list[object]:

--- a/src/codex_plugin_scanner/guard/adapters/copilot.py
+++ b/src/codex_plugin_scanner/guard/adapters/copilot.py
@@ -1,0 +1,317 @@
+"""Microsoft Copilot CLI harness adapter."""
+
+from __future__ import annotations
+
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+from ..models import GuardArtifact, HarnessDetection
+from ..shims import install_guard_shim, remove_guard_shim
+from .base import HarnessAdapter, HarnessContext, _command_available, _json_payload, _run_command_probe
+
+_HOOK_EVENTS = ("preToolUse", "postToolUse")
+_MANAGED_HOOK_FILENAME = "hol-guard-copilot.json"
+
+
+def _hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
+    command = [
+        sys.executable,
+        "-m",
+        "codex_plugin_scanner.cli",
+        "guard",
+        "hook",
+        "--guard-home",
+        str(context.guard_home),
+        "--harness",
+        "copilot",
+    ]
+    if context.home_dir.resolve() != Path.home().resolve():
+        command.extend(["--home", str(context.home_dir)])
+    if context.workspace_dir is not None:
+        command.extend(["--workspace", str(context.workspace_dir)])
+    return tuple(command)
+
+
+def _hook_shell_commands(context: HarnessContext) -> tuple[str, str]:
+    command_parts = _hook_command_parts(context)
+    return shlex.join(command_parts), subprocess.list2cmdline(list(command_parts))
+
+
+def _hook_entry(context: HarnessContext) -> dict[str, object]:
+    bash_command, powershell_command = _hook_shell_commands(context)
+    return {
+        "type": "command",
+        "bash": bash_command,
+        "powershell": powershell_command,
+        "cwd": ".",
+        "timeoutSec": 30,
+    }
+
+
+def _is_managed_hook_entry(entry: object, bash_command: str, powershell_command: str) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    if entry.get("bash") == bash_command and entry.get("powershell") == powershell_command:
+        return True
+    command = entry.get("command")
+    return isinstance(command, str) and command in {bash_command, powershell_command}
+
+
+def _merge_hook_entries(entries: object, hook_entry: dict[str, object]) -> list[object]:
+    normalized = list(entries) if isinstance(entries, list) else []
+    bash_command = str(hook_entry["bash"])
+    powershell_command = str(hook_entry["powershell"])
+    if any(_is_managed_hook_entry(entry, bash_command, powershell_command) for entry in normalized):
+        return normalized
+    return [*normalized, hook_entry]
+
+
+def _remove_hook_entries(entries: object, bash_command: str, powershell_command: str) -> list[object]:
+    if not isinstance(entries, list):
+        return []
+    return [entry for entry in entries if not _is_managed_hook_entry(entry, bash_command, powershell_command)]
+
+
+def _hooks_payload(payload: dict[str, object]) -> dict[str, object]:
+    hooks = payload.get("hooks")
+    if isinstance(hooks, dict):
+        return hooks
+    return payload
+
+
+def _managed_hook_payload(payload: dict[str, object]) -> dict[str, object]:
+    hooks_payload = _hooks_payload(payload)
+    normalized_hooks = {
+        hook_name: list(entries)
+        for hook_name in _HOOK_EVENTS
+        if isinstance((entries := hooks_payload.get(hook_name)), list)
+    }
+    return {"version": 1, "hooks": normalized_hooks}
+
+
+def _command_parts(server_config: dict[str, object]) -> tuple[str | None, tuple[str, ...]]:
+    command = server_config.get("command")
+    args = tuple(str(value) for value in server_config.get("args", []) if isinstance(value, str))
+    if isinstance(command, str):
+        return command, args
+    if isinstance(command, list):
+        command_parts = [str(value) for value in command if isinstance(value, str)]
+        if len(command_parts) == 0:
+            return None, args
+        return command_parts[0], (*tuple(command_parts[1:]), *args)
+    return None, args
+
+
+class CopilotHarnessAdapter(HarnessAdapter):
+    """Discover Microsoft Copilot CLI repo hooks and MCP config artifacts."""
+
+    harness = "copilot"
+    executable = "copilot"
+    approval_tier = "native-or-center"
+    approval_summary = (
+        "Guard can install documented Copilot CLI repo hooks and falls back to the local approval center when needed."
+    )
+    fallback_hint = "Use Guard-managed repo hooks for Copilot CLI tool events and the local approval center for review."
+
+    @staticmethod
+    def _scope_for(context: HarnessContext, path: Path) -> str:
+        if context.workspace_dir is not None and path.is_relative_to(context.workspace_dir):
+            return "project"
+        return "global"
+
+    @staticmethod
+    def _hook_path(context: HarnessContext) -> Path | None:
+        if context.workspace_dir is None:
+            return None
+        return context.workspace_dir / ".github" / "hooks" / _MANAGED_HOOK_FILENAME
+
+    def detect(self, context: HarnessContext) -> HarnessDetection:
+        workspace_mcp_path = (
+            context.workspace_dir / ".vscode" / "mcp.json" if context.workspace_dir is not None else None
+        )
+        config_candidates = [
+            context.home_dir / ".copilot" / "config.json",
+            context.home_dir / ".copilot" / "mcp-config.json",
+        ]
+        if context.workspace_dir is not None:
+            config_candidates.append(workspace_mcp_path)
+        artifacts: list[GuardArtifact] = []
+        found_paths: list[str] = []
+        for config_path in config_candidates:
+            payload = _json_payload(config_path)
+            if not payload:
+                continue
+            found_paths.append(str(config_path))
+            scope = self._scope_for(context, config_path)
+            if config_path.name == "mcp-config.json" or config_path == workspace_mcp_path:
+                artifacts.extend(self._mcp_artifacts(config_path, payload, scope))
+        if context.workspace_dir is not None:
+            hooks_dir = context.workspace_dir / ".github" / "hooks"
+            if hooks_dir.is_dir():
+                for hook_path in sorted(path for path in hooks_dir.glob("*.json") if path.is_file()):
+                    payload = _json_payload(hook_path)
+                    if not payload:
+                        continue
+                    found_paths.append(str(hook_path))
+                    artifacts.extend(self._hook_artifacts(hook_path, payload))
+        return HarnessDetection(
+            harness=self.harness,
+            installed=bool(found_paths) or _command_available(self.executable),
+            command_available=_command_available(self.executable),
+            config_paths=tuple(found_paths),
+            artifacts=tuple(artifacts),
+            warnings=(),
+        )
+
+    def install(self, context: HarnessContext) -> dict[str, object]:
+        shim_manifest = install_guard_shim(self.harness, context)
+        hook_path = self._hook_path(context)
+        if hook_path is None:
+            return {
+                "harness": self.harness,
+                "active": True,
+                "config_path": shim_manifest["shim_path"],
+                **shim_manifest,
+                "notes": [
+                    "Guard created the Copilot launcher shim. Pass --workspace to install repo-local Copilot hooks.",
+                    *[str(note) for note in shim_manifest.get("notes", [])],
+                ],
+            }
+        payload = {"version": 1, "hooks": {}}
+        hooks_payload = payload["hooks"]
+        hook_entry = _hook_entry(context)
+        for hook_name in _HOOK_EVENTS:
+            hooks_payload[hook_name] = _merge_hook_entries(hooks_payload.get(hook_name), hook_entry)
+        hook_path.parent.mkdir(parents=True, exist_ok=True)
+        hook_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        return {
+            "harness": self.harness,
+            "active": True,
+            "config_path": str(hook_path),
+            **shim_manifest,
+            "notes": [
+                "Guard hook entries added to .github/hooks/hol-guard-copilot.json",
+                *[str(note) for note in shim_manifest.get("notes", [])],
+            ],
+        }
+
+    def uninstall(self, context: HarnessContext) -> dict[str, object]:
+        shim_manifest = remove_guard_shim(self.harness, context)
+        hook_path = self._hook_path(context)
+        if hook_path is None:
+            return {
+                "harness": self.harness,
+                "active": False,
+                "config_path": shim_manifest["shim_path"],
+                **shim_manifest,
+            }
+        payload = _json_payload(hook_path)
+        payload = _managed_hook_payload(payload)
+        hooks_payload = payload["hooks"]
+        bash_command, powershell_command = _hook_shell_commands(context)
+        for hook_name in _HOOK_EVENTS:
+            updated_entries = _remove_hook_entries(hooks_payload.get(hook_name), bash_command, powershell_command)
+            if len(updated_entries) > 0:
+                hooks_payload[hook_name] = updated_entries
+                continue
+            hooks_payload.pop(hook_name, None)
+        if len(hooks_payload) > 0:
+            hook_path.parent.mkdir(parents=True, exist_ok=True)
+            hook_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        elif hook_path.exists():
+            hook_path.unlink()
+        return {
+            "harness": self.harness,
+            "active": False,
+            "config_path": str(hook_path),
+            **shim_manifest,
+            "notes": [
+                "Guard hook entries removed from .github/hooks/hol-guard-copilot.json",
+                *[str(note) for note in shim_manifest.get("notes", [])],
+            ],
+        }
+
+    def runtime_probe(self, context: HarnessContext) -> dict[str, object] | None:
+        if not _command_available(self.executable):
+            return None
+        return _run_command_probe([self.executable, "--help"])
+
+    def diagnostic_warnings(
+        self,
+        detection: HarnessDetection,
+        runtime_probe: dict[str, object] | None,
+    ) -> list[str]:
+        warnings = super().diagnostic_warnings(detection, runtime_probe)
+        if (
+            runtime_probe is not None
+            and runtime_probe.get("ok") is False
+            and runtime_probe.get("timed_out") is not True
+        ):
+            warnings.append("Copilot CLI was found on PATH, but `copilot --help` did not complete successfully.")
+        return warnings
+
+    def _mcp_artifacts(
+        self,
+        config_path: Path,
+        payload: dict[str, object],
+        scope: str,
+    ) -> list[GuardArtifact]:
+        servers = payload.get("servers")
+        if not isinstance(servers, dict):
+            return []
+        artifacts: list[GuardArtifact] = []
+        for name, server_config in servers.items():
+            if not isinstance(name, str) or not isinstance(server_config, dict):
+                continue
+            command, args = _command_parts(server_config)
+            url = server_config.get("url")
+            artifacts.append(
+                GuardArtifact(
+                    artifact_id=f"copilot:{scope}:{name}",
+                    name=name,
+                    harness=self.harness,
+                    artifact_type="mcp_server",
+                    source_scope=scope,
+                    config_path=str(config_path),
+                    command=command,
+                    args=args,
+                    url=url if isinstance(url, str) else None,
+                    transport="http" if isinstance(url, str) else "stdio",
+                )
+            )
+        return artifacts
+
+    def _hook_artifacts(
+        self,
+        config_path: Path,
+        payload: dict[str, object],
+    ) -> list[GuardArtifact]:
+        artifacts: list[GuardArtifact] = []
+        hooks_payload = _hooks_payload(payload)
+        for hook_name in _HOOK_EVENTS:
+            entries = hooks_payload.get(hook_name)
+            if not isinstance(entries, list):
+                continue
+            for index, entry in enumerate(entries):
+                if not isinstance(entry, dict):
+                    continue
+                command = entry.get("command")
+                if not isinstance(command, str):
+                    command = entry.get("bash")
+                if not isinstance(command, str):
+                    command = entry.get("powershell")
+                artifacts.append(
+                    GuardArtifact(
+                        artifact_id=f"copilot:project:hook:{config_path.stem}:{hook_name.lower()}:{index}",
+                        name=hook_name,
+                        harness=self.harness,
+                        artifact_type="hook",
+                        source_scope="project",
+                        config_path=str(config_path),
+                        command=command if isinstance(command, str) else None,
+                    )
+                )
+        return artifacts

--- a/src/codex_plugin_scanner/guard/adapters/copilot.py
+++ b/src/codex_plugin_scanner/guard/adapters/copilot.py
@@ -83,13 +83,23 @@ def _hooks_payload(payload: dict[str, object]) -> dict[str, object]:
 
 
 def _managed_hook_payload(payload: dict[str, object]) -> dict[str, object]:
-    hooks_payload = _hooks_payload(payload)
-    normalized_hooks = {
-        hook_name: list(entries)
-        for hook_name in _HOOK_EVENTS
-        if isinstance((entries := hooks_payload.get(hook_name)), list)
+    normalized_payload: dict[str, object] = {"version": 1, "hooks": {}}
+    version = payload.get("version")
+    if isinstance(version, int):
+        normalized_payload["version"] = version
+    hooks = payload.get("hooks")
+    if isinstance(hooks, dict):
+        normalized_payload["hooks"] = {
+            str(hook_name): list(entries) if isinstance(entries, list) else entries
+            for hook_name, entries in hooks.items()
+        }
+        return normalized_payload
+    normalized_payload["hooks"] = {
+        str(hook_name): list(entries)
+        for hook_name, entries in payload.items()
+        if hook_name != "version" and hook_name not in _HOOK_EVENTS and isinstance(entries, list)
     }
-    return {"version": 1, "hooks": normalized_hooks}
+    return normalized_payload
 
 
 def _command_parts(server_config: dict[str, object]) -> tuple[str | None, tuple[str, ...]]:
@@ -180,7 +190,7 @@ class CopilotHarnessAdapter(HarnessAdapter):
                     *[str(note) for note in shim_manifest.get("notes", [])],
                 ],
             }
-        payload = {"version": 1, "hooks": {}}
+        payload = _managed_hook_payload(_json_payload(hook_path))
         hooks_payload = payload["hooks"]
         hook_entry = _hook_entry(context)
         for hook_name in _HOOK_EVENTS:

--- a/src/codex_plugin_scanner/guard/cli/bootstrap.py
+++ b/src/codex_plugin_scanner/guard/cli/bootstrap.py
@@ -136,8 +136,7 @@ def _build_bootstrap_steps(
                 "title": "Detect a supported harness",
                 "command": f"{GUARD_COMMAND} detect",
                 "detail": (
-                    "Install Codex, Claude Code, Copilot CLI, Cursor, Gemini, "
-                    "or OpenCode first, then rerun bootstrap."
+                    "Install Codex, Claude Code, Copilot CLI, Cursor, Gemini, or OpenCode first, then rerun bootstrap."
                 ),
             }
         ]

--- a/src/codex_plugin_scanner/guard/cli/bootstrap.py
+++ b/src/codex_plugin_scanner/guard/cli/bootstrap.py
@@ -135,7 +135,10 @@ def _build_bootstrap_steps(
             {
                 "title": "Detect a supported harness",
                 "command": f"{GUARD_COMMAND} detect",
-                "detail": "Install Codex, Claude Code, Cursor, Gemini, or OpenCode first, then rerun bootstrap.",
+                "detail": (
+                    "Install Codex, Claude Code, Copilot CLI, Cursor, Gemini, "
+                    "or OpenCode first, then rerun bootstrap."
+                ),
             }
         ]
     install_reason = str(bootstrap_install.get("reason") or "")

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -675,6 +675,16 @@ def run_guard_command(args: argparse.Namespace) -> int:
                     approval_center_url=approval_center_url,
                     queued=queued,
                 )
+            if _should_emit_copilot_hook_response(args):
+                _emit_copilot_hook_response(
+                    policy_action=policy_action,
+                    reason=_copilot_hook_reason(
+                        response_payload.get("why_now"),
+                        response_payload.get("review_hint"),
+                        response_payload.get("risk_headline"),
+                    ),
+                )
+                return 0
             _emit("hook", response_payload, getattr(args, "json", False))
             return 1 if policy_action in {"block", "require-reapproval"} else 0
         artifact_id = _coalesce_string(
@@ -723,6 +733,12 @@ def run_guard_command(args: argparse.Namespace) -> int:
             user_override=_optional_string(payload.get("user_override")),
         )
         store.add_receipt(receipt)
+        if _should_emit_copilot_hook_response(args):
+            _emit_copilot_hook_response(
+                policy_action=policy_action,
+                reason=_copilot_hook_reason(payload.get("permission_decision_reason")),
+            )
+            return 0
         _emit(
             "hook",
             {
@@ -740,6 +756,28 @@ def run_guard_command(args: argparse.Namespace) -> int:
 
 def _emit(command: str, payload: dict[str, object], as_json: bool) -> None:
     emit_guard_payload(command, payload, as_json)
+
+
+def _should_emit_copilot_hook_response(args: argparse.Namespace) -> bool:
+    return args.harness == "copilot" and not getattr(args, "json", False)
+
+
+def _copilot_hook_reason(*values: object | None) -> str:
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return "Guard blocked this tool call."
+
+
+def _emit_copilot_hook_response(*, policy_action: str, reason: str) -> None:
+    if policy_action in {"block", "sandbox-required", "require-reapproval"}:
+        payload = {
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    else:
+        payload = {"permissionDecision": "allow"}
+    print(json.dumps(payload, separators=(",", ":")))
 
 
 def _headless_approval_resolver(
@@ -805,12 +843,66 @@ def _open_approval_center(approval_center_url: str) -> None:
 
 def _load_hook_payload(event_file: str | None) -> dict[str, object]:
     if event_file:
-        return json.loads(Path(event_file).read_text(encoding="utf-8"))
+        payload = json.loads(Path(event_file).read_text(encoding="utf-8"))
+        return _normalize_hook_payload(payload) if isinstance(payload, dict) else {}
     raw = sys.stdin.read().strip()
     if not raw:
         return {}
     payload = json.loads(raw)
-    return payload if isinstance(payload, dict) else {}
+    return _normalize_hook_payload(payload) if isinstance(payload, dict) else {}
+
+
+def _normalize_hook_payload(payload: dict[str, object]) -> dict[str, object]:
+    normalized = dict(payload)
+    for source_key, target_key in (
+        ("artifactId", "artifact_id"),
+        ("artifactHash", "artifact_hash"),
+        ("artifactName", "artifact_name"),
+        ("changedCapabilities", "changed_capabilities"),
+        ("policyAction", "policy_action"),
+        ("sourceScope", "source_scope"),
+        ("toolName", "tool_name"),
+        ("userOverride", "user_override"),
+    ):
+        if target_key not in normalized and source_key in payload:
+            normalized[target_key] = payload[source_key]
+    arguments = _normalize_hook_arguments(
+        normalized.get("tool_input"),
+        normalized.get("arguments"),
+        payload.get("toolArgs"),
+        payload.get("toolInput"),
+    )
+    if arguments is not None:
+        normalized["tool_input"] = arguments
+        normalized["arguments"] = arguments
+    return normalized
+
+
+def _normalize_hook_arguments(*values: object | None) -> object | None:
+    for value in values:
+        normalized = _normalize_hook_argument_value(value)
+        if normalized is not None:
+            return normalized
+    return None
+
+
+def _normalize_hook_argument_value(value: object | None) -> object | None:
+    if value is None:
+        return None
+    if isinstance(value, (dict, list)):
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            return stripped
+        if isinstance(parsed, (dict, list, str)):
+            return parsed
+        return stripped
+    return value
 
 
 def _coalesce_string(*values: object | None) -> str:
@@ -876,6 +968,10 @@ def _runtime_policy_path(harness: str, home_dir: Path, workspace: Path | None) -
         if workspace is not None:
             return workspace / ".codex" / "config.toml"
         return home_dir / ".codex" / "config.toml"
+    if harness == "copilot":
+        if workspace is not None:
+            return workspace / ".github" / "hooks" / "hol-guard-copilot.json"
+        return home_dir / ".copilot" / "config.json"
     if workspace is not None:
         return workspace / ".mcp.json"
     return home_dir / ".mcp.json"

--- a/src/codex_plugin_scanner/guard/cli/product.py
+++ b/src/codex_plugin_scanner/guard/cli/product.py
@@ -12,7 +12,7 @@ from ..daemon import load_guard_daemon_url
 from ..models import HarnessDetection
 from ..store import GuardStore
 
-HARNESS_PRIORITY = ("codex", "claude-code", "cursor", "gemini", "opencode")
+HARNESS_PRIORITY = ("codex", "claude-code", "copilot", "cursor", "gemini", "opencode")
 GUARD_COMMAND = "hol-guard"
 
 
@@ -132,7 +132,7 @@ def _build_next_steps(recommended: dict[str, object] | None) -> list[dict[str, s
                 "command": f"{GUARD_COMMAND} detect",
                 "detail": (
                     "Guard did not find a local harness config yet. Start by installing "
-                    "Codex, Claude Code, Cursor, Gemini, or OpenCode."
+                    "Codex, Claude Code, Copilot CLI, Cursor, Gemini, or OpenCode."
                 ),
             }
         ]

--- a/src/codex_plugin_scanner/guard/incident.py
+++ b/src/codex_plugin_scanner/guard/incident.py
@@ -9,6 +9,7 @@ from .models import GuardAction, GuardArtifact
 _HARNESS_LABELS = {
     "codex": "Codex",
     "claude-code": "Claude Code",
+    "copilot": "Copilot CLI",
     "cursor": "Cursor",
     "gemini": "Gemini",
     "opencode": "OpenCode",

--- a/src/codex_plugin_scanner/guard/models.py
+++ b/src/codex_plugin_scanner/guard/models.py
@@ -40,7 +40,7 @@ def _redact_arg(value: str) -> str:
     if "authorization:" in lower_value or "api-key:" in lower_value or "bearer " in lower_value:
         prefix, _, _ = value.partition(":")
         return f"{prefix}: *****"
-    if any(token in lower_value for token in ("apikey=", "api_key=", "token=", "secret=")):
+    if any(token in lower_value for token in ("apikey=", "api_key=", "api-key=", "token=", "secret=")):
         key, _, _ = value.partition("=")
         return f"{key}=*****"
     return value

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -15,6 +15,7 @@ _FILE_READ_TOOL_NAMES = frozenset(
         "read",
         "read_file",
         "open_file",
+        "view",
         "view_file",
         "cat_file",
     }

--- a/tests/test_guard_bootstrap.py
+++ b/tests/test_guard_bootstrap.py
@@ -160,6 +160,40 @@ def test_guard_bootstrap_invalid_harness_returns_cli_error(tmp_path, capsys, mon
     assert "Unsupported harness" in stderr
 
 
+def test_guard_bootstrap_installs_copilot_when_it_is_the_detected_harness(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    (home_dir / ".copilot").mkdir(parents=True, exist_ok=True)
+    (workspace_dir / ".github" / "hooks").mkdir(parents=True, exist_ok=True)
+    _write_text(
+        home_dir / ".copilot" / "mcp-config.json",
+        '{"servers":{"global-tool":{"command":"npx","args":["server.js"]}}}\n',
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.bootstrap.ensure_guard_daemon",
+        lambda _guard_home: "http://127.0.0.1:4781",
+    )
+    monkeypatch.setattr("shutil.which", lambda _command: None)
+
+    rc = main(
+        [
+            "guard",
+            "bootstrap",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["recommended_harness"] == "copilot"
+    assert output["bootstrap_install"]["harness"] == "copilot"
+    assert output["next_steps"][0]["command"] == "hol-guard run copilot --dry-run"
+
+
 def test_guard_bootstrap_skip_install_still_rejects_invalid_harness(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -464,7 +464,7 @@ args = ["workspace-skill.js"]
         assert output["harnesses"][0]["harness"] == "copilot"
         assert "copilot:global:global-tool" in artifacts
         assert "copilot:project:workspace-tool" in artifacts
-        assert "copilot:project:hook:custom:pretooluse:0" in artifacts
+        assert "copilot:project:hook:custom:pretooluse:0:command" in artifacts
 
     def test_guard_scan_emits_consumer_contract(self, capsys):
         rc = main(

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -428,6 +428,44 @@ args = ["workspace-skill.js"]
         assert "global_tools" in output
         assert "Run `hol-guard doctor <harness>`" in output
 
+    def test_guard_detect_reports_copilot_surfaces(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _write_json(home_dir / ".copilot" / "config.json", {"trusted_repositories": ["demo"]})
+        _write_json(
+            home_dir / ".copilot" / "mcp-config.json",
+            {"servers": {"global-tool": {"command": "npx", "args": ["server.js"]}}},
+        )
+        _write_json(
+            workspace_dir / ".vscode" / "mcp.json",
+            {"servers": {"workspace-tool": {"command": "python", "args": ["server.py"]}}},
+        )
+        _write_json(
+            workspace_dir / ".github" / "hooks" / "custom.json",
+            {"version": 1, "hooks": {"preToolUse": [{"command": "python pre.py"}]}},
+        )
+
+        rc = main(
+            [
+                "guard",
+                "detect",
+                "copilot",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        artifacts = {item["artifact_id"] for item in output["harnesses"][0]["artifacts"]}
+
+        assert rc == 0
+        assert output["harnesses"][0]["harness"] == "copilot"
+        assert "copilot:global:global-tool" in artifacts
+        assert "copilot:project:workspace-tool" in artifacts
+        assert "copilot:project:hook:custom:pretooluse:0" in artifacts
+
     def test_guard_scan_emits_consumer_contract(self, capsys):
         rc = main(
             [

--- a/tests/test_guard_copilot_adapter.py
+++ b/tests/test_guard_copilot_adapter.py
@@ -1,0 +1,171 @@
+"""Guard adapter tests for Microsoft Copilot surfaces."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.copilot import CopilotHarnessAdapter
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _build_context(tmp_path: Path) -> HarnessContext:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    guard_home = tmp_path / "guard-home"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    return HarnessContext(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        guard_home=guard_home,
+    )
+
+
+def test_copilot_detects_documented_local_surfaces_and_redacts_secrets(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = CopilotHarnessAdapter()
+    _write_json(context.home_dir / ".copilot" / "config.json", {"trusted_repositories": ["demo"]})
+    _write_json(
+        context.home_dir / ".copilot" / "mcp-config.json",
+        {
+            "servers": {
+                "global-tool": {
+                    "command": "npx",
+                    "args": ["--token=secret-token", "server.js"],
+                    "url": "https://example.com/mcp?token=secret-token&label=demo",
+                }
+            }
+        },
+    )
+    _write_json(
+        context.workspace_dir / ".vscode" / "mcp.json",
+        {
+            "servers": {
+                "workspace-tool": {
+                    "command": ["python", "-m", "workspace_server"],
+                    "args": ["--api-key=workspace-secret"],
+                }
+            }
+        },
+    )
+    _write_json(
+        context.workspace_dir / ".github" / "hooks" / "custom.json",
+        {
+            "version": 1,
+            "hooks": {
+                "preToolUse": [{"command": "python pre.py"}],
+                "postToolUse": [{"command": "python post.py"}],
+            },
+        },
+    )
+
+    detection = adapter.detect(context).to_dict()
+
+    assert detection["harness"] == "copilot"
+    assert set(detection["config_paths"]) == {
+        str(context.home_dir / ".copilot" / "config.json"),
+        str(context.home_dir / ".copilot" / "mcp-config.json"),
+        str(context.workspace_dir / ".vscode" / "mcp.json"),
+        str(context.workspace_dir / ".github" / "hooks" / "custom.json"),
+    }
+    artifacts = {item["artifact_id"]: item for item in detection["artifacts"]}
+    assert "copilot:global:global-tool" in artifacts
+    assert "copilot:project:workspace-tool" in artifacts
+    assert "copilot:project:hook:custom:pretooluse:0" in artifacts
+    assert "copilot:project:hook:custom:posttooluse:0" in artifacts
+    assert artifacts["copilot:global:global-tool"]["args"] == ["--token=*****", "server.js"]
+    assert artifacts["copilot:global:global-tool"]["url"] == "https://example.com/mcp?token=%2A%2A%2A%2A%2A&label=demo"
+    assert artifacts["copilot:project:workspace-tool"]["command"] == "python"
+    assert artifacts["copilot:project:workspace-tool"]["args"] == ["-m", "workspace_server", "--api-key=*****"]
+
+
+def test_copilot_detect_tolerates_malformed_json(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = CopilotHarnessAdapter()
+    malformed_hook = context.workspace_dir / ".github" / "hooks" / "broken.json"
+    malformed_hook.parent.mkdir(parents=True, exist_ok=True)
+    malformed_hook.write_text("{broken", encoding="utf-8")
+    _write_json(
+        context.workspace_dir / ".vscode" / "mcp.json",
+        {"servers": {"workspace-tool": {"command": "python", "args": ["server.py"]}}},
+    )
+
+    detection = adapter.detect(context)
+
+    assert str(malformed_hook) not in detection.config_paths
+    assert [artifact.artifact_id for artifact in detection.artifacts] == ["copilot:project:workspace-tool"]
+
+
+def test_copilot_install_and_uninstall_manage_guard_owned_hook_file_idempotently(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = CopilotHarnessAdapter()
+    custom_hook_path = context.workspace_dir / ".github" / "hooks" / "custom.json"
+    _write_json(
+        custom_hook_path,
+        {
+            "version": 1,
+            "hooks": {
+                "preToolUse": [{"command": "python custom-pre.py"}],
+                "postToolUse": [{"command": "python custom-post.py"}],
+            },
+        },
+    )
+
+    first_install = adapter.install(context)
+    second_install = adapter.install(context)
+    managed_hook_path = context.workspace_dir / ".github" / "hooks" / "hol-guard-copilot.json"
+    managed_payload = json.loads(managed_hook_path.read_text(encoding="utf-8"))
+
+    assert first_install["active"] is True
+    assert second_install["active"] is True
+    assert managed_hook_path.exists() is True
+    assert managed_payload["version"] == 1
+    assert len(managed_payload["hooks"]["preToolUse"]) == 1
+    assert len(managed_payload["hooks"]["postToolUse"]) == 1
+    assert managed_payload["hooks"]["preToolUse"][0]["type"] == "command"
+    assert managed_payload["hooks"]["preToolUse"][0]["cwd"] == "."
+    assert managed_payload["hooks"]["preToolUse"][0]["timeoutSec"] == 30
+    assert "guard hook" in managed_payload["hooks"]["preToolUse"][0]["bash"]
+    assert "--harness copilot" in managed_payload["hooks"]["preToolUse"][0]["bash"]
+    assert "guard hook" in managed_payload["hooks"]["preToolUse"][0]["powershell"]
+    assert managed_payload["hooks"]["postToolUse"][0]["type"] == "command"
+    assert "guard hook" in managed_payload["hooks"]["postToolUse"][0]["bash"]
+    assert json.loads(custom_hook_path.read_text(encoding="utf-8")) == {
+        "version": 1,
+        "hooks": {
+            "preToolUse": [{"command": "python custom-pre.py"}],
+            "postToolUse": [{"command": "python custom-post.py"}],
+        },
+    }
+
+
+def test_copilot_install_rewrites_legacy_guard_owned_hook_file_to_documented_schema(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = CopilotHarnessAdapter()
+    managed_hook_path = context.workspace_dir / ".github" / "hooks" / "hol-guard-copilot.json"
+    _write_json(
+        managed_hook_path,
+        {
+            "preToolUse": [{"command": "python old-pre.py"}],
+            "postToolUse": [{"command": "python old-post.py"}],
+        },
+    )
+
+    adapter.install(context)
+    managed_payload = json.loads(managed_hook_path.read_text(encoding="utf-8"))
+
+    assert managed_payload["version"] == 1
+    assert set(managed_payload) == {"version", "hooks"}
+    assert len(managed_payload["hooks"]["preToolUse"]) == 1
+    assert len(managed_payload["hooks"]["postToolUse"]) == 1
+    assert "old-pre.py" not in managed_payload["hooks"]["preToolUse"][0]["bash"]
+
+    uninstall_payload = adapter.uninstall(context)
+
+    assert uninstall_payload["active"] is False
+    assert managed_hook_path.exists() is False

--- a/tests/test_guard_copilot_adapter.py
+++ b/tests/test_guard_copilot_adapter.py
@@ -256,3 +256,63 @@ def test_copilot_install_and_uninstall_preserve_existing_managed_hook_content(tm
             "preToolUse": [{"command": "python existing-pre.py"}],
         },
     }
+
+
+def test_copilot_install_and_uninstall_match_managed_hooks_after_path_changes(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = CopilotHarnessAdapter()
+    managed_hook_path = context.workspace_dir / ".github" / "hooks" / "hol-guard-copilot.json"
+    _write_json(
+        managed_hook_path,
+        {
+            "version": 1,
+            "hooks": {
+                "preToolUse": [
+                    {
+                        "type": "command",
+                        "bash": (
+                            "/opt/python/bin/python -m codex_plugin_scanner.cli guard hook "
+                            "--guard-home /tmp/old-guard --harness copilot --home /tmp/old-home "
+                            "--workspace /tmp/old-workspace"
+                        ),
+                        "powershell": (
+                            '"C:\\Python\\python.exe" -m codex_plugin_scanner.cli guard hook '
+                            '--guard-home C:\\old-guard --harness copilot --home C:\\old-home '
+                            '--workspace C:\\old-workspace'
+                        ),
+                        "cwd": ".",
+                        "timeoutSec": 30,
+                    }
+                ],
+                "postToolUse": [
+                    {
+                        "type": "command",
+                        "bash": (
+                            "/opt/python/bin/python -m codex_plugin_scanner.cli guard hook "
+                            "--guard-home /tmp/old-guard --harness copilot --home /tmp/old-home "
+                            "--workspace /tmp/old-workspace"
+                        ),
+                        "powershell": (
+                            '"C:\\Python\\python.exe" -m codex_plugin_scanner.cli guard hook '
+                            '--guard-home C:\\old-guard --harness copilot --home C:\\old-home '
+                            '--workspace C:\\old-workspace'
+                        ),
+                        "cwd": ".",
+                        "timeoutSec": 30,
+                    }
+                ],
+            },
+        },
+    )
+
+    adapter.install(context)
+    managed_payload = json.loads(managed_hook_path.read_text(encoding="utf-8"))
+
+    assert len(managed_payload["hooks"]["preToolUse"]) == 1
+    assert len(managed_payload["hooks"]["postToolUse"]) == 1
+    assert "--workspace /tmp/old-workspace" not in managed_payload["hooks"]["preToolUse"][0]["bash"]
+
+    uninstall_payload = adapter.uninstall(context)
+
+    assert uninstall_payload["active"] is False
+    assert managed_hook_path.exists() is False

--- a/tests/test_guard_copilot_adapter.py
+++ b/tests/test_guard_copilot_adapter.py
@@ -101,6 +101,22 @@ def test_copilot_detect_tolerates_malformed_json(tmp_path):
     assert [artifact.artifact_id for artifact in detection.artifacts] == ["copilot:project:workspace-tool"]
 
 
+def test_copilot_detect_ignores_hook_json_without_hook_entries(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = CopilotHarnessAdapter()
+    unrelated_hook = context.workspace_dir / ".github" / "hooks" / "notes.json"
+    _write_json(unrelated_hook, {"message": "not a hook file"})
+    _write_json(
+        context.workspace_dir / ".vscode" / "mcp.json",
+        {"servers": {"workspace-tool": {"command": "python", "args": ["server.py"]}}},
+    )
+
+    detection = adapter.detect(context)
+
+    assert str(unrelated_hook) not in detection.config_paths
+    assert [artifact.artifact_id for artifact in detection.artifacts] == ["copilot:project:workspace-tool"]
+
+
 def test_copilot_install_and_uninstall_manage_guard_owned_hook_file_idempotently(tmp_path):
     context = _build_context(tmp_path)
     adapter = CopilotHarnessAdapter()

--- a/tests/test_guard_copilot_adapter.py
+++ b/tests/test_guard_copilot_adapter.py
@@ -77,9 +77,9 @@ def test_copilot_detects_documented_local_surfaces_and_redacts_secrets(tmp_path)
     artifacts = {item["artifact_id"]: item for item in detection["artifacts"]}
     assert "copilot:global:global-tool" in artifacts
     assert "copilot:project:workspace-tool" in artifacts
-    assert "copilot:project:hook:custom:sessionstart:0" in artifacts
-    assert "copilot:project:hook:custom:pretooluse:0" in artifacts
-    assert "copilot:project:hook:custom:posttooluse:0" in artifacts
+    assert "copilot:project:hook:custom:sessionstart:0:command" in artifacts
+    assert "copilot:project:hook:custom:pretooluse:0:command" in artifacts
+    assert "copilot:project:hook:custom:posttooluse:0:command" in artifacts
     assert artifacts["copilot:global:global-tool"]["args"] == ["--token=*****", "server.js"]
     assert artifacts["copilot:global:global-tool"]["url"] == "https://example.com/mcp?token=%2A%2A%2A%2A%2A&label=demo"
     assert artifacts["copilot:project:workspace-tool"]["command"] == "python"
@@ -117,6 +117,40 @@ def test_copilot_detect_ignores_hook_json_without_hook_entries(tmp_path):
 
     assert str(unrelated_hook) not in detection.config_paths
     assert [artifact.artifact_id for artifact in detection.artifacts] == ["copilot:project:workspace-tool"]
+
+
+def test_copilot_detect_records_bash_and_powershell_hook_commands_separately(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = CopilotHarnessAdapter()
+    _write_json(
+        context.workspace_dir / ".github" / "hooks" / "custom.json",
+        {
+            "version": 1,
+            "hooks": {
+                "preToolUse": [
+                    {
+                        "bash": "python guard-hook.py",
+                        "powershell": "pwsh -File guard-hook.ps1",
+                    }
+                ]
+            },
+        },
+    )
+
+    detection = adapter.detect(context).to_dict()
+    artifacts = {item["artifact_id"]: item for item in detection["artifacts"]}
+
+    assert "copilot:project:hook:custom:pretooluse:0:bash" in artifacts
+    assert "copilot:project:hook:custom:pretooluse:0:powershell" in artifacts
+    assert artifacts["copilot:project:hook:custom:pretooluse:0:bash"]["command"] == "python guard-hook.py"
+    assert artifacts["copilot:project:hook:custom:pretooluse:0:bash"]["metadata"] == {"shell": "bash"}
+    assert (
+        artifacts["copilot:project:hook:custom:pretooluse:0:powershell"]["command"]
+        == "pwsh -File guard-hook.ps1"
+    )
+    assert artifacts["copilot:project:hook:custom:pretooluse:0:powershell"]["metadata"] == {
+        "shell": "powershell"
+    }
 
 
 def test_copilot_install_and_uninstall_manage_guard_owned_hook_file_idempotently(tmp_path):

--- a/tests/test_guard_copilot_adapter.py
+++ b/tests/test_guard_copilot_adapter.py
@@ -33,7 +33,7 @@ def test_copilot_detects_documented_local_surfaces_and_redacts_secrets(tmp_path)
     _write_json(
         context.home_dir / ".copilot" / "mcp-config.json",
         {
-            "servers": {
+            "mcpServers": {
                 "global-tool": {
                     "command": "npx",
                     "args": ["--token=secret-token", "server.js"],

--- a/tests/test_guard_copilot_adapter.py
+++ b/tests/test_guard_copilot_adapter.py
@@ -58,6 +58,7 @@ def test_copilot_detects_documented_local_surfaces_and_redacts_secrets(tmp_path)
         {
             "version": 1,
             "hooks": {
+                "sessionStart": [{"command": "python banner.py"}],
                 "preToolUse": [{"command": "python pre.py"}],
                 "postToolUse": [{"command": "python post.py"}],
             },
@@ -76,6 +77,7 @@ def test_copilot_detects_documented_local_surfaces_and_redacts_secrets(tmp_path)
     artifacts = {item["artifact_id"]: item for item in detection["artifacts"]}
     assert "copilot:global:global-tool" in artifacts
     assert "copilot:project:workspace-tool" in artifacts
+    assert "copilot:project:hook:custom:sessionstart:0" in artifacts
     assert "copilot:project:hook:custom:pretooluse:0" in artifacts
     assert "copilot:project:hook:custom:posttooluse:0" in artifacts
     assert artifacts["copilot:global:global-tool"]["args"] == ["--token=*****", "server.js"]

--- a/tests/test_guard_copilot_adapter.py
+++ b/tests/test_guard_copilot_adapter.py
@@ -169,3 +169,38 @@ def test_copilot_install_rewrites_legacy_guard_owned_hook_file_to_documented_sch
 
     assert uninstall_payload["active"] is False
     assert managed_hook_path.exists() is False
+
+
+def test_copilot_install_and_uninstall_preserve_existing_managed_hook_content(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = CopilotHarnessAdapter()
+    managed_hook_path = context.workspace_dir / ".github" / "hooks" / "hol-guard-copilot.json"
+    _write_json(
+        managed_hook_path,
+        {
+            "version": 1,
+            "hooks": {
+                "sessionStart": [{"command": "python banner.py"}],
+                "preToolUse": [{"command": "python existing-pre.py"}],
+            },
+        },
+    )
+
+    adapter.install(context)
+    managed_payload = json.loads(managed_hook_path.read_text(encoding="utf-8"))
+
+    assert managed_payload["hooks"]["sessionStart"] == [{"command": "python banner.py"}]
+    assert len(managed_payload["hooks"]["preToolUse"]) == 2
+    assert managed_payload["hooks"]["preToolUse"][0] == {"command": "python existing-pre.py"}
+
+    uninstall_payload = adapter.uninstall(context)
+    remaining_payload = json.loads(managed_hook_path.read_text(encoding="utf-8"))
+
+    assert uninstall_payload["active"] is False
+    assert remaining_payload == {
+        "version": 1,
+        "hooks": {
+            "sessionStart": [{"command": "python banner.py"}],
+            "preToolUse": [{"command": "python existing-pre.py"}],
+        },
+    }

--- a/tests/test_guard_launch_env.py
+++ b/tests/test_guard_launch_env.py
@@ -98,6 +98,46 @@ def test_guard_run_launches_with_configured_home(monkeypatch, tmp_path, capsys):
     assert captured_cwd == workspace_dir
 
 
+def test_guard_run_launches_copilot_with_passthrough_args(monkeypatch, tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\ndefault_action = "allow"\n')
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    (home_dir / ".copilot").mkdir(parents=True, exist_ok=True)
+    _write_text(
+        home_dir / ".copilot" / "mcp-config.json",
+        json.dumps({"servers": {"global-tool": {"command": "npx", "args": ["server.js"]}}}),
+    )
+    captured_command: list[str] = []
+
+    def _fake_run(command, cwd=None, check=False, env=None):
+        del cwd, check, env
+        captured_command.extend(command)
+        return _CompletedProcess(0)
+
+    monkeypatch.setattr(guard_runner_module.subprocess, "run", _fake_run)
+
+    rc = main(
+        [
+            "guard",
+            "run",
+            "copilot",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--arg=suggest",
+            "--arg=explain this function",
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["launched"] is True
+    assert captured_command == ["copilot", "suggest", "explain this function"]
+
+
 def test_guard_run_blocks_direct_env_prompt_until_approved(monkeypatch, tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_product_flow.py
+++ b/tests/test_guard_product_flow.py
@@ -106,6 +106,34 @@ class TestGuardProductFlow:
         assert output["next_steps"][0]["command"] == "hol-guard install codex"
         assert output["next_steps"][1]["command"] == "hol-guard run codex --dry-run"
 
+    def test_guard_start_recommends_copilot_when_it_is_the_only_detected_harness(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _write_json(
+            home_dir / ".copilot" / "mcp-config.json",
+            {"servers": {"global-tool": {"command": "npx", "args": ["server.js"]}}},
+        )
+        monkeypatch.setattr("shutil.which", lambda _command: None)
+
+        rc = main(
+            [
+                "guard",
+                "start",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        copilot_summary = next(item for item in output["harnesses"] if item["harness"] == "copilot")
+
+        assert rc == 0
+        assert output["recommended_harness"] == "copilot"
+        assert copilot_summary["install_command"] == "hol-guard install copilot"
+        assert output["next_steps"][1]["command"] == "hol-guard run copilot --dry-run"
+
     def test_guard_start_human_output_highlights_guard_loop(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -224,14 +224,18 @@ def test_secret_file_path_classifier_stays_precise(tmp_path):
 def test_file_read_request_classifier_is_argument_aware(tmp_path):
     env_request = extract_sensitive_file_read_request("read_file", {"path": ".env.local"})
     claude_request = extract_sensitive_file_read_request("Read", {"file_path": "~/.ssh/config"}, home_dir=tmp_path)
+    copilot_request = extract_sensitive_file_read_request("view", {"path": ".env"})
 
     assert is_file_read_tool_name("read_file") is True
     assert is_file_read_tool_name("Read") is True
+    assert is_file_read_tool_name("view") is True
     assert is_file_read_tool_name("write_file") is False
     assert env_request is not None
     assert env_request.path_match.path_class == "local .env file"
     assert claude_request is not None
     assert claude_request.path_match.path_class == "SSH client config"
+    assert copilot_request is not None
+    assert copilot_request.path_match.path_class == "local .env file"
     assert extract_sensitive_file_read_request("read_file", {"path": "README.md"}) is None
     assert extract_sensitive_file_read_request("write_file", {"path": ".env"}) is None
 

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -489,6 +489,129 @@ class TestGuardRuntime:
         assert rc == 0
         assert output["artifact_id"] == "claude-code:project:workspace-tools"
 
+    def test_guard_hook_uses_copilot_repo_hook_runtime_path(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        event = {
+            "tool_name": "read_file",
+            "tool_input": {"path": str(home_dir / ".env")},
+            "policy_action": "require-reapproval",
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "copilot",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 1
+        assert output["artifact_type"] == "file_read_request"
+        assert output["policy_action"] == "require-reapproval"
+        assert output["path_summary"] == str(home_dir / ".env")
+
+    def test_guard_hook_normalizes_copilot_camel_case_payload(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        event = {
+            "toolName": "view",
+            "toolArgs": json.dumps({"path": str(home_dir / ".env")}),
+            "sourceScope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "copilot",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 1
+        assert output["artifact_type"] == "file_read_request"
+        assert output["policy_action"] == "require-reapproval"
+        assert output["path_summary"] == str(home_dir / ".env")
+
+    def test_guard_hook_emits_copilot_native_deny_response(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        event = {
+            "toolName": "view",
+            "toolArgs": json.dumps({"path": str(home_dir / ".env")}),
+            "sourceScope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "copilot",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["permissionDecision"] == "deny"
+        assert "approve" in output["permissionDecisionReason"]
+
+    def test_guard_hook_emits_copilot_native_allow_response_for_safe_requests(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        event = {
+            "toolName": "view",
+            "toolArgs": json.dumps({"path": str(workspace_dir / "README.md")}),
+            "sourceScope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "copilot",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output == {"permissionDecision": "allow"}
+
     def test_guard_run_returns_structured_error_when_executable_missing(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.hermes import (
     HermesHarnessAdapter,
@@ -87,7 +85,7 @@ class TestSkillDiscovery:
         )
         adapter = HermesHarnessAdapter()
         detection = adapter.detect(_ctx(tmp_path))
-        skill = [a for a in detection.artifacts if a.artifact_type == "skill"][0]
+        skill = next(a for a in detection.artifacts if a.artifact_type == "skill")
         assert len(skill.args) == 1
         assert "curl" in skill.args[0]
 
@@ -100,8 +98,8 @@ class TestSkillDiscovery:
         adapter = HermesHarnessAdapter()
         d1 = adapter.detect(_ctx(tmp_path))
         d2 = adapter.detect(_ctx(tmp_path))
-        h1 = [a for a in d1.artifacts if a.artifact_type == "skill"][0].metadata["content_hash"]
-        h2 = [a for a in d2.artifacts if a.artifact_type == "skill"][0].metadata["content_hash"]
+        h1 = next(a for a in d1.artifacts if a.artifact_type == "skill").metadata["content_hash"]
+        h2 = next(a for a in d2.artifacts if a.artifact_type == "skill").metadata["content_hash"]
         assert h1 == h2
         assert len(h1) == 16
 
@@ -112,7 +110,7 @@ class TestSkillDiscovery:
         )
         adapter = HermesHarnessAdapter()
         detection = adapter.detect(_ctx(tmp_path))
-        skill = [a for a in detection.artifacts if a.artifact_type == "skill"][0]
+        skill = next(a for a in detection.artifacts if a.artifact_type == "skill")
         assert "mcporter" in skill.metadata.get("related_skills", "")
 
 
@@ -248,7 +246,7 @@ class TestMCPDiscovery:
         )
         adapter = HermesHarnessAdapter()
         detection = adapter.detect(_ctx(tmp_path))
-        mcp = [a for a in detection.artifacts if a.artifact_type == "mcp_server"][0]
+        mcp = next(a for a in detection.artifacts if a.artifact_type == "mcp_server")
         assert mcp.transport == "http"
         assert mcp.url == "https://mcp.example.com/v1/mcp"
 
@@ -268,7 +266,7 @@ class TestMCPDiscovery:
         )
         adapter = HermesHarnessAdapter()
         detection = adapter.detect(_ctx(tmp_path))
-        mcp = [a for a in detection.artifacts if a.artifact_type == "mcp_server"][0]
+        mcp = next(a for a in detection.artifacts if a.artifact_type == "mcp_server")
         assert mcp.args == ("valid",)
 
     def test_handles_non_dict_env(self, tmp_path: Path):
@@ -280,7 +278,7 @@ class TestMCPDiscovery:
         )
         adapter = HermesHarnessAdapter()
         detection = adapter.detect(_ctx(tmp_path))
-        mcp = [a for a in detection.artifacts if a.artifact_type == "mcp_server"][0]
+        mcp = next(a for a in detection.artifacts if a.artifact_type == "mcp_server")
         assert mcp.metadata["env_keys"] == []
 
     def test_both_yaml_and_json_mcp_configs(self, tmp_path: Path):
@@ -317,28 +315,34 @@ class TestYAMLNestedParsing:
         )
         adapter = HermesHarnessAdapter()
         detection = adapter.detect(_ctx(tmp_path))
-        mcp = [a for a in detection.artifacts if a.artifact_type == "mcp_server"][0]
+        mcp = next(a for a in detection.artifacts if a.artifact_type == "mcp_server")
         assert "GITHUB_TOKEN" in mcp.metadata["env_keys"]
 
     def test_yaml_parses_headers_block(self, tmp_path: Path):
         _write(
             tmp_path / ".hermes" / "config.yaml",
-            'mcp_servers:\n  remote:\n    url: "https://mcp.example.com/mcp"\n    headers:\n      Authorization: "Bearer sk-proj-token1234567890"\n',
+            (
+                'mcp_servers:\n  remote:\n    url: "https://mcp.example.com/mcp"\n'
+                '    headers:\n      Authorization: "Bearer sk-proj-token1234567890"\n'
+            ),
         )
         adapter = HermesHarnessAdapter()
         detection = adapter.detect(_ctx(tmp_path))
-        mcp = [a for a in detection.artifacts if a.artifact_type == "mcp_server"][0]
+        mcp = next(a for a in detection.artifacts if a.artifact_type == "mcp_server")
         assert "Authorization" in mcp.metadata["header_keys"]
         assert "Authorization" in mcp.metadata["auth_header_keys"]
 
     def test_yaml_parses_sampling_block(self, tmp_path: Path):
         _write(
             tmp_path / ".hermes" / "config.yaml",
-            'mcp_servers:\n  ai-server:\n    command: "npx"\n    sampling:\n      enabled: true\n      model: "gpt-4"\n',
+            (
+                'mcp_servers:\n  ai-server:\n    command: "npx"\n'
+                '    sampling:\n      enabled: true\n      model: "gpt-4"\n'
+            ),
         )
         adapter = HermesHarnessAdapter()
         detection = adapter.detect(_ctx(tmp_path))
-        mcp = [a for a in detection.artifacts if a.artifact_type == "mcp_server"][0]
+        mcp = next(a for a in detection.artifacts if a.artifact_type == "mcp_server")
         assert mcp.metadata["sampling_enabled"] is True
         assert mcp.metadata["sampling_model"] == "gpt-4"
 
@@ -349,13 +353,16 @@ class TestYAMLNestedParsing:
         )
         adapter = HermesHarnessAdapter()
         detection = adapter.detect(_ctx(tmp_path))
-        mcp = [a for a in detection.artifacts if a.artifact_type == "mcp_server"][0]
+        mcp = next(a for a in detection.artifacts if a.artifact_type == "mcp_server")
         assert "OPENAI_API_KEY" in mcp.metadata.get("env_value_secret_keys", [])
 
     def test_yaml_disabled_server_skipped(self, tmp_path: Path):
         _write(
             tmp_path / ".hermes" / "config.yaml",
-            'mcp_servers:\n  disabled-srv:\n    command: "npx"\n    enabled: false\n  active-srv:\n    command: "uvx"\n',
+            (
+                'mcp_servers:\n  disabled-srv:\n    command: "npx"\n'
+                '    enabled: false\n  active-srv:\n    command: "uvx"\n'
+            ),
         )
         adapter = HermesHarnessAdapter()
         detection = adapter.detect(_ctx(tmp_path))
@@ -385,7 +392,7 @@ class TestMCPSecuritySignals:
         )
         adapter = HermesHarnessAdapter()
         detection = adapter.detect(_ctx(tmp_path))
-        mcp = [a for a in detection.artifacts if a.artifact_type == "mcp_server"][0]
+        mcp = next(a for a in detection.artifacts if a.artifact_type == "mcp_server")
         assert "GITHUB_PERSONAL_ACCESS_TOKEN" in mcp.metadata["env_keys"]
 
     def test_secret_env_values_flagged(self, tmp_path: Path):
@@ -400,7 +407,7 @@ class TestMCPSecuritySignals:
         )
         adapter = HermesHarnessAdapter()
         detection = adapter.detect(_ctx(tmp_path))
-        mcp = [a for a in detection.artifacts if a.artifact_type == "mcp_server"][0]
+        mcp = next(a for a in detection.artifacts if a.artifact_type == "mcp_server")
         assert "OPENAI_API_KEY" in mcp.metadata.get("env_value_secret_keys", [])
 
     def test_auth_headers_detected(self, tmp_path: Path):
@@ -418,7 +425,7 @@ class TestMCPSecuritySignals:
         )
         adapter = HermesHarnessAdapter()
         detection = adapter.detect(_ctx(tmp_path))
-        mcp = [a for a in detection.artifacts if a.artifact_type == "mcp_server"][0]
+        mcp = next(a for a in detection.artifacts if a.artifact_type == "mcp_server")
         assert "Authorization" in mcp.metadata["auth_header_keys"]
         assert "X-Custom-Auth" in mcp.metadata["auth_header_keys"]
         assert mcp.metadata["has_auth_headers"] is True
@@ -436,7 +443,7 @@ class TestMCPSecuritySignals:
         )
         adapter = HermesHarnessAdapter()
         detection = adapter.detect(_ctx(tmp_path))
-        mcp = [a for a in detection.artifacts if a.artifact_type == "mcp_server"][0]
+        mcp = next(a for a in detection.artifacts if a.artifact_type == "mcp_server")
         assert mcp.metadata["sampling_enabled"] is True
         assert mcp.metadata["sampling_model"] == "gpt-4"
 
@@ -453,7 +460,7 @@ class TestMCPSecuritySignals:
         )
         adapter = HermesHarnessAdapter()
         detection = adapter.detect(_ctx(tmp_path))
-        mcp = [a for a in detection.artifacts if a.artifact_type == "mcp_server"][0]
+        mcp = next(a for a in detection.artifacts if a.artifact_type == "mcp_server")
         signals = artifact_risk_signals(mcp)
         assert "can send or receive network traffic" in signals
         assert "receives environment variables that may contain secrets" in signals
@@ -466,7 +473,7 @@ class TestMCPSecuritySignals:
         )
         adapter = HermesHarnessAdapter()
         detection = adapter.detect(_ctx(tmp_path))
-        mcp = [a for a in detection.artifacts if a.artifact_type == "mcp_server"][0]
+        mcp = next(a for a in detection.artifacts if a.artifact_type == "mcp_server")
         assert mcp.artifact_id == "hermes:mcp:json:srv"
         assert mcp.metadata["source"] == "json"
 
@@ -561,7 +568,7 @@ class TestFixtureIntegration:
         adapter = HermesHarnessAdapter()
         detection = adapter.detect(_ctx(tmp_path))
 
-        malicious = [a for a in detection.artifacts if a.name == "malicious"][0]
+        malicious = next(a for a in detection.artifacts if a.name == "malicious")
         signals = artifact_risk_signals(malicious)
         assert "can send or receive network traffic" in signals
         assert "mentions sensitive local files" in signals
@@ -573,10 +580,10 @@ class TestFixtureIntegration:
         adapter = HermesHarnessAdapter()
         detection = adapter.detect(_ctx(tmp_path))
 
-        api_ref = [
+        api_ref = next(
             a for a in detection.artifacts
             if a.artifact_type == "skill_file" and "api-setup" in a.name
-        ][0]
+        )
         signals = artifact_risk_signals(api_ref)
         assert "can send or receive network traffic" in signals
 
@@ -587,7 +594,7 @@ class TestFixtureIntegration:
         adapter = HermesHarnessAdapter()
         detection = adapter.detect(_ctx(tmp_path))
 
-        benign = [a for a in detection.artifacts if a.name == "benign"][0]
+        benign = next(a for a in detection.artifacts if a.name == "benign")
         signals = artifact_risk_signals(benign)
         assert len(signals) == 0
 
@@ -598,10 +605,10 @@ class TestFixtureIntegration:
         adapter = HermesHarnessAdapter()
         detection = adapter.detect(_ctx(tmp_path))
 
-        yaml_exfil = [
+        yaml_exfil = next(
             a for a in detection.artifacts
             if a.artifact_type == "mcp_server" and a.name == "yaml-exfiltrator"
-        ][0]
+        )
         signals = artifact_risk_signals(yaml_exfil)
         assert "can send or receive network traffic" in signals
         assert "runs through a shell wrapper" in signals
@@ -613,10 +620,10 @@ class TestFixtureIntegration:
         adapter = HermesHarnessAdapter()
         detection = adapter.detect(_ctx(tmp_path))
 
-        deploy_script = [
+        deploy_script = next(
             a for a in detection.artifacts
             if a.artifact_type == "skill_file" and "deploy.sh" in a.name
-        ][0]
+        )
         # Raw .sh content should be in args for risk scanning.
         assert len(deploy_script.args) == 1
         assert "curl" in deploy_script.args[0]


### PR DESCRIPTION
## Summary
- add a real HOL Guard `copilot` adapter with repo hook install/uninstall, detection, and `guard run copilot` support
- detect Copilot CLI and VS Code MCP surfaces while keeping VS Code limited to artifact detection and leaving Cisco AIBOM out of runtime policy
- normalize live Copilot hook payloads and return native preToolUse deny responses so sensitive `.env` reads are blocked before content is returned

## Verification
- `uv run --extra dev python -m pytest tests/test_guard_cli.py tests/test_guard_bootstrap.py tests/test_guard_product_flow.py tests/test_guard_launch_env.py tests/test_guard_runtime.py tests/test_guard_consumer_mode.py tests/test_schema_contracts.py tests/test_guard_copilot_adapter.py tests/test_guard_risk.py -q`
- `uv run --extra dev python -m ruff check src tests`
- live Copilot CLI E2E from an isolated workspace: `guard install copilot` + `copilot -p "Read the file .../.env and print its contents exactly." --allow-all`, which was denied by the `preToolUse` hook and recorded an approval request in Guard DB

## Scope notes
- supported runtime surface: Copilot CLI repo hooks
- supported VS Code surface: `.vscode/mcp.json` artifact detection only
- Cisco AIBOM remains deferred to future evidence/export work only