### PR TITLE
fix: harden hol-guard sync reliability and token scoping

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import re
+import socket
 import subprocess
 import urllib.error
 import urllib.parse
@@ -74,6 +75,12 @@ _GUARD_BYPASS_PROMPT_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _GUARD_SYNC_USER_AGENT = f"hol-guard/{__version__}"
+_SYNC_HTTP_TIMEOUT_SECONDS = 20
+_SYNC_HTTP_RETRY_TIMEOUT_SECONDS = 120
+_RUNTIME_SYNC_TIMEOUT_SECONDS = 10
+_RUNTIME_SYNC_RETRY_TIMEOUT_SECONDS = 90
+_PAIN_SIGNAL_TIMEOUT_SECONDS = 10
+_PAIN_SIGNAL_RETRY_TIMEOUT_SECONDS = 90
 
 
 class GuardSyncNotConfiguredError(RuntimeError):
@@ -416,8 +423,11 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
         headers=_guard_sync_headers(str(credentials["token"])),
     )
     try:
-        with urllib.request.urlopen(request, timeout=20) as response:
-            payload = json.loads(response.read().decode("utf-8"))
+        payload = _urlopen_json_with_timeout_retry(
+            request=request,
+            timeout_seconds=_SYNC_HTTP_TIMEOUT_SECONDS,
+            retry_timeout_seconds=_SYNC_HTTP_RETRY_TIMEOUT_SECONDS,
+        )
     except urllib.error.HTTPError as error:
         if error.code == 403:
             _is_plan, _msg = _check_plan_restriction_403(error)
@@ -494,8 +504,11 @@ def sync_runtime_session(
         headers=_guard_sync_headers(str(credentials["token"])),
     )
     try:
-        with urllib.request.urlopen(request, timeout=10) as response:
-            payload = json.loads(response.read().decode("utf-8"))
+        payload = _urlopen_json_with_timeout_retry(
+            request=request,
+            timeout_seconds=_RUNTIME_SYNC_TIMEOUT_SECONDS,
+            retry_timeout_seconds=_RUNTIME_SYNC_RETRY_TIMEOUT_SECONDS,
+        )
     except urllib.error.HTTPError as error:
         if error.code == 404:
             recorded_at = _now()
@@ -527,7 +540,6 @@ def sync_pain_signals(store: GuardStore) -> int:
     credentials = store.get_sync_credentials()
     if credentials is None:
         return 0
-    timeout_seconds = 10
     normalized_sync_url = _normalized_receipts_sync_url(str(credentials["sync_url"]))
     cursor_payload = store.get_sync_payload("pain_signal_cursor")
     last_event_id = _last_uploaded_event_id(cursor_payload)
@@ -551,8 +563,11 @@ def sync_pain_signals(store: GuardStore) -> int:
                 headers=_guard_sync_headers(str(credentials["token"])),
             )
             try:
-                with urllib.request.urlopen(request, timeout=timeout_seconds):
-                    pass
+                _urlopen_with_timeout_retry(
+                    request=request,
+                    timeout_seconds=_PAIN_SIGNAL_TIMEOUT_SECONDS,
+                    retry_timeout_seconds=_PAIN_SIGNAL_RETRY_TIMEOUT_SECONDS,
+                )
             except urllib.error.HTTPError as error:
                 if error.code == 404:
                     current_event_id = last_processed_event_id
@@ -726,6 +741,50 @@ def _sync_url_error_message(error: urllib.error.URLError) -> str:
         if reason_text:
             return f"Guard sync failed: {reason_text}"
     return "Guard sync failed because the remote endpoint could not be reached."
+
+
+def _is_timeout_url_error(error: urllib.error.URLError) -> bool:
+    reason = getattr(error, "reason", None)
+    if isinstance(reason, TimeoutError | socket.timeout):
+        return True
+    if isinstance(reason, str) and "timed out" in reason.lower():
+        return True
+    return "timed out" in str(reason).lower()
+
+
+def _urlopen_json_with_timeout_retry(
+    *,
+    request: urllib.request.Request,
+    timeout_seconds: int,
+    retry_timeout_seconds: int,
+) -> dict[str, object]:
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.URLError as error:
+        if not _is_timeout_url_error(error):
+            raise
+        with urllib.request.urlopen(request, timeout=retry_timeout_seconds) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise RuntimeError("Invalid sync response")
+    return payload
+
+
+def _urlopen_with_timeout_retry(
+    *,
+    request: urllib.request.Request,
+    timeout_seconds: int,
+    retry_timeout_seconds: int,
+) -> None:
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds):
+            return
+    except urllib.error.URLError as error:
+        if not _is_timeout_url_error(error):
+            raise
+        with urllib.request.urlopen(request, timeout=retry_timeout_seconds):
+            return
 
 
 def _remote_harness(value: object, *, allow_wildcard: bool = True) -> str | None:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -435,7 +435,7 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
                 raise GuardSyncNotAvailableError(_msg) from error
             raise RuntimeError(_msg) from error
         raise RuntimeError(_sync_http_error_message(error)) from error
