### PR TITLE
fix: guard encoded runtime shell payloads

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -153,7 +153,7 @@ _ENCODED_EXECUTION_TARGET_PATTERN = (
 )
 _ENCODED_EXECUTION_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(
-        rf"\bbase64(?:\s+--decode|\s+-(?:d|D))\b[^\n|;]*(?:\|\s*{_ENCODED_EXECUTION_TARGET_PATTERN})",
+        rf"\bbase64(?:\s+--decode|\s+-(?:[A-Za-z]*[dD][A-Za-z]*))\b[^\n|;]*(?:\|\s*{_ENCODED_EXECUTION_TARGET_PATTERN})",
         re.IGNORECASE,
     ),
     re.compile(
@@ -684,6 +684,8 @@ def _shell_script_path_from_segment(segment_args: list[str]) -> str | None:
         if _SHELL_ASSIGNMENT_PATTERN.match(token):
             index += 1
             continue
+        if token.startswith("-") and not token.startswith("--") and "c" in token[1:]:
+            return None
         if not token.startswith("-") and not token.startswith("+"):
             return token
         if token in {"-c", "--command"} or token.startswith(("-c", "--command=")):

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -40,8 +40,10 @@ _COMMAND_LIST_KEYS = ("argv", "command_args", "commandArgs")
 _DOCKER_SUBCOMMANDS = frozenset({"build", "compose", "login", "push", "run"})
 _SHELL_TOOL_NAMES = frozenset(
     {
+        "ash",
         "bash",
         "cmd",
+        "dash",
         "powershell",
         "pwsh",
         "run_command",
@@ -52,7 +54,7 @@ _SHELL_TOOL_NAMES = frozenset(
         "zsh",
     }
 )
-_SHELL_SCRIPT_INTERPRETER_COMMANDS = frozenset({"bash", "sh", "zsh"})
+_SHELL_SCRIPT_INTERPRETER_COMMANDS = frozenset({"ash", "bash", "dash", "sh", "zsh", ".", "source"})
 _DESTRUCTIVE_SHELL_COMMANDS = frozenset(
     {
         "chmod",
@@ -565,7 +567,10 @@ def _decoded_payload_looks_sensitive(
 def _decoded_shell_payloads(command_text: str) -> tuple[str, ...]:
     lowered = command_text.lower()
     payloads: list[str] = []
-    if any(token in lowered for token in ("base64", "b64decode", "frombase64string", "-encodedcommand", " -enc ")):
+    if any(
+        token in lowered
+        for token in ("base64", "b64decode", "frombase64string", "-encodedcommand", " -enc ", "openssl", "gpg")
+    ):
         for literal in _BASE64_LITERAL_PATTERN.findall(command_text):
             decoded = _decode_base64_literal(literal)
             if decoded is not None:
@@ -657,10 +662,16 @@ def _shell_script_path_from_segment(segment_args: list[str]) -> str | None:
         if token == "--":
             index += 1
             break
-        if not token.startswith("-"):
+        if not token.startswith("-") and not token.startswith("+"):
             return token
-        if "c" in token[1:]:
+        if token in {"-c", "--command"} or token.startswith(("-c", "--command=")):
             return None
+        if token in {"-O", "-o", "+O", "+o", "--rcfile", "--init-file"}:
+            index += 2
+            continue
+        if token.startswith(("--rcfile=", "--init-file=")):
+            index += 1
+            continue
         index += 1
     while index < len(segment_args):
         token = segment_args[index].strip()

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -500,12 +500,15 @@ def _contains_encoded_or_encrypted_shell_command(
     normalized = command_text.strip()
     if not normalized:
         return False
-    if any(pattern.search(normalized) for pattern in _ENCODED_EXECUTION_PATTERNS):
+    executable_surface = _shell_text_without_quoted_literals(normalized)
+    if any(pattern.search(executable_surface) for pattern in _ENCODED_EXECUTION_PATTERNS):
+        return True
+    if _contains_command_substitution_decode_exec(normalized):
         return True
     parts = _split_shell_parts(normalized)
     if not parts:
         return False
-    for payload in _decoded_shell_payloads(normalized):
+    for payload in _decoded_shell_payloads(executable_surface):
         if _decoded_payload_looks_sensitive(
             payload,
             cwd=cwd,
@@ -547,6 +550,148 @@ def _contains_encoded_or_encrypted_shell_command(
         ):
             return True
     return False
+
+
+def _contains_command_substitution_decode_exec(command_text: str) -> bool:
+    substitution_payloads = _shell_command_substitution_payloads(command_text)
+    if not substitution_payloads:
+        return False
+    if not any(_contains_decode_primitive(payload) for payload in substitution_payloads):
+        return False
+    lowered = command_text.lower()
+    if re.search(r"\b(?:ash|bash|dash|sh|zsh)\b[^\n;|&]*-[A-Za-z]*c[A-Za-z]*", lowered):
+        return True
+    return bool(re.search(r"\beval\b[^\n;|&]*\$\(", lowered))
+
+
+def _contains_decode_primitive(command_text: str) -> bool:
+    lowered = command_text.lower()
+    return bool(
+        re.search(r"\bbase64\b(?=[^\n|;]*\s(?:--decode|-[A-Za-z]*[dD][A-Za-z]*))", lowered)
+        or re.search(r"\bxxd\s+(?:-r\s+-p|-rp)\b", lowered)
+        or re.search(r"\bopenssl\s+enc\b[^\n|;]*\s-(?:d|decrypt)\b", lowered)
+        or re.search(r"\b(?:gpg|gpg2)\b[^\n|;]*(?:--decrypt|-d)\b", lowered)
+    )
+
+
+def _shell_text_without_quoted_literals(command_text: str) -> str:
+    characters: list[str] = []
+    index = 0
+    single_quoted = False
+    double_quoted = False
+    while index < len(command_text):
+        character = command_text[index]
+        if single_quoted:
+            if character == "'":
+                single_quoted = False
+            characters.append(" ")
+            index += 1
+            continue
+        if double_quoted:
+            if character == "\\":
+                characters.append(" ")
+                if index + 1 < len(command_text):
+                    characters.append(" ")
+                    index += 2
+                else:
+                    index += 1
+                continue
+            if character == '"':
+                double_quoted = False
+                characters.append(" ")
+                index += 1
+                continue
+            if character == "$" and index + 1 < len(command_text) and command_text[index + 1] == "(":
+                payload, next_index = _read_command_substitution(command_text, index + 2)
+                characters.append(f"$({payload})")
+                index = next_index
+                continue
+            characters.append(" ")
+            index += 1
+            continue
+        if character == "'":
+            single_quoted = True
+            characters.append(" ")
+            index += 1
+            continue
+        if character == '"':
+            double_quoted = True
+            characters.append(" ")
+            index += 1
+            continue
+        characters.append(character)
+        index += 1
+    return "".join(characters)
+
+
+def _shell_command_substitution_payloads(command_text: str) -> tuple[str, ...]:
+    payloads: list[str] = []
+    index = 0
+    while index < len(command_text):
+        if command_text[index] == "$" and index + 1 < len(command_text) and command_text[index + 1] == "(":
+            payload, next_index = _read_command_substitution(command_text, index + 2)
+            if payload.strip():
+                payloads.append(payload)
+            index = next_index
+            continue
+        index += 1
+    return tuple(payloads)
+
+
+def _read_command_substitution(command_text: str, start_index: int) -> tuple[str, int]:
+    index = start_index
+    depth = 1
+    payload_characters: list[str] = []
+    single_quoted = False
+    double_quoted = False
+    while index < len(command_text):
+        character = command_text[index]
+        if single_quoted:
+            payload_characters.append(character)
+            if character == "'":
+                single_quoted = False
+            index += 1
+            continue
+        if double_quoted:
+            payload_characters.append(character)
+            if character == "\\" and index + 1 < len(command_text):
+                payload_characters.append(command_text[index + 1])
+                index += 2
+                continue
+            if character == '"':
+                double_quoted = False
+            index += 1
+            continue
+        if character == "'":
+            single_quoted = True
+            payload_characters.append(character)
+            index += 1
+            continue
+        if character == '"':
+            double_quoted = True
+            payload_characters.append(character)
+            index += 1
+            continue
+        if character == "$" and index + 1 < len(command_text) and command_text[index + 1] == "(":
+            nested_payload, next_index = _read_command_substitution(command_text, index + 2)
+            payload_characters.append(f"$({nested_payload})")
+            index = next_index
+            continue
+        if character == "(":
+            depth += 1
+            payload_characters.append(character)
+            index += 1
+            continue
+        if character == ")":
+            depth -= 1
+            if depth == 0:
+                return "".join(payload_characters), index + 1
+            payload_characters.append(character)
+            index += 1
+            continue
+        payload_characters.append(character)
+        index += 1
+    return "".join(payload_characters), index
 
 
 def _decoded_payload_looks_sensitive(

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -170,7 +170,7 @@ _ENCODED_EXECUTION_PATTERNS: tuple[re.Pattern[str], ...] = (
         re.IGNORECASE,
     ),
     re.compile(r"\b(?:powershell|pwsh)\b[^\n;]*\s-(?:e|ec|enc|encodedcommand)\b", re.IGNORECASE),
-    re.compile(r"\bfrombase64string\s*\(", re.IGNORECASE),
+    re.compile(r"\b(?:powershell|pwsh)\b[^\n;]*\bfrombase64string\s*\(", re.IGNORECASE),
 )
 _BASE64_LITERAL_PATTERN = re.compile(r"(?<![A-Za-z0-9+/=])[A-Za-z0-9+/]{20,}={0,2}(?![A-Za-z0-9+/=])")
 _HEX_LITERAL_PATTERN = re.compile(r"(?<![A-Fa-f0-9])[A-Fa-f0-9]{24,}(?![A-Fa-f0-9])")
@@ -1542,14 +1542,7 @@ def _shell_command_names_from_parts(parts: list[str]) -> tuple[str, ...]:
 
 
 def _shell_command_scripts(parts: list[str]) -> tuple[str, ...]:
-    scripts: list[str] = []
-    for index, part in enumerate(parts[:-1]):
-        if not _is_shell_command_flag(part):
-            continue
-        script = parts[index + 1].strip()
-        if script:
-            scripts.append(script)
-    return tuple(scripts)
+    return _script_interpreter_texts(parts)
 
 
 def _script_interpreter_texts(parts: list[str]) -> tuple[str, ...]:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -55,6 +55,7 @@ _SHELL_TOOL_NAMES = frozenset(
     }
 )
 _SHELL_SCRIPT_INTERPRETER_COMMANDS = frozenset({"ash", "bash", "dash", "sh", "zsh", ".", "source"})
+_SHELL_COMMAND_STRING_INTERPRETERS = frozenset({"ash", "bash", "dash", "sh", "zsh"})
 _DESTRUCTIVE_SHELL_COMMANDS = frozenset(
     {
         "chmod",
@@ -1542,7 +1543,20 @@ def _shell_command_names_from_parts(parts: list[str]) -> tuple[str, ...]:
 
 
 def _shell_command_scripts(parts: list[str]) -> tuple[str, ...]:
-    return _script_interpreter_texts(parts)
+    scripts: list[str] = []
+    for segment in _iter_shell_command_segments(parts):
+        command_name, command_index = _shell_segment_primary_command(segment)
+        if command_name not in _SHELL_COMMAND_STRING_INTERPRETERS or command_index is None:
+            continue
+        index = command_index + 1
+        while index < len(segment):
+            flag_payload = _interpreter_flag_payload(segment, index)
+            if flag_payload is not None:
+                scripts.append(flag_payload.script_text)
+                index += flag_payload.tokens_consumed
+                continue
+            index += 1
+    return tuple(scripts)
 
 
 def _script_interpreter_texts(parts: list[str]) -> tuple[str, ...]:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -150,11 +150,11 @@ _WRAPPER_FLAGS_WITH_VALUES = {
 }
 _ENCODED_EXECUTION_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(
-        r"\bbase64(?:\s+--decode|\s+-d)\b[^\n|;]*(?:\|\s*(?:bash|sh|zsh|python(?:3)?|node|perl|ruby|pwsh|powershell)\b)",
+        r"\bbase64(?:\s+--decode|\s+-(?:d|D))\b[^\n|;]*(?:\|\s*(?:bash|sh|zsh|python(?:3)?|node|perl|ruby|pwsh|powershell)\b)",
         re.IGNORECASE,
     ),
     re.compile(
-        r"\bxxd\s+-r\s+-p\b[^\n|;]*(?:\|\s*(?:bash|sh|zsh|python(?:3)?|node|perl|ruby|pwsh|powershell)\b)",
+        r"\bxxd\s+(?:-r\s+-p|-rp)\b[^\n|;]*(?:\|\s*(?:bash|sh|zsh|python(?:3)?|node|perl|ruby|pwsh|powershell)\b)",
         re.IGNORECASE,
     ),
     re.compile(
@@ -162,10 +162,10 @@ _ENCODED_EXECUTION_PATTERNS: tuple[re.Pattern[str], ...] = (
         re.IGNORECASE,
     ),
     re.compile(
-        r"\bgpg\b[^\n|;]*(?:--decrypt|-d)\b[^\n|;]*(?:\|\s*(?:bash|sh|zsh|python(?:3)?|node|perl|ruby|pwsh|powershell)\b)",
+        r"\b(?:gpg|gpg2)\b[^\n|;]*(?:--decrypt|-d)\b[^\n|;]*(?:\|\s*(?:bash|sh|zsh|python(?:3)?|node|perl|ruby|pwsh|powershell)\b)",
         re.IGNORECASE,
     ),
-    re.compile(r"\bpowershell\b[^\n;]*\s-(?:enc|encodedcommand)\b", re.IGNORECASE),
+    re.compile(r"\b(?:powershell|pwsh)\b[^\n;]*\s-(?:e|ec|enc|encodedcommand)\b", re.IGNORECASE),
     re.compile(r"\bfrombase64string\s*\(", re.IGNORECASE),
 )
 _BASE64_LITERAL_PATTERN = re.compile(r"(?<![A-Za-z0-9+/=])[A-Za-z0-9+/]{20,}={0,2}(?![A-Za-z0-9+/=])")
@@ -631,9 +631,9 @@ def _local_shell_script_payloads(
     payloads: list[tuple[str, Path | None, str]] = []
     for segment in _iter_shell_command_segments(parts):
         command_name, command_index = _shell_segment_primary_command(segment)
-        if command_name not in _SHELL_SCRIPT_INTERPRETER_COMMANDS or command_index is None:
+        if command_index is None:
             continue
-        script_path = _shell_script_path_from_segment(segment[command_index + 1 :])
+        script_path = _shell_script_path_for_segment(segment, command_name=command_name, command_index=command_index)
         if script_path is None:
             continue
         normalized_script_path = _normalize_path(_expand_home(script_path, home_dir), cwd)
@@ -652,6 +652,20 @@ def _local_shell_script_payloads(
     return tuple(payloads)
 
 
+def _shell_script_path_for_segment(
+    segment: list[str],
+    *,
+    command_name: str | None,
+    command_index: int,
+) -> str | None:
+    if command_name in _SHELL_SCRIPT_INTERPRETER_COMMANDS:
+        return _shell_script_path_from_segment(segment[command_index + 1 :])
+    command_token = segment[command_index].strip()
+    if not command_token or command_token.startswith("-") or _SHELL_ASSIGNMENT_PATTERN.match(command_token):
+        return None
+    return command_token
+
+
 def _shell_script_path_from_segment(segment_args: list[str]) -> str | None:
     index = 0
     while index < len(segment_args):
@@ -662,6 +676,9 @@ def _shell_script_path_from_segment(segment_args: list[str]) -> str | None:
         if token == "--":
             index += 1
             break
+        if _SHELL_ASSIGNMENT_PATTERN.match(token):
+            index += 1
+            continue
         if not token.startswith("-") and not token.startswith("+"):
             return token
         if token in {"-c", "--command"} or token.startswith(("-c", "--command=")):

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -148,21 +148,24 @@ _WRAPPER_FLAGS_WITH_VALUES = {
     "stdbuf": frozenset({"-i", "--input", "-o", "--output", "-e", "--error"}),
     "time": frozenset({"-f", "--format", "-o", "--output"}),
 }
+_ENCODED_EXECUTION_TARGET_PATTERN = (
+    r"(?:[A-Za-z0-9_./~-]+/)?(?:bash|sh|zsh|python(?:3)?|node|perl|ruby|pwsh|powershell)\b"
+)
 _ENCODED_EXECUTION_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(
-        r"\bbase64(?:\s+--decode|\s+-(?:d|D))\b[^\n|;]*(?:\|\s*(?:bash|sh|zsh|python(?:3)?|node|perl|ruby|pwsh|powershell)\b)",
+        rf"\bbase64(?:\s+--decode|\s+-(?:d|D))\b[^\n|;]*(?:\|\s*{_ENCODED_EXECUTION_TARGET_PATTERN})",
         re.IGNORECASE,
     ),
     re.compile(
-        r"\bxxd\s+(?:-r\s+-p|-rp)\b[^\n|;]*(?:\|\s*(?:bash|sh|zsh|python(?:3)?|node|perl|ruby|pwsh|powershell)\b)",
+        rf"\bxxd\s+(?:-r\s+-p|-rp)\b[^\n|;]*(?:\|\s*{_ENCODED_EXECUTION_TARGET_PATTERN})",
         re.IGNORECASE,
     ),
     re.compile(
-        r"\bopenssl\s+enc\b[^\n|;]*\s-(?:d|decrypt)\b[^\n|;]*(?:\|\s*(?:bash|sh|zsh|python(?:3)?|node|perl|ruby|pwsh|powershell)\b)",
+        rf"\bopenssl\s+enc\b[^\n|;]*\s-(?:d|decrypt)\b[^\n|;]*(?:\|\s*{_ENCODED_EXECUTION_TARGET_PATTERN})",
         re.IGNORECASE,
     ),
     re.compile(
-        r"\b(?:gpg|gpg2)\b[^\n|;]*(?:--decrypt|-d)\b[^\n|;]*(?:\|\s*(?:bash|sh|zsh|python(?:3)?|node|perl|ruby|pwsh|powershell)\b)",
+        rf"\b(?:gpg|gpg2)\b[^\n|;]*(?:--decrypt|-d)\b[^\n|;]*(?:\|\s*{_ENCODED_EXECUTION_TARGET_PATTERN})",
         re.IGNORECASE,
     ),
     re.compile(r"\b(?:powershell|pwsh)\b[^\n;]*\s-(?:e|ec|enc|encodedcommand)\b", re.IGNORECASE),
@@ -663,6 +666,8 @@ def _shell_script_path_for_segment(
     command_token = segment[command_index].strip()
     if not command_token or command_token.startswith("-") or _SHELL_ASSIGNMENT_PATTERN.match(command_token):
         return None
+    if not _is_explicit_shell_script_path_token(command_token):
+        return None
     return command_token
 
 
@@ -696,6 +701,17 @@ def _shell_script_path_from_segment(segment_args: list[str]) -> str | None:
             return token
         index += 1
     return None
+
+
+def _is_explicit_shell_script_path_token(token: str) -> bool:
+    normalized_token = token.strip()
+    if not normalized_token:
+        return False
+    return (
+        normalized_token.startswith((".", "/", "~"))
+        or normalized_token.startswith("../")
+        or normalized_token.startswith("./")
+    )
 
 
 def build_tool_action_request_artifact(

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -149,7 +149,8 @@ _WRAPPER_FLAGS_WITH_VALUES = {
     "time": frozenset({"-f", "--format", "-o", "--output"}),
 }
 _ENCODED_EXECUTION_TARGET_PATTERN = (
-    r"(?:[A-Za-z0-9_./~-]+/)?(?:bash|sh|zsh|python(?:3)?|node|perl|ruby|pwsh|powershell)\b"
+    r"(?:env(?:\s+[A-Za-z_][A-Za-z0-9_]*=\S+)*\s+)?"
+    r"(?:[A-Za-z0-9_./~-]+/)?(?:ash|bash|dash|sh|zsh|python(?:3)?|node|perl|ruby|pwsh|powershell)\b"
 )
 _ENCODED_EXECUTION_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -149,7 +149,7 @@ _WRAPPER_FLAGS_WITH_VALUES = {
     "time": frozenset({"-f", "--format", "-o", "--output"}),
 }
 _ENCODED_EXECUTION_TARGET_PATTERN = (
-    r"(?:env(?:(?:\s+--?[A-Za-z][A-Za-z-]*|\s+--|\s+[A-Za-z_][A-Za-z0-9_]*=\S+))*\s+)?"
+    r"(?:env(?:(?:\s+--?[A-Za-z][A-Za-z-]*(?:=\S+)?|\s+--|\s+[A-Za-z_][A-Za-z0-9_]*=\S+|\s+\S+))*\s+)?"
     r"(?:[A-Za-z0-9_./~-]+/)?(?:ash|bash|dash|sh|zsh|python(?:3)?|node|perl|ruby|pwsh|powershell)\b"
 )
 _ENCODED_EXECUTION_PATTERNS: tuple[re.Pattern[str], ...] = (

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -686,6 +686,8 @@ def _shell_script_path_from_segment(segment_args: list[str]) -> str | None:
         if _SHELL_ASSIGNMENT_PATTERN.match(token):
             index += 1
             continue
+        if token == "-s":
+            return None
         if token.startswith("-") and not token.startswith("--") and "c" in token[1:]:
             return None
         if not token.startswith("-") and not token.startswith("+"):

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -149,12 +149,12 @@ _WRAPPER_FLAGS_WITH_VALUES = {
     "time": frozenset({"-f", "--format", "-o", "--output"}),
 }
 _ENCODED_EXECUTION_TARGET_PATTERN = (
-    r"(?:env(?:\s+[A-Za-z_][A-Za-z0-9_]*=\S+)*\s+)?"
+    r"(?:env(?:(?:\s+--?[A-Za-z][A-Za-z-]*|\s+--|\s+[A-Za-z_][A-Za-z0-9_]*=\S+))*\s+)?"
     r"(?:[A-Za-z0-9_./~-]+/)?(?:ash|bash|dash|sh|zsh|python(?:3)?|node|perl|ruby|pwsh|powershell)\b"
 )
 _ENCODED_EXECUTION_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(
-        rf"\bbase64(?:\s+--decode|\s+-(?:[A-Za-z]*[dD][A-Za-z]*))\b[^\n|;]*(?:\|\s*{_ENCODED_EXECUTION_TARGET_PATTERN})",
+        rf"\bbase64\b(?=[^\n|;]*\s(?:--decode|-[A-Za-z]*[dD][A-Za-z]*))[^\n|;]*(?:\|\s*{_ENCODED_EXECUTION_TARGET_PATTERN})",
         re.IGNORECASE,
     ),
     re.compile(
@@ -714,6 +714,7 @@ def _is_explicit_shell_script_path_token(token: str) -> bool:
         normalized_token.startswith((".", "/", "~"))
         or normalized_token.startswith("../")
         or normalized_token.startswith("./")
+        or "/" in normalized_token
     )
 
 

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -150,7 +150,8 @@ _WRAPPER_FLAGS_WITH_VALUES = {
     "time": frozenset({"-f", "--format", "-o", "--output"}),
 }
 _ENCODED_EXECUTION_TARGET_PATTERN = (
-    r"(?:env(?:(?:\s+--?[A-Za-z][A-Za-z-]*(?:=\S+)?|\s+--|\s+[A-Za-z_][A-Za-z0-9_]*=\S+|\s+\S+))*\s+)?"
+    r"(?:(?:[A-Za-z0-9_./~-]+/)?env"
+    r"(?:(?:\s+--?[A-Za-z][A-Za-z-]*(?:=\S+)?|\s+--|\s+[A-Za-z_][A-Za-z0-9_]*=\S+|\s+\S+))*\s+)?"
     r"(?:[A-Za-z0-9_./~-]+/)?(?:ash|bash|dash|sh|zsh|python(?:3)?|node|perl|ruby|pwsh|powershell)\b"
 )
 _ENCODED_EXECUTION_PATTERNS: tuple[re.Pattern[str], ...] = (
@@ -1632,10 +1633,24 @@ def _interpreter_flag_payload(parts: list[str], index: int) -> _InterpreterFlagP
     normalized_token = parts[index].strip().lstrip("(").rstrip(")")
     if not normalized_token.startswith("-"):
         return None
+    if normalized_token.startswith("--"):
+        for long_flag in ("--command", "--eval", "--execute"):
+            if normalized_token == long_flag:
+                if index + 1 >= len(parts):
+                    return None
+                next_script = parts[index + 1].strip()
+                if not next_script:
+                    return None
+                return _InterpreterFlagPayload(script_text=next_script, tokens_consumed=2)
+            if normalized_token.startswith(f"{long_flag}="):
+                attached_script = normalized_token.split("=", 1)[1].strip()
+                if not attached_script:
+                    return None
+                return _InterpreterFlagPayload(script_text=attached_script, tokens_consumed=1)
+        return None
     flag_text = normalized_token[1:]
-    for flag_name in ("c", "e"):
-        flag_index = flag_text.find(flag_name)
-        if flag_index == -1:
+    for flag_index, flag_name in enumerate(flag_text):
+        if flag_name not in {"c", "e"}:
             continue
         attached_script = flag_text[flag_index + 1 :].strip()
         if attached_script:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
 import hashlib
 import json
 import os
@@ -50,6 +52,7 @@ _SHELL_TOOL_NAMES = frozenset(
         "zsh",
     }
 )
+_SHELL_SCRIPT_INTERPRETER_COMMANDS = frozenset({"bash", "sh", "zsh"})
 _DESTRUCTIVE_SHELL_COMMANDS = frozenset(
     {
         "chmod",
@@ -143,6 +146,48 @@ _WRAPPER_FLAGS_WITH_VALUES = {
     "stdbuf": frozenset({"-i", "--input", "-o", "--output", "-e", "--error"}),
     "time": frozenset({"-f", "--format", "-o", "--output"}),
 }
+_ENCODED_EXECUTION_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        r"\bbase64(?:\s+--decode|\s+-d)\b[^\n|;]*(?:\|\s*(?:bash|sh|zsh|python(?:3)?|node|perl|ruby|pwsh|powershell)\b)",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\bxxd\s+-r\s+-p\b[^\n|;]*(?:\|\s*(?:bash|sh|zsh|python(?:3)?|node|perl|ruby|pwsh|powershell)\b)",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\bopenssl\s+enc\b[^\n|;]*\s-(?:d|decrypt)\b[^\n|;]*(?:\|\s*(?:bash|sh|zsh|python(?:3)?|node|perl|ruby|pwsh|powershell)\b)",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\bgpg\b[^\n|;]*(?:--decrypt|-d)\b[^\n|;]*(?:\|\s*(?:bash|sh|zsh|python(?:3)?|node|perl|ruby|pwsh|powershell)\b)",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\bpowershell\b[^\n;]*\s-(?:enc|encodedcommand)\b", re.IGNORECASE),
+    re.compile(r"\bfrombase64string\s*\(", re.IGNORECASE),
+)
+_BASE64_LITERAL_PATTERN = re.compile(r"(?<![A-Za-z0-9+/=])[A-Za-z0-9+/]{20,}={0,2}(?![A-Za-z0-9+/=])")
+_HEX_LITERAL_PATTERN = re.compile(r"(?<![A-Fa-f0-9])[A-Fa-f0-9]{24,}(?![A-Fa-f0-9])")
+_MAX_DECODED_PAYLOAD_BYTES = 32 * 1024
+_SENSITIVE_DECODED_PAYLOAD_TOKENS = (
+    ".env",
+    ".ssh/",
+    ".aws/credentials",
+    ".git-credentials",
+    "process.env",
+    "os.environ",
+    "getenv(",
+    "curl ",
+    "wget ",
+    "requests.",
+    "fetch(",
+    "axios.",
+    "approval_policy",
+    "hol-guard",
+    "guard-bypass",
+    ".codex/config.toml",
+    "scp ",
+)
 _SENSITIVE_BASENAME_LABELS = {
     ".npmrc": "npm registry credentials",
     ".pypirc": "Python package credentials",
@@ -351,6 +396,8 @@ def extract_sensitive_tool_action_request(
             tool_name=requested_tool_name,
             normalized_tool_name=normalized_tool_name,
             command_text=command_text,
+            cwd=cwd,
+            home_dir=home_dir,
         )
         if destructive_shell_request is not None:
             return destructive_shell_request
@@ -401,9 +448,22 @@ def _destructive_shell_tool_action_request(
     tool_name: str,
     normalized_tool_name: str,
     command_text: str,
+    cwd: Path | None,
+    home_dir: Path | None,
 ) -> ToolActionRequestMatch | None:
     if normalized_tool_name not in _SHELL_TOOL_NAMES:
         return None
+    if _contains_encoded_or_encrypted_shell_command(command_text, cwd=cwd, home_dir=home_dir):
+        return ToolActionRequestMatch(
+            tool_name=tool_name,
+            normalized_tool_name=normalized_tool_name,
+            command_text=command_text,
+            action_class="encoded or encrypted shell command",
+            reason=(
+                "Guard treats encoded or encrypted decode-and-exec shell flows as sensitive and inspects bounded "
+                "payloads in-process without executing them during evaluation."
+            ),
+        )
     if not _looks_destructive_shell_command(command_text):
         return None
     return ToolActionRequestMatch(
@@ -416,6 +476,198 @@ def _destructive_shell_tool_action_request(
             "local machine before the user confirms the action."
         ),
     )
+
+
+def _contains_encoded_or_encrypted_shell_command(
+    command_text: str,
+    *,
+    cwd: Path | None,
+    home_dir: Path | None,
+    depth: int = 0,
+    visited_script_paths: frozenset[str] = frozenset(),
+) -> bool:
+    if depth > 4:
+        return False
+    normalized = command_text.strip()
+    if not normalized:
+        return False
+    if any(pattern.search(normalized) for pattern in _ENCODED_EXECUTION_PATTERNS):
+        return True
+    parts = _split_shell_parts(normalized)
+    if not parts:
+        return False
+    for payload in _decoded_shell_payloads(normalized):
+        if _decoded_payload_looks_sensitive(
+            payload,
+            cwd=cwd,
+            home_dir=home_dir,
+            depth=depth + 1,
+            visited_script_paths=visited_script_paths,
+        ):
+            return True
+    for env_split_string in _env_split_string_payloads(parts):
+        if _contains_encoded_or_encrypted_shell_command(
+            env_split_string,
+            cwd=cwd,
+            home_dir=home_dir,
+            depth=depth + 1,
+            visited_script_paths=visited_script_paths,
+        ):
+            return True
+    for shell_script in _shell_command_scripts(parts):
+        if _contains_encoded_or_encrypted_shell_command(
+            shell_script,
+            cwd=cwd,
+            home_dir=home_dir,
+            depth=depth + 1,
+            visited_script_paths=visited_script_paths,
+        ):
+            return True
+    for script_text, script_cwd, script_path in _local_shell_script_payloads(
+        parts,
+        cwd=cwd,
+        home_dir=home_dir,
+        visited_script_paths=visited_script_paths,
+    ):
+        if _contains_encoded_or_encrypted_shell_command(
+            script_text,
+            cwd=script_cwd,
+            home_dir=home_dir,
+            depth=depth + 1,
+            visited_script_paths=visited_script_paths | frozenset({script_path}),
+        ):
+            return True
+    return False
+
+
+def _decoded_payload_looks_sensitive(
+    payload: str,
+    *,
+    cwd: Path | None,
+    home_dir: Path | None,
+    depth: int,
+    visited_script_paths: frozenset[str],
+) -> bool:
+    lowered = payload.lower()
+    if _looks_destructive_shell_command(payload):
+        return True
+    if any(token in lowered for token in _SENSITIVE_DECODED_PAYLOAD_TOKENS):
+        return True
+    return _contains_encoded_or_encrypted_shell_command(
+        payload,
+        cwd=cwd,
+        home_dir=home_dir,
+        depth=depth,
+        visited_script_paths=visited_script_paths,
+    )
+
+
+def _decoded_shell_payloads(command_text: str) -> tuple[str, ...]:
+    lowered = command_text.lower()
+    payloads: list[str] = []
+    if any(token in lowered for token in ("base64", "b64decode", "frombase64string", "-encodedcommand", " -enc ")):
+        for literal in _BASE64_LITERAL_PATTERN.findall(command_text):
+            decoded = _decode_base64_literal(literal)
+            if decoded is not None:
+                payloads.append(decoded)
+    if "xxd" in lowered:
+        for literal in _HEX_LITERAL_PATTERN.findall(command_text):
+            decoded = _decode_hex_literal(literal)
+            if decoded is not None:
+                payloads.append(decoded)
+    return tuple(payloads)
+
+
+def _decode_base64_literal(literal: str) -> str | None:
+    try:
+        decoded_bytes = base64.b64decode(literal, validate=True)
+    except binascii.Error:
+        return None
+    return _decoded_bytes_to_text(decoded_bytes)
+
+
+def _decode_hex_literal(literal: str) -> str | None:
+    if len(literal) % 2 != 0:
+        return None
+    try:
+        decoded_bytes = binascii.unhexlify(literal)
+    except binascii.Error:
+        return None
+    return _decoded_bytes_to_text(decoded_bytes)
+
+
+def _decoded_bytes_to_text(decoded_bytes: bytes) -> str | None:
+    if not decoded_bytes or len(decoded_bytes) > _MAX_DECODED_PAYLOAD_BYTES:
+        return None
+    for encoding in ("utf-8", "utf-16-le"):
+        try:
+            text = decoded_bytes.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+        if _text_is_probably_source(text):
+            return text
+    return None
+
+
+def _text_is_probably_source(text: str) -> bool:
+    if not text.strip():
+        return False
+    printable = sum(1 for character in text if character.isprintable() or character in "\n\r\t")
+    return printable / len(text) >= 0.85
+
+
+def _local_shell_script_payloads(
+    parts: list[str],
+    *,
+    cwd: Path | None,
+    home_dir: Path | None,
+    visited_script_paths: frozenset[str],
+) -> tuple[tuple[str, Path | None, str], ...]:
+    payloads: list[tuple[str, Path | None, str]] = []
+    for segment in _iter_shell_command_segments(parts):
+        command_name, command_index = _shell_segment_primary_command(segment)
+        if command_name not in _SHELL_SCRIPT_INTERPRETER_COMMANDS or command_index is None:
+            continue
+        script_path = _shell_script_path_from_segment(segment[command_index + 1 :])
+        if script_path is None:
+            continue
+        normalized_script_path = _normalize_path(_expand_home(script_path, home_dir), cwd)
+        if normalized_script_path in visited_script_paths:
+            continue
+        script_file = Path(normalized_script_path)
+        if not script_file.is_file():
+            continue
+        try:
+            if script_file.stat().st_size > _MAX_DECODED_PAYLOAD_BYTES:
+                continue
+            script_text = script_file.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        payloads.append((script_text, script_file.parent, normalized_script_path))
+    return tuple(payloads)
+
+
+def _shell_script_path_from_segment(segment_args: list[str]) -> str | None:
+    index = 0
+    while index < len(segment_args):
+        token = segment_args[index].strip()
+        if not token:
+            index += 1
+            continue
+        if token == "--":
+            index += 1
+            break
+        if not token.startswith("-"):
+            return token
+        if "c" in token[1:]:
+            return None
+        index += 1
+    while index < len(segment_args):
+        token = segment_args[index].strip()
+        if token:
+            return token
+        index += 1
+    return None
 
 
 def build_tool_action_request_artifact(

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1125,6 +1125,26 @@ def test_tool_action_request_classifier_detects_clustered_base64_decode_and_exec
     assert request.action_class == "encoded or encrypted shell command"
 
 
+def test_tool_action_request_classifier_detects_base64_decode_and_dash_exec_command():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | dash"},
+    )
+
+    assert request is not None
+    assert request.action_class == "encoded or encrypted shell command"
+
+
+def test_tool_action_request_classifier_detects_base64_decode_and_env_wrapped_exec_command():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | env bash"},
+    )
+
+    assert request is not None
+    assert request.action_class == "encoded or encrypted shell command"
+
+
 def test_tool_action_request_classifier_detects_xxd_compact_reverse_hex_exec_command():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1258,6 +1258,36 @@ echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
     assert request is None
 
 
+def test_tool_action_request_classifier_ignores_echo_frombase64string_text():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "echo 'frombase64string('"},
+    )
+
+    assert request is None
+
+
+def test_tool_action_request_classifier_ignores_ls_long_flag_with_encoded_named_file(tmp_path):
+    workspace_dir = tmp_path / "workspace"
+    _write_text(
+        workspace_dir / "encoded-wrapper.sh",
+        """
+#!/bin/sh
+set -eu
+echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
+""".strip()
+        + "\n",
+    )
+
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "ls -l ./encoded-wrapper.sh"},
+        cwd=workspace_dir,
+    )
+
+    assert request is None
+
+
 def test_tool_action_request_classifier_detects_encrypted_decrypt_and_exec_command():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1277,6 +1277,15 @@ def test_tool_action_request_classifier_ignores_echo_frombase64string_text():
     assert request is None
 
 
+def test_tool_action_request_classifier_ignores_quoted_encoded_pipeline_literal_text():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "echo 'cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash'"},
+    )
+
+    assert request is None
+
+
 def test_tool_action_request_classifier_ignores_ls_long_flag_with_encoded_named_file(tmp_path):
     workspace_dir = tmp_path / "workspace"
     _write_text(
@@ -1306,6 +1315,16 @@ def test_tool_action_request_classifier_detects_bash_c_destructive_command():
 
     assert request is not None
     assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_bash_c_command_substitution_decode_exec():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "bash -c \"$(echo ZWNobyBoaQ== | base64 -d)\""},
+    )
+
+    assert request is not None
+    assert request.action_class == "encoded or encrypted shell command"
 
 
 def test_tool_action_request_classifier_detects_bash_norc_c_destructive_command():

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1127,6 +1127,50 @@ echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
     assert request.action_class == "encoded or encrypted shell command"
 
 
+def test_tool_action_request_classifier_detects_bash_norc_local_shell_script_with_encoded_payload(tmp_path):
+    workspace_dir = tmp_path / "workspace"
+    _write_text(
+        workspace_dir / "encoded-wrapper.sh",
+        """
+#!/bin/sh
+set -eu
+echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
+""".strip()
+        + "\n",
+    )
+
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "bash --norc ./encoded-wrapper.sh"},
+        cwd=workspace_dir,
+    )
+
+    assert request is not None
+    assert request.action_class == "encoded or encrypted shell command"
+
+
+def test_tool_action_request_classifier_detects_source_local_shell_script_with_encoded_payload(tmp_path):
+    workspace_dir = tmp_path / "workspace"
+    _write_text(
+        workspace_dir / "encoded-wrapper.sh",
+        """
+#!/bin/sh
+set -eu
+echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
+""".strip()
+        + "\n",
+    )
+
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "source ./encoded-wrapper.sh"},
+        cwd=workspace_dir,
+    )
+
+    assert request is not None
+    assert request.action_class == "encoded or encrypted shell command"
+
+
 def test_tool_action_request_classifier_detects_env_wrapped_destructive_command():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1237,6 +1237,27 @@ echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
     assert request is None
 
 
+def test_tool_action_request_classifier_ignores_bash_s_stdin_mode_with_same_named_local_file(tmp_path):
+    workspace_dir = tmp_path / "workspace"
+    _write_text(
+        workspace_dir / "ls",
+        """
+#!/bin/sh
+set -eu
+echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
+""".strip()
+        + "\n",
+    )
+
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "bash -s ls"},
+        cwd=workspace_dir,
+    )
+
+    assert request is None
+
+
 def test_tool_action_request_classifier_detects_encrypted_decrypt_and_exec_command():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1288,6 +1288,16 @@ echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
     assert request is None
 
 
