### PR TITLE
fix: harden guard connect runtime flow

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -44,47 +44,91 @@ def run_guard_connect_command(
         pairing_secret=str(connect_request["pairing_secret"]),
     )
     browser_opened = bool(opener(browser_url))
-    completion = wait_for_connect_completion(
-        store=store,
+    transition = wait_for_connect_transition(
+        daemon_client=daemon_client,
         request_id=str(connect_request["request_id"]),
         timeout_seconds=wait_timeout_seconds,
     )
-    if completion is None:
-        return {
-            "connected": False,
-            "browser_opened": browser_opened,
-            "connect_url": browser_url,
-            "sync_url": sync_url,
-            "status": "waiting_for_browser",
-        }
+    if transition is None:
+        return build_connect_payload(
+            state={
+                "request_id": str(connect_request["request_id"]),
+                "status": "waiting",
+                "milestone": "waiting_for_browser",
+                "reason": "waiting_for_browser",
+                "completed_at": None,
+                "expires_at": connect_request.get("expires_at"),
+                "proof": {},
+            },
+            browser_opened=browser_opened,
+            connect_url=browser_url,
+            sync_url=sync_url,
+            connected=False,
+        )
+    if str(transition.get("status")) == "expired":
+        return build_connect_payload(
+            state=transition,
+            browser_opened=browser_opened,
+            connect_url=browser_url,
+            sync_url=sync_url,
+            connected=False,
+        )
+    if str(transition.get("status")) == "retry_required":
+        return build_connect_payload(
+            state=transition,
+            browser_opened=browser_opened,
+            connect_url=browser_url,
+            sync_url=sync_url,
+            connected=False,
+        )
     try:
         sync_payload = sync_receipts(store)
     except RuntimeError as error:
         sync_message = str(error)
-        if _is_plan_limited_sync_error(sync_message):
-            return {
-                "connected": True,
-                "browser_opened": browser_opened,
-                "connect_url": browser_url,
-                "sync_url": sync_url,
-                "status": "paired_without_cloud_sync",
-                "request_id": str(completion["request_id"]),
-                "completed_at": completion.get("completed_at"),
-                "sync_message": sync_message,
-            }
-        raise RuntimeError(f"Guard paired successfully but sync failed: {sync_message}") from error
+        pending_state = daemon_client.report_connect_result(
+            request_id=str(connect_request["request_id"]),
+            status="connected",
+            milestone="first_sync_pending",
+            reason=sync_message,
+        )
+        return build_connect_payload(
+            state=pending_state,
+            browser_opened=browser_opened,
+            connect_url=browser_url,
+            sync_url=sync_url,
+            connected=True,
+            sync_message=sync_message,
+        )
     except (OSError, json.JSONDecodeError, urllib.error.URLError) as error:
-        raise RuntimeError(f"Guard paired successfully but sync failed: {error}") from error
-    return {
-        "connected": True,
-        "browser_opened": browser_opened,
-        "connect_url": browser_url,
-        "sync_url": sync_url,
-        "status": str(completion["status"]),
-        "request_id": str(completion["request_id"]),
-        "completed_at": completion.get("completed_at"),
-        "sync": sync_payload,
-    }
+        sync_message = str(error)
+        pending_state = daemon_client.report_connect_result(
+            request_id=str(connect_request["request_id"]),
+            status="connected",
+            milestone="first_sync_pending",
+            reason=sync_message,
+        )
+        return build_connect_payload(
+            state=pending_state,
+            browser_opened=browser_opened,
+            connect_url=browser_url,
+            sync_url=sync_url,
+            connected=True,
+            sync_message=sync_message,
+        )
+    final_state = daemon_client.report_connect_result(
+        request_id=str(connect_request["request_id"]),
+        status="connected",
+        milestone="first_sync_succeeded",
+        sync=sync_payload,
+    )
+    return build_connect_payload(
+        state=final_state,
+        browser_opened=browser_opened,
+        connect_url=browser_url,
+        sync_url=sync_url,
+        connected=True,
+        sync=sync_payload,
+    )
 
 
 def resolve_connect_url(connect_url: str) -> tuple[str, str]:
@@ -98,8 +142,6 @@ def resolve_connect_url(connect_url: str) -> tuple[str, str]:
 
 
 def _is_plan_limited_sync_error(message: str) -> bool:
-    """Match the stable plan-limit phrases returned by Guard Cloud sync today."""
-
     normalized = message.strip().lower()
     has_plan_limit_phrase = any(phrase in normalized for phrase in _PLAN_LIMITED_SYNC_PHRASES)
     if "guard" in normalized and has_plan_limit_phrase:
@@ -134,17 +176,75 @@ def build_guard_connect_browser_url(
     )
 
 
-def wait_for_connect_completion(
+def wait_for_connect_transition(
     *,
-    store: GuardStore,
+    daemon_client,
     request_id: str,
     timeout_seconds: int,
     poll_interval_seconds: float = 0.25,
 ) -> dict[str, object] | None:
     deadline = time.monotonic() + max(1, timeout_seconds)
     while time.monotonic() < deadline:
-        request = store.get_guard_connect_request(request_id)
-        if request is not None and str(request.get("status")) == "completed":
-            return request
+        state = daemon_client.get_connect_state(request_id=request_id)
+        if str(state.get("status")) in {"connected", "retry_required", "expired"}:
+            return state
+        if str(state.get("milestone")) == "first_sync_pending":
+            return state
         time.sleep(poll_interval_seconds)
     return None
+
+
+def build_connect_payload(
+    *,
+    state: dict[str, object],
+    browser_opened: bool,
+    connect_url: str,
+    sync_url: str,
+    connected: bool,
+    sync: dict[str, object] | None = None,
+    sync_message: str | None = None,
+) -> dict[str, object]:
+    milestones = [
+        {
+            "label": "browser_opened",
+            "status": "completed" if browser_opened else "pending",
+        },
+        {
+            "label": "pairing_completed",
+            "status": "completed" if state.get("completed_at") else "pending",
+        },
+        {
+            "label": "first_sync",
+            "status": _resolve_first_sync_milestone(state),
+        },
+    ]
+    payload = {
+        "connected": connected,
+        "browser_opened": browser_opened,
+        "connect_url": connect_url,
+        "sync_url": sync_url,
+        "status": str(state.get("status") or "waiting"),
+        "milestone": str(state.get("milestone") or "waiting_for_browser"),
+        "reason": state.get("reason"),
+        "request_id": state.get("request_id"),
+        "completed_at": state.get("completed_at"),
+        "expires_at": state.get("expires_at"),
+        "proof": dict(state.get("proof")) if isinstance(state.get("proof"), dict) else {},
+        "milestones": milestones,
+    }
+    if sync is not None:
+        payload["sync"] = sync
+    if sync_message is not None and sync_message.strip():
+        payload["sync_message"] = sync_message
+    return payload
+
+
+def _resolve_first_sync_milestone(state: dict[str, object]) -> str:
+    milestone = str(state.get("milestone") or "")
+    if milestone == "first_sync_succeeded":
+        return "completed"
+    if milestone == "first_sync_failed":
+        return "failed"
+    if milestone == "first_sync_pending":
+        return "waiting"
+    return "pending"

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -8,17 +8,12 @@ import urllib.error
 import urllib.parse
 from pathlib import Path
 
-from ..daemon import ensure_guard_daemon, load_guard_surface_daemon_client
+from ..daemon import GuardSurfaceDaemonClient, ensure_guard_daemon, load_guard_surface_daemon_client
 from ..runtime import sync_receipts
 from ..store import GuardStore
 
 DEFAULT_GUARD_SYNC_URL = "https://hol.org/api/guard/receipts/sync"
 DEFAULT_GUARD_CONNECT_URL = "https://hol.org/guard/connect"
-_PLAN_LIMITED_SYNC_PHRASES = (
-    "paid guard plan",
-    "guard plan required",
-    "guard plan upgrade",
-)
 
 
 def run_guard_connect_command(
@@ -83,23 +78,7 @@ def run_guard_connect_command(
         )
     try:
         sync_payload = sync_receipts(store)
-    except RuntimeError as error:
-        sync_message = str(error)
-        pending_state = daemon_client.report_connect_result(
-            request_id=str(connect_request["request_id"]),
-            status="connected",
-            milestone="first_sync_pending",
-            reason=sync_message,
-        )
-        return build_connect_payload(
-            state=pending_state,
-            browser_opened=browser_opened,
-            connect_url=browser_url,
-            sync_url=sync_url,
-            connected=True,
-            sync_message=sync_message,
-        )
-    except (OSError, json.JSONDecodeError, urllib.error.URLError) as error:
+    except (RuntimeError, OSError, json.JSONDecodeError, urllib.error.URLError) as error:
         sync_message = str(error)
         pending_state = daemon_client.report_connect_result(
             request_id=str(connect_request["request_id"]),
@@ -141,14 +120,6 @@ def resolve_connect_url(connect_url: str) -> tuple[str, str]:
     return normalized_url, allowed_origin
 
 
-def _is_plan_limited_sync_error(message: str) -> bool:
-    normalized = message.strip().lower()
-    has_plan_limit_phrase = any(phrase in normalized for phrase in _PLAN_LIMITED_SYNC_PHRASES)
-    if "guard" in normalized and has_plan_limit_phrase:
-        return True
-    return "guard" in normalized and "sync" in normalized and "guard plan" in normalized and "upgrade" in normalized
-
-
 def build_guard_connect_browser_url(
     *,
     connect_url: str,
@@ -178,7 +149,7 @@ def build_guard_connect_browser_url(
 
 def wait_for_connect_transition(
     *,
-    daemon_client,
+    daemon_client: GuardSurfaceDaemonClient,
     request_id: str,
     timeout_seconds: int,
     poll_interval_seconds: float = 0.25,

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -438,9 +438,12 @@ def _render_login(console: Console, payload: dict[str, object]) -> None:
 def _render_connect(console: Console, payload: dict[str, object]) -> None:
     if "connected" in payload or "browser_opened" in payload or "status" in payload:
         body = Table.grid(padding=(0, 1))
+        milestone = str(payload.get("milestone") or "")
         body.add_row("Connected", _bool_label(bool(payload.get("connected"))))
         body.add_row("Browser opened", _bool_label(bool(payload.get("browser_opened"))))
-        body.add_row("Status", str(payload.get("status") or "unknown"))
+        body.add_row("Status", _connect_status_text(payload))
+        if milestone:
+            body.add_row("Stage", _connect_milestone_text(milestone))
         body.add_row("Connect URL", str(payload.get("connect_url") or "unknown"))
         body.add_row("Sync endpoint", str(payload.get("sync_url") or "unknown"))
         sync_payload = payload.get("sync")
@@ -491,6 +494,36 @@ def _render_sync(console: Console, payload: dict[str, object]) -> None:
     body.add_row("Receipts stored", str(payload.get("receipts_stored") or 0))
     body.add_row("Advisories stored", str(payload.get("advisories_stored") or 0))
     console.print(Panel(body, title="Guard sync complete", border_style="green"))
+
+
+def _connect_status_text(payload: dict[str, object]) -> str:
+    status = str(payload.get("status") or "unknown")
+    milestone = str(payload.get("milestone") or "")
+    if status == "connected" and milestone == "first_sync_pending":
+        return "Paired locally"
+    if status == "connected" and milestone == "first_sync_succeeded":
+        return "Connected"
+    if status == "waiting":
+        return "Waiting for the browser"
+    if status == "retry_required":
+        return "Retry required"
+    if status == "expired":
+        return "Expired"
+    return status
+
+
+def _connect_milestone_text(milestone: str) -> str:
+    if milestone == "waiting_for_browser":
+        return "Waiting for browser approval"
+    if milestone == "first_sync_pending":
+        return "First shared proof is still on the way"
+    if milestone == "first_sync_succeeded":
+        return "First shared proof reached the dashboard"
+    if milestone == "first_sync_failed":
+        return "First shared proof needs another try"
+    if milestone == "expired":
+        return "The request expired before pairing finished"
+    return milestone.replace("_", " ")
 
 
 def _render_hook(console: Console, payload: dict[str, object]) -> None:

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import shutil
 import sqlite3
+import time
 from dataclasses import dataclass, replace
 from pathlib import Path
 
@@ -24,6 +25,8 @@ NON_MIGRATED_GUARD_RUNTIME_FILES = frozenset(
         "guard.db-wal",
     }
 )
+GUARD_DB_BACKUP_TIMEOUT_SECONDS = 5.0
+GUARD_DB_BACKUP_SLEEP_SECONDS = 0.05
 WORKSPACE_CONFIG_FILENAMES = (".ai-plugin-scanner-guard.toml", ".hol-guard.toml")
 VALID_GUARD_ACTIONS = {"allow", "warn", "review", "block", "sandbox-required", "require-reapproval"}
 VALID_GUARD_MODES = {"observe", "prompt", "enforce"}
@@ -223,14 +226,28 @@ def _migrate_guard_home_state(*, source: Path, destination: Path) -> None:
 
 def _copy_guard_database(*, source: Path, destination: Path) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary_destination = destination.with_name(f"{destination.name}.migrating")
+    deadline = time.monotonic() + GUARD_DB_BACKUP_TIMEOUT_SECONDS
     try:
         with (
             sqlite3.connect(f"file:{source}?mode=ro", uri=True) as source_connection,
-            sqlite3.connect(destination) as destination_connection,
+            sqlite3.connect(temporary_destination) as destination_connection,
         ):
-            source_connection.backup(destination_connection)
-    except sqlite3.Error:
-        shutil.copy2(source, destination)
+            source_connection.backup(
+                destination_connection,
+                pages=128,
+                progress=lambda *_: _raise_when_backup_deadline_elapsed(deadline),
+                sleep=GUARD_DB_BACKUP_SLEEP_SECONDS,
+            )
+        temporary_destination.replace(destination)
+    except (TimeoutError, sqlite3.Error):
+        if temporary_destination.exists():
+            temporary_destination.unlink()
+
+
+def _raise_when_backup_deadline_elapsed(deadline: float) -> None:
+    if time.monotonic() >= deadline:
+        raise TimeoutError("guard.db migration timed out")
 
 
 def _load_workspace_guard_config(workspace: Path | None) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import shutil
 import sqlite3
+import tempfile
 import time
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -30,6 +31,10 @@ GUARD_DB_BACKUP_SLEEP_SECONDS = 0.05
 WORKSPACE_CONFIG_FILENAMES = (".ai-plugin-scanner-guard.toml", ".hol-guard.toml")
 VALID_GUARD_ACTIONS = {"allow", "warn", "review", "block", "sandbox-required", "require-reapproval"}
 VALID_GUARD_MODES = {"observe", "prompt", "enforce"}
+
+
+class GuardHomeMigrationError(RuntimeError):
+    """Raised when legacy Guard state cannot be migrated safely."""
 
 
 def _coerce_action_map(payload: object) -> dict[str, GuardAction]:
@@ -101,7 +106,10 @@ def resolve_guard_home(override: str | None = None) -> Path:
     if _guard_home_has_state(canonical_home):
         return canonical_home
     if _guard_home_has_sync_credentials(legacy_home) or _guard_home_has_state(legacy_home):
-        _migrate_guard_home_state(source=legacy_home, destination=canonical_home)
+        try:
+            _migrate_guard_home_transactionally(source=legacy_home, destination=canonical_home)
+        except GuardHomeMigrationError:
+            return legacy_home
         return canonical_home
     return canonical_home
 
@@ -224,6 +232,18 @@ def _migrate_guard_home_state(*, source: Path, destination: Path) -> None:
         shutil.copy2(entry, target)
 
 
+def _migrate_guard_home_transactionally(*, source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=destination.parent, prefix=f"{destination.name}-migration-") as temp_dir:
+        staging_root = Path(temp_dir)
+        _migrate_guard_home_state(source=source, destination=staging_root)
+        if destination.exists():
+            for entry in staging_root.iterdir():
+                shutil.move(str(entry), destination / entry.name)
+            return
+        shutil.move(str(staging_root), str(destination))
+
+
 def _copy_guard_database(*, source: Path, destination: Path) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
     temporary_destination = destination.with_name(f"{destination.name}.migrating")
@@ -243,6 +263,7 @@ def _copy_guard_database(*, source: Path, destination: Path) -> None:
     except (TimeoutError, sqlite3.Error):
         if temporary_destination.exists():
             temporary_destination.unlink()
+        raise GuardHomeMigrationError("guard.db migration failed") from None
 
 
 def _raise_when_backup_deadline_elapsed(deadline: float) -> None:

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -16,6 +16,7 @@ from .models import GuardAction, GuardMode
 
 DEFAULT_GUARD_DIRNAME = ".hol-guard"
 LEGACY_GUARD_DIRNAMES = (".config/.ai-plugin-scanner-guard", ".ai-plugin-scanner-guard", ".holguard")
+NON_MIGRATED_GUARD_RUNTIME_FILES = frozenset({"daemon-state.json"})
 WORKSPACE_CONFIG_FILENAMES = (".ai-plugin-scanner-guard.toml", ".hol-guard.toml")
 VALID_GUARD_ACTIONS = {"allow", "warn", "review", "block", "sandbox-required", "require-reapproval"}
 VALID_GUARD_MODES = {"observe", "prompt", "enforce"}
@@ -194,6 +195,8 @@ def _migrate_guard_home_state(*, source: Path, destination: Path) -> None:
     destination.mkdir(parents=True, exist_ok=True)
     replace_database = not _guard_home_has_sync_credentials(destination) and not _guard_home_has_state(destination)
     for entry in source.iterdir():
+        if entry.name in NON_MIGRATED_GUARD_RUNTIME_FILES:
+            continue
         target = destination / entry.name
         if target.exists():
             if entry.is_dir() and target.is_dir():

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -16,7 +16,14 @@ from .models import GuardAction, GuardMode
 
 DEFAULT_GUARD_DIRNAME = ".hol-guard"
 LEGACY_GUARD_DIRNAMES = (".config/.ai-plugin-scanner-guard", ".ai-plugin-scanner-guard", ".holguard")
-NON_MIGRATED_GUARD_RUNTIME_FILES = frozenset({"daemon-state.json"})
+NON_MIGRATED_GUARD_RUNTIME_FILES = frozenset(
+    {
+        "daemon-state.json",
+        "guard.db-journal",
+        "guard.db-shm",
+        "guard.db-wal",
+    }
+)
 WORKSPACE_CONFIG_FILENAMES = (".ai-plugin-scanner-guard.toml", ".hol-guard.toml")
 VALID_GUARD_ACTIONS = {"allow", "warn", "review", "block", "sandbox-required", "require-reapproval"}
 VALID_GUARD_MODES = {"observe", "prompt", "enforce"}
@@ -217,9 +224,10 @@ def _migrate_guard_home_state(*, source: Path, destination: Path) -> None:
 def _copy_guard_database(*, source: Path, destination: Path) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
     try:
-        with sqlite3.connect(f"file:{source}?mode=ro", uri=True) as source_connection, sqlite3.connect(
-            destination
-        ) as destination_connection:
+        with (
+            sqlite3.connect(f"file:{source}?mode=ro", uri=True) as source_connection,
+            sqlite3.connect(destination) as destination_connection,
+        ):
             source_connection.backup(destination_connection)
     except sqlite3.Error:
         shutil.copy2(source, destination)

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -196,6 +196,9 @@ def _migrate_guard_home_state(*, source: Path, destination: Path) -> None:
     for entry in source.iterdir():
         target = destination / entry.name
         if target.exists():
+            if entry.is_dir() and target.is_dir():
+                _migrate_guard_home_state(source=entry, destination=target)
+                continue
             if replace_database and entry.name == "guard.db" and entry.is_file():
                 shutil.copy2(entry, target)
             continue

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -234,14 +234,17 @@ def _migrate_guard_home_state(*, source: Path, destination: Path) -> None:
 
 def _migrate_guard_home_transactionally(*, source: Path, destination: Path) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.TemporaryDirectory(dir=destination.parent, prefix=f"{destination.name}-migration-") as temp_dir:
-        staging_root = Path(temp_dir)
-        _migrate_guard_home_state(source=source, destination=staging_root)
-        if destination.exists():
-            for entry in staging_root.iterdir():
-                shutil.move(str(entry), destination / entry.name)
-            return
-        shutil.move(str(staging_root), str(destination))
+    try:
+        with tempfile.TemporaryDirectory(dir=destination.parent, prefix=f"{destination.name}-migration-") as temp_dir:
+            staging_root = Path(temp_dir)
+            _migrate_guard_home_state(source=source, destination=staging_root)
+            if destination.exists():
+                for entry in staging_root.iterdir():
+                    shutil.move(str(entry), destination / entry.name)
+                return
+            shutil.move(str(staging_root), str(destination))
+    except OSError:
+        raise GuardHomeMigrationError("guard home migration failed") from None
 
 
 def _copy_guard_database(*, source: Path, destination: Path) -> None:

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -236,15 +236,22 @@ def _migrate_guard_home_transactionally(*, source: Path, destination: Path) -> N
     destination.parent.mkdir(parents=True, exist_ok=True)
     try:
         with tempfile.TemporaryDirectory(dir=destination.parent, prefix=f"{destination.name}-migration-") as temp_dir:
-            staging_root = Path(temp_dir)
+            staging_root = Path(temp_dir) / destination.name
             _migrate_guard_home_state(source=source, destination=staging_root)
             if destination.exists():
-                for entry in staging_root.iterdir():
-                    shutil.move(str(entry), destination / entry.name)
-                return
+                _remove_guard_home_destination(destination)
             shutil.move(str(staging_root), str(destination))
     except OSError:
         raise GuardHomeMigrationError("guard home migration failed") from None
+
+
+def _remove_guard_home_destination(path: Path) -> None:
+    for entry in path.iterdir():
+        if entry.is_dir():
+            shutil.rmtree(entry)
+            continue
+        entry.unlink()
+    path.rmdir()
 
 
 def _copy_guard_database(*, source: Path, destination: Path) -> None:

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -203,12 +203,26 @@ def _migrate_guard_home_state(*, source: Path, destination: Path) -> None:
                 _migrate_guard_home_state(source=entry, destination=target)
                 continue
             if replace_database and entry.name == "guard.db" and entry.is_file():
-                shutil.copy2(entry, target)
+                _copy_guard_database(source=entry, destination=target)
             continue
         if entry.is_dir():
             shutil.copytree(entry, target)
             continue
+        if entry.name == "guard.db" and entry.is_file():
+            _copy_guard_database(source=entry, destination=target)
+            continue
         shutil.copy2(entry, target)
+
+
+def _copy_guard_database(*, source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with sqlite3.connect(f"file:{source}?mode=ro", uri=True) as source_connection, sqlite3.connect(
+            destination
+        ) as destination_connection:
+            source_connection.backup(destination_connection)
+    except sqlite3.Error:
+        shutil.copy2(source, destination)
 
 
 def _load_workspace_guard_config(workspace: Path | None) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 import sqlite3
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -88,11 +89,10 @@ def resolve_guard_home(override: str | None = None) -> Path:
         return canonical_home
     if _guard_home_has_state(canonical_home):
         return canonical_home
-    if _guard_home_has_sync_credentials(legacy_home):
-        return legacy_home
-    if canonical_home.exists() and _guard_home_has_state(legacy_home):
-        return legacy_home
-    return legacy_home if not canonical_home.exists() else canonical_home
+    if _guard_home_has_sync_credentials(legacy_home) or _guard_home_has_state(legacy_home):
+        _migrate_guard_home_state(source=legacy_home, destination=canonical_home)
+        return canonical_home
+    return canonical_home
 
 
 def _read_toml(path: Path) -> dict[str, object]:
@@ -186,6 +186,23 @@ def _existing_legacy_guard_home() -> Path | None:
         if candidate.exists():
             return candidate
     return None
+
+
+def _migrate_guard_home_state(*, source: Path, destination: Path) -> None:
+    if not source.exists():
+        return
+    destination.mkdir(parents=True, exist_ok=True)
+    replace_database = not _guard_home_has_sync_credentials(destination) and not _guard_home_has_state(destination)
+    for entry in source.iterdir():
+        target = destination / entry.name
+        if target.exists():
+            if replace_database and entry.name == "guard.db" and entry.is_file():
+                shutil.copy2(entry, target)
+            continue
+        if entry.is_dir():
+            shutil.copytree(entry, target)
+            continue
+        shutil.copy2(entry, target)
 
 
 def _load_workspace_guard_config(workspace: Path | None) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/daemon/client.py
+++ b/src/codex_plugin_scanner/guard/daemon/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 
@@ -136,6 +137,52 @@ class GuardSurfaceDaemonClient:
                 "lifetime_seconds": lifetime_seconds,
             },
         )
+
+    def get_connect_state(self, *, request_id: str) -> dict[str, object]:
+        query = urllib.parse.urlencode({"request_id": request_id})
+        request = urllib.request.Request(
+            f"{self.daemon_url}/v1/connect/state?{query}",
+            headers={
+                "X-Guard-Token": self.auth_token,
+            },
+            method="GET",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=5) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as error:
+            try:
+                payload = json.loads(error.read().decode("utf-8"))
+                message = payload.get("error", str(error))
+            except (OSError, json.JSONDecodeError):
+                message = str(error)
+            raise RuntimeError(f"Guard daemon request failed: {message}") from error
+        state = payload.get("state")
+        if isinstance(state, dict):
+            return state
+        return payload
+
+    def report_connect_result(
+        self,
+        *,
+        request_id: str,
+        status: str,
+        milestone: str,
+        reason: str | None = None,
+        sync: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        payload = {
+            "request_id": request_id,
+            "status": status,
+            "milestone": milestone,
+            "reason": reason,
+            "sync": sync or {},
+        }
+        response = self._post("/v1/connect/result", payload)
+        state = response.get("state")
+        if isinstance(state, dict):
+            return state
+        return response
 
     def _post(self, path: str, payload: dict[str, object]) -> dict[str, object]:
         request = urllib.request.Request(

--- a/src/codex_plugin_scanner/guard/daemon/client.py
+++ b/src/codex_plugin_scanner/guard/daemon/client.py
@@ -149,14 +149,16 @@ class GuardSurfaceDaemonClient:
         )
         try:
             with urllib.request.urlopen(request, timeout=5) as response:
-                payload = json.loads(response.read().decode("utf-8"))
+                payload = self._decode_json_response(response.read().decode("utf-8"))
         except urllib.error.HTTPError as error:
             try:
-                payload = json.loads(error.read().decode("utf-8"))
+                payload = self._decode_json_response(error.read().decode("utf-8"))
                 message = payload.get("error", str(error))
             except (OSError, json.JSONDecodeError):
                 message = str(error)
             raise RuntimeError(f"Guard daemon request failed: {message}") from error
+        except (OSError, urllib.error.URLError, json.JSONDecodeError) as error:
+            raise RuntimeError(f"Guard daemon request failed: {error}") from error
         state = payload.get("state")
         if isinstance(state, dict):
             return state
@@ -196,16 +198,23 @@ class GuardSurfaceDaemonClient:
         )
         try:
             with urllib.request.urlopen(request, timeout=5) as response:
-                return json.loads(response.read().decode("utf-8"))
+                return self._decode_json_response(response.read().decode("utf-8"))
         except urllib.error.HTTPError as error:
             try:
-                payload = json.loads(error.read().decode("utf-8"))
+                payload = self._decode_json_response(error.read().decode("utf-8"))
                 message = payload.get("error", str(error))
             except (OSError, json.JSONDecodeError):
                 message = str(error)
             raise RuntimeError(f"Guard daemon request failed: {message}") from error
-        except (OSError, urllib.error.URLError) as error:
+        except (OSError, urllib.error.URLError, json.JSONDecodeError) as error:
             raise RuntimeError(f"Guard daemon request failed: {error}") from error
+
+    @staticmethod
+    def _decode_json_response(raw_payload: str) -> dict[str, object]:
+        payload = json.loads(raw_payload)
+        if not isinstance(payload, dict):
+            raise json.JSONDecodeError("Guard daemon returned a non-object response", raw_payload, 0)
+        return payload
 
 
 def load_guard_surface_daemon_client(guard_home: Path) -> GuardSurfaceDaemonClient:

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 DEFAULT_GUARD_DAEMON_PORT = 4781
 GUARD_DAEMON_PORT_RANGE = 1000
+REQUIRED_DAEMON_TABLES = frozenset({"guard_connect_states"})
 
 
 def ensure_guard_daemon(guard_home: Path) -> str:
@@ -64,9 +65,9 @@ def load_guard_daemon_url(guard_home: Path) -> str | None:
     url = f"http://127.0.0.1:{port}"
     try:
         with urllib.request.urlopen(f"{url}/healthz", timeout=1) as response:
-            if response.status == 200:
+            if response.status == 200 and _healthz_payload_is_current(response.read().decode("utf-8")):
                 return url
-    except (OSError, urllib.error.URLError):
+    except (OSError, ValueError, urllib.error.URLError):
         return None
     return None
 
@@ -137,3 +138,14 @@ def _candidate_ports(guard_home: Path) -> list[int]:
         candidate_offset = (offset + step) % GUARD_DAEMON_PORT_RANGE
         ports.append(DEFAULT_GUARD_DAEMON_PORT + candidate_offset)
     return ports
+
+
+def _healthz_payload_is_current(raw_payload: str) -> bool:
+    payload = json.loads(raw_payload)
+    if not isinstance(payload, dict):
+        return False
+    tables = payload.get("tables")
+    if not isinstance(tables, list):
+        return False
+    table_names = {table for table in tables if isinstance(table, str)}
+    return REQUIRED_DAEMON_TABLES.issubset(table_names)

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -44,12 +44,15 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
 
     def do_OPTIONS(self) -> None:
         parsed = urlparse(self.path)
-        if parsed.path == "/v1/connect/complete":
+        if parsed.path in {"/v1/connect/complete", "/v1/connect/state"}:
             origin = self._normalize_origin(self.headers.get("Origin"))
             if origin is None:
                 self._write_empty(status=400)
                 return
-            self._write_empty(status=200, extra_headers=self._cors_headers(origin))
+            self._write_empty(
+                status=200,
+                extra_headers=self._cors_headers(origin, allow_methods="GET, POST, OPTIONS"),
+            )
             return
         self._write_empty(status=404)
 
@@ -97,6 +100,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         if parsed.path == "/v1/requests":
             self._write_json({"items": store.list_approval_requests(limit=200)})
+            return
+        if parsed.path == "/v1/connect/state":
+            self._handle_connect_state_read(parsed.query)
             return
         if len(path_parts) == 3 and path_parts[:2] == ["v1", "requests"]:
             approval = store.get_approval_request(path_parts[2])
@@ -217,6 +223,12 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         if parsed.path == "/v1/connect/complete":
             self._handle_connect_complete(payload)
+            return
+        if parsed.path == "/v1/connect/result":
+            if not self._header_token_is_valid():
+                self._write_json({"error": "unauthorized"}, status=401)
+                return
+            self._handle_connect_result_update(payload)
             return
         if parsed.path == "/v1/operations/block":
             if not self._header_token_is_valid():
@@ -532,6 +544,72 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             extra_headers=self._cors_headers(origin),
         )
 
+    def _handle_connect_state_read(self, query: str) -> None:
+        params = parse_qs(query)
+        request_id = self._optional_string(params.get("request_id", [None])[-1])
+        pairing_secret = self._optional_string(params.get("pairing_secret", [None])[-1])
+        origin = self._normalize_origin(self.headers.get("Origin"))
+        if request_id is None:
+            self._write_json({"error": "missing_required_fields"}, status=400)
+            return
+        if self._header_token_is_valid():
+            state = self.server.store.get_guard_connect_state(request_id, now=_now())  # type: ignore[attr-defined]
+            if state is None:
+                self._write_json({"error": "not_found"}, status=404)
+                return
+            self._write_json({"state": state})
+            return
+        if origin is None or pairing_secret is None:
+            self._write_json({"error": "unauthorized"}, status=401)
+            return
+        access = self.server.store.verify_guard_connect_access(  # type: ignore[attr-defined]
+            request_id=request_id,
+            pairing_secret=pairing_secret,
+        )
+        if access is None:
+            self._write_json({"error": "forbidden"}, status=403, extra_headers=self._cors_headers(origin))
+            return
+        if origin != str(access["allowed_origin"]):
+            self._write_json(
+                {"error": "forbidden_origin"},
+                status=403,
+                extra_headers=self._cors_headers(origin),
+            )
+            return
+        state = self.server.store.get_guard_connect_state(request_id, now=_now())  # type: ignore[attr-defined]
+        if state is None:
+            self._write_json({"error": "not_found"}, status=404, extra_headers=self._cors_headers(origin))
+            return
+        self._write_json({"state": state}, extra_headers=self._cors_headers(origin))
+
+    def _handle_connect_result_update(self, payload: dict[str, object]) -> None:
+        request_id = self._optional_string(payload.get("request_id"))
+        status = self._optional_string(payload.get("status"))
+        milestone = self._optional_string(payload.get("milestone"))
+        reason = self._optional_string(payload.get("reason"))
+        sync_payload = payload.get("sync")
+        if request_id is None or status is None or milestone is None:
+            self._write_json({"error": "missing_required_fields"}, status=400)
+            return
+        normalized_sync_payload = dict(sync_payload) if isinstance(sync_payload, dict) else None
+        try:
+            state = self.server.store.record_guard_connect_result(  # type: ignore[attr-defined]
+                request_id=request_id,
+                status=status,
+                milestone=milestone,
+                now=_now(),
+                reason=reason,
+                sync_payload=normalized_sync_payload,
+            )
+        except ValueError as error:
+            error_code = str(error)
+            status_code = 400
+            if error_code == "connect_state_not_found":
+                status_code = 404
+            self._write_json({"error": error_code}, status=status_code)
+            return
+        self._write_json({"state": state})
+
     def _token_is_valid(self, query: str) -> bool:
         params = parse_qs(query)
         token = params.get("token", [None])[-1]
@@ -608,10 +686,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         return f"{parsed.scheme}://{host}{port_suffix}"
 
     @staticmethod
-    def _cors_headers(origin: str) -> dict[str, str]:
+    def _cors_headers(origin: str, *, allow_methods: str = "POST, OPTIONS") -> dict[str, str]:
         return {
             "Access-Control-Allow-Origin": origin,
-            "Access-Control-Allow-Methods": "POST, OPTIONS",
+            "Access-Control-Allow-Methods": allow_methods,
             "Access-Control-Allow-Headers": "Content-Type",
             "Vary": "Origin",
         }

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -38,13 +38,27 @@ from .store_connect import (
 )
 from .store_connect import (
     connect_request_schema_statement,
+    connect_state_schema_statement,
     hash_pairing_secret,
+    verify_connect_request_access,
 )
 from .store_connect import (
     create_connect_request as persist_connect_request,
 )
 from .store_connect import (
+    create_connect_state as persist_connect_state,
+)
+from .store_connect import (
     get_connect_request as load_connect_request,
+)
+from .store_connect import (
+    get_connect_state as load_connect_state,
+)
+from .store_connect import (
+    mark_connect_pairing_completed as persist_connect_pairing_completed,
+)
+from .store_connect import (
+    mark_connect_result as persist_connect_result,
 )
 
 
@@ -265,6 +279,7 @@ class GuardStore:
             )
             """,
             connect_request_schema_statement(),
+            connect_state_schema_statement(),
             approval_schema_statement(),
         )
         with self._connect() as connection:
@@ -1273,11 +1288,29 @@ class GuardStore:
                 created_at=str(payload["created_at"]),
                 expires_at=str(payload["expires_at"]),
             )
+            persist_connect_state(
+                connection,
+                request_id=request_id,
+                sync_url=sync_url,
+                allowed_origin=allowed_origin,
+                created_at=str(payload["created_at"]),
+                expires_at=str(payload["expires_at"]),
+                updated_at=now,
+            )
         return {**payload, "pairing_secret": pairing_secret}
 
     def get_guard_connect_request(self, request_id: str) -> dict[str, object] | None:
         with self._connect() as connection:
             return load_connect_request(connection, request_id)
+
+    def get_guard_connect_state(
+        self,
+        request_id: str,
+        *,
+        now: str,
+    ) -> dict[str, object] | None:
+        with self._connect() as connection:
+            return load_connect_state(connection, request_id, now=now)
 
     def complete_guard_connect_request(
         self,
@@ -1302,7 +1335,46 @@ class GuardStore:
                 """,
                 ("sign_in", json.dumps({"sync_url": request["sync_url"], "source": "browser-connect"}), now),
             )
+            persist_connect_pairing_completed(
+                connection,
+                request_id=request_id,
+                completed_at=now,
+            )
         return request
+
+    def record_guard_connect_result(
+        self,
+        *,
+        request_id: str,
+        status: str,
+        milestone: str,
+        now: str,
+        reason: str | None = None,
+        sync_payload: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        with self._connect() as connection:
+            return persist_connect_result(
+                connection,
+                request_id=request_id,
+                status=status,
+                milestone=milestone,
+                updated_at=now,
+                reason=reason,
+                sync_payload=sync_payload,
+            )
+
+    def verify_guard_connect_access(
+        self,
+        *,
+        request_id: str,
+        pairing_secret: str,
+    ) -> dict[str, object] | None:
+        with self._connect() as connection:
+            return verify_connect_request_access(
+                connection,
+                request_id=request_id,
+                pairing_secret=pairing_secret,
+            )
 
     def _set_sync_credentials_in_connection(
         self,

--- a/src/codex_plugin_scanner/guard/store_connect.py
+++ b/src/codex_plugin_scanner/guard/store_connect.py
@@ -245,7 +245,8 @@ def mark_connect_pairing_completed(
     connection.execute(
         """
         update guard_connect_states
-        set milestone = 'first_sync_pending',
+        set status = 'connected',
+            milestone = 'first_sync_pending',
             reason = 'waiting_for_first_sync',
             updated_at = ?,
             completed_at = ?,

--- a/src/codex_plugin_scanner/guard/store_connect.py
+++ b/src/codex_plugin_scanner/guard/store_connect.py
@@ -259,9 +259,9 @@ def mark_connect_result(
     proof = _coerce_proof(state.get("proof"))
     if sync_payload is not None:
         proof["first_synced_at"] = sync_payload.get("synced_at")
-        proof["receipts_stored"] = int(sync_payload.get("receipts_stored") or 0)
-        proof["inventory_items"] = int(
-            sync_payload.get("inventory_tracked", sync_payload.get("inventory")) or 0
+        proof["receipts_stored"] = _coerce_non_negative_int(sync_payload.get("receipts_stored"))
+        proof["inventory_items"] = _coerce_non_negative_int(
+            sync_payload.get("inventory_tracked", sync_payload.get("inventory"))
         )
     connection.execute(
         """
@@ -396,6 +396,19 @@ def build_connect_state_response(
     response["poll_after_ms"] = poll_after_ms if poll_after_ms is not None else _resolve_poll_after_ms(response)
     response["proof"] = _coerce_proof(response.get("proof"))
     return response
+
+
+def _coerce_non_negative_int(value: object) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return max(0, value)
+    if isinstance(value, str) and value.strip():
+        try:
+            return max(0, int(value.strip()))
+        except ValueError:
+            return 0
+    return 0
 
 
 def _hash_secret(value: str) -> str:

--- a/src/codex_plugin_scanner/guard/store_connect.py
+++ b/src/codex_plugin_scanner/guard/store_connect.py
@@ -3,9 +3,20 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import secrets
 import sqlite3
 from datetime import datetime, timedelta, timezone
+
+CONNECT_STATE_VERSION = "guard-connect-state.v1"
+CONNECT_STATE_STATUS_VALUES = {"waiting", "connected", "retry_required", "expired"}
+CONNECT_STATE_MILESTONE_VALUES = {
+    "waiting_for_browser",
+    "first_sync_pending",
+    "first_sync_succeeded",
+    "first_sync_failed",
+    "expired",
+}
 
 
 def connect_request_schema_statement() -> str:
@@ -19,6 +30,24 @@ def connect_request_schema_statement() -> str:
           created_at text not null,
           expires_at text not null,
           completed_at text
+        )
+        """
+
+
+def connect_state_schema_statement() -> str:
+    return """
+        create table if not exists guard_connect_states (
+          request_id text primary key,
+          sync_url text not null,
+          allowed_origin text not null,
+          status text not null,
+          milestone text not null,
+          reason text,
+          created_at text not null,
+          updated_at text not null,
+          expires_at text not null,
+          completed_at text,
+          proof_json text not null default '{}'
         )
         """
 
@@ -80,6 +109,203 @@ def get_connect_request(
         "created_at": str(row["created_at"]),
         "expires_at": str(row["expires_at"]),
         "completed_at": str(row["completed_at"]) if row["completed_at"] is not None else None,
+    }
+
+
+def create_connect_state(
+    connection: sqlite3.Connection,
+    *,
+    request_id: str,
+    sync_url: str,
+    allowed_origin: str,
+    created_at: str,
+    expires_at: str,
+    updated_at: str,
+) -> dict[str, object]:
+    proof = {
+        "pairing_completed_at": None,
+        "first_synced_at": None,
+        "receipts_stored": 0,
+        "inventory_items": 0,
+    }
+    connection.execute(
+        """
+        insert into guard_connect_states (
+          request_id,
+          sync_url,
+          allowed_origin,
+          status,
+          milestone,
+          reason,
+          created_at,
+          updated_at,
+          expires_at,
+          completed_at,
+          proof_json
+        )
+        values (?, ?, ?, 'waiting', 'waiting_for_browser', 'waiting_for_browser', ?, ?, ?, null, ?)
+        """,
+        (
+            request_id,
+            sync_url,
+            allowed_origin,
+            created_at,
+            updated_at,
+            expires_at,
+            json.dumps(proof),
+        ),
+    )
+    return get_connect_state(connection, request_id, now=updated_at) or {}
+
+
+def get_connect_state(
+    connection: sqlite3.Connection,
+    request_id: str,
+    *,
+    now: str | None = None,
+) -> dict[str, object] | None:
+    row = connection.execute(
+        """
+        select request_id, sync_url, allowed_origin, status, milestone, reason,
+               created_at, updated_at, expires_at, completed_at, proof_json
+        from guard_connect_states
+        where request_id = ?
+        """,
+        (request_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    payload = _build_connect_state_payload(row)
+    if now is not None and payload["status"] == "waiting":
+        expires_at = _parse_timestamp(str(payload["expires_at"]))
+        if expires_at <= _parse_timestamp(now):
+            connection.execute(
+                """
+                update guard_connect_states
+                set status = 'expired',
+                    milestone = 'expired',
+                    reason = 'request_expired',
+                    updated_at = ?
+                where request_id = ?
+                """,
+                (now, request_id),
+            )
+            connection.execute(
+                """
+                update guard_connect_requests
+                set status = 'expired'
+                where request_id = ? and status = 'pending'
+                """,
+                (request_id,),
+            )
+            row = connection.execute(
+                """
+                select request_id, sync_url, allowed_origin, status, milestone, reason,
+                       created_at, updated_at, expires_at, completed_at, proof_json
+                from guard_connect_states
+                where request_id = ?
+                """,
+                (request_id,),
+            ).fetchone()
+            if row is None:
+                return None
+            payload = _build_connect_state_payload(row)
+    return payload
+
+
+def mark_connect_pairing_completed(
+    connection: sqlite3.Connection,
+    *,
+    request_id: str,
+    completed_at: str,
+) -> dict[str, object]:
+    state = get_connect_state(connection, request_id, now=completed_at)
+    if state is None:
+        raise ValueError("connect_state_not_found")
+    proof = _coerce_proof(state.get("proof"))
+    proof["pairing_completed_at"] = completed_at
+    connection.execute(
+        """
+        update guard_connect_states
+        set milestone = 'first_sync_pending',
+            reason = 'waiting_for_first_sync',
+            updated_at = ?,
+            completed_at = ?,
+            proof_json = ?
+        where request_id = ?
+        """,
+        (completed_at, completed_at, json.dumps(proof), request_id),
+    )
+    return get_connect_state(connection, request_id, now=completed_at) or {}
+
+
+def mark_connect_result(
+    connection: sqlite3.Connection,
+    *,
+    request_id: str,
+    status: str,
+    milestone: str,
+    updated_at: str,
+    reason: str | None = None,
+    sync_payload: dict[str, object] | None = None,
+) -> dict[str, object]:
+    if status not in CONNECT_STATE_STATUS_VALUES:
+        raise ValueError("invalid_connect_state_status")
+    if milestone not in CONNECT_STATE_MILESTONE_VALUES:
+        raise ValueError("invalid_connect_state_milestone")
+    state = get_connect_state(connection, request_id, now=updated_at)
+    if state is None:
+        raise ValueError("connect_state_not_found")
+    proof = _coerce_proof(state.get("proof"))
+    if sync_payload is not None:
+        proof["first_synced_at"] = sync_payload.get("synced_at")
+        proof["receipts_stored"] = int(sync_payload.get("receipts_stored") or 0)
+        proof["inventory_items"] = int(
+            sync_payload.get("inventory_tracked", sync_payload.get("inventory")) or 0
+        )
+    connection.execute(
+        """
+        update guard_connect_states
+        set status = ?,
+            milestone = ?,
+            reason = ?,
+            updated_at = ?,
+            proof_json = ?
+        where request_id = ?
+        """,
+        (
+            status,
+            milestone,
+            reason,
+            updated_at,
+            json.dumps(proof),
+            request_id,
+        ),
+    )
+    return get_connect_state(connection, request_id, now=updated_at) or {}
+
+
+def verify_connect_request_access(
+    connection: sqlite3.Connection,
+    *,
+    request_id: str,
+    pairing_secret: str,
+) -> dict[str, object] | None:
+    row = connection.execute(
+        """
+        select request_id, allowed_origin, pairing_secret_hash
+        from guard_connect_requests
+        where request_id = ?
+        """,
+        (request_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    if not secrets.compare_digest(str(row["pairing_secret_hash"]), _hash_secret(pairing_secret)):
+        return None
+    return {
+        "request_id": str(row["request_id"]),
+        "allowed_origin": str(row["allowed_origin"]),
     }
 
 
@@ -160,8 +386,56 @@ def hash_pairing_secret(pairing_secret: str) -> str:
     return _hash_secret(pairing_secret)
 
 
+def build_connect_state_response(
+    payload: dict[str, object],
+    *,
+    poll_after_ms: int | None = None,
+) -> dict[str, object]:
+    response = dict(payload)
+    response["version"] = CONNECT_STATE_VERSION
+    response["poll_after_ms"] = poll_after_ms if poll_after_ms is not None else _resolve_poll_after_ms(response)
+    response["proof"] = _coerce_proof(response.get("proof"))
+    return response
+
+
 def _hash_secret(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _build_connect_state_payload(row: sqlite3.Row) -> dict[str, object]:
+    payload = {
+        "request_id": str(row["request_id"]),
+        "sync_url": str(row["sync_url"]),
+        "allowed_origin": str(row["allowed_origin"]),
+        "status": str(row["status"]),
+        "milestone": str(row["milestone"]),
+        "reason": str(row["reason"]) if row["reason"] is not None else None,
+        "created_at": str(row["created_at"]),
+        "updated_at": str(row["updated_at"]),
+        "expires_at": str(row["expires_at"]),
+        "completed_at": str(row["completed_at"]) if row["completed_at"] is not None else None,
+        "proof": _coerce_proof(row["proof_json"]),
+    }
+    return build_connect_state_response(payload)
+
+
+def _coerce_proof(value: object) -> dict[str, object]:
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(parsed, dict):
+            return dict(parsed)
+    return {}
+
+
+def _resolve_poll_after_ms(payload: dict[str, object]) -> int:
+    if str(payload.get("status")) == "waiting":
+        return 1500
+    return 0
 
 
 def _parse_timestamp(value: str) -> datetime:

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -443,6 +443,43 @@ class TestGuardApprovals:
         assert launched_commands
         assert launched_commands[0][-2:] == ["--port", str(expected_port)]
 
+    def test_load_guard_daemon_url_rejects_stale_runtime_without_connect_state_support(self, tmp_path, monkeypatch):
+        guard_home = tmp_path / "guard-home"
+
+        class FakeResponse:
+            status = 200
+
+            def __enter__(self) -> FakeResponse:
+                return self
+
+            def __exit__(self, exc_type, exc, tb) -> None:
+                return None
+
+            def read(self) -> bytes:
+                return json.dumps(
+                    {
+                        "ok": True,
+                        "tables": [
+                            "approval_requests",
+                            "guard_connect_requests",
+                            "sync_state",
+                        ],
+                    }
+                ).encode("utf-8")
+
+        monkeypatch.setattr(
+            daemon_manager_module,
+            "_load_state",
+            lambda _guard_home: {"port": 5530, "auth_token": "token-123"},
+        )
+        monkeypatch.setattr(
+            daemon_manager_module.urllib.request,
+            "urlopen",
+            lambda request, timeout=1: FakeResponse(),
+        )
+
+        assert daemon_manager_module.load_guard_daemon_url(guard_home) is None
+
     def test_guard_daemon_serves_approval_queue_and_resolves_requests(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
         store.add_approval_request(

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -180,6 +180,28 @@ class TestGuardApprovals:
                 allowed_origin="https://hol.org",
             )
 
+    def test_guard_surface_daemon_client_wraps_malformed_state_payloads(self, monkeypatch):
+        client = daemon_client_module.GuardSurfaceDaemonClient("http://127.0.0.1:4781", "auth-token")
+
+        class FakeResponse:
+            def __enter__(self) -> FakeResponse:
+                return self
+
+            def __exit__(self, exc_type, exc, tb) -> None:
+                return None
+
+            def read(self) -> bytes:
+                return b"not-json"
+
+        monkeypatch.setattr(
+            daemon_client_module.urllib.request,
+            "urlopen",
+            lambda request, timeout=5: FakeResponse(),
+        )
+
+        with pytest.raises(RuntimeError, match="Guard daemon request failed"):
+            client.get_connect_state(request_id="req-123")
+
     def test_browser_connect_completion_clears_stale_cloud_state(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
         store.set_sync_credentials("https://old.example/registry/api/v1", "old-token", "2026-04-10T00:00:00+00:00")
@@ -230,6 +252,37 @@ class TestGuardApprovals:
         assert request_after_failure is not None
         assert request_after_failure["status"] == "pending"
         assert store.get_sync_credentials() is None
+
+    def test_browser_connect_result_coerces_invalid_sync_counts(self, tmp_path):
+        store = GuardStore(tmp_path / "guard-home")
+        request = store.create_guard_connect_request(
+            sync_url="https://hol.org/api/guard/receipts/sync",
+            allowed_origin="https://hol.org",
+            now="2026-04-16T00:00:00+00:00",
+            lifetime_seconds=600,
+        )
+
+        store.complete_guard_connect_request(
+            request_id=str(request["request_id"]),
+            pairing_secret=str(request["pairing_secret"]),
+            token="session-token-123",
+            now="2026-04-16T00:01:00+00:00",
+        )
+
+        result = store.record_guard_connect_result(
+            request_id=str(request["request_id"]),
+            status="connected",
+            milestone="first_sync_succeeded",
+            now="2026-04-16T00:02:00+00:00",
+            sync_payload={
+                "synced_at": "2026-04-16T00:02:00+00:00",
+                "receipts_stored": "bad-value",
+                "inventory_tracked": "still-bad",
+            },
+        )
+
+        assert result["proof"]["receipts_stored"] == 0
+        assert result["proof"]["inventory_items"] == 0
 
     def test_guard_store_keeps_request_id_when_duplicate_pending_request_is_requeued(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -2468,6 +2468,19 @@ args = ["workspace-skill.js", "--changed"]
                     "allowed_origin": allowed_origin,
                 }
 
+            def get_connect_state(self, *, request_id: str) -> dict[str, object]:
+                return {
+                    "request_id": request_id,
+                    "status": "waiting",
+                    "milestone": "waiting_for_browser",
+                    "completed_at": None,
+                    "expires_at": "2026-04-15T00:05:00Z",
+                    "proof": {},
+                }
+
+            def report_connect_result(self, **kwargs) -> dict[str, object]:
+                raise AssertionError("report_connect_result should not be called when the browser never completes")
+
         monkeypatch.setattr(
             guard_connect_flow_module, "ensure_guard_daemon", lambda guard_home: "http://127.0.0.1:4779"
         )
@@ -2476,8 +2489,6 @@ args = ["workspace-skill.js", "--changed"]
             "load_guard_surface_daemon_client",
             lambda guard_home: FakeDaemonClient(),
         )
-        monkeypatch.setattr(guard_connect_flow_module, "wait_for_connect_completion", lambda **kwargs: None)
-
         payload = guard_connect_flow_module.run_guard_connect_command(
             guard_home=tmp_path / "guard-home",
             store=store,
@@ -2489,7 +2500,8 @@ args = ["workspace-skill.js", "--changed"]
 
         parsed = urllib.parse.urlparse(opened_urls[0])
         query = urllib.parse.parse_qs(parsed.query)
-        assert payload["status"] == "waiting_for_browser"
+        assert payload["status"] == "waiting"
+        assert payload["milestone"] == "waiting_for_browser"
         assert query["guardDaemon"] == ["http://127.0.0.1:4781"]
 
     def test_guard_connect_preserves_custom_connect_query_params(self, tmp_path, monkeypatch):
@@ -2507,6 +2519,19 @@ args = ["workspace-skill.js", "--changed"]
                     "allowed_origin": allowed_origin,
                 }
 
+            def get_connect_state(self, *, request_id: str) -> dict[str, object]:
+                return {
+                    "request_id": request_id,
+                    "status": "waiting",
+                    "milestone": "waiting_for_browser",
+                    "completed_at": None,
+                    "expires_at": "2026-04-15T00:05:00Z",
+                    "proof": {},
+                }
+
+            def report_connect_result(self, **kwargs) -> dict[str, object]:
+                raise AssertionError("report_connect_result should not be called when the browser never completes")
+
         monkeypatch.setattr(
             guard_connect_flow_module, "ensure_guard_daemon", lambda guard_home: "http://127.0.0.1:4781"
         )
@@ -2515,8 +2540,6 @@ args = ["workspace-skill.js", "--changed"]
             "load_guard_surface_daemon_client",
             lambda guard_home: FakeDaemonClient(),
         )
-        monkeypatch.setattr(guard_connect_flow_module, "wait_for_connect_completion", lambda **kwargs: None)
-
         payload = guard_connect_flow_module.run_guard_connect_command(
             guard_home=tmp_path / "guard-home",
             store=store,
@@ -2528,7 +2551,8 @@ args = ["workspace-skill.js", "--changed"]
 
         parsed = urllib.parse.urlparse(opened_urls[0])
         query = urllib.parse.parse_qs(parsed.query)
-        assert payload["status"] == "waiting_for_browser"
+        assert payload["status"] == "waiting"
+        assert payload["milestone"] == "waiting_for_browser"
         assert query["tenant"] == ["enterprise"]
         assert query["invite"] == ["abc123"]
         assert query["guardPairRequest"] == ["req-123"]
@@ -2548,6 +2572,31 @@ args = ["workspace-skill.js", "--changed"]
                     "allowed_origin": allowed_origin,
                 }
 
+            def get_connect_state(self, *, request_id: str) -> dict[str, object]:
+                return {
+                    "request_id": request_id,
+                    "status": "connected",
+                    "milestone": "first_sync_pending",
+                    "completed_at": "2026-04-15T00:00:00Z",
+                    "expires_at": "2026-04-15T00:05:00Z",
+                    "proof": {
+                        "pairing_completed_at": "2026-04-15T00:00:00Z",
+                    },
+                }
+
+            def report_connect_result(self, *, request_id: str, status: str, milestone: str, reason=None, sync=None):
+                return {
+                    "request_id": request_id,
+                    "status": status,
+                    "milestone": milestone,
+                    "completed_at": "2026-04-15T00:00:00Z",
+                    "expires_at": "2026-04-15T00:05:00Z",
+                    "reason": reason,
+                    "proof": {
+                        "pairing_completed_at": "2026-04-15T00:00:00Z",
+                    },
+                }
+
         monkeypatch.setattr(
             guard_connect_flow_module, "ensure_guard_daemon", lambda guard_home: "http://127.0.0.1:4781"
         )
@@ -2558,24 +2607,23 @@ args = ["workspace-skill.js", "--changed"]
         )
         monkeypatch.setattr(
             guard_connect_flow_module,
-            "wait_for_connect_completion",
-            lambda **kwargs: {"status": "completed", "request_id": "req-123", "completed_at": "2026-04-15T00:00:00Z"},
-        )
-        monkeypatch.setattr(
-            guard_connect_flow_module,
             "sync_receipts",
             lambda current_store: (_ for _ in ()).throw(urllib.error.URLError("offline")),
         )
 
-        with pytest.raises(RuntimeError, match="Guard paired successfully but sync failed"):
-            guard_connect_flow_module.run_guard_connect_command(
-                guard_home=tmp_path / "guard-home",
-                store=store,
-                sync_url="https://hol.org/api/guard/receipts/sync",
-                connect_url="https://hol.org/guard/connect",
-                opener=lambda url: True,
-                wait_timeout_seconds=1,
-            )
+        payload = guard_connect_flow_module.run_guard_connect_command(
+            guard_home=tmp_path / "guard-home",
+            store=store,
+            sync_url="https://hol.org/api/guard/receipts/sync",
+            connect_url="https://hol.org/guard/connect",
+            opener=lambda url: True,
+            wait_timeout_seconds=1,
+        )
+
+        assert payload["connected"] is True
+        assert payload["status"] == "connected"
+        assert payload["milestone"] == "first_sync_pending"
+        assert payload["sync_message"] == "<urlopen error offline>"
 
     def test_guard_connect_reports_paid_plan_limit_without_failing_pairing(self, tmp_path, monkeypatch):
         store = GuardStore(tmp_path / "guard-home")
@@ -2591,6 +2639,31 @@ args = ["workspace-skill.js", "--changed"]
                     "allowed_origin": allowed_origin,
                 }
 
+            def get_connect_state(self, *, request_id: str) -> dict[str, object]:
+                return {
+                    "request_id": request_id,
+                    "status": "connected",
+                    "milestone": "first_sync_pending",
+                    "completed_at": "2026-04-15T00:00:00Z",
+                    "expires_at": "2026-04-15T00:05:00Z",
+                    "proof": {
+                        "pairing_completed_at": "2026-04-15T00:00:00Z",
+                    },
+                }
+
+            def report_connect_result(self, *, request_id: str, status: str, milestone: str, reason=None, sync=None):
+                return {
+                    "request_id": request_id,
+                    "status": status,
+                    "milestone": milestone,
+                    "completed_at": "2026-04-15T00:00:00Z",
+                    "expires_at": "2026-04-15T00:05:00Z",
+                    "reason": reason,
+                    "proof": {
+                        "pairing_completed_at": "2026-04-15T00:00:00Z",
+                    },
+                }
+
         monkeypatch.setattr(
             guard_connect_flow_module, "ensure_guard_daemon", lambda guard_home: "http://127.0.0.1:4781"
         )
@@ -2598,11 +2671,6 @@ args = ["workspace-skill.js", "--changed"]
             guard_connect_flow_module,
             "load_guard_surface_daemon_client",
             lambda guard_home: FakeDaemonClient(),
-        )
-        monkeypatch.setattr(
-            guard_connect_flow_module,
-            "wait_for_connect_completion",
-            lambda **kwargs: {"status": "completed", "request_id": "req-123", "completed_at": "2026-04-15T00:00:00Z"},
         )
         monkeypatch.setattr(
             guard_connect_flow_module,
@@ -2620,7 +2688,8 @@ args = ["workspace-skill.js", "--changed"]
         )
 
         assert payload["connected"] is True
-        assert payload["status"] == "paired_without_cloud_sync"
+        assert payload["status"] == "connected"
+        assert payload["milestone"] == "first_sync_pending"
         assert payload["sync_message"] == "Guard Cloud sync requires a paid Guard plan"
 
     def test_guard_connect_reports_guard_plan_required_without_failing_pairing(self, tmp_path, monkeypatch):
@@ -2637,6 +2706,31 @@ args = ["workspace-skill.js", "--changed"]
                     "allowed_origin": allowed_origin,
                 }
 
+            def get_connect_state(self, *, request_id: str) -> dict[str, object]:
+                return {
+                    "request_id": request_id,
+                    "status": "connected",
+                    "milestone": "first_sync_pending",
+                    "completed_at": "2026-04-15T00:00:00Z",
+                    "expires_at": "2026-04-15T00:05:00Z",
+                    "proof": {
+                        "pairing_completed_at": "2026-04-15T00:00:00Z",
+                    },
+                }
+
+            def report_connect_result(self, *, request_id: str, status: str, milestone: str, reason=None, sync=None):
+                return {
+                    "request_id": request_id,
+                    "status": status,
+                    "milestone": milestone,
+                    "completed_at": "2026-04-15T00:00:00Z",
+                    "expires_at": "2026-04-15T00:05:00Z",
+                    "reason": reason,
+                    "proof": {
+                        "pairing_completed_at": "2026-04-15T00:00:00Z",
+                    },
+                }
+
         monkeypatch.setattr(
             guard_connect_flow_module, "ensure_guard_daemon", lambda guard_home: "http://127.0.0.1:4781"
         )
@@ -2644,11 +2738,6 @@ args = ["workspace-skill.js", "--changed"]
             guard_connect_flow_module,
             "load_guard_surface_daemon_client",
             lambda guard_home: FakeDaemonClient(),
-        )
-        monkeypatch.setattr(
-            guard_connect_flow_module,
-            "wait_for_connect_completion",
-            lambda **kwargs: {"status": "completed", "request_id": "req-124", "completed_at": "2026-04-15T00:00:00Z"},
         )
         monkeypatch.setattr(
             guard_connect_flow_module,
@@ -2666,7 +2755,8 @@ args = ["workspace-skill.js", "--changed"]
         )
 
         assert payload["connected"] is True
-        assert payload["status"] == "paired_without_cloud_sync"
+        assert payload["status"] == "connected"
+        assert payload["milestone"] == "first_sync_pending"
         assert payload["sync_message"] == "Guard plan required"
 
     def test_guard_sync_persists_advisories_from_endpoint(self, tmp_path, capsys):

--- a/tests/test_guard_config_paths.py
+++ b/tests/test_guard_config_paths.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from codex_plugin_scanner.guard import bridge as bridge_module
-from codex_plugin_scanner.guard.config import load_guard_config, resolve_guard_home
+from codex_plugin_scanner.guard.config import _migrate_guard_home_state, load_guard_config, resolve_guard_home
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -57,6 +57,18 @@ def test_resolve_guard_home_migrates_legacy_credentials_into_canonical_database(
         "token": "legacy-token",
         "sync_url": "https://hol.org/api/guard/receipts/sync",
     }
+
+
+def test_migrate_guard_home_state_merges_nested_legacy_directories(tmp_path):
+    canonical_home = tmp_path / ".hol-guard"
+    legacy_home = tmp_path / ".ai-plugin-scanner-guard"
+    _write_text(canonical_home / "bin" / "keep.txt", "canonical")
+    _write_text(legacy_home / "bin" / "legacy.txt", "legacy")
+
+    _migrate_guard_home_state(source=legacy_home, destination=canonical_home)
+
+    assert (canonical_home / "bin" / "keep.txt").read_text(encoding="utf-8") == "canonical"
+    assert (canonical_home / "bin" / "legacy.txt").read_text(encoding="utf-8") == "legacy"
 
 
 def test_resolve_guard_home_keeps_canonical_state_when_legacy_only_has_credentials(tmp_path, monkeypatch):

--- a/tests/test_guard_config_paths.py
+++ b/tests/test_guard_config_paths.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from codex_plugin_scanner.guard import bridge as bridge_module
 from codex_plugin_scanner.guard import config as guard_config_module
 from codex_plugin_scanner.guard.config import (
+    GuardHomeMigrationError,
     _copy_guard_database,
     _migrate_guard_home_state,
     load_guard_config,
@@ -145,7 +146,11 @@ def test_copy_guard_database_does_not_fallback_to_raw_copy_on_sqlite_error(tmp_p
         lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("raw copy fallback should not run")),
     )
 
-    _copy_guard_database(source=source, destination=destination)
+    try:
+        _copy_guard_database(source=source, destination=destination)
+        raise AssertionError("expected GuardHomeMigrationError")
+    except GuardHomeMigrationError:
+        pass
 
     assert not destination.exists()
 
@@ -175,9 +180,30 @@ def test_copy_guard_database_aborts_when_backup_deadline_elapses(tmp_path, monke
         lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("raw copy fallback should not run")),
     )
 
-    _copy_guard_database(source=source, destination=destination)
+    try:
+        _copy_guard_database(source=source, destination=destination)
+        raise AssertionError("expected GuardHomeMigrationError")
+    except GuardHomeMigrationError:
+        pass
 
     assert not destination.exists()
+
+
+def test_resolve_guard_home_falls_back_to_legacy_home_when_database_migration_fails(tmp_path, monkeypatch):
+    home_dir = tmp_path / "home"
+    canonical_home = home_dir / ".hol-guard"
+    legacy_home = home_dir / ".ai-plugin-scanner-guard"
+    _write_text(legacy_home / "guard.db", "legacy-db")
+    _write_text(legacy_home / "config.toml", 'default_action = "warn"\n')
+    monkeypatch.setattr(Path, "home", lambda: home_dir)
+
+    def _fail_copy(*, source: Path, destination: Path) -> None:
+        raise GuardHomeMigrationError("guard.db migration failed")
+
+    monkeypatch.setattr(guard_config_module, "_copy_guard_database", _fail_copy)
+
+    assert resolve_guard_home() == legacy_home
+    assert not canonical_home.exists()
 
 
 def test_resolve_guard_home_keeps_canonical_state_when_legacy_only_has_credentials(tmp_path, monkeypatch):

--- a/tests/test_guard_config_paths.py
+++ b/tests/test_guard_config_paths.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 from codex_plugin_scanner.guard import bridge as bridge_module
@@ -12,6 +13,13 @@ from codex_plugin_scanner.guard.store import GuardStore
 def _write_text(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
+
+
+def _create_sqlite_guard_db(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as connection:
+        connection.execute("create table migration_probe (value text)")
+        connection.execute("insert into migration_probe(value) values ('legacy')")
 
 
 def test_resolve_guard_home_defaults_to_hol_guard_directory(tmp_path, monkeypatch):
@@ -29,16 +37,16 @@ def test_resolve_guard_home_migrates_legacy_directory_into_canonical_home(tmp_pa
 
     assert resolve_guard_home() == home_dir / ".hol-guard"
 
-def test_resolve_guard_home_copies_legacy_state_into_canonical_directory(tmp_path, monkeypatch):
-    home_dir = tmp_path / "home"
-    canonical_home = home_dir / ".hol-guard"
-    legacy_home = home_dir / ".config" / ".ai-plugin-scanner-guard"
-    canonical_home.mkdir(parents=True, exist_ok=True)
-    _write_text(legacy_home / "guard.db", "sqlite placeholder")
-    monkeypatch.setattr(Path, "home", lambda: home_dir)
+def test_migrate_guard_home_state_copies_guard_db_with_sqlite_backup(tmp_path):
+    canonical_home = tmp_path / ".hol-guard"
+    legacy_home = tmp_path / ".config" / ".ai-plugin-scanner-guard"
+    _create_sqlite_guard_db(legacy_home / "guard.db")
 
-    assert resolve_guard_home() == canonical_home
-    assert (canonical_home / "guard.db").read_text(encoding="utf-8") == "sqlite placeholder"
+    _migrate_guard_home_state(source=legacy_home, destination=canonical_home)
+
+    with sqlite3.connect(canonical_home / "guard.db") as connection:
+        row = connection.execute("select value from migration_probe").fetchone()
+    assert row == ("legacy",)
 
 def test_resolve_guard_home_migrates_legacy_credentials_into_canonical_database(tmp_path, monkeypatch):
     home_dir = tmp_path / "home"

--- a/tests/test_guard_config_paths.py
+++ b/tests/test_guard_config_paths.py
@@ -71,6 +71,18 @@ def test_migrate_guard_home_state_merges_nested_legacy_directories(tmp_path):
     assert (canonical_home / "bin" / "legacy.txt").read_text(encoding="utf-8") == "legacy"
 
 
+def test_migrate_guard_home_state_skips_legacy_daemon_runtime_state(tmp_path):
+    canonical_home = tmp_path / ".hol-guard"
+    legacy_home = tmp_path / ".ai-plugin-scanner-guard"
+    _write_text(legacy_home / "daemon-state.json", '{"port": 1, "auth_token": "legacy"}')
+    _write_text(legacy_home / "config.toml", 'default_action = "warn"\n')
+
+    _migrate_guard_home_state(source=legacy_home, destination=canonical_home)
+
+    assert not (canonical_home / "daemon-state.json").exists()
+    assert (canonical_home / "config.toml").read_text(encoding="utf-8") == 'default_action = "warn"\n'
+
+
 def test_resolve_guard_home_keeps_canonical_state_when_legacy_only_has_credentials(tmp_path, monkeypatch):
     home_dir = tmp_path / "home"
     canonical_home = home_dir / ".hol-guard"

--- a/tests/test_guard_config_paths.py
+++ b/tests/test_guard_config_paths.py
@@ -6,7 +6,13 @@ import sqlite3
 from pathlib import Path
 
 from codex_plugin_scanner.guard import bridge as bridge_module
-from codex_plugin_scanner.guard.config import _migrate_guard_home_state, load_guard_config, resolve_guard_home
+from codex_plugin_scanner.guard import config as guard_config_module
+from codex_plugin_scanner.guard.config import (
+    _copy_guard_database,
+    _migrate_guard_home_state,
+    load_guard_config,
+    resolve_guard_home,
+)
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -93,20 +99,85 @@ def test_migrate_guard_home_state_skips_legacy_daemon_runtime_state(tmp_path):
     assert (canonical_home / "config.toml").read_text(encoding="utf-8") == 'default_action = "warn"\n'
 
 
-def test_migrate_guard_home_state_skips_legacy_sqlite_sidecars(tmp_path):
+def test_migrate_guard_home_state_skips_legacy_sqlite_sidecars(tmp_path, monkeypatch):
     canonical_home = tmp_path / ".hol-guard"
     legacy_home = tmp_path / ".ai-plugin-scanner-guard"
-    _create_sqlite_guard_db(legacy_home / "guard.db")
+    _write_text(legacy_home / "guard.db", "legacy-db")
     _write_text(legacy_home / "guard.db-wal", "wal")
     _write_text(legacy_home / "guard.db-shm", "shm")
     _write_text(legacy_home / "guard.db-journal", "journal")
+    copied: list[tuple[Path, Path]] = []
+
+    def _record_copy(*, source: Path, destination: Path) -> None:
+        copied.append((source, destination))
+        _write_text(destination, "copied-db")
+
+    monkeypatch.setattr(guard_config_module, "_copy_guard_database", _record_copy)
 
     _migrate_guard_home_state(source=legacy_home, destination=canonical_home)
 
+    assert copied == [(legacy_home / "guard.db", canonical_home / "guard.db")]
     assert (canonical_home / "guard.db").is_file()
     assert not (canonical_home / "guard.db-wal").exists()
     assert not (canonical_home / "guard.db-shm").exists()
     assert not (canonical_home / "guard.db-journal").exists()
+
+
+def test_copy_guard_database_does_not_fallback_to_raw_copy_on_sqlite_error(tmp_path, monkeypatch):
+    source = tmp_path / "legacy" / "guard.db"
+    destination = tmp_path / "canonical" / "guard.db"
+    _write_text(source, "legacy")
+
+    class _FailingConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def backup(self, *_args, **_kwargs):
+            raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(guard_config_module.sqlite3, "connect", lambda *_args, **_kwargs: _FailingConnection())
+    monkeypatch.setattr(
+        guard_config_module.shutil,
+        "copy2",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("raw copy fallback should not run")),
+    )
+
+    _copy_guard_database(source=source, destination=destination)
+
+    assert not destination.exists()
+
+
+def test_copy_guard_database_aborts_when_backup_deadline_elapses(tmp_path, monkeypatch):
+    source = tmp_path / "legacy" / "guard.db"
+    destination = tmp_path / "canonical" / "guard.db"
+    _write_text(source, "legacy")
+
+    class _ProgressConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def backup(self, _target, *, progress=None, **_kwargs):
+            if progress is not None:
+                progress(0, 1, 1)
+
+    monkeypatch.setattr(guard_config_module, "GUARD_DB_BACKUP_TIMEOUT_SECONDS", 0.0)
+    monkeypatch.setattr(guard_config_module.time, "monotonic", lambda: 0.0)
+    monkeypatch.setattr(guard_config_module.sqlite3, "connect", lambda *_args, **_kwargs: _ProgressConnection())
+    monkeypatch.setattr(
+        guard_config_module.shutil,
+        "copy2",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("raw copy fallback should not run")),
+    )
+
+    _copy_guard_database(source=source, destination=destination)
+
+    assert not destination.exists()
 
 
 def test_resolve_guard_home_keeps_canonical_state_when_legacy_only_has_credentials(tmp_path, monkeypatch):

--- a/tests/test_guard_config_paths.py
+++ b/tests/test_guard_config_paths.py
@@ -206,6 +206,22 @@ def test_resolve_guard_home_falls_back_to_legacy_home_when_database_migration_fa
     assert not canonical_home.exists()
 
 
+def test_resolve_guard_home_falls_back_to_legacy_home_when_file_copy_fails(tmp_path, monkeypatch):
+    home_dir = tmp_path / "home"
+    canonical_home = home_dir / ".hol-guard"
+    legacy_home = home_dir / ".ai-plugin-scanner-guard"
+    _write_text(legacy_home / "config.toml", 'default_action = "warn"\n')
+    monkeypatch.setattr(Path, "home", lambda: home_dir)
+    monkeypatch.setattr(
+        guard_config_module,
+        "_migrate_guard_home_state",
+        lambda **_kwargs: (_ for _ in ()).throw(PermissionError("unreadable legacy file")),
+    )
+
+    assert resolve_guard_home() == legacy_home
+    assert not canonical_home.exists()
+
+
 def test_resolve_guard_home_keeps_canonical_state_when_legacy_only_has_credentials(tmp_path, monkeypatch):
     home_dir = tmp_path / "home"
     canonical_home = home_dir / ".hol-guard"

--- a/tests/test_guard_config_paths.py
+++ b/tests/test_guard_config_paths.py
@@ -21,16 +21,15 @@ def test_resolve_guard_home_defaults_to_hol_guard_directory(tmp_path, monkeypatc
     assert resolve_guard_home() == home_dir / ".hol-guard"
 
 
-def test_resolve_guard_home_falls_back_to_legacy_directory(tmp_path, monkeypatch):
+def test_resolve_guard_home_migrates_legacy_directory_into_canonical_home(tmp_path, monkeypatch):
     home_dir = tmp_path / "home"
     legacy_home = home_dir / ".config" / ".ai-plugin-scanner-guard"
     legacy_home.mkdir(parents=True, exist_ok=True)
     monkeypatch.setattr(Path, "home", lambda: home_dir)
 
-    assert resolve_guard_home() == legacy_home
+    assert resolve_guard_home() == home_dir / ".hol-guard"
 
-
-def test_resolve_guard_home_prefers_legacy_state_over_empty_canonical_directory(tmp_path, monkeypatch):
+def test_resolve_guard_home_copies_legacy_state_into_canonical_directory(tmp_path, monkeypatch):
     home_dir = tmp_path / "home"
     canonical_home = home_dir / ".hol-guard"
     legacy_home = home_dir / ".config" / ".ai-plugin-scanner-guard"
@@ -38,10 +37,10 @@ def test_resolve_guard_home_prefers_legacy_state_over_empty_canonical_directory(
     _write_text(legacy_home / "guard.db", "sqlite placeholder")
     monkeypatch.setattr(Path, "home", lambda: home_dir)
 
-    assert resolve_guard_home() == legacy_home
+    assert resolve_guard_home() == canonical_home
+    assert (canonical_home / "guard.db").read_text(encoding="utf-8") == "sqlite placeholder"
 
-
-def test_resolve_guard_home_prefers_legacy_credentials_over_empty_canonical_database(tmp_path, monkeypatch):
+def test_resolve_guard_home_migrates_legacy_credentials_into_canonical_database(tmp_path, monkeypatch):
     home_dir = tmp_path / "home"
     canonical_home = home_dir / ".hol-guard"
     legacy_home = home_dir / ".ai-plugin-scanner-guard"
@@ -50,7 +49,14 @@ def test_resolve_guard_home_prefers_legacy_credentials_over_empty_canonical_data
     legacy_store.set_sync_credentials("https://hol.org/api/guard/receipts/sync", "legacy-token", "2026-04-15T00:00:00Z")
     monkeypatch.setattr(Path, "home", lambda: home_dir)
 
-    assert resolve_guard_home() == legacy_home
+    resolved_home = resolve_guard_home()
+
+    assert resolved_home == canonical_home
+    canonical_store = GuardStore(canonical_home)
+    assert canonical_store.get_sync_credentials() == {
+        "token": "legacy-token",
+        "sync_url": "https://hol.org/api/guard/receipts/sync",
+    }
 
 
 def test_resolve_guard_home_keeps_canonical_state_when_legacy_only_has_credentials(tmp_path, monkeypatch):

--- a/tests/test_guard_config_paths.py
+++ b/tests/test_guard_config_paths.py
@@ -37,6 +37,7 @@ def test_resolve_guard_home_migrates_legacy_directory_into_canonical_home(tmp_pa
 
     assert resolve_guard_home() == home_dir / ".hol-guard"
 
+
 def test_migrate_guard_home_state_copies_guard_db_with_sqlite_backup(tmp_path):
     canonical_home = tmp_path / ".hol-guard"
     legacy_home = tmp_path / ".config" / ".ai-plugin-scanner-guard"
@@ -47,6 +48,7 @@ def test_migrate_guard_home_state_copies_guard_db_with_sqlite_backup(tmp_path):
     with sqlite3.connect(canonical_home / "guard.db") as connection:
         row = connection.execute("select value from migration_probe").fetchone()
     assert row == ("legacy",)
+
 
 def test_resolve_guard_home_migrates_legacy_credentials_into_canonical_database(tmp_path, monkeypatch):
     home_dir = tmp_path / "home"
@@ -89,6 +91,22 @@ def test_migrate_guard_home_state_skips_legacy_daemon_runtime_state(tmp_path):
 
     assert not (canonical_home / "daemon-state.json").exists()
     assert (canonical_home / "config.toml").read_text(encoding="utf-8") == 'default_action = "warn"\n'
+
+
+def test_migrate_guard_home_state_skips_legacy_sqlite_sidecars(tmp_path):
+    canonical_home = tmp_path / ".hol-guard"
+    legacy_home = tmp_path / ".ai-plugin-scanner-guard"
+    _create_sqlite_guard_db(legacy_home / "guard.db")
+    _write_text(legacy_home / "guard.db-wal", "wal")
+    _write_text(legacy_home / "guard.db-shm", "shm")
+    _write_text(legacy_home / "guard.db-journal", "journal")
+
+    _migrate_guard_home_state(source=legacy_home, destination=canonical_home)
+
+    assert (canonical_home / "guard.db").is_file()
+    assert not (canonical_home / "guard.db-wal").exists()
+    assert not (canonical_home / "guard.db-shm").exists()
+    assert not (canonical_home / "guard.db-journal").exists()
 
 
 def test_resolve_guard_home_keeps_canonical_state_when_legacy_only_has_credentials(tmp_path, monkeypatch):

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -79,7 +79,7 @@ def test_guard_daemon_exposes_canonical_connect_state_endpoint(tmp_path) -> None
     assert state_payload["state"]["milestone"] == "waiting_for_browser"
 
 
-def test_guard_connect_returns_retry_required_when_first_sync_fails(
+def test_guard_connect_preserves_pairing_when_first_sync_fails(
     tmp_path,
     monkeypatch,
 ) -> None:
@@ -142,10 +142,11 @@ def test_guard_connect_returns_retry_required_when_first_sync_fails(
     finally:
         daemon.stop()
 
-    assert payload["connected"] is False
-    assert payload["status"] == "retry_required"
-    assert payload["milestone"] == "first_sync_failed"
+    assert payload["connected"] is True
+    assert payload["status"] == "connected"
+    assert payload["milestone"] == "first_sync_pending"
     assert payload["reason"] == "sync_unreachable"
+    assert payload["sync_message"] == "sync_unreachable"
     assert payload["request_id"].startswith("connect-")
 
 
@@ -176,7 +177,7 @@ def test_guard_store_backfills_missing_connect_state_on_pairing_completion(tmp_p
 
     assert completed_request["status"] == "completed"
     assert completed_state is not None
-    assert completed_state["status"] == "waiting"
+    assert completed_state["status"] == "connected"
     assert completed_state["milestone"] == "first_sync_pending"
     assert completed_state["proof"]["pairing_completed_at"] == "2026-04-15T00:00:01+00:00"
 
@@ -202,6 +203,6 @@ def test_guard_store_keeps_first_sync_pending_state_after_request_expiry(tmp_pat
     )
 
     assert pending_state is not None
-    assert pending_state["status"] == "waiting"
+    assert pending_state["status"] == "connected"
     assert pending_state["milestone"] == "first_sync_pending"
     assert pending_state["reason"] == "waiting_for_first_sync"


### PR DESCRIPTION
## Summary
- persist a richer Guard connect state model so browser pairing, first sync, and retry states share one runtime contract
- migrate active Guard state into ~/.hol-guard and refuse stale daemons that do not expose the new connect-state support
- clarify pending-first-sync messaging in the CLI while keeping pairing successful when cloud proof is still pending

## Verification
- python3 -m ruff check src tests
- PYTHONPATH=src python3 -m pytest tests/test_guard_approvals.py tests/test_guard_config_paths.py tests/test_guard_cli.py -q
- python3 -m build
- hol-guard connect --wait-timeout-seconds 15 --json
- hol-guard connect --wait-timeout-seconds 15