-    except urllib.error.URLError as error:
+    except OSError as error:
         raise RuntimeError(_sync_url_error_message(error)) from error
     now = _sync_timestamp(payload)
     advisories = payload.get("advisories")
@@ -523,6 +523,8 @@ def sync_runtime_session(
             store.set_sync_payload("runtime_session_summary", summary, recorded_at)
             return summary
         raise RuntimeError(_sync_http_error_message(error)) from error
+    except OSError as error:
+        raise RuntimeError(_sync_url_error_message(error)) from error
     if not isinstance(payload, dict):
         raise RuntimeError("Invalid sync response")
     synced_at = _sync_timestamp(payload)
@@ -578,7 +580,7 @@ def sync_pain_signals(store: GuardStore) -> int:
                     )
                     return uploaded_count
                 raise RuntimeError(_sync_http_error_message(error)) from error
-            except urllib.error.URLError as error:
+            except OSError as error:
                 raise RuntimeError(_sync_url_error_message(error)) from error
             uploaded_count += len(signal_items)
         current_event_id = last_processed_event_id
@@ -734,8 +736,8 @@ def _check_plan_restriction_403(
     return False, message_str
 
 
-def _sync_url_error_message(error: urllib.error.URLError) -> str:
-    reason = getattr(error, "reason", None)
+def _sync_url_error_message(error: OSError) -> str:
+    reason = getattr(error, "reason", error)
     if reason is not None:
         reason_text = str(reason).strip()
         if reason_text:
@@ -743,13 +745,16 @@ def _sync_url_error_message(error: urllib.error.URLError) -> str:
     return "Guard sync failed because the remote endpoint could not be reached."
 
 
-def _is_timeout_url_error(error: urllib.error.URLError) -> bool:
-    reason = getattr(error, "reason", None)
+def _is_timeout_error(error: OSError) -> bool:
+    if isinstance(error, TimeoutError | socket.timeout):
+        return True
+    reason = getattr(error, "reason", error)
     if isinstance(reason, TimeoutError | socket.timeout):
         return True
-    if isinstance(reason, str) and "timed out" in reason.lower():
-        return True
-    return "timed out" in str(reason).lower()
+    reason_text = str(reason).strip().lower()
+    if not reason_text:
+        return False
+    return reason_text == "timed out" or reason_text.endswith(" timed out") or "timed out" in reason_text
 
 
 def _urlopen_json_with_timeout_retry(
@@ -761,8 +766,8 @@ def _urlopen_json_with_timeout_retry(
     try:
         with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
             payload = json.loads(response.read().decode("utf-8"))
-    except urllib.error.URLError as error:
-        if not _is_timeout_url_error(error):
+    except OSError as error:
+        if not _is_timeout_error(error):
             raise
         with urllib.request.urlopen(request, timeout=retry_timeout_seconds) as response:
             payload = json.loads(response.read().decode("utf-8"))
@@ -780,8 +785,8 @@ def _urlopen_with_timeout_retry(
     try:
         with urllib.request.urlopen(request, timeout=timeout_seconds):
             return
-    except urllib.error.URLError as error:
-        if not _is_timeout_url_error(error):
+    except OSError as error:
+        if not _is_timeout_error(error):
             raise
         with urllib.request.urlopen(request, timeout=retry_timeout_seconds):
             return

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -316,8 +316,14 @@ class GuardStore:
         self.guard_home = guard_home
         self.guard_home.mkdir(parents=True, exist_ok=True)
         self._secret_store = _build_secret_store(self.guard_home)
+        self._sync_token_ref = self._build_sync_token_ref()
         self.path = self.guard_home / "guard.db"
         self._initialize()
+
+    def _build_sync_token_ref(self) -> str:
+        scoped_home = str(self.guard_home.expanduser().resolve())
+        scoped_hash = sha256(scoped_home.encode("utf-8")).hexdigest()[:16]
+        return f"{_SYNC_TOKEN_REF}:{scoped_hash}"
 
     @contextmanager
     def _connect(self) -> Iterator[sqlite3.Connection]:
@@ -1710,10 +1716,25 @@ class GuardStore:
             return None
         token_reference = payload.get("token_ref")
         if isinstance(token_reference, str) and token_reference:
-            token = self._secret_store.get_secret(token_reference)
-            if token is None:
-                return None
-            return {"sync_url": sync_url, "token": token}
+            expected_hash = payload.get(_SYNC_TOKEN_HASH_KEY)
+            expected_hash_value = expected_hash if isinstance(expected_hash, str) and expected_hash else None
+
+            reference_candidates = [token_reference]
+            if self._sync_token_ref not in reference_candidates:
+                reference_candidates.append(self._sync_token_ref)
+
+            for secret_ref in reference_candidates:
+                token = self._secret_store.get_secret(secret_ref)
+                if token is None:
+                    continue
+                if expected_hash_value is not None and _token_sha256(token) != expected_hash_value:
+                    continue
+                if secret_ref != token_reference:
+                    now = _now()
+                    with self._connect() as connection:
+                        self._set_sync_credentials_in_connection(connection, sync_url, token, now)
+                return {"sync_url": sync_url, "token": token}
+            return None
         legacy_token = payload.get("token")
         if isinstance(legacy_token, str) and legacy_token:
             now = _now()
@@ -1871,10 +1892,10 @@ class GuardStore:
         token: str,
         now: str,
     ) -> None:
-        self._secret_store.set_secret(_SYNC_TOKEN_REF, token)
+        self._secret_store.set_secret(self._sync_token_ref, token)
         payload = {
             "sync_url": sync_url,
-            "token_ref": _SYNC_TOKEN_REF,
+            "token_ref": self._sync_token_ref,
             _SYNC_TOKEN_HASH_KEY: _token_sha256(token),
         }
         previous_row = connection.execute(

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1719,9 +1719,9 @@ class GuardStore:
             expected_hash = payload.get(_SYNC_TOKEN_HASH_KEY)
             expected_hash_value = expected_hash if isinstance(expected_hash, str) and expected_hash else None
 
-            reference_candidates = [token_reference]
-            if self._sync_token_ref not in reference_candidates:
-                reference_candidates.append(self._sync_token_ref)
+            reference_candidates = [self._sync_token_ref]
+            if token_reference != self._sync_token_ref:
+                reference_candidates.append(token_reference)
 
             for secret_ref in reference_candidates:
                 token = self._secret_store.get_secret(secret_ref)
@@ -1729,7 +1729,7 @@ class GuardStore:
                     continue
                 if expected_hash_value is not None and _token_sha256(token) != expected_hash_value:
                     continue
-                if secret_ref != token_reference:
+                if token_reference != self._sync_token_ref:
                     now = _now()
                     with self._connect() as connection:
                         self._set_sync_credentials_in_connection(connection, sync_url, token, now)

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -24,7 +24,6 @@ from codex_plugin_scanner.guard.cli.render import emit_guard_payload
 from codex_plugin_scanner.guard.config import GuardConfig, load_guard_config
 from codex_plugin_scanner.guard.consumer import artifact_hash, evaluate_detection
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
-from codex_plugin_scanner.guard.daemon import server as daemon_server_module
 from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
 from codex_plugin_scanner.guard.policy import decide_action
 from codex_plugin_scanner.guard.proxy import RemoteGuardProxy, StdioGuardProxy
@@ -4413,7 +4412,7 @@ def test_guard_run_headless_waits_for_local_approval_and_resumes(tmp_path, capsy
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
-    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 5\n")
+    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 8\n")
 
     store = GuardStore(home_dir)
     monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
@@ -4423,8 +4422,10 @@ def test_guard_run_headless_waits_for_local_approval_and_resumes(tmp_path, capsy
         lambda *args, **kwargs: type("CompletedProcess", (), {"returncode": 0})(),
     )
 
+    stop_resolver = threading.Event()
+
     def resolve_pending() -> None:
-        for _ in range(100):
+        while not stop_resolver.is_set():
             pending = store.list_approval_requests(limit=10)
             if pending:
                 for request in pending:
@@ -4438,7 +4439,7 @@ def test_guard_run_headless_waits_for_local_approval_and_resumes(tmp_path, capsy
                     )
                 if not store.list_approval_requests(limit=10):
                     return
-            threading.Event().wait(0.05)
+            threading.Event().wait(0.03)
 
     worker = threading.Thread(target=resolve_pending, daemon=True)
     worker.start()
@@ -4454,6 +4455,8 @@ def test_guard_run_headless_waits_for_local_approval_and_resumes(tmp_path, capsy
             str(workspace_dir),
         ]
     )
+    stop_resolver.set()
+    worker.join(timeout=1.0)
     output = capsys.readouterr().out
 
     assert rc == 0
@@ -5385,3 +5388,90 @@ def test_guard_daemon_serves_health_and_receipt_state(tmp_path):
     assert health_payload["ok"] is True
     assert health_payload["receipts"] == 1
     assert receipts_payload["items"][0]["artifact_id"] == "codex:workspace_skill"
+
+
+def test_sync_receipts_retries_once_after_timeout(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "guard-live-token",
+        "2026-04-19T00:00:00+00:00",
+    )
+    timeouts: list[int] = []
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps({"syncedAt": "2026-04-19T00:00:10+00:00", "receiptsStored": 0}).encode("utf-8")
+
+    def _fake_urlopen(request, timeout):
+        timeouts.append(timeout)
+        if len(timeouts) == 1:
+            raise urllib.error.URLError(TimeoutError("timed out"))
+        return _Response()
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+
+    payload = guard_runner_module.sync_receipts(store)
+
+    assert timeouts == [20, 120]
+    assert payload["synced_at"] == "2026-04-19T00:00:10+00:00"
+
+
+def test_sync_runtime_session_retries_once_after_timeout(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "guard-live-token",
+        "2026-04-19T00:00:00+00:00",
+    )
+    timeouts: list[int] = []
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "generatedAt": "2026-04-19T00:00:10+00:00",
+                    "items": [{"sessionId": "session-1"}],
+                }
+            ).encode("utf-8")
+
+    def _fake_urlopen(request, timeout):
+        timeouts.append(timeout)
+        if len(timeouts) == 1:
+            raise urllib.error.URLError(TimeoutError("timed out"))
+        return _Response()
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+
+    payload = guard_runner_module.sync_runtime_session(
+        store,
+        session={
+            "session_id": "session-1",
+            "harness": "hermes",
+            "surface": "agent-sdk",
+            "status": "active",
+            "client_name": "Hermes",
+            "client_title": "Hermes Agent",
+            "client_version": "1.0.0",
+            "workspace": "prod-e2e",
+            "capabilities": ["chat"],
+            "started_at": "2026-04-19T00:00:00+00:00",
+            "updated_at": "2026-04-19T00:00:00+00:00",
+            "operations": [],
+        },
+    )
+
+    assert timeouts == [10, 90]
+    assert payload["runtime_session_id"] == "session-1"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -5475,3 +5475,60 @@ def test_sync_runtime_session_retries_once_after_timeout(tmp_path, monkeypatch):
 
     assert timeouts == [10, 90]
     assert payload["runtime_session_id"] == "session-1"
+
+
+def test_sync_runtime_session_retries_once_after_read_timeout(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "guard-live-token",
+        "2026-04-19T00:00:00+00:00",
+    )
+    timeouts: list[int] = []
+
+    class _Response:
+        def __init__(self, should_timeout: bool) -> None:
+            self._should_timeout = should_timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            if self._should_timeout:
+                raise TimeoutError("timed out")
+            return json.dumps(
+                {
+                    "generatedAt": "2026-04-19T00:00:10+00:00",
+                    "items": [{"sessionId": "session-read-timeout"}],
+                }
+            ).encode("utf-8")
+
+    def _fake_urlopen(request, timeout):
+        timeouts.append(timeout)
+        return _Response(should_timeout=len(timeouts) == 1)
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+
+    payload = guard_runner_module.sync_runtime_session(
+        store,
+        session={
+            "session_id": "session-read-timeout",
+            "harness": "hermes",
+            "surface": "agent-sdk",
+            "status": "active",
+            "client_name": "Hermes",
+            "client_title": "Hermes Agent",
+            "client_version": "1.0.0",
+            "workspace": "prod-e2e",
+            "capabilities": ["chat"],
+            "started_at": "2026-04-19T00:00:00+00:00",
+            "updated_at": "2026-04-19T00:00:00+00:00",
+            "operations": [],
+        },
+    )
+
+    assert timeouts == [10, 90]
+    assert payload["runtime_session_id"] == "session-read-timeout"

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -22,7 +22,8 @@ def test_sync_credentials_are_not_persisted_in_plaintext_sqlite(tmp_path):
     assert row is not None
     payload = json.loads(str(row[0]))
     assert payload["sync_url"] == "https://hol.org/api/guard/receipts/sync"
-    assert payload.get("token_ref") == "guard-cloud-token"
+    assert isinstance(payload.get("token_ref"), str)
+    assert str(payload["token_ref"]).startswith("guard-cloud-token:")
     assert isinstance(payload.get("token_sha256"), str)
     assert "token" not in payload
     assert store.get_sync_credentials() == {
@@ -62,8 +63,36 @@ def test_legacy_plaintext_sync_payload_is_migrated_on_read(tmp_path):
 
     payload = json.loads(str(row[0])) if row is not None else {}
     assert "token" not in payload
-    assert payload.get("token_ref") == "guard-cloud-token"
+    assert isinstance(payload.get("token_ref"), str)
+    assert str(payload["token_ref"]).startswith("guard-cloud-token:")
     assert isinstance(payload.get("token_sha256"), str)
+
+
+def test_sync_credentials_are_scoped_per_guard_home(tmp_path):
+    home_a = tmp_path / "guard-home-a"
+    home_b = tmp_path / "guard-home-b"
+    store_a = GuardStore(home_a)
+    store_b = GuardStore(home_b)
+
+    store_a.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "token-a",
+        "2026-04-19T00:00:00+00:00",
+    )
+    store_b.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "token-b",
+        "2026-04-19T00:00:05+00:00",
+    )
+
+    assert store_a.get_sync_credentials() == {
+        "sync_url": "https://hol.org/api/guard/receipts/sync",
+        "token": "token-a",
+    }
+    assert store_b.get_sync_credentials() == {
+        "sync_url": "https://hol.org/api/guard/receipts/sync",
+        "token": "token-b",
+    }
 
 
 def test_sync_token_rotation_with_same_url_clears_cloud_sync_payloads(tmp_path):

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
 
@@ -93,6 +94,43 @@ def test_sync_credentials_are_scoped_per_guard_home(tmp_path):
         "sync_url": "https://hol.org/api/guard/receipts/sync",
         "token": "token-b",
     }
