### PR TITLE
fix: rename Guard local state to hol-guard

### DIFF
--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -83,10 +83,12 @@ default_action = "sandbox-required"
 Optional project override:
 
 ```toml
-# .ai-plugin-scanner-guard.toml
+# .hol-guard.toml
 [artifacts."codex:project:workspace_tools"]
 default_action = "block"
 ```
+
+Guard still reads the legacy `.ai-plugin-scanner-guard.toml` file if you already have one, but new local overrides should use `.hol-guard.toml`.
 
 Guard resolves decisions in this order:
 
@@ -107,8 +109,8 @@ Use these actions in config or saved decisions:
 
 `guard install <harness>` creates a local launcher shim under Guard’s home directory:
 
-- macOS/Linux: `~/.config/.ai-plugin-scanner-guard/bin/guard-<harness>`
-- Windows: `~/.config/.ai-plugin-scanner-guard/bin/guard-<harness>.cmd`
+- macOS/Linux: `~/.hol-guard/bin/guard-<harness>`
+- Windows: `~/.hol-guard/bin/guard-<harness>.cmd`
 
 Claude Code also gets Guard hook entries in `.claude/settings.local.json` when you install from a workspace.
 

--- a/src/codex_plugin_scanner/guard/bridge/__init__.py
+++ b/src/codex_plugin_scanner/guard/bridge/__init__.py
@@ -9,11 +9,11 @@ import sys
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Any
 
 import requests
 
+from ..config import resolve_guard_home
 from ..store import GuardStore
 
 
