### PR TITLE
fix: route Guard approval blocks through harness surfaces first

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/base.py
+++ b/src/codex_plugin_scanner/guard/adapters/base.py
@@ -76,6 +76,8 @@ class HarnessAdapter:
     approval_tier = "approval-center"
     approval_summary = "Guard pauses the launch and routes approval through the local approval center."
     fallback_hint = "Use `hol-guard approvals` if you want to resolve it from the terminal."
+    approval_prompt_channel = "browser"
+    approval_auto_open_browser = True
 
     def detect(self, context: HarnessContext) -> HarnessDetection:
         raise NotImplementedError
@@ -125,11 +127,13 @@ class HarnessAdapter:
             warnings.append(f"{self.executable} diagnostics timed out before Guard could confirm runtime state.")
         return warnings
 
-    def approval_flow(self) -> dict[str, str]:
+    def approval_flow(self) -> dict[str, object]:
         return {
             "tier": self.approval_tier,
             "summary": self.approval_summary,
             "fallback_hint": self.fallback_hint,
+            "prompt_channel": self.approval_prompt_channel,
+            "auto_open_browser": self.approval_auto_open_browser,
         }
 
     def diagnostics(self, context: HarnessContext) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -34,6 +34,8 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
         "Guard uses Claude hooks first and falls back to the local approval center when the shell cannot prompt."
     )
     fallback_hint = "Claude is the best current harness for deferred Guard approvals."
+    approval_prompt_channel = "hook"
+    approval_auto_open_browser = False
 
     @staticmethod
     def _scope_for(context: HarnessContext, path: Path) -> str:

--- a/src/codex_plugin_scanner/guard/adapters/copilot.py
+++ b/src/codex_plugin_scanner/guard/adapters/copilot.py
@@ -172,6 +172,8 @@ class CopilotHarnessAdapter(HarnessAdapter):
         "Guard can install documented Copilot CLI repo hooks and falls back to the local approval center when needed."
     )
     fallback_hint = "Use Guard-managed repo hooks for Copilot CLI tool events and the local approval center for review."
+    approval_prompt_channel = "hook"
+    approval_auto_open_browser = False
 
     @staticmethod
     def _scope_for(context: HarnessContext, path: Path) -> str:

--- a/src/codex_plugin_scanner/guard/adapters/cursor.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor.py
@@ -16,6 +16,8 @@ class CursorHarnessAdapter(HarnessAdapter):
         "Cursor already owns tool approval, so Guard focuses on artifact trust, provenance, and preflight review."
     )
     fallback_hint = "Resolve package-level trust in Guard and let Cursor keep its built-in tool approval flow."
+    approval_prompt_channel = "native"
+    approval_auto_open_browser = False
 
     @staticmethod
     def _scope_for(context: HarnessContext, path) -> str:

--- a/src/codex_plugin_scanner/guard/adapters/opencode.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode.py
@@ -33,6 +33,8 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
     fallback_hint = (
         "Use Guard approvals for blocked artifacts and OpenCode's native allow once or allow session flow for skills."
     )
+    approval_prompt_channel = "native"
+    approval_auto_open_browser = False
 
     @staticmethod
     def _scope_for(context: HarnessContext, path: Path) -> str:

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -159,16 +159,29 @@ def approval_center_hint(
     approval_center_url: str,
     queued: list[dict[str, object]],
 ) -> str:
-    adapter = get_adapter(harness)
-    flow = adapter.approval_flow()
+    del context
+    flow = approval_prompt_flow(harness)
     count = len(queued)
     risk_summary = _queue_risk_summary(queued)
     return (
         f"Guard queued {count} approval request{'s' if count != 1 else ''} for {harness}. "
+        f"{flow['summary']} "
         f"Open {approval_center_url} to review them. "
         f"{risk_summary} "
         f"{flow['fallback_hint']}"
     )