+def test_tool_action_request_classifier_detects_bash_c_destructive_command():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "bash -c 'rm -rf dangerous-marker.json'"},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_detects_encrypted_decrypt_and_exec_command():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1155,6 +1155,16 @@ def test_tool_action_request_classifier_detects_base64_decode_and_env_option_wra
     assert request.action_class == "encoded or encrypted shell command"
 
 
+def test_tool_action_request_classifier_detects_base64_decode_and_path_qualified_env_wrapped_exec_command():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | /usr/bin/env -i bash"},
+    )
+
+    assert request is not None
+    assert request.action_class == "encoded or encrypted shell command"
+
+
 def test_tool_action_request_classifier_detects_base64_decode_and_env_unset_wrapped_exec_command():
     request = extract_sensitive_tool_action_request(
         "bash",
@@ -1292,6 +1302,16 @@ def test_tool_action_request_classifier_detects_bash_c_destructive_command():
     request = extract_sensitive_tool_action_request(
         "bash",
         {"command": "bash -c 'rm -rf dangerous-marker.json'"},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_bash_norc_c_destructive_command():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "bash --norc -c 'rm -rf dangerous-marker.json'"},
     )
 
     assert request is not None

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1145,6 +1145,26 @@ def test_tool_action_request_classifier_detects_base64_decode_and_env_wrapped_ex
     assert request.action_class == "encoded or encrypted shell command"
 
 
