### PR TITLE
fix: harden Guard connect runtime flow

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -12,13 +12,8 @@ from ..daemon import ensure_guard_daemon, load_guard_surface_daemon_client
 from ..runtime import sync_receipts
 from ..store import GuardStore
 
-DEFAULT_GUARD_SYNC_URL = "https://hol.org/api/guard/receipts/sync"
+DEFAULT_GUARD_SYNC_URL = "https://hol.org/registry/api/v1"
 DEFAULT_GUARD_CONNECT_URL = "https://hol.org/guard/connect"
-_PLAN_LIMITED_SYNC_PHRASES = (
-    "paid guard plan",
-    "guard plan required",
-    "guard plan upgrade",
-)
 
 
 def run_guard_connect_command(
@@ -44,47 +39,73 @@ def run_guard_connect_command(
         pairing_secret=str(connect_request["pairing_secret"]),
     )
     browser_opened = bool(opener(browser_url))
-    completion = wait_for_connect_completion(
-        store=store,
+    transition = wait_for_connect_transition(
+        daemon_client=daemon_client,
         request_id=str(connect_request["request_id"]),
         timeout_seconds=wait_timeout_seconds,
     )
-    if completion is None:
-        return {
-            "connected": False,
-            "browser_opened": browser_opened,
-            "connect_url": browser_url,
-            "sync_url": sync_url,
-            "status": "waiting_for_browser",
-        }
+    if transition is None:
+        return build_connect_payload(
+            state={
+                "request_id": str(connect_request["request_id"]),
+                "status": "waiting",
+                "milestone": "waiting_for_browser",
+                "reason": "waiting_for_browser",
+                "completed_at": None,
+                "expires_at": connect_request.get("expires_at"),
+                "proof": {},
+            },
+            browser_opened=browser_opened,
+            connect_url=browser_url,
+            sync_url=sync_url,
+            connected=False,
+        )
+    if str(transition.get("status")) == "expired":
+        return build_connect_payload(
+            state=transition,
+            browser_opened=browser_opened,
+            connect_url=browser_url,
+            sync_url=sync_url,
+            connected=False,
+        )
+    if str(transition.get("status")) == "retry_required":
+        return build_connect_payload(
+            state=transition,
+            browser_opened=browser_opened,
+            connect_url=browser_url,
+            sync_url=sync_url,
+            connected=False,
+        )
     try:
         sync_payload = sync_receipts(store)
-    except RuntimeError as error:
-        sync_message = str(error)
-        if _is_plan_limited_sync_error(sync_message):
-            return {
-                "connected": True,
-                "browser_opened": browser_opened,
-                "connect_url": browser_url,
-                "sync_url": sync_url,
-                "status": "paired_without_cloud_sync",
-                "request_id": str(completion["request_id"]),
-                "completed_at": completion.get("completed_at"),
-                "sync_message": sync_message,
-            }
-        raise RuntimeError(f"Guard paired successfully but sync failed: {sync_message}") from error
-    except (OSError, json.JSONDecodeError, urllib.error.URLError) as error:
-        raise RuntimeError(f"Guard paired successfully but sync failed: {error}") from error
-    return {
-        "connected": True,
-        "browser_opened": browser_opened,
-        "connect_url": browser_url,
-        "sync_url": sync_url,
-        "status": str(completion["status"]),
-        "request_id": str(completion["request_id"]),
-        "completed_at": completion.get("completed_at"),
-        "sync": sync_payload,
-    }
+    except (RuntimeError, OSError, urllib.error.URLError, json.JSONDecodeError) as error:
+        failed_state = daemon_client.report_connect_result(
+            request_id=str(connect_request["request_id"]),
+            status="retry_required",
+            milestone="first_sync_failed",
+            reason=str(error),
+        )
+        return build_connect_payload(
+            state=failed_state,
+            browser_opened=browser_opened,
+            connect_url=browser_url,
+            sync_url=sync_url,
+            connected=False,
+        )
+    final_state = daemon_client.report_connect_result(
+        request_id=str(connect_request["request_id"]),
+        status="connected",
+        milestone="first_sync_succeeded",
+        sync=sync_payload,
+    )
+    return build_connect_payload(
+        state=final_state,
+        browser_opened=browser_opened,
+        connect_url=browser_url,
+        sync_url=sync_url,
+        connected=True,
+        sync=sync_payload,
+    )
 
 
 def resolve_connect_url(connect_url: str) -> tuple[str, str]:
@@ -95,16 +116,6 @@ def resolve_connect_url(connect_url: str) -> tuple[str, str]:
     normalized_url = urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, path, parsed.query, ""))
     allowed_origin = urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
     return normalized_url, allowed_origin
