### PR TITLE
fix(guard): gracefully handle free-plan sync 403 in connect flow

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from ..daemon import ensure_guard_daemon, load_guard_surface_daemon_client
-from ..daemon.client import GuardSurfaceDaemonClient
+from ..daemon.client import GuardDaemonRequestError, GuardDaemonTransportError, GuardSurfaceDaemonClient
 from ..runtime import GuardSyncNotAvailableError, sync_receipts, sync_runtime_session
 from ..store import GuardStore
 
@@ -240,9 +240,11 @@ def wait_for_connect_transition(
     while time.monotonic() < deadline:
         try:
             state = daemon_client.get_connect_state(request_id=request_id)
-        except RuntimeError:
+        except GuardDaemonTransportError:
             time.sleep(poll_interval_seconds)
             continue
+        except GuardDaemonRequestError:
+            raise
         if not isinstance(state, dict):
             raise RuntimeError("Guard daemon request failed: invalid connect state response")
         if str(state.get("status")) in {"connected", "retry_required", "expired"}:

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -102,7 +102,7 @@ def run_guard_connect_command(
             store=store,
             request_id=str(connect_request["request_id"]),
             status="connected",
-            milestone="first_sync_pending",
+            milestone="sync_not_available",
             reason=plan_msg,
         )
         return build_connect_payload(

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -116,6 +116,7 @@ def run_guard_connect_command(
         sync_message = str(error)
         if runtime_sync_error and not _is_paid_plan_sync_error(sync_message):
             sync_message = runtime_sync_error
+        sync_is_plan_limited = _is_paid_plan_sync_error(sync_message)
         pending_sync_payload = dict(runtime_sync_summary)
         pending_sync_payload["synced_at"] = None
         pending_state = _record_connect_result(
@@ -135,6 +136,7 @@ def run_guard_connect_command(
             connected=True,
             sync=pending_sync_payload,
             sync_message=sync_message,
+            sync_available=False if sync_is_plan_limited else None,
         )
     sync_payload["runtime_session_synced_at"] = runtime_sync_summary["runtime_session_synced_at"]
     sync_payload["runtime_session_id"] = runtime_sync_summary["runtime_session_id"]

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -95,22 +95,24 @@ def run_guard_connect_command(
         }
     try:
         sync_payload = sync_receipts(store)
-    except GuardSyncNotAvailableError:
-        local_only_state = _record_connect_result(
+    except GuardSyncNotAvailableError as plan_error:
+        plan_msg = str(plan_error).strip() or "Cloud sync requires a paid Guard plan."
+        pending_state = _record_connect_result(
             daemon_client=daemon_client,
             store=store,
             request_id=str(connect_request["request_id"]),
             status="connected",
-            milestone="sync_not_available",
-            reason="Cloud sync requires a Pro plan. Guard is active locally.",
+            milestone="first_sync_pending",
+            reason=plan_msg,
         )
         return build_connect_payload(
-            state=local_only_state,
+            state=pending_state,
             browser_opened=browser_opened,
             connect_url=browser_url,
             sync_url=sync_url,
             connected=True,
             sync_available=False,
+            sync_message=plan_msg,
         )
     except (RuntimeError, OSError, urllib.error.URLError, json.JSONDecodeError) as error:
         sync_message = str(error)

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -2,20 +2,15 @@
 
 from __future__ import annotations
 
-import json
 import time
-import urllib.error
 import urllib.parse
-import uuid
-from datetime import datetime, timezone
 from pathlib import Path
 
 from ..daemon import ensure_guard_daemon, load_guard_surface_daemon_client
-from ..daemon.client import GuardDaemonRequestError, GuardDaemonTransportError, GuardSurfaceDaemonClient
-from ..runtime import sync_receipts, sync_runtime_session
+from ..runtime import GuardSyncNotAvailableError, sync_receipts
 from ..store import GuardStore
 
-DEFAULT_GUARD_SYNC_URL = "https://hol.org/api/guard/receipts/sync"
+DEFAULT_GUARD_SYNC_URL = "https://hol.org/registry/api/v1"
 DEFAULT_GUARD_CONNECT_URL = "https://hol.org/guard/connect"
 
 
@@ -28,7 +23,7 @@ def run_guard_connect_command(
     opener,
     wait_timeout_seconds: int,
 ) -> dict[str, object]:
-    ensure_guard_daemon(guard_home)
+    daemon_url = ensure_guard_daemon(guard_home)
     daemon_client = load_guard_surface_daemon_client(guard_home)
     normalized_connect_url, allowed_origin = resolve_connect_url(connect_url)
     connect_request = daemon_client.create_connect_request(
@@ -37,7 +32,7 @@ def run_guard_connect_command(
     )
     browser_url = build_guard_connect_browser_url(
         connect_url=normalized_connect_url,
-        daemon_url=daemon_client.daemon_url,
+        daemon_url=daemon_url,
         request_id=str(connect_request["request_id"]),
         pairing_secret=str(connect_request["pairing_secret"]),
     )
@@ -71,8 +66,7 @@ def run_guard_connect_command(
             sync_url=sync_url,
             connected=False,
         )
-    pairing_completed_at = (transition.get("completed_at") or "").strip()
-    if str(transition.get("status")) == "retry_required" and not pairing_completed_at:
+    if str(transition.get("status")) == "retry_required":
         return build_connect_payload(
             state=transition,
             browser_opened=browser_opened,
@@ -80,74 +74,38 @@ def run_guard_connect_command(
             sync_url=sync_url,
             connected=False,
         )
-    runtime_session = _start_guard_runtime_session(daemon_client)
-    runtime_sync_error: str | None = None
-    try:
-        runtime_sync_summary = sync_runtime_session(store, session=runtime_session)
-    except (RuntimeError, OSError, urllib.error.URLError, json.JSONDecodeError) as error:
-        runtime_sync_error = str(error)
-        runtime_sync_summary = {
-            "runtime_session_id": str(runtime_session.get("session_id") or runtime_session.get("sessionId") or ""),
-            "runtime_session_synced_at": None,
-            "runtime_sessions_visible": 0,
-            "runtime_session_sync_pending": True,
-            "runtime_session_sync_reason": runtime_sync_error,
-        }
     try:
         sync_payload = sync_receipts(store)
-    except (RuntimeError, OSError, urllib.error.URLError, json.JSONDecodeError) as error:
-        sync_message = str(error)
-        if runtime_sync_error and not _is_paid_plan_sync_error(sync_message):
-            sync_message = runtime_sync_error
-        pending_sync_payload = dict(runtime_sync_summary)
-        pending_sync_payload["synced_at"] = None
-        pending_state = _record_connect_result(
-            daemon_client=daemon_client,
-            store=store,
+    except GuardSyncNotAvailableError:
+        local_only_state = daemon_client.report_connect_result(
             request_id=str(connect_request["request_id"]),
             status="connected",
-            milestone="first_sync_pending",
-            reason=sync_message,
-            sync=pending_sync_payload,
+            milestone="sync_not_available",
+            reason="Cloud sync requires a Pro plan. Guard is active locally.",
         )
         return build_connect_payload(
-            state=pending_state,
+            state=local_only_state,
             browser_opened=browser_opened,
             connect_url=browser_url,
             sync_url=sync_url,
             connected=True,
-            sync=pending_sync_payload,
-            sync_message=sync_message,
+            sync_available=False,
         )
-    sync_payload["runtime_session_synced_at"] = runtime_sync_summary["runtime_session_synced_at"]
-    sync_payload["runtime_session_id"] = runtime_sync_summary["runtime_session_id"]
-    sync_payload["runtime_sessions_visible"] = runtime_sync_summary["runtime_sessions_visible"]
-    if runtime_sync_error is not None:
-        sync_payload["runtime_session_sync_pending"] = True
-        sync_payload["runtime_session_sync_reason"] = runtime_sync_error
-        pending_sync_payload = dict(sync_payload)
-        pending_sync_payload["synced_at"] = None
-        pending_state = _record_connect_result(
-            daemon_client=daemon_client,
-            store=store,
+    except RuntimeError as error:
+        failed_state = daemon_client.report_connect_result(
             request_id=str(connect_request["request_id"]),
-            status="connected",
-            milestone="first_sync_pending",
-            reason=runtime_sync_error,
-            sync=pending_sync_payload,
+            status="retry_required",
+            milestone="first_sync_failed",
+            reason=str(error),
         )
         return build_connect_payload(
-            state=pending_state,
+            state=failed_state,
             browser_opened=browser_opened,
             connect_url=browser_url,
             sync_url=sync_url,
-            connected=True,
-            sync=pending_sync_payload,
-            sync_message=runtime_sync_error,
+            connected=False,
         )
-    final_state = _record_connect_result(
-        daemon_client=daemon_client,
-        store=store,
+    final_state = daemon_client.report_connect_result(
         request_id=str(connect_request["request_id"]),
         status="connected",
         milestone="first_sync_succeeded",
@@ -160,17 +118,7 @@ def run_guard_connect_command(
         sync_url=sync_url,
         connected=True,
         sync=sync_payload,
-    )
-
-
-def _is_paid_plan_sync_error(message: str) -> bool:
-    normalized = message.strip().lower()
-    return (
-        "paid guard plan" in normalized
-        or "paid plan" in normalized
-        or "guard plan required" in normalized
-        or "payment required" in normalized
-        or "http error 402" in normalized
+        sync_available=True,
     )
 
 
@@ -179,7 +127,7 @@ def resolve_connect_url(connect_url: str) -> tuple[str, str]:
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         raise ValueError("Guard connect URL must be an absolute http(s) URL.")
     path = parsed.path or "/guard/connect"
-    normalized_url = urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, path, parsed.query, ""))
+    normalized_url = urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
     allowed_origin = urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
     return normalized_url, allowed_origin
 
@@ -213,20 +161,14 @@ def build_guard_connect_browser_url(
 
 def wait_for_connect_transition(
     *,
-    daemon_client: GuardSurfaceDaemonClient,
+    daemon_client,
     request_id: str,
     timeout_seconds: int,
     poll_interval_seconds: float = 0.25,
 ) -> dict[str, object] | None:
     deadline = time.monotonic() + max(1, timeout_seconds)
     while time.monotonic() < deadline:
-        try:
-            state = daemon_client.get_connect_state(request_id=request_id)
-        except GuardDaemonTransportError:
-            time.sleep(poll_interval_seconds)
-            continue
-        if not isinstance(state, dict):
-            raise GuardDaemonRequestError("Guard daemon request failed: invalid connect state response")
+        state = daemon_client.get_connect_state(request_id=request_id)
         if str(state.get("status")) in {"connected", "retry_required", "expired"}:
             return state
         if str(state.get("milestone")) == "first_sync_pending":
@@ -243,7 +185,7 @@ def build_connect_payload(
     sync_url: str,
     connected: bool,
     sync: dict[str, object] | None = None,
-    sync_message: str | None = None,
+    sync_available: bool | None = None,
 ) -> dict[str, object]:
     milestones = [
         {
@@ -261,6 +203,7 @@ def build_connect_payload(
     ]
     payload = {
         "connected": connected,
+        "sync_available": sync_available if sync_available is not None else connected,
         "browser_opened": browser_opened,
         "connect_url": connect_url,
         "sync_url": sync_url,
@@ -275,38 +218,7 @@ def build_connect_payload(
     }
     if sync is not None:
         payload["sync"] = sync
-    if sync_message is not None and sync_message.strip():
-        payload["sync_message"] = sync_message
     return payload
-
-
-def _record_connect_result(
-    *,
-    daemon_client: GuardSurfaceDaemonClient,
-    store: GuardStore,
-    request_id: str,
-    status: str,
-    milestone: str,
-    reason: str | None = None,
-    sync: dict[str, object] | None = None,
-) -> dict[str, object]:
-    try:
-        return daemon_client.report_connect_result(
-            request_id=request_id,
-            status=status,
-            milestone=milestone,
-            reason=reason,
-            sync=sync,
-        )
-    except RuntimeError:
-        return store.record_guard_connect_result(
-            request_id=request_id,
-            status=status,
-            milestone=milestone,
-            now=datetime.now(timezone.utc).isoformat(),
-            reason=reason,
-            sync_payload=sync,
-        )
 
 
 def _resolve_first_sync_milestone(state: dict[str, object]) -> str:
@@ -317,36 +229,6 @@ def _resolve_first_sync_milestone(state: dict[str, object]) -> str:
         return "failed"
     if milestone == "first_sync_pending":
         return "waiting"
+    if milestone == "sync_not_available":
+        return "skipped"
     return "pending"
-
-
-def _start_guard_runtime_session(daemon_client: GuardSurfaceDaemonClient) -> dict[str, object]:
-    start_session = getattr(daemon_client, "start_session", None)
-    if callable(start_session):
-        try:
-            return start_session(
-                harness="hol-guard",
-                surface="cli",
-                workspace=str(Path.cwd()),
-                client_name="hol-guard",
-                client_title="HOL Guard CLI",
-                client_version=None,
-                capabilities=["approval-resolution", "receipt-view", "runtime-sync"],
-            )
-        except (GuardDaemonRequestError, GuardDaemonTransportError):
-            pass
-    now = datetime.now(timezone.utc).isoformat()
-    return {
-        "session_id": f"guard-session-{uuid.uuid4().hex}",
-        "harness": "hol-guard",
-        "surface": "cli",
-        "status": "active",
-        "client_name": "hol-guard",
-        "client_title": "HOL Guard CLI",
-        "client_version": None,
-        "workspace": str(Path.cwd()),
-        "capabilities": ["approval-resolution", "receipt-view", "runtime-sync"],
-        "operations": [],
-        "created_at": now,
-        "updated_at": now,
-    }

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
+import json
 import time
+import urllib.error
 import urllib.parse
+import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 
 from ..daemon import ensure_guard_daemon, load_guard_surface_daemon_client
-from ..runtime import GuardSyncNotAvailableError, sync_receipts
+from ..daemon.client import GuardSurfaceDaemonClient
+from ..runtime import GuardSyncNotAvailableError, sync_receipts, sync_runtime_session
 from ..store import GuardStore
 
-DEFAULT_GUARD_SYNC_URL = "https://hol.org/registry/api/v1"
+DEFAULT_GUARD_SYNC_URL = "https://hol.org/api/guard/receipts/sync"
 DEFAULT_GUARD_CONNECT_URL = "https://hol.org/guard/connect"
 
 
@@ -23,7 +28,7 @@ def run_guard_connect_command(
     opener,
     wait_timeout_seconds: int,
 ) -> dict[str, object]:
-    daemon_url = ensure_guard_daemon(guard_home)
+    ensure_guard_daemon(guard_home)
     daemon_client = load_guard_surface_daemon_client(guard_home)
     normalized_connect_url, allowed_origin = resolve_connect_url(connect_url)
     connect_request = daemon_client.create_connect_request(
@@ -32,7 +37,7 @@ def run_guard_connect_command(
     )
     browser_url = build_guard_connect_browser_url(
         connect_url=normalized_connect_url,
-        daemon_url=daemon_url,
+        daemon_url=daemon_client.daemon_url,
         request_id=str(connect_request["request_id"]),
         pairing_secret=str(connect_request["pairing_secret"]),
     )
@@ -66,7 +71,8 @@ def run_guard_connect_command(
             sync_url=sync_url,
             connected=False,
         )
-    if str(transition.get("status")) == "retry_required":
+    pairing_completed_at = (transition.get("completed_at") or "").strip()
+    if str(transition.get("status")) == "retry_required" and not pairing_completed_at:
         return build_connect_payload(
             state=transition,
             browser_opened=browser_opened,
@@ -74,10 +80,25 @@ def run_guard_connect_command(
             sync_url=sync_url,
             connected=False,
         )
+    runtime_session = _start_guard_runtime_session(daemon_client)
+    runtime_sync_error: str | None = None
+    try:
+        runtime_sync_summary = sync_runtime_session(store, session=runtime_session)
+    except (RuntimeError, OSError, urllib.error.URLError, json.JSONDecodeError) as error:
+        runtime_sync_error = str(error)
+        runtime_sync_summary = {
+            "runtime_session_id": str(runtime_session.get("session_id") or runtime_session.get("sessionId") or ""),
+            "runtime_session_synced_at": None,
+            "runtime_sessions_visible": 0,
+            "runtime_session_sync_pending": True,
+            "runtime_session_sync_reason": runtime_sync_error,
+        }
     try:
         sync_payload = sync_receipts(store)
     except GuardSyncNotAvailableError:
-        local_only_state = daemon_client.report_connect_result(
+        local_only_state = _record_connect_result(
+            daemon_client=daemon_client,
+            store=store,
             request_id=str(connect_request["request_id"]),
             status="connected",
             milestone="sync_not_available",
@@ -91,21 +112,59 @@ def run_guard_connect_command(
             connected=True,
             sync_available=False,
         )
-    except RuntimeError as error:
-        failed_state = daemon_client.report_connect_result(
+    except (RuntimeError, OSError, urllib.error.URLError, json.JSONDecodeError) as error:
+        sync_message = str(error)
+        if runtime_sync_error and not _is_paid_plan_sync_error(sync_message):
+            sync_message = runtime_sync_error
+        pending_sync_payload = dict(runtime_sync_summary)
+        pending_sync_payload["synced_at"] = None
+        pending_state = _record_connect_result(
+            daemon_client=daemon_client,
+            store=store,
             request_id=str(connect_request["request_id"]),
-            status="retry_required",
-            milestone="first_sync_failed",
-            reason=str(error),
+            status="connected",
+            milestone="first_sync_pending",
+            reason=sync_message,
+            sync=pending_sync_payload,
         )
         return build_connect_payload(
-            state=failed_state,
+            state=pending_state,
             browser_opened=browser_opened,
             connect_url=browser_url,
             sync_url=sync_url,
-            connected=False,
+            connected=True,
+            sync=pending_sync_payload,
+            sync_message=sync_message,
         )
-    final_state = daemon_client.report_connect_result(
+    sync_payload["runtime_session_synced_at"] = runtime_sync_summary["runtime_session_synced_at"]
+    sync_payload["runtime_session_id"] = runtime_sync_summary["runtime_session_id"]
+    sync_payload["runtime_sessions_visible"] = runtime_sync_summary["runtime_sessions_visible"]
+    if runtime_sync_error is not None:
+        sync_payload["runtime_session_sync_pending"] = True
+        sync_payload["runtime_session_sync_reason"] = runtime_sync_error
+        pending_sync_payload = dict(sync_payload)
+        pending_sync_payload["synced_at"] = None
+        pending_state = _record_connect_result(
+            daemon_client=daemon_client,
+            store=store,
+            request_id=str(connect_request["request_id"]),
+            status="connected",
+            milestone="first_sync_pending",
+            reason=runtime_sync_error,
+            sync=pending_sync_payload,
+        )
+        return build_connect_payload(
+            state=pending_state,
+            browser_opened=browser_opened,
+            connect_url=browser_url,
+            sync_url=sync_url,
+            connected=True,
+            sync=pending_sync_payload,
+            sync_message=runtime_sync_error,
+        )
+    final_state = _record_connect_result(
+        daemon_client=daemon_client,
+        store=store,
         request_id=str(connect_request["request_id"]),
         status="connected",
         milestone="first_sync_succeeded",
@@ -122,12 +181,23 @@ def run_guard_connect_command(
     )
 
 
+def _is_paid_plan_sync_error(message: str) -> bool:
+    normalized = message.strip().lower()
+    return (
+        "paid guard plan" in normalized
+        or "paid plan" in normalized
+        or "guard plan required" in normalized
+        or "payment required" in normalized
+        or "http error 402" in normalized
+    )
+
+
 def resolve_connect_url(connect_url: str) -> tuple[str, str]:
     parsed = urllib.parse.urlparse(connect_url.strip() or DEFAULT_GUARD_CONNECT_URL)
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         raise ValueError("Guard connect URL must be an absolute http(s) URL.")
     path = parsed.path or "/guard/connect"
-    normalized_url = urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
+    normalized_url = urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, path, parsed.query, ""))
     allowed_origin = urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
     return normalized_url, allowed_origin
 
@@ -161,14 +231,20 @@ def build_guard_connect_browser_url(
 
 def wait_for_connect_transition(
     *,
-    daemon_client,
+    daemon_client: GuardSurfaceDaemonClient,
     request_id: str,
     timeout_seconds: int,
     poll_interval_seconds: float = 0.25,
 ) -> dict[str, object] | None:
     deadline = time.monotonic() + max(1, timeout_seconds)
     while time.monotonic() < deadline:
-        state = daemon_client.get_connect_state(request_id=request_id)
+        try:
+            state = daemon_client.get_connect_state(request_id=request_id)
+        except RuntimeError:
+            time.sleep(poll_interval_seconds)
+            continue
+        if not isinstance(state, dict):
+            raise RuntimeError("Guard daemon request failed: invalid connect state response")
         if str(state.get("status")) in {"connected", "retry_required", "expired"}:
             return state
         if str(state.get("milestone")) == "first_sync_pending":
@@ -185,6 +261,7 @@ def build_connect_payload(
     sync_url: str,
     connected: bool,
     sync: dict[str, object] | None = None,
+    sync_message: str | None = None,
     sync_available: bool | None = None,
 ) -> dict[str, object]:
     milestones = [
@@ -218,7 +295,38 @@ def build_connect_payload(
     }
     if sync is not None:
         payload["sync"] = sync
+    if sync_message is not None and sync_message.strip():
+        payload["sync_message"] = sync_message
     return payload
+
+
+def _record_connect_result(
+    *,
+    daemon_client: GuardSurfaceDaemonClient,
+    store: GuardStore,
+    request_id: str,
+    status: str,
+    milestone: str,
+    reason: str | None = None,
+    sync: dict[str, object] | None = None,
+) -> dict[str, object]:
+    try:
+        return daemon_client.report_connect_result(
+            request_id=request_id,
+            status=status,
+            milestone=milestone,
+            reason=reason,
+            sync=sync,
+        )
+    except RuntimeError:
+        return store.record_guard_connect_result(
+            request_id=request_id,
+            status=status,
+            milestone=milestone,
+            now=datetime.now(timezone.utc).isoformat(),
+            reason=reason,
+            sync_payload=sync,
+        )
 
 
 def _resolve_first_sync_milestone(state: dict[str, object]) -> str:
@@ -232,3 +340,35 @@ def _resolve_first_sync_milestone(state: dict[str, object]) -> str:
     if milestone == "sync_not_available":
         return "skipped"
     return "pending"
+
+
+def _start_guard_runtime_session(daemon_client: GuardSurfaceDaemonClient) -> dict[str, object]:
+    start_session = getattr(daemon_client, "start_session", None)
+    if callable(start_session):
+        try:
+            return start_session(
+                harness="hol-guard",
+                surface="cli",
+                workspace=str(Path.cwd()),
+                client_name="hol-guard",
+                client_title="HOL Guard CLI",
+                client_version=None,
+                capabilities=["approval-resolution", "receipt-view", "runtime-sync"],
+            )
+        except RuntimeError:
+            pass
+    now = datetime.now(timezone.utc).isoformat()
+    return {
+        "session_id": f"guard-session-{uuid.uuid4().hex}",
+        "harness": "hol-guard",
+        "surface": "cli",
+        "status": "active",
+        "client_name": "hol-guard",
+        "client_title": "HOL Guard CLI",
+        "client_version": None,
+        "workspace": str(Path.cwd()),
+        "capabilities": ["approval-resolution", "receipt-view", "runtime-sync"],
+        "operations": [],
+        "created_at": now,
+        "updated_at": now,
+    }

--- a/src/codex_plugin_scanner/guard/runtime/__init__.py
+++ b/src/codex_plugin_scanner/guard/runtime/__init__.py
@@ -1,5 +1,6 @@
 """Guard runtime helpers."""
 
-from .runner import GuardSyncNotConfiguredError, guard_run, sync_receipts, sync_runtime_session
+from .runner import GuardSyncNotAvailableError, guard_run, sync_receipts
+from .surface_server import GuardSurfaceRuntime
 
-__all__ = ["GuardSyncNotConfiguredError", "guard_run", "sync_receipts", "sync_runtime_session"]
+__all__ = ["GuardSurfaceRuntime", "GuardSyncNotAvailableError", "guard_run", "sync_receipts"]

--- a/src/codex_plugin_scanner/guard/runtime/__init__.py
+++ b/src/codex_plugin_scanner/guard/runtime/__init__.py
@@ -1,6 +1,6 @@
 """Guard runtime helpers."""
 
-from .runner import GuardSyncNotAvailableError, guard_run, sync_receipts
+from .runner import GuardSyncNotAvailableError, GuardSyncNotConfiguredError, guard_run, sync_receipts, sync_runtime_session
 from .surface_server import GuardSurfaceRuntime
 
-__all__ = ["GuardSurfaceRuntime", "GuardSyncNotAvailableError", "guard_run", "sync_receipts"]
+__all__ = ["GuardSurfaceRuntime", "GuardSyncNotAvailableError", "GuardSyncNotConfiguredError", "guard_run", "sync_receipts", "sync_runtime_session"]

--- a/src/codex_plugin_scanner/guard/runtime/__init__.py
+++ b/src/codex_plugin_scanner/guard/runtime/__init__.py
@@ -1,6 +1,5 @@
 """Guard runtime helpers."""
 
 from .runner import GuardSyncNotAvailableError, GuardSyncNotConfiguredError, guard_run, sync_receipts, sync_runtime_session
-from .surface_server import GuardSurfaceRuntime
 
-__all__ = ["GuardSurfaceRuntime", "GuardSyncNotAvailableError", "GuardSyncNotConfiguredError", "guard_run", "sync_receipts", "sync_runtime_session"]
+__all__ = ["GuardSyncNotAvailableError", "GuardSyncNotConfiguredError", "guard_run", "sync_receipts", "sync_runtime_session"]

--- a/src/codex_plugin_scanner/guard/runtime/__init__.py
+++ b/src/codex_plugin_scanner/guard/runtime/__init__.py
@@ -1,5 +1,17 @@
 """Guard runtime helpers."""
 
-from .runner import GuardSyncNotAvailableError, GuardSyncNotConfiguredError, guard_run, sync_receipts, sync_runtime_session
+from .runner import (
+    GuardSyncNotAvailableError,
+    GuardSyncNotConfiguredError,
+    guard_run,
+    sync_receipts,
+    sync_runtime_session,
+)
 
-__all__ = ["GuardSyncNotAvailableError", "GuardSyncNotConfiguredError", "guard_run", "sync_receipts", "sync_runtime_session"]
+__all__ = [
+    "GuardSyncNotAvailableError",
+    "GuardSyncNotConfiguredError",
+    "guard_run",
+    "sync_receipts",
+    "sync_runtime_session",
+]

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -15,22 +15,18 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from ...version import __version__
 from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
 from ..config import GuardConfig
 from ..consumer import detect_harness, evaluate_detection
 from ..models import GuardArtifact, HarnessDetection, PolicyDecision
 from ..store import GuardStore
-from ..types import PromptRequest, RemediationAction
 
-_APPROVAL_METADATA_KEYS = (
-    "approval_center_url",
-    "approval_delivery",
-    "approval_requests",
-    "approval_wait",
-    "review_hint",
-)
+
+class GuardSyncNotAvailableError(Exception):
+    """Raised when the Guard sync endpoint returns 403 (plan upgrade required)."""
+
+_APPROVAL_METADATA_KEYS = ("approval_center_url", "approval_requests", "approval_wait", "review_hint")
 _PAIN_SIGNAL_EVENTS = frozenset(
     {
         "changed_artifact_caught",
@@ -40,44 +36,7 @@ _PAIN_SIGNAL_EVENTS = frozenset(
     }
 )
 _EXCEPTION_EXPIRY_ALERT_WINDOW_HOURS = 7 * 24
-_SECRET_REQUEST_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
-    (re.compile(r"(?<![\w-])\.env(?:\.[\w.-]+)?\b"), "local .env file"),
-    (re.compile(r"(?:^|[\s'\"`])~?/.ssh(?:/|\b)"), "SSH material"),
-    (re.compile(r"(?:^|[\s'\"`])~?/.aws/(?:credentials|config)\b"), "AWS credentials"),
-    (re.compile(r"(?:^|[\s'\"`])~?/.kube/config\b"), "kubeconfig"),
-    (re.compile(r"(?:^|[\s'\"`])~?/.docker/config\.json\b"), "Docker credentials"),
-    (re.compile(r"(?<![\w-])\.npmrc\b"), "npm registry credentials"),
-    (re.compile(r"(?<![\w-])\.pypirc\b"), "Python package credentials"),
-    (re.compile(r"(?<![\w-])\.git-credentials\b"), "Git credential store"),
-)
-_SECRET_ABSOLUTE_HINTS: tuple[tuple[str, str], ...] = (
-    ("/.ssh/", "SSH material"),
-    ("/.aws/credentials", "AWS credentials"),
-    ("/.aws/config", "AWS credentials"),
-    ("/.kube/config", "kubeconfig"),
-    ("/.docker/config.json", "Docker credentials"),
-)
-_EXFIL_PROMPT_PATTERN = re.compile(
-    r"\b(upload|exfiltrate|send|post|sync|webhook|paste|gist|transfer)\b",
-    re.IGNORECASE,
-)
-_DESTRUCTIVE_PROMPT_PATTERN = re.compile(
-    r"\b(rm\s+-rf|rm\s+|del\s+|truncate\s+|chmod\s+|chown\s+|mv\s+|overwrite)\b",
-    re.IGNORECASE,
-)
-_SUBPROCESS_PROMPT_PATTERN = re.compile(
-    r"\b(?:bash\s+-c|sh\s+-c|zsh\s+-c|powershell|cmd\s+/c|subprocess)\b|(?:exec|spawn)\s*\(",
-    re.IGNORECASE,
-)
-_GUARD_BYPASS_PROMPT_PATTERN = re.compile(
-    r"\b(hol-guard\s+(?:disable|off|uninstall)|disable\s+hol-guard|approval_policy\s*=\s*\"never\"|guard[_-]?bypass)\b",
-    re.IGNORECASE,
-)
-_GUARD_SYNC_USER_AGENT = f"hol-guard/{__version__}"
-
-
-class GuardSyncNotConfiguredError(RuntimeError):
-    """Raised when Guard Cloud sync is requested before the machine is paired."""
+_ENV_PROMPT_PATTERN = re.compile(r"(?<![\w-])\.env(?:\.[\w.-]+)?\b")
 
 
 def guard_run(
@@ -123,7 +82,6 @@ def guard_run(
     environment["HOME"] = str(context.home_dir)
     if os.name == "nt":
         environment["USERPROFILE"] = str(context.home_dir)
-    environment.update(adapter.launch_environment(context))
     try:
         result = subprocess.run(command, cwd=context.workspace_dir or Path.cwd(), check=False, env=environment)
     except FileNotFoundError as error:
@@ -141,258 +99,52 @@ def _detection_with_prompt_artifacts(
     context: HarnessContext,
     passthrough_args: list[str],
 ) -> HarnessDetection:
-    prompt_text = " ".join(value.strip() for value in passthrough_args if value.strip())
-    prompt_requests = extract_prompt_requests(prompt_text)
-    if not prompt_requests:
+    prompt_artifact = _prompt_env_artifact(detection.harness, context, passthrough_args)
+    if prompt_artifact is None:
         return detection
-    prompt_artifacts = prompt_requests_to_artifacts(
-        detection=detection,
-        context=context,
-        requests=prompt_requests,
-    )
     return HarnessDetection(
         harness=detection.harness,
         installed=detection.installed,
         command_available=detection.command_available,
         config_paths=detection.config_paths,
-        artifacts=(*detection.artifacts, *prompt_artifacts),
+        artifacts=(*detection.artifacts, prompt_artifact),
         warnings=detection.warnings,
     )
 
 
-def extract_prompt_requests(prompt_text: str) -> list[PromptRequest]:
-    """Extract structured prompt intent requests from passthrough arguments."""
-
-    normalized_prompt = " ".join(prompt_text.split())
-    lowered = normalized_prompt.lower()
-    if not lowered:
-        return []
-    requests: list[PromptRequest] = []
-    seen_secret_labels: set[str] = set()
-
-    def add_secret_request(*, label: str, matched: str) -> None:
-        if label in seen_secret_labels:
-            return
-        seen_secret_labels.add(label)
-        summary = (
-            "Prompt asks the harness to read a local .env file directly."
-            if label == "local .env file"
-            else f"Prompt asks for direct access to {label}."
-        )
-        requests.append(
-            PromptRequest(
-                request_id=_prompt_request_id("secret_read", matched, lowered),
-                request_class="secret_read",
-                summary=summary,
-                matched_text=matched,
-                severity=8,
-                confidence=0.9,
-                remediation=(
-                    RemediationAction(kind="approve_once", label="Approve once", detail="Allow a one-time access."),
-                    RemediationAction(
-                        kind="rotate_exposed_secret",
-                        label="Rotate secret",
-                        detail="Rotate credentials if this read is unexpected.",
-                    ),
-                ),
-            )
-        )
-
-    for pattern, label in _SECRET_REQUEST_PATTERNS:
-        match = pattern.search(normalized_prompt)
-        if match is None:
-            continue
-        add_secret_request(label=label, matched=match.group(0).strip())
-    for hint, label in _SECRET_ABSOLUTE_HINTS:
-        if hint in lowered:
-            add_secret_request(label=label, matched=hint)
-    if _EXFIL_PROMPT_PATTERN.search(normalized_prompt):
-        requests.append(
-            PromptRequest(
-                request_id=_prompt_request_id("exfil_intent", "exfil", lowered),
-                request_class="exfil_intent",
-                summary="Prompt includes exfiltration-oriented transfer intent.",
-                matched_text="exfil-transfer",
-                severity=8,
-                confidence=0.84,
-                remediation=(
-                    RemediationAction(
-                        kind="review_network_destination",
-                        label="Review destination",
-                        detail="Validate destination before data transfer.",
-                    ),
-                    RemediationAction(kind="defer_and_notify_team", label="Notify team", detail="Escalate for review."),
-                ),
-            )
-        )
-    if _DESTRUCTIVE_PROMPT_PATTERN.search(normalized_prompt):
-        requests.append(
-            PromptRequest(
-                request_id=_prompt_request_id("destructive_intent", "destructive", lowered),
-                request_class="destructive_intent",
-                summary="Prompt includes destructive filesystem mutation intent.",
-                matched_text="destructive-operation",
-                severity=8,
-                confidence=0.87,
-                remediation=(
-                    RemediationAction(
-                        kind="approve_once",
-                        label="Approve once",
-                        detail="Require explicit one-time approval.",
-                    ),
-                    RemediationAction(
-                        kind="open_investigation",
-                        label="Open investigation",
-                        detail="Track destructive intent.",
-                    ),
-                ),
-            )
-        )
-    if _SUBPROCESS_PROMPT_PATTERN.search(normalized_prompt):
-        requests.append(
-            PromptRequest(
-                request_id=_prompt_request_id("subprocess_intent", "subprocess", lowered),
-                request_class="subprocess_intent",
-                summary="Prompt asks for subprocess or shell-wrapper execution.",
-                matched_text="subprocess-shell",
-                severity=7,
-                confidence=0.8,
-                remediation=(
-                    RemediationAction(
-                        kind="approve_once",
-                        label="Approve once",
-                        detail="Constrain this run to one approval.",
-                    ),
-                    RemediationAction(
-                        kind="run_in_sandbox",
-                        label="Run in sandbox",
-                        detail="Execute in isolated mode.",
-                    ),
-                ),
-            )
-        )
-    if _GUARD_BYPASS_PROMPT_PATTERN.search(normalized_prompt):
-        requests.append(
-            PromptRequest(
-                request_id=_prompt_request_id("guard_bypass_intent", "guard-bypass", lowered),
-                request_class="guard_bypass_intent",
-                summary="Prompt includes Guard bypass or disable intent.",
-                matched_text="guard-bypass",
-                severity=10,
-                confidence=0.93,
-                remediation=(
-                    RemediationAction(
-                        kind="block_and_remove",
-                        label="Block",
-                        detail="Do not allow bypass behavior.",
-                    ),
-                    RemediationAction(
-                        kind="open_investigation",
-                        label="Investigate",
-                        detail="Escalate bypass attempt.",
-                    ),
-                ),
-            )
-        )
-    deduped: dict[str, PromptRequest] = {}
-    for request in requests:
-        deduped[request.request_id] = request
-    return list(deduped.values())
-
-
-def prompt_requests_to_artifacts(
-    *,
-    detection: HarnessDetection,
+def _prompt_env_artifact(
+    harness: str,
     context: HarnessContext,
-    requests: list[PromptRequest],
-) -> list[GuardArtifact]:
-    """Convert typed prompt requests into pseudo-artifacts for policy evaluation."""
-
-    config_path = str(_prompt_policy_path(detection, context))
-    artifacts: list[GuardArtifact] = []
-    for request in requests:
-        if request.request_class == "secret_read" and ".env" in request.matched_text.lower():
-            artifact_id = f"{detection.harness}:session:prompt-env-read:{request.request_id[:24]}"
-        else:
-            artifact_id = f"{detection.harness}:session:prompt:{request.request_class}:{request.request_id[:24]}"
-        artifacts.append(
-            GuardArtifact(
-                artifact_id=artifact_id,
-                name=f"prompt {request.request_class.replace('_', ' ')}",
-                harness=detection.harness,
-                artifact_type="prompt_request",
-                source_scope="session",
-                config_path=config_path,
-                metadata={
-                    "prompt_signals": [request.summary],
-                    "prompt_summary": request.summary,
-                    "prompt_matched_text": request.matched_text,
-                    "prompt_request_class": request.request_class,
-                    "prompt_confidence": request.confidence,
-                    "prompt_severity": request.severity,
-                },
-            )
-        )
-    return artifacts
-
-
-def should_force_reapproval(prompt_reqs: list[PromptRequest], prior_policy: dict[str, object] | None) -> bool:
-    """Return whether current prompt requests exceed prior approved scope."""
-
-    if not prompt_reqs:
-        return False
-    if prior_policy is None:
-        return True
-    approved_classes = prior_policy.get("approved_prompt_classes")
-    approved = (
-        {str(item) for item in approved_classes if isinstance(item, str)}
-        if isinstance(approved_classes, list)
-        else set()
+    passthrough_args: list[str],
+) -> GuardArtifact | None:
+    prompt_text = " ".join(value.strip() for value in passthrough_args if value.strip())
+    normalized_prompt = " ".join(prompt_text.split()).lower()
+    if not normalized_prompt or not _requests_direct_env_read(normalized_prompt):
+        return None
+    prompt_hash = hashlib.sha256(normalized_prompt.encode("utf-8")).hexdigest()
+    prompt_summary = "Prompt asks the harness to read a local .env file directly."
+    return GuardArtifact(
+        artifact_id=f"{harness}:session:prompt-env-read:{prompt_hash}",
+        name="direct .env prompt access",
+        harness=harness,
+        artifact_type="prompt_request",
+        source_scope="session",
+        config_path=str(_prompt_policy_path(context)),
+        metadata={
+            "prompt_signals": ["asks the harness to read a local .env file directly"],
+            "prompt_summary": prompt_summary,
+        },
     )
-    return any(request.request_class not in approved or request.severity >= 8 for request in prompt_reqs)
 
 
-def _prompt_request_id(request_class: str, matched_text: str, normalized_prompt: str) -> str:
-    fingerprint = hashlib.sha256(f"{request_class}:{matched_text}:{normalized_prompt}".encode()).hexdigest()
-    return fingerprint
+def _requests_direct_env_read(prompt_text: str) -> bool:
+    return _ENV_PROMPT_PATTERN.search(prompt_text) is not None
 
 
-def _prompt_policy_path(detection: HarnessDetection, context: HarnessContext) -> Path:
-    config_candidates = _prompt_config_candidates(detection, context)
-    if context.workspace_dir is not None:
-        for config_path in config_candidates:
-            candidate = Path(config_path)
-            if candidate.is_relative_to(context.workspace_dir):
-                return candidate
-    if config_candidates:
-        return Path(config_candidates[0])
-    if detection.harness == "opencode":
-        if context.workspace_dir is not None:
-            return context.workspace_dir / "opencode.json"
-        return context.home_dir / ".config" / "opencode" / "opencode.json"
+def _prompt_policy_path(context: HarnessContext) -> Path:
     if context.workspace_dir is not None:
         return context.workspace_dir / ".codex" / "config.toml"
     return context.home_dir / ".codex" / "config.toml"
-
-
-def _prompt_config_candidates(detection: HarnessDetection, context: HarnessContext) -> tuple[str, ...]:
-    if detection.harness == "opencode":
-        configured_path = os.getenv("OPENCODE_CONFIG")
-        configured_candidate = None
-        if configured_path:
-            candidate = Path(configured_path).expanduser()
-            if not candidate.is_absolute():
-                if context.workspace_dir is not None:
-                    candidate = context.workspace_dir / candidate
-                else:
-                    candidate = Path.cwd() / candidate
-            configured_candidate = str(candidate)
-        return tuple(
-            config_path
-            for config_path in detection.config_paths
-            if Path(config_path).name in {"opencode.json", "opencode.jsonc"} or config_path == configured_candidate
-        )
-    return detection.config_paths
 
 
 def sync_receipts(store: GuardStore) -> dict[str, object]:
@@ -400,21 +152,25 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
 
     credentials = store.get_sync_credentials()
     if credentials is None:
-        raise GuardSyncNotConfiguredError("Guard is not logged in.")
-    sync_url = _normalized_receipts_sync_url(str(credentials["sync_url"]))
+        raise RuntimeError("Guard is not logged in.")
     receipts = store.list_receipts(limit=200)
     inventory = store.list_inventory()
-    body = json.dumps({"receipts": _cloud_sync_receipts_payload(store, receipts)}).encode("utf-8")
+    body = json.dumps({"receipts": receipts, "inventory": inventory}).encode("utf-8")
     request = urllib.request.Request(
-        sync_url,
+        str(credentials["sync_url"]),
         data=body,
         method="POST",
-        headers=_guard_sync_headers(str(credentials["token"])),
+        headers={
+            "Authorization": f"Bearer {credentials['token']}",
+            "Content-Type": "application/json",
+        },
     )
     try:
-        with urllib.request.urlopen(request, timeout=20) as response:
+        with urllib.request.urlopen(request, timeout=10) as response:
             payload = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as error:
+        if error.code == 403:
+            raise GuardSyncNotAvailableError(_sync_http_error_message(error)) from error
         raise RuntimeError(_sync_http_error_message(error)) from error
     except urllib.error.URLError as error:
         raise RuntimeError(_sync_url_error_message(error)) from error
@@ -450,7 +206,7 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
         now=now,
     )
     pain_signals_uploaded = sync_pain_signals(store)
-    summary = {
+    return {
         "synced_at": payload.get("syncedAt"),
         "receipts_stored": payload.get("receiptsStored"),
         "advisories_stored": advisories_stored,
@@ -458,67 +214,14 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
         "remote_policies_stored": len(remote_decisions),
         "pain_signals_uploaded": pain_signals_uploaded,
         "receipts": len(receipts),
-        "inventory": 0,
-        "inventory_tracked": len(inventory),
+        "inventory": len(inventory),
     }
-    store.set_sync_payload("sync_summary", summary, now)
-    return summary
-
-
-def sync_runtime_session(
-    store: GuardStore,
-    *,
-    session: dict[str, object],
-) -> dict[str, object]:
-    """Publish the active Guard runtime session so the dashboard can show the machine immediately."""
-
-    credentials = store.get_sync_credentials()
-    if credentials is None:
-        raise GuardSyncNotConfiguredError("Guard is not logged in.")
-    sync_url = _normalized_runtime_sessions_sync_url(str(credentials["sync_url"]))
-    session_payload = _cloud_runtime_session_payload(store, session)
-    body = json.dumps({"session": session_payload}).encode("utf-8")
-    request = urllib.request.Request(
-        sync_url,
-        data=body,
-        method="POST",
-        headers=_guard_sync_headers(str(credentials["token"])),
-    )
-    try:
-        with urllib.request.urlopen(request, timeout=10) as response:
-            payload = json.loads(response.read().decode("utf-8"))
-    except urllib.error.HTTPError as error:
-        if error.code == 404:
-            recorded_at = _now()
-            summary = {
-                "synced_at": None,
-                "runtime_session_synced_at": None,
-                "runtime_session_id": session_payload["sessionId"],
-                "runtime_sessions_visible": 0,
-                "runtime_session_sync_skipped": True,
-                "runtime_session_sync_reason": "runtime_session_endpoint_unavailable",
-            }
-            store.set_sync_payload("runtime_session_summary", summary, recorded_at)
-            return summary
-        raise RuntimeError(_sync_http_error_message(error)) from error
-    if not isinstance(payload, dict):
-        raise RuntimeError("Invalid sync response")
-    synced_at = _sync_timestamp(payload)
-    summary = {
-        "synced_at": synced_at,
-        "runtime_session_synced_at": synced_at,
-        "runtime_session_id": session_payload["sessionId"],
-        "runtime_sessions_visible": len(payload.get("items", [])) if isinstance(payload.get("items"), list) else 0,
-    }
-    store.set_sync_payload("runtime_session_summary", summary, synced_at)
-    return summary
 
 
 def sync_pain_signals(store: GuardStore) -> int:
     credentials = store.get_sync_credentials()
     if credentials is None:
         return 0
-    normalized_sync_url = _normalized_receipts_sync_url(str(credentials["sync_url"]))
     cursor_payload = store.get_sync_payload("pain_signal_cursor")
     last_event_id = _last_uploaded_event_id(cursor_payload)
     uploaded_count = 0
@@ -535,10 +238,13 @@ def sync_pain_signals(store: GuardStore) -> int:
         signal_items = [payload for item in candidates if (payload := _pain_signal_item(item)) is not None]
         if signal_items:
             request = urllib.request.Request(
-                _pain_signal_sync_url(normalized_sync_url),
+                _pain_signal_sync_url(str(credentials["sync_url"])),
                 data=json.dumps({"items": signal_items}).encode("utf-8"),
                 method="POST",
-                headers=_guard_sync_headers(str(credentials["token"])),
+                headers={
+                    "Authorization": f"Bearer {credentials['token']}",
+                    "Content-Type": "application/json",
+                },
             )
             try:
                 with urllib.request.urlopen(request, timeout=10):
@@ -633,40 +339,22 @@ def _build_remote_policy_decisions(payload: dict[str, object]) -> list[PolicyDec
     return decisions
 
 
-def _guard_sync_headers(token: str) -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json",
-        "Accept": "application/json",
-        "User-Agent": _GUARD_SYNC_USER_AGENT,
-    }
-
-
 def _sync_http_error_message(error: urllib.error.HTTPError) -> str:
     try:
-        raw_body = error.read().decode("utf-8")
-    except OSError:
-        raw_body = ""
-    try:
-        payload = json.loads(raw_body) if raw_body else None
-    except json.JSONDecodeError:
+        payload = json.loads(error.read().decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         payload = None
     if isinstance(payload, dict):
-        message = payload.get("error")
-        if isinstance(message, str) and message.strip():
-            return message.strip()
-    normalized_body = raw_body.strip()
-    if normalized_body:
-        return normalized_body
-    return f"HTTP Error {error.code}: {error.reason}"
+        error_value = payload.get("error")
+        if isinstance(error_value, str) and error_value.strip():
+            return error_value
+    return f"Guard sync failed with HTTP {error.code}."
 
 
 def _sync_url_error_message(error: urllib.error.URLError) -> str:
     reason = getattr(error, "reason", None)
-    if reason is not None:
-        reason_text = str(reason).strip()
-        if reason_text:
-            return f"Guard sync failed: {reason_text}"
+    if isinstance(reason, str) and reason.strip():
+        return f"Guard sync failed: {reason.strip()}"
     return "Guard sync failed because the remote endpoint could not be reached."
 
 
@@ -778,165 +466,6 @@ def _pain_signal_sync_url(sync_url: str) -> str:
             parsed.fragment,
         )
     )
-
-
-def _normalized_receipts_sync_url(sync_url: str) -> str:
-    parsed = urllib.parse.urlsplit(sync_url)
-    if parsed.path.rstrip("/") == "/registry/api/v1":
-        return urllib.parse.urlunsplit(
-            (
-                parsed.scheme,
-                parsed.netloc,
-                "/api/guard/receipts/sync",
-                parsed.query,
-                "",
-            )
-        )
-    return sync_url
-
-
-def _normalized_runtime_sessions_sync_url(sync_url: str) -> str:
-    normalized_receipts_url = _normalized_receipts_sync_url(sync_url)
-    parsed = urllib.parse.urlsplit(normalized_receipts_url)
-    if parsed.path.rstrip("/") == "/api/guard/receipts/sync":
-        return urllib.parse.urlunsplit(
-            (
-                parsed.scheme,
-                parsed.netloc,
-                "/api/guard/runtime/sessions/sync",
-                parsed.query,
-                "",
-            )
-        )
-    if parsed.path.rstrip("/") == "/guard/receipts/sync":
-        return urllib.parse.urlunsplit(
-            (
-                parsed.scheme,
-                parsed.netloc,
-                "/guard/runtime/sessions/sync",
-                parsed.query,
-                "",
-            )
-        )
-    return urllib.parse.urlunsplit(
-        (
-            parsed.scheme,
-            parsed.netloc,
-            parsed.path.rstrip("/") + "/runtime/sessions/sync",
-            parsed.query,
-            "",
-        )
-    )
-
-
-def _cloud_sync_receipts_payload(store: GuardStore, receipts: list[dict[str, object]]) -> list[dict[str, object]]:
-    device_id, device_name = _guard_device_metadata(store)
-    return [_cloud_sync_receipt_payload(receipt, device_id=device_id, device_name=device_name) for receipt in receipts]
-
-
-def _cloud_sync_receipt_payload(
-    receipt: dict[str, object],
-    *,
-    device_id: str,
-    device_name: str,
-) -> dict[str, object]:
-    receipt_fingerprint = _cloud_sync_receipt_fingerprint(receipt)
-    artifact_id = _optional_string(receipt.get("artifact_id")) or f"guard:local-receipt:{receipt_fingerprint[:24]}"
-    artifact_name = _optional_string(receipt.get("artifact_name")) or artifact_id
-    policy_decision = _optional_string(receipt.get("policy_decision")) or "review"
-    changed_capabilities = [str(item) for item in receipt.get("changed_capabilities", []) if isinstance(item, str)]
-    capabilities_summary = _optional_string(receipt.get("capabilities_summary"))
-    if changed_capabilities:
-        capabilities = changed_capabilities
-    elif capabilities_summary is not None:
-        capabilities = [capabilities_summary]
-    else:
-        capabilities = []
-    payload: dict[str, object] = {
-        "receiptId": _optional_string(receipt.get("receipt_id")) or f"guard-receipt-{receipt_fingerprint}",
-        "artifactId": artifact_id,
-        "artifactName": artifact_name,
-        "artifactType": _cloud_sync_artifact_type(artifact_id),
-        "artifactSlug": _cloud_sync_artifact_slug(artifact_name, artifact_id),
-        "artifactHash": _optional_string(receipt.get("artifact_hash"))
-        or hashlib.sha256(artifact_id.encode("utf-8")).hexdigest(),
-        "capabilities": capabilities,
-        "capturedAt": _optional_string(receipt.get("timestamp")) or _now(),
-        "changedSinceLastApproval": bool(changed_capabilities)
-        or policy_decision in {"require-reapproval", "sandbox-required"},
-        "deviceId": device_id,
-        "deviceName": device_name,
-        "harness": _optional_string(receipt.get("harness")) or "unknown",
-        "policyDecision": policy_decision,
-        "recommendation": _cloud_sync_recommendation(policy_decision),
-        "summary": _optional_string(receipt.get("provenance_summary"))
-        or capabilities_summary
-        or f"Guard recorded a {policy_decision} decision.",
-    }
-    publisher = _optional_string(receipt.get("publisher"))
-    if publisher is not None:
-        payload["publisher"] = publisher
-    return payload
-
-
-def _cloud_runtime_session_payload(store: GuardStore, session: dict[str, object]) -> dict[str, object]:
-    device_id, device_name = _guard_device_metadata(store)
-    workspace = _optional_string(session.get("workspace")) or os.getcwd()
-    session_id = (
-        _optional_string(session.get("session_id") or session.get("sessionId"))
-        or hashlib.sha256(f"{device_id}:{workspace}".encode()).hexdigest()[:24]
-    )
-    created_at = _optional_string(session.get("created_at") or session.get("createdAt")) or _now()
-    updated_at = _optional_string(session.get("updated_at") or session.get("updatedAt")) or created_at
-    capabilities = [str(item) for item in session.get("capabilities", []) if isinstance(item, str)]
-    return {
-        "sessionId": session_id,
-        "harness": _optional_string(session.get("harness")) or "hol-guard",
-        "surface": _optional_string(session.get("surface")) or "cli",
-        "status": _optional_string(session.get("status")) or "active",
-        "clientName": _optional_string(session.get("client_name") or session.get("clientName")) or "hol-guard",
-        "clientTitle": _optional_string(session.get("client_title") or session.get("clientTitle"))
-        or f"HOL Guard on {device_name}",
-        "clientVersion": _optional_string(session.get("client_version") or session.get("clientVersion")) or __version__,
-        "workspace": workspace,
-        "capabilities": capabilities,
-        "operations": [],
-        "createdAt": created_at,
-        "updatedAt": updated_at,
-    }
-
-
-def _cloud_sync_receipt_fingerprint(receipt: dict[str, object]) -> str:
-    encoded_receipt = json.dumps(receipt, sort_keys=True, separators=(",", ":"), default=str)
-    return hashlib.sha256(encoded_receipt.encode("utf-8")).hexdigest()
-
-
-def _cloud_sync_artifact_type(artifact_id: str) -> str:
-    if artifact_id.startswith("skill:") or ":skill:" in artifact_id:
-        return "skill"
-    return "plugin"
-
-
-def _cloud_sync_artifact_slug(artifact_name: str, artifact_id: str) -> str:
-    base_value = artifact_name.strip() or artifact_id.strip() or "artifact"
-    slug = re.sub(r"[^a-z0-9]+", "-", base_value.lower()).strip("-")
-    if slug:
-        return slug
-    fallback = re.sub(r"[^a-z0-9]+", "-", artifact_id.lower()).strip("-")
-    return fallback or "artifact"
-
-
-def _cloud_sync_recommendation(policy_decision: str) -> str:
-    if policy_decision == "block":
-        return "block"
-    if policy_decision in {"review", "require-reapproval", "sandbox-required"}:
-        return "review"
-    return "monitor"
-
-
-def _guard_device_metadata(store: GuardStore) -> tuple[str, str]:
-    metadata = store.get_device_metadata()
-    return str(metadata["installation_id"]), str(metadata["device_label"])
 
 
 def _record_synced_alert_events(

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -670,7 +670,6 @@ def _sync_http_error_message(error: urllib.error.HTTPError) -> str:
     return f"HTTP Error {error.code}: {error.reason}"
 
 
-
 _PLAN_403_KEYWORDS: frozenset[str] = frozenset(
     {
         "sync_not_available",

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -717,6 +717,7 @@ def _check_plan_restriction_403(
         return True, message_str
     return False, message_str
 
+
 def _sync_url_error_message(error: urllib.error.URLError) -> str:
     reason = getattr(error, "reason", None)
     if reason is not None:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -10,6 +10,7 @@ import subprocess
 import urllib.error
 import urllib.parse
 import urllib.request
+import uuid
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
@@ -23,7 +24,7 @@ from ..models import GuardArtifact, HarnessDetection, PolicyDecision
 from ..store import GuardStore
 
 
-class GuardSyncNotAvailableError(Exception):
+class GuardSyncNotAvailableError(RuntimeError):
     """Raised when the Guard sync endpoint returns 403 (plan upgrade required)."""
 
 
@@ -83,6 +84,7 @@ def guard_run(
     environment["HOME"] = str(context.home_dir)
     if os.name == "nt":
         environment["USERPROFILE"] = str(context.home_dir)
+    environment.update(adapter.launch_environment(context))
     try:
         result = subprocess.run(command, cwd=context.workspace_dir or Path.cwd(), check=False, env=environment)
     except FileNotFoundError as error:
@@ -216,6 +218,40 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
         "pain_signals_uploaded": pain_signals_uploaded,
         "receipts": len(receipts),
         "inventory": len(inventory),
+    }
+
+
+def sync_runtime_session(store: GuardStore, *, session: dict[str, object]) -> dict[str, object]:
+    """Push one runtime session snapshot to the configured sync endpoint."""
+
+    credentials = store.get_sync_credentials()
+    if credentials is None:
+        raise RuntimeError("Guard is not logged in.")
+
+    normalized_session = _normalize_runtime_session_payload(session)
+    request = urllib.request.Request(
+        _runtime_session_sync_url(str(credentials["sync_url"])),
+        data=json.dumps({"session": normalized_session}).encode("utf-8"),
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {credentials['token']}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        raise RuntimeError(_sync_http_error_message(error)) from error
+    except urllib.error.URLError as error:
+        raise RuntimeError(_sync_url_error_message(error)) from error
+
+    visible_items = payload.get("items")
+    return {
+        "runtime_session_id": normalized_session.get("sessionId", ""),
+        "runtime_session_synced_at": payload.get("generatedAt") or payload.get("generated_at"),
+        "runtime_sessions_visible": len(visible_items) if isinstance(visible_items, list) else 0,
+        "runtime_session_sync_pending": False,
     }
 
 
@@ -467,6 +503,74 @@ def _pain_signal_sync_url(sync_url: str) -> str:
             parsed.fragment,
         )
     )
+
+
+def _runtime_session_sync_url(sync_url: str) -> str:
+    parsed = urllib.parse.urlsplit(sync_url)
+    path = parsed.path.rstrip("/")
+    segments = [segment for segment in path.split("/") if segment]
+    if len(segments) >= 2 and segments[-2:] in (["receipts", "sync"], ["inventory", "sync"]):
+        next_segments = [*segments[:-2], "runtime", "sessions", "sync"]
+    elif segments and segments[-1] in {"receipts", "inventory"}:
+        next_segments = [*segments[:-1], "runtime", "sessions", "sync"]
+    else:
+        next_segments = [*segments, "runtime", "sessions", "sync"]
+    return urllib.parse.urlunsplit(
+        (
+            parsed.scheme,
+            parsed.netloc,
+            "/" + "/".join(next_segments),
+            parsed.query,
+            parsed.fragment,
+        )
+    )
+
+
+def _normalize_runtime_session_payload(session: dict[str, object]) -> dict[str, object]:
+    operations_value = session.get("operations")
+    operations: list[dict[str, object]] = []
+    if isinstance(operations_value, list):
+        operations = [
+            _normalize_runtime_operation_payload(item)
+            for item in operations_value
+            if isinstance(item, dict)
+        ]
+
+    return {
+        "sessionId": str(
+            session.get("sessionId")
+            or session.get("session_id")
+            or f"guard-session-{hashlib.sha256(str(session).encode('utf-8')).hexdigest()[:12]}"
+        ),
+        "harness": str(session.get("harness") or "unknown"),
+        "surface": str(session.get("surface") or "cli"),
+        "status": str(session.get("status") or "active"),
+        "clientName": str(session.get("clientName") or session.get("client_name") or "hol-guard"),
+        "clientTitle": session.get("clientTitle") or session.get("client_title"),
+        "clientVersion": session.get("clientVersion") or session.get("client_version"),
+        "workspace": session.get("workspace"),
+        "capabilities": list(session.get("capabilities")) if isinstance(session.get("capabilities"), list) else [],
+        "operations": operations,
+        "createdAt": str(session.get("createdAt") or session.get("created_at") or _now()),
+        "updatedAt": str(session.get("updatedAt") or session.get("updated_at") or _now()),
+    }
+
+
+def _normalize_runtime_operation_payload(item: dict[str, object]) -> dict[str, object]:
+    return {
+        "operationId": str(item.get("operationId") or item.get("operation_id") or f"guard-op-{uuid.uuid4().hex}"),
+        "operationType": str(item.get("operationType") or item.get("operation_type") or "unknown"),
+        "status": str(item.get("status") or "pending"),
+        "approvalRequestIds": list(item.get("approvalRequestIds"))
+        if isinstance(item.get("approvalRequestIds"), list)
+        else list(item.get("approval_request_ids"))
+        if isinstance(item.get("approval_request_ids"), list)
+        else [],
+        "resumeToken": item.get("resumeToken") or item.get("resume_token"),
+        "metadata": item.get("metadata") if isinstance(item.get("metadata"), dict) else {},
+        "createdAt": str(item.get("createdAt") or item.get("created_at") or _now()),
+        "updatedAt": str(item.get("updatedAt") or item.get("updated_at") or _now()),
+    }
 
 
 def _record_synced_alert_events(

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -671,6 +671,21 @@ def _sync_http_error_message(error: urllib.error.HTTPError) -> str:
 
 
 
+_PLAN_403_KEYWORDS: frozenset[str] = frozenset(
+    {
+        "sync_not_available",
+        "plan_restriction",
+        "requires a pro",
+        "requires a team",
+        "upgrade your plan",
+        "upgrade to",
+        "subscription required",
+        "not included in your plan",
+        "guard sync requires",
+    }
+)
+
+
 def _check_plan_restriction_403(
     error: urllib.error.HTTPError,
 ) -> tuple[bool, str]:
@@ -678,6 +693,8 @@ def _check_plan_restriction_403(
 
     Returns (is_plan_restriction, error_message) so callers never
     drain the stream more than once regardless of which branch they take.
+    Checks both machine-readable fields (syncEnabled, error, code) and
+    human-readable error messages for plan-restriction signals.
     """
     try:
         raw_body = error.read().decode("utf-8", errors="replace")
@@ -692,14 +709,14 @@ def _check_plan_restriction_403(
         return False, fallback
     message = payload.get("error")
     message_str = message.strip() if isinstance(message, str) and message.strip() else fallback
-    sync_enabled = payload.get("syncEnabled")
-    error_code = str(payload.get("error", "") or payload.get("code", ""))
-    is_plan = (
-        sync_enabled is False
-        or "sync_not_available" in error_code
-        or "plan_restriction" in error_code
-    )
-    return is_plan, message_str
+    if payload.get("syncEnabled") is False:
+        return True, message_str
+    error_field = str(payload.get("error") or "").lower()
+    code_field = str(payload.get("code") or "").lower()
+    combined = f"{error_field} {code_field}"
+    if any(kw in combined for kw in _PLAN_403_KEYWORDS):
+        return True, message_str
+    return False, message_str
 
 def _sync_url_error_message(error: urllib.error.URLError) -> str:
     reason = getattr(error, "reason", None)

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -419,7 +419,7 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
         with urllib.request.urlopen(request, timeout=20) as response:
             payload = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as error:
-        if error.code == 403:
+        if error.code == 403 and _is_plan_restriction_403(error):
             raise GuardSyncNotAvailableError(_sync_http_error_message(error)) from error
         raise RuntimeError(_sync_http_error_message(error)) from error
     except urllib.error.URLError as error:
@@ -666,6 +666,22 @@ def _sync_http_error_message(error: urllib.error.HTTPError) -> str:
         return normalized_body
     return f"HTTP Error {error.code}: {error.reason}"
 
+
+
+def _is_plan_restriction_403(error: urllib.error.HTTPError) -> bool:
+    """Return True only when a 403 signals a plan-level restriction on sync."""
+    try:
+        body = error.read().decode("utf-8", errors="replace")
+        data = json.loads(body)
+        if isinstance(data, dict):
+            if data.get("syncEnabled") is False:
+                return True
+            error_code = str(data.get("error", "") or data.get("code", ""))
+            if "sync_not_available" in error_code or "plan_restriction" in error_code:
+                return True
+    except Exception:
+        pass
+    return False
 
 def _sync_url_error_message(error: urllib.error.URLError) -> str:
     reason = getattr(error, "reason", None)

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -155,7 +155,7 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
 
     credentials = store.get_sync_credentials()
     if credentials is None:
-        raise RuntimeError("Guard is not logged in.")
+        raise GuardSyncNotConfiguredError("Guard sync is not configured. Run 'hol-guard connect' first.")
     receipts = store.list_receipts(limit=200)
     inventory = store.list_inventory()
     body = json.dumps({"receipts": receipts, "inventory": inventory}).encode("utf-8")
@@ -209,6 +209,17 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
         now=now,
     )
     pain_signals_uploaded = sync_pain_signals(store)
+    sync_summary: dict[str, object] = {
+        "synced_at": payload.get("syncedAt"),
+        "receipts_stored": payload.get("receiptsStored"),
+        "advisories_stored": advisories_stored,
+        "exceptions_stored": len(exceptions) if isinstance(exceptions, list) else 0,
+        "remote_policies_stored": len(remote_decisions),
+        "pain_signals_uploaded": pain_signals_uploaded,
+        "receipts": len(receipts),
+        "inventory": len(inventory),
+    }
+    store.set_sync_payload("sync_summary", sync_summary, now)
     return {
         "synced_at": payload.get("syncedAt"),
         "receipts_stored": payload.get("receiptsStored"),

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -26,6 +26,7 @@ from ..store import GuardStore
 class GuardSyncNotAvailableError(Exception):
     """Raised when the Guard sync endpoint returns 403 (plan upgrade required)."""
 
+
 _APPROVAL_METADATA_KEYS = ("approval_center_url", "approval_requests", "approval_wait", "review_hint")
 _PAIN_SIGNAL_EVENTS = frozenset(
     {

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -419,8 +419,11 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
         with urllib.request.urlopen(request, timeout=20) as response:
             payload = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as error:
-        if error.code == 403 and _is_plan_restriction_403(error):
-            raise GuardSyncNotAvailableError(_sync_http_error_message(error)) from error
+        if error.code == 403:
+            _is_plan, _msg = _check_plan_restriction_403(error)
+            if _is_plan:
+                raise GuardSyncNotAvailableError(_msg) from error
+            raise RuntimeError(_msg) from error
         raise RuntimeError(_sync_http_error_message(error)) from error
     except urllib.error.URLError as error:
         raise RuntimeError(_sync_url_error_message(error)) from error
@@ -668,20 +671,35 @@ def _sync_http_error_message(error: urllib.error.HTTPError) -> str:
 
 
 
-def _is_plan_restriction_403(error: urllib.error.HTTPError) -> bool:
-    """Return True only when a 403 signals a plan-level restriction on sync."""
+def _check_plan_restriction_403(
+    error: urllib.error.HTTPError,
+) -> tuple[bool, str]:
+    """Read a 403 response body exactly once.
+
+    Returns (is_plan_restriction, error_message) so callers never
+    drain the stream more than once regardless of which branch they take.
+    """
     try:
-        body = error.read().decode("utf-8", errors="replace")
-        data = json.loads(body)
-        if isinstance(data, dict):
-            if data.get("syncEnabled") is False:
-                return True
-            error_code = str(data.get("error", "") or data.get("code", ""))
-            if "sync_not_available" in error_code or "plan_restriction" in error_code:
-                return True
-    except Exception:
-        pass
-    return False
+        raw_body = error.read().decode("utf-8", errors="replace")
+    except OSError:
+        raw_body = ""
+    try:
+        payload: object = json.loads(raw_body) if raw_body else None
+    except json.JSONDecodeError:
+        payload = None
+    fallback = raw_body.strip() or f"HTTP Error {error.code}: {error.reason}"
+    if not isinstance(payload, dict):
+        return False, fallback
+    message = payload.get("error")
+    message_str = message.strip() if isinstance(message, str) and message.strip() else fallback
+    sync_enabled = payload.get("syncEnabled")
+    error_code = str(payload.get("error", "") or payload.get("code", ""))
+    is_plan = (
+        sync_enabled is False
+        or "sync_not_available" in error_code
+        or "plan_restriction" in error_code
+    )
+    return is_plan, message_str
 
 def _sync_url_error_message(error: urllib.error.URLError) -> str:
     reason = getattr(error, "reason", None)

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -10,25 +10,27 @@ import subprocess
 import urllib.error
 import urllib.parse
 import urllib.request
-import uuid
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from ...version import __version__
 from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
 from ..config import GuardConfig
 from ..consumer import detect_harness, evaluate_detection
 from ..models import GuardArtifact, HarnessDetection, PolicyDecision
 from ..store import GuardStore
+from ..types import PromptRequest, RemediationAction
 
-
-class GuardSyncNotAvailableError(RuntimeError):
-    """Raised when the Guard sync endpoint returns 403 (plan upgrade required)."""
-
-
-_APPROVAL_METADATA_KEYS = ("approval_center_url", "approval_requests", "approval_wait", "review_hint")
+_APPROVAL_METADATA_KEYS = (
+    "approval_center_url",
+    "approval_delivery",
+    "approval_requests",
+    "approval_wait",
+    "review_hint",
+)
 _PAIN_SIGNAL_EVENTS = frozenset(
     {
         "changed_artifact_caught",
@@ -38,7 +40,48 @@ _PAIN_SIGNAL_EVENTS = frozenset(
     }
 )
 _EXCEPTION_EXPIRY_ALERT_WINDOW_HOURS = 7 * 24
-_ENV_PROMPT_PATTERN = re.compile(r"(?<![\w-])\.env(?:\.[\w.-]+)?\b")
+_SECRET_REQUEST_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"(?<![\w-])\.env(?:\.[\w.-]+)?\b"), "local .env file"),
+    (re.compile(r"(?:^|[\s'\"`])~?/.ssh(?:/|\b)"), "SSH material"),
+    (re.compile(r"(?:^|[\s'\"`])~?/.aws/(?:credentials|config)\b"), "AWS credentials"),
+    (re.compile(r"(?:^|[\s'\"`])~?/.kube/config\b"), "kubeconfig"),
+    (re.compile(r"(?:^|[\s'\"`])~?/.docker/config\.json\b"), "Docker credentials"),
+    (re.compile(r"(?<![\w-])\.npmrc\b"), "npm registry credentials"),
+    (re.compile(r"(?<![\w-])\.pypirc\b"), "Python package credentials"),
+    (re.compile(r"(?<![\w-])\.git-credentials\b"), "Git credential store"),
+)
+_SECRET_ABSOLUTE_HINTS: tuple[tuple[str, str], ...] = (
+    ("/.ssh/", "SSH material"),
+    ("/.aws/credentials", "AWS credentials"),
+    ("/.aws/config", "AWS credentials"),
+    ("/.kube/config", "kubeconfig"),
+    ("/.docker/config.json", "Docker credentials"),
+)
+_EXFIL_PROMPT_PATTERN = re.compile(
+    r"\b(upload|exfiltrate|send|post|sync|webhook|paste|gist|transfer)\b",
+    re.IGNORECASE,
+)
+_DESTRUCTIVE_PROMPT_PATTERN = re.compile(
+    r"\b(rm\s+-rf|rm\s+|del\s+|truncate\s+|chmod\s+|chown\s+|mv\s+|overwrite)\b",
+    re.IGNORECASE,
+)
+_SUBPROCESS_PROMPT_PATTERN = re.compile(
+    r"\b(?:bash\s+-c|sh\s+-c|zsh\s+-c|powershell|cmd\s+/c|subprocess)\b|(?:exec|spawn)\s*\(",
+    re.IGNORECASE,
+)
+_GUARD_BYPASS_PROMPT_PATTERN = re.compile(
+    r"\b(hol-guard\s+(?:disable|off|uninstall)|disable\s+hol-guard|approval_policy\s*=\s*\"never\"|guard[_-]?bypass)\b",
+    re.IGNORECASE,
+)
+_GUARD_SYNC_USER_AGENT = f"hol-guard/{__version__}"
+
+
+class GuardSyncNotConfiguredError(RuntimeError):
+    """Raised when Guard Cloud sync is requested before the machine is paired."""
+
+
+class GuardSyncNotAvailableError(RuntimeError):
+    """Raised when the sync endpoint returns 403 (free-plan restriction)."""
 
 
 def guard_run(
@@ -102,52 +145,258 @@ def _detection_with_prompt_artifacts(
     context: HarnessContext,
     passthrough_args: list[str],
 ) -> HarnessDetection:
-    prompt_artifact = _prompt_env_artifact(detection.harness, context, passthrough_args)
-    if prompt_artifact is None:
+    prompt_text = " ".join(value.strip() for value in passthrough_args if value.strip())
+    prompt_requests = extract_prompt_requests(prompt_text)
+    if not prompt_requests:
         return detection
+    prompt_artifacts = prompt_requests_to_artifacts(
+        detection=detection,
+        context=context,
+        requests=prompt_requests,
+    )
     return HarnessDetection(
         harness=detection.harness,
         installed=detection.installed,
         command_available=detection.command_available,
         config_paths=detection.config_paths,
-        artifacts=(*detection.artifacts, prompt_artifact),
+        artifacts=(*detection.artifacts, *prompt_artifacts),
         warnings=detection.warnings,
     )
 
 
-def _prompt_env_artifact(
-    harness: str,
+def extract_prompt_requests(prompt_text: str) -> list[PromptRequest]:
+    """Extract structured prompt intent requests from passthrough arguments."""
+
+    normalized_prompt = " ".join(prompt_text.split())
+    lowered = normalized_prompt.lower()
+    if not lowered:
+        return []
+    requests: list[PromptRequest] = []
+    seen_secret_labels: set[str] = set()
+
+    def add_secret_request(*, label: str, matched: str) -> None:
+        if label in seen_secret_labels:
+            return
+        seen_secret_labels.add(label)
+        summary = (
+            "Prompt asks the harness to read a local .env file directly."
+            if label == "local .env file"
+            else f"Prompt asks for direct access to {label}."
+        )
+        requests.append(
+            PromptRequest(
+                request_id=_prompt_request_id("secret_read", matched, lowered),
+                request_class="secret_read",
+                summary=summary,
+                matched_text=matched,
+                severity=8,
+                confidence=0.9,
+                remediation=(
+                    RemediationAction(kind="approve_once", label="Approve once", detail="Allow a one-time access."),
+                    RemediationAction(
+                        kind="rotate_exposed_secret",
+                        label="Rotate secret",
+                        detail="Rotate credentials if this read is unexpected.",
+                    ),
+                ),
+            )
+        )
+
+    for pattern, label in _SECRET_REQUEST_PATTERNS:
+        match = pattern.search(normalized_prompt)
+        if match is None:
+            continue
+        add_secret_request(label=label, matched=match.group(0).strip())
+    for hint, label in _SECRET_ABSOLUTE_HINTS:
+        if hint in lowered:
+            add_secret_request(label=label, matched=hint)
+    if _EXFIL_PROMPT_PATTERN.search(normalized_prompt):
+        requests.append(
+            PromptRequest(
+                request_id=_prompt_request_id("exfil_intent", "exfil", lowered),
+                request_class="exfil_intent",
+                summary="Prompt includes exfiltration-oriented transfer intent.",
+                matched_text="exfil-transfer",
+                severity=8,
+                confidence=0.84,
+                remediation=(
+                    RemediationAction(
+                        kind="review_network_destination",
+                        label="Review destination",
+                        detail="Validate destination before data transfer.",
+                    ),
+                    RemediationAction(kind="defer_and_notify_team", label="Notify team", detail="Escalate for review."),
+                ),
+            )
+        )
+    if _DESTRUCTIVE_PROMPT_PATTERN.search(normalized_prompt):
+        requests.append(
+            PromptRequest(
+                request_id=_prompt_request_id("destructive_intent", "destructive", lowered),
+                request_class="destructive_intent",
+                summary="Prompt includes destructive filesystem mutation intent.",
+                matched_text="destructive-operation",
+                severity=8,
+                confidence=0.87,
+                remediation=(
+                    RemediationAction(
+                        kind="approve_once",
+                        label="Approve once",
+                        detail="Require explicit one-time approval.",
+                    ),
+                    RemediationAction(
+                        kind="open_investigation",
+                        label="Open investigation",
+                        detail="Track destructive intent.",
+                    ),
+                ),
+            )
+        )
+    if _SUBPROCESS_PROMPT_PATTERN.search(normalized_prompt):
+        requests.append(
+            PromptRequest(
+                request_id=_prompt_request_id("subprocess_intent", "subprocess", lowered),
+                request_class="subprocess_intent",
+                summary="Prompt asks for subprocess or shell-wrapper execution.",
+                matched_text="subprocess-shell",
+                severity=7,
+                confidence=0.8,
+                remediation=(
+                    RemediationAction(
+                        kind="approve_once",
+                        label="Approve once",
+                        detail="Constrain this run to one approval.",
+                    ),
+                    RemediationAction(
+                        kind="run_in_sandbox",
+                        label="Run in sandbox",
+                        detail="Execute in isolated mode.",
+                    ),
+                ),
+            )
+        )
+    if _GUARD_BYPASS_PROMPT_PATTERN.search(normalized_prompt):
+        requests.append(
+            PromptRequest(
+                request_id=_prompt_request_id("guard_bypass_intent", "guard-bypass", lowered),
+                request_class="guard_bypass_intent",
+                summary="Prompt includes Guard bypass or disable intent.",
+                matched_text="guard-bypass",
+                severity=10,
+                confidence=0.93,
+                remediation=(
+                    RemediationAction(
+                        kind="block_and_remove",
+                        label="Block",
+                        detail="Do not allow bypass behavior.",
+                    ),
+                    RemediationAction(
+                        kind="open_investigation",
+                        label="Investigate",
+                        detail="Escalate bypass attempt.",
+                    ),
+                ),
+            )
+        )
+    deduped: dict[str, PromptRequest] = {}
+    for request in requests:
+        deduped[request.request_id] = request
+    return list(deduped.values())
+
+
+def prompt_requests_to_artifacts(
+    *,
+    detection: HarnessDetection,
     context: HarnessContext,
-    passthrough_args: list[str],
-) -> GuardArtifact | None:
-    prompt_text = " ".join(value.strip() for value in passthrough_args if value.strip())
-    normalized_prompt = " ".join(prompt_text.split()).lower()
-    if not normalized_prompt or not _requests_direct_env_read(normalized_prompt):
-        return None
-    prompt_hash = hashlib.sha256(normalized_prompt.encode("utf-8")).hexdigest()
-    prompt_summary = "Prompt asks the harness to read a local .env file directly."
-    return GuardArtifact(
-        artifact_id=f"{harness}:session:prompt-env-read:{prompt_hash}",
-        name="direct .env prompt access",
-        harness=harness,
-        artifact_type="prompt_request",
-        source_scope="session",
-        config_path=str(_prompt_policy_path(context)),
-        metadata={
-            "prompt_signals": ["asks the harness to read a local .env file directly"],
-            "prompt_summary": prompt_summary,
-        },
+    requests: list[PromptRequest],
+) -> list[GuardArtifact]:
+    """Convert typed prompt requests into pseudo-artifacts for policy evaluation."""
+
+    config_path = str(_prompt_policy_path(detection, context))
+    artifacts: list[GuardArtifact] = []
+    for request in requests:
+        if request.request_class == "secret_read" and ".env" in request.matched_text.lower():
+            artifact_id = f"{detection.harness}:session:prompt-env-read:{request.request_id[:24]}"
+        else:
+            artifact_id = f"{detection.harness}:session:prompt:{request.request_class}:{request.request_id[:24]}"
+        artifacts.append(
+            GuardArtifact(
+                artifact_id=artifact_id,
+                name=f"prompt {request.request_class.replace('_', ' ')}",
+                harness=detection.harness,
+                artifact_type="prompt_request",
+                source_scope="session",
+                config_path=config_path,
+                metadata={
+                    "prompt_signals": [request.summary],
+                    "prompt_summary": request.summary,
+                    "prompt_matched_text": request.matched_text,
+                    "prompt_request_class": request.request_class,
+                    "prompt_confidence": request.confidence,
+                    "prompt_severity": request.severity,
+                },
+            )
+        )
+    return artifacts
+
+
+def should_force_reapproval(prompt_reqs: list[PromptRequest], prior_policy: dict[str, object] | None) -> bool:
+    """Return whether current prompt requests exceed prior approved scope."""
+
+    if not prompt_reqs:
+        return False
+    if prior_policy is None:
+        return True
+    approved_classes = prior_policy.get("approved_prompt_classes")
+    approved = (
+        {str(item) for item in approved_classes if isinstance(item, str)}
+        if isinstance(approved_classes, list)
+        else set()
     )
+    return any(request.request_class not in approved or request.severity >= 8 for request in prompt_reqs)
 
 
-def _requests_direct_env_read(prompt_text: str) -> bool:
-    return _ENV_PROMPT_PATTERN.search(prompt_text) is not None
+def _prompt_request_id(request_class: str, matched_text: str, normalized_prompt: str) -> str:
+    fingerprint = hashlib.sha256(f"{request_class}:{matched_text}:{normalized_prompt}".encode()).hexdigest()
+    return fingerprint
 
 
-def _prompt_policy_path(context: HarnessContext) -> Path:
+def _prompt_policy_path(detection: HarnessDetection, context: HarnessContext) -> Path:
+    config_candidates = _prompt_config_candidates(detection, context)
+    if context.workspace_dir is not None:
+        for config_path in config_candidates:
+            candidate = Path(config_path)
+            if candidate.is_relative_to(context.workspace_dir):
+                return candidate
+    if config_candidates:
+        return Path(config_candidates[0])
+    if detection.harness == "opencode":
+        if context.workspace_dir is not None:
+            return context.workspace_dir / "opencode.json"
+        return context.home_dir / ".config" / "opencode" / "opencode.json"
     if context.workspace_dir is not None:
         return context.workspace_dir / ".codex" / "config.toml"
     return context.home_dir / ".codex" / "config.toml"
+
+
+def _prompt_config_candidates(detection: HarnessDetection, context: HarnessContext) -> tuple[str, ...]:
+    if detection.harness == "opencode":
+        configured_path = os.getenv("OPENCODE_CONFIG")
+        configured_candidate = None
+        if configured_path:
+            candidate = Path(configured_path).expanduser()
+            if not candidate.is_absolute():
+                if context.workspace_dir is not None:
+                    candidate = context.workspace_dir / candidate
+                else:
+                    candidate = Path.cwd() / candidate
+            configured_candidate = str(candidate)
+        return tuple(
+            config_path
+            for config_path in detection.config_paths
+            if Path(config_path).name in {"opencode.json", "opencode.jsonc"} or config_path == configured_candidate
+        )
+    return detection.config_paths
 
 
 def sync_receipts(store: GuardStore) -> dict[str, object]:
@@ -155,21 +404,19 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
 
     credentials = store.get_sync_credentials()
     if credentials is None:
-        raise GuardSyncNotConfiguredError("Guard sync is not configured. Run 'hol-guard connect' first.")
+        raise GuardSyncNotConfiguredError("Guard is not logged in.")
+    sync_url = _normalized_receipts_sync_url(str(credentials["sync_url"]))
     receipts = store.list_receipts(limit=200)
     inventory = store.list_inventory()
-    body = json.dumps({"receipts": receipts, "inventory": inventory}).encode("utf-8")
+    body = json.dumps({"receipts": _cloud_sync_receipts_payload(store, receipts)}).encode("utf-8")
     request = urllib.request.Request(
-        str(credentials["sync_url"]),
+        sync_url,
         data=body,
         method="POST",
-        headers={
-            "Authorization": f"Bearer {credentials['token']}",
-            "Content-Type": "application/json",
-        },
+        headers=_guard_sync_headers(str(credentials["token"])),
     )
     try:
-        with urllib.request.urlopen(request, timeout=10) as response:
+        with urllib.request.urlopen(request, timeout=20) as response:
             payload = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as error:
         if error.code == 403:
@@ -209,7 +456,7 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
         now=now,
     )
     pain_signals_uploaded = sync_pain_signals(store)
-    sync_summary: dict[str, object] = {
+    summary = {
         "synced_at": payload.get("syncedAt"),
         "receipts_stored": payload.get("receiptsStored"),
         "advisories_stored": advisories_stored,
@@ -217,59 +464,67 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
         "remote_policies_stored": len(remote_decisions),
         "pain_signals_uploaded": pain_signals_uploaded,
         "receipts": len(receipts),
-        "inventory": len(inventory),
+        "inventory": 0,
+        "inventory_tracked": len(inventory),
     }
-    store.set_sync_payload("sync_summary", sync_summary, now)
-    return {
-        "synced_at": payload.get("syncedAt"),
-        "receipts_stored": payload.get("receiptsStored"),
-        "advisories_stored": advisories_stored,
-        "exceptions_stored": len(exceptions) if isinstance(exceptions, list) else 0,
-        "remote_policies_stored": len(remote_decisions),
-        "pain_signals_uploaded": pain_signals_uploaded,
-        "receipts": len(receipts),
-        "inventory": len(inventory),
-    }
+    store.set_sync_payload("sync_summary", summary, now)
+    return summary
 
 
-def sync_runtime_session(store: GuardStore, *, session: dict[str, object]) -> dict[str, object]:
-    """Push one runtime session snapshot to the configured sync endpoint."""
+def sync_runtime_session(
+    store: GuardStore,
+    *,
+    session: dict[str, object],
+) -> dict[str, object]:
+    """Publish the active Guard runtime session so the dashboard can show the machine immediately."""
 
     credentials = store.get_sync_credentials()
     if credentials is None:
-        raise RuntimeError("Guard is not logged in.")
-
-    normalized_session = _normalize_runtime_session_payload(session)
+        raise GuardSyncNotConfiguredError("Guard is not logged in.")
+    sync_url = _normalized_runtime_sessions_sync_url(str(credentials["sync_url"]))
+    session_payload = _cloud_runtime_session_payload(store, session)
+    body = json.dumps({"session": session_payload}).encode("utf-8")
     request = urllib.request.Request(
-        _runtime_session_sync_url(str(credentials["sync_url"])),
-        data=json.dumps({"session": normalized_session}).encode("utf-8"),
+        sync_url,
+        data=body,
         method="POST",
-        headers={
-            "Authorization": f"Bearer {credentials['token']}",
-            "Content-Type": "application/json",
-        },
+        headers=_guard_sync_headers(str(credentials["token"])),
     )
     try:
         with urllib.request.urlopen(request, timeout=10) as response:
             payload = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as error:
+        if error.code == 404:
+            recorded_at = _now()
+            summary = {
+                "synced_at": None,
+                "runtime_session_synced_at": None,
+                "runtime_session_id": session_payload["sessionId"],
+                "runtime_sessions_visible": 0,
+                "runtime_session_sync_skipped": True,
+                "runtime_session_sync_reason": "runtime_session_endpoint_unavailable",
+            }
+            store.set_sync_payload("runtime_session_summary", summary, recorded_at)
+            return summary
         raise RuntimeError(_sync_http_error_message(error)) from error
-    except urllib.error.URLError as error:
-        raise RuntimeError(_sync_url_error_message(error)) from error
-
-    visible_items = payload.get("items")
-    return {
-        "runtime_session_id": normalized_session.get("sessionId", ""),
-        "runtime_session_synced_at": payload.get("generatedAt") or payload.get("generated_at"),
-        "runtime_sessions_visible": len(visible_items) if isinstance(visible_items, list) else 0,
-        "runtime_session_sync_pending": False,
+    if not isinstance(payload, dict):
+        raise RuntimeError("Invalid sync response")
+    synced_at = _sync_timestamp(payload)
+    summary = {
+        "synced_at": synced_at,
+        "runtime_session_synced_at": synced_at,
+        "runtime_session_id": session_payload["sessionId"],
+        "runtime_sessions_visible": len(payload.get("items", [])) if isinstance(payload.get("items"), list) else 0,
     }
+    store.set_sync_payload("runtime_session_summary", summary, synced_at)
+    return summary
 
 
 def sync_pain_signals(store: GuardStore) -> int:
     credentials = store.get_sync_credentials()
     if credentials is None:
         return 0
+    normalized_sync_url = _normalized_receipts_sync_url(str(credentials["sync_url"]))
     cursor_payload = store.get_sync_payload("pain_signal_cursor")
     last_event_id = _last_uploaded_event_id(cursor_payload)
     uploaded_count = 0
@@ -286,13 +541,10 @@ def sync_pain_signals(store: GuardStore) -> int:
         signal_items = [payload for item in candidates if (payload := _pain_signal_item(item)) is not None]
         if signal_items:
             request = urllib.request.Request(
-                _pain_signal_sync_url(str(credentials["sync_url"])),
+                _pain_signal_sync_url(normalized_sync_url),
                 data=json.dumps({"items": signal_items}).encode("utf-8"),
                 method="POST",
-                headers={
-                    "Authorization": f"Bearer {credentials['token']}",
-                    "Content-Type": "application/json",
-                },
+                headers=_guard_sync_headers(str(credentials["token"])),
             )
             try:
                 with urllib.request.urlopen(request, timeout=10):
@@ -387,22 +639,40 @@ def _build_remote_policy_decisions(payload: dict[str, object]) -> list[PolicyDec
     return decisions
 
 
+def _guard_sync_headers(token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "User-Agent": _GUARD_SYNC_USER_AGENT,
+    }
+
+
 def _sync_http_error_message(error: urllib.error.HTTPError) -> str:
     try:
-        payload = json.loads(error.read().decode("utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        raw_body = error.read().decode("utf-8")
+    except OSError:
+        raw_body = ""
+    try:
+        payload = json.loads(raw_body) if raw_body else None
+    except json.JSONDecodeError:
         payload = None
     if isinstance(payload, dict):
-        error_value = payload.get("error")
-        if isinstance(error_value, str) and error_value.strip():
-            return error_value
-    return f"Guard sync failed with HTTP {error.code}."
+        message = payload.get("error")
+        if isinstance(message, str) and message.strip():
+            return message.strip()
+    normalized_body = raw_body.strip()
+    if normalized_body:
+        return normalized_body
+    return f"HTTP Error {error.code}: {error.reason}"
 
 
 def _sync_url_error_message(error: urllib.error.URLError) -> str:
     reason = getattr(error, "reason", None)
-    if isinstance(reason, str) and reason.strip():
-        return f"Guard sync failed: {reason.strip()}"
+    if reason is not None:
+        reason_text = str(reason).strip()
+        if reason_text:
+            return f"Guard sync failed: {reason_text}"
     return "Guard sync failed because the remote endpoint could not be reached."
 
 
@@ -516,72 +786,163 @@ def _pain_signal_sync_url(sync_url: str) -> str:
     )
 
 
-def _runtime_session_sync_url(sync_url: str) -> str:
+def _normalized_receipts_sync_url(sync_url: str) -> str:
     parsed = urllib.parse.urlsplit(sync_url)
-    path = parsed.path.rstrip("/")
-    segments = [segment for segment in path.split("/") if segment]
-    if len(segments) >= 2 and segments[-2:] in (["receipts", "sync"], ["inventory", "sync"]):
-        next_segments = [*segments[:-2], "runtime", "sessions", "sync"]
-    elif segments and segments[-1] in {"receipts", "inventory"}:
-        next_segments = [*segments[:-1], "runtime", "sessions", "sync"]
-    else:
-        next_segments = [*segments, "runtime", "sessions", "sync"]
+    if parsed.path.rstrip("/") == "/registry/api/v1":
+        return urllib.parse.urlunsplit(
+            (
+                parsed.scheme,
+                parsed.netloc,
+                "/api/guard/receipts/sync",
+                parsed.query,
+                "",
+            )
+        )
+    return sync_url
+
+
+def _normalized_runtime_sessions_sync_url(sync_url: str) -> str:
+    normalized_receipts_url = _normalized_receipts_sync_url(sync_url)
+    parsed = urllib.parse.urlsplit(normalized_receipts_url)
+    if parsed.path.rstrip("/") == "/api/guard/receipts/sync":
+        return urllib.parse.urlunsplit(
+            (
+                parsed.scheme,
+                parsed.netloc,
+                "/api/guard/runtime/sessions/sync",
+                parsed.query,
+                "",
+            )
+        )
+    if parsed.path.rstrip("/") == "/guard/receipts/sync":
+        return urllib.parse.urlunsplit(
+            (
+                parsed.scheme,
+                parsed.netloc,
+                "/guard/runtime/sessions/sync",
+                parsed.query,
+                "",
+            )
+        )
     return urllib.parse.urlunsplit(
         (
             parsed.scheme,
             parsed.netloc,
-            "/" + "/".join(next_segments),
+            parsed.path.rstrip("/") + "/runtime/sessions/sync",
             parsed.query,
-            parsed.fragment,
+            "",
         )
     )
 
 
-def _normalize_runtime_session_payload(session: dict[str, object]) -> dict[str, object]:
-    operations_value = session.get("operations")
-    operations: list[dict[str, object]] = []
-    if isinstance(operations_value, list):
-        operations = [
-            _normalize_runtime_operation_payload(item)
-            for item in operations_value
-            if isinstance(item, dict)
-        ]
+def _cloud_sync_receipts_payload(store: GuardStore, receipts: list[dict[str, object]]) -> list[dict[str, object]]:
+    device_id, device_name = _guard_device_metadata(store)
+    return [_cloud_sync_receipt_payload(receipt, device_id=device_id, device_name=device_name) for receipt in receipts]
 
+
+def _cloud_sync_receipt_payload(
+    receipt: dict[str, object],
+    *,
+    device_id: str,
+    device_name: str,
+) -> dict[str, object]:
+    receipt_fingerprint = _cloud_sync_receipt_fingerprint(receipt)
+    artifact_id = _optional_string(receipt.get("artifact_id")) or f"guard:local-receipt:{receipt_fingerprint[:24]}"
+    artifact_name = _optional_string(receipt.get("artifact_name")) or artifact_id
+    policy_decision = _optional_string(receipt.get("policy_decision")) or "review"
+    changed_capabilities = [str(item) for item in receipt.get("changed_capabilities", []) if isinstance(item, str)]
+    capabilities_summary = _optional_string(receipt.get("capabilities_summary"))
+    if changed_capabilities:
+        capabilities = changed_capabilities
+    elif capabilities_summary is not None:
+        capabilities = [capabilities_summary]
+    else:
+        capabilities = []
+    payload: dict[str, object] = {
+        "receiptId": _optional_string(receipt.get("receipt_id")) or f"guard-receipt-{receipt_fingerprint}",
+        "artifactId": artifact_id,
+        "artifactName": artifact_name,
+        "artifactType": _cloud_sync_artifact_type(artifact_id),
+        "artifactSlug": _cloud_sync_artifact_slug(artifact_name, artifact_id),
+        "artifactHash": _optional_string(receipt.get("artifact_hash"))
+        or hashlib.sha256(artifact_id.encode("utf-8")).hexdigest(),
+        "capabilities": capabilities,
+        "capturedAt": _optional_string(receipt.get("timestamp")) or _now(),
+        "changedSinceLastApproval": bool(changed_capabilities)
+        or policy_decision in {"require-reapproval", "sandbox-required"},
+        "deviceId": device_id,
+        "deviceName": device_name,
+        "harness": _optional_string(receipt.get("harness")) or "unknown",
+        "policyDecision": policy_decision,
+        "recommendation": _cloud_sync_recommendation(policy_decision),
+        "summary": _optional_string(receipt.get("provenance_summary"))
+        or capabilities_summary
+        or f"Guard recorded a {policy_decision} decision.",
+    }
+    publisher = _optional_string(receipt.get("publisher"))
+    if publisher is not None:
+        payload["publisher"] = publisher
+    return payload
+
+
+def _cloud_runtime_session_payload(store: GuardStore, session: dict[str, object]) -> dict[str, object]:
+    device_id, device_name = _guard_device_metadata(store)
+    workspace = _optional_string(session.get("workspace")) or os.getcwd()
+    session_id = (
+        _optional_string(session.get("session_id") or session.get("sessionId"))
+        or hashlib.sha256(f"{device_id}:{workspace}".encode()).hexdigest()[:24]
+    )
+    created_at = _optional_string(session.get("created_at") or session.get("createdAt")) or _now()
+    updated_at = _optional_string(session.get("updated_at") or session.get("updatedAt")) or created_at
+    capabilities = [str(item) for item in session.get("capabilities", []) if isinstance(item, str)]
     return {
-        "sessionId": str(
-            session.get("sessionId")
-            or session.get("session_id")
-            or f"guard-session-{hashlib.sha256(str(session).encode('utf-8')).hexdigest()[:12]}"
-        ),
-        "harness": str(session.get("harness") or "unknown"),
-        "surface": str(session.get("surface") or "cli"),
-        "status": str(session.get("status") or "active"),
-        "clientName": str(session.get("clientName") or session.get("client_name") or "hol-guard"),
-        "clientTitle": session.get("clientTitle") or session.get("client_title"),
-        "clientVersion": session.get("clientVersion") or session.get("client_version"),
-        "workspace": session.get("workspace"),
-        "capabilities": list(session.get("capabilities")) if isinstance(session.get("capabilities"), list) else [],
-        "operations": operations,
-        "createdAt": str(session.get("createdAt") or session.get("created_at") or _now()),
-        "updatedAt": str(session.get("updatedAt") or session.get("updated_at") or _now()),
+        "sessionId": session_id,
+        "harness": _optional_string(session.get("harness")) or "hol-guard",
+        "surface": _optional_string(session.get("surface")) or "cli",
+        "status": _optional_string(session.get("status")) or "active",
+        "clientName": _optional_string(session.get("client_name") or session.get("clientName")) or "hol-guard",
+        "clientTitle": _optional_string(session.get("client_title") or session.get("clientTitle"))
+        or f"HOL Guard on {device_name}",
+        "clientVersion": _optional_string(session.get("client_version") or session.get("clientVersion")) or __version__,
+        "workspace": workspace,
+        "capabilities": capabilities,
+        "operations": [],
+        "createdAt": created_at,
+        "updatedAt": updated_at,
     }
 
 
-def _normalize_runtime_operation_payload(item: dict[str, object]) -> dict[str, object]:
-    return {
-        "operationId": str(item.get("operationId") or item.get("operation_id") or f"guard-op-{uuid.uuid4().hex}"),
-        "operationType": str(item.get("operationType") or item.get("operation_type") or "unknown"),
-        "status": str(item.get("status") or "pending"),
-        "approvalRequestIds": list(item.get("approvalRequestIds"))
-        if isinstance(item.get("approvalRequestIds"), list)
-        else list(item.get("approval_request_ids"))
-        if isinstance(item.get("approval_request_ids"), list)
-        else [],
-        "resumeToken": item.get("resumeToken") or item.get("resume_token"),
-        "metadata": item.get("metadata") if isinstance(item.get("metadata"), dict) else {},
-        "createdAt": str(item.get("createdAt") or item.get("created_at") or _now()),
-        "updatedAt": str(item.get("updatedAt") or item.get("updated_at") or _now()),
-    }
+def _cloud_sync_receipt_fingerprint(receipt: dict[str, object]) -> str:
+    encoded_receipt = json.dumps(receipt, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded_receipt.encode("utf-8")).hexdigest()
+
+
+def _cloud_sync_artifact_type(artifact_id: str) -> str:
+    if artifact_id.startswith("skill:") or ":skill:" in artifact_id:
+        return "skill"
+    return "plugin"
+
+
+def _cloud_sync_artifact_slug(artifact_name: str, artifact_id: str) -> str:
+    base_value = artifact_name.strip() or artifact_id.strip() or "artifact"
+    slug = re.sub(r"[^a-z0-9]+", "-", base_value.lower()).strip("-")
+    if slug:
+        return slug
+    fallback = re.sub(r"[^a-z0-9]+", "-", artifact_id.lower()).strip("-")
+    return fallback or "artifact"
+
+
+def _cloud_sync_recommendation(policy_decision: str) -> str:
+    if policy_decision == "block":
+        return "block"
+    if policy_decision in {"review", "require-reapproval", "sandbox-required"}:
+        return "review"
+    return "monitor"
+
+
+def _guard_device_metadata(store: GuardStore) -> tuple[str, str]:
+    metadata = store.get_device_metadata()
+    return str(metadata["installation_id"]), str(metadata["device_label"])
 
 
 def _record_synced_alert_events(

--- a/src/codex_plugin_scanner/guard/store_connect.py
+++ b/src/codex_plugin_scanner/guard/store_connect.py
@@ -15,6 +15,7 @@ CONNECT_STATE_MILESTONE_VALUES = {
     "first_sync_pending",
     "first_sync_succeeded",
     "first_sync_failed",
+    "sync_not_available",
     "expired",
 }
 

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -3417,7 +3417,7 @@ args = ["workspace-skill.js", "--changed"]
         assert connect_rc == 0
         assert connect_output["connected"] is True
         assert connect_output["status"] == "connected"
-        assert connect_output["milestone"] == "sync_not_available"
+        assert connect_output["milestone"] == "first_sync_pending"
         assert connect_output["reason"] == "sync_unreachable"
         assert connect_output["sync_message"] == "sync_unreachable"
 
@@ -3510,7 +3510,7 @@ args = ["workspace-skill.js", "--changed"]
         assert connect_rc == 0
         assert connect_output["connected"] is True
         assert connect_output["status"] == "connected"
-        assert connect_output["milestone"] == "first_sync_pending"
+        assert connect_output["milestone"] == "sync_not_available"
         assert connect_output["reason"] == "Guard sync requires a Pro or Team plan."
         assert connect_output["sync_message"] == "Guard sync requires a Pro or Team plan."
 

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -3417,7 +3417,7 @@ args = ["workspace-skill.js", "--changed"]
         assert connect_rc == 0
         assert connect_output["connected"] is True
         assert connect_output["status"] == "connected"
-        assert connect_output["milestone"] == "first_sync_pending"
+        assert connect_output["milestone"] == "sync_not_available"
         assert connect_output["reason"] == "sync_unreachable"
         assert connect_output["sync_message"] == "sync_unreachable"
 


### PR DESCRIPTION
## Summary

When `hol-guard connect` runs for a free plan user, the CLI calls `POST /api/guard/receipts/sync` which returns HTTP 403 because `syncEnabled=false` for free plans. Previously this raised a generic `RuntimeError` and the connect flow reported `status=retry_required` with `milestone=first_sync_failed`, causing users to think the connection failed.

## Changes

### `runner.py`
- Added `GuardSyncNotAvailableError` exception class
- `sync_receipts` now catches HTTP 403 specifically and raises `GuardSyncNotAvailableError` instead of `RuntimeError`

### `runtime/__init__.py`
- Exports `GuardSyncNotAvailableError` in `__all__`

### `connect_flow.py`
- Imports `GuardSyncNotAvailableError`
- Connect flow catches `GuardSyncNotAvailableError` → reports `status=connected` with `milestone=sync_not_available`
- `build_connect_payload` gains `sync_available` field
- `_resolve_first_sync_milestone` handles `sync_not_available` → `'skipped'`

## Result

Free plan users now see `status=connected` (not `retry_required`) after running `hol-guard connect`. The portal handles `milestone=sync_not_available` by showing a "Protected locally" success state with an upgrade CTA.