+def test_tool_action_request_classifier_detects_base64_decode_and_env_option_wrapped_exec_command():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | env -i bash"},
+    )
+
+    assert request is not None
+    assert request.action_class == "encoded or encrypted shell command"
+
+
+def test_tool_action_request_classifier_detects_base64_decode_when_flag_not_first():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -i -d | bash"},
+    )
+
+    assert request is not None
+    assert request.action_class == "encoded or encrypted shell command"
+
+
 def test_tool_action_request_classifier_detects_xxd_compact_reverse_hex_exec_command():
     request = extract_sensitive_tool_action_request(
         "bash",
@@ -1264,6 +1284,28 @@ echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
     request = extract_sensitive_tool_action_request(
         "bash",
         {"command": "./encoded-wrapper.sh"},
+        cwd=workspace_dir,
+    )
+
+    assert request is not None
+    assert request.action_class == "encoded or encrypted shell command"
+
+
+def test_tool_action_request_classifier_detects_slash_path_local_shell_script_with_encoded_payload(tmp_path):
+    workspace_dir = tmp_path / "workspace"
+    _write_text(
+        workspace_dir / "scripts" / "encoded-wrapper.sh",
+        """
+#!/bin/sh
+set -eu
+echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
+""".strip()
+        + "\n",
+    )
+
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "scripts/encoded-wrapper.sh"},
         cwd=workspace_dir,
     )
 

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1085,6 +1085,48 @@ def test_tool_action_request_classifier_detects_shell_wrapper_script_command():
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_detects_base64_decode_and_exec_command():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash"},
+    )
+
+    assert request is not None
+    assert request.action_class == "encoded or encrypted shell command"
+
+
+def test_tool_action_request_classifier_detects_encrypted_decrypt_and_exec_command():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "openssl enc -d -aes-256-cbc -base64 -in payload.enc | bash"},
+    )
+
+    assert request is not None
+    assert request.action_class == "encoded or encrypted shell command"
+
+
+def test_tool_action_request_classifier_detects_local_shell_script_with_encoded_payload(tmp_path):
+    workspace_dir = tmp_path / "workspace"
+    _write_text(
+        workspace_dir / "encoded-wrapper.sh",
+        """
+#!/bin/sh
+set -eu
+echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
+""".strip()
+        + "\n",
+    )
+
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "sh ./encoded-wrapper.sh"},
+        cwd=workspace_dir,
+    )
+
+    assert request is not None
+    assert request.action_class == "encoded or encrypted shell command"
+
+
 def test_tool_action_request_classifier_detects_env_wrapped_destructive_command():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1095,10 +1095,50 @@ def test_tool_action_request_classifier_detects_base64_decode_and_exec_command()
     assert request.action_class == "encoded or encrypted shell command"
 
 
