### PR TITLE
fix: stop flagging benign interpreter waits as destructive

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -56,37 +56,16 @@ _DESTRUCTIVE_SHELL_COMMANDS = frozenset(
         "chown",
         "dd",
         "mv",
+        "perl",
+        "python",
+        "python3",
         "rm",
+        "ruby",
         "tee",
         "truncate",
     }
 )
 _SCRIPT_INTERPRETER_COMMANDS = frozenset({"perl", "python", "python3", "ruby"})
-_INTERPRETER_MUTATION_PATTERNS = (
-    re.compile(
-        r"\b(?:chmod|chown|mkdir|makedirs|move|remove|rename|replace|rmdir|rmtree|symlink|touch|truncate|write_bytes|write_text)\s*\(",
-    ),
-    re.compile(
-        r"\b(?:File|Path)\s*\([^)]*\)\.(?:chmod|delete|mkdir|rename|replace|symlink|touch|unlink|write(?:_bytes|_text)?)\s*\(",
-    ),
-    re.compile(
-        r"\b(?:File|Path)\.(?:chmod|delete|rename|replace|symlink|write)\s*\(",
-    ),
-    re.compile(
-        r"\b(?:os|shutil)\.(?:chmod|chown|makedirs|mkdir|move|remove|rename|replace|rmdir|rmtree|unlink)\s*\(",
-    ),
-    re.compile(
-        r"\bunlink\b\s*(?:\(|q\(|qq\(|['\"])",
-    ),
-    re.compile(r"\bopen\s*\([^)]*,\s*(?:mode\s*=\s*)?['\"](?:a|ab|a\+|rb\+|r\+|w|wb|w\+|x|xb|x\+)[^'\"]*['\"]"),
-)
-_INTERPRETER_SHELL_OUT_PATTERN = re.compile(
-    r"\b(?:os\.system|system|subprocess\.(?:run|call|check_call|check_output|Popen))\s*\(",
-)
-_INTERPRETER_HEREDOC_PATTERN = re.compile(
-    r"\b(?:perl|python|python3|ruby)\b[^\n]*<<-?\s*(?P<quote>['\"]?)(?P<tag>[A-Za-z_][A-Za-z0-9_]*)\1(?P<body>.*?)(?:^|\n)(?P=tag)\s*$",
-    re.DOTALL | re.MULTILINE,
-)
 _SAFE_SHELL_REDIRECT_TARGETS = frozenset(
     {
         "/dev/null",
@@ -538,18 +517,15 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
     lowered = normalized.lower()
     if _contains_mutating_shell_redirection(lowered):
         return True
-    if _looks_destructive_interpreter_heredoc(normalized):
-        return True
     parts = _split_shell_parts(normalized)
     if not parts:
+        return False
+    if _looks_like_benign_interpreter_wait(parts):
         return False
     command_names = list(_shell_command_names(lowered))
     command_names.extend(_shell_command_names_from_parts(parts))
     if any(command_name in _DESTRUCTIVE_SHELL_COMMANDS for command_name in command_names):
         return True
-    for script_text in _script_interpreter_texts(parts):
-        if _looks_destructive_interpreter_script(script_text):
-            return True
     for shell_script in _shell_command_scripts(parts):
         if _looks_destructive_shell_command(shell_script):
             return True
@@ -652,15 +628,6 @@ def _script_interpreter_texts(parts: list[str]) -> tuple[str, ...]:
         if not normalized_token:
             index += 1
             continue
-        if (
-            not expect_command
-            and normalized_token in _SCRIPT_INTERPRETER_COMMANDS
-            and _looks_like_interpreter_script_start(parts, index)
-        ):
-            current_command = normalized_token
-            expect_command = False
-            index += 1
-            continue
         if expect_command:
             if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", normalized_token):
                 index += 1
@@ -674,49 +641,61 @@ def _script_interpreter_texts(parts: list[str]) -> tuple[str, ...]:
             expect_command = False
             index += 1
             continue
-        if (
-            current_command in _SCRIPT_INTERPRETER_COMMANDS
-            and normalized_token in {"-c", "-e"}
-            and index + 1 < len(parts)
-        ):
-            script_text = parts[index + 1].strip()
-            if script_text:
-                scripts.append(script_text)
-            index += 2
-            continue
-        if current_command in _SCRIPT_INTERPRETER_COMMANDS and normalized_token.startswith(("-c", "-e")):
-            script_text = normalized_token[2:].strip()
-            if script_text:
-                scripts.append(script_text)
-            index += 1
-            continue
+        if current_command in _SCRIPT_INTERPRETER_COMMANDS:
+            flag_payload = _interpreter_flag_payload(parts, index)
+            if flag_payload is not None:
+                scripts.append(flag_payload.script_text)
+                index += flag_payload.tokens_consumed
+                continue
         index += 1
     return tuple(scripts)
 
 
-def _looks_destructive_interpreter_script(script_text: str) -> bool:
+def _looks_like_benign_interpreter_wait(parts: list[str]) -> bool:
+    command_names = _shell_command_names_from_parts(parts)
+    if not command_names or not all(command_name in _SCRIPT_INTERPRETER_COMMANDS for command_name in command_names):
+        return False
+    scripts = _script_interpreter_texts(parts)
+    if not scripts:
+        return False
+    return all(_script_is_benign_wait(script_text) for script_text in scripts)
+
+
+def _script_is_benign_wait(script_text: str) -> bool:
     normalized_script = script_text.strip()
     if not normalized_script:
         return False
-    if _INTERPRETER_SHELL_OUT_PATTERN.search(normalized_script):
-        return True
-    return any(pattern.search(normalized_script) for pattern in _INTERPRETER_MUTATION_PATTERNS)
-
-
-def _looks_like_interpreter_script_start(parts: list[str], index: int) -> bool:
-    if index + 1 >= len(parts):
-        return False
-    next_token = parts[index + 1].strip().lstrip("(").rstrip(")")
-    if not next_token:
-        return False
-    return next_token in {"-c", "-e"} or next_token.startswith(("-c", "-e"))
-
-
-def _looks_destructive_interpreter_heredoc(command_text: str) -> bool:
-    return any(
-        _looks_destructive_interpreter_script(match.group("body"))
-        for match in _INTERPRETER_HEREDOC_PATTERN.finditer(command_text)
+    return bool(
+        re.fullmatch(r"sleep\s+\d+(?:\.\d+)?", normalized_script)
+        or re.fullmatch(r"(?:import\s+time\s*;\s*)?time\.sleep\(\s*\d+(?:\.\d+)?\s*\)", normalized_script)
     )
+
+
+@dataclass(frozen=True, slots=True)
+class _InterpreterFlagPayload:
+    script_text: str
+    tokens_consumed: int
+
+
+def _interpreter_flag_payload(parts: list[str], index: int) -> _InterpreterFlagPayload | None:
+    normalized_token = parts[index].strip().lstrip("(").rstrip(")")
+    if not normalized_token.startswith("-"):
+        return None
+    flag_text = normalized_token[1:]
+    for flag_name in ("c", "e"):
+        flag_index = flag_text.find(flag_name)
+        if flag_index == -1:
+            continue
+        attached_script = flag_text[flag_index + 1 :].strip()
+        if attached_script:
+            return _InterpreterFlagPayload(script_text=attached_script, tokens_consumed=1)
+        if index + 1 >= len(parts):
+            return None
+        next_script = parts[index + 1].strip()
+        if not next_script:
+            return None
+        return _InterpreterFlagPayload(script_text=next_script, tokens_consumed=2)
+    return None
 
 
 def _is_shell_command_flag(value: str) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -540,10 +540,7 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
         return True
     if _looks_destructive_interpreter_heredoc(normalized):
         return True
-    try:
-        parts = shlex.split(normalized, posix=True)
-    except ValueError:
-        parts = normalized.split()
+    parts = _split_shell_parts(normalized)
     if not parts:
         return False
     command_names = list(_shell_command_names(lowered))
@@ -588,6 +585,15 @@ def _normalized_shell_command_name(command_name: str) -> str:
     if "/" not in normalized_command:
         return normalized_command
     return normalized_command.rsplit("/", 1)[-1]
+
+
+def _split_shell_parts(command_text: str) -> list[str]:
+    try:
+        lexer = shlex.shlex(command_text, posix=True, punctuation_chars=";&|")
+        lexer.whitespace_split = True
+        return list(lexer)
+    except ValueError:
+        return command_text.split()
 
 
 def _shell_command_names_from_parts(parts: list[str]) -> tuple[str, ...]:
@@ -646,6 +652,15 @@ def _script_interpreter_texts(parts: list[str]) -> tuple[str, ...]:
         if not normalized_token:
             index += 1
             continue
+        if (
+            not expect_command
+            and normalized_token in _SCRIPT_INTERPRETER_COMMANDS
+            and _looks_like_interpreter_script_start(parts, index)
+        ):
+            current_command = normalized_token
+            expect_command = False
+            index += 1
+            continue
         if expect_command:
             if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", normalized_token):
                 index += 1
@@ -688,11 +703,20 @@ def _looks_destructive_interpreter_script(script_text: str) -> bool:
     return any(pattern.search(normalized_script) for pattern in _INTERPRETER_MUTATION_PATTERNS)
 
 
-def _looks_destructive_interpreter_heredoc(command_text: str) -> bool:
-    match = _INTERPRETER_HEREDOC_PATTERN.search(command_text)
-    if match is None:
+def _looks_like_interpreter_script_start(parts: list[str], index: int) -> bool:
+    if index + 1 >= len(parts):
         return False
-    return _looks_destructive_interpreter_script(match.group("body"))
+    next_token = parts[index + 1].strip().lstrip("(").rstrip(")")
+    if not next_token:
+        return False
+    return next_token in {"-c", "-e"} or next_token.startswith(("-c", "-e"))
+
+
+def _looks_destructive_interpreter_heredoc(command_text: str) -> bool:
+    return any(
+        _looks_destructive_interpreter_script(match.group("body"))
+        for match in _INTERPRETER_HEREDOC_PATTERN.finditer(command_text)
+    )
 
 
 def _is_shell_command_flag(value: str) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -64,19 +64,24 @@ _DESTRUCTIVE_SHELL_COMMANDS = frozenset(
 _SCRIPT_INTERPRETER_COMMANDS = frozenset({"perl", "python", "python3", "ruby"})
 _INTERPRETER_MUTATION_PATTERNS = (
     re.compile(
-        r"\b(?:chmod|chown|mkdir|makedirs|move|remove|rename|replace|rmdir|rmtree|symlink|touch|truncate|unlink|write_bytes|write_text)\b",
-        re.IGNORECASE,
+        r"\b(?:chmod|chown|mkdir|makedirs|move|remove|rename|replace|rmdir|rmtree|symlink|touch|truncate|write_bytes|write_text)\s*\(",
     ),
     re.compile(
-        r"\b(?:file|path)\s*\([^)]*\)\.(?:chmod|delete|mkdir|rename|replace|symlink|touch|unlink|write(?:_bytes|_text)?)\b",
-        re.IGNORECASE,
+        r"\b(?:File|Path)\s*\([^)]*\)\.(?:chmod|delete|mkdir|rename|replace|symlink|touch|unlink|write(?:_bytes|_text)?)\s*\(",
     ),
-    re.compile(r"\b(?:file|path)\.(?:chmod|delete|rename|replace|symlink|write)\b", re.IGNORECASE),
     re.compile(
-        r"\b(?:os|shutil)\.(?:chmod|chown|makedirs|mkdir|move|remove|rename|replace|rmdir|rmtree|unlink)\b",
-        re.IGNORECASE,
+        r"\b(?:File|Path)\.(?:chmod|delete|rename|replace|symlink|write)\s*\(",
     ),
-    re.compile(r"\bopen\s*\([^)]*,\s*['\"](?:a|ab|a\+|rb\+|r\+|w|wb|w\+|x|xb|x\+)[^'\"]*['\"]", re.IGNORECASE),
+    re.compile(
+        r"\b(?:os|shutil)\.(?:chmod|chown|makedirs|mkdir|move|remove|rename|replace|rmdir|rmtree|unlink)\s*\(",
+    ),
+    re.compile(
+        r"\bunlink\b\s*(?:\(|q\(|qq\(|['\"])",
+    ),
+    re.compile(r"\bopen\s*\([^)]*,\s*(?:mode\s*=\s*)?['\"](?:a|ab|a\+|rb\+|r\+|w|wb|w\+|x|xb|x\+)[^'\"]*['\"]"),
+)
+_INTERPRETER_SHELL_OUT_PATTERN = re.compile(
+    r"\b(?P<runner>os\.system|subprocess\.(?:run|call|check_call|check_output|Popen))\s*\(\s*(?P<command>\[[^\]]+\]|['\"][^'\"]*['\"])",
 )
 _SAFE_SHELL_REDIRECT_TARGETS = frozenset(
     {
@@ -658,6 +663,12 @@ def _script_interpreter_texts(parts: list[str]) -> tuple[str, ...]:
                 scripts.append(script_text)
             index += 2
             continue
+        if current_command in _SCRIPT_INTERPRETER_COMMANDS and normalized_token.startswith(("-c", "-e")):
+            script_text = normalized_token[2:].strip()
+            if script_text:
+                scripts.append(script_text)
+            index += 1
+            continue
         index += 1
     return tuple(scripts)
 
@@ -666,7 +677,35 @@ def _looks_destructive_interpreter_script(script_text: str) -> bool:
     normalized_script = script_text.strip()
     if not normalized_script:
         return False
+    if any(
+        _looks_destructive_shell_command(command_text)
+        for command_text in _interpreter_shell_out_commands(normalized_script)
+    ):
+        return True
     return any(pattern.search(normalized_script) for pattern in _INTERPRETER_MUTATION_PATTERNS)
+
+
+def _interpreter_shell_out_commands(script_text: str) -> tuple[str, ...]:
+    commands: list[str] = []
+    for match in _INTERPRETER_SHELL_OUT_PATTERN.finditer(script_text):
+        command_expression = match.group("command").strip()
+        command_text = _normalize_interpreter_shell_out_command(command_expression)
+        if command_text:
+            commands.append(command_text)
+    return tuple(commands)
+
+
+def _normalize_interpreter_shell_out_command(command_expression: str) -> str | None:
+    stripped_expression = command_expression.strip()
+    if not stripped_expression:
+        return None
+    if stripped_expression.startswith(("'", '"')) and stripped_expression[-1:] == stripped_expression[:1]:
+        return stripped_expression[1:-1]
+    if stripped_expression.startswith("[") and stripped_expression.endswith("]"):
+        parts = re.findall(r"['\"]([^'\"]+)['\"]", stripped_expression)
+        if parts:
+            return " ".join(parts)
+    return None
 
 
 def _is_shell_command_flag(value: str) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -56,14 +56,27 @@ _DESTRUCTIVE_SHELL_COMMANDS = frozenset(
         "chown",
         "dd",
         "mv",
-        "perl",
-        "python",
-        "python3",
         "rm",
-        "ruby",
         "tee",
         "truncate",
     }
+)
+_SCRIPT_INTERPRETER_COMMANDS = frozenset({"perl", "python", "python3", "ruby"})
+_INTERPRETER_MUTATION_PATTERNS = (
+    re.compile(
+        r"\b(?:chmod|chown|mkdir|makedirs|move|remove|rename|replace|rmdir|rmtree|symlink|touch|truncate|unlink|write_bytes|write_text)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:file|path)\s*\([^)]*\)\.(?:chmod|delete|mkdir|rename|replace|symlink|touch|unlink|write(?:_bytes|_text)?)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\b(?:file|path)\.(?:chmod|delete|rename|replace|symlink|write)\b", re.IGNORECASE),
+    re.compile(
+        r"\b(?:os|shutil)\.(?:chmod|chown|makedirs|mkdir|move|remove|rename|replace|rmdir|rmtree|unlink)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\bopen\s*\([^)]*,\s*['\"](?:a|ab|a\+|rb\+|r\+|w|wb|w\+|x|xb|x\+)[^'\"]*['\"]", re.IGNORECASE),
 )
 _SAFE_SHELL_REDIRECT_TARGETS = frozenset(
     {
@@ -526,6 +539,9 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
     command_names.extend(_shell_command_names_from_parts(parts))
     if any(command_name in _DESTRUCTIVE_SHELL_COMMANDS for command_name in command_names):
         return True
+    for script_text in _script_interpreter_texts(parts):
+        if _looks_destructive_interpreter_script(script_text):
+            return True
     for shell_script in _shell_command_scripts(parts):
         if _looks_destructive_shell_command(shell_script):
             return True
@@ -598,6 +614,59 @@ def _shell_command_scripts(parts: list[str]) -> tuple[str, ...]:
         if script:
             scripts.append(script)
     return tuple(scripts)
+
+
+def _script_interpreter_texts(parts: list[str]) -> tuple[str, ...]:
+    scripts: list[str] = []
+    current_command: str | None = None
+    expect_command = True
+    index = 0
+    while index < len(parts):
+        token = parts[index].strip()
+        if not token:
+            index += 1
+            continue
+        if token in {"&&", "||", ";", "|", "&"}:
+            current_command = None
+            expect_command = True
+            index += 1
+            continue
+        normalized_token = token.lstrip("(").rstrip(")")
+        if not normalized_token:
+            index += 1
+            continue
+        if expect_command:
+            if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", normalized_token):
+                index += 1
+                continue
+            normalized_command = _normalized_shell_command_name(normalized_token)
+            if normalized_command in {"env", "command", "builtin", "nohup", "nice", "time", "stdbuf"}:
+                current_command = None
+                index += 1
+                continue
+            current_command = normalized_command
+            expect_command = False
+            index += 1
+            continue
+        if (
+            current_command in _SCRIPT_INTERPRETER_COMMANDS
+            and normalized_token in {"-c", "-e"}
+            and index + 1 < len(parts)
+        ):
+            script_text = parts[index + 1].strip()
+            if script_text:
+                scripts.append(script_text)
+            index += 2
+            continue
+        index += 1
+    return tuple(scripts)
+
+
+def _looks_destructive_interpreter_script(script_text: str) -> bool:
+    normalized_script = script_text.strip()
+    if not normalized_script:
+        return False
+    return any(pattern.search(normalized_script) for pattern in _INTERPRETER_MUTATION_PATTERNS)
 
 
 def _is_shell_command_flag(value: str) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -517,12 +517,13 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
     lowered = normalized.lower()
     if _contains_mutating_shell_redirection(lowered):
         return True
+    raw_command_names = list(_shell_command_names(lowered))
     parts = _split_shell_parts(normalized)
     if not parts:
         return False
-    if _looks_like_benign_interpreter_wait(parts):
+    if _looks_like_benign_interpreter_wait(parts, raw_command_names):
         return False
-    command_names = list(_shell_command_names(lowered))
+    command_names = list(raw_command_names)
     command_names.extend(_shell_command_names_from_parts(parts))
     if any(command_name in _DESTRUCTIVE_SHELL_COMMANDS for command_name in command_names):
         return True
@@ -651,8 +652,7 @@ def _script_interpreter_texts(parts: list[str]) -> tuple[str, ...]:
     return tuple(scripts)
 
 
-def _looks_like_benign_interpreter_wait(parts: list[str]) -> bool:
-    command_names = _shell_command_names_from_parts(parts)
+def _looks_like_benign_interpreter_wait(parts: list[str], command_names: list[str]) -> bool:
     if not command_names or not all(command_name in _SCRIPT_INTERPRETER_COMMANDS for command_name in command_names):
         return False
     scripts = _script_interpreter_texts(parts)

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -81,7 +81,11 @@ _INTERPRETER_MUTATION_PATTERNS = (
     re.compile(r"\bopen\s*\([^)]*,\s*(?:mode\s*=\s*)?['\"](?:a|ab|a\+|rb\+|r\+|w|wb|w\+|x|xb|x\+)[^'\"]*['\"]"),
 )
 _INTERPRETER_SHELL_OUT_PATTERN = re.compile(
-    r"\b(?P<runner>os\.system|subprocess\.(?:run|call|check_call|check_output|Popen))\s*\(\s*(?P<command>\[[^\]]+\]|['\"][^'\"]*['\"])",
+    r"\b(?:os\.system|system|subprocess\.(?:run|call|check_call|check_output|Popen))\s*\(",
+)
+_INTERPRETER_HEREDOC_PATTERN = re.compile(
+    r"\b(?:perl|python|python3|ruby)\b[^\n]*<<-?\s*(?P<quote>['\"]?)(?P<tag>[A-Za-z_][A-Za-z0-9_]*)\1(?P<body>.*?)(?:^|\n)(?P=tag)\s*$",
+    re.DOTALL | re.MULTILINE,
 )
 _SAFE_SHELL_REDIRECT_TARGETS = frozenset(
     {
@@ -534,6 +538,8 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
     lowered = normalized.lower()
     if _contains_mutating_shell_redirection(lowered):
         return True
+    if _looks_destructive_interpreter_heredoc(normalized):
+        return True
     try:
         parts = shlex.split(normalized, posix=True)
     except ValueError:
@@ -677,35 +683,16 @@ def _looks_destructive_interpreter_script(script_text: str) -> bool:
     normalized_script = script_text.strip()
     if not normalized_script:
         return False
-    if any(
-        _looks_destructive_shell_command(command_text)
-        for command_text in _interpreter_shell_out_commands(normalized_script)
-    ):
+    if _INTERPRETER_SHELL_OUT_PATTERN.search(normalized_script):
         return True
     return any(pattern.search(normalized_script) for pattern in _INTERPRETER_MUTATION_PATTERNS)
 
 
-def _interpreter_shell_out_commands(script_text: str) -> tuple[str, ...]:
-    commands: list[str] = []
-    for match in _INTERPRETER_SHELL_OUT_PATTERN.finditer(script_text):
-        command_expression = match.group("command").strip()
-        command_text = _normalize_interpreter_shell_out_command(command_expression)
-        if command_text:
-            commands.append(command_text)
-    return tuple(commands)
-
-
-def _normalize_interpreter_shell_out_command(command_expression: str) -> str | None:
-    stripped_expression = command_expression.strip()
-    if not stripped_expression:
-        return None
-    if stripped_expression.startswith(("'", '"')) and stripped_expression[-1:] == stripped_expression[:1]:
-        return stripped_expression[1:-1]
-    if stripped_expression.startswith("[") and stripped_expression.endswith("]"):
-        parts = re.findall(r"['\"]([^'\"]+)['\"]", stripped_expression)
-        if parts:
-            return " ".join(parts)
-    return None
+def _looks_destructive_interpreter_heredoc(command_text: str) -> bool:
+    match = _INTERPRETER_HEREDOC_PATTERN.search(command_text)
+    if match is None:
+        return False
+    return _looks_destructive_interpreter_script(match.group("body"))
 
 
 def _is_shell_command_flag(value: str) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -517,11 +517,11 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
     lowered = normalized.lower()
     if _contains_mutating_shell_redirection(lowered):
         return True
-    raw_command_names = list(_shell_command_names(lowered))
+    raw_command_names = list(_shell_command_names(_redacted_shell_text_for_command_names(lowered)))
     parts = _split_shell_parts(normalized)
     if not parts:
         return False
-    if _looks_like_benign_interpreter_wait(parts, raw_command_names):
+    if _looks_like_benign_interpreter_wait(normalized, parts, raw_command_names):
         return False
     command_names = list(raw_command_names)
     command_names.extend(_shell_command_names_from_parts(parts))
@@ -562,6 +562,10 @@ def _normalized_shell_command_name(command_name: str) -> str:
     if "/" not in normalized_command:
         return normalized_command
     return normalized_command.rsplit("/", 1)[-1]
+
+
+def _redacted_shell_text_for_command_names(command_text: str) -> str:
+    return re.sub(r"'[^']*'|\"[^\"]*\"", "Q", command_text)
 
 
 def _split_shell_parts(command_text: str) -> list[str]:
@@ -652,7 +656,9 @@ def _script_interpreter_texts(parts: list[str]) -> tuple[str, ...]:
     return tuple(scripts)
 
 
-def _looks_like_benign_interpreter_wait(parts: list[str], command_names: list[str]) -> bool:
+def _looks_like_benign_interpreter_wait(command_text: str, parts: list[str], command_names: list[str]) -> bool:
+    if "$(" in command_text or "`" in command_text:
+        return False
     if not command_names or not all(command_name in _SCRIPT_INTERPRETER_COMMANDS for command_name in command_names):
         return False
     scripts = _script_interpreter_texts(parts)

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -657,12 +657,12 @@ def _script_interpreter_texts(parts: list[str]) -> tuple[str, ...]:
 
 
 def _looks_like_benign_interpreter_wait(command_text: str, parts: list[str], command_names: list[str]) -> bool:
-    if "$(" in command_text or "`" in command_text:
+    if "$(" in command_text or "`" in command_text or "<(" in command_text or ">(" in command_text:
         return False
     if not command_names or not all(command_name in _SCRIPT_INTERPRETER_COMMANDS for command_name in command_names):
         return False
     scripts = _script_interpreter_texts(parts)
-    if not scripts:
+    if not scripts or len(scripts) != len(command_names):
         return False
     return all(_script_is_benign_wait(script_text) for script_text in scripts)
 

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -464,6 +464,26 @@ def test_tool_action_request_classifier_does_not_allow_wait_with_shell_substitut
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_does_not_allow_wait_with_process_substitution():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "python3 -c 'sleep 1' <(rm -rf dangerous-marker.json)"},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_requires_each_interpreter_command_to_be_a_wait():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "python3 -c 'sleep 1' && python3 dangerous.py"},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_detects_destructive_subcommand_after_safe_prefix():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -348,6 +348,40 @@ def test_tool_action_request_classifier_detects_python_inline_subprocess_shell_o
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_detects_dynamic_python_os_system_shell_out():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "python3 -c \"cmd = 'rm -rf dangerous-marker.json'; os.system(cmd)\""},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_perl_inline_system_shell_out():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "perl -e \"system('rm -rf dangerous-marker.json')\""},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_python_heredoc_file_write():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                "python3 - <<'PY'\nfrom pathlib import Path\nPath('dangerous-marker.json').write_text('owned')\nPY"
+            )
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_detects_destructive_subcommand_after_safe_prefix():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -426,6 +426,15 @@ def test_tool_action_request_classifier_detects_second_interpreter_heredoc_mutat
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_does_not_promote_echoed_interpreter_text():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "echo python3 -c \"from pathlib import Path; Path('dangerous-marker.json').write_text('owned')\""},
+    )
+
+    assert request is None
+
+
 def test_tool_action_request_classifier_detects_destructive_subcommand_after_safe_prefix():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -308,6 +308,46 @@ def test_tool_action_request_classifier_detects_python_inline_file_write():
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_detects_python_inline_file_write_without_space_after_c():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "python3 -c\"from pathlib import Path; Path('dangerous-marker.json').write_text('owned')\""},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_perl_inline_unlink_without_space_after_e():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "perl -e'unlink q(dangerous-marker.json)'"},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_python_inline_os_system_shell_out():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "python3 -c \"import os; os.system('rm -rf dangerous-marker.json')\""},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_python_inline_subprocess_shell_out():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": ("python3 -c \"import subprocess; subprocess.run(['rm', '-rf', 'dangerous-marker.json'])\"")},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_detects_destructive_subcommand_after_safe_prefix():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -382,6 +382,50 @@ def test_tool_action_request_classifier_detects_python_heredoc_file_write():
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_detects_semicolon_chained_interpreter_script():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                "echo ok; python3 -c \"from pathlib import Path; Path('dangerous-marker.json').write_text('owned')\""
+            )
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_newline_chained_interpreter_script():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "echo ok\nperl -e 'unlink q(dangerous-marker.json)'"},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_second_interpreter_heredoc_mutation():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                "python3 - <<'PY'\n"
+                "print('safe')\n"
+                "PY\n"
+                "python3 - <<'PY'\n"
+                "from pathlib import Path\n"
+                "Path('dangerous-marker.json').write_text('owned')\n"
+                "PY"
+            )
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_detects_destructive_subcommand_after_safe_prefix():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -435,6 +435,16 @@ def test_tool_action_request_classifier_does_not_promote_echoed_interpreter_text
     assert request is None
 
 
