### PR TITLE
fix: stabilize hol-guard browser connect sync

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -81,39 +81,22 @@ def run_guard_connect_command(
             connected=False,
         )
     runtime_session = _start_guard_runtime_session(daemon_client)
+    runtime_sync_error: str | None = None
     try:
         runtime_sync_summary = sync_runtime_session(store, session=runtime_session)
     except (RuntimeError, OSError, urllib.error.URLError, json.JSONDecodeError) as error:
-        sync_message = str(error)
-        pending_sync = {
+        runtime_sync_error = str(error)
+        runtime_sync_summary = {
             "runtime_session_id": str(runtime_session.get("session_id") or runtime_session.get("sessionId") or ""),
             "runtime_session_synced_at": None,
             "runtime_sessions_visible": 0,
             "runtime_session_sync_pending": True,
-            "runtime_session_sync_reason": sync_message,
+            "runtime_session_sync_reason": runtime_sync_error,
         }
-        pending_state = _record_connect_result(
-            daemon_client=daemon_client,
-            store=store,
-            request_id=str(connect_request["request_id"]),
-            status="connected",
-            milestone="first_sync_pending",
-            reason=sync_message,
-            sync=pending_sync,
-        )
-        return build_connect_payload(
-            state=pending_state,
-            browser_opened=browser_opened,
-            connect_url=browser_url,
-            sync_url=sync_url,
-            connected=True,
-            sync=pending_sync,
-            sync_message=sync_message,
-        )
     try:
         sync_payload = sync_receipts(store)
     except (RuntimeError, OSError, urllib.error.URLError, json.JSONDecodeError) as error:
-        sync_message = str(error)
+        sync_message = runtime_sync_error or str(error)
         pending_state = _record_connect_result(
             daemon_client=daemon_client,
             store=store,
@@ -129,11 +112,33 @@ def run_guard_connect_command(
             connect_url=browser_url,
             sync_url=sync_url,
             connected=True,
+            sync=runtime_sync_summary,
             sync_message=sync_message,
         )
     sync_payload["runtime_session_synced_at"] = runtime_sync_summary["runtime_session_synced_at"]
     sync_payload["runtime_session_id"] = runtime_sync_summary["runtime_session_id"]
     sync_payload["runtime_sessions_visible"] = runtime_sync_summary["runtime_sessions_visible"]
+    if runtime_sync_error is not None:
+        sync_payload["runtime_session_sync_pending"] = True
+        sync_payload["runtime_session_sync_reason"] = runtime_sync_error
+        pending_state = _record_connect_result(
+            daemon_client=daemon_client,
+            store=store,
+            request_id=str(connect_request["request_id"]),
+            status="connected",
+            milestone="first_sync_pending",
+            reason=runtime_sync_error,
+            sync=sync_payload,
+        )
+        return build_connect_payload(
+            state=pending_state,
+            browser_opened=browser_opened,
+            connect_url=browser_url,
+            sync_url=sync_url,
+            connected=True,
+            sync=sync_payload,
+            sync_message=runtime_sync_error,
+        )
     final_state = _record_connect_result(
         daemon_client=daemon_client,
         store=store,

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -71,7 +71,7 @@ def run_guard_connect_command(
             sync_url=sync_url,
             connected=False,
         )
-    pairing_completed_at = str(transition.get("completed_at") or "").strip()
+    pairing_completed_at = (transition.get("completed_at") or "").strip()
     if str(transition.get("status")) == "retry_required" and not pairing_completed_at:
         return build_connect_payload(
             state=transition,
@@ -112,9 +112,7 @@ def run_guard_connect_command(
             status="connected",
             milestone="first_sync_pending",
             reason=sync_message,
-            sync={
-                **runtime_sync_summary,
-            },
+            sync=runtime_sync_summary,
         )
         return build_connect_payload(
             state=pending_state,
@@ -294,27 +292,30 @@ def _resolve_first_sync_milestone(state: dict[str, object]) -> str:
 def _start_guard_runtime_session(daemon_client: GuardSurfaceDaemonClient) -> dict[str, object]:
     start_session = getattr(daemon_client, "start_session", None)
     if callable(start_session):
-        return start_session(
-            harness="hol-guard",
-            surface="cli",
-            workspace=str(Path.cwd()),
-            client_name="hol-guard",
-            client_title="HOL Guard CLI",
-            client_version=None,
-            capabilities=["approval-resolution", "receipt-view", "runtime-sync"],
-        )
+        try:
+            return start_session(
+                harness="hol-guard",
+                surface="cli",
+                workspace=str(Path.cwd()),
+                client_name="hol-guard",
+                client_title="HOL Guard CLI",
+                client_version=None,
+                capabilities=["approval-resolution", "receipt-view", "runtime-sync"],
+            )
+        except (GuardDaemonRequestError, GuardDaemonTransportError):
+            pass
     now = datetime.now(timezone.utc).isoformat()
     return {
-        "sessionId": f"guard-session-{uuid.uuid4().hex}",
+        "session_id": f"guard-session-{uuid.uuid4().hex}",
         "harness": "hol-guard",
         "surface": "cli",
         "status": "active",
-        "clientName": "hol-guard",
-        "clientTitle": "HOL Guard CLI",
-        "clientVersion": None,
+        "client_name": "hol-guard",
+        "client_title": "HOL Guard CLI",
+        "client_version": None,
         "workspace": str(Path.cwd()),
         "capabilities": ["approval-resolution", "receipt-view", "runtime-sync"],
         "operations": [],
-        "createdAt": now,
-        "updatedAt": now,
+        "created_at": now,
+        "updated_at": now,
     }

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -6,12 +6,13 @@ import json
 import time
 import urllib.error
 import urllib.parse
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
 from ..daemon import ensure_guard_daemon, load_guard_surface_daemon_client
 from ..daemon.client import GuardDaemonRequestError, GuardDaemonTransportError, GuardSurfaceDaemonClient
-from ..runtime import sync_receipts
+from ..runtime import sync_receipts, sync_runtime_session
 from ..store import GuardStore
 
 DEFAULT_GUARD_SYNC_URL = "https://hol.org/api/guard/receipts/sync"
@@ -70,13 +71,35 @@ def run_guard_connect_command(
             sync_url=sync_url,
             connected=False,
         )
-    if str(transition.get("status")) == "retry_required":
+    pairing_completed_at = str(transition.get("completed_at") or "").strip()
+    if str(transition.get("status")) == "retry_required" and not pairing_completed_at:
         return build_connect_payload(
             state=transition,
             browser_opened=browser_opened,
             connect_url=browser_url,
             sync_url=sync_url,
             connected=False,
+        )
+    runtime_session = _start_guard_runtime_session(daemon_client)
+    try:
+        runtime_sync_summary = sync_runtime_session(store, session=runtime_session)
+    except (RuntimeError, OSError, urllib.error.URLError, json.JSONDecodeError) as error:
+        sync_message = str(error)
+        failed_state = _record_connect_result(
+            daemon_client=daemon_client,
+            store=store,
+            request_id=str(connect_request["request_id"]),
+            status="retry_required",
+            milestone="first_sync_failed",
+            reason=sync_message,
+        )
+        return build_connect_payload(
+            state=failed_state,
+            browser_opened=browser_opened,
+            connect_url=browser_url,
+            sync_url=sync_url,
+            connected=False,
+            sync_message=sync_message,
         )
     try:
         sync_payload = sync_receipts(store)
@@ -89,6 +112,9 @@ def run_guard_connect_command(
             status="connected",
             milestone="first_sync_pending",
             reason=sync_message,
+            sync={
+                **runtime_sync_summary,
+            },
         )
         return build_connect_payload(
             state=pending_state,
@@ -98,6 +124,9 @@ def run_guard_connect_command(
             connected=True,
             sync_message=sync_message,
         )
+    sync_payload["runtime_session_synced_at"] = runtime_sync_summary["runtime_session_synced_at"]
+    sync_payload["runtime_session_id"] = runtime_sync_summary["runtime_session_id"]
+    sync_payload["runtime_sessions_visible"] = runtime_sync_summary["runtime_sessions_visible"]
     final_state = _record_connect_result(
         daemon_client=daemon_client,
         store=store,
@@ -260,3 +289,32 @@ def _resolve_first_sync_milestone(state: dict[str, object]) -> str:
     if milestone == "first_sync_pending":
         return "waiting"
     return "pending"
+
+
+def _start_guard_runtime_session(daemon_client: GuardSurfaceDaemonClient) -> dict[str, object]:
+    start_session = getattr(daemon_client, "start_session", None)
+    if callable(start_session):
+        return start_session(
+            harness="hol-guard",
+            surface="cli",
+            workspace=str(Path.cwd()),
+            client_name="hol-guard",
+            client_title="HOL Guard CLI",
+            client_version=None,
+            capabilities=["approval-resolution", "receipt-view", "runtime-sync"],
+        )
+    now = datetime.now(timezone.utc).isoformat()
+    return {
+        "sessionId": f"guard-session-{uuid.uuid4().hex}",
+        "harness": "hol-guard",
+        "surface": "cli",
+        "status": "active",
+        "clientName": "hol-guard",
+        "clientTitle": "HOL Guard CLI",
+        "clientVersion": None,
+        "workspace": str(Path.cwd()),
+        "capabilities": ["approval-resolution", "receipt-view", "runtime-sync"],
+        "operations": [],
+        "createdAt": now,
+        "updatedAt": now,
+    }

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -121,6 +121,8 @@ def run_guard_connect_command(
     if runtime_sync_error is not None:
         sync_payload["runtime_session_sync_pending"] = True
         sync_payload["runtime_session_sync_reason"] = runtime_sync_error
+        pending_sync_payload = dict(sync_payload)
+        pending_sync_payload["synced_at"] = None
         pending_state = _record_connect_result(
             daemon_client=daemon_client,
             store=store,
@@ -128,7 +130,7 @@ def run_guard_connect_command(
             status="connected",
             milestone="first_sync_pending",
             reason=runtime_sync_error,
-            sync=sync_payload,
+            sync=pending_sync_payload,
         )
         return build_connect_payload(
             state=pending_state,

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -85,20 +85,27 @@ def run_guard_connect_command(
         runtime_sync_summary = sync_runtime_session(store, session=runtime_session)
     except (RuntimeError, OSError, urllib.error.URLError, json.JSONDecodeError) as error:
         sync_message = str(error)
-        failed_state = _record_connect_result(
+        pending_sync = {
+            "runtime_session_id": str(runtime_session.get("session_id") or runtime_session.get("sessionId") or ""),
+            "runtime_session_sync_pending": True,
+            "runtime_session_sync_reason": sync_message,
+        }
+        pending_state = _record_connect_result(
             daemon_client=daemon_client,
             store=store,
             request_id=str(connect_request["request_id"]),
-            status="retry_required",
-            milestone="first_sync_failed",
+            status="connected",
+            milestone="first_sync_pending",
             reason=sync_message,
+            sync=pending_sync,
         )
         return build_connect_payload(
-            state=failed_state,
+            state=pending_state,
             browser_opened=browser_opened,
             connect_url=browser_url,
             sync_url=sync_url,
-            connected=False,
+            connected=True,
+            sync=pending_sync,
             sync_message=sync_message,
         )
     try:

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -87,6 +87,8 @@ def run_guard_connect_command(
         sync_message = str(error)
         pending_sync = {
             "runtime_session_id": str(runtime_session.get("session_id") or runtime_session.get("sessionId") or ""),
+            "runtime_session_synced_at": None,
+            "runtime_sessions_visible": 0,
             "runtime_session_sync_pending": True,
             "runtime_session_sync_reason": sync_message,
         }

--- a/src/codex_plugin_scanner/guard/runtime/__init__.py
+++ b/src/codex_plugin_scanner/guard/runtime/__init__.py
@@ -1,5 +1,5 @@
 """Guard runtime helpers."""
 
-from .runner import guard_run, sync_receipts
+from .runner import guard_run, sync_receipts, sync_runtime_session
 
-__all__ = ["guard_run", "sync_receipts"]
+__all__ = ["guard_run", "sync_receipts", "sync_runtime_session"]

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -253,6 +253,43 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
     return summary
 
 
+def sync_runtime_session(
+    store: GuardStore,
+    *,
+    session: dict[str, object],
+) -> dict[str, object]:
+    """Publish the active Guard runtime session so the dashboard can show the machine immediately."""
+
+    credentials = store.get_sync_credentials()
+    if credentials is None:
+        raise RuntimeError("Guard is not logged in.")
+    sync_url = _normalized_runtime_sessions_sync_url(str(credentials["sync_url"]))
+    session_payload = _cloud_runtime_session_payload(session)
+    body = json.dumps({"session": session_payload}).encode("utf-8")
+    request = urllib.request.Request(
+        sync_url,
+        data=body,
+        method="POST",
+        headers=_guard_sync_headers(str(credentials["token"])),
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        raise RuntimeError(_sync_http_error_message(error)) from error
+    synced_at = _sync_timestamp(payload)
+    summary = {
+        "synced_at": synced_at,
+        "runtime_session_synced_at": synced_at,
+        "runtime_session_id": session_payload["sessionId"],
+        "runtime_sessions_visible": len(payload.get("items", []))
+        if isinstance(payload.get("items"), list)
+        else 0,
+    }
+    store.set_sync_payload("runtime_session_summary", summary, synced_at)
+    return summary
+
+
 def sync_pain_signals(store: GuardStore) -> int:
     credentials = store.get_sync_credentials()
     if credentials is None:
@@ -523,6 +560,32 @@ def _normalized_receipts_sync_url(sync_url: str) -> str:
     return sync_url
 
 
+def _normalized_runtime_sessions_sync_url(sync_url: str) -> str:
+    normalized_receipts_url = _normalized_receipts_sync_url(sync_url)
+    parsed = urllib.parse.urlsplit(normalized_receipts_url)
+    if parsed.path.rstrip("/") == "/api/guard/receipts/sync":
+        return urllib.parse.urlunsplit(
+            (
+                parsed.scheme,
+                parsed.netloc,
+                "/api/guard/runtime/sessions/sync",
+                parsed.query,
+                "",
+            )
+        )
+    if parsed.path.rstrip("/") == "/guard/receipts/sync":
+        return urllib.parse.urlunsplit(
+            (
+                parsed.scheme,
+                parsed.netloc,
+                "/guard/runtime/sessions/sync",
+                parsed.query,
+                "",
+            )
+        )
+    return normalized_receipts_url.rstrip("/") + "/runtime/sessions/sync"
+
+
 def _cloud_sync_receipts_payload(receipts: list[dict[str, object]]) -> list[dict[str, object]]:
     device_id, device_name = _guard_device_metadata()
     return [_cloud_sync_receipt_payload(receipt, device_id=device_id, device_name=device_name) for receipt in receipts]
@@ -571,6 +634,31 @@ def _cloud_sync_receipt_payload(
     if publisher is not None:
         payload["publisher"] = publisher
     return payload
+
+
+def _cloud_runtime_session_payload(session: dict[str, object]) -> dict[str, object]:
+    device_id, device_name = _guard_device_metadata()
+    workspace = _optional_string(session.get("workspace")) or os.getcwd()
+    session_id = _optional_string(session.get("session_id")) or hashlib.sha256(
+        f"{device_id}:{workspace}".encode()
+    ).hexdigest()[:24]
+    created_at = _optional_string(session.get("created_at")) or _now()
+    updated_at = _optional_string(session.get("updated_at")) or created_at
+    capabilities = [str(item) for item in session.get("capabilities", []) if isinstance(item, str)]
+    return {
+        "sessionId": session_id,
+        "harness": _optional_string(session.get("harness")) or "hol-guard",
+        "surface": _optional_string(session.get("surface")) or "cli",
+        "status": _optional_string(session.get("status")) or "active",
+        "clientName": _optional_string(session.get("client_name")) or "hol-guard",
+        "clientTitle": _optional_string(session.get("client_title")) or f"HOL Guard on {device_name}",
+        "clientVersion": _optional_string(session.get("client_version")) or __version__,
+        "workspace": workspace,
+        "capabilities": capabilities,
+        "operations": [],
+        "createdAt": created_at,
+        "updatedAt": updated_at,
+    }
 
 
 def _cloud_sync_receipt_fingerprint(receipt: dict[str, object]) -> str:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -276,6 +276,18 @@ def sync_runtime_session(
         with urllib.request.urlopen(request, timeout=10) as response:
             payload = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as error:
+        if error.code == 404:
+            synced_at = _now()
+            summary = {
+                "synced_at": synced_at,
+                "runtime_session_synced_at": synced_at,
+                "runtime_session_id": session_payload["sessionId"],
+                "runtime_sessions_visible": 0,
+                "runtime_session_sync_skipped": True,
+                "runtime_session_sync_reason": "runtime_session_endpoint_unavailable",
+            }
+            store.set_sync_payload("runtime_session_summary", summary, synced_at)
+            return summary
         raise RuntimeError(_sync_http_error_message(error)) from error
     if not isinstance(payload, dict):
         raise RuntimeError("Invalid sync response")

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -277,14 +277,14 @@ def sync_runtime_session(
             payload = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as error:
         raise RuntimeError(_sync_http_error_message(error)) from error
+    if not isinstance(payload, dict):
+        raise RuntimeError("Invalid sync response")
     synced_at = _sync_timestamp(payload)
     summary = {
         "synced_at": synced_at,
         "runtime_session_synced_at": synced_at,
         "runtime_session_id": session_payload["sessionId"],
-        "runtime_sessions_visible": len(payload.get("items", []))
-        if isinstance(payload.get("items"), list)
-        else 0,
+        "runtime_sessions_visible": len(payload.get("items", [])) if isinstance(payload.get("items"), list) else 0,
     }
     store.set_sync_payload("runtime_session_summary", summary, synced_at)
     return summary
@@ -583,7 +583,15 @@ def _normalized_runtime_sessions_sync_url(sync_url: str) -> str:
                 "",
             )
         )
-    return normalized_receipts_url.rstrip("/") + "/runtime/sessions/sync"
+    return urllib.parse.urlunsplit(
+        (
+            parsed.scheme,
+            parsed.netloc,
+            parsed.path.rstrip("/") + "/runtime/sessions/sync",
+            parsed.query,
+            "",
+        )
+    )
 
 
 def _cloud_sync_receipts_payload(receipts: list[dict[str, object]]) -> list[dict[str, object]]:
@@ -639,20 +647,22 @@ def _cloud_sync_receipt_payload(
 def _cloud_runtime_session_payload(session: dict[str, object]) -> dict[str, object]:
     device_id, device_name = _guard_device_metadata()
     workspace = _optional_string(session.get("workspace")) or os.getcwd()
-    session_id = _optional_string(session.get("session_id")) or hashlib.sha256(
-        f"{device_id}:{workspace}".encode()
-    ).hexdigest()[:24]
-    created_at = _optional_string(session.get("created_at")) or _now()
-    updated_at = _optional_string(session.get("updated_at")) or created_at
+    session_id = (
+        _optional_string(session.get("session_id") or session.get("sessionId"))
+        or hashlib.sha256(f"{device_id}:{workspace}".encode()).hexdigest()[:24]
+    )
+    created_at = _optional_string(session.get("created_at") or session.get("createdAt")) or _now()
+    updated_at = _optional_string(session.get("updated_at") or session.get("updatedAt")) or created_at
     capabilities = [str(item) for item in session.get("capabilities", []) if isinstance(item, str)]
     return {
         "sessionId": session_id,
         "harness": _optional_string(session.get("harness")) or "hol-guard",
         "surface": _optional_string(session.get("surface")) or "cli",
         "status": _optional_string(session.get("status")) or "active",
-        "clientName": _optional_string(session.get("client_name")) or "hol-guard",
-        "clientTitle": _optional_string(session.get("client_title")) or f"HOL Guard on {device_name}",
-        "clientVersion": _optional_string(session.get("client_version")) or __version__,
+        "clientName": _optional_string(session.get("client_name") or session.get("clientName")) or "hol-guard",
+        "clientTitle": _optional_string(session.get("client_title") or session.get("clientTitle"))
+        or f"HOL Guard on {device_name}",
+        "clientVersion": _optional_string(session.get("client_version") or session.get("clientVersion")) or __version__,
         "workspace": workspace,
         "capabilities": capabilities,
         "operations": [],

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -277,16 +277,16 @@ def sync_runtime_session(
             payload = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as error:
         if error.code == 404:
-            synced_at = _now()
+            recorded_at = _now()
             summary = {
-                "synced_at": synced_at,
-                "runtime_session_synced_at": synced_at,
+                "synced_at": None,
+                "runtime_session_synced_at": None,
                 "runtime_session_id": session_payload["sessionId"],
                 "runtime_sessions_visible": 0,
                 "runtime_session_sync_skipped": True,
                 "runtime_session_sync_reason": "runtime_session_endpoint_unavailable",
             }
-            store.set_sync_payload("runtime_session_summary", summary, synced_at)
+            store.set_sync_payload("runtime_session_summary", summary, recorded_at)
             return summary
         raise RuntimeError(_sync_http_error_message(error)) from error
     if not isinstance(payload, dict):

--- a/src/codex_plugin_scanner/guard/store_connect.py
+++ b/src/codex_plugin_scanner/guard/store_connect.py
@@ -127,6 +127,8 @@ def create_connect_state(
         "first_synced_at": None,
         "receipts_stored": 0,
         "inventory_items": 0,
+        "runtime_session_id": None,
+        "runtime_session_synced_at": None,
     }
     connection.execute(
         """
@@ -282,6 +284,8 @@ def mark_connect_result(
         proof["inventory_items"] = _coerce_non_negative_int(
             sync_payload.get("inventory_tracked", sync_payload.get("inventory"))
         )
+        proof["runtime_session_id"] = sync_payload.get("runtime_session_id")
+        proof["runtime_session_synced_at"] = sync_payload.get("runtime_session_synced_at")
     connection.execute(
         """
         update guard_connect_states

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -2517,6 +2517,14 @@ args = ["workspace-skill.js", "--changed"]
             "codex_plugin_scanner.guard.cli.connect_flow.sync_receipts",
             lambda current_store: (_ for _ in ()).throw(RuntimeError("sync_unreachable")),
         )
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.cli.connect_flow.sync_runtime_session",
+            lambda current_store, *, session: {
+                "runtime_session_id": str(session.get("session_id") or session.get("sessionId")),
+                "runtime_session_synced_at": "2026-04-15T00:00:01Z",
+                "runtime_sessions_visible": 1,
+            },
+        )
 
         def open_browser(url: str) -> bool:
             parsed = urllib.parse.urlparse(url)
@@ -2812,6 +2820,15 @@ args = ["workspace-skill.js", "--changed"]
             "sync_receipts",
             lambda current_store: (_ for _ in ()).throw(urllib.error.URLError("offline")),
         )
+        monkeypatch.setattr(
+            guard_connect_flow_module,
+            "sync_runtime_session",
+            lambda current_store, *, session: {
+                "runtime_session_id": str(session.get("session_id") or session.get("sessionId")),
+                "runtime_session_synced_at": "2026-04-15T00:00:01Z",
+                "runtime_sessions_visible": 1,
+            },
+        )
 
         payload = guard_connect_flow_module.run_guard_connect_command(
             guard_home=tmp_path / "guard-home",
@@ -2883,6 +2900,15 @@ args = ["workspace-skill.js", "--changed"]
                 "receipts_stored": 3,
                 "inventory_tracked": 1,
                 "first_synced_at": "2026-04-15T00:00:01Z",
+            },
+        )
+        monkeypatch.setattr(
+            guard_connect_flow_module,
+            "sync_runtime_session",
+            lambda current_store, *, session: {
+                "runtime_session_id": str(session.get("session_id") or session.get("sessionId")),
+                "runtime_session_synced_at": "2026-04-15T00:00:01Z",
+                "runtime_sessions_visible": 1,
             },
         )
 
@@ -2968,6 +2994,15 @@ args = ["workspace-skill.js", "--changed"]
             "sync_receipts",
             lambda current_store: (_ for _ in ()).throw(RuntimeError("Guard Cloud sync requires a paid Guard plan")),
         )
+        monkeypatch.setattr(
+            guard_connect_flow_module,
+            "sync_runtime_session",
+            lambda current_store, *, session: {
+                "runtime_session_id": str(session.get("session_id") or session.get("sessionId")),
+                "runtime_session_synced_at": "2026-04-15T00:00:01Z",
+                "runtime_sessions_visible": 1,
+            },
+        )
 
         payload = guard_connect_flow_module.run_guard_connect_command(
             guard_home=tmp_path / "guard-home",
@@ -3041,6 +3076,15 @@ args = ["workspace-skill.js", "--changed"]
             guard_connect_flow_module,
             "sync_receipts",
             lambda current_store: (_ for _ in ()).throw(RuntimeError("Guard plan required")),
+        )
+        monkeypatch.setattr(
+            guard_connect_flow_module,
+            "sync_runtime_session",
+            lambda current_store, *, session: {
+                "runtime_session_id": str(session.get("session_id") or session.get("sessionId")),
+                "runtime_session_synced_at": "2026-04-15T00:00:01Z",
+                "runtime_sessions_visible": 1,
+            },
         )
 
         payload = guard_connect_flow_module.run_guard_connect_command(

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -6,6 +6,7 @@ import json
 import threading
 import urllib.parse
 import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 from codex_plugin_scanner.guard.cli.connect_flow import run_guard_connect_command
@@ -129,6 +130,14 @@ def test_guard_connect_preserves_pairing_when_first_sync_fails(
         "codex_plugin_scanner.guard.cli.connect_flow.sync_receipts",
         lambda current_store: (_ for _ in ()).throw(RuntimeError("sync_unreachable")),
     )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.connect_flow.sync_runtime_session",
+        lambda current_store, *, session: {
+            "runtime_session_id": str(session.get("session_id") or session.get("sessionId")),
+            "runtime_session_synced_at": "2026-04-15T00:00:01Z",
+            "runtime_sessions_visible": 1,
+        },
+    )
 
     try:
         payload = run_guard_connect_command(
@@ -206,3 +215,204 @@ def test_guard_store_keeps_first_sync_pending_state_after_request_expiry(tmp_pat
     assert pending_state["status"] == "connected"
     assert pending_state["milestone"] == "first_sync_pending"
     assert pending_state["reason"] == "waiting_for_first_sync"
+
+
+def test_guard_connect_recovers_when_browser_pairing_completed_before_cli_sync(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+
+    store = GuardStore(home_dir)
+
+    class _DaemonClient:
+        daemon_url = "http://127.0.0.1:9999"
+
+        def create_connect_request(self, *, sync_url: str, allowed_origin: str) -> dict[str, object]:
+            return {
+                "request_id": "connect-recovered",
+                "pairing_secret": "pairing-secret",
+                "expires_at": "2026-04-16T00:05:00+00:00",
+            }
+
+        def report_connect_result(
+            self,
+            *,
+            request_id: str,
+            status: str,
+            milestone: str,
+            reason: str | None = None,
+            sync: dict[str, object] | None = None,
+        ) -> dict[str, object]:
+            return {
+                "request_id": request_id,
+                "status": status,
+                "milestone": milestone,
+                "reason": reason,
+                "completed_at": "2026-04-16T00:00:30+00:00",
+                "expires_at": "2026-04-16T00:05:00+00:00",
+                "proof": sync or {},
+            }
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.connect_flow.ensure_guard_daemon",
+        lambda guard_home: "http://127.0.0.1:9999",
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.connect_flow.load_guard_surface_daemon_client",
+        lambda guard_home: _DaemonClient(),
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.connect_flow.wait_for_connect_transition",
+        lambda **kwargs: {
+            "request_id": "connect-recovered",
+            "status": "retry_required",
+            "milestone": "first_sync_failed",
+            "reason": "timed out",
+            "completed_at": "2026-04-16T00:00:30+00:00",
+            "expires_at": "2026-04-16T00:05:00+00:00",
+            "proof": {},
+        },
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.connect_flow.sync_runtime_session",
+        lambda current_store, *, session: {
+            "runtime_session_id": str(session.get("sessionId")),
+            "runtime_session_synced_at": "2026-04-16T00:00:31Z",
+            "runtime_sessions_visible": 1,
+        },
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.connect_flow.sync_receipts",
+        lambda current_store: {
+            "synced_at": "2026-04-16T00:00:32Z",
+            "receipts_stored": 0,
+            "inventory_tracked": 0,
+        },
+    )
+
+    payload = run_guard_connect_command(
+        guard_home=home_dir,
+        store=store,
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        connect_url="https://hol.org/guard/connect",
+        opener=lambda url: True,
+        wait_timeout_seconds=5,
+    )
+
+    assert payload["connected"] is True
+    assert payload["status"] == "connected"
+    assert payload["milestone"] == "first_sync_succeeded"
+
+
+def test_guard_connect_registers_runtime_session_before_first_sync(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+
+    observed_requests: list[tuple[str, dict[str, object]]] = []
+
+    class SyncHandler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            content_length = int(self.headers.get("Content-Length", "0"))
+            payload = json.loads(self.rfile.read(content_length).decode("utf-8"))
+            observed_requests.append((self.path, payload))
+            if self.path == "/api/guard/runtime/sessions/sync":
+                response = {
+                    "generatedAt": "2026-04-16T00:00:02.000Z",
+                    "items": [payload["session"]],
+                }
+            elif self.path == "/api/guard/receipts/sync":
+                response = {
+                    "syncedAt": "2026-04-16T00:00:03.000Z",
+                    "receiptsStored": len(payload.get("receipts", [])),
+                    "advisories": [],
+                    "policy": {},
+                    "alertPreferences": {},
+                    "teamPolicyPack": {},
+                    "exceptions": [],
+                }
+            else:
+                self.send_response(404)
+                self.end_headers()
+                return
+            body = json.dumps(response).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, message_format: str, *args: object) -> None:
+            return
+
+    sync_server = ThreadingHTTPServer(("127.0.0.1", 0), SyncHandler)
+    sync_thread = threading.Thread(target=sync_server.serve_forever, daemon=True)
+    sync_thread.start()
+
+    store = GuardStore(home_dir)
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.connect_flow.ensure_guard_daemon",
+        lambda guard_home: f"http://127.0.0.1:{daemon.port}",
+    )
+
+    def open_browser(url: str) -> bool:
+        parsed = urllib.parse.urlparse(url)
+        query = urllib.parse.parse_qs(parsed.query)
+        fragment = urllib.parse.parse_qs(parsed.fragment)
+        request_id = query["guardPairRequest"][-1]
+        daemon_url = query["guardDaemon"][-1]
+        pairing_secret = fragment["guardPairSecret"][-1]
+
+        def complete_pairing() -> None:
+            request = urllib.request.Request(
+                f"{daemon_url}/v1/connect/complete",
+                data=urllib.parse.urlencode(
+                    {
+                        "request_id": request_id,
+                        "pairing_secret": pairing_secret,
+                        "token": "session-token-123",
+                    }
+                ).encode("utf-8"),
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "Origin": f"http://127.0.0.1:{sync_server.server_port}",
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=5):
+                pass
+
+        threading.Thread(target=complete_pairing, daemon=True).start()
+        return True
+
+    try:
+        payload = run_guard_connect_command(
+            guard_home=home_dir,
+            store=store,
+            sync_url=f"http://127.0.0.1:{sync_server.server_port}/api/guard/receipts/sync",
+            connect_url=f"http://127.0.0.1:{sync_server.server_port}/guard/connect",
+            opener=open_browser,
+            wait_timeout_seconds=5,
+        )
+    finally:
+        daemon.stop()
+        sync_server.shutdown()
+        sync_server.server_close()
+
+    assert payload["connected"] is True
+    assert [path for path, _payload in observed_requests] == [
+        "/api/guard/runtime/sessions/sync",
+        "/api/guard/receipts/sync",
+    ]
+    runtime_session = observed_requests[0][1]["session"]
+    assert isinstance(runtime_session, dict)
+    assert runtime_session["clientName"] == "hol-guard"
+    assert runtime_session["surface"] == "cli"

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -246,6 +246,8 @@ def test_guard_connect_keeps_pairing_when_runtime_sync_fails(
     assert payload["sync"]["runtime_session_synced_at"] is None
     assert payload["sync"]["runtime_sessions_visible"] == 0
     assert payload["sync"]["runtime_session_id"]
+    assert payload["sync"]["synced_at"] == "2026-04-15T00:00:02Z"
+    assert payload["proof"]["first_synced_at"] is None
     assert sync_receipts_calls == [True]
 
 

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -209,9 +209,19 @@ def test_guard_connect_keeps_pairing_when_runtime_sync_fails(
         threading.Thread(target=complete_pairing, daemon=True).start()
         return True
 
+    sync_receipts_calls: list[bool] = []
+
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.cli.connect_flow.sync_runtime_session",
         lambda current_store, *, session: (_ for _ in ()).throw(RuntimeError("runtime_sync_unreachable")),
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.connect_flow.sync_receipts",
+        lambda current_store: sync_receipts_calls.append(True) or {
+            "synced_at": "2026-04-15T00:00:02Z",
+            "receipts_stored": 0,
+            "inventory_tracked": 0,
+        },
     )
 
     try:
@@ -236,6 +246,7 @@ def test_guard_connect_keeps_pairing_when_runtime_sync_fails(
     assert payload["sync"]["runtime_session_synced_at"] is None
     assert payload["sync"]["runtime_sessions_visible"] == 0
     assert payload["sync"]["runtime_session_id"]
+    assert sync_receipts_calls == [True]
 
 
 def test_guard_store_backfills_missing_connect_state_on_pairing_completion(tmp_path) -> None:

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -233,6 +233,8 @@ def test_guard_connect_keeps_pairing_when_runtime_sync_fails(
     assert payload["sync_message"] == "runtime_sync_unreachable"
     assert payload["sync"]["runtime_session_sync_pending"] is True
     assert payload["sync"]["runtime_session_sync_reason"] == "runtime_sync_unreachable"
+    assert payload["sync"]["runtime_session_synced_at"] is None
+    assert payload["sync"]["runtime_sessions_visible"] == 0
     assert payload["sync"]["runtime_session_id"]
 
 

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -9,8 +9,12 @@ import urllib.request
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
-from codex_plugin_scanner.guard.cli.connect_flow import run_guard_connect_command
+from codex_plugin_scanner.guard.cli.connect_flow import (
+    _start_guard_runtime_session,
+    run_guard_connect_command,
+)
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
+from codex_plugin_scanner.guard.daemon.client import GuardDaemonTransportError
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -215,6 +219,18 @@ def test_guard_store_keeps_first_sync_pending_state_after_request_expiry(tmp_pat
     assert pending_state["status"] == "connected"
     assert pending_state["milestone"] == "first_sync_pending"
     assert pending_state["reason"] == "waiting_for_first_sync"
+
+
+def test_start_guard_runtime_session_falls_back_when_daemon_start_fails() -> None:
+    class FailingDaemonClient:
+        def start_session(self, **kwargs: object) -> dict[str, object]:
+            raise GuardDaemonTransportError("daemon_unavailable")
+
+    runtime_session = _start_guard_runtime_session(FailingDaemonClient())
+
+    assert runtime_session["session_id"].startswith("guard-session-")
+    assert runtime_session["client_name"] == "hol-guard"
+    assert runtime_session["surface"] == "cli"
 
 
 def test_guard_connect_recovers_when_browser_pairing_completed_before_cli_sync(

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -163,6 +163,79 @@ def test_guard_connect_preserves_pairing_when_first_sync_fails(
     assert payload["request_id"].startswith("connect-")
 
 
+def test_guard_connect_keeps_pairing_when_runtime_sync_fails(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+
+    store = GuardStore(home_dir)
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.connect_flow.ensure_guard_daemon",
+        lambda guard_home: f"http://127.0.0.1:{daemon.port}",
+    )
+
+    def open_browser(url: str) -> bool:
+        parsed = urllib.parse.urlparse(url)
+        query = urllib.parse.parse_qs(parsed.query)
+        fragment = urllib.parse.parse_qs(parsed.fragment)
+        request_id = query["guardPairRequest"][-1]
+        daemon_url = query["guardDaemon"][-1]
+        pairing_secret = fragment["guardPairSecret"][-1]
+
+        def complete_pairing() -> None:
+            request = urllib.request.Request(
+                f"{daemon_url}/v1/connect/complete",
+                data=urllib.parse.urlencode(
+                    {
+                        "request_id": request_id,
+                        "pairing_secret": pairing_secret,
+                        "token": "session-token-123",
+                    }
+                ).encode("utf-8"),
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "Origin": "https://hol.org",
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=5):
+                pass
+
+        threading.Thread(target=complete_pairing, daemon=True).start()
+        return True
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.connect_flow.sync_runtime_session",
+        lambda current_store, *, session: (_ for _ in ()).throw(RuntimeError("runtime_sync_unreachable")),
+    )
+
+    try:
+        payload = run_guard_connect_command(
+            guard_home=home_dir,
+            store=store,
+            sync_url="https://hol.org/registry/api/v1",
+            connect_url="https://hol.org/guard/connect",
+            opener=open_browser,
+            wait_timeout_seconds=5,
+        )
+    finally:
+        daemon.stop()
+
+    assert payload["connected"] is True
+    assert payload["status"] == "connected"
+    assert payload["milestone"] == "first_sync_pending"
+    assert payload["reason"] == "runtime_sync_unreachable"
+    assert payload["sync_message"] == "runtime_sync_unreachable"
+    assert payload["sync"]["runtime_session_sync_pending"] is True
+    assert payload["sync"]["runtime_session_sync_reason"] == "runtime_sync_unreachable"
+    assert payload["sync"]["runtime_session_id"]
+
+
 def test_guard_store_backfills_missing_connect_state_on_pairing_completion(tmp_path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     created_request = store.create_guard_connect_request(

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -8,6 +8,7 @@ import json
 import subprocess
 import sys
 import threading
+import urllib.error
 import urllib.request
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -125,6 +126,42 @@ class TestGuardRuntime:
         )
 
         assert runtime_sync_url == "https://hol.org/custom/sync/runtime/sessions/sync?tenant=guard"
+
+    def test_sync_runtime_session_treats_missing_runtime_endpoint_as_non_fatal(
+        self,
+        monkeypatch,
+        tmp_path,
+    ) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        store.set_sync_credentials(
+            "https://hol.org/api/guard/receipts/sync",
+            "guard-token",
+            "2026-04-16T00:00:00.000Z",
+        )
+
+        def _raise_not_found(*args, **kwargs):
+            raise urllib.error.HTTPError(
+                "https://hol.org/api/guard/runtime/sessions/sync",
+                404,
+                "Not Found",
+                hdrs=None,
+                fp=None,
+            )
+
+        monkeypatch.setattr(urllib.request, "urlopen", _raise_not_found)
+
+        summary = guard_runner_module.sync_runtime_session(
+            store,
+            session={
+                "session_id": "session-live",
+                "created_at": "2026-04-16T00:00:00.000Z",
+                "updated_at": "2026-04-16T00:00:00.000Z",
+            },
+        )
+
+        assert summary["runtime_session_id"] == "session-live"
+        assert summary["runtime_session_sync_skipped"] is True
+        assert summary["runtime_session_sync_reason"] == "runtime_session_endpoint_unavailable"
 
     def test_guard_store_initializes_runtime_tables_and_receipt_columns(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -119,6 +119,13 @@ class _FlushTrackingOutput(io.StringIO):
 
 
 class TestGuardRuntime:
+    def test_runtime_sessions_sync_url_preserves_query_parameters(self) -> None:
+        runtime_sync_url = guard_runner_module._normalized_runtime_sessions_sync_url(
+            "https://hol.org/custom/sync?tenant=guard",
+        )
+
+        assert runtime_sync_url == "https://hol.org/custom/sync/runtime/sessions/sync?tenant=guard"
+
     def test_guard_store_initializes_runtime_tables_and_receipt_columns(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
 
@@ -2477,6 +2484,7 @@ class TestGuardRuntime:
         assert blocked["responses"][0]["error"]["code"] == -32001
         assert blocked["responses"][0]["error"]["data"]["approvalDelivery"]["destination"] == "browser"
         assert blocked["events"][0]["approval_delivery"]["destination"] == "browser"
+
     def test_stdio_proxy_uses_native_delivery_for_managed_hermes(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
         workspace_dir = tmp_path / "workspace"
@@ -2565,6 +2573,7 @@ class TestGuardRuntime:
         assert output["policy_action"] == "require-reapproval"
         assert output["approval_delivery"]["destination"] == "harness"
         assert "docker" in output["risk_summary"].lower()
+
     def test_remote_proxy_forwards_local_requests_and_redacts_auth_headers(self):
         server = HTTPServer(("127.0.0.1", 0), _RemoteProxyHandler)
         thread = threading.Thread(target=server.serve_forever, daemon=True)

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -160,6 +160,8 @@ class TestGuardRuntime:
         )
 
         assert summary["runtime_session_id"] == "session-live"
+        assert summary["synced_at"] is None
+        assert summary["runtime_session_synced_at"] is None
         assert summary["runtime_session_sync_skipped"] is True
         assert summary["runtime_session_sync_reason"] == "runtime_session_endpoint_unavailable"
 


### PR DESCRIPTION
## Summary
- make `hol-guard connect` recover when browser pairing finishes before the CLI posts sync results
- sync runtime sessions before receipt sync and persist runtime-session proof data
- add regression coverage for successful browser pairing, runtime session sync, and late daemon transitions

## Verification
- ./.venv/bin/pytest tests/test_guard_connect_flow.py tests/test_guard_cli.py -k 'guard_connect or browser_connect'\n- ./.venv/bin/ruff check src tests\n- live local browser+CLI connect against dockerized registry-broker + hol-points-portal