+def test_tool_action_request_classifier_detects_bsd_base64_decode_and_exec_command():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -D | bash"},
+    )
+
+    assert request is not None
+    assert request.action_class == "encoded or encrypted shell command"
+
+
+def test_tool_action_request_classifier_detects_xxd_compact_reverse_hex_exec_command():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "printf 726d202d662064616e6765726f75732d6d61726b65722e6a736f6e0a | xxd -rp | bash"},
+    )
+
+    assert request is not None
+    assert request.action_class == "encoded or encrypted shell command"
+
+
 def test_tool_action_request_classifier_detects_encrypted_decrypt_and_exec_command():
     request = extract_sensitive_tool_action_request(
         "bash",
         {"command": "openssl enc -d -aes-256-cbc -base64 -in payload.enc | bash"},
+    )
+
+    assert request is not None
+    assert request.action_class == "encoded or encrypted shell command"
+
+
+def test_tool_action_request_classifier_detects_gpg2_decrypt_and_exec_command():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "gpg2 --decrypt payload.asc | bash"},
+    )
+
+    assert request is not None
+    assert request.action_class == "encoded or encrypted shell command"
+
+
+def test_tool_action_request_classifier_detects_pwsh_short_encoded_command():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "pwsh -ec ZQBjAGgAbwAgAGQAYQBuAGcAZQByAA=="},
     )
 
     assert request is not None