+
+
+def test_legacy_token_reference_is_migrated_to_scoped_reference(tmp_path):
+    store = GuardStore(tmp_path / "guard-home")
+    legacy_token = "legacy-token-ref"
+    legacy_ref = "guard-cloud-token"
+    store._secret_store.set_secret(legacy_ref, legacy_token)
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            """
+            insert into sync_state (state_key, payload_json, updated_at)
+            values ('credentials', ?, ?)
+            on conflict(state_key) do update set payload_json = excluded.payload_json, updated_at = excluded.updated_at
+            """,
+            (
+                json.dumps(
+                    {
+                        "sync_url": "https://hol.org/api/guard/receipts/sync",
+                        "token_ref": legacy_ref,
+                        "token_sha256": hashlib.sha256(legacy_token.encode("utf-8")).hexdigest(),
+                    }
+                ),
+                "2026-04-19T00:00:00+00:00",
+            ),
+        )
+
+    credentials = store.get_sync_credentials()
+    assert credentials == {
+        "sync_url": "https://hol.org/api/guard/receipts/sync",
+        "token": legacy_token,
+    }
+    assert store._secret_store.get_secret(store._sync_token_ref) == legacy_token
+
+    with sqlite3.connect(store.path) as connection:
+        row = connection.execute("select payload_json from sync_state where state_key = 'credentials'").fetchone()
+    payload = json.loads(str(row[0])) if row is not None else {}
+    assert payload["token_ref"] == store._sync_token_ref
 
 
 def test_sync_token_rotation_with_same_url_clears_cloud_sync_payloads(tmp_path):


### PR DESCRIPTION
## Summary
- retry Guard cloud sync calls once on timeout with a longer fallback timeout
- scope local sync token secret refs per  to prevent cross-home token collisions
- harden the approval wait test to remove flakiness
- add retry regression tests and scoped-token store regression coverage

## Verification
- 
no tests ran in 0.00s
- E902 No such file or directory (os error 2)
--> src:1:1

E902 No such file or directory (os error 2)
--> tests/test_guard_runtime.py:1:1

E902 No such file or directory (os error 2)
--> tests/test_guard_store_migrations.py:1:1

Found 3 errors.
- local E2E: 
- local E2E:  (received synced payload with receipts/inventory counts)
