### PR TITLE
fix(guard): surface sync failures cleanly

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -808,10 +808,17 @@ def run_guard_command(args: argparse.Namespace) -> int:
         try:
             payload = sync_receipts(store)
         except GuardSyncNotConfiguredError:
-            print(_guard_sync_prerequisite_message(), file=sys.stderr)
+            message = _guard_sync_prerequisite_message()
+            if getattr(args, "json", False):
+                _emit("sync", {"synced": False, "error": message}, True)
+            else:
+                print(message, file=sys.stderr)
             return 1
         except RuntimeError as error:
-            print(str(error), file=sys.stderr)
+            if getattr(args, "json", False):
+                _emit("sync", {"synced": False, "error": str(error)}, True)
+            else:
+                print(str(error), file=sys.stderr)
             return 1
         _emit("sync", payload, getattr(args, "json", False))
         return 0

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -457,8 +457,10 @@ def _sync_http_error_message(error: urllib.error.HTTPError) -> str:
 
 def _sync_url_error_message(error: urllib.error.URLError) -> str:
     reason = getattr(error, "reason", None)
-    if isinstance(reason, str) and reason.strip():
-        return f"Guard sync failed: {reason.strip()}"
+    if reason is not None:
+        reason_text = str(reason).strip()
+        if reason_text:
+            return f"Guard sync failed: {reason_text}"
     return "Guard sync failed because the remote endpoint could not be reached."
 
 

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -210,6 +210,8 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
             payload = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as error:
         raise RuntimeError(_sync_http_error_message(error)) from error
+    except urllib.error.URLError as error:
+        raise RuntimeError(_sync_url_error_message(error)) from error
     now = _sync_timestamp(payload)
     advisories = payload.get("advisories")
     advisories_stored = 0
@@ -345,6 +347,8 @@ def sync_pain_signals(store: GuardStore) -> int:
                     )
                     return uploaded_count
                 raise RuntimeError(_sync_http_error_message(error)) from error
