### PR TITLE
fix: harden copilot autopilot destructive-call interception

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -562,14 +562,14 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
     normalized = command_text.strip()
     if not normalized:
         return False
-    lowered = normalized.lower()
-    redacted_command_text = _redacted_shell_text_for_command_names(lowered)
-    if _contains_mutating_shell_redirection(lowered):
-        return True
-    raw_command_names = list(_shell_command_names(redacted_command_text))
     parts = _split_shell_parts(normalized)
     if not parts:
         return False
+    lowered = normalized.lower()
+    redacted_command_text = _redacted_shell_text_for_command_names(lowered)
+    if _contains_mutating_shell_redirection(parts):
+        return True
+    raw_command_names = list(_shell_command_names(redacted_command_text))
     if _looks_like_benign_interpreter_wait(normalized, parts, raw_command_names):
         return False
     if _contains_destructive_node_inline_eval(parts):
@@ -605,7 +605,7 @@ def _contains_destructive_node_inline_eval(parts: list[str]) -> bool:
 def _contains_destructive_node_inline_script(script: str) -> bool:
     for call_name in _DESTRUCTIVE_NODE_INLINE_CALLS:
         escaped_call_name = re.escape(call_name)
-        if re.search(rf"(?<![a-z0-9_$'\"]){escaped_call_name}\s*(?:\?\.\s*)?\(", script):
+        if re.search(rf"(?<![A-Za-z0-9_$'\"]){escaped_call_name}\s*(?:\?\.\s*)?\(", script):
             return True
         for base_pattern in (
             rf"\.\s*{escaped_call_name}",
@@ -688,6 +688,9 @@ def _segment_contains_destructive_node_inline_eval(segment_args: list[str]) -> b
         if token == "--":
             break
         if token in _NODE_INLINE_EVAL_FLAGS and index + 1 < len(lowered_args):
+            if token in {"-p", "--print"} and lowered_args[index + 1].startswith("-"):
+                index += 1
+                continue
             if _contains_destructive_node_inline_script(segment_args[index + 1]):
                 return True
             index += 2
@@ -771,8 +774,11 @@ def _env_split_string_payloads(parts: list[str]) -> tuple[str, ...]:
                     payloads.append(payload)
                 index += _wrapper_option_tokens_consumed("env", token)
                 continue
-            if token.startswith("-S") and token != "-S":
-                payload = token[2:].strip()
+            clustered_split_string_payload = _env_clustered_split_string_payload(token)
+            if clustered_split_string_payload is not None:
+                payload = clustered_split_string_payload.strip()
+                if not payload and index + 1 < len(segment):
+                    payload = segment[index + 1].strip()
                 if payload:
                     payloads.append(payload)
                 index += _wrapper_option_tokens_consumed("env", token)
@@ -803,13 +809,43 @@ def _shell_segment_env_index(segment: list[str]) -> int | None:
     return None
 
 
-def _contains_mutating_shell_redirection(command_text: str) -> bool:
-    for match in re.finditer(r"(?<!<)(?P<fd>[0-2]?)(?P<op>>\||>>|>)\s*(?P<target>\S+)", command_text):
-        fd = match.group("fd")
-        target = _normalized_redirect_target(match.group("target"))
-        if fd == "2" and target in _SAFE_SHELL_REDIRECT_TARGETS:
+def _contains_mutating_shell_redirection(parts: list[str]) -> bool:
+    index = 0
+    while index < len(parts):
+        token = parts[index].strip()
+        if not token:
+            index += 1
             continue
-        if target in _SAFE_SHELL_REDIRECT_TARGETS or target.startswith("&"):
+        fd = ""
+        target: str | None = None
+        if token in {">", ">>", ">|", "1>", "1>>", "1>|", "2>", "2>>", "2>|"}:
+            if token[0].isdigit():
+                fd = token[0]
+            if index + 1 < len(parts):
+                target = parts[index + 1]
+                index += 2
+            else:
+                index += 1
+        else:
+            match = re.fullmatch(r"(?P<fd>[0-2]?)(?P<op>>\||>>|>)(?P<target>.+)?", token)
+            if match is None:
+                index += 1
+                continue
+            fd = match.group("fd")
+            target = match.group("target")
+            if target:
+                index += 1
+            elif index + 1 < len(parts):
+                target = parts[index + 1]
+                index += 2
+            else:
+                index += 1
+        if target is None:
+            continue
+        normalized_target = _normalized_redirect_target(target)
+        if fd == "2" and normalized_target in _SAFE_SHELL_REDIRECT_TARGETS:
+            continue
+        if normalized_target in _SAFE_SHELL_REDIRECT_TARGETS or normalized_target.startswith("&"):
             continue
         return True
     return False
@@ -905,6 +941,17 @@ def _env_short_option_tokens_consumed(token: str) -> int | None:
             return 1
         return 2
     return 1
+
+
+def _env_clustered_split_string_payload(token: str) -> str | None:
+    if not token.startswith("-") or token.startswith("--") or len(token) <= 2:
+        return None
+    split_index = token.find("S", 1)
+    if split_index == -1:
+        return None
+    if split_index + 1 >= len(token):
+        return ""
+    return token[split_index + 1 :]
 
 
 def _wrapper_flag_has_attached_value(command_name: str, token: str) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -98,20 +98,20 @@ _SHELL_ASSIGNMENT_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*")
 _SHELL_NEWLINE_SEPARATOR = ";"
 _DESTRUCTIVE_NODE_INLINE_CALLS = frozenset(
     {
-        "appendfile",
-        "appendfilesync",
-        "copyfile",
-        "copyfilesync",
+        "appendFile",
+        "appendFileSync",
+        "copyFile",
+        "copyFileSync",
         "mkdir",
-        "mkdirsync",
+        "mkdirSync",
         "rename",
-        "renamesync",
+        "renameSync",
         "rm",
-        "rmsync",
+        "rmSync",
         "unlink",
-        "unlinksync",
-        "writefile",
-        "writefilesync",
+        "unlinkSync",
+        "writeFile",
+        "writeFileSync",
     }
 )
 _WRAPPER_FLAGS_WITH_VALUES = {
@@ -561,9 +561,10 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
     if not normalized:
         return False
     lowered = normalized.lower()
-    if _contains_mutating_shell_redirection(lowered):
+    redacted_command_text = _redacted_shell_text_for_command_names(lowered)
+    if _contains_mutating_shell_redirection(redacted_command_text):
         return True
-    raw_command_names = list(_shell_command_names(_redacted_shell_text_for_command_names(lowered)))
+    raw_command_names = list(_shell_command_names(redacted_command_text))
     parts = _split_shell_parts(normalized)
     if not parts:
         return False
@@ -600,12 +601,19 @@ def _contains_destructive_node_inline_eval(parts: list[str]) -> bool:
 
 
 def _contains_destructive_node_inline_script(script: str) -> bool:
-    return any(
-        re.search(rf"(?<![a-z0-9_$'\"]){re.escape(call_name)}\s*\(", script)
-        or re.search(rf"\.\s*{re.escape(call_name)}\s*(?:\)\s*)?\(", script)
-        or re.search(rf"\[\s*['\"]{re.escape(call_name)}['\"]\s*\]\s*(?:\)\s*)?\(", script)
-        for call_name in _DESTRUCTIVE_NODE_INLINE_CALLS
-    )
+    for call_name in _DESTRUCTIVE_NODE_INLINE_CALLS:
+        escaped_call_name = re.escape(call_name)
+        if re.search(rf"(?<![a-z0-9_$'\"]){escaped_call_name}\s*(?:\?\.\s*)?\(", script):
+            return True
+        for base_pattern in (
+            rf"\.\s*{escaped_call_name}",
+            rf"\[\s*['\"]{escaped_call_name}['\"]\s*\]",
+        ):
+            if re.search(rf"{base_pattern}\s*(?:\?\.\s*)?(?:\)\s*)?\(", script):
+                return True
+            if re.search(rf"{base_pattern}\s*\.\s*call\s*\(", script):
+                return True
+    return False
 
 
 def _is_combined_node_inline_eval_flag(token: str) -> bool:
@@ -678,32 +686,32 @@ def _segment_contains_destructive_node_inline_eval(segment_args: list[str]) -> b
         if token == "--":
             break
         if token in _NODE_INLINE_EVAL_FLAGS and index + 1 < len(lowered_args):
-            if _contains_destructive_node_inline_script(lowered_args[index + 1]):
+            if _contains_destructive_node_inline_script(segment_args[index + 1]):
                 return True
             index += 2
             continue
         if _is_combined_node_inline_eval_flag(token) and index + 1 < len(lowered_args):
-            if _contains_destructive_node_inline_script(lowered_args[index + 1]):
+            if _contains_destructive_node_inline_script(segment_args[index + 1]):
                 return True
             index += 2
             continue
         if token.startswith("--eval="):
-            if _contains_destructive_node_inline_script(token.split("=", 1)[1]):
+            if _contains_destructive_node_inline_script(segment_args[index].split("=", 1)[1]):
                 return True
             index += 1
             continue
         if token.startswith("--print="):
-            if _contains_destructive_node_inline_script(token.split("=", 1)[1]):
+            if _contains_destructive_node_inline_script(segment_args[index].split("=", 1)[1]):
                 return True
             index += 1
             continue
         if token.startswith("-e") and token not in _NODE_INLINE_EVAL_FLAGS:
-            if _contains_destructive_node_inline_script(token[2:]):
+            if _contains_destructive_node_inline_script(segment_args[index][2:]):
                 return True
             index += 1
             continue
         if token.startswith("-p") and token not in _NODE_INLINE_EVAL_FLAGS:
-            if _contains_destructive_node_inline_script(token[2:]):
+            if _contains_destructive_node_inline_script(segment_args[index][2:]):
                 return True
             index += 1
             continue

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -615,6 +615,8 @@ def _contains_destructive_node_inline_script(script: str) -> bool:
                 return True
             if re.search(rf"{base_pattern}\s*\.\s*call\s*\(", script):
                 return True
+            if re.search(rf"{base_pattern}\s*\.\s*apply\s*\(", script):
+                return True
     return False
 
 

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -92,7 +92,7 @@ _NODE_OPTION_FLAGS_WITH_VALUE = frozenset(
     }
 )
 _SHELL_COMMAND_SEPARATORS = frozenset({"&&", "||", ";", "|", "&"})
-_SHELL_COMMAND_WRAPPERS = frozenset({"command", "env", "nohup"})
+_SHELL_COMMAND_WRAPPERS = frozenset({"command", "env", "nice", "nohup", "stdbuf", "time"})
 _SHELL_ASSIGNMENT_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*")
 _DESTRUCTIVE_NODE_INLINE_CALLS = frozenset(
     {
@@ -637,11 +637,26 @@ def _shell_segment_primary_command(segment: list[str]) -> tuple[str | None, int 
         command_name = _normalized_shell_command_name(normalized_token)
         if command_name == "env":
             index += 1
-            while index < len(segment) and _SHELL_ASSIGNMENT_PATTERN.match(segment[index]):
+            while index < len(segment):
+                token = segment[index]
+                if token in {"-u", "--unset"} and index + 1 < len(segment):
+                    index += 2
+                    continue
+                if token.startswith("-"):
+                    index += 1
+                    continue
+                if not _SHELL_ASSIGNMENT_PATTERN.match(token):
+                    break
                 index += 1
             continue
         if command_name in _SHELL_COMMAND_WRAPPERS:
             index += 1
+            while index < len(segment) and segment[index].startswith("-"):
+                token = segment[index]
+                if command_name == "nice" and token in {"-n", "--adjustment"} and index + 1 < len(segment):
+                    index += 2
+                    continue
+                index += 1
             continue
         return command_name, index
     return None, None

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -810,8 +810,8 @@ def _shell_command_names(command_text: str) -> tuple[str, ...]:
 def _normalized_shell_command_name(command_name: str) -> str:
     normalized_command = command_name.replace("\\", "/").strip()
     if "/" not in normalized_command:
-        return normalized_command
-    return normalized_command.rsplit("/", 1)[-1]
+        return normalized_command.lower()
+    return normalized_command.rsplit("/", 1)[-1].lower()
 
 
 def _redacted_shell_text_for_command_names(command_text: str) -> str:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -91,6 +91,9 @@ _NODE_OPTION_FLAGS_WITH_VALUE = frozenset(
         "--conditions",
     }
 )
+_SHELL_COMMAND_SEPARATORS = frozenset({"&&", "||", ";", "|", "&"})
+_SHELL_COMMAND_WRAPPERS = frozenset({"command", "env", "nohup"})
+_SHELL_ASSIGNMENT_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*")
 _DESTRUCTIVE_NODE_INLINE_CALLS = frozenset(
     {
         "appendfile",
@@ -576,44 +579,12 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
 
 
 def _contains_destructive_node_inline_eval(parts: list[str]) -> bool:
-    lowered_parts = [part.lower() for part in parts]
-    for index, part in enumerate(lowered_parts):
-        if _normalized_shell_command_name(part) != "node":
+    for segment in _iter_shell_command_segments(parts):
+        command_name, command_index = _shell_segment_primary_command(segment)
+        if command_name != "node" or command_index is None:
             continue
-        inner_index = index + 1
-        while inner_index < len(lowered_parts):
-            token = lowered_parts[inner_index]
-            if token in {"&&", "||", ";", "|", "&"}:
-                break
-            if token == "--":
-                break
-            if token in _NODE_INLINE_EVAL_FLAGS and inner_index + 1 < len(lowered_parts):
-                return _contains_destructive_node_inline_script(lowered_parts[inner_index + 1])
-            if _is_combined_node_inline_eval_flag(token) and inner_index + 1 < len(lowered_parts):
-                return _contains_destructive_node_inline_script(lowered_parts[inner_index + 1])
-            if token.startswith("--eval=") and _contains_destructive_node_inline_script(token.split("=", 1)[1]):
-                return True
-            if token.startswith("--print=") and _contains_destructive_node_inline_script(token.split("=", 1)[1]):
-                return True
-            if (
-                token.startswith("-e")
-                and token not in _NODE_INLINE_EVAL_FLAGS
-                and _contains_destructive_node_inline_script(token[2:])
-            ):
-                return True
-            if (
-                token.startswith("-p")
-                and token not in _NODE_INLINE_EVAL_FLAGS
-                and _contains_destructive_node_inline_script(token[2:])
-            ):
-                return True
-            if token in _NODE_OPTION_FLAGS_WITH_VALUE and inner_index + 1 < len(lowered_parts):
-                inner_index += 1
-                inner_index += 1
-                continue
-            if not token.startswith("-"):
-                break
-            inner_index += 1
+        if _segment_contains_destructive_node_inline_eval(segment[command_index + 1 :]):
+            return True
     return False
 
 
@@ -629,35 +600,111 @@ def _is_combined_node_inline_eval_flag(token: str) -> bool:
 
 
 def _find_command_uses_delete(parts: list[str]) -> bool:
-    expect_command = True
-    current_command: str | None = None
-    index = 0
-    while index < len(parts):
-        token = parts[index].strip()
+    for segment in _iter_shell_command_segments(parts):
+        command_name, command_index = _shell_segment_primary_command(segment)
+        if command_name != "find" or command_index is None:
+            continue
+        if _find_segment_uses_delete(segment[command_index + 1 :]):
+            return True
+    return False
+
+
+def _iter_shell_command_segments(parts: list[str]) -> list[list[str]]:
+    segments: list[list[str]] = []
+    current_segment: list[str] = []
+    for part in parts:
+        token = part.strip()
         if not token:
+            continue
+        if token in _SHELL_COMMAND_SEPARATORS:
+            if current_segment:
+                segments.append(current_segment)
+                current_segment = []
+            continue
+        current_segment.append(token)
+    if current_segment:
+        segments.append(current_segment)
+    return segments
+
+
+def _shell_segment_primary_command(segment: list[str]) -> tuple[str | None, int | None]:
+    index = 0
+    while index < len(segment):
+        normalized_token = segment[index].lstrip("(").rstrip(")")
+        if _SHELL_ASSIGNMENT_PATTERN.match(normalized_token):
             index += 1
             continue
-        if token in {"&&", "||", ";", "|", "&"}:
-            expect_command = True
-            current_command = None
+        command_name = _normalized_shell_command_name(normalized_token)
+        if command_name == "env":
             index += 1
-            continue
-        normalized_token = token.lstrip("(").rstrip(")")
-        if expect_command:
-            if re.match(r"^[a-z_][a-z0-9_]*=.*", normalized_token):
+            while index < len(segment) and _SHELL_ASSIGNMENT_PATTERN.match(segment[index]):
                 index += 1
-                continue
-            current_command = _normalized_shell_command_name(normalized_token)
-            expect_command = False
+            continue
+        if command_name in _SHELL_COMMAND_WRAPPERS:
             index += 1
             continue
-        if current_command == "find" and token in {"-exec", "-execdir", "-ok", "-okdir"}:
+        return command_name, index
+    return None, None
+
+
+def _segment_contains_destructive_node_inline_eval(segment_args: list[str]) -> bool:
+    lowered_args = [arg.lower() for arg in segment_args]
+    index = 0
+    while index < len(lowered_args):
+        token = lowered_args[index]
+        if token == "--":
+            break
+        if token in _NODE_INLINE_EVAL_FLAGS and index + 1 < len(lowered_args):
+            if _contains_destructive_node_inline_script(lowered_args[index + 1]):
+                return True
+            index += 2
+            continue
+        if _is_combined_node_inline_eval_flag(token) and index + 1 < len(lowered_args):
+            if _contains_destructive_node_inline_script(lowered_args[index + 1]):
+                return True
+            index += 2
+            continue
+        if token.startswith("--eval="):
+            if _contains_destructive_node_inline_script(token.split("=", 1)[1]):
+                return True
             index += 1
-            while index < len(parts) and parts[index] not in {";", "+"}:
+            continue
+        if token.startswith("--print="):
+            if _contains_destructive_node_inline_script(token.split("=", 1)[1]):
+                return True
+            index += 1
+            continue
+        if token.startswith("-e") and token not in _NODE_INLINE_EVAL_FLAGS:
+            if _contains_destructive_node_inline_script(token[2:]):
+                return True
+            index += 1
+            continue
+        if token.startswith("-p") and token not in _NODE_INLINE_EVAL_FLAGS:
+            if _contains_destructive_node_inline_script(token[2:]):
+                return True
+            index += 1
+            continue
+        if token in _NODE_OPTION_FLAGS_WITH_VALUE and index + 1 < len(lowered_args):
+            index += 2
+            continue
+        if not token.startswith("-"):
+            break
+        index += 1
+    return False
+
+
+def _find_segment_uses_delete(segment_args: list[str]) -> bool:
+    index = 0
+    while index < len(segment_args):
+        token = segment_args[index]
+        if token in {"-exec", "-execdir", "-ok", "-okdir"}:
+            index += 1
+            while index < len(segment_args) and segment_args[index] not in {";", "+"}:
                 index += 1
-            index += 1
+            if index < len(segment_args):
+                index += 1
             continue
-        if current_command == "find" and token == "-delete":
+        if token == "-delete":
             return True
         index += 1
     return False

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -553,7 +553,7 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
     command_names.extend(_shell_command_names_from_parts(parts))
     if any(command_name in _DESTRUCTIVE_SHELL_COMMANDS for command_name in command_names):
         return True
-    if "find" in command_names and any(part == "-delete" for part in parts):
+    if _find_command_uses_delete(parts):
         return True
     for shell_script in _shell_command_scripts(parts):
         if _looks_destructive_shell_command(shell_script):
@@ -577,6 +577,10 @@ def _contains_destructive_node_inline_eval(parts: list[str]) -> bool:
                 if _contains_destructive_node_inline_script(lowered_parts[inner_index + 1]):
                     return True
                 continue
+            if _is_combined_node_inline_eval_flag(token) and inner_index + 1 < len(lowered_parts):
+                if _contains_destructive_node_inline_script(lowered_parts[inner_index + 1]):
+                    return True
+                continue
             if token.startswith("--eval=") and _contains_destructive_node_inline_script(token.split("=", 1)[1]):
                 return True
             if (
@@ -593,6 +597,45 @@ def _contains_destructive_node_inline_script(script: str) -> bool:
         re.search(rf"(?<![a-z0-9_$'\"]){re.escape(call_name)}\s*\(", script)
         for call_name in _DESTRUCTIVE_NODE_INLINE_CALLS
     )
+
+
+def _is_combined_node_inline_eval_flag(token: str) -> bool:
+    return token.startswith("-") and not token.startswith("--") and any(flag in token[1:] for flag in {"e", "p"})
+
+
+def _find_command_uses_delete(parts: list[str]) -> bool:
+    expect_command = True
+    current_command: str | None = None
+    index = 0
+    while index < len(parts):
+        token = parts[index].strip()
+        if not token:
+            index += 1
+            continue
+        if token in {"&&", "||", ";", "|", "&"}:
+            expect_command = True
+            current_command = None
+            index += 1
+            continue
+        normalized_token = token.lstrip("(").rstrip(")")
+        if expect_command:
+            if re.match(r"^[a-z_][a-z0-9_]*=.*", normalized_token):
+                index += 1
+                continue
+            current_command = _normalized_shell_command_name(normalized_token)
+            expect_command = False
+            index += 1
+            continue
+        if current_command == "find" and token in {"-exec", "-execdir"}:
+            index += 1
+            while index < len(parts) and parts[index] not in {";", "+"}:
+                index += 1
+            index += 1
+            continue
+        if current_command == "find" and token == "-delete":
+            return True
+        index += 1
+    return False
 
 
 def _contains_mutating_shell_redirection(command_text: str) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -564,7 +564,7 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
         return False
     lowered = normalized.lower()
     redacted_command_text = _redacted_shell_text_for_command_names(lowered)
-    if _contains_mutating_shell_redirection(redacted_command_text):
+    if _contains_mutating_shell_redirection(lowered):
         return True
     raw_command_names = list(_shell_command_names(redacted_command_text))
     parts = _split_shell_parts(normalized)

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -92,7 +92,7 @@ _NODE_OPTION_FLAGS_WITH_VALUE = frozenset(
         "--title",
     }
 )
-_SHELL_COMMAND_SEPARATORS = frozenset({"&&", "||", ";", "|", "&"})
+_SHELL_COMMAND_SEPARATORS = frozenset({"&&", "||", ";", "|", "&", "|&"})
 _SHELL_COMMAND_WRAPPERS = frozenset({"command", "env", "nice", "nohup", "stdbuf", "time"})
 _SHELL_ASSIGNMENT_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*")
 _SHELL_NEWLINE_SEPARATOR = ";"
@@ -750,25 +750,32 @@ def _env_split_string_payloads(parts: list[str]) -> tuple[str, ...]:
         index = env_index + 1
         while index < len(segment):
             token = segment[index]
+            if _SHELL_ASSIGNMENT_PATTERN.match(token):
+                index += 1
+                continue
+            if token == "--":
+                break
+            if not token.startswith("-"):
+                break
             if token in {"-S", "--split-string"} and index + 1 < len(segment):
                 payload = segment[index + 1].strip()
                 if payload:
                     payloads.append(payload)
-                index += 2
+                index += _wrapper_option_tokens_consumed("env", token)
                 continue
             if token.startswith("--split-string="):
                 payload = token.split("=", 1)[1].strip()
                 if payload:
                     payloads.append(payload)
-                index += 1
+                index += _wrapper_option_tokens_consumed("env", token)
                 continue
             if token.startswith("-S") and token != "-S":
                 payload = token[2:].strip()
                 if payload:
                     payloads.append(payload)
-                index += 1
+                index += _wrapper_option_tokens_consumed("env", token)
                 continue
-            index += 1
+            index += _wrapper_option_tokens_consumed("env", token)
     return tuple(payloads)
 
 
@@ -873,11 +880,27 @@ def _replace_unquoted_newlines_with_separators(command_text: str) -> str:
 def _wrapper_option_tokens_consumed(command_name: str, token: str) -> int:
     if not token.startswith("-"):
         return 1
+    if command_name == "env":
+        env_short_option_tokens = _env_short_option_tokens_consumed(token)
+        if env_short_option_tokens is not None:
+            return env_short_option_tokens
     exact_flags = _WRAPPER_FLAGS_WITH_VALUES.get(command_name, frozenset())
     if token in exact_flags:
         return 2
     if _wrapper_flag_has_attached_value(command_name, token):
         return 1
+    return 1
+
+
+def _env_short_option_tokens_consumed(token: str) -> int | None:
+    if not token.startswith("-") or token.startswith("--") or len(token) <= 2:
+        return None
+    for index, flag_character in enumerate(token[1:], start=1):
+        if flag_character not in {"C", "S", "u"}:
+            continue
+        if index < len(token) - 1:
+            return 1
+        return 2
     return 1
 
 
@@ -910,7 +933,7 @@ def _shell_command_names_from_parts(parts: list[str]) -> tuple[str, ...]:
         token = part.strip()
         if not token:
             continue
-        if token in {"&&", "||", ";", "|", "&"}:
+        if token in _SHELL_COMMAND_SEPARATORS:
             expect_command = True
             continue
         normalized_token = token.lstrip("(").rstrip(")")
@@ -950,7 +973,7 @@ def _script_interpreter_texts(parts: list[str]) -> tuple[str, ...]:
         if not token:
             index += 1
             continue
-        if token in {"&&", "||", ";", "|", "&"}:
+        if token in _SHELL_COMMAND_SEPARATORS:
             current_command = None
             expect_command = True
             index += 1

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -616,9 +616,9 @@ def _contains_destructive_node_inline_script(script: str) -> bool:
         ):
             if re.search(rf"{base_pattern}\s*(?:\?\.\s*)?(?:\)\s*)?\(", member_scan_script):
                 return True
-            if re.search(rf"{base_pattern}\s*\.\s*call\s*\(", member_scan_script):
+            if re.search(rf"{base_pattern}\s*(?:\?\s*)?\.\s*call\s*\(", member_scan_script):
                 return True
-            if re.search(rf"{base_pattern}\s*\.\s*apply\s*\(", member_scan_script):
+            if re.search(rf"{base_pattern}\s*(?:\?\s*)?\.\s*apply\s*\(", member_scan_script):
                 return True
     return False
 
@@ -735,6 +735,18 @@ def _segment_contains_destructive_node_inline_eval(segment_args: list[str]) -> b
 
 
 def _find_segment_uses_delete(segment_args: list[str]) -> bool:
+    value_taking_predicates = {
+        "-name",
+        "-iname",
+        "-path",
+        "-ipath",
+        "-wholename",
+        "-iwholename",
+        "-regex",
+        "-iregex",
+        "-lname",
+        "-ilname",
+    }
     index = 0
     while index < len(segment_args):
         token = segment_args[index]
@@ -744,6 +756,9 @@ def _find_segment_uses_delete(segment_args: list[str]) -> bool:
                 index += 1
             if index < len(segment_args):
                 index += 1
+            continue
+        if token in value_taking_predicates and index + 1 < len(segment_args):
+            index += 2
             continue
         if token == "-delete":
             return True

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -589,7 +589,10 @@ def _contains_destructive_node_inline_eval(parts: list[str]) -> bool:
 
 
 def _contains_destructive_node_inline_script(script: str) -> bool:
-    return any(re.search(rf"{re.escape(call_name)}\s*\(", script) for call_name in _DESTRUCTIVE_NODE_INLINE_CALLS)
+    return any(
+        re.search(rf"(?<![a-z0-9_$'\"]){re.escape(call_name)}\s*\(", script)
+        for call_name in _DESTRUCTIVE_NODE_INLINE_CALLS
+    )
 
 
 def _contains_mutating_shell_redirection(command_text: str) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -834,9 +834,7 @@ def _wrapper_flag_has_attached_value(command_name: str, token: str) -> bool:
             len(token) > 2 and token[:2] in {"-i", "-o", "-e"}
         )
     if command_name == "time":
-        return token.startswith(("--format=", "--output=")) or (
-            len(token) > 2 and token[:2] in {"-f", "-o"}
-        )
+        return token.startswith(("--format=", "--output=")) or (len(token) > 2 and token[:2] in {"-f", "-o"})
     return False
 
 

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -89,6 +89,8 @@ _NODE_OPTION_FLAGS_WITH_VALUE = frozenset(
         "--experimental-loader",
         "--input-type",
         "--conditions",
+        "--debug-port",
+        "--inspect-port",
         "--title",
     }
 )
@@ -870,8 +872,9 @@ def _replace_unquoted_newlines_with_separators(command_text: str) -> str:
         if quote_char is None and character in {"\n", "\r"}:
             if not result or result[-1] != " ":
                 result.append(" ")
+            result.append("\n")
             result.append(_SHELL_NEWLINE_SEPARATOR)
-            result.append(" ")
+            result.append("\n")
             continue
         result.append(character)
     return "".join(result)

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -821,7 +821,10 @@ def _contains_mutating_shell_redirection(parts: list[str]) -> bool:
         if token in {">", ">>", ">|", "1>", "1>>", "1>|", "2>", "2>>", "2>|"}:
             if token[0].isdigit():
                 fd = token[0]
-            if index + 1 < len(parts):
+            if token.endswith(">") and index + 2 < len(parts) and parts[index + 1] == "|":
+                target = parts[index + 2]
+                index += 3
+            elif index + 1 < len(parts):
                 target = parts[index + 1]
                 index += 2
             else:
@@ -849,7 +852,7 @@ def _contains_mutating_shell_redirection(parts: list[str]) -> bool:
                 index += 1
         if target is None:
             continue
-        normalized_target = _normalized_redirect_target(target)
+        normalized_target = _normalized_redirect_target(target).lower()
         if fd == "2" and normalized_target in _SAFE_SHELL_REDIRECT_TARGETS:
             continue
         if normalized_target in _SAFE_SHELL_REDIRECT_TARGETS or normalized_target.startswith("&"):

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -827,8 +827,15 @@ def _contains_mutating_shell_redirection(parts: list[str]) -> bool:
             else:
                 index += 1
         else:
-            match = re.fullmatch(r"(?P<fd>[0-2]?)(?P<op>>\||>>|>)(?P<target>.+)?", token)
+            if re.search(r"\s", token):
+                index += 1
+                continue
+            match = re.fullmatch(r"(?P<prefix>[^<>\s]*?)(?P<fd>[0-2]?)(?P<op>>\||>>|>)(?P<target>.*)", token)
             if match is None:
+                index += 1
+                continue
+            prefix = match.group("prefix") or ""
+            if prefix.endswith("="):
                 index += 1
                 continue
             fd = match.group("fd")

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -89,6 +89,7 @@ _NODE_OPTION_FLAGS_WITH_VALUE = frozenset(
         "--experimental-loader",
         "--input-type",
         "--conditions",
+        "--title",
     }
 )
 _SHELL_COMMAND_SEPARATORS = frozenset({"&&", "||", ";", "|", "&"})
