### PR TITLE
fix: improve guard update and command recovery

### DIFF
--- a/src/codex_plugin_scanner/argparse_utils.py
+++ b/src/codex_plugin_scanner/argparse_utils.py
@@ -66,7 +66,7 @@ def _rewrite_invalid_choice_message(parser: argparse.ArgumentParser, message: st
     if not visible_choices:
         return message
     rewritten = f"invalid choice: '{match.group(1)}' (choose from {', '.join(visible_choices)})"
-    return f"{message[:match.start()]}{rewritten}{message[match.end():]}"
+    return f"{message[: match.start()]}{rewritten}{message[match.end() :]}"
 
 
 def _visible_subparser_choices(parser: argparse.ArgumentParser) -> list[str]:

--- a/src/codex_plugin_scanner/argparse_utils.py
+++ b/src/codex_plugin_scanner/argparse_utils.py
@@ -27,7 +27,9 @@ def should_default_to_scan_target(token: str, *, known_commands: set[str]) -> bo
     candidate = Path(token)
     if candidate.exists() or token in {".", ".."}:
         return True
-    return "/" in token or "\\" in token
+    if "/" in token or "\\" in token:
+        return True
+    return not _looks_like_command_typo(token, known_commands)
 
 
 def _error_hint(message: str, prog: str) -> str | None:
@@ -79,6 +81,10 @@ def _guard_help_command(prog: str) -> str:
     if prog.endswith(" guard") or _is_guard_prog(prog):
         return f"{prog} --help"
     return f"{prog} guard --help"
+
+
+def _looks_like_command_typo(token: str, known_commands: set[str]) -> bool:
+    return bool(difflib.get_close_matches(token, sorted(known_commands), n=1, cutoff=0.55))
 
 
 def _is_guard_prog(prog: str) -> bool:

--- a/src/codex_plugin_scanner/argparse_utils.py
+++ b/src/codex_plugin_scanner/argparse_utils.py
@@ -1,0 +1,96 @@
+"""Shared argparse helpers for friendly CLI errors."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import re
+from pathlib import Path
+
+_INVALID_CHOICE_PATTERN = re.compile(r"invalid choice: '([^']+)' \(choose from ([^)]+)\)")
+
+
+class FriendlyArgumentParser(argparse.ArgumentParser):
+    """Augment argparse errors with command recovery hints."""
+
+    def error(self, message: str) -> None:
+        message = _rewrite_invalid_choice_message(self, message)
+        hint = _error_hint(message, self.prog)
+        if hint:
+            message = f"{message}\n{hint}"
+        super().error(message)
+
+
+def should_default_to_scan_target(token: str, *, known_commands: set[str]) -> bool:
+    if not token or token.startswith("-") or token in known_commands:
+        return False
+    candidate = Path(token)
+    if candidate.exists() or token in {".", ".."}:
+        return True
+    return "/" in token or "\\" in token
+
+
+def _error_hint(message: str, prog: str) -> str | None:
+    invalid_choice = _invalid_choice_hint(message)
+    if invalid_choice is not None:
+        return invalid_choice
+    if "the following arguments are required:" in message:
+        if _is_guard_prog(prog):
+            return f"Run `{_guard_help_command(prog)}` to inspect available Guard commands."
+        return f"Run `{prog} --help` to inspect available commands."
+    if "the following arguments are required: guard_command" in message:
+        return f"Run `{_guard_help_command(prog)}` to inspect available Guard commands."
+    if "the following arguments are required: command" in message:
+        return f"Run `{prog} --help` to inspect available commands."
+    return None
+
+
+def _invalid_choice_hint(message: str) -> str | None:
+    match = _INVALID_CHOICE_PATTERN.search(message)
+    if match is None:
+        return None
+    attempted = match.group(1)
+    raw_choices = [item.strip().strip("'") for item in match.group(2).split(",")]
+    choices = [item for item in raw_choices if item]
+    closest = difflib.get_close_matches(attempted, choices, n=1, cutoff=0.55)
+    if not closest:
+        return None
+    return f"Did you mean `{closest[0]}`?"
+
+
+def _rewrite_invalid_choice_message(parser: argparse.ArgumentParser, message: str) -> str:
+    match = _INVALID_CHOICE_PATTERN.search(message)
+    if match is None:
+        return message
+    visible_choices = _visible_subparser_choices(parser)
+    if not visible_choices:
+        return message
+    rewritten = f"invalid choice: '{match.group(1)}' (choose from {', '.join(visible_choices)})"
+    return f"{message[:match.start()]}{rewritten}{message[match.end():]}"
+
+
+def _visible_subparser_choices(parser: argparse.ArgumentParser) -> list[str]:
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            visible_actions = getattr(action, "_choices_actions", [])
+            if visible_actions:
+                return [str(item.dest) for item in visible_actions]
+            return list(action.choices)
+    return []
+
+
+def _guard_help_command(prog: str) -> str:
+    if prog.endswith(" guard"):
+        return f"{prog} --help"
+    return f"{prog} guard --help"
+
+
+def _is_guard_prog(prog: str) -> bool:
+    if prog.endswith(" guard"):
+        return True
+    first_token = prog.split()[0] if prog else ""
+    normalized = Path(first_token).stem.lower()
+    return normalized in {"hol-guard", "plugin-guard"}
+
+
+__all__ = ["FriendlyArgumentParser", "should_default_to_scan_target"]

--- a/src/codex_plugin_scanner/argparse_utils.py
+++ b/src/codex_plugin_scanner/argparse_utils.py
@@ -38,10 +38,6 @@ def _error_hint(message: str, prog: str) -> str | None:
         if _is_guard_prog(prog):
             return f"Run `{_guard_help_command(prog)}` to inspect available Guard commands."
         return f"Run `{prog} --help` to inspect available commands."
-    if "the following arguments are required: guard_command" in message:
-        return f"Run `{_guard_help_command(prog)}` to inspect available Guard commands."
-    if "the following arguments are required: command" in message:
-        return f"Run `{prog} --help` to inspect available commands."
     return None
 
 
@@ -50,7 +46,7 @@ def _invalid_choice_hint(message: str) -> str | None:
     if match is None:
         return None
     attempted = match.group(1)
-    raw_choices = [item.strip().strip("'") for item in match.group(2).split(",")]
+    raw_choices = [item.strip("' ") for item in match.group(2).split(",")]
     choices = [item for item in raw_choices if item]
     closest = difflib.get_close_matches(attempted, choices, n=1, cutoff=0.55)
     if not closest:
@@ -80,7 +76,7 @@ def _visible_subparser_choices(parser: argparse.ArgumentParser) -> list[str]:
 
 
 def _guard_help_command(prog: str) -> str:
-    if prog.endswith(" guard"):
+    if prog.endswith(" guard") or _is_guard_prog(prog):
         return f"{prog} --help"
     return f"{prog} guard --help"
 

--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -10,6 +10,7 @@ import zipfile
 from dataclasses import asdict, replace
 from pathlib import Path
 
+from .argparse_utils import FriendlyArgumentParser, should_default_to_scan_target
 from .cli_ui import (
     build_cli_epilog,
     build_plain_text,
@@ -77,7 +78,7 @@ def _is_scanner_program(program_name: str) -> bool:
 
 def _build_parser(program_name: str, *, program_mode: str) -> argparse.ArgumentParser:
     if program_mode == "guard":
-        parser = argparse.ArgumentParser(
+        parser = FriendlyArgumentParser(
             prog=program_name,
             description="Protect local harnesses before tools run.",
             epilog=build_cli_epilog(program_name, include_guard=False),
@@ -91,7 +92,7 @@ def _build_parser(program_name: str, *, program_mode: str) -> argparse.ArgumentP
     if program_mode == "combined":
         description = "Run HOL Guard locally or scan plugin ecosystems for CI and publish readiness."
 
-    parser = argparse.ArgumentParser(
+    parser = FriendlyArgumentParser(
         prog=program_name,
         description=description,
         epilog=build_cli_epilog(program_name, include_guard=program_mode == "combined"),
@@ -99,7 +100,7 @@ def _build_parser(program_name: str, *, program_mode: str) -> argparse.ArgumentP
     )
     parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     parser.add_argument("--list-ecosystems", action="store_true", help="List supported plugin ecosystems and exit")
-    subparsers = parser.add_subparsers(dest="command")
+    subparsers = parser.add_subparsers(dest="command", parser_class=FriendlyArgumentParser)
 
     scan_parser = subparsers.add_parser(
         "scan",
@@ -214,6 +215,8 @@ def _resolve_legacy_args(argv: list[str] | None, *, program_mode: str) -> list[s
     if program_mode == "combined":
         known_commands.add("guard")
     if argv[0] in known_commands:
+        return argv
+    if not should_default_to_scan_target(argv[0], known_commands=known_commands):
         return argv
     return ["scan", *argv]
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -14,6 +14,7 @@ import webbrowser
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from ...argparse_utils import FriendlyArgumentParser
 from ...models import ScanOptions
 from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
@@ -124,6 +125,7 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     guard_subparsers = guard_parser.add_subparsers(
         dest="guard_command",
         required=True,
+        parser_class=FriendlyArgumentParser,
         metavar=(
             "{start,status,bootstrap,detect,install,update,uninstall,run,protect,preflight,scan,diff,receipts,inventory,abom,"
             "approvals,explain,allow,deny,policies,exceptions,advisories,events,doctor,connect,login,sync,device,bridge}"
@@ -314,7 +316,11 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     device_parser = guard_subparsers.add_parser("device", help="Manage local Guard installation identity")
     _add_guard_common_args(device_parser)
     device_parser.add_argument("--json", action="store_true")
-    device_subparsers = device_parser.add_subparsers(dest="device_command", required=True)
+    device_subparsers = device_parser.add_subparsers(
+        dest="device_command",
+        required=True,
+        parser_class=FriendlyArgumentParser,
+    )
 
     device_show_parser = device_subparsers.add_parser("show", help="Show local installation ID and label")
     device_show_parser.add_argument("--json", action="store_true")
@@ -324,7 +330,11 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
 
     device_label_parser = device_subparsers.add_parser("label", help="Manage local device label")
     device_label_parser.add_argument("--json", action="store_true")
-    device_label_subparsers = device_label_parser.add_subparsers(dest="device_label_command", required=True)
+    device_label_subparsers = device_label_parser.add_subparsers(
+        dest="device_label_command",
+        required=True,
+        parser_class=FriendlyArgumentParser,
+    )
     device_label_set_parser = device_label_subparsers.add_parser("set", help="Set local device label")
     device_label_set_parser.add_argument("label")
     device_label_set_parser.add_argument("--json", action="store_true")

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -551,7 +551,7 @@ def _render_update(console: Console, payload: dict[str, object]) -> None:
     error = str(payload.get("error") or "").strip()
     if notes:
         console.print(Panel("\n".join(f"• {note}" for note in notes), title="Notes", border_style="blue"))
-    if status == "updated" and stdout and stdout != str(payload.get("message") or "").strip():
+    if status in {"updated", "failed"} and stdout and stdout != str(payload.get("message") or "").strip():
         console.print(Panel(stdout, title="stdout", border_style="green"))
     if status == "failed" and stderr:
         console.print(Panel(stderr, title="stderr", border_style="yellow"))

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -532,15 +532,28 @@ def _render_update(console: Console, payload: dict[str, object]) -> None:
         body.add_row("Resulting version", str(payload.get("resulting_version")))
     if payload.get("editable_install") is not None:
         body.add_row("Editable install", _bool_label(bool(payload.get("editable_install"))))
+    if payload.get("changed") is not None:
+        body.add_row("Changed", _bool_label(bool(payload.get("changed"))))
+    if payload.get("message"):
+        body.add_row("Message", str(payload.get("message")))
     status = str(payload.get("status") or "unknown")
-    border_style = "green" if status in {"planned", "updated"} else "red"
+    border_style = {
+        "planned": "blue",
+        "current": "blue",
+        "updated": "green",
+        "skipped": "yellow",
+        "failed": "red",
+    }.get(status, "red")
     console.print(Panel(body, title=f"Guard update: {status}", border_style=border_style))
+    notes = _coerce_string_list(payload.get("notes"))
     stdout = str(payload.get("stdout") or "").strip()
     stderr = str(payload.get("stderr") or "").strip()
     error = str(payload.get("error") or "").strip()
-    if stdout:
+    if notes:
+        console.print(Panel("\n".join(f"• {note}" for note in notes), title="Notes", border_style="blue"))
+    if status == "updated" and stdout and stdout != str(payload.get("message") or "").strip():
         console.print(Panel(stdout, title="stdout", border_style="green"))
-    if stderr:
+    if status == "failed" and stderr:
         console.print(Panel(stderr, title="stderr", border_style="yellow"))
     if error:
         console.print(Panel(error, title="error", border_style="red"))

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -9,6 +9,13 @@ import subprocess
 import sys
 from pathlib import Path
 
+_ALREADY_CURRENT_HINTS = (
+    "already at latest version",
+    "already up-to-date",
+    "already installed",
+    "requirement already satisfied",
+)
+
 
 def run_guard_update(*, dry_run: bool) -> tuple[dict[str, object], int]:
     current_version = _current_version()
@@ -27,12 +34,15 @@ def run_guard_update(*, dry_run: bool) -> tuple[dict[str, object], int]:
         payload["editable_install"] = is_editable
         if is_editable:
             payload["status"] = "skipped"
+            payload["changed"] = False
             payload["error"] = (
                 "Automatic update is disabled for editable installs. Re-run your local install workflow instead."
             )
             return payload, 0
     if dry_run:
         payload["status"] = "planned"
+        payload["changed"] = False
+        payload["message"] = "Review the planned installer command before updating."
         return payload, 0
     try:
         result = subprocess.run(
@@ -43,15 +53,77 @@ def run_guard_update(*, dry_run: bool) -> tuple[dict[str, object], int]:
         )
     except OSError as error:
         payload["status"] = "failed"
+        payload["changed"] = False
         payload["error"] = str(error)
         return payload, 1
-    payload["status"] = "updated" if result.returncode == 0 else "failed"
-    payload["stdout"] = result.stdout.strip()
-    payload["stderr"] = result.stderr.strip()
+    payload["stdout"] = _normalize_output_text(result.stdout)
+    payload["stderr"] = _normalize_output_text(result.stderr)
     payload["return_code"] = result.returncode
     importlib.invalidate_caches()
     payload["resulting_version"] = _current_version_from_subprocess()
+    if result.returncode != 0:
+        payload["status"] = "failed"
+        payload["changed"] = False
+        payload["message"] = "HOL Guard update failed."
+        return payload, 1
+    payload["status"] = _success_status(payload)
+    payload["changed"] = payload["status"] == "updated"
+    payload["message"] = _success_message(
+        status=str(payload["status"]),
+        current_version=current_version,
+        resulting_version=str(payload.get("resulting_version") or ""),
+    )
+    notes = _success_notes(payload)
+    if notes:
+        payload["notes"] = notes
     return payload, 0 if result.returncode == 0 else 1
+
+
+def _normalize_output_text(value: str) -> str:
+    return value.strip()
+
+
+def _output_lines(value: str) -> list[str]:
+    return [line.strip() for line in value.splitlines() if line.strip()]
+
+
+def _success_status(payload: dict[str, object]) -> str:
+    current_version = str(payload.get("current_version") or "").strip()
+    resulting_version = str(payload.get("resulting_version") or "").strip()
+    if (
+        current_version
+        and resulting_version
+        and current_version != "unknown"
+        and resulting_version != "unknown"
+        and current_version != resulting_version
+    ):
+        return "updated"
+    output_text = "\n".join(
+        part for part in [str(payload.get("stdout") or "").lower(), str(payload.get("stderr") or "").lower()] if part
+    )
+    if any(hint in output_text for hint in _ALREADY_CURRENT_HINTS):
+        return "current"
+    return "updated"
+
+
+def _success_message(*, status: str, current_version: str, resulting_version: str) -> str:
+    if status == "current":
+        return "HOL Guard is already current."
+    if (
+        current_version
+        and resulting_version
+        and current_version != "unknown"
+        and resulting_version != "unknown"
+        and current_version != resulting_version
+    ):
+        return f"Updated HOL Guard from {current_version} to {resulting_version}."
+    return "HOL Guard update completed successfully."
+
+
+def _success_notes(payload: dict[str, object]) -> list[str]:
+    if str(payload.get("status") or "") not in {"current", "updated"}:
+        return []
+    return _output_lines(str(payload.get("stderr") or ""))
 
 
 def _current_version() -> str:

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -76,7 +76,7 @@ def run_guard_update(*, dry_run: bool) -> tuple[dict[str, object], int]:
     notes = _success_notes(payload)
     if notes:
         payload["notes"] = notes
-    return payload, 0 if result.returncode == 0 else 1
+    return payload, 0
 
 
 def _normalize_output_text(value: str) -> str:

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -12,8 +12,6 @@ from pathlib import Path
 _ALREADY_CURRENT_HINTS = (
     "already at latest version",
     "already up-to-date",
-    "already installed",
-    "requirement already satisfied",
 )
 
 
@@ -98,10 +96,10 @@ def _success_status(payload: dict[str, object]) -> str:
         and current_version != resulting_version
     ):
         return "updated"
-    output_text = "\n".join(
-        part for part in [str(payload.get("stdout") or "").lower(), str(payload.get("stderr") or "").lower()] if part
-    )
+    output_text = str(payload.get("stdout") or "").lower()
     if any(hint in output_text for hint in _ALREADY_CURRENT_HINTS):
+        return "current"
+    if "requirement already satisfied: hol-guard" in output_text or "hol-guard is already installed" in output_text:
         return "current"
     return "updated"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,8 @@ import zipfile
 from dataclasses import replace
 from pathlib import Path
 
+import pytest
+
 from codex_plugin_scanner import cli as cli_module
 from codex_plugin_scanner.cli import format_json, format_text, main
 from codex_plugin_scanner.models import IntegrationResult
@@ -159,6 +161,13 @@ class TestMain:
     def test_returns_1_for_nonexistent_dir(self):
         rc = main(["/nonexistent/path/that/does/not/exist"])
         assert rc == 1
+
+    def test_invalid_top_level_command_suggests_closest_match(self, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            main(["verfy"])
+
+        assert exc_info.value.code == 2
+        assert "Did you mean `verify`?" in capsys.readouterr().err
 
     def test_returns_0_for_file_not_dir(self):
         rc = main([str(FIXTURES / "good-plugin" / "README.md")])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -169,6 +169,14 @@ class TestMain:
         assert exc_info.value.code == 2
         assert "Did you mean `verify`?" in capsys.readouterr().err
 
+    def test_missing_relative_scan_target_keeps_legacy_scan_fallback(self, capsys):
+        rc = main(["missing-plugin"])
+        error_output = capsys.readouterr().err
+
+        assert rc == 1
+        assert "missing-plugin" in error_output
+        assert "is not a directory." in error_output
+
     def test_returns_0_for_file_not_dir(self):
         rc = main([str(FIXTURES / "good-plugin" / "README.md")])
         assert rc == 1

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -2952,6 +2952,37 @@ args = ["workspace-skill.js", "--changed"]
         assert output["stdout"].startswith("hol-guard is already at latest version 2.0.36")
         assert output["stderr"] == "upgrading shared libraries...\nupgrading hol-guard..."
 
+    def test_guard_update_treats_first_install_as_updated_when_only_dependencies_are_current(self, monkeypatch, capsys):
+        commands: list[list[str]] = []
+
+        def fake_run(command: list[str], **_: object):
+            commands.append(command)
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=(
+                    "Requirement already satisfied: pip in /mock/python/site-packages\n"
+                    "Successfully installed hol-guard-2.0.36"
+                ),
+                stderr="",
+            )
+
+        monkeypatch.setattr(guard_update_commands_module.subprocess, "run", fake_run)
+        monkeypatch.setattr(guard_update_commands_module.sys, "prefix", "/opt/guard-venv")
+        monkeypatch.setattr(guard_update_commands_module.sys, "executable", "/opt/guard-venv/bin/python")
+        monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
+        monkeypatch.setattr(guard_update_commands_module, "_current_version", lambda: "unknown")
+        monkeypatch.setattr(guard_update_commands_module, "_current_version_from_subprocess", lambda: "2.0.36")
+
+        rc = main(["guard", "update", "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert commands == [["/opt/guard-venv/bin/python", "-m", "pip", "install", "--upgrade", "hol-guard"]]
+        assert output["status"] == "updated"
+        assert output["changed"] is True
+        assert output["message"] == "HOL Guard update completed successfully."
+
     def test_guard_update_dry_run_emits_planned_command(self, monkeypatch, capsys):
         monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
 

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 import threading
 import urllib.parse
 import urllib.request
@@ -244,6 +245,15 @@ class TestGuardCli:
         assert "Did you mean `update`?" in error_output
         assert "hook" not in error_output
         assert "daemon" not in error_output
+
+    def test_root_guard_missing_subcommand_points_to_root_help(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["hol-guard"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            main([])
+
+        assert exc_info.value.code == 2
+        assert "Run `hol-guard --help` to inspect available Guard commands." in capsys.readouterr().err
 
     def test_guard_detect_reports_supported_harnesses(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -229,7 +229,21 @@ class TestGuardCli:
             main(["guard"])
 
         assert exc_info.value.code == 2
-        assert "the following arguments are required" in capsys.readouterr().err
+        error_output = capsys.readouterr().err
+
+        assert "the following arguments are required" in error_output
+        assert "guard --help" in error_output
+
+    def test_guard_invalid_subcommand_suggests_closest_match(self, capsys):
+        with pytest.raises(SystemExit) as exc_info:
+            main(["guard", "updte"])
+
+        assert exc_info.value.code == 2
+        error_output = capsys.readouterr().err
+
+        assert "Did you mean `update`?" in error_output
+        assert "hook" not in error_output
+        assert "daemon" not in error_output
 
     def test_guard_detect_reports_supported_harnesses(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -2895,6 +2909,39 @@ args = ["workspace-skill.js", "--changed"]
         assert commands == [["pipx", "upgrade", "hol-guard"]]
         assert output["status"] == "updated"
 
+    def test_guard_update_marks_already_current_pipx_runs_as_current(self, monkeypatch, capsys):
+        commands: list[list[str]] = []
+
+        def fake_run(command: list[str], **_: object):
+            commands.append(command)
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=(
+                    "hol-guard is already at latest version 2.0.36 "
+                    "(location: /Users/michaelkantor/.local/pipx/venvs/hol-guard)"
+                ),
+                stderr="upgrading shared libraries...\nupgrading hol-guard...\n",
+            )
+
+        monkeypatch.setattr(guard_update_commands_module.subprocess, "run", fake_run)
+        monkeypatch.setattr(guard_update_commands_module.sys, "prefix", "/mock-home/.local/pipx/venvs/hol-guard")
+        monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
+        monkeypatch.setattr(guard_update_commands_module, "_current_version", lambda: "2.0.36")
+        monkeypatch.setattr(guard_update_commands_module, "_current_version_from_subprocess", lambda: "2.0.36")
+
+        rc = main(["guard", "update", "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["installer"] == "pipx"
+        assert commands == [["pipx", "upgrade", "hol-guard"]]
+        assert output["status"] == "current"
+        assert output["message"] == "HOL Guard is already current."
+        assert output["notes"] == ["upgrading shared libraries...", "upgrading hol-guard..."]
+        assert output["stdout"].startswith("hol-guard is already at latest version 2.0.36")
+        assert output["stderr"] == "upgrading shared libraries...\nupgrading hol-guard..."
+
     def test_guard_update_dry_run_emits_planned_command(self, monkeypatch, capsys):
         monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
 
@@ -2920,6 +2967,33 @@ args = ["workspace-skill.js", "--changed"]
         assert output["status"] == "skipped"
         assert output["editable_install"] is True
         assert "disabled for editable installs" in output["error"]
+
+    def test_guard_update_human_output_uses_notes_instead_of_stderr_for_current(self, capsys):
+        emit_guard_payload(
+            "update",
+            {
+                "current_version": "2.0.36",
+                "installer": "pipx",
+                "command": ["pipx", "upgrade", "hol-guard"],
+                "dry_run": False,
+                "resulting_version": "2.0.36",
+                "status": "current",
+                "message": "HOL Guard is already current.",
+                "notes": ["upgrading shared libraries...", "upgrading hol-guard..."],
+                "stdout": "hol-guard is already at latest version 2.0.36",
+                "stderr": "upgrading shared libraries...\nupgrading hol-guard...",
+            },
+            False,
+        )
+
+        output = capsys.readouterr().out
+
+        assert "Guard update: current" in output
+        assert "HOL Guard is already current." in output
+        assert "Notes" in output
+        assert "upgrading shared libraries..." in output
+        assert "stdout" not in output
+        assert "stderr" not in output
 
     def test_guard_uninstall_auto_detects_managed_harnesses(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -3005,6 +3005,29 @@ args = ["workspace-skill.js", "--changed"]
         assert "stdout" not in output
         assert "stderr" not in output
 
+    def test_guard_update_failed_output_keeps_stdout_details(self, capsys):
+        emit_guard_payload(
+            "update",
+            {
+                "current_version": "2.0.36",
+                "installer": "pipx",
+                "command": ["pipx", "upgrade", "hol-guard"],
+                "dry_run": False,
+                "status": "failed",
+                "message": "HOL Guard update failed.",
+                "stdout": "pipx could not upgrade hol-guard in the current environment",
+                "stderr": "",
+                "error": "",
+            },
+            False,
+        )
+
+        output = capsys.readouterr().out
+
+        assert "Guard update: failed" in output
+        assert "stdout" in output
+        assert "pipx could not upgrade hol-guard in the current environment" in output
+
     def test_guard_uninstall_auto_detects_managed_harnesses(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"


### PR DESCRIPTION
## Summary
- classify `guard update` no-op runs as already current and render installer progress as notes instead of a warning-looking stderr panel
- add shared argparse recovery helpers so mistyped scanner and Guard commands suggest the closest public command
- keep bare path scan behavior intact while preventing command typos from silently falling through to scan

## Verification
- pytest tests/test_cli.py
- pytest tests/test_guard_cli.py -k "guard_update or guard_requires_a_subcommand or invalid_subcommand_suggests or guard_detect_reports_supported_harnesses"
- ruff check src/codex_plugin_scanner/argparse_utils.py src/codex_plugin_scanner/cli.py src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/cli/update_commands.py src/codex_plugin_scanner/guard/cli/render.py tests/test_cli.py tests/test_guard_cli.py
- python -m build