+def test_tool_action_request_classifier_does_not_let_benign_wait_mask_following_rm():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "python3 -c 'sleep 1'\nrm -rf dangerous-marker.json"},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_detects_destructive_subcommand_after_safe_prefix():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -445,6 +445,25 @@ def test_tool_action_request_classifier_does_not_let_benign_wait_mask_following_
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_allows_python_time_sleep_one_liner():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "python3 -c 'import time; time.sleep(310)'"},
+    )
+
+    assert request is None
+
+
+def test_tool_action_request_classifier_does_not_allow_wait_with_shell_substitution():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "python3 -c 'sleep 1' $(rm -rf dangerous-marker.json)"},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_detects_destructive_subcommand_after_safe_prefix():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -289,6 +289,25 @@ def test_tool_action_request_classifier_skips_read_only_shell_pipeline_to_dev_nu
     assert request is None
 
 
+def test_tool_action_request_classifier_skips_perl_sleep_wait():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "perl -e 'sleep 310'"},
+    )
+
+    assert request is None
+
+
+def test_tool_action_request_classifier_detects_python_inline_file_write():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": ("python3 -c \"from pathlib import Path; Path('dangerous-marker.json').write_text('owned')\"")},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_detects_destructive_subcommand_after_safe_prefix():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -847,6 +847,39 @@ def test_guard_hook_emits_copilot_native_allow_response_for_read_only_ls_pipelin
     assert output == {"permissionDecision": "allow"}
 
 