@@ -576,6 +577,9 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
         return True
     if _find_command_uses_delete(parts):
         return True
+    for env_split_string in _env_split_string_payloads(parts):
+        if _looks_destructive_shell_command(env_split_string):
+            return True
     for shell_script in _shell_command_scripts(parts):
         if _looks_destructive_shell_command(shell_script):
             return True
@@ -727,6 +731,59 @@ def _find_segment_uses_delete(segment_args: list[str]) -> bool:
             return True
         index += 1
     return False
+
+
+def _env_split_string_payloads(parts: list[str]) -> tuple[str, ...]:
+    payloads: list[str] = []
+    for segment in _iter_shell_command_segments(parts):
+        env_index = _shell_segment_env_index(segment)
+        if env_index is None:
+            continue
+        index = env_index + 1
+        while index < len(segment):
+            token = segment[index]
+            if token in {"-S", "--split-string"} and index + 1 < len(segment):
+                payload = segment[index + 1].strip()
+                if payload:
+                    payloads.append(payload)
+                index += 2
+                continue
+            if token.startswith("--split-string="):
+                payload = token.split("=", 1)[1].strip()
+                if payload:
+                    payloads.append(payload)
+                index += 1
+                continue
+            if token.startswith("-S") and token != "-S":
+                payload = token[2:].strip()
+                if payload:
+                    payloads.append(payload)
+                index += 1
+                continue
+            index += 1
+    return tuple(payloads)
+
+
+def _shell_segment_env_index(segment: list[str]) -> int | None:
+    index = 0
+    while index < len(segment):
+        normalized_token = segment[index].lstrip("(").rstrip(")")
+        if _SHELL_ASSIGNMENT_PATTERN.match(normalized_token):
+            index += 1
+            continue
+        command_name = _normalized_shell_command_name(normalized_token)
+        if command_name == "env":
+            return index
+        if command_name in _SHELL_COMMAND_WRAPPERS:
+            index += 1
+            while index < len(segment):
+                token = segment[index]
+                if not token.startswith("-"):
+                    break
+                index += _wrapper_option_tokens_consumed(command_name, token)
+            continue
+        return None
+    return None
 
 
 def _contains_mutating_shell_redirection(command_text: str) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -80,22 +80,22 @@ _SAFE_SHELL_REDIRECT_TARGETS = frozenset(
     }
 )
 _NODE_INLINE_EVAL_FLAGS = frozenset({"-e", "--eval"})