-
-
-def _is_plan_limited_sync_error(message: str) -> bool:
-    """Match the stable plan-limit phrases returned by Guard Cloud sync today."""
-
-    normalized = message.strip().lower()
-    has_plan_limit_phrase = any(phrase in normalized for phrase in _PLAN_LIMITED_SYNC_PHRASES)
-    if "guard" in normalized and has_plan_limit_phrase:
-        return True
-    return "guard" in normalized and "sync" in normalized and "guard plan" in normalized and "upgrade" in normalized
 
 
 def build_guard_connect_browser_url(
@@ -134,17 +145,72 @@ def build_guard_connect_browser_url(
     )
 
 
-def wait_for_connect_completion(
+def wait_for_connect_transition(
     *,
-    store: GuardStore,
+    daemon_client,
     request_id: str,
     timeout_seconds: int,
     poll_interval_seconds: float = 0.25,
 ) -> dict[str, object] | None:
     deadline = time.monotonic() + max(1, timeout_seconds)
     while time.monotonic() < deadline:
-        request = store.get_guard_connect_request(request_id)
-        if request is not None and str(request.get("status")) == "completed":
-            return request
+        state = daemon_client.get_connect_state(request_id=request_id)
+        if str(state.get("status")) in {"connected", "retry_required", "expired"}:
+            return state
+        if str(state.get("milestone")) == "first_sync_pending":
+            return state
         time.sleep(poll_interval_seconds)
     return None
+
+
+def build_connect_payload(
+    *,
+    state: dict[str, object],
+    browser_opened: bool,
+    connect_url: str,
+    sync_url: str,
+    connected: bool,
+    sync: dict[str, object] | None = None,
+) -> dict[str, object]:
+    milestones = [
+        {
+            "label": "browser_opened",
+            "status": "completed" if browser_opened else "pending",
+        },
+        {
+            "label": "pairing_completed",
+            "status": "completed" if state.get("completed_at") else "pending",
+        },
+        {
+            "label": "first_sync",
+            "status": _resolve_first_sync_milestone(state),
+        },
+    ]
+    payload = {
+        "connected": connected,
+        "browser_opened": browser_opened,
+        "connect_url": connect_url,
+        "sync_url": sync_url,
+        "status": str(state.get("status") or "waiting"),
+        "milestone": str(state.get("milestone") or "waiting_for_browser"),
+        "reason": state.get("reason"),
+        "request_id": state.get("request_id"),
+        "completed_at": state.get("completed_at"),
+        "expires_at": state.get("expires_at"),
+        "proof": dict(state.get("proof")) if isinstance(state.get("proof"), dict) else {},
+        "milestones": milestones,
+    }
+    if sync is not None:
+        payload["sync"] = sync
+    return payload
+
+
+def _resolve_first_sync_milestone(state: dict[str, object]) -> str:
+    milestone = str(state.get("milestone") or "")
+    if milestone == "first_sync_succeeded":
+        return "completed"
+    if milestone == "first_sync_failed":
+        return "failed"
+    if milestone == "first_sync_pending":
+        return "waiting"
+    return "pending"

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -160,7 +160,11 @@ def wait_for_connect_transition(
 ) -> dict[str, object] | None:
     deadline = time.monotonic() + max(1, timeout_seconds)
     while time.monotonic() < deadline:
-        state = daemon_client.get_connect_state(request_id=request_id)
+        try:
+            state = daemon_client.get_connect_state(request_id=request_id)
+        except RuntimeError:
+            time.sleep(poll_interval_seconds)
+            continue
         if not isinstance(state, dict):
             raise RuntimeError("Guard daemon request failed: invalid connect state response")
         if str(state.get("status")) in {"connected", "retry_required", "expired"}:

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from ..daemon import ensure_guard_daemon, load_guard_surface_daemon_client
-from ..daemon.client import GuardSurfaceDaemonClient
+from ..daemon.client import GuardDaemonRequestError, GuardDaemonTransportError, GuardSurfaceDaemonClient
 from ..runtime import sync_receipts
 from ..store import GuardStore
 
@@ -162,11 +162,11 @@ def wait_for_connect_transition(
     while time.monotonic() < deadline:
         try:
             state = daemon_client.get_connect_state(request_id=request_id)
-        except RuntimeError:
+        except GuardDaemonTransportError:
             time.sleep(poll_interval_seconds)
             continue
         if not isinstance(state, dict):
-            raise RuntimeError("Guard daemon request failed: invalid connect state response")
+            raise GuardDaemonRequestError("Guard daemon request failed: invalid connect state response")
         if str(state.get("status")) in {"connected", "retry_required", "expired"}:
             return state
         if str(state.get("milestone")) == "first_sync_pending":

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -6,6 +6,7 @@ import json
 import time
 import urllib.error
 import urllib.parse
+from datetime import datetime, timezone
 from pathlib import Path
 
 from ..daemon import ensure_guard_daemon, load_guard_surface_daemon_client
@@ -80,7 +81,9 @@ def run_guard_connect_command(
     try:
         sync_payload = sync_receipts(store)
     except (RuntimeError, OSError, urllib.error.URLError, json.JSONDecodeError) as error:
-        failed_state = daemon_client.report_connect_result(
+        failed_state = _record_connect_result(
+            daemon_client=daemon_client,
+            store=store,
             request_id=str(connect_request["request_id"]),
             status="retry_required",
             milestone="first_sync_failed",
@@ -93,7 +96,9 @@ def run_guard_connect_command(
             sync_url=sync_url,
             connected=False,
         )
-    final_state = daemon_client.report_connect_result(
+    final_state = _record_connect_result(
+        daemon_client=daemon_client,
+        store=store,
         request_id=str(connect_request["request_id"]),
         status="connected",
         milestone="first_sync_succeeded",
@@ -206,6 +211,35 @@ def build_connect_payload(
     if sync is not None:
         payload["sync"] = sync
     return payload
+
+
+def _record_connect_result(
+    *,
+    daemon_client: GuardSurfaceDaemonClient,
+    store: GuardStore,
+    request_id: str,
+    status: str,
+    milestone: str,
+    reason: str | None = None,
+    sync: dict[str, object] | None = None,
+) -> dict[str, object]:
+    try:
+        return daemon_client.report_connect_result(
+            request_id=request_id,
+            status=status,
+            milestone=milestone,
+            reason=reason,
+            sync=sync,
+        )
+    except RuntimeError:
+        return store.record_guard_connect_result(
+            request_id=request_id,
+            status=status,
+            milestone=milestone,
+            now=datetime.now(timezone.utc).isoformat(),
+            reason=reason,
+            sync_payload=sync,
+        )
 
 
 def _resolve_first_sync_milestone(state: dict[str, object]) -> str:

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -9,6 +9,7 @@ import urllib.parse
 from pathlib import Path
 
 from ..daemon import ensure_guard_daemon, load_guard_surface_daemon_client
+from ..daemon.client import GuardSurfaceDaemonClient
 from ..runtime import sync_receipts
 from ..store import GuardStore
 
@@ -147,7 +148,7 @@ def build_guard_connect_browser_url(
 
 def wait_for_connect_transition(
     *,
-    daemon_client,
+    daemon_client: GuardSurfaceDaemonClient,
     request_id: str,
     timeout_seconds: int,
     poll_interval_seconds: float = 0.25,
@@ -155,6 +156,8 @@ def wait_for_connect_transition(
     deadline = time.monotonic() + max(1, timeout_seconds)
     while time.monotonic() < deadline:
         state = daemon_client.get_connect_state(request_id=request_id)
+        if not isinstance(state, dict):
+            raise RuntimeError("Guard daemon request failed: invalid connect state response")
         if str(state.get("status")) in {"connected", "retry_required", "expired"}:
             return state
         if str(state.get("milestone")) == "first_sync_pending":

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -429,7 +429,10 @@ def _render_connect(console: Console, payload: dict[str, object]) -> None:
     if isinstance(payload.get("sync"), dict):
         sync_payload = payload["sync"]
         body.add_row("Receipts stored", str(sync_payload.get("receipts_stored") or 0))
-        body.add_row("Inventory sent", str(sync_payload.get("inventory") or 0))
+        inventory_value = sync_payload.get("inventory_tracked")
+        if inventory_value is None:
+            inventory_value = sync_payload.get("inventory")
+        body.add_row("Inventory sent", str(inventory_value or 0))
     proof = payload.get("proof")
     if isinstance(proof, dict) and proof.get("first_synced_at"):
         body.add_row("First synced at", str(proof.get("first_synced_at")))

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -59,6 +59,7 @@ def _render_start(console: Console, payload: dict[str, object]) -> None:
             border_style="cyan",
         )
     )
+    console.print(_build_cloud_summary_panel(payload))
     console.print(_build_product_table(harnesses))
     if payload.get("approval_center_url"):
         console.print(f"Approval center: [bold]{payload.get('approval_center_url')}[/bold]")
@@ -77,6 +78,7 @@ def _render_status(console: Console, payload: dict[str, object]) -> None:
             border_style="cyan",
         )
     )
+    console.print(_build_cloud_summary_panel(payload))
     console.print(_build_product_table(harnesses))
     if payload.get("approval_center_url"):
         console.print(f"Approval center: [bold]{payload.get('approval_center_url')}[/bold]")
@@ -158,12 +160,24 @@ def _render_doctor(console: Console, payload: dict[str, object]) -> None:
 def _render_run(console: Console, payload: dict[str, object]) -> None:
     blocked = bool(payload.get("blocked"))
     launched = bool(payload.get("launched"))
-    title = "Blocked before launch" if blocked else "Launch allowed"
+    dry_run = bool(payload.get("dry_run"))
+    artifacts = _coerce_dict_list(payload.get("artifacts"))
+    visible_artifacts = [artifact for artifact in artifacts if _run_artifact_should_be_visible(artifact)]
+    summarized_artifacts = _summarize_run_artifacts(visible_artifacts)
+    title = _run_title(blocked=blocked, dry_run=dry_run)
     border_style = "red" if blocked else "green"
     body = Table.grid(padding=(0, 1))
+    approval_delivery = payload.get("approval_delivery")
     body.add_row("Harness", f"[bold]{payload.get('harness', 'unknown')}[/bold]")
+    body.add_row("Mode", "dry run" if dry_run else "launch")
+    body.add_row("Outcome", _run_outcome_text(blocked=blocked, dry_run=dry_run, launched=launched))
+    body.add_row("Artifacts", str(len(summarized_artifacts)))
+    if blocked:
+        needs_review = sum(1 for artifact in visible_artifacts if _artifact_needs_review(artifact))
+        body.add_row("Needs review", str(needs_review))
     body.add_row("Receipts", str(payload.get("receipts_recorded", 0)))
-    body.add_row("Launched", _bool_label(launched))
+    if isinstance(approval_delivery, dict) and approval_delivery.get("summary"):
+        body.add_row("Prompt route", str(approval_delivery.get("summary")))
     if payload.get("approval_center_url"):
         body.add_row("Approval center", str(payload.get("approval_center_url")))
     if payload.get("review_hint"):
@@ -171,7 +185,11 @@ def _render_run(console: Console, payload: dict[str, object]) -> None:
     if launched:
         body.add_row("Command", _command_text(payload.get("launch_command")))
     console.print(Panel(body, title=title, border_style=border_style))
-    console.print(_build_artifact_result_table(_coerce_dict_list(payload.get("artifacts"))))
+    if summarized_artifacts:
+        console.print(_build_run_artifact_table(summarized_artifacts))
+    steps = _build_run_steps(payload, blocked=blocked, dry_run=dry_run)
+    if steps:
+        console.print(_build_steps_panel(steps))
     approval_requests = _coerce_dict_list(payload.get("approval_requests"))
     if approval_requests:
         console.print(_build_approval_table(approval_requests, title="Queued approvals"))
@@ -418,35 +436,58 @@ def _render_login(console: Console, payload: dict[str, object]) -> None:
 
 
 def _render_connect(console: Console, payload: dict[str, object]) -> None:
-    body = Table.grid(padding=(0, 1))
-    body.add_row("Status", str(payload.get("status") or "waiting"))
-    body.add_row("Milestone", str(payload.get("milestone") or "waiting_for_browser"))
-    body.add_row("Browser opened", _bool_label(bool(payload.get("browser_opened"))))
-    body.add_row("Connect URL", str(payload.get("connect_url") or "unknown"))
-    body.add_row("Sync endpoint", str(payload.get("sync_url") or "unknown"))
-    if payload.get("reason"):
-        body.add_row("Reason", str(payload.get("reason")))
-    if isinstance(payload.get("sync"), dict):
-        sync_payload = payload["sync"]
-        body.add_row("Receipts stored", str(sync_payload.get("receipts_stored") or 0))
-        inventory_value = sync_payload.get("inventory_tracked")
-        if inventory_value is None:
-            inventory_value = sync_payload.get("inventory")
-        body.add_row("Inventory sent", str(inventory_value or 0))
-    proof = payload.get("proof")
-    if isinstance(proof, dict) and proof.get("first_synced_at"):
-        body.add_row("First synced at", str(proof.get("first_synced_at")))
-    border_style = "green" if bool(payload.get("connected")) else "yellow"
-    if str(payload.get("status")) in {"retry_required", "expired"}:
-        border_style = "red"
-    console.print(Panel(body, title="Guard connect", border_style=border_style))
+    if "connected" in payload or "browser_opened" in payload or "status" in payload:
+        body = Table.grid(padding=(0, 1))
+        body.add_row("Connected", _bool_label(bool(payload.get("connected"))))
+        body.add_row("Browser opened", _bool_label(bool(payload.get("browser_opened"))))
+        body.add_row("Status", str(payload.get("status") or "unknown"))
+        body.add_row("Connect URL", str(payload.get("connect_url") or "unknown"))
+        body.add_row("Sync endpoint", str(payload.get("sync_url") or "unknown"))
+        sync_payload = payload.get("sync")
+        if isinstance(sync_payload, dict):
+            body.add_row("Receipts stored", str(sync_payload.get("receipts_stored") or 0))
+            body.add_row(
+                "Inventory tracked",
+                str(sync_payload.get("inventory_tracked", sync_payload.get("inventory")) or 0),
+            )
+        sync_message = payload.get("sync_message")
+        if isinstance(sync_message, str) and sync_message.strip():
+            body.add_row("Sync note", sync_message)
+        console.print(Panel(body, title="Guard connect", border_style="green"))
+        return
+
+    border_style = _cloud_border_style(str(payload.get("cloud_state") or "local_only"))
+    console.print(
+        Panel.fit(
+            f"[bold]HOL Guard connect[/bold]\n"
+            f"{payload.get('cloud_state_label', 'Local only')} • "
+            f"{payload.get('receipt_count', 0)} receipts • "
+            f"{payload.get('pending_approvals', 0)} approvals",
+            border_style=border_style,
+        )
+    )
+    console.print(_build_cloud_summary_panel(payload))
+    sync_result = payload.get("sync_result")
+    if isinstance(sync_result, dict):
+        body = Table.grid(padding=(0, 1))
+        body.add_row("Synced at", str(sync_result.get("synced_at") or "unknown"))
+        body.add_row("Receipts stored", str(sync_result.get("receipts_stored") or 0))
+        body.add_row("Advisories stored", str(sync_result.get("advisories_stored") or 0))
+        body.add_row("Remote policies", str(sync_result.get("remote_policies_stored") or 0))
+        console.print(Panel(body, title="Connect sync", border_style="green"))
+    if payload.get("sync_error"):
+        console.print(Panel(str(payload.get("sync_error")), title="Connect failed", border_style="red"))
+    if payload.get("approval_center_url"):
+        console.print(f"Approval center: [bold]{payload.get('approval_center_url')}[/bold]")
+    console.print(_build_product_table(_coerce_dict_list(payload.get("harnesses"))))
+    console.print(_build_steps_panel(_coerce_dict_list(payload.get("next_steps"))))
 
 
 def _render_sync(console: Console, payload: dict[str, object]) -> None:
     body = Table.grid(padding=(0, 1))
     body.add_row("Synced at", str(payload.get("synced_at") or "unknown"))
     body.add_row("Receipts sent", str(payload.get("receipts") or 0))
-    body.add_row("Inventory sent", str(payload.get("inventory") or 0))
+    body.add_row("Inventory tracked", str(payload.get("inventory_tracked", payload.get("inventory")) or 0))
     body.add_row("Receipts stored", str(payload.get("receipts_stored") or 0))
     body.add_row("Advisories stored", str(payload.get("advisories_stored") or 0))
     console.print(Panel(body, title="Guard sync complete", border_style="green"))
@@ -457,6 +498,12 @@ def _render_hook(console: Console, payload: dict[str, object]) -> None:
     body.add_row("Recorded", _bool_label(bool(payload.get("recorded"))))
     body.add_row("Artifact", str(payload.get("artifact_name") or payload.get("artifact_id") or "unknown"))
     body.add_row("Decision", _action_text(str(payload.get("policy_action", "warn"))))
+    if payload.get("path_summary"):
+        body.add_row("Path", str(payload.get("path_summary")))
+    if payload.get("approval_center_url"):
+        body.add_row("Approval center", str(payload.get("approval_center_url")))
+    if payload.get("review_hint"):
+        body.add_row("Review", str(payload.get("review_hint")))
     console.print(Panel(body, title="Guard hook event", border_style="cyan"))
 
 
@@ -739,6 +786,278 @@ def _build_artifact_result_table(artifacts: list[dict[str, object]]) -> Table:
     return table
 
 
+def _build_run_artifact_table(artifacts: list[dict[str, str]]) -> Table:
+    table = Table(title="What changed", box=box.SIMPLE_HEAVY, show_header=True)
+    table.add_column("Artifact", style="bold")
+    table.add_column("Guard saw")
+    table.add_column("Reason")
+    table.add_column("Risk")
+    for artifact in artifacts:
+        table.add_row(
+            artifact["artifact_name"],
+            artifact["change_summary"],
+            artifact["reason_summary"],
+            artifact["risk_summary"],
+        )
+    return table
+
+
+def _run_title(*, blocked: bool, dry_run: bool) -> str:
+    if blocked and dry_run:
+        return "Dry run paused for review"
+    if blocked:
+        return "Blocked before launch"
+    if dry_run:
+        return "Dry run complete"
+    return "Launch allowed"
+
+
+def _run_outcome_text(*, blocked: bool, dry_run: bool, launched: bool) -> str:
+    if blocked and dry_run:
+        return "Guard found artifacts that need review before a real launch."
+    if blocked:
+        return "Guard paused the launch until you review the artifacts that need attention."
+    if dry_run:
+        return "Guard reviewed the current config without launching the harness."
+    if launched:
+        return "Guard approved the launch and handed control to the harness."
+    return "Guard finished the check without launching the harness."
+
+
+def _build_run_steps(payload: dict[str, object], *, blocked: bool, dry_run: bool) -> list[dict[str, str]]:
+    harness = str(payload.get("harness") or "codex")
+    approval_center_url = payload.get("approval_center_url")
+    review_hint = payload.get("review_hint")
+    rerun_command = payload.get("rerun_command")
+    diff_command = payload.get("diff_command")
+    approvals_command = payload.get("approvals_command")
+    if blocked and dry_run:
+        review_command = (
+            str(approvals_command)
+            if approval_center_url and isinstance(approvals_command, str) and approvals_command
+            else "hol-guard approvals"
+            if approval_center_url
+            else str(rerun_command)
+            if isinstance(rerun_command, str) and rerun_command
+            else f"hol-guard run {harness}"
+        )
+        inspect_command = (
+            str(diff_command) if isinstance(diff_command, str) and diff_command else f"hol-guard diff {harness}"
+        )
+        review_detail = (
+            str(review_hint)
+            if isinstance(review_hint, str) and review_hint
+            else "Rerun without --dry-run to review the full blocker set and continue into the harness launch."
+        )
+        return [
+            {
+                "title": "Resolve the blocked launch",
+                "command": review_command,
+                "detail": review_detail,
+            },
+            {
+                "title": "Inspect only the changed config entries (optional)",
+                "command": inspect_command,
+                "detail": (
+                    "See the config-level diff only. This view can omit policy-only blockers "
+                    "Guard still needs you to review."
+                ),
+            },
+        ]
+    if blocked and isinstance(review_hint, str) and review_hint:
+        command = (
+            str(approvals_command)
+            if approval_center_url and isinstance(approvals_command, str) and approvals_command
+            else "hol-guard approvals"
+            if approval_center_url
+            else str(rerun_command)
+            if isinstance(rerun_command, str) and rerun_command
+            else f"hol-guard run {harness}"
+        )
+        return [{"title": "Resolve the blocked launch", "command": command, "detail": review_hint}]
+    if dry_run:
+        launch_command = (
+            str(rerun_command) if isinstance(rerun_command, str) and rerun_command else f"hol-guard run {harness}"
+        )
+        return [
+            {
+                "title": "Launch for real",
+                "command": launch_command,
+                "detail": "Dry run finished cleanly; rerun without --dry-run when you are ready to launch.",
+            }
+        ]
+    return []
+
+
+def _summarize_run_artifacts(artifacts: list[dict[str, object]]) -> list[dict[str, str]]:
+    summarized: list[dict[str, str]] = []
+    used_indexes: set[int] = set()
+    for index, artifact in enumerate(artifacts):
+        if index in used_indexes:
+            continue
+        partner_index = _find_replaced_artifact_partner(artifacts, index, used_indexes)
+        if partner_index is not None:
+            used_indexes.add(index)
+            used_indexes.add(partner_index)
+            primary, secondary = _replacement_pair(artifact, artifacts[partner_index])
+            summarized.append(
+                {
+                    "artifact_name": _artifact_display_name(primary),
+                    "change_summary": "definition replaced",
+                    "reason_summary": (
+                        "Guard saw the previous definition disappear and a new definition with the same name appear, "
+                        "so it is asking for a fresh approval."
+                    ),
+                    "risk_summary": _artifact_risk_text(primary, secondary),
+                    "policy_action": str(primary.get("policy_action") or "review"),
+                }
+            )
+            continue
+        used_indexes.add(index)
+        summarized.append(
+            {
+                "artifact_name": _artifact_display_name(artifact),
+                "change_summary": _artifact_change_summary(artifact),
+                "reason_summary": _artifact_reason_text(artifact),
+                "risk_summary": _artifact_risk_text(artifact),
+                "policy_action": str(artifact.get("policy_action") or "review"),
+            }
+        )
+    return summarized
+
+
+def _find_replaced_artifact_partner(
+    artifacts: list[dict[str, object]],
+    index: int,
+    used_indexes: set[int],
+) -> int | None:
+    artifact = artifacts[index]
+    fields = set(_coerce_string_list(artifact.get("changed_fields")))
+    if fields not in ({"first_seen"}, {"removed"}):
+        return None
+    target_fields = {"removed"} if fields == {"first_seen"} else {"first_seen"}
+    artifact_name = _artifact_display_name(artifact)
+    policy_action = str(artifact.get("policy_action") or "")
+    artifact_label = str(artifact.get("artifact_label") or "")
+    artifact_identity = _artifact_replacement_identity(artifact)
+    for partner_index in range(index + 1, len(artifacts)):
+        if partner_index in used_indexes:
+            continue
+        partner = artifacts[partner_index]
+        if _artifact_display_name(partner) != artifact_name:
+            continue
+        if set(_coerce_string_list(partner.get("changed_fields"))) != target_fields:
+            continue
+        if policy_action and str(partner.get("policy_action") or "") != policy_action:
+            continue
+        if artifact_label and str(partner.get("artifact_label") or "") != artifact_label:
+            continue
+        if _artifact_replacement_identity(partner) != artifact_identity:
+            continue
+        return partner_index
+    return None
+
+
+def _replacement_pair(
+    first: dict[str, object],
+    second: dict[str, object],
+) -> tuple[dict[str, object], dict[str, object]]:
+    if set(_coerce_string_list(first.get("changed_fields"))) == {"first_seen"}:
+        return first, second
+    return second, first
+
+
+def _artifact_display_name(artifact: dict[str, object]) -> str:
+    return str(artifact.get("artifact_name") or artifact.get("artifact_id") or "unknown")
+
+
+def _artifact_replacement_identity(artifact: dict[str, object]) -> tuple[tuple[str, str], ...]:
+    identity_keys = ("source_scope", "config_path", "publisher")
+    identity: list[tuple[str, str]] = []
+    for key in identity_keys:
+        value = artifact.get(key)
+        if value in (None, ""):
+            continue
+        identity.append((key, str(value)))
+    return tuple(identity)
+
+
+def _artifact_change_summary(artifact: dict[str, object]) -> str:
+    fields = set(_coerce_string_list(artifact.get("changed_fields")))
+    if fields == {"first_seen"}:
+        return "new artifact"
+    if fields == {"removed"}:
+        return "removed from config"
+    if "prompt_request" in fields:
+        return "prompt requested secret access"
+    if "file_read_request" in fields:
+        return "protected file read requested"
+    if "command" in fields or "args" in fields:
+        return "launch command changed"
+    if "url" in fields or "transport" in fields:
+        return "connection target changed"
+    if "publisher" in fields or "source_scope" in fields:
+        return "publisher or source changed"
+    if "env_keys" in fields:
+        return "environment access changed"
+    labels = [_field_label(field) for field in _coerce_string_list(artifact.get("changed_fields"))]
+    if not labels:
+        return "no material change"
+    if len(labels) == 1:
+        return f"{labels[0]} changed"
+    if len(labels) == 2:
+        return f"{labels[0]} and {labels[1]} changed"
+    return "multiple settings changed"
+
+
+def _field_label(field: str) -> str:
+    labels = {
+        "artifact_type": "artifact type",
+        "args": "launch arguments",
+        "command": "launch command",
+        "config_path": "config location",
+        "env_keys": "environment access",
+        "publisher": "publisher",
+        "source_scope": "source scope",
+        "transport": "transport",
+        "url": "remote endpoint",
+    }
+    return labels.get(field, field.replace("_", " "))
+
+
+def _artifact_reason_text(artifact: dict[str, object]) -> str:
+    reason = artifact.get("why_now")
+    if isinstance(reason, str) and reason:
+        return reason
+    policy_action = str(artifact.get("policy_action") or "review")
+    if policy_action == "allow":
+        return "Guard matched an existing allow rule for this exact definition."
+    if policy_action == "block":
+        return "Guard blocked this definition because the configured policy does not trust it yet."
+    if policy_action == "sandbox-required":
+        return "Guard requires extra isolation before this launch can continue."
+    return "Guard found a meaningful config change and paused the launch for review."
+
+
+def _artifact_risk_text(*artifacts: dict[str, object]) -> str:
+    for artifact in artifacts:
+        for key in ("risk_summary", "risk_headline"):
+            value = artifact.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return "No obvious secret-access or network signal was detected in the launch definition."
+
+
+def _run_artifact_should_be_visible(artifact: dict[str, object]) -> bool:
+    if bool(artifact.get("changed")):
+        return True
+    return str(artifact.get("policy_action") or "allow") in {"block", "sandbox-required", "require-reapproval"}
+
+
+def _artifact_needs_review(artifact: dict[str, object]) -> bool:
+    return str(artifact.get("policy_action") or "allow") in {"block", "sandbox-required", "require-reapproval"}
+
+
 def _build_approval_table(items: list[dict[str, object]], *, title: str | None) -> Table:
     table = Table(title=title, box=box.SIMPLE_HEAVY, show_header=True)
     table.add_column("Request", style="dim", no_wrap=True)
@@ -779,6 +1098,39 @@ def _build_runtime_probe_panel(runtime_probe: dict[str, object]) -> Panel:
         preview = "\n".join(stdout.splitlines()[:6])
         body.add_row("stdout", preview)
     return Panel(body, title="Runtime probe", border_style="magenta")
+
+
+def _build_cloud_summary_panel(payload: dict[str, object]) -> Panel:
+    cloud_state = str(payload.get("cloud_state") or "local_only")
+    body = Table.grid(padding=(0, 1))
+    body.add_row("State", f"[bold]{payload.get('cloud_state_label', 'Local only')}[/bold]")
+    body.add_row("Summary", str(payload.get("cloud_state_detail") or "Guard is protecting this machine locally."))
+    body.add_row("Dashboard", str(payload.get("dashboard_url") or "https://hol.org/guard"))
+    body.add_row("Connect guide", str(payload.get("connect_url") or "https://hol.org/guard/connect"))
+    if payload.get("sync_url"):
+        body.add_row("Sync endpoint", str(payload.get("sync_url")))
+    if payload.get("last_sync_at"):
+        body.add_row("Last sync", str(payload.get("last_sync_at")))
+    body.add_row("Cached advisories", str(payload.get("advisory_count") or 0))
+    if payload.get("advisory_headline"):
+        body.add_row("Latest advisory", str(payload.get("advisory_headline")))
+    if payload.get("team_policy_name"):
+        body.add_row("Team policy", str(payload.get("team_policy_name")))
+    elif payload.get("team_policy_active"):
+        body.add_row("Team policy", "active")
+    if payload.get("watchlist_enabled"):
+        body.add_row("Watchlist", "enabled")
+    if payload.get("team_alerts_enabled"):
+        body.add_row("Team alerts", "enabled")
+    return Panel(body, title="Local to cloud", border_style=_cloud_border_style(cloud_state))
+
+
+def _cloud_border_style(cloud_state: str) -> str:
+    if cloud_state == "paired_active":
+        return "green"
+    if cloud_state == "paired_waiting":
+        return "yellow"
+    return "cyan"
 
 
 def _artifact_source_text(artifact: dict[str, object]) -> str:
@@ -873,6 +1225,7 @@ _RENDERERS: dict[str, Any] = {
     "approvals": _render_approvals,
     "start": _render_start,
     "status": _render_status,
+    "connect": _render_connect,
     "bootstrap": _render_bootstrap,
     "detect": _render_detect,
     "doctor": _render_doctor,
@@ -890,7 +1243,6 @@ _RENDERERS: dict[str, Any] = {
     "allow": _render_decision,
     "deny": _render_decision,
     "login": _render_login,
-    "connect": _render_connect,
     "sync": _render_sync,
     "hook": _render_hook,
     "protect": _render_protect,

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -59,7 +59,6 @@ def _render_start(console: Console, payload: dict[str, object]) -> None:
             border_style="cyan",
         )
     )
-    console.print(_build_cloud_summary_panel(payload))
     console.print(_build_product_table(harnesses))
     if payload.get("approval_center_url"):
         console.print(f"Approval center: [bold]{payload.get('approval_center_url')}[/bold]")
@@ -78,7 +77,6 @@ def _render_status(console: Console, payload: dict[str, object]) -> None:
             border_style="cyan",
         )
     )
-    console.print(_build_cloud_summary_panel(payload))
     console.print(_build_product_table(harnesses))
     if payload.get("approval_center_url"):
         console.print(f"Approval center: [bold]{payload.get('approval_center_url')}[/bold]")
@@ -160,24 +158,12 @@ def _render_doctor(console: Console, payload: dict[str, object]) -> None:
 def _render_run(console: Console, payload: dict[str, object]) -> None:
     blocked = bool(payload.get("blocked"))
     launched = bool(payload.get("launched"))
-    dry_run = bool(payload.get("dry_run"))
-    artifacts = _coerce_dict_list(payload.get("artifacts"))
-    visible_artifacts = [artifact for artifact in artifacts if _run_artifact_should_be_visible(artifact)]
-    summarized_artifacts = _summarize_run_artifacts(visible_artifacts)
-    title = _run_title(blocked=blocked, dry_run=dry_run)
+    title = "Blocked before launch" if blocked else "Launch allowed"
     border_style = "red" if blocked else "green"
     body = Table.grid(padding=(0, 1))
-    approval_delivery = payload.get("approval_delivery")
     body.add_row("Harness", f"[bold]{payload.get('harness', 'unknown')}[/bold]")
-    body.add_row("Mode", "dry run" if dry_run else "launch")
-    body.add_row("Outcome", _run_outcome_text(blocked=blocked, dry_run=dry_run, launched=launched))
-    body.add_row("Artifacts", str(len(summarized_artifacts)))
-    if blocked:
-        needs_review = sum(1 for artifact in visible_artifacts if _artifact_needs_review(artifact))
-        body.add_row("Needs review", str(needs_review))
     body.add_row("Receipts", str(payload.get("receipts_recorded", 0)))
-    if isinstance(approval_delivery, dict) and approval_delivery.get("summary"):
-        body.add_row("Prompt route", str(approval_delivery.get("summary")))
+    body.add_row("Launched", _bool_label(launched))
     if payload.get("approval_center_url"):
         body.add_row("Approval center", str(payload.get("approval_center_url")))
     if payload.get("review_hint"):
@@ -185,11 +171,7 @@ def _render_run(console: Console, payload: dict[str, object]) -> None:
     if launched:
         body.add_row("Command", _command_text(payload.get("launch_command")))
     console.print(Panel(body, title=title, border_style=border_style))
-    if summarized_artifacts:
-        console.print(_build_run_artifact_table(summarized_artifacts))
-    steps = _build_run_steps(payload, blocked=blocked, dry_run=dry_run)
-    if steps:
-        console.print(_build_steps_panel(steps))
+    console.print(_build_artifact_result_table(_coerce_dict_list(payload.get("artifacts"))))
     approval_requests = _coerce_dict_list(payload.get("approval_requests"))
     if approval_requests:
         console.print(_build_approval_table(approval_requests, title="Queued approvals"))
@@ -436,58 +418,32 @@ def _render_login(console: Console, payload: dict[str, object]) -> None:
 
 
 def _render_connect(console: Console, payload: dict[str, object]) -> None:
-    if "connected" in payload or "browser_opened" in payload or "status" in payload:
-        body = Table.grid(padding=(0, 1))
-        body.add_row("Connected", _bool_label(bool(payload.get("connected"))))
-        body.add_row("Browser opened", _bool_label(bool(payload.get("browser_opened"))))
-        body.add_row("Status", str(payload.get("status") or "unknown"))
-        body.add_row("Connect URL", str(payload.get("connect_url") or "unknown"))
-        body.add_row("Sync endpoint", str(payload.get("sync_url") or "unknown"))
-        sync_payload = payload.get("sync")
-        if isinstance(sync_payload, dict):
-            body.add_row("Receipts stored", str(sync_payload.get("receipts_stored") or 0))
-            body.add_row(
-                "Inventory tracked",
-                str(sync_payload.get("inventory_tracked", sync_payload.get("inventory")) or 0),
-            )
-        sync_message = payload.get("sync_message")
-        if isinstance(sync_message, str) and sync_message.strip():
-            body.add_row("Sync note", sync_message)
-        console.print(Panel(body, title="Guard connect", border_style="green"))
-        return
-
-    border_style = _cloud_border_style(str(payload.get("cloud_state") or "local_only"))
-    console.print(
-        Panel.fit(
-            f"[bold]HOL Guard connect[/bold]\n"
-            f"{payload.get('cloud_state_label', 'Local only')} • "
-            f"{payload.get('receipt_count', 0)} receipts • "
-            f"{payload.get('pending_approvals', 0)} approvals",
-            border_style=border_style,
-        )
-    )
-    console.print(_build_cloud_summary_panel(payload))
-    sync_result = payload.get("sync_result")
-    if isinstance(sync_result, dict):
-        body = Table.grid(padding=(0, 1))
-        body.add_row("Synced at", str(sync_result.get("synced_at") or "unknown"))
-        body.add_row("Receipts stored", str(sync_result.get("receipts_stored") or 0))
-        body.add_row("Advisories stored", str(sync_result.get("advisories_stored") or 0))
-        body.add_row("Remote policies", str(sync_result.get("remote_policies_stored") or 0))
-        console.print(Panel(body, title="Connect sync", border_style="green"))
-    if payload.get("sync_error"):
-        console.print(Panel(str(payload.get("sync_error")), title="Connect failed", border_style="red"))
-    if payload.get("approval_center_url"):
-        console.print(f"Approval center: [bold]{payload.get('approval_center_url')}[/bold]")
-    console.print(_build_product_table(_coerce_dict_list(payload.get("harnesses"))))
-    console.print(_build_steps_panel(_coerce_dict_list(payload.get("next_steps"))))
+    body = Table.grid(padding=(0, 1))
+    body.add_row("Status", str(payload.get("status") or "waiting"))
+    body.add_row("Milestone", str(payload.get("milestone") or "waiting_for_browser"))
+    body.add_row("Browser opened", _bool_label(bool(payload.get("browser_opened"))))
+    body.add_row("Connect URL", str(payload.get("connect_url") or "unknown"))
+    body.add_row("Sync endpoint", str(payload.get("sync_url") or "unknown"))
+    if payload.get("reason"):
+        body.add_row("Reason", str(payload.get("reason")))
+    if isinstance(payload.get("sync"), dict):
+        sync_payload = payload["sync"]
+        body.add_row("Receipts stored", str(sync_payload.get("receipts_stored") or 0))
+        body.add_row("Inventory sent", str(sync_payload.get("inventory") or 0))
+    proof = payload.get("proof")
+    if isinstance(proof, dict) and proof.get("first_synced_at"):
+        body.add_row("First synced at", str(proof.get("first_synced_at")))
+    border_style = "green" if bool(payload.get("connected")) else "yellow"
+    if str(payload.get("status")) in {"retry_required", "expired"}:
+        border_style = "red"
+    console.print(Panel(body, title="Guard connect", border_style=border_style))
 
 
 def _render_sync(console: Console, payload: dict[str, object]) -> None:
     body = Table.grid(padding=(0, 1))
     body.add_row("Synced at", str(payload.get("synced_at") or "unknown"))
     body.add_row("Receipts sent", str(payload.get("receipts") or 0))
-    body.add_row("Inventory tracked", str(payload.get("inventory_tracked", payload.get("inventory")) or 0))
+    body.add_row("Inventory sent", str(payload.get("inventory") or 0))
     body.add_row("Receipts stored", str(payload.get("receipts_stored") or 0))
     body.add_row("Advisories stored", str(payload.get("advisories_stored") or 0))
     console.print(Panel(body, title="Guard sync complete", border_style="green"))
@@ -498,12 +454,6 @@ def _render_hook(console: Console, payload: dict[str, object]) -> None:
     body.add_row("Recorded", _bool_label(bool(payload.get("recorded"))))
     body.add_row("Artifact", str(payload.get("artifact_name") or payload.get("artifact_id") or "unknown"))
     body.add_row("Decision", _action_text(str(payload.get("policy_action", "warn"))))
-    if payload.get("path_summary"):
-        body.add_row("Path", str(payload.get("path_summary")))
-    if payload.get("approval_center_url"):
-        body.add_row("Approval center", str(payload.get("approval_center_url")))
-    if payload.get("review_hint"):
-        body.add_row("Review", str(payload.get("review_hint")))
     console.print(Panel(body, title="Guard hook event", border_style="cyan"))
 
 
@@ -786,278 +736,6 @@ def _build_artifact_result_table(artifacts: list[dict[str, object]]) -> Table:
     return table
 
 
-def _build_run_artifact_table(artifacts: list[dict[str, str]]) -> Table:
-    table = Table(title="What changed", box=box.SIMPLE_HEAVY, show_header=True)
-    table.add_column("Artifact", style="bold")
-    table.add_column("Guard saw")
-    table.add_column("Reason")
-    table.add_column("Risk")
-    for artifact in artifacts:
-        table.add_row(
-            artifact["artifact_name"],
-            artifact["change_summary"],
-            artifact["reason_summary"],
-            artifact["risk_summary"],
-        )
-    return table
-
-
-def _run_title(*, blocked: bool, dry_run: bool) -> str:
-    if blocked and dry_run:
-        return "Dry run paused for review"
-    if blocked:
-        return "Blocked before launch"
-    if dry_run:
-        return "Dry run complete"
-    return "Launch allowed"
-
-
-def _run_outcome_text(*, blocked: bool, dry_run: bool, launched: bool) -> str:
-    if blocked and dry_run:
-        return "Guard found artifacts that need review before a real launch."
-    if blocked:
-        return "Guard paused the launch until you review the artifacts that need attention."
-    if dry_run:
-        return "Guard reviewed the current config without launching the harness."
-    if launched:
-        return "Guard approved the launch and handed control to the harness."
-    return "Guard finished the check without launching the harness."
-
-
-def _build_run_steps(payload: dict[str, object], *, blocked: bool, dry_run: bool) -> list[dict[str, str]]:
-    harness = str(payload.get("harness") or "codex")
-    approval_center_url = payload.get("approval_center_url")
-    review_hint = payload.get("review_hint")
-    rerun_command = payload.get("rerun_command")
-    diff_command = payload.get("diff_command")
-    approvals_command = payload.get("approvals_command")
-    if blocked and dry_run:
-        review_command = (
-            str(approvals_command)
-            if approval_center_url and isinstance(approvals_command, str) and approvals_command
-            else "hol-guard approvals"
-            if approval_center_url
-            else str(rerun_command)
-            if isinstance(rerun_command, str) and rerun_command
-            else f"hol-guard run {harness}"
-        )
-        inspect_command = (
-            str(diff_command) if isinstance(diff_command, str) and diff_command else f"hol-guard diff {harness}"
-        )
-        review_detail = (
-            str(review_hint)
-            if isinstance(review_hint, str) and review_hint
-            else "Rerun without --dry-run to review the full blocker set and continue into the harness launch."
-        )
-        return [
-            {
-                "title": "Resolve the blocked launch",
-                "command": review_command,
-                "detail": review_detail,
-            },
-            {
-                "title": "Inspect only the changed config entries (optional)",
-                "command": inspect_command,
-                "detail": (
-                    "See the config-level diff only. This view can omit policy-only blockers "
-                    "Guard still needs you to review."
-                ),
-            },
-        ]
-    if blocked and isinstance(review_hint, str) and review_hint:
-        command = (
-            str(approvals_command)
-            if approval_center_url and isinstance(approvals_command, str) and approvals_command
-            else "hol-guard approvals"
-            if approval_center_url
-            else str(rerun_command)
-            if isinstance(rerun_command, str) and rerun_command
-            else f"hol-guard run {harness}"
-        )
-        return [{"title": "Resolve the blocked launch", "command": command, "detail": review_hint}]
-    if dry_run:
-        launch_command = (
-            str(rerun_command) if isinstance(rerun_command, str) and rerun_command else f"hol-guard run {harness}"
-        )
-        return [
-            {
-                "title": "Launch for real",
-                "command": launch_command,
-                "detail": "Dry run finished cleanly; rerun without --dry-run when you are ready to launch.",
-            }
-        ]
-    return []
-
-
-def _summarize_run_artifacts(artifacts: list[dict[str, object]]) -> list[dict[str, str]]:
-    summarized: list[dict[str, str]] = []
-    used_indexes: set[int] = set()
-    for index, artifact in enumerate(artifacts):
-        if index in used_indexes:
-            continue
-        partner_index = _find_replaced_artifact_partner(artifacts, index, used_indexes)
-        if partner_index is not None:
-            used_indexes.add(index)
-            used_indexes.add(partner_index)
-            primary, secondary = _replacement_pair(artifact, artifacts[partner_index])
-            summarized.append(
-                {
-                    "artifact_name": _artifact_display_name(primary),
-                    "change_summary": "definition replaced",
-                    "reason_summary": (
-                        "Guard saw the previous definition disappear and a new definition with the same name appear, "
-                        "so it is asking for a fresh approval."
-                    ),
-                    "risk_summary": _artifact_risk_text(primary, secondary),
-                    "policy_action": str(primary.get("policy_action") or "review"),
-                }
-            )
-            continue
-        used_indexes.add(index)
-        summarized.append(
-            {
-                "artifact_name": _artifact_display_name(artifact),
-                "change_summary": _artifact_change_summary(artifact),
-                "reason_summary": _artifact_reason_text(artifact),
-                "risk_summary": _artifact_risk_text(artifact),
-                "policy_action": str(artifact.get("policy_action") or "review"),
-            }
-        )
-    return summarized
-
-
-def _find_replaced_artifact_partner(
-    artifacts: list[dict[str, object]],
-    index: int,
-    used_indexes: set[int],
-) -> int | None:
-    artifact = artifacts[index]
-    fields = set(_coerce_string_list(artifact.get("changed_fields")))
-    if fields not in ({"first_seen"}, {"removed"}):
-        return None
-    target_fields = {"removed"} if fields == {"first_seen"} else {"first_seen"}
-    artifact_name = _artifact_display_name(artifact)
-    policy_action = str(artifact.get("policy_action") or "")
-    artifact_label = str(artifact.get("artifact_label") or "")
-    artifact_identity = _artifact_replacement_identity(artifact)
-    for partner_index in range(index + 1, len(artifacts)):
-        if partner_index in used_indexes:
-            continue
-        partner = artifacts[partner_index]
-        if _artifact_display_name(partner) != artifact_name:
-            continue
-        if set(_coerce_string_list(partner.get("changed_fields"))) != target_fields:
-            continue
-        if policy_action and str(partner.get("policy_action") or "") != policy_action:
-            continue
-        if artifact_label and str(partner.get("artifact_label") or "") != artifact_label:
-            continue
-        if _artifact_replacement_identity(partner) != artifact_identity:
-            continue
-        return partner_index
-    return None
-
-
-def _replacement_pair(
-    first: dict[str, object],
-    second: dict[str, object],
-) -> tuple[dict[str, object], dict[str, object]]:
-    if set(_coerce_string_list(first.get("changed_fields"))) == {"first_seen"}:
-        return first, second
-    return second, first
-
-
-def _artifact_display_name(artifact: dict[str, object]) -> str:
-    return str(artifact.get("artifact_name") or artifact.get("artifact_id") or "unknown")
-
-
-def _artifact_replacement_identity(artifact: dict[str, object]) -> tuple[tuple[str, str], ...]:
-    identity_keys = ("source_scope", "config_path", "publisher")
-    identity: list[tuple[str, str]] = []
-    for key in identity_keys:
-        value = artifact.get(key)
-        if value in (None, ""):
-            continue
-        identity.append((key, str(value)))
-    return tuple(identity)
-
-
-def _artifact_change_summary(artifact: dict[str, object]) -> str:
-    fields = set(_coerce_string_list(artifact.get("changed_fields")))
-    if fields == {"first_seen"}:
-        return "new artifact"
-    if fields == {"removed"}:
-        return "removed from config"
-    if "prompt_request" in fields:
-        return "prompt requested secret access"
-    if "file_read_request" in fields:
-        return "protected file read requested"
-    if "command" in fields or "args" in fields:
-        return "launch command changed"
-    if "url" in fields or "transport" in fields:
-        return "connection target changed"
-    if "publisher" in fields or "source_scope" in fields:
-        return "publisher or source changed"
-    if "env_keys" in fields:
-        return "environment access changed"
-    labels = [_field_label(field) for field in _coerce_string_list(artifact.get("changed_fields"))]
-    if not labels:
-        return "no material change"
-    if len(labels) == 1:
-        return f"{labels[0]} changed"
-    if len(labels) == 2:
-        return f"{labels[0]} and {labels[1]} changed"
-    return "multiple settings changed"
-
-
-def _field_label(field: str) -> str:
-    labels = {
-        "artifact_type": "artifact type",
-        "args": "launch arguments",
-        "command": "launch command",
-        "config_path": "config location",
-        "env_keys": "environment access",
-        "publisher": "publisher",
-        "source_scope": "source scope",
-        "transport": "transport",
-        "url": "remote endpoint",
-    }
-    return labels.get(field, field.replace("_", " "))
-
-
-def _artifact_reason_text(artifact: dict[str, object]) -> str:
-    reason = artifact.get("why_now")
-    if isinstance(reason, str) and reason:
-        return reason
-    policy_action = str(artifact.get("policy_action") or "review")
-    if policy_action == "allow":
-        return "Guard matched an existing allow rule for this exact definition."
-    if policy_action == "block":
-        return "Guard blocked this definition because the configured policy does not trust it yet."
-    if policy_action == "sandbox-required":
-        return "Guard requires extra isolation before this launch can continue."
-    return "Guard found a meaningful config change and paused the launch for review."
-
-
-def _artifact_risk_text(*artifacts: dict[str, object]) -> str:
-    for artifact in artifacts:
-        for key in ("risk_summary", "risk_headline"):
-            value = artifact.get(key)
-            if isinstance(value, str) and value:
-                return value
-    return "No obvious secret-access or network signal was detected in the launch definition."
-
-
-def _run_artifact_should_be_visible(artifact: dict[str, object]) -> bool:
-    if bool(artifact.get("changed")):
-        return True
-    return str(artifact.get("policy_action") or "allow") in {"block", "sandbox-required", "require-reapproval"}
-
-
-def _artifact_needs_review(artifact: dict[str, object]) -> bool:
-    return str(artifact.get("policy_action") or "allow") in {"block", "sandbox-required", "require-reapproval"}
-
-
 def _build_approval_table(items: list[dict[str, object]], *, title: str | None) -> Table:
     table = Table(title=title, box=box.SIMPLE_HEAVY, show_header=True)
     table.add_column("Request", style="dim", no_wrap=True)
@@ -1098,39 +776,6 @@ def _build_runtime_probe_panel(runtime_probe: dict[str, object]) -> Panel:
         preview = "\n".join(stdout.splitlines()[:6])
         body.add_row("stdout", preview)
     return Panel(body, title="Runtime probe", border_style="magenta")
-
-
-def _build_cloud_summary_panel(payload: dict[str, object]) -> Panel:
-    cloud_state = str(payload.get("cloud_state") or "local_only")
-    body = Table.grid(padding=(0, 1))
-    body.add_row("State", f"[bold]{payload.get('cloud_state_label', 'Local only')}[/bold]")
-    body.add_row("Summary", str(payload.get("cloud_state_detail") or "Guard is protecting this machine locally."))
-    body.add_row("Dashboard", str(payload.get("dashboard_url") or "https://hol.org/guard"))
-    body.add_row("Connect guide", str(payload.get("connect_url") or "https://hol.org/guard/connect"))
-    if payload.get("sync_url"):
-        body.add_row("Sync endpoint", str(payload.get("sync_url")))
-    if payload.get("last_sync_at"):
-        body.add_row("Last sync", str(payload.get("last_sync_at")))
-    body.add_row("Cached advisories", str(payload.get("advisory_count") or 0))
-    if payload.get("advisory_headline"):
-        body.add_row("Latest advisory", str(payload.get("advisory_headline")))
-    if payload.get("team_policy_name"):
-        body.add_row("Team policy", str(payload.get("team_policy_name")))
-    elif payload.get("team_policy_active"):
-        body.add_row("Team policy", "active")
-    if payload.get("watchlist_enabled"):
-        body.add_row("Watchlist", "enabled")
-    if payload.get("team_alerts_enabled"):
-        body.add_row("Team alerts", "enabled")
-    return Panel(body, title="Local to cloud", border_style=_cloud_border_style(cloud_state))
-
-
-def _cloud_border_style(cloud_state: str) -> str:
-    if cloud_state == "paired_active":
-        return "green"
-    if cloud_state == "paired_waiting":
-        return "yellow"
-    return "cyan"
 
 
 def _artifact_source_text(artifact: dict[str, object]) -> str:
@@ -1225,7 +870,6 @@ _RENDERERS: dict[str, Any] = {
     "approvals": _render_approvals,
     "start": _render_start,
     "status": _render_status,
-    "connect": _render_connect,
     "bootstrap": _render_bootstrap,
     "detect": _render_detect,
     "doctor": _render_doctor,
@@ -1243,6 +887,7 @@ _RENDERERS: dict[str, Any] = {
     "allow": _render_decision,
     "deny": _render_decision,
     "login": _render_login,
+    "connect": _render_connect,
     "sync": _render_sync,
     "hook": _render_hook,
     "protect": _render_protect,

--- a/src/codex_plugin_scanner/guard/daemon/client.py
+++ b/src/codex_plugin_scanner/guard/daemon/client.py
@@ -157,6 +157,8 @@ class GuardSurfaceDaemonClient:
             except (OSError, json.JSONDecodeError):
                 message = str(error)
             raise RuntimeError(f"Guard daemon request failed: {message}") from error
+        except (OSError, urllib.error.URLError) as error:
+            raise RuntimeError(f"Guard daemon request failed: {error}") from error
         state = payload.get("state")
         if isinstance(state, dict):
             return state

--- a/src/codex_plugin_scanner/guard/daemon/client.py
+++ b/src/codex_plugin_scanner/guard/daemon/client.py
@@ -16,6 +16,14 @@ from .manager import (
 )
 
 
+class GuardDaemonRequestError(RuntimeError):
+    """Raised when the Guard daemon returns a non-retryable request failure."""
+
+
+class GuardDaemonTransportError(GuardDaemonRequestError):
+    """Raised when the Guard daemon request fails due to transport issues."""
+
+
 class GuardSurfaceDaemonClient:
     """Small authenticated client for the local Guard daemon."""
 
@@ -156,9 +164,9 @@ class GuardSurfaceDaemonClient:
                 message = payload.get("error", str(error))
             except (OSError, json.JSONDecodeError):
                 message = str(error)
-            raise RuntimeError(f"Guard daemon request failed: {message}") from error
+            raise GuardDaemonRequestError(f"Guard daemon request failed: {message}") from error
         except (OSError, urllib.error.URLError) as error:
-            raise RuntimeError(f"Guard daemon request failed: {error}") from error
+            raise GuardDaemonTransportError(f"Guard daemon request failed: {error}") from error
         state = payload.get("state")
         if isinstance(state, dict):
             return state
@@ -205,9 +213,9 @@ class GuardSurfaceDaemonClient:
                 message = payload.get("error", str(error))
             except (OSError, json.JSONDecodeError):
                 message = str(error)
-            raise RuntimeError(f"Guard daemon request failed: {message}") from error
+            raise GuardDaemonRequestError(f"Guard daemon request failed: {message}") from error
         except (OSError, urllib.error.URLError) as error:
-            raise RuntimeError(f"Guard daemon request failed: {error}") from error
+            raise GuardDaemonTransportError(f"Guard daemon request failed: {error}") from error
 
 
 def load_guard_surface_daemon_client(guard_home: Path) -> GuardSurfaceDaemonClient:

--- a/src/codex_plugin_scanner/guard/daemon/client.py
+++ b/src/codex_plugin_scanner/guard/daemon/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 
@@ -136,6 +137,52 @@ class GuardSurfaceDaemonClient:
                 "lifetime_seconds": lifetime_seconds,
             },
         )
+
+    def get_connect_state(self, *, request_id: str) -> dict[str, object]:
+        query = urllib.parse.urlencode({"request_id": request_id})
+        request = urllib.request.Request(
+            f"{self.daemon_url}/v1/connect/state?{query}",
+            headers={
+                "X-Guard-Token": self.auth_token,
+            },
+            method="GET",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=5) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as error:
+            try:
+                payload = json.loads(error.read().decode("utf-8"))
+                message = payload.get("error", str(error))
+            except (OSError, json.JSONDecodeError):
+                message = str(error)
+            raise RuntimeError(f"Guard daemon request failed: {message}") from error
+        state = payload.get("state")
+        if isinstance(state, dict):
+            return state
+        return payload
+
+    def report_connect_result(
+        self,
+        *,
+        request_id: str,
+        status: str,
+        milestone: str,
+        reason: str | None = None,
+        sync: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        payload = {
+            "request_id": request_id,
+            "status": status,
+            "milestone": milestone,
+            "reason": reason,
+            "sync": sync or {},
+        }
+        response = self._post("/v1/connect/result", payload)
+        state = response.get("state")
+        if isinstance(state, dict):
+            return state
+        return response
 
     def _post(self, path: str, payload: dict[str, object]) -> dict[str, object]:
         request = urllib.request.Request(

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -609,11 +609,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
     def _touch_runtime_heartbeat(self, path: str) -> None:
         if path != "/healthz" and not path.startswith("/v1/"):
             return
-        runtime_state = self.server.store.get_runtime_state()  # type: ignore[attr-defined]
-        if runtime_state is None:
-            return
         self.server.store.touch_runtime_state(  # type: ignore[attr-defined]
-            session_id=str(runtime_state["session_id"]),
+            session_id=self.server.runtime_session_id,  # type: ignore[attr-defined]
             last_heartbeat_at=_now(),
         )
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, unquote, urlparse
 
-from ..approvals import apply_approval_resolution, build_runtime_snapshot
+from ..approvals import apply_approval_resolution
 from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES
 from ..runtime.surface_server import GuardSurfaceRuntime
 from ..store import GuardStore
@@ -24,9 +24,6 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
     store: GuardStore
     runtime: GuardSurfaceRuntime
     auth_token: str
-    runtime_host: str
-    runtime_session_id: str
-    runtime_started_at: str
 
 
 _STATIC_DIR = Path(__file__).with_name("static")
@@ -44,21 +41,24 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
 
     def do_OPTIONS(self) -> None:
         parsed = urlparse(self.path)
-        if parsed.path == "/v1/connect/complete":
+        if parsed.path in {"/v1/connect/complete", "/v1/connect/state"}:
             origin = self._normalize_origin(self.headers.get("Origin"))
             if origin is None:
-                self._write_empty(status=400)
+                self.send_response(400)
+                self.end_headers()
                 return
-            self._write_empty(status=200, extra_headers=self._cors_headers(origin))
+            self.send_response(200)
+            self.send_header("Access-Control-Allow-Origin", origin)
+            self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+            self.send_header("Access-Control-Allow-Headers", "Content-Type")
+            self.send_header("Vary", "Origin")
+            self.end_headers()
             return
-        self._write_empty(status=404)
+        self.send_response(404)
+        self.end_headers()
 
     def do_GET(self) -> None:
         store = self.server.store  # type: ignore[attr-defined]
-        store.touch_runtime_state(
-            session_id=self.server.runtime_session_id,  # type: ignore[attr-defined]
-            last_heartbeat_at=_now(),
-        )
         parsed = urlparse(self.path)
         path_parts = [part for part in parsed.path.split("/") if part]
         if parsed.path == "/healthz":
@@ -69,14 +69,6 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     "approvals": store.count_approval_requests(),
                     "tables": store.list_table_names(),
                 }
-            )
-            return
-        if parsed.path == "/v1/runtime":
-            self._write_json(
-                build_runtime_snapshot(
-                    store=store,
-                    approval_center_url=f"http://{self.server.runtime_host}:{self.server.server_port}",  # type: ignore[attr-defined]
-                )
             )
             return
         if parsed.path == "/v1/sessions":
@@ -97,6 +89,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         if parsed.path == "/v1/requests":
             self._write_json({"items": store.list_approval_requests(limit=200)})
+            return
+        if parsed.path == "/v1/connect/state":
+            self._handle_connect_state_read(parsed.query)
             return
         if len(path_parts) == 3 and path_parts[:2] == ["v1", "requests"]:
             approval = store.get_approval_request(path_parts[2])
@@ -169,10 +164,6 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         self.end_headers()
 
     def do_POST(self) -> None:
-        self.server.store.touch_runtime_state(  # type: ignore[attr-defined]
-            session_id=self.server.runtime_session_id,  # type: ignore[attr-defined]
-            last_heartbeat_at=_now(),
-        )
         parsed = urlparse(self.path)
         if parsed.path != "/v1/connect/complete" and not self._origin_is_allowed():
             self._write_json({"error": "forbidden_origin"}, status=403)
@@ -217,6 +208,12 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         if parsed.path == "/v1/connect/complete":
             self._handle_connect_complete(payload)
+            return
+        if parsed.path == "/v1/connect/result":
+            if not self._header_token_is_valid():
+                self._write_json({"error": "unauthorized"}, status=401)
+                return
+            self._handle_connect_result_update(payload)
             return
         if parsed.path == "/v1/operations/block":
             if not self._header_token_is_valid():
@@ -291,7 +288,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         surface = self._optional_string(payload.get("surface")) or "cli"
         capabilities = payload.get("capabilities")
         capability_items = (
-            tuple(str(item) for item in capabilities if isinstance(item, str)) if isinstance(capabilities, list) else ()
+            tuple(str(item) for item in capabilities if isinstance(item, str))
+            if isinstance(capabilities, list)
+            else ()
         )
         supported_versions = payload.get("supported_protocol_versions")
         try:
@@ -301,7 +300,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 version=self._optional_string(payload.get("version")),
                 surface=surface,
                 capabilities=capability_items,
-                supported_protocol_versions=tuple(str(item) for item in supported_versions if isinstance(item, str))
+                supported_protocol_versions=tuple(
+                    str(item) for item in supported_versions if isinstance(item, str)
+                )
                 if isinstance(supported_versions, list)
                 else (),
             )
@@ -317,17 +318,13 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if client_id is None or surface is None:
             self._write_json({"attached": False, "error": "missing_required_fields"}, status=400)
             return
-        try:
-            attachment = self.server.runtime.attach_client(  # type: ignore[attr-defined]
-                client_id=client_id,
-                surface=surface,
-                session_id=self._optional_string(payload.get("session_id")),
-                metadata={"title": self._optional_string(payload.get("client_title")) or surface},
-                lease_seconds=self._optional_int(payload.get("lease_seconds")) or 60,
-            )
-        except ValueError as error:
-            self._write_json({"attached": False, "error": str(error)}, status=400)
-            return
+        attachment = self.server.runtime.attach_client(  # type: ignore[attr-defined]
+            client_id=client_id,
+            surface=surface,
+            session_id=self._optional_string(payload.get("session_id")),
+            metadata={"title": self._optional_string(payload.get("client_title")) or surface},
+            lease_seconds=self._optional_int(payload.get("lease_seconds")) or 60,
+        )
         self._write_json({"attached": True, "item": attachment})
 
     def _handle_client_heartbeat(self, payload: dict[str, object]) -> None:
@@ -376,16 +373,12 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json({"error": "missing_required_fields"}, status=400)
             return
         metadata = payload.get("metadata")
-        try:
-            operation = self.server.runtime.start_operation(  # type: ignore[attr-defined]
-                session_id=session_id,
-                operation_type=operation_type,
-                harness=harness,
-                metadata=metadata if isinstance(metadata, dict) else {},
-            )
-        except ValueError as error:
-            self._write_json({"error": str(error)}, status=400)
-            return
+        operation = self.server.runtime.start_operation(  # type: ignore[attr-defined]
+            session_id=session_id,
+            operation_type=operation_type,
+            harness=harness,
+            metadata=metadata if isinstance(metadata, dict) else {},
+        )
         self._write_json(operation)
 
     def _handle_operation_block(self, payload: dict[str, object]) -> None:
@@ -433,15 +426,11 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if item_type is None or not isinstance(item_payload, dict):
             self._write_json({"error": "missing_required_fields"}, status=400)
             return
-        try:
-            item = self.server.runtime.add_item(  # type: ignore[attr-defined]
-                operation_id=operation_id,
-                item_type=item_type,
-                payload=item_payload,
-            )
-        except ValueError as error:
-            self._write_json({"error": str(error)}, status=400)
-            return
+        item = self.server.runtime.add_item(  # type: ignore[attr-defined]
+            operation_id=operation_id,
+            item_type=item_type,
+            payload=item_payload,
+        )
         self._write_json({"item": item})
 
     def _handle_operation_status(self, operation_id: str, payload: dict[str, object]) -> None:
@@ -450,17 +439,13 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json({"error": "missing_required_fields"}, status=400)
             return
         request_ids = payload.get("approval_request_ids")
-        try:
-            operation = self.server.runtime.update_operation_status(  # type: ignore[attr-defined]
-                operation_id=operation_id,
-                status=status,
-                approval_request_ids=[str(item) for item in request_ids if isinstance(item, str)]
-                if isinstance(request_ids, list)
-                else [],
-            )
-        except ValueError as error:
-            self._write_json({"error": str(error)}, status=400)
-            return
+        operation = self.server.runtime.update_operation_status(  # type: ignore[attr-defined]
+            operation_id=operation_id,
+            status=status,
+            approval_request_ids=[str(item) for item in request_ids if isinstance(item, str)]
+            if isinstance(request_ids, list)
+            else [],
+        )
         self._write_json({"operation": operation})
 
     def _handle_session_resume(self, session_id: str) -> None:
@@ -532,6 +517,72 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             extra_headers=self._cors_headers(origin),
         )
 
+    def _handle_connect_state_read(self, query: str) -> None:
+        params = parse_qs(query)
+        request_id = self._optional_string(params.get("request_id", [None])[-1])
+        pairing_secret = self._optional_string(params.get("pairing_secret", [None])[-1])
+        origin = self._normalize_origin(self.headers.get("Origin"))
+        if request_id is None:
+            self._write_json({"error": "missing_required_fields"}, status=400)
+            return
+        if self._header_token_is_valid():
+            state = self.server.store.get_guard_connect_state(request_id, now=_now())  # type: ignore[attr-defined]
+            if state is None:
+                self._write_json({"error": "not_found"}, status=404)
+                return
+            self._write_json({"state": state})
+            return
+        if origin is None or pairing_secret is None:
+            self._write_json({"error": "unauthorized"}, status=401)
+            return
+        access = self.server.store.verify_guard_connect_access(  # type: ignore[attr-defined]
+            request_id=request_id,
+            pairing_secret=pairing_secret,
+        )
+        if access is None:
+            self._write_json({"error": "forbidden"}, status=403, extra_headers=self._cors_headers(origin))
+            return
+        if origin != str(access["allowed_origin"]):
+            self._write_json(
+                {"error": "forbidden_origin"},
+                status=403,
+                extra_headers=self._cors_headers(origin),
+            )
+            return
+        state = self.server.store.get_guard_connect_state(request_id, now=_now())  # type: ignore[attr-defined]
+        if state is None:
+            self._write_json({"error": "not_found"}, status=404, extra_headers=self._cors_headers(origin))
+            return
+        self._write_json({"state": state}, extra_headers=self._cors_headers(origin))
+
+    def _handle_connect_result_update(self, payload: dict[str, object]) -> None:
+        request_id = self._optional_string(payload.get("request_id"))
+        status = self._optional_string(payload.get("status"))
+        milestone = self._optional_string(payload.get("milestone"))
+        reason = self._optional_string(payload.get("reason"))
+        sync_payload = payload.get("sync")
+        if request_id is None or status is None or milestone is None:
+            self._write_json({"error": "missing_required_fields"}, status=400)
+            return
+        normalized_sync_payload = dict(sync_payload) if isinstance(sync_payload, dict) else None
+        try:
+            state = self.server.store.record_guard_connect_result(  # type: ignore[attr-defined]
+                request_id=request_id,
+                status=status,
+                milestone=milestone,
+                now=_now(),
+                reason=reason,
+                sync_payload=normalized_sync_payload,
+            )
+        except ValueError as error:
+            error_code = str(error)
+            status_code = 400
+            if error_code == "connect_state_not_found":
+                status_code = 404
+            self._write_json({"error": error_code}, status=status_code)
+            return
+        self._write_json({"state": state})
+
     def _token_is_valid(self, query: str) -> bool:
         params = parse_qs(query)
         token = params.get("token", [None])[-1]
@@ -585,27 +636,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if not isinstance(origin, str) or not origin.strip():
             return None
         parsed = urlparse(origin.strip())
-        if (
-            parsed.scheme not in {"http", "https"}
-            or parsed.hostname is None
-            or parsed.username is not None
-            or parsed.password is not None
-            or parsed.path not in {"", "/"}
-            or parsed.params
-            or parsed.query
-            or parsed.fragment
-        ):
+        if parsed.scheme not in {"http", "https"} or parsed.hostname is None:
             return None
-        host = parsed.hostname
-        if ":" in host and not host.startswith("["):
-            host = f"[{host}]"
-        default_port = 80 if parsed.scheme == "http" else 443
-        try:
-            port = parsed.port
-        except ValueError:
-            return None
-        port_suffix = f":{port}" if port not in {None, default_port} else ""
-        return f"{parsed.scheme}://{host}{port_suffix}"
+        return f"{parsed.scheme}://{parsed.netloc}"
 
     @staticmethod
     def _cors_headers(origin: str) -> dict[str, str]:
@@ -710,38 +743,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
-        for key, value in self._validated_headers(extra_headers).items():
+        for key, value in (extra_headers or {}).items():
             self.send_header(key, value)
         self.end_headers()
         self.wfile.write(body)
-
-    def _write_empty(
-        self,
-        *,
-        status: int,
-        extra_headers: dict[str, str] | None = None,
-    ) -> None:
-        self.send_response(status)
-        for key, value in self._validated_headers(extra_headers).items():
-            self.send_header(key, value)
-        self.end_headers()
-
-    @staticmethod
-    def _validated_headers(extra_headers: dict[str, str] | None) -> dict[str, str]:
-        allowed_headers = {
-            "Access-Control-Allow-Origin",
-            "Access-Control-Allow-Methods",
-            "Access-Control-Allow-Headers",
-            "Vary",
-        }
-        validated: dict[str, str] = {}
-        for key, value in (extra_headers or {}).items():
-            if key not in allowed_headers or not isinstance(value, str):
-                continue
-            if "\r" in value or "\n" in value:
-                continue
-            validated[key] = value
-        return validated
 
     def _write_static_asset(self, relative_path: str) -> None:
         target = (_STATIC_DIR / relative_path).resolve()
@@ -781,9 +786,6 @@ class GuardDaemonServer:
         self._server.store = store
         self._server.runtime = GuardSurfaceRuntime(store)
         self._server.auth_token = uuid.uuid4().hex
-        self._server.runtime_host = host
-        self._server.runtime_session_id = uuid.uuid4().hex
-        self._server.runtime_started_at = _now()
         self.port = int(self._server.server_address[1])
         self._thread: threading.Thread | None = None
 
@@ -791,36 +793,20 @@ class GuardDaemonServer:
         if self._thread is not None:
             return
         write_guard_daemon_state(self._server.store.guard_home, self.port, self._server.auth_token)
-        self._server.store.upsert_runtime_state(
-            session_id=self._server.runtime_session_id,
-            daemon_host=self._server.runtime_host,
-            daemon_port=self.port,
-            started_at=self._server.runtime_started_at,
-            last_heartbeat_at=_now(),
-        )
         self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
         self._thread.start()
 
     def serve(self) -> None:
         write_guard_daemon_state(self._server.store.guard_home, self.port, self._server.auth_token)
-        self._server.store.upsert_runtime_state(
-            session_id=self._server.runtime_session_id,
-            daemon_host=self._server.runtime_host,
-            daemon_port=self.port,
-            started_at=self._server.runtime_started_at,
-            last_heartbeat_at=_now(),
-        )
         try:
             self._server.serve_forever()
         finally:
             clear_guard_daemon_state(self._server.store.guard_home)
-            self._server.store.clear_runtime_state(session_id=self._server.runtime_session_id)
 
     def stop(self) -> None:
         self._server.shutdown()
         self._server.server_close()
         clear_guard_daemon_state(self._server.store.guard_home)
-        self._server.store.clear_runtime_state(session_id=self._server.runtime_session_id)
         if self._thread is not None:
             self._thread.join(timeout=5)
             self._thread = None

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, unquote, urlparse
 
-from ..approvals import apply_approval_resolution
+from ..approvals import apply_approval_resolution, build_runtime_snapshot
 from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES
 from ..runtime.surface_server import GuardSurfaceRuntime
 from ..store import GuardStore
@@ -66,6 +66,14 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         if parsed.path == "/v1/sessions":
             self._write_json({"items": store.list_guard_sessions(limit=200)})
+            return
+        if parsed.path == "/v1/runtime":
+            self._write_json(
+                build_runtime_snapshot(
+                    store=store,
+                    approval_center_url=f"http://{self.server.server_address[0]}:{self.server.server_address[1]}",
+                )
+            )
             return
         if len(path_parts) == 4 and path_parts[:2] == ["v1", "sessions"] and path_parts[3] == "resume":
             self._handle_session_resume(path_parts[2])
@@ -837,6 +845,9 @@ class GuardDaemonServer:
         self._server.store = store
         self._server.runtime = GuardSurfaceRuntime(store)
         self._server.auth_token = uuid.uuid4().hex
+        self._server.runtime_host = host
+        self._server.runtime_session_id = uuid.uuid4().hex
+        self._server.runtime_started_at = _now()
         self.port = int(self._server.server_address[1])
         self._thread: threading.Thread | None = None
 
@@ -844,20 +855,36 @@ class GuardDaemonServer:
         if self._thread is not None:
             return
         write_guard_daemon_state(self._server.store.guard_home, self.port, self._server.auth_token)
+        self._server.store.upsert_runtime_state(
+            session_id=self._server.runtime_session_id,
+            daemon_host=self._server.runtime_host,
+            daemon_port=self.port,
+            started_at=self._server.runtime_started_at,
+            last_heartbeat_at=_now(),
+        )
         self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
         self._thread.start()
 
     def serve(self) -> None:
         write_guard_daemon_state(self._server.store.guard_home, self.port, self._server.auth_token)
+        self._server.store.upsert_runtime_state(
+            session_id=self._server.runtime_session_id,
+            daemon_host=self._server.runtime_host,
+            daemon_port=self.port,
+            started_at=self._server.runtime_started_at,
+            last_heartbeat_at=_now(),
+        )
         try:
             self._server.serve_forever()
         finally:
             clear_guard_daemon_state(self._server.store.guard_home)
+            self._server.store.clear_runtime_state(session_id=self._server.runtime_session_id)
 
     def stop(self) -> None:
         self._server.shutdown()
         self._server.server_close()
         clear_guard_daemon_state(self._server.store.guard_home)
+        self._server.store.clear_runtime_state(session_id=self._server.runtime_session_id)
         if self._thread is not None:
             self._thread.join(timeout=5)
             self._thread = None

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -366,12 +366,16 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json({"error": "missing_required_fields"}, status=400)
             return
         metadata = payload.get("metadata")
-        operation = self.server.runtime.start_operation(  # type: ignore[attr-defined]
-            session_id=session_id,
-            operation_type=operation_type,
-            harness=harness,
-            metadata=metadata if isinstance(metadata, dict) else {},
-        )
+        try:
+            operation = self.server.runtime.start_operation(  # type: ignore[attr-defined]
+                session_id=session_id,
+                operation_type=operation_type,
+                harness=harness,
+                metadata=metadata if isinstance(metadata, dict) else {},
+            )
+        except ValueError as error:
+            self._write_json({"error": str(error)}, status=400)
+            return
         self._write_json(operation)
 
     def _handle_operation_block(self, payload: dict[str, object]) -> None:
@@ -419,11 +423,15 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if item_type is None or not isinstance(item_payload, dict):
             self._write_json({"error": "missing_required_fields"}, status=400)
             return
-        item = self.server.runtime.add_item(  # type: ignore[attr-defined]
-            operation_id=operation_id,
-            item_type=item_type,
-            payload=item_payload,
-        )
+        try:
+            item = self.server.runtime.add_item(  # type: ignore[attr-defined]
+                operation_id=operation_id,
+                item_type=item_type,
+                payload=item_payload,
+            )
+        except ValueError as error:
+            self._write_json({"error": str(error)}, status=400)
+            return
         self._write_json({"item": item})
 
     def _handle_operation_status(self, operation_id: str, payload: dict[str, object]) -> None:
@@ -432,13 +440,17 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json({"error": "missing_required_fields"}, status=400)
             return
         request_ids = payload.get("approval_request_ids")
-        operation = self.server.runtime.update_operation_status(  # type: ignore[attr-defined]
-            operation_id=operation_id,
-            status=status,
-            approval_request_ids=[str(item) for item in request_ids if isinstance(item, str)]
-            if isinstance(request_ids, list)
-            else [],
-        )
+        try:
+            operation = self.server.runtime.update_operation_status(  # type: ignore[attr-defined]
+                operation_id=operation_id,
+                status=status,
+                approval_request_ids=[str(item) for item in request_ids if isinstance(item, str)]
+                if isinstance(request_ids, list)
+                else [],
+            )
+        except ValueError as error:
+            self._write_json({"error": str(error)}, status=400)
+            return
         self._write_json({"operation": operation})
 
     def _handle_session_resume(self, session_id: str) -> None:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -315,13 +315,17 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if client_id is None or surface is None:
             self._write_json({"attached": False, "error": "missing_required_fields"}, status=400)
             return
-        attachment = self.server.runtime.attach_client(  # type: ignore[attr-defined]
-            client_id=client_id,
-            surface=surface,
-            session_id=self._optional_string(payload.get("session_id")),
-            metadata={"title": self._optional_string(payload.get("client_title")) or surface},
-            lease_seconds=self._optional_int(payload.get("lease_seconds")) or 60,
-        )
+        try:
+            attachment = self.server.runtime.attach_client(  # type: ignore[attr-defined]
+                client_id=client_id,
+                surface=surface,
+                session_id=self._optional_string(payload.get("session_id")),
+                metadata={"title": self._optional_string(payload.get("client_title")) or surface},
+                lease_seconds=self._optional_int(payload.get("lease_seconds")) or 60,
+            )
+        except ValueError as error:
+            self._write_json({"attached": False, "error": str(error)}, status=400)
+            return
         self._write_json({"attached": True, "item": attachment})
 
     def _handle_client_heartbeat(self, payload: dict[str, object]) -> None:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -53,6 +53,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:
         store = self.server.store  # type: ignore[attr-defined]
         parsed = urlparse(self.path)
+        self._touch_runtime_heartbeat(parsed.path)
         path_parts = [part for part in parsed.path.split("/") if part]
         if parsed.path == "/healthz":
             self._write_json(
@@ -166,6 +167,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
 
     def do_POST(self) -> None:
         parsed = urlparse(self.path)
+        self._touch_runtime_heartbeat(parsed.path)
         if parsed.path != "/v1/connect/complete" and not self._origin_is_allowed():
             self._write_json({"error": "forbidden_origin"}, status=403)
             return
@@ -603,6 +605,17 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
 
     def _header_token_is_valid(self) -> bool:
         return self.headers.get("X-Guard-Token") == self.server.auth_token  # type: ignore[attr-defined]
+
+    def _touch_runtime_heartbeat(self, path: str) -> None:
+        if path != "/healthz" and not path.startswith("/v1/"):
+            return
+        runtime_state = self.server.store.get_runtime_state()  # type: ignore[attr-defined]
+        if runtime_state is None:
+            return
+        self.server.store.touch_runtime_state(  # type: ignore[attr-defined]
+            session_id=str(runtime_state["session_id"]),
+            last_heartbeat_at=_now(),
+        )
 
     @staticmethod
     def _optional_int(value: object) -> int | None:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -44,18 +44,11 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if parsed.path in {"/v1/connect/complete", "/v1/connect/state"}:
             origin = self._normalize_origin(self.headers.get("Origin"))
             if origin is None:
-                self.send_response(400)
-                self.end_headers()
+                self._write_empty(status=400)
                 return
-            self.send_response(200)
-            self.send_header("Access-Control-Allow-Origin", origin)
-            self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-            self.send_header("Access-Control-Allow-Headers", "Content-Type")
-            self.send_header("Vary", "Origin")
-            self.end_headers()
+            self._write_empty(status=200, extra_headers=self._cors_headers(origin))
             return
-        self.send_response(404)
-        self.end_headers()
+        self._write_empty(status=404)
 
     def do_GET(self) -> None:
         store = self.server.store  # type: ignore[attr-defined]
@@ -636,15 +629,33 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if not isinstance(origin, str) or not origin.strip():
             return None
         parsed = urlparse(origin.strip())
-        if parsed.scheme not in {"http", "https"} or parsed.hostname is None:
+        if (
+            parsed.scheme not in {"http", "https"}
+            or parsed.hostname is None
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.path not in {"", "/"}
+            or parsed.params
+            or parsed.query
+            or parsed.fragment
+        ):
             return None
-        return f"{parsed.scheme}://{parsed.netloc}"
+        host = parsed.hostname
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        default_port = 80 if parsed.scheme == "http" else 443
+        try:
+            port = parsed.port
+        except ValueError:
+            return None
+        port_suffix = f":{port}" if port not in {None, default_port} else ""
+        return f"{parsed.scheme}://{host}{port_suffix}"
 
     @staticmethod
     def _cors_headers(origin: str) -> dict[str, str]:
         return {
             "Access-Control-Allow-Origin": origin,
-            "Access-Control-Allow-Methods": "POST, OPTIONS",
+            "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
             "Access-Control-Allow-Headers": "Content-Type",
             "Vary": "Origin",
         }
@@ -743,10 +754,38 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
-        for key, value in (extra_headers or {}).items():
+        for key, value in self._validated_headers(extra_headers).items():
             self.send_header(key, value)
         self.end_headers()
         self.wfile.write(body)
+
+    def _write_empty(
+        self,
+        *,
+        status: int,
+        extra_headers: dict[str, str] | None = None,
+    ) -> None:
+        self.send_response(status)
+        for key, value in self._validated_headers(extra_headers).items():
+            self.send_header(key, value)
+        self.end_headers()
+
+    @staticmethod
+    def _validated_headers(extra_headers: dict[str, str] | None) -> dict[str, str]:
+        allowed_headers = {
+            "Access-Control-Allow-Origin",
+            "Access-Control-Allow-Methods",
+            "Access-Control-Allow-Headers",
+            "Vary",
+        }
+        validated: dict[str, str] = {}
+        for key, value in (extra_headers or {}).items():
+            if key not in allowed_headers or not isinstance(value, str):
+                continue
+            if "\r" in value or "\n" in value:
+                continue
+            validated[key] = value
+        return validated
 
     def _write_static_asset(self, relative_path: str) -> None:
         target = (_STATIC_DIR / relative_path).resolve()

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -289,9 +289,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         surface = self._optional_string(payload.get("surface")) or "cli"
         capabilities = payload.get("capabilities")
         capability_items = (
-            tuple(str(item) for item in capabilities if isinstance(item, str))
-            if isinstance(capabilities, list)
-            else ()
+            tuple(str(item) for item in capabilities if isinstance(item, str)) if isinstance(capabilities, list) else ()
         )
         supported_versions = payload.get("supported_protocol_versions")
         try:
@@ -301,9 +299,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 version=self._optional_string(payload.get("version")),
                 surface=surface,
                 capabilities=capability_items,
-                supported_protocol_versions=tuple(
-                    str(item) for item in supported_versions if isinstance(item, str)
-                )
+                supported_protocol_versions=tuple(str(item) for item in supported_versions if isinstance(item, str))
                 if isinstance(supported_versions, list)
                 else (),
             )

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1070,18 +1070,8 @@ class GuardStore:
         return items
 
     def set_sync_credentials(self, sync_url: str, token: str, now: str) -> None:
-        payload = {"sync_url": sync_url, "token": token}
         with self._connect() as connection:
-            connection.execute(
-                """
-                insert into sync_state (state_key, payload_json, updated_at)
-                values ('credentials', ?, ?)
-                on conflict(state_key) do update set
-                  payload_json = excluded.payload_json,
-                  updated_at = excluded.updated_at
-                """,
-                (json.dumps(payload), now),
-            )
+            self._set_sync_credentials_in_connection(connection, sync_url, token, now)
 
     def set_sync_payload(self, state_key: str, payload: dict[str, object] | list[object], now: str) -> None:
         with self._connect() as connection:
@@ -1266,16 +1256,7 @@ class GuardStore:
                 pairing_secret=pairing_secret,
                 completed_at=now,
             )
-            connection.execute(
-                """
-                insert into sync_state (state_key, payload_json, updated_at)
-                values ('credentials', ?, ?)
-                on conflict(state_key) do update set
-                  payload_json = excluded.payload_json,
-                  updated_at = excluded.updated_at
-                """,
-                (json.dumps({"sync_url": request["sync_url"], "token": token}), now),
-            )
+            self._set_sync_credentials_in_connection(connection, str(request["sync_url"]), token, now)
             connection.execute(
                 """
                 insert into guard_events (event_name, payload_json, occurred_at)
@@ -1289,6 +1270,38 @@ class GuardStore:
                 completed_at=now,
             )
         return request
+
+    def _set_sync_credentials_in_connection(
+        self,
+        connection: sqlite3.Connection,
+        sync_url: str,
+        token: str,
+        now: str,
+    ) -> None:
+        payload = {"sync_url": sync_url, "token": token}
+        previous_row = connection.execute(
+            "select payload_json from sync_state where state_key = 'credentials'"
+        ).fetchone()
+        credentials_changed = False
+        if previous_row is None:
+            credentials_changed = True
+        else:
+            previous_payload = json.loads(str(previous_row["payload_json"]))
+            credentials_changed = previous_payload != payload
+        connection.execute(
+            """
+            insert into sync_state (state_key, payload_json, updated_at)
+            values ('credentials', ?, ?)
+            on conflict(state_key) do update set
+              payload_json = excluded.payload_json,
+              updated_at = excluded.updated_at
+            """,
+            (json.dumps(payload), now),
+        )
+        if credentials_changed:
+            connection.execute("delete from sync_state where state_key != 'credentials'")
+            connection.execute("delete from publisher_cache")
+            connection.execute("delete from policy_decisions where source in ('cloud-sync', 'team-policy')")
 
     def record_guard_connect_result(
         self,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -11,7 +11,7 @@ from hashlib import sha256
 from pathlib import Path
 from uuid import uuid4
 
-from .models import GuardApprovalRequest, GuardArtifact, GuardReceipt, PolicyDecision
+from .models import GuardApprovalRequest, GuardArtifact, GuardReceipt, GuardRuntimeState, PolicyDecision
 from .store_approvals import (
     add_approval_request as persist_approval_request,
 )
@@ -201,6 +201,16 @@ class GuardStore:
               event_name text not null,
               payload_json text not null,
               occurred_at text not null
+            )
+            """,
+            """
+            create table if not exists guard_runtime_state (
+              state_key text primary key,
+              session_id text not null,
+              daemon_host text not null,
+              daemon_port integer not null,
+              started_at text not null,
+              last_heartbeat_at text not null
             )
             """,
             """
@@ -806,6 +816,74 @@ class GuardStore:
         with self._connect() as connection:
             row = connection.execute(query, params).fetchone()
         return int(row["total"]) if row is not None else 0
+
+    def upsert_runtime_state(
+        self,
+        *,
+        session_id: str,
+        daemon_host: str,
+        daemon_port: int,
+        started_at: str,
+        last_heartbeat_at: str,
+    ) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                insert into guard_runtime_state (
+                  state_key, session_id, daemon_host, daemon_port, started_at, last_heartbeat_at
+                )
+                values ('runtime', ?, ?, ?, ?, ?)
+                on conflict(state_key) do update set
+                  session_id = excluded.session_id,
+                  daemon_host = excluded.daemon_host,
+                  daemon_port = excluded.daemon_port,
+                  started_at = excluded.started_at,
+                  last_heartbeat_at = excluded.last_heartbeat_at
+                """,
+                (session_id, daemon_host, daemon_port, started_at, last_heartbeat_at),
+            )
+
+    def touch_runtime_state(self, *, session_id: str, last_heartbeat_at: str) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                update guard_runtime_state
+                set last_heartbeat_at = ?
+                where state_key = 'runtime'
+                  and session_id = ?
+                """,
+                (last_heartbeat_at, session_id),
+            )
+
+    def get_runtime_state(self) -> dict[str, object] | None:
+        with self._connect() as connection:
+            row = connection.execute(
+                """
+                select session_id, daemon_host, daemon_port, started_at, last_heartbeat_at
+                from guard_runtime_state
+                where state_key = 'runtime'
+                """
+            ).fetchone()
+        if row is None:
+            return None
+        return GuardRuntimeState(
+            session_id=str(row["session_id"]),
+            daemon_host=str(row["daemon_host"]),
+            daemon_port=int(row["daemon_port"]),
+            started_at=str(row["started_at"]),
+            last_heartbeat_at=str(row["last_heartbeat_at"]),
+        ).to_dict()
+
+    def clear_runtime_state(self, *, session_id: str) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                delete from guard_runtime_state
+                where state_key = 'runtime'
+                  and session_id = ?
+                """,
+                (session_id,),
+            )
 
     def add_approval_request(self, request: GuardApprovalRequest, now: str) -> str:
         with self._connect() as connection:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1334,6 +1334,16 @@ class GuardStore:
                 pairing_secret=pairing_secret,
                 completed_at=now,
             )
+            if load_connect_state(connection, request_id, now=now) is None:
+                persist_connect_state(
+                    connection,
+                    request_id=request_id,
+                    sync_url=str(request["sync_url"]),
+                    allowed_origin=str(request["allowed_origin"]),
+                    created_at=str(request["created_at"]),
+                    expires_at=str(request["expires_at"]),
+                    updated_at=now,
+                )
             self._set_sync_credentials_in_connection(connection, str(request["sync_url"]), token, now)
             connection.execute(
                 """

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -11,7 +11,7 @@ from hashlib import sha256
 from pathlib import Path
 from uuid import uuid4
 
-from .models import GuardApprovalRequest, GuardArtifact, GuardReceipt, GuardRuntimeState, PolicyDecision
+from .models import GuardApprovalRequest, GuardArtifact, GuardReceipt, PolicyDecision
 from .store_approvals import (
     add_approval_request as persist_approval_request,
 )
@@ -38,13 +38,30 @@ from .store_connect import (
 )
 from .store_connect import (
     connect_request_schema_statement,
+    connect_state_schema_statement,
     hash_pairing_secret,
+    verify_connect_request_access,
 )
 from .store_connect import (
     create_connect_request as persist_connect_request,
 )
 from .store_connect import (
+    create_connect_state as persist_connect_state,
+)
+from .store_connect import (
     get_connect_request as load_connect_request,
+)
+from .store_connect import (
+    get_connect_state as load_connect_state,
+)
+from .store_connect import (
+    get_latest_connect_state as load_latest_connect_state,
+)
+from .store_connect import (
+    mark_connect_pairing_completed as persist_connect_pairing_completed,
+)
+from .store_connect import (
+    mark_connect_result as persist_connect_result,
 )
 
 
@@ -187,16 +204,6 @@ class GuardStore:
             )
             """,
             """
-            create table if not exists guard_runtime_state (
-              state_key text primary key,
-              session_id text not null,
-              daemon_host text not null,
-              daemon_port integer not null,
-              started_at text not null,
-              last_heartbeat_at text not null
-            )
-            """,
-            """
             create table if not exists managed_installs (
               harness text primary key,
               active integer not null,
@@ -264,6 +271,7 @@ class GuardStore:
               primary key (surface, open_key)
             )
             """,
+            connect_state_schema_statement(),
             connect_request_schema_statement(),
             approval_schema_statement(),
         )
@@ -799,74 +807,6 @@ class GuardStore:
             row = connection.execute(query, params).fetchone()
         return int(row["total"]) if row is not None else 0
 
-    def upsert_runtime_state(
-        self,
-        *,
-        session_id: str,
-        daemon_host: str,
-        daemon_port: int,
-        started_at: str,
-        last_heartbeat_at: str,
-    ) -> None:
-        with self._connect() as connection:
-            connection.execute(
-                """
-                insert into guard_runtime_state (
-                  state_key, session_id, daemon_host, daemon_port, started_at, last_heartbeat_at
-                )
-                values ('runtime', ?, ?, ?, ?, ?)
-                on conflict(state_key) do update set
-                  session_id = excluded.session_id,
-                  daemon_host = excluded.daemon_host,
-                  daemon_port = excluded.daemon_port,
-                  started_at = excluded.started_at,
-                  last_heartbeat_at = excluded.last_heartbeat_at
-                """,
-                (session_id, daemon_host, daemon_port, started_at, last_heartbeat_at),
-            )
-
-    def touch_runtime_state(self, *, session_id: str, last_heartbeat_at: str) -> None:
-        with self._connect() as connection:
-            connection.execute(
-                """
-                update guard_runtime_state
-                set last_heartbeat_at = ?
-                where state_key = 'runtime'
-                  and session_id = ?
-                """,
-                (last_heartbeat_at, session_id),
-            )
-
-    def get_runtime_state(self) -> dict[str, object] | None:
-        with self._connect() as connection:
-            row = connection.execute(
-                """
-                select session_id, daemon_host, daemon_port, started_at, last_heartbeat_at
-                from guard_runtime_state
-                where state_key = 'runtime'
-                """
-            ).fetchone()
-        if row is None:
-            return None
-        return GuardRuntimeState(
-            session_id=str(row["session_id"]),
-            daemon_host=str(row["daemon_host"]),
-            daemon_port=int(row["daemon_port"]),
-            started_at=str(row["started_at"]),
-            last_heartbeat_at=str(row["last_heartbeat_at"]),
-        ).to_dict()
-
-    def clear_runtime_state(self, *, session_id: str) -> None:
-        with self._connect() as connection:
-            connection.execute(
-                """
-                delete from guard_runtime_state
-                where state_key = 'runtime'
-                  and session_id = ?
-                """,
-                (session_id,),
-            )
-
     def add_approval_request(self, request: GuardApprovalRequest, now: str) -> str:
         with self._connect() as connection:
             return persist_approval_request(connection, request, now)
@@ -1130,8 +1070,18 @@ class GuardStore:
         return items
 
     def set_sync_credentials(self, sync_url: str, token: str, now: str) -> None:
+        payload = {"sync_url": sync_url, "token": token}
         with self._connect() as connection:
-            self._set_sync_credentials_in_connection(connection, sync_url, token, now)
+            connection.execute(
+                """
+                insert into sync_state (state_key, payload_json, updated_at)
+                values ('credentials', ?, ?)
+                on conflict(state_key) do update set
+                  payload_json = excluded.payload_json,
+                  updated_at = excluded.updated_at
+                """,
+                (json.dumps(payload), now),
+            )
 
     def set_sync_payload(self, state_key: str, payload: dict[str, object] | list[object], now: str) -> None:
         with self._connect() as connection:
@@ -1273,11 +1223,33 @@ class GuardStore:
                 created_at=str(payload["created_at"]),
                 expires_at=str(payload["expires_at"]),
             )