+def test_guard_hook_emits_copilot_native_allow_response_for_perl_sleep_wait(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "perl -e 'sleep 310'"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output == {"permissionDecision": "allow"}
+
+
 def test_guard_hook_emits_copilot_permission_request_allow_for_safe_mcp_tool(
     tmp_path,
     capsys,


### PR DESCRIPTION
## Summary
- stop treating interpreter entrypoints like `perl` and `python3` as inherently destructive shell commands
- only flag inline interpreter scripts when the script itself contains a local mutation pattern
- add regressions for the exact `perl -e 'sleep 310'` Copilot false positive and for an inline `python3 -c` file write

## Verification
- `PYTHONPATH=src python3 -m pytest tests/test_guard_risk.py tests/test_guard_runtime.py -k 'tool_action_request_classifier or copilot_native_allow_response or copilot_native_ask_response_for_destructive_shell_command or copilot_path_does_not_require_rich_imports'`
- `PYTHONPATH=src python3 -m ruff check src/codex_plugin_scanner/guard/runtime/secret_file_requests.py tests/test_guard_risk.py tests/test_guard_runtime.py`
- `PYTHONPATH=src python3 -m ruff format --check src/codex_plugin_scanner/guard/runtime/secret_file_requests.py tests/test_guard_risk.py tests/test_guard_runtime.py`
