### PR TITLE
fix: harden hol-guard sync and sensitive prompt runtime checks

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/base.py
+++ b/src/codex_plugin_scanner/guard/adapters/base.py
@@ -124,6 +124,11 @@ class HarnessAdapter:
             command.append(str(context.workspace_dir))
         return [*command, *passthrough_args]
 
+    def policy_path(self, context: HarnessContext) -> Path:
+        if context.workspace_dir is not None:
+            return context.workspace_dir / ".mcp.json"
+        return context.home_dir / ".mcp.json"
+
     def launch_environment(self, context: HarnessContext) -> dict[str, str]:
         del context
         return {}

--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -49,6 +49,11 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
             return "project"
         return "global"
 
+    def policy_path(self, context: HarnessContext) -> Path:
+        if context.workspace_dir is not None:
+            return context.workspace_dir / ".claude" / "settings.local.json"
+        return context.home_dir / ".claude" / "settings.json"
+
     def detect(self, context: HarnessContext) -> HarnessDetection:
         config_candidates = [context.home_dir / ".claude" / "settings.json"]
         if context.workspace_dir is not None:

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -59,6 +59,11 @@ class CodexHarnessAdapter(HarnessAdapter):
             return "project"
         return "global"
 
+    def policy_path(self, context: HarnessContext) -> Path:
+        if context.workspace_dir is not None:
+            return context.workspace_dir / ".codex" / "config.toml"
+        return context.home_dir / ".codex" / "config.toml"
+
     def detect(self, context: HarnessContext) -> HarnessDetection:
         config_paths = [context.home_dir / ".codex" / "config.toml"]
         if context.workspace_dir is not None:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -81,6 +81,8 @@ from .install_commands import apply_managed_install
 from .product import build_guard_start_payload, build_guard_status_payload
 from .update_commands import run_guard_update
 