+            persist_connect_state(
+                connection,
+                request_id=request_id,
+                sync_url=sync_url,
+                allowed_origin=allowed_origin,
+                created_at=str(payload["created_at"]),
+                expires_at=str(payload["expires_at"]),
+                updated_at=now,
+            )
         return {**payload, "pairing_secret": pairing_secret}
 
     def get_guard_connect_request(self, request_id: str) -> dict[str, object] | None:
         with self._connect() as connection:
             return load_connect_request(connection, request_id)
+
+    def get_guard_connect_state(
+        self,
+        request_id: str,
+        *,
+        now: str,
+    ) -> dict[str, object] | None:
+        with self._connect() as connection:
+            return load_connect_state(connection, request_id, now=now)
+
+    def get_latest_guard_connect_state(self, *, now: str) -> dict[str, object] | None:
+        with self._connect() as connection:
+            return load_latest_connect_state(connection, now=now)
 
     def complete_guard_connect_request(
         self,
@@ -1294,7 +1266,16 @@ class GuardStore:
                 pairing_secret=pairing_secret,
                 completed_at=now,
             )
-            self._set_sync_credentials_in_connection(connection, str(request["sync_url"]), token, now)
+            connection.execute(
+                """
+                insert into sync_state (state_key, payload_json, updated_at)
+                values ('credentials', ?, ?)
+                on conflict(state_key) do update set
+                  payload_json = excluded.payload_json,
+                  updated_at = excluded.updated_at
+                """,
+                (json.dumps({"sync_url": request["sync_url"], "token": token}), now),
+            )
             connection.execute(
                 """
                 insert into guard_events (event_name, payload_json, occurred_at)
@@ -1302,39 +1283,46 @@ class GuardStore:
                 """,
                 ("sign_in", json.dumps({"sync_url": request["sync_url"], "source": "browser-connect"}), now),
             )
