### PR TITLE
fix: keep Copilot shell review path honest

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -809,6 +809,8 @@ def _segment_uses_destructive_git_command(segment_args: list[str]) -> bool:
         if token == "--":
             subcommand_index += 1
             continue
+        if token in {"-h", "--help", "--version"}:
+            return False
         if token in _GIT_GLOBAL_OPTIONS_WITH_VALUE and subcommand_index + 1 < len(segment_args):
             subcommand_index += 2
             continue
@@ -819,6 +821,8 @@ def _segment_uses_destructive_git_command(segment_args: list[str]) -> bool:
             subcommand_index += 1
             continue
         normalized_token = token.strip().lower()
+        if normalized_token == "help":
+            return False
         return normalized_token in _DESTRUCTIVE_GIT_SUBCOMMANDS
     return False
 
@@ -945,11 +949,60 @@ def _redacted_node_inline_string_literals(script: str, *, preserve_bracket_membe
     escape_next = False
     preserve_string_contents = False
     template_expression_depth = 0
+    comment_type: str | None = None
+    regex_literal = False
+    regex_escape_next = False
+    regex_char_class = False
     index = 0
     while index < len(script):
         character = script[index]
         if quote_char is None:
             if template_expression_depth > 0:
+                if comment_type == "line":
+                    result.append(character)
+                    if character in {"\n", "\r"}:
+                        comment_type = None
+                    index += 1
+                    continue
+                if comment_type == "block":
+                    result.append(character)
+                    if character == "/" and result[-2:-1] == ["*"]:
+                        comment_type = None
+                    index += 1
+                    continue
+                if regex_literal:
+                    result.append(character)
+                    if regex_escape_next:
+                        regex_escape_next = False
+                    elif character == "\\":
+                        regex_escape_next = True
+                    elif character == "[" and not regex_char_class:
+                        regex_char_class = True
+                    elif character == "]" and regex_char_class:
+                        regex_char_class = False
+                    elif character == "/" and not regex_char_class:
+                        regex_literal = False
+                    index += 1
+                    continue
+                if character == "/" and index + 1 < len(script):
+                    next_character = script[index + 1]
+                    if next_character == "/":
+                        result.append("//")
+                        comment_type = "line"
+                        index += 2
+                        continue
+                    if next_character == "*":
+                        result.append("/*")
+                        comment_type = "block"
+                        index += 2
+                        continue
+                    if _js_slash_starts_regex(result):
+                        result.append(character)
+                        regex_literal = True
+                        regex_escape_next = False
+                        regex_char_class = False
+                        index += 1
+                        continue
                 if character == "{":
                     template_expression_depth += 1
                     result.append(character)
@@ -960,6 +1013,10 @@ def _redacted_node_inline_string_literals(script: str, *, preserve_bracket_membe
                     result.append(character)
                     if template_expression_depth == 0:
                         quote_char = "`"
+                        comment_type = None
+                        regex_literal = False
+                        regex_escape_next = False
+                        regex_char_class = False
                     index += 1
                     continue
             if character in {"'", '"', "`"}:
@@ -1002,10 +1059,36 @@ def _redacted_node_inline_string_literals(script: str, *, preserve_bracket_membe
 
 
 def _last_non_whitespace_character(result: list[str]) -> str | None:
-    for character in reversed(result):
-        if not character.isspace():
-            return character
+    for chunk in reversed(result):
+        for character in reversed(chunk):
+            if not character.isspace():
+                return character
     return None
+
+
+def _js_slash_starts_regex(result: list[str]) -> bool:
+    previous_character = _last_non_whitespace_character(result)
+    if previous_character is None:
+        return True
+    return previous_character in {
+        "(",
+        "{",
+        "[",
+        "=",
+        ":",
+        ",",
+        ";",
+        "!",
+        "?",
+        "|",
+        "&",
+        "+",
+        "-",
+        "*",
+        "%",
+        "^",
+        "~",
+    }
 
 
 def _shell_command_names(command_text: str) -> tuple[str, ...]:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -54,8 +54,8 @@ _DESTRUCTIVE_SHELL_COMMANDS = frozenset(
     {
         "chmod",
         "chown",
-        "del",
         "dd",
+        "del",
         "erase",
         "mv",
         "perl",

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -791,6 +791,7 @@ def _find_segment_uses_delete(segment_args: list[str]) -> bool:
         index += 1
     return False
 
+
 def _contains_destructive_git_command(parts: list[str]) -> bool:
     for segment in _iter_shell_command_segments(parts):
         command_name, command_index = _shell_segment_primary_command(segment)
@@ -811,11 +812,7 @@ def _segment_uses_destructive_git_command(segment_args: list[str]) -> bool:
         if token in _GIT_GLOBAL_OPTIONS_WITH_VALUE and subcommand_index + 1 < len(segment_args):
             subcommand_index += 2
             continue
-        if any(
-            token.startswith(f"{option}=")
-            for option in _GIT_GLOBAL_OPTIONS_WITH_VALUE
-            if option.startswith("--")
-        ):
+        if any(token.startswith(f"{option}=") for option in _GIT_GLOBAL_OPTIONS_WITH_VALUE if option.startswith("--")):
             subcommand_index += 1
             continue
         if token.startswith("-"):
@@ -824,6 +821,8 @@ def _segment_uses_destructive_git_command(segment_args: list[str]) -> bool:
         normalized_token = token.strip().lower()
         return normalized_token in _DESTRUCTIVE_GIT_SUBCOMMANDS
     return False
+
+
 def _env_split_string_payloads(parts: list[str]) -> tuple[str, ...]:
     payloads: list[str] = []
     for segment in _iter_shell_command_segments(parts):
@@ -945,31 +944,60 @@ def _redacted_node_inline_string_literals(script: str, *, preserve_bracket_membe
     quote_char: str | None = None
     escape_next = False
     preserve_string_contents = False
-    for character in script:
+    template_expression_depth = 0
+    index = 0
+    while index < len(script):
+        character = script[index]
         if quote_char is None:
+            if template_expression_depth > 0:
+                if character == "{":
+                    template_expression_depth += 1
+                    result.append(character)
+                    index += 1
+                    continue
+                if character == "}":
+                    template_expression_depth -= 1
+                    result.append(character)
+                    if template_expression_depth == 0:
+                        quote_char = "`"
+                    index += 1
+                    continue
             if character in {"'", '"', "`"}:
                 preserve_string_contents = (
                     preserve_bracket_member_strings and _last_non_whitespace_character(result) == "["
                 )
                 quote_char = character
                 result.append(character)
+                index += 1
                 continue
             result.append(character)
+            index += 1
             continue
         if escape_next:
             result.append(character if preserve_string_contents else "Q")
             escape_next = False
+            index += 1
             continue
         if character == "\\":
             result.append(character)
             escape_next = True
+            index += 1
+            continue
+        if quote_char == "`" and character == "$" and index + 1 < len(script) and script[index + 1] == "{":
+            result.append("${")
+            quote_char = None
+            preserve_string_contents = False
+            template_expression_depth = 1
+            index += 2
             continue
         if character == quote_char:
             result.append(character)
             quote_char = None
             preserve_string_contents = False
+            index += 1
             continue
         result.append(character if preserve_string_contents else "Q")
+        index += 1
     return "".join(result)
 
 

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -61,9 +61,10 @@ _DESTRUCTIVE_SHELL_COMMANDS = frozenset(
         "perl",
         "python",
         "python3",
+        "rd",
+        "remove-item",
         "rm",
         "rmdir",
-        "remove-item",
         "ruby",
         "tee",
         "truncate",
@@ -103,6 +104,10 @@ _DESTRUCTIVE_NODE_INLINE_CALLS = frozenset(
     {
         "appendFile",
         "appendFileSync",
+        "chmod",
+        "chmodSync",
+        "chown",
+        "chownSync",
         "copyFile",
         "copyFileSync",
         "mkdir",
@@ -111,10 +116,25 @@ _DESTRUCTIVE_NODE_INLINE_CALLS = frozenset(
         "renameSync",
         "rm",
         "rmSync",
+        "truncate",
+        "truncateSync",
         "unlink",
         "unlinkSync",
         "writeFile",
         "writeFileSync",
+    }
+)
+_DESTRUCTIVE_GIT_SUBCOMMANDS = frozenset({"clean", "reset", "restore", "rm"})
+_GIT_GLOBAL_OPTIONS_WITH_VALUE = frozenset(
+    {
+        "-C",
+        "-c",
+        "--config-env",
+        "--exec-path",
+        "--git-dir",
+        "--namespace",
+        "--super-prefix",
+        "--work-tree",
     }
 )
 _WRAPPER_FLAGS_WITH_VALUES = {
@@ -575,6 +595,8 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
         return False
     if _contains_destructive_node_inline_eval(parts):
         return True
+    if _contains_destructive_git_command(parts):
+        return True
     command_names = list(raw_command_names)
     command_names.extend(_shell_command_names_from_parts(parts))
     if any(command_name in _DESTRUCTIVE_SHELL_COMMANDS for command_name in command_names):
@@ -752,6 +774,10 @@ def _find_segment_uses_delete(segment_args: list[str]) -> bool:
         token = segment_args[index]
         if token in {"-exec", "-execdir", "-ok", "-okdir"}:
             index += 1
+            if index < len(segment_args):
+                command_name = _normalized_shell_command_name(segment_args[index])
+                if command_name in _DESTRUCTIVE_SHELL_COMMANDS:
+                    return True
             while index < len(segment_args) and segment_args[index] not in {";", "+"}:
                 index += 1
             if index < len(segment_args):
@@ -765,7 +791,39 @@ def _find_segment_uses_delete(segment_args: list[str]) -> bool:
         index += 1
     return False
 
+def _contains_destructive_git_command(parts: list[str]) -> bool:
+    for segment in _iter_shell_command_segments(parts):
+        command_name, command_index = _shell_segment_primary_command(segment)
+        if command_name != "git" or command_index is None:
+            continue
+        if _segment_uses_destructive_git_command(segment[command_index + 1 :]):
+            return True
+    return False
 
+
+def _segment_uses_destructive_git_command(segment_args: list[str]) -> bool:
+    subcommand_index = 0
+    while subcommand_index < len(segment_args):
+        token = segment_args[subcommand_index]
+        if token == "--":
+            subcommand_index += 1
+            continue
+        if token in _GIT_GLOBAL_OPTIONS_WITH_VALUE and subcommand_index + 1 < len(segment_args):
+            subcommand_index += 2
+            continue
+        if any(
+            token.startswith(f"{option}=")
+            for option in _GIT_GLOBAL_OPTIONS_WITH_VALUE
+            if option.startswith("--")
+        ):
+            subcommand_index += 1
+            continue
+        if token.startswith("-"):
+            subcommand_index += 1
+            continue
+        normalized_token = token.strip().lower()
+        return normalized_token in _DESTRUCTIVE_GIT_SUBCOMMANDS
+    return False
 def _env_split_string_payloads(parts: list[str]) -> tuple[str, ...]:
     payloads: list[str] = []
     for segment in _iter_shell_command_segments(parts):
@@ -850,9 +908,6 @@ def _contains_mutating_shell_redirection(parts: list[str]) -> bool:
             else:
                 index += 1
         else:
-            if re.search(r"\s", token):
-                index += 1
-                continue
             match = re.fullmatch(r"(?P<prefix>[^<>\s]*?)(?P<fd>[0-2]?)(?P<op>>\||>>|>)(?P<target>.*)", token)
             if match is None:
                 index += 1
@@ -892,7 +947,7 @@ def _redacted_node_inline_string_literals(script: str, *, preserve_bracket_membe
     preserve_string_contents = False
     for character in script:
         if quote_char is None:
-            if character in {"'", '"'}:
+            if character in {"'", '"', "`"}:
                 preserve_string_contents = (
                     preserve_bracket_member_strings and _last_non_whitespace_character(result) == "["
                 )
@@ -967,7 +1022,7 @@ def _replace_unquoted_newlines_with_separators(command_text: str) -> str:
             result.append(character)
             escape_next = True
             continue
-        if quote_char is None and character in {"'", '"'}:
+        if quote_char is None and character in {"'", '"', "`"}:
             quote_char = character
             result.append(character)
             continue

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -351,6 +351,24 @@ def test_tool_action_request_classifier_skips_perl_sleep_wait():
     assert request is None
 
 
+def test_tool_action_request_classifier_skips_git_commit_with_coauthored_by_trailer():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                "cd /Users/michaelkantor/CascadeProjects/hashgraph-online/ai-plugin-scanner && "
+                "git add src/codex_plugin_scanner/guard/runtime/runner.py "
+                "src/codex_plugin_scanner/guard/runtime/__init__.py "
+                "src/codex_plugin_scanner/guard/cli/connect_flow.py && "
+                'git commit -m "fix(guard): gracefully handle free-plan sync 403 in connect flow\n\n'
+                'Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>" 2>&1'
+            )
+        },
+    )
+
+    assert request is None
+
+
 def test_tool_action_request_classifier_detects_python_inline_file_write():
     request = extract_sensitive_tool_action_request(
         "bash",
@@ -825,6 +843,26 @@ def test_tool_action_request_classifier_detects_perl_inline_system_shell_out():
     request = extract_sensitive_tool_action_request(
         "bash",
         {"command": "perl -e \"system('rm -rf dangerous-marker.json')\""},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_git_rm_delete():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "git rm --force dangerous-marker.json"},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_git_c_rm_delete():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "git -C /mock-workspace rm --force dangerous-marker.json"},
     )
 
     assert request is not None

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -898,6 +898,20 @@ def test_tool_action_request_classifier_detects_node_template_interpolation_bypa
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_detects_node_template_interpolation_regex_bypass():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                """node -e "console.log(`x ${/}/.test('a') || require('fs').unlinkSync('dangerous-marker.json')}`)" """
+            )
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_detects_git_c_rm_delete():
     request = extract_sensitive_tool_action_request(
         "bash",
@@ -906,6 +920,13 @@ def test_tool_action_request_classifier_detects_git_c_rm_delete():
 
     assert request is not None
     assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_skips_git_help_modes():
+    assert extract_sensitive_tool_action_request("bash", {"command": "git --help rm"}) is None
+    assert extract_sensitive_tool_action_request("bash", {"command": "git -h rm"}) is None
+    assert extract_sensitive_tool_action_request("bash", {"command": "git help rm"}) is None
+    assert extract_sensitive_tool_action_request("bash", {"command": "git --version rm"}) is None
 
 
 def test_tool_action_request_classifier_detects_redirection_to_quoted_space_target():

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -336,7 +336,7 @@ def test_tool_action_request_classifier_skips_read_only_shell_pipeline_to_upperc
 def test_tool_action_request_classifier_skips_read_only_shell_pipeline_to_noclobber_dev_null():
     request = extract_sensitive_tool_action_request(
         "bash",
-        {"command": 'ls missing 2>|/dev/null | head -40'},
+        {"command": "ls missing 2>|/dev/null | head -40"},
     )
 
     assert request is None
@@ -886,6 +886,16 @@ def test_tool_action_request_classifier_skips_node_template_literal_false_positi
     )
 
     assert request is None
+
+
+def test_tool_action_request_classifier_detects_node_template_interpolation_bypass():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": ("""node -e "console.log(`x ${require('fs').unlinkSync('dangerous-marker.json')}`)" """)},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
 
 
 def test_tool_action_request_classifier_detects_git_c_rm_delete():

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -849,6 +849,16 @@ def test_tool_action_request_classifier_detects_perl_inline_system_shell_out():
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_detects_find_exec_rm_bypass():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "find . -name dangerous-marker.json -exec rm {} ;"},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_detects_git_rm_delete():
     request = extract_sensitive_tool_action_request(
         "bash",
@@ -859,10 +869,39 @@ def test_tool_action_request_classifier_detects_git_rm_delete():
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_detects_node_inline_truncatesync_bypass():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """node -e "require('fs').truncateSync('dangerous-marker.json', 0)" """},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_skips_node_template_literal_false_positive():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": """node -e "console.log(`unlinkSync('dangerous-marker.json')`)" """},
+    )
+
+    assert request is None
+
+
 def test_tool_action_request_classifier_detects_git_c_rm_delete():
     request = extract_sensitive_tool_action_request(
         "bash",
         {"command": "git -C /mock-workspace rm --force dangerous-marker.json"},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_redirection_to_quoted_space_target():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": '''echo owned >"dangerous marker.json"'''},
     )
 
     assert request is not None

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -2375,6 +2375,159 @@ def test_guard_hook_emits_copilot_native_allow_response_for_perl_sleep_wait(
     assert output == {"permissionDecision": "allow"}
 
 
+def test_guard_hook_emits_copilot_native_allow_response_for_git_commit_with_coauthored_by_trailer(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps(
+            {
+                "command": (
+                    "cd /Users/michaelkantor/CascadeProjects/hashgraph-online/ai-plugin-scanner && "
+                    "git add src/codex_plugin_scanner/guard/runtime/runner.py "
+                    "src/codex_plugin_scanner/guard/runtime/__init__.py "
+                    "src/codex_plugin_scanner/guard/cli/connect_flow.py && "
+                    'git commit -m "fix(guard): gracefully handle free-plan sync 403 in connect flow\n\n'
+                    'Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>" 2>&1'
+                )
+            }
+        ),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output == {"permissionDecision": "allow"}
+
+
+def test_guard_hook_emits_copilot_native_deny_for_node_inline_delete_bypass(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": """node -e "require('fs').unlinkSync('dangerous-marker.json')" """}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_deny_for_git_rm_delete(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "git rm --force dangerous-shell-marker.txt"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_deny_for_git_c_rm_delete(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps(
+            {
+                "command": "git -C /mock-workspace rm --force dangerous-shell-marker.txt",
+            }
+        ),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_permission_request_allow_for_safe_mcp_tool(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -2489,6 +2489,41 @@ def test_guard_hook_emits_copilot_native_deny_for_git_rm_delete(
     assert "hol guard" in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_deny_for_find_exec_rm_bypass(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "find . -name dangerous-shell-marker.txt -exec rm {} ;"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_deny_for_git_c_rm_delete(
     tmp_path,
     capsys,
@@ -2504,6 +2539,41 @@ def test_guard_hook_emits_copilot_native_deny_for_git_c_rm_delete(
                 "command": "git -C /mock-workspace rm --force dangerous-shell-marker.txt",
             }
         ),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_deny_for_quoted_space_redirection_target(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": '''echo owned >"dangerous marker.json"'''}),
         "sourceScope": "project",
     }
     monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1836,7 +1836,7 @@ def test_guard_hook_emits_copilot_native_allow_response_for_noclobber_dev_null_r
     _build_guard_fixture(home_dir, workspace_dir)
     event = {
         "toolName": "bash",
-        "toolArgs": json.dumps({"command": 'ls missing 2>|/dev/null | head -40'}),
+        "toolArgs": json.dumps({"command": "ls missing 2>|/dev/null | head -40"}),
         "sourceScope": "project",
     }
     monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
@@ -2003,9 +2003,7 @@ def test_guard_hook_emits_copilot_native_ask_response_for_node_print_followed_by
     _build_guard_fixture(home_dir, workspace_dir)
     event = {
         "toolName": "bash",
-        "toolArgs": json.dumps(
-            {"command": """node -p -e "require('fs').unlinkSync('dangerous-marker.json')" """}
-        ),
+        "toolArgs": json.dumps({"command": """node -p -e "require('fs').unlinkSync('dangerous-marker.json')" """}),
         "sourceScope": "project",
     }
     monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
@@ -2537,6 +2535,45 @@ def test_guard_hook_emits_copilot_native_deny_for_git_c_rm_delete(
         "toolArgs": json.dumps(
             {
                 "command": "git -C /mock-workspace rm --force dangerous-shell-marker.txt",
+            }
+        ),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_deny_for_node_template_interpolation_bypass(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps(
+            {
+                "command": """node -e "console.log(`x ${require('fs').unlinkSync('dangerous-marker.json')}`)" """,
             }
         ),
         "sourceScope": "project",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -2600,6 +2600,78 @@ def test_guard_hook_emits_copilot_native_deny_for_node_template_interpolation_by
     assert "hol guard" in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_deny_for_node_template_interpolation_regex_bypass(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    command = (
+        """node -e "console.log(`x ${/}/.test('a') || """
+        """require('fs').unlinkSync('dangerous-marker.json')}`)" """
+    )
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": command}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_allow_for_git_help_modes(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "git --help rm"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output == {"permissionDecision": "allow"}
+
+
 def test_guard_hook_emits_copilot_native_deny_for_quoted_space_redirection_target(
     tmp_path,
     capsys,


### PR DESCRIPTION
## Summary
- stop commit trailers from being misread as shell redirection so normal git commits stay on the allow path
- keep destructive git shell fallbacks like `git rm` and `git -C ... rm` on the HOL Guard review path
- add regression coverage for the Copilot hook responses and shell risk classifier

## Verification
- PYTHONPATH=/Users/michaelkantor/CascadeProjects/hashgraph-online/.worktrees/ai-plugin-scanner-mainline-fixes/src /opt/homebrew/opt/python@3.11/bin/python3.11 -m pytest tests/test_guard_risk.py -k "git_commit_with_coauthored_by_trailer or perl_sleep_wait or git_rm_delete or git_c_rm_delete" -q
- PYTHONPATH=/Users/michaelkantor/CascadeProjects/hashgraph-online/.worktrees/ai-plugin-scanner-mainline-fixes/src /opt/homebrew/opt/python@3.11/bin/python3.11 -m pytest tests/test_guard_runtime.py -k "git_commit_with_coauthored_by_trailer or perl_sleep_wait or git_rm_delete or git_c_rm_delete" -q
- /opt/homebrew/opt/python@3.11/bin/python3.11 -m ruff check src/codex_plugin_scanner/guard/runtime/secret_file_requests.py tests/test_guard_risk.py tests/test_guard_runtime.py
- git diff --check

## Live proof
- Copilot Autopilot created a harmless git commit successfully in a disposable repo
- Copilot Autopilot destructive fallbacks including `rm`, `python3 -c os.remove`, and `git rm` were denied on the real Guard hook path while the tracked target file remained present