+_GUARD_CLIENT_VERSION = "2.0.0"
+
 
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -1542,7 +1544,7 @@ def _headless_approval_resolver(
             workspace=str(context.workspace_dir) if context.workspace_dir is not None else None,
             client_name="hol-guard",
             client_title="HOL Guard CLI",
-            client_version="2.0.0",
+            client_version=_GUARD_CLIENT_VERSION,
             capabilities=["approval-resolution", "receipt-view"],
         )
         blocked_operation = daemon_client.queue_blocked_operation(

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -13,10 +13,20 @@ from pathlib import Path
 from ..daemon import ensure_guard_daemon, load_guard_surface_daemon_client
 from ..daemon.client import GuardDaemonRequestError, GuardDaemonTransportError, GuardSurfaceDaemonClient
 from ..runtime import GuardSyncNotAvailableError, sync_receipts, sync_runtime_session
+from ..daemon.manager import clear_guard_daemon_state
 from ..store import GuardStore
 
 DEFAULT_GUARD_SYNC_URL = "https://hol.org/api/guard/receipts/sync"
 DEFAULT_GUARD_CONNECT_URL = "https://hol.org/guard/connect"
+
+
+def _load_connect_daemon_client(guard_home: Path) -> GuardSurfaceDaemonClient:
+    try:
+        return load_guard_surface_daemon_client(guard_home)
+    except RuntimeError:
+        clear_guard_daemon_state(guard_home)
+        ensure_guard_daemon(guard_home)
+        return load_guard_surface_daemon_client(guard_home)
 
 
 def run_guard_connect_command(
@@ -29,7 +39,7 @@ def run_guard_connect_command(
     wait_timeout_seconds: int,
 ) -> dict[str, object]:
     ensure_guard_daemon(guard_home)
-    daemon_client = load_guard_surface_daemon_client(guard_home)
+    daemon_client = _load_connect_daemon_client(guard_home)
     normalized_connect_url, allowed_origin = resolve_connect_url(connect_url)
     connect_request = daemon_client.create_connect_request(
         sync_url=sync_url,

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -12,8 +12,8 @@ from pathlib import Path
 
 from ..daemon import ensure_guard_daemon, load_guard_surface_daemon_client
 from ..daemon.client import GuardDaemonRequestError, GuardDaemonTransportError, GuardSurfaceDaemonClient
-from ..runtime import GuardSyncNotAvailableError, sync_receipts, sync_runtime_session
 from ..daemon.manager import clear_guard_daemon_state
+from ..runtime import GuardSyncNotAvailableError, sync_receipts, sync_runtime_session
 from ..store import GuardStore
 
 DEFAULT_GUARD_SYNC_URL = "https://hol.org/api/guard/receipts/sync"

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -652,7 +652,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     self.wfile.flush()
                 except BrokenPipeError:
                     return
-            time.sleep(0.25)
+            time.sleep(0.5)
 
     def _origin_is_allowed(self) -> bool:
         origin = self.headers.get("Origin")

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -10,6 +10,7 @@ import subprocess
 import urllib.error
 import urllib.parse
 import urllib.request
+import uuid
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
@@ -523,6 +524,41 @@ def sync_runtime_session(
     return summary
 
 
+def sync_runtime_session(store: GuardStore, *, session: dict[str, object]) -> dict[str, object]:
+    """Push one runtime session snapshot to the configured sync endpoint."""
+
+    credentials = store.get_sync_credentials()
+    if credentials is None:
+        raise RuntimeError("Guard is not logged in.")
+    timeout_seconds = _sync_http_timeout_seconds()
+
+    normalized_session = _normalize_runtime_session_payload(session)
+    request = urllib.request.Request(
+        _runtime_session_sync_url(str(credentials["sync_url"])),
+        data=json.dumps({"session": normalized_session}).encode("utf-8"),
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {credentials['token']}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        raise RuntimeError(_sync_http_error_message(error)) from error
+    except urllib.error.URLError as error:
+        raise RuntimeError(_sync_url_error_message(error)) from error
+
+    visible_items = payload.get("items")
+    return {
+        "runtime_session_id": normalized_session.get("sessionId", ""),
+        "runtime_session_synced_at": payload.get("generatedAt") or payload.get("generated_at"),
+        "runtime_sessions_visible": len(visible_items) if isinstance(visible_items, list) else 0,
+        "runtime_session_sync_pending": False,
+    }
+
+
 def sync_pain_signals(store: GuardStore) -> int:
     credentials = store.get_sync_credentials()
     if credentials is None:
@@ -550,7 +586,7 @@ def sync_pain_signals(store: GuardStore) -> int:
                 headers=_guard_sync_headers(str(credentials["token"])),
             )
             try:
-                with urllib.request.urlopen(request, timeout=10):
+                with urllib.request.urlopen(request, timeout=timeout_seconds):
                     pass
             except urllib.error.HTTPError as error:
                 if error.code == 404:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -524,41 +524,6 @@ def sync_runtime_session(
     return summary
 
 
-def sync_runtime_session(store: GuardStore, *, session: dict[str, object]) -> dict[str, object]:
-    """Push one runtime session snapshot to the configured sync endpoint."""
-
-    credentials = store.get_sync_credentials()
-    if credentials is None:
-        raise RuntimeError("Guard is not logged in.")
-    timeout_seconds = _sync_http_timeout_seconds()
-
-    normalized_session = _normalize_runtime_session_payload(session)
-    request = urllib.request.Request(
-        _runtime_session_sync_url(str(credentials["sync_url"])),
-        data=json.dumps({"session": normalized_session}).encode("utf-8"),
-        method="POST",
-        headers={
-            "Authorization": f"Bearer {credentials['token']}",
-            "Content-Type": "application/json",
-        },
-    )
-    try:
-        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
-            payload = json.loads(response.read().decode("utf-8"))
-    except urllib.error.HTTPError as error:
-        raise RuntimeError(_sync_http_error_message(error)) from error
-    except urllib.error.URLError as error:
-        raise RuntimeError(_sync_url_error_message(error)) from error
-
-    visible_items = payload.get("items")
-    return {
-        "runtime_session_id": normalized_session.get("sessionId", ""),
-        "runtime_session_synced_at": payload.get("generatedAt") or payload.get("generated_at"),
-        "runtime_sessions_visible": len(visible_items) if isinstance(visible_items, list) else 0,
-        "runtime_session_sync_pending": False,
-    }
-
-
 def sync_pain_signals(store: GuardStore) -> int:
     credentials = store.get_sync_credentials()
     if credentials is None:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -528,6 +528,7 @@ def sync_pain_signals(store: GuardStore) -> int:
     credentials = store.get_sync_credentials()
     if credentials is None:
         return 0
+    timeout_seconds = 10
     normalized_sync_url = _normalized_receipts_sync_url(str(credentials["sync_url"]))
     cursor_payload = store.get_sync_payload("pain_signal_cursor")
     last_event_id = _last_uploaded_event_id(cursor_payload)

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -10,7 +10,6 @@ import subprocess
 import urllib.error
 import urllib.parse
 import urllib.request
-import uuid
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -155,6 +155,7 @@ _SENSITIVE_SUFFIX_LABELS = {
     (".docker", "config.json"): "Docker client config",
     (".ssh", "id_rsa"): "SSH private key",
     (".ssh", "id_ed25519"): "SSH private key",
+    (".ssh", "id_ecdsa"): "SSH private key",
     (".ssh", "config"): "SSH client config",
 }
 _SENSITIVE_PATH_REASONS = {

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -479,6 +479,75 @@ def test_start_guard_runtime_session_falls_back_when_daemon_start_fails() -> Non
     assert runtime_session["surface"] == "cli"
 
 
+def test_guard_connect_recovers_from_legacy_daemon_state_without_auth_token(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    store = GuardStore(home_dir)
+
+    ensure_calls: list[Path] = []
+    clear_calls: list[Path] = []
+    load_attempts = {"count": 0}
+
+    class _DaemonClient:
+        daemon_url = "http://127.0.0.1:9999"
+
+        def create_connect_request(self, *, sync_url: str, allowed_origin: str) -> dict[str, object]:
+            return {
+                "request_id": "connect-legacy-recovery",
+                "pairing_secret": "pairing-secret",
+                "expires_at": "2026-04-16T00:05:00+00:00",
+            }
+
+    def _ensure_guard_daemon(path: Path) -> str:
+        ensure_calls.append(path)
+        return "http://127.0.0.1:9999"
+
+    def _clear_guard_daemon_state(path: Path) -> None:
+        clear_calls.append(path)
+
+    def _load_guard_surface_daemon_client(path: Path) -> _DaemonClient:
+        load_attempts["count"] += 1
+        if load_attempts["count"] == 1:
+            raise RuntimeError("Guard daemon state is incomplete.")
+        return _DaemonClient()
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.connect_flow.ensure_guard_daemon",
+        _ensure_guard_daemon,
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.connect_flow.clear_guard_daemon_state",
+        _clear_guard_daemon_state,
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.connect_flow.load_guard_surface_daemon_client",
+        _load_guard_surface_daemon_client,
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.connect_flow.wait_for_connect_transition",
+        lambda **kwargs: None,
+    )
+
+    payload = run_guard_connect_command(
+        guard_home=home_dir,
+        store=store,
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        connect_url="https://hol.org/guard/connect",
+        opener=lambda url: True,
+        wait_timeout_seconds=5,
+    )
+
+    assert payload["status"] == "waiting"
+    assert payload["milestone"] == "waiting_for_browser"
+    assert load_attempts["count"] == 2
+    assert len(clear_calls) == 1
+    assert len(ensure_calls) >= 2
+
+
 def test_guard_connect_recovers_when_browser_pairing_completed_before_cli_sync(
     tmp_path,
     monkeypatch,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -24,6 +24,7 @@ from codex_plugin_scanner.guard.cli.render import emit_guard_payload
 from codex_plugin_scanner.guard.config import GuardConfig, load_guard_config
 from codex_plugin_scanner.guard.consumer import artifact_hash, evaluate_detection
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
+from codex_plugin_scanner.guard.daemon import server as daemon_server_module
 from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
 from codex_plugin_scanner.guard.policy import decide_action
 from codex_plugin_scanner.guard.proxy import RemoteGuardProxy, StdioGuardProxy


### PR DESCRIPTION
## Summary\n- expand runtime prompt-sensitive path detection beyond narrow .env matching (aws/ssh/git-credentials/npmrc/pypirc/netrc)\n- add configurable HTTP timeout handling for Guard sync + runtime-session sync and better sync HTTP/URL error messages\n- harden guard runtime tests around daemon-backed approval center and ensure launch environment hook has a safe adapter default\n\n## Verification\n- PYTHONPATH=src uv run pytest tests/test_guard_launch_env.py tests/test_guard_runtime.py -q\n- PYTHONPATH=src uv run pytest tests/test_guard_launch_env.py::test_guard_run_blocks_aws_credentials_prompt tests/test_guard_runtime.py::TestGuardRuntime::test_sync_receipts_uses_configurable_http_timeout tests/test_guard_runtime.py::TestGuardRuntime::test_sync_runtime_session_uses_configurable_http_timeout -q\n- local live CLI checks against local portal token path:\n  - guard login --sync-url http://127.0.0.1:3001/api/guard/receipts/sync --token <portal principal token>\n  - guard sync --json\n  - guard hook (read_file ~/.aws/credentials) blocks with require-reapproval\n\n## Notes\n- commit is GPG-signed\n