### PR TITLE
fix: sync version computation with GitHub releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,10 @@ jobs:
             LAST_TAG_VERSION="${LAST_TAG#v}"
 
             # Also check GitHub releases (they may exist without corresponding git tags)
-            GH_RELEASE_VERSION=$(gh release list --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null | sed 's/^v//')
+            # Null-safe: returns empty if no releases exist
+            # Collect all releases and pick max semver (not just first which may not be highest)
+            GH_RELEASES=$(gh release list --json tagName --jq '.[].tagName' 2>/dev/null | sed 's/^v//' | sort -V 2>/dev/null || echo "")
+            GH_RELEASE_VERSION=$(echo "$GH_RELEASES" | grep -v '^$' | tail -n1)
 
             # Use whichever version is higher
             if [[ -n "$GH_RELEASE_VERSION" && -n "$LAST_TAG_VERSION" ]]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,9 +57,13 @@ jobs:
             LAST_TAG_VERSION="${LAST_TAG#v}"
 
             # Also check GitHub releases (they may exist without corresponding git tags)
+            # GH_TOKEN needed for authenticated gh calls in GitHub Actions
+            export GH_TOKEN="$GITHUB_TOKEN"
             # Null-safe: returns empty if no releases exist
             # Collect all releases and pick max semver (not just first which may not be highest)
-            GH_RELEASES=$(gh release list --json tagName --jq '.[].tagName' 2>/dev/null | sed 's/^v//' | sort -V 2>/dev/null || echo "")
+            # Filter to strict semver tags (vX.Y.Z) to exclude non-semver like "nightly" or "rc"
+            GH_RELEASES=$(gh release list --json tagName --jq '.[].tagName' 2>/dev/null | \
+              grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sed 's/^v//' | sort -V 2>/dev/null || echo "")
             GH_RELEASE_VERSION=$(echo "$GH_RELEASES" | grep -v '^$' | tail -n1)
 
             # Use whichever version is higher

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,7 @@ jobs:
         env:
           GITHUB_REF: ${{ github.ref }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           BASE_VERSION=$(python3 -c "import tomllib; p=tomllib.load(open('pyproject.toml','rb')); print(p['project']['version'])")
           VERSION="$BASE_VERSION"
@@ -57,12 +58,11 @@ jobs:
             LAST_TAG_VERSION="${LAST_TAG#v}"
 
             # Also check GitHub releases (they may exist without corresponding git tags)
-            # GH_TOKEN needed for authenticated gh calls in GitHub Actions
-            export GH_TOKEN="$GITHUB_TOKEN"
+            # GH_TOKEN provided via env block above
             # Null-safe: returns empty if no releases exist
-            # Collect all releases and pick max semver (not just first which may not be highest)
+            # Fetch all releases (--limit 100) and pick max semver
             # Filter to strict semver tags (vX.Y.Z) to exclude non-semver like "nightly" or "rc"
-            GH_RELEASES=$(gh release list --json tagName --jq '.[].tagName' 2>/dev/null | \
+            GH_RELEASES=$(gh release list --limit 100 --json tagName --jq '.[].tagName' 2>/dev/null | \
               grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sed 's/^v//' | sort -V 2>/dev/null || echo "")
             GH_RELEASE_VERSION=$(echo "$GH_RELEASES" | grep -v '^$' | tail -n1)
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,11 +52,27 @@ jobs:
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
           elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
-            LAST_TAG=$(git tag --list 'v*' --sort=-version:refname | head -n1)
-            if [[ -n "$LAST_TAG" ]]; then
-              IFS=. read -r MAJOR MINOR PATCH <<< "${LAST_TAG#v}"
+            # Check git tags first
+            LAST_TAG=$(git tag --list 'v*' --sort=-version:refname 2>/dev/null | head -n1)
+            LAST_TAG_VERSION="${LAST_TAG#v}"
+
+            # Also check GitHub releases (they may exist without corresponding git tags)
+            GH_RELEASE_VERSION=$(gh release list --limit 1 --json tagName --jq '.[0].tagName' 2>/dev/null | sed 's/^v//')
+
+            # Use whichever version is higher
+            if [[ -n "$GH_RELEASE_VERSION" && -n "$LAST_TAG_VERSION" ]]; then
+              COMPARE=$(printf '%s\n%s\n' "$LAST_TAG_VERSION" "$GH_RELEASE_VERSION" | sort -V | tail -n1)
+              HIGHEST="$COMPARE"
+            elif [[ -n "$GH_RELEASE_VERSION" ]]; then
+              HIGHEST="$GH_RELEASE_VERSION"
+            elif [[ -n "$LAST_TAG_VERSION" ]]; then
+              HIGHEST="$LAST_TAG_VERSION"
+            fi
+
+            if [[ -n "$HIGHEST" ]]; then
+              IFS=. read -r MAJOR MINOR PATCH <<< "$HIGHEST"
               if [[ -z "$MAJOR" || -z "$MINOR" || -z "$PATCH" ]]; then
-                echo "Unsupported release tag format: $LAST_TAG" >&2
+                echo "Unsupported release tag format: $HIGHEST" >&2
                 exit 1
               fi
               VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
@@ -304,6 +320,7 @@ jobs:
           VERSION="${{ needs.build.outputs.version }}"
           gh release create "v${VERSION}" \
             --title "v${VERSION}" \
+            --target main \
             --notes-file ${{ steps.changelog.outputs.notes_path }} \
             "${RELEASE_ASSETS[@]}"
 


### PR DESCRIPTION
The auto-publish workflow was stuck because:

1. Git tags only went up to v2.0.9
2. A v2.0.10 release was created (likely via UI) without a corresponding git tag
3. The workflow computes next version from git tags only, so it kept trying to publish v2.0.10
4. Both PyPI publish (skip-existing) and release creation (already exists) were skipped

This fix:
- Uses `gh release list` to also check GitHub releases when computing next version
- Compares git tag version vs release version and uses whichever is higher
- Adds `--target main` flag to release creation to ensure a git tag gets created

Test: after merging, push to main should compute v2.0.11 (incrementing from v2.0.10 release)