-_DESTRUCTIVE_NODE_INLINE_TOKENS = frozenset(
+_DESTRUCTIVE_NODE_INLINE_CALLS = frozenset(
     {
-        "appendfile(",
-        "appendfilesync(",
-        "copyfile(",
-        "copyfilesync(",
-        "mkdir(",
-        "mkdirsync(",
-        "rename(",
-        "renamesync(",
-        "rm(",
-        "rmsync(",
-        "unlink(",
-        "unlinksync(",
-        "writefile(",
-        "writefilesync(",
+        "appendfile",
+        "appendfilesync",
+        "copyfile",
+        "copyfilesync",
+        "mkdir",
+        "mkdirsync",
+        "rename",
+        "renamesync",
+        "rm",
+        "rmsync",
+        "unlink",
+        "unlinksync",
+        "writefile",
+        "writefilesync",
     }
 )
 _SENSITIVE_BASENAME_LABELS = {
@@ -553,7 +553,7 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
     command_names.extend(_shell_command_names_from_parts(parts))
     if any(command_name in _DESTRUCTIVE_SHELL_COMMANDS for command_name in command_names):
         return True
-    if "find" in command_names and " -delete" in lowered:
+    if "find" in command_names and any(part == "-delete" for part in parts):
         return True
     for shell_script in _shell_command_scripts(parts):
         if _looks_destructive_shell_command(shell_script):
@@ -566,15 +566,30 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
 
 def _contains_destructive_node_inline_eval(parts: list[str]) -> bool:
     lowered_parts = [part.lower() for part in parts]
-    for index, part in enumerate(lowered_parts[:-2]):
+    for index, part in enumerate(lowered_parts):
         if _normalized_shell_command_name(part) != "node":
             continue
-        if lowered_parts[index + 1] not in _NODE_INLINE_EVAL_FLAGS:
-            continue
-        script = lowered_parts[index + 2]
-        if any(token in script for token in _DESTRUCTIVE_NODE_INLINE_TOKENS):
-            return True
+        for inner_index in range(index + 1, len(lowered_parts)):
+            token = lowered_parts[inner_index]
+            if token in {"&&", "||", ";", "|", "&"}:
+                break
+            if token in _NODE_INLINE_EVAL_FLAGS and inner_index + 1 < len(lowered_parts):
+                if _contains_destructive_node_inline_script(lowered_parts[inner_index + 1]):
+                    return True
+                continue
+            if token.startswith("--eval=") and _contains_destructive_node_inline_script(token.split("=", 1)[1]):
+                return True
+            if (
+                token.startswith("-e")
+                and token not in _NODE_INLINE_EVAL_FLAGS
+                and _contains_destructive_node_inline_script(token[2:])
+            ):
+                return True
     return False
+
+
+def _contains_destructive_node_inline_script(script: str) -> bool:
+    return any(re.search(rf"{re.escape(call_name)}\s*\(", script) for call_name in _DESTRUCTIVE_NODE_INLINE_CALLS)
 
 
 def _contains_mutating_shell_redirection(command_text: str) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -79,7 +79,18 @@ _SAFE_SHELL_REDIRECT_TARGETS = frozenset(
         "nul",
     }
 )
-_NODE_INLINE_EVAL_FLAGS = frozenset({"-e", "--eval"})
+_NODE_INLINE_EVAL_FLAGS = frozenset({"-e", "--eval", "-p", "--print"})
+_NODE_OPTION_FLAGS_WITH_VALUE = frozenset(
+    {
+        "-r",
+        "--require",
+        "--import",
+        "--loader",
+        "--experimental-loader",
+        "--input-type",
+        "--conditions",
+    }
+)
 _DESTRUCTIVE_NODE_INLINE_CALLS = frozenset(
     {
         "appendfile",
@@ -569,19 +580,20 @@ def _contains_destructive_node_inline_eval(parts: list[str]) -> bool:
     for index, part in enumerate(lowered_parts):
         if _normalized_shell_command_name(part) != "node":
             continue
-        for inner_index in range(index + 1, len(lowered_parts)):
+        inner_index = index + 1
+        while inner_index < len(lowered_parts):
             token = lowered_parts[inner_index]
             if token in {"&&", "||", ";", "|", "&"}:
                 break
+            if token == "--":
+                break
             if token in _NODE_INLINE_EVAL_FLAGS and inner_index + 1 < len(lowered_parts):
-                if _contains_destructive_node_inline_script(lowered_parts[inner_index + 1]):
-                    return True
-                continue
+                return _contains_destructive_node_inline_script(lowered_parts[inner_index + 1])
             if _is_combined_node_inline_eval_flag(token) and inner_index + 1 < len(lowered_parts):
-                if _contains_destructive_node_inline_script(lowered_parts[inner_index + 1]):
-                    return True
-                continue
+                return _contains_destructive_node_inline_script(lowered_parts[inner_index + 1])
             if token.startswith("--eval=") and _contains_destructive_node_inline_script(token.split("=", 1)[1]):
+                return True
+            if token.startswith("--print=") and _contains_destructive_node_inline_script(token.split("=", 1)[1]):
                 return True
             if (
                 token.startswith("-e")
@@ -589,6 +601,19 @@ def _contains_destructive_node_inline_eval(parts: list[str]) -> bool:
                 and _contains_destructive_node_inline_script(token[2:])
             ):
                 return True
+            if (
+                token.startswith("-p")
+                and token not in _NODE_INLINE_EVAL_FLAGS
+                and _contains_destructive_node_inline_script(token[2:])
+            ):
+                return True
+            if token in _NODE_OPTION_FLAGS_WITH_VALUE and inner_index + 1 < len(lowered_parts):
+                inner_index += 1
+                inner_index += 1
+                continue
+            if not token.startswith("-"):
+                break
+            inner_index += 1
     return False
 
 
@@ -600,7 +625,7 @@ def _contains_destructive_node_inline_script(script: str) -> bool:
 
 
 def _is_combined_node_inline_eval_flag(token: str) -> bool:
-    return token.startswith("-") and not token.startswith("--") and any(flag in token[1:] for flag in {"e", "p"})
+    return token in {"-pe", "-ep"}
 
 
 def _find_command_uses_delete(parts: list[str]) -> bool:
@@ -626,7 +651,7 @@ def _find_command_uses_delete(parts: list[str]) -> bool:
             expect_command = False
             index += 1
             continue
-        if current_command == "find" and token in {"-exec", "-execdir"}:
+        if current_command == "find" and token in {"-exec", "-execdir", "-ok", "-okdir"}:
             index += 1
             while index < len(parts) and parts[index] not in {";", "+"}:
                 index += 1

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -54,15 +54,20 @@ _DESTRUCTIVE_SHELL_COMMANDS = frozenset(
     {
         "chmod",
         "chown",
+        "del",
         "dd",
+        "erase",
         "mv",
         "perl",
         "python",
         "python3",
         "rm",
+        "rmdir",
+        "remove-item",
         "ruby",
         "tee",
         "truncate",
+        "unlink",
     }
 )
 _SCRIPT_INTERPRETER_COMMANDS = frozenset({"perl", "python", "python3", "ruby"})
@@ -72,6 +77,25 @@ _SAFE_SHELL_REDIRECT_TARGETS = frozenset(
         "/dev/stdout",
         "/dev/stderr",
         "nul",
+    }
+)
+_NODE_INLINE_EVAL_FLAGS = frozenset({"-e", "--eval"})
+_DESTRUCTIVE_NODE_INLINE_TOKENS = frozenset(
+    {
+        "appendfile(",
+        "appendfilesync(",
+        "copyfile(",
+        "copyfilesync(",
+        "mkdir(",
+        "mkdirsync(",
+        "rename(",
+        "renamesync(",
+        "rm(",
+        "rmsync(",
+        "unlink(",
+        "unlinksync(",
+        "writefile(",
+        "writefilesync(",
     }
 )
 _SENSITIVE_BASENAME_LABELS = {
@@ -523,9 +547,13 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
         return False
     if _looks_like_benign_interpreter_wait(normalized, parts, raw_command_names):
         return False
+    if _contains_destructive_node_inline_eval(parts):
+        return True
     command_names = list(raw_command_names)
     command_names.extend(_shell_command_names_from_parts(parts))
     if any(command_name in _DESTRUCTIVE_SHELL_COMMANDS for command_name in command_names):
+        return True
+    if "find" in command_names and " -delete" in lowered:
         return True
     for shell_script in _shell_command_scripts(parts):
         if _looks_destructive_shell_command(shell_script):
@@ -534,6 +562,19 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
         command_name == "sed" and any(part == "-i" or part.startswith("-i") for part in parts[1:])
         for command_name in command_names
     )
+
+
+def _contains_destructive_node_inline_eval(parts: list[str]) -> bool:
+    lowered_parts = [part.lower() for part in parts]
+    for index, part in enumerate(lowered_parts[:-2]):
+        if _normalized_shell_command_name(part) != "node":
+            continue
+        if lowered_parts[index + 1] not in _NODE_INLINE_EVAL_FLAGS:
+            continue
+        script = lowered_parts[index + 2]
+        if any(token in script for token in _DESTRUCTIVE_NODE_INLINE_TOKENS):
+            return True
+    return False
 
 
 def _contains_mutating_shell_redirection(command_text: str) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -91,6 +91,7 @@ _NODE_OPTION_FLAGS_WITH_VALUE = frozenset(
         "--conditions",
         "--debug-port",
         "--inspect-port",
+        "--redirect-warnings",
         "--title",
     }
 )
@@ -603,19 +604,21 @@ def _contains_destructive_node_inline_eval(parts: list[str]) -> bool:
 
 
 def _contains_destructive_node_inline_script(script: str) -> bool:
+    redacted_script = _redacted_node_inline_string_literals(script)
+    member_scan_script = _redacted_node_inline_string_literals(script, preserve_bracket_member_strings=True)
     for call_name in _DESTRUCTIVE_NODE_INLINE_CALLS:
         escaped_call_name = re.escape(call_name)
-        if re.search(rf"(?<![A-Za-z0-9_$'\"]){escaped_call_name}\s*(?:\?\.\s*)?\(", script):
+        if re.search(rf"(?<![A-Za-z0-9_$'\"]){escaped_call_name}\s*(?:\?\.\s*)?\(", redacted_script):
             return True
         for base_pattern in (
             rf"\.\s*{escaped_call_name}",
             rf"\[\s*['\"]{escaped_call_name}['\"]\s*\]",
         ):
-            if re.search(rf"{base_pattern}\s*(?:\?\.\s*)?(?:\)\s*)?\(", script):
+            if re.search(rf"{base_pattern}\s*(?:\?\.\s*)?(?:\)\s*)?\(", member_scan_script):
                 return True
-            if re.search(rf"{base_pattern}\s*\.\s*call\s*\(", script):
+            if re.search(rf"{base_pattern}\s*\.\s*call\s*\(", member_scan_script):
                 return True
-            if re.search(rf"{base_pattern}\s*\.\s*apply\s*\(", script):
+            if re.search(rf"{base_pattern}\s*\.\s*apply\s*\(", member_scan_script):
                 return True
     return False
 
@@ -865,6 +868,46 @@ def _contains_mutating_shell_redirection(parts: list[str]) -> bool:
 
 def _normalized_redirect_target(target: str) -> str:
     return target.strip().strip(");,").strip("'\"")
+
+
+def _redacted_node_inline_string_literals(script: str, *, preserve_bracket_member_strings: bool = False) -> str:
+    result: list[str] = []
+    quote_char: str | None = None
+    escape_next = False
+    preserve_string_contents = False
+    for character in script:
+        if quote_char is None:
+            if character in {"'", '"'}:
+                preserve_string_contents = (
+                    preserve_bracket_member_strings and _last_non_whitespace_character(result) == "["
+                )
+                quote_char = character
+                result.append(character)
+                continue
+            result.append(character)
+            continue
+        if escape_next:
+            result.append(character if preserve_string_contents else "Q")
+            escape_next = False
+            continue
+        if character == "\\":
+            result.append(character)
+            escape_next = True
+            continue
+        if character == quote_char:
+            result.append(character)
+            quote_char = None
+            preserve_string_contents = False
+            continue
+        result.append(character if preserve_string_contents else "Q")
+    return "".join(result)
+
+
+def _last_non_whitespace_character(result: list[str]) -> str | None:
+    for character in reversed(result):
+        if not character.isspace():
+            return character
+    return None
 
 
 def _shell_command_names(command_text: str) -> tuple[str, ...]:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -94,6 +94,7 @@ _NODE_OPTION_FLAGS_WITH_VALUE = frozenset(
 _SHELL_COMMAND_SEPARATORS = frozenset({"&&", "||", ";", "|", "&"})
 _SHELL_COMMAND_WRAPPERS = frozenset({"command", "env", "nice", "nohup", "stdbuf", "time"})
 _SHELL_ASSIGNMENT_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*")
+_SHELL_NEWLINE_SEPARATOR = ";"
 _DESTRUCTIVE_NODE_INLINE_CALLS = frozenset(
     {
         "appendfile",
@@ -112,6 +113,12 @@ _DESTRUCTIVE_NODE_INLINE_CALLS = frozenset(
         "writefilesync",
     }
 )
+_WRAPPER_FLAGS_WITH_VALUES = {
+    "env": frozenset({"-u", "--unset", "-C", "--chdir", "-S", "--split-string"}),
+    "nice": frozenset({"-n", "--adjustment"}),
+    "stdbuf": frozenset({"-i", "--input", "-o", "--output", "-e", "--error"}),
+    "time": frozenset({"-f", "--format", "-o", "--output"}),
+}
 _SENSITIVE_BASENAME_LABELS = {
     ".npmrc": "npm registry credentials",
     ".pypirc": "Python package credentials",
@@ -591,6 +598,8 @@ def _contains_destructive_node_inline_eval(parts: list[str]) -> bool:
 def _contains_destructive_node_inline_script(script: str) -> bool:
     return any(
         re.search(rf"(?<![a-z0-9_$'\"]){re.escape(call_name)}\s*\(", script)
+        or re.search(rf"\.\s*{re.escape(call_name)}\s*(?:\)\s*)?\(", script)
+        or re.search(rf"\[\s*['\"]{re.escape(call_name)}['\"]\s*\]\s*(?:\)\s*)?\(", script)
         for call_name in _DESTRUCTIVE_NODE_INLINE_CALLS
     )
 
@@ -639,24 +648,19 @@ def _shell_segment_primary_command(segment: list[str]) -> tuple[str | None, int 
             index += 1
             while index < len(segment):
                 token = segment[index]
-                if token in {"-u", "--unset"} and index + 1 < len(segment):
-                    index += 2
-                    continue
-                if token.startswith("-"):
-                    index += 1
-                    continue
-                if not _SHELL_ASSIGNMENT_PATTERN.match(token):
+                if not token.startswith("-") and not _SHELL_ASSIGNMENT_PATTERN.match(token):
                     break
-                index += 1
+                tokens_consumed = _wrapper_option_tokens_consumed(command_name, token)
+                index += tokens_consumed
+                continue
             continue
         if command_name in _SHELL_COMMAND_WRAPPERS:
             index += 1
-            while index < len(segment) and segment[index].startswith("-"):
+            while index < len(segment):
                 token = segment[index]
-                if command_name == "nice" and token in {"-n", "--adjustment"} and index + 1 < len(segment):
-                    index += 2
-                    continue
-                index += 1
+                if not token.startswith("-"):
+                    break
+                index += _wrapper_option_tokens_consumed(command_name, token)
             continue
         return command_name, index
     return None, None
@@ -759,11 +763,81 @@ def _redacted_shell_text_for_command_names(command_text: str) -> str:
 
 def _split_shell_parts(command_text: str) -> list[str]:
     try:
-        lexer = shlex.shlex(command_text, posix=True, punctuation_chars=";&|")
+        lexer = shlex.shlex(
+            _replace_unquoted_newlines_with_separators(command_text),
+            posix=True,
+            punctuation_chars=";&|",
+        )
         lexer.whitespace_split = True
         return list(lexer)
     except ValueError:
         return command_text.split()
+
+
+def _replace_unquoted_newlines_with_separators(command_text: str) -> str:
+    result: list[str] = []
+    quote_char: str | None = None
+    escape_next = False
+    for character in command_text:
+        if escape_next:
+            result.append(character)
+            escape_next = False
+            continue
+        if character == "\\":
+            result.append(character)
+            escape_next = True
+            continue
+        if quote_char is None and character in {"'", '"'}:
+            quote_char = character
+            result.append(character)
+            continue
+        if quote_char == character:
+            quote_char = None
+            result.append(character)
+            continue
+        if quote_char is None and character in {"\n", "\r"}:
+            if not result or result[-1] != " ":
+                result.append(" ")
+            result.append(_SHELL_NEWLINE_SEPARATOR)
+            result.append(" ")
+            continue
+        result.append(character)
+    return "".join(result)
+
+
+def _wrapper_option_tokens_consumed(command_name: str, token: str) -> int:
+    if not token.startswith("-"):
+        return 1
+    exact_flags = _WRAPPER_FLAGS_WITH_VALUES.get(command_name, frozenset())
+    if token in exact_flags:
+        return 2
+    if _wrapper_flag_has_attached_value(command_name, token):
+        return 1
+    return 1
+
+
+def _wrapper_flag_has_attached_value(command_name: str, token: str) -> bool:
+    if command_name == "env":
+        return any(
+            token.startswith(prefix)
+            for prefix in (
+                "--unset=",
+                "--chdir=",
+                "--split-string=",
+                "-C",
+            )
+        )
+    if command_name == "nice":
+        return token.startswith("--adjustment=") or (token.startswith("-n") and token != "-n")
+    if command_name == "stdbuf":
+        return token.startswith(("--input=", "--output=", "--error=")) or (
+            len(token) > 2 and token[:2] in {"-i", "-o", "-e"}
+        )
+    if command_name == "time":
+        return token.startswith(("--format=", "--output=")) or (
+            len(token) > 2 and token[:2] in {"-f", "-o"}
+        )
+    return False
 
 
 def _shell_command_names_from_parts(parts: list[str]) -> tuple[str, ...]:

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -520,6 +520,16 @@ def test_tool_action_request_classifier_skips_benign_mixed_case_node_identifier(
     assert request is None
 
 
+def test_tool_action_request_classifier_detects_node_print_followed_by_eval_flag():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """node -p -e "require('fs').unlinkSync('dangerous-marker.json')" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_skips_find_exec_literal_delete_string():
     request = extract_sensitive_tool_action_request(
         "bash",
@@ -582,6 +592,16 @@ def test_tool_action_request_classifier_detects_clustered_env_short_option_find_
     request = extract_sensitive_tool_action_request(
         "bash",
         {"command": "env -iu FOO find . -name dangerous-marker.json -delete"},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_clustered_env_split_string_find_delete():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """env -iS "find . -name dangerous-marker.json -delete" """},
     )
 
     assert request is not None

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -500,6 +500,35 @@ def test_tool_action_request_classifier_skips_node_script_argument_named_eval_fl
     assert request is None
 
 
+def test_tool_action_request_classifier_detects_later_destructive_node_eval_flag():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """node -e "console.log('ok')" -e "require('fs').unlinkSync('dangerous-marker.json')" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_env_wrapped_find_delete():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "env FOO=bar find . -name dangerous-marker.json -delete"},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_skips_echoed_node_eval_string():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """echo node -e "require('fs').unlinkSync('dangerous-marker.json')" """},
+    )
+
+    assert request is None
+
+
 def test_tool_action_request_classifier_skips_find_ok_literal_delete_string():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -414,6 +414,36 @@ def test_tool_action_request_classifier_detects_node_inline_unlinksync_bypass():
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_detects_node_inline_unlinksync_with_shifted_eval_flag():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """node --trace-warnings -e "require('fs').unlinkSync('dangerous-marker.json')" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_node_inline_eval_equals_form():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """node --eval="require('fs').unlinkSync('dangerous-marker.json')" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_node_inline_unlinksync_with_space_before_call_paren():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """node -e "require('fs').unlinkSync ('dangerous-marker.json')" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_skips_benign_node_inline_read_only_script():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -453,6 +453,15 @@ def test_tool_action_request_classifier_skips_benign_node_inline_read_only_scrip
     assert request is None
 
 
+def test_tool_action_request_classifier_skips_benign_node_inline_transform_call():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """node -e "const value = transform('ok'); console.log(value)" """},
+    )
+
+    assert request is None
+
+
 def test_tool_action_request_classifier_detects_perl_inline_system_shell_out():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -559,6 +559,16 @@ def test_tool_action_request_classifier_detects_env_ignore_environment_find_dele
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_detects_node_inspect_port_before_eval_delete():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """node --inspect-port 0 -e "require('fs').unlinkSync('dangerous-marker.json')" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_detects_clustered_env_short_option_find_delete():
     request = extract_sensitive_tool_action_request(
         "bash",
@@ -593,6 +603,16 @@ def test_tool_action_request_classifier_detects_pipe_and_stderr_followed_node_ev
     request = extract_sensitive_tool_action_request(
         "bash",
         {"command": """echo ok |& node -e "require('fs').unlinkSync('dangerous-marker.json')" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_commented_newline_followed_node_eval_delete():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """echo ok # note\nnode -e "require('fs').unlinkSync('dangerous-marker.json')" """},
     )
 
     assert request is not None

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -755,6 +755,16 @@ def test_tool_action_request_classifier_detects_node_inline_call_unlinksync_bypa
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_detects_node_inline_apply_unlinksync_bypass():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """node -e "require('fs').unlinkSync.apply(null, ['dangerous-marker.json'])" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_skips_echoed_node_eval_string():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -559,6 +559,16 @@ def test_tool_action_request_classifier_detects_env_ignore_environment_find_dele
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_detects_clustered_env_short_option_find_delete():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "env -iu FOO find . -name dangerous-marker.json -delete"},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_detects_stdbuf_wrapped_node_eval_delete():
     request = extract_sensitive_tool_action_request(
         "bash",
@@ -573,6 +583,16 @@ def test_tool_action_request_classifier_detects_newline_followed_node_eval_delet
     request = extract_sensitive_tool_action_request(
         "bash",
         {"command": """echo ok\nnode -e "require('fs').unlinkSync('dangerous-marker.json')" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_pipe_and_stderr_followed_node_eval_delete():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """echo ok |& node -e "require('fs').unlinkSync('dangerous-marker.json')" """},
     )
 
     assert request is not None
@@ -617,6 +637,15 @@ def test_tool_action_request_classifier_detects_env_split_string_node_eval_delet
 
     assert request is not None
     assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_skips_wrapped_command_split_string_argument():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """env echo -S "node -e \\\"require('fs').unlinkSync('dangerous-marker.json')\\\"\" """},
+    )
+
+    assert request is None
 
 
 def test_tool_action_request_classifier_detects_node_inline_bracket_unlinksync_bypass():

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -502,6 +502,15 @@ def test_tool_action_request_classifier_skips_benign_node_inline_transform_call(
     assert request is None
 
 
+def test_tool_action_request_classifier_skips_benign_mixed_case_node_identifier():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """node -e "const UnlinkSync = () => {}; UnlinkSync('dangerous-marker.json')" """},
+    )
+
+    assert request is None
+
+
 def test_tool_action_request_classifier_skips_find_exec_literal_delete_string():
     request = extract_sensitive_tool_action_request(
         "bash",
@@ -624,6 +633,26 @@ def test_tool_action_request_classifier_detects_node_inline_parenthesized_unlink
     request = extract_sensitive_tool_action_request(
         "bash",
         {"command": """node -e "(require('fs').unlinkSync)('dangerous-marker.json')" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_node_inline_optional_chain_unlinksync_bypass():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """node -e "require('fs').unlinkSync?.('dangerous-marker.json')" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_node_inline_call_unlinksync_bypass():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """node -e "require('fs').unlinkSync.call(null, 'dangerous-marker.json')" """},
     )
 
     assert request is not None

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -324,6 +324,24 @@ def test_tool_action_request_classifier_skips_read_only_shell_pipeline_to_quoted
     assert request is None
 
 
+def test_tool_action_request_classifier_skips_read_only_shell_pipeline_to_uppercase_dev_null():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": 'ls missing 2>"/DEV/NULL" | head -40'},
+    )
+
+    assert request is None
+
+
+def test_tool_action_request_classifier_skips_read_only_shell_pipeline_to_noclobber_dev_null():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": 'ls missing 2>|/dev/null | head -40'},
+    )
+
+    assert request is None
+
+
 def test_tool_action_request_classifier_skips_perl_sleep_wait():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -454,6 +454,16 @@ def test_tool_action_request_classifier_detects_node_inline_print_flag():
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_detects_node_title_option_before_eval_delete():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """node --title guard-proof -e "require('fs').unlinkSync('dangerous-marker.json')" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_detects_node_inline_unlinksync_with_space_before_call_paren():
     request = extract_sensitive_tool_action_request(
         "bash",
@@ -564,6 +574,26 @@ def test_tool_action_request_classifier_detects_stdbuf_value_wrapped_node_eval_d
     request = extract_sensitive_tool_action_request(
         "bash",
         {"command": """stdbuf -o L node -e "require('fs').unlinkSync('dangerous-marker.json')" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_env_split_string_find_delete():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """env -S "find . -name dangerous-marker.json -delete" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_env_split_string_node_eval_delete():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """env -S "node -e \\\"require('fs').unlinkSync('dangerous-marker.json')\\\"\" """},
     )
 
     assert request is not None

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -557,6 +557,15 @@ def test_tool_action_request_classifier_skips_find_exec_literal_delete_string():
     assert request is None
 
 