@@ -1127,6 +1167,28 @@ echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
     assert request.action_class == "encoded or encrypted shell command"
 
 
+def test_tool_action_request_classifier_detects_direct_local_shell_script_with_encoded_payload(tmp_path):
+    workspace_dir = tmp_path / "workspace"
+    _write_text(
+        workspace_dir / "encoded-wrapper.sh",
+        """
+#!/bin/sh
+set -eu
+echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
+""".strip()
+        + "\n",
+    )
+
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "./encoded-wrapper.sh"},
+        cwd=workspace_dir,
+    )
+
+    assert request is not None
+    assert request.action_class == "encoded or encrypted shell command"
+
+
 def test_tool_action_request_classifier_detects_bash_norc_local_shell_script_with_encoded_payload(tmp_path):
     workspace_dir = tmp_path / "workspace"
     _write_text(
@@ -1142,6 +1204,30 @@ echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
     request = extract_sensitive_tool_action_request(
         "bash",
         {"command": "bash --norc ./encoded-wrapper.sh"},
+        cwd=workspace_dir,
+    )
+
+    assert request is not None
+    assert request.action_class == "encoded or encrypted shell command"
+
+
+def test_tool_action_request_classifier_detects_bash_assignment_prefixed_local_shell_script_with_encoded_payload(
+    tmp_path,
+):
+    workspace_dir = tmp_path / "workspace"
+    _write_text(
+        workspace_dir / "encoded-wrapper.sh",
+        """
+#!/bin/sh
+set -eu
+echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
+""".strip()
+        + "\n",
+    )
+
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "bash VAR=1 ./encoded-wrapper.sh"},
         cwd=workspace_dir,
     )
 

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1155,6 +1155,26 @@ def test_tool_action_request_classifier_detects_base64_decode_and_env_option_wra
     assert request.action_class == "encoded or encrypted shell command"
 
 
