### PR TITLE
feat: add Guard runtime connect flow

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -394,7 +394,7 @@ def run_guard_command(args: argparse.Namespace) -> int:
             return 0
         try:
             sync_payload = sync_receipts(store)
-        except (RuntimeError, urllib.error.URLError) as exc:
+        except (RuntimeError, urllib.error.URLError, json.JSONDecodeError) as exc:
             payload = build_guard_connect_payload(
                 context,
                 store,

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -369,10 +369,15 @@ def run_guard_command(args: argparse.Namespace) -> int:
 
     if args.guard_command == "connect":
         try:
-            sync_url = getattr(args, "sync_url", None)
-            token = getattr(args, "token", None)
+            raw_sync_url = getattr(args, "sync_url", None)
+            raw_token = getattr(args, "token", None)
+            sync_url = raw_sync_url.strip() if isinstance(raw_sync_url, str) else None
+            token = raw_token.strip() if isinstance(raw_token, str) else None
+            credentials_requested = raw_sync_url is not None or raw_token is not None
+            if credentials_requested and (not sync_url or not token):
+                raise ValueError("connect requires non-empty --sync-url and --token when saving credentials")
             if bool(sync_url) != bool(token):
-                raise ValueError("connect requires both --sync-url and --token when saving credentials")
+                raise ValueError("connect requires non-empty --sync-url and --token when saving credentials")
         except ValueError as error:
             print(str(error), file=sys.stderr)
             return 2

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -368,10 +368,14 @@ def run_guard_command(args: argparse.Namespace) -> int:
         return 0
 
     if args.guard_command == "connect":
-        sync_url = getattr(args, "sync_url", None)
-        token = getattr(args, "token", None)
-        if bool(sync_url) != bool(token):
-            raise ValueError("connect requires both --sync-url and --token when saving credentials")
+        try:
+            sync_url = getattr(args, "sync_url", None)
+            token = getattr(args, "token", None)
+            if bool(sync_url) != bool(token):
+                raise ValueError("connect requires both --sync-url and --token when saving credentials")
+        except ValueError as error:
+            print(str(error), file=sys.stderr)
+            return 2
         credentials_saved = False
         if isinstance(sync_url, str) and isinstance(token, str):
             store.set_sync_credentials(sync_url, token, _now())
@@ -390,7 +394,7 @@ def run_guard_command(args: argparse.Namespace) -> int:
             return 0
         try:
             sync_payload = sync_receipts(store)
-        except (RuntimeError, urllib.error.URLError, urllib.error.HTTPError) as exc:
+        except (RuntimeError, urllib.error.URLError) as exc:
             payload = build_guard_connect_payload(
                 context,
                 store,
@@ -963,6 +967,7 @@ def _normalize_hook_argument_value(value: object | None) -> object | None:
             return parsed
         return stripped
     return value
+
 
 def _record_sync_event(store: GuardStore, payload: dict[str, object]) -> None:
     store.add_event(

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -406,7 +406,6 @@ def run_guard_command(args: argparse.Namespace) -> int:
             )
             _emit("connect", payload, getattr(args, "json", False))
             return 1
-        _record_sync_event(store, sync_payload)
         payload = build_guard_connect_payload(
             context,
             store,
@@ -627,7 +626,6 @@ def run_guard_command(args: argparse.Namespace) -> int:
 
     if args.guard_command == "sync":
         payload = sync_receipts(store)
-        _record_sync_event(store, payload)
         _emit("sync", payload, getattr(args, "json", False))
         return 0
 
@@ -967,21 +965,6 @@ def _normalize_hook_argument_value(value: object | None) -> object | None:
             return parsed
         return stripped
     return value
-
-
-def _record_sync_event(store: GuardStore, payload: dict[str, object]) -> None:
-    store.add_event(
-        "sync_complete",
-        {
-            "synced_at": payload.get("synced_at"),
-            "receipts_stored": payload.get("receipts_stored"),
-            "advisories_stored": payload.get("advisories_stored"),
-            "exceptions_stored": payload.get("exceptions_stored"),
-            "remote_policies_stored": payload.get("remote_policies_stored"),
-            "pain_signals_uploaded": payload.get("pain_signals_uploaded"),
-        },
-        _now(),
-    )
 
 
 def _coalesce_string(*values: object | None) -> str:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import urllib.error
 import webbrowser
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -28,7 +29,7 @@ from ..store import GuardStore
 from .approval_commands import add_approval_parser, run_approval_command
 from .bootstrap import DEFAULT_ALIAS_NAME, build_guard_bootstrap_payload
 from .install_commands import apply_managed_install
-from .product import build_guard_start_payload, build_guard_status_payload
+from .product import build_guard_connect_payload, build_guard_start_payload, build_guard_status_payload
 from .prompt import build_prompt_artifacts, resolve_interactive_decisions
 from .render import emit_guard_payload
 
@@ -75,7 +76,7 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
         required=True,
         metavar=(
             "{start,status,bootstrap,detect,install,uninstall,run,protect,preflight,scan,diff,receipts,inventory,abom,"
-            "approvals,explain,allow,deny,policies,exceptions,advisories,events,doctor,login,sync}"
+            "approvals,explain,allow,deny,policies,exceptions,advisories,events,doctor,connect,login,sync}"
         ),
     )
 
@@ -86,6 +87,16 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     status_parser = guard_subparsers.add_parser("status", help="Show current Guard protection status")
     _add_guard_common_args(status_parser)
     status_parser.add_argument("--json", action="store_true")
+
+    connect_parser = guard_subparsers.add_parser(
+        "connect",
+        help="Pair local Guard with Guard Cloud and show the next local-to-cloud actions",
+    )
+    _add_guard_common_args(connect_parser)
+    connect_parser.add_argument("--sync-url")
+    connect_parser.add_argument("--token")
+    connect_parser.add_argument("--save-only", action="store_true")
+    connect_parser.add_argument("--json", action="store_true")
 
     bootstrap_parser = guard_subparsers.add_parser(
         "bootstrap",
@@ -356,6 +367,54 @@ def run_guard_command(args: argparse.Namespace) -> int:
         _emit("status", payload, getattr(args, "json", False))
         return 0
 
+    if args.guard_command == "connect":
+        sync_url = getattr(args, "sync_url", None)
+        token = getattr(args, "token", None)
+        if bool(sync_url) != bool(token):
+            raise ValueError("connect requires both --sync-url and --token when saving credentials")
+        credentials_saved = False
+        if isinstance(sync_url, str) and isinstance(token, str):
+            store.set_sync_credentials(sync_url, token, _now())
+            store.add_event("sign_in", {"sync_url": sync_url, "source": "local-cli-connect"}, _now())
+            credentials_saved = True
+        if not credentials_saved or bool(getattr(args, "save_only", False)):
+            payload = build_guard_connect_payload(
+                context,
+                store,
+                config,
+                credentials_saved=credentials_saved,
+                sync_attempted=False,
+                sync_succeeded=False,
+            )
+            _emit("connect", payload, getattr(args, "json", False))
+            return 0
+        try:
+            sync_payload = sync_receipts(store)
+        except (RuntimeError, urllib.error.URLError, urllib.error.HTTPError) as exc:
+            payload = build_guard_connect_payload(
+                context,
+                store,
+                config,
+                credentials_saved=credentials_saved,
+                sync_attempted=True,
+                sync_succeeded=False,
+                sync_error=str(exc),
+            )
+            _emit("connect", payload, getattr(args, "json", False))
+            return 1
+        _record_sync_event(store, sync_payload)
+        payload = build_guard_connect_payload(
+            context,
+            store,
+            config,
+            credentials_saved=credentials_saved,
+            sync_attempted=True,
+            sync_succeeded=True,
+        )
+        payload["sync_result"] = sync_payload
+        _emit("connect", payload, getattr(args, "json", False))
+        return 0
+
     if args.guard_command == "bootstrap":
         try:
             payload = build_guard_bootstrap_payload(
@@ -564,6 +623,7 @@ def run_guard_command(args: argparse.Namespace) -> int:
 
     if args.guard_command == "sync":
         payload = sync_receipts(store)
+        _record_sync_event(store, payload)
         _emit("sync", payload, getattr(args, "json", False))
         return 0
 
@@ -903,6 +963,20 @@ def _normalize_hook_argument_value(value: object | None) -> object | None:
             return parsed
         return stripped
     return value
+
+def _record_sync_event(store: GuardStore, payload: dict[str, object]) -> None:
+    store.add_event(
+        "sync_complete",
+        {
+            "synced_at": payload.get("synced_at"),
+            "receipts_stored": payload.get("receipts_stored"),
+            "advisories_stored": payload.get("advisories_stored"),
+            "exceptions_stored": payload.get("exceptions_stored"),
+            "remote_policies_stored": payload.get("remote_policies_stored"),
+            "pain_signals_uploaded": payload.get("pain_signals_uploaded"),
+        },
+        _now(),
+    )
 
 
 def _coalesce_string(*values: object | None) -> str:

--- a/src/codex_plugin_scanner/guard/cli/product.py
+++ b/src/codex_plugin_scanner/guard/cli/product.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from urllib.parse import urlparse
 
 from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
@@ -14,6 +15,8 @@ from ..store import GuardStore
 
 HARNESS_PRIORITY = ("codex", "claude-code", "copilot", "cursor", "gemini", "opencode")
 GUARD_COMMAND = "hol-guard"
+GUARD_DASHBOARD_URL = "https://hol.org/guard"
+GUARD_CONNECT_URL = f"{GUARD_DASHBOARD_URL}/connect"
 
 
 def build_guard_start_payload(
@@ -34,6 +37,31 @@ def build_guard_status_payload(
     """Build an ongoing Guard status payload."""
 
     return _build_guard_product_payload(context, store, config, include_steps=False)
+
+
+def build_guard_connect_payload(
+    context: HarnessContext,
+    store: GuardStore,
+    config: GuardConfig,
+    *,
+    credentials_saved: bool = False,
+    sync_attempted: bool = False,
+    sync_succeeded: bool = False,
+    sync_error: str | None = None,
+) -> dict[str, object]:
+    """Build a pairing-aware Guard connect payload."""
+
+    payload = _build_guard_product_payload(context, store, config, include_steps=False)
+    payload.update(
+        {
+            "credentials_saved": credentials_saved,
+            "sync_attempted": sync_attempted,
+            "sync_succeeded": sync_succeeded,
+            "sync_error": sync_error,
+        }
+    )
+    payload["next_steps"] = _build_connect_steps(payload)
+    return payload
 
 
 def _build_guard_product_payload(
@@ -60,8 +88,9 @@ def _build_guard_product_payload(
         "recommended_harness": recommended["harness"] if recommended is not None else None,
         "harnesses": harnesses,
     }
+    payload.update(_build_cloud_context(store))
     if include_steps:
-        payload["next_steps"] = _build_next_steps(recommended)
+        payload["next_steps"] = _build_next_steps(recommended, payload)
     return payload
 
 
@@ -124,7 +153,7 @@ def _resolve_next_action(detection: HarnessDetection, managed: bool, review_coun
     return "run"
 
 
-def _build_next_steps(recommended: dict[str, object] | None) -> list[dict[str, str]]:
+def _build_next_steps(recommended: dict[str, object] | None, payload: dict[str, object]) -> list[dict[str, str]]:
     if recommended is None:
         return [
             {
@@ -139,16 +168,243 @@ def _build_next_steps(recommended: dict[str, object] | None) -> list[dict[str, s
     steps = [_install_or_review_step(recommended), _run_step(recommended), _receipts_step()]
     steps.append(_approvals_step())
     steps.append(
-        {
-            "title": "Optional sync later",
-            "command": f"{GUARD_COMMAND} login --sync-url <url> --token <token>",
-            "detail": (
-                "Keep receipts local by default, then connect sync only when you want "
-                "shared history or premium trust checks."
-            ),
-        }
+        _connect_or_dashboard_step(
+            str(payload.get("cloud_state") or "local_only"),
+            str(payload.get("connect_url") or GUARD_CONNECT_URL),
+            str(payload.get("dashboard_url") or GUARD_DASHBOARD_URL),
+        )
     )
     return steps
+
+
+def _build_cloud_context(store: GuardStore) -> dict[str, object]:
+    credentials = store.get_sync_credentials()
+    sync_url = credentials["sync_url"] if credentials is not None else None
+    dashboard_url, connect_url = _resolve_guard_urls(sync_url)
+    advisories = store.list_cached_advisories(limit=3)
+    alert_preferences = _coerce_payload_dict(store.get_sync_payload("alert_preferences"))
+    remote_policy = _coerce_payload_dict(store.get_sync_payload("policy"))
+    team_policy_pack = _coerce_payload_dict(store.get_sync_payload("team_policy_pack"))
+    last_sync_event = _latest_event(store, "sync_complete")
+    last_sync_at = _last_sync_at(last_sync_event)
+    remote_payload_active = bool(advisories or alert_preferences or remote_policy or team_policy_pack)
+    cloud_state = _resolve_cloud_state(
+        sync_configured=credentials is not None,
+        last_sync_at=last_sync_at,
+        remote_payload_active=remote_payload_active,
+    )
+    return {
+        "cloud_state": cloud_state,
+        "cloud_state_label": _cloud_state_label(cloud_state),
+        "cloud_state_detail": _cloud_state_detail(cloud_state, connect_url, dashboard_url),
+        "sync_url": sync_url,
+        "dashboard_url": dashboard_url,
+        "connect_url": connect_url,
+        "connect_command": f"{GUARD_COMMAND} connect --sync-url <url> --token <token>",
+        "sync_command": f"{GUARD_COMMAND} sync",
+        "last_sync_at": last_sync_at,
+        "advisory_count": len(advisories),
+        "advisory_headline": _advisory_headline(advisories),
+        "remote_policy_active": bool(remote_policy),
+        "alert_preferences_active": bool(alert_preferences),
+        "watchlist_enabled": bool(alert_preferences.get("watchlistEnabled")),
+        "team_alerts_enabled": bool(alert_preferences.get("teamAlertsEnabled")),
+        "team_policy_active": bool(team_policy_pack),
+        "team_policy_name": _optional_string(team_policy_pack.get("name")),
+        "team_policy_updated_at": _optional_string(team_policy_pack.get("updatedAt")),
+    }
+
+
+def _build_connect_steps(payload: dict[str, object]) -> list[dict[str, str]]:
+    cloud_state = str(payload.get("cloud_state") or "local_only")
+    recommended = _recommended_summary(payload)
+    dashboard_url = str(payload.get("dashboard_url") or GUARD_DASHBOARD_URL)
+    connect_url = str(payload.get("connect_url") or GUARD_CONNECT_URL)
+    steps: list[dict[str, str]]
+    if cloud_state == "local_only":
+        steps = [
+            {
+                "title": "Generate a Guard Cloud token",
+                "command": connect_url,
+                "detail": (
+                    "Open the Guard connect page, copy the sync URL and short-lived token, "
+                    "then pair this runtime."
+                ),
+            },
+            {
+                "title": "Pair this runtime",
+                "command": str(
+                    payload.get("connect_command") or f"{GUARD_COMMAND} connect --sync-url <url> --token <token>"
+                ),
+                "detail": (
+                    "Save the credentials locally and pull down the first Guard Cloud policy bundle "
+                    "in one step."
+                ),
+            },
+        ]
+        if recommended is not None:
+            steps.append(_run_step(recommended))
+        return steps
+    if cloud_state == "paired_waiting":
+        steps = [
+            {
+                "title": "Pull the first cloud sync",
+                "command": str(payload.get("sync_command") or f"{GUARD_COMMAND} sync"),
+                "detail": (
+                    "Finish the first sync so this machine has Guard Cloud history, advisories, "
+                    "and team defaults."
+                ),
+            }
+        ]
+        if int(payload.get("receipt_count") or 0) == 0 and recommended is not None:
+            steps.append(_run_step(recommended))
+        steps.append(
+            {
+                "title": "Open the Guard dashboard",
+                "command": dashboard_url,
+                "detail": "Use the signed-in dashboard to confirm pairing and watch your first device appear.",
+            }
+        )
+        return steps
+    steps = [
+        {
+            "title": "Open the Guard dashboard",
+            "command": dashboard_url,
+            "detail": "Review receipts, devices, changes, and upgrade prompts from the signed-in command center.",
+        }
+    ]
+    if int(payload.get("pending_approvals") or 0) > 0:
+        steps.append(_approvals_step())
+    elif recommended is not None and str(recommended.get("next_action")) == "review":
+        steps.append(_install_or_review_step(recommended))
+    else:
+        steps.append(
+            {
+                "title": "Check local Guard status",
+                "command": f"{GUARD_COMMAND} status",
+                "detail": "See what is protected locally, what synced last, and what Guard thinks you should do next.",
+            }
+        )
+    if bool(payload.get("team_policy_active")):
+        steps.append(
+            {
+                "title": "Inspect synced team policy",
+                "command": f"{GUARD_COMMAND} policies",
+                "detail": "Confirm the shared workspace policy Guard pulled down for this machine.",
+            }
+        )
+    elif int(payload.get("advisory_count") or 0) > 0:
+        steps.append(
+            {
+                "title": "Review Guard advisories",
+                "command": f"{GUARD_COMMAND} advisories",
+                "detail": "Inspect the latest premium trust signals and publisher changes Guard cached locally.",
+            }
+        )
+    return steps
+
+
+def _connect_or_dashboard_step(cloud_state: str, connect_url: str, dashboard_url: str) -> dict[str, str]:
+    if cloud_state == "local_only":
+        return {
+            "title": "Optional sync later",
+            "command": connect_url,
+            "detail": (
+                "Keep receipts local by default, then use the Guard connect page when you want "
+                "shared history, trust checks, or team policy."
+            ),
+        }
+    return {
+        "title": "Open the Guard dashboard",
+        "command": dashboard_url,
+        "detail": "Guard Cloud is already paired. Use the signed-in dashboard for devices, receipts, and upgrades.",
+    }
+
+
+def _recommended_summary(payload: dict[str, object]) -> dict[str, object] | None:
+    recommended_harness = payload.get("recommended_harness")
+    if not isinstance(recommended_harness, str):
+        return None
+    for harness in payload.get("harnesses", []):
+        if isinstance(harness, dict) and harness.get("harness") == recommended_harness:
+            return harness
+    return None
+
+
+def _resolve_guard_urls(sync_url: str | None) -> tuple[str, str]:
+    if not isinstance(sync_url, str) or not sync_url:
+        return GUARD_DASHBOARD_URL, GUARD_CONNECT_URL
+    parsed = urlparse(sync_url)
+    if not parsed.scheme or not parsed.netloc:
+        return GUARD_DASHBOARD_URL, GUARD_CONNECT_URL
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+    return f"{origin}/guard", f"{origin}/guard/connect"
+
+
+def _resolve_cloud_state(*, sync_configured: bool, last_sync_at: str | None, remote_payload_active: bool) -> str:
+    if not sync_configured:
+        return "local_only"
+    if last_sync_at is None and not remote_payload_active:
+        return "paired_waiting"
+    return "paired_active"
+
+
+def _cloud_state_label(cloud_state: str) -> str:
+    labels = {
+        "local_only": "Local only",
+        "paired_waiting": "Connected, waiting for first sync",
+        "paired_active": "Connected and active",
+    }
+    return labels.get(cloud_state, "Local only")
+
+
+def _cloud_state_detail(cloud_state: str, connect_url: str, dashboard_url: str) -> str:
+    if cloud_state == "paired_waiting":
+        return (
+            "Guard Cloud credentials are saved, but this machine has not finished a full sync yet. "
+            f"Run `{GUARD_COMMAND} sync` or reopen {connect_url} to finish the pairing loop."
+        )
+    if cloud_state == "paired_active":
+        return (
+            "Guard is paired with Guard Cloud. Use the local CLI for protection and the signed-in dashboard "
+            f"at {dashboard_url} for receipts, devices, upgrades, and team workflows."
+        )
+    return (
+        "Receipts stay on this machine until you choose to pair Guard Cloud. "
+        f"Start from {connect_url} when you want shared history, trust advisories, or team policy."
+    )
+
+
+def _latest_event(store: GuardStore, event_name: str) -> dict[str, object] | None:
+    events = store.list_events(limit=1, event_name=event_name)
+    return events[0] if events else None
+
+
+def _last_sync_at(event: dict[str, object] | None) -> str | None:
+    if not isinstance(event, dict):
+        return None
+    payload = event.get("payload")
+    if isinstance(payload, dict):
+        synced_at = payload.get("synced_at")
+        if isinstance(synced_at, str) and synced_at:
+            return synced_at
+    occurred_at = event.get("occurred_at")
+    return occurred_at if isinstance(occurred_at, str) and occurred_at else None
+
+
+def _coerce_payload_dict(payload: dict[str, object] | list[object] | None) -> dict[str, object]:
+    return payload if isinstance(payload, dict) else {}
+
+
+def _advisory_headline(advisories: list[dict[str, object]]) -> str | None:
+    if not advisories:
+        return None
+    headline = advisories[0].get("headline")
+    return headline if isinstance(headline, str) and headline else None
+
+
+def _optional_string(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
 
 
 def _install_or_review_step(recommended: dict[str, object]) -> dict[str, str]:
@@ -202,4 +458,4 @@ def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-__all__ = ["build_guard_start_payload", "build_guard_status_payload"]
+__all__ = ["build_guard_connect_payload", "build_guard_start_payload", "build_guard_status_payload"]

--- a/src/codex_plugin_scanner/guard/cli/product.py
+++ b/src/codex_plugin_scanner/guard/cli/product.py
@@ -185,12 +185,12 @@ def _build_cloud_context(store: GuardStore) -> dict[str, object]:
     alert_preferences = _coerce_payload_dict(store.get_sync_payload("alert_preferences"))
     remote_policy = _coerce_payload_dict(store.get_sync_payload("policy"))
     team_policy_pack = _coerce_payload_dict(store.get_sync_payload("team_policy_pack"))
-    last_sync_event = _latest_event(store, "sync_complete")
-    last_sync_at = _last_sync_at(last_sync_event)
+    sync_summary = _coerce_payload_dict(store.get_sync_payload("sync_summary"))
+    last_sync_at = _optional_string(sync_summary.get("synced_at"))
     remote_payload_active = bool(advisories or alert_preferences or remote_policy or team_policy_pack)
     cloud_state = _resolve_cloud_state(
         sync_configured=credentials is not None,
-        last_sync_at=last_sync_at,
+        sync_completed=bool(sync_summary),
         remote_payload_active=remote_payload_active,
     )
     return {
@@ -338,10 +338,10 @@ def _resolve_guard_urls(sync_url: str | None) -> tuple[str, str]:
     return f"{origin}/guard", f"{origin}/guard/connect"
 
 
-def _resolve_cloud_state(*, sync_configured: bool, last_sync_at: str | None, remote_payload_active: bool) -> str:
+def _resolve_cloud_state(*, sync_configured: bool, sync_completed: bool, remote_payload_active: bool) -> str:
     if not sync_configured:
         return "local_only"
-    if last_sync_at is None and not remote_payload_active:
+    if not sync_completed and not remote_payload_active:
         return "paired_waiting"
     return "paired_active"
 
@@ -370,23 +370,6 @@ def _cloud_state_detail(cloud_state: str, connect_url: str, dashboard_url: str) 
         "Receipts stay on this machine until you choose to pair Guard Cloud. "
         f"Start from {connect_url} when you want shared history, trust advisories, or team policy."
     )
-
-
-def _latest_event(store: GuardStore, event_name: str) -> dict[str, object] | None:
-    events = store.list_events(limit=1, event_name=event_name)
-    return events[0] if events else None
-
-
-def _last_sync_at(event: dict[str, object] | None) -> str | None:
-    if not isinstance(event, dict):
-        return None
-    payload = event.get("payload")
-    if isinstance(payload, dict):
-        synced_at = payload.get("synced_at")
-        if isinstance(synced_at, str) and synced_at:
-            return synced_at
-    occurred_at = event.get("occurred_at")
-    return occurred_at if isinstance(occurred_at, str) and occurred_at else None
 
 
 def _coerce_payload_dict(payload: dict[str, object] | list[object] | None) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/cli/product.py
+++ b/src/codex_plugin_scanner/guard/cli/product.py
@@ -227,8 +227,7 @@ def _build_connect_steps(payload: dict[str, object]) -> list[dict[str, str]]:
                 "title": "Generate a Guard Cloud token",
                 "command": connect_url,
                 "detail": (
-                    "Open the Guard connect page, copy the sync URL and short-lived token, "
-                    "then pair this runtime."
+                    "Open the Guard connect page, copy the sync URL and short-lived token, then pair this runtime."
                 ),
             },
             {
@@ -237,8 +236,7 @@ def _build_connect_steps(payload: dict[str, object]) -> list[dict[str, str]]:
                     payload.get("connect_command") or f"{GUARD_COMMAND} connect --sync-url <url> --token <token>"
                 ),
                 "detail": (
-                    "Save the credentials locally and pull down the first Guard Cloud policy bundle "
-                    "in one step."
+                    "Save the credentials locally and pull down the first Guard Cloud policy bundle in one step."
                 ),
             },
         ]
@@ -251,8 +249,7 @@ def _build_connect_steps(payload: dict[str, object]) -> list[dict[str, str]]:
                 "title": "Pull the first cloud sync",
                 "command": str(payload.get("sync_command") or f"{GUARD_COMMAND} sync"),
                 "detail": (
-                    "Finish the first sync so this machine has Guard Cloud history, advisories, "
-                    "and team defaults."
+                    "Finish the first sync so this machine has Guard Cloud history, advisories, and team defaults."
                 ),
             }
         ]

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -59,6 +59,7 @@ def _render_start(console: Console, payload: dict[str, object]) -> None:
             border_style="cyan",
         )
     )
+    console.print(_build_cloud_summary_panel(payload))
     console.print(_build_product_table(harnesses))
     if payload.get("approval_center_url"):
         console.print(f"Approval center: [bold]{payload.get('approval_center_url')}[/bold]")
@@ -77,6 +78,7 @@ def _render_status(console: Console, payload: dict[str, object]) -> None:
             border_style="cyan",
         )
     )
+    console.print(_build_cloud_summary_panel(payload))
     console.print(_build_product_table(harnesses))
     if payload.get("approval_center_url"):
         console.print(f"Approval center: [bold]{payload.get('approval_center_url')}[/bold]")
@@ -415,6 +417,34 @@ def _render_login(console: Console, payload: dict[str, object]) -> None:
             border_style="green",
         )
     )
+
+
+def _render_connect(console: Console, payload: dict[str, object]) -> None:
+    border_style = _cloud_border_style(str(payload.get("cloud_state") or "local_only"))
+    console.print(
+        Panel.fit(
+            f"[bold]HOL Guard connect[/bold]\n"
+            f"{payload.get('cloud_state_label', 'Local only')} • "
+            f"{payload.get('receipt_count', 0)} receipts • "
+            f"{payload.get('pending_approvals', 0)} approvals",
+            border_style=border_style,
+        )
+    )
+    console.print(_build_cloud_summary_panel(payload))
+    sync_result = payload.get("sync_result")
+    if isinstance(sync_result, dict):
+        body = Table.grid(padding=(0, 1))
+        body.add_row("Synced at", str(sync_result.get("synced_at") or "unknown"))
+        body.add_row("Receipts stored", str(sync_result.get("receipts_stored") or 0))
+        body.add_row("Advisories stored", str(sync_result.get("advisories_stored") or 0))
+        body.add_row("Remote policies", str(sync_result.get("remote_policies_stored") or 0))
+        console.print(Panel(body, title="Connect sync", border_style="green"))
+    if payload.get("sync_error"):
+        console.print(Panel(str(payload.get("sync_error")), title="Connect failed", border_style="red"))
+    if payload.get("approval_center_url"):
+        console.print(f"Approval center: [bold]{payload.get('approval_center_url')}[/bold]")
+    console.print(_build_product_table(_coerce_dict_list(payload.get("harnesses"))))
+    console.print(_build_steps_panel(_coerce_dict_list(payload.get("next_steps"))))
 
 
 def _render_sync(console: Console, payload: dict[str, object]) -> None:
@@ -756,6 +786,39 @@ def _build_runtime_probe_panel(runtime_probe: dict[str, object]) -> Panel:
     return Panel(body, title="Runtime probe", border_style="magenta")
 
 
+def _build_cloud_summary_panel(payload: dict[str, object]) -> Panel:
+    cloud_state = str(payload.get("cloud_state") or "local_only")
+    body = Table.grid(padding=(0, 1))
+    body.add_row("State", f"[bold]{payload.get('cloud_state_label', 'Local only')}[/bold]")
+    body.add_row("Summary", str(payload.get("cloud_state_detail") or "Guard is protecting this machine locally."))
+    body.add_row("Dashboard", str(payload.get("dashboard_url") or "https://hol.org/guard"))
+    body.add_row("Connect guide", str(payload.get("connect_url") or "https://hol.org/guard/connect"))
+    if payload.get("sync_url"):
+        body.add_row("Sync endpoint", str(payload.get("sync_url")))
+    if payload.get("last_sync_at"):
+        body.add_row("Last sync", str(payload.get("last_sync_at")))
+    body.add_row("Cached advisories", str(payload.get("advisory_count") or 0))
+    if payload.get("advisory_headline"):
+        body.add_row("Latest advisory", str(payload.get("advisory_headline")))
+    if payload.get("team_policy_name"):
+        body.add_row("Team policy", str(payload.get("team_policy_name")))
+    elif payload.get("team_policy_active"):
+        body.add_row("Team policy", "active")
+    if payload.get("watchlist_enabled"):
+        body.add_row("Watchlist", "enabled")
+    if payload.get("team_alerts_enabled"):
+        body.add_row("Team alerts", "enabled")
+    return Panel(body, title="Local to cloud", border_style=_cloud_border_style(cloud_state))
+
+
+def _cloud_border_style(cloud_state: str) -> str:
+    if cloud_state == "paired_active":
+        return "green"
+    if cloud_state == "paired_waiting":
+        return "yellow"
+    return "cyan"
+
+
 def _artifact_source_text(artifact: dict[str, object]) -> str:
     url = artifact.get("url")
     if isinstance(url, str) and url:
@@ -848,6 +911,7 @@ _RENDERERS: dict[str, Any] = {
     "approvals": _render_approvals,
     "start": _render_start,
     "status": _render_status,
+    "connect": _render_connect,
     "bootstrap": _render_bootstrap,
     "detect": _render_detect,
     "doctor": _render_doctor,

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -195,7 +195,7 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
         now=now,
     )
     pain_signals_uploaded = sync_pain_signals(store)
-    return {
+    summary = {
         "synced_at": payload.get("syncedAt"),
         "receipts_stored": payload.get("receiptsStored"),
         "advisories_stored": advisories_stored,
@@ -205,6 +205,8 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
         "receipts": len(receipts),
         "inventory": len(inventory),
     }
+    store.set_sync_payload("sync_summary", summary, now)
+    return summary
 
 
 def sync_pain_signals(store: GuardStore) -> int:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -967,6 +967,15 @@ class GuardStore:
     def set_sync_credentials(self, sync_url: str, token: str, now: str) -> None:
         payload = {"sync_url": sync_url, "token": token}
         with self._connect() as connection:
+            previous_row = connection.execute(
+                "select payload_json from sync_state where state_key = 'credentials'"
+            ).fetchone()
+            credentials_changed = False
+            if previous_row is None:
+                credentials_changed = True
+            else:
+                previous_payload = json.loads(str(previous_row["payload_json"]))
+                credentials_changed = previous_payload != payload
             connection.execute(
                 """
                 insert into sync_state (state_key, payload_json, updated_at)
@@ -977,6 +986,10 @@ class GuardStore:
                 """,
                 (json.dumps(payload), now),
             )
+            if credentials_changed:
+                connection.execute("delete from sync_state where state_key != 'credentials'")
+                connection.execute("delete from publisher_cache")
+                connection.execute("delete from policy_decisions where source in ('cloud-sync', 'team-policy')")
 
     def set_sync_payload(self, state_key: str, payload: dict[str, object] | list[object], now: str) -> None:
         with self._connect() as connection:

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -117,6 +117,7 @@ class _SyncRequestHandler(BaseHTTPRequestHandler):
     response_code = 200
     captured_headers: ClassVar[dict[str, str]] = {}
     captured_body: ClassVar[dict[str, object] | None] = None
+    raw_response_body: ClassVar[str | None] = None
     response_payload: ClassVar[dict[str, object]] = {
         "syncedAt": "2026-04-09T00:00:00Z",
         "receiptsStored": 1,
@@ -130,7 +131,10 @@ class _SyncRequestHandler(BaseHTTPRequestHandler):
         self.send_response(self.response_code)
         self.send_header("Content-Type", "application/json")
         self.end_headers()
-        self.wfile.write(json.dumps(_SyncRequestHandler.response_payload).encode("utf-8"))
+        response_body = _SyncRequestHandler.raw_response_body
+        if response_body is None:
+            response_body = json.dumps(_SyncRequestHandler.response_payload)
+        self.wfile.write(response_body.encode("utf-8"))
 
     def log_message(self, fmt: str, *args) -> None:
         return
@@ -1622,6 +1626,46 @@ args = ["workspace-skill.js", "--changed"]
         assert _SyncRequestHandler.captured_headers["authorization"] == "Bearer demo-token"
         assert _SyncRequestHandler.captured_body is not None
         assert len(_SyncRequestHandler.captured_body["receipts"]) >= 1
+
+    def test_guard_connect_handles_invalid_sync_response(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        guard_home = tmp_path / "guard-home"
+        _build_guard_fixture(home_dir, workspace_dir)
+        _SyncRequestHandler.raw_response_body = "not-json"
+
+        server = HTTPServer(("127.0.0.1", 0), _SyncRequestHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            connect_rc = main(
+                [
+                    "guard",
+                    "connect",
+                    "--home",
+                    str(home_dir),
+                    "--guard-home",
+                    str(guard_home),
+                    "--workspace",
+                    str(workspace_dir),
+                    "--sync-url",
+                    f"http://127.0.0.1:{server.server_port}/receipts",
+                    "--token",
+                    "demo-token",
+                    "--json",
+                ]
+            )
+            connect_output = json.loads(capsys.readouterr().out)
+        finally:
+            _SyncRequestHandler.raw_response_body = None
+            server.shutdown()
+            thread.join(timeout=5)
+
+        assert connect_rc == 1
+        assert connect_output["sync_attempted"] is True
+        assert connect_output["sync_succeeded"] is False
+        assert connect_output["cloud_state"] == "paired_waiting"
+        assert "Expecting value" in str(connect_output["sync_error"])
 
     def test_guard_sync_persists_advisories_from_endpoint(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -1521,6 +1521,33 @@ args = ["workspace-skill.js", "--changed"]
         assert output["dashboard_url"] == "https://hol.org/guard"
         assert output["connect_url"] == "https://hol.org/guard/connect"
 
+    def test_guard_connect_rejects_empty_credentials(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        guard_home = tmp_path / "guard-home"
+        _build_guard_fixture(home_dir, workspace_dir)
+
+        rc = main(
+            [
+                "guard",
+                "connect",
+                "--home",
+                str(home_dir),
+                "--guard-home",
+                str(guard_home),
+                "--workspace",
+                str(workspace_dir),
+                "--sync-url",
+                "",
+                "--token",
+                "",
+            ]
+        )
+        stderr = capsys.readouterr().err
+
+        assert rc == 2
+        assert "connect requires non-empty --sync-url and --token when saving credentials" in stderr
+
     def test_guard_connect_syncs_and_surfaces_cloud_state(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
@@ -1626,6 +1653,78 @@ args = ["workspace-skill.js", "--changed"]
         assert _SyncRequestHandler.captured_headers["authorization"] == "Bearer demo-token"
         assert _SyncRequestHandler.captured_body is not None
         assert len(_SyncRequestHandler.captured_body["receipts"]) >= 1
+
+    def test_guard_connect_save_only_clears_previous_sync_state(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        guard_home = tmp_path / "guard-home"
+        _build_guard_fixture(home_dir, workspace_dir)
+        _SyncRequestHandler.response_payload = {
+            "syncedAt": "2026-04-09T00:00:00Z",
+            "receiptsStored": 1,
+            "advisories": [
+                {
+                    "id": "adv-001",
+                    "publisher": "hashgraph-online",
+                    "severity": "high",
+                    "headline": "Publisher rotated to a new remote domain.",
+                }
+            ],
+        }
+
+        server = HTTPServer(("127.0.0.1", 0), _SyncRequestHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            first_connect_rc = main(
+                [
+                    "guard",
+                    "connect",
+                    "--home",
+                    str(home_dir),
+                    "--guard-home",
+                    str(guard_home),
+                    "--workspace",
+                    str(workspace_dir),
+                    "--sync-url",
+                    f"http://127.0.0.1:{server.server_port}/receipts",
+                    "--token",
+                    "demo-token",
+                    "--json",
+                ]
+            )
+            first_connect_output = json.loads(capsys.readouterr().out)
+
+            second_connect_rc = main(
+                [
+                    "guard",
+                    "connect",
+                    "--home",
+                    str(home_dir),
+                    "--guard-home",
+                    str(guard_home),
+                    "--workspace",
+                    str(workspace_dir),
+                    "--sync-url",
+                    "https://hol.org/registry/api/v1/guard/receipts",
+                    "--token",
+                    "second-token",
+                    "--save-only",
+                    "--json",
+                ]
+            )
+            second_connect_output = json.loads(capsys.readouterr().out)
+        finally:
+            server.shutdown()
+            thread.join(timeout=5)
+
+        assert first_connect_rc == 0
+        assert first_connect_output["cloud_state"] == "paired_active"
+        assert first_connect_output["advisory_count"] == 1
+        assert second_connect_rc == 0
+        assert second_connect_output["cloud_state"] == "paired_waiting"
+        assert second_connect_output["advisory_count"] == 0
+        assert second_connect_output["last_sync_at"] is None
 
     def test_guard_connect_handles_invalid_sync_response(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -1478,6 +1478,146 @@ args = ["workspace-skill.js", "--changed"]
         assert len(_SyncRequestHandler.captured_body["receipts"]) >= 1
         assert len(_SyncRequestHandler.captured_body["inventory"]) >= 1
 
+    def test_guard_connect_save_only_surfaces_waiting_state(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        guard_home = tmp_path / "guard-home"
+        _build_guard_fixture(home_dir, workspace_dir)
+
+        rc = main(
+            [
+                "guard",
+                "connect",
+                "--home",
+                str(home_dir),
+                "--guard-home",
+                str(guard_home),
+                "--workspace",
+                str(workspace_dir),
+                "--sync-url",
+                "https://hol.org/registry/api/v1/guard/receipts",
+                "--token",
+                "demo-token",
+                "--save-only",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["credentials_saved"] is True
+        assert output["sync_attempted"] is False
+        assert output["cloud_state"] == "paired_waiting"
+        assert output["sync_configured"] is True
+        assert output["dashboard_url"] == "https://hol.org/guard"
+        assert output["connect_url"] == "https://hol.org/guard/connect"
+
+    def test_guard_connect_syncs_and_surfaces_cloud_state(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        guard_home = tmp_path / "guard-home"
+        _build_guard_fixture(home_dir, workspace_dir)
+        _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\n')
+        _SyncRequestHandler.response_payload = {
+            "syncedAt": "2026-04-09T00:00:00Z",
+            "receiptsStored": 1,
+            "advisories": [
+                {
+                    "id": "adv-001",
+                    "publisher": "hashgraph-online",
+                    "severity": "high",
+                    "headline": "Publisher rotated to a new remote domain.",
+                }
+            ],
+            "policy": {
+                "mode": "enforce",
+                "defaultAction": "warn",
+                "unknownPublisherAction": "review",
+                "changedHashAction": "allow",
+                "newNetworkDomainAction": "warn",
+                "subprocessAction": "block",
+                "telemetryEnabled": False,
+                "syncEnabled": True,
+                "updatedAt": "2026-04-09T00:00:00Z",
+            },
+            "alertPreferences": {
+                "emailEnabled": True,
+                "digestMode": "daily",
+                "watchlistEnabled": True,
+                "advisoriesEnabled": True,
+                "repeatedWarningsEnabled": True,
+                "teamAlertsEnabled": True,
+                "updatedAt": "2026-04-09T00:00:00Z",
+            },
+            "teamPolicyPack": {
+                "name": "Security team default",
+                "sharedHarnessDefaults": {"codex": "enforce"},
+                "allowedPublishers": ["hashgraph-online"],
+                "blockedArtifacts": [],
+                "alertChannel": "email",
+                "updatedAt": "2026-04-09T00:00:00Z",
+                "auditTrail": [],
+            },
+        }
+
+        server = HTTPServer(("127.0.0.1", 0), _SyncRequestHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            run_rc = main(
+                [
+                    "guard",
+                    "run",
+                    "codex",
+                    "--home",
+                    str(home_dir),
+                    "--guard-home",
+                    str(guard_home),
+                    "--workspace",
+                    str(workspace_dir),
+                    "--dry-run",
+                    "--default-action",
+                    "allow",
+                    "--json",
+                ]
+            )
+            json.loads(capsys.readouterr().out)
+
+            connect_rc = main(
+                [
+                    "guard",
+                    "connect",
+                    "--home",
+                    str(home_dir),
+                    "--guard-home",
+                    str(guard_home),
+                    "--workspace",
+                    str(workspace_dir),
+                    "--sync-url",
+                    f"http://127.0.0.1:{server.server_port}/receipts",
+                    "--token",
+                    "demo-token",
+                    "--json",
+                ]
+            )
+            connect_output = json.loads(capsys.readouterr().out)
+        finally:
+            server.shutdown()
+            thread.join(timeout=5)
+
+        assert run_rc == 0
+        assert connect_rc == 0
+        assert connect_output["credentials_saved"] is True
+        assert connect_output["sync_attempted"] is True
+        assert connect_output["sync_succeeded"] is True
+        assert connect_output["cloud_state"] == "paired_active"
+        assert connect_output["dashboard_url"] == f"http://127.0.0.1:{server.server_port}/guard"
+        assert connect_output["advisory_count"] == 1
+        assert connect_output["team_policy_active"] is True
+        assert _SyncRequestHandler.captured_headers["authorization"] == "Bearer demo-token"
+        assert _SyncRequestHandler.captured_body is not None
+        assert len(_SyncRequestHandler.captured_body["receipts"]) >= 1
+
     def test_guard_sync_persists_advisories_from_endpoint(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -1465,6 +1465,8 @@ args = ["workspace-skill.js", "--changed"]
                 ]
             )
             sync_output = json.loads(capsys.readouterr().out)
+            status_rc = main(["guard", "status", "--home", str(home_dir), "--workspace", str(workspace_dir), "--json"])
+            status_output = json.loads(capsys.readouterr().out)
         finally:
             server.shutdown()
             thread.join(timeout=5)
@@ -1472,7 +1474,10 @@ args = ["workspace-skill.js", "--changed"]
         assert login_rc == 0
         assert run_rc == 0
         assert sync_rc == 0
+        assert status_rc == 0
         assert sync_output["receipts_stored"] == 1
+        assert status_output["cloud_state"] == "paired_active"
+        assert status_output["last_sync_at"] == "2026-04-09T00:00:00Z"
         assert _SyncRequestHandler.captured_headers["authorization"] == "Bearer demo-token"
         assert _SyncRequestHandler.captured_body is not None
         assert len(_SyncRequestHandler.captured_body["receipts"]) >= 1

--- a/tests/test_guard_product_flow.py
+++ b/tests/test_guard_product_flow.py
@@ -100,6 +100,7 @@ class TestGuardProductFlow:
         assert rc == 0
         assert output["recommended_harness"] == "codex"
         assert output["sync_configured"] is False
+        assert output["cloud_state"] == "local_only"
         assert output["receipt_count"] == 0
         assert codex_summary["managed"] is False
         assert codex_summary["next_action"] == "install"
@@ -133,6 +134,34 @@ class TestGuardProductFlow:
         assert output["recommended_harness"] == "copilot"
         assert copilot_summary["install_command"] == "hol-guard install copilot"
         assert output["next_steps"][1]["command"] == "hol-guard run copilot --dry-run"
+
+    def test_guard_connect_json_surfaces_local_only_state(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        guard_home = tmp_path / "guard-home"
+        _build_guard_fixture(home_dir, workspace_dir)
+
+        rc = main(
+            [
+                "guard",
+                "connect",
+                "--home",
+                str(home_dir),
+                "--guard-home",
+                str(guard_home),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["cloud_state"] == "local_only"
+        assert output["sync_configured"] is False
+        assert output["connect_url"] == "https://hol.org/guard/connect"
+        assert output["dashboard_url"] == "https://hol.org/guard"
+        assert output["next_steps"][0]["command"] == "https://hol.org/guard/connect"
 
     def test_guard_start_human_output_highlights_guard_loop(self, tmp_path, capsys):
         home_dir = tmp_path / "home"


### PR DESCRIPTION
Summary
- add a first-class guard connect command that saves Guard Cloud credentials, optionally syncs immediately, and emits pairing-aware next steps
- enrich guard start and guard status with local-to-cloud state, dashboard/connect URLs, and synced advisory/team-policy signals
- add regression coverage for local-only, saved-only, and one-step connect-and-sync flows

Validation
- python -m ruff check src/codex_plugin_scanner/guard/cli/product.py src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/cli/render.py tests/test_guard_product_flow.py tests/test_guard_cli.py
- python -m pytest
- python -m build