+def test_tool_action_request_classifier_skips_find_name_delete_literal():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """find . -name "-delete" """},
+    )
+
+    assert request is None
+
+
 def test_tool_action_request_classifier_skips_node_script_argument_named_eval_flag():
     request = extract_sensitive_tool_action_request(
         "bash",
@@ -769,6 +778,16 @@ def test_tool_action_request_classifier_detects_node_inline_apply_unlinksync_byp
     request = extract_sensitive_tool_action_request(
         "bash",
         {"command": """node -e "require('fs').unlinkSync.apply(null, ['dangerous-marker.json'])" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_node_inline_optional_chain_apply_unlinksync_bypass():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """node -e "require('fs').unlinkSync?.apply(null, ['dangerous-marker.json'])" """},
     )
 
     assert request is not None

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -540,6 +540,56 @@ def test_tool_action_request_classifier_detects_stdbuf_wrapped_node_eval_delete(
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_detects_newline_followed_node_eval_delete():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """echo ok\nnode -e "require('fs').unlinkSync('dangerous-marker.json')" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_env_chdir_wrapped_find_delete():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "env -C /tmp find . -name dangerous-marker.json -delete"},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_stdbuf_value_wrapped_node_eval_delete():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """stdbuf -o L node -e "require('fs').unlinkSync('dangerous-marker.json')" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_node_inline_bracket_unlinksync_bypass():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """node -e "require('fs')['unlinkSync']('dangerous-marker.json')" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_node_inline_parenthesized_unlinksync_bypass():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """node -e "(require('fs').unlinkSync)('dangerous-marker.json')" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_skips_echoed_node_eval_string():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -434,6 +434,16 @@ def test_tool_action_request_classifier_detects_node_inline_eval_equals_form():
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_detects_node_inline_combined_print_eval_flag():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """node -pe "require('fs').unlinkSync('dangerous-marker.json')" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_detects_node_inline_unlinksync_with_space_before_call_paren():
     request = extract_sensitive_tool_action_request(
         "bash",
@@ -457,6 +467,15 @@ def test_tool_action_request_classifier_skips_benign_node_inline_transform_call(
     request = extract_sensitive_tool_action_request(
         "bash",
         {"command": """node -e "const value = transform('ok'); console.log(value)" """},
+    )
+
+    assert request is None
+
+
+def test_tool_action_request_classifier_skips_find_exec_literal_delete_string():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """find . -name dangerous-marker.json -exec echo "-delete" \\;"""},
     )
 
     assert request is None

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -520,6 +520,26 @@ def test_tool_action_request_classifier_detects_env_wrapped_find_delete():
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_detects_env_ignore_environment_find_delete():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "env -i find . -name dangerous-marker.json -delete"},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_stdbuf_wrapped_node_eval_delete():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """stdbuf -oL node -e "require('fs').unlinkSync('dangerous-marker.json')" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_skips_echoed_node_eval_string():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -315,6 +315,15 @@ def test_tool_action_request_classifier_skips_read_only_shell_pipeline_to_dev_nu
     assert request is None
 
 
+def test_tool_action_request_classifier_skips_read_only_shell_pipeline_to_quoted_dev_null():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": 'ls missing 2>"/dev/null" | head -40'},
+    )
+
+    assert request is None
+
+
 def test_tool_action_request_classifier_skips_perl_sleep_wait():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -384,6 +384,45 @@ def test_tool_action_request_classifier_detects_dynamic_python_os_system_shell_o
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_detects_unlink_delete_command():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "unlink dangerous-marker.json"},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_find_delete_flag():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "find . -name dangerous-marker.json -delete"},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_node_inline_unlinksync_bypass():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """node -e "require('fs').unlinkSync('dangerous-marker.json')" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_skips_benign_node_inline_read_only_script():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """node -e "console.log('ok')" """},
+    )
+
+    assert request is None
+
+
 def test_tool_action_request_classifier_detects_perl_inline_system_shell_out():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -444,6 +444,16 @@ def test_tool_action_request_classifier_detects_node_inline_combined_print_eval_
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_detects_node_inline_print_flag():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """node --print "require('fs').unlinkSync('dangerous-marker.json')" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_detects_node_inline_unlinksync_with_space_before_call_paren():
     request = extract_sensitive_tool_action_request(
         "bash",
@@ -476,6 +486,24 @@ def test_tool_action_request_classifier_skips_find_exec_literal_delete_string():
     request = extract_sensitive_tool_action_request(
         "bash",
         {"command": """find . -name dangerous-marker.json -exec echo "-delete" \\;"""},
+    )
+
+    assert request is None
+
+
+def test_tool_action_request_classifier_skips_node_script_argument_named_eval_flag():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """node tool.js -e "require('fs').unlinkSync('dangerous-marker.json')" """},
+    )
+
+    assert request is None
+
+
+def test_tool_action_request_classifier_skips_find_ok_literal_delete_string():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """find . -name dangerous-marker.json -ok echo "-delete" \\;"""},
     )
 
     assert request is None

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -606,6 +606,16 @@ def test_tool_action_request_classifier_detects_node_inspect_port_before_eval_de
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_detects_node_redirect_warnings_before_eval_delete():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """node --redirect-warnings /tmp/w.log -e "require('fs').unlinkSync('dangerous-marker.json')" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_detects_clustered_env_short_option_find_delete():
     request = extract_sensitive_tool_action_request(
         "bash",
@@ -763,6 +773,15 @@ def test_tool_action_request_classifier_detects_node_inline_apply_unlinksync_byp
 
     assert request is not None
     assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_skips_node_string_literal_with_dotted_mutator_text():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """node -e "console.log('foo.unlinkSync(')" """},
