### PR TITLE
feat: harden antigravity and gemini guard adapters

### DIFF
--- a/docs/guard/approval-audit.md
+++ b/docs/guard/approval-audit.md
@@ -44,8 +44,10 @@ This note audits the current scanner-owned Guard approval flow in `ai-plugin-sca
   - App Server remains the future richer path
 - `cursor`
   - Guard focuses on artifact trust before native tool approval
+- `antigravity`
+  - Guard focuses on extension, MCP, and skill trust before editor launch
 - `gemini`
-  - Guard scans extensions and routes blocked changes to the approval center
+  - Guard scans settings, hooks, extensions, skills, and MCP registrations, then routes blocked changes to the approval center
 - `opencode`
   - Guard manages artifact trust while OpenCode keeps tool permission semantics
 

--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -138,11 +138,14 @@ Current strategy:
   uses the Guard approval center today; App Server is the long-term richer in-client path
 - `cursor`
   keeps Cursor’s native tool approval and lets Guard own artifact trust before tool use
+- `antigravity`
+  scans Antigravity settings, installed extensions, and Antigravity-owned MCP or skill roots before launch
 - `opencode`
   detects OpenCode MCP servers, commands, plugins, and skills before launch, and `guard install opencode` adds a
   Guard-owned runtime overlay that keeps native skill loads on ask
 - `gemini`
-  scans extension manifests and routes blocked changes to the approval center
+  scans `.gemini/settings.json`, extension manifests, hooks, MCP registrations, and Gemini skill directories before
+  launch, then routes blocked changes to the approval center
 
 Guard does not claim VS Code Copilot extension-host interception in this pass, and it does not add Cisco AIBOM runtime policy logic. AIBOM can come back later only as evidence or export.
 

--- a/docs/guard/harness-support.md
+++ b/docs/guard/harness-support.md
@@ -21,8 +21,12 @@ Current Guard support in this repo:
   - detects global and project `mcp.json`
   - supports wrapper-mode management state
   - leaves native Cursor tool approval in place and focuses Guard on artifact trust
+- `antigravity`
+  - detects Antigravity user settings, installed extension profiles, and Antigravity-owned MCP and skill roots
+  - supports wrapper-mode management state
+  - uses the local approval center for blocked artifact changes today
 - `gemini`
-  - detects local extension manifests and embedded MCP server declarations
+  - detects `.gemini/settings.json`, local extension manifests, embedded MCP declarations, hooks, and Gemini skill directories
   - supports wrapper-mode management state
   - falls back to the local approval center when Guard blocks a launch
 - `opencode`

--- a/docs/guard/testing-matrix.md
+++ b/docs/guard/testing-matrix.md
@@ -15,6 +15,7 @@ Manual verification should include:
 - `hol-guard status`
 - `hol-guard detect codex --json`
 - `hol-guard detect cursor --json`
+- `hol-guard detect antigravity --json`
 - `hol-guard detect gemini --json`
 - `hol-guard detect opencode --json`
 - `hol-guard install opencode --json`
@@ -26,6 +27,7 @@ Manual verification should include:
 - `hol-guard receipts`
 - `codex mcp list`
 - `cursor-agent mcp list`
+- `antigravity --help`
 - `gemini --help`
 - `opencode --help`
 - `opencode run --help`

--- a/src/codex_plugin_scanner/guard/adapters/__init__.py
+++ b/src/codex_plugin_scanner/guard/adapters/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .antigravity import AntigravityHarnessAdapter
 from .base import HarnessAdapter, HarnessContext
 from .claude_code import ClaudeCodeHarnessAdapter
 from .codex import CodexHarnessAdapter
@@ -16,6 +17,7 @@ ADAPTERS: tuple[HarnessAdapter, ...] = (
     ClaudeCodeHarnessAdapter(),
     CopilotHarnessAdapter(),
     CursorHarnessAdapter(),
+    AntigravityHarnessAdapter(),
     GeminiHarnessAdapter(),
     HermesHarnessAdapter(),
     OpenCodeHarnessAdapter(),

--- a/src/codex_plugin_scanner/guard/adapters/antigravity.py
+++ b/src/codex_plugin_scanner/guard/adapters/antigravity.py
@@ -69,9 +69,9 @@ class AntigravityHarnessAdapter(HarnessAdapter):
             return "settings:workspace-vscode"
         token_parts = []
         for part in config_path.parts[-4:]:
-            normalized_part = "".join(
-                character if character.isalnum() else "-" for character in part.lower()
-            ).strip("-")
+            normalized_part = "".join(character if character.isalnum() else "-" for character in part.lower()).strip(
+                "-"
+            )
             if normalized_part:
                 token_parts.append(normalized_part)
         return f"settings:{'-'.join(token_parts)}"

--- a/src/codex_plugin_scanner/guard/adapters/antigravity.py
+++ b/src/codex_plugin_scanner/guard/adapters/antigravity.py
@@ -45,8 +45,6 @@ class AntigravityHarnessAdapter(HarnessAdapter):
 
     @staticmethod
     def _contains_antigravity_settings(payload: dict[str, object]) -> bool:
-        if isinstance(payload.get("mcpServers"), dict):
-            return True
         return any(isinstance(key, str) and key.startswith("antigravity.") for key in payload)
 
     @staticmethod
@@ -99,6 +97,7 @@ class AntigravityHarnessAdapter(HarnessAdapter):
                 )
 
         settings_paths = self._settings_paths(context)
+        owned_settings_paths = set(settings_paths)
         if context.workspace_dir is not None:
             settings_paths.append(context.workspace_dir / ".vscode" / "settings.json")
         has_non_settings_signal = bool(found_paths)
@@ -106,14 +105,17 @@ class AntigravityHarnessAdapter(HarnessAdapter):
             payload = _json_payload(settings_path)
             if not payload:
                 continue
+            owns_settings = (
+                settings_path in owned_settings_paths
+                or self._contains_antigravity_settings(payload)
+                or has_non_settings_signal
+            )
+            if not owns_settings:
+                continue
             scope = self._scope_for(context, settings_path)
             before_artifact_count = len(artifacts)
             self._append_mcp_artifacts(artifacts, settings_path, payload, scope)
-            if (
-                len(artifacts) > before_artifact_count
-                or self._contains_antigravity_settings(payload)
-                or has_non_settings_signal
-            ):
+            if len(artifacts) > before_artifact_count or owns_settings:
                 self._append_found_path(found_paths, settings_path)
 
         return HarnessDetection(

--- a/src/codex_plugin_scanner/guard/adapters/antigravity.py
+++ b/src/codex_plugin_scanner/guard/adapters/antigravity.py
@@ -54,6 +54,10 @@ class AntigravityHarnessAdapter(HarnessAdapter):
             return ()
         return tuple(str(value) for value in raw_args if isinstance(value, str))
 
+    @staticmethod
+    def _mcp_source(config_path: Path) -> str:
+        return "bridge" if config_path.name == "mcp_config.json" else "settings"
+
     def detect(self, context: HarnessContext) -> HarnessDetection:
         artifacts: list[GuardArtifact] = []
         found_paths: list[str] = []
@@ -152,7 +156,7 @@ class AntigravityHarnessAdapter(HarnessAdapter):
             url = server_config.get("url")
             artifacts.append(
                 GuardArtifact(
-                    artifact_id=f"antigravity:{scope}:mcp:{name}",
+                    artifact_id=f"antigravity:{scope}:mcp:{self._mcp_source(config_path)}:{name}",
                     name=name,
                     harness=self.harness,
                     artifact_type="mcp_server",

--- a/src/codex_plugin_scanner/guard/adapters/antigravity.py
+++ b/src/codex_plugin_scanner/guard/adapters/antigravity.py
@@ -56,7 +56,25 @@ class AntigravityHarnessAdapter(HarnessAdapter):
 
     @staticmethod
     def _mcp_source(config_path: Path) -> str:
-        return "bridge" if config_path.name == "mcp_config.json" else "settings"
+        if config_path.name == "mcp_config.json":
+            return "bridge"
+        normalized_path = config_path.as_posix().lower()
+        if normalized_path.endswith("/library/application support/antigravity/user/settings.json"):
+            return "settings:macos-user"
+        if normalized_path.endswith("/.config/antigravity/user/settings.json"):
+            return "settings:xdg-user"
+        if normalized_path.endswith("/appdata/roaming/antigravity/user/settings.json"):
+            return "settings:windows-user"
+        if normalized_path.endswith("/.vscode/settings.json"):
+            return "settings:workspace-vscode"
+        token_parts = []
+        for part in config_path.parts[-4:]:
+            normalized_part = "".join(
+                character if character.isalnum() else "-" for character in part.lower()
+            ).strip("-")
+            if normalized_part:
+                token_parts.append(normalized_part)
+        return f"settings:{'-'.join(token_parts)}"
 
     def detect(self, context: HarnessContext) -> HarnessDetection:
         artifacts: list[GuardArtifact] = []

--- a/src/codex_plugin_scanner/guard/adapters/antigravity.py
+++ b/src/codex_plugin_scanner/guard/adapters/antigravity.py
@@ -20,8 +20,7 @@ class AntigravityHarnessAdapter(HarnessAdapter):
         "and routes review through the local approval center."
     )
     fallback_hint = (
-        "Use Guard review for new Antigravity artifacts before launch, then hand off to "
-        "the local editor normally."
+        "Use Guard review for new Antigravity artifacts before launch, then hand off to the local editor normally."
     )
 
     @staticmethod
@@ -36,27 +35,30 @@ class AntigravityHarnessAdapter(HarnessAdapter):
         if candidate not in found_paths:
             found_paths.append(candidate)
 
+    @staticmethod
+    def _settings_paths(context: HarnessContext) -> list[Path]:
+        return [
+            context.home_dir / "Library" / "Application Support" / "Antigravity" / "User" / "settings.json",
+            context.home_dir / ".config" / "Antigravity" / "User" / "settings.json",
+            context.home_dir / "AppData" / "Roaming" / "Antigravity" / "User" / "settings.json",
+        ]
+
+    @staticmethod
+    def _contains_antigravity_settings(payload: dict[str, object]) -> bool:
+        if isinstance(payload.get("mcpServers"), dict):
+            return True
+        return any(isinstance(key, str) and key.startswith("antigravity.") for key in payload)
+
+    @staticmethod
+    def _string_args(server_config: dict[str, object]) -> tuple[str, ...]:
+        raw_args = server_config.get("args")
+        if not isinstance(raw_args, list):
+            return ()
+        return tuple(str(value) for value in raw_args if isinstance(value, str))
+
     def detect(self, context: HarnessContext) -> HarnessDetection:
         artifacts: list[GuardArtifact] = []
         found_paths: list[str] = []
-
-        settings_paths = [
-            context.home_dir
-            / "Library"
-            / "Application Support"
-            / "Antigravity"
-            / "User"
-            / "settings.json"
-        ]
-        if context.workspace_dir is not None:
-            settings_paths.append(context.workspace_dir / ".vscode" / "settings.json")
-        for settings_path in settings_paths:
-            payload = _json_payload(settings_path)
-            if not payload:
-                continue
-            self._append_found_path(found_paths, settings_path)
-            scope = self._scope_for(context, settings_path)
-            self._append_mcp_artifacts(artifacts, settings_path, payload, scope)
 
         extension_index = context.home_dir / ".antigravity" / "extensions" / "extensions.json"
         extension_payload = self._extension_index_payload(extension_index)
@@ -95,6 +97,24 @@ class AntigravityHarnessAdapter(HarnessAdapter):
                         config_path=str(skill_path),
                     )
                 )
+
+        settings_paths = self._settings_paths(context)
+        if context.workspace_dir is not None:
+            settings_paths.append(context.workspace_dir / ".vscode" / "settings.json")
+        has_non_settings_signal = bool(found_paths)
+        for settings_path in settings_paths:
+            payload = _json_payload(settings_path)
+            if not payload:
+                continue
+            scope = self._scope_for(context, settings_path)
+            before_artifact_count = len(artifacts)
+            self._append_mcp_artifacts(artifacts, settings_path, payload, scope)
+            if (
+                len(artifacts) > before_artifact_count
+                or self._contains_antigravity_settings(payload)
+                or has_non_settings_signal
+            ):
+                self._append_found_path(found_paths, settings_path)
 
         return HarnessDetection(
             harness=self.harness,
@@ -137,7 +157,7 @@ class AntigravityHarnessAdapter(HarnessAdapter):
                     source_scope=scope,
                     config_path=str(config_path),
                     command=command if isinstance(command, str) else None,
-                    args=tuple(str(value) for value in server_config.get("args", []) if isinstance(value, str)),
+                    args=self._string_args(server_config),
                     url=url if isinstance(url, str) else None,
                     transport="http" if isinstance(url, str) else "stdio",
                 )
@@ -166,9 +186,7 @@ class AntigravityHarnessAdapter(HarnessAdapter):
             if manifest_payload:
                 self._append_found_path(found_paths, manifest_path)
             publisher = (
-                manifest_payload.get("publisher")
-                if isinstance(manifest_payload.get("publisher"), str)
-                else None
+                manifest_payload.get("publisher") if isinstance(manifest_payload.get("publisher"), str) else None
             )
             if publisher is None and isinstance(metadata, dict):
                 publisher_display_name = metadata.get("publisherDisplayName")

--- a/src/codex_plugin_scanner/guard/adapters/antigravity.py
+++ b/src/codex_plugin_scanner/guard/adapters/antigravity.py
@@ -1,0 +1,195 @@
+"""Antigravity harness adapter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ..models import GuardArtifact, HarnessDetection
+from .base import HarnessAdapter, HarnessContext, _command_available, _json_payload
+
+
+class AntigravityHarnessAdapter(HarnessAdapter):
+    """Discover Antigravity extensions plus Antigravity-owned MCP and skill roots."""
+
+    harness = "antigravity"
+    executable = "antigravity"
+    approval_tier = "approval-center"
+    approval_summary = (
+        "Guard scans Antigravity extensions, MCP registrations, and skills before launch "
+        "and routes review through the local approval center."
+    )
+    fallback_hint = (
+        "Use Guard review for new Antigravity artifacts before launch, then hand off to "
+        "the local editor normally."
+    )
+
+    @staticmethod
+    def _scope_for(context: HarnessContext, path: Path) -> str:
+        if context.workspace_dir is not None and path.is_relative_to(context.workspace_dir):
+            return "project"
+        return "global"
+
+    @staticmethod
+    def _append_found_path(found_paths: list[str], path: Path) -> None:
+        candidate = str(path)
+        if candidate not in found_paths:
+            found_paths.append(candidate)
+
+    def detect(self, context: HarnessContext) -> HarnessDetection:
+        artifacts: list[GuardArtifact] = []
+        found_paths: list[str] = []
+
+        settings_paths = [
+            context.home_dir
+            / "Library"
+            / "Application Support"
+            / "Antigravity"
+            / "User"
+            / "settings.json"
+        ]
+        if context.workspace_dir is not None:
+            settings_paths.append(context.workspace_dir / ".vscode" / "settings.json")
+        for settings_path in settings_paths:
+            payload = _json_payload(settings_path)
+            if not payload:
+                continue
+            self._append_found_path(found_paths, settings_path)
+            scope = self._scope_for(context, settings_path)
+            self._append_mcp_artifacts(artifacts, settings_path, payload, scope)
+
+        extension_index = context.home_dir / ".antigravity" / "extensions" / "extensions.json"
+        extension_payload = self._extension_index_payload(extension_index)
+        if extension_payload:
+            self._append_found_path(found_paths, extension_index)
+            artifacts.extend(self._extension_artifacts(extension_payload, found_paths))
+
+        antigravity_config_paths = [context.home_dir / ".gemini" / "antigravity" / "mcp_config.json"]
+        if context.workspace_dir is not None:
+            antigravity_config_paths.append(context.workspace_dir / ".gemini" / "antigravity" / "mcp_config.json")
+        for config_path in antigravity_config_paths:
+            payload = _json_payload(config_path)
+            if not payload:
+                continue
+            self._append_found_path(found_paths, config_path)
+            scope = self._scope_for(context, config_path)
+            self._append_mcp_artifacts(artifacts, config_path, payload, scope)
+
+        skill_roots = [context.home_dir / ".gemini" / "antigravity" / "skills"]
+        if context.workspace_dir is not None:
+            skill_roots.append(context.workspace_dir / ".gemini" / "antigravity" / "skills")
+        for skill_root in skill_roots:
+            if not skill_root.is_dir():
+                continue
+            scope = self._scope_for(context, skill_root)
+            for skill_path in sorted(skill_root.rglob("SKILL.md")):
+                self._append_found_path(found_paths, skill_path)
+                relative_id = f"skills/{skill_path.parent.relative_to(skill_root).as_posix()}"
+                artifacts.append(
+                    GuardArtifact(
+                        artifact_id=f"antigravity:{scope}:skill:{relative_id}",
+                        name=relative_id,
+                        harness=self.harness,
+                        artifact_type="skill",
+                        source_scope=scope,
+                        config_path=str(skill_path),
+                    )
+                )
+
+        return HarnessDetection(
+            harness=self.harness,
+            installed=bool(found_paths) or _command_available(self.executable),
+            command_available=_command_available(self.executable),
+            config_paths=tuple(found_paths),
+            artifacts=tuple(artifacts),
+            warnings=(),
+        )
+
+    @staticmethod
+    def _extension_index_payload(path: Path) -> list[object]:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return []
+        return payload if isinstance(payload, list) else []
+
+    def _append_mcp_artifacts(
+        self,
+        artifacts: list[GuardArtifact],
+        config_path: Path,
+        payload: dict[str, object],
+        scope: str,
+    ) -> None:
+        mcp_servers = payload.get("mcpServers")
+        if not isinstance(mcp_servers, dict):
+            return
+        for name, server_config in mcp_servers.items():
+            if not isinstance(name, str) or not isinstance(server_config, dict):
+                continue
+            command = server_config.get("command")
+            url = server_config.get("url")
+            artifacts.append(
+                GuardArtifact(
+                    artifact_id=f"antigravity:{scope}:mcp:{name}",
+                    name=name,
+                    harness=self.harness,
+                    artifact_type="mcp_server",
+                    source_scope=scope,
+                    config_path=str(config_path),
+                    command=command if isinstance(command, str) else None,
+                    args=tuple(str(value) for value in server_config.get("args", []) if isinstance(value, str)),
+                    url=url if isinstance(url, str) else None,
+                    transport="http" if isinstance(url, str) else "stdio",
+                )
+            )
+
+    def _extension_artifacts(
+        self,
+        payload: list[object],
+        found_paths: list[str],
+    ) -> list[GuardArtifact]:
+        artifacts: list[GuardArtifact] = []
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            identifier = item.get("identifier")
+            location = item.get("location")
+            metadata = item.get("metadata")
+            if not isinstance(identifier, dict) or not isinstance(location, dict):
+                continue
+            extension_id = identifier.get("id")
+            location_path = location.get("path")
+            if not isinstance(extension_id, str) or not isinstance(location_path, str):
+                continue
+            manifest_path = Path(location_path) / "package.json"
+            manifest_payload = _json_payload(manifest_path)
+            if manifest_payload:
+                self._append_found_path(found_paths, manifest_path)
+            publisher = (
+                manifest_payload.get("publisher")
+                if isinstance(manifest_payload.get("publisher"), str)
+                else None
+            )
+            if publisher is None and isinstance(metadata, dict):
+                publisher_display_name = metadata.get("publisherDisplayName")
+                if isinstance(publisher_display_name, str):
+                    publisher = publisher_display_name
+            artifacts.append(
+                GuardArtifact(
+                    artifact_id=f"antigravity:global:{extension_id}",
+                    name=extension_id,
+                    harness=self.harness,
+                    artifact_type="extension",
+                    source_scope="global",
+                    config_path=str(manifest_path if manifest_payload else Path(location_path)),
+                    publisher=publisher,
+                    metadata={
+                        "display_name": (
+                            manifest_payload.get("displayName")
+                            if isinstance(manifest_payload.get("displayName"), str)
+                            else None
+                        )
+                    },
+                )
+            )
+        return artifacts

--- a/src/codex_plugin_scanner/guard/adapters/antigravity.py
+++ b/src/codex_plugin_scanner/guard/adapters/antigravity.py
@@ -104,7 +104,7 @@ class AntigravityHarnessAdapter(HarnessAdapter):
         owned_settings_paths = set(settings_paths)
         if context.workspace_dir is not None:
             settings_paths.append(context.workspace_dir / ".vscode" / "settings.json")
-        has_non_settings_signal = bool(found_paths)
+        has_antigravity_signal = bool(found_paths)
         for settings_path in settings_paths:
             payload = _json_payload(settings_path)
             if not payload:
@@ -112,7 +112,7 @@ class AntigravityHarnessAdapter(HarnessAdapter):
             owns_settings = (
                 settings_path in owned_settings_paths
                 or self._contains_antigravity_settings(payload)
-                or has_non_settings_signal
+                or has_antigravity_signal
             )
             if not owns_settings:
                 continue
@@ -121,6 +121,7 @@ class AntigravityHarnessAdapter(HarnessAdapter):
             self._append_mcp_artifacts(artifacts, settings_path, payload, scope)
             if len(artifacts) > before_artifact_count or owns_settings:
                 self._append_found_path(found_paths, settings_path)
+            has_antigravity_signal = True
 
         return HarnessDetection(
             harness=self.harness,

--- a/src/codex_plugin_scanner/guard/adapters/gemini.py
+++ b/src/codex_plugin_scanner/guard/adapters/gemini.py
@@ -171,6 +171,7 @@ class GeminiHarnessAdapter(HarnessAdapter):
                         source_scope=scope,
                         config_path=str(settings_path),
                         command=self._hook_command(entry),
+                        metadata={"hook_config": entry},
                     )
                 )
 

--- a/src/codex_plugin_scanner/guard/adapters/gemini.py
+++ b/src/codex_plugin_scanner/guard/adapters/gemini.py
@@ -32,6 +32,13 @@ class GeminiHarnessAdapter(HarnessAdapter):
         if candidate not in found_paths:
             found_paths.append(candidate)
 
+    @staticmethod
+    def _string_args(server_config: dict[str, object]) -> tuple[str, ...]:
+        raw_args = server_config.get("args")
+        if not isinstance(raw_args, list):
+            return ()
+        return tuple(str(value) for value in raw_args if isinstance(value, str))
+
     def detect(self, context: HarnessContext) -> HarnessDetection:
         artifacts: list[GuardArtifact] = []
         found_paths: list[str] = []
@@ -112,7 +119,7 @@ class GeminiHarnessAdapter(HarnessAdapter):
                         source_scope=scope,
                         config_path=str(manifest_path),
                         command=command if isinstance(command, str) else None,
-                        args=tuple(str(value) for value in server_config.get("args", []) if isinstance(value, str)),
+                        args=self._string_args(server_config),
                         url=url if isinstance(url, str) else None,
                         transport="http" if isinstance(url, str) else "stdio",
                     )
@@ -141,7 +148,7 @@ class GeminiHarnessAdapter(HarnessAdapter):
                         source_scope=scope,
                         config_path=str(settings_path),
                         command=command if isinstance(command, str) else None,
-                        args=tuple(str(value) for value in server_config.get("args", []) if isinstance(value, str)),
+                        args=self._string_args(server_config),
                         url=url if isinstance(url, str) else None,
                         transport="http" if isinstance(url, str) else "stdio",
                     )

--- a/src/codex_plugin_scanner/guard/adapters/gemini.py
+++ b/src/codex_plugin_scanner/guard/adapters/gemini.py
@@ -2,102 +2,62 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from ..models import GuardArtifact, HarnessDetection
 from .base import HarnessAdapter, HarnessContext, _command_available, _json_payload
 
 
 class GeminiHarnessAdapter(HarnessAdapter):
-    """Discover Gemini extensions and local command definitions."""
+    """Discover Gemini CLI settings, extensions, hooks, skills, and MCP definitions."""
 
     harness = "gemini"
     executable = "gemini"
     approval_tier = "approval-center"
     approval_summary = (
-        "Guard scans Gemini extensions before launch and sends blocked changes to the local approval center."
+        "Guard scans Gemini settings, extensions, hooks, skills, and MCP registrations "
+        "before launch and sends blocked changes to the local approval center."
     )
     fallback_hint = "Gemini gets preflight approval through Guard until it exposes a richer native approval surface."
 
     @staticmethod
-    def _scope_for(context: HarnessContext, path) -> str:
+    def _scope_for(context: HarnessContext, path: Path) -> str:
         if context.workspace_dir is not None and path.is_relative_to(context.workspace_dir):
             return "project"
         return "global"
 
+    @staticmethod
+    def _append_found_path(found_paths: list[str], path: Path) -> None:
+        candidate = str(path)
+        if candidate not in found_paths:
+            found_paths.append(candidate)
+
     def detect(self, context: HarnessContext) -> HarnessDetection:
-        extension_roots = [context.home_dir / ".gemini" / "extensions"]
-        if context.workspace_dir is not None:
-            extension_roots.append(context.workspace_dir / ".gemini" / "extensions")
         artifacts: list[GuardArtifact] = []
         found_paths: list[str] = []
-        for extension_root in extension_roots:
-            if not extension_root.is_dir():
-                continue
-            for manifest_path in sorted(extension_root.glob("*/gemini-extension.json")):
-                payload = _json_payload(manifest_path)
-                if not payload:
-                    continue
-                found_paths.append(str(manifest_path))
-                scope = self._scope_for(context, manifest_path)
-                raw_name = payload.get("name")
-                extension_name = raw_name if isinstance(raw_name, str) else manifest_path.parent.name
-                artifacts.append(
-                    GuardArtifact(
-                        artifact_id=f"gemini:{scope}:{extension_name}",
-                        name=extension_name,
-                        harness=self.harness,
-                        artifact_type="extension",
-                        source_scope=scope,
-                        config_path=str(manifest_path),
-                        publisher=payload.get("publisher") if isinstance(payload.get("publisher"), str) else None,
-                        metadata={"context_file": payload.get("contextFileName")},
-                    )
+        scope_specs = [
+            (
+                context.home_dir / ".gemini" / "settings.json",
+                context.home_dir / ".gemini" / "extensions",
+                context.home_dir / ".gemini" / "skills",
+            )
+        ]
+        if context.workspace_dir is not None:
+            scope_specs.append(
+                (
+                    context.workspace_dir / ".gemini" / "settings.json",
+                    context.workspace_dir / ".gemini" / "extensions",
+                    context.workspace_dir / ".gemini" / "skills",
                 )
-                mcp_servers = payload.get("mcpServers")
-                if isinstance(mcp_servers, dict):
-                    for server_name, server_config in mcp_servers.items():
-                        if not isinstance(server_name, str) or not isinstance(server_config, dict):
-                            continue
-                        command = server_config.get("command")
-                        artifacts.append(
-                            GuardArtifact(
-                                artifact_id=f"gemini:{scope}:{extension_name}:{server_name}",
-                                name=server_name,
-                                harness=self.harness,
-                                artifact_type="mcp_server",
-                                source_scope=scope,
-                                config_path=str(manifest_path),
-                                command=command if isinstance(command, str) else None,
-                                args=tuple(
-                                    str(value) for value in server_config.get("args", []) if isinstance(value, str)
-                                ),
-                                transport="stdio",
-                            )
-                        )
-        fallback_mcp_paths = sorted((context.home_dir / ".gemini").glob("*/mcp_config.json"))
-        for config_path in fallback_mcp_paths:
-            payload = _json_payload(config_path)
-            if not payload:
-                continue
-            found_paths.append(str(config_path))
-            mcp_servers = payload.get("mcpServers")
-            if isinstance(mcp_servers, dict):
-                for server_name, server_config in mcp_servers.items():
-                    if not isinstance(server_name, str) or not isinstance(server_config, dict):
-                        continue
-                    command = server_config.get("command")
-                    artifacts.append(
-                        GuardArtifact(
-                            artifact_id=f"gemini:global:mcp:{server_name}",
-                            name=server_name,
-                            harness=self.harness,
-                            artifact_type="mcp_server",
-                            source_scope="global",
-                            config_path=str(config_path),
-                            command=command if isinstance(command, str) else None,
-                            args=tuple(str(value) for value in server_config.get("args", []) if isinstance(value, str)),
-                            transport="stdio",
-                        )
-                    )
+            )
+        for settings_path, extension_root, skill_root in scope_specs:
+            scope = self._scope_for(context, settings_path)
+            self._append_extension_artifacts(artifacts, found_paths, extension_root, scope)
+            payload = _json_payload(settings_path)
+            if payload:
+                self._append_found_path(found_paths, settings_path)
+                self._append_settings_artifacts(artifacts, settings_path, payload, scope)
+            self._append_skill_artifacts(artifacts, found_paths, skill_root, scope)
         return HarnessDetection(
             harness=self.harness,
             installed=bool(found_paths) or _command_available(self.executable),
@@ -106,3 +66,142 @@ class GeminiHarnessAdapter(HarnessAdapter):
             artifacts=tuple(artifacts),
             warnings=(),
         )
+
+    def _append_extension_artifacts(
+        self,
+        artifacts: list[GuardArtifact],
+        found_paths: list[str],
+        extension_root: Path,
+        scope: str,
+    ) -> None:
+        if not extension_root.is_dir():
+            return
+        for manifest_path in sorted(extension_root.glob("*/gemini-extension.json")):
+            payload = _json_payload(manifest_path)
+            if not payload:
+                continue
+            self._append_found_path(found_paths, manifest_path)
+            raw_name = payload.get("name")
+            extension_name = raw_name if isinstance(raw_name, str) else manifest_path.parent.name
+            artifacts.append(
+                GuardArtifact(
+                    artifact_id=f"gemini:{scope}:{extension_name}",
+                    name=extension_name,
+                    harness=self.harness,
+                    artifact_type="extension",
+                    source_scope=scope,
+                    config_path=str(manifest_path),
+                    publisher=payload.get("publisher") if isinstance(payload.get("publisher"), str) else None,
+                    metadata={"context_file": payload.get("contextFileName")},
+                )
+            )
+            mcp_servers = payload.get("mcpServers")
+            if not isinstance(mcp_servers, dict):
+                continue
+            for server_name, server_config in mcp_servers.items():
+                if not isinstance(server_name, str) or not isinstance(server_config, dict):
+                    continue
+                command = server_config.get("command")
+                url = server_config.get("url")
+                artifacts.append(
+                    GuardArtifact(
+                        artifact_id=f"gemini:{scope}:{extension_name}:{server_name}",
+                        name=server_name,
+                        harness=self.harness,
+                        artifact_type="mcp_server",
+                        source_scope=scope,
+                        config_path=str(manifest_path),
+                        command=command if isinstance(command, str) else None,
+                        args=tuple(str(value) for value in server_config.get("args", []) if isinstance(value, str)),
+                        url=url if isinstance(url, str) else None,
+                        transport="http" if isinstance(url, str) else "stdio",
+                    )
+                )
+
+    def _append_settings_artifacts(
+        self,
+        artifacts: list[GuardArtifact],
+        settings_path: Path,
+        payload: dict[str, object],
+        scope: str,
+    ) -> None:
+        mcp_servers = payload.get("mcpServers")
+        if isinstance(mcp_servers, dict):
+            for server_name, server_config in mcp_servers.items():
+                if not isinstance(server_name, str) or not isinstance(server_config, dict):
+                    continue
+                command = server_config.get("command")
+                url = server_config.get("url")
+                artifacts.append(
+                    GuardArtifact(
+                        artifact_id=f"gemini:{scope}:mcp:{server_name}",
+                        name=server_name,
+                        harness=self.harness,
+                        artifact_type="mcp_server",
+                        source_scope=scope,
+                        config_path=str(settings_path),
+                        command=command if isinstance(command, str) else None,
+                        args=tuple(str(value) for value in server_config.get("args", []) if isinstance(value, str)),
+                        url=url if isinstance(url, str) else None,
+                        transport="http" if isinstance(url, str) else "stdio",
+                    )
+                )
+        hooks = payload.get("hooks")
+        if not isinstance(hooks, dict):
+            return
+        for hook_name, hook_entries in hooks.items():
+            if not isinstance(hook_name, str) or not isinstance(hook_entries, list):
+                continue
+            for index, entry in enumerate(hook_entries):
+                if not isinstance(entry, dict):
+                    continue
+                artifacts.append(
+                    GuardArtifact(
+                        artifact_id=f"gemini:{scope}:hook:{hook_name.lower()}:{index}",
+                        name=hook_name,
+                        harness=self.harness,
+                        artifact_type="hook",
+                        source_scope=scope,
+                        config_path=str(settings_path),
+                        command=self._hook_command(entry),
+                    )
+                )
+
+    def _append_skill_artifacts(
+        self,
+        artifacts: list[GuardArtifact],
+        found_paths: list[str],
+        skill_root: Path,
+        scope: str,
+    ) -> None:
+        if not skill_root.is_dir():
+            return
+        for skill_path in sorted(skill_root.rglob("SKILL.md")):
+            self._append_found_path(found_paths, skill_path)
+            relative_id = f"skills/{skill_path.parent.relative_to(skill_root).as_posix()}"
+            artifacts.append(
+                GuardArtifact(
+                    artifact_id=f"gemini:{scope}:skill:{relative_id}",
+                    name=relative_id,
+                    harness=self.harness,
+                    artifact_type="skill",
+                    source_scope=scope,
+                    config_path=str(skill_path),
+                )
+            )
+
+    @staticmethod
+    def _hook_command(entry: dict[str, object]) -> str | None:
+        direct_command = entry.get("command")
+        if isinstance(direct_command, str):
+            return direct_command
+        nested_hooks = entry.get("hooks")
+        if not isinstance(nested_hooks, list):
+            return None
+        for nested_entry in nested_hooks:
+            if not isinstance(nested_entry, dict):
+                continue
+            command = nested_entry.get("command")
+            if isinstance(command, str):
+                return command
+        return None

--- a/src/codex_plugin_scanner/guard/adapters/gemini.py
+++ b/src/codex_plugin_scanner/guard/adapters/gemini.py
@@ -199,16 +199,20 @@ class GeminiHarnessAdapter(HarnessAdapter):
 
     @staticmethod
     def _hook_command(entry: dict[str, object]) -> str | None:
+        commands: list[str] = []
         direct_command = entry.get("command")
         if isinstance(direct_command, str):
-            return direct_command
+            commands.append(direct_command)
         nested_hooks = entry.get("hooks")
-        if not isinstance(nested_hooks, list):
+        if isinstance(nested_hooks, list):
+            for nested_entry in nested_hooks:
+                if not isinstance(nested_entry, dict):
+                    continue
+                command = nested_entry.get("command")
+                if isinstance(command, str):
+                    commands.append(command)
+        if not commands:
             return None
-        for nested_entry in nested_hooks:
-            if not isinstance(nested_entry, dict):
-                continue
-            command = nested_entry.get("command")
-            if isinstance(command, str):
-                return command
-        return None
+        if len(commands) == 1:
+            return commands[0]
+        return "\n".join(commands)

--- a/src/codex_plugin_scanner/guard/cli/product.py
+++ b/src/codex_plugin_scanner/guard/cli/product.py
@@ -13,7 +13,7 @@ from ..daemon import load_guard_daemon_url
 from ..models import HarnessDetection
 from ..store import GuardStore
 
-HARNESS_PRIORITY = ("codex", "claude-code", "copilot", "cursor", "gemini", "opencode")
+HARNESS_PRIORITY = ("codex", "claude-code", "copilot", "cursor", "antigravity", "gemini", "opencode")
 GUARD_COMMAND = "hol-guard"
 GUARD_DASHBOARD_URL = "https://hol.org/guard"
 GUARD_CONNECT_URL = f"{GUARD_DASHBOARD_URL}/connect"
@@ -161,7 +161,7 @@ def _build_next_steps(recommended: dict[str, object] | None, payload: dict[str, 
                 "command": f"{GUARD_COMMAND} detect",
                 "detail": (
                     "Guard did not find a local harness config yet. Start by installing "
-                    "Codex, Claude Code, Copilot CLI, Cursor, Gemini, or OpenCode."
+                    "Codex, Claude Code, Copilot CLI, Cursor, Antigravity, Gemini, or OpenCode."
                 ),
             }
         ]

--- a/src/codex_plugin_scanner/guard/protect.py
+++ b/src/codex_plugin_scanner/guard/protect.py
@@ -550,9 +550,7 @@ def _parse_antigravity_mcp_target(raw_payload: str) -> ProtectTarget:
     if command_or_url is None and isinstance(payload.get("command"), str):
         command_or_url = payload["command"]
     source_url = (
-        command_or_url
-        if isinstance(command_or_url, str) and _is_remote_transport(command_or_url, None)
-        else None
+        command_or_url if isinstance(command_or_url, str) and _is_remote_transport(command_or_url, None) else None
     )
     return ProtectTarget(
         artifact_id=f"install:antigravity:mcp:{name}",

--- a/src/codex_plugin_scanner/guard/protect.py
+++ b/src/codex_plugin_scanner/guard/protect.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import shlex
 import subprocess
@@ -213,6 +214,7 @@ def parse_protect_command(command: list[str]) -> ProtectRequest:
         "go": _parse_go_request,
         "codex": _parse_codex_request,
         "cursor": _parse_cursor_request,
+        "antigravity": _parse_antigravity_request,
         "gemini": _parse_gemini_request,
         "opencode": _parse_opencode_request,
     }
@@ -326,6 +328,65 @@ def _parse_gemini_request(command: list[str]) -> ProtectRequest:
             harness="gemini",
         )
         return ProtectRequest(tuple(command), "harness_registration", "gemini", None, "gemini", (target,))
+    if len(command) >= 4 and tuple(command[1:3]) in {
+        ("extensions", "link"),
+        ("skills", "install"),
+        ("skills", "link"),
+    }:
+        spec = command[3]
+        name = _target_name_from_spec(spec)
+        artifact_type = "extension" if command[1] == "extensions" else "skill"
+        target = ProtectTarget(
+            artifact_id=f"install:gemini:{artifact_type}:{name}",
+            artifact_name=name,
+            artifact_type=artifact_type,
+            ecosystem="gemini",
+            package_name=name if artifact_type == "extension" else None,
+            raw_spec=spec,
+            version=None,
+            source_url=_spec_url(spec),
+            harness="gemini",
+        )
+        return ProtectRequest(tuple(command), "harness_registration", "gemini", None, "gemini", (target,))
+    if len(command) >= 5 and command[1:3] == ["mcp", "add"]:
+        name = command[3]
+        command_or_url = command[4]
+        transport = _option_value(command, "--transport") or _option_value(command, "--type")
+        source_url = command_or_url if _is_remote_transport(command_or_url, transport) else None
+        target = ProtectTarget(
+            artifact_id=f"install:gemini:mcp:{name}",
+            artifact_name=name,
+            artifact_type="mcp_server",
+            ecosystem="gemini",
+            package_name=name,
+            raw_spec=command_or_url,
+            version=None,
+            source_url=source_url,
+            harness="gemini",
+        )
+        return ProtectRequest(tuple(command), "harness_registration", "gemini", None, "gemini", (target,))
+    return _parse_custom_request(command)
+
+
+def _parse_antigravity_request(command: list[str]) -> ProtectRequest:
+    extension_name = _option_value(command, "--install-extension")
+    if extension_name is not None:
+        target = ProtectTarget(
+            artifact_id=f"install:antigravity:extension:{extension_name}",
+            artifact_name=extension_name,
+            artifact_type="extension",
+            ecosystem="antigravity",
+            package_name=extension_name,
+            raw_spec=extension_name,
+            version=None,
+            source_url=_spec_url(extension_name),
+            harness="antigravity",
+        )
+        return ProtectRequest(tuple(command), "harness_registration", "antigravity", None, "antigravity", (target,))
+    raw_mcp_payload = _option_value(command, "--add-mcp")
+    if raw_mcp_payload is not None:
+        target = _parse_antigravity_mcp_target(raw_mcp_payload)
+        return ProtectRequest(tuple(command), "harness_registration", "antigravity", None, "antigravity", (target,))
     return _parse_custom_request(command)
 
 
@@ -456,6 +517,13 @@ def _spec_url(spec: str) -> str | None:
     return None
 
 
+def _target_name_from_spec(spec: str) -> str:
+    parsed_name = _spec_name(spec)
+    if parsed_name is None:
+        return spec
+    return parsed_name.removesuffix(".git")
+
+
 def _option_value(command: list[str], option: str) -> str | None:
     for index, value in enumerate(command):
         if value == option and index + 1 < len(command):
@@ -468,6 +536,43 @@ def _first_url(command: list[str]) -> str | None:
         if value.startswith(("http://", "https://", "git+", "file:")):
             return value
     return None
+
+
+def _parse_antigravity_mcp_target(raw_payload: str) -> ProtectTarget:
+    try:
+        payload = json.loads(raw_payload)
+    except json.JSONDecodeError:
+        payload = {}
+    if not isinstance(payload, dict):
+        payload = {}
+    name = payload.get("name") if isinstance(payload.get("name"), str) else "antigravity-mcp"
+    command_or_url = payload.get("url") if isinstance(payload.get("url"), str) else None
+    if command_or_url is None and isinstance(payload.get("command"), str):
+        command_or_url = payload["command"]
+    source_url = (
+        command_or_url
+        if isinstance(command_or_url, str) and _is_remote_transport(command_or_url, None)
+        else None
+    )
+    return ProtectTarget(
+        artifact_id=f"install:antigravity:mcp:{name}",
+        artifact_name=name,
+        artifact_type="mcp_server",
+        ecosystem="antigravity",
+        package_name=name,
+        raw_spec=raw_payload,
+        version=None,
+        source_url=source_url,
+        harness="antigravity",
+    )
+
+
+def _is_remote_transport(command_or_url: str, transport: str | None) -> bool:
+    if transport == "stdio":
+        return False
+    if transport in {"http", "sse"}:
+        return command_or_url.startswith(("http://", "https://"))
+    return command_or_url.startswith(("http://", "https://"))
 
 
 def _matching_advisories(
@@ -526,6 +631,8 @@ def _request_risk_signals(request: ProtectRequest) -> tuple[str, ...]:
     if request.install_kind == "harness_registration":
         if any(target.source_url is not None for target in request.targets):
             signals.append("registers a remote server endpoint")
+        if any(target.artifact_type in {"extension", "plugin", "skill"} for target in request.targets):
+            signals.append("registers executable harness code")
         if any(value in joined for value in ("http://", "https://", "curl ", "wget ")):
             signals.append("can fetch or talk to a remote server during registration")
     if any(value in joined for value in (".env", "printenv", "process.env", "os.environ", "getenv(")):

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -691,10 +691,11 @@ args = ["workspace-skill.js"]
                 "hooks": {
                     "PreToolUse": [
                         {
+                            "matcher": "write_file",
                             "hooks": [
-                                {"type": "command", "command": "python first-hook.py"},
-                                {"type": "command", "command": "python second-hook.py"},
-                            ]
+                                {"type": "command", "command": "python first-hook.py", "timeout": 5},
+                                {"type": "command", "command": "python second-hook.py", "name": "second"},
+                            ],
                         }
                     ]
                 }
@@ -719,6 +720,9 @@ args = ["workspace-skill.js"]
         assert rc == 0
         assert hook_artifact["artifact_id"] == "gemini:global:hook:pretooluse:0"
         assert hook_artifact["command"] == "python first-hook.py\npython second-hook.py"
+        assert hook_artifact["metadata"]["hook_config"]["matcher"] == "write_file"
+        assert hook_artifact["metadata"]["hook_config"]["hooks"][0]["timeout"] == 5
+        assert hook_artifact["metadata"]["hook_config"]["hooks"][1]["name"] == "second"
 
     def test_guard_detect_scopes_opencode_artifact_ids(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -558,7 +558,7 @@ args = ["workspace-skill.js"]
         assert str(home_dir / ".gemini" / "antigravity" / "mcp_config.json") in detection["config_paths"]
         assert artifact_ids == [
             "antigravity:global:hashgraph.tools",
-            "antigravity:global:mcp:gravity-tools",
+            "antigravity:global:mcp:bridge:gravity-tools",
             "antigravity:global:skill:skills/gravity-review",
         ]
 
@@ -602,8 +602,48 @@ args = ["workspace-skill.js"]
         assert rc == 0
         assert str(home_dir / ".config" / "Antigravity" / "User" / "settings.json") in detection["config_paths"]
         assert str(workspace_dir / ".vscode" / "settings.json") not in detection["config_paths"]
-        assert [item["artifact_id"] for item in detection["artifacts"]] == ["antigravity:global:mcp:gravity-tools"]
+        assert [item["artifact_id"] for item in detection["artifacts"]] == [
+            "antigravity:global:mcp:settings:gravity-tools"
+        ]
         assert detection["artifacts"][0]["args"] == []
+
+    def test_guard_detect_disambiguates_antigravity_mcp_sources(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _write_json(
+            home_dir / "Library" / "Application Support" / "Antigravity" / "User" / "settings.json",
+            {
+                "antigravity.profile": "default",
+                "mcpServers": {"shared-tools": {"command": "node", "args": ["settings.js"]}},
+            },
+        )
+        _write_json(
+            home_dir / ".gemini" / "antigravity" / "mcp_config.json",
+            {
+                "mcpServers": {"shared-tools": {"command": "node", "args": ["bridge.js"]}},
+            },
+        )
+
+        rc = main(
+            [
+                "guard",
+                "detect",
+                "antigravity",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        artifact_ids = [item["artifact_id"] for item in output["harnesses"][0]["artifacts"]]
+
+        assert rc == 0
+        assert artifact_ids == [
+            "antigravity:global:mcp:bridge:shared-tools",
+            "antigravity:global:mcp:settings:shared-tools",
+        ]
 
     def test_guard_detect_tolerates_gemini_malformed_args(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -641,6 +681,44 @@ args = ["workspace-skill.js"]
         assert rc == 0
         assert artifacts["gemini:global:shared:shared-tools"]["args"] == []
         assert artifacts["gemini:global:mcp:settings-tools"]["args"] == []
+
+    def test_guard_detect_hashes_full_gemini_hook_lists(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _write_json(
+            home_dir / ".gemini" / "settings.json",
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "hooks": [
+                                {"type": "command", "command": "python first-hook.py"},
+                                {"type": "command", "command": "python second-hook.py"},
+                            ]
+                        }
+                    ]
+                }
+            },
+        )
+
+        rc = main(
+            [
+                "guard",
+                "detect",
+                "gemini",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        hook_artifact = output["harnesses"][0]["artifacts"][0]
+
+        assert rc == 0
+        assert hook_artifact["artifact_id"] == "gemini:global:hook:pretooluse:0"
+        assert hook_artifact["command"] == "python first-hook.py\npython second-hook.py"
 
     def test_guard_detect_scopes_opencode_artifact_ids(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -591,7 +591,7 @@ args = ["workspace-skill.js"]
         assert rc == 0
         assert str(home_dir / ".config" / "Antigravity" / "User" / "settings.json") in detection["config_paths"]
         assert [item["artifact_id"] for item in detection["artifacts"]] == [
-            "antigravity:global:mcp:settings:gravity-tools"
+            "antigravity:global:mcp:settings:xdg-user:gravity-tools"
         ]
         assert detection["artifacts"][0]["args"] == []
 
@@ -669,7 +669,7 @@ args = ["workspace-skill.js"]
         assert rc == 0
         assert str(home_dir / ".config" / "Antigravity" / "User" / "settings.json") in detection["config_paths"]
         assert str(workspace_dir / ".vscode" / "settings.json") in detection["config_paths"]
-        assert artifact_ids == ["antigravity:project:mcp:settings:workspace-tools"]
+        assert artifact_ids == ["antigravity:project:mcp:settings:workspace-vscode:workspace-tools"]
 
     def test_guard_detect_disambiguates_antigravity_mcp_sources(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -706,7 +706,46 @@ args = ["workspace-skill.js"]
         assert rc == 0
         assert artifact_ids == [
             "antigravity:global:mcp:bridge:shared-tools",
-            "antigravity:global:mcp:settings:shared-tools",
+            "antigravity:global:mcp:settings:macos-user:shared-tools",
+        ]
+
+    def test_guard_detect_disambiguates_antigravity_settings_paths_with_same_server_name(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _write_json(
+            home_dir / "Library" / "Application Support" / "Antigravity" / "User" / "settings.json",
+            {
+                "antigravity.profile": "default",
+                "mcpServers": {"shared-tools": {"command": "node", "args": ["macos.js"]}},
+            },
+        )
+        _write_json(
+            home_dir / ".config" / "Antigravity" / "User" / "settings.json",
+            {
+                "antigravity.profile": "default",
+                "mcpServers": {"shared-tools": {"command": "node", "args": ["linux.js"]}},
+            },
+        )
+
+        rc = main(
+            [
+                "guard",
+                "detect",
+                "antigravity",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        artifact_ids = [item["artifact_id"] for item in output["harnesses"][0]["artifacts"]]
+
+        assert rc == 0
+        assert artifact_ids == [
+            "antigravity:global:mcp:settings:macos-user:shared-tools",
+            "antigravity:global:mcp:settings:xdg-user:shared-tools",
         ]
 
     def test_guard_detect_tolerates_gemini_malformed_args(self, tmp_path, capsys):

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -571,7 +571,10 @@ args = ["workspace-skill.js"]
         workspace_dir = tmp_path / "workspace"
         _write_json(
             workspace_dir / ".vscode" / "settings.json",
-            {"workbench.colorTheme": "Default Dark+"},
+            {
+                "workbench.colorTheme": "Default Dark+",
+                "mcpServers": {"generic-tools": {"command": "node", "args": ["generic.js"]}},
+            },
         )
         _write_json(
             home_dir / ".config" / "Antigravity" / "User" / "settings.json",

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -80,6 +80,63 @@ args = ["workspace-skill.js"]
     )
 
     _write_json(
+        home_dir / "Library" / "Application Support" / "Antigravity" / "User" / "settings.json",
+        {
+            "workbench.colorTheme": "Default Dark+",
+        },
+    )
+    antigravity_extension_root = home_dir / ".antigravity" / "extensions" / "hashgraph.antigravity-tools-1.0.0"
+    _write_json(
+        home_dir / ".antigravity" / "extensions" / "extensions.json",
+        [
+            {
+                "identifier": {"id": "hashgraph.antigravity-tools"},
+                "location": {"path": str(antigravity_extension_root)},
+                "metadata": {"publisherDisplayName": "Hashgraph"},
+            }
+        ],
+    )
+    _write_json(
+        antigravity_extension_root / "package.json",
+        {
+            "name": "antigravity-tools",
+            "publisher": "hashgraph",
+            "displayName": "Antigravity Tools",
+        },
+    )
+    _write_json(
+        home_dir / ".gemini" / "antigravity" / "mcp_config.json",
+        {
+            "mcpServers": {
+                "gravity-tools": {"command": "node", "args": ["gravity.js"]},
+            }
+        },
+    )
+    _write_text(
+        home_dir / ".gemini" / "antigravity" / "skills" / "gravity-review" / "SKILL.md",
+        "---\nname: gravity-review\ndescription: Gravity skill\n---\n",
+    )
+
+    _write_json(
+        home_dir / ".gemini" / "settings.json",
+        {
+            "mcpServers": {
+                "gemini-tools": {"command": "node", "args": ["gemini.js"]},
+            },
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "hooks": [{"type": "command", "command": "python global-gemini-hook.py"}],
+                    }
+                ]
+            },
+        },
+    )
+    _write_text(
+        home_dir / ".gemini" / "skills" / "gemini-review" / "SKILL.md",
+        "---\nname: gemini-review\ndescription: Gemini skill\n---\n",
+    )
+    _write_json(
         home_dir / ".gemini" / "extensions" / "hashnet" / "gemini-extension.json",
         {
             "name": "hashnet",
@@ -90,6 +147,25 @@ args = ["workspace-skill.js"]
         },
     )
     _write_text(home_dir / ".gemini" / "extensions" / "hashnet" / "GEMINI.md", "context\n")
+    _write_json(
+        workspace_dir / ".gemini" / "settings.json",
+        {
+            "mcpServers": {
+                "workspace-gemini": {"command": "node", "args": ["workspace-gemini.js"]},
+            },
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "hooks": [{"type": "command", "command": "python workspace-gemini-hook.py"}],
+                    }
+                ]
+            },
+        },
+    )
+    _write_text(
+        workspace_dir / ".gemini" / "skills" / "workspace-review" / "SKILL.md",
+        "---\nname: workspace-review\ndescription: Workspace Gemini skill\n---\n",
+    )
 
     _write_json(
         home_dir / ".config" / "opencode" / "opencode.json",
@@ -169,7 +245,7 @@ class TestGuardCli:
         harnesses = {item["harness"]: item for item in output["harnesses"]}
 
         assert rc == 0
-        assert {"codex", "claude-code", "cursor", "gemini", "opencode"} <= harnesses.keys()
+        assert {"codex", "claude-code", "cursor", "antigravity", "gemini", "opencode"} <= harnesses.keys()
         assert harnesses["codex"]["artifacts"][0]["source_scope"] == "global"
         assert harnesses["claude-code"]["artifacts"][0]["artifact_type"] in {"mcp_server", "hook", "agent"}
 
@@ -334,11 +410,57 @@ args = ["workspace-skill.js"]
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         _write_json(
+            home_dir / ".gemini" / "settings.json",
+            {
+                "mcpServers": {
+                    "shared-settings": {"command": "node", "args": ["global-settings.js"]},
+                },
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "hooks": [{"type": "command", "command": "python global-hook.py"}],
+                        }
+                    ]
+                },
+            },
+        )
+        _write_text(
+            home_dir / ".gemini" / "skills" / "shared-skill" / "SKILL.md",
+            "---\nname: shared-skill\ndescription: Global Gemini skill\n---\n",
+        )
+        _write_json(
             home_dir / ".gemini" / "extensions" / "shared" / "gemini-extension.json",
             {
                 "name": "shared",
                 "mcpServers": {"shared-tools": {"command": "node", "args": ["global.js"]}},
             },
+        )
+        _write_json(
+            home_dir / ".gemini" / "antigravity" / "mcp_config.json",
+            {
+                "mcpServers": {
+                    "should-belong-to-antigravity": {"command": "node", "args": ["antigravity.js"]},
+                }
+            },
+        )
+        _write_json(
+            workspace_dir / ".gemini" / "settings.json",
+            {
+                "mcpServers": {
+                    "shared-settings": {"command": "node", "args": ["project-settings.js"]},
+                },
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "hooks": [{"type": "command", "command": "python project-hook.py"}],
+                        }
+                    ]
+                },
+            },
+        )
+        _write_text(
+            workspace_dir / ".gemini" / "skills" / "shared-skill" / "SKILL.md",
+            "---\nname: shared-skill\ndescription: Project Gemini skill\n---\n",
         )
         _write_json(
             workspace_dir / ".gemini" / "extensions" / "shared" / "gemini-extension.json",
@@ -367,8 +489,76 @@ args = ["workspace-skill.js"]
         assert artifact_ids == [
             "gemini:global:shared",
             "gemini:global:shared:shared-tools",
+            "gemini:global:mcp:shared-settings",
+            "gemini:global:hook:pretooluse:0",
+            "gemini:global:skill:skills/shared-skill",
             "gemini:project:shared",
             "gemini:project:shared:shared-tools",
+            "gemini:project:mcp:shared-settings",
+            "gemini:project:hook:pretooluse:0",
+            "gemini:project:skill:skills/shared-skill",
+        ]
+
+    def test_guard_detect_reports_antigravity_extensions_skills_and_mcp(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        antigravity_extension_root = home_dir / ".antigravity" / "extensions" / "hashgraph.tools-1.0.0"
+        _write_json(
+            home_dir / "Library" / "Application Support" / "Antigravity" / "User" / "settings.json",
+            {"workbench.colorTheme": "Solarized Dark"},
+        )
+        _write_json(
+            home_dir / ".antigravity" / "extensions" / "extensions.json",
+            [
+                {
+                    "identifier": {"id": "hashgraph.tools"},
+                    "location": {"path": str(antigravity_extension_root)},
+                    "metadata": {"publisherDisplayName": "Hashgraph"},
+                }
+            ],
+        )
+        _write_json(
+            antigravity_extension_root / "package.json",
+            {"name": "tools", "publisher": "hashgraph", "displayName": "Hashgraph Tools"},
+        )
+        _write_json(
+            home_dir / ".gemini" / "antigravity" / "mcp_config.json",
+            {
+                "mcpServers": {
+                    "gravity-tools": {"command": "node", "args": ["gravity.js"]},
+                }
+            },
+        )
+        _write_text(
+            home_dir / ".gemini" / "antigravity" / "skills" / "gravity-review" / "SKILL.md",
+            "---\nname: gravity-review\ndescription: Gravity review skill\n---\n",
+        )
+
+        rc = main(
+            [
+                "guard",
+                "detect",
+                "antigravity",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        detection = output["harnesses"][0]
+        artifact_ids = [item["artifact_id"] for item in detection["artifacts"]]
+
+        assert rc == 0
+        assert str(home_dir / "Library" / "Application Support" / "Antigravity" / "User" / "settings.json") in (
+            detection["config_paths"]
+        )
+        assert str(home_dir / ".gemini" / "antigravity" / "mcp_config.json") in detection["config_paths"]
+        assert artifact_ids == [
+            "antigravity:global:hashgraph.tools",
+            "antigravity:global:mcp:gravity-tools",
+            "antigravity:global:skill:skills/gravity-review",
         ]
 
     def test_guard_detect_scopes_opencode_artifact_ids(self, tmp_path, capsys):
@@ -1628,7 +1818,7 @@ args = ["workspace-skill.js", "--changed"]
         assert rc == 0
         assert output["auto_detected"] is True
         harnesses = {item["harness"] for item in output["managed_installs"]}
-        assert {"codex", "claude-code", "cursor", "gemini", "opencode"} <= harnesses
+        assert {"codex", "claude-code", "cursor", "antigravity", "gemini", "opencode"} <= harnesses
 
     def test_guard_install_creates_opencode_runtime_overlay(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -562,20 +562,9 @@ args = ["workspace-skill.js"]
             "antigravity:global:skill:skills/gravity-review",
         ]
 
-    def test_guard_detect_recognizes_cross_platform_antigravity_settings_and_ignores_generic_workspace_settings(
-        self,
-        tmp_path,
-        capsys,
-    ):
+    def test_guard_detect_recognizes_cross_platform_antigravity_settings(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
-        _write_json(
-            workspace_dir / ".vscode" / "settings.json",
-            {
-                "workbench.colorTheme": "Default Dark+",
-                "mcpServers": {"generic-tools": {"command": "node", "args": ["generic.js"]}},
-            },
-        )
         _write_json(
             home_dir / ".config" / "Antigravity" / "User" / "settings.json",
             {
@@ -601,11 +590,86 @@ args = ["workspace-skill.js"]
 
         assert rc == 0
         assert str(home_dir / ".config" / "Antigravity" / "User" / "settings.json") in detection["config_paths"]
-        assert str(workspace_dir / ".vscode" / "settings.json") not in detection["config_paths"]
         assert [item["artifact_id"] for item in detection["artifacts"]] == [
             "antigravity:global:mcp:settings:gravity-tools"
         ]
         assert detection["artifacts"][0]["args"] == []
+
+    def test_guard_detect_ignores_generic_workspace_vscode_settings_without_antigravity_ownership(
+        self,
+        tmp_path,
+        capsys,
+    ):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _write_json(
+            workspace_dir / ".vscode" / "settings.json",
+            {
+                "workbench.colorTheme": "Default Dark+",
+                "mcpServers": {"generic-tools": {"command": "node", "args": ["generic.js"]}},
+            },
+        )
+
+        rc = main(
+            [
+                "guard",
+                "detect",
+                "antigravity",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        detection = output["harnesses"][0]
+
+        assert rc == 0
+        assert detection["config_paths"] == []
+        assert detection["artifacts"] == []
+
+    def test_guard_detect_includes_workspace_vscode_settings_after_antigravity_ownership(
+        self,
+        tmp_path,
+        capsys,
+    ):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _write_json(
+            home_dir / ".config" / "Antigravity" / "User" / "settings.json",
+            {
+                "antigravity.profile": "default",
+            },
+        )
+        _write_json(
+            workspace_dir / ".vscode" / "settings.json",
+            {
+                "workbench.colorTheme": "Default Dark+",
+                "mcpServers": {"workspace-tools": {"command": "node", "args": ["workspace.js"]}},
+            },
+        )
+
+        rc = main(
+            [
+                "guard",
+                "detect",
+                "antigravity",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        detection = output["harnesses"][0]
+        artifact_ids = [item["artifact_id"] for item in detection["artifacts"]]
+
+        assert rc == 0
+        assert str(home_dir / ".config" / "Antigravity" / "User" / "settings.json") in detection["config_paths"]
+        assert str(workspace_dir / ".vscode" / "settings.json") in detection["config_paths"]
+        assert artifact_ids == ["antigravity:project:mcp:settings:workspace-tools"]
 
     def test_guard_detect_disambiguates_antigravity_mcp_sources(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -551,8 +551,9 @@ args = ["workspace-skill.js"]
         artifact_ids = [item["artifact_id"] for item in detection["artifacts"]]
 
         assert rc == 0
-        assert str(home_dir / "Library" / "Application Support" / "Antigravity" / "User" / "settings.json") in (
-            detection["config_paths"]
+        assert (
+            str(home_dir / "Library" / "Application Support" / "Antigravity" / "User" / "settings.json")
+            in (detection["config_paths"])
         )
         assert str(home_dir / ".gemini" / "antigravity" / "mcp_config.json") in detection["config_paths"]
         assert artifact_ids == [
@@ -560,6 +561,83 @@ args = ["workspace-skill.js"]
             "antigravity:global:mcp:gravity-tools",
             "antigravity:global:skill:skills/gravity-review",
         ]
+
+    def test_guard_detect_recognizes_cross_platform_antigravity_settings_and_ignores_generic_workspace_settings(
+        self,
+        tmp_path,
+        capsys,
+    ):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _write_json(
+            workspace_dir / ".vscode" / "settings.json",
+            {"workbench.colorTheme": "Default Dark+"},
+        )
+        _write_json(
+            home_dir / ".config" / "Antigravity" / "User" / "settings.json",
+            {
+                "antigravity.profile": "default",
+                "mcpServers": {"gravity-tools": {"command": "node", "args": True}},
+            },
+        )
+
+        rc = main(
+            [
+                "guard",
+                "detect",
+                "antigravity",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        detection = output["harnesses"][0]
+
+        assert rc == 0
+        assert str(home_dir / ".config" / "Antigravity" / "User" / "settings.json") in detection["config_paths"]
+        assert str(workspace_dir / ".vscode" / "settings.json") not in detection["config_paths"]
+        assert [item["artifact_id"] for item in detection["artifacts"]] == ["antigravity:global:mcp:gravity-tools"]
+        assert detection["artifacts"][0]["args"] == []
+
+    def test_guard_detect_tolerates_gemini_malformed_args(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _write_json(
+            home_dir / ".gemini" / "extensions" / "shared" / "gemini-extension.json",
+            {
+                "name": "shared",
+                "mcpServers": {"shared-tools": {"command": "node", "args": True}},
+            },
+        )
+        _write_json(
+            home_dir / ".gemini" / "settings.json",
+            {
+                "mcpServers": {"settings-tools": {"command": "node", "args": True}},
+            },
+        )
+
+        rc = main(
+            [
+                "guard",
+                "detect",
+                "gemini",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        detection = output["harnesses"][0]
+        artifacts = {item["artifact_id"]: item for item in detection["artifacts"]}
+
+        assert rc == 0
+        assert artifacts["gemini:global:shared:shared-tools"]["args"] == []
+        assert artifacts["gemini:global:mcp:settings-tools"]["args"] == []
 
     def test_guard_detect_scopes_opencode_artifact_ids(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_protect.py
+++ b/tests/test_guard_protect.py
@@ -225,6 +225,123 @@ class TestGuardProtect:
         assert skill_output["targets"][0]["artifact_type"] == "skill"
         assert skill_output["targets"][0]["artifact_id"] == "install:opencode:fixture-skill"
 
+    def test_guard_protect_intercepts_gemini_skill_installs_and_mcp_additions(self, tmp_path, capsys) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir(parents=True)
+
+        skill_rc = main(
+            [
+                "guard",
+                "protect",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+                "gemini",
+                "skills",
+                "install",
+                "https://example.invalid/skills/review-skill.git",
+                "--scope",
+                "user",
+            ]
+        )
+        skill_output = json.loads(capsys.readouterr().out)
+
+        mcp_rc = main(
+            [
+                "guard",
+                "protect",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+                "gemini",
+                "mcp",
+                "add",
+                "remote-risk",
+                "https://evil.example/mcp",
+                "--transport",
+                "http",
+                "--scope",
+                "user",
+            ]
+        )
+        mcp_output = json.loads(capsys.readouterr().out)
+
+        assert skill_rc == 2
+        assert skill_output["executed"] is False
+        assert skill_output["targets"][0]["artifact_type"] == "skill"
+        assert skill_output["targets"][0]["artifact_id"] == "install:gemini:skill:review-skill"
+        assert mcp_rc == 2
+        assert mcp_output["executed"] is False
+        assert mcp_output["targets"][0]["artifact_type"] == "mcp_server"
+        assert mcp_output["targets"][0]["artifact_id"] == "install:gemini:mcp:remote-risk"
+
+    def test_guard_protect_keeps_gemini_stdio_mcp_targets_local(self) -> None:
+        request = protect.parse_protect_command(
+            [
+                "gemini",
+                "mcp",
+                "add",
+                "stdio-risk",
+                "https://example.invalid/not-a-remote-endpoint",
+                "--transport",
+                "stdio",
+            ]
+        )
+
+        assert request.targets[0].source_url is None
+        assert "registers a remote server endpoint" not in protect._request_risk_signals(request)
+
+    def test_guard_protect_intercepts_antigravity_extension_and_mcp_registration(self, tmp_path, capsys) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir(parents=True)
+
+        extension_rc = main(
+            [
+                "guard",
+                "protect",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+                "antigravity",
+                "--install-extension",
+                "hashgraph.tools",
+            ]
+        )
+        extension_output = json.loads(capsys.readouterr().out)
+
+        mcp_rc = main(
+            [
+                "guard",
+                "protect",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+                "antigravity",
+                "--add-mcp",
+                '{"name":"remote-risk","url":"https://evil.example/mcp"}',
+            ]
+        )
+        mcp_output = json.loads(capsys.readouterr().out)
+
+        assert extension_rc == 2
+        assert extension_output["executed"] is False
+        assert extension_output["targets"][0]["artifact_type"] == "extension"
+        assert extension_output["targets"][0]["artifact_id"] == "install:antigravity:extension:hashgraph.tools"
+        assert mcp_rc == 2
+        assert mcp_output["executed"] is False
+        assert mcp_output["targets"][0]["artifact_type"] == "mcp_server"
+        assert mcp_output["targets"][0]["artifact_id"] == "install:antigravity:mcp:remote-risk"
+
     def test_guard_protect_uses_configurable_execution_timeout(
         self,
         tmp_path,


### PR DESCRIPTION
## Summary
- add a first-class Antigravity Guard adapter and narrow Gemini ownership to real Gemini settings, hooks, skills, and extensions
- expand Guard protect parsing for Gemini and Antigravity native registration commands
- update docs and regression coverage for the new harness split

## Validation
- uv run --extra dev ruff check .
- uv run --extra dev python -m pytest -q
- uv run --extra dev python -m build
- live Antigravity E2E: blocked new extension, queued approval, approved exact request, reran into real `antigravity --version`
- live Gemini E2E: blocked new skill, queued approval, approved exact request, reran into real `gemini --version`