+            persist_connect_pairing_completed(
+                connection,
+                request_id=request_id,
+                completed_at=now,
+            )
         return request
 
-    def _set_sync_credentials_in_connection(
+    def record_guard_connect_result(
         self,
-        connection: sqlite3.Connection,
-        sync_url: str,
-        token: str,
+        *,
+        request_id: str,
+        status: str,
+        milestone: str,
         now: str,
-    ) -> None:
-        payload = {"sync_url": sync_url, "token": token}
-        previous_row = connection.execute(
-            "select payload_json from sync_state where state_key = 'credentials'"
-        ).fetchone()
-        credentials_changed = False
-        if previous_row is None:
-            credentials_changed = True
-        else:
-            previous_payload = json.loads(str(previous_row["payload_json"]))
-            credentials_changed = previous_payload != payload
-        connection.execute(
-            """
-            insert into sync_state (state_key, payload_json, updated_at)
-            values ('credentials', ?, ?)
-            on conflict(state_key) do update set
-              payload_json = excluded.payload_json,
-              updated_at = excluded.updated_at
-            """,
-            (json.dumps(payload), now),
-        )
-        if credentials_changed:
-            connection.execute("delete from sync_state where state_key != 'credentials'")
-            connection.execute("delete from publisher_cache")
-            connection.execute("delete from policy_decisions where source in ('cloud-sync', 'team-policy')")
+        reason: str | None = None,
+        sync_payload: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        with self._connect() as connection:
+            return persist_connect_result(
+                connection,
+                request_id=request_id,
+                status=status,
+                milestone=milestone,
+                updated_at=now,
+                reason=reason,
+                sync_payload=sync_payload,
+            )
+
+    def verify_guard_connect_access(
+        self,
+        *,
+        request_id: str,
+        pairing_secret: str,
+    ) -> dict[str, object] | None:
+        with self._connect() as connection:
+            return verify_connect_request_access(
+                connection,
+                request_id=request_id,
+                pairing_secret=pairing_secret,
+            )
 
     def upsert_guard_session(
         self,

--- a/src/codex_plugin_scanner/guard/store_connect.py
+++ b/src/codex_plugin_scanner/guard/store_connect.py
@@ -176,7 +176,7 @@ def load_connect_state(
     if row is None:
         return None
     payload = _build_connect_state_payload(row)
-    if now is not None and payload["status"] == "waiting":
+    if now is not None and payload["status"] == "waiting" and payload["milestone"] == "waiting_for_browser":
         expires_at = _parse_timestamp(str(payload["expires_at"]))
         if expires_at <= _parse_timestamp(now):
             connection.execute(

--- a/src/codex_plugin_scanner/guard/store_connect.py
+++ b/src/codex_plugin_scanner/guard/store_connect.py
@@ -389,9 +389,7 @@ def build_connect_request(
     lifetime_seconds: int = 300,
 ) -> tuple[dict[str, object], str]:
     pairing_secret = secrets.token_urlsafe(24)
-    expires_at = (
-        _parse_timestamp(now) + timedelta(seconds=max(30, lifetime_seconds))
-    ).isoformat()
+    expires_at = (_parse_timestamp(now) + timedelta(seconds=max(30, lifetime_seconds))).isoformat()
     payload = {
         "request_id": request_id,
         "sync_url": sync_url,

--- a/src/codex_plugin_scanner/guard/store_connect.py
+++ b/src/codex_plugin_scanner/guard/store_connect.py
@@ -155,10 +155,10 @@ def create_connect_state(
             json.dumps(proof),
         ),
     )
-    return get_connect_state(connection, request_id, now=updated_at) or {}
+    return load_connect_state(connection, request_id, now=updated_at) or {}
 
 
-def get_connect_state(
+def load_connect_state(
     connection: sqlite3.Connection,
     request_id: str,
     *,
@@ -228,7 +228,7 @@ def get_latest_connect_state(
     ).fetchone()
     if row is None:
         return None
-    return get_connect_state(connection, str(row["request_id"]), now=now)
+    return load_connect_state(connection, str(row["request_id"]), now=now)
 
 
 def mark_connect_pairing_completed(
@@ -237,7 +237,7 @@ def mark_connect_pairing_completed(
     request_id: str,
     completed_at: str,
 ) -> dict[str, object]:
-    state = get_connect_state(connection, request_id, now=completed_at)
+    state = load_connect_state(connection, request_id, now=completed_at)
     if state is None:
         raise ValueError("connect_state_not_found")
     proof = _coerce_proof(state.get("proof"))
@@ -254,7 +254,7 @@ def mark_connect_pairing_completed(
         """,
         (completed_at, completed_at, json.dumps(proof), request_id),
     )
-    return get_connect_state(connection, request_id, now=completed_at) or {}
+    return load_connect_state(connection, request_id, now=completed_at) or {}
 
 
 def mark_connect_result(
@@ -271,7 +271,7 @@ def mark_connect_result(
         raise ValueError("invalid_connect_state_status")
     if milestone not in CONNECT_STATE_MILESTONE_VALUES:
         raise ValueError("invalid_connect_state_milestone")
-    state = get_connect_state(connection, request_id, now=updated_at)
+    state = load_connect_state(connection, request_id, now=updated_at)
     if state is None:
         raise ValueError("connect_state_not_found")
     proof = _coerce_proof(state.get("proof"))
@@ -298,7 +298,10 @@ def mark_connect_result(
             request_id,
         ),
     )
-    return get_connect_state(connection, request_id, now=updated_at) or {}
+    return load_connect_state(connection, request_id, now=updated_at) or {}
+
+
+get_connect_state = load_connect_state
 
 
 def verify_connect_request_access(

--- a/src/codex_plugin_scanner/guard/store_connect.py
+++ b/src/codex_plugin_scanner/guard/store_connect.py
@@ -3,9 +3,20 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import secrets
 import sqlite3
 from datetime import datetime, timedelta, timezone
+
+CONNECT_STATE_VERSION = "guard-connect-state.v1"
+CONNECT_STATE_STATUS_VALUES = {"waiting", "connected", "retry_required", "expired"}
+CONNECT_STATE_MILESTONE_VALUES = {
+    "waiting_for_browser",
+    "first_sync_pending",
+    "first_sync_succeeded",
+    "first_sync_failed",
+    "expired",
+}
 
 
 def connect_request_schema_statement() -> str:
@@ -19,6 +30,24 @@ def connect_request_schema_statement() -> str:
           created_at text not null,
           expires_at text not null,
           completed_at text
+        )
+        """
+
+
+def connect_state_schema_statement() -> str:
+    return """
+        create table if not exists guard_connect_states (
+          request_id text primary key,
+          sync_url text not null,
+          allowed_origin text not null,
+          status text not null,
+          milestone text not null,
+          reason text,
+          created_at text not null,
+          updated_at text not null,
+          expires_at text not null,
+          completed_at text,
+          proof_json text not null default '{}'
         )
         """
 
@@ -83,6 +112,219 @@ def get_connect_request(
     }
 
 
+def create_connect_state(
+    connection: sqlite3.Connection,
+    *,
+    request_id: str,
+    sync_url: str,
+    allowed_origin: str,
+    created_at: str,
+    expires_at: str,
+    updated_at: str,
+) -> dict[str, object]:
+    proof = {
+        "pairing_completed_at": None,
+        "first_synced_at": None,
+        "receipts_stored": 0,
+        "inventory_items": 0,
+    }
+    connection.execute(
+        """
+        insert into guard_connect_states (
+          request_id,
+          sync_url,
+          allowed_origin,
+          status,
+          milestone,
+          reason,
+          created_at,
+          updated_at,
+          expires_at,
+          completed_at,
+          proof_json
+        )
+        values (?, ?, ?, 'waiting', 'waiting_for_browser', 'waiting_for_browser', ?, ?, ?, null, ?)
+        """,
+        (
+            request_id,
+            sync_url,
+            allowed_origin,
+            created_at,
+            updated_at,
+            expires_at,
+            json.dumps(proof),
+        ),
+    )
+    return get_connect_state(connection, request_id, now=updated_at) or {}
+
+
+def get_connect_state(
+    connection: sqlite3.Connection,
+    request_id: str,
+    *,
+    now: str | None = None,
+) -> dict[str, object] | None:
+    row = connection.execute(
+        """
+        select request_id, sync_url, allowed_origin, status, milestone, reason,
+               created_at, updated_at, expires_at, completed_at, proof_json
+        from guard_connect_states
+        where request_id = ?
+        """,
+        (request_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    payload = _build_connect_state_payload(row)
+    if now is not None and payload["status"] == "waiting":
+        expires_at = _parse_timestamp(str(payload["expires_at"]))
+        if expires_at <= _parse_timestamp(now):
+            connection.execute(
+                """
+                update guard_connect_states
+                set status = 'expired',
+                    milestone = 'expired',
+                    reason = 'request_expired',
+                    updated_at = ?
+                where request_id = ?
+                """,
+                (now, request_id),
+            )
+            connection.execute(
+                """
+                update guard_connect_requests
+                set status = 'expired'
+                where request_id = ? and status = 'pending'
+                """,
+                (request_id,),
+            )
+            row = connection.execute(
+                """
+                select request_id, sync_url, allowed_origin, status, milestone, reason,
+                       created_at, updated_at, expires_at, completed_at, proof_json
+                from guard_connect_states
+                where request_id = ?
+                """,
+                (request_id,),
+            ).fetchone()
+            if row is None:
+                return None
+            payload = _build_connect_state_payload(row)
+    return payload
+
+
+def get_latest_connect_state(
+    connection: sqlite3.Connection,
+    *,
+    now: str | None = None,
+) -> dict[str, object] | None:
+    row = connection.execute(
+        """
+        select request_id
+        from guard_connect_states
+        order by updated_at desc
+        limit 1
+        """
+    ).fetchone()
+    if row is None:
+        return None
+    return get_connect_state(connection, str(row["request_id"]), now=now)
+
+
+def mark_connect_pairing_completed(
+    connection: sqlite3.Connection,
+    *,
+    request_id: str,
+    completed_at: str,
+) -> dict[str, object]:
+    state = get_connect_state(connection, request_id, now=completed_at)
+    if state is None:
+        raise ValueError("connect_state_not_found")
+    proof = _coerce_proof(state.get("proof"))
+    proof["pairing_completed_at"] = completed_at
+    connection.execute(
+        """
+        update guard_connect_states
+        set milestone = 'first_sync_pending',
+            reason = 'waiting_for_first_sync',
+            updated_at = ?,
+            completed_at = ?,
+            proof_json = ?
+        where request_id = ?
+        """,
+        (completed_at, completed_at, json.dumps(proof), request_id),
+    )
+    return get_connect_state(connection, request_id, now=completed_at) or {}
+
+
+def mark_connect_result(
+    connection: sqlite3.Connection,
+    *,
+    request_id: str,
+    status: str,
+    milestone: str,
+    updated_at: str,
+    reason: str | None = None,
+    sync_payload: dict[str, object] | None = None,
+) -> dict[str, object]:
+    if status not in CONNECT_STATE_STATUS_VALUES:
+        raise ValueError("invalid_connect_state_status")
+    if milestone not in CONNECT_STATE_MILESTONE_VALUES:
+        raise ValueError("invalid_connect_state_milestone")
+    state = get_connect_state(connection, request_id, now=updated_at)
+    if state is None:
+        raise ValueError("connect_state_not_found")
+    proof = _coerce_proof(state.get("proof"))
+    if sync_payload is not None:
+        proof["first_synced_at"] = sync_payload.get("synced_at")
+        proof["receipts_stored"] = int(sync_payload.get("receipts_stored") or 0)
+        proof["inventory_items"] = int(sync_payload.get("inventory") or 0)
+    connection.execute(
+        """
+        update guard_connect_states
+        set status = ?,
+            milestone = ?,
+            reason = ?,
+            updated_at = ?,
+            proof_json = ?
+        where request_id = ?
+        """,
+        (
+            status,
+            milestone,
+            reason,
+            updated_at,
+            json.dumps(proof),
+            request_id,
+        ),
+    )
+    return get_connect_state(connection, request_id, now=updated_at) or {}
+
+
+def verify_connect_request_access(
+    connection: sqlite3.Connection,
+    *,
+    request_id: str,
+    pairing_secret: str,
+) -> dict[str, object] | None:
+    row = connection.execute(
+        """
+        select request_id, allowed_origin, pairing_secret_hash
+        from guard_connect_requests
+        where request_id = ?
+        """,
+        (request_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    if not secrets.compare_digest(str(row["pairing_secret_hash"]), _hash_secret(pairing_secret)):
+        return None
+    return {
+        "request_id": str(row["request_id"]),
+        "allowed_origin": str(row["allowed_origin"]),
+    }
+
+
 def complete_connect_request(
     connection: sqlite3.Connection,
     *,
@@ -144,7 +386,9 @@ def build_connect_request(
     lifetime_seconds: int = 300,
 ) -> tuple[dict[str, object], str]:
     pairing_secret = secrets.token_urlsafe(24)
-    expires_at = (_parse_timestamp(now) + timedelta(seconds=max(30, lifetime_seconds))).isoformat()
+    expires_at = (
+        _parse_timestamp(now) + timedelta(seconds=max(30, lifetime_seconds))
+    ).isoformat()
     payload = {
         "request_id": request_id,
         "sync_url": sync_url,
@@ -160,8 +404,56 @@ def hash_pairing_secret(pairing_secret: str) -> str:
     return _hash_secret(pairing_secret)
 
 
+def build_connect_state_response(
+    payload: dict[str, object],
+    *,
+    poll_after_ms: int | None = None,
+) -> dict[str, object]:
+    response = dict(payload)
+    response["version"] = CONNECT_STATE_VERSION
+    response["poll_after_ms"] = poll_after_ms if poll_after_ms is not None else _resolve_poll_after_ms(response)
+    response["proof"] = _coerce_proof(response.get("proof"))
+    return response
+
+
 def _hash_secret(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _build_connect_state_payload(row: sqlite3.Row) -> dict[str, object]:
+    payload = {
+        "request_id": str(row["request_id"]),
+        "sync_url": str(row["sync_url"]),
+        "allowed_origin": str(row["allowed_origin"]),
+        "status": str(row["status"]),
+        "milestone": str(row["milestone"]),
+        "reason": str(row["reason"]) if row["reason"] is not None else None,
+        "created_at": str(row["created_at"]),
+        "updated_at": str(row["updated_at"]),
+        "expires_at": str(row["expires_at"]),
+        "completed_at": str(row["completed_at"]) if row["completed_at"] is not None else None,
+        "proof": _coerce_proof(row["proof_json"]),
+    }
+    return build_connect_state_response(payload)
+
+
+def _coerce_proof(value: object) -> dict[str, object]:
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(parsed, dict):
+            return dict(parsed)
+    return {}
+
+
+def _resolve_poll_after_ms(payload: dict[str, object]) -> int:
+    if str(payload.get("status")) == "waiting":
+        return 1500
+    return 0
 
 
 def _parse_timestamp(value: str) -> datetime:

--- a/src/codex_plugin_scanner/guard/store_connect.py
+++ b/src/codex_plugin_scanner/guard/store_connect.py
@@ -458,7 +458,8 @@ def _resolve_poll_after_ms(payload: dict[str, object]) -> int:
 
 
 def _parse_timestamp(value: str) -> datetime:
-    parsed = datetime.fromisoformat(value)
+    normalized_value = value[:-1] + "+00:00" if value.endswith("Z") else value
+    parsed = datetime.fromisoformat(normalized_value)
     if parsed.tzinfo is None:
         return parsed.replace(tzinfo=timezone.utc)
     return parsed.astimezone(timezone.utc)

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -20,6 +20,7 @@ from codex_plugin_scanner.guard.consumer import artifact_hash, evaluate_detectio
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.daemon import client as daemon_client_module
 from codex_plugin_scanner.guard.daemon import manager as daemon_manager_module
+from codex_plugin_scanner.guard.daemon import server as daemon_server_module
 from codex_plugin_scanner.guard.models import (
     GuardApprovalRequest,
     GuardArtifact,
@@ -550,6 +551,33 @@ class TestGuardApprovals:
 
         assert snapshot_payload["pending_count"] == 205
         assert len(snapshot_payload["items"]) == 200
+
+    def test_guard_daemon_updates_runtime_heartbeat_while_serving_requests(self, tmp_path, monkeypatch):
+        store = GuardStore(tmp_path / "guard-home")
+        heartbeat_values = [
+            "2026-04-11T00:00:00+00:00",
+            "2026-04-11T00:00:00+00:00",
+            "2026-04-11T00:05:00+00:00",
+        ]
+
+        def next_heartbeat() -> str:
+            if len(heartbeat_values) > 1:
+                return heartbeat_values.pop(0)
+            return heartbeat_values[0]
+
+        monkeypatch.setattr(daemon_server_module, "_now", next_heartbeat)
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/healthz", timeout=5):
+                pass
+            runtime_state = store.get_runtime_state()
+        finally:
+            daemon.stop()
+
+        assert runtime_state is not None
+        assert runtime_state["last_heartbeat_at"] == "2026-04-11T00:05:00+00:00"
 
     def test_guard_store_clears_runtime_state_only_for_matching_session(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -2681,6 +2681,88 @@ args = ["workspace-skill.js", "--changed"]
         assert payload["milestone"] == "first_sync_failed"
         assert payload["reason"] == "<urlopen error offline>"
 
+    def test_guard_connect_persists_success_when_daemon_result_write_fails(self, tmp_path, monkeypatch):
+        store = GuardStore(tmp_path / "guard-home")
+
+        class FakeDaemonClient:
+            daemon_url = "http://127.0.0.1:4781"
+
+            def __init__(self) -> None:
+                self.request_id = ""
+
+            def create_connect_request(self, *, sync_url: str, allowed_origin: str) -> dict[str, object]:
+                request = store.create_guard_connect_request(
+                    sync_url=sync_url,
+                    allowed_origin=allowed_origin,
+                    now="2026-04-15T00:00:00Z",
+                )
+                self.request_id = str(request["request_id"])
+                return request
+
+            def report_connect_result(
+                self,
+                *,
+                request_id: str,
+                status: str,
+                milestone: str,
+                reason: str | None = None,
+                sync: dict[str, object] | None = None,
+            ) -> dict[str, object]:
+                raise RuntimeError("daemon restarted")
+
+        fake_daemon_client = FakeDaemonClient()
+        monkeypatch.setattr(
+            guard_connect_flow_module, "ensure_guard_daemon", lambda guard_home: "http://127.0.0.1:4781"
+        )
+        monkeypatch.setattr(
+            guard_connect_flow_module,
+            "load_guard_surface_daemon_client",
+            lambda guard_home: fake_daemon_client,
+        )
+        monkeypatch.setattr(
+            guard_connect_flow_module,
+            "wait_for_connect_transition",
+            lambda **kwargs: {
+                "status": "waiting",
+                "milestone": "first_sync_pending",
+                "request_id": fake_daemon_client.request_id,
+                "completed_at": "2026-04-15T00:00:00Z",
+                "proof": {},
+            },
+        )
+        monkeypatch.setattr(
+            guard_connect_flow_module,
+            "sync_receipts",
+            lambda current_store: {
+                "receipts_stored": 3,
+                "inventory_tracked": 1,
+                "first_synced_at": "2026-04-15T00:00:01Z",
+            },
+        )
+
+        payload = guard_connect_flow_module.run_guard_connect_command(
+            guard_home=tmp_path / "guard-home",
+            store=store,
+            sync_url="https://hol.org/api/guard/receipts/sync",
+            connect_url="https://hol.org/guard/connect",
+            opener=lambda url: True,
+            wait_timeout_seconds=1,
+        )
+
+        persisted_state = store.get_guard_connect_state(
+            request_id=fake_daemon_client.request_id,
+            now="2026-04-15T00:00:02Z",
+        )
+
+        assert payload["connected"] is True
+        assert payload["status"] == "connected"
+        assert payload["milestone"] == "first_sync_succeeded"
+        assert payload["sync"]["receipts_stored"] == 3
+        assert persisted_state is not None
+        assert persisted_state["status"] == "connected"
+        assert persisted_state["milestone"] == "first_sync_succeeded"
+        assert persisted_state["proof"]["receipts_stored"] == 3
+
     def test_guard_connect_marks_retry_required_for_paid_plan_limit(self, tmp_path, monkeypatch):
         store = GuardStore(tmp_path / "guard-home")
 

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -2610,6 +2610,38 @@ args = ["workspace-skill.js", "--changed"]
         assert query["guardPairRequest"] == ["req-123"]
         assert query["guardDaemon"] == ["http://127.0.0.1:4781"]
 
+    def test_guard_connect_wait_recovers_from_transient_daemon_poll_failures(self, monkeypatch):
+        class FakeDaemonClient:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def get_connect_state(self, *, request_id: str) -> dict[str, object]:
+                self.calls += 1
+                if self.calls == 1:
+                    raise RuntimeError("daemon restarting")
+                return {
+                    "request_id": request_id,
+                    "status": "connected",
+                    "milestone": "first_sync_succeeded",
+                    "completed_at": "2026-04-15T00:00:00Z",
+                    "proof": {"receipts_stored": 3},
+                }
+
+        monotonic_values = iter((0.0, 0.0, 0.2))
+        monkeypatch.setattr(guard_connect_flow_module.time, "monotonic", lambda: next(monotonic_values))
+        monkeypatch.setattr(guard_connect_flow_module.time, "sleep", lambda seconds: None)
+
+        state = guard_connect_flow_module.wait_for_connect_transition(
+            daemon_client=FakeDaemonClient(),
+            request_id="req-123",
+            timeout_seconds=1,
+            poll_interval_seconds=0,
+        )
+
+        assert state is not None
+        assert state["status"] == "connected"
+        assert state["milestone"] == "first_sync_succeeded"
+
     def test_guard_connect_marks_retry_required_for_sync_transport_failures(self, tmp_path, monkeypatch):
         store = GuardStore(tmp_path / "guard-home")
 

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -2618,7 +2618,7 @@ args = ["workspace-skill.js", "--changed"]
             def get_connect_state(self, *, request_id: str) -> dict[str, object]:
                 self.calls += 1
                 if self.calls == 1:
-                    raise RuntimeError("daemon restarting")
+                    raise guard_connect_flow_module.GuardDaemonTransportError("daemon restarting")
                 return {
                     "request_id": request_id,
                     "status": "connected",
@@ -2641,6 +2641,23 @@ args = ["workspace-skill.js", "--changed"]
         assert state is not None
         assert state["status"] == "connected"
         assert state["milestone"] == "first_sync_succeeded"
+
+    def test_guard_connect_wait_surfaces_permanent_daemon_poll_failures(self, monkeypatch):
+        class FakeDaemonClient:
+            def get_connect_state(self, *, request_id: str) -> dict[str, object]:
+                raise guard_connect_flow_module.GuardDaemonRequestError("unauthorized")
+
+        monotonic_values = iter((0.0, 0.0))
+        monkeypatch.setattr(guard_connect_flow_module.time, "monotonic", lambda: next(monotonic_values))
+        monkeypatch.setattr(guard_connect_flow_module.time, "sleep", lambda seconds: None)
+
+        with pytest.raises(guard_connect_flow_module.GuardDaemonRequestError, match="unauthorized"):
+            guard_connect_flow_module.wait_for_connect_transition(
+                daemon_client=FakeDaemonClient(),
+                request_id="req-123",
+                timeout_seconds=1,
+                poll_interval_seconds=0,
+            )
 
     def test_guard_connect_marks_retry_required_for_sync_transport_failures(self, tmp_path, monkeypatch):
         store = GuardStore(tmp_path / "guard-home")

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -2418,8 +2418,9 @@ args = ["workspace-skill.js", "--changed"]
         assert run_rc == 0
         assert connect_rc == 0
         assert connect_output["connected"] is True
+        assert connect_output["status"] == "connected"
+        assert connect_output["milestone"] == "first_sync_succeeded"
         assert connect_output["sync"]["receipts_stored"] == 1
-        assert connect_output["sync"]["inventory"] == 0
         assert connect_output["sync"]["inventory_tracked"] >= 1
         assert connect_output["browser_opened"] is True
         assert opened_urls and opened_urls[0].startswith("https://hol.org/guard/connect?")
@@ -2429,6 +2430,79 @@ args = ["workspace-skill.js", "--changed"]
             "sync_url": f"http://127.0.0.1:{server.server_port}/receipts",
             "token": "session-token-123",
         }
+
+    def test_guard_connect_returns_retry_required_when_first_sync_fails(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+
+        store = GuardStore(home_dir)
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+        monkeypatch.setattr(
+            guard_commands_module,
+            "ensure_guard_daemon",
+            lambda guard_home: f"http://127.0.0.1:{daemon.port}",
+        )
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.cli.connect_flow.sync_receipts",
+            lambda current_store: (_ for _ in ()).throw(RuntimeError("sync_unreachable")),
+        )
+
+        def open_browser(url: str) -> bool:
+            parsed = urllib.parse.urlparse(url)
+            query = urllib.parse.parse_qs(parsed.query)
+            fragment = urllib.parse.parse_qs(parsed.fragment)
+            request_id = query["guardPairRequest"][-1]
+            daemon_url = query["guardDaemon"][-1]
+            pairing_secret = fragment["guardPairSecret"][-1]
+
+            def complete_pairing() -> None:
+                request = urllib.request.Request(
+                    f"{daemon_url}/v1/connect/complete",
+                    data=urllib.parse.urlencode(
+                        {
+                            "request_id": request_id,
+                            "pairing_secret": pairing_secret,
+                            "token": "session-token-123",
+                        }
+                    ).encode("utf-8"),
+                    headers={
+                        "Content-Type": "application/x-www-form-urlencoded",
+                        "Origin": "https://hol.org",
+                    },
+                    method="POST",
+                )
+                with urllib.request.urlopen(request, timeout=5):
+                    pass
+
+            threading.Thread(target=complete_pairing, daemon=True).start()
+            return True
+
+        monkeypatch.setattr(guard_commands_module.webbrowser, "open", open_browser)
+        try:
+            connect_rc = main(
+                [
+                    "guard",
+                    "connect",
+                    "--home",
+                    str(home_dir),
+                    "--sync-url",
+                    "https://hol.org/registry/api/v1",
+                    "--connect-url",
+                    "https://hol.org/guard/connect",
+                    "--json",
+                ]
+            )
+            connect_output = json.loads(capsys.readouterr().out)
+        finally:
+            daemon.stop()
+
+        assert connect_rc == 1
+        assert connect_output["connected"] is False
+        assert connect_output["status"] == "retry_required"
+        assert connect_output["milestone"] == "first_sync_failed"
+        assert connect_output["reason"] == "sync_unreachable"
 
     def test_guard_connect_rejects_invalid_sync_url(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -2476,7 +2550,7 @@ args = ["workspace-skill.js", "--changed"]
             "load_guard_surface_daemon_client",
             lambda guard_home: FakeDaemonClient(),
         )
-        monkeypatch.setattr(guard_connect_flow_module, "wait_for_connect_completion", lambda **kwargs: None)
+        monkeypatch.setattr(guard_connect_flow_module, "wait_for_connect_transition", lambda **kwargs: None)
 
         payload = guard_connect_flow_module.run_guard_connect_command(
             guard_home=tmp_path / "guard-home",
@@ -2489,7 +2563,8 @@ args = ["workspace-skill.js", "--changed"]
 
         parsed = urllib.parse.urlparse(opened_urls[0])
         query = urllib.parse.parse_qs(parsed.query)
-        assert payload["status"] == "waiting_for_browser"
+        assert payload["status"] == "waiting"
+        assert payload["milestone"] == "waiting_for_browser"
         assert query["guardDaemon"] == ["http://127.0.0.1:4781"]
 
     def test_guard_connect_preserves_custom_connect_query_params(self, tmp_path, monkeypatch):
@@ -2515,7 +2590,7 @@ args = ["workspace-skill.js", "--changed"]
             "load_guard_surface_daemon_client",
             lambda guard_home: FakeDaemonClient(),
         )
-        monkeypatch.setattr(guard_connect_flow_module, "wait_for_connect_completion", lambda **kwargs: None)
+        monkeypatch.setattr(guard_connect_flow_module, "wait_for_connect_transition", lambda **kwargs: None)
 
         payload = guard_connect_flow_module.run_guard_connect_command(
             guard_home=tmp_path / "guard-home",
@@ -2528,13 +2603,14 @@ args = ["workspace-skill.js", "--changed"]
 
         parsed = urllib.parse.urlparse(opened_urls[0])
         query = urllib.parse.parse_qs(parsed.query)
-        assert payload["status"] == "waiting_for_browser"
+        assert payload["status"] == "waiting"
+        assert payload["milestone"] == "waiting_for_browser"
         assert query["tenant"] == ["enterprise"]
         assert query["invite"] == ["abc123"]
         assert query["guardPairRequest"] == ["req-123"]
         assert query["guardDaemon"] == ["http://127.0.0.1:4781"]
 
-    def test_guard_connect_wraps_sync_transport_failures(self, tmp_path, monkeypatch):
+    def test_guard_connect_marks_retry_required_for_sync_transport_failures(self, tmp_path, monkeypatch):
         store = GuardStore(tmp_path / "guard-home")
 
         class FakeDaemonClient:
@@ -2548,6 +2624,24 @@ args = ["workspace-skill.js", "--changed"]
                     "allowed_origin": allowed_origin,
                 }
 
+            def report_connect_result(
+                self,
+                *,
+                request_id: str,
+                status: str,
+                milestone: str,
+                reason: str | None = None,
+                sync: dict[str, object] | None = None,
+            ) -> dict[str, object]:
+                return {
+                    "request_id": request_id,
+                    "status": status,
+                    "milestone": milestone,
+                    "reason": reason,
+                    "completed_at": "2026-04-15T00:00:00Z",
+                    "proof": sync or {},
+                }
+
         monkeypatch.setattr(
             guard_connect_flow_module, "ensure_guard_daemon", lambda guard_home: "http://127.0.0.1:4781"
         )
@@ -2558,8 +2652,14 @@ args = ["workspace-skill.js", "--changed"]
         )
         monkeypatch.setattr(
             guard_connect_flow_module,
-            "wait_for_connect_completion",
-            lambda **kwargs: {"status": "completed", "request_id": "req-123", "completed_at": "2026-04-15T00:00:00Z"},
+            "wait_for_connect_transition",
+            lambda **kwargs: {
+                "status": "waiting",
+                "milestone": "first_sync_pending",
+                "request_id": "req-123",
+                "completed_at": "2026-04-15T00:00:00Z",
+                "proof": {},
+            },
         )
         monkeypatch.setattr(
             guard_connect_flow_module,
@@ -2567,17 +2667,21 @@ args = ["workspace-skill.js", "--changed"]
             lambda current_store: (_ for _ in ()).throw(urllib.error.URLError("offline")),
         )
 
-        with pytest.raises(RuntimeError, match="Guard paired successfully but sync failed"):
-            guard_connect_flow_module.run_guard_connect_command(
-                guard_home=tmp_path / "guard-home",
-                store=store,
-                sync_url="https://hol.org/api/guard/receipts/sync",
-                connect_url="https://hol.org/guard/connect",
-                opener=lambda url: True,
-                wait_timeout_seconds=1,
-            )
+        payload = guard_connect_flow_module.run_guard_connect_command(
+            guard_home=tmp_path / "guard-home",
+            store=store,
+            sync_url="https://hol.org/api/guard/receipts/sync",
+            connect_url="https://hol.org/guard/connect",
+            opener=lambda url: True,
+            wait_timeout_seconds=1,
+        )
 
-    def test_guard_connect_reports_paid_plan_limit_without_failing_pairing(self, tmp_path, monkeypatch):
+        assert payload["connected"] is False
+        assert payload["status"] == "retry_required"
+        assert payload["milestone"] == "first_sync_failed"
+        assert payload["reason"] == "<urlopen error offline>"
+
+    def test_guard_connect_marks_retry_required_for_paid_plan_limit(self, tmp_path, monkeypatch):
         store = GuardStore(tmp_path / "guard-home")
 
         class FakeDaemonClient:
@@ -2591,6 +2695,24 @@ args = ["workspace-skill.js", "--changed"]
                     "allowed_origin": allowed_origin,
                 }
 
+            def report_connect_result(
+                self,
+                *,
+                request_id: str,
+                status: str,
+                milestone: str,
+                reason: str | None = None,
+                sync: dict[str, object] | None = None,
+            ) -> dict[str, object]:
+                return {
+                    "request_id": request_id,
+                    "status": status,
+                    "milestone": milestone,
+                    "reason": reason,
+                    "completed_at": "2026-04-15T00:00:00Z",
+                    "proof": sync or {},
+                }
+
         monkeypatch.setattr(
             guard_connect_flow_module, "ensure_guard_daemon", lambda guard_home: "http://127.0.0.1:4781"
         )
@@ -2601,8 +2723,14 @@ args = ["workspace-skill.js", "--changed"]
         )
         monkeypatch.setattr(
             guard_connect_flow_module,
-            "wait_for_connect_completion",
-            lambda **kwargs: {"status": "completed", "request_id": "req-123", "completed_at": "2026-04-15T00:00:00Z"},
+            "wait_for_connect_transition",
+            lambda **kwargs: {
+                "status": "waiting",
+                "milestone": "first_sync_pending",
+                "request_id": "req-123",
+                "completed_at": "2026-04-15T00:00:00Z",
+                "proof": {},
+            },
         )
         monkeypatch.setattr(
             guard_connect_flow_module,
@@ -2619,11 +2747,12 @@ args = ["workspace-skill.js", "--changed"]
             wait_timeout_seconds=1,
         )
 
-        assert payload["connected"] is True
-        assert payload["status"] == "paired_without_cloud_sync"
-        assert payload["sync_message"] == "Guard Cloud sync requires a paid Guard plan"
+        assert payload["connected"] is False
+        assert payload["status"] == "retry_required"
+        assert payload["milestone"] == "first_sync_failed"
+        assert payload["reason"] == "Guard Cloud sync requires a paid Guard plan"
 
-    def test_guard_connect_reports_guard_plan_required_without_failing_pairing(self, tmp_path, monkeypatch):
+    def test_guard_connect_marks_retry_required_for_guard_plan_required(self, tmp_path, monkeypatch):
         store = GuardStore(tmp_path / "guard-home")
 
         class FakeDaemonClient:
@@ -2637,6 +2766,24 @@ args = ["workspace-skill.js", "--changed"]
                     "allowed_origin": allowed_origin,
                 }
 
+            def report_connect_result(
+                self,
+                *,
+                request_id: str,
+                status: str,
+                milestone: str,
+                reason: str | None = None,
+                sync: dict[str, object] | None = None,
+            ) -> dict[str, object]:
+                return {
+                    "request_id": request_id,
+                    "status": status,
+                    "milestone": milestone,
+                    "reason": reason,
+                    "completed_at": "2026-04-15T00:00:00Z",
+                    "proof": sync or {},
+                }
+
         monkeypatch.setattr(
             guard_connect_flow_module, "ensure_guard_daemon", lambda guard_home: "http://127.0.0.1:4781"
         )
@@ -2647,8 +2794,14 @@ args = ["workspace-skill.js", "--changed"]
         )
         monkeypatch.setattr(
             guard_connect_flow_module,
-            "wait_for_connect_completion",
-            lambda **kwargs: {"status": "completed", "request_id": "req-124", "completed_at": "2026-04-15T00:00:00Z"},
+            "wait_for_connect_transition",
+            lambda **kwargs: {
+                "status": "waiting",
+                "milestone": "first_sync_pending",
+                "request_id": "req-124",
+                "completed_at": "2026-04-15T00:00:00Z",
+                "proof": {},
+            },
         )
         monkeypatch.setattr(
             guard_connect_flow_module,
@@ -2665,9 +2818,10 @@ args = ["workspace-skill.js", "--changed"]
             wait_timeout_seconds=1,
         )
 
-        assert payload["connected"] is True
-        assert payload["status"] == "paired_without_cloud_sync"
-        assert payload["sync_message"] == "Guard plan required"
+        assert payload["connected"] is False
+        assert payload["status"] == "retry_required"
+        assert payload["milestone"] == "first_sync_failed"
+        assert payload["reason"] == "Guard plan required"
 
     def test_guard_sync_persists_advisories_from_endpoint(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -147,3 +147,35 @@ def test_guard_connect_returns_retry_required_when_first_sync_fails(
     assert payload["milestone"] == "first_sync_failed"
     assert payload["reason"] == "sync_unreachable"
     assert payload["request_id"].startswith("connect-")
+
+
+def test_guard_store_backfills_missing_connect_state_on_pairing_completion(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    created_request = store.create_guard_connect_request(
+        sync_url="https://hol.org/registry/api/v1",
+        allowed_origin="https://hol.org",
+        now="2026-04-15T00:00:00+00:00",
+    )
+
+    with store._connect() as connection:
+        connection.execute(
+            "delete from guard_connect_states where request_id = ?",
+            (created_request["request_id"],),
+        )
+
+    completed_request = store.complete_guard_connect_request(
+        request_id=str(created_request["request_id"]),
+        pairing_secret=str(created_request["pairing_secret"]),
+        token="session-token-123",
+        now="2026-04-15T00:00:01+00:00",
+    )
+    completed_state = store.get_guard_connect_state(
+        str(created_request["request_id"]),
+        now="2026-04-15T00:00:01+00:00",
+    )
+
+    assert completed_request["status"] == "completed"
+    assert completed_state is not None
+    assert completed_state["status"] == "waiting"
+    assert completed_state["milestone"] == "first_sync_pending"
+    assert completed_state["proof"]["pairing_completed_at"] == "2026-04-15T00:00:01+00:00"

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -179,3 +179,29 @@ def test_guard_store_backfills_missing_connect_state_on_pairing_completion(tmp_p
     assert completed_state["status"] == "waiting"
     assert completed_state["milestone"] == "first_sync_pending"
     assert completed_state["proof"]["pairing_completed_at"] == "2026-04-15T00:00:01+00:00"
+
+
+def test_guard_store_keeps_first_sync_pending_state_after_request_expiry(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    created_request = store.create_guard_connect_request(
+        sync_url="https://hol.org/registry/api/v1",
+        allowed_origin="https://hol.org",
+        now="2026-04-15T00:00:00+00:00",
+        lifetime_seconds=60,
+    )
+    store.complete_guard_connect_request(
+        request_id=str(created_request["request_id"]),
+        pairing_secret=str(created_request["pairing_secret"]),
+        token="session-token-123",
+        now="2026-04-15T00:00:30+00:00",
+    )
+
+    pending_state = store.get_guard_connect_state(
+        str(created_request["request_id"]),
+        now="2026-04-15T00:05:00+00:00",
+    )
+
+    assert pending_state is not None
+    assert pending_state["status"] == "waiting"
+    assert pending_state["milestone"] == "first_sync_pending"
+    assert pending_state["reason"] == "waiting_for_first_sync"

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -1,0 +1,149 @@
+"""Focused tests for the Guard connect runtime flow."""
+
+from __future__ import annotations
+
+import json
+import threading
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+from codex_plugin_scanner.guard.cli.connect_flow import run_guard_connect_command
+from codex_plugin_scanner.guard.daemon import GuardDaemonServer
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _build_guard_fixture(home_dir: Path, workspace_dir: Path) -> None:
+    home_dir.mkdir(parents=True, exist_ok=True)
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    (home_dir / ".codex").mkdir(parents=True, exist_ok=True)
+    (workspace_dir / ".codex").mkdir(parents=True, exist_ok=True)
+    (home_dir / ".codex" / "config.toml").write_text('approval_policy = "never"\n', encoding="utf-8")
+    (workspace_dir / ".codex" / "config.toml").write_text("", encoding="utf-8")
+
+
+def test_guard_daemon_exposes_canonical_connect_state_endpoint(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+
+    try:
+        initialize_request = urllib.request.Request(
+            f"http://127.0.0.1:{daemon.port}/v1/initialize",
+            data=json.dumps(
+                {
+                    "client_name": "hol-guard-cli",
+                    "surface": "cli",
+                    "supported_protocol_versions": ["1.1"],
+                }
+            ).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(initialize_request, timeout=5) as response:
+            initialize_payload = json.loads(response.read().decode("utf-8"))
+
+        create_request = urllib.request.Request(
+            f"http://127.0.0.1:{daemon.port}/v1/connect/requests",
+            data=json.dumps(
+                {
+                    "sync_url": "https://hol.org/registry/api/v1",
+                    "allowed_origin": "https://hol.org",
+                }
+            ).encode("utf-8"),
+            headers={
+                "Content-Type": "application/json",
+                "X-Guard-Token": initialize_payload["auth_token"],
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(create_request, timeout=5) as response:
+            created_payload = json.loads(response.read().decode("utf-8"))
+
+        state_request = urllib.request.Request(
+            (
+                f"http://127.0.0.1:{daemon.port}/v1/connect/state"
+                f"?request_id={created_payload['request_id']}"
+                f"&pairing_secret={created_payload['pairing_secret']}"
+            ),
+            headers={"Origin": "https://hol.org"},
+            method="GET",
+        )
+        with urllib.request.urlopen(state_request, timeout=5) as response:
+            state_payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        daemon.stop()
+
+    assert state_payload["state"]["version"] == "guard-connect-state.v1"
+    assert state_payload["state"]["status"] == "waiting"
+    assert state_payload["state"]["milestone"] == "waiting_for_browser"
+
+
+def test_guard_connect_returns_retry_required_when_first_sync_fails(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+
+    store = GuardStore(home_dir)
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.connect_flow.ensure_guard_daemon",
+        lambda guard_home: f"http://127.0.0.1:{daemon.port}",
+    )
+
+    def open_browser(url: str) -> bool:
+        parsed = urllib.parse.urlparse(url)
+        query = urllib.parse.parse_qs(parsed.query)
+        fragment = urllib.parse.parse_qs(parsed.fragment)
+        request_id = query["guardPairRequest"][-1]
+        daemon_url = query["guardDaemon"][-1]
+        pairing_secret = fragment["guardPairSecret"][-1]
+
+        def complete_pairing() -> None:
+            request = urllib.request.Request(
+                f"{daemon_url}/v1/connect/complete",
+                data=urllib.parse.urlencode(
+                    {
+                        "request_id": request_id,
+                        "pairing_secret": pairing_secret,
+                        "token": "session-token-123",
+                    }
+                ).encode("utf-8"),
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "Origin": "https://hol.org",
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=5):
+                pass
+
+        threading.Thread(target=complete_pairing, daemon=True).start()
+        return True
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.connect_flow.sync_receipts",
+        lambda current_store: (_ for _ in ()).throw(RuntimeError("sync_unreachable")),
+    )
+
+    try:
+        payload = run_guard_connect_command(
+            guard_home=home_dir,
+            store=store,
+            sync_url="https://hol.org/registry/api/v1",
+            connect_url="https://hol.org/guard/connect",
+            opener=open_browser,
+            wait_timeout_seconds=5,
+        )
+    finally:
+        daemon.stop()
+
+    assert payload["connected"] is False
+    assert payload["status"] == "retry_required"
+    assert payload["milestone"] == "first_sync_failed"
+    assert payload["reason"] == "sync_unreachable"
+    assert payload["request_id"].startswith("connect-")


### PR DESCRIPTION
## Summary
- move Guard connect to daemon-owned runtime state with explicit waiting, connected, retry-required, and expired milestones
- keep browser pairing URLs aligned with the recovered daemon state and preserve connect URL query params
- add CLI/runtime regressions for first-sync failure and runtime state transitions without dropping newer adapter coverage

## Validation
- PYTHONPATH=$PWD/src ./.venv/bin/pytest tests/test_guard_connect_flow.py tests/test_guard_surface_server.py tests/test_guard_cli.py -k 'connect'
- PYTHONPATH=$PWD/src ./.venv/bin/ruff check src tests
- PYTHONPATH=$PWD/src ./.venv/bin/python -m build

## Companion
- portal UX companion PR opened from hashgraph-online/points-portal guard-connect-dx-pr