+    )
+
+    assert request is None
 
 
 def test_tool_action_request_classifier_skips_echoed_node_eval_string():

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -464,6 +464,16 @@ def test_tool_action_request_classifier_detects_node_title_option_before_eval_de
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_detects_uppercase_node_eval_delete():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """NODE -e "require('fs').unlinkSync('dangerous-marker.json')" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_detects_node_inline_unlinksync_with_space_before_call_paren():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1014,6 +1014,39 @@ def test_guard_hook_emits_copilot_native_allow_response_for_read_only_ls_pipelin
     assert output == {"permissionDecision": "allow"}
 
 
+def test_guard_hook_emits_copilot_native_allow_response_for_benign_node_transform_script(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": """node -e "const value = transform('ok'); console.log(value)" """}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output == {"permissionDecision": "allow"}
+
+
 def test_guard_hook_emits_copilot_native_allow_response_for_perl_sleep_wait(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1571,6 +1571,48 @@ def test_guard_hook_emits_copilot_native_ask_response_for_node_inspect_port_befo
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_node_redirect_warnings_before_eval_delete(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps(
+            {
+                "command": (
+                    """node --redirect-warnings /tmp/w.log -e "require('fs').unlinkSync('dangerous-marker.json')" """
+                )
+            }
+        ),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_ask_response_for_pipe_and_stderr_followed_node_eval_delete(
     tmp_path,
     capsys,
@@ -1790,6 +1832,39 @@ def test_guard_hook_emits_copilot_native_allow_response_for_benign_node_transfor
     event = {
         "toolName": "bash",
         "toolArgs": json.dumps({"command": """node -e "const value = transform('ok'); console.log(value)" """}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output == {"permissionDecision": "allow"}
+
+
+def test_guard_hook_emits_copilot_native_allow_response_for_node_string_literal_with_dotted_mutator_text(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": """node -e "console.log('foo.unlinkSync(')" """}),
         "sourceScope": "project",
     }
     monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1459,6 +1459,44 @@ def test_guard_hook_emits_copilot_native_ask_response_for_clustered_env_short_op
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_node_inspect_port_before_eval_delete(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps(
+            {"command": """node --inspect-port 0 -e "require('fs').unlinkSync('dangerous-marker.json')" """}
+        ),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_ask_response_for_pipe_and_stderr_followed_node_eval_delete(
     tmp_path,
     capsys,
@@ -1471,6 +1509,44 @@ def test_guard_hook_emits_copilot_native_ask_response_for_pipe_and_stderr_follow
         "toolName": "bash",
         "toolArgs": json.dumps(
             {"command": """echo ok |& node -e "require('fs').unlinkSync('dangerous-marker.json')" """}
+        ),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_ask_response_for_commented_newline_followed_node_eval_delete(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps(
+            {"command": """echo ok # note\nnode -e "require('fs').unlinkSync('dangerous-marker.json')" """}
         ),
         "sourceScope": "project",
     }

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1387,6 +1387,44 @@ def test_guard_hook_emits_copilot_native_ask_response_for_node_inline_apply_dele
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_node_inline_optional_chain_apply_delete_bypass(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps(
+            {"command": """node -e "require('fs').unlinkSync?.apply(null, ['dangerous-marker.json'])" """}
+        ),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_ask_response_for_env_split_string_find_delete(
     tmp_path,
     capsys,
@@ -1865,6 +1903,39 @@ def test_guard_hook_emits_copilot_native_allow_response_for_node_string_literal_
     event = {
         "toolName": "bash",
         "toolArgs": json.dumps({"command": """node -e "console.log('foo.unlinkSync(')" """}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output == {"permissionDecision": "allow"}
+
+
+def test_guard_hook_emits_copilot_native_allow_response_for_find_name_delete_literal(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": """find . -name "-delete" """}),
         "sourceScope": "project",
     }
     monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1675,6 +1675,72 @@ def test_guard_hook_emits_copilot_native_allow_response_for_quoted_dev_null_redi
     assert output == {"permissionDecision": "allow"}
 
 
+def test_guard_hook_emits_copilot_native_allow_response_for_uppercase_dev_null_redirection(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": 'ls missing 2>"/DEV/NULL" | head -40'}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output == {"permissionDecision": "allow"}
+
+
+def test_guard_hook_emits_copilot_native_allow_response_for_noclobber_dev_null_redirection(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": 'ls missing 2>|/dev/null | head -40'}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output == {"permissionDecision": "allow"}
+
+
 def test_guard_hook_emits_copilot_native_allow_response_for_benign_node_transform_script(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -981,6 +981,42 @@ def test_guard_hook_emits_copilot_native_ask_response_for_node_inline_combined_p
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_node_inline_print_flag(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": """node --print "require('fs').unlinkSync('dangerous-marker.json')" """}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_ask_response_for_unlink_delete_bypass(
     tmp_path,
     capsys,
@@ -1094,6 +1130,72 @@ def test_guard_hook_emits_copilot_native_allow_response_for_benign_find_exec_del
     event = {
         "toolName": "bash",
         "toolArgs": json.dumps({"command": """find . -name dangerous-marker.json -exec echo "-delete" \\;"""}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output == {"permissionDecision": "allow"}
+
+
+def test_guard_hook_emits_copilot_native_allow_response_for_node_script_argument_named_eval_flag(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": """node tool.js -e "require('fs').unlinkSync('dangerous-marker.json')" """}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output == {"permissionDecision": "allow"}
+
+
+def test_guard_hook_emits_copilot_native_allow_response_for_benign_find_ok_delete_literal(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": """find . -name dangerous-marker.json -ok echo "-delete" \\;"""}),
         "sourceScope": "project",
     }
     monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -945,6 +945,42 @@ def test_guard_hook_emits_copilot_native_ask_response_for_node_inline_delete_wit
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_node_inline_combined_print_eval_flag(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": """node -pe "require('fs').unlinkSync('dangerous-marker.json')" """}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_ask_response_for_unlink_delete_bypass(
     tmp_path,
     capsys,
@@ -1025,6 +1061,39 @@ def test_guard_hook_emits_copilot_native_allow_response_for_benign_node_transfor
     event = {
         "toolName": "bash",
         "toolArgs": json.dumps({"command": """node -e "const value = transform('ok'); console.log(value)" """}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output == {"permissionDecision": "allow"}
+
+
+def test_guard_hook_emits_copilot_native_allow_response_for_benign_find_exec_delete_literal(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": """find . -name dangerous-marker.json -exec echo "-delete" \\;"""}),
         "sourceScope": "project",
     }
     monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1606,6 +1606,39 @@ def test_guard_hook_emits_copilot_native_allow_response_for_read_only_ls_pipelin
     assert output == {"permissionDecision": "allow"}
 
 
+def test_guard_hook_emits_copilot_native_allow_response_for_quoted_dev_null_redirection(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": 'ls missing 2>"/dev/null" | head -40'}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output == {"permissionDecision": "allow"}
+
+
 def test_guard_hook_emits_copilot_native_allow_response_for_benign_node_transform_script(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1275,6 +1275,80 @@ def test_guard_hook_emits_copilot_native_ask_response_for_node_inline_parenthesi
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_node_inline_optional_chain_delete_bypass(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": """node -e "require('fs').unlinkSync?.('dangerous-marker.json')" """}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_ask_response_for_node_inline_call_delete_bypass(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps(
+            {"command": """node -e "require('fs').unlinkSync.call(null, 'dangerous-marker.json')" """}
+        ),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_ask_response_for_env_split_string_find_delete(
     tmp_path,
     capsys,
@@ -1393,6 +1467,41 @@ def test_guard_hook_emits_copilot_native_allow_response_for_benign_node_transfor
     event = {
         "toolName": "bash",
         "toolArgs": json.dumps({"command": """node -e "const value = transform('ok'); console.log(value)" """}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output == {"permissionDecision": "allow"}
+
+
+def test_guard_hook_emits_copilot_native_allow_response_for_benign_mixed_case_node_identifier(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps(
+            {"command": """node -e "const UnlinkSync = () => {}; UnlinkSync('dangerous-marker.json')" """}
+        ),
         "sourceScope": "project",
     }
     monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1131,6 +1131,42 @@ def test_guard_hook_emits_copilot_native_ask_response_for_node_title_option_befo
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_uppercase_node_eval_delete(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": """NODE -e "require('fs').unlinkSync('dangerous-marker.json')" """}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_ask_response_for_unlink_delete_bypass(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1185,6 +1185,113 @@ def test_guard_hook_emits_copilot_native_allow_response_for_node_script_argument
     assert output == {"permissionDecision": "allow"}
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_later_destructive_node_eval_flag(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps(
+            {
+                "command": """node -e "console.log('ok')" -e "require('fs').unlinkSync('dangerous-marker.json')" """
+            }
+        ),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_ask_response_for_env_wrapped_find_delete(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "env FOO=bar find . -name dangerous-marker.json -delete"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_allow_response_for_echoed_node_eval_string(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": """echo node -e "require('fs').unlinkSync('dangerous-marker.json')" """}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output == {"permissionDecision": "allow"}
+
+
 def test_guard_hook_emits_copilot_native_allow_response_for_benign_find_ok_delete_literal(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1349,6 +1349,44 @@ def test_guard_hook_emits_copilot_native_ask_response_for_node_inline_call_delet
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_node_inline_apply_delete_bypass(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps(
+            {"command": """node -e "require('fs').unlinkSync.apply(null, ['dangerous-marker.json'])" """}
+        ),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_ask_response_for_env_split_string_find_delete(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1423,6 +1423,80 @@ def test_guard_hook_emits_copilot_native_ask_response_for_env_split_string_node_
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_clustered_env_short_option_find_delete(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "env -iu FOO find . -name dangerous-marker.json -delete"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_ask_response_for_pipe_and_stderr_followed_node_eval_delete(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps(
+            {"command": """echo ok |& node -e "require('fs').unlinkSync('dangerous-marker.json')" """}
+        ),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_allow_response_for_read_only_ls_pipeline(
     tmp_path,
     capsys,
@@ -1535,6 +1609,41 @@ def test_guard_hook_emits_copilot_native_allow_response_for_benign_find_exec_del
     event = {
         "toolName": "bash",
         "toolArgs": json.dumps({"command": """find . -name dangerous-marker.json -exec echo "-delete" \\;"""}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output == {"permissionDecision": "allow"}
+
+
+def test_guard_hook_emits_copilot_native_allow_response_for_wrapped_command_split_string_argument(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps(
+            {"command": """env echo -S "node -e \\\"require('fs').unlinkSync('dangerous-marker.json')\\\"\" """}
+        ),
         "sourceScope": "project",
     }
     monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -871,6 +871,78 @@ def test_guard_hook_emits_copilot_native_ask_response_for_destructive_shell_redi
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_node_inline_delete_bypass(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": """node -e "require('fs').unlinkSync('dangerous-marker.json')" """}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_ask_response_for_unlink_delete_bypass(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "unlink dangerous-marker.json"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_allow_response_for_read_only_ls_pipeline(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1093,6 +1093,44 @@ def test_guard_hook_emits_copilot_native_ask_response_for_node_inline_print_flag
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_node_title_option_before_eval_delete(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps(
+            {"command": """node --title guard-proof -e "require('fs').unlinkSync('dangerous-marker.json')" """}
+        ),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_ask_response_for_unlink_delete_bypass(
     tmp_path,
     capsys,
@@ -1176,6 +1214,80 @@ def test_guard_hook_emits_copilot_native_ask_response_for_node_inline_parenthesi
     event = {
         "toolName": "bash",
         "toolArgs": json.dumps({"command": """node -e "(require('fs').unlinkSync)('dangerous-marker.json')" """}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_ask_response_for_env_split_string_find_delete(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": """env -S "find . -name dangerous-marker.json -delete" """}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_ask_response_for_env_split_string_node_eval_delete(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps(
+            {"command": """env -S "node -e \\\"require('fs').unlinkSync('dangerous-marker.json')\\\"\" """}
+        ),
         "sourceScope": "project",
     }
     monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
