### PR TITLE
fix: preserve opencode native approval flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,14 @@ See [docs/guard/get-started.md](docs/guard/get-started.md) for the full local fl
 - `claude-code`
   Guard prefers Claude hooks first, then the local approval center when the shell cannot prompt.
 - `copilot`
-  Guard can wrap the `copilot` CLI, detect `~/.copilot/config.json`, `~/.copilot/mcp-config.json`, workspace `.vscode/mcp.json`, and install repo-local `.github/hooks/hol-guard-copilot.json` hook entries for documented `preToolUse` and `postToolUse` events.
+  Guard can wrap the `copilot` CLI, detect `~/.copilot/config.json`, `~/.copilot/mcp-config.json`, workspace `.vscode/mcp.json`, and install Guard-managed Copilot hook wiring for documented `preToolUse` and `postToolUse` events.
+  Guard does not treat a VS Code Copilot inline permission sheet by itself as proof of Guard interception; current proof should come from Guard hook responses, Guard receipts, or an MCP client that explicitly answers Guard elicitation.
 - `codex`
-  Guard asks inline in the same Codex chat when the interactive CLI or Codex App can answer MCP elicitations, and falls back to the local approval center for `codex exec` or any nonresponsive session.
+  Guard asks inline in the same Codex chat when the interactive CLI or Codex App can answer MCP elicitations, and falls back to the local approval center only for `codex exec` or any other nonresponsive session.
 - `cursor`
   Guard respects Cursor’s native tool approval and focuses on artifact trust before launch.
 - `opencode`
-  Guard authors package-level policy while OpenCode keeps native allow or deny rules.
+  Guard authors package-level policy while OpenCode keeps native once, always, or reject prompts for managed MCP tools.
 - `hermes`
   Guard installs a managed Hermes overlay bundle, routes MCP servers through Guard proxies, and prefers native-or-center delivery for blocked requests.
 - `gemini`

--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -166,7 +166,11 @@ Current strategy:
   scans `.gemini/settings.json`, extension manifests, hooks, MCP registrations, and Gemini skill directories before
   launch, then routes blocked changes to the approval center
 
-Guard does not claim VS Code Copilot extension-host interception in this pass, and it does not add Cisco AIBOM runtime policy logic. AIBOM can come back later only as evidence or export.
+Guard does not claim VS Code Copilot extension-host interception in this pass. A VS Code inline tool prompt by itself is
+not proof that Guard blocked the action, because that prompt can come from VS Code's own permission surface. For Copilot,
+count Guard proof only from CLI hook responses, Guard runtime receipts, or an MCP client that explicitly answers Guard
+elicitation. Guard also does not add Cisco AIBOM runtime policy logic in this pass. AIBOM can come back later only as
+evidence or export.
 
 ## First-party canaries
 

--- a/docs/guard/harness-support.md
+++ b/docs/guard/harness-support.md
@@ -6,7 +6,8 @@ Current Guard support in this repo:
   - detects global and project `config.toml`
   - parses configured MCP servers
   - supports wrapper-mode `guard run codex`
-  - uses the local approval center for blocked artifact changes today
+  - uses same-chat MCP elicitation for live managed MCP tool approvals in the interactive CLI and Codex App
+  - falls back to the local approval center only for nonresponsive or headless Codex sessions such as `codex exec`
 - `claude-code`
   - detects global and project settings, hooks, `.mcp.json`, and workspace agents
   - supports local hook install and uninstall in `.claude/settings.local.json`
@@ -39,6 +40,7 @@ Current Guard support in this repo:
     plugin files, and OpenCode-compatible skill directories
   - supports wrapper-mode management state plus a Guard-owned runtime overlay for native skill approval prompts
   - supports wrapper-mode `guard run opencode`
+  - keeps managed MCP tools on OpenCode native ask so the user can allow once, allow for the session, or reject inline
   - blocks newly introduced OpenCode MCP, plugin, and skill artifacts before launch when local Guard policy requires
     approval
 
@@ -53,6 +55,8 @@ The harness adapters are designed to prefer discovery and reversible overlay beh
 Explicit non-support:
 
 - Guard does not claim VS Code Copilot extension-host interception.
+- A VS Code Copilot inline tool prompt by itself is not proof that Guard blocked the action; that prompt can come from VS Code's own permission surface.
+- Current Copilot proof should come from Guard-owned CLI hook responses, Guard runtime receipts, or an MCP client that explicitly answers Guard elicitation.
 - Guard does not add `guard run vscode-copilot`.
 - Guard treats `~/.copilot/*` as read-only detection input and does not auto-write user-level Copilot config.
 - Guard does not add Cisco AIBOM runtime or policy integration in this pass. If revisited later, AIBOM belongs on evidence or export surfaces.

--- a/src/codex_plugin_scanner/guard/adapters/base.py
+++ b/src/codex_plugin_scanner/guard/adapters/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 from dataclasses import dataclass
@@ -31,6 +32,16 @@ def _json_payload(path: Path) -> dict[str, object]:
 
 def _command_available(command: str) -> bool:
     return shutil.which(command) is not None
+
+
+def _resolve_command(command: str, candidates: tuple[Path, ...] = ()) -> str | None:
+    resolved = shutil.which(command)
+    if resolved is not None:
+        return resolved
+    for candidate in candidates:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    return None
 
 
 def _run_command_probe(command: list[str], timeout_seconds: int = 5) -> dict[str, object]:
@@ -100,8 +111,15 @@ class HarnessAdapter:
             **shim_manifest,
         }
 
+    def executable_candidates(self, context: HarnessContext) -> tuple[Path, ...]:
+        del context
+        return ()
+
+    def resolved_executable(self, context: HarnessContext) -> str | None:
+        return _resolve_command(self.executable, self.executable_candidates(context))
+
     def launch_command(self, context: HarnessContext, passthrough_args: list[str]) -> list[str]:
-        command = [self.executable]
+        command = [self.resolved_executable(context) or self.executable]
         if context.workspace_dir is not None and self.harness in {"opencode", "claude-code"}:
             command.append(str(context.workspace_dir))
         return [*command, *passthrough_args]
@@ -211,5 +229,6 @@ __all__ = [
     "HarnessContext",
     "_command_available",
     "_json_payload",
+    "_resolve_command",
     "_run_command_probe",
 ]

--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
 
+from ..launcher import merge_guard_launcher_env
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
-from .base import HarnessAdapter, HarnessContext, _command_available, _json_payload
+from .base import HarnessAdapter, HarnessContext, _json_payload, _run_command_probe
 
 
 def _merge_hook_entry(entries: list[dict[str, object]], command: str) -> list[dict[str, object]]:
@@ -36,6 +38,10 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
     fallback_hint = "Claude is the best current harness for deferred Guard approvals."
     approval_prompt_channel = "hook"
     approval_auto_open_browser = False
+
+    def executable_candidates(self, context: HarnessContext) -> tuple[Path, ...]:
+        del context
+        return (Path.home() / ".claude" / "local" / "claude",)
 
     @staticmethod
     def _scope_for(context: HarnessContext, path: Path) -> str:
@@ -116,10 +122,11 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
                             config_path=str(agent_path),
                         )
                     )
+        resolved_executable = self.resolved_executable(context)
         return HarnessDetection(
             harness=self.harness,
-            installed=bool(found_paths) or _command_available(self.executable),
-            command_available=_command_available(self.executable),
+            installed=bool(found_paths) or resolved_executable is not None,
+            command_available=resolved_executable is not None,
             config_paths=tuple(found_paths),
             artifacts=tuple(artifacts),
             warnings=(),
@@ -127,20 +134,39 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
 
     @staticmethod
     def _hook_command(context: HarnessContext) -> str:
-        command = [
-            sys.executable,
-            "-m",
-            "codex_plugin_scanner.cli",
+        command = ClaudeCodeHarnessAdapter._hook_command_parts(context)
+        return subprocess.list2cmdline(list(command))
+
+    @staticmethod
+    def _hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
+        guard_args = [
             "guard",
             "hook",
             "--guard-home",
             str(context.guard_home),
         ]
         if context.home_dir.resolve() != Path.home().resolve():
-            command.extend(["--home", str(context.home_dir)])
+            guard_args.extend(["--home", str(context.home_dir)])
         if context.workspace_dir is not None:
-            command.extend(["--workspace", str(context.workspace_dir)])
-        return subprocess.list2cmdline(command)
+            guard_args.extend(["--workspace", str(context.workspace_dir)])
+        launcher_env = merge_guard_launcher_env()
+        pythonpath = launcher_env.get("PYTHONPATH", "")
+        if not pythonpath.strip():
+            return (sys.executable, "-m", "codex_plugin_scanner.cli", *guard_args)
+        path_entries = [entry for entry in pythonpath.split(os.pathsep) if entry.strip()]
+        code = (
+            "import sys;"
+            f"sys.path[:0]={path_entries!r};"
+            "from codex_plugin_scanner.cli import main;"
+            f"raise SystemExit(main({guard_args!r}))"
+        )
+        return (sys.executable, "-c", code)
+
+    def runtime_probe(self, context: HarnessContext) -> dict[str, object] | None:
+        resolved_executable = self.resolved_executable(context)
+        if resolved_executable is None:
+            return None
+        return _run_command_probe([resolved_executable, "--help"], timeout_seconds=5)
 
     def install(self, context: HarnessContext) -> dict[str, object]:
         shim_manifest = install_guard_shim(self.harness, context)

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -16,7 +16,13 @@ from ..launcher import merge_guard_launcher_env
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
 from .base import HarnessAdapter, HarnessContext, _command_available
-from .mcp_servers import ManagedMcpServer, managed_stdio_servers, proxy_cli_args, skipped_stdio_server_names
+from .mcp_servers import (
+    ManagedMcpServer,
+    is_guard_proxy_command,
+    managed_stdio_servers,
+    proxy_cli_args,
+    skipped_stdio_server_names,
+)
 
 
 def _read_toml(path: Path) -> dict[str, object]:
@@ -36,10 +42,16 @@ class CodexHarnessAdapter(HarnessAdapter):
     harness = "codex"
     executable = "codex"
     approval_tier = "native-or-center"
-    approval_summary = "Guard can stop live Codex MCP tool calls inline and fall back to the local approval center."
-    fallback_hint = (
-        "If Codex cannot render the inline approval request, Guard will queue it in the local approval center."
+    approval_summary = (
+        "Guard prefers same-chat Codex approvals for live MCP tool calls and falls back to the "
+        "local approval center only when Codex cannot answer."
     )
+    fallback_hint = (
+        "If Codex cannot render or return the inline approval request, Guard will queue it in the "
+        "local approval center."
+    )
+    approval_prompt_channel = "native"
+    approval_auto_open_browser = False
 
     @staticmethod
     def _scope_for(context: HarnessContext, path: Path) -> str:
@@ -66,6 +78,8 @@ class CodexHarnessAdapter(HarnessAdapter):
                         continue
                     command = server_config.get("command")
                     args = tuple(str(value) for value in server_config.get("args", []) if isinstance(value, str))
+                    if is_guard_proxy_command(command if isinstance(command, str) else None, args):
+                        continue
                     url = server_config.get("url")
                     env = server_config.get("env")
                     artifacts.append(

--- a/src/codex_plugin_scanner/guard/adapters/copilot.py
+++ b/src/codex_plugin_scanner/guard/adapters/copilot.py
@@ -167,13 +167,15 @@ def _managed_hook_payload(payload: dict[str, object]) -> dict[str, object]:
     return normalized_payload
 
 
-def _mcp_servers_payload(payload: dict[str, object]) -> dict[str, object] | None:
-    servers = payload.get("servers")
-    if isinstance(servers, dict):
-        return servers
-    mcp_servers = payload.get("mcpServers")
-    if isinstance(mcp_servers, dict):
-        return mcp_servers
+def _mcp_servers_payload(target_path: Path, payload: dict[str, object]) -> dict[str, object] | None:
+    preferred_key = CopilotHarnessAdapter._mcp_payload_key(target_path, payload)
+    preferred_servers = payload.get(preferred_key)
+    if isinstance(preferred_servers, dict):
+        return preferred_servers
+    fallback_key = "servers" if preferred_key == "mcpServers" else "mcpServers"
+    fallback_servers = payload.get(fallback_key)
+    if isinstance(fallback_servers, dict):
+        return fallback_servers
     return None
 
 
@@ -272,9 +274,23 @@ class CopilotHarnessAdapter(HarnessAdapter):
     def _mcp_payload_key(target_path: Path, payload: dict[str, object]) -> str:
         if "mcpServers" in payload and "servers" not in payload:
             return "mcpServers"
+        if "servers" in payload and "mcpServers" not in payload:
+            return "servers"
         if target_path.name in {".mcp.json", "mcp-config.json"}:
             return "mcpServers"
         return "servers"
+
+    @staticmethod
+    def _strict_json_object(path: Path, *, label: str) -> dict[str, object]:
+        if not path.is_file():
+            return {}
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RuntimeError(f"Guard refused to overwrite unreadable {label} at {path}") from exc
+        if not isinstance(payload, dict):
+            raise RuntimeError(f"Guard refused to overwrite non-object {label} at {path}")
+        return payload
 
     def detect(self, context: HarnessContext) -> HarnessDetection:
         config_candidates = [
@@ -350,7 +366,7 @@ class CopilotHarnessAdapter(HarnessAdapter):
                 encoding="utf-8",
             )
             mcp_payload = _json_payload(target_mcp_path)
-            existing_servers = _mcp_servers_payload(mcp_payload)
+            existing_servers = _mcp_servers_payload(target_mcp_path, mcp_payload)
             normalized_servers = dict(existing_servers) if isinstance(existing_servers, dict) else {}
             for name, server_config in tuple(normalized_servers.items()):
                 if not isinstance(name, str) or not isinstance(server_config, dict):
@@ -380,6 +396,8 @@ class CopilotHarnessAdapter(HarnessAdapter):
                 normalized_servers[server.name] = self._proxy_server_entry(context, server, target_mcp_path)
             payload_key = self._mcp_payload_key(target_mcp_path, mcp_payload)
             mcp_payload[payload_key] = normalized_servers
+            alternate_key = "servers" if payload_key == "mcpServers" else "mcpServers"
+            mcp_payload.pop(alternate_key, None)
             target_mcp_path.parent.mkdir(parents=True, exist_ok=True)
             target_mcp_path.write_text(json.dumps(mcp_payload, indent=2) + "\n", encoding="utf-8")
         shim_manifest = install_guard_shim(self.harness, context)
@@ -387,7 +405,7 @@ class CopilotHarnessAdapter(HarnessAdapter):
         primary_backup_path = backup_paths[0]
         primary_state_path = state_paths[0]
         config_path = self._config_path(context)
-        config_payload = _json_payload(config_path)
+        config_payload = self._strict_json_object(config_path, label="Copilot config")
         hooks_payload = _inline_hooks_payload(config_payload)
         hook_entry = _hook_entry(context, include_workspace=False)
         for hook_name in _MANAGED_HOOK_EVENTS:
@@ -458,7 +476,7 @@ class CopilotHarnessAdapter(HarnessAdapter):
         primary_backup_path = backup_paths[0] if backup_paths else ""
         primary_state_path = state_paths[0] if state_paths else ""
         config_path = self._config_path(context)
-        config_payload = _json_payload(config_path)
+        config_payload = self._strict_json_object(config_path, label="Copilot config")
         hooks_payload = _inline_hooks_payload(config_payload)
         bash_command, powershell_command = _hook_shell_commands(context, include_workspace=False)
         if len(remaining_state_entries) == 0:
@@ -556,7 +574,7 @@ class CopilotHarnessAdapter(HarnessAdapter):
         payload: dict[str, object],
         scope: str,
     ) -> list[GuardArtifact]:
-        servers = _mcp_servers_payload(payload)
+        servers = _mcp_servers_payload(config_path, payload)
         if servers is None:
             return []
         artifacts: list[GuardArtifact] = []

--- a/src/codex_plugin_scanner/guard/adapters/copilot.py
+++ b/src/codex_plugin_scanner/guard/adapters/copilot.py
@@ -7,19 +7,29 @@ import re
 import shlex
 import subprocess
 import sys
+from hashlib import sha256
 from pathlib import Path
 
+from ..launcher import merge_guard_launcher_env
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
-from .base import HarnessAdapter, HarnessContext, _command_available, _json_payload, _run_command_probe
+from .base import HarnessAdapter, HarnessContext, _json_payload, _run_command_probe
+from .mcp_servers import (
+    ManagedMcpServer,
+    is_guard_proxy_command,
+    managed_stdio_servers,
+    proxy_cli_args,
+    skipped_stdio_server_names,
+)
 
-_MANAGED_HOOK_EVENTS = ("preToolUse", "postToolUse")
+_MANAGED_HOOK_EVENTS = ("preToolUse", "postToolUse", "permissionRequest")
 _DETECTABLE_HOOK_EVENTS = (
     "sessionStart",
     "sessionEnd",
     "userPromptSubmitted",
     "preToolUse",
     "postToolUse",
+    "permissionRequest",
     "errorOccurred",
 )
 _MANAGED_HOOK_FILENAME = "hol-guard-copilot.json"
@@ -31,7 +41,7 @@ _MANAGED_HOOK_COMMAND_PATTERNS = (
 )
 
 
-def _hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
+def _hook_command_parts(context: HarnessContext, *, include_workspace: bool) -> tuple[str, ...]:
     command = [
         sys.executable,
         "-m",
@@ -45,25 +55,29 @@ def _hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
     ]
     if context.home_dir.resolve() != Path.home().resolve():
         command.extend(["--home", str(context.home_dir)])
-    if context.workspace_dir is not None:
+    if include_workspace and context.workspace_dir is not None:
         command.extend(["--workspace", str(context.workspace_dir)])
     return tuple(command)
 
 
-def _hook_shell_commands(context: HarnessContext) -> tuple[str, str]:
-    command_parts = _hook_command_parts(context)
+def _hook_shell_commands(context: HarnessContext, *, include_workspace: bool) -> tuple[str, str]:
+    command_parts = _hook_command_parts(context, include_workspace=include_workspace)
     return shlex.join(command_parts), subprocess.list2cmdline(list(command_parts))
 
 
-def _hook_entry(context: HarnessContext) -> dict[str, object]:
-    bash_command, powershell_command = _hook_shell_commands(context)
-    return {
+def _hook_entry(context: HarnessContext, *, include_workspace: bool) -> dict[str, object]:
+    bash_command, powershell_command = _hook_shell_commands(context, include_workspace=include_workspace)
+    entry: dict[str, object] = {
         "type": "command",
         "bash": bash_command,
         "powershell": powershell_command,
         "cwd": ".",
         "timeoutSec": 30,
     }
+    env = merge_guard_launcher_env()
+    if env:
+        entry["env"] = env
+    return entry
 
 
 def _is_managed_hook_command(command: str) -> bool:
@@ -107,6 +121,20 @@ def _hooks_payload(payload: dict[str, object]) -> dict[str, object]:
     if isinstance(hooks, dict):
         return hooks
     return payload
+
+
+def _inline_hooks_payload(payload: dict[str, object]) -> dict[str, object]:
+    hooks = payload.get("hooks")
+    if isinstance(hooks, dict):
+        normalized = {
+            str(hook_name): list(entries) if isinstance(entries, list) else entries
+            for hook_name, entries in hooks.items()
+        }
+        payload["hooks"] = normalized
+        return normalized
+    normalized: dict[str, object] = {}
+    payload["hooks"] = normalized
+    return normalized
 
 
 def _hook_command_variants(entry: dict[str, object]) -> tuple[tuple[str, str], ...]:
@@ -162,6 +190,23 @@ def _command_parts(server_config: dict[str, object]) -> tuple[str | None, tuple[
     return None, args
 
 
+def _refresh_guard_proxy_entry(
+    server_config: dict[str, object],
+    *,
+    launcher_env: dict[str, str],
+) -> dict[str, object]:
+    refreshed = dict(server_config)
+    _command, args = _command_parts(server_config)
+    refreshed["command"] = sys.executable
+    refreshed["args"] = list(args)
+    if launcher_env:
+        refreshed["env"] = launcher_env
+    else:
+        refreshed.pop("env", None)
+        refreshed.pop("environment", None)
+    return refreshed
+
+
 class CopilotHarnessAdapter(HarnessAdapter):
     """Discover Microsoft Copilot CLI repo hooks and MCP config artifacts."""
 
@@ -169,11 +214,21 @@ class CopilotHarnessAdapter(HarnessAdapter):
     executable = "copilot"
     approval_tier = "native-or-center"
     approval_summary = (
-        "Guard can install documented Copilot CLI repo hooks and falls back to the local approval center when needed."
+        "Guard uses native Copilot prompts through Copilot CLI hook surfaces and VS Code workspace hooks when "
+        "those surfaces are installed. Guard falls back to the local approval center only when the active Copilot "
+        "surface cannot prompt."
     )
-    fallback_hint = "Use Guard-managed repo hooks for Copilot CLI tool events and the local approval center for review."
+    fallback_hint = (
+        "Guard prefers native Copilot prompts where the active Copilot surface exposes them. Proof for Copilot "
+        "should come from native hook responses and Guard runtime receipts in Copilot CLI or VS Code workspace "
+        "hooks, or from the local approval center when prompting is unavailable."
+    )
     approval_prompt_channel = "hook"
     approval_auto_open_browser = False
+
+    def executable_candidates(self, context: HarnessContext) -> tuple[Path, ...]:
+        del context
+        return (Path.home() / ".local" / "copilot-cli" / "copilot",)
 
     @staticmethod
     def _scope_for(context: HarnessContext, path: Path) -> str:
@@ -187,16 +242,46 @@ class CopilotHarnessAdapter(HarnessAdapter):
             return None
         return context.workspace_dir / ".github" / "hooks" / _MANAGED_HOOK_FILENAME
 
-    def detect(self, context: HarnessContext) -> HarnessDetection:
-        workspace_mcp_path = (
-            context.workspace_dir / ".vscode" / "mcp.json" if context.workspace_dir is not None else None
+    @staticmethod
+    def _config_path(context: HarnessContext) -> Path:
+        return context.home_dir / ".copilot" / "config.json"
+
+    @staticmethod
+    def _workspace_mcp_paths(context: HarnessContext) -> tuple[Path, ...]:
+        if context.workspace_dir is None:
+            return ()
+        return (
+            context.workspace_dir / ".mcp.json",
+            context.workspace_dir / ".vscode" / "mcp.json",
         )
+
+    @staticmethod
+    def _target_mcp_paths(context: HarnessContext) -> tuple[Path, ...]:
+        workspace_paths = CopilotHarnessAdapter._workspace_mcp_paths(context)
+        if len(workspace_paths) > 0:
+            return workspace_paths
+        return (context.home_dir / ".copilot" / "mcp-config.json",)
+
+    @staticmethod
+    def _backup_path(target_path: Path, context: HarnessContext) -> Path:
+        target = str(target_path.resolve())
+        digest = sha256(target.encode("utf-8")).hexdigest()[:12]
+        return context.guard_home / "managed" / "copilot" / f"{digest}.backup.json"
+
+    @staticmethod
+    def _mcp_payload_key(target_path: Path, payload: dict[str, object]) -> str:
+        if "mcpServers" in payload and "servers" not in payload:
+            return "mcpServers"
+        if target_path.name in {".mcp.json", "mcp-config.json"}:
+            return "mcpServers"
+        return "servers"
+
+    def detect(self, context: HarnessContext) -> HarnessDetection:
         config_candidates = [
             context.home_dir / ".copilot" / "config.json",
             context.home_dir / ".copilot" / "mcp-config.json",
         ]
-        if context.workspace_dir is not None:
-            config_candidates.append(workspace_mcp_path)
+        config_candidates.extend(self._workspace_mcp_paths(context))
         artifacts: list[GuardArtifact] = []
         found_paths: list[str] = []
         for config_path in config_candidates:
@@ -205,7 +290,10 @@ class CopilotHarnessAdapter(HarnessAdapter):
                 continue
             found_paths.append(str(config_path))
             scope = self._scope_for(context, config_path)
-            if config_path.name == "mcp-config.json" or config_path == workspace_mcp_path:
+            hook_artifacts = self._hook_artifacts(config_path, payload, scope)
+            if len(hook_artifacts) > 0:
+                artifacts.extend(hook_artifacts)
+            if config_path.name == "mcp-config.json" or config_path in self._workspace_mcp_paths(context):
                 artifacts.extend(self._mcp_artifacts(config_path, payload, scope))
         if context.workspace_dir is not None:
             hooks_dir = context.workspace_dir / ".github" / "hooks"
@@ -214,92 +302,239 @@ class CopilotHarnessAdapter(HarnessAdapter):
                     payload = _json_payload(hook_path)
                     if not payload:
                         continue
-                    hook_artifacts = self._hook_artifacts(hook_path, payload)
+                    hook_artifacts = self._hook_artifacts(hook_path, payload, "project")
                     if len(hook_artifacts) == 0:
                         continue
                     found_paths.append(str(hook_path))
                     artifacts.extend(hook_artifacts)
         return HarnessDetection(
             harness=self.harness,
-            installed=bool(found_paths) or _command_available(self.executable),
-            command_available=_command_available(self.executable),
+            installed=bool(found_paths) or self.resolved_executable(context) is not None,
+            command_available=self.resolved_executable(context) is not None,
             config_paths=tuple(found_paths),
             artifacts=tuple(artifacts),
             warnings=(),
         )
 
     def install(self, context: HarnessContext) -> dict[str, object]:
-        shim_manifest = install_guard_shim(self.harness, context)
-        hook_path = self._hook_path(context)
-        if hook_path is None:
-            return {
-                "harness": self.harness,
-                "active": True,
-                "config_path": shim_manifest["shim_path"],
-                **shim_manifest,
-                "notes": [
-                    "Guard created the Copilot launcher shim. Pass --workspace to install repo-local Copilot hooks.",
-                    *[str(note) for note in shim_manifest.get("notes", [])],
-                ],
+        detection = self.detect(context)
+        managed_servers = managed_stdio_servers(detection)
+        skipped_servers = skipped_stdio_server_names(detection)
+        target_mcp_paths = self._target_mcp_paths(context)
+        backup_paths: list[str] = []
+        state_paths: list[str] = []
+        for target_mcp_path in target_mcp_paths:
+            original_text = target_mcp_path.read_text(encoding="utf-8") if target_mcp_path.is_file() else None
+            backup_path = self._backup_path(target_mcp_path, context)
+            backup_paths.append(str(backup_path))
+            if not backup_path.exists():
+                backup_path.parent.mkdir(parents=True, exist_ok=True)
+                backup_payload = {"existed": original_text is not None, "content": original_text}
+                backup_path.write_text(json.dumps(backup_payload, indent=2) + "\n", encoding="utf-8")
+            state_path = self._state_path(target_mcp_path, context)
+            state_paths.append(str(state_path))
+            state_path.parent.mkdir(parents=True, exist_ok=True)
+            state_path.write_text(
+                json.dumps(
+                    {
+                        "managed_config_path": str(target_mcp_path),
+                        "backup_path": str(backup_path),
+                        "scope": self._scope_for(context, target_mcp_path),
+                        "workspace_dir": (
+                            str(context.workspace_dir.resolve()) if context.workspace_dir is not None else None
+                        ),
+                    },
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            mcp_payload = _json_payload(target_mcp_path)
+            existing_servers = _mcp_servers_payload(mcp_payload)
+            normalized_servers = dict(existing_servers) if isinstance(existing_servers, dict) else {}
+            for name, server_config in tuple(normalized_servers.items()):
+                if not isinstance(name, str) or not isinstance(server_config, dict):
+                    continue
+                command, args = _command_parts(server_config)
+                if not is_guard_proxy_command(command, args):
+                    continue
+                existing_env = server_config.get("env")
+                if not isinstance(existing_env, dict):
+                    existing_env = server_config.get("environment")
+                normalized_servers[name] = _refresh_guard_proxy_entry(
+                    server_config,
+                    launcher_env=merge_guard_launcher_env(existing_env if isinstance(existing_env, dict) else {}),
+                )
+            existing_workspace_server_names = {
+                name
+                for name, server in normalized_servers.items()
+                if isinstance(name, str) and isinstance(server, dict)
             }
-        payload = _managed_hook_payload(_json_payload(hook_path))
-        hooks_payload = payload["hooks"]
-        hook_entry = _hook_entry(context)
+            for server in self._managed_servers_for_target(managed_servers, target_mcp_path):
+                if self._should_skip_workspace_override(
+                    context=context,
+                    server=server,
+                    existing_workspace_server_names=existing_workspace_server_names,
+                ):
+                    continue
+                normalized_servers[server.name] = self._proxy_server_entry(context, server, target_mcp_path)
+            payload_key = self._mcp_payload_key(target_mcp_path, mcp_payload)
+            mcp_payload[payload_key] = normalized_servers
+            target_mcp_path.parent.mkdir(parents=True, exist_ok=True)
+            target_mcp_path.write_text(json.dumps(mcp_payload, indent=2) + "\n", encoding="utf-8")
+        shim_manifest = install_guard_shim(self.harness, context)
+        primary_target_mcp_path = target_mcp_paths[0]
+        primary_backup_path = backup_paths[0]
+        primary_state_path = state_paths[0]
+        config_path = self._config_path(context)
+        config_payload = _json_payload(config_path)
+        hooks_payload = _inline_hooks_payload(config_payload)
+        hook_entry = _hook_entry(context, include_workspace=False)
         for hook_name in _MANAGED_HOOK_EVENTS:
             hooks_payload[hook_name] = _merge_hook_entries(hooks_payload.get(hook_name), hook_entry)
-        hook_path.parent.mkdir(parents=True, exist_ok=True)
-        hook_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config_payload, indent=2) + "\n", encoding="utf-8")
+        managed_hook_path = self._hook_path(context)
+        if managed_hook_path is not None:
+            managed_hook_payload = _managed_hook_payload(_json_payload(managed_hook_path))
+            managed_workspace_hooks = managed_hook_payload["hooks"]
+            managed_workspace_entry = _hook_entry(context, include_workspace=True)
+            for hook_name in _MANAGED_HOOK_EVENTS:
+                managed_workspace_hooks[hook_name] = _merge_hook_entries(
+                    managed_workspace_hooks.get(hook_name),
+                    managed_workspace_entry,
+                )
+            managed_hook_path.parent.mkdir(parents=True, exist_ok=True)
+            managed_hook_path.write_text(json.dumps(managed_hook_payload, indent=2) + "\n", encoding="utf-8")
         return {
             "harness": self.harness,
             "active": True,
-            "config_path": str(hook_path),
+            "config_path": str(config_path),
             **shim_manifest,
+            "managed_config_path": str(primary_target_mcp_path),
+            "managed_config_paths": [str(path) for path in target_mcp_paths],
+            "backup_path": primary_backup_path,
+            "backup_paths": backup_paths,
+            "state_path": primary_state_path,
+            "state_paths": state_paths,
+            "managed_servers": [server.name for server in managed_servers],
+            "skipped_servers": list(skipped_servers),
             "notes": [
-                "Guard hook entries added to .github/hooks/hol-guard-copilot.json",
+                "Guard hook entries added to ~/.copilot/config.json for Copilot CLI.",
+                "Guard workspace hook entries added to .github/hooks/hol-guard-copilot.json for VS Code Copilot.",
+                "Guard MCP proxies added to Copilot CLI and VS Code workspace MCP config files.",
                 *[str(note) for note in shim_manifest.get("notes", [])],
             ],
         }
 
     def uninstall(self, context: HarnessContext) -> dict[str, object]:
-        shim_manifest = remove_guard_shim(self.harness, context)
-        hook_path = self._hook_path(context)
-        if hook_path is None:
-            return {
-                "harness": self.harness,
-                "active": False,
-                "config_path": shim_manifest["shim_path"],
-                **shim_manifest,
-            }
-        payload = _json_payload(hook_path)
-        payload = _managed_hook_payload(payload)
-        hooks_payload = payload["hooks"]
-        bash_command, powershell_command = _hook_shell_commands(context)
-        for hook_name in _MANAGED_HOOK_EVENTS:
-            updated_entries = _remove_hook_entries(hooks_payload.get(hook_name), bash_command, powershell_command)
-            if len(updated_entries) > 0:
-                hooks_payload[hook_name] = updated_entries
+        uninstall_targets = self._uninstall_targets(context)
+        for state_path, target_mcp_path, backup_path in uninstall_targets:
+            cleanup_complete = False
+            if not backup_path.is_file():
                 continue
-            hooks_payload.pop(hook_name, None)
-        if len(hooks_payload) > 0:
-            hook_path.parent.mkdir(parents=True, exist_ok=True)
-            hook_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-        elif hook_path.exists():
-            hook_path.unlink()
+            backup_payload = self._backup_payload(backup_path)
+            if backup_payload["readable"] is not True:
+                continue
+            if backup_payload["existed"] and isinstance(backup_payload["content"], str):
+                target_mcp_path.parent.mkdir(parents=True, exist_ok=True)
+                target_mcp_path.write_text(str(backup_payload["content"]), encoding="utf-8")
+                cleanup_complete = True
+            elif backup_payload["existed"] is not True and target_mcp_path.is_file():
+                target_mcp_path.unlink()
+                cleanup_complete = True
+            elif backup_payload["existed"] is not True:
+                cleanup_complete = True
+            if cleanup_complete:
+                backup_path.unlink()
+            if cleanup_complete and state_path.is_file():
+                state_path.unlink()
+        shim_manifest = remove_guard_shim(self.harness, context)
+        remaining_state_entries = self._state_entries(context)
+        managed_config_paths = [str(target_path) for _state_path, target_path, _backup_path in uninstall_targets]
+        backup_paths = [str(backup_path) for _state_path, _target_path, backup_path in uninstall_targets]
+        state_paths = [str(state_path) for state_path, _target_path, _backup_path in uninstall_targets]
+        primary_target_mcp_path = managed_config_paths[0] if managed_config_paths else ""
+        primary_backup_path = backup_paths[0] if backup_paths else ""
+        primary_state_path = state_paths[0] if state_paths else ""
+        config_path = self._config_path(context)
+        config_payload = _json_payload(config_path)
+        hooks_payload = _inline_hooks_payload(config_payload)
+        bash_command, powershell_command = _hook_shell_commands(context, include_workspace=False)
+        if len(remaining_state_entries) == 0:
+            for hook_name in _MANAGED_HOOK_EVENTS:
+                updated_entries = _remove_hook_entries(hooks_payload.get(hook_name), bash_command, powershell_command)
+                if len(updated_entries) > 0:
+                    hooks_payload[hook_name] = updated_entries
+                    continue
+                hooks_payload.pop(hook_name, None)
+            if len(hooks_payload) == 0:
+                config_payload.pop("hooks", None)
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config_payload, indent=2) + "\n", encoding="utf-8")
+        managed_hook_path = self._hook_path(context)
+        if managed_hook_path is not None and managed_hook_path.is_file():
+            managed_hook_payload = _managed_hook_payload(_json_payload(managed_hook_path))
+            managed_workspace_hooks = managed_hook_payload["hooks"]
+            managed_bash_command, managed_powershell_command = _hook_shell_commands(
+                context,
+                include_workspace=True,
+            )
+            for hook_name in _MANAGED_HOOK_EVENTS:
+                updated_entries = _remove_hook_entries(
+                    managed_workspace_hooks.get(hook_name),
+                    managed_bash_command,
+                    managed_powershell_command,
+                )
+                if len(updated_entries) > 0:
+                    managed_workspace_hooks[hook_name] = updated_entries
+                    continue
+                managed_workspace_hooks.pop(hook_name, None)
+            if len(managed_workspace_hooks) > 0:
+                managed_hook_path.parent.mkdir(parents=True, exist_ok=True)
+                managed_hook_path.write_text(json.dumps(managed_hook_payload, indent=2) + "\n", encoding="utf-8")
+            else:
+                managed_hook_path.unlink()
         return {
             "harness": self.harness,
             "active": False,
-            "config_path": str(hook_path),
+            "config_path": str(config_path),
             **shim_manifest,
+            "managed_config_path": primary_target_mcp_path,
+            "managed_config_paths": managed_config_paths,
+            "backup_path": primary_backup_path,
+            "backup_paths": backup_paths,
+            "state_path": primary_state_path,
+            "state_paths": state_paths,
             "notes": [
-                "Guard hook entries removed from .github/hooks/hol-guard-copilot.json",
+                "Guard hook entries removed from ~/.copilot/config.json for Copilot CLI.",
+                "Guard workspace hook entries removed from .github/hooks/hol-guard-copilot.json for VS Code Copilot.",
+                "Guard restored the prior Copilot MCP config for the active Copilot surfaces.",
                 *[str(note) for note in shim_manifest.get("notes", [])],
             ],
         }
 
     def runtime_probe(self, context: HarnessContext) -> dict[str, object] | None:
-        if not _command_available(self.executable):
+        executable = self.resolved_executable(context)
+        if executable is None:
             return None
-        return _run_command_probe([self.executable, "--help"])
+        return _run_command_probe([executable, "--help"])
+
+    def launch_command(self, context: HarnessContext, passthrough_args: list[str]) -> list[str]:
+        executable = self.resolved_executable(context) or self.executable
+        workspace_paths = self._workspace_mcp_paths(context)
+        cli_workspace_config = next(
+            (path for path in workspace_paths if path.name == ".mcp.json" and path.is_file()),
+            None,
+        )
+        if cli_workspace_config is None:
+            return [executable, *passthrough_args]
+        return [
+            executable,
+            "--additional-mcp-config",
+            f"@{cli_workspace_config}",
+            *passthrough_args,
+        ]
 
     def diagnostic_warnings(
         self,
@@ -329,7 +564,12 @@ class CopilotHarnessAdapter(HarnessAdapter):
             if not isinstance(name, str) or not isinstance(server_config, dict):
                 continue
             command, args = _command_parts(server_config)
+            if is_guard_proxy_command(command, args):
+                continue
             url = server_config.get("url")
+            environment = server_config.get("env")
+            if not isinstance(environment, dict):
+                environment = server_config.get("environment")
             artifacts.append(
                 GuardArtifact(
                     artifact_id=f"copilot:{scope}:{name}",
@@ -342,6 +582,15 @@ class CopilotHarnessAdapter(HarnessAdapter):
                     args=args,
                     url=url if isinstance(url, str) else None,
                     transport="http" if isinstance(url, str) else "stdio",
+                    metadata={
+                        "env": {
+                            str(key): str(value)
+                            for key, value in environment.items()
+                            if isinstance(key, str) and isinstance(value, str)
+                        }
+                        if isinstance(environment, dict)
+                        else {}
+                    },
                 )
             )
         return artifacts
@@ -350,6 +599,7 @@ class CopilotHarnessAdapter(HarnessAdapter):
         self,
         config_path: Path,
         payload: dict[str, object],
+        scope: str,
     ) -> list[GuardArtifact]:
         artifacts: list[GuardArtifact] = []
         hooks_payload = _hooks_payload(payload)
@@ -364,15 +614,152 @@ class CopilotHarnessAdapter(HarnessAdapter):
                     artifacts.append(
                         GuardArtifact(
                             artifact_id=(
-                                f"copilot:project:hook:{config_path.stem}:{hook_name.lower()}:{index}:{shell_name}"
+                                f"copilot:{scope}:hook:{config_path.stem}:{hook_name.lower()}:{index}:{shell_name}"
                             ),
                             name=hook_name,
                             harness=self.harness,
                             artifact_type="hook",
-                            source_scope="project",
+                            source_scope=scope,
                             config_path=str(config_path),
                             command=command,
                             metadata={"shell": shell_name},
                         )
                     )
         return artifacts
+
+    def _proxy_server_entry(
+        self,
+        context: HarnessContext,
+        server: ManagedMcpServer,
+        target_path: Path,
+    ) -> dict[str, object]:
+        args = proxy_cli_args(
+            proxy_command="copilot-mcp-proxy",
+            guard_home=str(context.guard_home),
+            server=server,
+            home=str(context.home_dir) if context.home_dir.resolve() != Path.home().resolve() else None,
+            workspace=str(context.workspace_dir) if context.workspace_dir is not None else None,
+        )
+        entry: dict[str, object] = {
+            "command": sys.executable,
+            "args": args,
+        }
+        env = merge_guard_launcher_env(getattr(server, "env", {}))
+        if env:
+            entry["env"] = env
+        if target_path.name in {".mcp.json", "mcp-config.json"}:
+            entry["type"] = "local"
+            entry["tools"] = ["*"]
+        else:
+            entry["type"] = "stdio"
+        return entry
+
+    @staticmethod
+    def _backup_payload(backup_path: Path) -> dict[str, str | bool | None]:
+        try:
+            payload = json.loads(backup_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {"readable": False, "existed": False, "content": None}
+        if not isinstance(payload, dict):
+            return {"readable": False, "existed": False, "content": None}
+        existed = payload.get("existed") is True
+        content = payload.get("content")
+        return {"readable": True, "existed": existed, "content": content if isinstance(content, str) else None}
+
+    @staticmethod
+    def _state_path(target_path: Path, context: HarnessContext) -> Path:
+        target = str(target_path.resolve())
+        digest = sha256(target.encode("utf-8")).hexdigest()[:12]
+        return context.guard_home / "managed" / "copilot" / f"{digest}.state.json"
+
+    @staticmethod
+    def _state_payload(state_path: Path) -> dict[str, str]:
+        if not state_path.is_file():
+            return {}
+        try:
+            payload = json.loads(state_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {}
+        if not isinstance(payload, dict):
+            return {}
+        result: dict[str, str] = {}
+        for key in ("managed_config_path", "backup_path", "scope", "workspace_dir"):
+            value = payload.get(key)
+            if isinstance(value, str):
+                result[key] = value
+        return result
+
+    @classmethod
+    def _state_entries(cls, context: HarnessContext) -> list[tuple[Path, Path, Path, dict[str, str]]]:
+        state_dir = context.guard_home / "managed" / "copilot"
+        entries: list[tuple[Path, Path, Path, dict[str, str]]] = []
+        for state_path in sorted(state_dir.glob("*.state.json")):
+            payload = cls._state_payload(state_path)
+            managed_config_path = payload.get("managed_config_path")
+            backup_path = payload.get("backup_path")
+            if not isinstance(managed_config_path, str) or not isinstance(backup_path, str):
+                continue
+            entries.append((state_path, Path(managed_config_path), Path(backup_path), payload))
+        return entries
+
+    @classmethod
+    def _uninstall_targets(cls, context: HarnessContext) -> list[tuple[Path, Path, Path]]:
+        current_targets = cls._target_mcp_paths(context)
+        current_target_paths = {str(target_path.resolve()) for target_path in current_targets}
+        state_entries = cls._state_entries(context)
+        exact_matches = [
+            (state_path, managed_config_path, backup_path)
+            for state_path, managed_config_path, backup_path, _payload in state_entries
+            if str(managed_config_path.resolve()) in current_target_paths
+        ]
+        if exact_matches:
+            return exact_matches
+        if context.workspace_dir is not None:
+            current_workspace = str(context.workspace_dir.resolve())
+            workspace_matches = [
+                (state_path, managed_config_path, backup_path)
+                for state_path, managed_config_path, backup_path, payload in state_entries
+                if payload.get("workspace_dir") == current_workspace
+            ]
+            if workspace_matches:
+                return workspace_matches
+        if context.workspace_dir is None and state_entries:
+            return [
+                (state_path, managed_config_path, backup_path)
+                for state_path, managed_config_path, backup_path, _payload in state_entries
+            ]
+        return [
+            (
+                cls._state_path(target_path, context),
+                target_path,
+                cls._backup_path(target_path, context),
+            )
+            for target_path in current_targets
+        ]
+
+    @staticmethod
+    def _managed_servers_for_target(
+        servers: tuple[ManagedMcpServer, ...],
+        target_mcp_path: Path,
+    ) -> tuple[ManagedMcpServer, ...]:
+        filtered: list[ManagedMcpServer] = []
+        for server in servers:
+            if server.source_scope == "global":
+                filtered.append(server)
+                continue
+            if Path(server.config_path) == target_mcp_path:
+                filtered.append(server)
+        return tuple(filtered)
+
+    @staticmethod
+    def _should_skip_workspace_override(
+        *,
+        context: HarnessContext,
+        server: ManagedMcpServer,
+        existing_workspace_server_names: set[str],
+    ) -> bool:
+        if context.workspace_dir is None:
+            return False
+        if server.source_scope == "project":
+            return False
+        return server.name in existing_workspace_server_names

--- a/src/codex_plugin_scanner/guard/adapters/mcp_servers.py
+++ b/src/codex_plugin_scanner/guard/adapters/mcp_servers.py
@@ -22,6 +22,16 @@ class ManagedMcpServer:
     enabled: bool
 
 
+_GUARD_PROXY_COMMANDS = frozenset(
+    {
+        "codex-mcp-proxy",
+        "opencode-mcp-proxy",
+        "copilot-mcp-proxy",
+        "mcp-proxy",
+    }
+)
+
+
 def managed_stdio_servers(detection: HarnessDetection) -> tuple[ManagedMcpServer, ...]:
     """Extract local stdio MCP servers from a harness detection payload."""
 
@@ -89,6 +99,8 @@ def _managed_stdio_server(artifact: GuardArtifact) -> ManagedMcpServer | None:
         return None
     if artifact.command is None or not artifact.name.strip():
         return None
+    if is_guard_proxy_command(artifact.command, artifact.args):
+        return None
     transport = artifact.transport or "stdio"
     if transport not in {"stdio", "local"}:
         return None
@@ -123,8 +135,17 @@ def _bool_metadata(value: object, *, default: bool) -> bool:
     return default
 
 
+def is_guard_proxy_command(command: str | None, args: tuple[str, ...]) -> bool:
+    if not isinstance(command, str):
+        return False
+    if "codex_plugin_scanner.cli" not in args or "guard" not in args:
+        return False
+    return any(value in _GUARD_PROXY_COMMANDS for value in args)
+
+
 __all__ = [
     "ManagedMcpServer",
+    "is_guard_proxy_command",
     "managed_stdio_servers",
     "proxy_cli_args",
     "skipped_stdio_server_names",

--- a/src/codex_plugin_scanner/guard/adapters/opencode.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import sys
@@ -14,10 +15,12 @@ from ..shims import install_guard_shim, remove_guard_shim
 from .base import HarnessAdapter, HarnessContext, _command_available, _run_command_probe
 from .mcp_servers import ManagedMcpServer, managed_stdio_servers, proxy_cli_args, skipped_stdio_server_names
 from .opencode_artifacts import (
+    CONFIG_FILENAMES,
     append_config_artifacts,
     append_directory_artifacts,
     append_found_path,
     config_paths,
+    configured_config_path,
     runtime_config_path,
     runtime_overlay,
 )
@@ -31,13 +34,62 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
     approval_tier = "mixed"
     approval_summary = (
         "Guard evaluates OpenCode skills, MCP servers, commands, and plugins before launch, and the managed "
-        "runtime overlay keeps native skill loads on ask."
+        "runtime overlay keeps managed MCP tools on native ask."
     )
     fallback_hint = (
-        "Use Guard approvals for blocked artifacts and OpenCode's native allow once or allow session flow for skills."
+        "Use Guard approvals for blocked artifacts and OpenCode's native allow once or allow session flow for "
+        "managed MCP tools."
     )
     approval_prompt_channel = "native"
     approval_auto_open_browser = False
+
+    _SUBCOMMANDS = frozenset(
+        {
+            "completion",
+            "acp",
+            "mcp",
+            "attach",
+            "run",
+            "auth",
+            "agent",
+            "upgrade",
+            "uninstall",
+            "serve",
+            "web",
+            "models",
+            "stats",
+            "export",
+            "import",
+            "github",
+            "pr",
+            "session",
+            "db",
+        }
+    )
+    _REQUIRED_VALUE_OPTIONS = frozenset(
+        {
+            "--hostname",
+            "--mdns-domain",
+            "--cors",
+            "--model",
+            "-m",
+            "--session",
+            "-s",
+            "--prompt",
+            "--agent",
+            "--variant",
+            "--log-level",
+            "--command",
+            "--format",
+            "--file",
+            "-f",
+            "--attach",
+            "--password",
+            "-p",
+            "--dir",
+        }
+    )
+    _OPTIONAL_VALUE_OPTIONS = frozenset({"--port", "--title"})
 
     @staticmethod
     def _scope_for(context: HarnessContext, path: Path) -> str:
@@ -81,7 +133,50 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
         detection = self.detect(context)
         managed_servers = managed_stdio_servers(detection)
         skipped_servers = skipped_stdio_server_names(detection)
+        target_config_path = self._target_config_path(context)
+        original_text = None
+        if target_config_path.is_file():
+            original_text = target_config_path.read_text(encoding="utf-8")
+        backup_path = self._backup_path(context)
+        if not backup_path.exists():
+            backup_path.parent.mkdir(parents=True, exist_ok=True)
+            backup_payload = {"existed": original_text is not None, "content": original_text}
+            backup_path.write_text(json.dumps(backup_payload, indent=2) + "\n", encoding="utf-8")
+        state_path = self._state_path(context, target_config_path)
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(
+            json.dumps(
+                {
+                    "managed_config_path": str(target_config_path),
+                    "backup_path": str(backup_path),
+                    "scope": "workspace" if context.workspace_dir is not None else "global",
+                    "workspace_dir": (
+                        str(context.workspace_dir.resolve()) if context.workspace_dir is not None else None
+                    ),
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        target_payload, parse_error, _parse_reason = _load_json_or_jsonc(target_config_path)
+        if parse_error or not isinstance(target_payload, dict):
+            target_payload = {}
         existing_workspace_server_names = self._workspace_server_names(context)
+        target_payload["permission"] = self._managed_permission_payload(
+            target_payload.get("permission"),
+            context=context,
+            servers=managed_servers,
+            existing_workspace_server_names=existing_workspace_server_names,
+        )
+        target_payload["mcp"] = self._managed_mcp_payload(
+            target_payload.get("mcp"),
+            context=context,
+            servers=managed_servers,
+            existing_workspace_server_names=existing_workspace_server_names,
+        )
+        target_config_path.parent.mkdir(parents=True, exist_ok=True)
+        target_config_path.write_text(json.dumps(target_payload, indent=2) + "\n", encoding="utf-8")
         shim_manifest = install_guard_shim(self.harness, context)
         overlay_path = runtime_config_path(context)
         overlay_path.parent.mkdir(parents=True, exist_ok=True)
@@ -106,14 +201,17 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
         )
         notes = [
             *list(shim_manifest.get("notes", [])),
-            "Guard added an OpenCode runtime overlay that keeps native skill loads on ask and routes managed "
-            "local MCP servers through Guard runtime interception when you launch through Guard.",
+            "Guard added an OpenCode runtime overlay that keeps managed MCP tools on native ask and routes "
+            "managed local MCP servers through Guard runtime interception when you launch through Guard.",
         ]
         return {
             "harness": self.harness,
             "active": True,
-            "config_path": str(overlay_path),
+            "config_path": str(target_config_path),
             **shim_manifest,
+            "managed_config_path": str(target_config_path),
+            "backup_path": str(backup_path),
+            "state_path": str(state_path),
             "runtime_config_path": str(overlay_path),
             "runtime_env_var": "OPENCODE_CONFIG_CONTENT",
             "managed_servers": [server.name for server in managed_servers],
@@ -123,6 +221,30 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
         }
 
     def uninstall(self, context: HarnessContext) -> dict[str, object]:
+        state_path, state_payload = self._state_entry(context)
+        target_config_path = self._managed_config_path_from_state(context, state_payload)
+        backup_path = self._backup_path_from_state(context, state_payload, target_config_path)
+        state_cleanup_complete = False
+        if backup_path.is_file():
+            backup_payload = self._backup_payload(backup_path)
+            if backup_payload["readable"] is not True:
+                pass
+            elif backup_payload["existed"]:
+                original_text = backup_payload["content"]
+                if isinstance(original_text, str):
+                    target_config_path.parent.mkdir(parents=True, exist_ok=True)
+                    target_config_path.write_text(original_text, encoding="utf-8")
+                    backup_path.unlink()
+                    state_cleanup_complete = True
+            elif target_config_path.is_file():
+                target_config_path.unlink()
+                backup_path.unlink()
+                state_cleanup_complete = True
+            else:
+                backup_path.unlink()
+                state_cleanup_complete = True
+        if state_cleanup_complete and state_path.is_file():
+            state_path.unlink()
         shim_manifest = remove_guard_shim(self.harness, context)
         notes = [
             *list(shim_manifest.get("notes", [])),
@@ -132,8 +254,11 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
         return {
             "harness": self.harness,
             "active": False,
-            "config_path": str(runtime_config_path(context)),
+            "config_path": str(target_config_path),
             **shim_manifest,
+            "managed_config_path": str(target_config_path),
+            "backup_path": str(backup_path),
+            "state_path": str(state_path),
             "runtime_config_path": str(runtime_config_path(context)),
             "runtime_env_var": "OPENCODE_CONFIG_CONTENT",
             "notes": notes,
@@ -152,13 +277,11 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
         return {"OPENCODE_CONFIG_CONTENT": json.dumps(merged_config)}
 
     def launch_command(self, context: HarnessContext, passthrough_args: list[str]) -> list[str]:
-        if context.workspace_dir is not None and passthrough_args:
-            return [self.executable, "run", *passthrough_args]
-        if context.workspace_dir is not None:
-            return [self.executable, str(context.workspace_dir)]
-        if passthrough_args:
-            return [self.executable, "run", *passthrough_args]
-        return [self.executable]
+        if not passthrough_args:
+            return self._interactive_command(context)
+        if passthrough_args[0] in self._SUBCOMMANDS:
+            return [self.executable, *self._subcommand_args(context, passthrough_args)]
+        return [*self._interactive_command(context), *self._interactive_args(passthrough_args)]
 
     def runtime_probe(self, context: HarnessContext) -> dict[str, object] | None:
         if not _command_available(self.executable):
@@ -251,6 +374,209 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
                 if isinstance(name, str) and isinstance(value, dict):
                     workspace_server_names.add(name)
         return workspace_server_names
+
+    @staticmethod
+    def _target_config_path(context: HarnessContext) -> Path:
+        workspace_dir = context.workspace_dir
+        if workspace_dir is not None:
+            for name in CONFIG_FILENAMES:
+                candidate = workspace_dir / name
+                if candidate.is_file():
+                    return candidate
+        configured_path = configured_config_path(context)
+        if configured_path is not None:
+            return configured_path
+        if workspace_dir is not None:
+            return workspace_dir / CONFIG_FILENAMES[0]
+        global_dir = context.home_dir / ".config" / "opencode"
+        for name in CONFIG_FILENAMES:
+            candidate = global_dir / name
+            if candidate.is_file():
+                return candidate
+        return global_dir / CONFIG_FILENAMES[0]
+
+    @staticmethod
+    def _backup_path(context: HarnessContext) -> Path:
+        target_path = str(OpenCodeHarnessAdapter._target_config_path(context).resolve())
+        digest = hashlib.sha256(target_path.encode("utf-8")).hexdigest()[:12]
+        return context.guard_home / "managed" / "opencode" / f"{digest}.backup.json"
+
+    @staticmethod
+    def _state_path(context: HarnessContext, target_config_path: Path) -> Path:
+        target_path = str(target_config_path.resolve())
+        digest = hashlib.sha256(target_path.encode("utf-8")).hexdigest()[:12]
+        return context.guard_home / "managed" / "opencode" / f"{digest}.state.json"
+
+    @classmethod
+    def _state_entry(cls, context: HarnessContext) -> tuple[Path, dict[str, str]]:
+        state_dir = context.guard_home / "managed" / "opencode"
+        target_config_path = cls._target_config_path(context)
+        preferred_path = cls._state_path(context, target_config_path)
+        current_workspace = str(context.workspace_dir.resolve()) if context.workspace_dir is not None else None
+        candidate_entries: list[tuple[Path, dict[str, str]]] = []
+        for state_path in sorted(state_dir.glob("*.state.json")):
+            payload = cls._state_payload(state_path)
+            if not payload:
+                continue
+            candidate_entries.append((state_path, payload))
+        for state_path, payload in candidate_entries:
+            if payload.get("managed_config_path") == str(target_config_path):
+                return state_path, payload
+        if current_workspace is not None:
+            workspace_entries = [
+                (state_path, payload)
+                for state_path, payload in candidate_entries
+                if payload.get("workspace_dir") == current_workspace
+            ]
+            if len(workspace_entries) == 1:
+                return workspace_entries[0]
+            return preferred_path, {}
+        global_entries = [
+            (state_path, payload) for state_path, payload in candidate_entries if payload.get("scope") == "global"
+        ]
+        if len(global_entries) == 1:
+            return global_entries[0]
+        return preferred_path, {}
+
+    @staticmethod
+    def _state_payload(state_path: Path) -> dict[str, str]:
+        if not state_path.is_file():
+            return {}
+        try:
+            payload = json.loads(state_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {}
+        if not isinstance(payload, dict):
+            return {}
+        result: dict[str, str] = {}
+        for key in ("managed_config_path", "backup_path", "scope", "workspace_dir"):
+            value = payload.get(key)
+            if isinstance(value, str):
+                result[key] = value
+        return result
+
+    @classmethod
+    def _managed_config_path_from_state(cls, context: HarnessContext, state_payload: dict[str, str]) -> Path:
+        managed_config_path = state_payload.get("managed_config_path")
+        if isinstance(managed_config_path, str):
+            return Path(managed_config_path)
+        return cls._target_config_path(context)
+
+    @classmethod
+    def _backup_path_from_state(
+        cls,
+        context: HarnessContext,
+        state_payload: dict[str, str],
+        target_config_path: Path,
+    ) -> Path:
+        backup_path = state_payload.get("backup_path")
+        if isinstance(backup_path, str):
+            return Path(backup_path)
+        digest = hashlib.sha256(str(target_config_path.resolve()).encode("utf-8")).hexdigest()[:12]
+        return context.guard_home / "managed" / "opencode" / f"{digest}.backup.json"
+
+    @staticmethod
+    def _backup_payload(backup_path: Path) -> dict[str, str | bool | None]:
+        try:
+            payload = json.loads(backup_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {"readable": False, "existed": False, "content": None}
+        if not isinstance(payload, dict):
+            return {"readable": False, "existed": False, "content": None}
+        existed = payload.get("existed") is True
+        content = payload.get("content")
+        return {"readable": True, "existed": existed, "content": content if isinstance(content, str) else None}
+
+    def _interactive_command(self, context: HarnessContext) -> list[str]:
+        command = [self.executable]
+        if context.workspace_dir is not None:
+            command.append(str(context.workspace_dir))
+        return command
+
+    def _subcommand_args(self, context: HarnessContext, passthrough_args: list[str]) -> list[str]:
+        del context
+        return list(passthrough_args)
+
+    def _interactive_args(self, passthrough_args: list[str]) -> list[str]:
+        if any(value == "--prompt" or value.startswith("--prompt=") for value in passthrough_args):
+            return list(passthrough_args)
+        normalized: list[str] = []
+        prompt_tokens: list[str] = []
+        index = 0
+        while index < len(passthrough_args):
+            value = passthrough_args[index]
+            if value == "--":
+                prompt_tokens.extend(passthrough_args[index + 1 :])
+                break
+            if value.startswith("-"):
+                normalized.append(value)
+                if self._consumes_next_value(value, passthrough_args, index):
+                    index += 1
+                    normalized.append(passthrough_args[index])
+                index += 1
+                continue
+            prompt_tokens.extend(passthrough_args[index:])
+            break
+        if prompt_tokens:
+            normalized.extend(["--prompt", " ".join(prompt_tokens)])
+        return normalized
+
+    def _consumes_next_value(self, value: str, passthrough_args: list[str], index: int) -> bool:
+        if index + 1 >= len(passthrough_args) or "=" in value:
+            return False
+        if value in self._REQUIRED_VALUE_OPTIONS:
+            return True
+        next_value = passthrough_args[index + 1]
+        if value == "--port":
+            return next_value.isdigit()
+        if value == "--title":
+            return not next_value.startswith("-")
+        return False
+
+    def _managed_permission_payload(
+        self,
+        current_permission: object,
+        *,
+        context: HarnessContext,
+        servers: tuple[ManagedMcpServer, ...],
+        existing_workspace_server_names: set[str],
+    ) -> dict[str, object]:
+        permission = self._coerce_permission_payload(current_permission)
+        permission.update(
+            self._proxy_permission_rules(
+                context=context,
+                servers=servers,
+                existing_workspace_server_names=existing_workspace_server_names,
+            )
+        )
+        return permission
+
+    def _managed_mcp_payload(
+        self,
+        current_mcp: object,
+        *,
+        context: HarnessContext,
+        servers: tuple[ManagedMcpServer, ...],
+        existing_workspace_server_names: set[str],
+    ) -> dict[str, object]:
+        payload = _object_dict(current_mcp) or {}
+        payload.update(
+            self._proxy_mcp_overrides(
+                context,
+                servers,
+                existing_workspace_server_names,
+            )
+        )
+        return payload
+
+    @staticmethod
+    def _coerce_permission_payload(current_permission: object) -> dict[str, object]:
+        payload = _object_dict(current_permission)
+        if payload is not None:
+            return payload
+        if isinstance(current_permission, str):
+            return {"*": current_permission}
+        return {}
 
 
 __all__ = ["OpenCodeHarnessAdapter"]

--- a/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
@@ -185,11 +185,7 @@ def runtime_overlay(
     permission_rules: dict[str, object] | None = None,
     mcp_servers: dict[str, object] | None = None,
 ) -> dict[str, object]:
-    permission: dict[str, object] = {
-        "skill": {
-            "*": "ask",
-        }
-    }
+    permission: dict[str, object] = {}
     if permission_rules:
         permission.update(permission_rules)
     overlay: dict[str, object] = {

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import shlex
 import subprocess
 import sys
@@ -41,10 +42,23 @@ from ..consumer import (
 )
 from ..daemon import GuardDaemonServer, ensure_guard_daemon, load_guard_surface_daemon_client
 from ..incident import build_incident_context
+from ..mcp_tool_calls import (
+    allow_tool_call,
+    block_tool_call,
+    build_tool_call_artifact,
+    build_tool_call_hash,
+    evaluate_tool_call,
+)
 from ..models import GuardArtifact, HarnessDetection
 from ..policy.engine import SAFE_CHANGED_HASH_ACTION, VALID_GUARD_ACTIONS
 from ..protect import build_protect_payload
-from ..proxy import CodexMcpGuardProxy, OpenCodeMcpGuardProxy, RemoteGuardProxy, StdioGuardProxy
+from ..proxy import (
+    CodexMcpGuardProxy,
+    CopilotMcpGuardProxy,
+    OpenCodeMcpGuardProxy,
+    RemoteGuardProxy,
+    StdioGuardProxy,
+)
 from ..receipts import build_receipt
 from ..risk import artifact_risk_signals, artifact_risk_summary
 from ..runtime.runner import GuardSyncNotConfiguredError, guard_run, sync_receipts
@@ -65,8 +79,6 @@ from .connect_flow import (
 )
 from .install_commands import apply_managed_install
 from .product import build_guard_start_payload, build_guard_status_payload
-from .prompt import build_prompt_artifacts, resolve_interactive_decisions
-from .render import emit_guard_payload
 from .update_commands import run_guard_update
 
 
@@ -346,11 +358,27 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     opencode_proxy_parser.add_argument("--command", dest="server_command", required=True)
     opencode_proxy_parser.add_argument("--arg", dest="server_args", action="append", default=[])
 
+    copilot_proxy_parser = guard_subparsers.add_parser("copilot-mcp-proxy", help=argparse.SUPPRESS)
+    _add_guard_common_args(copilot_proxy_parser)
+    copilot_proxy_parser.add_argument("--server-name", required=True)
+    copilot_proxy_parser.add_argument("--source-scope", default="project")
+    copilot_proxy_parser.add_argument("--config-path", required=True)
+    copilot_proxy_parser.add_argument("--transport", default="stdio")
+    copilot_proxy_parser.add_argument("--command", dest="server_command", required=True)
+    copilot_proxy_parser.add_argument("--arg", dest="server_args", action="append", default=[])
+
     hermes_mcp_proxy_parser = guard_subparsers.add_parser("hermes-mcp-proxy", help=argparse.SUPPRESS)
     _add_guard_common_args(hermes_mcp_proxy_parser)
     hermes_mcp_proxy_parser.add_argument("--server", required=True)
     hermes_mcp_proxy_parser.add_argument("--stdio", action="store_true")
-    hidden_commands = {"hook", "daemon", "codex-mcp-proxy", "opencode-mcp-proxy", "hermes-mcp-proxy"}
+    hidden_commands = {
+        "hook",
+        "daemon",
+        "codex-mcp-proxy",
+        "opencode-mcp-proxy",
+        "copilot-mcp-proxy",
+        "hermes-mcp-proxy",
+    }
     guard_subparsers._choices_actions = [
         action for action in guard_subparsers._choices_actions if action.dest not in hidden_commands
     ]
@@ -533,6 +561,19 @@ def run_guard_command(args: argparse.Namespace) -> int:
         )
         return proxy.serve()
 
+    if args.guard_command == "copilot-mcp-proxy":
+        proxy = CopilotMcpGuardProxy(
+            server_name=args.server_name,
+            command=[args.server_command, *list(args.server_args)],
+            context=context,
+            store=store,
+            config=config,
+            source_scope=args.source_scope,
+            config_path=args.config_path,
+            transport=args.transport,
+        )
+        return proxy.serve()
+
     if args.guard_command == "hermes-mcp-proxy":
         return _run_hermes_mcp_proxy(args=args, context=context, store=store, config=config)
 
@@ -564,6 +605,7 @@ def run_guard_command(args: argparse.Namespace) -> int:
             and config.mode == "prompt"
             and sys.stdin.isatty()
         ):
+            from .prompt import build_prompt_artifacts, resolve_interactive_decisions
 
             def interactive_resolver(detection, payload):
                 return resolve_interactive_decisions(
@@ -785,11 +827,224 @@ def run_guard_command(args: argparse.Namespace) -> int:
     if args.guard_command == "hook":
         payload = _load_hook_payload(getattr(args, "event_file", None))
         managed_install = _managed_install_for(store, args.harness)
+        payload_cwd = payload.get("cwd")
+        workspace_was_explicit = workspace is not None
+        runtime_workspace = workspace
+        if runtime_workspace is None and isinstance(payload_cwd, str) and payload_cwd.strip():
+            runtime_workspace = Path(payload_cwd).expanduser().resolve()
+        if args.harness == "copilot":
+            runtime_workspace = _resolve_copilot_workspace_root(runtime_workspace)
+        copilot_hook_stage = _copilot_hook_stage(payload) if args.harness == "copilot" else None
+        copilot_runtime_tool_call = (
+            _copilot_runtime_tool_call(
+                payload=payload,
+                home_dir=context.home_dir,
+                workspace=runtime_workspace,
+                preferred_workspace_config="ide" if workspace_was_explicit else "cli",
+            )
+            if args.harness == "copilot"
+            else None
+        )
+        if copilot_runtime_tool_call is not None and copilot_hook_stage == "pretooluse":
+            runtime_artifact, runtime_artifact_hash, runtime_arguments = copilot_runtime_tool_call
+            decision = evaluate_tool_call(
+                store=store,
+                config=config,
+                artifact=runtime_artifact,
+                artifact_hash=runtime_artifact_hash,
+                arguments=runtime_arguments,
+            )
+            policy_action = {
+                "allow": "allow",
+                "warn": "allow",
+                "review": "require-reapproval",
+                "block": "block",
+                "sandbox-required": "sandbox-required",
+                "require-reapproval": "require-reapproval",
+            }.get(decision.action, "require-reapproval")
+            now = _now()
+            if policy_action == "allow":
+                allow_tool_call(
+                    store=store,
+                    artifact=runtime_artifact,
+                    artifact_hash=runtime_artifact_hash,
+                    decision_source="pre-tool-hook",
+                    now=now,
+                    signals=decision.signals,
+                    remember=False,
+                )
+                if _should_emit_copilot_hook_response(args):
+                    _emit_copilot_hook_response(policy_action="allow", reason="")
+                    return 0
+            else:
+                if policy_action in {"block", "sandbox-required"}:
+                    block_tool_call(
+                        store=store,
+                        artifact=runtime_artifact,
+                        artifact_hash=runtime_artifact_hash,
+                        decision_source="pre-tool-hook",
+                        now=now,
+                        signals=decision.signals,
+                    )
+                if _should_emit_copilot_hook_response(args):
+                    _emit_copilot_hook_response(
+                        policy_action=policy_action,
+                        reason=_copilot_hook_reason(decision.summary, runtime_artifact.name),
+                    )
+                    return 0
+        copilot_permission_request = (
+            _copilot_runtime_tool_call(
+                payload=payload,
+                home_dir=context.home_dir,
+                workspace=runtime_workspace,
+                preferred_workspace_config="ide" if workspace_was_explicit else "cli",
+            )
+            if args.harness == "copilot" and _is_copilot_permission_request(payload)
+            else None
+        )
+        if copilot_permission_request is not None:
+            runtime_artifact, runtime_artifact_hash, runtime_arguments = copilot_permission_request
+            artifact_id = runtime_artifact.artifact_id
+            artifact_name = runtime_artifact.name
+            decision = evaluate_tool_call(
+                store=store,
+                config=config,
+                artifact=runtime_artifact,
+                artifact_hash=runtime_artifact_hash,
+                arguments=runtime_arguments,
+            )
+            policy_action = {
+                "allow": "allow",
+                "warn": "allow",
+                "review": "require-reapproval",
+                "block": "block",
+                "sandbox-required": "sandbox-required",
+                "require-reapproval": "require-reapproval",
+            }.get(decision.action, "require-reapproval")
+            runtime_detection = _runtime_detection(args.harness, runtime_artifact)
+            evaluation_payload = {
+                "artifacts": [
+                    {
+                        "artifact_id": artifact_id,
+                        "artifact_name": artifact_name,
+                        "artifact_hash": runtime_artifact_hash,
+                        "policy_action": policy_action,
+                        "changed_fields": ["runtime_tool_call", *decision.signals],
+                        "artifact_type": runtime_artifact.artifact_type,
+                        "source_scope": runtime_artifact.source_scope,
+                        "config_path": runtime_artifact.config_path,
+                        "launch_target": json.dumps(runtime_arguments, sort_keys=True)
+                        if runtime_arguments is not None
+                        else runtime_artifact.command,
+                    }
+                ]
+            }
+            now = _now()
+            response_payload = {
+                "recorded": True,
+                "artifact_id": artifact_id,
+                "artifact_name": artifact_name,
+                "artifact_type": runtime_artifact.artifact_type,
+                "policy_action": policy_action,
+                "risk_signals": list(decision.signals),
+                "risk_summary": decision.summary,
+                "launch_summary": json.dumps(runtime_arguments, sort_keys=True)
+                if runtime_arguments is not None
+                else runtime_artifact.command,
+            }
+            if policy_action == "allow":
+                allow_tool_call(
+                    store=store,
+                    artifact=runtime_artifact,
+                    artifact_hash=runtime_artifact_hash,
+                    decision_source=decision.source,
+                    now=now,
+                    signals=decision.signals,
+                    remember=False,
+                )
+                if _should_emit_copilot_hook_response(args):
+                    _emit_copilot_permission_request_response(behavior="allow")
+                    return 0
+                _emit("hook", response_payload, getattr(args, "json", False))
+                return 0
+            block_tool_call(
+                store=store,
+                artifact=runtime_artifact,
+                artifact_hash=runtime_artifact_hash,
+                decision_source="permission-request-hook",
+                now=now,
+                signals=decision.signals,
+            )
+            approval_center_url = ensure_guard_daemon(guard_home)
+            approval_flow = get_adapter(args.harness).approval_flow(managed_install=managed_install)
+            try:
+                daemon_client = load_guard_surface_daemon_client(guard_home)
+            except RuntimeError:
+                queued = queue_blocked_approvals(
+                    detection=runtime_detection,
+                    evaluation=evaluation_payload,
+                    store=store,
+                    approval_center_url=approval_center_url,
+                    now=now,
+                )
+            else:
+                session = daemon_client.start_session(
+                    harness=args.harness,
+                    surface="harness-adapter",
+                    workspace=str(runtime_workspace) if runtime_workspace else None,
+                    client_name=f"{args.harness}-permission-hook",
+                    client_title=f"{args.harness} permission hook",
+                    client_version="1.0.0",
+                    capabilities=["approval-resolution", "receipt-view"],
+                )
+                blocked_operation = daemon_client.queue_blocked_operation(
+                    session_id=str(session["session_id"]),
+                    operation_type="tool_call",
+                    harness=args.harness,
+                    metadata={
+                        "tool_name": str(payload.get("tool_name", "")),
+                        "hook_name": "permissionRequest",
+                    },
+                    detection=runtime_detection.to_dict(),
+                    evaluation=evaluation_payload,
+                    approval_center_url=approval_center_url,
+                    approval_surface_policy=_approval_surface_policy_for_flow(
+                        config.approval_surface_policy,
+                        approval_flow,
+                    ),
+                    open_key=artifact_id,
+                )
+                queued = (
+                    blocked_operation["approval_requests"]
+                    if isinstance(blocked_operation.get("approval_requests"), list)
+                    else []
+                )
+            response_payload["approval_requests"] = queued
+            response_payload["approval_center_url"] = approval_center_url
+            response_payload["review_hint"] = approval_center_hint(
+                context=context,
+                harness=args.harness,
+                approval_center_url=approval_center_url,
+                queued=queued,
+                managed_install=managed_install,
+            )
+            if _should_emit_copilot_hook_response(args):
+                _emit_copilot_permission_request_response(
+                    behavior="deny",
+                    message=(
+                        f"HOL Guard blocked {artifact_name}. {decision.summary} "
+                        f"Approve the exact call in Guard, then retry."
+                    ),
+                    interrupt=True,
+                )
+                return 0
+            _emit("hook", response_payload, getattr(args, "json", False))
+            return 1
         runtime_artifact = _hook_runtime_artifact(
             harness=args.harness,
             payload=payload,
             home_dir=context.home_dir,
-            workspace=workspace,
+            workspace=runtime_workspace,
         )
         if runtime_artifact is not None:
             runtime_artifact_hash = artifact_hash(runtime_artifact)
@@ -802,7 +1057,7 @@ def run_guard_command(args: argparse.Namespace) -> int:
                     args.harness,
                     artifact_id,
                     runtime_artifact_hash,
-                    str(workspace) if workspace else None,
+                    str(runtime_workspace) if runtime_workspace else None,
                 ),
             )
             if policy_action not in VALID_GUARD_ACTIONS:
@@ -853,6 +1108,26 @@ def run_guard_command(args: argparse.Namespace) -> int:
                 "path_summary": _runtime_requested_path(runtime_artifact),
             }
             if policy_action in {"block", "sandbox-required", "require-reapproval"}:
+                if _should_emit_copilot_hook_response(args):
+                    _emit_copilot_hook_response(
+                        policy_action=policy_action,
+                        reason=_copilot_hook_reason(
+                            response_payload.get("why_now"),
+                            response_payload.get("risk_headline"),
+                            response_payload.get("path_summary"),
+                        ),
+                    )
+                    return 0
+                if _should_emit_claude_hook_response(args):
+                    _emit_claude_hook_response(
+                        policy_action=policy_action,
+                        reason=_native_hook_reason(
+                            response_payload.get("why_now"),
+                            response_payload.get("risk_headline"),
+                            response_payload.get("path_summary"),
+                        ),
+                    )
+                    return 0
                 approval_flow = get_adapter(args.harness).approval_flow(managed_install=managed_install)
                 approval_center_url = ensure_guard_daemon(guard_home)
                 runtime_detection = _runtime_detection(args.harness, runtime_artifact)
@@ -941,6 +1216,16 @@ def run_guard_command(args: argparse.Namespace) -> int:
                     ),
                 )
                 return 0
+            if _should_emit_claude_hook_response(args):
+                _emit_claude_hook_response(
+                    policy_action=policy_action,
+                    reason=_native_hook_reason(
+                        response_payload.get("why_now"),
+                        response_payload.get("review_hint"),
+                        response_payload.get("risk_headline"),
+                    ),
+                )
+                return 0
             _emit("hook", response_payload, getattr(args, "json", False))
             return 1 if policy_action in {"block", "require-reapproval"} else 0
         artifact_id = _coalesce_string(
@@ -995,6 +1280,12 @@ def run_guard_command(args: argparse.Namespace) -> int:
                 reason=_copilot_hook_reason(payload.get("permission_decision_reason")),
             )
             return 0
+        if _should_emit_claude_hook_response(args):
+            _emit_claude_hook_response(
+                policy_action=policy_action,
+                reason=_native_hook_reason(payload.get("permission_decision_reason")),
+            )
+            return 0
         _emit(
             "hook",
             {
@@ -1011,11 +1302,17 @@ def run_guard_command(args: argparse.Namespace) -> int:
 
 
 def _emit(command: str, payload: dict[str, object], as_json: bool) -> None:
+    from .render import emit_guard_payload
+
     emit_guard_payload(command, payload, as_json)
 
 
 def _should_emit_copilot_hook_response(args: argparse.Namespace) -> bool:
     return args.harness == "copilot" and not getattr(args, "json", False)
+
+
+def _should_emit_claude_hook_response(args: argparse.Namespace) -> bool:
+    return args.harness == "claude-code" and not getattr(args, "json", False)
 
 
 def _approval_delivery_payload(
@@ -1026,7 +1323,7 @@ def _approval_delivery_payload(
     return approval_delivery_payload(approval_prompt_flow(harness, managed_install=managed_install))
 
 
-def _copilot_hook_reason(*values: object | None) -> str:
+def _native_hook_reason(*values: object | None) -> str:
     messages: list[str] = []
     for value in values:
         if isinstance(value, str) and value.strip():
@@ -1035,7 +1332,16 @@ def _copilot_hook_reason(*values: object | None) -> str:
                 messages.append(candidate)
     if messages:
         return " ".join(messages)
-    return "Guard blocked this tool call. Open the Guard approval center to review the request."
+    return "HOL Guard flagged this tool call for review."
+
+
+def _copilot_hook_reason(*values: object | None) -> str:
+    reason = _native_hook_reason(*values)
+    if reason.startswith("Guard "):
+        reason = f"HOL {reason}"
+    if "approve" in reason.lower():
+        return reason
+    return f"{reason} Approve it in HOL Guard, then retry."
 
 
 def _guard_rerun_command(args: argparse.Namespace) -> str:
@@ -1079,14 +1385,50 @@ def _append_guard_context_args(command: list[str], args: argparse.Namespace) -> 
 
 
 def _emit_copilot_hook_response(*, policy_action: str, reason: str) -> None:
-    if policy_action in {"block", "sandbox-required", "require-reapproval"}:
-        payload = {
-            "permissionDecision": "deny",
-            "permissionDecisionReason": reason,
-        }
-    else:
-        payload = {"permissionDecision": "allow"}
+    payload = {"permissionDecision": _copilot_hook_permission_decision(policy_action)}
+    if payload["permissionDecision"] != "allow":
+        payload["permissionDecisionReason"] = reason
     print(json.dumps(payload, separators=(",", ":")))
+
+
+def _emit_copilot_permission_request_response(
+    *,
+    behavior: str,
+    message: str | None = None,
+    interrupt: bool | None = None,
+) -> None:
+    payload: dict[str, object] = {"behavior": behavior}
+    if isinstance(message, str) and message.strip():
+        payload["message"] = message.strip()
+    if isinstance(interrupt, bool):
+        payload["interrupt"] = interrupt
+    print(json.dumps(payload, separators=(",", ":")))
+
+
+def _emit_claude_hook_response(*, policy_action: str, reason: str) -> None:
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": _native_hook_permission_decision(policy_action),
+        }
+    }
+    if payload["hookSpecificOutput"]["permissionDecision"] != "allow":
+        payload["hookSpecificOutput"]["permissionDecisionReason"] = reason
+    print(json.dumps(payload, separators=(",", ":")))
+
+
+def _native_hook_permission_decision(policy_action: str) -> str:
+    if policy_action in {"block", "sandbox-required"}:
+        return "deny"
+    if policy_action == "require-reapproval":
+        return "ask"
+    return "allow"
+
+
+def _copilot_hook_permission_decision(policy_action: str) -> str:
+    if policy_action in {"block", "sandbox-required", "require-reapproval"}:
+        return "deny"
+    return "allow"
 
 
 def _headless_approval_resolver(
@@ -1267,6 +1609,7 @@ def _normalize_hook_payload(payload: dict[str, object]) -> dict[str, object]:
         ("artifactHash", "artifact_hash"),
         ("artifactName", "artifact_name"),
         ("changedCapabilities", "changed_capabilities"),
+        ("hookName", "hook_name"),
         ("policyAction", "policy_action"),
         ("sourceScope", "source_scope"),
         ("toolName", "tool_name"),
@@ -1274,6 +1617,12 @@ def _normalize_hook_payload(payload: dict[str, object]) -> dict[str, object]:
     ):
         if target_key not in normalized and source_key in payload:
             normalized[target_key] = payload[source_key]
+    if "tool_name" not in normalized or "tool_input" not in normalized:
+        tool_name, tool_input = _first_hook_tool_call(payload.get("toolCalls"))
+        if "tool_name" not in normalized and tool_name is not None:
+            normalized["tool_name"] = tool_name
+        if "tool_input" not in normalized and tool_input is not None:
+            normalized["tool_input"] = tool_input
     arguments = _normalize_hook_arguments(
         normalized.get("tool_input"),
         normalized.get("arguments"),
@@ -1311,6 +1660,19 @@ def _normalize_hook_argument_value(value: object | None) -> object | None:
             return parsed
         return stripped
     return value
+
+
+def _first_hook_tool_call(value: object | None) -> tuple[str | None, object | None]:
+    if not isinstance(value, list):
+        return None, None
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        tool_name = item.get("name")
+        tool_input = _normalize_hook_argument_value(item.get("args"))
+        if isinstance(tool_name, str) and tool_name.strip():
+            return tool_name.strip(), tool_input
+    return None, None
 
 
 def _coalesce_string(*values: object | None) -> str:
@@ -1379,6 +1741,180 @@ def _hook_runtime_artifact(
         config_path=config_path,
         source_scope=source_scope,
     )
+
+
+def _is_copilot_permission_request(payload: dict[str, object]) -> bool:
+    for key in ("hook_name", "hook_event_name", "hookEventName"):
+        hook_name = payload.get(key)
+        if isinstance(hook_name, str) and hook_name == "permissionRequest":
+            return True
+    return False
+
+
+def _copilot_hook_stage(payload: dict[str, object]) -> str | None:
+    for key in ("hook_name", "hook_event_name", "hookEventName"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip().lower()
+    return None
+
+
+def _copilot_runtime_tool_call(
+    *,
+    payload: dict[str, object],
+    home_dir: Path,
+    workspace: Path | None,
+    preferred_workspace_config: str | None = None,
+) -> tuple[GuardArtifact, str, object] | None:
+    tool_name = payload.get("tool_name")
+    if not isinstance(tool_name, str) or not tool_name.strip():
+        return None
+    server_name: str | None = None
+    runtime_tool_name: str | None = None
+    source_scope = _coalesce_string(payload.get("source_scope"), "project" if workspace is not None else "global")
+    config_path = str(_runtime_policy_path("copilot", home_dir, workspace))
+    if "/" in tool_name:
+        server_name, runtime_tool_name = tool_name.split("/", 1)
+    elif tool_name.startswith("mcp_"):
+        resolved = _resolve_copilot_mcp_runtime_tool(
+            tool_name=tool_name,
+            home_dir=home_dir,
+            workspace=workspace,
+            preferred_workspace_config=preferred_workspace_config,
+        )
+        if resolved is None:
+            return None
+        server_name, runtime_tool_name, source_scope, config_path = resolved
+    if (
+        not isinstance(server_name, str)
+        or not server_name.strip()
+        or not isinstance(runtime_tool_name, str)
+        or not runtime_tool_name.strip()
+    ):
+        return None
+    artifact = build_tool_call_artifact(
+        harness="copilot",
+        server_name=server_name.strip(),
+        tool_name=runtime_tool_name.strip(),
+        source_scope=source_scope,
+        config_path=config_path,
+        transport="stdio",
+    )
+    arguments = payload.get("tool_input", payload.get("arguments"))
+    artifact_hash = build_tool_call_hash(artifact, arguments)
+    return artifact, artifact_hash, arguments
+
+
+def _resolve_copilot_mcp_runtime_tool(
+    *,
+    tool_name: str,
+    home_dir: Path,
+    workspace: Path | None,
+    preferred_workspace_config: str | None = None,
+) -> tuple[str, str, str, str] | None:
+    if not tool_name.startswith("mcp_"):
+        return None
+    suffix = tool_name[len("mcp_") :]
+    if not suffix:
+        return None
+    matches: list[tuple[int, int, str, str, str, str]] = []
+    for server_name, source_scope, config_path in _copilot_runtime_server_entries(home_dir, workspace):
+        server_token = _copilot_mcp_tool_token(server_name)
+        if suffix.startswith(f"{server_token}_"):
+            runtime_tool_name = suffix[len(server_token) + 1 :]
+            if runtime_tool_name:
+                matches.append(
+                    (
+                        len(server_token),
+                        _copilot_runtime_match_priority(
+                            config_path=config_path,
+                            preferred_workspace_config=preferred_workspace_config,
+                        ),
+                        server_name,
+                        runtime_tool_name,
+                        source_scope,
+                        config_path,
+                    )
+                )
+    if matches:
+        _length, _priority, server_name, runtime_tool_name, source_scope, config_path = max(
+            matches,
+            key=lambda item: (item[0], item[1], item[5]),
+        )
+        return server_name, runtime_tool_name, source_scope, config_path
+    return None
+
+
+def _copilot_runtime_server_entries(home_dir: Path, workspace: Path | None) -> list[tuple[str, str, str]]:
+    entries: list[tuple[str, str, str]] = []
+    if workspace is not None:
+        for path in (workspace / ".vscode" / "mcp.json", workspace / ".mcp.json"):
+            entries.extend(_mcp_server_entries_from_path(path, source_scope="project"))
+    entries.extend(_mcp_server_entries_from_path(home_dir / ".copilot" / "mcp-config.json", source_scope="global"))
+    return entries
+
+
+def _copilot_runtime_match_priority(*, config_path: str, preferred_workspace_config: str | None) -> int:
+    path = Path(config_path)
+    is_cli_workspace_config = path.name == ".mcp.json"
+    is_ide_workspace_config = path.name == "mcp.json" and path.parent.name == ".vscode"
+    if preferred_workspace_config == "cli":
+        if is_cli_workspace_config:
+            return 2
+        if is_ide_workspace_config:
+            return 1
+        return 0
+    if preferred_workspace_config == "ide":
+        if is_ide_workspace_config:
+            return 2
+        if is_cli_workspace_config:
+            return 1
+        return 0
+    return 0
+
+
+def _resolve_copilot_workspace_root(workspace: Path | None) -> Path | None:
+    if workspace is None:
+        return None
+    candidates = [workspace, *workspace.parents]
+    for candidate in candidates:
+        if (candidate / ".mcp.json").is_file() or (candidate / ".vscode" / "mcp.json").is_file():
+            return candidate
+    return workspace
+
+
+def _mcp_server_entries_from_path(path: Path, *, source_scope: str) -> list[tuple[str, str, str]]:
+    if not path.exists():
+        return []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    servers = _mcp_servers_payload(payload)
+    if not isinstance(servers, dict):
+        return []
+    return [
+        (str(server_name), source_scope, str(path))
+        for server_name in servers
+        if isinstance(server_name, str) and server_name.strip()
+    ]
+
+
+def _mcp_servers_payload(payload: dict[str, object]) -> dict[str, object] | None:
+    servers = payload.get("servers")
+    if isinstance(servers, dict):
+        return servers
+    mcp_servers = payload.get("mcpServers")
+    if isinstance(mcp_servers, dict):
+        return mcp_servers
+    return None
+
+
+def _copilot_mcp_tool_token(value: str) -> str:
+    token = re.sub(r"[^a-z0-9]+", "_", value.strip().lower())
+    return token.strip("_")
 
 
 def _runtime_policy_path(harness: str, home_dir: Path, workspace: Path | None) -> Path:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1618,7 +1618,10 @@ def _normalize_hook_payload(payload: dict[str, object]) -> dict[str, object]:
         if target_key not in normalized and source_key in payload:
             normalized[target_key] = payload[source_key]
     if "tool_name" not in normalized or "tool_input" not in normalized:
-        tool_name, tool_input = _first_hook_tool_call(payload.get("toolCalls"))
+        tool_name, tool_input = _first_hook_tool_call(
+            payload.get("toolCalls"),
+            expected_tool_name=normalized.get("tool_name"),
+        )
         if "tool_name" not in normalized and tool_name is not None:
             normalized["tool_name"] = tool_name
         if "tool_input" not in normalized and tool_input is not None:
@@ -1662,16 +1665,28 @@ def _normalize_hook_argument_value(value: object | None) -> object | None:
     return value
 
 
-def _first_hook_tool_call(value: object | None) -> tuple[str | None, object | None]:
+def _first_hook_tool_call(
+    value: object | None,
+    *,
+    expected_tool_name: object | None = None,
+) -> tuple[str | None, object | None]:
     if not isinstance(value, list):
         return None, None
+    normalized_expected_tool_name = expected_tool_name.strip() if isinstance(expected_tool_name, str) else None
+    fallback_tool_call: tuple[str, object | None] | None = None
     for item in value:
         if not isinstance(item, dict):
             continue
         tool_name = item.get("name")
         tool_input = _normalize_hook_argument_value(item.get("args"))
         if isinstance(tool_name, str) and tool_name.strip():
-            return tool_name.strip(), tool_input
+            stripped_tool_name = tool_name.strip()
+            if fallback_tool_call is None:
+                fallback_tool_call = (stripped_tool_name, tool_input)
+            if normalized_expected_tool_name is None or stripped_tool_name == normalized_expected_tool_name:
+                return stripped_tool_name, tool_input
+    if fallback_tool_call is not None:
+        return fallback_tool_call
     return None, None
 
 

--- a/src/codex_plugin_scanner/guard/cli/product.py
+++ b/src/codex_plugin_scanner/guard/cli/product.py
@@ -141,10 +141,29 @@ def _recommended_harness(harnesses: list[dict[str, object]]) -> dict[str, object
         harnesses,
         key=lambda item: (
             0 if bool(item["installed"]) else 1,
+            0 if int(item.get("artifact_count", 0)) > 0 else 1,
             0 if bool(item["command_available"]) else 1,
+            _approval_experience_rank(item.get("approval_flow")),
             priority.get(str(item["harness"]), len(HARNESS_PRIORITY)),
         ),
     )
+
+
+def _approval_experience_rank(flow: object) -> int:
+    if not isinstance(flow, dict):
+        return 4
+    prompt_channel = str(flow.get("prompt_channel") or "browser")
+    tier = str(flow.get("tier") or "approval-center")
+    auto_open_browser = bool(flow.get("auto_open_browser", True))
+    if prompt_channel in {"native", "hook"} and tier in {"native-harness", "native-or-center", "mixed"}:
+        return 0
+    if prompt_channel in {"native", "hook"} and not auto_open_browser:
+        return 1
+    if not auto_open_browser:
+        return 2
+    if tier == "approval-center":
+        return 3
+    return 4
 
 
 def _resolve_next_action(detection: HarnessDetection, managed: bool, review_count: int) -> str:

--- a/src/codex_plugin_scanner/guard/incident.py
+++ b/src/codex_plugin_scanner/guard/incident.py
@@ -47,13 +47,19 @@ def build_incident_context(
     if artifact_type == "prompt_request":
         source_label = f"{harness_label} session prompt"
         trigger_summary = (
-            f"Guard paused the {artifact_label} `{artifact_name or artifact_id}` from the active "
+            f"HOL Guard paused the {artifact_label} `{artifact_name or artifact_id}` from the active "
             f"{harness_label} prompt."
         )
     elif artifact_type == "file_read_request":
         source_label = f"{harness_label} runtime tool call"
         trigger_summary = (
-            f"Guard paused the {artifact_label} `{artifact_name or artifact_id}` from an active "
+            f"HOL Guard paused the {artifact_label} `{artifact_name or artifact_id}` from an active "
+            f"{harness_label} tool call."
+        )
+    elif artifact_type == "tool_action_request":
+        source_label = f"{harness_label} runtime tool call"
+        trigger_summary = (
+            f"HOL Guard paused the native tool action `{artifact_name or artifact_id}` from an active "
             f"{harness_label} tool call."
         )
     else:
@@ -61,10 +67,10 @@ def build_incident_context(
         source_label = f"{normalized_scope} {harness_label} config"
         action_verb = _trigger_verb(policy_action=policy_action, changed_fields=changed_fields)
         trigger_summary = (
-            f"Guard {action_verb} the {artifact_label} `{artifact_name or artifact_id}` from "
+            f"HOL Guard {action_verb} the {artifact_label} `{artifact_name or artifact_id}` from "
             f"`{short_config_path}` for {harness_label}."
         )
-    why_now = _why_now_text(changed_fields, policy_action, harness_label)
+    why_now = _why_now_text(changed_fields, policy_action, harness_label, artifact_type)
     launch_summary = _launch_summary(artifact=artifact, launch_target=launch_target)
     risk_headline = risk_summary or "Guard could not classify a high-confidence secret or network signal."
     return {
@@ -77,32 +83,39 @@ def build_incident_context(
     }
 
 
-def _why_now_text(changed_fields: list[str], policy_action: GuardAction, harness_label: str) -> str:
+def _why_now_text(
+    changed_fields: list[str],
+    policy_action: GuardAction,
+    harness_label: str,
+    artifact_type: str | None,
+) -> str:
     normalized = {field.strip().lower() for field in changed_fields}
     if len(normalized) == 0 and policy_action == "allow":
-        return "Guard matched an existing allow rule for this exact version, so the launch can continue."
+        return "HOL Guard matched an existing allow rule for this exact version, so the launch can continue."
     if "prompt_request" in normalized:
         return (
             "The prompt asks the agent to read a local .env file directly, "
-            "so Guard paused it until you approve that secret access."
+            "so HOL Guard paused it until you approve that secret access."
         )
     if "file_read_request" in normalized:
-        return "The tool requested a protected local secret file, so Guard paused the read until you approve it."
+        return "The tool requested a protected local secret file, so HOL Guard paused the read until you approve it."
+    if artifact_type == "tool_action_request" or "tool_action_request" in normalized:
+        return "HOL Guard paused this native tool action because it can change the local machine before you confirm it."
     if "first_seen" in normalized:
-        return f"It is new in this {harness_label.lower()} workspace, so Guard paused it for review."
+        return f"It is new in this {harness_label.lower()} workspace, so HOL Guard paused it for review."
     if "removed" in normalized:
-        return "It disappeared from the harness config, so Guard paused the change until you confirm the removal."
+        return "It disappeared from the harness config, so HOL Guard paused the change until you confirm the removal."
     if "command" in normalized or "args" in normalized:
-        return "Its launch command changed, so Guard is treating this as a new executable fingerprint."
+        return "Its launch command changed, so HOL Guard is treating this as a new executable fingerprint."
     if "url" in normalized or "transport" in normalized:
-        return "Its connection target changed, so Guard is treating this as a new remote endpoint."
+        return "Its connection target changed, so HOL Guard is treating this as a new remote endpoint."
     if "publisher" in normalized:
-        return "Its publisher or source changed, so Guard needs a fresh trust decision."
+        return "Its publisher or source changed, so HOL Guard needs a fresh trust decision."
     if policy_action == "sandbox-required":
-        return "Guard requires extra isolation before this launch can continue."
+        return "HOL Guard requires extra isolation before this launch can continue."
     if policy_action == "block":
-        return "Guard blocked this definition because the configured policy does not trust it yet."
-    return "Guard found a meaningful config change and paused the launch for review."
+        return "HOL Guard blocked this definition because the configured policy does not trust it yet."
+    return "HOL Guard found a meaningful config change and paused the launch for review."
 
 
 def _trigger_verb(*, policy_action: GuardAction, changed_fields: list[str]) -> str:

--- a/src/codex_plugin_scanner/guard/mcp_tool_calls.py
+++ b/src/codex_plugin_scanner/guard/mcp_tool_calls.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import PurePath
@@ -112,14 +113,15 @@ def evaluate_tool_call(
 
 
 def tool_call_risk_signals(artifact: GuardArtifact, arguments: object) -> tuple[str, ...]:
-    tool_name = PurePath(artifact.command or artifact.name).name.lower()
+    tool_name = PurePath(artifact.command or artifact.name).name
     serialized_arguments = json.dumps(arguments, sort_keys=True).lower() if arguments is not None else ""
     combined = f"{artifact.name.lower()} {serialized_arguments}"
+    tool_name_tokens = set(_tool_name_tokens(tool_name))
     signals: list[str] = []
 
-    if any(token in tool_name for token in ("delete", "remove", "rm", "destroy", "erase")):
+    if len(tool_name_tokens.intersection({"delete", "remove", "rm", "destroy", "erase"})) > 0:
         signals.append("tool name implies destructive file or system changes")
-    if any(token in tool_name for token in ("shell", "bash", "exec", "command", "powershell")):
+    if len(tool_name_tokens.intersection({"shell", "bash", "exec", "execute", "command", "powershell"})) > 0:
         signals.append("tool name implies shell or command execution")
     if any(token in combined for token in ("http://", "https://", "curl", "wget", "fetch", "axios", "requests")):
         signals.append("call arguments imply outbound network activity")
@@ -253,6 +255,11 @@ def _dedupe(values: list[str]) -> list[str]:
         seen.add(value)
         ordered.append(value)
     return ordered
+
+
+def _tool_name_tokens(tool_name: str) -> tuple[str, ...]:
+    camel_normalized = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", tool_name)
+    return tuple(token for token in re.findall(r"[a-z0-9]+", camel_normalized.lower()) if token)
 
 
 def _coerce_guard_action(value: str) -> GuardAction | None:

--- a/src/codex_plugin_scanner/guard/proxy/__init__.py
+++ b/src/codex_plugin_scanner/guard/proxy/__init__.py
@@ -1,11 +1,19 @@
 """Guard proxy helpers."""
 
 from .remote import RemoteGuardProxy
-from .runtime_mcp import CodexMcpGuardProxy, OpenCodeMcpGuardProxy, RuntimeMcpGuardProxy
+from .runtime_mcp import (
+    CodexMcpGuardProxy,
+    CopilotMcpGuardProxy,
+    ElicitationMcpGuardProxy,
+    OpenCodeMcpGuardProxy,
+    RuntimeMcpGuardProxy,
+)
 from .stdio import StdioGuardProxy
 
 __all__ = [
     "CodexMcpGuardProxy",
+    "CopilotMcpGuardProxy",
+    "ElicitationMcpGuardProxy",
     "OpenCodeMcpGuardProxy",
     "RemoteGuardProxy",
     "RuntimeMcpGuardProxy",

--- a/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
+++ b/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
@@ -559,11 +559,8 @@ class RuntimeMcpGuardProxy:
         return f"{tool_name} {serialized_arguments}".strip()
 
 
-class CodexMcpGuardProxy(RuntimeMcpGuardProxy):
-    """Guard-managed runtime MCP proxy for Codex."""
-
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(harness="codex", **kwargs)
+class ElicitationMcpGuardProxy(RuntimeMcpGuardProxy):
+    """Runtime MCP proxy that can ask for in-band approval via elicitation."""
 
     def _record_client_capabilities(self, method: str, params: object) -> None:
         if method != "initialize" or not isinstance(params, dict):
@@ -580,6 +577,7 @@ class CodexMcpGuardProxy(RuntimeMcpGuardProxy):
             "id": f"guard-elicitation-{self._inline_prompt_counter}",
             "method": "elicitation/create",
             "params": {
+                "mode": "form",
                 "message": (
                     f"HOL Guard intercepted {self.server_name}.{tool_name}. {summary} Approve this exact call?"
                 ),
@@ -597,6 +595,20 @@ class CodexMcpGuardProxy(RuntimeMcpGuardProxy):
                 },
             },
         }
+
+
+class CodexMcpGuardProxy(ElicitationMcpGuardProxy):
+    """Guard-managed runtime MCP proxy for Codex."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(harness="codex", **kwargs)
+
+
+class CopilotMcpGuardProxy(ElicitationMcpGuardProxy):
+    """Guard-managed runtime MCP proxy for Copilot MCP clients that support elicitation."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(harness="copilot", **kwargs)
 
 
 class OpenCodeMcpGuardProxy(RuntimeMcpGuardProxy):
@@ -664,4 +676,10 @@ def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-__all__ = ["CodexMcpGuardProxy", "OpenCodeMcpGuardProxy", "RuntimeMcpGuardProxy"]
+__all__ = [
+    "CodexMcpGuardProxy",
+    "CopilotMcpGuardProxy",
+    "ElicitationMcpGuardProxy",
+    "OpenCodeMcpGuardProxy",
+    "RuntimeMcpGuardProxy",
+]

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -525,6 +525,9 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
     command_names = list(_shell_command_names(lowered))
     if any(command_name in _DESTRUCTIVE_SHELL_COMMANDS for command_name in command_names):
         return True
+    for shell_script in _shell_command_scripts(parts):
+        if _looks_destructive_shell_command(shell_script):
+            return True
     return any(
         command_name == "sed" and any(part == "-i" or part.startswith("-i") for part in parts[1:])
         for command_name in command_names
@@ -557,6 +560,26 @@ def _normalized_shell_command_name(command_name: str) -> str:
     if "/" not in normalized_command:
         return normalized_command
     return normalized_command.rsplit("/", 1)[-1]
+
+
+def _shell_command_scripts(parts: list[str]) -> tuple[str, ...]:
+    scripts: list[str] = []
+    for index, part in enumerate(parts[:-1]):
+        if not _is_shell_command_flag(part):
+            continue
+        script = parts[index + 1].strip()
+        if script:
+            scripts.append(script)
+    return tuple(scripts)
+
+
+def _is_shell_command_flag(value: str) -> bool:
+    if value == "-c":
+        return True
+    if not value.startswith("-"):
+        return False
+    flag_characters = value[1:]
+    return bool(flag_characters) and set(flag_characters) <= {"c", "l"}
 
 
 def _file_read_request_fingerprint(*, harness: str, tool_name: str, normalized_path: str) -> str:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -523,6 +523,7 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
     if not parts:
         return False
     command_names = list(_shell_command_names(lowered))
+    command_names.extend(_shell_command_names_from_parts(parts))
     if any(command_name in _DESTRUCTIVE_SHELL_COMMANDS for command_name in command_names):
         return True
     for shell_script in _shell_command_scripts(parts):
@@ -560,6 +561,32 @@ def _normalized_shell_command_name(command_name: str) -> str:
     if "/" not in normalized_command:
         return normalized_command
     return normalized_command.rsplit("/", 1)[-1]
+
+
+def _shell_command_names_from_parts(parts: list[str]) -> tuple[str, ...]:
+    command_names: list[str] = []
+    expect_command = True
+    for part in parts:
+        token = part.strip()
+        if not token:
+            continue
+        if token in {"&&", "||", ";", "|", "&"}:
+            expect_command = True
+            continue
+        normalized_token = token.lstrip("(").rstrip(")")
+        if not normalized_token:
+            continue
+        if not expect_command:
+            continue
+        if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", normalized_token):
+            continue
+        normalized_command = _normalized_shell_command_name(normalized_token)
+        if normalized_command in {"env", "command", "builtin", "nohup", "nice", "time", "stdbuf"}:
+            expect_command = True
+            continue
+        command_names.append(normalized_command)
+        expect_command = False
+    return tuple(command_names)
 
 
 def _shell_command_scripts(parts: list[str]) -> tuple[str, ...]:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
+import shlex
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -34,6 +36,43 @@ _PATH_LIST_KEYS = ("paths", "file_paths", "filePaths")
 _COMMAND_KEYS = ("command", "cmd", "shell_command", "shellCommand")
 _COMMAND_LIST_KEYS = ("argv", "command_args", "commandArgs")
 _DOCKER_SUBCOMMANDS = frozenset({"build", "compose", "login", "push", "run"})
+_SHELL_TOOL_NAMES = frozenset(
+    {
+        "bash",
+        "cmd",
+        "powershell",
+        "pwsh",
+        "run_command",
+        "run_terminal_command",
+        "shell",
+        "sh",
+        "terminal",
+        "zsh",
+    }
+)
+_DESTRUCTIVE_SHELL_COMMANDS = frozenset(
+    {
+        "chmod",
+        "chown",
+        "dd",
+        "mv",
+        "perl",
+        "python",
+        "python3",
+        "rm",
+        "ruby",
+        "tee",
+        "truncate",
+    }
+)
+_SAFE_SHELL_REDIRECT_TARGETS = frozenset(
+    {
+        "/dev/null",
+        "/dev/stdout",
+        "/dev/stderr",
+        "nul",
+    }
+)
 _SENSITIVE_BASENAME_LABELS = {
     ".npmrc": "npm registry credentials",
     ".pypirc": "Python package credentials",
@@ -215,7 +254,7 @@ def extract_sensitive_tool_action_request(
     cwd: Path | None = None,
     home_dir: Path | None = None,
 ) -> ToolActionRequestMatch | None:
-    """Extract a sensitive Docker or Docker-auth native tool action from arguments."""
+    """Extract a sensitive native tool action from arguments."""
 
     normalized_tool_name = _normalize_tool_name(tool_name)
     if normalized_tool_name is None:
@@ -238,6 +277,13 @@ def extract_sensitive_tool_action_request(
         )
         if docker_config_request is not None:
             return docker_config_request
+        destructive_shell_request = _destructive_shell_tool_action_request(
+            tool_name=requested_tool_name,
+            normalized_tool_name=normalized_tool_name,
+            command_text=command_text,
+        )
+        if destructive_shell_request is not None:
+            return destructive_shell_request
     return None
 
 
@@ -280,6 +326,28 @@ def _docker_config_tool_action_request(
     )
 
 
+def _destructive_shell_tool_action_request(
+    *,
+    tool_name: str,
+    normalized_tool_name: str,
+    command_text: str,
+) -> ToolActionRequestMatch | None:
+    if normalized_tool_name not in _SHELL_TOOL_NAMES:
+        return None
+    if not _looks_destructive_shell_command(command_text):
+        return None
+    return ToolActionRequestMatch(
+        tool_name=tool_name,
+        normalized_tool_name=normalized_tool_name,
+        command_text=command_text,
+        action_class="destructive shell command",
+        reason=(
+            "Guard treats destructive shell writes and delete operations as sensitive because they can mutate the "
+            "local machine before the user confirms the action."
+        ),
+    )
+
+
 def build_tool_action_request_artifact(
     harness: str,
     request: ToolActionRequestMatch,
@@ -301,7 +369,7 @@ def build_tool_action_request_artifact(
         ).encode("utf-8")
     ).hexdigest()
     request_summary = f"Requested `{request.tool_name}` action `{request.command_text}` ({request.action_class})."
-    risk_summary = f"Requests a Docker-sensitive native tool action: {request.action_class}."
+    risk_summary = f"Requests a sensitive native tool action: {request.action_class}."
     return GuardArtifact(
         artifact_id=f"{harness}:{source_scope}:tool-action:{fingerprint}",
         name=f"{request.tool_name} {request.action_class}",
@@ -313,7 +381,7 @@ def build_tool_action_request_artifact(
             "tool_name": request.tool_name,
             "command_text": request.command_text,
             "request_summary": request_summary,
-            "runtime_request_signals": ["invokes a Docker-sensitive command before execution"],
+            "runtime_request_signals": [f"invokes a sensitive native tool action: {request.action_class}"],
             "runtime_request_summary": risk_summary,
             "runtime_request_reason": request.reason,
         },
@@ -439,6 +507,56 @@ def _docker_config_path_from_command(
     if match is None:
         return None
     return match.normalized_path
+
+
+def _looks_destructive_shell_command(command_text: str) -> bool:
+    normalized = command_text.strip()
+    if not normalized:
+        return False
+    lowered = normalized.lower()
+    if _contains_mutating_shell_redirection(lowered):
+        return True
+    try:
+        parts = shlex.split(normalized, posix=True)
+    except ValueError:
+        parts = normalized.split()
+    if not parts:
+        return False
+    command_names = list(_shell_command_names(lowered))
+    if any(command_name in _DESTRUCTIVE_SHELL_COMMANDS for command_name in command_names):
+        return True
+    return any(
+        command_name == "sed" and any(part == "-i" or part.startswith("-i") for part in parts[1:])
+        for command_name in command_names
+    )
+
+
+def _contains_mutating_shell_redirection(command_text: str) -> bool:
+    for match in re.finditer(r"(?<!<)(?P<fd>[0-2]?)(?P<op>>\||>>|>)\s*(?P<target>\S+)", command_text):
+        fd = match.group("fd")
+        target = _normalized_redirect_target(match.group("target"))
+        if fd == "2" and target in _SAFE_SHELL_REDIRECT_TARGETS:
+            continue
+        if target in _SAFE_SHELL_REDIRECT_TARGETS or target.startswith("&"):
+            continue
+        return True
+    return False
+
+
+def _normalized_redirect_target(target: str) -> str:
+    return target.strip().strip(");,").strip("'\"")
+
+
+def _shell_command_names(command_text: str) -> tuple[str, ...]:
+    pattern = re.compile(r"(?:^|&&|\|\||[;&|\n])\s*(?:[a-z_][a-z0-9_]*=\S+\s+)*(?P<command>[a-z0-9_./\\\\-]+)")
+    return tuple(_normalized_shell_command_name(match.group("command")) for match in pattern.finditer(command_text))
+
+
+def _normalized_shell_command_name(command_name: str) -> str:
+    normalized_command = command_name.replace("\\", "/").strip()
+    if "/" not in normalized_command:
+        return normalized_command
+    return normalized_command.rsplit("/", 1)[-1]
 
 
 def _file_read_request_fingerprint(*, harness: str, tool_name: str, normalized_path: str) -> str:

--- a/tests/test_guard_claude_adapter.py
+++ b/tests/test_guard_claude_adapter.py
@@ -1,0 +1,95 @@
+"""Guard adapter tests for Claude Code surfaces."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.claude_code import ClaudeCodeHarnessAdapter
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _build_context(tmp_path: Path) -> HarnessContext:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    guard_home = tmp_path / "guard-home"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    return HarnessContext(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        guard_home=guard_home,
+    )
+
+
+def test_claude_detect_marks_local_cli_install_as_available_when_not_on_path(monkeypatch, tmp_path):
+    context = _build_context(tmp_path)
+    adapter = ClaudeCodeHarnessAdapter()
+    actual_home = tmp_path / "actual-home"
+    local_claude = actual_home / ".claude" / "local" / "claude"
+    local_claude.parent.mkdir(parents=True, exist_ok=True)
+    local_claude.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    local_claude.chmod(0o755)
+    monkeypatch.setattr("shutil.which", lambda command: None)
+    monkeypatch.setattr(Path, "home", lambda: actual_home)
+
+    detection = adapter.detect(context)
+
+    assert detection.installed is True
+    assert detection.command_available is True
+
+
+def test_claude_launch_command_uses_local_cli_install_when_not_on_path(monkeypatch, tmp_path):
+    context = _build_context(tmp_path)
+    adapter = ClaudeCodeHarnessAdapter()
+    actual_home = tmp_path / "actual-home"
+    local_claude = actual_home / ".claude" / "local" / "claude"
+    local_claude.parent.mkdir(parents=True, exist_ok=True)
+    local_claude.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    local_claude.chmod(0o755)
+    monkeypatch.setattr("shutil.which", lambda command: None)
+    monkeypatch.setattr(Path, "home", lambda: actual_home)
+
+    launch_command = adapter.launch_command(context, ["--print", "hello"])
+
+    assert launch_command[0] == str(local_claude)
+    assert launch_command[1] == str(context.workspace_dir)
+    assert launch_command[2:] == ["--print", "hello"]
+
+
+def test_claude_detect_ignores_non_executable_local_cli_candidate_when_not_on_path(monkeypatch, tmp_path):
+    context = _build_context(tmp_path)
+    adapter = ClaudeCodeHarnessAdapter()
+    local_binary = tmp_path / "actual-home" / ".claude" / "local" / "claude"
+    local_binary.parent.mkdir(parents=True, exist_ok=True)
+    local_binary.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    local_binary.chmod(0o644)
+
+    monkeypatch.setattr("shutil.which", lambda command: None)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "actual-home")
+
+    detection = adapter.detect(context)
+
+    assert detection.installed is False
+    assert detection.command_available is False
+
+
+def test_claude_install_bakes_launcher_pythonpath_into_hook_command(monkeypatch, tmp_path):
+    context = _build_context(tmp_path)
+    adapter = ClaudeCodeHarnessAdapter()
+    monkeypatch.setenv("PYTHONPATH", str(Path("/repo/src")))
+
+    install_output = adapter.install(context)
+
+    settings_path = context.workspace_dir / ".claude" / "settings.local.json"
+    payload = json.loads(settings_path.read_text(encoding="utf-8"))
+    hook_command = str(payload["hooks"]["PreToolUse"][0]["command"])
+
+    assert install_output["active"] is True
+    assert "from codex_plugin_scanner.cli import main" in hook_command
+    assert "/repo/src" in hook_command
+    assert "\"guard\", \"hook\"" not in hook_command

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import subprocess
-import sys
 import threading
 import urllib.parse
 import urllib.request
@@ -16,6 +15,9 @@ import pytest
 
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.adapters import cursor as cursor_adapter_module
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.claude_code import ClaudeCodeHarnessAdapter
+from codex_plugin_scanner.guard.adapters.opencode import OpenCodeHarnessAdapter
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
 from codex_plugin_scanner.guard.cli import connect_flow as guard_connect_flow_module
 from codex_plugin_scanner.guard.cli import update_commands as guard_update_commands_module
@@ -1199,6 +1201,10 @@ args = ["workspace-skill.js"]
             {"servers": {"global-tool": {"command": "npx", "args": ["server.js"]}}},
         )
         _write_json(
+            workspace_dir / ".mcp.json",
+            {"servers": {"workspace-cli-tool": {"command": "python", "args": ["cli-server.py"]}}},
+        )
+        _write_json(
             workspace_dir / ".vscode" / "mcp.json",
             {"servers": {"workspace-tool": {"command": "python", "args": ["server.py"]}}},
         )
@@ -1225,6 +1231,7 @@ args = ["workspace-skill.js"]
         assert rc == 0
         assert output["harnesses"][0]["harness"] == "copilot"
         assert "copilot:global:global-tool" in artifacts
+        assert "copilot:project:workspace-cli-tool" in artifacts
         assert "copilot:project:workspace-tool" in artifacts
         assert "copilot:project:hook:custom:pretooluse:0:command" in artifacts
 
@@ -2002,20 +2009,12 @@ args = ["workspace-skill.js", "--changed"]
         assert settings_local.exists()
         assert len(install_settings_payload["hooks"]["PreToolUse"]) == 1
         assert install_output["managed_install"]["manifest"]["notes"][0]
-        expected_hook_command = subprocess.list2cmdline(
-            [
-                sys.executable,
-                "-m",
-                "codex_plugin_scanner.cli",
-                "guard",
-                "hook",
-                "--guard-home",
-                str(home_dir),
-                "--home",
-                str(home_dir),
-                "--workspace",
-                str(workspace_dir),
-            ]
+        expected_hook_command = ClaudeCodeHarnessAdapter._hook_command(
+            HarnessContext(
+                home_dir=home_dir,
+                workspace_dir=workspace_dir,
+                guard_home=home_dir,
+            )
         )
         assert install_settings_payload["hooks"]["PreToolUse"][0]["command"] == expected_hook_command
         assert uninstall_rc == 0
@@ -2027,20 +2026,12 @@ args = ["workspace-skill.js", "--changed"]
         workspace_dir = tmp_path / "workspace"
         _build_guard_fixture(home_dir, workspace_dir)
         settings_local = workspace_dir / ".claude" / "settings.local.json"
-        expected_hook_command = subprocess.list2cmdline(
-            [
-                sys.executable,
-                "-m",
-                "codex_plugin_scanner.cli",
-                "guard",
-                "hook",
-                "--guard-home",
-                str(home_dir),
-                "--home",
-                str(home_dir),
-                "--workspace",
-                str(workspace_dir),
-            ]
+        expected_hook_command = ClaudeCodeHarnessAdapter._hook_command(
+            HarnessContext(
+                home_dir=home_dir,
+                workspace_dir=workspace_dir,
+                guard_home=home_dir,
+            )
         )
         _write_json(
             settings_local,
@@ -2128,17 +2119,221 @@ args = ["workspace-skill.js", "--changed"]
         manifest = output["managed_install"]["manifest"]
         runtime_config_path = Path(str(manifest["runtime_config_path"]))
         runtime_payload = json.loads(runtime_config_path.read_text(encoding="utf-8"))
+        managed_config_path = Path(str(manifest["managed_config_path"]))
+        managed_payload = json.loads(managed_config_path.read_text(encoding="utf-8"))
 
         assert rc == 0
         assert output["managed_install"]["active"] is True
         assert manifest["shim_command"] == "guard-opencode"
-        assert runtime_payload["permission"]["skill"]["*"] == "ask"
+        assert "skill" not in runtime_payload["permission"]
         assert runtime_payload["permission"]["danger_lab_*"] == "ask"
         assert runtime_payload["mcp"]["danger_lab"]["type"] == "local"
         assert runtime_payload["mcp"]["danger_lab"]["command"][0]
         assert runtime_payload["mcp"]["danger_lab"]["command"][3] == "guard"
         assert runtime_payload["mcp"]["danger_lab"]["command"][4] == "opencode-mcp-proxy"
         assert runtime_payload["mcp"]["danger_lab"]["environment"]["API_BASE"] == "https://hol.org"
+        assert manifest["managed_config_path"] == str(workspace_dir / "opencode.json")
+        assert Path(str(manifest["backup_path"])).is_file()
+        assert managed_payload["permission"]["danger_lab_*"] == "ask"
+        assert managed_payload["mcp"]["danger_lab"]["type"] == "local"
+        assert managed_payload["mcp"]["danger_lab"]["command"][2] == "codex_plugin_scanner.cli"
+        assert managed_payload["mcp"]["danger_lab"]["command"][3] == "guard"
+        assert managed_payload["mcp"]["danger_lab"]["command"][4] == "opencode-mcp-proxy"
+        assert managed_payload["mcp"]["danger_lab"]["environment"]["API_BASE"] == "https://hol.org"
+
+    def test_guard_reinstall_does_not_double_wrap_opencode_mcp_proxies(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _write_json(
+            workspace_dir / "opencode.json",
+            {
+                "mcp": {
+                    "danger_lab": {
+                        "type": "local",
+                        "command": ["python3", "danger-server.py"],
+                    }
+                }
+            },
+        )
+
+        first_rc = main(
+            [
+                "guard",
+                "install",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        json.loads(capsys.readouterr().out)
+
+        second_rc = main(
+            [
+                "guard",
+                "install",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        second_output = json.loads(capsys.readouterr().out)
+        managed_config_path = Path(str(second_output["managed_install"]["manifest"]["managed_config_path"]))
+        managed_payload = json.loads(managed_config_path.read_text(encoding="utf-8"))
+        proxy_command = managed_payload["mcp"]["danger_lab"]["command"]
+
+        assert first_rc == 0
+        assert second_rc == 0
+        assert proxy_command.count("opencode-mcp-proxy") == 1
+        assert proxy_command[proxy_command.index("--command") + 1] == "python3"
+        assert "--arg=danger-server.py" in proxy_command
+
+    def test_guard_install_prefers_existing_opencode_jsonc_target(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        jsonc_path = workspace_dir / "opencode.jsonc"
+        jsonc_text = (
+            "{\n"
+            "  // keep jsonc target\n"
+            '  "provider": {"openai": {}},\n'
+            '  "mcp": {"danger_lab": {"type": "local", "command": ["python3", "danger-server.py"]}}\n'
+            "}\n"
+        )
+        _write_text(
+            jsonc_path,
+            jsonc_text,
+        )
+
+        rc = main(
+            [
+                "guard",
+                "install",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        managed_config_path = Path(str(output["managed_install"]["manifest"]["managed_config_path"]))
+        managed_payload = json.loads(managed_config_path.read_text(encoding="utf-8"))
+
+        assert rc == 0
+        assert managed_config_path == jsonc_path
+        assert managed_payload["provider"] == {"openai": {}}
+        assert managed_payload["permission"]["danger_lab_*"] == "ask"
+
+    def test_guard_install_prefers_opencode_environment_config_target(self, monkeypatch, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        custom_config_path = workspace_dir / "custom" / "guard-opencode.jsonc"
+        _write_text(custom_config_path, '{\n  "provider": {"openrouter": {}}\n}\n')
+        monkeypatch.setenv("OPENCODE_CONFIG", str(custom_config_path))
+
+        rc = main(
+            [
+                "guard",
+                "install",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        managed_config_path = Path(str(output["managed_install"]["manifest"]["managed_config_path"]))
+        managed_payload = json.loads(managed_config_path.read_text(encoding="utf-8"))
+
+        assert rc == 0
+        assert managed_config_path == custom_config_path
+        assert managed_payload["provider"] == {"openrouter": {}}
+
+    def test_guard_install_prefers_workspace_target_over_existing_global_opencode_config(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        global_config_path = home_dir / ".config" / "opencode" / "opencode.json"
+        global_text = '{\n  "provider": {"openai": {}}\n}\n'
+        _write_text(global_config_path, global_text)
+
+        rc = main(
+            [
+                "guard",
+                "install",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        managed_config_path = Path(str(output["managed_install"]["manifest"]["managed_config_path"]))
+
+        assert rc == 0
+        assert managed_config_path == workspace_dir / "opencode.json"
+        assert managed_config_path.exists() is True
+        assert global_config_path.read_text(encoding="utf-8") == global_text
+
+    def test_guard_uninstall_restores_opencode_project_config(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        original_payload = {
+            "name": "workspace-opencode",
+            "mcp": {
+                "danger_lab": {
+                    "type": "local",
+                    "command": ["python3", "danger-server.py"],
+                    "environment": {"API_BASE": "https://hol.org"},
+                }
+            },
+        }
+        _write_json(workspace_dir / "opencode.json", original_payload)
+        original_text = (workspace_dir / "opencode.json").read_text(encoding="utf-8")
+
+        install_rc = main(
+            [
+                "guard",
+                "install",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        install_output = json.loads(capsys.readouterr().out)
+        backup_path = Path(str(install_output["managed_install"]["manifest"]["backup_path"]))
+
+        uninstall_rc = main(
+            [
+                "guard",
+                "uninstall",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        uninstall_output = json.loads(capsys.readouterr().out)
+
+        assert install_rc == 0
+        assert uninstall_rc == 0
+        assert uninstall_output["managed_install"]["active"] is False
+        assert (workspace_dir / "opencode.json").read_text(encoding="utf-8") == original_text
+        assert backup_path.exists() is False
 
     def test_guard_install_keeps_pythonpath_in_opencode_runtime_overlay(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
@@ -2176,6 +2371,385 @@ args = ["workspace-skill.js", "--changed"]
 
         assert rc == 0
         assert runtime_payload["mcp"]["danger_lab"]["environment"]["PYTHONPATH"] == str(tmp_path / "src")
+
+    def test_guard_uninstall_removes_generated_opencode_config_when_no_original_exists(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        config_path = workspace_dir / "opencode.json"
+
+        install_rc = main(
+            [
+                "guard",
+                "install",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        install_output = json.loads(capsys.readouterr().out)
+        backup_path = Path(str(install_output["managed_install"]["manifest"]["backup_path"]))
+
+        uninstall_rc = main(
+            [
+                "guard",
+                "uninstall",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        json.loads(capsys.readouterr().out)
+
+        assert install_rc == 0
+        assert uninstall_rc == 0
+        assert config_path.exists() is False
+        assert backup_path.exists() is False
+
+    def test_guard_uninstall_uses_install_state_when_opencode_config_changes(self, monkeypatch, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        custom_config_path = workspace_dir / "custom" / "guard-opencode.jsonc"
+        original_text = '{\n  "provider": {"openrouter": {}}\n}\n'
+        _write_text(custom_config_path, original_text)
+        monkeypatch.setenv("OPENCODE_CONFIG", str(custom_config_path))
+
+        install_rc = main(
+            [
+                "guard",
+                "install",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        install_output = json.loads(capsys.readouterr().out)
+        backup_path = Path(str(install_output["managed_install"]["manifest"]["backup_path"]))
+        state_path = Path(str(install_output["managed_install"]["manifest"]["state_path"]))
+        monkeypatch.delenv("OPENCODE_CONFIG")
+
+        uninstall_rc = main(
+            [
+                "guard",
+                "uninstall",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        uninstall_output = json.loads(capsys.readouterr().out)
+
+        assert install_rc == 0
+        assert uninstall_rc == 0
+        assert uninstall_output["managed_install"]["manifest"]["managed_config_path"] == str(custom_config_path)
+        assert custom_config_path.read_text(encoding="utf-8") == original_text
+        assert backup_path.exists() is False
+        assert state_path.exists() is False
+
+    def test_guard_uninstall_uses_workspace_scoped_state(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_a = tmp_path / "workspace-a"
+        workspace_b = tmp_path / "workspace-b"
+        original_a = '{\n  "provider": {"openai": {}}\n}\n'
+        original_b = '{\n  "provider": {"openrouter": {}}\n}\n'
+        _write_text(workspace_a / "opencode.json", original_a)
+        _write_text(workspace_b / "opencode.json", original_b)
+
+        install_a_rc = main(
+            [
+                "guard",
+                "install",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_a),
+                "--json",
+            ]
+        )
+        install_a_output = json.loads(capsys.readouterr().out)
+        state_a_path = Path(str(install_a_output["managed_install"]["manifest"]["state_path"]))
+
+        install_b_rc = main(
+            [
+                "guard",
+                "install",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_b),
+                "--json",
+            ]
+        )
+        install_b_output = json.loads(capsys.readouterr().out)
+        state_b_path = Path(str(install_b_output["managed_install"]["manifest"]["state_path"]))
+
+        uninstall_a_rc = main(
+            [
+                "guard",
+                "uninstall",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_a),
+                "--json",
+            ]
+        )
+        uninstall_a_output = json.loads(capsys.readouterr().out)
+
+        assert install_a_rc == 0
+        assert install_b_rc == 0
+        assert uninstall_a_rc == 0
+        assert uninstall_a_output["managed_install"]["manifest"]["managed_config_path"] == str(
+            workspace_a / "opencode.json"
+        )
+        assert (workspace_a / "opencode.json").read_text(encoding="utf-8") == original_a
+        assert (workspace_b / "opencode.json").read_text(encoding="utf-8") != original_b
+        assert state_a_path.exists() is False
+        assert state_b_path.exists() is True
+
+    def test_guard_uninstall_uses_single_global_state_without_opencode_config(self, monkeypatch, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        custom_config_path = home_dir / "custom" / "opencode.jsonc"
+        original_text = '{\n  "provider": {"openrouter": {}}\n}\n'
+        _write_text(custom_config_path, original_text)
+        monkeypatch.setenv("OPENCODE_CONFIG", str(custom_config_path))
+
+        install_rc = main(
+            [
+                "guard",
+                "install",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--json",
+            ]
+        )
+        install_output = json.loads(capsys.readouterr().out)
+        state_path = Path(str(install_output["managed_install"]["manifest"]["state_path"]))
+        monkeypatch.delenv("OPENCODE_CONFIG")
+
+        uninstall_rc = main(
+            [
+                "guard",
+                "uninstall",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--json",
+            ]
+        )
+        uninstall_output = json.loads(capsys.readouterr().out)
+
+        assert install_rc == 0
+        assert uninstall_rc == 0
+        assert uninstall_output["managed_install"]["manifest"]["managed_config_path"] == str(custom_config_path)
+        assert custom_config_path.read_text(encoding="utf-8") == original_text
+        assert state_path.exists() is False
+
+    def test_guard_uninstall_keeps_config_when_backup_metadata_is_unreadable(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+
+        install_rc = main(
+            [
+                "guard",
+                "install",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        install_output = json.loads(capsys.readouterr().out)
+        backup_path = Path(str(install_output["managed_install"]["manifest"]["backup_path"]))
+        config_path = Path(str(install_output["managed_install"]["manifest"]["managed_config_path"]))
+        state_path = Path(str(install_output["managed_install"]["manifest"]["state_path"]))
+        backup_path.write_text("{\n  bad json\n", encoding="utf-8")
+
+        uninstall_rc = main(
+            [
+                "guard",
+                "uninstall",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        json.loads(capsys.readouterr().out)
+
+        assert install_rc == 0
+        assert uninstall_rc == 0
+        assert config_path.exists() is True
+        assert backup_path.exists() is True
+        assert state_path.exists() is True
+
+    def test_guard_uninstall_keeps_config_when_backup_content_is_missing(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+
+        install_rc = main(
+            [
+                "guard",
+                "install",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        install_output = json.loads(capsys.readouterr().out)
+        backup_path = Path(str(install_output["managed_install"]["manifest"]["backup_path"]))
+        config_path = Path(str(install_output["managed_install"]["manifest"]["managed_config_path"]))
+        state_path = Path(str(install_output["managed_install"]["manifest"]["state_path"]))
+        backup_path.write_text('{\n  "existed": true\n}\n', encoding="utf-8")
+
+        uninstall_rc = main(
+            [
+                "guard",
+                "uninstall",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        json.loads(capsys.readouterr().out)
+
+        assert install_rc == 0
+        assert uninstall_rc == 0
+        assert config_path.exists() is True
+        assert backup_path.exists() is True
+        assert state_path.exists() is True
+
+    def test_guard_uninstall_keeps_state_when_opencode_backup_is_missing(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+
+        install_rc = main(
+            [
+                "guard",
+                "install",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        install_output = json.loads(capsys.readouterr().out)
+        backup_path = Path(str(install_output["managed_install"]["manifest"]["backup_path"]))
+        config_path = Path(str(install_output["managed_install"]["manifest"]["managed_config_path"]))
+        state_path = Path(str(install_output["managed_install"]["manifest"]["state_path"]))
+        backup_path.unlink()
+
+        uninstall_rc = main(
+            [
+                "guard",
+                "uninstall",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        json.loads(capsys.readouterr().out)
+
+        assert install_rc == 0
+        assert uninstall_rc == 0
+        assert config_path.exists() is True
+        assert backup_path.exists() is False
+        assert state_path.exists() is True
+
+    def test_guard_uninstall_avoids_ambiguous_workspace_state_matches(self, monkeypatch, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        config_a_path = workspace_dir / "custom-a" / "opencode.jsonc"
+        config_b_path = workspace_dir / "custom-b" / "opencode.jsonc"
+        _write_text(config_a_path, '{\n  "provider": {"openai": {}}\n}\n')
+        _write_text(config_b_path, '{\n  "provider": {"openrouter": {}}\n}\n')
+
+        monkeypatch.setenv("OPENCODE_CONFIG", str(config_a_path))
+        install_a_rc = main(
+            [
+                "guard",
+                "install",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        install_a_output = json.loads(capsys.readouterr().out)
+        state_a_path = Path(str(install_a_output["managed_install"]["manifest"]["state_path"]))
+
+        monkeypatch.setenv("OPENCODE_CONFIG", str(config_b_path))
+        install_b_rc = main(
+            [
+                "guard",
+                "install",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        install_b_output = json.loads(capsys.readouterr().out)
+        state_b_path = Path(str(install_b_output["managed_install"]["manifest"]["state_path"]))
+        monkeypatch.delenv("OPENCODE_CONFIG")
+        config_a_before_uninstall = config_a_path.read_text(encoding="utf-8")
+        config_b_before_uninstall = config_b_path.read_text(encoding="utf-8")
+
+        uninstall_rc = main(
+            [
+                "guard",
+                "uninstall",
+                "opencode",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        json.loads(capsys.readouterr().out)
+
+        assert install_a_rc == 0
+        assert install_b_rc == 0
+        assert uninstall_rc == 0
+        assert config_a_path.read_text(encoding="utf-8") == config_a_before_uninstall
+        assert config_b_path.read_text(encoding="utf-8") == config_b_before_uninstall
+        assert state_a_path.exists() is True
+        assert state_b_path.exists() is True
 
     def test_guard_install_keeps_disabled_opencode_servers_disabled(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -2267,6 +2841,18 @@ args = ["workspace-skill.js", "--changed"]
         assert runtime_payload["mcp"]["global_only_lab"]["type"] == "local"
         assert runtime_payload["permission"]["global_only_lab_*"] == "ask"
 
+    def test_opencode_launch_command_treats_debug_tokens_as_interactive_prompt(self, tmp_path):
+        adapter = OpenCodeHarnessAdapter()
+        context = HarnessContext(
+            home_dir=tmp_path / "home",
+            workspace_dir=tmp_path / "workspace",
+            guard_home=tmp_path / "guard-home",
+        )
+
+        command = adapter.launch_command(context, ["debug", "oauth"])
+
+        assert command == ["opencode", str(context.workspace_dir), "--prompt", "debug oauth"]
+
     def test_guard_update_runs_pip_upgrade_in_current_environment(self, monkeypatch, capsys):
         commands: list[list[str]] = []
 
@@ -2297,7 +2883,7 @@ args = ["workspace-skill.js", "--changed"]
             return subprocess.CompletedProcess(command, 0, stdout="pipx-updated", stderr="")
 
         monkeypatch.setattr(guard_update_commands_module.subprocess, "run", fake_run)
-        monkeypatch.setattr(guard_update_commands_module.sys, "prefix", "/Users/test/.local/pipx/venvs/hol-guard")
+        monkeypatch.setattr(guard_update_commands_module.sys, "prefix", "/mock-home/.local/pipx/venvs/hol-guard")
         monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
         monkeypatch.setattr(guard_update_commands_module, "_current_version_from_subprocess", lambda: "2.0.18")
 
@@ -2324,7 +2910,7 @@ args = ["workspace-skill.js", "--changed"]
         monkeypatch.setattr(
             guard_update_commands_module,
             "_direct_url_payload",
-            lambda: {"dir_info": {"editable": True}, "url": "file:///Users/test/ai-plugin-scanner"},
+            lambda: {"dir_info": {"editable": True}, "url": "file:///mock-workspace/ai-plugin-scanner"},
         )
 
         rc = main(["guard", "update", "--json"])

--- a/tests/test_guard_copilot_adapter.py
+++ b/tests/test_guard_copilot_adapter.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+import os
+import sys
 from pathlib import Path
 
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
-from codex_plugin_scanner.guard.adapters.copilot import CopilotHarnessAdapter
+from codex_plugin_scanner.guard.adapters.copilot import CopilotHarnessAdapter, _refresh_guard_proxy_entry
 
 
 def _write_json(path: Path, payload: dict[str, object]) -> None:
@@ -43,6 +45,17 @@ def test_copilot_detects_documented_local_surfaces_and_redacts_secrets(tmp_path)
         },
     )
     _write_json(
+        context.workspace_dir / ".mcp.json",
+        {
+            "servers": {
+                "workspace-cli-tool": {
+                    "command": ["python", "-m", "workspace_cli_server"],
+                    "args": ["--api-key=workspace-cli-secret"],
+                }
+            }
+        },
+    )
+    _write_json(
         context.workspace_dir / ".vscode" / "mcp.json",
         {
             "servers": {
@@ -71,17 +84,25 @@ def test_copilot_detects_documented_local_surfaces_and_redacts_secrets(tmp_path)
     assert set(detection["config_paths"]) == {
         str(context.home_dir / ".copilot" / "config.json"),
         str(context.home_dir / ".copilot" / "mcp-config.json"),
+        str(context.workspace_dir / ".mcp.json"),
         str(context.workspace_dir / ".vscode" / "mcp.json"),
         str(context.workspace_dir / ".github" / "hooks" / "custom.json"),
     }
     artifacts = {item["artifact_id"]: item for item in detection["artifacts"]}
     assert "copilot:global:global-tool" in artifacts
+    assert "copilot:project:workspace-cli-tool" in artifacts
     assert "copilot:project:workspace-tool" in artifacts
     assert "copilot:project:hook:custom:sessionstart:0:command" in artifacts
     assert "copilot:project:hook:custom:pretooluse:0:command" in artifacts
     assert "copilot:project:hook:custom:posttooluse:0:command" in artifacts
     assert artifacts["copilot:global:global-tool"]["args"] == ["--token=*****", "server.js"]
     assert artifacts["copilot:global:global-tool"]["url"] == "https://example.com/mcp?token=%2A%2A%2A%2A%2A&label=demo"
+    assert artifacts["copilot:project:workspace-cli-tool"]["command"] == "python"
+    assert artifacts["copilot:project:workspace-cli-tool"]["args"] == [
+        "-m",
+        "workspace_cli_server",
+        "--api-key=*****",
+    ]
     assert artifacts["copilot:project:workspace-tool"]["command"] == "python"
     assert artifacts["copilot:project:workspace-tool"]["args"] == ["-m", "workspace_server", "--api-key=*****"]
 
@@ -153,10 +174,15 @@ def test_copilot_detect_records_bash_and_powershell_hook_commands_separately(tmp
     }
 
 
-def test_copilot_install_and_uninstall_manage_guard_owned_hook_file_idempotently(tmp_path):
+def test_copilot_install_and_uninstall_manage_inline_config_hooks_idempotently(tmp_path):
     context = _build_context(tmp_path)
     adapter = CopilotHarnessAdapter()
+    original_pythonpath = sys.path[0]
+    previous_pythonpath = os.environ.get("PYTHONPATH")
+    os.environ["PYTHONPATH"] = original_pythonpath
+    config_path = context.home_dir / ".copilot" / "config.json"
     custom_hook_path = context.workspace_dir / ".github" / "hooks" / "custom.json"
+    _write_json(config_path, {"trusted_repositories": ["demo"]})
     _write_json(
         custom_hook_path,
         {
@@ -168,38 +194,92 @@ def test_copilot_install_and_uninstall_manage_guard_owned_hook_file_idempotently
         },
     )
 
-    first_install = adapter.install(context)
-    second_install = adapter.install(context)
-    managed_hook_path = context.workspace_dir / ".github" / "hooks" / "hol-guard-copilot.json"
-    managed_payload = json.loads(managed_hook_path.read_text(encoding="utf-8"))
+    try:
+        first_install = adapter.install(context)
+        second_install = adapter.install(context)
+        config_payload = json.loads(config_path.read_text(encoding="utf-8"))
+        managed_hook_path = context.workspace_dir / ".github" / "hooks" / "hol-guard-copilot.json"
+        managed_hook_payload = json.loads(managed_hook_path.read_text(encoding="utf-8"))
+        managed_hooks = config_payload["hooks"]
+        managed_workspace_hooks = managed_hook_payload["hooks"]
 
-    assert first_install["active"] is True
-    assert second_install["active"] is True
-    assert managed_hook_path.exists() is True
-    assert managed_payload["version"] == 1
-    assert len(managed_payload["hooks"]["preToolUse"]) == 1
-    assert len(managed_payload["hooks"]["postToolUse"]) == 1
-    assert managed_payload["hooks"]["preToolUse"][0]["type"] == "command"
-    assert managed_payload["hooks"]["preToolUse"][0]["cwd"] == "."
-    assert managed_payload["hooks"]["preToolUse"][0]["timeoutSec"] == 30
-    assert "guard hook" in managed_payload["hooks"]["preToolUse"][0]["bash"]
-    assert "--harness copilot" in managed_payload["hooks"]["preToolUse"][0]["bash"]
-    assert "guard hook" in managed_payload["hooks"]["preToolUse"][0]["powershell"]
-    assert managed_payload["hooks"]["postToolUse"][0]["type"] == "command"
-    assert "guard hook" in managed_payload["hooks"]["postToolUse"][0]["bash"]
-    assert json.loads(custom_hook_path.read_text(encoding="utf-8")) == {
-        "version": 1,
-        "hooks": {
-            "preToolUse": [{"command": "python custom-pre.py"}],
-            "postToolUse": [{"command": "python custom-post.py"}],
+        assert first_install["active"] is True
+        assert second_install["active"] is True
+        assert first_install["config_path"] == str(config_path)
+        assert len(managed_hooks["preToolUse"]) == 1
+        assert len(managed_hooks["postToolUse"]) == 1
+        assert len(managed_hooks["permissionRequest"]) == 1
+        assert managed_hooks["preToolUse"][0]["type"] == "command"
+        assert managed_hooks["preToolUse"][0]["cwd"] == "."
+        assert managed_hooks["preToolUse"][0]["timeoutSec"] == 30
+        assert managed_hooks["preToolUse"][0]["env"]["PYTHONPATH"] == original_pythonpath
+        assert "guard hook" in managed_hooks["preToolUse"][0]["bash"]
+        assert "--harness copilot" in managed_hooks["preToolUse"][0]["bash"]
+        assert "--workspace" not in managed_hooks["preToolUse"][0]["bash"]
+        assert "guard hook" in managed_hooks["preToolUse"][0]["powershell"]
+        assert managed_hooks["postToolUse"][0]["type"] == "command"
+        assert "guard hook" in managed_hooks["postToolUse"][0]["bash"]
+        assert len(managed_workspace_hooks["preToolUse"]) == 1
+        assert len(managed_workspace_hooks["postToolUse"]) == 1
+        assert len(managed_workspace_hooks["permissionRequest"]) == 1
+        assert "--workspace" in managed_workspace_hooks["preToolUse"][0]["bash"]
+        assert config_payload["trusted_repositories"] == ["demo"]
+        assert json.loads(custom_hook_path.read_text(encoding="utf-8")) == {
+            "version": 1,
+            "hooks": {
+                "preToolUse": [{"command": "python custom-pre.py"}],
+                "postToolUse": [{"command": "python custom-post.py"}],
+            },
+        }
+
+        uninstall_payload = adapter.uninstall(context)
+        restored_payload = json.loads(config_path.read_text(encoding="utf-8"))
+
+        assert uninstall_payload["active"] is False
+        assert "hooks" not in restored_payload
+        assert managed_hook_path.exists() is False
+        assert restored_payload["trusted_repositories"] == ["demo"]
+    finally:
+        if previous_pythonpath is None:
+            os.environ.pop("PYTHONPATH", None)
+        else:
+            os.environ["PYTHONPATH"] = previous_pythonpath
+
+
+def test_refresh_guard_proxy_entry_preserves_list_form_proxy_args():
+    refreshed = _refresh_guard_proxy_entry(
+        {
+            "command": [
+                "/old/python",
+                "-m",
+                "codex_plugin_scanner.cli",
+                "guard",
+                "copilot-mcp-proxy",
+                "--server-name",
+                "danger_lab",
+            ]
         },
-    }
+        launcher_env={"PYTHONPATH": "/tmp/src"},
+    )
+
+    assert refreshed["command"] == sys.executable
+    assert refreshed["args"] == [
+        "-m",
+        "codex_plugin_scanner.cli",
+        "guard",
+        "copilot-mcp-proxy",
+        "--server-name",
+        "danger_lab",
+    ]
+    assert refreshed["env"] == {"PYTHONPATH": "/tmp/src"}
 
 
-def test_copilot_install_rewrites_legacy_guard_owned_hook_file_to_documented_schema(tmp_path):
+def test_copilot_install_migrates_legacy_workspace_hook_file_out_of_band(tmp_path):
     context = _build_context(tmp_path)
     adapter = CopilotHarnessAdapter()
+    config_path = context.home_dir / ".copilot" / "config.json"
     managed_hook_path = context.workspace_dir / ".github" / "hooks" / "hol-guard-copilot.json"
+    _write_json(config_path, {"trusted_repositories": ["demo"]})
     _write_json(
         managed_hook_path,
         {
@@ -208,29 +288,29 @@ def test_copilot_install_rewrites_legacy_guard_owned_hook_file_to_documented_sch
         },
     )
 
-    adapter.install(context)
-    managed_payload = json.loads(managed_hook_path.read_text(encoding="utf-8"))
+    install_payload = adapter.install(context)
+    config_payload = json.loads(config_path.read_text(encoding="utf-8"))
+    managed_hook_payload = json.loads(managed_hook_path.read_text(encoding="utf-8"))
 
-    assert managed_payload["version"] == 1
-    assert set(managed_payload) == {"version", "hooks"}
-    assert len(managed_payload["hooks"]["preToolUse"]) == 1
-    assert len(managed_payload["hooks"]["postToolUse"]) == 1
-    assert "old-pre.py" not in managed_payload["hooks"]["preToolUse"][0]["bash"]
+    assert install_payload["active"] is True
+    assert len(config_payload["hooks"]["preToolUse"]) == 1
+    assert len(config_payload["hooks"]["postToolUse"]) == 1
+    assert len(config_payload["hooks"]["permissionRequest"]) == 1
+    assert "old-pre.py" not in config_payload["hooks"]["preToolUse"][0]["bash"]
+    assert managed_hook_path.exists() is True
+    assert len(managed_hook_payload["hooks"]["preToolUse"]) == 1
+    assert "old-pre.py" not in managed_hook_payload["hooks"]["preToolUse"][0]["bash"]
+    assert "--workspace" in managed_hook_payload["hooks"]["preToolUse"][0]["bash"]
 
-    uninstall_payload = adapter.uninstall(context)
 
-    assert uninstall_payload["active"] is False
-    assert managed_hook_path.exists() is False
-
-
-def test_copilot_install_and_uninstall_preserve_existing_managed_hook_content(tmp_path):
+def test_copilot_install_and_uninstall_preserve_existing_inline_hook_content(tmp_path):
     context = _build_context(tmp_path)
     adapter = CopilotHarnessAdapter()
-    managed_hook_path = context.workspace_dir / ".github" / "hooks" / "hol-guard-copilot.json"
+    config_path = context.home_dir / ".copilot" / "config.json"
     _write_json(
-        managed_hook_path,
+        config_path,
         {
-            "version": 1,
+            "trusted_repositories": ["demo"],
             "hooks": {
                 "sessionStart": [{"command": "python banner.py"}],
                 "preToolUse": [{"command": "python existing-pre.py"}],
@@ -239,18 +319,18 @@ def test_copilot_install_and_uninstall_preserve_existing_managed_hook_content(tm
     )
 
     adapter.install(context)
-    managed_payload = json.loads(managed_hook_path.read_text(encoding="utf-8"))
+    managed_payload = json.loads(config_path.read_text(encoding="utf-8"))
 
     assert managed_payload["hooks"]["sessionStart"] == [{"command": "python banner.py"}]
     assert len(managed_payload["hooks"]["preToolUse"]) == 2
     assert managed_payload["hooks"]["preToolUse"][0] == {"command": "python existing-pre.py"}
 
     uninstall_payload = adapter.uninstall(context)
-    remaining_payload = json.loads(managed_hook_path.read_text(encoding="utf-8"))
+    remaining_payload = json.loads(config_path.read_text(encoding="utf-8"))
 
     assert uninstall_payload["active"] is False
     assert remaining_payload == {
-        "version": 1,
+        "trusted_repositories": ["demo"],
         "hooks": {
             "sessionStart": [{"command": "python banner.py"}],
             "preToolUse": [{"command": "python existing-pre.py"}],
@@ -258,14 +338,13 @@ def test_copilot_install_and_uninstall_preserve_existing_managed_hook_content(tm
     }
 
 
-def test_copilot_install_and_uninstall_match_managed_hooks_after_path_changes(tmp_path):
+def test_copilot_install_and_uninstall_match_inline_hooks_after_path_changes(tmp_path):
     context = _build_context(tmp_path)
     adapter = CopilotHarnessAdapter()
-    managed_hook_path = context.workspace_dir / ".github" / "hooks" / "hol-guard-copilot.json"
+    config_path = context.home_dir / ".copilot" / "config.json"
     _write_json(
-        managed_hook_path,
+        config_path,
         {
-            "version": 1,
             "hooks": {
                 "preToolUse": [
                     {
@@ -306,13 +385,476 @@ def test_copilot_install_and_uninstall_match_managed_hooks_after_path_changes(tm
     )
 
     adapter.install(context)
-    managed_payload = json.loads(managed_hook_path.read_text(encoding="utf-8"))
+    managed_payload = json.loads(config_path.read_text(encoding="utf-8"))
 
     assert len(managed_payload["hooks"]["preToolUse"]) == 1
     assert len(managed_payload["hooks"]["postToolUse"]) == 1
+    assert len(managed_payload["hooks"]["permissionRequest"]) == 1
     assert "--workspace /tmp/old-workspace" not in managed_payload["hooks"]["preToolUse"][0]["bash"]
+    assert "--workspace" not in managed_payload["hooks"]["preToolUse"][0]["bash"]
 
     uninstall_payload = adapter.uninstall(context)
 
     assert uninstall_payload["active"] is False
-    assert managed_hook_path.exists() is False
+    assert "hooks" not in json.loads(config_path.read_text(encoding="utf-8"))
+
+
+def test_copilot_uninstall_keeps_workspace_mcp_config_when_backup_metadata_is_unreadable(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = CopilotHarnessAdapter()
+    workspace_cli_mcp_path = context.workspace_dir / ".mcp.json"
+    original_payload = {
+        "mcpServers": {
+            "danger_lab": {
+                "command": "python3",
+                "args": ["server.py"],
+            }
+        }
+    }
+    _write_json(workspace_cli_mcp_path, original_payload)
+
+    install_payload = adapter.install(context)
+    primary_backup_path = Path(str(install_payload["backup_paths"][0]))
+    primary_backup_path.write_text("{\n  bad json\n", encoding="utf-8")
+
+    uninstall_payload = adapter.uninstall(context)
+
+    assert uninstall_payload["active"] is False
+    assert workspace_cli_mcp_path.exists() is True
+    assert json.loads(workspace_cli_mcp_path.read_text(encoding="utf-8")) != {}
+    assert primary_backup_path.exists() is True
+
+
+def test_copilot_uninstall_keeps_backup_when_restore_content_is_missing(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = CopilotHarnessAdapter()
+    workspace_cli_mcp_path = context.workspace_dir / ".mcp.json"
+    original_payload = {
+        "mcpServers": {
+            "danger_lab": {
+                "command": "python3",
+                "args": ["server.py"],
+            }
+        }
+    }
+    _write_json(workspace_cli_mcp_path, original_payload)
+
+    install_payload = adapter.install(context)
+    primary_backup_path = Path(str(install_payload["backup_paths"][0]))
+    primary_backup_path.write_text(json.dumps({"existed": True}, indent=2) + "\n", encoding="utf-8")
+
+    uninstall_payload = adapter.uninstall(context)
+
+    assert uninstall_payload["active"] is False
+    assert workspace_cli_mcp_path.exists() is True
+    assert primary_backup_path.exists() is True
+
+
+def test_copilot_install_manages_workspace_mcp_servers_for_ide(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = CopilotHarnessAdapter()
+    workspace_cli_mcp_path = context.workspace_dir / ".mcp.json"
+    workspace_mcp_path = context.workspace_dir / ".vscode" / "mcp.json"
+    _write_json(
+        context.home_dir / ".copilot" / "mcp-config.json",
+        {
+            "servers": {
+                "global-tool": {
+                    "command": "python",
+                    "args": ["-m", "global_server"],
+                }
+            }
+        },
+    )
+    _write_json(
+        workspace_cli_mcp_path,
+        {
+            "servers": {
+                "workspace-cli-tool": {
+                    "command": "python",
+                    "args": ["-m", "workspace_cli_server"],
+                }
+            }
+        },
+    )
+    _write_json(
+        workspace_mcp_path,
+        {
+            "servers": {
+                "workspace-tool": {
+                    "command": "python",
+                    "args": ["-m", "workspace_server"],
+                },
+                "existing-tool": {
+                    "command": "node",
+                    "args": ["existing.js"],
+                },
+            }
+        },
+    )
+
+    install_payload = adapter.install(context)
+    cli_payload = json.loads(workspace_cli_mcp_path.read_text(encoding="utf-8"))
+    managed_payload = json.loads(workspace_mcp_path.read_text(encoding="utf-8"))
+
+    assert install_payload["active"] is True
+    assert set(install_payload["managed_servers"]) == {
+        "global-tool",
+        "workspace-cli-tool",
+        "workspace-tool",
+        "existing-tool",
+    }
+    assert install_payload["managed_config_paths"] == [str(workspace_cli_mcp_path), str(workspace_mcp_path)]
+    assert len(install_payload["backup_paths"]) == 2
+    assert cli_payload["mcpServers"]["workspace-cli-tool"]["type"] == "local"
+    assert cli_payload["mcpServers"]["workspace-cli-tool"]["tools"] == ["*"]
+    assert managed_payload["servers"]["global-tool"]["type"] == "stdio"
+    assert managed_payload["servers"]["workspace-tool"]["type"] == "stdio"
+    assert managed_payload["servers"]["existing-tool"]["type"] == "stdio"
+    assert cli_payload["mcpServers"]["workspace-cli-tool"]["command"] == sys.executable
+    assert cli_payload["mcpServers"]["workspace-cli-tool"]["args"][:4] == [
+        "-m",
+        "codex_plugin_scanner.cli",
+        "guard",
+        "copilot-mcp-proxy",
+    ]
+    assert managed_payload["servers"]["global-tool"]["args"][2:5] == [
+        "guard",
+        "copilot-mcp-proxy",
+        "--guard-home",
+    ]
+    assert managed_payload["servers"]["global-tool"]["command"] == sys.executable
+    assert managed_payload["servers"]["workspace-tool"]["command"] == sys.executable
+    assert managed_payload["servers"]["existing-tool"]["command"] == sys.executable
+
+
+def test_copilot_install_keeps_target_specific_workspace_servers_distinct(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = CopilotHarnessAdapter()
+    workspace_cli_mcp_path = context.workspace_dir / ".mcp.json"
+    workspace_mcp_path = context.workspace_dir / ".vscode" / "mcp.json"
+    _write_json(
+        workspace_cli_mcp_path,
+        {
+            "mcpServers": {
+                "danger_lab": {
+                    "command": "python",
+                    "args": ["-m", "cli_server"],
+                }
+            }
+        },
+    )
+    _write_json(
+        workspace_mcp_path,
+        {
+            "servers": {
+                "danger_lab": {
+                    "command": "node",
+                    "args": ["ide-server.js"],
+                }
+            }
+        },
+    )
+
+    install_payload = adapter.install(context)
+    cli_payload = json.loads(workspace_cli_mcp_path.read_text(encoding="utf-8"))
+    ide_payload = json.loads(workspace_mcp_path.read_text(encoding="utf-8"))
+    cli_args = cli_payload["mcpServers"]["danger_lab"]["args"]
+    ide_args = ide_payload["servers"]["danger_lab"]["args"]
+
+    assert install_payload["active"] is True
+    assert cli_payload["mcpServers"]["danger_lab"]["command"] == sys.executable
+    assert ide_payload["servers"]["danger_lab"]["command"] == sys.executable
+    assert cli_args[cli_args.index("--command") + 1] == "python"
+    assert "--arg=-m" in cli_args
+    assert "--arg=cli_server" in cli_args
+    assert ide_args[ide_args.index("--command") + 1] == "node"
+    assert "--arg=ide-server.js" in ide_args
+
+
+def test_copilot_install_refreshes_existing_guard_proxy_entries_to_current_interpreter(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = CopilotHarnessAdapter()
+    original_pythonpath = sys.path[0]
+    previous_pythonpath = os.environ.get("PYTHONPATH")
+    os.environ["PYTHONPATH"] = original_pythonpath
+    workspace_cli_mcp_path = context.workspace_dir / ".mcp.json"
+    _write_json(
+        workspace_cli_mcp_path,
+        {
+            "mcpServers": {
+                "danger_lab": {
+                    "command": "/tmp/old-python",
+                    "args": [
+                        "-m",
+                        "codex_plugin_scanner.cli",
+                        "guard",
+                        "copilot-mcp-proxy",
+                        "--guard-home",
+                        str(context.guard_home),
+                        "--server-name",
+                        "danger_lab",
+                        "--source-scope",
+                        "project",
+                        "--config-path",
+                        str(context.workspace_dir / ".vscode" / "mcp.json"),
+                        "--transport",
+                        "stdio",
+                        "--command",
+                        "python3",
+                    ],
+                    "env": {"PYTHONPATH": "/tmp/old-src"},
+                    "type": "local",
+                    "tools": ["*"],
+                }
+            }
+        },
+    )
+
+    try:
+        adapter.install(context)
+        cli_payload = json.loads(workspace_cli_mcp_path.read_text(encoding="utf-8"))
+
+        assert cli_payload["mcpServers"]["danger_lab"]["command"] == sys.executable
+        assert cli_payload["mcpServers"]["danger_lab"]["args"][2:5] == [
+            "guard",
+            "copilot-mcp-proxy",
+            "--guard-home",
+        ]
+        assert cli_payload["mcpServers"]["danger_lab"]["env"]["PYTHONPATH"].startswith(original_pythonpath)
+        assert cli_payload["mcpServers"]["danger_lab"]["env"]["PYTHONPATH"].endswith("/tmp/old-src")
+    finally:
+        if previous_pythonpath is None:
+            os.environ.pop("PYTHONPATH", None)
+        else:
+            os.environ["PYTHONPATH"] = previous_pythonpath
+
+
+def test_copilot_install_refreshes_list_form_guard_proxy_entries_without_losing_args(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = CopilotHarnessAdapter()
+    workspace_cli_mcp_path = context.workspace_dir / ".mcp.json"
+    _write_json(
+        workspace_cli_mcp_path,
+        {
+            "mcpServers": {
+                "danger_lab": {
+                    "command": [
+                        "/tmp/old-python",
+                        "-m",
+                        "codex_plugin_scanner.cli",
+                        "guard",
+                        "copilot-mcp-proxy",
+                        "--guard-home",
+                        str(context.guard_home),
+                        "--server-name",
+                        "danger_lab",
+                        "--source-scope",
+                        "project",
+                        "--config-path",
+                        str(workspace_cli_mcp_path),
+                        "--transport",
+                        "stdio",
+                        "--command",
+                        "python3",
+                    ],
+                    "type": "local",
+                    "tools": ["*"],
+                }
+            }
+        },
+    )
+
+    adapter.install(context)
+    cli_payload = json.loads(workspace_cli_mcp_path.read_text(encoding="utf-8"))
+
+    assert cli_payload["mcpServers"]["danger_lab"]["command"] == sys.executable
+    assert cli_payload["mcpServers"]["danger_lab"]["args"][:4] == [
+        "-m",
+        "codex_plugin_scanner.cli",
+        "guard",
+        "copilot-mcp-proxy",
+    ]
+
+
+def test_copilot_detect_ignores_guard_managed_proxy_entries(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = CopilotHarnessAdapter()
+    _write_json(
+        context.workspace_dir / ".mcp.json",
+        {
+            "mcpServers": {
+                "guarded-tool": {
+                    "type": "local",
+                    "command": sys.executable,
+                    "args": [
+                        "-m",
+                        "codex_plugin_scanner.cli",
+                        "guard",
+                        "copilot-mcp-proxy",
+                        "--guard-home",
+                        str(context.guard_home),
+                    ],
+                    "tools": ["*"],
+                }
+            }
+        },
+    )
+
+    detection = adapter.detect(context)
+
+    assert detection.artifacts == ()
+
+
+def test_copilot_detect_marks_local_cli_install_as_available_when_not_on_path(tmp_path, monkeypatch):
+    context = _build_context(tmp_path)
+    adapter = CopilotHarnessAdapter()
+    local_binary = tmp_path / "actual-home" / ".local" / "copilot-cli" / "copilot"
+    local_binary.parent.mkdir(parents=True, exist_ok=True)
+    local_binary.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    local_binary.chmod(0o755)
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.base.shutil.which", lambda command: None)
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "actual-home")
+
+    detection = adapter.detect(context)
+
+    assert detection.command_available is True
+    assert detection.installed is True
+
+
+def test_copilot_detect_ignores_non_executable_local_cli_candidate_when_not_on_path(tmp_path, monkeypatch):
+    context = _build_context(tmp_path)
+    adapter = CopilotHarnessAdapter()
+    local_binary = tmp_path / "actual-home" / ".local" / "copilot-cli" / "copilot"
+    local_binary.parent.mkdir(parents=True, exist_ok=True)
+    local_binary.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    local_binary.chmod(0o644)
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.base.shutil.which", lambda command: None)
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "actual-home")
+
+    detection = adapter.detect(context)
+
+    assert detection.command_available is False
+    assert detection.installed is False
+
+
+def test_copilot_launch_command_uses_local_cli_install_when_not_on_path(tmp_path, monkeypatch):
+    context = _build_context(tmp_path)
+    adapter = CopilotHarnessAdapter()
+    local_binary = tmp_path / "actual-home" / ".local" / "copilot-cli" / "copilot"
+    local_binary.parent.mkdir(parents=True, exist_ok=True)
+    local_binary.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    local_binary.chmod(0o755)
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.base.shutil.which", lambda command: None)
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "actual-home")
+
+    command = adapter.launch_command(context, ["--help"])
+
+    assert command[0] == str(local_binary)
+    assert command[1:] == ["--help"]
+
+
+def test_copilot_uninstall_restores_install_time_workspace_targets_when_scope_changes(tmp_path):
+    workspace_context = _build_context(tmp_path)
+    global_context = HarnessContext(
+        home_dir=workspace_context.home_dir,
+        workspace_dir=None,
+        guard_home=workspace_context.guard_home,
+    )
+    adapter = CopilotHarnessAdapter()
+    workspace_cli_mcp_path = workspace_context.workspace_dir / ".mcp.json"
+    workspace_mcp_path = workspace_context.workspace_dir / ".vscode" / "mcp.json"
+    cli_payload = {
+        "mcpServers": {
+            "danger_lab": {
+                "command": "python",
+                "args": ["-m", "cli_server"],
+            }
+        }
+    }
+    ide_payload = {
+        "servers": {
+            "danger_lab": {
+                "command": "node",
+                "args": ["ide-server.js"],
+            }
+        }
+    }
+    _write_json(workspace_cli_mcp_path, cli_payload)
+    _write_json(workspace_mcp_path, ide_payload)
+
+    install_payload = adapter.install(workspace_context)
+    uninstall_payload = adapter.uninstall(global_context)
+
+    assert install_payload["active"] is True
+    assert uninstall_payload["active"] is False
+    assert set(uninstall_payload["managed_config_paths"]) == {
+        str(workspace_cli_mcp_path),
+        str(workspace_mcp_path),
+    }
+    assert json.loads(workspace_cli_mcp_path.read_text(encoding="utf-8")) == cli_payload
+    assert json.loads(workspace_mcp_path.read_text(encoding="utf-8")) == ide_payload
+    for state_path in uninstall_payload["state_paths"]:
+        assert Path(state_path).exists() is False
+
+
+def test_copilot_uninstall_keeps_shared_cli_hook_while_other_workspace_remains_installed(tmp_path):
+    first_context = _build_context(tmp_path / "first")
+    second_workspace = tmp_path / "second" / "workspace"
+    second_workspace.mkdir(parents=True, exist_ok=True)
+    second_context = HarnessContext(
+        home_dir=first_context.home_dir,
+        workspace_dir=second_workspace,
+        guard_home=first_context.guard_home,
+    )
+    adapter = CopilotHarnessAdapter()
+
+    first_install = adapter.install(first_context)
+    second_install = adapter.install(second_context)
+    first_uninstall = adapter.uninstall(first_context)
+
+    config_payload = json.loads((first_context.home_dir / ".copilot" / "config.json").read_text(encoding="utf-8"))
+    managed_hook_path = second_context.workspace_dir / ".github" / "hooks" / "hol-guard-copilot.json"
+
+    assert first_install["active"] is True
+    assert second_install["active"] is True
+    assert first_uninstall["active"] is False
+    assert "hooks" in config_payload
+    assert "preToolUse" in config_payload["hooks"]
+    assert len(config_payload["hooks"]["preToolUse"]) == 1
+    assert managed_hook_path.exists() is True
+
+
+def test_copilot_launch_command_adds_workspace_mcp_config_for_cli_sessions(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = CopilotHarnessAdapter()
+    _write_json(
+        context.workspace_dir / ".mcp.json",
+        {"mcpServers": {"danger_lab": {"command": "python3", "args": ["server.py"]}}},
+    )
+
+    command = adapter.launch_command(context, ["--help"])
+
+    assert command[0].endswith("copilot")
+    assert command[1:] == [
+        "--additional-mcp-config",
+        f"@{context.workspace_dir / '.mcp.json'}",
+        "--help",
+    ]
+
+
+def test_copilot_launch_command_skips_workspace_override_when_cli_mcp_config_is_missing(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = CopilotHarnessAdapter()
+    _write_json(
+        context.workspace_dir / ".vscode" / "mcp.json",
+        {"servers": {"danger_lab": {"command": "python3", "args": ["server.py"]}}},
+    )
+
+    command = adapter.launch_command(context, ["--help"])
+
+    assert command[0].endswith("copilot")
+    assert command[1:] == ["--help"]

--- a/tests/test_guard_copilot_adapter.py
+++ b/tests/test_guard_copilot_adapter.py
@@ -124,6 +124,24 @@ def test_copilot_detect_tolerates_malformed_json(tmp_path):
     assert [artifact.artifact_id for artifact in detection.artifacts] == ["copilot:project:workspace-tool"]
 
 
+def test_copilot_install_fails_closed_when_global_config_is_unreadable(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = CopilotHarnessAdapter()
+    config_path = context.home_dir / ".copilot" / "config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text("{broken", encoding="utf-8")
+
+    try:
+        adapter.install(context)
+    except RuntimeError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("expected install to refuse unreadable Copilot config")
+
+    assert "unreadable Copilot config" in message
+    assert config_path.read_text(encoding="utf-8") == "{broken"
+
+
 def test_copilot_detect_ignores_hook_json_without_hook_entries(tmp_path):
     context = _build_context(tmp_path)
     adapter = CopilotHarnessAdapter()
@@ -165,13 +183,8 @@ def test_copilot_detect_records_bash_and_powershell_hook_commands_separately(tmp
     assert "copilot:project:hook:custom:pretooluse:0:powershell" in artifacts
     assert artifacts["copilot:project:hook:custom:pretooluse:0:bash"]["command"] == "python guard-hook.py"
     assert artifacts["copilot:project:hook:custom:pretooluse:0:bash"]["metadata"] == {"shell": "bash"}
-    assert (
-        artifacts["copilot:project:hook:custom:pretooluse:0:powershell"]["command"]
-        == "pwsh -File guard-hook.ps1"
-    )
-    assert artifacts["copilot:project:hook:custom:pretooluse:0:powershell"]["metadata"] == {
-        "shell": "powershell"
-    }
+    assert artifacts["copilot:project:hook:custom:pretooluse:0:powershell"]["command"] == "pwsh -File guard-hook.ps1"
+    assert artifacts["copilot:project:hook:custom:pretooluse:0:powershell"]["metadata"] == {"shell": "powershell"}
 
 
 def test_copilot_install_and_uninstall_manage_inline_config_hooks_idempotently(tmp_path):
@@ -356,8 +369,8 @@ def test_copilot_install_and_uninstall_match_inline_hooks_after_path_changes(tmp
                         ),
                         "powershell": (
                             '"C:\\Python\\python.exe" -m codex_plugin_scanner.cli guard hook '
-                            '--guard-home C:\\old-guard --harness copilot --home C:\\old-home '
-                            '--workspace C:\\old-workspace'
+                            "--guard-home C:\\old-guard --harness copilot --home C:\\old-home "
+                            "--workspace C:\\old-workspace"
                         ),
                         "cwd": ".",
                         "timeoutSec": 30,
@@ -373,8 +386,8 @@ def test_copilot_install_and_uninstall_match_inline_hooks_after_path_changes(tmp
                         ),
                         "powershell": (
                             '"C:\\Python\\python.exe" -m codex_plugin_scanner.cli guard hook '
-                            '--guard-home C:\\old-guard --harness copilot --home C:\\old-home '
-                            '--workspace C:\\old-workspace'
+                            "--guard-home C:\\old-guard --harness copilot --home C:\\old-home "
+                            "--workspace C:\\old-workspace"
                         ),
                         "cwd": ".",
                         "timeoutSec": 30,
@@ -506,13 +519,13 @@ def test_copilot_install_manages_workspace_mcp_servers_for_ide(tmp_path):
     }
     assert install_payload["managed_config_paths"] == [str(workspace_cli_mcp_path), str(workspace_mcp_path)]
     assert len(install_payload["backup_paths"]) == 2
-    assert cli_payload["mcpServers"]["workspace-cli-tool"]["type"] == "local"
-    assert cli_payload["mcpServers"]["workspace-cli-tool"]["tools"] == ["*"]
+    assert cli_payload["servers"]["workspace-cli-tool"]["type"] == "local"
+    assert cli_payload["servers"]["workspace-cli-tool"]["tools"] == ["*"]
     assert managed_payload["servers"]["global-tool"]["type"] == "stdio"
     assert managed_payload["servers"]["workspace-tool"]["type"] == "stdio"
     assert managed_payload["servers"]["existing-tool"]["type"] == "stdio"
-    assert cli_payload["mcpServers"]["workspace-cli-tool"]["command"] == sys.executable
-    assert cli_payload["mcpServers"]["workspace-cli-tool"]["args"][:4] == [
+    assert cli_payload["servers"]["workspace-cli-tool"]["command"] == sys.executable
+    assert cli_payload["servers"]["workspace-cli-tool"]["args"][:4] == [
         "-m",
         "codex_plugin_scanner.cli",
         "guard",
@@ -526,6 +539,30 @@ def test_copilot_install_manages_workspace_mcp_servers_for_ide(tmp_path):
     assert managed_payload["servers"]["global-tool"]["command"] == sys.executable
     assert managed_payload["servers"]["workspace-tool"]["command"] == sys.executable
     assert managed_payload["servers"]["existing-tool"]["command"] == sys.executable
+
+
+def test_copilot_install_preserves_existing_workspace_mcp_key_schema(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = CopilotHarnessAdapter()
+    workspace_cli_mcp_path = context.workspace_dir / ".mcp.json"
+    _write_json(
+        workspace_cli_mcp_path,
+        {
+            "servers": {
+                "workspace-cli-tool": {
+                    "command": "python",
+                    "args": ["-m", "workspace_cli_server"],
+                }
+            }
+        },
+    )
+
+    adapter.install(context)
+    payload = json.loads(workspace_cli_mcp_path.read_text(encoding="utf-8"))
+
+    assert "servers" in payload
+    assert "mcpServers" not in payload
+    assert payload["servers"]["workspace-cli-tool"]["command"] == sys.executable
 
 
 def test_copilot_install_keeps_target_specific_workspace_servers_distinct(tmp_path):

--- a/tests/test_guard_copilot_proxy.py
+++ b/tests/test_guard_copilot_proxy.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+import sys
+from io import StringIO
+from pathlib import Path
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.proxy import CopilotMcpGuardProxy
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _child_command(marker_path: Path) -> list[str]:
+    return [
+        sys.executable,
+        "-u",
+        "-c",
+        "\n".join(
+            [
+                "import json",
+                "import sys",
+                "from pathlib import Path",
+                f"marker_path = Path({str(marker_path)!r})",
+                "for line in sys.stdin:",
+                "    message = json.loads(line)",
+                "    message_id = message.get('id')",
+                "    method = message.get('method')",
+                "    if method is None or message_id is None:",
+                "        continue",
+                "    if method == 'initialize':",
+                "        result = {",
+                "            'protocolVersion': '2025-06-18',",
+                "            'capabilities': {'tools': {}},",
+                "            'serverInfo': {'name': 'fixture', 'version': '1.0.0'},",
+                "        }",
+                "        print(json.dumps({'jsonrpc': '2.0', 'id': message_id, 'result': result}))",
+                "        sys.stdout.flush()",
+                "        continue",
+                "    if method == 'tools/call':",
+                "        params = message.get('params', {})",
+                "        if params.get('name') == 'dangerous_delete':",
+                "            marker_path.write_text(json.dumps(params), encoding='utf-8')",
+                "        result = {'content': [{'type': 'text', 'text': params.get('name', 'unknown')}]}",
+                "        print(json.dumps({'jsonrpc': '2.0', 'id': message_id, 'result': result}))",
+                "        sys.stdout.flush()",
+                "        continue",
+                "    print(json.dumps({'jsonrpc': '2.0', 'id': message_id, 'result': {}}))",
+                "    sys.stdout.flush()",
+            ]
+        ),
+    ]
+
+
+def _context(tmp_path: Path) -> HarnessContext:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    guard_home = tmp_path / "guard-home"
+    home_dir.mkdir(parents=True, exist_ok=True)
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    guard_home.mkdir(parents=True, exist_ok=True)
+    return HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=guard_home)
+
+
+def test_copilot_guard_proxy_prompts_inline_when_client_supports_elicitation(tmp_path):
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    config = GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir)
+    marker_path = tmp_path / "dangerous-call.json"
+    proxy = CopilotMcpGuardProxy(
+        server_name="danger_lab",
+        command=_child_command(marker_path),
+        context=context,
+        store=store,
+        config=config,
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".vscode" / "mcp.json"),
+    )
+    input_stream = StringIO(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "initialize",
+                        "params": {"capabilities": {"elicitation": {"form": {}}}},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "method": "tools/call",
+                        "params": {"name": "dangerous_delete", "arguments": {"target": ".env"}},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "guard-elicitation-1",
+                        "result": {"action": "accept", "content": {"decision": "approve"}},
+                    }
+                ),
+            ]
+        )
+        + "\n"
+    )
+    output_stream = StringIO()
+
+    exit_code = proxy.serve(stdin=input_stream, stdout=output_stream)
+    responses = [json.loads(line) for line in output_stream.getvalue().splitlines()]
+
+    assert exit_code == 0
+    assert responses[1]["id"] == "guard-elicitation-1"
+    assert responses[1]["method"] == "elicitation/create"
+    assert responses[2]["id"] == 2
+    assert responses[2]["result"]["content"][0]["text"] == "dangerous_delete"
+    assert json.loads(marker_path.read_text(encoding="utf-8"))["name"] == "dangerous_delete"

--- a/tests/test_guard_launch_env.py
+++ b/tests/test_guard_launch_env.py
@@ -123,12 +123,21 @@ def test_guard_run_launches_with_configured_home(monkeypatch, tmp_path, capsys):
 def test_guard_run_launches_copilot_with_passthrough_args(monkeypatch, tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
+    actual_home = tmp_path / "actual-home"
+    local_copilot = actual_home / ".local" / "copilot-cli" / "copilot"
+    local_copilot.parent.mkdir(parents=True, exist_ok=True)
+    local_copilot.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    local_copilot.chmod(0o755)
     _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\ndefault_action = "allow"\n')
     workspace_dir.mkdir(parents=True, exist_ok=True)
     (home_dir / ".copilot").mkdir(parents=True, exist_ok=True)
     _write_text(
         home_dir / ".copilot" / "mcp-config.json",
         json.dumps({"servers": {"global-tool": {"command": "npx", "args": ["server.js"]}}}),
+    )
+    _write_text(
+        workspace_dir / ".mcp.json",
+        json.dumps({"mcpServers": {"danger_lab": {"command": "python3", "args": ["server.py"]}}}),
     )
     captured_command: list[str] = []
 
@@ -138,6 +147,8 @@ def test_guard_run_launches_copilot_with_passthrough_args(monkeypatch, tmp_path,
         return _CompletedProcess(0)
 
     monkeypatch.setattr(guard_runner_module.subprocess, "run", _fake_run)
+    monkeypatch.setattr("shutil.which", lambda command: None)
+    monkeypatch.setattr(Path, "home", lambda: actual_home)
 
     rc = main(
         [
@@ -157,7 +168,13 @@ def test_guard_run_launches_copilot_with_passthrough_args(monkeypatch, tmp_path,
 
     assert rc == 0
     assert output["launched"] is True
-    assert captured_command == ["copilot", "suggest", "explain this function"]
+    assert captured_command[0].endswith("/copilot")
+    assert captured_command[1:] == [
+        "--additional-mcp-config",
+        f"@{workspace_dir / '.mcp.json'}",
+        "suggest",
+        "explain this function",
+    ]
 def test_guard_run_blocks_direct_env_prompt_until_approved(monkeypatch, tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
@@ -278,12 +295,261 @@ def test_guard_run_launches_opencode_with_runtime_overlay(monkeypatch, tmp_path,
     assert install_rc == 0
     assert rc == 0
     assert output["launched"] is True
-    assert captured_command == ["opencode", "run", "--help"]
+    assert captured_command == ["opencode", str(workspace_dir), "--help"]
     assert captured_env["HOME"] == str(home_dir)
-    assert overlay_payload["permission"]["skill"]["*"] == "ask"
+    assert "skill" not in overlay_payload["permission"]
     assert overlay_payload["permission"]["safe-mcp_*"] == "ask"
     assert overlay_payload["mcp"]["safe-mcp"]["command"][4] == "opencode-mcp-proxy"
     assert overlay_payload["mcp"]["safe-mcp"]["environment"]["TOKEN_SOURCE"] == "workspace"
+
+
+def test_guard_run_launches_opencode_prompt_through_interactive_tui(monkeypatch, tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_opencode_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\ndefault_action = "allow"\n')
+    captured_command: list[str] = []
+
+    def _fake_run(command, cwd=None, check=False, env=None):
+        del cwd, check, env
+        captured_command.extend(command)
+        return _CompletedProcess(0)
+
+    main(
+        [
+            "guard",
+            "install",
+            "opencode",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+    monkeypatch.setattr(guard_runner_module.subprocess, "run", _fake_run)
+
+    rc = main(
+        [
+            "guard",
+            "run",
+            "opencode",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--arg=Use",
+            "--arg=the",
+            "--arg=danger_lab",
+            "--arg=MCP",
+            "--arg=tool",
+            "--arg=dangerous_delete",
+            "--arg=right",
+            "--arg=now",
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["launched"] is True
+    assert captured_command == [
+        "opencode",
+        str(workspace_dir),
+        "--prompt",
+        "Use the danger_lab MCP tool dangerous_delete right now",
+    ]
+
+
+def test_guard_run_launches_opencode_prompt_with_flags_through_interactive_tui(monkeypatch, tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_opencode_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\ndefault_action = "allow"\n')
+    captured_command: list[str] = []
+
+    def _fake_run(command, cwd=None, check=False, env=None):
+        del cwd, check, env
+        captured_command.extend(command)
+        return _CompletedProcess(0)
+
+    main(
+        [
+            "guard",
+            "install",
+            "opencode",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+    monkeypatch.setattr(guard_runner_module.subprocess, "run", _fake_run)
+
+    rc = main(
+        [
+            "guard",
+            "run",
+            "opencode",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--arg=--model",
+            "--arg=openai/gpt-5.4",
+            "--arg=Use",
+            "--arg=the",
+            "--arg=danger_lab",
+            "--arg=MCP",
+            "--arg=tool",
+            "--arg=dangerous_delete",
+            "--arg=right",
+            "--arg=now",
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["launched"] is True
+    assert captured_command == [
+        "opencode",
+        str(workspace_dir),
+        "--model",
+        "openai/gpt-5.4",
+        "--prompt",
+        "Use the danger_lab MCP tool dangerous_delete right now",
+    ]
+
+
+def test_guard_run_keeps_attach_and_file_flags_out_of_prompt(monkeypatch, tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_opencode_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\ndefault_action = "allow"\n')
+    captured_command: list[str] = []
+
+    def _fake_run(command, cwd=None, check=False, env=None):
+        del cwd, check, env
+        captured_command.extend(command)
+        return _CompletedProcess(0)
+
+    main(
+        [
+            "guard",
+            "install",
+            "opencode",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+    monkeypatch.setattr(guard_runner_module.subprocess, "run", _fake_run)
+
+    rc = main(
+        [
+            "guard",
+            "run",
+            "opencode",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--arg=--attach",
+            "--arg=http://127.0.0.1:4096",
+            "--arg=--file",
+            "--arg=README.md",
+            "--arg=Use",
+            "--arg=the",
+            "--arg=danger_lab",
+            "--arg=tool",
+            "--arg=now",
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["launched"] is True
+    assert captured_command == [
+        "opencode",
+        str(workspace_dir),
+        "--attach",
+        "http://127.0.0.1:4096",
+        "--file",
+        "README.md",
+        "--prompt",
+        "Use the danger_lab tool now",
+    ]
+
+
+def test_guard_run_keeps_explicit_opencode_run_args_unchanged(monkeypatch, tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_opencode_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\ndefault_action = "allow"\n')
+    captured_command: list[str] = []
+    captured_cwd: list[Path | None] = []
+
+    def _fake_run(command, cwd=None, check=False, env=None):
+        del check, env
+        captured_command.extend(command)
+        captured_cwd.append(Path(cwd) if cwd is not None else None)
+        return _CompletedProcess(0)
+
+    main(
+        [
+            "guard",
+            "install",
+            "opencode",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+    monkeypatch.setattr(guard_runner_module.subprocess, "run", _fake_run)
+
+    rc = main(
+        [
+            "guard",
+            "run",
+            "opencode",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--arg=run",
+            "--arg=--attach",
+            "--arg=http://127.0.0.1:4096",
+            "--arg=Use",
+            "--arg=the",
+            "--arg=tool",
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["launched"] is True
+    assert captured_command == [
+        "opencode",
+        "run",
+        "--attach",
+        "http://127.0.0.1:4096",
+        "Use",
+        "the",
+        "tool",
+    ]
+    assert captured_cwd == [workspace_dir]
 
 
 def test_guard_run_merges_existing_opencode_config_content(monkeypatch, tmp_path, capsys):
@@ -337,7 +603,6 @@ def test_guard_run_merges_existing_opencode_config_content(monkeypatch, tmp_path
     assert output["launched"] is True
     assert overlay_payload["model"] == "gpt-4.1"
     assert overlay_payload["permission"]["network"]["*"] == "allow"
-    assert overlay_payload["permission"]["skill"]["*"] == "ask"
     assert overlay_payload["permission"]["safe-mcp_*"] == "ask"
 
 

--- a/tests/test_guard_product_flow.py
+++ b/tests/test_guard_product_flow.py
@@ -106,6 +106,9 @@ class TestGuardProductFlow:
         assert output["receipt_count"] == 0
         assert codex_summary["managed"] is False
         assert codex_summary["next_action"] == "install"
+        assert codex_summary["approval_flow"]["prompt_channel"] == "native"
+        assert codex_summary["approval_flow"]["auto_open_browser"] is False
+        assert "same-chat Codex approvals" in codex_summary["approval_flow"]["summary"]
         assert output["next_steps"][0]["command"] == "hol-guard install codex"
         assert output["next_steps"][1]["command"] == "hol-guard run codex --dry-run"
 
@@ -136,6 +139,83 @@ class TestGuardProductFlow:
         assert output["recommended_harness"] == "copilot"
         assert copilot_summary["install_command"] == "hol-guard install copilot"
         assert output["next_steps"][1]["command"] == "hol-guard run copilot --dry-run"
+
+    def test_guard_start_surfaces_opencode_native_approval_path(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _write_json(
+            workspace_dir / "opencode.json",
+            {
+                "permission": {"bash": "allow"},
+                "mcp": {
+                    "danger_lab": {
+                        "type": "local",
+                        "command": ["python3", "danger-lab.py"],
+                    }
+                },
+            },
+        )
+
+        rc = main(
+            [
+                "guard",
+                "start",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        opencode_summary = next(item for item in output["harnesses"] if item["harness"] == "opencode")
+
+        assert rc == 0
+        assert opencode_summary["approval_flow"]["prompt_channel"] == "native"
+        assert opencode_summary["approval_flow"]["auto_open_browser"] is False
+        assert "native ask" in opencode_summary["approval_flow"]["summary"]
+
+    def test_guard_start_prefers_opencode_over_browser_only_harnesses(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _write_json(
+            workspace_dir / "opencode.json",
+            {
+                "mcp": {
+                    "danger_lab": {
+                        "type": "local",
+                        "command": ["python3", "danger-lab.py"],
+                    }
+                }
+            },
+        )
+        _write_json(
+            workspace_dir / ".gemini" / "settings.json",
+            {
+                "mcpServers": {
+                    "browser-only-lab": {
+                        "command": "python3",
+                        "args": ["browser-only.py"],
+                    }
+                }
+            },
+        )
+
+        rc = main(
+            [
+                "guard",
+                "start",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["recommended_harness"] == "opencode"
 
     def test_guard_status_json_surfaces_local_only_state(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -319,6 +319,26 @@ def test_tool_action_request_classifier_detects_shell_wrapper_script_command():
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_detects_env_wrapped_destructive_command():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "env FOO=1 rm -rf dangerous-marker.json"},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_parenthesized_destructive_command():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "(rm -rf dangerous-marker.json)"},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_incident_context_describes_runtime_tool_action_requests():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -309,6 +309,16 @@ def test_tool_action_request_classifier_detects_absolute_path_destructive_comman
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_detects_shell_wrapper_script_command():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": 'bash -lc "rm -rf dangerous-marker.json"'},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_incident_context_describes_runtime_tool_action_requests():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -10,12 +10,20 @@ from codex_plugin_scanner.guard.approvals import queue_blocked_approvals
 from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.consumer import artifact_hash, evaluate_detection
 from codex_plugin_scanner.guard.incident import build_incident_context
+from codex_plugin_scanner.guard.mcp_tool_calls import (
+    build_tool_call_artifact,
+    build_tool_call_hash,
+    evaluate_tool_call,
+    tool_call_risk_signals,
+)
 from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
 from codex_plugin_scanner.guard.risk import artifact_risk_signals, artifact_risk_summary
 from codex_plugin_scanner.guard.runtime.secret_file_requests import (
     build_file_read_request_artifact,
+    build_tool_action_request_artifact,
     classify_sensitive_path,
     extract_sensitive_file_read_request,
+    extract_sensitive_tool_action_request,
     is_file_read_tool_name,
 )
 from codex_plugin_scanner.guard.store import GuardStore
@@ -270,3 +278,104 @@ def test_file_read_request_artifact_hash_is_exact_to_tool_and_path():
 
     assert artifact_hash(first_artifact) == artifact_hash(same_artifact)
     assert artifact_hash(first_artifact) != artifact_hash(different_artifact)
+
+
+def test_tool_action_request_classifier_skips_read_only_shell_pipeline_to_dev_null():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "ls /mock-workspace/app/guard/_components/ 2>/dev/null | head -40"},
+    )
+
+    assert request is None
+
+
+def test_tool_action_request_classifier_detects_destructive_subcommand_after_safe_prefix():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "echo ok && rm -rf dangerous-marker.json"},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_absolute_path_destructive_command():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "/bin/rm -rf dangerous-marker.json"},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_incident_context_describes_runtime_tool_action_requests():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "echo MALICIOUS > dangerous-marker.json"},
+    )
+
+    assert request is not None
+
+    artifact = build_tool_action_request_artifact(
+        "copilot",
+        request,
+        config_path="/workspace/.github/hooks/hol-guard-copilot.json",
+        source_scope="project",
+    )
+    incident = build_incident_context(
+        harness="copilot",
+        artifact=artifact,
+        artifact_id=artifact.artifact_id,
+        artifact_name=artifact.name,
+        artifact_type=artifact.artifact_type,
+        source_scope=artifact.source_scope,
+        config_path=artifact.config_path,
+        changed_fields=["tool_action_request"],
+        policy_action="require-reapproval",
+        launch_target=artifact.metadata.get("request_summary"),
+        risk_summary=artifact.metadata.get("runtime_request_summary"),
+    )
+
+    assert incident["source_label"] == "Copilot CLI runtime tool call"
+    assert incident["trigger_summary"].startswith("HOL Guard paused the native tool action")
+    assert incident["why_now"].startswith("HOL Guard paused this native tool action")
+
+
+def test_tool_call_risk_signals_do_not_treat_format_name_as_destructive():
+    artifact = build_tool_call_artifact(
+        harness="copilot",
+        server_name="workspace_tools",
+        tool_name="format_component",
+        source_scope="project",
+        config_path="/workspace/.mcp.json",
+        transport="stdio",
+    )
+
+    signals = tool_call_risk_signals(artifact, {"path": "app/button.tsx"})
+
+    assert "tool name implies destructive file or system changes" not in signals
+
+
+def test_prompt_mode_keeps_destructive_tool_calls_on_review_path(tmp_path):
+    store = GuardStore(tmp_path / "guard-home")
+    config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=tmp_path / "workspace", mode="prompt")
+    artifact = build_tool_call_artifact(
+        harness="copilot",
+        server_name="danger_lab",
+        tool_name="dangerous_delete",
+        source_scope="project",
+        config_path="/workspace/.mcp.json",
+        transport="stdio",
+    )
+
+    decision = evaluate_tool_call(
+        store=store,
+        config=config,
+        artifact=artifact,
+        artifact_hash=build_tool_call_hash(artifact, {"target": "dangerous-marker.json"}),
+        arguments={"target": "dangerous-marker.json"},
+    )
+
+    assert decision.action == "review"
+    assert "tool name implies destructive file or system changes" in decision.signals

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -994,6 +994,30 @@ def test_guard_hook_emits_copilot_permission_request_deny_from_tool_calls_payloa
     assert "danger_lab:dangerous_delete" in output["message"]
 
 
+def test_normalize_hook_payload_prefers_matching_tool_call_args() -> None:
+    payload = guard_commands_module._normalize_hook_payload(
+        {
+            "toolName": "danger_lab/dangerous_delete",
+            "toolCalls": [
+                {
+                    "id": "call-safe",
+                    "name": "safe_tools/read_file",
+                    "args": json.dumps({"path": "README.md"}),
+                },
+                {
+                    "id": "call-dangerous",
+                    "name": "danger_lab/dangerous_delete",
+                    "args": json.dumps({"target": "dangerous-marker.json"}),
+                },
+            ],
+        }
+    )
+
+    assert payload["tool_name"] == "danger_lab/dangerous_delete"
+    assert payload["tool_input"] == {"target": "dangerous-marker.json"}
+    assert payload["arguments"] == {"target": "dangerous-marker.json"}
+
+
 def test_copilot_runtime_tool_call_prefers_cli_workspace_config_when_workspace_is_inferred(tmp_path):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import builtins
 import io
 import json
 import subprocess
@@ -126,6 +127,89 @@ class TestGuardRuntime:
         )
 
         assert runtime_sync_url == "https://hol.org/custom/sync/runtime/sessions/sync?tenant=guard"
+
+    def test_guard_hook_uses_payload_cwd_for_global_copilot_hooks(self, tmp_path, capsys) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        marker_path = workspace_dir / "dangerous-marker.json"
+        marker_path.parent.mkdir(parents=True, exist_ok=True)
+        marker_path.write_text('{"status":"armed"}\n', encoding="utf-8")
+        event_path = tmp_path / "copilot-hook.json"
+        _write_json(
+            event_path,
+            {
+                "cwd": str(workspace_dir),
+                "toolName": "bash",
+                "toolInput": {"command": "rm dangerous-marker.json"},
+                "policyAction": "allow",
+            },
+        )
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--harness",
+                "copilot",
+                "--event-file",
+                str(event_path),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["artifact_type"] == "tool_action_request"
+        assert "rm dangerous-marker.json" in output["launch_summary"]
+        assert output["trigger_summary"].startswith("HOL Guard paused the native tool action")
+
+    def test_guard_hook_copilot_path_does_not_require_rich_imports(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        event_path = tmp_path / "copilot-hook.json"
+        _write_json(
+            event_path,
+            {
+                "cwd": str(workspace_dir),
+                "toolName": "bash",
+                "toolArgs": '{"command":"rm dangerous-marker.json"}',
+                "policyAction": "require-reapproval",
+            },
+        )
+        original_import = builtins.__import__
+
+        def _guarded_import(name, global_ns=None, local_ns=None, fromlist=(), level=0):
+            if name == "rich" or name.startswith("rich."):
+                raise ModuleNotFoundError("No module named 'rich'")
+            return original_import(name, global_ns, local_ns, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", _guarded_import)
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--harness",
+                "copilot",
+                "--event-file",
+                str(event_path),
+            ]
+        )
+        output = capsys.readouterr().out.strip()
+
+        assert rc == 0
+        assert '"permissionDecision":"deny"' in output
+        assert "destructive shell command" in output
+        assert "Approve it in HOL Guard, then retry." in output
 
     def test_sync_runtime_session_treats_missing_runtime_endpoint_as_non_fatal(
         self,
@@ -626,17 +710,628 @@ class TestGuardRuntime:
         assert output["policy_action"] == "require-reapproval"
         assert output["path_summary"] == str(home_dir / ".env")
 
-    def test_guard_hook_emits_copilot_native_deny_response(self, tmp_path, capsys, monkeypatch):
+
+def test_guard_hook_emits_copilot_native_ask_response(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "view",
+        "toolArgs": json.dumps({"path": str(home_dir / ".env")}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "approve" in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_ask_response_for_destructive_shell_command(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "echo MALICIOUS > dangerous-marker.json"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_ask_response_for_destructive_shell_redirection_without_spaces(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "echo MALICIOUS>dangerous-marker.json"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_allow_response_for_read_only_ls_pipeline(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "ls /mock-workspace/app/guard/_components/ 2>/dev/null | head -40"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output == {"permissionDecision": "allow"}
+
+
+def test_guard_hook_emits_copilot_permission_request_allow_for_safe_mcp_tool(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "hookName": "permissionRequest",
+        "toolName": "danger_lab/safe_echo",
+        "toolInput": {"text": "ok"},
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output == {"behavior": "allow"}
+
+
+def test_guard_hook_emits_copilot_permission_request_allow_for_hook_event_name_variant(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "hookEventName": "permissionRequest",
+        "toolName": "danger_lab/safe_echo",
+        "toolInput": {"text": "ok"},
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output == {"behavior": "allow"}
+
+
+def test_guard_hook_emits_copilot_permission_request_deny_for_risky_mcp_tool(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    event = {
+        "hookName": "permissionRequest",
+        "toolName": "danger_lab/dangerous_delete",
+        "toolInput": {"target": "dangerous-marker.json"},
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["behavior"] == "deny"
+    assert output["interrupt"] is True
+    assert "HOL Guard blocked" in output["message"]
+    assert "danger_lab:dangerous_delete" in output["message"]
+
+
+def test_guard_hook_emits_copilot_permission_request_deny_from_tool_calls_payload(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    event = {
+        "hookName": "permissionRequest",
+        "toolCalls": [
+            {
+                "id": "call-dangerous",
+                "name": "danger_lab/dangerous_delete",
+                "args": json.dumps({"target": "dangerous-marker.json"}),
+            }
+        ],
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["behavior"] == "deny"
+    assert "danger_lab:dangerous_delete" in output["message"]
+
+
+def test_copilot_runtime_tool_call_prefers_cli_workspace_config_when_workspace_is_inferred(tmp_path):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_json(
+        workspace_dir / ".mcp.json",
+        {"mcpServers": {"danger_lab": {"command": "python3", "args": ["cli-danger-lab.py"]}}},
+    )
+    _write_json(
+        workspace_dir / ".vscode" / "mcp.json",
+        {"servers": {"danger_lab": {"command": "python3", "args": ["ide-danger-lab.py"]}}},
+    )
+
+    artifact = guard_commands_module._copilot_runtime_tool_call(
+        payload={
+            "tool_name": "mcp_danger_lab_dangerous_delete",
+            "tool_input": {"target": "dangerous-marker.json"},
+            "source_scope": "project",
+        },
+        home_dir=home_dir,
+        workspace=workspace_dir,
+        preferred_workspace_config="cli",
+    )
+
+    assert artifact is not None
+    runtime_artifact, _artifact_hash, _arguments = artifact
+    assert runtime_artifact.config_path == str(workspace_dir / ".mcp.json")
+
+
+def test_copilot_runtime_tool_call_prefers_ide_workspace_config_when_workspace_is_explicit(tmp_path):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_json(
+        workspace_dir / ".mcp.json",
+        {"mcpServers": {"danger_lab": {"command": "python3", "args": ["cli-danger-lab.py"]}}},
+    )
+    _write_json(
+        workspace_dir / ".vscode" / "mcp.json",
+        {"servers": {"danger_lab": {"command": "python3", "args": ["ide-danger-lab.py"]}}},
+    )
+
+    artifact = guard_commands_module._copilot_runtime_tool_call(
+        payload={
+            "tool_name": "mcp_danger_lab_dangerous_delete",
+            "tool_input": {"target": "dangerous-marker.json"},
+            "source_scope": "project",
+        },
+        home_dir=home_dir,
+        workspace=workspace_dir,
+        preferred_workspace_config="ide",
+    )
+
+    assert artifact is not None
+    runtime_artifact, _artifact_hash, _arguments = artifact
+    assert runtime_artifact.config_path == str(workspace_dir / ".vscode" / "mcp.json")
+
+
+def test_guard_hook_emits_copilot_native_deny_for_risky_mcp_pre_tool_use(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    guard_home = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_json(
+        workspace_dir / ".vscode" / "mcp.json",
+        {
+            "servers": {
+                "danger_lab": {
+                    "type": "local",
+                    "command": "python3",
+                    "args": ["danger-lab.py"],
+                }
+            }
+        },
+    )
+    event = {
+        "hook_event_name": "PreToolUse",
+        "toolName": "mcp_danger_lab_dangerous_delete",
+        "toolArgs": json.dumps({"target": "dangerous-marker.json"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--guard-home",
+            str(guard_home),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+    store = GuardStore(guard_home)
+    receipts = store.list_receipts(limit=20)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "destructive" in output["permissionDecisionReason"].lower()
+    assert receipts == []
+
+
+def test_guard_hook_emits_copilot_native_allow_for_safe_mcp_pre_tool_use(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    guard_home = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_json(
+        workspace_dir / ".vscode" / "mcp.json",
+        {
+            "servers": {
+                "danger_lab": {
+                    "type": "local",
+                    "command": "python3",
+                    "args": ["danger-lab.py"],
+                }
+            }
+        },
+    )
+    event = {
+        "hook_event_name": "PreToolUse",
+        "toolName": "mcp_danger_lab_safe_echo",
+        "toolArgs": json.dumps({"text": "ok"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--guard-home",
+            str(guard_home),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+    store = GuardStore(guard_home)
+    receipts = store.list_receipts(limit=20)
+
+    assert rc == 0
+    assert output == {"permissionDecision": "allow"}
+    assert any(
+        receipt["artifact_id"] == "copilot:runtime:project:danger_lab:safe_echo"
+        and receipt["policy_decision"] == "allow"
+        for receipt in receipts
+    )
+
+
+def test_guard_hook_resolves_copilot_nested_cwd_back_to_workspace_root(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    guard_home = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    nested_dir = workspace_dir / "src" / "components"
+    nested_dir.mkdir(parents=True, exist_ok=True)
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_json(
+        workspace_dir / ".vscode" / "mcp.json",
+        {
+            "servers": {
+                "danger_lab": {
+                    "type": "local",
+                    "command": "python3",
+                    "args": ["danger-lab.py"],
+                }
+            }
+        },
+    )
+    event = {
+        "hook_event_name": "PreToolUse",
+        "cwd": str(nested_dir),
+        "toolName": "mcp_danger_lab_safe_echo",
+        "toolArgs": json.dumps({"text": "ok"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--guard-home",
+            str(guard_home),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+    store = GuardStore(guard_home)
+    receipts = store.list_receipts(limit=20)
+
+    assert rc == 0
+    assert output == {"permissionDecision": "allow"}
+    assert any(
+        receipt["artifact_id"] == "copilot:runtime:project:danger_lab:safe_echo"
+        and receipt["policy_decision"] == "allow"
+        for receipt in receipts
+    )
+
+
+def test_guard_hook_emits_copilot_native_deny_response_for_sandbox_required_requests(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "docker run --rm alpine sh"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+            "--policy-action",
+            "sandbox-required",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+
+
+def test_guard_hook_emits_claude_native_ask_response(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "tool_name": "Read",
+        "tool_input": {"file_path": str(home_dir / ".env")},
+        "source_scope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "claude-code",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+    assert output["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert "approve" in output["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+def test_guard_hook_emits_claude_native_deny_response_for_sandbox_required_requests(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "tool_name": "Bash",
+        "tool_input": {"command": "docker run --rm alpine sh"},
+        "source_scope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "claude-code",
+            "--policy-action",
+            "sandbox-required",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+    def test_guard_hook_emits_copilot_native_allow_response_for_safe_requests(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         _build_guard_fixture(home_dir, workspace_dir)
         event = {
             "toolName": "view",
-            "toolArgs": json.dumps({"path": str(home_dir / ".env")}),
+            "toolArgs": json.dumps({"path": str(workspace_dir / "README.md")}),
             "sourceScope": "project",
         }
         monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
-        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
 
         rc = main(
             [
@@ -653,17 +1348,20 @@ class TestGuardRuntime:
         output = json.loads(capsys.readouterr().out)
 
         assert rc == 0
-        assert output["permissionDecision"] == "deny"
-        assert "approve" in output["permissionDecisionReason"]
-        assert "http://127.0.0.1:4455" in output["permissionDecisionReason"]
+        assert output == {"permissionDecision": "allow"}
 
-    def test_guard_hook_emits_copilot_native_allow_response_for_safe_requests(self, tmp_path, capsys, monkeypatch):
+    def test_guard_hook_emits_copilot_native_allow_response_for_read_only_sed_requests(
+        self,
+        tmp_path,
+        capsys,
+        monkeypatch,
+    ):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         _build_guard_fixture(home_dir, workspace_dir)
         event = {
-            "toolName": "view",
-            "toolArgs": json.dumps({"path": str(workspace_dir / "README.md")}),
+            "toolName": "bash",
+            "toolArgs": json.dumps({"command": "sed -n '1p' README.md"}),
             "sourceScope": "project",
         }
         monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
@@ -820,7 +1518,7 @@ class TestGuardRuntime:
         assert rc == 1
         assert output["approval_center_url"] == "http://127.0.0.1:4455"
         assert output["blocked"] is True
-        assert output["approval_delivery"]["destination"] == "browser"
+        assert output["approval_delivery"]["destination"] == "harness"
         assert opened_urls == []
 
     def test_headless_approval_resolver_skips_browser_for_hook_first_harnesses(self, tmp_path, monkeypatch):
@@ -2476,7 +3174,7 @@ class TestGuardRuntime:
         assert blocked["responses"][0]["error"]["data"]["approvalCenterUrl"] == "http://127.0.0.1:4455"
         assert blocked["responses"][0]["error"]["data"]["reviewHint"]
         assert blocked["events"][0]["decision"] == "block"
-        assert blocked["events"][0]["approval_delivery"]["destination"] == "browser"
+        assert blocked["events"][0]["approval_delivery"]["destination"] == "harness"
         assert blocked["events"][0]["redacted_params"]["arguments"]["headers"]["Authorization"] == "*****"
         assert blocked["events"][0]["path_summary"].endswith("/.env")
         pending = store.list_approval_requests(limit=10)
@@ -2612,6 +3310,46 @@ class TestGuardRuntime:
         assert output["policy_action"] == "require-reapproval"
         assert output["approval_delivery"]["destination"] == "harness"
         assert "docker" in output["risk_summary"].lower()
+
+    def test_hermes_pretool_blocks_destructive_shell_command_requests(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir(parents=True, exist_ok=True)
+        _write_text(home_dir / "config.toml", 'mode = "prompt"\n')
+        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+        monkeypatch.setattr(
+            sys,
+            "stdin",
+            io.StringIO(
+                json.dumps(
+                    {
+                        "event": "PreToolUse",
+                        "tool_name": "shell",
+                        "tool_input": {"command": "echo MALICIOUS > dangerous-marker.json"},
+                        "source_scope": "project",
+                    }
+                )
+            ),
+        )
+
+        rc = main(
+            [
+                "hermes",
+                "pretool",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 1
+        assert output["artifact_type"] == "tool_action_request"
+        assert output["policy_action"] == "require-reapproval"
+        assert output["approval_delivery"]["destination"] == "harness"
+        assert "destructive shell command" in output["risk_summary"].lower()
 
     def test_remote_proxy_forwards_local_requests_and_redacts_auth_headers(self):
         server = HTTPServer(("127.0.0.1", 0), _RemoteProxyHandler)

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1346,2132 +1346,2181 @@ def test_guard_hook_emits_claude_native_deny_response_for_sandbox_required_reque
     assert rc == 0
     assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
 
-    def test_guard_hook_emits_copilot_native_allow_response_for_safe_requests(self, tmp_path, capsys, monkeypatch):
-        home_dir = tmp_path / "home"
-        workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
-        event = {
-            "toolName": "view",
-            "toolArgs": json.dumps({"path": str(workspace_dir / "README.md")}),
-            "sourceScope": "project",
-        }
-        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
 
-        rc = main(
-            [
-                "guard",
-                "hook",
-                "--home",
-                str(home_dir),
-                "--workspace",
-                str(workspace_dir),
-                "--harness",
-                "copilot",
-            ]
-        )
-        output = json.loads(capsys.readouterr().out)
+def test_guard_hook_emits_copilot_native_allow_response_for_safe_requests(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "view",
+        "toolArgs": json.dumps({"path": str(workspace_dir / "README.md")}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
 
-        assert rc == 0
-        assert output == {"permissionDecision": "allow"}
-
-    def test_guard_hook_emits_copilot_native_allow_response_for_read_only_sed_requests(
-        self,
-        tmp_path,
-        capsys,
-        monkeypatch,
-    ):
-        home_dir = tmp_path / "home"
-        workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
-        event = {
-            "toolName": "bash",
-            "toolArgs": json.dumps({"command": "sed -n '1p' README.md"}),
-            "sourceScope": "project",
-        }
-        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
-
-        rc = main(
-            [
-                "guard",
-                "hook",
-                "--home",
-                str(home_dir),
-                "--workspace",
-                str(workspace_dir),
-                "--harness",
-                "copilot",
-            ]
-        )
-        output = json.loads(capsys.readouterr().out)
-
-        assert rc == 0
-        assert output == {"permissionDecision": "allow"}
-
-    def test_guard_run_returns_structured_error_when_executable_missing(self, tmp_path, capsys, monkeypatch):
-        home_dir = tmp_path / "home"
-        workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
-        _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\n')
-        monkeypatch.setattr(
-            guard_runner_module.subprocess,
-            "run",
-            lambda *args, **kwargs: (_ for _ in ()).throw(FileNotFoundError("codex not found")),
-        )
-
-        rc = main(
-            [
-                "guard",
-                "run",
-                "claude-code",
-                "--home",
-                str(home_dir),
-                "--workspace",
-                str(workspace_dir),
-                "--default-action",
-                "allow",
-                "--json",
-            ]
-        )
-        output = json.loads(capsys.readouterr().out)
-
-        assert rc == 127
-        assert output["launched"] is False
-        assert output["return_code"] == 127
-        assert "codex not found" in output["launch_error"]
-
-    def test_guard_run_prompt_allow_once_launches_and_records_override(self, tmp_path, capsys, monkeypatch):
-        home_dir = tmp_path / "home"
-        workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
-        answers = iter(["1", "1"])
-        monkeypatch.setattr(guard_commands_module.sys.stdin, "isatty", lambda: True)
-        monkeypatch.setattr("rich.console.Console.input", lambda self, prompt="": next(answers))
-        monkeypatch.setattr(
-            guard_runner_module.subprocess,
-            "run",
-            lambda *args, **kwargs: type("CompletedProcess", (), {"returncode": 0})(),
-        )
-
-        rc = main(
-            [
-                "guard",
-                "run",
-                "codex",
-                "--home",
-                str(home_dir),
-                "--workspace",
-                str(workspace_dir),
-            ]
-        )
-        output = capsys.readouterr().out
-        receipts = GuardStore(Path(home_dir)).list_receipts(limit=10)
-
-        assert rc == 0
-        assert "Launch allowed" in output
-        assert any(item.get("user_override") == "allow-once" for item in receipts)
-
-    def test_guard_run_prompt_allow_artifact_persists_for_next_run(self, tmp_path, capsys, monkeypatch):
-        home_dir = tmp_path / "home"
-        workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
-        answers = iter(["2", "2"])
-        monkeypatch.setattr(guard_commands_module.sys.stdin, "isatty", lambda: True)
-        monkeypatch.setattr("rich.console.Console.input", lambda self, prompt="": next(answers))
-        monkeypatch.setattr(
-            guard_runner_module.subprocess,
-            "run",
-            lambda *args, **kwargs: type("CompletedProcess", (), {"returncode": 0})(),
-        )
-
-        first_rc = main(
-            [
-                "guard",
-                "run",
-                "codex",
-                "--home",
-                str(home_dir),
-                "--workspace",
-                str(workspace_dir),
-            ]
-        )
-        first_output = capsys.readouterr().out
-
-        second_rc = main(
-            [
-                "guard",
-                "run",
-                "codex",
-                "--home",
-                str(home_dir),
-                "--workspace",
-                str(workspace_dir),
-                "--dry-run",
-                "--json",
-            ]
-        )
-        second_output = json.loads(capsys.readouterr().out)
-
-        assert first_rc == 0
-        assert "Launch allowed" in first_output
-        assert second_rc == 0
-        assert second_output["blocked"] is False
-        assert all(item["policy_action"] == "allow" for item in second_output["artifacts"])
-
-    def test_guard_run_headless_blocks_with_review_hint_without_opening_browser(self, tmp_path, capsys, monkeypatch):
-        home_dir = tmp_path / "home"
-        workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
-        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
-        opened_urls: list[str] = []
-        monkeypatch.setattr(guard_commands_module.webbrowser, "open", lambda url: opened_urls.append(url) or True)
-
-        rc = main(
-            [
-                "guard",
-                "run",
-                "codex",
-                "--home",
-                str(home_dir),
-                "--workspace",
-                str(workspace_dir),
-                "--json",
-            ]
-        )
-        output = json.loads(capsys.readouterr().out)
-
-        assert rc == 1
-        assert output["approval_center_url"] == "http://127.0.0.1:4455"
-        assert output["blocked"] is True
-        assert output["approval_delivery"]["destination"] == "harness"
-        assert opened_urls == []
-
-    def test_headless_approval_resolver_skips_browser_for_hook_first_harnesses(self, tmp_path, monkeypatch):
-        home_dir = tmp_path / "home"
-        workspace_dir = tmp_path / "workspace"
-        store = GuardStore(home_dir)
-        config = GuardConfig(guard_home=home_dir, workspace=workspace_dir, approval_wait_timeout_seconds=1)
-        artifact = GuardArtifact(
-            artifact_id="copilot:project:workspace-tools",
-            name="workspace-tools",
-            harness="copilot",
-            artifact_type="mcp_server",
-            source_scope="project",
-            config_path=str(workspace_dir / ".vscode" / "mcp.json"),
-            command="python",
-            args=("-m", "http.server", "9100"),
-            transport="stdio",
-        )
-        detection = HarnessDetection(
-            harness="copilot",
-            installed=True,
-            command_available=True,
-            config_paths=(artifact.config_path,),
-            artifacts=(artifact,),
-        )
-        payload = {
-            "blocked": True,
-            "artifacts": [
-                {
-                    "artifact_id": artifact.artifact_id,
-                    "artifact_name": artifact.name,
-                    "artifact_hash": artifact_hash(artifact),
-                    "policy_action": "require-reapproval",
-                    "changed_fields": ["args"],
-                    "artifact_type": artifact.artifact_type,
-                    "source_scope": artifact.source_scope,
-                    "config_path": artifact.config_path,
-                    "launch_target": "python -m http.server 9100",
-                }
-            ],
-        }
-        opened_urls: list[str] = []
-        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
-        monkeypatch.setattr(guard_commands_module.webbrowser, "open", lambda url: opened_urls.append(url) or True)
-
-        blocked_resolver = guard_commands_module._headless_approval_resolver(
-            args=argparse.Namespace(harness="copilot"),
-            context=HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir),
-            store=store,
-            config=config,
-        )
-        result = blocked_resolver(detection, payload)
-
-        assert opened_urls == []
-        assert result["approval_center_url"] == "http://127.0.0.1:4455"
-        assert result["approval_delivery"]["destination"] == "harness"
-        assert result["approval_delivery"]["prompt_channel"] == "hook"
-        assert result["approval_wait"]["resolved"] is False
-
-    def test_headless_approval_resolver_treats_managed_hermes_as_native_or_center(self, tmp_path, monkeypatch):
-        home_dir = tmp_path / "home"
-        workspace_dir = tmp_path / "workspace"
-        store = GuardStore(home_dir)
-        config = GuardConfig(guard_home=home_dir, workspace=workspace_dir, approval_wait_timeout_seconds=1)
-        artifact = GuardArtifact(
-            artifact_id="hermes:global:github",
-            name="github",
-            harness="hermes",
-            artifact_type="mcp_server",
-            source_scope="global",
-            config_path=str(home_dir / ".hermes" / "config.yaml"),
-            command="npx",
-            args=("-y", "@modelcontextprotocol/server-github"),
-            transport="stdio",
-        )
-        detection = HarnessDetection(
-            harness="hermes",
-            installed=True,
-            command_available=True,
-            config_paths=(artifact.config_path,),
-            artifacts=(artifact,),
-        )
-        payload = {
-            "blocked": True,
-            "artifacts": [
-                {
-                    "artifact_id": artifact.artifact_id,
-                    "artifact_name": artifact.name,
-                    "artifact_hash": artifact_hash(artifact),
-                    "policy_action": "require-reapproval",
-                    "changed_fields": ["args"],
-                    "artifact_type": artifact.artifact_type,
-                    "source_scope": artifact.source_scope,
-                    "config_path": artifact.config_path,
-                    "launch_target": "npx -y @modelcontextprotocol/server-github",
-                }
-            ],
-        }
-        store.set_managed_install(
-            "hermes",
-            True,
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
             str(workspace_dir),
-            {"capabilities": {"same_channel": True}},
-            "2026-04-15T00:00:00+00:00",
-        )
-        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
-
-        blocked_resolver = guard_commands_module._headless_approval_resolver(
-            args=argparse.Namespace(harness="hermes"),
-            context=HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir),
-            store=store,
-            config=config,
-        )
-        result = blocked_resolver(detection, payload)
-
-        assert result["approval_delivery"]["destination"] == "harness"
-        assert result["approval_delivery"]["prompt_channel"] == "native"
-        assert result["approval_wait"]["resolved"] is False
-
-    def test_hermes_mcp_proxy_streams_stdio_messages_without_waiting_for_eof(self, tmp_path, monkeypatch, capsys):
-        guard_home = tmp_path / "guard-home"
-        workspace = tmp_path / "workspace"
-        workspace.mkdir()
-        store = GuardStore(guard_home)
-        store.set_managed_install(
-            "hermes",
-            True,
-            str(workspace),
-            {
-                "servers": {
-                    "yaml:demo": {
-                        "transport": "stdio",
-                        "command": "python",
-                        "args": ["-m", "demo"],
-                    }
-                }
-            },
-            "2026-04-15T00:00:00+00:00",
-        )
-        captured_messages: list[dict[str, object]] = []
-
-        class _FakeProxy:
-            def __init__(self, **kwargs) -> None:
-                self.kwargs = kwargs
-
-            def run_stream(self, *, input_stream, output_stream, error_stream) -> int:
-                for line in input_stream:
-                    payload = json.loads(line)
-                    captured_messages.append(payload)
-                    output_stream.write(
-                        json.dumps({"jsonrpc": "2.0", "id": payload["id"], "result": {"ok": True}}) + "\n"
-                    )
-                    output_stream.flush()
-                return 0
-
-        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
-        monkeypatch.setattr(guard_commands_module, "StdioGuardProxy", _FakeProxy)
-        monkeypatch.setattr(sys, "stdin", _LineOnlyInput(['{"jsonrpc":"2.0","id":7,"method":"tools/list"}\n']))
-
-        rc = guard_commands_module._run_hermes_mcp_proxy(
-            args=argparse.Namespace(server="yaml:demo"),
-            context=HarnessContext(home_dir=tmp_path, workspace_dir=workspace, guard_home=guard_home),
-            store=store,
-            config=load_guard_config(guard_home),
-        )
-        output = capsys.readouterr()
-
-        assert rc == 0
-        assert captured_messages == [{"jsonrpc": "2.0", "id": 7, "method": "tools/list"}]
-        assert '"id": 7' in output.out
-
-    def test_hermes_mcp_proxy_passes_manifest_env_to_stdio_proxy(self, tmp_path, monkeypatch):
-        guard_home = tmp_path / "guard-home"
-        workspace = tmp_path / "workspace"
-        workspace.mkdir()
-        store = GuardStore(guard_home)
-        store.set_managed_install(
-            "hermes",
-            True,
-            str(workspace),
-            {
-                "servers": {
-                    "yaml:demo": {
-                        "transport": "stdio",
-                        "command": "python",
-                        "args": ["-m", "demo"],
-                        "env": {"GITHUB_TOKEN": "ghp_test_token"},
-                    }
-                }
-            },
-            "2026-04-15T00:00:00+00:00",
-        )
-        captured_init: list[dict[str, object]] = []
-
-        class _FakeProxy:
-            def __init__(self, **kwargs) -> None:
-                captured_init.append(kwargs)
-
-            def run_stream(self, *, input_stream, output_stream, error_stream) -> int:
-                return 0
-
-        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
-        monkeypatch.setattr(guard_commands_module, "StdioGuardProxy", _FakeProxy)
-        monkeypatch.setattr(sys, "stdin", _LineOnlyInput([]))
-
-        rc = guard_commands_module._run_hermes_mcp_proxy(
-            args=argparse.Namespace(server="yaml:demo"),
-            context=HarnessContext(home_dir=tmp_path, workspace_dir=workspace, guard_home=guard_home),
-            store=store,
-            config=load_guard_config(guard_home),
-        )
-
-        assert rc == 0
-        assert captured_init[0]["env"] == {"GITHUB_TOKEN": "ghp_test_token"}
-
-    def test_hermes_mcp_proxy_rejects_invalid_json(self, tmp_path, monkeypatch, capsys):
-        guard_home = tmp_path / "guard-home"
-        store = GuardStore(guard_home)
-        store.set_managed_install(
-            "hermes",
-            True,
-            None,
-            {
-                "servers": {
-                    "yaml:demo": {
-                        "transport": "http",
-                        "url": "https://mcp.example.com/v1/mcp",
-                    }
-                }
-            },
-            "2026-04-15T00:00:00+00:00",
-        )
-        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
-        monkeypatch.setattr(sys, "stdin", io.StringIO("{not-json}\n"))
-
-        rc = guard_commands_module._run_hermes_mcp_proxy(
-            args=argparse.Namespace(server="yaml:demo"),
-            context=HarnessContext(home_dir=tmp_path, workspace_dir=None, guard_home=guard_home),
-            store=store,
-            config=load_guard_config(guard_home),
-        )
-        output = capsys.readouterr()
-
-        assert rc == 2
-        assert "invalid JSON" in output.err
-
-    def test_hermes_mcp_proxy_forwards_remote_headers_and_flushes_stdout(self, tmp_path, monkeypatch):
-        guard_home = tmp_path / "guard-home"
-        store = GuardStore(guard_home)
-        store.set_managed_install(
-            "hermes",
-            True,
-            None,
-            {
-                "servers": {
-                    "yaml:demo": {
-                        "transport": "http",
-                        "url": "https://mcp.example.com/v1/mcp",
-                        "headers": {"Authorization": "Bearer test-token"},
-                    }
-                }
-            },
-            "2026-04-15T00:00:00+00:00",
-        )
-        captured_headers: list[dict[str, str]] = []
-        output_stream = _FlushTrackingOutput()
-
-        class _FakeRemoteProxy:
-            def __init__(self, *, base_url: str, allow_insecure_localhost: bool = False) -> None:
-                self.base_url = base_url
-                self.allow_insecure_localhost = allow_insecure_localhost
-
-            def forward(
-                self,
-                path: str,
-                payload: dict[str, object],
-                headers: dict[str, str] | None = None,
-                expect_response: bool = True,
-            ) -> dict[str, object]:
-                captured_headers.append(headers or {})
-                assert expect_response is True
-                return {"jsonrpc": "2.0", "id": payload["id"], "result": {"ok": True}}
-
-        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
-        monkeypatch.setattr(guard_commands_module, "RemoteGuardProxy", _FakeRemoteProxy)
-        monkeypatch.setattr(sys, "stdin", io.StringIO('{"jsonrpc":"2.0","id":9,"method":"tools/list"}\n'))
-        monkeypatch.setattr(sys, "stdout", output_stream)
-
-        rc = guard_commands_module._run_hermes_mcp_proxy(
-            args=argparse.Namespace(server="yaml:demo"),
-            context=HarnessContext(home_dir=tmp_path, workspace_dir=None, guard_home=guard_home),
-            store=store,
-            config=load_guard_config(guard_home),
-        )
-
-        assert rc == 0
-        assert captured_headers == [{"Authorization": "Bearer test-token"}]
-        assert '"id":9' in output_stream.getvalue()
-        assert output_stream.flush_count >= 1
-
-    def test_hermes_mcp_proxy_skips_http_notification_responses(self, tmp_path, monkeypatch):
-        guard_home = tmp_path / "guard-home"
-        store = GuardStore(guard_home)
-        store.set_managed_install(
-            "hermes",
-            True,
-            None,
-            {
-                "servers": {
-                    "yaml:demo": {
-                        "transport": "http",
-                        "url": "https://mcp.example.com/v1/mcp",
-                    }
-                }
-            },
-            "2026-04-15T00:00:00+00:00",
-        )
-        captured_expect_response: list[bool] = []
-        output_stream = _FlushTrackingOutput()
-
-        class _FakeRemoteProxy:
-            def __init__(self, *, base_url: str, allow_insecure_localhost: bool = False) -> None:
-                self.base_url = base_url
-                self.allow_insecure_localhost = allow_insecure_localhost
-
-            def forward(
-                self,
-                path: str,
-                payload: dict[str, object],
-                headers: dict[str, str] | None = None,
-                expect_response: bool = True,
-            ) -> dict[str, object] | None:
-                captured_expect_response.append(expect_response)
-                return None
-
-        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
-        monkeypatch.setattr(guard_commands_module, "RemoteGuardProxy", _FakeRemoteProxy)
-        monkeypatch.setattr(
-            sys,
-            "stdin",
-            io.StringIO('{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}\n'),
-        )
-        monkeypatch.setattr(sys, "stdout", output_stream)
-
-        rc = guard_commands_module._run_hermes_mcp_proxy(
-            args=argparse.Namespace(server="yaml:demo"),
-            context=HarnessContext(home_dir=tmp_path, workspace_dir=None, guard_home=guard_home),
-            store=store,
-            config=load_guard_config(guard_home),
-        )
-
-        assert rc == 0
-        assert captured_expect_response == [False]
-        assert output_stream.getvalue() == ""
-
-    def test_hermes_mcp_proxy_http_transport_does_not_require_guard_daemon(self, tmp_path, monkeypatch):
-        guard_home = tmp_path / "guard-home"
-        store = GuardStore(guard_home)
-        store.set_managed_install(
-            "hermes",
-            True,
-            None,
-            {
-                "servers": {
-                    "yaml:demo": {
-                        "transport": "http",
-                        "url": "https://mcp.example.com/v1/mcp",
-                    }
-                }
-            },
-            "2026-04-15T00:00:00+00:00",
-        )
-        output_stream = _FlushTrackingOutput()
-
-        class _FakeRemoteProxy:
-            def __init__(self, *, base_url: str, allow_insecure_localhost: bool = False) -> None:
-                self.base_url = base_url
-                self.allow_insecure_localhost = allow_insecure_localhost
-
-            def forward(
-                self,
-                path: str,
-                payload: dict[str, object],
-                headers: dict[str, str] | None = None,
-                expect_response: bool = True,
-            ) -> dict[str, object]:
-                return {"jsonrpc": "2.0", "id": payload["id"], "result": {"ok": True}}
-
-        def _raise_daemon_error(_guard_home):
-            raise RuntimeError("daemon unavailable")
-
-        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", _raise_daemon_error)
-        monkeypatch.setattr(guard_commands_module, "RemoteGuardProxy", _FakeRemoteProxy)
-        monkeypatch.setattr(sys, "stdin", io.StringIO('{"jsonrpc":"2.0","id":9,"method":"tools/list"}\n'))
-        monkeypatch.setattr(sys, "stdout", output_stream)
-
-        rc = guard_commands_module._run_hermes_mcp_proxy(
-            args=argparse.Namespace(server="yaml:demo"),
-            context=HarnessContext(home_dir=tmp_path, workspace_dir=None, guard_home=guard_home),
-            store=store,
-            config=load_guard_config(guard_home),
-        )
-
-        assert rc == 0
-        assert '"id":9' in output_stream.getvalue()
-
-    def test_approval_surface_policy_disables_auto_open_when_flow_forbids_browser(self):
-        assert (
-            guard_commands_module._approval_surface_policy_for_flow(
-                "auto-open-once",
-                {"tier": "approval-center", "auto_open_browser": False, "prompt_channel": "native-fallback"},
-            )
-            == "never-auto-open"
-        )
-
-    def test_hermes_pretool_uses_managed_same_channel_policy_for_blocked_operations(
-        self,
-        tmp_path,
-        capsys,
-        monkeypatch,
-    ):
-        home_dir = tmp_path / "home"
-        workspace_dir = tmp_path / "workspace"
-        workspace_dir.mkdir(parents=True, exist_ok=True)
-        _write_text(home_dir / "config.toml", 'mode = "prompt"\napproval_surface_policy = "auto-open-once"\n')
-        GuardStore(home_dir).set_managed_install(
-            "hermes",
-            True,
-            str(workspace_dir),
-            {"capabilities": {"same_channel": True}},
-            "2026-04-15T00:00:00+00:00",
-        )
-
-        captured_surface_policy: list[str] = []
-
-        class _FakeDaemonClient:
-            def start_session(self, **kwargs) -> dict[str, object]:
-                return {"session_id": "session-1"}
-
-            def queue_blocked_operation(self, **kwargs) -> dict[str, object]:
-                captured_surface_policy.append(str(kwargs["approval_surface_policy"]))
-                return {
-                    "operation": {"operation_id": "operation-1"},
-                    "approval_requests": [{"request_id": "request-1"}],
-                }
-
-        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
-        monkeypatch.setattr(
-            guard_commands_module,
-            "load_guard_surface_daemon_client",
-            lambda _guard_home: _FakeDaemonClient(),
-        )
-        monkeypatch.setattr(
-            sys,
-            "stdin",
-            io.StringIO(
-                json.dumps(
-                    {
-                        "event": "PreToolUse",
-                        "tool_name": "shell",
-                        "tool_input": {"command": "docker login ghcr.io", "docker_mode": True},
-                        "source_scope": "project",
-                    }
-                )
-            ),
-        )
-
-        rc = main(
-            [
-                "hermes",
-                "pretool",
-                "--home",
-                str(home_dir),
-                "--workspace",
-                str(workspace_dir),
-                "--json",
-            ]
-        )
-        output = json.loads(capsys.readouterr().out)
-
-        assert rc == 1
-        assert captured_surface_policy == ["notify-only"]
-        assert output["approval_delivery"]["destination"] == "harness"
-        assert output["approval_delivery"]["prompt_channel"] == "native"
-
-    def test_guard_run_dry_run_human_output_is_summary_first(self, tmp_path, capsys):
-        home_dir = tmp_path / "home"
-        workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
-
-        rc = main(
-            [
-                "guard",
-                "run",
-                "codex",
-                "--home",
-                str(home_dir),
-                "--workspace",
-                str(workspace_dir),
-                "--dry-run",
-            ]
-        )
-        output = capsys.readouterr().out
-
-        assert rc == 1
-        assert "What changed" in output
-        assert "Next step" in output
-        assert "rerun without --dry-run" in output.lower()
-        assert "Fields" not in output
-        assert "first_seen" not in output
-
-    def test_guard_run_renderer_coalesces_replaced_artifacts(self, capsys):
-        emit_guard_payload(
-            "run",
-            {
-                "harness": "codex",
-                "blocked": True,
-                "dry_run": True,
-                "launched": False,
-                "receipts_recorded": 2,
-                "artifacts": [
-                    {
-                        "artifact_id": "codex:project:chrome-devtools:new",
-                        "artifact_name": "chrome-devtools",
-                        "changed": True,
-                        "changed_fields": ["first_seen"],
-                        "policy_action": "require-reapproval",
-                        "artifact_label": "MCP server",
-                        "why_now": "It is new in this codex workspace, so Guard paused it for review.",
-                        "risk_summary": "Connects to a remote server.",
-                    },
-                    {
-                        "artifact_id": "codex:project:chrome-devtools:old",
-                        "artifact_name": "chrome-devtools",
-                        "changed": True,
-                        "changed_fields": ["removed"],
-                        "policy_action": "require-reapproval",
-                        "artifact_label": "MCP server",
-                        "why_now": (
-                            "It disappeared from the harness config, so Guard paused the change until you "
-                            "confirm the removal."
-                        ),
-                    },
-                ],
-            },
-            False,
-        )
-        output = capsys.readouterr().out
-
-        assert "chrome-devtools" in output
-        assert output.lower().count("chrome-devtools") == 1
-        assert "definition" in output.lower()
-        assert "replaced" in output.lower()
-        assert "first_seen" not in output
-        assert "removed" not in output
-
-    def test_guard_run_renderer_keeps_same_named_artifacts_separate_across_configs(self, capsys):
-        emit_guard_payload(
-            "run",
-            {
-                "harness": "codex",
-                "blocked": True,
-                "dry_run": True,
-                "launched": False,
-                "receipts_recorded": 2,
-                "artifacts": [
-                    {
-                        "artifact_id": "codex:project:chrome-devtools:new",
-                        "artifact_name": "chrome-devtools",
-                        "changed": True,
-                        "changed_fields": ["first_seen"],
-                        "policy_action": "require-reapproval",
-                        "artifact_label": "MCP server",
-                        "source_scope": "project",
-                        "config_path": "/workspace/.codex/config.toml",
-                        "why_now": "It is new in this codex workspace, so Guard paused it for review.",
-                    },
-                    {
-                        "artifact_id": "codex:global:chrome-devtools:old",
-                        "artifact_name": "chrome-devtools",
-                        "changed": True,
-                        "changed_fields": ["removed"],
-                        "policy_action": "require-reapproval",
-                        "artifact_label": "MCP server",
-                        "source_scope": "global",
-                        "config_path": "/home/.codex/config.toml",
-                        "why_now": (
-                            "It disappeared from the global harness config, so Guard paused the change until "
-                            "you confirm the removal."
-                        ),
-                    },
-                ],
-            },
-            False,
-        )
-        output = capsys.readouterr().out
-
-        assert "chrome-devtools" in output
-        assert output.lower().count("chrome-devtools") == 2
-        assert "definition replaced" not in output.lower()
-
-    def test_guard_run_renderer_filters_unchanged_artifacts_and_counts_review_items(self, capsys):
-        emit_guard_payload(
-            "run",
-            {
-                "harness": "codex",
-                "blocked": True,
-                "dry_run": True,
-                "launched": False,
-                "receipts_recorded": 3,
-                "artifacts": [
-                    {
-                        "artifact_id": "codex:project:stable-tool",
-                        "artifact_name": "stable-tool",
-                        "changed": False,
-                        "changed_fields": [],
-                        "policy_action": "allow",
-                        "why_now": "Guard matched an existing allow rule for this exact version.",
-                    },
-                    {
-                        "artifact_id": "codex:project:already-approved",
-                        "artifact_name": "already-approved",
-                        "changed": True,
-                        "changed_fields": ["command"],
-                        "policy_action": "allow",
-                        "why_now": "Guard matched an existing allow rule for this exact definition.",
-                    },
-                    {
-                        "artifact_id": "codex:project:review-tool",
-                        "artifact_name": "review-tool",
-                        "changed": True,
-                        "changed_fields": ["first_seen"],
-                        "policy_action": "require-reapproval",
-                        "why_now": "It is new in this codex workspace, so Guard paused it for review.",
-                    },
-                ],
-            },
-            False,
-        )
-        output = capsys.readouterr().out
-
-        assert "stable-tool" not in output
-        assert "already-approved" in output
-        assert "review-tool" in output
-        assert "Needs review 1" in output
-
-    def test_guard_run_renderer_keeps_unchanged_blockers_visible(self, capsys):
-        emit_guard_payload(
-            "run",
-            {
-                "harness": "codex",
-                "blocked": True,
-                "dry_run": True,
-                "launched": False,
-                "receipts_recorded": 1,
-                "artifacts": [
-                    {
-                        "artifact_id": "codex:project:blocked-tool",
-                        "artifact_name": "blocked-tool",
-                        "changed": False,
-                        "changed_fields": [],
-                        "policy_action": "require-reapproval",
-                        "why_now": "Guard blocked this definition because the configured policy does not trust it yet.",
-                    }
-                ],
-            },
-            False,
-        )
-        output = capsys.readouterr().out
-
-        assert "blocked-tool" in output
-        assert "Needs review 1" in output
-
-    def test_guard_run_renderer_counts_each_visible_blocker_even_when_rows_coalesce(self, capsys):
-        emit_guard_payload(
-            "run",
-            {
-                "harness": "codex",
-                "blocked": True,
-                "dry_run": True,
-                "launched": False,
-                "receipts_recorded": 2,
-                "artifacts": [
-                    {
-                        "artifact_id": "codex:project:chrome-devtools:new",
-                        "artifact_name": "chrome-devtools",
-                        "changed": True,
-                        "changed_fields": ["first_seen"],
-                        "policy_action": "require-reapproval",
-                        "why_now": "It is new in this codex workspace, so Guard paused it for review.",
-                    },
-                    {
-                        "artifact_id": "codex:project:chrome-devtools:old",
-                        "artifact_name": "chrome-devtools",
-                        "changed": True,
-                        "changed_fields": ["removed"],
-                        "policy_action": "require-reapproval",
-                        "why_now": (
-                            "It disappeared from the harness config, so Guard paused the change until you confirm it."
-                        ),
-                    },
-                ],
-            },
-            False,
-        )
-        output = capsys.readouterr().out
-
-        assert "Needs review 2" in output
-        assert output.lower().count("chrome-devtools") == 1
-
-    def test_guard_run_renderer_leads_blocked_dry_runs_with_full_review_path(self, capsys):
-        emit_guard_payload(
-            "run",
-            {
-                "harness": "codex",
-                "blocked": True,
-                "dry_run": True,
-                "launched": False,
-                "receipts_recorded": 1,
-                "artifacts": [
-                    {
-                        "artifact_id": "codex:project:blocked-tool",
-                        "artifact_name": "blocked-tool",
-                        "changed": False,
-                        "changed_fields": [],
-                        "policy_action": "require-reapproval",
-                        "why_now": "Guard blocked this definition because the configured policy does not trust it yet.",
-                    }
-                ],
-            },
-            False,
-        )
-        output = capsys.readouterr().out
-
-        assert "Resolve the blocked launch" in output
-        assert "hol-guard run codex" in output
-        assert "Inspect only the changed config entries (optional)" in output
-        assert "hol-guard diff codex" in output
-
-    def test_guard_run_renderer_counts_only_blocking_actions_as_needing_review(self, capsys):
-        emit_guard_payload(
-            "run",
-            {
-                "harness": "codex",
-                "blocked": True,
-                "dry_run": True,
-                "launched": False,
-                "receipts_recorded": 2,
-                "artifacts": [
-                    {
-                        "artifact_id": "codex:project:warn-only-tool",
-                        "artifact_name": "warn-only-tool",
-                        "changed": True,
-                        "changed_fields": ["command"],
-                        "policy_action": "warn",
-                        "why_now": "Guard wants to highlight this change, but it does not block launch.",
-                    },
-                    {
-                        "artifact_id": "codex:project:blocked-tool",
-                        "artifact_name": "blocked-tool",
-                        "changed": True,
-                        "changed_fields": ["first_seen"],
-                        "policy_action": "require-reapproval",
-                        "why_now": "Guard blocked this definition because the configured policy does not trust it yet.",
-                    },
-                ],
-            },
-            False,
-        )
-        output = capsys.readouterr().out
-
-        assert "warn-only-tool" in output
-        assert "blocked-tool" in output
-        assert "Needs review 1" in output
-
-    def test_guard_run_renderer_uses_neutral_blocked_copy_for_policy_only_blockers(self, capsys):
-        emit_guard_payload(
-            "run",
-            {
-                "harness": "codex",
-                "blocked": True,
-                "dry_run": True,
-                "launched": False,
-                "receipts_recorded": 1,
-                "artifacts": [
-                    {
-                        "artifact_id": "codex:project:blocked-tool",
-                        "artifact_name": "blocked-tool",
-                        "changed": False,
-                        "changed_fields": [],
-                        "policy_action": "require-reapproval",
-                        "why_now": "Guard blocked this definition because the configured policy does not trust it yet.",
-                    }
-                ],
-            },
-            False,
-        )
-        output = capsys.readouterr().out
-
-        assert "Guard found changes that need review before a real launch." not in output
-        assert "Guard found artifacts that need review before a real launch." in output
-
-    def test_guard_run_renderer_prefers_context_preserving_rerun_command(self):
-        steps = guard_render_module._build_run_steps(
-            {
-                "harness": "codex",
-                "blocked": True,
-                "dry_run": True,
-                "rerun_command": (
-                    "hol-guard run codex --home /guard-home --workspace /workspace "
-                    "--default-action warn --arg '--model gpt-5'"
-                ),
-            },
-            blocked=True,
-            dry_run=True,
-        )
-
-        assert steps[0]["command"] == (
-            "hol-guard run codex --home /guard-home --workspace /workspace --default-action warn --arg '--model gpt-5'"
-        )
-
-    def test_guard_rerun_command_preserves_run_context(self):
-        command = guard_commands_module._guard_rerun_command(
-            argparse.Namespace(
-                harness="codex",
-                home="/guard-home",
-                guard_home=None,
-                workspace="/workspace",
-                default_action="warn",
-                passthrough_args=["--model gpt-5"],
-            )
-        )
-
-        assert command == (
-            "hol-guard run codex --home /guard-home --workspace /workspace --default-action warn --arg '--model gpt-5'"
-        )
-
-    def test_guard_rerun_command_uses_windows_safe_quoting(self, monkeypatch):
-        monkeypatch.setattr(guard_commands_module.sys, "platform", "win32")
-        command = guard_commands_module._guard_rerun_command(
-            argparse.Namespace(
-                harness="codex",
-                home=r"C:\Guard Home",
-                guard_home=None,
-                workspace=r"C:\Workspace Root",
-                default_action="warn",
-                passthrough_args=["--model gpt-5"],
-            )
-        )
-
-        expected = subprocess.list2cmdline(
-            [
-                "hol-guard",
-                "run",
-                "codex",
-                "--home",
-                r"C:\Guard Home",
-                "--workspace",
-                r"C:\Workspace Root",
-                "--default-action",
-                "warn",
-                "--arg",
-                "--model gpt-5",
-            ]
-        )
-
-        assert command == expected
-
-    def test_guard_diff_command_preserves_common_context(self):
-        command = guard_commands_module._guard_diff_command(
-            argparse.Namespace(
-                harness="codex",
-                home="/guard-home",
-                guard_home=None,
-                workspace="/workspace",
-            )
-        )
-
-        assert command == "hol-guard diff codex --home /guard-home --workspace /workspace"
-
-    def test_guard_run_renderer_uses_context_preserving_diff_command(self):
-        steps = guard_render_module._build_run_steps(
-            {
-                "harness": "codex",
-                "blocked": True,
-                "dry_run": True,
-                "diff_command": "hol-guard diff codex --home /guard-home --workspace /workspace",
-            },
-            blocked=True,
-            dry_run=True,
-        )
-
-        assert steps[1]["command"] == "hol-guard diff codex --home /guard-home --workspace /workspace"
-
-    def test_guard_run_renderer_uses_context_preserving_launch_command_for_clean_dry_runs(self):
-        steps = guard_render_module._build_run_steps(
-            {
-                "harness": "codex",
-                "dry_run": True,
-                "rerun_command": (
-                    "hol-guard run codex --home /guard-home --workspace /workspace "
-                    "--default-action warn --arg '--model gpt-5'"
-                ),
-            },
-            blocked=False,
-            dry_run=True,
-        )
-
-        assert steps[0]["command"] == (
-            "hol-guard run codex --home /guard-home --workspace /workspace --default-action warn --arg '--model gpt-5'"
-        )
-
-    def test_guard_approvals_command_preserves_common_context(self):
-        command = guard_commands_module._guard_approvals_command(
-            argparse.Namespace(
-                harness="codex",
-                home="/guard-home",
-                guard_home="/guard-db",
-                workspace="/workspace",
-            )
-        )
-
-        assert command == "hol-guard approvals --home /guard-home --guard-home /guard-db --workspace /workspace"
-
-    def test_guard_run_renderer_uses_context_preserving_approvals_command_for_blocked_launches(self):
-        steps = guard_render_module._build_run_steps(
-            {
-                "harness": "codex",
-                "approval_center_url": "http://127.0.0.1:4455",
-                "approvals_command": "hol-guard approvals --home /guard-home --workspace /workspace",
-                "review_hint": "Open the approval center and resolve the pending request.",
-            },
-            blocked=True,
-            dry_run=False,
-        )
-
-        assert steps[0]["command"] == "hol-guard approvals --home /guard-home --workspace /workspace"
-
-    def test_guard_run_headless_allow_persists_state_when_approval_center_is_available(
-        self, tmp_path, capsys, monkeypatch
-    ):
-        home_dir = tmp_path / "home"
-        workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
-        monkeypatch.setattr(
-            guard_runner_module.subprocess,
-            "run",
-            lambda *args, **kwargs: type("CompletedProcess", (), {"returncode": 0})(),
-        )
-
-        rc = main(
-            [
-                "guard",
-                "run",
-                "codex",
-                "--home",
-                str(home_dir),
-                "--workspace",
-                str(workspace_dir),
-                "--default-action",
-                "allow",
-            ]
-        )
-        output = capsys.readouterr().out
-        store = GuardStore(home_dir)
-        receipts = store.list_receipts(limit=10)
-        snapshots = store.list_snapshots("codex")
-
-        assert rc == 0
-        assert "Launch allowed" in output
-        assert len(receipts) == 2
-        assert {
-            "codex:global:global_tools",
-            "codex:project:workspace_skill",
-        } <= set(snapshots)
-
-    def test_guard_run_headless_waits_for_local_approval_and_resumes(self, tmp_path, capsys, monkeypatch):
-        home_dir = tmp_path / "home"
-        workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
-        _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 2\n")
-
-        store = GuardStore(home_dir)
-        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
-        monkeypatch.setattr(
-            guard_runner_module.subprocess,
-            "run",
-            lambda *args, **kwargs: type("CompletedProcess", (), {"returncode": 0})(),
-        )
-
-        def resolve_pending() -> None:
-            for _ in range(40):
-                pending = store.list_approval_requests(limit=10)
-                if pending:
-                    for request in pending:
-                        apply_approval_resolution(
-                            store=store,
-                            request_id=str(request["request_id"]),
-                            action="allow",
-                            scope="artifact",
-                            workspace=None,
-                            reason="approved from test",
-                        )
-                    if not store.list_approval_requests(limit=10):
-                        return
-                threading.Event().wait(0.05)
-
-        worker = threading.Thread(target=resolve_pending, daemon=True)
-        worker.start()
-
-        rc = main(
-            [
-                "guard",
-                "run",
-                "claude-code",
-                "--home",
-                str(home_dir),
-                "--workspace",
-                str(workspace_dir),
-            ]
-        )
-        output = capsys.readouterr().out
-
-        assert rc == 0
-        assert "Launch allowed" in output
-        assert "Approval received" in output
-
-    def test_guard_run_headless_redetects_before_persisted_resume(self, tmp_path, monkeypatch):
-        home_dir = tmp_path / "home"
-        workspace_dir = tmp_path / "workspace"
-        _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 1\n")
-
-        store = GuardStore(home_dir)
-        baseline = GuardArtifact(
-            artifact_id="claude-code:project:workspace-tools",
-            name="workspace-tools",
-            harness="claude-code",
-            artifact_type="mcp_server",
-            source_scope="project",
-            config_path=str(workspace_dir / ".mcp.json"),
-            command="python",
-            args=("-m", "http.server", "9100"),
-            transport="stdio",
-        )
-        baseline_hash = artifact_hash(baseline)
-        store.save_snapshot(
-            "claude-code",
-            baseline.artifact_id,
-            {**baseline.to_dict(), "artifact_hash": baseline_hash},
-            baseline_hash,
-            "2026-04-10T00:00:00+00:00",
-        )
-        detections = [
-            HarnessDetection(
-                harness="claude-code",
-                installed=True,
-                command_available=True,
-                config_paths=(str(workspace_dir / ".mcp.json"),),
-                artifacts=(
-                    GuardArtifact(
-                        artifact_id=baseline.artifact_id,
-                        name="workspace-tools",
-                        harness="claude-code",
-                        artifact_type="mcp_server",
-                        source_scope="project",
-                        config_path=str(workspace_dir / ".mcp.json"),
-                        command="python",
-                        args=("-m", "http.server", "9100", "--changed-1"),
-                        transport="stdio",
-                    ),
-                ),
-            ),
-            HarnessDetection(
-                harness="claude-code",
-                installed=True,
-                command_available=True,
-                config_paths=(str(workspace_dir / ".mcp.json"),),
-                artifacts=(
-                    GuardArtifact(
-                        artifact_id=baseline.artifact_id,
-                        name="workspace-tools",
-                        harness="claude-code",
-                        artifact_type="mcp_server",
-                        source_scope="project",
-                        config_path=str(workspace_dir / ".mcp.json"),
-                        command="python",
-                        args=("-m", "http.server", "9100", "--changed-2"),
-                        transport="stdio",
-                    ),
-                ),
-            ),
+            "--harness",
+            "copilot",
         ]
-        call_count = {"detect": 0}
-        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
-        monkeypatch.setattr(
-            guard_runner_module.subprocess,
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output == {"permissionDecision": "allow"}
+
+
+def test_guard_hook_emits_copilot_native_allow_response_for_read_only_sed_requests(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "sed -n '1p' README.md"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output == {"permissionDecision": "allow"}
+
+
+def test_guard_run_returns_structured_error_when_executable_missing(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\n')
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(FileNotFoundError("codex not found")),
+    )
+
+    rc = main(
+        [
+            "guard",
             "run",
-            lambda *args, **kwargs: type("CompletedProcess", (), {"returncode": 0})(),
+            "claude-code",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--default-action",
+            "allow",
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 127
+    assert output["launched"] is False
+    assert output["return_code"] == 127
+    assert "codex not found" in output["launch_error"]
+
+
+def test_guard_run_prompt_allow_once_launches_and_records_override(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    answers = iter(["1", "1"])
+    monkeypatch.setattr(guard_commands_module.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("rich.console.Console.input", lambda self, prompt="": next(answers))
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *args, **kwargs: type("CompletedProcess", (), {"returncode": 0})(),
+    )
+
+    rc = main(
+        [
+            "guard",
+            "run",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+        ]
+    )
+    output = capsys.readouterr().out
+    receipts = GuardStore(Path(home_dir)).list_receipts(limit=10)
+
+    assert rc == 0
+    assert "Launch allowed" in output
+    assert any(item.get("user_override") == "allow-once" for item in receipts)
+
+
+def test_guard_run_prompt_allow_artifact_persists_for_next_run(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    answers = iter(["2", "2"])
+    monkeypatch.setattr(guard_commands_module.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("rich.console.Console.input", lambda self, prompt="": next(answers))
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *args, **kwargs: type("CompletedProcess", (), {"returncode": 0})(),
+    )
+
+    first_rc = main(
+        [
+            "guard",
+            "run",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+        ]
+    )
+    first_output = capsys.readouterr().out
+
+    second_rc = main(
+        [
+            "guard",
+            "run",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--dry-run",
+            "--json",
+        ]
+    )
+    second_output = json.loads(capsys.readouterr().out)
+
+    assert first_rc == 0
+    assert "Launch allowed" in first_output
+    assert second_rc == 0
+    assert second_output["blocked"] is False
+    assert all(item["policy_action"] == "allow" for item in second_output["artifacts"])
+
+
+def test_guard_run_headless_blocks_with_review_hint_without_opening_browser(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    opened_urls: list[str] = []
+    monkeypatch.setattr(guard_commands_module.webbrowser, "open", lambda url: opened_urls.append(url) or True)
+
+    rc = main(
+        [
+            "guard",
+            "run",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert output["approval_center_url"] == "http://127.0.0.1:4455"
+    assert output["blocked"] is True
+    assert output["approval_delivery"]["destination"] == "harness"
+    assert opened_urls == []
+
+
+def test_headless_approval_resolver_skips_browser_for_hook_first_harnesses(tmp_path, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    store = GuardStore(home_dir)
+    config = GuardConfig(guard_home=home_dir, workspace=workspace_dir, approval_wait_timeout_seconds=1)
+    artifact = GuardArtifact(
+        artifact_id="copilot:project:workspace-tools",
+        name="workspace-tools",
+        harness="copilot",
+        artifact_type="mcp_server",
+        source_scope="project",
+        config_path=str(workspace_dir / ".vscode" / "mcp.json"),
+        command="python",
+        args=("-m", "http.server", "9100"),
+        transport="stdio",
+    )
+    detection = HarnessDetection(
+        harness="copilot",
+        installed=True,
+        command_available=True,
+        config_paths=(artifact.config_path,),
+        artifacts=(artifact,),
+    )
+    payload = {
+        "blocked": True,
+        "artifacts": [
+            {
+                "artifact_id": artifact.artifact_id,
+                "artifact_name": artifact.name,
+                "artifact_hash": artifact_hash(artifact),
+                "policy_action": "require-reapproval",
+                "changed_fields": ["args"],
+                "artifact_type": artifact.artifact_type,
+                "source_scope": artifact.source_scope,
+                "config_path": artifact.config_path,
+                "launch_target": "python -m http.server 9100",
+            }
+        ],
+    }
+    opened_urls: list[str] = []
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(guard_commands_module.webbrowser, "open", lambda url: opened_urls.append(url) or True)
+
+    blocked_resolver = guard_commands_module._headless_approval_resolver(
+        args=argparse.Namespace(harness="copilot"),
+        context=HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir),
+        store=store,
+        config=config,
+    )
+    result = blocked_resolver(detection, payload)
+
+    assert opened_urls == []
+    assert result["approval_center_url"] == "http://127.0.0.1:4455"
+    assert result["approval_delivery"]["destination"] == "harness"
+    assert result["approval_delivery"]["prompt_channel"] == "hook"
+    assert result["approval_wait"]["resolved"] is False
+
+
+def test_headless_approval_resolver_treats_managed_hermes_as_native_or_center(tmp_path, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    store = GuardStore(home_dir)
+    config = GuardConfig(guard_home=home_dir, workspace=workspace_dir, approval_wait_timeout_seconds=1)
+    artifact = GuardArtifact(
+        artifact_id="hermes:global:github",
+        name="github",
+        harness="hermes",
+        artifact_type="mcp_server",
+        source_scope="global",
+        config_path=str(home_dir / ".hermes" / "config.yaml"),
+        command="npx",
+        args=("-y", "@modelcontextprotocol/server-github"),
+        transport="stdio",
+    )
+    detection = HarnessDetection(
+        harness="hermes",
+        installed=True,
+        command_available=True,
+        config_paths=(artifact.config_path,),
+        artifacts=(artifact,),
+    )
+    payload = {
+        "blocked": True,
+        "artifacts": [
+            {
+                "artifact_id": artifact.artifact_id,
+                "artifact_name": artifact.name,
+                "artifact_hash": artifact_hash(artifact),
+                "policy_action": "require-reapproval",
+                "changed_fields": ["args"],
+                "artifact_type": artifact.artifact_type,
+                "source_scope": artifact.source_scope,
+                "config_path": artifact.config_path,
+                "launch_target": "npx -y @modelcontextprotocol/server-github",
+            }
+        ],
+    }
+    store.set_managed_install(
+        "hermes",
+        True,
+        str(workspace_dir),
+        {"capabilities": {"same_channel": True}},
+        "2026-04-15T00:00:00+00:00",
+    )
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    blocked_resolver = guard_commands_module._headless_approval_resolver(
+        args=argparse.Namespace(harness="hermes"),
+        context=HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir),
+        store=store,
+        config=config,
+    )
+    result = blocked_resolver(detection, payload)
+
+    assert result["approval_delivery"]["destination"] == "harness"
+    assert result["approval_delivery"]["prompt_channel"] == "native"
+    assert result["approval_wait"]["resolved"] is False
+
+
+def test_hermes_mcp_proxy_streams_stdio_messages_without_waiting_for_eof(tmp_path, monkeypatch, capsys):
+    guard_home = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(guard_home)
+    store.set_managed_install(
+        "hermes",
+        True,
+        str(workspace),
+        {
+            "servers": {
+                "yaml:demo": {
+                    "transport": "stdio",
+                    "command": "python",
+                    "args": ["-m", "demo"],
+                }
+            }
+        },
+        "2026-04-15T00:00:00+00:00",
+    )
+    captured_messages: list[dict[str, object]] = []
+
+    class _FakeProxy:
+        def __init__(self, **kwargs) -> None:
+            self.kwargs = kwargs
+
+        def run_stream(self, *, input_stream, output_stream, error_stream) -> int:
+            for line in input_stream:
+                payload = json.loads(line)
+                captured_messages.append(payload)
+                output_stream.write(json.dumps({"jsonrpc": "2.0", "id": payload["id"], "result": {"ok": True}}) + "\n")
+                output_stream.flush()
+            return 0
+
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(guard_commands_module, "StdioGuardProxy", _FakeProxy)
+    monkeypatch.setattr(sys, "stdin", _LineOnlyInput(['{"jsonrpc":"2.0","id":7,"method":"tools/list"}\n']))
+
+    rc = guard_commands_module._run_hermes_mcp_proxy(
+        args=argparse.Namespace(server="yaml:demo"),
+        context=HarnessContext(home_dir=tmp_path, workspace_dir=workspace, guard_home=guard_home),
+        store=store,
+        config=load_guard_config(guard_home),
+    )
+    output = capsys.readouterr()
+
+    assert rc == 0
+    assert captured_messages == [{"jsonrpc": "2.0", "id": 7, "method": "tools/list"}]
+    assert '"id": 7' in output.out
+
+
+def test_hermes_mcp_proxy_passes_manifest_env_to_stdio_proxy(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    store = GuardStore(guard_home)
+    store.set_managed_install(
+        "hermes",
+        True,
+        str(workspace),
+        {
+            "servers": {
+                "yaml:demo": {
+                    "transport": "stdio",
+                    "command": "python",
+                    "args": ["-m", "demo"],
+                    "env": {"GITHUB_TOKEN": "ghp_test_token"},
+                }
+            }
+        },
+        "2026-04-15T00:00:00+00:00",
+    )
+    captured_init: list[dict[str, object]] = []
+
+    class _FakeProxy:
+        def __init__(self, **kwargs) -> None:
+            captured_init.append(kwargs)
+
+        def run_stream(self, *, input_stream, output_stream, error_stream) -> int:
+            return 0
+
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(guard_commands_module, "StdioGuardProxy", _FakeProxy)
+    monkeypatch.setattr(sys, "stdin", _LineOnlyInput([]))
+
+    rc = guard_commands_module._run_hermes_mcp_proxy(
+        args=argparse.Namespace(server="yaml:demo"),
+        context=HarnessContext(home_dir=tmp_path, workspace_dir=workspace, guard_home=guard_home),
+        store=store,
+        config=load_guard_config(guard_home),
+    )
+
+    assert rc == 0
+    assert captured_init[0]["env"] == {"GITHUB_TOKEN": "ghp_test_token"}
+
+
+def test_hermes_mcp_proxy_rejects_invalid_json(tmp_path, monkeypatch, capsys):
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    store.set_managed_install(
+        "hermes",
+        True,
+        None,
+        {
+            "servers": {
+                "yaml:demo": {
+                    "transport": "http",
+                    "url": "https://mcp.example.com/v1/mcp",
+                }
+            }
+        },
+        "2026-04-15T00:00:00+00:00",
+    )
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(sys, "stdin", io.StringIO("{not-json}\n"))
+
+    rc = guard_commands_module._run_hermes_mcp_proxy(
+        args=argparse.Namespace(server="yaml:demo"),
+        context=HarnessContext(home_dir=tmp_path, workspace_dir=None, guard_home=guard_home),
+        store=store,
+        config=load_guard_config(guard_home),
+    )
+    output = capsys.readouterr()
+
+    assert rc == 2
+    assert "invalid JSON" in output.err
+
+
+def test_hermes_mcp_proxy_forwards_remote_headers_and_flushes_stdout(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    store.set_managed_install(
+        "hermes",
+        True,
+        None,
+        {
+            "servers": {
+                "yaml:demo": {
+                    "transport": "http",
+                    "url": "https://mcp.example.com/v1/mcp",
+                    "headers": {"Authorization": "Bearer test-token"},
+                }
+            }
+        },
+        "2026-04-15T00:00:00+00:00",
+    )
+    captured_headers: list[dict[str, str]] = []
+    output_stream = _FlushTrackingOutput()
+
+    class _FakeRemoteProxy:
+        def __init__(self, *, base_url: str, allow_insecure_localhost: bool = False) -> None:
+            self.base_url = base_url
+            self.allow_insecure_localhost = allow_insecure_localhost
+
+        def forward(
+            self,
+            path: str,
+            payload: dict[str, object],
+            headers: dict[str, str] | None = None,
+            expect_response: bool = True,
+        ) -> dict[str, object]:
+            captured_headers.append(headers or {})
+            assert expect_response is True
+            return {"jsonrpc": "2.0", "id": payload["id"], "result": {"ok": True}}
+
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(guard_commands_module, "RemoteGuardProxy", _FakeRemoteProxy)
+    monkeypatch.setattr(sys, "stdin", io.StringIO('{"jsonrpc":"2.0","id":9,"method":"tools/list"}\n'))
+    monkeypatch.setattr(sys, "stdout", output_stream)
+
+    rc = guard_commands_module._run_hermes_mcp_proxy(
+        args=argparse.Namespace(server="yaml:demo"),
+        context=HarnessContext(home_dir=tmp_path, workspace_dir=None, guard_home=guard_home),
+        store=store,
+        config=load_guard_config(guard_home),
+    )
+
+    assert rc == 0
+    assert captured_headers == [{"Authorization": "Bearer test-token"}]
+    assert '"id":9' in output_stream.getvalue()
+    assert output_stream.flush_count >= 1
+
+
+def test_hermes_mcp_proxy_skips_http_notification_responses(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    store.set_managed_install(
+        "hermes",
+        True,
+        None,
+        {
+            "servers": {
+                "yaml:demo": {
+                    "transport": "http",
+                    "url": "https://mcp.example.com/v1/mcp",
+                }
+            }
+        },
+        "2026-04-15T00:00:00+00:00",
+    )
+    captured_expect_response: list[bool] = []
+    output_stream = _FlushTrackingOutput()
+
+    class _FakeRemoteProxy:
+        def __init__(self, *, base_url: str, allow_insecure_localhost: bool = False) -> None:
+            self.base_url = base_url
+            self.allow_insecure_localhost = allow_insecure_localhost
+
+        def forward(
+            self,
+            path: str,
+            payload: dict[str, object],
+            headers: dict[str, str] | None = None,
+            expect_response: bool = True,
+        ) -> dict[str, object] | None:
+            captured_expect_response.append(expect_response)
+            return None
+
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(guard_commands_module, "RemoteGuardProxy", _FakeRemoteProxy)
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO('{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}\n'),
+    )
+    monkeypatch.setattr(sys, "stdout", output_stream)
+
+    rc = guard_commands_module._run_hermes_mcp_proxy(
+        args=argparse.Namespace(server="yaml:demo"),
+        context=HarnessContext(home_dir=tmp_path, workspace_dir=None, guard_home=guard_home),
+        store=store,
+        config=load_guard_config(guard_home),
+    )
+
+    assert rc == 0
+    assert captured_expect_response == [False]
+    assert output_stream.getvalue() == ""
+
+
+def test_hermes_mcp_proxy_http_transport_does_not_require_guard_daemon(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    store.set_managed_install(
+        "hermes",
+        True,
+        None,
+        {
+            "servers": {
+                "yaml:demo": {
+                    "transport": "http",
+                    "url": "https://mcp.example.com/v1/mcp",
+                }
+            }
+        },
+        "2026-04-15T00:00:00+00:00",
+    )
+    output_stream = _FlushTrackingOutput()
+
+    class _FakeRemoteProxy:
+        def __init__(self, *, base_url: str, allow_insecure_localhost: bool = False) -> None:
+            self.base_url = base_url
+            self.allow_insecure_localhost = allow_insecure_localhost
+
+        def forward(
+            self,
+            path: str,
+            payload: dict[str, object],
+            headers: dict[str, str] | None = None,
+            expect_response: bool = True,
+        ) -> dict[str, object]:
+            return {"jsonrpc": "2.0", "id": payload["id"], "result": {"ok": True}}
+
+    def _raise_daemon_error(_guard_home):
+        raise RuntimeError("daemon unavailable")
+
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", _raise_daemon_error)
+    monkeypatch.setattr(guard_commands_module, "RemoteGuardProxy", _FakeRemoteProxy)
+    monkeypatch.setattr(sys, "stdin", io.StringIO('{"jsonrpc":"2.0","id":9,"method":"tools/list"}\n'))
+    monkeypatch.setattr(sys, "stdout", output_stream)
+
+    rc = guard_commands_module._run_hermes_mcp_proxy(
+        args=argparse.Namespace(server="yaml:demo"),
+        context=HarnessContext(home_dir=tmp_path, workspace_dir=None, guard_home=guard_home),
+        store=store,
+        config=load_guard_config(guard_home),
+    )
+
+    assert rc == 0
+    assert '"id":9' in output_stream.getvalue()
+
+
+def test_approval_surface_policy_disables_auto_open_when_flow_forbids_browser():
+    assert (
+        guard_commands_module._approval_surface_policy_for_flow(
+            "auto-open-once",
+            {"tier": "approval-center", "auto_open_browser": False, "prompt_channel": "native-fallback"},
         )
+        == "never-auto-open"
+    )
 
-        def fake_detect(harness: str, context):
-            call_count["detect"] += 1
-            index = min(call_count["detect"] - 1, len(detections) - 1)
-            return detections[index]
 
-        monkeypatch.setattr(guard_runner_module, "detect_harness", fake_detect)
+def test_hermes_pretool_uses_managed_same_channel_policy_for_blocked_operations(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    _write_text(home_dir / "config.toml", 'mode = "prompt"\napproval_surface_policy = "auto-open-once"\n')
+    GuardStore(home_dir).set_managed_install(
+        "hermes",
+        True,
+        str(workspace_dir),
+        {"capabilities": {"same_channel": True}},
+        "2026-04-15T00:00:00+00:00",
+    )
 
-        def resolve_pending() -> None:
-            for _ in range(40):
-                pending = store.list_approval_requests(limit=10)
-                if pending:
+    captured_surface_policy: list[str] = []
+
+    class _FakeDaemonClient:
+        def start_session(self, **kwargs) -> dict[str, object]:
+            return {"session_id": "session-1"}
+
+        def queue_blocked_operation(self, **kwargs) -> dict[str, object]:
+            captured_surface_policy.append(str(kwargs["approval_surface_policy"]))
+            return {
+                "operation": {"operation_id": "operation-1"},
+                "approval_requests": [{"request_id": "request-1"}],
+            }
+
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(
+        guard_commands_module,
+        "load_guard_surface_daemon_client",
+        lambda _guard_home: _FakeDaemonClient(),
+    )
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(
+            json.dumps(
+                {
+                    "event": "PreToolUse",
+                    "tool_name": "shell",
+                    "tool_input": {"command": "docker login ghcr.io", "docker_mode": True},
+                    "source_scope": "project",
+                }
+            )
+        ),
+    )
+
+    rc = main(
+        [
+            "hermes",
+            "pretool",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert captured_surface_policy == ["notify-only"]
+    assert output["approval_delivery"]["destination"] == "harness"
+    assert output["approval_delivery"]["prompt_channel"] == "native"
+
+
+def test_guard_run_dry_run_human_output_is_summary_first(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+
+    rc = main(
+        [
+            "guard",
+            "run",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--dry-run",
+        ]
+    )
+    output = capsys.readouterr().out
+
+    assert rc == 1
+    assert "What changed" in output
+    assert "Next step" in output
+    assert "rerun without --dry-run" in output.lower()
+    assert "Fields" not in output
+    assert "first_seen" not in output
+
+
+def test_guard_run_renderer_coalesces_replaced_artifacts(capsys):
+    emit_guard_payload(
+        "run",
+        {
+            "harness": "codex",
+            "blocked": True,
+            "dry_run": True,
+            "launched": False,
+            "receipts_recorded": 2,
+            "artifacts": [
+                {
+                    "artifact_id": "codex:project:chrome-devtools:new",
+                    "artifact_name": "chrome-devtools",
+                    "changed": True,
+                    "changed_fields": ["first_seen"],
+                    "policy_action": "require-reapproval",
+                    "artifact_label": "MCP server",
+                    "why_now": "It is new in this codex workspace, so Guard paused it for review.",
+                    "risk_summary": "Connects to a remote server.",
+                },
+                {
+                    "artifact_id": "codex:project:chrome-devtools:old",
+                    "artifact_name": "chrome-devtools",
+                    "changed": True,
+                    "changed_fields": ["removed"],
+                    "policy_action": "require-reapproval",
+                    "artifact_label": "MCP server",
+                    "why_now": (
+                        "It disappeared from the harness config, so Guard paused the change until you "
+                        "confirm the removal."
+                    ),
+                },
+            ],
+        },
+        False,
+    )
+    output = capsys.readouterr().out
+
+    assert "chrome-devtools" in output
+    assert output.lower().count("chrome-devtools") == 1
+    assert "definition" in output.lower()
+    assert "replaced" in output.lower()
+    assert "first_seen" not in output
+    assert "removed" not in output
+
+
+def test_guard_run_renderer_keeps_same_named_artifacts_separate_across_configs(capsys):
+    emit_guard_payload(
+        "run",
+        {
+            "harness": "codex",
+            "blocked": True,
+            "dry_run": True,
+            "launched": False,
+            "receipts_recorded": 2,
+            "artifacts": [
+                {
+                    "artifact_id": "codex:project:chrome-devtools:new",
+                    "artifact_name": "chrome-devtools",
+                    "changed": True,
+                    "changed_fields": ["first_seen"],
+                    "policy_action": "require-reapproval",
+                    "artifact_label": "MCP server",
+                    "source_scope": "project",
+                    "config_path": "/workspace/.codex/config.toml",
+                    "why_now": "It is new in this codex workspace, so Guard paused it for review.",
+                },
+                {
+                    "artifact_id": "codex:global:chrome-devtools:old",
+                    "artifact_name": "chrome-devtools",
+                    "changed": True,
+                    "changed_fields": ["removed"],
+                    "policy_action": "require-reapproval",
+                    "artifact_label": "MCP server",
+                    "source_scope": "global",
+                    "config_path": "/home/.codex/config.toml",
+                    "why_now": (
+                        "It disappeared from the global harness config, so Guard paused the change until "
+                        "you confirm the removal."
+                    ),
+                },
+            ],
+        },
+        False,
+    )
+    output = capsys.readouterr().out
+
+    assert "chrome-devtools" in output
+    assert output.lower().count("chrome-devtools") == 2
+    assert "definition replaced" not in output.lower()
+
+
+def test_guard_run_renderer_filters_unchanged_artifacts_and_counts_review_items(capsys):
+    emit_guard_payload(
+        "run",
+        {
+            "harness": "codex",
+            "blocked": True,
+            "dry_run": True,
+            "launched": False,
+            "receipts_recorded": 3,
+            "artifacts": [
+                {
+                    "artifact_id": "codex:project:stable-tool",
+                    "artifact_name": "stable-tool",
+                    "changed": False,
+                    "changed_fields": [],
+                    "policy_action": "allow",
+                    "why_now": "Guard matched an existing allow rule for this exact version.",
+                },
+                {
+                    "artifact_id": "codex:project:already-approved",
+                    "artifact_name": "already-approved",
+                    "changed": True,
+                    "changed_fields": ["command"],
+                    "policy_action": "allow",
+                    "why_now": "Guard matched an existing allow rule for this exact definition.",
+                },
+                {
+                    "artifact_id": "codex:project:review-tool",
+                    "artifact_name": "review-tool",
+                    "changed": True,
+                    "changed_fields": ["first_seen"],
+                    "policy_action": "require-reapproval",
+                    "why_now": "It is new in this codex workspace, so Guard paused it for review.",
+                },
+            ],
+        },
+        False,
+    )
+    output = capsys.readouterr().out
+
+    assert "stable-tool" not in output
+    assert "already-approved" in output
+    assert "review-tool" in output
+    assert "Needs review 1" in output
+
+
+def test_guard_run_renderer_keeps_unchanged_blockers_visible(capsys):
+    emit_guard_payload(
+        "run",
+        {
+            "harness": "codex",
+            "blocked": True,
+            "dry_run": True,
+            "launched": False,
+            "receipts_recorded": 1,
+            "artifacts": [
+                {
+                    "artifact_id": "codex:project:blocked-tool",
+                    "artifact_name": "blocked-tool",
+                    "changed": False,
+                    "changed_fields": [],
+                    "policy_action": "require-reapproval",
+                    "why_now": "Guard blocked this definition because the configured policy does not trust it yet.",
+                }
+            ],
+        },
+        False,
+    )
+    output = capsys.readouterr().out
+
+    assert "blocked-tool" in output
+    assert "Needs review 1" in output
+
+
+def test_guard_run_renderer_counts_each_visible_blocker_even_when_rows_coalesce(capsys):
+    emit_guard_payload(
+        "run",
+        {
+            "harness": "codex",
+            "blocked": True,
+            "dry_run": True,
+            "launched": False,
+            "receipts_recorded": 2,
+            "artifacts": [
+                {
+                    "artifact_id": "codex:project:chrome-devtools:new",
+                    "artifact_name": "chrome-devtools",
+                    "changed": True,
+                    "changed_fields": ["first_seen"],
+                    "policy_action": "require-reapproval",
+                    "why_now": "It is new in this codex workspace, so Guard paused it for review.",
+                },
+                {
+                    "artifact_id": "codex:project:chrome-devtools:old",
+                    "artifact_name": "chrome-devtools",
+                    "changed": True,
+                    "changed_fields": ["removed"],
+                    "policy_action": "require-reapproval",
+                    "why_now": (
+                        "It disappeared from the harness config, so Guard paused the change until you confirm it."
+                    ),
+                },
+            ],
+        },
+        False,
+    )
+    output = capsys.readouterr().out
+
+    assert "Needs review 2" in output
+    assert output.lower().count("chrome-devtools") == 1
+
+
+def test_guard_run_renderer_leads_blocked_dry_runs_with_full_review_path(capsys):
+    emit_guard_payload(
+        "run",
+        {
+            "harness": "codex",
+            "blocked": True,
+            "dry_run": True,
+            "launched": False,
+            "receipts_recorded": 1,
+            "artifacts": [
+                {
+                    "artifact_id": "codex:project:blocked-tool",
+                    "artifact_name": "blocked-tool",
+                    "changed": False,
+                    "changed_fields": [],
+                    "policy_action": "require-reapproval",
+                    "why_now": "Guard blocked this definition because the configured policy does not trust it yet.",
+                }
+            ],
+        },
+        False,
+    )
+    output = capsys.readouterr().out
+
+    assert "Resolve the blocked launch" in output
+    assert "hol-guard run codex" in output
+    assert "Inspect only the changed config entries (optional)" in output
+    assert "hol-guard diff codex" in output
+
+
+def test_guard_run_renderer_counts_only_blocking_actions_as_needing_review(capsys):
+    emit_guard_payload(
+        "run",
+        {
+            "harness": "codex",
+            "blocked": True,
+            "dry_run": True,
+            "launched": False,
+            "receipts_recorded": 2,
+            "artifacts": [
+                {
+                    "artifact_id": "codex:project:warn-only-tool",
+                    "artifact_name": "warn-only-tool",
+                    "changed": True,
+                    "changed_fields": ["command"],
+                    "policy_action": "warn",
+                    "why_now": "Guard wants to highlight this change, but it does not block launch.",
+                },
+                {
+                    "artifact_id": "codex:project:blocked-tool",
+                    "artifact_name": "blocked-tool",
+                    "changed": True,
+                    "changed_fields": ["first_seen"],
+                    "policy_action": "require-reapproval",
+                    "why_now": "Guard blocked this definition because the configured policy does not trust it yet.",
+                },
+            ],
+        },
+        False,
+    )
+    output = capsys.readouterr().out
+
+    assert "warn-only-tool" in output
+    assert "blocked-tool" in output
+    assert "Needs review 1" in output
+
+
+def test_guard_run_renderer_uses_neutral_blocked_copy_for_policy_only_blockers(capsys):
+    emit_guard_payload(
+        "run",
+        {
+            "harness": "codex",
+            "blocked": True,
+            "dry_run": True,
+            "launched": False,
+            "receipts_recorded": 1,
+            "artifacts": [
+                {
+                    "artifact_id": "codex:project:blocked-tool",
+                    "artifact_name": "blocked-tool",
+                    "changed": False,
+                    "changed_fields": [],
+                    "policy_action": "require-reapproval",
+                    "why_now": "Guard blocked this definition because the configured policy does not trust it yet.",
+                }
+            ],
+        },
+        False,
+    )
+    output = capsys.readouterr().out
+
+    assert "Guard found changes that need review before a real launch." not in output
+    assert "Guard found artifacts that need review before a real launch." in output
+
+
+def test_guard_run_renderer_prefers_context_preserving_rerun_command():
+    steps = guard_render_module._build_run_steps(
+        {
+            "harness": "codex",
+            "blocked": True,
+            "dry_run": True,
+            "rerun_command": (
+                "hol-guard run codex --home /guard-home --workspace /workspace "
+                "--default-action warn --arg '--model gpt-5'"
+            ),
+        },
+        blocked=True,
+        dry_run=True,
+    )
+
+    assert steps[0]["command"] == (
+        "hol-guard run codex --home /guard-home --workspace /workspace --default-action warn --arg '--model gpt-5'"
+    )
+
+
+def test_guard_rerun_command_preserves_run_context():
+    command = guard_commands_module._guard_rerun_command(
+        argparse.Namespace(
+            harness="codex",
+            home="/guard-home",
+            guard_home=None,
+            workspace="/workspace",
+            default_action="warn",
+            passthrough_args=["--model gpt-5"],
+        )
+    )
+
+    assert command == (
+        "hol-guard run codex --home /guard-home --workspace /workspace --default-action warn --arg '--model gpt-5'"
+    )
+
+
+def test_guard_rerun_command_uses_windows_safe_quoting(monkeypatch):
+    monkeypatch.setattr(guard_commands_module.sys, "platform", "win32")
+    command = guard_commands_module._guard_rerun_command(
+        argparse.Namespace(
+            harness="codex",
+            home=r"C:\Guard Home",
+            guard_home=None,
+            workspace=r"C:\Workspace Root",
+            default_action="warn",
+            passthrough_args=["--model gpt-5"],
+        )
+    )
+
+    expected = subprocess.list2cmdline(
+        [
+            "hol-guard",
+            "run",
+            "codex",
+            "--home",
+            r"C:\Guard Home",
+            "--workspace",
+            r"C:\Workspace Root",
+            "--default-action",
+            "warn",
+            "--arg",
+            "--model gpt-5",
+        ]
+    )
+
+    assert command == expected
+
+
+def test_guard_diff_command_preserves_common_context():
+    command = guard_commands_module._guard_diff_command(
+        argparse.Namespace(
+            harness="codex",
+            home="/guard-home",
+            guard_home=None,
+            workspace="/workspace",
+        )
+    )
+
+    assert command == "hol-guard diff codex --home /guard-home --workspace /workspace"
+
+
+def test_guard_run_renderer_uses_context_preserving_diff_command():
+    steps = guard_render_module._build_run_steps(
+        {
+            "harness": "codex",
+            "blocked": True,
+            "dry_run": True,
+            "diff_command": "hol-guard diff codex --home /guard-home --workspace /workspace",
+        },
+        blocked=True,
+        dry_run=True,
+    )
+
+    assert steps[1]["command"] == "hol-guard diff codex --home /guard-home --workspace /workspace"
+
+
+def test_guard_run_renderer_uses_context_preserving_launch_command_for_clean_dry_runs():
+    steps = guard_render_module._build_run_steps(
+        {
+            "harness": "codex",
+            "dry_run": True,
+            "rerun_command": (
+                "hol-guard run codex --home /guard-home --workspace /workspace "
+                "--default-action warn --arg '--model gpt-5'"
+            ),
+        },
+        blocked=False,
+        dry_run=True,
+    )
+
+    assert steps[0]["command"] == (
+        "hol-guard run codex --home /guard-home --workspace /workspace --default-action warn --arg '--model gpt-5'"
+    )
+
+
+def test_guard_approvals_command_preserves_common_context():
+    command = guard_commands_module._guard_approvals_command(
+        argparse.Namespace(
+            harness="codex",
+            home="/guard-home",
+            guard_home="/guard-db",
+            workspace="/workspace",
+        )
+    )
+
+    assert command == "hol-guard approvals --home /guard-home --guard-home /guard-db --workspace /workspace"
+
+
+def test_guard_run_renderer_uses_context_preserving_approvals_command_for_blocked_launches():
+    steps = guard_render_module._build_run_steps(
+        {
+            "harness": "codex",
+            "approval_center_url": "http://127.0.0.1:4455",
+            "approvals_command": "hol-guard approvals --home /guard-home --workspace /workspace",
+            "review_hint": "Open the approval center and resolve the pending request.",
+        },
+        blocked=True,
+        dry_run=False,
+    )
+
+    assert steps[0]["command"] == "hol-guard approvals --home /guard-home --workspace /workspace"
+
+
+def test_guard_run_headless_allow_persists_state_when_approval_center_is_available(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *args, **kwargs: type("CompletedProcess", (), {"returncode": 0})(),
+    )
+
+    rc = main(
+        [
+            "guard",
+            "run",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--default-action",
+            "allow",
+        ]
+    )
+    output = capsys.readouterr().out
+    store = GuardStore(home_dir)
+    receipts = store.list_receipts(limit=10)
+    snapshots = store.list_snapshots("codex")
+
+    assert rc == 0
+    assert "Launch allowed" in output
+    assert len(receipts) == 2
+    assert {
+        "codex:global:global_tools",
+        "codex:project:workspace_skill",
+    } <= set(snapshots)
+
+
+def test_guard_run_headless_waits_for_local_approval_and_resumes(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 2\n")
+
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *args, **kwargs: type("CompletedProcess", (), {"returncode": 0})(),
+    )
+
+    def resolve_pending() -> None:
+        for _ in range(40):
+            pending = store.list_approval_requests(limit=10)
+            if pending:
+                for request in pending:
                     apply_approval_resolution(
                         store=store,
-                        request_id=str(pending[0]["request_id"]),
+                        request_id=str(request["request_id"]),
                         action="allow",
                         scope="artifact",
                         workspace=None,
                         reason="approved from test",
                     )
+                if not store.list_approval_requests(limit=10):
                     return
-                threading.Event().wait(0.05)
+            threading.Event().wait(0.05)
 
-        worker = threading.Thread(target=resolve_pending, daemon=True)
-        worker.start()
+    worker = threading.Thread(target=resolve_pending, daemon=True)
+    worker.start()
 
-        config = GuardConfig(guard_home=home_dir, workspace=workspace_dir, approval_wait_timeout_seconds=1)
-        blocked_resolver = guard_commands_module._headless_approval_resolver(
-            args=argparse.Namespace(harness="claude-code"),
-            context=HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir),
-            store=store,
-            config=config,
-        )
-        result = guard_runner_module.guard_run(
+    rc = main(
+        [
+            "guard",
+            "run",
             "claude-code",
-            HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir),
-            store,
-            config,
-            dry_run=False,
-            passthrough_args=[],
-            default_action=None,
-            interactive_resolver=None,
-            blocked_resolver=blocked_resolver,
-        )
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+        ]
+    )
+    output = capsys.readouterr().out
 
-        assert result["blocked"] is True
-        assert result["artifacts"][0]["changed_fields"] == ["args"]
-        assert result["artifacts"][0]["artifact_hash"] == artifact_hash(detections[-1].artifacts[0])
-        assert call_count["detect"] >= 2
+    assert rc == 0
+    assert "Launch allowed" in output
+    assert "Approval received" in output
 
-    def test_guard_headless_blocked_run_persists_receipts_and_diffs(self, tmp_path, monkeypatch):
-        home_dir = tmp_path / "home"
-        workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
-        store = GuardStore(home_dir)
-        baseline = GuardArtifact(
-            artifact_id="claude-code:project:workspace-tools",
-            name="workspace-tools",
-            harness="claude-code",
-            artifact_type="mcp_server",
-            source_scope="project",
-            config_path=str(workspace_dir / ".mcp.json"),
-            command="python",
-            args=("-m", "http.server", "9100"),
-            transport="stdio",
-        )
-        baseline_hash = artifact_hash(baseline)
-        store.save_snapshot(
-            "claude-code",
-            baseline.artifact_id,
-            {**baseline.to_dict(), "artifact_hash": baseline_hash},
-            baseline_hash,
-            "2026-04-10T00:00:00+00:00",
-        )
-        changed = GuardArtifact(
-            artifact_id=baseline.artifact_id,
-            name=baseline.name,
-            harness=baseline.harness,
-            artifact_type=baseline.artifact_type,
-            source_scope=baseline.source_scope,
-            config_path=baseline.config_path,
-            command="python",
-            args=("-m", "http.server", "9100", "--changed"),
-            transport="stdio",
-        )
-        detection = HarnessDetection(
+
+def test_guard_run_headless_redetects_before_persisted_resume(tmp_path, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 1\n")
+
+    store = GuardStore(home_dir)
+    baseline = GuardArtifact(
+        artifact_id="claude-code:project:workspace-tools",
+        name="workspace-tools",
+        harness="claude-code",
+        artifact_type="mcp_server",
+        source_scope="project",
+        config_path=str(workspace_dir / ".mcp.json"),
+        command="python",
+        args=("-m", "http.server", "9100"),
+        transport="stdio",
+    )
+    baseline_hash = artifact_hash(baseline)
+    store.save_snapshot(
+        "claude-code",
+        baseline.artifact_id,
+        {**baseline.to_dict(), "artifact_hash": baseline_hash},
+        baseline_hash,
+        "2026-04-10T00:00:00+00:00",
+    )
+    detections = [
+        HarnessDetection(
             harness="claude-code",
             installed=True,
             command_available=True,
-            config_paths=(baseline.config_path,),
-            artifacts=(changed,),
-        )
-
-        monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
-
-        config = GuardConfig(guard_home=home_dir, workspace=workspace_dir, approval_wait_timeout_seconds=1)
-        result = guard_runner_module.guard_run(
-            "claude-code",
-            HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir),
-            store,
-            config,
-            dry_run=False,
-            passthrough_args=[],
-            default_action=None,
-            interactive_resolver=None,
-            blocked_resolver=lambda _detection, evaluation: evaluation,
-        )
-
-        latest_diff = store.get_latest_diff("claude-code", baseline.artifact_id)
-        latest_receipt = store.get_latest_receipt("claude-code", baseline.artifact_id)
-
-        assert result["blocked"] is True
-        assert latest_diff is not None
-        assert latest_diff["current_hash"] == artifact_hash(changed)
-        assert latest_receipt is not None
-        assert latest_receipt["policy_decision"] == "require-reapproval"
-
-    def test_guard_invalid_changed_hash_action_falls_back_to_reapproval(self, tmp_path):
-        store = GuardStore(tmp_path / "guard-home")
-        baseline = GuardArtifact(
-            artifact_id="codex:project:workspace-tools",
-            name="workspace-tools",
-            harness="codex",
-            artifact_type="mcp_server",
-            source_scope="project",
-            config_path=str(tmp_path / "workspace" / ".codex" / "config.toml"),
-            command="node",
-            args=("workspace.js",),
-            transport="stdio",
-        )
-        changed = GuardArtifact(
-            artifact_id=baseline.artifact_id,
-            name=baseline.name,
-            harness=baseline.harness,
-            artifact_type=baseline.artifact_type,
-            source_scope=baseline.source_scope,
-            config_path=baseline.config_path,
-            command="node",
-            args=("workspace.js", "--changed"),
-            transport="stdio",
-        )
-        baseline_hash = artifact_hash(baseline)
-        store.save_snapshot(
-            "codex",
-            baseline.artifact_id,
-            {**baseline.to_dict(), "artifact_hash": baseline_hash},
-            baseline_hash,
-            "2026-04-10T00:00:00+00:00",
-        )
-        detection = HarnessDetection(
-            harness="codex",
+            config_paths=(str(workspace_dir / ".mcp.json"),),
+            artifacts=(
+                GuardArtifact(
+                    artifact_id=baseline.artifact_id,
+                    name="workspace-tools",
+                    harness="claude-code",
+                    artifact_type="mcp_server",
+                    source_scope="project",
+                    config_path=str(workspace_dir / ".mcp.json"),
+                    command="python",
+                    args=("-m", "http.server", "9100", "--changed-1"),
+                    transport="stdio",
+                ),
+            ),
+        ),
+        HarnessDetection(
+            harness="claude-code",
             installed=True,
             command_available=True,
-            config_paths=(baseline.config_path,),
-            artifacts=(changed,),
-        )
-        config = GuardConfig(
-            guard_home=tmp_path / "guard-home",
-            workspace=None,
-            changed_hash_action="require_reapproval",  # type: ignore[arg-type]
-        )
-
-        evaluation = evaluate_detection(detection, store, config, default_action="allow", persist=False)
-
-        assert evaluation["blocked"] is True
-        assert evaluation["artifacts"][0]["policy_action"] == "require-reapproval"
-
-    def test_guard_invalid_default_action_falls_back_to_reapproval(self, tmp_path):
-        config = GuardConfig(
-            guard_home=tmp_path / "guard-home",
-            workspace=None,
-            default_action="blok",  # type: ignore[arg-type]
-        )
-
-        action = decide_action(configured_action=None, default_action=None, config=config, changed=False)
-
-        assert action == "require-reapproval"
-
-    def test_guard_hook_invalid_policy_action_falls_back_to_reapproval(self, tmp_path, capsys, monkeypatch):
-        home_dir = tmp_path / "home"
-        workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
-
-        event = {
-            "event": "PreToolUse",
-            "tool_name": "workspace-tools",
-            "artifact_id": "claude-code:project:workspace-tools",
-            "policy_action": "require_reapproval",
-            "source_scope": "project",
-        }
-        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
-
-        rc = main(
-            [
-                "guard",
-                "hook",
-                "--home",
-                str(home_dir),
-                "--workspace",
-                str(workspace_dir),
-                "--harness",
-                "claude-code",
-                "--json",
-            ]
-        )
-        output = json.loads(capsys.readouterr().out)
-
-        assert rc == 1
-        assert output["policy_action"] == "require-reapproval"
-
-    def test_guard_hook_blocks_sensitive_runtime_file_read_until_exactly_approved(self, tmp_path, capsys, monkeypatch):
-        home_dir = tmp_path / "home"
-        workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
-        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
-
-        blocked_event = {
-            "event": "PreToolUse",
-            "tool_name": "Read",
-            "tool_input": {"file_path": ".env.local"},
-            "source_scope": "project",
-        }
-        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(blocked_event)))
-
-        first_rc = main(
-            [
-                "guard",
-                "hook",
-                "--home",
-                str(home_dir),
-                "--workspace",
-                str(workspace_dir),
-                "--harness",
-                "claude-code",
-                "--json",
-            ]
-        )
-        first_output = json.loads(capsys.readouterr().out)
-        approval_request = first_output["approval_requests"][0]
-
-        approval_rc = main(
-            [
-                "guard",
-                "approvals",
-                "approve",
-                str(approval_request["request_id"]),
-                "--home",
-                str(home_dir),
-                "--workspace",
-                str(workspace_dir),
-                "--json",
-            ]
-        )
-        json.loads(capsys.readouterr().out)
-
-        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(blocked_event)))
-        second_rc = main(
-            [
-                "guard",
-                "hook",
-                "--home",
-                str(home_dir),
-                "--workspace",
-                str(workspace_dir),
-                "--harness",
-                "claude-code",
-                "--json",
-            ]
-        )
-        second_output = json.loads(capsys.readouterr().out)
-
-        different_event = {
-            "event": "PreToolUse",
-            "tool_name": "Read",
-            "tool_input": {"file_path": "~/.aws/credentials"},
-            "source_scope": "project",
-        }
-        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(different_event)))
-        third_rc = main(
-            [
-                "guard",
-                "hook",
-                "--home",
-                str(home_dir),
-                "--workspace",
-                str(workspace_dir),
-                "--harness",
-                "claude-code",
-                "--json",
-            ]
-        )
-        third_output = json.loads(capsys.readouterr().out)
-
-        assert first_rc == 1
-        assert first_output["policy_action"] == "require-reapproval"
-        assert first_output["artifact_type"] == "file_read_request"
-        assert "sensitive local file" in first_output["risk_summary"].lower()
-        assert approval_request["recommended_scope"] == "artifact"
-        assert approval_rc == 0
-        assert second_rc == 0
-        assert second_output["policy_action"] == "allow"
-        assert third_rc == 1
-        assert third_output["policy_action"] == "require-reapproval"
-
-    def test_guard_hook_allows_non_sensitive_read_file_requests(self, tmp_path, capsys, monkeypatch):
-        home_dir = tmp_path / "home"
-        workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
-
-        safe_event = {
-            "event": "PreToolUse",
-            "tool_name": "Read",
-            "tool_input": {"file_path": "README.md"},
-            "source_scope": "project",
-        }
-        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(safe_event)))
-
-        rc = main(
-            [
-                "guard",
-                "hook",
-                "--home",
-                str(home_dir),
-                "--workspace",
-                str(workspace_dir),
-                "--harness",
-                "claude-code",
-                "--json",
-            ]
-        )
-        output = json.loads(capsys.readouterr().out)
-
-        assert rc == 0
-        assert output["policy_action"] in {"allow", "warn"}
-        assert output.get("approval_requests") in (None, [])
-
-    def test_stdio_proxy_blocks_disallowed_tools_and_redacts_headers(self):
-        proxy = StdioGuardProxy(
-            command=[
-                sys.executable,
-                "-u",
-                "-c",
-                "\n".join(
-                    [
-                        "import json, sys",
-                        "for line in sys.stdin:",
-                        "    message = json.loads(line)",
-                        "    result = {'echo': message.get('method')}",
-                        "    if message.get('method') == 'tools/call':",
-                        "        result['tool'] = message.get('params', {}).get('name')",
-                        "    print(json.dumps({'jsonrpc': '2.0', 'id': message.get('id'), 'result': result}))",
-                        "    sys.stdout.flush()",
-                    ]
+            config_paths=(str(workspace_dir / ".mcp.json"),),
+            artifacts=(
+                GuardArtifact(
+                    artifact_id=baseline.artifact_id,
+                    name="workspace-tools",
+                    harness="claude-code",
+                    artifact_type="mcp_server",
+                    source_scope="project",
+                    config_path=str(workspace_dir / ".mcp.json"),
+                    command="python",
+                    args=("-m", "http.server", "9100", "--changed-2"),
+                    transport="stdio",
                 ),
-            ],
-            blocked_tools={"dangerous"},
-        )
+            ),
+        ),
+    ]
+    call_count = {"detect": 0}
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(
+        guard_runner_module.subprocess,
+        "run",
+        lambda *args, **kwargs: type("CompletedProcess", (), {"returncode": 0})(),
+    )
 
-        allowed = proxy.run_session(
-            [
-                {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
-                {
-                    "jsonrpc": "2.0",
-                    "id": 2,
-                    "method": "tools/call",
-                    "params": {
-                        "name": "safe-tool",
-                        "arguments": {
-                            "headers": {
-                                "Authorization": "Bearer secret-token",
-                                "x-api-key": "hidden",
-                            }
-                        },
-                    },
-                },
-            ]
-        )
-        blocked = proxy.run_session(
-            [
-                {
-                    "jsonrpc": "2.0",
-                    "id": 3,
-                    "method": "tools/call",
-                    "params": {"name": "dangerous"},
-                }
-            ]
-        )
+    def fake_detect(harness: str, context):
+        call_count["detect"] += 1
+        index = min(call_count["detect"] - 1, len(detections) - 1)
+        return detections[index]
 
-        assert allowed["responses"][1]["result"]["tool"] == "safe-tool"
-        assert allowed["events"][1]["redacted_params"]["arguments"]["headers"]["Authorization"] == "*****"
-        assert blocked["responses"][0]["error"]["code"] == -32001
-        assert blocked["events"][0]["decision"] == "block"
+    monkeypatch.setattr(guard_runner_module, "detect_harness", fake_detect)
 
-    def test_stdio_proxy_waits_for_matching_response_id(self):
-        proxy = StdioGuardProxy(
-            command=[
-                sys.executable,
-                "-u",
-                "-c",
-                "\n".join(
-                    [
-                        "import json, sys",
-                        "for line in sys.stdin:",
-                        "    message = json.loads(line)",
-                        "    print(json.dumps({'jsonrpc': '2.0', 'method': 'tools/progress', 'params': {'step': 1}}))",
-                        "    result = {'echo': message.get('method')}",
-                        "    print(json.dumps({'jsonrpc': '2.0', 'id': message.get('id'), 'result': result}))",
-                        "    sys.stdout.flush()",
-                    ]
-                ),
-            ],
-        )
+    def resolve_pending() -> None:
+        for _ in range(40):
+            pending = store.list_approval_requests(limit=10)
+            if pending:
+                apply_approval_resolution(
+                    store=store,
+                    request_id=str(pending[0]["request_id"]),
+                    action="allow",
+                    scope="artifact",
+                    workspace=None,
+                    reason="approved from test",
+                )
+                return
+            threading.Event().wait(0.05)
 
-        result = proxy.run_session(
-            [
-                {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
-            ]
-        )
+    worker = threading.Thread(target=resolve_pending, daemon=True)
+    worker.start()
 
-        assert result["responses"][0]["id"] == 1
-        assert result["responses"][0]["result"]["echo"] == "initialize"
+    config = GuardConfig(guard_home=home_dir, workspace=workspace_dir, approval_wait_timeout_seconds=1)
+    blocked_resolver = guard_commands_module._headless_approval_resolver(
+        args=argparse.Namespace(harness="claude-code"),
+        context=HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir),
+        store=store,
+        config=config,
+    )
+    result = guard_runner_module.guard_run(
+        "claude-code",
+        HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir),
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=[],
+        default_action=None,
+        interactive_resolver=None,
+        blocked_resolver=blocked_resolver,
+    )
 
-    def test_stdio_proxy_stream_does_not_wait_for_notification_replies(self):
-        proxy = StdioGuardProxy(
-            command=[
-                sys.executable,
-                "-u",
-                "-c",
-                "\n".join(
-                    [
-                        "import json, sys",
-                        "for line in sys.stdin:",
-                        "    message = json.loads(line)",
-                        "    if message.get('id') is None:",
-                        "        continue",
-                        "    print(json.dumps({'jsonrpc': '2.0', 'id': message.get('id'), 'result': {'ok': True}}))",
-                        "    sys.stdout.flush()",
-                    ]
-                ),
-            ],
-        )
-        output_stream = _FlushTrackingOutput()
+    assert result["blocked"] is True
+    assert result["artifacts"][0]["changed_fields"] == ["args"]
+    assert result["artifacts"][0]["artifact_hash"] == artifact_hash(detections[-1].artifacts[0])
+    assert call_count["detect"] >= 2
 
-        exit_code = proxy.run_stream(
-            input_stream=_LineOnlyInput(
+
+def test_guard_headless_blocked_run_persists_receipts_and_diffs(tmp_path, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    store = GuardStore(home_dir)
+    baseline = GuardArtifact(
+        artifact_id="claude-code:project:workspace-tools",
+        name="workspace-tools",
+        harness="claude-code",
+        artifact_type="mcp_server",
+        source_scope="project",
+        config_path=str(workspace_dir / ".mcp.json"),
+        command="python",
+        args=("-m", "http.server", "9100"),
+        transport="stdio",
+    )
+    baseline_hash = artifact_hash(baseline)
+    store.save_snapshot(
+        "claude-code",
+        baseline.artifact_id,
+        {**baseline.to_dict(), "artifact_hash": baseline_hash},
+        baseline_hash,
+        "2026-04-10T00:00:00+00:00",
+    )
+    changed = GuardArtifact(
+        artifact_id=baseline.artifact_id,
+        name=baseline.name,
+        harness=baseline.harness,
+        artifact_type=baseline.artifact_type,
+        source_scope=baseline.source_scope,
+        config_path=baseline.config_path,
+        command="python",
+        args=("-m", "http.server", "9100", "--changed"),
+        transport="stdio",
+    )
+    detection = HarnessDetection(
+        harness="claude-code",
+        installed=True,
+        command_available=True,
+        config_paths=(baseline.config_path,),
+        artifacts=(changed,),
+    )
+
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+
+    config = GuardConfig(guard_home=home_dir, workspace=workspace_dir, approval_wait_timeout_seconds=1)
+    result = guard_runner_module.guard_run(
+        "claude-code",
+        HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir),
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=[],
+        default_action=None,
+        interactive_resolver=None,
+        blocked_resolver=lambda _detection, evaluation: evaluation,
+    )
+
+    latest_diff = store.get_latest_diff("claude-code", baseline.artifact_id)
+    latest_receipt = store.get_latest_receipt("claude-code", baseline.artifact_id)
+
+    assert result["blocked"] is True
+    assert latest_diff is not None
+    assert latest_diff["current_hash"] == artifact_hash(changed)
+    assert latest_receipt is not None
+    assert latest_receipt["policy_decision"] == "require-reapproval"
+
+
+def test_guard_invalid_changed_hash_action_falls_back_to_reapproval(tmp_path):
+    store = GuardStore(tmp_path / "guard-home")
+    baseline = GuardArtifact(
+        artifact_id="codex:project:workspace-tools",
+        name="workspace-tools",
+        harness="codex",
+        artifact_type="mcp_server",
+        source_scope="project",
+        config_path=str(tmp_path / "workspace" / ".codex" / "config.toml"),
+        command="node",
+        args=("workspace.js",),
+        transport="stdio",
+    )
+    changed = GuardArtifact(
+        artifact_id=baseline.artifact_id,
+        name=baseline.name,
+        harness=baseline.harness,
+        artifact_type=baseline.artifact_type,
+        source_scope=baseline.source_scope,
+        config_path=baseline.config_path,
+        command="node",
+        args=("workspace.js", "--changed"),
+        transport="stdio",
+    )
+    baseline_hash = artifact_hash(baseline)
+    store.save_snapshot(
+        "codex",
+        baseline.artifact_id,
+        {**baseline.to_dict(), "artifact_hash": baseline_hash},
+        baseline_hash,
+        "2026-04-10T00:00:00+00:00",
+    )
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(baseline.config_path,),
+        artifacts=(changed,),
+    )
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=None,
+        changed_hash_action="require_reapproval",  # type: ignore[arg-type]
+    )
+
+    evaluation = evaluate_detection(detection, store, config, default_action="allow", persist=False)
+
+    assert evaluation["blocked"] is True
+    assert evaluation["artifacts"][0]["policy_action"] == "require-reapproval"
+
+
+def test_guard_invalid_default_action_falls_back_to_reapproval(tmp_path):
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=None,
+        default_action="blok",  # type: ignore[arg-type]
+    )
+
+    action = decide_action(configured_action=None, default_action=None, config=config, changed=False)
+
+    assert action == "require-reapproval"
+
+
+def test_guard_hook_invalid_policy_action_falls_back_to_reapproval(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+
+    event = {
+        "event": "PreToolUse",
+        "tool_name": "workspace-tools",
+        "artifact_id": "claude-code:project:workspace-tools",
+        "policy_action": "require_reapproval",
+        "source_scope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "claude-code",
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert output["policy_action"] == "require-reapproval"
+
+
+def test_guard_hook_blocks_sensitive_runtime_file_read_until_exactly_approved(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    blocked_event = {
+        "event": "PreToolUse",
+        "tool_name": "Read",
+        "tool_input": {"file_path": ".env.local"},
+        "source_scope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(blocked_event)))
+
+    first_rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "claude-code",
+            "--json",
+        ]
+    )
+    first_output = json.loads(capsys.readouterr().out)
+    approval_request = first_output["approval_requests"][0]
+
+    approval_rc = main(
+        [
+            "guard",
+            "approvals",
+            "approve",
+            str(approval_request["request_id"]),
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(blocked_event)))
+    second_rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "claude-code",
+            "--json",
+        ]
+    )
+    second_output = json.loads(capsys.readouterr().out)
+
+    different_event = {
+        "event": "PreToolUse",
+        "tool_name": "Read",
+        "tool_input": {"file_path": "~/.aws/credentials"},
+        "source_scope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(different_event)))
+    third_rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "claude-code",
+            "--json",
+        ]
+    )
+    third_output = json.loads(capsys.readouterr().out)
+
+    assert first_rc == 1
+    assert first_output["policy_action"] == "require-reapproval"
+    assert first_output["artifact_type"] == "file_read_request"
+    assert "sensitive local file" in first_output["risk_summary"].lower()
+    assert approval_request["recommended_scope"] == "artifact"
+    assert approval_rc == 0
+    assert second_rc == 0
+    assert second_output["policy_action"] == "allow"
+    assert third_rc == 1
+    assert third_output["policy_action"] == "require-reapproval"
+
+
+def test_guard_hook_allows_non_sensitive_read_file_requests(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+
+    safe_event = {
+        "event": "PreToolUse",
+        "tool_name": "Read",
+        "tool_input": {"file_path": "README.md"},
+        "source_scope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(safe_event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "claude-code",
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["policy_action"] in {"allow", "warn"}
+    assert output.get("approval_requests") in (None, [])
+
+
+def test_stdio_proxy_blocks_disallowed_tools_and_redacts_headers():
+    proxy = StdioGuardProxy(
+        command=[
+            sys.executable,
+            "-u",
+            "-c",
+            "\n".join(
                 [
-                    '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}\n',
-                    '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}\n',
+                    "import json, sys",
+                    "for line in sys.stdin:",
+                    "    message = json.loads(line)",
+                    "    result = {'echo': message.get('method')}",
+                    "    if message.get('method') == 'tools/call':",
+                    "        result['tool'] = message.get('params', {}).get('name')",
+                    "    print(json.dumps({'jsonrpc': '2.0', 'id': message.get('id'), 'result': result}))",
+                    "    sys.stdout.flush()",
                 ]
             ),
-            output_stream=output_stream,
-            error_stream=io.StringIO(),
-        )
+        ],
+        blocked_tools={"dangerous"},
+    )
 
-        assert exit_code == 0
-        assert '"id":1' in output_stream.getvalue()
-
-    def test_stdio_proxy_stream_forwards_interleaved_notifications(self):
-        proxy = StdioGuardProxy(
-            command=[
-                sys.executable,
-                "-u",
-                "-c",
-                "\n".join(
-                    [
-                        "import json, sys",
-                        "for line in sys.stdin:",
-                        "    message = json.loads(line)",
-                        "    print(json.dumps({'jsonrpc': '2.0', 'method': 'tools/progress', 'params': {'step': 1}}))",
-                        "    print(json.dumps({'jsonrpc': '2.0', 'id': message.get('id'), 'result': {'ok': True}}))",
-                        "    sys.stdout.flush()",
-                    ]
-                ),
-            ],
-        )
-        output_stream = _FlushTrackingOutput()
-
-        exit_code = proxy.run_stream(
-            input_stream=_LineOnlyInput(['{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}\n']),
-            output_stream=output_stream,
-            error_stream=io.StringIO(),
-        )
-        output_lines = [json.loads(line) for line in output_stream.getvalue().splitlines()]
-
-        assert exit_code == 0
-        assert output_lines[0]["method"] == "tools/progress"
-        assert output_lines[1]["id"] == 1
-
-    def test_stdio_proxy_blocks_sensitive_file_reads_without_forwarding(self, tmp_path):
-        store = GuardStore(tmp_path / "guard-home")
-        (tmp_path / "workspace").mkdir(parents=True, exist_ok=True)
-        config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=tmp_path / "workspace")
-        proxy = StdioGuardProxy(
-            command=[
-                sys.executable,
-                "-u",
-                "-c",
-                "\n".join(
-                    [
-                        "import json, sys",
-                        "for line in sys.stdin:",
-                        "    message = json.loads(line)",
-                        "    result = {'tool': message.get('params', {}).get('name')}",
-                        "    print(json.dumps({'jsonrpc': '2.0', 'id': message.get('id'), 'result': result}))",
-                        "    sys.stdout.flush()",
-                    ]
-                ),
-            ],
-            cwd=tmp_path / "workspace",
-            guard_store=store,
-            guard_config=config,
-            approval_center_url="http://127.0.0.1:4455",
-            harness="codex",
-        )
-
-        allowed = proxy.run_session(
-            [
-                {
-                    "jsonrpc": "2.0",
-                    "id": 1,
-                    "method": "tools/call",
-                    "params": {
-                        "name": "read_file",
-                        "arguments": {
-                            "path": "README.md",
-                            "headers": {"Authorization": "Bearer secret-token"},
-                        },
+    allowed = proxy.run_session(
+        [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "safe-tool",
+                    "arguments": {
+                        "headers": {
+                            "Authorization": "Bearer secret-token",
+                            "x-api-key": "hidden",
+                        }
                     },
-                }
-            ]
-        )
-        blocked = proxy.run_session(
+                },
+            },
+        ]
+    )
+    blocked = proxy.run_session(
+        [
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {"name": "dangerous"},
+            }
+        ]
+    )
+
+    assert allowed["responses"][1]["result"]["tool"] == "safe-tool"
+    assert allowed["events"][1]["redacted_params"]["arguments"]["headers"]["Authorization"] == "*****"
+    assert blocked["responses"][0]["error"]["code"] == -32001
+    assert blocked["events"][0]["decision"] == "block"
+
+
+def test_stdio_proxy_waits_for_matching_response_id():
+    proxy = StdioGuardProxy(
+        command=[
+            sys.executable,
+            "-u",
+            "-c",
+            "\n".join(
+                [
+                    "import json, sys",
+                    "for line in sys.stdin:",
+                    "    message = json.loads(line)",
+                    "    print(json.dumps({'jsonrpc': '2.0', 'method': 'tools/progress', 'params': {'step': 1}}))",
+                    "    result = {'echo': message.get('method')}",
+                    "    print(json.dumps({'jsonrpc': '2.0', 'id': message.get('id'), 'result': result}))",
+                    "    sys.stdout.flush()",
+                ]
+            ),
+        ],
+    )
+
+    result = proxy.run_session(
+        [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        ]
+    )
+
+    assert result["responses"][0]["id"] == 1
+    assert result["responses"][0]["result"]["echo"] == "initialize"
+
+
+def test_stdio_proxy_stream_does_not_wait_for_notification_replies():
+    proxy = StdioGuardProxy(
+        command=[
+            sys.executable,
+            "-u",
+            "-c",
+            "\n".join(
+                [
+                    "import json, sys",
+                    "for line in sys.stdin:",
+                    "    message = json.loads(line)",
+                    "    if message.get('id') is None:",
+                    "        continue",
+                    "    print(json.dumps({'jsonrpc': '2.0', 'id': message.get('id'), 'result': {'ok': True}}))",
+                    "    sys.stdout.flush()",
+                ]
+            ),
+        ],
+    )
+    output_stream = _FlushTrackingOutput()
+
+    exit_code = proxy.run_stream(
+        input_stream=_LineOnlyInput(
             [
-                {
-                    "jsonrpc": "2.0",
-                    "id": 2,
-                    "method": "tools/call",
-                    "params": {
-                        "name": "read_file",
-                        "arguments": {
-                            "path": ".env",
-                            "headers": {"Authorization": "Bearer secret-token"},
-                        },
+                '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}\n',
+                '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}\n',
+            ]
+        ),
+        output_stream=output_stream,
+        error_stream=io.StringIO(),
+    )
+
+    assert exit_code == 0
+    assert '"id":1' in output_stream.getvalue()
+
+
+def test_stdio_proxy_stream_forwards_interleaved_notifications():
+    proxy = StdioGuardProxy(
+        command=[
+            sys.executable,
+            "-u",
+            "-c",
+            "\n".join(
+                [
+                    "import json, sys",
+                    "for line in sys.stdin:",
+                    "    message = json.loads(line)",
+                    "    print(json.dumps({'jsonrpc': '2.0', 'method': 'tools/progress', 'params': {'step': 1}}))",
+                    "    print(json.dumps({'jsonrpc': '2.0', 'id': message.get('id'), 'result': {'ok': True}}))",
+                    "    sys.stdout.flush()",
+                ]
+            ),
+        ],
+    )
+    output_stream = _FlushTrackingOutput()
+
+    exit_code = proxy.run_stream(
+        input_stream=_LineOnlyInput(['{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}\n']),
+        output_stream=output_stream,
+        error_stream=io.StringIO(),
+    )
+    output_lines = [json.loads(line) for line in output_stream.getvalue().splitlines()]
+
+    assert exit_code == 0
+    assert output_lines[0]["method"] == "tools/progress"
+    assert output_lines[1]["id"] == 1
+
+
+def test_stdio_proxy_blocks_sensitive_file_reads_without_forwarding(tmp_path):
+    store = GuardStore(tmp_path / "guard-home")
+    (tmp_path / "workspace").mkdir(parents=True, exist_ok=True)
+    config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=tmp_path / "workspace")
+    proxy = StdioGuardProxy(
+        command=[
+            sys.executable,
+            "-u",
+            "-c",
+            "\n".join(
+                [
+                    "import json, sys",
+                    "for line in sys.stdin:",
+                    "    message = json.loads(line)",
+                    "    result = {'tool': message.get('params', {}).get('name')}",
+                    "    print(json.dumps({'jsonrpc': '2.0', 'id': message.get('id'), 'result': result}))",
+                    "    sys.stdout.flush()",
+                ]
+            ),
+        ],
+        cwd=tmp_path / "workspace",
+        guard_store=store,
+        guard_config=config,
+        approval_center_url="http://127.0.0.1:4455",
+        harness="codex",
+    )
+
+    allowed = proxy.run_session(
+        [
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "read_file",
+                    "arguments": {
+                        "path": "README.md",
+                        "headers": {"Authorization": "Bearer secret-token"},
                     },
-                }
-            ]
-        )
+                },
+            }
+        ]
+    )
+    blocked = proxy.run_session(
+        [
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "read_file",
+                    "arguments": {
+                        "path": ".env",
+                        "headers": {"Authorization": "Bearer secret-token"},
+                    },
+                },
+            }
+        ]
+    )
 
-        assert allowed["responses"][0]["result"]["tool"] == "read_file"
-        assert allowed["events"][0]["decision"] == "forward"
-        assert blocked["responses"][0]["error"]["code"] == -32001
-        assert "sensitive local file" in blocked["responses"][0]["error"]["message"].lower()
-        assert "http://127.0.0.1:4455" in blocked["responses"][0]["error"]["message"]
-        assert blocked["responses"][0]["error"]["data"]["approvalCenterUrl"] == "http://127.0.0.1:4455"
-        assert blocked["responses"][0]["error"]["data"]["reviewHint"]
-        assert blocked["events"][0]["decision"] == "block"
-        assert blocked["events"][0]["approval_delivery"]["destination"] == "harness"
-        assert blocked["events"][0]["redacted_params"]["arguments"]["headers"]["Authorization"] == "*****"
-        assert blocked["events"][0]["path_summary"].endswith("/.env")
-        pending = store.list_approval_requests(limit=10)
-        assert len(pending) == 1
-        assert pending[0]["artifact_type"] == "file_read_request"
+    assert allowed["responses"][0]["result"]["tool"] == "read_file"
+    assert allowed["events"][0]["decision"] == "forward"
+    assert blocked["responses"][0]["error"]["code"] == -32001
+    assert "sensitive local file" in blocked["responses"][0]["error"]["message"].lower()
+    assert "http://127.0.0.1:4455" in blocked["responses"][0]["error"]["message"]
+    assert blocked["responses"][0]["error"]["data"]["approvalCenterUrl"] == "http://127.0.0.1:4455"
+    assert blocked["responses"][0]["error"]["data"]["reviewHint"]
+    assert blocked["events"][0]["decision"] == "block"
+    assert blocked["events"][0]["approval_delivery"]["destination"] == "harness"
+    assert blocked["events"][0]["redacted_params"]["arguments"]["headers"]["Authorization"] == "*****"
+    assert blocked["events"][0]["path_summary"].endswith("/.env")
+    pending = store.list_approval_requests(limit=10)
+    assert len(pending) == 1
+    assert pending[0]["artifact_type"] == "file_read_request"
 
-    def test_stdio_proxy_handles_unknown_harness_when_queueing_sensitive_read_blocks(self, tmp_path):
-        store = GuardStore(tmp_path / "guard-home")
-        workspace_dir = tmp_path / "workspace"
-        workspace_dir.mkdir(parents=True, exist_ok=True)
-        config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=workspace_dir)
-        proxy = StdioGuardProxy(
-            command=[
-                sys.executable,
-                "-u",
-                "-c",
-                "\n".join(
-                    [
-                        "import json, sys",
-                        "for line in sys.stdin:",
-                        "    message = json.loads(line)",
-                        "    print(json.dumps({'jsonrpc': '2.0', 'id': message.get('id'), 'result': {'ok': True}}))",
-                        "    sys.stdout.flush()",
-                    ]
-                ),
-            ],
-            cwd=workspace_dir,
-            guard_store=store,
-            guard_config=config,
-            approval_center_url="http://127.0.0.1:4455",
-        )
 
-        blocked = proxy.run_session(
-            [
+def test_stdio_proxy_handles_unknown_harness_when_queueing_sensitive_read_blocks(tmp_path):
+    store = GuardStore(tmp_path / "guard-home")
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=workspace_dir)
+    proxy = StdioGuardProxy(
+        command=[
+            sys.executable,
+            "-u",
+            "-c",
+            "\n".join(
+                [
+                    "import json, sys",
+                    "for line in sys.stdin:",
+                    "    message = json.loads(line)",
+                    "    print(json.dumps({'jsonrpc': '2.0', 'id': message.get('id'), 'result': {'ok': True}}))",
+                    "    sys.stdout.flush()",
+                ]
+            ),
+        ],
+        cwd=workspace_dir,
+        guard_store=store,
+        guard_config=config,
+        approval_center_url="http://127.0.0.1:4455",
+    )
+
+    blocked = proxy.run_session(
+        [
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "read_file", "arguments": {"path": ".env"}},
+            }
+        ]
+    )
+
+    assert blocked["responses"][0]["error"]["code"] == -32001
+    assert blocked["responses"][0]["error"]["data"]["approvalDelivery"]["destination"] == "browser"
+    assert blocked["events"][0]["approval_delivery"]["destination"] == "browser"
+
+
+def test_stdio_proxy_uses_native_delivery_for_managed_hermes(tmp_path):
+    store = GuardStore(tmp_path / "guard-home")
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    store.set_managed_install(
+        "hermes",
+        True,
+        str(workspace_dir),
+        {"capabilities": {"same_channel": True}},
+        "2026-04-15T00:00:00+00:00",
+    )
+    config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=workspace_dir)
+    proxy = StdioGuardProxy(
+        command=[
+            sys.executable,
+            "-u",
+            "-c",
+            "\n".join(
+                [
+                    "import json, sys",
+                    "for line in sys.stdin:",
+                    "    message = json.loads(line)",
+                    "    print(json.dumps({'jsonrpc': '2.0', 'id': message.get('id'), 'result': {'ok': True}}))",
+                    "    sys.stdout.flush()",
+                ]
+            ),
+        ],
+        cwd=workspace_dir,
+        guard_store=store,
+        guard_config=config,
+        approval_center_url="http://127.0.0.1:4455",
+        harness="hermes",
+    )
+
+    blocked = proxy.run_session(
+        [
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "read_file", "arguments": {"path": ".env"}},
+            }
+        ]
+    )
+
+    assert blocked["responses"][0]["error"]["data"]["approvalDelivery"]["destination"] == "harness"
+    assert blocked["responses"][0]["error"]["data"]["approvalDelivery"]["prompt_channel"] == "native"
+    assert blocked["events"][0]["approval_delivery"]["destination"] == "harness"
+
+
+def test_hermes_pretool_blocks_docker_sensitive_command_requests(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    _write_text(home_dir / "config.toml", 'mode = "prompt"\n')
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(
+            json.dumps(
                 {
-                    "jsonrpc": "2.0",
-                    "id": 1,
-                    "method": "tools/call",
-                    "params": {"name": "read_file", "arguments": {"path": ".env"}},
+                    "event": "PreToolUse",
+                    "tool_name": "shell",
+                    "tool_input": {"command": "docker login ghcr.io", "docker_mode": True},
+                    "source_scope": "project",
                 }
-            ]
-        )
+            )
+        ),
+    )
 
-        assert blocked["responses"][0]["error"]["code"] == -32001
-        assert blocked["responses"][0]["error"]["data"]["approvalDelivery"]["destination"] == "browser"
-        assert blocked["events"][0]["approval_delivery"]["destination"] == "browser"
-
-    def test_stdio_proxy_uses_native_delivery_for_managed_hermes(self, tmp_path):
-        store = GuardStore(tmp_path / "guard-home")
-        workspace_dir = tmp_path / "workspace"
-        workspace_dir.mkdir(parents=True, exist_ok=True)
-        store.set_managed_install(
+    rc = main(
+        [
             "hermes",
-            True,
+            "pretool",
+            "--home",
+            str(home_dir),
+            "--workspace",
             str(workspace_dir),
-            {"capabilities": {"same_channel": True}},
-            "2026-04-15T00:00:00+00:00",
-        )
-        config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=workspace_dir)
-        proxy = StdioGuardProxy(
-            command=[
-                sys.executable,
-                "-u",
-                "-c",
-                "\n".join(
-                    [
-                        "import json, sys",
-                        "for line in sys.stdin:",
-                        "    message = json.loads(line)",
-                        "    print(json.dumps({'jsonrpc': '2.0', 'id': message.get('id'), 'result': {'ok': True}}))",
-                        "    sys.stdout.flush()",
-                    ]
-                ),
-            ],
-            cwd=workspace_dir,
-            guard_store=store,
-            guard_config=config,
-            approval_center_url="http://127.0.0.1:4455",
-            harness="hermes",
-        )
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
 
-        blocked = proxy.run_session(
-            [
+    assert rc == 1
+    assert output["artifact_type"] == "tool_action_request"
+    assert output["policy_action"] == "require-reapproval"
+    assert output["approval_delivery"]["destination"] == "harness"
+    assert "docker" in output["risk_summary"].lower()
+
+
+def test_hermes_pretool_blocks_destructive_shell_command_requests(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    _write_text(home_dir / "config.toml", 'mode = "prompt"\n')
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(
+            json.dumps(
                 {
-                    "jsonrpc": "2.0",
-                    "id": 1,
-                    "method": "tools/call",
-                    "params": {"name": "read_file", "arguments": {"path": ".env"}},
+                    "event": "PreToolUse",
+                    "tool_name": "shell",
+                    "tool_input": {"command": "echo MALICIOUS > dangerous-marker.json"},
+                    "source_scope": "project",
                 }
-            ]
-        )
-
-        assert blocked["responses"][0]["error"]["data"]["approvalDelivery"]["destination"] == "harness"
-        assert blocked["responses"][0]["error"]["data"]["approvalDelivery"]["prompt_channel"] == "native"
-        assert blocked["events"][0]["approval_delivery"]["destination"] == "harness"
-
-    def test_hermes_pretool_blocks_docker_sensitive_command_requests(self, tmp_path, capsys, monkeypatch):
-        home_dir = tmp_path / "home"
-        workspace_dir = tmp_path / "workspace"
-        workspace_dir.mkdir(parents=True, exist_ok=True)
-        _write_text(home_dir / "config.toml", 'mode = "prompt"\n')
-        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
-        monkeypatch.setattr(
-            sys,
-            "stdin",
-            io.StringIO(
-                json.dumps(
-                    {
-                        "event": "PreToolUse",
-                        "tool_name": "shell",
-                        "tool_input": {"command": "docker login ghcr.io", "docker_mode": True},
-                        "source_scope": "project",
-                    }
-                )
-            ),
-        )
-
-        rc = main(
-            [
-                "hermes",
-                "pretool",
-                "--home",
-                str(home_dir),
-                "--workspace",
-                str(workspace_dir),
-                "--json",
-            ]
-        )
-        output = json.loads(capsys.readouterr().out)
-
-        assert rc == 1
-        assert output["artifact_type"] == "tool_action_request"
-        assert output["policy_action"] == "require-reapproval"
-        assert output["approval_delivery"]["destination"] == "harness"
-        assert "docker" in output["risk_summary"].lower()
-
-    def test_hermes_pretool_blocks_destructive_shell_command_requests(self, tmp_path, capsys, monkeypatch):
-        home_dir = tmp_path / "home"
-        workspace_dir = tmp_path / "workspace"
-        workspace_dir.mkdir(parents=True, exist_ok=True)
-        _write_text(home_dir / "config.toml", 'mode = "prompt"\n')
-        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
-        monkeypatch.setattr(
-            sys,
-            "stdin",
-            io.StringIO(
-                json.dumps(
-                    {
-                        "event": "PreToolUse",
-                        "tool_name": "shell",
-                        "tool_input": {"command": "echo MALICIOUS > dangerous-marker.json"},
-                        "source_scope": "project",
-                    }
-                )
-            ),
-        )
-
-        rc = main(
-            [
-                "hermes",
-                "pretool",
-                "--home",
-                str(home_dir),
-                "--workspace",
-                str(workspace_dir),
-                "--json",
-            ]
-        )
-        output = json.loads(capsys.readouterr().out)
-
-        assert rc == 1
-        assert output["artifact_type"] == "tool_action_request"
-        assert output["policy_action"] == "require-reapproval"
-        assert output["approval_delivery"]["destination"] == "harness"
-        assert "destructive shell command" in output["risk_summary"].lower()
-
-    def test_remote_proxy_forwards_local_requests_and_redacts_auth_headers(self):
-        server = HTTPServer(("127.0.0.1", 0), _RemoteProxyHandler)
-        thread = threading.Thread(target=server.serve_forever, daemon=True)
-        thread.start()
-
-        try:
-            proxy = RemoteGuardProxy(
-                base_url=f"http://127.0.0.1:{server.server_port}",
-                allow_insecure_localhost=True,
             )
-            response = proxy.forward(
-                "/mcp",
-                {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
-                headers={"Authorization": "Bearer secret-token", "x-api-key": "hidden"},
-            )
-        finally:
-            server.shutdown()
-            thread.join(timeout=5)
+        ),
+    )
 
-        assert response["result"]["ok"] is True
-        assert _RemoteProxyHandler.captured_headers["authorization"] == "Bearer secret-token"
-        assert proxy.events[0]["headers"]["Authorization"] == "*****"
+    rc = main(
+        [
+            "hermes",
+            "pretool",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
 
-    def test_remote_proxy_allows_notification_requests_without_response_body(self, monkeypatch):
-        class _EmptyResponse:
-            def __enter__(self):
-                return self
+    assert rc == 1
+    assert output["artifact_type"] == "tool_action_request"
+    assert output["policy_action"] == "require-reapproval"
+    assert output["approval_delivery"]["destination"] == "harness"
+    assert "destructive shell command" in output["risk_summary"].lower()
 
-            def __exit__(self, exc_type, exc, tb):
-                return False
 
-            def read(self) -> bytes:
-                return b""
+def test_remote_proxy_forwards_local_requests_and_redacts_auth_headers():
+    server = HTTPServer(("127.0.0.1", 0), _RemoteProxyHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
 
-        monkeypatch.setattr(urllib.request, "urlopen", lambda request, timeout: _EmptyResponse())
-        proxy = RemoteGuardProxy(base_url="https://mcp.example.com/v1/mcp")
-
+    try:
+        proxy = RemoteGuardProxy(
+            base_url=f"http://127.0.0.1:{server.server_port}",
+            allow_insecure_localhost=True,
+        )
         response = proxy.forward(
-            "",
-            {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
-            expect_response=False,
+            "/mcp",
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            headers={"Authorization": "Bearer secret-token", "x-api-key": "hidden"},
         )
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
 
-        assert response is None
+    assert response["result"]["ok"] is True
+    assert _RemoteProxyHandler.captured_headers["authorization"] == "Bearer secret-token"
+    assert proxy.events[0]["headers"]["Authorization"] == "*****"
 
-    def test_remote_proxy_preserves_exact_base_url_when_forwarding_empty_path(self, monkeypatch):
-        captured_urls: list[str] = []
 
-        class _FakeResponse:
-            def __enter__(self):
-                return self
+def test_remote_proxy_allows_notification_requests_without_response_body(monkeypatch):
+    class _EmptyResponse:
+        def __enter__(self):
+            return self
 
-            def __exit__(self, exc_type, exc, tb):
-                return False
+        def __exit__(self, exc_type, exc, tb):
+            return False
 
-            def read(self) -> bytes:
-                return b'{"jsonrpc":"2.0","id":1,"result":{"ok":true}}'
+        def read(self) -> bytes:
+            return b""
 
-        def _fake_urlopen(request, timeout):
-            captured_urls.append(request.full_url)
-            return _FakeResponse()
+    monkeypatch.setattr(urllib.request, "urlopen", lambda request, timeout: _EmptyResponse())
+    proxy = RemoteGuardProxy(base_url="https://mcp.example.com/v1/mcp")
 
-        monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
-        proxy = RemoteGuardProxy(base_url="https://mcp.example.com/v1/mcp")
+    response = proxy.forward(
+        "",
+        {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+        expect_response=False,
+    )
 
-        response = proxy.forward("", {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
+    assert response is None
 
-        assert response["result"]["ok"] is True
-        assert captured_urls == ["https://mcp.example.com/v1/mcp"]
 
-    def test_guard_daemon_serves_health_and_receipt_state(self, tmp_path):
-        store = GuardStore(tmp_path / "guard-home")
-        store.add_receipt(
-            build_receipt(
-                harness="codex",
-                artifact_id="codex:workspace_skill",
-                artifact_hash="hash-123",
-                policy_decision="allow",
-                capabilities_summary="mcp server • stdio • python",
-                changed_capabilities=["first_seen"],
-                provenance_summary="project artifact defined at .codex/config.toml",
-                artifact_name="workspace_skill",
-                source_scope="project",
-            )
+def test_remote_proxy_preserves_exact_base_url_when_forwarding_empty_path(monkeypatch):
+    captured_urls: list[str] = []
+
+    class _FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return b'{"jsonrpc":"2.0","id":1,"result":{"ok":true}}'
+
+    def _fake_urlopen(request, timeout):
+        captured_urls.append(request.full_url)
+        return _FakeResponse()
+
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+    proxy = RemoteGuardProxy(base_url="https://mcp.example.com/v1/mcp")
+
+    response = proxy.forward("", {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
+
+    assert response["result"]["ok"] is True
+    assert captured_urls == ["https://mcp.example.com/v1/mcp"]
+
+
+def test_guard_daemon_serves_health_and_receipt_state(tmp_path):
+    store = GuardStore(tmp_path / "guard-home")
+    store.add_receipt(
+        build_receipt(
+            harness="codex",
+            artifact_id="codex:workspace_skill",
+            artifact_hash="hash-123",
+            policy_decision="allow",
+            capabilities_summary="mcp server • stdio • python",
+            changed_capabilities=["first_seen"],
+            provenance_summary="project artifact defined at .codex/config.toml",
+            artifact_name="workspace_skill",
+            source_scope="project",
         )
+    )
 
-        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
-        daemon.start()
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
 
-        try:
-            with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/healthz", timeout=5) as response:
-                health_payload = json.loads(response.read().decode("utf-8"))
-            with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/receipts", timeout=5) as response:
-                receipts_payload = json.loads(response.read().decode("utf-8"))
-        finally:
-            daemon.stop()
+    try:
+        with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/healthz", timeout=5) as response:
+            health_payload = json.loads(response.read().decode("utf-8"))
+        with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/receipts", timeout=5) as response:
+            receipts_payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        daemon.stop()
 
-        assert health_payload["ok"] is True
-        assert health_payload["receipts"] == 1
-        assert receipts_payload["items"][0]["artifact_id"] == "codex:workspace_skill"
+    assert health_payload["ok"] is True
+    assert health_payload["receipts"] == 1
+    assert receipts_payload["items"][0]["artifact_id"] == "codex:workspace_skill"


### PR DESCRIPTION
## Summary
- manage OpenCode's actual project config in-place so Desktop and CLI both use Guard's proxied MCP servers and native ask prompts
- preserve interactive OpenCode launches instead of forcing prompt-only run mode for workspace sessions
- drop the extra skill ask overlay so the runtime prompt users see is the real tool permission gate
- add regression coverage for launch arg handling and install/uninstall config management

## Verification
- `PYTHONPATH=src /Users/michaelkantor/CascadeProjects/ai-plugin-scanner-live-test/.guard-e2e/opencode-guard-venv/bin/python -m pytest tests/test_guard_launch_env.py tests/test_guard_cli.py tests/test_guard_opencode_proxy.py`
- `PYTHONPATH=src /Users/michaelkantor/CascadeProjects/ai-plugin-scanner-live-test/.guard-e2e/opencode-guard-venv/bin/python -m ruff check src/codex_plugin_scanner/guard/adapters/opencode.py src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py tests/test_guard_launch_env.py tests/test_guard_cli.py tests/test_guard_opencode_proxy.py`
- real OpenCode Desktop proof with Computer Use on a guarded workspace: native inline permission prompt appeared, deny kept the marker untouched, allow-once executed the guarded tool
- real direct OpenCode CLI proof on the same guarded workspace: native inline permission prompt appeared and reject left the marker at baseline