### PR TITLE
fix: honor stored guard approvals on hook retries

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1101,15 +1101,16 @@ def run_guard_command(args: argparse.Namespace) -> int:
             runtime_artifact_hash = artifact_hash(runtime_artifact)
             artifact_id = runtime_artifact.artifact_id
             artifact_name = runtime_artifact.name
+            stored_policy_action = store.resolve_policy(
+                args.harness,
+                artifact_id,
+                runtime_artifact_hash,
+                str(runtime_workspace) if runtime_workspace else None,
+            )
             policy_action = _coalesce_string(
                 getattr(args, "policy_action", None),
+                stored_policy_action,
                 payload.get("policy_action"),
-                store.resolve_policy(
-                    args.harness,
-                    artifact_id,
-                    runtime_artifact_hash,
-                    str(runtime_workspace) if runtime_workspace else None,
-                ),
             )
             if policy_action not in VALID_GUARD_ACTIONS:
                 policy_action = SAFE_CHANGED_HASH_ACTION
@@ -1292,13 +1293,13 @@ def run_guard_command(args: argparse.Namespace) -> int:
         )
         policy_action = _coalesce_string(
             getattr(args, "policy_action", None),
-            payload.get("policy_action"),
             store.resolve_policy(
                 args.harness,
                 artifact_id,
                 str(payload.get("artifact_hash")) if isinstance(payload.get("artifact_hash"), str) else None,
-                str(workspace) if workspace else None,
+                str(runtime_workspace) if runtime_workspace else None,
             ),
+            payload.get("policy_action"),
             config.default_action,
         )
         if policy_action not in VALID_GUARD_ACTIONS:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1291,14 +1291,15 @@ def run_guard_command(args: argparse.Namespace) -> int:
             payload.get("tool_name"),
             artifact_id,
         )
+        stored_policy_action = store.resolve_policy(
+            args.harness,
+            artifact_id,
+            str(payload.get("artifact_hash")) if isinstance(payload.get("artifact_hash"), str) else None,
+            str(runtime_workspace) if runtime_workspace else None,
+        )
         policy_action = _coalesce_string(
             getattr(args, "policy_action", None),
-            store.resolve_policy(
-                args.harness,
-                artifact_id,
-                str(payload.get("artifact_hash")) if isinstance(payload.get("artifact_hash"), str) else None,
-                str(runtime_workspace) if runtime_workspace else None,
-            ),
+            stored_policy_action,
             payload.get("policy_action"),
             config.default_action,
         )

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -5730,6 +5730,107 @@ def test_guard_hook_blocks_sensitive_runtime_file_read_until_exactly_approved(tm
     assert third_output["policy_action"] == "require-reapproval"
 
 
+def test_guard_hook_keeps_artifact_approval_for_same_sensitive_tool_action_retry(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    blocked_event = {
+        "hookName": "preToolUse",
+        "toolName": "bash",
+        "toolArgs": {"command": "echo MALICIOUS > dangerous-marker.json"},
+        "policyAction": "block",
+        "sourceScope": "project",
+        "cwd": str(workspace_dir),
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(blocked_event)))
+
+    first_rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+            "--json",
+        ]
+    )
+    first_output = json.loads(capsys.readouterr().out)
+    approval_request = first_output["approval_requests"][0]
+
+    approval_rc = main(
+        [
+            "guard",
+            "approvals",
+            "approve",
+            str(approval_request["request_id"]),
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(blocked_event)))
+    second_rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+            "--json",
+        ]
+    )
+    second_output = json.loads(capsys.readouterr().out)
+
+    different_event = {
+        "hookName": "preToolUse",
+        "toolName": "bash",
+        "toolArgs": {"command": "echo MALICIOUS > danger-two.json"},
+        "policyAction": "block",
+        "sourceScope": "project",
+        "cwd": str(workspace_dir),
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(different_event)))
+    third_rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "copilot",
+            "--json",
+        ]
+    )
+    third_output = json.loads(capsys.readouterr().out)
+
+    assert first_rc == 1
+    assert first_output["policy_action"] == "block"
+    assert first_output["artifact_type"] == "tool_action_request"
+    assert "destructive shell command" in first_output["risk_summary"].lower()
+    assert approval_request["recommended_scope"] == "artifact"
+    assert approval_rc == 0
+    assert second_rc == 0
+    assert second_output["policy_action"] == "allow"
+    assert second_output.get("approval_requests") in (None, [])
+    assert third_rc == 1
+    assert third_output["policy_action"] == "block"
+    assert len(third_output["approval_requests"]) == 1
+
+
 def test_guard_hook_allows_non_sensitive_read_file_requests(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"


### PR DESCRIPTION
## Summary
- honor stored Guard approvals before repeated hook payload `policyAction` values for runtime tool-action artifacts
- use `runtime_workspace` when resolving generic hook fallback policy so lookup matches the actual hook context
- add a regression test covering approve-once, retry-same-command-allowed, different-command-still-blocked

## Verification
- `uv run --extra dev python -m pytest tests/test_guard_runtime.py -k 'uses_payload_cwd_for_global_copilot_hooks or blocks_sensitive_runtime_file_read_until_exactly_approved or same_sensitive_tool_action_retry or blocks_require_reapproval' -q`
- `uv run --extra dev ruff check src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_runtime.py`
- `uv run --extra dev python -m build`
- `uv run --extra dev python /Users/michaelkantor/.copilot/session-state/e32ee1bb-57f3-46df-aef9-2a6faee7772b/files/guard-bug-repro/repro.py`

## Root cause
`guard hook` persisted artifact approvals correctly, but on retry it still trusted the incoming hook payload's `policyAction` ahead of the stored Guard policy. For repeated native tool actions, the harness kept sending `block`, so the stored approval never won and the same command got re-blocked.
