### PR TITLE
feat: harden OpenCode Guard adapter

### DIFF
--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -114,6 +114,10 @@ Claude Code also gets Guard hook entries in `.claude/settings.local.json` when y
 
 Copilot CLI gets a Guard-owned repo hook file at `.github/hooks/hol-guard-copilot.json` when you install from a workspace. Guard only reads `~/.copilot/config.json` and `~/.copilot/mcp-config.json`; it does not auto-write user-level Copilot config.
 
+OpenCode gets the normal Guard shim plus a Guard-owned runtime overlay at `<guard-home>/opencode/runtime-config.json`. Guard
+injects that overlay through `OPENCODE_CONFIG_CONTENT` when you launch through Guard so native skill loads stay on ask
+without mutating your checked-in `opencode.json`.
+
 ## Harness approval model
 
 Guard uses three approval tiers:
@@ -133,7 +137,8 @@ Current strategy:
 - `cursor`
   keeps Cursor’s native tool approval and lets Guard own artifact trust before tool use
 - `opencode`
-  keeps OpenCode’s permission model and lets Guard manage package and provenance policy
+  detects OpenCode MCP servers, commands, plugins, and skills before launch, and `guard install opencode` adds a
+  Guard-owned runtime overlay that keeps native skill loads on ask
 - `gemini`
   scans extension manifests and routes blocked changes to the approval center
 

--- a/docs/guard/harness-support.md
+++ b/docs/guard/harness-support.md
@@ -26,9 +26,12 @@ Current Guard support in this repo:
   - supports wrapper-mode management state
   - falls back to the local approval center when Guard blocks a launch
 - `opencode`
-  - detects global and project config plus workspace commands
-  - supports wrapper-mode management state
-  - respects OpenCode permission rules and uses Guard for package-level policy
+  - detects global and project config, MCP servers, config-defined commands, markdown commands, npm plugins, local
+    plugin files, and OpenCode-compatible skill directories
+  - supports wrapper-mode management state plus a Guard-owned runtime overlay for native skill approval prompts
+  - supports wrapper-mode `guard run opencode`
+  - blocks newly introduced OpenCode MCP, plugin, and skill artifacts before launch when local Guard policy requires
+    approval
 
 Approval tiers:
 

--- a/docs/guard/testing-matrix.md
+++ b/docs/guard/testing-matrix.md
@@ -17,6 +17,10 @@ Manual verification should include:
 - `hol-guard detect cursor --json`
 - `hol-guard detect gemini --json`
 - `hol-guard detect opencode --json`
+- `hol-guard install opencode --json`
+- `hol-guard run opencode --dry-run --default-action allow --json`
+- `hol-guard run opencode --default-action require-reapproval --json`
+- `hol-guard approvals --json`
 - `hol-guard install codex`
 - `hol-guard run codex --dry-run --default-action allow --json`
 - `hol-guard receipts`
@@ -24,6 +28,7 @@ Manual verification should include:
 - `cursor-agent mcp list`
 - `gemini --help`
 - `opencode --help`
+- `opencode run --help`
 
 First-party canaries for local manual validation:
 
@@ -31,6 +36,15 @@ First-party canaries for local manual validation:
 - a local `registry-broker-skills` checkout for scanner fixtures and trust review
 
 Claude Code smoke tests remain conditional on the local `claude` binary being available.
+
+OpenCode manual validation should include one isolated local workspace where you prove all of the following against the
+real `opencode` binary:
+
+- a newly added MCP server blocks before launch
+- a newly added skill blocks before launch
+- a newly added plugin blocks before launch
+- a blocked prompt request queues an approval
+- approving that request lets Guard hand off to `opencode run --dir <workspace> ...`
 
 Nightly release-bar coverage should include:
 

--- a/src/codex_plugin_scanner/guard/adapters/base.py
+++ b/src/codex_plugin_scanner/guard/adapters/base.py
@@ -104,6 +104,10 @@ class HarnessAdapter:
             command.append(str(context.workspace_dir))
         return [*command, *passthrough_args]
 
+    def launch_environment(self, context: HarnessContext) -> dict[str, str]:
+        del context
+        return {}
+
     def runtime_probe(self, context: HarnessContext) -> dict[str, object] | None:
         return None
 

--- a/src/codex_plugin_scanner/guard/adapters/opencode.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode.py
@@ -30,8 +30,7 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
         "runtime overlay keeps native skill loads on ask."
     )
     fallback_hint = (
-        "Use Guard approvals for blocked artifacts and OpenCode's native allow once or allow session flow for "
-        "skills."
+        "Use Guard approvals for blocked artifacts and OpenCode's native allow once or allow session flow for skills."
     )
 
     @staticmethod
@@ -135,4 +134,6 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
             "paths": _run_command_probe([self.executable, "debug", "paths"]),
             "config": _run_command_probe([self.executable, "debug", "config"]),
         }
+
+
 __all__ = ["OpenCodeHarnessAdapter"]

--- a/src/codex_plugin_scanner/guard/adapters/opencode.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode.py
@@ -6,21 +6,16 @@ import json
 from pathlib import Path
 
 from ...ecosystems.opencode import _load_json_or_jsonc
-from ..models import GuardArtifact, HarnessDetection
+from ..models import HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
 from .base import HarnessAdapter, HarnessContext, _command_available, _run_command_probe