@@ -267,7 +267,7 @@ def run_bridge(
     """Run the Guard Bridge daemon."""
     config = BridgeConfig(guard_url=guard_url, poll_interval=poll_interval, dry_run=dry_run)
     if store is None:
-        store = GuardStore(Path.home() / ".holguard")
+        store = GuardStore(resolve_guard_home())
 
     bridge = GuardBridge(config=config, store=store, backend=backend)
     bridge.run()

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -12,7 +12,9 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10
 
 from .models import GuardAction, GuardMode
 
-DEFAULT_GUARD_DIRNAME = ".ai-plugin-scanner-guard"
+DEFAULT_GUARD_DIRNAME = ".hol-guard"
+LEGACY_GUARD_DIRNAMES = (".config/.ai-plugin-scanner-guard", ".ai-plugin-scanner-guard", ".holguard")
+WORKSPACE_CONFIG_FILENAMES = (".ai-plugin-scanner-guard.toml", ".hol-guard.toml")
 VALID_GUARD_ACTIONS = {"allow", "warn", "review", "block", "sandbox-required", "require-reapproval"}
 VALID_GUARD_MODES = {"observe", "prompt", "enforce"}
 
@@ -76,9 +78,11 @@ def resolve_guard_home(override: str | None = None) -> Path:
 
     if override:
         return Path(override).expanduser().resolve()
-    xdg_home = Path.home() / ".config" / DEFAULT_GUARD_DIRNAME
-    legacy_home = Path.home() / DEFAULT_GUARD_DIRNAME
-    return xdg_home if xdg_home.exists() else legacy_home
+    canonical_home = Path.home() / DEFAULT_GUARD_DIRNAME
+    if canonical_home.exists():
+        return canonical_home
+    legacy_home = _existing_legacy_guard_home()
+    return legacy_home if legacy_home is not None else canonical_home
 
 
 def _read_toml(path: Path) -> dict[str, object]:
@@ -97,7 +101,7 @@ def load_guard_config(guard_home: Path, workspace: Path | None = None) -> GuardC
 
     guard_home.mkdir(parents=True, exist_ok=True)
     home_config = _read_toml(guard_home / "config.toml")
-    workspace_config = _read_toml(workspace / ".ai-plugin-scanner-guard.toml") if workspace else {}
+    workspace_config = _load_workspace_guard_config(workspace)
 
     merged: dict[str, object] = {**home_config, **workspace_config}
     return GuardConfig(
@@ -163,3 +167,20 @@ def _coerce_action_value(value: object, fallback: GuardAction) -> GuardAction:
     if isinstance(value, str) and value in VALID_GUARD_ACTIONS:
         return value
     return fallback
+
+
+def _existing_legacy_guard_home() -> Path | None:
+    for relative_path in LEGACY_GUARD_DIRNAMES:
+        candidate = Path.home() / relative_path
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _load_workspace_guard_config(workspace: Path | None) -> dict[str, object]:
+    if workspace is None:
+        return {}
+    merged: dict[str, object] = {}
+    for filename in WORKSPACE_CONFIG_FILENAMES:
+        merged.update(_read_toml(workspace / filename))
+    return merged

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -197,6 +197,9 @@ def _merge_config_payload(base: dict[str, object], override: dict[str, object]) 
         if isinstance(existing, dict) and isinstance(value, dict):
             nested_existing = {name: nested_value for name, nested_value in existing.items() if isinstance(name, str)}
             nested_override = {name: nested_value for name, nested_value in value.items() if isinstance(name, str)}
+            if "action" in nested_override or "default_action" in nested_override:
+                nested_existing.pop("action", None)
+                nested_existing.pop("default_action", None)
             merged[key] = _merge_config_payload(nested_existing, nested_override)
             continue
         merged[key] = value

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -79,10 +79,14 @@ def resolve_guard_home(override: str | None = None) -> Path:
     if override:
         return Path(override).expanduser().resolve()
     canonical_home = Path.home() / DEFAULT_GUARD_DIRNAME
-    if canonical_home.exists():
-        return canonical_home
     legacy_home = _existing_legacy_guard_home()
-    return legacy_home if legacy_home is not None else canonical_home
+    if legacy_home is None:
+        return canonical_home
+    if _guard_home_has_state(canonical_home):
+        return canonical_home
+    if canonical_home.exists() and _guard_home_has_state(legacy_home):
+        return legacy_home
+    return legacy_home if not canonical_home.exists() else canonical_home
 
 
 def _read_toml(path: Path) -> dict[str, object]:
@@ -103,7 +107,7 @@ def load_guard_config(guard_home: Path, workspace: Path | None = None) -> GuardC
     home_config = _read_toml(guard_home / "config.toml")
     workspace_config = _load_workspace_guard_config(workspace)
 
-    merged: dict[str, object] = {**home_config, **workspace_config}
+    merged = _merge_config_payload(home_config, workspace_config)
     return GuardConfig(
         guard_home=guard_home,
         workspace=workspace,
@@ -182,5 +186,24 @@ def _load_workspace_guard_config(workspace: Path | None) -> dict[str, object]:
         return {}
     merged: dict[str, object] = {}
     for filename in WORKSPACE_CONFIG_FILENAMES:
-        merged.update(_read_toml(workspace / filename))
+        merged = _merge_config_payload(merged, _read_toml(workspace / filename))
     return merged
+
+
+def _merge_config_payload(base: dict[str, object], override: dict[str, object]) -> dict[str, object]:
+    merged = dict(base)
+    for key, value in override.items():
+        existing = merged.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            nested_existing = {name: nested_value for name, nested_value in existing.items() if isinstance(name, str)}
+            nested_override = {name: nested_value for name, nested_value in value.items() if isinstance(name, str)}
+            merged[key] = _merge_config_payload(nested_existing, nested_override)
+            continue
+        merged[key] = value
+    return merged
+
+
+def _guard_home_has_state(path: Path) -> bool:
+    if not path.exists():
+        return False
+    return any(path.iterdir())

--- a/tests/test_guard_config_paths.py
+++ b/tests/test_guard_config_paths.py
@@ -86,6 +86,36 @@ def test_load_guard_config_merges_nested_workspace_tables_across_legacy_and_hol_
     }
 
 
+def test_load_guard_config_new_action_alias_overrides_legacy_alias(tmp_path):
+    guard_home = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    guard_home.mkdir(parents=True, exist_ok=True)
+    _write_text(
+        workspace_dir / ".ai-plugin-scanner-guard.toml",
+        "\n".join(
+            [
+                "[harnesses.codex]",
+                'action = "block"',
+            ]
+        )
+        + "\n",
+    )
+    _write_text(
+        workspace_dir / ".hol-guard.toml",
+        "\n".join(
+            [
+                "[harnesses.codex]",
+                'default_action = "allow"',
+            ]
+        )
+        + "\n",
+    )
+
+    config = load_guard_config(guard_home, workspace_dir)
+
+    assert config.harness_actions == {"codex": "allow"}
+
+
 def test_run_bridge_uses_resolved_guard_home_by_default(tmp_path, monkeypatch):
     expected_guard_home = tmp_path / ".hol-guard"
     captured: dict[str, Path] = {}

--- a/tests/test_guard_config_paths.py
+++ b/tests/test_guard_config_paths.py
@@ -29,6 +29,17 @@ def test_resolve_guard_home_falls_back_to_legacy_directory(tmp_path, monkeypatch
     assert resolve_guard_home() == legacy_home
 
 
+def test_resolve_guard_home_prefers_legacy_state_over_empty_canonical_directory(tmp_path, monkeypatch):
+    home_dir = tmp_path / "home"
+    canonical_home = home_dir / ".hol-guard"
+    legacy_home = home_dir / ".config" / ".ai-plugin-scanner-guard"
+    canonical_home.mkdir(parents=True, exist_ok=True)
+    _write_text(legacy_home / "guard.db", "sqlite placeholder")
+    monkeypatch.setattr(Path, "home", lambda: home_dir)
+
+    assert resolve_guard_home() == legacy_home
+
+
 def test_load_guard_config_prefers_hol_guard_workspace_override(tmp_path):
     guard_home = tmp_path / "guard-home"
     workspace_dir = tmp_path / "workspace"
@@ -40,6 +51,39 @@ def test_load_guard_config_prefers_hol_guard_workspace_override(tmp_path):
     config = load_guard_config(guard_home, workspace_dir)
 
     assert config.default_action == "block"
+
+
+def test_load_guard_config_merges_nested_workspace_tables_across_legacy_and_hol_guard_files(tmp_path):
+    guard_home = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    guard_home.mkdir(parents=True, exist_ok=True)
+    _write_text(
+        workspace_dir / ".ai-plugin-scanner-guard.toml",
+        "\n".join(
+            [
+                "[harnesses.codex]",
+                'default_action = "allow"',
+            ]
+        )
+        + "\n",
+    )
+    _write_text(
+        workspace_dir / ".hol-guard.toml",
+        "\n".join(
+            [
+                "[harnesses.claude-code]",
+                'default_action = "block"',
+            ]
+        )
+        + "\n",
+    )
+
+    config = load_guard_config(guard_home, workspace_dir)
+
+    assert config.harness_actions == {
+        "codex": "allow",
+        "claude-code": "block",
+    }
 
 
 def test_run_bridge_uses_resolved_guard_home_by_default(tmp_path, monkeypatch):

--- a/tests/test_guard_config_paths.py
+++ b/tests/test_guard_config_paths.py
@@ -1,0 +1,61 @@
+"""Regression tests for Guard branding on local state paths."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_plugin_scanner.guard import bridge as bridge_module
+from codex_plugin_scanner.guard.config import load_guard_config, resolve_guard_home
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_resolve_guard_home_defaults_to_hol_guard_directory(tmp_path, monkeypatch):
+    home_dir = tmp_path / "home"
+    monkeypatch.setattr(Path, "home", lambda: home_dir)
+
+    assert resolve_guard_home() == home_dir / ".hol-guard"
+
+
+def test_resolve_guard_home_falls_back_to_legacy_directory(tmp_path, monkeypatch):
+    home_dir = tmp_path / "home"
+    legacy_home = home_dir / ".config" / ".ai-plugin-scanner-guard"
+    legacy_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(Path, "home", lambda: home_dir)
+
+    assert resolve_guard_home() == legacy_home
+
+
+def test_load_guard_config_prefers_hol_guard_workspace_override(tmp_path):
+    guard_home = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    guard_home.mkdir(parents=True, exist_ok=True)
+    _write_text(guard_home / "config.toml", 'default_action = "warn"\n')
+    _write_text(workspace_dir / ".ai-plugin-scanner-guard.toml", 'default_action = "allow"\n')
+    _write_text(workspace_dir / ".hol-guard.toml", 'default_action = "block"\n')
+
+    config = load_guard_config(guard_home, workspace_dir)
+
+    assert config.default_action == "block"
+
+
+def test_run_bridge_uses_resolved_guard_home_by_default(tmp_path, monkeypatch):
+    expected_guard_home = tmp_path / ".hol-guard"
+    captured: dict[str, Path] = {}
+
+    class _FakeGuardBridge:
+        def __init__(self, *, config, store, backend):
+            captured["guard_home"] = store.guard_home
+
+        def run(self) -> None:
+            return
+
+    monkeypatch.setattr(bridge_module, "resolve_guard_home", lambda: expected_guard_home)
+    monkeypatch.setattr(bridge_module, "GuardBridge", _FakeGuardBridge)
+
+    bridge_module.run_bridge(dry_run=True)
+
+    assert captured["guard_home"] == expected_guard_home


### PR DESCRIPTION
## Summary
- rename the default Guard home to `~/.hol-guard`
- keep reading legacy Guard homes and legacy workspace override files for compatibility
- route bridge storage through the shared Guard home resolver and document the branded paths

## Verification
- ruff check .
- pytest -q