### PR TITLE
fix: restore hol-guard self-update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ See [docs/guard/get-started.md](docs/guard/get-started.md) for the full local fl
   Shows what Guard is watching now.
 - `hol-guard install <harness>`
   Creates the launcher shim for that harness.
+- `hol-guard update`
+  Updates the installed `hol-guard` package in the current environment.
 - `hol-guard run <harness> --dry-run`
   Records the current state once before you trust it.
 - `hol-guard run <harness>`

--- a/docs/guard/architecture.md
+++ b/docs/guard/architecture.md
@@ -26,9 +26,10 @@ The local product loop is:
 
 1. `hol-guard start` detects supported harnesses and suggests the next step
 2. `hol-guard install <harness>` creates a local launcher shim
-3. `hol-guard run <harness>` evaluates changes before the harness launches
-4. `hol-guard receipts` and `hol-guard status` let users inspect local decisions
-5. `hol-guard login` and `hol-guard sync` stay optional
+3. `hol-guard update` upgrades the installed Guard CLI in the current environment
+4. `hol-guard run <harness>` evaluates changes before the harness launches
+5. `hol-guard receipts` and `hol-guard status` let users inspect local decisions
+6. `hol-guard login` and `hol-guard sync` stay optional
 
 Wrapper mode is still the core execution strategy in this phase. Config mutation is limited to documented local hook helpers, where Guard can add and remove its own hook entries in workspace-local Claude settings or workspace-local Copilot CLI repo hooks.
 

--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -25,6 +25,8 @@ Use it when you want to protect a harness before local MCP servers, skills, hook
    hol-guard install codex
    ```
 
+   After upgrading later, run `hol-guard update` to update the installed `hol-guard` package in that environment.
+
 3. Run one dry pass so Guard records the current state:
 
    ```bash

--- a/docs/guard/testing-matrix.md
+++ b/docs/guard/testing-matrix.md
@@ -19,6 +19,7 @@ Manual verification should include:
 - `hol-guard detect gemini --json`
 - `hol-guard detect opencode --json`
 - `hol-guard install opencode --json`
+- `hol-guard update --dry-run --json`
 - `hol-guard run opencode --dry-run --default-action allow --json`
 - `hol-guard run opencode --default-action require-reapproval --json`
 - `hol-guard approvals --json`

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -67,6 +67,7 @@ from .install_commands import apply_managed_install
 from .product import build_guard_start_payload, build_guard_status_payload
 from .prompt import build_prompt_artifacts, resolve_interactive_decisions
 from .render import emit_guard_payload
+from .update_commands import run_guard_update
 
 
 def _now() -> str:
@@ -110,7 +111,7 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
         dest="guard_command",
         required=True,
         metavar=(
-            "{start,status,bootstrap,detect,install,uninstall,run,protect,preflight,scan,diff,receipts,inventory,abom,"
+            "{start,status,bootstrap,detect,install,update,uninstall,run,protect,preflight,scan,diff,receipts,inventory,abom,"
             "approvals,explain,allow,deny,policies,exceptions,advisories,events,doctor,connect,login,sync,bridge}"
         ),
     )
@@ -144,6 +145,13 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     install_parser.add_argument("--all", action="store_true")
     _add_guard_common_args(install_parser)
     install_parser.add_argument("--json", action="store_true")
