### PR TITLE
fix: retire codex-plugin-scanner surface

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -4,6 +4,6 @@ COPY ./.clusterfuzzlite/requirements-atheris.txt $SRC/requirements-atheris.txt
 RUN python3 -m pip install --require-hashes --no-cache-dir --no-binary=:all: --no-deps \
     -r $SRC/requirements-atheris.txt
 
-COPY . $SRC/codex-plugin-scanner
-WORKDIR $SRC/codex-plugin-scanner
+COPY . $SRC/ai-plugin-scanner
+WORKDIR $SRC/ai-plugin-scanner
 COPY ./.clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-cd "$SRC/codex-plugin-scanner"
+cd "$SRC/ai-plugin-scanner"
 export PYTHONPATH="$PWD/src${PYTHONPATH:+:$PYTHONPATH}"
 
 for fuzzer in fuzzers/*_fuzzer.py; do

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,3 +1,3 @@
-homepage: "https://github.com/hashgraph-online/codex-plugin-scanner"
+homepage: "https://github.com/hashgraph-online/ai-plugin-scanner"
 language: python
-main_repo: "https://github.com/hashgraph-online/codex-plugin-scanner"
+main_repo: "https://github.com/hashgraph-online/ai-plugin-scanner"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -141,29 +141,6 @@ jobs:
           PY
           uv run --no-sync python -m build
           mv pyproject.toml.bak pyproject.toml
-      - name: Build codex compatibility alias (codex-plugin-scanner)
-        run: |
-          cp pyproject.toml pyproject.toml.bak
-          python3 - <<'PY'
-          from pathlib import Path
-
-          path = Path("pyproject.toml")
-          text = path.read_text(encoding="utf-8")
-          text = text.replace('name = "hol-guard"', 'name = "codex-plugin-scanner"', 1)
-          text = text.replace(
-              'description = "Protect local AI harnesses with HOL Guard and run scanner checks for Codex, Claude, Cursor, Gemini, and OpenCode."',
-              'description = "Compatibility alias for teams still pinned to the codex-plugin-scanner package name."',
-              1,
-          )
-          start = text.index("[project.scripts]")
-          end = text.index("\n\n[project.urls]")
-          scripts = "[project.scripts]\n" \
-              'codex-plugin-scanner = "codex_plugin_scanner.cli:main"'
-          text = text[:start] + scripts + text[end:]
-          path.write_text(text, encoding="utf-8")
-          PY
-          uv run --no-sync python -m build
-          mv pyproject.toml.bak pyproject.toml
       - name: Verify distributions
         run: uv run --no-sync twine check dist/*
       - name: Upload artifacts
@@ -264,10 +241,6 @@ jobs:
 
           \`\`\`bash
           uv tool install plugin-scanner==${VERSION}
-          \`\`\`
-
-          \`\`\`bash
-          uv tool install codex-plugin-scanner==${VERSION}
           \`\`\`
 
           Full Cisco coverage on Python 3.11+:

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,10 +1,10 @@
 repos:
-  - repo: https://github.com/hashgraph-online/codex-plugin-scanner
+  - repo: https://github.com/hashgraph-online/ai-plugin-scanner
     rev: v1.1.0
     hooks:
-      - id: codex-plugin-scanner
-        name: Codex Plugin Scanner
-        description: "Scan a Codex plugin directory for security and best practices."
-        entry: codex-plugin-scanner
+      - id: plugin-scanner
+        name: Plugin Scanner
+        description: "Scan a plugin directory for security and best practices."
+        entry: plugin-scanner
         language: python
         pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,6 @@ This repository ships:
 
 - `hol-guard` for local harness protection
 - `plugin-scanner` for CI and maintainer checks across supported AI plugin ecosystems
-- `codex-plugin-scanner` as a compatibility package alias
 
 ## Before You Start
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN python3 -m pip install --require-hashes -r /app/docker-requirements.txt
 
 COPY src /app/src
 
-RUN cat <<'EOF' >/usr/local/bin/codex-plugin-scanner
+RUN cat <<'EOF' >/usr/local/bin/plugin-scanner
 #!/usr/bin/env python3
 from __future__ import annotations
 
@@ -37,7 +37,7 @@ from codex_plugin_scanner.cli import main
 
 raise SystemExit(main())
 EOF
-RUN chmod 0755 /usr/local/bin/codex-plugin-scanner
+RUN chmod 0755 /usr/local/bin/plugin-scanner
 
 RUN groupadd --system scanner && \
     useradd --system --gid scanner --create-home --home-dir /home/scanner scanner && \
@@ -48,4 +48,4 @@ WORKDIR /workspace
 
 USER scanner
 
-ENTRYPOINT ["codex-plugin-scanner"]
+ENTRYPOINT ["plugin-scanner"]

--- a/docs/trust/skill-trust-local.md
+++ b/docs/trust/skill-trust-local.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-`codex-plugin-scanner` uses the published HCS-28 baseline adapter catalog for bundled Codex skills. The scanner does not define a private skill trust profile. Instead, it computes local bundled-skill evidence using the HCS-28 adapter ids, weights, contribution modes, and aggregation rules.
+`plugin-scanner` uses the published HCS-28 baseline adapter catalog for bundled Codex skills. The scanner does not define a private skill trust profile. Instead, it computes local bundled-skill evidence using the HCS-28 adapter ids, weights, contribution modes, and aggregation rules.
 
 ## Normative provenance
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ publish = [
 hol-guard = "codex_plugin_scanner.cli:main"
 plugin-scanner = "codex_plugin_scanner.cli:main"
 plugin-guard = "codex_plugin_scanner.cli:main"
-codex-plugin-scanner = "codex_plugin_scanner.cli:main"
 plugin-ecosystem-scanner = "codex_plugin_scanner.cli:main"
 
 [project.urls]

--- a/src/codex_plugin_scanner/__init__.py
+++ b/src/codex_plugin_scanner/__init__.py
@@ -1,4 +1,4 @@
-"""Codex Plugin Scanner - multi-ecosystem scanner for agent plugin packages."""
+"""Plugin Scanner package exports."""
 
 from .models import (
     GRADE_LABELS,

--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -1,4 +1,4 @@
-"""Codex Plugin Scanner - CLI entry point."""
+"""Plugin Scanner CLI entry point."""
 
 from __future__ import annotations
 
@@ -72,7 +72,7 @@ def _is_guard_program(program_name: str) -> bool:
 
 def _is_scanner_program(program_name: str) -> bool:
     normalized_name = Path(program_name).stem.lower()
-    return normalized_name in {"plugin-scanner", "codex-plugin-scanner", "plugin-ecosystem-scanner"}
+    return normalized_name in {"plugin-scanner", "plugin-ecosystem-scanner"}
 
 
 def _build_parser(program_name: str, *, program_mode: str) -> argparse.ArgumentParser:

--- a/src/codex_plugin_scanner/cli_ui.py
+++ b/src/codex_plugin_scanner/cli_ui.py
@@ -15,7 +15,7 @@ def build_plain_text(result: ScanResult) -> str:
     if getattr(result, "scope", "plugin") == "repository":
         trust_total = result.trust_report.total if getattr(result, "trust_report", None) else 0.0
         lines = [
-            f"🔗 Codex Plugin Scanner v{__version__}",
+            f"🔗 Plugin Scanner v{__version__}",
             f"Scanning repository: {result.plugin_dir}",
             f"Marketplace: {result.marketplace_file or 'not found'}",
             f"Local plugins scanned: {len(result.plugin_results)}",
@@ -37,7 +37,7 @@ def build_plain_text(result: ScanResult) -> str:
     else:
         trust_total = result.trust_report.total if getattr(result, "trust_report", None) else 0.0
         lines = [
-            f"🔗 Codex Plugin Scanner v{__version__}",
+            f"🔗 Plugin Scanner v{__version__}",
             f"Scanning: {result.plugin_dir}",
             f"Trust: {trust_total}/100",
             "",

--- a/src/codex_plugin_scanner/models.py
+++ b/src/codex_plugin_scanner/models.py
@@ -1,4 +1,4 @@
-"""Codex Plugin Scanner - types and data classes."""
+"""Plugin Scanner types and data classes."""
 
 from __future__ import annotations
 

--- a/src/codex_plugin_scanner/reporting.py
+++ b/src/codex_plugin_scanner/reporting.py
@@ -233,7 +233,7 @@ def format_markdown(result: ScanResult) -> str:
     """Render a scan result as a markdown report."""
 
     lines = [
-        "# Codex Plugin Scanner Report",
+        "# Plugin Scanner Report",
         "",
         f"- {'Repository' if result.scope == 'repository' else 'Plugin'}: `{result.plugin_dir}`",
         f"- Score: **{result.score}/100**",
@@ -354,8 +354,8 @@ def format_sarif(result: ScanResult) -> str:
             {
                 "tool": {
                     "driver": {
-                        "name": "codex-plugin-scanner",
-                        "informationUri": "https://github.com/hashgraph-online/codex-plugin-scanner",
+                        "name": "plugin-scanner",
+                        "informationUri": "https://github.com/hashgraph-online/ai-plugin-scanner",
                         "version": __version__,
                         "rules": rules,
                     }

--- a/src/codex_plugin_scanner/rules/registry.py
+++ b/src/codex_plugin_scanner/rules/registry.py
@@ -15,7 +15,7 @@ CATEGORY_WEIGHTS: dict[str, int] = {
     "code-quality": 10,
 }
 
-_DOC_ROOT = "https://github.com/hashgraph-online/codex-plugin-scanner/blob/main/docs/rules"
+_DOC_ROOT = "https://github.com/hashgraph-online/ai-plugin-scanner/blob/main/docs/rules"
 
 
 def _rule(

--- a/src/codex_plugin_scanner/scanner.py
+++ b/src/codex_plugin_scanner/scanner.py
@@ -1,4 +1,4 @@
-"""Codex Plugin Scanner - core scanning engine."""
+"""Plugin Scanner core scanning engine."""
 
 from __future__ import annotations
 

--- a/src/codex_plugin_scanner/submission.py
+++ b/src/codex_plugin_scanner/submission.py
@@ -13,7 +13,8 @@ from .checks.manifest import load_manifest
 from .models import GRADE_LABELS, ScanResult
 
 REQUEST_TIMEOUT_SECONDS = 30
-SUBMISSION_URL_MARKER_PREFIX = "<!-- codex-plugin-scanner-plugin-url: "
+SUBMISSION_URL_MARKER_PREFIX = "<!-- plugin-scanner-plugin-url: "
+LEGACY_SUBMISSION_URL_MARKER_PREFIX = "<!-- codex-plugin-scanner-plugin-url: "
 SUBMISSION_URL_MARKER_SUFFIX = " -->"
 
 
@@ -47,6 +48,10 @@ def _submission_url_marker(plugin_url: str) -> str:
     return f"{SUBMISSION_URL_MARKER_PREFIX}{plugin_url}{SUBMISSION_URL_MARKER_SUFFIX}"
 
 
+def _legacy_submission_url_marker(plugin_url: str) -> str:
+    return f"{LEGACY_SUBMISSION_URL_MARKER_PREFIX}{plugin_url}{SUBMISSION_URL_MARKER_SUFFIX}"
+
+
 def _parse_submission_issue(
     issue: dict[str, object],
     *,
@@ -75,7 +80,7 @@ def _request_json(
     request = Request(url, data=data, method=method)
     request.add_header("Accept", "application/vnd.github+json")
     request.add_header("Authorization", f"Bearer {token}")
-    request.add_header("User-Agent", "codex-plugin-scanner")
+    request.add_header("User-Agent", "plugin-scanner")
     if data is not None:
         request.add_header("Content-Type", "application/json")
     with urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS) as response:
@@ -116,7 +121,7 @@ def resolve_submission_metadata(
         (description or "").strip()
         or str(interface.get("shortDescription") or "").strip()
         or str(manifest.get("description") or "").strip()
-        or f"{resolved_name} scored {result.score}/100 with codex-plugin-scanner."
+        or f"{resolved_name} scored {result.score}/100 with plugin-scanner."
     )
     resolved_author = (
         (author or "").strip()
@@ -224,10 +229,10 @@ def find_existing_submission_issue(
 ) -> SubmissionIssue | None:
     """Find an existing open submission issue for the same plugin URL."""
 
-    marker = _submission_url_marker(plugin_url)
+    markers = (_submission_url_marker(plugin_url), _legacy_submission_url_marker(plugin_url))
     query = urlencode(
         {
-            "q": f'repo:{repo} is:issue is:open "{marker}" in:body',
+            "q": f'repo:{repo} is:issue is:open "{plugin_url}" in:body',
             "per_page": "10",
         }
     )
@@ -247,7 +252,7 @@ def find_existing_submission_issue(
         if not isinstance(issue, dict):
             continue
         body = str(issue.get("body") or "")
-        if issue.get("pull_request") or marker not in body:
+        if issue.get("pull_request") or not any(marker in body for marker in markers):
             continue
         return _parse_submission_issue(issue, repo=repo, created=False)
     return None

--- a/src/codex_plugin_scanner/submission.py
+++ b/src/codex_plugin_scanner/submission.py
@@ -230,31 +230,32 @@ def find_existing_submission_issue(
     """Find an existing open submission issue for the same plugin URL."""
 
     markers = (_submission_url_marker(plugin_url), _legacy_submission_url_marker(plugin_url))
-    query = urlencode(
-        {
-            "q": f'repo:{repo} is:issue is:open "{plugin_url}" in:body',
-            "per_page": "10",
-        }
-    )
-    issues = _request_json(
-        "GET",
-        f"{api_base_url.rstrip('/')}/search/issues?{query}",
-        token,
-    )
-    if not isinstance(issues, dict):
-        return None
+    for marker in markers:
+        query = urlencode(
+            {
+                "q": f'repo:{repo} is:issue is:open "{marker}" in:body',
+                "per_page": "10",
+            }
+        )
+        issues = _request_json(
+            "GET",
+            f"{api_base_url.rstrip('/')}/search/issues?{query}",
+            token,
+        )
+        if not isinstance(issues, dict):
+            return None
 
-    items = issues.get("items")
-    if not isinstance(items, list):
-        return None
+        items = issues.get("items")
+        if not isinstance(items, list):
+            return None
 
-    for issue in items:
-        if not isinstance(issue, dict):
-            continue
-        body = str(issue.get("body") or "")
-        if issue.get("pull_request") or not any(marker in body for marker in markers):
-            continue
-        return _parse_submission_issue(issue, repo=repo, created=False)
+        for issue in items:
+            if not isinstance(issue, dict):
+                continue
+            body = str(issue.get("body") or "")
+            if issue.get("pull_request") or marker not in body:
+                continue
+            return _parse_submission_issue(issue, repo=repo, created=False)
     return None
 
 

--- a/src/codex_plugin_scanner/verification.py
+++ b/src/codex_plugin_scanner/verification.py
@@ -520,7 +520,7 @@ def _check_mcp_stdio(servers: dict) -> tuple[list[VerificationCase], list[Runtim
                 "params": {
                     "protocolVersion": "2024-11-05",
                     "capabilities": {"tools": {}, "resources": {}, "prompts": {}},
-                    "clientInfo": {"name": "codex-plugin-scanner", "version": __version__},
+                    "clientInfo": {"name": "plugin-scanner", "version": __version__},
                 },
             }
             proc.stdin.write(json.dumps(initialize_request) + "\n")

--- a/tests/fixtures/good-plugin/.codex-plugin/plugin.json
+++ b/tests/fixtures/good-plugin/.codex-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Hashgraph Online",
     "email": "dev@hol.org"
   },
-  "homepage": "https://github.com/hashgraph-online/codex-plugin-scanner",
-  "repository": "https://github.com/hashgraph-online/codex-plugin-scanner",
+  "homepage": "https://github.com/hashgraph-online/ai-plugin-scanner",
+  "repository": "https://github.com/hashgraph-online/ai-plugin-scanner",
   "license": "Apache-2.0",
   "keywords": ["codex", "plugin", "security"],
   "interface": {
@@ -18,7 +18,7 @@
     "developerName": "Hashgraph Online",
     "category": "Developer Tools",
     "capabilities": ["Read", "Write"],
-    "websiteURL": "https://github.com/hashgraph-online/codex-plugin-scanner",
+    "websiteURL": "https://github.com/hashgraph-online/ai-plugin-scanner",
     "privacyPolicyURL": "https://example.com/privacy",
     "termsOfServiceURL": "https://example.com/terms",
     "defaultPrompt": [

--- a/tests/fixtures/good-plugin/skills/example/SKILL.md
+++ b/tests/fixtures/good-plugin/skills/example/SKILL.md
@@ -2,8 +2,8 @@
 name: example
 description: An example skill that does things with clear provenance, taxonomy, and metadata for trust scoring.
 license: Apache-2.0
-repo: https://github.com/hashgraph-online/codex-plugin-scanner
-homepage: https://github.com/hashgraph-online/codex-plugin-scanner
+repo: https://github.com/hashgraph-online/ai-plugin-scanner
+homepage: https://github.com/hashgraph-online/ai-plugin-scanner
 commit: 4078d8c2ce017ddd12b2352eb3a0434d573afaae
 tags:
   - codex

--- a/tests/test-trust-scoring.py
+++ b/tests/test-trust-scoring.py
@@ -24,7 +24,7 @@ def write_minimal_plugin(plugin_dir: Path) -> None:
                 "description": "Trust scoring demo plugin",
                 "author": {"name": "Hashgraph Online"},
                 "homepage": "https://example.com/plugin",
-                "repository": "https://github.com/hashgraph-online/codex-plugin-scanner",
+                "repository": "https://github.com/hashgraph-online/ai-plugin-scanner",
             }
         ),
         encoding="utf-8",
@@ -145,7 +145,7 @@ def test_declared_invalid_interface_keeps_interface_integrity_applicable(tmp_pat
                 "interface": "invalid",
                 "author": {"name": "Hashgraph Online"},
                 "homepage": "https://example.com/plugin",
-                "repository": "https://github.com/hashgraph-online/codex-plugin-scanner",
+                "repository": "https://github.com/hashgraph-online/ai-plugin-scanner",
             }
         ),
         encoding="utf-8",

--- a/tests/test_cisco_install_surfaces.py
+++ b/tests/test_cisco_install_surfaces.py
@@ -27,6 +27,17 @@ def test_pyproject_keeps_cisco_mcp_scanner_optional() -> None:
     assert "cisco-aibom" not in cisco_extra
 
 
+def test_pyproject_exposes_guard_and_scanner_commands_without_codex_alias() -> None:
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]
+    scripts = project["scripts"]
+
+    assert scripts["hol-guard"] == "codex_plugin_scanner.cli:main"
+    assert scripts["plugin-scanner"] == "codex_plugin_scanner.cli:main"
+    assert scripts["plugin-guard"] == "codex_plugin_scanner.cli:main"
+    assert scripts["plugin-ecosystem-scanner"] == "codex_plugin_scanner.cli:main"
+    assert "codex-plugin-scanner" not in scripts
+
+
 def test_readme_distinguishes_baseline_and_full_cisco_installs() -> None:
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
 
@@ -60,3 +71,14 @@ def test_repo_controlled_surfaces_prefer_cisco_extra_where_supported() -> None:
     assert "cisco-ai-mcp-scanner==" in docker_requirements
     assert "--hash=sha256:" in docker_requirements
     assert "uv sync --extra dev --extra cisco" in contributing
+
+
+def test_publish_workflow_builds_only_guard_and_scanner_packages() -> None:
+    publish_workflow = (ROOT / ".github/workflows/publish.yml").read_text(encoding="utf-8")
+
+    assert "Build Guard package (hol-guard)" in publish_workflow
+    assert "Build scanner package (plugin-scanner)" in publish_workflow
+    assert "Build codex compatibility alias" not in publish_workflow
+    assert 'name = "codex-plugin-scanner"' not in publish_workflow
+    assert 'codex-plugin-scanner = "codex_plugin_scanner.cli:main"' not in publish_workflow
+    assert 'uv tool install codex-plugin-scanner==' not in publish_workflow

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,7 +67,7 @@ class TestFormatText:
     def test_contains_header(self):
         result = scan_plugin(FIXTURES / "good-plugin")
         output = format_text(result)
-        assert "Codex Plugin Scanner" in output
+        assert "Plugin Scanner" in output
         assert f"{result.score}/100" in output
         assert "Excellent" in output
 
@@ -105,6 +105,11 @@ class TestFormatText:
 
 
 class TestMain:
+    def test_scanner_program_detection_excludes_retired_codex_alias(self):
+        assert cli_module._is_scanner_program("plugin-scanner") is True
+        assert cli_module._is_scanner_program("plugin-ecosystem-scanner") is True
+        assert cli_module._is_scanner_program("codex-plugin-scanner") is False
+
     def test_parser_accepts_cisco_mcp_scan(self):
         parser = cli_module._build_parser("plugin-scanner", program_mode="scanner")
         args = parser.parse_args(["scan", str(FIXTURES / "good-plugin"), "--cisco-mcp-scan", "on"])

--- a/tests/test_security_ops.py
+++ b/tests/test_security_ops.py
@@ -24,7 +24,7 @@ def test_markdown_output_contains_top_findings():
     result = scan_plugin(FIXTURES / "bad-plugin")
     output = format_markdown(result)
 
-    assert "# Codex Plugin Scanner Report" in output
+    assert "# Plugin Scanner Report" in output
     assert "## Top Findings" in output
     assert "Hardcoded secret detected" in output or "Dangerous MCP command pattern detected" in output
 
@@ -34,7 +34,8 @@ def test_sarif_output_contains_results():
     sarif = json.loads(format_sarif(result))
 
     assert sarif["version"] == "2.1.0"
-    assert sarif["runs"][0]["tool"]["driver"]["name"] == "codex-plugin-scanner"
+    assert sarif["runs"][0]["tool"]["driver"]["name"] == "plugin-scanner"
+    assert sarif["runs"][0]["tool"]["driver"]["informationUri"] == "https://github.com/hashgraph-online/ai-plugin-scanner"
     assert sarif["runs"][0]["results"]
 
 

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -140,7 +140,44 @@ def test_find_existing_submission_issue_uses_search_api_and_exact_marker(monkeyp
     assert issue.created is False
     assert captured["method"] == "GET"
     assert "/search/issues?" in captured["url"]
+    assert "plugin-scanner-plugin-url" in captured["url"]
     assert captured["token"] == "token-123"
+
+
+def test_find_existing_submission_issue_falls_back_to_legacy_marker_search(monkeypatch) -> None:
+    calls: list[str] = []
+
+    def fake_request_json(method: str, url: str, token: str, payload=None):
+        calls.append(url)
+        if len(calls) == 1:
+            return {"items": []}
+        return {
+            "items": [
+                {
+                    "number": 42,
+                    "html_url": "https://github.com/hashgraph-online/awesome-codex-plugins/issues/42",
+                    "body": (
+                        "## Plugin Submission\n"
+                        "<!-- codex-plugin-scanner-plugin-url: "
+                        "https://github.com/hashgraph-online/example-good-plugin -->\n"
+                    ),
+                }
+            ]
+        }
+
+    monkeypatch.setattr("codex_plugin_scanner.submission._request_json", fake_request_json)
+
+    issue = find_existing_submission_issue(
+        "hashgraph-online/awesome-codex-plugins",
+        "https://github.com/hashgraph-online/example-good-plugin",
+        "token-123",
+    )
+
+    assert issue is not None
+    assert issue.number == 42
+    assert len(calls) == 2
+    assert "plugin-scanner-plugin-url" in calls[0]
+    assert "codex-plugin-scanner-plugin-url" in calls[1]
 
 
 def test_create_submission_issue_retries_without_labels_on_invalid_labels(monkeypatch) -> None:

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -29,7 +29,7 @@ def test_resolve_submission_metadata_prefers_manifest_fields() -> None:
     )
 
     assert metadata.plugin_name == "Example Good Plugin"
-    assert metadata.plugin_url == "https://github.com/hashgraph-online/codex-plugin-scanner"
+    assert metadata.plugin_url == "https://github.com/hashgraph-online/ai-plugin-scanner"
     assert metadata.description == "Reusable security-first plugin fixture"
     assert metadata.author == "Hashgraph Online"
     assert metadata.category == "Community Plugins"
@@ -79,7 +79,7 @@ def test_submission_payload_and_issue_body_include_registry_data() -> None:
     assert payload["grade"] == "A"
     assert payload["pluginUrl"] == metadata.plugin_url
     assert "## Registry Payload" in body
-    assert "<!-- codex-plugin-scanner-plugin-url: https://github.com/hashgraph-online/example-good-plugin -->" in body
+    assert "<!-- plugin-scanner-plugin-url: https://github.com/hashgraph-online/example-good-plugin -->" in body
     assert '"pluginName": "Example Good Plugin"' in body
     assert metadata.plugin_url in body
 
@@ -111,7 +111,7 @@ def test_find_existing_submission_issue_uses_search_api_and_exact_marker(monkeyp
                     "html_url": "https://github.com/hashgraph-online/awesome-codex-plugins/issues/42",
                     "body": (
                         "## Plugin Submission\n"
-                        "<!-- codex-plugin-scanner-plugin-url: "
+                        "<!-- plugin-scanner-plugin-url: "
                         "https://github.com/hashgraph-online/example-good-plugin -->\n"
                     ),
                 },
@@ -120,7 +120,7 @@ def test_find_existing_submission_issue_uses_search_api_and_exact_marker(monkeyp
                     "html_url": "https://github.com/hashgraph-online/awesome-codex-plugins/issues/99",
                     "body": (
                         "## Plugin Submission\n"
-                        "<!-- codex-plugin-scanner-plugin-url: "
+                        "<!-- plugin-scanner-plugin-url: "
                         "https://github.com/hashgraph-online/example-good-plugin-extra -->\n"
                     ),
                 },

--- a/tests/test_trust_scoring.py
+++ b/tests/test_trust_scoring.py
@@ -24,7 +24,7 @@ def write_minimal_plugin(plugin_dir: Path) -> None:
                 "description": "Trust scoring demo plugin",
                 "author": {"name": "Hashgraph Online"},
                 "homepage": "https://example.com/plugin",
-                "repository": "https://github.com/hashgraph-online/codex-plugin-scanner",
+                "repository": "https://github.com/hashgraph-online/ai-plugin-scanner",
             }
         ),
         encoding="utf-8",
@@ -103,7 +103,7 @@ def test_invalid_skill_frontmatter_reduces_manifest_integrity(tmp_path: Path):
                 "skills": "skills",
                 "author": {"name": "Hashgraph Online"},
                 "homepage": "https://example.com/plugin",
-                "repository": "https://github.com/hashgraph-online/codex-plugin-scanner",
+                "repository": "https://github.com/hashgraph-online/ai-plugin-scanner",
                 "interface": {"category": "developer-tools"},
             }
         ),
@@ -201,7 +201,7 @@ def test_declared_invalid_interface_keeps_interface_integrity_applicable(tmp_pat
                 "interface": "invalid",
                 "author": {"name": "Hashgraph Online"},
                 "homepage": "https://example.com/plugin",
-                "repository": "https://github.com/hashgraph-online/codex-plugin-scanner",
+                "repository": "https://github.com/hashgraph-online/ai-plugin-scanner",
             }
         ),
         encoding="utf-8",

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -177,7 +177,7 @@ import sys
 init = json.loads(sys.stdin.readline())
 assert init["method"] == "initialize"
 assert init["params"]["protocolVersion"]
-assert init["params"]["clientInfo"]["name"] == "codex-plugin-scanner"
+assert init["params"]["clientInfo"]["name"] == "plugin-scanner"
 sys.stdout.write(json.dumps({
     "jsonrpc": "2.0",
     "id": init["id"],


### PR DESCRIPTION
## Summary
- remove the published `codex-plugin-scanner` package/script so the repo ships only `hol-guard` and `plugin-scanner`
- rebrand scanner-facing metadata and integration surfaces from `codex-plugin-scanner` to `plugin-scanner`
- preserve only intentional compatibility shims such as the internal module path and legacy submission-marker lookup

## Verification
- `ruff check src tests`
- `pytest tests/test_cisco_install_surfaces.py tests/test_cli.py tests/test_security_ops.py tests/test_submission.py tests/test_trust_scoring.py tests/test_verification.py --tb=short`
- `python -m build`

## Notes
- full `pytest` currently fails on `origin/main` in Guard tests (`tests/test_guard_cli.py`, `tests/test_guard_protect.py`); the same failures reproduce on a fresh `origin/main` worktree and are unrelated to this rename-only diff.