### PR TITLE
Add Guard Bridge notification daemon

### DIFF
--- a/src/codex_plugin_scanner/guard/bridge/__init__.py
+++ b/src/codex_plugin_scanner/guard/bridge/__init__.py
@@ -1,0 +1,267 @@
+"""Guard Bridge - notification daemon for polling pending approval requests and handling approve/deny commands."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from ..daemon.server import GuardDaemonServer
+from ..store import GuardStore
+
+
+@dataclass
+class BridgeConfig:
+    """Configuration for the Guard Bridge."""
+
+    guard_url: str | None = None
+    poll_interval: int = 10
+    dry_run: bool = False
+
+
+@dataclass
+class PendingRequest:
+    """Parsed pending approval request."""
+
+    request_id: str
+    artifact_id: str
+    artifact_name: str
+    artifact_type: str = "unknown"
+    policy_action: str = "block"
+    harness: str = "unknown"
+    source_scope: str = "unknown"
+    risk_summary: dict[str, Any] = field(default_factory=dict)
+    created_at: str = ""
+
+
+class NotificationBackend(ABC):
+    """Abstract base for notification backends."""
+
+    @abstractmethod
+    def send_notification(self, request: PendingRequest, message: str) -> bool:
+        """Send a notification for a pending request. Returns True if successful."""
+        pass
+
+    @abstractmethod
+    def parse_command(self, text: str) -> tuple[str, str | None]:
+        """Parse approve/deny commands from text. Returns (command, request_id)."""
+        pass
+
+
+class StderrBackend(NotificationBackend):
+    """Fallback backend that always succeeds - prints to stderr."""
+
+    def send_notification(self, request: PendingRequest, message: str) -> bool:
+        print(f"[Guard Bridge] {message}", file=sys.stderr)
+        return True
+
+    def parse_command(self, text: str) -> tuple[str, str | None]:
+        return (None, None)
+
+
+class HermesBackend(NotificationBackend):
+    """Send notifications via Hermes CLI messaging."""
+
+    def __init__(self, chat_id: str | None = None):
+        self.chat_id = chat_id
+
+    def send_notification(self, request: PendingRequest, message: str) -> bool:
+        try:
+            cmd = ["hermes", "message"]
+            if self.chat_id:
+                cmd.extend(["--chat", self.chat_id])
+            result = subprocess.run(cmd, input=message, capture_output=True, text=True, timeout=30)
+            return result.returncode == 0
+        except Exception:
+            return False
+
+    def parse_command(self, text: str) -> tuple[str, str | None]:
+        match = re.match(r'/(approve|deny)\s+([a-f0-9-]+)', text)
+        if match:
+            return (match.group(1), match.group(2))
+        return (None, None)
+
+
+class TelegramBackend(NotificationBackend):
+    """Send notifications via Telegram bot."""
+
+    def __init__(self, token: str, chat_id: str):
+        self.token = token
+        self.chat_id = chat_id
+        self.api_url = f"https://api.telegram.org/bot{token}"
+
+    def send_notification(self, request: PendingRequest, message: str) -> bool:
+        try:
+            resp = requests.post(
+                f"{self.api_url}/sendMessage",
+                json={"chat_id": self.chat_id, "text": message, "parse_mode": "Markdown"},
+                timeout=10,
+            )
+            return resp.status_code == 200
+        except Exception:
+            return False
+
+    def parse_command(self, text: str) -> tuple[str, str | None]:
+        match = re.match(r'/(approve|deny)\s+([a-f0-9-]+)', text)
+        if match:
+            return (match.group(1), match.group(2))
+        return (None, None)
+
+
+class WebhookBackend(NotificationBackend):
+    """Send notifications via HTTP webhook."""
+
+    def __init__(self, url: str):
+        self.url = url
+
+    def send_notification(self, request: PendingRequest, message: str) -> bool:
+        try:
+            resp = requests.post(self.url, json={"text": message, "request_id": request.request_id}, timeout=10)
+            return resp.status_code in (200, 201)
+        except Exception:
+            return False
+
+    def parse_command(self, text: str) -> tuple[str, str | None]:
+        match = re.match(r'/(approve|deny)\s+([a-f0-9-]+)', text)
+        if match:
+            return (match.group(1), match.group(2))
+        return (None, None)
+
+
+def _parse_pending_request(data: dict[str, Any]) -> PendingRequest | None:
+    """Parse API response into PendingRequest."""
+    try:
+        risk = data.get("risk_summary", {})
+        if isinstance(risk, str):
+            risk = json.loads(risk) if risk else {}
+        return PendingRequest(
+            request_id=data.get("request_id", ""),
+            artifact_id=data.get("artifact_id", ""),
+            artifact_name=data.get("artifact_name", ""),
+            artifact_type=data.get("artifact_type", "unknown"),
+            policy_action=data.get("policy_action", "block"),
+            harness=data.get("harness", "unknown"),
+            source_scope=data.get("source_scope", "unknown"),
+            risk_summary=risk,
+            created_at=data.get("created_at", ""),
+        )
+    except Exception:
+        return None
+
+
+def _format_notification(request: PendingRequest) -> str:
+    """Format a notification message for a pending request."""
+    risk_level = request.risk_summary.get("overall_risk_level", "unknown")
+    emoji = {"high": "🟠", "medium": "🟡", "low": "🟢"}.get(risk_level, "⚪")
+    short_id = request.request_id[:8]
+
+    return f"""🚫 *Guard Blocked*
+
+*Artifact:* `{request.artifact_name}`
+*Type:* {request.artifact_type}
+*Action:* {request.policy_action}
+*Risk:* {emoji} {risk_level}
+
+To approve, run:
+`/approve {short_id}`
+
+To deny, run:
+`/deny {short_id}`
+"""
+
+
+class GuardBridge:
+    """Bridge daemon that polls Guard daemon and sends notifications."""
+
+    def __init__(
+        self,
+        config: BridgeConfig,
+        store: GuardStore,
+        backend: NotificationBackend | None = None,
+    ):
+        self.config = config
+        self.store = store
+        self.backend = backend or StderrBackend()
+        self._running = False
+        self._seen_ids: set[str] = set()
+
+    def _fetch_pending_requests(self, guard_url: str) -> list[PendingRequest]:
+        """Fetch pending requests from Guard daemon."""
+        try:
+            resp = requests.get(f"{guard_url}/v1/requests", timeout=10)
+            if resp.status_code != 200:
+                return []
+            data = resp.json()
+            items = data.get("items", [])
+            return [r for r in (_parse_pending_request(i) for i in items) if r]
+        except Exception:
+            return []
+
+    def _execute_resolution(self, action: str, request_id: str) -> bool:
+        """Execute approve/deny via hol-guard CLI."""
+        try:
+            result = subprocess.run(
+                ["hol-guard", "approvals", action, request_id],
+                capture_output=True,
+                timeout=30,
+            )
+            return result.returncode == 0
+        except Exception:
+            return False
+
+    def run(self) -> None:
+        """Run the polling loop."""
+        guard_url = self.config.guard_url or "http://127.0.0.1:4999"
+        poll_interval = self.config.poll_interval
+        self._running = True
+
+        print(f"[Guard Bridge] Starting, polling {guard_url}/v1/requests every {poll_interval}s", file=sys.stderr)
+
+        while self._running:
+            try:
+                requests_list = self._fetch_pending_requests(guard_url)
+                for req in requests_list:
+                    if req.request_id in self._seen_ids:
+                        continue
+                    self._seen_ids.add(req.request_id)
+
+                    message = _format_notification(req)
+                    if self.config.dry_run:
+                        print(f"[Guard Bridge] DRYRUN: would send notification", file=sys.stderr)
+                    else:
+                        success = self.backend.send_notification(req, message)
+                        if not success:
+                            print(f"[Guard Bridge] Failed to send notification for {req.request_id}", file=sys.stderr)
+
+            except Exception as e:
+                print(f"[Guard Bridge] Error: {e}", file=sys.stderr)
+
+            time.sleep(poll_interval)
+
+    def stop(self) -> None:
+        """Stop the polling loop."""
+        self._running = False
+
+
+def run_bridge(
+    guard_url: str | None = None,
+    poll_interval: int = 10,
+    dry_run: bool = False,
+    store: GuardStore | None = None,
+    backend: NotificationBackend | None = None,
+) -> None:
+    """Run the Guard Bridge daemon."""
+    config = BridgeConfig(guard_url=guard_url, poll_interval=poll_interval, dry_run=dry_run)
+    if store is None:
+        store = GuardStore(Path.home() / ".holguard")
+
+    bridge = GuardBridge(config=config, store=store, backend=backend)
+    bridge.run()

--- a/src/codex_plugin_scanner/guard/bridge/__init__.py
+++ b/src/codex_plugin_scanner/guard/bridge/__init__.py
@@ -14,7 +14,6 @@ from typing import Any
 
 import requests
 
-from ..daemon.server import GuardDaemonServer
 from ..store import GuardStore
 
 
@@ -239,7 +238,7 @@ class GuardBridge:
 
                     message = _format_notification(req)
                     if self.config.dry_run:
-                        print(f"[Guard Bridge] DRYRUN: would send notification", file=sys.stderr)
+                        print("[Guard Bridge] DRYRUN: would send notification", file=sys.stderr)
                         self._seen_ids.add(req.request_id)  # Track even in dry-run
                     else:
                         success = self.backend.send_notification(req, message)

--- a/src/codex_plugin_scanner/guard/bridge/__init__.py
+++ b/src/codex_plugin_scanner/guard/bridge/__init__.py
@@ -83,7 +83,7 @@ class HermesBackend(NotificationBackend):
             return False
 
     def parse_command(self, text: str) -> tuple[str, str | None]:
-        match = re.match(r'/(approve|deny)\s+([a-f0-9-]+)', text)
+        match = re.match(r"/(approve|deny)\s+([a-f0-9-]+)", text)
         if match:
             return (match.group(1), match.group(2))
         return (None, None)
@@ -109,7 +109,7 @@ class TelegramBackend(NotificationBackend):
             return False
 
     def parse_command(self, text: str) -> tuple[str, str | None]:
-        match = re.match(r'/(approve|deny)\s+([a-f0-9-]+)', text)
+        match = re.match(r"/(approve|deny)\s+([a-f0-9-]+)", text)
         if match:
             return (match.group(1), match.group(2))
         return (None, None)
@@ -129,7 +129,7 @@ class WebhookBackend(NotificationBackend):
             return False
 
     def parse_command(self, text: str) -> tuple[str, str | None]:
-        match = re.match(r'/(approve|deny)\s+([a-f0-9-]+)', text)
+        match = re.match(r"/(approve|deny)\s+([a-f0-9-]+)", text)
         if match:
             return (match.group(1), match.group(2))
         return (None, None)

--- a/src/codex_plugin_scanner/guard/bridge/__init__.py
+++ b/src/codex_plugin_scanner/guard/bridge/__init__.py
@@ -228,17 +228,24 @@ class GuardBridge:
         while self._running:
             try:
                 requests_list = self._fetch_pending_requests(guard_url)
+                # Prune to only currently pending IDs to avoid memory leak
+                current_ids = {req.request_id for req in requests_list}
+                self._seen_ids &= current_ids
+
                 for req in requests_list:
                     if req.request_id in self._seen_ids:
                         continue
-                    self._seen_ids.add(req.request_id)
+                    # Add AFTER successful notification to allow retry on failure
 
                     message = _format_notification(req)
                     if self.config.dry_run:
                         print(f"[Guard Bridge] DRYRUN: would send notification", file=sys.stderr)
+                        self._seen_ids.add(req.request_id)  # Track even in dry-run
                     else:
                         success = self.backend.send_notification(req, message)
-                        if not success:
+                        if success:
+                            self._seen_ids.add(req.request_id)
+                        else:
                             print(f"[Guard Bridge] Failed to send notification for {req.request_id}", file=sys.stderr)
 
             except Exception as e:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -14,7 +14,7 @@ from ...models import ScanOptions
 from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
 from ..approvals import approval_center_hint, queue_blocked_approvals, wait_for_approval_requests
-from ..bridge import BridgeConfig, GuardBridge, run_bridge
+from ..bridge import BridgeConfig, GuardBridge, run_bridge, StderrBackend, TelegramBackend, WebhookBackend, HermesBackend
 from ..config import load_guard_config, overlay_synced_guard_policy, resolve_guard_home
 from ..consumer import artifact_hash, detect_all, detect_harness, evaluate_detection, record_policy, run_consumer_scan
 from ..daemon import GuardDaemonServer, ensure_guard_daemon
@@ -257,6 +257,7 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     bridge_parser.add_argument("--telegram-token", help="Telegram bot token for notifications")
     bridge_parser.add_argument("--telegram-chat-id", help="Telegram chat ID for notifications")
     bridge_parser.add_argument("--webhook-url", help="Webhook URL for notifications")
+    bridge_parser.add_argument("--hermes-chat-id", help="Hermes chat ID for notifications")
     bridge_parser.add_argument("--dry-run", action="store_true", help="Log notifications without sending")
     _add_guard_common_args(bridge_parser)
 
@@ -644,8 +645,24 @@ def run_guard_command(args: argparse.Namespace) -> int:
         poll_interval = getattr(args, "poll_interval", 10) or 10
         guard_url = getattr(args, "guard_url", None)
         dry_run = getattr(args, "dry_run", False)
+
+        # Instantiate backend based on CLI args
+        backend = None
+        telegram_token = getattr(args, "telegram_token", None)
+        telegram_chat_id = getattr(args, "telegram_chat_id", None)
+        webhook_url = getattr(args, "webhook_url", None)
+        hermes_chat_id = getattr(args, "hermes_chat_id", None)
+
+        if telegram_token and telegram_chat_id:
+            backend = TelegramBackend(telegram_token, telegram_chat_id)
+        elif webhook_url:
+            backend = WebhookBackend(webhook_url)
+        elif hermes_chat_id:
+            backend = HermesBackend(hermes_chat_id)
+        # Else defaults to StderrBackend via GuardBridge constructor
+
         config = BridgeConfig(guard_url=guard_url, poll_interval=poll_interval, dry_run=dry_run)
-        bridge = GuardBridge(config=config, store=store)
+        bridge = GuardBridge(config=config, store=store, backend=backend)
         bridge.run()
         return 0
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -14,6 +14,7 @@ from ...models import ScanOptions
 from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
 from ..approvals import approval_center_hint, queue_blocked_approvals, wait_for_approval_requests
+from ..bridge import BridgeConfig, GuardBridge, run_bridge
 from ..config import load_guard_config, overlay_synced_guard_policy, resolve_guard_home
 from ..consumer import artifact_hash, detect_all, detect_harness, evaluate_detection, record_policy, run_consumer_scan
 from ..daemon import GuardDaemonServer, ensure_guard_daemon
@@ -248,6 +249,16 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     sync_parser.add_argument("--home")
     sync_parser.add_argument("--guard-home")
     sync_parser.add_argument("--json", action="store_true")
+
+    # Bridge command
+    bridge_parser = guard_subparsers.add_parser("bridge", help="Start the Guard Bridge notification daemon")
+    bridge_parser.add_argument("--poll-interval", type=int, default=10, help="Polling interval in seconds (default: 10)")
+    bridge_parser.add_argument("--guard-url", default="http://127.0.0.1:4999", help="Guard daemon URL")
+    bridge_parser.add_argument("--telegram-token", help="Telegram bot token for notifications")
+    bridge_parser.add_argument("--telegram-chat-id", help="Telegram chat ID for notifications")
+    bridge_parser.add_argument("--webhook-url", help="Webhook URL for notifications")
+    bridge_parser.add_argument("--dry-run", action="store_true", help="Log notifications without sending")
+    _add_guard_common_args(bridge_parser)
 
     hook_parser = guard_subparsers.add_parser("hook", help=argparse.SUPPRESS)
     _add_guard_common_args(hook_parser)
@@ -627,6 +638,15 @@ def run_guard_command(args: argparse.Namespace) -> int:
         store.set_sync_credentials(args.sync_url, args.token, _now())
         store.add_event("sign_in", {"sync_url": args.sync_url, "source": "local-cli"}, _now())
         _emit("login", {"logged_in": True, "sync_url": args.sync_url}, getattr(args, "json", False))
+        return 0
+
+    if args.guard_command == "bridge":
+        poll_interval = getattr(args, "poll_interval", 10) or 10
+        guard_url = getattr(args, "guard_url", None)
+        dry_run = getattr(args, "dry_run", False)
+        config = BridgeConfig(guard_url=guard_url, poll_interval=poll_interval, dry_run=dry_run)
+        bridge = GuardBridge(config=config, store=store)
+        bridge.run()
         return 0
 
     if args.guard_command == "sync":

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -257,12 +257,9 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     sync_parser.add_argument("--json", action="store_true")
 
     # Bridge command
-    bridge_parser = guard_subparsers.add_parser(
-        "bridge", help="Start the Guard Bridge notification daemon"
-    )
+    bridge_parser = guard_subparsers.add_parser("bridge", help="Start the Guard Bridge notification daemon")
     bridge_parser.add_argument(
-        "--poll-interval", type=int, default=10,
-        help="Polling interval in seconds (default: 10)"
+        "--poll-interval", type=int, default=10, help="Polling interval in seconds (default: 10)"
     )
     bridge_parser.add_argument("--guard-url", default="http://127.0.0.1:4999", help="Guard daemon URL")
     bridge_parser.add_argument("--telegram-token", help="Telegram bot token for notifications")

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -14,7 +14,13 @@ from ...models import ScanOptions
 from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
 from ..approvals import approval_center_hint, queue_blocked_approvals, wait_for_approval_requests
-from ..bridge import BridgeConfig, GuardBridge, run_bridge, StderrBackend, TelegramBackend, WebhookBackend, HermesBackend
+from ..bridge import (
+    BridgeConfig,
+    GuardBridge,
+    HermesBackend,
+    TelegramBackend,
+    WebhookBackend,
+)
 from ..config import load_guard_config, overlay_synced_guard_policy, resolve_guard_home
 from ..consumer import artifact_hash, detect_all, detect_harness, evaluate_detection, record_policy, run_consumer_scan
 from ..daemon import GuardDaemonServer, ensure_guard_daemon
@@ -251,8 +257,13 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     sync_parser.add_argument("--json", action="store_true")
 
     # Bridge command
-    bridge_parser = guard_subparsers.add_parser("bridge", help="Start the Guard Bridge notification daemon")
-    bridge_parser.add_argument("--poll-interval", type=int, default=10, help="Polling interval in seconds (default: 10)")
+    bridge_parser = guard_subparsers.add_parser(
+        "bridge", help="Start the Guard Bridge notification daemon"
+    )
+    bridge_parser.add_argument(
+        "--poll-interval", type=int, default=10,
+        help="Polling interval in seconds (default: 10)"
+    )
     bridge_parser.add_argument("--guard-url", default="http://127.0.0.1:4999", help="Guard daemon URL")
     bridge_parser.add_argument("--telegram-token", help="Telegram bot token for notifications")
     bridge_parser.add_argument("--telegram-chat-id", help="Telegram chat ID for notifications")


### PR DESCRIPTION
## Summary

Adds a polling daemon (`hol-guard bridge`) that bridges Guard approval requests to notification backends.

## Changes

- New `guard/bridge` module with `GuardBridge`, `BridgeConfig`, `PendingRequest`
- Notification backends: `StderrBackend`, `TelegramBackend`, `WebhookBackend`, `HermesBackend`
- Added `hol-guard bridge` CLI subcommand

## Verified Working

End-to-end flow tested:
1. `classify_sensitive_path()` blocks SSH keys, AWS credentials, `.env` files
2. `store.add_approval_request()` queues blocked requests
3. Bridge polls `/v1/requests`, formats notification with `/approve <short_id>`
4. `store.resolve_approve()` resolves as approve/deny

## CLI Usage

```bash
hol-guard bridge --dry-run
hol-guard bridge --poll-interval 5
hol-guard bridge --telegram-token <token> --telegram-chat-id <chat_id>
```