+            except urllib.error.URLError as error:
+                raise RuntimeError(_sync_url_error_message(error)) from error
             uploaded_count += len(signal_items)
         current_event_id = last_processed_event_id
         store.set_sync_payload(
@@ -449,6 +453,13 @@ def _sync_http_error_message(error: urllib.error.HTTPError) -> str:
     if normalized_body:
         return normalized_body
     return f"HTTP Error {error.code}: {error.reason}"
+
+
+def _sync_url_error_message(error: urllib.error.URLError) -> str:
+    reason = getattr(error, "reason", None)
+    if isinstance(reason, str) and reason.strip():
+        return f"Guard sync failed: {reason.strip()}"
+    return "Guard sync failed because the remote endpoint could not be reached."
 
 
 def _remote_harness(value: object, *, allow_wildcard: bool = True) -> str | None:

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -3421,6 +3421,99 @@ args = ["workspace-skill.js", "--changed"]
         assert connect_output["reason"] == "sync_unreachable"
         assert connect_output["sync_message"] == "sync_unreachable"
 
+    def test_guard_connect_surfaces_remote_sync_errors_cleanly(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        _SyncRequestHandler.response_code = 403
+        _SyncRequestHandler.response_payload = {
+            "error": "Guard sync requires a Pro or Team plan.",
+        }
+
+        server = HTTPServer(("127.0.0.1", 0), _SyncRequestHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+
+        store = GuardStore(home_dir)
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+        monkeypatch.setattr(
+            guard_commands_module,
+            "ensure_guard_daemon",
+            lambda guard_home: f"http://127.0.0.1:{daemon.port}",
+        )
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.cli.connect_flow.sync_runtime_session",
+            lambda current_store, *, session: {
+                "runtime_session_id": str(session.get("session_id") or session.get("sessionId")),
+                "runtime_session_synced_at": "2026-04-15T00:00:01Z",
+                "runtime_sessions_visible": 1,
+            },
+        )
+
+        def open_browser(url: str) -> bool:
+            parsed = urllib.parse.urlparse(url)
+            query = urllib.parse.parse_qs(parsed.query)
+            fragment = urllib.parse.parse_qs(parsed.fragment)
+            request_id = query["guardPairRequest"][-1]
+            daemon_url = query["guardDaemon"][-1]
+            pairing_secret = fragment["guardPairSecret"][-1]
+
+            def complete_pairing() -> None:
+                request = urllib.request.Request(
+                    f"{daemon_url}/v1/connect/complete",
+                    data=urllib.parse.urlencode(
+                        {
+                            "request_id": request_id,
+                            "pairing_secret": pairing_secret,
+                            "token": "session-token-123",
+                        }
+                    ).encode("utf-8"),
+                    headers={
+                        "Content-Type": "application/x-www-form-urlencoded",
+                        "Origin": "https://hol.org",
+                    },
+                    method="POST",
+                )
+                with urllib.request.urlopen(request, timeout=5):
+                    pass
+
+            threading.Thread(target=complete_pairing, daemon=True).start()
+            return True
+
+        monkeypatch.setattr(guard_commands_module.webbrowser, "open", open_browser)
+        try:
+            connect_rc = main(
+                [
+                    "guard",
+                    "connect",
+                    "--home",
+                    str(home_dir),
+                    "--sync-url",
+                    f"http://127.0.0.1:{server.server_port}/receipts",
+                    "--connect-url",
+                    "https://hol.org/guard/connect",
+                    "--json",
+                ]
+            )
+            connect_output = json.loads(capsys.readouterr().out)
+        finally:
+            daemon.stop()
+            server.shutdown()
+            thread.join(timeout=5)
+            _SyncRequestHandler.response_code = 200
+            _SyncRequestHandler.response_payload = {
+                "syncedAt": "2026-04-09T00:00:00Z",
+                "receiptsStored": 1,
+            }
+
+        assert connect_rc == 0
+        assert connect_output["connected"] is True
+        assert connect_output["status"] == "connected"
+        assert connect_output["milestone"] == "first_sync_pending"
+        assert connect_output["reason"] == "Guard sync requires a Pro or Team plan."
+        assert connect_output["sync_message"] == "Guard sync requires a Pro or Team plan."
+
     def test_guard_connect_rejects_invalid_sync_url(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
@@ -4319,6 +4412,50 @@ args = ["workspace-skill.js", "--changed"]
         stderr = capsys.readouterr().err
         assert "Guard Cloud is not connected yet." in stderr
         assert "Run `hol-guard connect`" in stderr
+
+    def test_guard_sync_reports_remote_sync_errors_in_json_mode(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        _SyncRequestHandler.response_code = 403
+        _SyncRequestHandler.response_payload = {
+            "error": "Guard sync requires a Pro or Team plan.",
+        }
+
+        server = HTTPServer(("127.0.0.1", 0), _SyncRequestHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            login_rc = main(
+                [
+                    "guard",
+                    "login",
+                    "--home",
+                    str(home_dir),
+                    "--sync-url",
+                    f"http://127.0.0.1:{server.server_port}/receipts",
+                    "--token",
+                    "demo-token",
+                    "--json",
+                ]
+            )
+            json.loads(capsys.readouterr().out)
+
+            sync_rc = main(["guard", "sync", "--home", str(home_dir), "--json"])
+            sync_output = json.loads(capsys.readouterr().out)
+        finally:
+            server.shutdown()
+            thread.join(timeout=5)
+            _SyncRequestHandler.response_code = 200
+            _SyncRequestHandler.response_payload = {
+                "syncedAt": "2026-04-09T00:00:00Z",
+                "receiptsStored": 1,
+            }
+
+        assert login_rc == 0
+        assert sync_rc == 1
+        assert sync_output == {
+            "synced": False,
+            "error": "Guard sync requires a Pro or Team plan.",
+        }
 
     def test_guard_doctor_reports_runtime_mismatch_for_cursor(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -4457,6 +4457,38 @@ args = ["workspace-skill.js", "--changed"]
             "error": "Guard sync requires a Pro or Team plan.",
         }
 
+    def test_guard_sync_reports_non_string_url_errors_in_json_mode(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        main(
+            [
+                "guard",
+                "login",
+                "--home",
+                str(home_dir),
+                "--sync-url",
+                "https://hol.org/api/guard/receipts/sync",
+                "--token",
+                "demo-token",
+                "--json",
+            ]
+        )
+        json.loads(capsys.readouterr().out)
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.runtime.runner.urllib.request.urlopen",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                urllib.error.URLError(ConnectionRefusedError(61, "Connection refused"))
+            ),
+        )
+
+        sync_rc = main(["guard", "sync", "--home", str(home_dir), "--json"])
+        sync_output = json.loads(capsys.readouterr().out)
+
+        assert sync_rc == 1
+        assert sync_output == {
+            "synced": False,
+            "error": "Guard sync failed: [Errno 61] Connection refused",
+        }
+
     def test_guard_doctor_reports_runtime_mismatch_for_cursor(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"


### PR DESCRIPTION
## Purpose
- keep `hol-guard` connect and sync output actionable when the portal sync endpoint rejects or is unreachable
- return structured JSON failures instead of stderr-only dead ends in machine-readable mode

## Affected Paths
- `src/codex_plugin_scanner/guard/cli/commands.py`
- `src/codex_plugin_scanner/guard/runtime/runner.py`
- `tests/test_guard_cli.py`

## Verification
- `env PYTHONPATH=src uv run pytest -q tests/test_guard_cli.py -k 'connect_surfaces_remote_sync_errors_cleanly or sync_reports_remote_sync_errors_in_json_mode or connect_preserves_pairing_when_first_sync_fails'`\n- `uv run --with ruff ruff check src/codex_plugin_scanner/guard/runtime/runner.py src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_cli.py`\n- real local portal flow on `http://127.0.0.1:3118`:\n  - `hol-guard login --sync-url http://127.0.0.1:3118/api/guard/receipts/sync --token <local-dev-token> --guard-home /Users/michaelkantor/CascadeProjects/hashgraph-online/.hol-guard-login-e2e-built --json`\n  - `hol-guard sync --guard-home /Users/michaelkantor/CascadeProjects/hashgraph-online/.hol-guard-login-e2e-built --json` -> `{"synced": false, "error": "Guard sync requires a Pro or Team plan."}`\n  - `GET http://127.0.0.1:3118/guard/connect` -> `200`\n  - `GET http://127.0.0.1:3118/api/guard/connect/snapshot` -> `200`