+
+    update_parser = guard_subparsers.add_parser(
+        "update",
+        help="Update the installed hol-guard package in the current environment",
+    )
+    update_parser.add_argument("--dry-run", action="store_true")
+    update_parser.add_argument("--json", action="store_true")
 
     uninstall_parser = guard_subparsers.add_parser(
         "uninstall",
@@ -388,6 +396,11 @@ def run_guard_command(args: argparse.Namespace) -> int:
             if isinstance(install_verdict, dict) and str(install_verdict.get("action")) != "allow":
                 return 2
         return 0
+
+    if args.guard_command == "update":
+        payload, exit_code = run_guard_update(dry_run=bool(getattr(args, "dry_run", False)))
+        _emit("update", payload, getattr(args, "json", False))
+        return exit_code
 
     home_override = getattr(args, "home", None)
     guard_home = resolve_guard_home(getattr(args, "guard_home", None) or home_override)

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -29,7 +29,6 @@ def apply_managed_install(
             managed_installs.append(managed_install)
     payload: dict[str, object] = {
         "managed_installs": managed_installs,
-        "operation": command,
         "auto_detected": requested_harness is None or install_all,
     }
     if len(managed_installs) == 1:

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -29,6 +29,7 @@ def apply_managed_install(
             managed_installs.append(managed_install)
     payload: dict[str, object] = {
         "managed_installs": managed_installs,
+        "operation": command,
         "auto_detected": requested_harness is None or install_all,
     }
     if len(managed_installs) == 1:

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -496,6 +496,32 @@ def _render_sync(console: Console, payload: dict[str, object]) -> None:
     console.print(Panel(body, title="Guard sync complete", border_style="green"))
 
 
+def _render_update(console: Console, payload: dict[str, object]) -> None:
+    body = Table.grid(padding=(0, 1))
+    body.add_row("Current version", str(payload.get("current_version") or "unknown"))
+    body.add_row("Installer", str(payload.get("installer") or "unknown"))
+    command = payload.get("command")
+    if isinstance(command, list) and command:
+        body.add_row("Command", " ".join(str(part) for part in command))
+    body.add_row("Dry run", _bool_label(bool(payload.get("dry_run"))))
+    if payload.get("resulting_version"):
+        body.add_row("Resulting version", str(payload.get("resulting_version")))
+    if payload.get("editable_install") is not None:
+        body.add_row("Editable install", _bool_label(bool(payload.get("editable_install"))))
+    status = str(payload.get("status") or "unknown")
+    border_style = "green" if status in {"planned", "updated"} else "red"
+    console.print(Panel(body, title=f"Guard update: {status}", border_style=border_style))
+    stdout = str(payload.get("stdout") or "").strip()
+    stderr = str(payload.get("stderr") or "").strip()
+    error = str(payload.get("error") or "").strip()
+    if stdout:
+        console.print(Panel(stdout, title="stdout", border_style="green"))
+    if stderr:
+        console.print(Panel(stderr, title="stderr", border_style="yellow"))
+    if error:
+        console.print(Panel(error, title="error", border_style="red"))
+
+
 def _connect_status_text(payload: dict[str, object]) -> str:
     status = str(payload.get("status") or "unknown")
     milestone = str(payload.get("milestone") or "")
@@ -1277,6 +1303,7 @@ _RENDERERS: dict[str, Any] = {
     "deny": _render_decision,
     "login": _render_login,
     "sync": _render_sync,
+    "update": _render_update,
     "hook": _render_hook,
     "protect": _render_protect,
     "preflight": _render_preflight,

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -1,0 +1,83 @@
+"""Helpers for updating the installed HOL Guard CLI."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_guard_update(*, dry_run: bool) -> tuple[dict[str, object], int]:
+    current_version = _current_version()
+    installer = _installer_kind()
+    command = _update_command(installer)
+    payload: dict[str, object] = {
+        "current_version": current_version,
+        "installer": installer,
+        "command": command,
+        "dry_run": dry_run,
+    }
+    direct_url = _direct_url_payload()
+    if direct_url is not None:
+        payload["direct_url"] = direct_url
+        payload["editable_install"] = bool(direct_url.get("dir_info", {}).get("editable"))
+    if dry_run:
+        payload["status"] = "planned"
+        return payload, 0
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+    except FileNotFoundError as error:
+        payload["status"] = "failed"
+        payload["error"] = str(error)
+        return payload, 1
+    payload["status"] = "updated" if result.returncode == 0 else "failed"
+    payload["stdout"] = result.stdout.strip()
+    payload["stderr"] = result.stderr.strip()
+    payload["return_code"] = result.returncode
+    payload["resulting_version"] = _current_version()
+    return payload, 0 if result.returncode == 0 else 1
+
+
+def _current_version() -> str:
+    try:
+        return importlib.metadata.version("hol-guard")
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
+
+
+def _installer_kind() -> str:
+    prefix = Path(sys.prefix).resolve().as_posix()
+    if "/pipx/venvs/" in prefix:
+        return "pipx"
+    return "pip"
+
+
+def _update_command(installer: str) -> list[str]:
+    if installer == "pipx":
+        return ["pipx", "upgrade", "hol-guard"]
+    return [sys.executable, "-m", "pip", "install", "--upgrade", "hol-guard"]
+
+
+def _direct_url_payload() -> dict[str, object] | None:
+    try:
+        distribution = importlib.metadata.distribution("hol-guard")
+    except importlib.metadata.PackageNotFoundError:
+        return None
+    raw_payload = distribution.read_text("direct_url.json")
+    if raw_payload is None:
+        return None
+    try:
+        payload = json.loads(raw_payload)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+__all__ = ["run_guard_update"]

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import importlib.metadata
 import json
 import subprocess
@@ -22,7 +23,14 @@ def run_guard_update(*, dry_run: bool) -> tuple[dict[str, object], int]:
     direct_url = _direct_url_payload()
     if direct_url is not None:
         payload["direct_url"] = direct_url
-        payload["editable_install"] = bool(direct_url.get("dir_info", {}).get("editable"))
+        is_editable = bool(direct_url.get("dir_info", {}).get("editable"))
+        payload["editable_install"] = is_editable
+        if is_editable:
+            payload["status"] = "skipped"
+            payload["error"] = (
+                "Automatic update is disabled for editable installs. Re-run your local install workflow instead."
+            )
+            return payload, 0
     if dry_run:
         payload["status"] = "planned"
         return payload, 0
@@ -33,7 +41,7 @@ def run_guard_update(*, dry_run: bool) -> tuple[dict[str, object], int]:
             check=False,
             text=True,
         )
-    except FileNotFoundError as error:
+    except OSError as error:
         payload["status"] = "failed"
         payload["error"] = str(error)
         return payload, 1
@@ -41,7 +49,8 @@ def run_guard_update(*, dry_run: bool) -> tuple[dict[str, object], int]:
     payload["stdout"] = result.stdout.strip()
     payload["stderr"] = result.stderr.strip()
     payload["return_code"] = result.returncode
-    payload["resulting_version"] = _current_version()
+    importlib.invalidate_caches()
+    payload["resulting_version"] = _current_version_from_subprocess()
     return payload, 0 if result.returncode == 0 else 1
 
 
@@ -53,8 +62,10 @@ def _current_version() -> str:
 
 
 def _installer_kind() -> str:
-    prefix = Path(sys.prefix).resolve().as_posix()
-    if "/pipx/venvs/" in prefix:
+    prefix_path = Path(sys.prefix).resolve()
+    if (prefix_path / "pipx_metadata.json").exists():
+        return "pipx"
+    if "/pipx/venvs/" in prefix_path.as_posix().lower():
         return "pipx"
     return "pip"
 
@@ -78,6 +89,22 @@ def _direct_url_payload() -> dict[str, object] | None:
     except json.JSONDecodeError:
         return None
     return payload if isinstance(payload, dict) else None
+
+
+def _current_version_from_subprocess() -> str:
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", 'import importlib.metadata; print(importlib.metadata.version("hol-guard"))'],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+    except OSError:
+        return _current_version()
+    if result.returncode != 0:
+        return _current_version()
+    version = result.stdout.strip()
+    return version or _current_version()
 
 
 __all__ = ["run_guard_update"]

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -18,6 +18,7 @@ from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.adapters import cursor as cursor_adapter_module
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
 from codex_plugin_scanner.guard.cli import connect_flow as guard_connect_flow_module
+from codex_plugin_scanner.guard.cli import update_commands as guard_update_commands_module
 from codex_plugin_scanner.guard.cli.render import emit_guard_payload
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.store import GuardStore
@@ -2120,6 +2121,53 @@ args = ["workspace-skill.js", "--changed"]
         assert output["managed_install"]["active"] is True
         assert manifest["shim_command"] == "guard-opencode"
         assert runtime_payload["permission"]["skill"]["*"] == "ask"
+
+    def test_guard_update_runs_pip_upgrade_in_current_environment(self, monkeypatch, capsys):
+        commands: list[list[str]] = []
+
+        def fake_run(command: list[str], **_: object):
+            commands.append(command)
+            return subprocess.CompletedProcess(command, 0, stdout="updated", stderr="")
+
+        monkeypatch.setattr(guard_update_commands_module.subprocess, "run", fake_run)
+        monkeypatch.setattr(guard_update_commands_module.sys, "prefix", "/opt/guard-venv")
+        monkeypatch.setattr(guard_update_commands_module.sys, "executable", "/opt/guard-venv/bin/python")
+
+        rc = main(["guard", "update", "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["installer"] == "pip"
+        assert commands == [["/opt/guard-venv/bin/python", "-m", "pip", "install", "--upgrade", "hol-guard"]]
+        assert output["status"] == "updated"
+        assert output["stdout"] == "updated"
+
+    def test_guard_update_uses_pipx_when_running_from_pipx(self, monkeypatch, capsys):
+        commands: list[list[str]] = []
+
+        def fake_run(command: list[str], **_: object):
+            commands.append(command)
+            return subprocess.CompletedProcess(command, 0, stdout="pipx-updated", stderr="")
+
+        monkeypatch.setattr(guard_update_commands_module.subprocess, "run", fake_run)
+        monkeypatch.setattr(guard_update_commands_module.sys, "prefix", "/Users/test/.local/pipx/venvs/hol-guard")
+
+        rc = main(["guard", "update", "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["installer"] == "pipx"
+        assert commands == [["pipx", "upgrade", "hol-guard"]]
+        assert output["status"] == "updated"
+
+    def test_guard_update_dry_run_emits_planned_command(self, capsys):
+        rc = main(["guard", "update", "--dry-run", "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["status"] == "planned"
+        assert output["dry_run"] is True
+        assert output["command"]
 
     def test_guard_uninstall_auto_detects_managed_harnesses(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -2132,6 +2132,8 @@ args = ["workspace-skill.js", "--changed"]
         monkeypatch.setattr(guard_update_commands_module.subprocess, "run", fake_run)
         monkeypatch.setattr(guard_update_commands_module.sys, "prefix", "/opt/guard-venv")
         monkeypatch.setattr(guard_update_commands_module.sys, "executable", "/opt/guard-venv/bin/python")
+        monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
+        monkeypatch.setattr(guard_update_commands_module, "_current_version_from_subprocess", lambda: "2.0.18")
 
         rc = main(["guard", "update", "--json"])
         output = json.loads(capsys.readouterr().out)
@@ -2151,6 +2153,8 @@ args = ["workspace-skill.js", "--changed"]
 
         monkeypatch.setattr(guard_update_commands_module.subprocess, "run", fake_run)
         monkeypatch.setattr(guard_update_commands_module.sys, "prefix", "/Users/test/.local/pipx/venvs/hol-guard")
+        monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
+        monkeypatch.setattr(guard_update_commands_module, "_current_version_from_subprocess", lambda: "2.0.18")
 
         rc = main(["guard", "update", "--json"])
         output = json.loads(capsys.readouterr().out)
@@ -2160,7 +2164,9 @@ args = ["workspace-skill.js", "--changed"]
         assert commands == [["pipx", "upgrade", "hol-guard"]]
         assert output["status"] == "updated"
 
-    def test_guard_update_dry_run_emits_planned_command(self, capsys):
+    def test_guard_update_dry_run_emits_planned_command(self, monkeypatch, capsys):
+        monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
+
         rc = main(["guard", "update", "--dry-run", "--json"])
         output = json.loads(capsys.readouterr().out)
 
@@ -2168,6 +2174,21 @@ args = ["workspace-skill.js", "--changed"]
         assert output["status"] == "planned"
         assert output["dry_run"] is True
         assert output["command"]
+
+    def test_guard_update_skips_editable_installs(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            guard_update_commands_module,
+            "_direct_url_payload",
+            lambda: {"dir_info": {"editable": True}, "url": "file:///Users/test/ai-plugin-scanner"},
+        )
+
+        rc = main(["guard", "update", "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["status"] == "skipped"
+        assert output["editable_install"] is True
+        assert "disabled for editable installs" in output["error"]
 
     def test_guard_uninstall_auto_detects_managed_harnesses(self, tmp_path, capsys):
         home_dir = tmp_path / "home"


### PR DESCRIPTION
## Summary
- restore `hol-guard update` as a real self-update command for the installed `hol-guard` package
- use `pipx upgrade hol-guard` for pipx installs and `python -m pip install --upgrade hol-guard` elsewhere
- add dry-run/json output, CLI coverage, and docs for the updater flow

## Verification
- `./.venv/bin/ruff check src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/cli/install_commands.py src/codex_plugin_scanner/guard/cli/render.py src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_guard_cli.py`
- `./.venv/bin/pytest tests/test_guard_cli.py -k "guard_update or guard_install or guard_uninstall"`
- disposable venv e2e: `hol-guard update --dry-run --json` and `hol-guard update --json`, which upgraded `hol-guard` from `2.0.0` to `2.0.18` in the test environment