@@ -1344,9 +1456,7 @@ def test_guard_hook_emits_copilot_native_ask_response_for_later_destructive_node
     event = {
         "toolName": "bash",
         "toolArgs": json.dumps(
-            {
-                "command": """node -e "console.log('ok')" -e "require('fs').unlinkSync('dangerous-marker.json')" """
-            }
+            {"command": """node -e "console.log('ok')" -e "require('fs').unlinkSync('dangerous-marker.json')" """}
         ),
         "sourceScope": "project",
     }

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -907,6 +907,44 @@ def test_guard_hook_emits_copilot_native_ask_response_for_node_inline_delete_byp
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_newline_followed_node_inline_delete(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps(
+            {"command": """echo ok\nnode -e "require('fs').unlinkSync('dangerous-marker.json')" """}
+        ),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_ask_response_for_node_inline_delete_with_shifted_flag(
     tmp_path,
     capsys,
@@ -919,6 +957,44 @@ def test_guard_hook_emits_copilot_native_ask_response_for_node_inline_delete_wit
         "toolName": "bash",
         "toolArgs": json.dumps(
             {"command": """node --trace-warnings -e "require('fs').unlinkSync ('dangerous-marker.json')" """}
+        ),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_ask_response_for_stdbuf_value_wrapped_node_inline_delete(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps(
+            {"command": """stdbuf -o L node -e "require('fs').unlinkSync('dangerous-marker.json')" """}
         ),
         "sourceScope": "project",
     }
@@ -1028,6 +1104,78 @@ def test_guard_hook_emits_copilot_native_ask_response_for_unlink_delete_bypass(
     event = {
         "toolName": "bash",
         "toolArgs": json.dumps({"command": "unlink dangerous-marker.json"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_ask_response_for_node_inline_bracket_delete_bypass(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": """node -e "require('fs')['unlinkSync']('dangerous-marker.json')" """}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_ask_response_for_node_inline_parenthesized_delete_bypass(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": """node -e "(require('fs').unlinkSync)('dangerous-marker.json')" """}),
         "sourceScope": "project",
     }
     monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1459,6 +1459,42 @@ def test_guard_hook_emits_copilot_native_ask_response_for_clustered_env_short_op
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_clustered_env_split_string_find_delete(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": """env -iS "find . -name dangerous-marker.json -delete" """}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_ask_response_for_node_inspect_port_before_eval_delete(
     tmp_path,
     capsys,
@@ -1705,6 +1741,44 @@ def test_guard_hook_emits_copilot_native_allow_response_for_benign_mixed_case_no
 
     assert rc == 0
     assert output == {"permissionDecision": "allow"}
+
+
+def test_guard_hook_emits_copilot_native_ask_response_for_node_print_followed_by_eval_flag(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps(
+            {"command": """node -p -e "require('fs').unlinkSync('dangerous-marker.json')" """}
+        ),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
 def test_guard_hook_emits_copilot_native_allow_response_for_benign_find_exec_delete_literal(

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -907,6 +907,44 @@ def test_guard_hook_emits_copilot_native_ask_response_for_node_inline_delete_byp
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_node_inline_delete_with_shifted_flag(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps(
+            {"command": """node --trace-warnings -e "require('fs').unlinkSync ('dangerous-marker.json')" """}
+        ),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_ask_response_for_unlink_delete_bypass(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1259,6 +1259,78 @@ def test_guard_hook_emits_copilot_native_ask_response_for_env_wrapped_find_delet
     assert "hol guard" in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_env_ignore_environment_find_delete(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "env -i find . -name dangerous-marker.json -delete"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_ask_response_for_stdbuf_wrapped_node_eval_delete(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps(
+            {"command": """stdbuf -oL node -e "require('fs').unlinkSync('dangerous-marker.json')" """}
+        ),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_allow_response_for_echoed_node_eval_string(
     tmp_path,
     capsys,


### PR DESCRIPTION
## Summary
- classify additional destructive shell deletion variants that Copilot Autopilot used to bypass Guard review
- keep benign waits and read-only shell probes on the allow path
- add regression coverage for the new bypasses in risk and runtime tests

## Verification
- `PYTHONPATH=src python3 -m pytest tests/test_guard_risk.py -k 'tool_action_request_classifier or prompt_mode_keeps_destructive_tool_calls_on_review_path'`
- `PYTHONPATH=src python3 -m pytest tests/test_guard_runtime.py -k 'copilot_native_ask_response_for_destructive_shell_command or copilot_native_ask_response_for_destructive_shell_redirection_without_spaces or copilot_native_allow_response_for_read_only_ls_pipeline or node_inline_delete_bypass or unlink_delete_bypass'`
- `python3 -m ruff check src/codex_plugin_scanner/guard/runtime/secret_file_requests.py tests/test_guard_risk.py tests/test_guard_runtime.py`
- `git diff --check`
- real Copilot CLI `--autopilot --allow-all-tools --allow-all-paths` proof against shell delete retries and the `danger_lab.dangerous_delete` MCP tool in `/Users/michaelkantor/CascadeProjects/guard-harness-proof/copilot-autopilot/workspace`; both marker files remained intact after Guard blocks