-
-_CONFIG_FILENAMES = ("opencode.json", "opencode.jsonc")
-_PLUGIN_SUFFIXES = {".js", ".ts", ".mjs", ".cjs"}
-_GLOBAL_SKILL_DIRECTORIES = (
-    (".config/opencode/skills", "opencode"),
-    (".claude/skills", "claude"),
-    (".agents/skills", "agents"),
-)
-_PROJECT_SKILL_DIRECTORIES = (
-    (".opencode/skills", "opencode"),
-    (".claude/skills", "claude"),
-    (".agents/skills", "agents"),
+from .opencode_artifacts import (
+    append_config_artifacts,
+    append_directory_artifacts,
+    append_found_path,
+    config_paths,
+    runtime_config_path,
+    runtime_overlay,
 )
 
 
@@ -46,23 +41,23 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
         return "global"
 
     def detect(self, context: HarnessContext) -> HarnessDetection:
-        artifacts: list[GuardArtifact] = []
+        artifacts = []
         found_paths: list[str] = []
         seen_artifact_ids: set[str] = set()
-        for config_path in _config_paths(context):
+        for config_path in config_paths(context):
             payload, parse_error, _parse_reason = _load_json_or_jsonc(config_path)
             if parse_error or not payload:
                 continue
-            _append_found_path(found_paths, config_path)
+            append_found_path(found_paths, config_path)
             scope = self._scope_for(context, config_path)
-            _append_config_artifacts(
+            append_config_artifacts(
                 artifacts=artifacts,
                 seen_artifact_ids=seen_artifact_ids,
                 scope=scope,
                 config_path=config_path,
                 payload=payload,
             )
-        _append_directory_artifacts(
+        append_directory_artifacts(
             context=context,
             artifacts=artifacts,
             found_paths=found_paths,
@@ -79,9 +74,9 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
 
     def install(self, context: HarnessContext) -> dict[str, object]:
         shim_manifest = install_guard_shim(self.harness, context)
-        runtime_config_path = _runtime_config_path(context)
-        runtime_config_path.parent.mkdir(parents=True, exist_ok=True)
-        runtime_config_path.write_text(json.dumps(_runtime_overlay(), indent=2) + "\n", encoding="utf-8")
+        overlay_path = runtime_config_path(context)
+        overlay_path.parent.mkdir(parents=True, exist_ok=True)
+        overlay_path.write_text(json.dumps(runtime_overlay(), indent=2) + "\n", encoding="utf-8")
         notes = [
             *list(shim_manifest.get("notes", [])),
             "Guard added an OpenCode runtime overlay that keeps native skill loads on ask when you launch "
@@ -90,9 +85,9 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
         return {
             "harness": self.harness,
             "active": True,
-            "config_path": str(runtime_config_path),
+            "config_path": str(overlay_path),
             **shim_manifest,
-            "runtime_config_path": str(runtime_config_path),
+            "runtime_config_path": str(overlay_path),
             "runtime_env_var": "OPENCODE_CONFIG_CONTENT",
             "notes": notes,
         }
@@ -107,19 +102,19 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
         return {
             "harness": self.harness,
             "active": False,
-            "config_path": str(_runtime_config_path(context)),
+            "config_path": str(runtime_config_path(context)),
             **shim_manifest,
-            "runtime_config_path": str(_runtime_config_path(context)),
+            "runtime_config_path": str(runtime_config_path(context)),
             "runtime_env_var": "OPENCODE_CONFIG_CONTENT",
             "notes": notes,
         }
 
     def launch_environment(self, context: HarnessContext) -> dict[str, str]:
-        runtime_config_path = _runtime_config_path(context)
-        if not runtime_config_path.exists():
+        overlay_path = runtime_config_path(context)
+        if not overlay_path.exists():
             return {}
         try:
-            runtime_config = runtime_config_path.read_text(encoding="utf-8")
+            runtime_config = overlay_path.read_text(encoding="utf-8")
         except OSError:
             return {}
         return {"OPENCODE_CONFIG_CONTENT": runtime_config}
@@ -140,279 +135,4 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
             "paths": _run_command_probe([self.executable, "debug", "paths"]),
             "config": _run_command_probe([self.executable, "debug", "config"]),
         }
-
-
-def _config_paths(context: HarnessContext) -> tuple[Path, ...]:
-    config_paths = [context.home_dir / ".config" / "opencode" / name for name in _CONFIG_FILENAMES]
-    if context.workspace_dir is not None:
-        config_paths.extend(context.workspace_dir / name for name in _CONFIG_FILENAMES)
-    return tuple(config_paths)
-
-
-def _append_config_artifacts(
-    *,
-    artifacts: list[GuardArtifact],
-    seen_artifact_ids: set[str],
-    scope: str,
-    config_path: Path,
-    payload: dict[str, object],
-) -> None:
-    _append_mcp_artifacts(
-        artifacts=artifacts,
-        seen_artifact_ids=seen_artifact_ids,
-        scope=scope,
-        config_path=config_path,
-        payload=payload,
-    )
-    _append_plugin_artifacts(
-        artifacts=artifacts,
-        seen_artifact_ids=seen_artifact_ids,
-        scope=scope,
-        config_path=config_path,
-        payload=payload,
-    )
-    _append_config_command_artifacts(
-        artifacts=artifacts,
-        seen_artifact_ids=seen_artifact_ids,
-        scope=scope,
-        config_path=config_path,
-        payload=payload,
-    )
-
-
-def _append_mcp_artifacts(
-    *,
-    artifacts: list[GuardArtifact],
-    seen_artifact_ids: set[str],
-    scope: str,
-    config_path: Path,
-    payload: dict[str, object],
-) -> None:
-    mcp_config = payload.get("mcp")
-    if not isinstance(mcp_config, dict):
-        return
-    for name, server_config in mcp_config.items():
-        if not isinstance(name, str) or not isinstance(server_config, dict):
-            continue
-        command, args = _command_parts(server_config)
-        transport = server_config.get("type") if isinstance(server_config.get("type"), str) else None
-        url = server_config.get("url") if isinstance(server_config.get("url"), str) else None
-        artifact = GuardArtifact(
-            artifact_id=f"opencode:{scope}:{name}",
-            name=name,
-            harness="opencode",
-            artifact_type="mcp_server",
-            source_scope=scope,
-            config_path=str(config_path),
-            command=command,
-            args=args,
-            url=url,
-            transport=transport or ("remote" if url is not None else "stdio"),
-            metadata={
-                "enabled": bool(server_config.get("enabled", True)),
-            },
-        )
-        _append_artifact(artifacts, seen_artifact_ids, artifact)
-
-
-def _append_plugin_artifacts(
-    *,
-    artifacts: list[GuardArtifact],
-    seen_artifact_ids: set[str],
-    scope: str,
-    config_path: Path,
-    payload: dict[str, object],
-) -> None:
-    plugin_config = payload.get("plugin")
-    if not isinstance(plugin_config, list):
-        return
-    for item in plugin_config:
-        plugin_name: str | None = None
-        plugin_options: dict[str, object] = {}
-        if isinstance(item, str):
-            plugin_name = item
-        elif (
-            isinstance(item, list)
-            and len(item) == 2
-            and isinstance(item[0], str)
-            and isinstance(item[1], dict)
-        ):
-            plugin_name = item[0]
-            plugin_options = item[1]
-        if plugin_name is None:
-            continue
-        artifact = GuardArtifact(
-            artifact_id=f"opencode:{scope}:plugin:{plugin_name}",
-            name=plugin_name,
-            harness="opencode",
-            artifact_type="plugin",
-            source_scope=scope,
-            config_path=str(config_path),
-            publisher=_publisher_from_package(plugin_name),
-            metadata=plugin_options,
-        )
-        _append_artifact(artifacts, seen_artifact_ids, artifact)
-
-
-def _append_config_command_artifacts(
-    *,
-    artifacts: list[GuardArtifact],
-    seen_artifact_ids: set[str],
-    scope: str,
-    config_path: Path,
-    payload: dict[str, object],
-) -> None:
-    command_config = payload.get("command")
-    if not isinstance(command_config, dict):
-        return
-    for name, command_payload in command_config.items():
-        if not isinstance(name, str) or not isinstance(command_payload, dict):
-            continue
-        template = command_payload.get("template")
-        if not isinstance(template, str) or not template.strip():
-            continue
-        metadata = {
-            key: value
-            for key in ("description", "agent", "model", "subtask")
-            if (value := command_payload.get(key)) is not None
-        }
-        artifact = GuardArtifact(
-            artifact_id=f"opencode:{scope}:config-command:{name}",
-            name=name,
-            harness="opencode",
-            artifact_type="command",
-            source_scope=scope,
-            config_path=str(config_path),
-            metadata=metadata,
-        )
-        _append_artifact(artifacts, seen_artifact_ids, artifact)
-
-
-def _append_directory_artifacts(
-    *,
-    context: HarnessContext,
-    artifacts: list[GuardArtifact],
-    found_paths: list[str],
-    seen_artifact_ids: set[str],
-) -> None:
-    directory_specs: list[tuple[Path, str, str]] = [
-        (context.home_dir / ".config" / "opencode" / "commands", "global", "command"),
-        (context.home_dir / ".config" / "opencode" / "plugins", "global", "plugin-file"),
-    ]
-    if context.workspace_dir is not None:
-        directory_specs.extend(
-            [
-                (context.workspace_dir / ".opencode" / "commands", "project", "command"),
-                (context.workspace_dir / ".opencode" / "plugins", "project", "plugin-file"),
-            ]
-        )
-    for directory, scope, artifact_kind in directory_specs:
-        if not directory.is_dir():
-            continue
-        pattern = "*.md" if artifact_kind == "command" else "*"
-        iterator = directory.rglob(pattern)
-        for path in sorted(iterator):
-            if not path.is_file():
-                continue
-            if artifact_kind == "plugin-file" and path.suffix not in _PLUGIN_SUFFIXES:
-                continue
-            _append_found_path(found_paths, path)
-            artifact = GuardArtifact(
-                artifact_id=f"opencode:{scope}:{artifact_kind}:{path.stem}",
-                name=path.stem,
-                harness="opencode",
-                artifact_type="plugin" if artifact_kind == "plugin-file" else "command",
-                source_scope=scope,
-                config_path=str(path),
-            )
-            _append_artifact(artifacts, seen_artifact_ids, artifact)
-    for skill_root, source_kind in _skill_roots(context):
-        if not skill_root.is_dir():
-            continue
-        scope = (
-            "project"
-            if context.workspace_dir is not None and skill_root.is_relative_to(context.workspace_dir)
-            else "global"
-        )
-        for skill_path in sorted(skill_root.rglob("SKILL.md")):
-            if not skill_path.is_file():
-                continue
-            _append_found_path(found_paths, skill_path)
-            artifact = GuardArtifact(
-                artifact_id=f"opencode:{scope}:skill:{source_kind}:{skill_path.parent.name}",
-                name=skill_path.parent.name,
-                harness="opencode",
-                artifact_type="skill",
-                source_scope=scope,
-                config_path=str(skill_path),
-                metadata={"skill_source": source_kind},
-            )
-            _append_artifact(artifacts, seen_artifact_ids, artifact)
-
-
-def _skill_roots(context: HarnessContext) -> tuple[tuple[Path, str], ...]:
-    roots = [
-        (context.home_dir / Path(relative_path), source_kind)
-        for relative_path, source_kind in _GLOBAL_SKILL_DIRECTORIES
-    ]
-    if context.workspace_dir is not None:
-        roots.extend(
-            (context.workspace_dir / Path(relative_path), source_kind)
-            for relative_path, source_kind in _PROJECT_SKILL_DIRECTORIES
-        )
-    return tuple(roots)
-
-
-def _command_parts(server_config: dict[str, object]) -> tuple[str | None, tuple[str, ...]]:
-    command_value = server_config.get("command")
-    args_value = server_config.get("args")
-    if isinstance(command_value, list):
-        command_list = [value for value in command_value if isinstance(value, str)]
-        if not command_list:
-            return (None, ())
-        return (command_list[0], tuple(command_list[1:]))
-    if isinstance(command_value, str):
-        args = tuple(value for value in args_value if isinstance(value, str)) if isinstance(args_value, list) else ()
-        return (command_value, args)
-    return (None, ())
-
-
-def _append_artifact(
-    artifacts: list[GuardArtifact],
-    seen_artifact_ids: set[str],
-    artifact: GuardArtifact,
-) -> None:
-    if artifact.artifact_id in seen_artifact_ids:
-        return
-    seen_artifact_ids.add(artifact.artifact_id)
-    artifacts.append(artifact)
-
-
-def _append_found_path(found_paths: list[str], path: Path) -> None:
-    candidate = str(path)
-    if candidate not in found_paths:
-        found_paths.append(candidate)
-
-
-def _publisher_from_package(package_name: str) -> str | None:
-    if package_name.startswith("@") and "/" in package_name:
-        return package_name.split("/", 1)[0][1:]
-    return None
-
-
-def _runtime_config_path(context: HarnessContext) -> Path:
-    return context.guard_home / "opencode" / "runtime-config.json"
-
-
-def _runtime_overlay() -> dict[str, object]:
-    return {
-        "$schema": "https://opencode.ai/config.json",
-        "permission": {
-            "skill": {
-                "*": "ask",
-            }
-        },
-    }
-
-
 __all__ = ["OpenCodeHarnessAdapter"]

--- a/src/codex_plugin_scanner/guard/adapters/opencode.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode.py
@@ -120,7 +120,7 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
 
     def launch_command(self, context: HarnessContext, passthrough_args: list[str]) -> list[str]:
         if context.workspace_dir is not None and passthrough_args:
-            return [self.executable, "run", "--dir", str(context.workspace_dir), *passthrough_args]
+            return [self.executable, "run", *passthrough_args]
         if context.workspace_dir is not None:
             return [self.executable, str(context.workspace_dir)]
         if passthrough_args:

--- a/src/codex_plugin_scanner/guard/adapters/opencode.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode.py
@@ -2,77 +2,72 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from ...ecosystems.opencode import _load_json_or_jsonc
 from ..models import GuardArtifact, HarnessDetection
-from .base import HarnessAdapter, HarnessContext, _command_available
+from ..shims import install_guard_shim, remove_guard_shim
+from .base import HarnessAdapter, HarnessContext, _command_available, _run_command_probe
+
+_CONFIG_FILENAMES = ("opencode.json", "opencode.jsonc")
+_PLUGIN_SUFFIXES = {".js", ".ts", ".mjs", ".cjs"}
+_GLOBAL_SKILL_DIRECTORIES = (
+    (".config/opencode/skills", "opencode"),
+    (".claude/skills", "claude"),
+    (".agents/skills", "agents"),
+)
+_PROJECT_SKILL_DIRECTORIES = (
+    (".opencode/skills", "opencode"),
+    (".claude/skills", "claude"),
+    (".agents/skills", "agents"),
+)
 
 
 class OpenCodeHarnessAdapter(HarnessAdapter):
-    """Discover OpenCode config and workspace plugins."""
+    """Discover OpenCode config, commands, plugins, and skills."""
 
     harness = "opencode"
     executable = "opencode"
-    approval_tier = "native-harness"
+    approval_tier = "mixed"
     approval_summary = (
-        "OpenCode already has tool permissions, so Guard authors policy and provenance rules before launch."
+        "Guard evaluates OpenCode skills, MCP servers, commands, and plugins before launch, and the managed "
+        "runtime overlay keeps native skill loads on ask."
     )
-    fallback_hint = "Use Guard for artifact-level trust and keep OpenCode's native allow or deny model intact."
+    fallback_hint = (
+        "Use Guard approvals for blocked artifacts and OpenCode's native allow once or allow session flow for "
+        "skills."
+    )
 
     @staticmethod
-    def _scope_for(context: HarnessContext, path) -> str:
+    def _scope_for(context: HarnessContext, path: Path) -> str:
         if context.workspace_dir is not None and path.is_relative_to(context.workspace_dir):
             return "project"
         return "global"
 
     def detect(self, context: HarnessContext) -> HarnessDetection:
-        config_paths = [context.home_dir / ".config" / "opencode" / "opencode.json"]
-        if context.workspace_dir is not None:
-            config_paths.extend((context.workspace_dir / "opencode.json", context.workspace_dir / "opencode.jsonc"))
         artifacts: list[GuardArtifact] = []
         found_paths: list[str] = []
-        for config_path in config_paths:
+        seen_artifact_ids: set[str] = set()
+        for config_path in _config_paths(context):
             payload, parse_error, _parse_reason = _load_json_or_jsonc(config_path)
-            if parse_error:
-                payload = {}
-            if not payload:
+            if parse_error or not payload:
                 continue
-            found_paths.append(str(config_path))
+            _append_found_path(found_paths, config_path)
             scope = self._scope_for(context, config_path)
-            mcp_config = payload.get("mcp")
-            if isinstance(mcp_config, dict):
-                for name, server_config in mcp_config.items():
-                    if not isinstance(name, str) or not isinstance(server_config, dict):
-                        continue
-                    command = server_config.get("command")
-                    command_list = command if isinstance(command, list) else []
-                    artifacts.append(
-                        GuardArtifact(
-                            artifact_id=f"opencode:{scope}:{name}",
-                            name=name,
-                            harness=self.harness,
-                            artifact_type="mcp_server",
-                            source_scope=scope,
-                            config_path=str(config_path),
-                            command=command_list[0] if command_list and isinstance(command_list[0], str) else None,
-                            args=tuple(str(value) for value in command_list[1:] if isinstance(value, str)),
-                            transport="stdio",
-                        )
-                    )
-        if context.workspace_dir is not None:
-            commands_dir = context.workspace_dir / ".opencode" / "commands"
-            if commands_dir.is_dir():
-                for command_path in sorted(path for path in commands_dir.glob("*.md") if path.is_file()):
-                    found_paths.append(str(command_path))
-                    artifacts.append(
-                        GuardArtifact(
-                            artifact_id=f"opencode:project:command:{command_path.stem}",
-                            name=command_path.stem,
-                            harness=self.harness,
-                            artifact_type="command",
-                            source_scope="project",
-                            config_path=str(command_path),
-                        )
-                    )
+            _append_config_artifacts(
+                artifacts=artifacts,
+                seen_artifact_ids=seen_artifact_ids,
+                scope=scope,
+                config_path=config_path,
+                payload=payload,
+            )
+        _append_directory_artifacts(
+            context=context,
+            artifacts=artifacts,
+            found_paths=found_paths,
+            seen_artifact_ids=seen_artifact_ids,
+        )
         return HarnessDetection(
             harness=self.harness,
             installed=bool(found_paths) or _command_available(self.executable),
@@ -81,3 +76,343 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
             artifacts=tuple(artifacts),
             warnings=(),
         )
+
+    def install(self, context: HarnessContext) -> dict[str, object]:
+        shim_manifest = install_guard_shim(self.harness, context)
+        runtime_config_path = _runtime_config_path(context)
+        runtime_config_path.parent.mkdir(parents=True, exist_ok=True)
+        runtime_config_path.write_text(json.dumps(_runtime_overlay(), indent=2) + "\n", encoding="utf-8")
+        notes = [
+            *list(shim_manifest.get("notes", [])),
+            "Guard added an OpenCode runtime overlay that keeps native skill loads on ask when you launch "
+            "through Guard.",
+        ]
+        return {
+            "harness": self.harness,
+            "active": True,
+            "config_path": str(runtime_config_path),
+            **shim_manifest,
+            "runtime_config_path": str(runtime_config_path),
+            "runtime_env_var": "OPENCODE_CONFIG_CONTENT",
+            "notes": notes,
+        }
+
+    def uninstall(self, context: HarnessContext) -> dict[str, object]:
+        shim_manifest = remove_guard_shim(self.harness, context)
+        notes = [
+            *list(shim_manifest.get("notes", [])),
+            "Guard leaves the OpenCode runtime overlay on disk for auditability, but it is ignored unless you "
+            "launch through Guard.",
+        ]
+        return {
+            "harness": self.harness,
+            "active": False,
+            "config_path": str(_runtime_config_path(context)),
+            **shim_manifest,
+            "runtime_config_path": str(_runtime_config_path(context)),
+            "runtime_env_var": "OPENCODE_CONFIG_CONTENT",
+            "notes": notes,
+        }
+
+    def launch_environment(self, context: HarnessContext) -> dict[str, str]:
+        runtime_config_path = _runtime_config_path(context)
+        if not runtime_config_path.exists():
+            return {}
+        try:
+            runtime_config = runtime_config_path.read_text(encoding="utf-8")
+        except OSError:
+            return {}
+        return {"OPENCODE_CONFIG_CONTENT": runtime_config}
+
+    def launch_command(self, context: HarnessContext, passthrough_args: list[str]) -> list[str]:
+        if context.workspace_dir is not None and passthrough_args:
+            return [self.executable, "run", "--dir", str(context.workspace_dir), *passthrough_args]
+        if context.workspace_dir is not None:
+            return [self.executable, str(context.workspace_dir)]
+        if passthrough_args:
+            return [self.executable, "run", *passthrough_args]
+        return [self.executable]
+
+    def runtime_probe(self, context: HarnessContext) -> dict[str, object] | None:
+        if not _command_available(self.executable):
+            return None
+        return {
+            "paths": _run_command_probe([self.executable, "debug", "paths"]),
+            "config": _run_command_probe([self.executable, "debug", "config"]),
+        }
+
+
+def _config_paths(context: HarnessContext) -> tuple[Path, ...]:
+    config_paths = [context.home_dir / ".config" / "opencode" / name for name in _CONFIG_FILENAMES]
+    if context.workspace_dir is not None:
+        config_paths.extend(context.workspace_dir / name for name in _CONFIG_FILENAMES)
+    return tuple(config_paths)
+
+
+def _append_config_artifacts(
+    *,
+    artifacts: list[GuardArtifact],
+    seen_artifact_ids: set[str],
+    scope: str,
+    config_path: Path,
+    payload: dict[str, object],
+) -> None:
+    _append_mcp_artifacts(
+        artifacts=artifacts,
+        seen_artifact_ids=seen_artifact_ids,
+        scope=scope,
+        config_path=config_path,
+        payload=payload,
+    )
+    _append_plugin_artifacts(
+        artifacts=artifacts,
+        seen_artifact_ids=seen_artifact_ids,
+        scope=scope,
+        config_path=config_path,
+        payload=payload,
+    )
+    _append_config_command_artifacts(
+        artifacts=artifacts,
+        seen_artifact_ids=seen_artifact_ids,
+        scope=scope,
+        config_path=config_path,
+        payload=payload,
+    )
+
+
+def _append_mcp_artifacts(
+    *,
+    artifacts: list[GuardArtifact],
+    seen_artifact_ids: set[str],
+    scope: str,
+    config_path: Path,
+    payload: dict[str, object],
+) -> None:
+    mcp_config = payload.get("mcp")
+    if not isinstance(mcp_config, dict):
+        return
+    for name, server_config in mcp_config.items():
+        if not isinstance(name, str) or not isinstance(server_config, dict):
+            continue
+        command, args = _command_parts(server_config)
+        transport = server_config.get("type") if isinstance(server_config.get("type"), str) else None
+        url = server_config.get("url") if isinstance(server_config.get("url"), str) else None
+        artifact = GuardArtifact(
+            artifact_id=f"opencode:{scope}:{name}",
+            name=name,
+            harness="opencode",
+            artifact_type="mcp_server",
+            source_scope=scope,
+            config_path=str(config_path),
+            command=command,
+            args=args,
+            url=url,
+            transport=transport or ("remote" if url is not None else "stdio"),
+            metadata={
+                "enabled": bool(server_config.get("enabled", True)),
+            },
+        )
+        _append_artifact(artifacts, seen_artifact_ids, artifact)
+
+
+def _append_plugin_artifacts(
+    *,
+    artifacts: list[GuardArtifact],
+    seen_artifact_ids: set[str],
+    scope: str,
+    config_path: Path,
+    payload: dict[str, object],
+) -> None:
+    plugin_config = payload.get("plugin")
+    if not isinstance(plugin_config, list):
+        return
+    for item in plugin_config:
+        plugin_name: str | None = None
+        plugin_options: dict[str, object] = {}
+        if isinstance(item, str):
+            plugin_name = item
+        elif (
+            isinstance(item, list)
+            and len(item) == 2
+            and isinstance(item[0], str)
+            and isinstance(item[1], dict)
+        ):
+            plugin_name = item[0]
+            plugin_options = item[1]
+        if plugin_name is None:
+            continue
+        artifact = GuardArtifact(
+            artifact_id=f"opencode:{scope}:plugin:{plugin_name}",
+            name=plugin_name,
+            harness="opencode",
+            artifact_type="plugin",
+            source_scope=scope,
+            config_path=str(config_path),
+            publisher=_publisher_from_package(plugin_name),
+            metadata=plugin_options,
+        )
+        _append_artifact(artifacts, seen_artifact_ids, artifact)
+
+
+def _append_config_command_artifacts(
+    *,
+    artifacts: list[GuardArtifact],
+    seen_artifact_ids: set[str],
+    scope: str,
+    config_path: Path,
+    payload: dict[str, object],
+) -> None:
+    command_config = payload.get("command")
+    if not isinstance(command_config, dict):
+        return
+    for name, command_payload in command_config.items():
+        if not isinstance(name, str) or not isinstance(command_payload, dict):
+            continue
+        template = command_payload.get("template")
+        if not isinstance(template, str) or not template.strip():
+            continue
+        metadata = {
+            key: value
+            for key in ("description", "agent", "model", "subtask")
+            if (value := command_payload.get(key)) is not None
+        }
+        artifact = GuardArtifact(
+            artifact_id=f"opencode:{scope}:config-command:{name}",
+            name=name,
+            harness="opencode",
+            artifact_type="command",
+            source_scope=scope,
+            config_path=str(config_path),
+            metadata=metadata,
+        )
+        _append_artifact(artifacts, seen_artifact_ids, artifact)
+
+
+def _append_directory_artifacts(
+    *,
+    context: HarnessContext,
+    artifacts: list[GuardArtifact],
+    found_paths: list[str],
+    seen_artifact_ids: set[str],
+) -> None:
+    directory_specs: list[tuple[Path, str, str]] = [
+        (context.home_dir / ".config" / "opencode" / "commands", "global", "command"),
+        (context.home_dir / ".config" / "opencode" / "plugins", "global", "plugin-file"),
+    ]
+    if context.workspace_dir is not None:
+        directory_specs.extend(
+            [
+                (context.workspace_dir / ".opencode" / "commands", "project", "command"),
+                (context.workspace_dir / ".opencode" / "plugins", "project", "plugin-file"),
+            ]
+        )
+    for directory, scope, artifact_kind in directory_specs:
+        if not directory.is_dir():
+            continue
+        pattern = "*.md" if artifact_kind == "command" else "*"
+        iterator = directory.rglob(pattern)
+        for path in sorted(iterator):
+            if not path.is_file():
+                continue
+            if artifact_kind == "plugin-file" and path.suffix not in _PLUGIN_SUFFIXES:
+                continue
+            _append_found_path(found_paths, path)
+            artifact = GuardArtifact(
+                artifact_id=f"opencode:{scope}:{artifact_kind}:{path.stem}",
+                name=path.stem,
+                harness="opencode",
+                artifact_type="plugin" if artifact_kind == "plugin-file" else "command",
+                source_scope=scope,
+                config_path=str(path),
+            )
+            _append_artifact(artifacts, seen_artifact_ids, artifact)
+    for skill_root, source_kind in _skill_roots(context):
+        if not skill_root.is_dir():
+            continue
+        scope = (
+            "project"
+            if context.workspace_dir is not None and skill_root.is_relative_to(context.workspace_dir)
+            else "global"
+        )
+        for skill_path in sorted(skill_root.rglob("SKILL.md")):
+            if not skill_path.is_file():
+                continue
+            _append_found_path(found_paths, skill_path)
+            artifact = GuardArtifact(
+                artifact_id=f"opencode:{scope}:skill:{source_kind}:{skill_path.parent.name}",
+                name=skill_path.parent.name,
+                harness="opencode",
+                artifact_type="skill",
+                source_scope=scope,
+                config_path=str(skill_path),
+                metadata={"skill_source": source_kind},
+            )
+            _append_artifact(artifacts, seen_artifact_ids, artifact)
+
+
+def _skill_roots(context: HarnessContext) -> tuple[tuple[Path, str], ...]:
+    roots = [
+        (context.home_dir / Path(relative_path), source_kind)
+        for relative_path, source_kind in _GLOBAL_SKILL_DIRECTORIES
+    ]
+    if context.workspace_dir is not None:
+        roots.extend(
+            (context.workspace_dir / Path(relative_path), source_kind)
+            for relative_path, source_kind in _PROJECT_SKILL_DIRECTORIES
+        )
+    return tuple(roots)
+
+
+def _command_parts(server_config: dict[str, object]) -> tuple[str | None, tuple[str, ...]]:
+    command_value = server_config.get("command")
+    args_value = server_config.get("args")
+    if isinstance(command_value, list):
+        command_list = [value for value in command_value if isinstance(value, str)]
+        if not command_list:
+            return (None, ())
+        return (command_list[0], tuple(command_list[1:]))
+    if isinstance(command_value, str):
+        args = tuple(value for value in args_value if isinstance(value, str)) if isinstance(args_value, list) else ()
+        return (command_value, args)
+    return (None, ())
+
+
+def _append_artifact(
+    artifacts: list[GuardArtifact],
+    seen_artifact_ids: set[str],
+    artifact: GuardArtifact,
+) -> None:
+    if artifact.artifact_id in seen_artifact_ids:
+        return
+    seen_artifact_ids.add(artifact.artifact_id)
+    artifacts.append(artifact)
+
+
+def _append_found_path(found_paths: list[str], path: Path) -> None:
+    candidate = str(path)
+    if candidate not in found_paths:
+        found_paths.append(candidate)
+
+
+def _publisher_from_package(package_name: str) -> str | None:
+    if package_name.startswith("@") and "/" in package_name:
+        return package_name.split("/", 1)[0][1:]
+    return None
+
+
+def _runtime_config_path(context: HarnessContext) -> Path:
+    return context.guard_home / "opencode" / "runtime-config.json"
+
+
+def _runtime_overlay() -> dict[str, object]:
+    return {
+        "$schema": "https://opencode.ai/config.json",
+        "permission": {
+            "skill": {
+                "*": "ask",
+            }
+        },
+    }
+
+
+__all__ = ["OpenCodeHarnessAdapter"]

--- a/src/codex_plugin_scanner/guard/adapters/opencode.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 from ...ecosystems.opencode import _load_json_or_jsonc
@@ -113,10 +114,12 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
         if not overlay_path.exists():
             return {}
         try:
-            runtime_config = overlay_path.read_text(encoding="utf-8")
-        except OSError:
+            runtime_config = json.loads(overlay_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
             return {}
-        return {"OPENCODE_CONFIG_CONTENT": runtime_config}
+        existing_config = _inline_config(os.getenv("OPENCODE_CONFIG_CONTENT"))
+        merged_config = _merge_configs(existing_config, runtime_config)
+        return {"OPENCODE_CONFIG_CONTENT": json.dumps(merged_config)}
 
     def launch_command(self, context: HarnessContext, passthrough_args: list[str]) -> list[str]:
         if context.workspace_dir is not None and passthrough_args:
@@ -137,3 +140,37 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
 
 
 __all__ = ["OpenCodeHarnessAdapter"]
+
+
+def _inline_config(raw_content: str | None) -> dict[str, object]:
+    if not raw_content:
+        return {}
+    try:
+        payload = json.loads(raw_content)
+    except json.JSONDecodeError:
+        return {}
+    parsed = _object_dict(payload)
+    return parsed if parsed is not None else {}
+
+
+def _merge_configs(base: dict[str, object], overlay: dict[str, object]) -> dict[str, object]:
+    merged = dict(base)
+    for key, value in overlay.items():
+        existing_value = merged.get(key)
+        nested_overlay = _object_dict(value)
+        nested_existing = _object_dict(existing_value)
+        if nested_overlay is not None and nested_existing is not None:
+            merged[key] = _merge_configs(nested_existing, nested_overlay)
+            continue
+        merged[key] = value
+    return merged
+
+
+def _object_dict(value: object) -> dict[str, object] | None:
+    if not isinstance(value, dict):
+        return None
+    result: dict[str, object] = {}
+    for key, item in value.items():
+        if isinstance(key, str):
+            result[key] = item
+    return result

--- a/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
@@ -13,11 +13,13 @@ CONFIG_FILENAMES = ("opencode.json", "opencode.jsonc")
 PLUGIN_SUFFIXES = {".js", ".ts", ".mjs", ".cjs"}
 GLOBAL_SKILL_DIRECTORIES = (
     (".config/opencode/skills", "opencode"),
+    (".config/opencode/skill", "opencode"),
     (".claude/skills", "claude"),
     (".agents/skills", "agents"),
 )
 PROJECT_SKILL_DIRECTORIES = (
     (".opencode/skills", "opencode"),
+    (".opencode/skill", "opencode"),
     (".claude/skills", "claude"),
     (".agents/skills", "agents"),
 )
@@ -71,12 +73,14 @@ def append_directory_artifacts(
     directory_specs: list[tuple[Path, str, str]] = [
         (context.home_dir / ".config" / "opencode" / "commands", "global", "command"),
         (context.home_dir / ".config" / "opencode" / "plugins", "global", "plugin-file"),
+        (context.home_dir / ".config" / "opencode" / "plugin", "global", "plugin-file"),
     ]
     if context.workspace_dir is not None:
         directory_specs.extend(
             [
                 (context.workspace_dir / ".opencode" / "commands", "project", "command"),
                 (context.workspace_dir / ".opencode" / "plugins", "project", "plugin-file"),
+                (context.workspace_dir / ".opencode" / "plugin", "project", "plugin-file"),
             ]
         )
     for directory, scope, artifact_kind in directory_specs:
@@ -86,7 +90,7 @@ def append_directory_artifacts(
         exact_name = None if artifact_kind == "plugin-file" else "*.md"
         for path in _iter_directory_files(directory, allowed_suffixes=allowed_suffixes, exact_name=exact_name):
             append_found_path(found_paths, path)
-            relative_id = _relative_artifact_id(path, directory)
+            relative_id = _relative_artifact_id(path, directory, strip_suffix=artifact_kind == "command")
             artifact = GuardArtifact(
                 artifact_id=f"opencode:{scope}:{artifact_kind}:{relative_id}",
                 name=relative_id,
@@ -304,5 +308,6 @@ def _iter_directory_files(
             yield path
 
 
-def _relative_artifact_id(path: Path, root: Path) -> str:
-    return path.relative_to(root).with_suffix("").as_posix()
+def _relative_artifact_id(path: Path, root: Path, *, strip_suffix: bool) -> str:
+    relative_path = path.relative_to(root)
+    return (relative_path.with_suffix("") if strip_suffix else relative_path).as_posix()

--- a/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
@@ -28,12 +28,12 @@ PROJECT_SKILL_DIRECTORIES = (
 
 def config_paths(context: HarnessContext) -> tuple[Path, ...]:
     paths: list[Path] = []
-    configured_path = configured_config_path(context)
-    if configured_path is not None:
-        paths.append(configured_path)
     paths.extend(context.home_dir / ".config" / "opencode" / name for name in CONFIG_FILENAMES)
     if context.workspace_dir is not None:
         paths.extend(context.workspace_dir / name for name in CONFIG_FILENAMES)
+    configured_path = configured_config_path(context)
+    if configured_path is not None:
+        paths.append(configured_path)
     deduped_paths: list[Path] = []
     seen_paths: set[str] = set()
     for path in paths:
@@ -47,6 +47,18 @@ def config_paths(context: HarnessContext) -> tuple[Path, ...]:
 
 def configured_config_path(context: HarnessContext) -> Path | None:
     raw_path = os.getenv("OPENCODE_CONFIG")
+    if not raw_path:
+        return None
+    candidate = Path(raw_path).expanduser()
+    if candidate.is_absolute():
+        return candidate
+    if context.workspace_dir is not None:
+        return context.workspace_dir / candidate
+    return Path.cwd() / candidate
+
+
+def configured_config_dir(context: HarnessContext) -> Path | None:
+    raw_path = os.getenv("OPENCODE_CONFIG_DIR")
     if not raw_path:
         return None
     candidate = Path(raw_path).expanduser()
@@ -106,6 +118,20 @@ def append_directory_artifacts(
                 (context.workspace_dir / ".opencode" / "commands", "project", "command"),
                 (context.workspace_dir / ".opencode" / "plugins", "project", "plugin-file"),
                 (context.workspace_dir / ".opencode" / "plugin", "project", "plugin-file"),
+            ]
+        )
+    configured_dir = configured_config_dir(context)
+    if configured_dir is not None:
+        scope = (
+            "project"
+            if context.workspace_dir is not None and configured_dir.is_relative_to(context.workspace_dir)
+            else "global"
+        )
+        directory_specs.extend(
+            [
+                (configured_dir / "commands", scope, "command"),
+                (configured_dir / "plugins", scope, "plugin-file"),
+                (configured_dir / "plugin", scope, "plugin-file"),
             ]
         )
     for directory, scope, artifact_kind in directory_specs:

--- a/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
@@ -298,7 +298,10 @@ def _plugin_items(payload: dict[str, object]) -> Iterator[object]:
 
 
 def _file_metadata(path: Path) -> dict[str, object]:
-    return {"content_digest": _file_digest(path)}
+    try:
+        return {"content_digest": _file_digest(path)}
+    except OSError:
+        return {"content_digest_unavailable": True}
 
 
 def _file_digest(path: Path) -> str:

--- a/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
@@ -27,10 +27,34 @@ PROJECT_SKILL_DIRECTORIES = (
 
 
 def config_paths(context: HarnessContext) -> tuple[Path, ...]:
-    paths = [context.home_dir / ".config" / "opencode" / name for name in CONFIG_FILENAMES]
+    paths: list[Path] = []
+    configured_path = configured_config_path(context)
+    if configured_path is not None:
+        paths.append(configured_path)
+    paths.extend(context.home_dir / ".config" / "opencode" / name for name in CONFIG_FILENAMES)
     if context.workspace_dir is not None:
         paths.extend(context.workspace_dir / name for name in CONFIG_FILENAMES)
-    return tuple(paths)
+    deduped_paths: list[Path] = []
+    seen_paths: set[str] = set()
+    for path in paths:
+        candidate = str(path)
+        if candidate in seen_paths:
+            continue
+        seen_paths.add(candidate)
+        deduped_paths.append(path)
+    return tuple(deduped_paths)
+
+
+def configured_config_path(context: HarnessContext) -> Path | None:
+    raw_path = os.getenv("OPENCODE_CONFIG")
+    if not raw_path:
+        return None
+    candidate = Path(raw_path).expanduser()
+    if candidate.is_absolute():
+        return candidate
+    if context.workspace_dir is not None:
+        return context.workspace_dir / candidate
+    return Path.cwd() / candidate
 
 
 def append_config_artifacts(

--- a/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from pathlib import Path
 
 from ..models import GuardArtifact
@@ -80,16 +81,14 @@ def append_directory_artifacts(
     for directory, scope, artifact_kind in directory_specs:
         if not directory.is_dir():
             continue
-        pattern = "*.md" if artifact_kind == "command" else "*"
-        for path in sorted(directory.rglob(pattern)):
-            if not path.is_file():
-                continue
-            if artifact_kind == "plugin-file" and path.suffix not in PLUGIN_SUFFIXES:
-                continue
+        allowed_suffixes = None if artifact_kind == "command" else PLUGIN_SUFFIXES
+        exact_name = None if artifact_kind == "plugin-file" else "*.md"
+        for path in _iter_directory_files(directory, allowed_suffixes=allowed_suffixes, exact_name=exact_name):
             append_found_path(found_paths, path)
+            relative_id = _relative_artifact_id(path, directory)
             artifact = GuardArtifact(
-                artifact_id=f"opencode:{scope}:{artifact_kind}:{path.stem}",
-                name=path.stem,
+                artifact_id=f"opencode:{scope}:{artifact_kind}:{relative_id}",
+                name=relative_id,
                 harness="opencode",
                 artifact_type="plugin" if artifact_kind == "plugin-file" else "command",
                 source_scope=scope,
@@ -104,13 +103,12 @@ def append_directory_artifacts(
             if context.workspace_dir is not None and skill_root.is_relative_to(context.workspace_dir)
             else "global"
         )
-        for skill_path in sorted(skill_root.rglob("SKILL.md")):
-            if not skill_path.is_file():
-                continue
+        for skill_path in _iter_directory_files(skill_root, exact_name="SKILL.md"):
             append_found_path(found_paths, skill_path)
+            relative_id = skill_path.parent.relative_to(skill_root).as_posix()
             artifact = GuardArtifact(
-                artifact_id=f"opencode:{scope}:skill:{source_kind}:{skill_path.parent.name}",
-                name=skill_path.parent.name,
+                artifact_id=f"opencode:{scope}:skill:{source_kind}:{relative_id}",
+                name=relative_id,
                 harness="opencode",
                 artifact_type="skill",
                 source_scope=scope,
@@ -259,6 +257,7 @@ def _append_config_command_artifacts(
             for key in ("description", "agent", "model", "subtask")
             if (value := command_payload.get(key)) is not None
         }
+        metadata["template"] = template
         artifact = GuardArtifact(
             artifact_id=f"opencode:{scope}:config-command:{name}",
             name=name,
@@ -289,3 +288,26 @@ def _publisher_from_package(package_name: str) -> str | None:
     if package_name.startswith("@") and "/" in package_name:
         return package_name.split("/", 1)[0][1:]
     return None
+
+
+def _iter_directory_files(
+    directory: Path,
+    *,
+    allowed_suffixes: set[str] | None = None,
+    exact_name: str | None = None,
+) -> Iterator[Path]:
+    for root, dirnames, filenames in directory.walk():
+        dirnames.sort()
+        for filename in sorted(filenames):
+            path = root / filename
+            if exact_name == "*.md" and path.suffix != ".md":
+                continue
+            if exact_name is not None and exact_name != "*.md" and filename != exact_name:
+                continue
+            if allowed_suffixes is not None and path.suffix not in allowed_suffixes:
+                continue
+            yield path
+
+
+def _relative_artifact_id(path: Path, root: Path) -> str:
+    return path.relative_to(root).with_suffix("").as_posix()

--- a/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
@@ -29,11 +29,11 @@ PROJECT_SKILL_DIRECTORIES = (
 def config_paths(context: HarnessContext) -> tuple[Path, ...]:
     paths: list[Path] = []
     paths.extend(context.home_dir / ".config" / "opencode" / name for name in CONFIG_FILENAMES)
-    if context.workspace_dir is not None:
-        paths.extend(context.workspace_dir / name for name in CONFIG_FILENAMES)
     configured_path = configured_config_path(context)
     if configured_path is not None:
         paths.append(configured_path)
+    if context.workspace_dir is not None:
+        paths.extend(context.workspace_dir / name for name in CONFIG_FILENAMES)
     deduped_paths: list[Path] = []
     seen_paths: set[str] = set()
     for path in paths:
@@ -197,7 +197,10 @@ def append_artifact(
     artifact: GuardArtifact,
 ) -> None:
     if artifact.artifact_id in seen_artifact_ids:
-        return
+        for index, existing_artifact in enumerate(artifacts):
+            if existing_artifact.artifact_id == artifact.artifact_id:
+                artifacts[index] = artifact
+                return
     seen_artifact_ids.add(artifact.artifact_id)
     artifacts.append(artifact)
 

--- a/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -152,8 +153,7 @@ def append_found_path(found_paths: list[str], path: Path) -> None:
 
 def skill_roots(context: HarnessContext) -> tuple[tuple[Path, str], ...]:
     roots = [
-        (context.home_dir / Path(relative_path), source_kind)
-        for relative_path, source_kind in GLOBAL_SKILL_DIRECTORIES
+        (context.home_dir / Path(relative_path), source_kind) for relative_path, source_kind in GLOBAL_SKILL_DIRECTORIES
     ]
     if context.workspace_dir is not None:
         roots.extend(
@@ -212,12 +212,7 @@ def _append_plugin_artifacts(
         plugin_options: dict[str, object] = {}
         if isinstance(item, str):
             plugin_name = item
-        elif (
-            isinstance(item, list)
-            and len(item) == 2
-            and isinstance(item[0], str)
-            and isinstance(item[1], dict)
-        ):
+        elif isinstance(item, list) and len(item) == 2 and isinstance(item[0], str) and isinstance(item[1], dict):
             plugin_name = item[0]
             plugin_options = item[1]
         if plugin_name is None:
@@ -296,10 +291,10 @@ def _iter_directory_files(
     allowed_suffixes: set[str] | None = None,
     exact_name: str | None = None,
 ) -> Iterator[Path]:
-    for root, dirnames, filenames in directory.walk():
+    for root, dirnames, filenames in os.walk(directory):
         dirnames.sort()
         for filename in sorted(filenames):
-            path = root / filename
+            path = Path(root) / filename
             if exact_name == "*.md" and path.suffix != ".md":
                 continue
             if exact_name is not None and exact_name != "*.md" and filename != exact_name:

--- a/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 from collections.abc import Iterator
 from pathlib import Path
@@ -99,6 +100,7 @@ def append_directory_artifacts(
                 artifact_type="plugin" if artifact_kind == "plugin-file" else "command",
                 source_scope=scope,
                 config_path=str(path),
+                metadata=_file_metadata(path),
             )
             append_artifact(artifacts, seen_artifact_ids, artifact)
     for skill_root, source_kind in skill_roots(context):
@@ -119,7 +121,7 @@ def append_directory_artifacts(
                 artifact_type="skill",
                 source_scope=scope,
                 config_path=str(skill_path),
-                metadata={"skill_source": source_kind},
+                metadata={"skill_source": source_kind, **_file_metadata(skill_path)},
             )
             append_artifact(artifacts, seen_artifact_ids, artifact)
 
@@ -209,10 +211,7 @@ def _append_plugin_artifacts(
     config_path: Path,
     payload: dict[str, object],
 ) -> None:
-    plugin_config = payload.get("plugin")
-    if not isinstance(plugin_config, list):
-        return
-    for item in plugin_config:
+    for item in _plugin_items(payload):
         plugin_name: str | None = None
         plugin_options: dict[str, object] = {}
         if isinstance(item, str):
@@ -288,6 +287,22 @@ def _publisher_from_package(package_name: str) -> str | None:
     if package_name.startswith("@") and "/" in package_name:
         return package_name.split("/", 1)[0][1:]
     return None
+
+
+def _plugin_items(payload: dict[str, object]) -> Iterator[object]:
+    for key in ("plugins", "plugin"):
+        plugin_config = payload.get(key)
+        if not isinstance(plugin_config, list):
+            continue
+        yield from plugin_config
+
+
+def _file_metadata(path: Path) -> dict[str, object]:
+    return {"content_digest": _file_digest(path)}
+
+
+def _file_digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 def _iter_directory_files(

--- a/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
@@ -1,0 +1,291 @@
+"""OpenCode artifact discovery helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..models import GuardArtifact
+from .base import HarnessContext
+
+CONFIG_FILENAMES = ("opencode.json", "opencode.jsonc")
+PLUGIN_SUFFIXES = {".js", ".ts", ".mjs", ".cjs"}
+GLOBAL_SKILL_DIRECTORIES = (
+    (".config/opencode/skills", "opencode"),
+    (".claude/skills", "claude"),
+    (".agents/skills", "agents"),
+)
+PROJECT_SKILL_DIRECTORIES = (
+    (".opencode/skills", "opencode"),
+    (".claude/skills", "claude"),
+    (".agents/skills", "agents"),
+)
+
+
+def config_paths(context: HarnessContext) -> tuple[Path, ...]:
+    paths = [context.home_dir / ".config" / "opencode" / name for name in CONFIG_FILENAMES]
+    if context.workspace_dir is not None:
+        paths.extend(context.workspace_dir / name for name in CONFIG_FILENAMES)
+    return tuple(paths)
+
+
+def append_config_artifacts(
+    *,
+    artifacts: list[GuardArtifact],
+    seen_artifact_ids: set[str],
+    scope: str,
+    config_path: Path,
+    payload: dict[str, object],
+) -> None:
+    _append_mcp_artifacts(
+        artifacts=artifacts,
+        seen_artifact_ids=seen_artifact_ids,
+        scope=scope,
+        config_path=config_path,
+        payload=payload,
+    )
+    _append_plugin_artifacts(
+        artifacts=artifacts,
+        seen_artifact_ids=seen_artifact_ids,
+        scope=scope,
+        config_path=config_path,
+        payload=payload,
+    )
+    _append_config_command_artifacts(
+        artifacts=artifacts,
+        seen_artifact_ids=seen_artifact_ids,
+        scope=scope,
+        config_path=config_path,
+        payload=payload,
+    )
+
+
+def append_directory_artifacts(
+    *,
+    context: HarnessContext,
+    artifacts: list[GuardArtifact],
+    found_paths: list[str],
+    seen_artifact_ids: set[str],
+) -> None:
+    directory_specs: list[tuple[Path, str, str]] = [
+        (context.home_dir / ".config" / "opencode" / "commands", "global", "command"),
+        (context.home_dir / ".config" / "opencode" / "plugins", "global", "plugin-file"),
+    ]
+    if context.workspace_dir is not None:
+        directory_specs.extend(
+            [
+                (context.workspace_dir / ".opencode" / "commands", "project", "command"),
+                (context.workspace_dir / ".opencode" / "plugins", "project", "plugin-file"),
+            ]
+        )
+    for directory, scope, artifact_kind in directory_specs:
+        if not directory.is_dir():
+            continue
+        pattern = "*.md" if artifact_kind == "command" else "*"
+        for path in sorted(directory.rglob(pattern)):
+            if not path.is_file():
+                continue
+            if artifact_kind == "plugin-file" and path.suffix not in PLUGIN_SUFFIXES:
+                continue
+            append_found_path(found_paths, path)
+            artifact = GuardArtifact(
+                artifact_id=f"opencode:{scope}:{artifact_kind}:{path.stem}",
+                name=path.stem,
+                harness="opencode",
+                artifact_type="plugin" if artifact_kind == "plugin-file" else "command",
+                source_scope=scope,
+                config_path=str(path),
+            )
+            append_artifact(artifacts, seen_artifact_ids, artifact)
+    for skill_root, source_kind in skill_roots(context):
+        if not skill_root.is_dir():
+            continue
+        scope = (
+            "project"
+            if context.workspace_dir is not None and skill_root.is_relative_to(context.workspace_dir)
+            else "global"
+        )
+        for skill_path in sorted(skill_root.rglob("SKILL.md")):
+            if not skill_path.is_file():
+                continue
+            append_found_path(found_paths, skill_path)
+            artifact = GuardArtifact(
+                artifact_id=f"opencode:{scope}:skill:{source_kind}:{skill_path.parent.name}",
+                name=skill_path.parent.name,
+                harness="opencode",
+                artifact_type="skill",
+                source_scope=scope,
+                config_path=str(skill_path),
+                metadata={"skill_source": source_kind},
+            )
+            append_artifact(artifacts, seen_artifact_ids, artifact)
+
+
+def runtime_config_path(context: HarnessContext) -> Path:
+    return context.guard_home / "opencode" / "runtime-config.json"
+
+
+def runtime_overlay() -> dict[str, object]:
+    return {
+        "$schema": "https://opencode.ai/config.json",
+        "permission": {
+            "skill": {
+                "*": "ask",
+            }
+        },
+    }
+
+
+def append_artifact(
+    artifacts: list[GuardArtifact],
+    seen_artifact_ids: set[str],
+    artifact: GuardArtifact,
+) -> None:
+    if artifact.artifact_id in seen_artifact_ids:
+        return
+    seen_artifact_ids.add(artifact.artifact_id)
+    artifacts.append(artifact)
+
+
+def append_found_path(found_paths: list[str], path: Path) -> None:
+    candidate = str(path)
+    if candidate not in found_paths:
+        found_paths.append(candidate)
+
+
+def skill_roots(context: HarnessContext) -> tuple[tuple[Path, str], ...]:
+    roots = [
+        (context.home_dir / Path(relative_path), source_kind)
+        for relative_path, source_kind in GLOBAL_SKILL_DIRECTORIES
+    ]
+    if context.workspace_dir is not None:
+        roots.extend(
+            (context.workspace_dir / Path(relative_path), source_kind)
+            for relative_path, source_kind in PROJECT_SKILL_DIRECTORIES
+        )
+    return tuple(roots)
+
+
+def _append_mcp_artifacts(
+    *,
+    artifacts: list[GuardArtifact],
+    seen_artifact_ids: set[str],
+    scope: str,
+    config_path: Path,
+    payload: dict[str, object],
+) -> None:
+    mcp_config = payload.get("mcp")
+    if not isinstance(mcp_config, dict):
+        return
+    for name, server_config in mcp_config.items():
+        if not isinstance(name, str) or not isinstance(server_config, dict):
+            continue
+        command, args = _command_parts(server_config)
+        transport = server_config.get("type") if isinstance(server_config.get("type"), str) else None
+        url = server_config.get("url") if isinstance(server_config.get("url"), str) else None
+        artifact = GuardArtifact(
+            artifact_id=f"opencode:{scope}:{name}",
+            name=name,
+            harness="opencode",
+            artifact_type="mcp_server",
+            source_scope=scope,
+            config_path=str(config_path),
+            command=command,
+            args=args,
+            url=url,
+            transport=transport or ("remote" if url is not None else "stdio"),
+            metadata={"enabled": bool(server_config.get("enabled", True))},
+        )
+        append_artifact(artifacts, seen_artifact_ids, artifact)
+
+
+def _append_plugin_artifacts(
+    *,
+    artifacts: list[GuardArtifact],
+    seen_artifact_ids: set[str],
+    scope: str,
+    config_path: Path,
+    payload: dict[str, object],
+) -> None:
+    plugin_config = payload.get("plugin")
+    if not isinstance(plugin_config, list):
+        return
+    for item in plugin_config:
+        plugin_name: str | None = None
+        plugin_options: dict[str, object] = {}
+        if isinstance(item, str):
+            plugin_name = item
+        elif (
+            isinstance(item, list)
+            and len(item) == 2
+            and isinstance(item[0], str)
+            and isinstance(item[1], dict)
+        ):
+            plugin_name = item[0]
+            plugin_options = item[1]
+        if plugin_name is None:
+            continue
+        artifact = GuardArtifact(
+            artifact_id=f"opencode:{scope}:plugin:{plugin_name}",
+            name=plugin_name,
+            harness="opencode",
+            artifact_type="plugin",
+            source_scope=scope,
+            config_path=str(config_path),
+            publisher=_publisher_from_package(plugin_name),
+            metadata=plugin_options,
+        )
+        append_artifact(artifacts, seen_artifact_ids, artifact)
+
+
+def _append_config_command_artifacts(
+    *,
+    artifacts: list[GuardArtifact],
+    seen_artifact_ids: set[str],
+    scope: str,
+    config_path: Path,
+    payload: dict[str, object],
+) -> None:
+    command_config = payload.get("command")
+    if not isinstance(command_config, dict):
+        return
+    for name, command_payload in command_config.items():
+        if not isinstance(name, str) or not isinstance(command_payload, dict):
+            continue
+        template = command_payload.get("template")
+        if not isinstance(template, str) or not template.strip():
+            continue
+        metadata = {
+            key: value
+            for key in ("description", "agent", "model", "subtask")
+            if (value := command_payload.get(key)) is not None
+        }
+        artifact = GuardArtifact(
+            artifact_id=f"opencode:{scope}:config-command:{name}",
+            name=name,
+            harness="opencode",
+            artifact_type="command",
+            source_scope=scope,
+            config_path=str(config_path),
+            metadata=metadata,
+        )
+        append_artifact(artifacts, seen_artifact_ids, artifact)
+
+
+def _command_parts(server_config: dict[str, object]) -> tuple[str | None, tuple[str, ...]]:
+    command_value = server_config.get("command")
+    args_value = server_config.get("args")
+    if isinstance(command_value, list):
+        command_list = [value for value in command_value if isinstance(value, str)]
+        if not command_list:
+            return (None, ())
+        return (command_list[0], tuple(command_list[1:]))
+    if isinstance(command_value, str):
+        args = tuple(value for value in args_value if isinstance(value, str)) if isinstance(args_value, list) else ()
+        return (command_value, args)
+    return (None, ())
+
+
+def _publisher_from_package(package_name: str) -> str | None:
+    if package_name.startswith("@") and "/" in package_name:
+        return package_name.split("/", 1)[0][1:]
+    return None

--- a/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
@@ -91,9 +91,10 @@ def append_directory_artifacts(
         for path in _iter_directory_files(directory, allowed_suffixes=allowed_suffixes, exact_name=exact_name):
             append_found_path(found_paths, path)
             relative_id = _relative_artifact_id(path, directory, strip_suffix=artifact_kind == "command")
+            artifact_name = relative_id if artifact_kind == "command" else f"{directory.name}/{relative_id}"
             artifact = GuardArtifact(
-                artifact_id=f"opencode:{scope}:{artifact_kind}:{relative_id}",
-                name=relative_id,
+                artifact_id=f"opencode:{scope}:{artifact_kind}:{artifact_name}",
+                name=artifact_name,
                 harness="opencode",
                 artifact_type="plugin" if artifact_kind == "plugin-file" else "command",
                 source_scope=scope,
@@ -110,7 +111,7 @@ def append_directory_artifacts(
         )
         for skill_path in _iter_directory_files(skill_root, exact_name="SKILL.md"):
             append_found_path(found_paths, skill_path)
-            relative_id = skill_path.parent.relative_to(skill_root).as_posix()
+            relative_id = f"{skill_root.name}/{skill_path.parent.relative_to(skill_root).as_posix()}"
             artifact = GuardArtifact(
                 artifact_id=f"opencode:{scope}:skill:{source_kind}:{relative_id}",
                 name=relative_id,

--- a/src/codex_plugin_scanner/guard/consumer/service.py
+++ b/src/codex_plugin_scanner/guard/consumer/service.py
@@ -32,10 +32,18 @@ def _serialize_artifact(artifact: GuardArtifact) -> dict[str, object]:
     return payload
 
 
+def _hash_payload(artifact: GuardArtifact) -> dict[str, object]:
+    payload = artifact.to_dict()
+    payload["metadata"] = artifact.metadata
+    metadata = payload.get("metadata")
+    payload["env_keys"] = metadata.get("env_keys", []) if isinstance(metadata, dict) else []
+    return payload
+
+
 def artifact_hash(artifact: GuardArtifact) -> str:
     """Hash a detected artifact definition."""
 
-    payload = _serialize_artifact(artifact)
+    payload = _hash_payload(artifact)
     return hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
 
 
@@ -58,10 +66,13 @@ def diff_artifact(previous: dict[str, object] | None, current: GuardArtifact) ->
         previous_payload["env_keys"] = []
     changed_fields = [key for key, value in current_payload.items() if previous_payload.get(key) != value]
     previous_hash = previous.get("artifact_hash")
+    previous_hash_value = previous_hash if isinstance(previous_hash, str) else None
+    if previous_hash_value is not None and previous_hash_value != current_hash and not changed_fields:
+        changed_fields = ["metadata"]
     return {
         "changed": bool(changed_fields),
         "changed_fields": changed_fields,
-        "previous_hash": previous_hash if isinstance(previous_hash, str) else None,
+        "previous_hash": previous_hash_value,
         "current_hash": current_hash,
         "current_snapshot": current_payload,
     }

--- a/src/codex_plugin_scanner/guard/consumer/service.py
+++ b/src/codex_plugin_scanner/guard/consumer/service.py
@@ -249,6 +249,8 @@ def evaluate_detection(
                 "risk_signals": list(risk_signals),
                 "risk_summary": risk_summary,
                 "artifact_type": artifact.artifact_type,
+                "config_path": artifact.config_path,
+                "source_scope": artifact.source_scope,
                 "artifact_label": incident["artifact_label"],
                 "source_label": incident["source_label"],
                 "trigger_summary": incident["trigger_summary"],

--- a/src/codex_plugin_scanner/guard/models.py
+++ b/src/codex_plugin_scanner/guard/models.py
@@ -46,6 +46,18 @@ def _redact_arg(value: str) -> str:
     return value
 
 
+def _redact_metadata(value: object, key: str | None = None) -> object:
+    if key is not None and any(
+        token in key.lower() for token in ("key", "token", "auth", "secret", "password", "credential")
+    ):
+        return "*****"
+    if isinstance(value, dict):
+        return {item_key: _redact_metadata(item_value, item_key) for item_key, item_value in value.items()}
+    if isinstance(value, list):
+        return [_redact_metadata(item) for item in value]
+    return value
+
+
 @dataclass(frozen=True, slots=True)
 class GuardArtifact:
     """A local harness artifact that Guard can reason about."""
@@ -67,6 +79,7 @@ class GuardArtifact:
         payload = asdict(self)
         payload["args"] = [_redact_arg(value) for value in self.args]
         payload["url"] = _redact_url(self.url)
+        payload["metadata"] = _redact_metadata(payload.get("metadata", {}))
         return payload
 
 

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -139,7 +139,7 @@ def _requests_direct_env_read(prompt_text: str) -> bool:
 
 
 def _prompt_policy_path(detection: HarnessDetection, context: HarnessContext) -> Path:
-    config_candidates = _prompt_config_candidates(detection)
+    config_candidates = _prompt_config_candidates(detection, context)
     if context.workspace_dir is not None:
         for config_path in config_candidates:
             candidate = Path(config_path)
@@ -156,12 +156,22 @@ def _prompt_policy_path(detection: HarnessDetection, context: HarnessContext) ->
     return context.home_dir / ".codex" / "config.toml"
 
 
-def _prompt_config_candidates(detection: HarnessDetection) -> tuple[str, ...]:
+def _prompt_config_candidates(detection: HarnessDetection, context: HarnessContext) -> tuple[str, ...]:
     if detection.harness == "opencode":
+        configured_path = os.getenv("OPENCODE_CONFIG")
+        configured_candidate = None
+        if configured_path:
+            candidate = Path(configured_path).expanduser()
+            if not candidate.is_absolute():
+                if context.workspace_dir is not None:
+                    candidate = context.workspace_dir / candidate
+                else:
+                    candidate = Path.cwd() / candidate
+            configured_candidate = str(candidate)
         return tuple(
             config_path
             for config_path in detection.config_paths
-            if Path(config_path).name in {"opencode.json", "opencode.jsonc"}
+            if Path(config_path).name in {"opencode.json", "opencode.jsonc"} or config_path == configured_candidate
         )
     return detection.config_paths
 

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -139,16 +139,31 @@ def _requests_direct_env_read(prompt_text: str) -> bool:
 
 
 def _prompt_policy_path(detection: HarnessDetection, context: HarnessContext) -> Path:
+    config_candidates = _prompt_config_candidates(detection)
     if context.workspace_dir is not None:
-        for config_path in detection.config_paths:
+        for config_path in config_candidates:
             candidate = Path(config_path)
             if candidate.is_relative_to(context.workspace_dir):
                 return candidate
-    if detection.config_paths:
-        return Path(detection.config_paths[0])
+    if config_candidates:
+        return Path(config_candidates[0])
+    if detection.harness == "opencode":
+        if context.workspace_dir is not None:
+            return context.workspace_dir / "opencode.json"
+        return context.home_dir / ".config" / "opencode" / "opencode.json"
     if context.workspace_dir is not None:
         return context.workspace_dir / ".codex" / "config.toml"
     return context.home_dir / ".codex" / "config.toml"
+
+
+def _prompt_config_candidates(detection: HarnessDetection) -> tuple[str, ...]:
+    if detection.harness == "opencode":
+        return tuple(
+            config_path
+            for config_path in detection.config_paths
+            if Path(config_path).name in {"opencode.json", "opencode.jsonc"}
+        )
+    return detection.config_paths
 
 
 def sync_receipts(store: GuardStore) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -78,6 +78,7 @@ def guard_run(
     environment["HOME"] = str(context.home_dir)
     if os.name == "nt":
         environment["USERPROFILE"] = str(context.home_dir)
+    environment.update(adapter.launch_environment(context))
     try:
         result = subprocess.run(command, cwd=context.workspace_dir or Path.cwd(), check=False, env=environment)
     except FileNotFoundError as error:
@@ -95,7 +96,7 @@ def _detection_with_prompt_artifacts(
     context: HarnessContext,
     passthrough_args: list[str],
 ) -> HarnessDetection:
-    prompt_artifact = _prompt_env_artifact(detection.harness, context, passthrough_args)
+    prompt_artifact = _prompt_env_artifact(detection, context, passthrough_args)
     if prompt_artifact is None:
         return detection
     return HarnessDetection(
@@ -109,7 +110,7 @@ def _detection_with_prompt_artifacts(
 
 
 def _prompt_env_artifact(
-    harness: str,
+    detection: HarnessDetection,
     context: HarnessContext,
     passthrough_args: list[str],
 ) -> GuardArtifact | None:
@@ -120,12 +121,12 @@ def _prompt_env_artifact(
     prompt_hash = hashlib.sha256(normalized_prompt.encode("utf-8")).hexdigest()
     prompt_summary = "Prompt asks the harness to read a local .env file directly."
     return GuardArtifact(
-        artifact_id=f"{harness}:session:prompt-env-read:{prompt_hash}",
+        artifact_id=f"{detection.harness}:session:prompt-env-read:{prompt_hash}",
         name="direct .env prompt access",
-        harness=harness,
+        harness=detection.harness,
         artifact_type="prompt_request",
         source_scope="session",
-        config_path=str(_prompt_policy_path(context)),
+        config_path=str(_prompt_policy_path(detection, context)),
         metadata={
             "prompt_signals": ["asks the harness to read a local .env file directly"],
             "prompt_summary": prompt_summary,
@@ -137,7 +138,14 @@ def _requests_direct_env_read(prompt_text: str) -> bool:
     return _ENV_PROMPT_PATTERN.search(prompt_text) is not None
 
 
-def _prompt_policy_path(context: HarnessContext) -> Path:
+def _prompt_policy_path(detection: HarnessDetection, context: HarnessContext) -> Path:
+    if context.workspace_dir is not None:
+        for config_path in detection.config_paths:
+            candidate = Path(config_path)
+            if candidate.is_relative_to(context.workspace_dir):
+                return candidate
+    if detection.config_paths:
+        return Path(detection.config_paths[0])
     if context.workspace_dir is not None:
         return context.workspace_dir / ".codex" / "config.toml"
     return context.home_dir / ".codex" / "config.toml"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -467,20 +467,20 @@ args = ["workspace-skill.js"]
         assert rc == 0
         assert "opencode:global:plugin:opencode-global-plugin" in artifacts
         assert "opencode:project:plugin:opencode-project-plugin" in artifacts
-        assert "opencode:global:plugin-file:global-local.mjs" in artifacts
-        assert "opencode:project:plugin-file:project-local.mjs" in artifacts
+        assert "opencode:global:plugin-file:plugins/global-local.mjs" in artifacts
+        assert "opencode:project:plugin-file:plugins/project-local.mjs" in artifacts
         assert "opencode:global:config-command:global-review" in artifacts
         assert "opencode:project:config-command:project-review" in artifacts
         assert "opencode:global:command:global-cmd" in artifacts
         assert "opencode:project:command:triage" in artifacts
-        assert "opencode:global:skill:opencode:global-skill" in artifacts
-        assert "opencode:project:skill:opencode:repo-skill" in artifacts
-        assert "opencode:project:skill:claude:claude-skill" in artifacts
-        assert artifacts["opencode:project:plugin-file:project-local.mjs"]["artifact_type"] == "plugin"
+        assert "opencode:global:skill:opencode:skills/global-skill" in artifacts
+        assert "opencode:project:skill:opencode:skills/repo-skill" in artifacts
+        assert "opencode:project:skill:claude:skills/claude-skill" in artifacts
+        assert artifacts["opencode:project:plugin-file:plugins/project-local.mjs"]["artifact_type"] == "plugin"
         assert artifacts["opencode:project:config-command:project-review"]["metadata"]["template"] == (
             "Review the workspace change set."
         )
-        assert artifacts["opencode:project:skill:claude:claude-skill"]["artifact_type"] == "skill"
+        assert artifacts["opencode:project:skill:claude:skills/claude-skill"]["artifact_type"] == "skill"
 
     def test_guard_detect_keeps_unique_opencode_file_artifact_ids(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -511,11 +511,11 @@ args = ["workspace-skill.js"]
         artifact_ids = {item["artifact_id"] for item in output["harnesses"][0]["artifacts"]}
 
         assert rc == 0
-        assert "opencode:project:plugin-file:shared.js" in artifact_ids
-        assert "opencode:project:plugin-file:shared.mjs" in artifact_ids
-        assert "opencode:project:plugin-file:nested/shared.mjs" in artifact_ids
-        assert "opencode:project:skill:opencode:shared" in artifact_ids
-        assert "opencode:project:skill:opencode:nested/shared" in artifact_ids
+        assert "opencode:project:plugin-file:plugin/shared.js" in artifact_ids
+        assert "opencode:project:plugin-file:plugins/shared.mjs" in artifact_ids
+        assert "opencode:project:plugin-file:plugins/nested/shared.mjs" in artifact_ids
+        assert "opencode:project:skill:opencode:skill/shared" in artifact_ids
+        assert "opencode:project:skill:opencode:skills/nested/shared" in artifact_ids
 
     def test_guard_detect_human_output_surfaces_next_steps(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -477,7 +477,43 @@ args = ["workspace-skill.js"]
         assert "opencode:project:skill:opencode:repo-skill" in artifacts
         assert "opencode:project:skill:claude:claude-skill" in artifacts
         assert artifacts["opencode:project:plugin-file:project-local"]["artifact_type"] == "plugin"
+        assert artifacts["opencode:project:config-command:project-review"]["metadata"]["template"] == (
+            "Review the workspace change set."
+        )
         assert artifacts["opencode:project:skill:claude:claude-skill"]["artifact_type"] == "skill"
+
+    def test_guard_detect_keeps_unique_opencode_file_artifact_ids(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _write_json(workspace_dir / "opencode.json", {})
+        _write_text(workspace_dir / ".opencode" / "plugins" / "shared.mjs", "export default {};\n")
+        _write_text(workspace_dir / ".opencode" / "plugins" / "nested" / "shared.mjs", "export default {};\n")
+        _write_text(workspace_dir / ".opencode" / "skills" / "shared" / "SKILL.md", "---\nname: shared\n---\n")
+        _write_text(
+            workspace_dir / ".opencode" / "skills" / "nested" / "shared" / "SKILL.md",
+            "---\nname: shared\n---\n",
+        )
+
+        rc = main(
+            [
+                "guard",
+                "detect",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        artifact_ids = {item["artifact_id"] for item in output["harnesses"][0]["artifacts"]}
+
+        assert rc == 0
+        assert "opencode:project:plugin-file:shared" in artifact_ids
+        assert "opencode:project:plugin-file:nested/shared" in artifact_ids
+        assert "opencode:project:skill:opencode:shared" in artifact_ids
+        assert "opencode:project:skill:opencode:nested/shared" in artifact_ids
 
     def test_guard_detect_human_output_surfaces_next_steps(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -467,8 +467,8 @@ args = ["workspace-skill.js"]
         assert rc == 0
         assert "opencode:global:plugin:opencode-global-plugin" in artifacts
         assert "opencode:project:plugin:opencode-project-plugin" in artifacts
-        assert "opencode:global:plugin-file:global-local" in artifacts
-        assert "opencode:project:plugin-file:project-local" in artifacts
+        assert "opencode:global:plugin-file:global-local.mjs" in artifacts
+        assert "opencode:project:plugin-file:project-local.mjs" in artifacts
         assert "opencode:global:config-command:global-review" in artifacts
         assert "opencode:project:config-command:project-review" in artifacts
         assert "opencode:global:command:global-cmd" in artifacts
@@ -476,7 +476,7 @@ args = ["workspace-skill.js"]
         assert "opencode:global:skill:opencode:global-skill" in artifacts
         assert "opencode:project:skill:opencode:repo-skill" in artifacts
         assert "opencode:project:skill:claude:claude-skill" in artifacts
-        assert artifacts["opencode:project:plugin-file:project-local"]["artifact_type"] == "plugin"
+        assert artifacts["opencode:project:plugin-file:project-local.mjs"]["artifact_type"] == "plugin"
         assert artifacts["opencode:project:config-command:project-review"]["metadata"]["template"] == (
             "Review the workspace change set."
         )
@@ -486,9 +486,10 @@ args = ["workspace-skill.js"]
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         _write_json(workspace_dir / "opencode.json", {})
+        _write_text(workspace_dir / ".opencode" / "plugin" / "shared.js", "export default {};\n")
         _write_text(workspace_dir / ".opencode" / "plugins" / "shared.mjs", "export default {};\n")
         _write_text(workspace_dir / ".opencode" / "plugins" / "nested" / "shared.mjs", "export default {};\n")
-        _write_text(workspace_dir / ".opencode" / "skills" / "shared" / "SKILL.md", "---\nname: shared\n---\n")
+        _write_text(workspace_dir / ".opencode" / "skill" / "shared" / "SKILL.md", "---\nname: shared\n---\n")
         _write_text(
             workspace_dir / ".opencode" / "skills" / "nested" / "shared" / "SKILL.md",
             "---\nname: shared\n---\n",
@@ -510,8 +511,9 @@ args = ["workspace-skill.js"]
         artifact_ids = {item["artifact_id"] for item in output["harnesses"][0]["artifacts"]}
 
         assert rc == 0
-        assert "opencode:project:plugin-file:shared" in artifact_ids
-        assert "opencode:project:plugin-file:nested/shared" in artifact_ids
+        assert "opencode:project:plugin-file:shared.js" in artifact_ids
+        assert "opencode:project:plugin-file:shared.mjs" in artifact_ids
+        assert "opencode:project:plugin-file:nested/shared.mjs" in artifact_ids
         assert "opencode:project:skill:opencode:shared" in artifact_ids
         assert "opencode:project:skill:opencode:nested/shared" in artifact_ids
 

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -411,7 +411,7 @@ args = ["workspace-skill.js"]
         _write_json(
             home_dir / ".config" / "opencode" / "opencode.json",
             {
-                "plugins": ["opencode-global-plugin"],
+                "plugins": [["opencode-global-plugin", {"mode": "strict", "token": "top-secret"}]],
                 "command": {
                     "global-review": {
                         "template": "Review the current diff.",
@@ -480,6 +480,8 @@ args = ["workspace-skill.js"]
         assert artifacts["opencode:project:config-command:project-review"]["metadata"]["template"] == (
             "Review the workspace change set."
         )
+        assert artifacts["opencode:global:plugin:opencode-global-plugin"]["metadata"]["mode"] == "strict"
+        assert artifacts["opencode:global:plugin:opencode-global-plugin"]["metadata"]["token"] == "*****"
         assert artifacts["opencode:project:skill:claude:skills/claude-skill"]["artifact_type"] == "skill"
 
     def test_guard_detect_keeps_unique_opencode_file_artifact_ids(self, tmp_path, capsys):
@@ -516,6 +518,41 @@ args = ["workspace-skill.js"]
         assert "opencode:project:plugin-file:plugins/nested/shared.mjs" in artifact_ids
         assert "opencode:project:skill:opencode:skill/shared" in artifact_ids
         assert "opencode:project:skill:opencode:skills/nested/shared" in artifact_ids
+
+    def test_guard_detect_handles_unreadable_opencode_plugin_files(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _write_json(workspace_dir / "opencode.json", {})
+        _write_text(workspace_dir / ".opencode" / "plugins" / "broken.mjs", "export default {};\n")
+        original_read_bytes = Path.read_bytes
+
+        def _patched_read_bytes(path: Path) -> bytes:
+            if path.name == "broken.mjs":
+                raise OSError("Permission denied")
+            return original_read_bytes(path)
+
+        monkeypatch.setattr(Path, "read_bytes", _patched_read_bytes)
+
+        rc = main(
+            [
+                "guard",
+                "detect",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        artifacts = {item["artifact_id"]: item for item in output["harnesses"][0]["artifacts"]}
+
+        assert rc == 0
+        assert (
+            artifacts["opencode:project:plugin-file:plugins/broken.mjs"]["metadata"]["content_digest_unavailable"]
+            is True
+        )
 
     def test_guard_detect_human_output_surfaces_next_steps(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -550,6 +550,64 @@ args = ["workspace-skill.js"]
         assert "opencode:project:plugin:env-plugin" in artifact_ids
         assert str(custom_config_path) in detection["config_paths"]
 
+    def test_guard_detect_prefers_project_opencode_config_over_environment_override(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        custom_config_path = workspace_dir / "custom" / "guard-opencode.json"
+        _write_json(custom_config_path, {"plugins": [["shared-plugin", {"mode": "custom"}]]})
+        _write_json(workspace_dir / "opencode.json", {"plugins": [["shared-plugin", {"mode": "project"}]]})
+        monkeypatch.setenv("OPENCODE_CONFIG", str(custom_config_path))
+
+        rc = main(
+            [
+                "guard",
+                "detect",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        artifacts = {item["artifact_id"]: item for item in output["harnesses"][0]["artifacts"]}
+
+        assert rc == 0
+        assert artifacts["opencode:project:plugin:shared-plugin"]["metadata"]["mode"] == "project"
+
+    def test_guard_detect_reads_opencode_config_dir_from_environment_override(self, monkeypatch, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        custom_config_dir = workspace_dir / "custom-dir"
+        _write_text(custom_config_dir / "plugins" / "env-plugin.mjs", "export default {};\n")
+        _write_text(custom_config_dir / "commands" / "env-command.md", "# env command\n")
+        monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(custom_config_dir))
+
+        rc = main(
+            [
+                "guard",
+                "detect",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        artifact_ids = {item["artifact_id"] for item in output["harnesses"][0]["artifacts"]}
+
+        assert rc == 0
+        assert "opencode:project:plugin-file:plugins/env-plugin.mjs" in artifact_ids
+        assert "opencode:project:command:env-command" in artifact_ids
+
     def test_guard_detect_handles_unreadable_opencode_plugin_files(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -405,6 +405,80 @@ args = ["workspace-skill.js"]
         assert rc == 0
         assert artifact_ids == ["opencode:global:shared-tools", "opencode:project:shared-tools"]
 
+    def test_guard_detect_reports_opencode_plugins_skills_and_commands(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _write_json(
+            home_dir / ".config" / "opencode" / "opencode.json",
+            {
+                "plugin": ["opencode-global-plugin"],
+                "command": {
+                    "global-review": {
+                        "template": "Review the current diff.",
+                        "description": "Global review command",
+                    }
+                },
+            },
+        )
+        _write_json(
+            workspace_dir / "opencode.json",
+            {
+                "plugin": ["opencode-project-plugin"],
+                "command": {
+                    "project-review": {
+                        "template": "Review the workspace change set.",
+                        "description": "Project review command",
+                    }
+                },
+            },
+        )
+        _write_text(home_dir / ".config" / "opencode" / "plugins" / "global-local.mjs", "export default {};\n")
+        _write_text(workspace_dir / ".opencode" / "plugins" / "project-local.mjs", "export default {};\n")
+        _write_text(home_dir / ".config" / "opencode" / "commands" / "global-cmd.md", "# global\n")
+        _write_text(workspace_dir / ".opencode" / "commands" / "triage.md", "# triage\n")
+        _write_text(
+            home_dir / ".config" / "opencode" / "skills" / "global-skill" / "SKILL.md",
+            "---\nname: global-skill\ndescription: Global skill\n---\n",
+        )
+        _write_text(
+            workspace_dir / ".opencode" / "skills" / "repo-skill" / "SKILL.md",
+            "---\nname: repo-skill\ndescription: Repo skill\n---\n",
+        )
+        _write_text(
+            workspace_dir / ".claude" / "skills" / "claude-skill" / "SKILL.md",
+            "---\nname: claude-skill\ndescription: Claude-compatible skill\n---\n",
+        )
+
+        rc = main(
+            [
+                "guard",
+                "detect",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        artifacts = {item["artifact_id"]: item for item in output["harnesses"][0]["artifacts"]}
+
+        assert rc == 0
+        assert "opencode:global:plugin:opencode-global-plugin" in artifacts
+        assert "opencode:project:plugin:opencode-project-plugin" in artifacts
+        assert "opencode:global:plugin-file:global-local" in artifacts
+        assert "opencode:project:plugin-file:project-local" in artifacts
+        assert "opencode:global:config-command:global-review" in artifacts
+        assert "opencode:project:config-command:project-review" in artifacts
+        assert "opencode:global:command:global-cmd" in artifacts
+        assert "opencode:project:command:triage" in artifacts
+        assert "opencode:global:skill:opencode:global-skill" in artifacts
+        assert "opencode:project:skill:opencode:repo-skill" in artifacts
+        assert "opencode:project:skill:claude:claude-skill" in artifacts
+        assert artifacts["opencode:project:plugin-file:project-local"]["artifact_type"] == "plugin"
+        assert artifacts["opencode:project:skill:claude:claude-skill"]["artifact_type"] == "skill"
+
     def test_guard_detect_human_output_surfaces_next_steps(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
@@ -1328,6 +1402,33 @@ args = ["workspace-skill.js", "--changed"]
         assert output["auto_detected"] is True
         harnesses = {item["harness"] for item in output["managed_installs"]}
         assert {"codex", "claude-code", "cursor", "gemini", "opencode"} <= harnesses
+
+    def test_guard_install_creates_opencode_runtime_overlay(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _write_json(workspace_dir / "opencode.json", {"name": "workspace-opencode"})
+
+        rc = main(
+            [
+                "guard",
+                "install",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        manifest = output["managed_install"]["manifest"]
+        runtime_config_path = Path(str(manifest["runtime_config_path"]))
+        runtime_payload = json.loads(runtime_config_path.read_text(encoding="utf-8"))
+
+        assert rc == 0
+        assert output["managed_install"]["active"] is True
+        assert manifest["shim_command"] == "guard-opencode"
+        assert runtime_payload["permission"]["skill"]["*"] == "ask"
 
     def test_guard_uninstall_auto_detects_managed_harnesses(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -608,6 +608,69 @@ args = ["workspace-skill.js"]
         assert "opencode:project:plugin-file:plugins/env-plugin.mjs" in artifact_ids
         assert "opencode:project:command:env-command" in artifact_ids
 
+    def test_guard_detect_prefers_opencode_environment_config_over_global_config(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        custom_config_path = workspace_dir / "custom" / "guard-opencode.json"
+        _write_json(
+            home_dir / ".config" / "opencode" / "opencode.json",
+            {"plugins": [["shared-plugin", {"mode": "global"}]]},
+        )
+        _write_json(custom_config_path, {"plugins": [["shared-plugin", {"mode": "custom"}]]})
+        monkeypatch.setenv("OPENCODE_CONFIG", str(custom_config_path))
+
+        rc = main(
+            [
+                "guard",
+                "detect",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        artifacts = {item["artifact_id"]: item for item in output["harnesses"][0]["artifacts"]}
+
+        assert rc == 0
+        assert artifacts["opencode:project:plugin:shared-plugin"]["metadata"]["mode"] == "custom"
+
+    def test_guard_detect_prefers_opencode_config_dir_over_default_plugin_file(self, monkeypatch, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        custom_config_dir = workspace_dir / "custom-dir"
+        _write_json(workspace_dir / "opencode.json", {})
+        _write_text(workspace_dir / ".opencode" / "plugins" / "shared.mjs", "export default { name: 'default' };\n")
+        _write_text(custom_config_dir / "plugins" / "shared.mjs", "export default { name: 'override' };\n")
+        monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(custom_config_dir))
+
+        rc = main(
+            [
+                "guard",
+                "detect",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        artifacts = {item["artifact_id"]: item for item in output["harnesses"][0]["artifacts"]}
+
+        assert rc == 0
+        assert artifacts["opencode:project:plugin-file:plugins/shared.mjs"]["config_path"] == str(
+            custom_config_dir / "plugins" / "shared.mjs"
+        )
+
     def test_guard_detect_handles_unreadable_opencode_plugin_files(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -411,7 +411,7 @@ args = ["workspace-skill.js"]
         _write_json(
             home_dir / ".config" / "opencode" / "opencode.json",
             {
-                "plugin": ["opencode-global-plugin"],
+                "plugins": ["opencode-global-plugin"],
                 "command": {
                     "global-review": {
                         "template": "Review the current diff.",
@@ -423,7 +423,7 @@ args = ["workspace-skill.js"]
         _write_json(
             workspace_dir / "opencode.json",
             {
-                "plugin": ["opencode-project-plugin"],
+                "plugins": ["opencode-project-plugin"],
                 "command": {
                     "project-review": {
                         "template": "Review the workspace change set.",

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -523,6 +523,33 @@ args = ["workspace-skill.js"]
         assert "opencode:project:skill:opencode:skill/shared" in artifact_ids
         assert "opencode:project:skill:opencode:skills/nested/shared" in artifact_ids
 
+    def test_guard_detect_reads_opencode_config_from_environment_override(self, monkeypatch, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        custom_config_path = workspace_dir / "custom" / "guard-opencode.json"
+        _write_json(custom_config_path, {"plugins": ["env-plugin"]})
+        monkeypatch.setenv("OPENCODE_CONFIG", str(custom_config_path))
+
+        rc = main(
+            [
+                "guard",
+                "detect",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        detection = output["harnesses"][0]
+        artifact_ids = [item["artifact_id"] for item in detection["artifacts"]]
+
+        assert rc == 0
+        assert "opencode:project:plugin:env-plugin" in artifact_ids
+        assert str(custom_config_path) in detection["config_paths"]
+
     def test_guard_detect_handles_unreadable_opencode_plugin_files(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_launch_env.py
+++ b/tests/test_guard_launch_env.py
@@ -363,7 +363,7 @@ def test_guard_run_opencode_blocks_new_plugin_when_unknown_artifacts_require_app
     plugin_artifact = next(
         item
         for item in second_output["artifacts"]
-        if item["artifact_id"] == "opencode:project:plugin-file:env-read-plugin"
+        if item["artifact_id"] == "opencode:project:plugin-file:env-read-plugin.mjs"
     )
 
     assert first_rc == 0
@@ -399,9 +399,7 @@ def test_guard_run_still_blocks_when_prompt_contains_negation_elsewhere(monkeypa
         ]
     )
     output = json.loads(capsys.readouterr().out)
-    prompt_artifact = next(
-        item for item in output["artifacts"] if item.get("artifact_type") == "prompt_request"
-    )
+    prompt_artifact = next(item for item in output["artifacts"] if item.get("artifact_type") == "prompt_request")
 
     assert rc == 1
     assert output["blocked"] is True
@@ -435,9 +433,7 @@ def test_guard_run_blocks_env_content_request_without_read_verb(monkeypatch, tmp
         ]
     )
     output = json.loads(capsys.readouterr().out)
-    prompt_artifact = next(
-        item for item in output["artifacts"] if item.get("artifact_type") == "prompt_request"
-    )
+    prompt_artifact = next(item for item in output["artifacts"] if item.get("artifact_type") == "prompt_request")
 
     assert rc == 1
     assert output["blocked"] is True

--- a/tests/test_guard_launch_env.py
+++ b/tests/test_guard_launch_env.py
@@ -285,6 +285,60 @@ def test_guard_run_launches_opencode_with_runtime_overlay(monkeypatch, tmp_path,
     assert overlay_payload["permission"]["skill"]["*"] == "ask"
 
 
+def test_guard_run_merges_existing_opencode_config_content(monkeypatch, tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_opencode_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\ndefault_action = "allow"\n')
+    captured_env: dict[str, str] = {}
+
+    def _fake_run(command, cwd=None, check=False, env=None):
+        del command, cwd, check
+        captured_env.update(env or {})
+        return _CompletedProcess(0)
+
+    main(
+        [
+            "guard",
+            "install",
+            "opencode",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+    monkeypatch.setattr(guard_runner_module.subprocess, "run", _fake_run)
+    monkeypatch.setenv(
+        "OPENCODE_CONFIG_CONTENT",
+        json.dumps({"model": "gpt-4.1", "permission": {"network": {"*": "allow"}}}),
+    )
+
+    rc = main(
+        [
+            "guard",
+            "run",
+            "opencode",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--arg=--help",
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+    overlay_payload = json.loads(captured_env["OPENCODE_CONFIG_CONTENT"])
+
+    assert rc == 0
+    assert output["launched"] is True
+    assert overlay_payload["model"] == "gpt-4.1"
+    assert overlay_payload["permission"]["network"]["*"] == "allow"
+    assert overlay_payload["permission"]["skill"]["*"] == "ask"
+
+
 def test_guard_run_opencode_prompt_request_uses_opencode_policy_path(monkeypatch, tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_launch_env.py
+++ b/tests/test_guard_launch_env.py
@@ -449,6 +449,97 @@ def test_guard_run_opencode_reapproves_changed_plugin_and_skill_content(monkeypa
     assert "metadata" in skill_artifact["changed_fields"]
 
 
+def test_guard_run_opencode_reapproves_changed_secret_plugin_option(monkeypatch, tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _write_json(
+        home_dir / ".config" / "opencode" / "opencode.json",
+        {"plugins": [["opencode-global-plugin", {"token": "alpha"}]]},
+    )
+    _write_json(workspace_dir / "opencode.json", {})
+    _write_text(home_dir / "config.toml", 'changed_hash_action = "require-reapproval"\nmode = "prompt"\n')
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(guard_commands_module.webbrowser, "open", lambda _url: True)
+
+    first_rc = main(
+        [
+            "guard",
+            "run",
+            "opencode",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--dry-run",
+            "--default-action",
+            "allow",
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+    _write_json(
+        home_dir / ".config" / "opencode" / "opencode.json",
+        {"plugins": [["opencode-global-plugin", {"token": "beta"}]]},
+    )
+
+    second_rc = main(
+        [
+            "guard",
+            "run",
+            "opencode",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--default-action",
+            "require-reapproval",
+            "--json",
+        ]
+    )
+    second_output = json.loads(capsys.readouterr().out)
+    plugin_artifact = next(
+        item
+        for item in second_output["artifacts"]
+        if item["artifact_id"] == "opencode:global:plugin:opencode-global-plugin"
+    )
+
+    assert first_rc == 0
+    assert second_rc == 1
+    assert second_output["blocked"] is True
+    assert plugin_artifact["policy_action"] == "require-reapproval"
+    assert "metadata" in plugin_artifact["changed_fields"]
+
+
+def test_guard_run_opencode_prompt_request_prefers_real_config_file(monkeypatch, tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _write_json(home_dir / ".config" / "opencode" / "opencode.json", {"name": "guard-opencode"})
+    _write_text(workspace_dir / ".opencode" / "plugins" / "workspace-plugin.mjs", "export default {};\n")
+    _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\nmode = "prompt"\n')
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(guard_commands_module.webbrowser, "open", lambda _url: True)
+
+    rc = main(
+        [
+            "guard",
+            "run",
+            "opencode",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--arg=Please read the .env.guard-test file directly and summarize it",
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+    prompt_artifact = next(item for item in output["artifacts"] if item.get("artifact_type") == "prompt_request")
+
+    assert rc == 1
+    assert output["blocked"] is True
+    assert prompt_artifact["config_path"] == str(home_dir / ".config" / "opencode" / "opencode.json")
+
+
 def test_guard_run_still_blocks_when_prompt_contains_negation_elsewhere(monkeypatch, tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_launch_env.py
+++ b/tests/test_guard_launch_env.py
@@ -280,7 +280,7 @@ def test_guard_run_launches_opencode_with_runtime_overlay(monkeypatch, tmp_path,
     assert install_rc == 0
     assert rc == 0
     assert output["launched"] is True
-    assert captured_command == ["opencode", "run", "--dir", str(workspace_dir), "--help"]
+    assert captured_command == ["opencode", "run", "--help"]
     assert captured_env["HOME"] == str(home_dir)
     assert overlay_payload["permission"]["skill"]["*"] == "ask"
 
@@ -363,7 +363,7 @@ def test_guard_run_opencode_blocks_new_plugin_when_unknown_artifacts_require_app
     plugin_artifact = next(
         item
         for item in second_output["artifacts"]
-        if item["artifact_id"] == "opencode:project:plugin-file:env-read-plugin.mjs"
+        if item["artifact_id"] == "opencode:project:plugin-file:plugins/env-read-plugin.mjs"
     )
 
     assert first_rc == 0

--- a/tests/test_guard_launch_env.py
+++ b/tests/test_guard_launch_env.py
@@ -16,6 +16,10 @@ def _write_text(path: Path, text: str) -> None:
     path.write_text(text, encoding="utf-8")
 
 
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    _write_text(path, json.dumps(payload, indent=2) + "\n")
+
+
 def _build_guard_fixture(home_dir: Path, workspace_dir: Path) -> None:
     _write_text(
         home_dir / ".codex" / "config.toml",
@@ -58,6 +62,22 @@ def _make_fake_codex(fake_bin: Path, marker_path: Path) -> Path:
     )
     fake_codex.chmod(fake_codex.stat().st_mode | 0o755)
     return fake_codex
+
+
+def _build_opencode_fixture(home_dir: Path, workspace_dir: Path) -> None:
+    _write_json(
+        home_dir / ".config" / "opencode" / "opencode.json",
+        {
+            "mcp": {
+                "safe-mcp": {
+                    "type": "local",
+                    "command": ["/usr/bin/true"],
+                }
+            }
+        },
+    )
+    _write_json(workspace_dir / "opencode.json", {"name": "guard-opencode"})
+    _write_text(workspace_dir / ".opencode" / "commands" / "hello.md", "# hello\n")
 
 
 def test_guard_run_launches_with_configured_home(monkeypatch, tmp_path, capsys):
@@ -210,6 +230,149 @@ def test_guard_run_blocks_direct_env_prompt_until_approved(monkeypatch, tmp_path
     assert second_output["blocked"] is False
     assert second_output["launched"] is True
     assert marker_path.read_text(encoding="utf-8").strip() == "Please read the .env file directly and summarize it"
+
+
+def test_guard_run_launches_opencode_with_runtime_overlay(monkeypatch, tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_opencode_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\ndefault_action = "allow"\n')
+    captured_env: dict[str, str] = {}
+    captured_command: list[str] = []
+
+    def _fake_run(command, cwd=None, check=False, env=None):
+        del cwd, check
+        captured_command.extend(command)
+        captured_env.update(env or {})
+        return _CompletedProcess(0)
+
+    install_rc = main(
+        [
+            "guard",
+            "install",
+            "opencode",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+    monkeypatch.setattr(guard_runner_module.subprocess, "run", _fake_run)
+
+    rc = main(
+        [
+            "guard",
+            "run",
+            "opencode",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--arg=--help",
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+    overlay_payload = json.loads(captured_env["OPENCODE_CONFIG_CONTENT"])
+
+    assert install_rc == 0
+    assert rc == 0
+    assert output["launched"] is True
+    assert captured_command == ["opencode", "run", "--dir", str(workspace_dir), "--help"]
+    assert captured_env["HOME"] == str(home_dir)
+    assert overlay_payload["permission"]["skill"]["*"] == "ask"
+
+
+def test_guard_run_opencode_prompt_request_uses_opencode_policy_path(monkeypatch, tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_opencode_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\nmode = "prompt"\n')
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(guard_commands_module.webbrowser, "open", lambda _url: True)
+
+    rc = main(
+        [
+            "guard",
+            "run",
+            "opencode",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--arg=Please read the .env.guard-test file directly and summarize it",
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+    prompt_artifact = next(item for item in output["artifacts"] if item.get("artifact_type") == "prompt_request")
+
+    assert rc == 1
+    assert output["blocked"] is True
+    assert prompt_artifact["artifact_id"].startswith("opencode:session:prompt-env-read:")
+    assert prompt_artifact["config_path"] == str(workspace_dir / "opencode.json")
+
+
+def test_guard_run_opencode_blocks_new_plugin_when_unknown_artifacts_require_approval(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_opencode_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\nmode = "prompt"\n')
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(guard_commands_module.webbrowser, "open", lambda _url: True)
+
+    first_rc = main(
+        [
+            "guard",
+            "run",
+            "opencode",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--dry-run",
+            "--default-action",
+            "allow",
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+    _write_text(workspace_dir / ".opencode" / "plugins" / "env-read-plugin.mjs", "export default {};\n")
+
+    second_rc = main(
+        [
+            "guard",
+            "run",
+            "opencode",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--default-action",
+            "require-reapproval",
+            "--json",
+        ]
+    )
+    second_output = json.loads(capsys.readouterr().out)
+    plugin_artifact = next(
+        item
+        for item in second_output["artifacts"]
+        if item["artifact_id"] == "opencode:project:plugin-file:env-read-plugin"
+    )
+
+    assert first_rc == 0
+    assert second_rc == 1
+    assert second_output["blocked"] is True
+    assert plugin_artifact["policy_action"] == "require-reapproval"
+    assert plugin_artifact["artifact_type"] == "plugin"
+
+
 def test_guard_run_still_blocks_when_prompt_contains_negation_elsewhere(monkeypatch, tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_launch_env.py
+++ b/tests/test_guard_launch_env.py
@@ -289,7 +289,7 @@ def test_guard_run_opencode_prompt_request_uses_opencode_policy_path(monkeypatch
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_opencode_fixture(home_dir, workspace_dir)
-    _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\nmode = "prompt"\n')
+    _write_text(home_dir / "config.toml", 'changed_hash_action = "require-reapproval"\nmode = "prompt"\n')
     monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
     monkeypatch.setattr(guard_commands_module.webbrowser, "open", lambda _url: True)
 
@@ -371,6 +371,82 @@ def test_guard_run_opencode_blocks_new_plugin_when_unknown_artifacts_require_app
     assert second_output["blocked"] is True
     assert plugin_artifact["policy_action"] == "require-reapproval"
     assert plugin_artifact["artifact_type"] == "plugin"
+
+
+def test_guard_run_opencode_reapproves_changed_plugin_and_skill_content(monkeypatch, tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_opencode_fixture(home_dir, workspace_dir)
+    _write_text(
+        workspace_dir / ".opencode" / "plugins" / "env-read-plugin.mjs",
+        "export default { name: 'baseline' };\n",
+    )
+    _write_text(
+        workspace_dir / ".opencode" / "skills" / "review-skill" / "SKILL.md",
+        "---\nname: review-skill\ndescription: baseline\n---\n",
+    )
+    _write_text(home_dir / "config.toml", 'changed_hash_action = "require-reapproval"\nmode = "prompt"\n')
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(guard_commands_module.webbrowser, "open", lambda _url: True)
+
+    first_rc = main(
+        [
+            "guard",
+            "run",
+            "opencode",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--dry-run",
+            "--default-action",
+            "allow",
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+    _write_text(
+        workspace_dir / ".opencode" / "plugins" / "env-read-plugin.mjs",
+        "export default { name: 'updated' };\n",
+    )
+    _write_text(
+        workspace_dir / ".opencode" / "skills" / "review-skill" / "SKILL.md",
+        "---\nname: review-skill\ndescription: updated\n---\n",
+    )
+
+    second_rc = main(
+        [
+            "guard",
+            "run",
+            "opencode",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--default-action",
+            "require-reapproval",
+            "--json",
+        ]
+    )
+    second_output = json.loads(capsys.readouterr().out)
+    plugin_artifact = next(
+        item
+        for item in second_output["artifacts"]
+        if item["artifact_id"] == "opencode:project:plugin-file:plugins/env-read-plugin.mjs"
+    )
+    skill_artifact = next(
+        item
+        for item in second_output["artifacts"]
+        if item["artifact_id"] == "opencode:project:skill:opencode:skills/review-skill"
+    )
+
+    assert first_rc == 0
+    assert second_rc == 1
+    assert second_output["blocked"] is True
+    assert plugin_artifact["policy_action"] == "require-reapproval"
+    assert skill_artifact["policy_action"] == "require-reapproval"
+    assert "metadata" in plugin_artifact["changed_fields"]
+    assert "metadata" in skill_artifact["changed_fields"]
 
 
 def test_guard_run_still_blocks_when_prompt_contains_negation_elsewhere(monkeypatch, tmp_path, capsys):

--- a/tests/test_guard_protect.py
+++ b/tests/test_guard_protect.py
@@ -173,6 +173,58 @@ class TestGuardProtect:
         assert output["targets"][0]["artifact_type"] == "mcp_server"
         assert "remote server" in output["verdict"]["reason"].lower()
 
+    def test_guard_protect_intercepts_opencode_plugin_and_skill_installs(self, tmp_path, capsys) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir(parents=True)
+
+        plugin_rc = main(
+            [
+                "guard",
+                "protect",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+                "opencode",
+                "plugin",
+                "install",
+                "fixture-plugin",
+                "--url",
+                "https://example.invalid/opencode-plugin.tgz",
+            ]
+        )
+        plugin_output = json.loads(capsys.readouterr().out)
+
+        skill_rc = main(
+            [
+                "guard",
+                "protect",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+                "opencode",
+                "skill",
+                "install",
+                "fixture-skill",
+                "--url",
+                "https://example.invalid/opencode-skill.tgz",
+            ]
+        )
+        skill_output = json.loads(capsys.readouterr().out)
+
+        assert plugin_rc == 2
+        assert plugin_output["executed"] is False
+        assert plugin_output["targets"][0]["artifact_type"] == "plugin"
+        assert plugin_output["targets"][0]["artifact_id"] == "install:opencode:fixture-plugin"
+        assert skill_rc == 2
+        assert skill_output["executed"] is False
+        assert skill_output["targets"][0]["artifact_type"] == "skill"
+        assert skill_output["targets"][0]["artifact_id"] == "install:opencode:fixture-skill"
+
     def test_guard_protect_uses_configurable_execution_timeout(
         self,
         tmp_path,


### PR DESCRIPTION
## Summary
- expand the OpenCode adapter to detect config-defined commands, markdown commands, npm plugins, local plugin files, and OpenCode-compatible skill directories
- add Guard-managed OpenCode install and launch behavior with a runtime overlay injected through OPENCODE_CONFIG_CONTENT
- fix OpenCode prompt handoff and policy-path selection so blocked prompt requests and approvals point at the real harness config surface

## Live harness proof
- blocked a new OpenCode MCP artifact before launch in an isolated local workspace
- blocked a new OpenCode skill before launch in an isolated local workspace
- blocked a new OpenCode plugin before launch in an isolated local workspace
- blocked a prompt asking OpenCode to read a protected env-style file, queued a Guard approval request, then handed off to the real `opencode run` flow after approval
- re-verified the final launch path after removing `--dir`: Guard blocked a fresh OpenCode MCP artifact, accepted the exact approval, and then launched the real local OpenCode harness with `opencode run ...` from the workspace cwd

## Verification
- uv sync --extra dev
- uv run --extra dev ruff check src tests
- uv run --extra dev pytest tests/test_guard_cli.py tests/test_guard_launch_env.py tests/test_guard_protect.py
- uv run --extra dev pytest
- uv build