+def test_tool_action_request_classifier_detects_base64_decode_and_env_unset_wrapped_exec_command():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | env -u FOO bash"},
+    )
+
+    assert request is not None
+    assert request.action_class == "encoded or encrypted shell command"
+
+
+def test_tool_action_request_classifier_detects_base64_decode_and_env_unset_equals_wrapped_exec_command():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | env --unset=FOO bash"},
+    )
+
+    assert request is not None
+    assert request.action_class == "encoded or encrypted shell command"
+
+
 def test_tool_action_request_classifier_detects_base64_decode_when_flag_not_first():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1115,6 +1115,16 @@ def test_tool_action_request_classifier_detects_path_qualified_base64_decode_and
     assert request.action_class == "encoded or encrypted shell command"
 
 
+def test_tool_action_request_classifier_detects_clustered_base64_decode_and_exec_command():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -di | bash"},
+    )
+
+    assert request is not None
+    assert request.action_class == "encoded or encrypted shell command"
+
+
 def test_tool_action_request_classifier_detects_xxd_compact_reverse_hex_exec_command():
     request = extract_sensitive_tool_action_request(
         "bash",
@@ -1140,6 +1150,27 @@ echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
     request = extract_sensitive_tool_action_request(
         "bash",
         {"command": "echo hello"},
+        cwd=workspace_dir,
+    )
+
+    assert request is None
+
+
+def test_tool_action_request_classifier_ignores_bash_lc_with_same_named_local_file(tmp_path):
+    workspace_dir = tmp_path / "workspace"
+    _write_text(
+        workspace_dir / "ls",
+        """
+#!/bin/sh
+set -eu
+echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
+""".strip()
+        + "\n",
+    )
+
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "bash -lc ls"},
         cwd=workspace_dir,
     )
 

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1105,6 +1105,16 @@ def test_tool_action_request_classifier_detects_bsd_base64_decode_and_exec_comma
     assert request.action_class == "encoded or encrypted shell command"
 
 