+
+
+def approval_prompt_flow(harness: str) -> dict[str, object]:
+    adapter = get_adapter(harness)
+    flow = adapter.approval_flow()
+    return {
+        "tier": str(flow.get("tier") or "approval-center"),
+        "summary": str(flow.get("summary") or ""),
+        "fallback_hint": str(flow.get("fallback_hint") or ""),
+        "prompt_channel": str(flow.get("prompt_channel") or "browser"),
+        "auto_open_browser": bool(flow.get("auto_open_browser")),
+    }
 
 
 def wait_for_approval_requests(

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -184,6 +184,15 @@ def approval_prompt_flow(harness: str) -> dict[str, object]:
     }
 
 
+def approval_delivery_payload(flow: dict[str, object]) -> dict[str, object]:
+    auto_open_browser = bool(flow.get("auto_open_browser"))
+    return {
+        "destination": "browser" if auto_open_browser else "harness",
+        "prompt_channel": str(flow.get("prompt_channel") or "browser"),
+        "summary": str(flow.get("summary") or ""),
+    }
+
+
 def wait_for_approval_requests(
     *,
     store: GuardStore,

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -173,14 +173,16 @@ def approval_center_hint(
 
 
 def approval_prompt_flow(harness: str) -> dict[str, object]:
-    adapter = get_adapter(harness)
-    flow = adapter.approval_flow()
+    try:
+        flow = get_adapter(harness).approval_flow()
+    except ValueError:
+        flow = {}
     return {
         "tier": str(flow.get("tier") or "approval-center"),
         "summary": str(flow.get("summary") or ""),
         "fallback_hint": str(flow.get("fallback_hint") or ""),
         "prompt_channel": str(flow.get("prompt_channel") or "browser"),
-        "auto_open_browser": bool(flow.get("auto_open_browser")),
+        "auto_open_browser": bool(flow.get("auto_open_browser", True)),
     }
 
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from ...models import ScanOptions
 from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
-from ..approvals import approval_center_hint, queue_blocked_approvals, wait_for_approval_requests
+from ..approvals import approval_center_hint, approval_prompt_flow, queue_blocked_approvals, wait_for_approval_requests
 from ..bridge import (
     BridgeConfig,
     GuardBridge,
@@ -787,6 +787,7 @@ def run_guard_command(args: argparse.Namespace) -> int:
                     approval_center_url=approval_center_url,
                     queued=queued,
                 )
+                response_payload["approval_delivery"] = _approval_delivery_payload(args.harness)
             if _should_emit_copilot_hook_response(args):
                 _emit_copilot_hook_response(
                     policy_action=policy_action,
@@ -874,11 +875,26 @@ def _should_emit_copilot_hook_response(args: argparse.Namespace) -> bool:
     return args.harness == "copilot" and not getattr(args, "json", False)
 
 
+def _approval_delivery_payload(harness: str) -> dict[str, object]:
+    flow = approval_prompt_flow(harness)
+    auto_open_browser = bool(flow["auto_open_browser"])
+    return {
+        "destination": "browser" if auto_open_browser else "harness",
+        "prompt_channel": str(flow["prompt_channel"]),
+        "summary": str(flow["summary"]),
+    }
+
+
 def _copilot_hook_reason(*values: object | None) -> str:
+    messages: list[str] = []
     for value in values:
         if isinstance(value, str) and value.strip():
-            return value.strip()
-    return "Guard blocked this tool call."
+            candidate = value.strip()
+            if candidate not in messages:
+                messages.append(candidate)
+    if messages:
+        return " ".join(messages)
+    return "Guard blocked this tool call. Open the Guard approval center to review the request."
 
 
 def _emit_copilot_hook_response(*, policy_action: str, reason: str) -> None:
@@ -900,7 +916,7 @@ def _headless_approval_resolver(
     config,
 ):
     def resolve(detection, payload):
-        approval_flow = get_adapter(args.harness).approval_flow()
+        approval_flow = approval_prompt_flow(args.harness)
         approval_center_url = ensure_guard_daemon(context.guard_home)
         queued = queue_blocked_approvals(
             detection=detection,
@@ -917,8 +933,10 @@ def _headless_approval_resolver(
             approval_center_url=approval_center_url,
             queued=queued,
         )
-        _open_approval_center(approval_center_url)
-        if approval_flow["tier"] != "native-or-center":
+        payload["approval_delivery"] = _approval_delivery_payload(args.harness)
+        if bool(approval_flow["auto_open_browser"]):
+            _open_approval_center(approval_center_url)
+        if str(approval_flow["tier"]) != "native-or-center":
             payload["approval_wait"] = {
                 "resolved": False,
                 "pending_request_ids": [str(item["request_id"]) for item in queued if "request_id" in item],

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -13,7 +13,13 @@ from pathlib import Path
 from ...models import ScanOptions
 from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
-from ..approvals import approval_center_hint, approval_prompt_flow, queue_blocked_approvals, wait_for_approval_requests
+from ..approvals import (
+    approval_center_hint,
+    approval_delivery_payload,
+    approval_prompt_flow,
+    queue_blocked_approvals,
+    wait_for_approval_requests,
+)
 from ..bridge import (
     BridgeConfig,
     GuardBridge,
@@ -876,13 +882,7 @@ def _should_emit_copilot_hook_response(args: argparse.Namespace) -> bool:
 
 
 def _approval_delivery_payload(harness: str) -> dict[str, object]:
-    flow = approval_prompt_flow(harness)
-    auto_open_browser = bool(flow["auto_open_browser"])
-    return {
-        "destination": "browser" if auto_open_browser else "harness",
-        "prompt_channel": str(flow["prompt_channel"]),
-        "summary": str(flow["summary"]),
-    }
+    return approval_delivery_payload(approval_prompt_flow(harness))
 
 
 def _copilot_hook_reason(*values: object | None) -> str:

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -163,9 +163,12 @@ def _render_run(console: Console, payload: dict[str, object]) -> None:
     title = "Blocked before launch" if blocked else "Launch allowed"
     border_style = "red" if blocked else "green"
     body = Table.grid(padding=(0, 1))
+    approval_delivery = payload.get("approval_delivery")
     body.add_row("Harness", f"[bold]{payload.get('harness', 'unknown')}[/bold]")
     body.add_row("Receipts", str(payload.get("receipts_recorded", 0)))
     body.add_row("Launched", _bool_label(launched))
+    if isinstance(approval_delivery, dict) and approval_delivery.get("summary"):
+        body.add_row("Prompt route", str(approval_delivery.get("summary")))
     if payload.get("approval_center_url"):
         body.add_row("Approval center", str(payload.get("approval_center_url")))
     if payload.get("review_hint"):
@@ -462,6 +465,12 @@ def _render_hook(console: Console, payload: dict[str, object]) -> None:
     body.add_row("Recorded", _bool_label(bool(payload.get("recorded"))))
     body.add_row("Artifact", str(payload.get("artifact_name") or payload.get("artifact_id") or "unknown"))
     body.add_row("Decision", _action_text(str(payload.get("policy_action", "warn"))))
+    if payload.get("path_summary"):
+        body.add_row("Path", str(payload.get("path_summary")))
+    if payload.get("approval_center_url"):
+        body.add_row("Approval center", str(payload.get("approval_center_url")))
+    if payload.get("review_hint"):
+        body.add_row("Review", str(payload.get("review_hint")))
     console.print(Panel(body, title="Guard hook event", border_style="cyan"))
 
 

--- a/src/codex_plugin_scanner/guard/proxy/stdio.py
+++ b/src/codex_plugin_scanner/guard/proxy/stdio.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
-from ..approvals import queue_blocked_approvals
+from ..approvals import approval_prompt_flow, queue_blocked_approvals
 from ..consumer import artifact_hash
 from ..models import HarnessDetection
 from ..receipts import build_receipt
@@ -48,8 +48,13 @@ def _redact_json(value: Any) -> Any:
     return value
 
 
-def _blocked_tool_response(message_id: Any, tool_name: str, reason: str | None = None) -> dict[str, Any]:
-    return {
+def _blocked_tool_response(
+    message_id: Any,
+    tool_name: str,
+    reason: str | None = None,
+    data: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
         "jsonrpc": "2.0",
         "id": message_id,
         "error": {
@@ -57,6 +62,9 @@ def _blocked_tool_response(message_id: Any, tool_name: str, reason: str | None =
             "message": reason or f"Guard blocked tool call for {tool_name}.",
         },
     }
+    if data:
+        payload["error"]["data"] = data
+    return payload
 
 
 class StdioGuardProxy:
@@ -162,6 +170,11 @@ class StdioGuardProxy:
                             )
                         if policy_action in {"block", "sandbox-required", "require-reapproval"}:
                             event["decision"] = "block"
+                            blocked_message = (
+                                f"Guard blocked sensitive local file access for {tool_name}: "
+                                f"{sensitive_request.path_match.path_class}."
+                            )
+                            response_data = None
                             if self.guard_store is not None and self.approval_center_url is not None:
                                 event["approval_requests"] = queue_blocked_approvals(
                                     detection=HarnessDetection(
@@ -189,13 +202,33 @@ class StdioGuardProxy:
                                     store=self.guard_store,
                                     approval_center_url=self.approval_center_url,
                                 )
+                                approval_flow = approval_prompt_flow(self.harness)
+                                event["approval_center_url"] = self.approval_center_url
+                                event["approval_delivery"] = {
+                                    "destination": (
+                                        "browser" if bool(approval_flow["auto_open_browser"]) else "harness"
+                                    ),
+                                    "prompt_channel": str(approval_flow["prompt_channel"]),
+                                    "summary": str(approval_flow["summary"]),
+                                }
+                                event["review_hint"] = (
+                                    f"{approval_flow['summary']} Open {self.approval_center_url} to review the "
+                                    "blocked request."
+                                )
+                                blocked_message = f"{blocked_message} {event['review_hint']}"
+                                response_data = {
+                                    "approvalCenterUrl": self.approval_center_url,
+                                    "approvalRequests": event["approval_requests"],
+                                    "approvalDelivery": event["approval_delivery"],
+                                    "reviewHint": event["review_hint"],
+                                }
                             events.append(event)
                             responses.append(
                                 _blocked_tool_response(
                                     message.get("id"),
                                     tool_name,
-                                    f"Guard blocked sensitive local file access for {tool_name}: "
-                                    f"{sensitive_request.path_match.path_class}.",
+                                    blocked_message,
+                                    response_data,
                                 )
                             )
                             continue

--- a/src/codex_plugin_scanner/guard/proxy/stdio.py
+++ b/src/codex_plugin_scanner/guard/proxy/stdio.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
-from ..approvals import approval_prompt_flow, queue_blocked_approvals
+from ..approvals import approval_delivery_payload, approval_prompt_flow, queue_blocked_approvals
 from ..consumer import artifact_hash
 from ..models import HarnessDetection
 from ..receipts import build_receipt
@@ -204,13 +204,7 @@ class StdioGuardProxy:
                                 )
                                 approval_flow = approval_prompt_flow(self.harness)
                                 event["approval_center_url"] = self.approval_center_url
-                                event["approval_delivery"] = {
-                                    "destination": (
-                                        "browser" if bool(approval_flow["auto_open_browser"]) else "harness"
-                                    ),
-                                    "prompt_channel": str(approval_flow["prompt_channel"]),
-                                    "summary": str(approval_flow["summary"]),
-                                }
+                                event["approval_delivery"] = approval_delivery_payload(approval_flow)
                                 event["review_hint"] = (
                                     f"{approval_flow['summary']} Open {self.approval_center_url} to review the "
                                     "blocked request."

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -22,7 +22,13 @@ from ..consumer import detect_harness, evaluate_detection
 from ..models import GuardArtifact, HarnessDetection, PolicyDecision
 from ..store import GuardStore
 
-_APPROVAL_METADATA_KEYS = ("approval_center_url", "approval_requests", "approval_wait", "review_hint")
+_APPROVAL_METADATA_KEYS = (
+    "approval_center_url",
+    "approval_delivery",
+    "approval_requests",
+    "approval_wait",
+    "review_hint",
+)
 _PAIN_SIGNAL_EVENTS = frozenset(
     {
         "changed_artifact_caught",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -743,11 +743,12 @@ class TestGuardRuntime:
                 "--json",
             ]
         )
-        output = capsys.readouterr().out
+        output = json.loads(capsys.readouterr().out)
 
         assert rc == 1
-        assert '"approval_center_url": "http://127.0.0.1:4455"' in output
-        assert '"blocked": true' in output
+        assert output["approval_center_url"] == "http://127.0.0.1:4455"
+        assert output["blocked"] is True
+        assert output["approval_delivery"]["destination"] == "browser"
         assert opened_urls == ["http://127.0.0.1:4455"]
 
     def test_headless_approval_resolver_skips_browser_for_hook_first_harnesses(self, tmp_path, monkeypatch):
@@ -1438,6 +1439,47 @@ class TestGuardRuntime:
         pending = store.list_approval_requests(limit=10)
         assert len(pending) == 1
         assert pending[0]["artifact_type"] == "file_read_request"
+
+    def test_stdio_proxy_handles_unknown_harness_when_queueing_sensitive_read_blocks(self, tmp_path):
+        store = GuardStore(tmp_path / "guard-home")
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir(parents=True, exist_ok=True)
+        config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=workspace_dir)
+        proxy = StdioGuardProxy(
+            command=[
+                sys.executable,
+                "-u",
+                "-c",
+                "\n".join(
+                    [
+                        "import json, sys",
+                        "for line in sys.stdin:",
+                        "    message = json.loads(line)",
+                        "    print(json.dumps({'jsonrpc': '2.0', 'id': message.get('id'), 'result': {'ok': True}}))",
+                        "    sys.stdout.flush()",
+                    ]
+                ),
+            ],
+            cwd=workspace_dir,
+            guard_store=store,
+            guard_config=config,
+            approval_center_url="http://127.0.0.1:4455",
+        )
+
+        blocked = proxy.run_session(
+            [
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "tools/call",
+                    "params": {"name": "read_file", "arguments": {"path": ".env"}},
+                }
+            ]
+        )
+
+        assert blocked["responses"][0]["error"]["code"] == -32001
+        assert blocked["responses"][0]["error"]["data"]["approvalDelivery"]["destination"] == "browser"
+        assert blocked["events"][0]["approval_delivery"]["destination"] == "browser"
 
     def test_remote_proxy_forwards_local_requests_and_redacts_auth_headers(self):
         server = HTTPServer(("127.0.0.1", 0), _RemoteProxyHandler)

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -583,6 +583,7 @@ class TestGuardRuntime:
         assert rc == 0
         assert output["permissionDecision"] == "deny"
         assert "approve" in output["permissionDecisionReason"]
+        assert "http://127.0.0.1:4455" in output["permissionDecisionReason"]
 
     def test_guard_hook_emits_copilot_native_allow_response_for_safe_requests(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
@@ -727,7 +728,8 @@ class TestGuardRuntime:
         workspace_dir = tmp_path / "workspace"
         _build_guard_fixture(home_dir, workspace_dir)
         monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
-        monkeypatch.setattr(guard_commands_module.webbrowser, "open", lambda _url: True)
+        opened_urls: list[str] = []
+        monkeypatch.setattr(guard_commands_module.webbrowser, "open", lambda url: opened_urls.append(url) or True)
 
         rc = main(
             [
@@ -746,6 +748,64 @@ class TestGuardRuntime:
         assert rc == 1
         assert '"approval_center_url": "http://127.0.0.1:4455"' in output
         assert '"blocked": true' in output
+        assert opened_urls == ["http://127.0.0.1:4455"]
+
+    def test_headless_approval_resolver_skips_browser_for_hook_first_harnesses(self, tmp_path, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        store = GuardStore(home_dir)
+        config = GuardConfig(guard_home=home_dir, workspace=workspace_dir, approval_wait_timeout_seconds=1)
+        artifact = GuardArtifact(
+            artifact_id="copilot:project:workspace-tools",
+            name="workspace-tools",
+            harness="copilot",
+            artifact_type="mcp_server",
+            source_scope="project",
+            config_path=str(workspace_dir / ".vscode" / "mcp.json"),
+            command="python",
+            args=("-m", "http.server", "9100"),
+            transport="stdio",
+        )
+        detection = HarnessDetection(
+            harness="copilot",
+            installed=True,
+            command_available=True,
+            config_paths=(artifact.config_path,),
+            artifacts=(artifact,),
+        )
+        payload = {
+            "blocked": True,
+            "artifacts": [
+                {
+                    "artifact_id": artifact.artifact_id,
+                    "artifact_name": artifact.name,
+                    "artifact_hash": artifact_hash(artifact),
+                    "policy_action": "require-reapproval",
+                    "changed_fields": ["args"],
+                    "artifact_type": artifact.artifact_type,
+                    "source_scope": artifact.source_scope,
+                    "config_path": artifact.config_path,
+                    "launch_target": "python -m http.server 9100",
+                }
+            ],
+        }
+        opened_urls: list[str] = []
+        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+        monkeypatch.setattr(guard_commands_module.webbrowser, "open", lambda url: opened_urls.append(url) or True)
+
+        blocked_resolver = guard_commands_module._headless_approval_resolver(
+            args=argparse.Namespace(harness="copilot"),
+            context=HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir),
+            store=store,
+            config=config,
+        )
+        result = blocked_resolver(detection, payload)
+
+        assert opened_urls == []
+        assert result["approval_center_url"] == "http://127.0.0.1:4455"
+        assert result["approval_delivery"]["destination"] == "harness"
+        assert result["approval_delivery"]["prompt_channel"] == "hook"
+        assert result["approval_wait"]["resolved"] is False
 
     def test_guard_run_headless_allow_persists_state_when_approval_center_is_available(
         self, tmp_path, capsys, monkeypatch
@@ -1368,7 +1428,11 @@ class TestGuardRuntime:
         assert allowed["events"][0]["decision"] == "forward"
         assert blocked["responses"][0]["error"]["code"] == -32001
         assert "sensitive local file" in blocked["responses"][0]["error"]["message"].lower()
+        assert "http://127.0.0.1:4455" in blocked["responses"][0]["error"]["message"]
+        assert blocked["responses"][0]["error"]["data"]["approvalCenterUrl"] == "http://127.0.0.1:4455"
+        assert blocked["responses"][0]["error"]["data"]["reviewHint"]
         assert blocked["events"][0]["decision"] == "block"
+        assert blocked["events"][0]["approval_delivery"]["destination"] == "browser"
         assert blocked["events"][0]["redacted_params"]["arguments"]["headers"]["Authorization"] == "*****"
         assert blocked["events"][0]["path_summary"].endswith("/.env")
         pending = store.list_approval_requests(limit=10)


### PR DESCRIPTION
## Summary
- route blocked approval UX through adapter-declared harness surfaces before falling back to browser auto-open
- enrich hook and MCP proxy block payloads with approval-center URLs, review hints, and delivery metadata
- cover browser-first versus harness-first routing and the richer inline deny/error contracts

## Verification
- ruff check .
- pytest -q
- live Copilot CLI repo-hook E2E against a fake `.env` confirmed the deny reason included the Guard approval-center URL instead of allowing the read