+def test_tool_action_request_classifier_detects_path_qualified_base64_decode_and_exec_command():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | /bin/bash"},
+    )
+
+    assert request is not None
+    assert request.action_class == "encoded or encrypted shell command"
+
+
 def test_tool_action_request_classifier_detects_xxd_compact_reverse_hex_exec_command():
     request = extract_sensitive_tool_action_request(
         "bash",
@@ -1113,6 +1123,27 @@ def test_tool_action_request_classifier_detects_xxd_compact_reverse_hex_exec_com
 
     assert request is not None
     assert request.action_class == "encoded or encrypted shell command"
+
+
+def test_tool_action_request_classifier_ignores_non_path_command_name_with_same_named_local_file(tmp_path):
+    workspace_dir = tmp_path / "workspace"
+    _write_text(
+        workspace_dir / "echo",
+        """
+#!/bin/sh
+set -eu
+echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
+""".strip()
+        + "\n",
+    )
+
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "echo hello"},
+        cwd=workspace_dir,
+    )
+
+    assert request is None
 
 
 def test_tool_action_request_classifier_detects_encrypted_decrypt_and_exec_command():

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -907,6 +907,42 @@ def test_guard_hook_emits_copilot_native_ask_response_for_base64_decode_and_exec
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_bsd_base64_decode_and_exec_command(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -D | bash"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_ask_response_for_encrypted_decrypt_and_exec_command(
     tmp_path,
     capsys,
@@ -918,6 +954,51 @@ def test_guard_hook_emits_copilot_native_ask_response_for_encrypted_decrypt_and_
     event = {
         "toolName": "bash",
         "toolArgs": json.dumps({"command": "openssl enc -d -aes-256-cbc -base64 -in payload.enc | bash"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_ask_response_for_direct_local_shell_script_with_encoded_payload(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(
+        workspace_dir / "encoded-wrapper.sh",
+        """
+#!/bin/sh
+set -eu
+echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
+""".strip()
+        + "\n",
+    )
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "./encoded-wrapper.sh"}),
         "sourceScope": "project",
     }
     monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1123,6 +1123,82 @@ def test_guard_hook_emits_copilot_native_ask_response_for_base64_decode_and_env_
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_base64_decode_and_env_unset_wrapped_exec_command(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps(
+            {"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | env -u FOO bash"}
+        ),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_ask_response_for_base64_decode_and_env_unset_equals_wrapped_exec_command(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps(
+            {"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | env --unset=FOO bash"}
+        ),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_ask_response_for_base64_decode_when_flag_not_first(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -979,6 +979,42 @@ def test_guard_hook_emits_copilot_native_ask_response_for_path_qualified_base64_
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_clustered_base64_decode_and_exec_command(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -di | bash"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_ask_response_for_encrypted_decrypt_and_exec_command(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1123,6 +1123,44 @@ def test_guard_hook_emits_copilot_native_ask_response_for_base64_decode_and_env_
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_base64_decode_and_path_qualified_env_wrapped_exec_command(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps(
+            {"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | /usr/bin/env -i bash"}
+        ),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_ask_response_for_base64_decode_and_env_unset_wrapped_exec_command(
     tmp_path,
     capsys,
@@ -1369,6 +1407,42 @@ def test_guard_hook_emits_copilot_native_ask_response_for_bash_c_destructive_com
     event = {
         "toolName": "bash",
         "toolArgs": json.dumps({"command": "bash -c 'rm -rf dangerous-marker.json'"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_ask_response_for_bash_norc_c_destructive_command(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "bash --norc -c 'rm -rf dangerous-marker.json'"}),
         "sourceScope": "project",
     }
     monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1235,6 +1235,50 @@ def test_guard_hook_emits_copilot_native_ask_response_for_base64_decode_when_fla
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_keeps_allow_response_for_bash_s_stdin_mode_with_same_named_local_file(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(
+        workspace_dir / "ls",
+        """
+#!/bin/sh
+set -eu
+echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
+""".strip()
+        + "\n",
+    )
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "bash -s ls"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "allow"
+    assert "permissionDecisionReason" not in output
+
+
 def test_guard_hook_emits_copilot_native_ask_response_for_encrypted_decrypt_and_exec_command(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1015,6 +1015,78 @@ def test_guard_hook_emits_copilot_native_ask_response_for_clustered_base64_decod
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_base64_decode_and_dash_exec_command(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | dash"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_ask_response_for_base64_decode_and_env_wrapped_exec_command(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | env bash"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_ask_response_for_encrypted_decrypt_and_exec_command(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1279,6 +1279,85 @@ echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
     assert "permissionDecisionReason" not in output
 
 
+def test_guard_hook_keeps_allow_response_for_echo_frombase64string_text(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "echo 'frombase64string('"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "allow"
+    assert "permissionDecisionReason" not in output
+
+
+def test_guard_hook_keeps_allow_response_for_ls_long_flag_with_encoded_named_file(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(
+        workspace_dir / "encoded-wrapper.sh",
+        """
+#!/bin/sh
+set -eu
+echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
+""".strip()
+        + "\n",
+    )
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "ls -l ./encoded-wrapper.sh"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "allow"
+    assert "permissionDecisionReason" not in output
+
+
 def test_guard_hook_emits_copilot_native_ask_response_for_encrypted_decrypt_and_exec_command(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -988,6 +988,51 @@ echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_bash_norc_local_shell_script_with_encoded_payload(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(
+        workspace_dir / "encoded-wrapper.sh",
+        """
+#!/bin/sh
+set -eu
+echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
+""".strip()
+        + "\n",
+    )
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "bash --norc ./encoded-wrapper.sh"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_ask_response_for_node_inline_delete_bypass(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -871,6 +871,123 @@ def test_guard_hook_emits_copilot_native_ask_response_for_destructive_shell_redi
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_base64_decode_and_exec_command(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_ask_response_for_encrypted_decrypt_and_exec_command(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "openssl enc -d -aes-256-cbc -base64 -in payload.enc | bash"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_ask_response_for_local_shell_script_with_encoded_payload(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(
+        workspace_dir / "encoded-wrapper.sh",
+        """
+#!/bin/sh
+set -eu
+echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
+""".strip()
+        + "\n",
+    )
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "sh ./encoded-wrapper.sh"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_ask_response_for_node_inline_delete_bypass(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1352,6 +1352,41 @@ def test_guard_hook_keeps_allow_response_for_echo_frombase64string_text(
     assert "permissionDecisionReason" not in output
 
 
+def test_guard_hook_keeps_allow_response_for_quoted_encoded_pipeline_literal_text(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "echo 'cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash'"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "allow"
+    assert "permissionDecisionReason" not in output
+
+
 def test_guard_hook_keeps_allow_response_for_ls_long_flag_with_encoded_named_file(
     tmp_path,
     capsys,
@@ -1407,6 +1442,42 @@ def test_guard_hook_emits_copilot_native_ask_response_for_bash_c_destructive_com
     event = {
         "toolName": "bash",
         "toolArgs": json.dumps({"command": "bash -c 'rm -rf dangerous-marker.json'"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_ask_response_for_bash_c_command_substitution_decode_exec(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "bash -c \"$(echo ZWNobyBoaQ== | base64 -d)\""}),
         "sourceScope": "project",
     }
     monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -943,6 +943,42 @@ def test_guard_hook_emits_copilot_native_ask_response_for_bsd_base64_decode_and_
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_path_qualified_base64_decode_and_exec_command(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | /bin/bash"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_ask_response_for_encrypted_decrypt_and_exec_command(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1087,6 +1087,78 @@ def test_guard_hook_emits_copilot_native_ask_response_for_base64_decode_and_env_
     assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_base64_decode_and_env_option_wrapped_exec_command(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | env -i bash"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_ask_response_for_base64_decode_when_flag_not_first(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -i -d | bash"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_ask_response_for_encrypted_decrypt_and_exec_command(
     tmp_path,
     capsys,
@@ -1143,6 +1215,51 @@ echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
     event = {
         "toolName": "bash",
         "toolArgs": json.dumps({"command": "./encoded-wrapper.sh"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
+def test_guard_hook_emits_copilot_native_ask_response_for_slash_path_local_shell_script_with_encoded_payload(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(
+        workspace_dir / "scripts" / "encoded-wrapper.sh",
+        """
+#!/bin/sh
+set -eu
+echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
+""".strip()
+        + "\n",
+    )
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "scripts/encoded-wrapper.sh"}),
         "sourceScope": "project",
     }
     monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1358,6 +1358,42 @@ echo cm0gLWYgZGFuZ2Vyb3VzLW1hcmtlci5qc29uCg== | base64 -d | bash
     assert "permissionDecisionReason" not in output
 
 
+def test_guard_hook_emits_copilot_native_ask_response_for_bash_c_destructive_command(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "toolName": "bash",
+        "toolArgs": json.dumps({"command": "bash -c 'rm -rf dangerous-marker.json'"}),
+        "sourceScope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["permissionDecision"] == "deny"
+    assert "hol guard" in output["permissionDecisionReason"].lower()
+    assert "approve it in hol guard, then retry." in output["permissionDecisionReason"].lower()
+
+
 def test_guard_hook_emits_copilot_native_ask_response_for_encrypted_decrypt_and_exec_command(
     tmp_path,
     capsys,


### PR DESCRIPTION
## Summary
- treat encoded or encrypted decode-and-exec shell flows as sensitive runtime tool actions
- inspect bounded encoded payloads and local shell wrapper scripts in-process without executing them during evaluation
- add runtime and risk regressions for base64 decode-to-shell, decrypt-to-shell, and local encoded wrapper scripts

## Verification
- `PYTHONPATH=src /opt/homebrew/opt/python@3.11/bin/python3.11 -m pytest tests/test_guard_risk.py -k 'encoded or encrypted' -q`
- `PYTHONPATH=src /opt/homebrew/opt/python@3.11/bin/python3.11 -m pytest tests/test_guard_runtime.py -k 'encoded or encrypted' -q`
- `/opt/homebrew/opt/python@3.11/bin/python3.11 -m ruff check src/codex_plugin_scanner/guard/runtime/secret_file_requests.py tests/test_guard_risk.py tests/test_guard_runtime.py`
- real Copilot Autopilot proof: `sh ./.guard-encoded-run.sh` blocked by the `preToolUse` hook as `encoded or encrypted shell command`
- real Copilot Autopilot proof: `sh ./.guard-encrypted-run.sh` blocked by the `preToolUse` hook as `encoded or encrypted shell command`
