### PR TITLE
fix: polish guard setup summaries

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -110,14 +110,7 @@ def _render_status(console: Console, payload: dict[str, object]) -> None:
 def _render_bootstrap(console: Console, payload: dict[str, object]) -> None:
     harness = payload.get("recommended_harness") or "none"
     bootstrap_install = payload.get("bootstrap_install")
-    install_summary = "not changed"
-    if isinstance(bootstrap_install, dict):
-        if bool(bootstrap_install.get("installed")):
-            install_summary = f"installed for {bootstrap_install.get('harness', harness)}"
-        elif bootstrap_install.get("reason") == "already_managed":
-            install_summary = f"already managing {bootstrap_install.get('harness', harness)}"
-        else:
-            install_summary = str(bootstrap_install.get("reason") or install_summary)
+    install_summary = _bootstrap_install_summary(bootstrap_install, fallback_harness=str(harness))
     body = Table.grid(padding=(0, 1))
     body.add_row("Recommended harness", str(harness))
     body.add_row("Approval center", str(payload.get("approval_center_url") or "not running"))
@@ -128,6 +121,24 @@ def _render_bootstrap(console: Console, payload: dict[str, object]) -> None:
         body.add_row("Protect alias", str(alias.get("snippet") or "not configured"))
     console.print(Panel(body, title="Guard bootstrap", border_style="cyan"))
     console.print(_build_steps_panel(_coerce_dict_list(payload.get("next_steps"))))
+
+
+def _bootstrap_install_summary(bootstrap_install: object, *, fallback_harness: str) -> str:
+    if not isinstance(bootstrap_install, dict):
+        return "not changed"
+    harness = str(bootstrap_install.get("harness") or fallback_harness)
+    reason = str(bootstrap_install.get("reason") or "")
+    if bool(bootstrap_install.get("installed")):
+        if reason == "repaired_managed_install":
+            return f"repaired Guard install for {harness}"
+        return f"installed for {harness}"
+    if reason == "already_managed":
+        return f"already managing {harness}"
+    if reason == "skipped_by_flag":
+        return "Install skipped for now"
+    if reason == "no_harness_detected":
+        return "No supported harness detected yet"
+    return reason.replace("_", " ").strip() or "not changed"
 
 
 def _render_doctor(console: Console, payload: dict[str, object]) -> None:
@@ -872,16 +883,30 @@ def _build_product_table(harnesses: list[dict[str, object]]) -> Table:
     table.add_column("Managed")
     table.add_column("Artifacts", justify="right")
     table.add_column("Review", justify="right")
-    table.add_column("Next step")
+    table.add_column("Recommended action")
     for harness in harnesses:
         table.add_row(
             str(harness.get("harness", "unknown")),
             _bool_label(bool(harness.get("managed"))),
             str(harness.get("artifact_count", 0)),
             str(harness.get("review_count", 0)),
-            str(harness.get("next_action", "install")),
+            _next_action_label(harness),
         )
     return table
+
+
+def _next_action_label(harness: dict[str, object]) -> str:
+    next_action = str(harness.get("next_action") or "install")
+    review_count = _coerce_int(harness.get("review_count"))
+    if next_action == "install-harness":
+        return "Install harness first"
+    if next_action == "install":
+        return "Install Guard"
+    if next_action == "review":
+        return f"Review {review_count} change{'s' if review_count != 1 else ''}"
+    if next_action == "run":
+        return "Run through Guard"
+    return next_action.replace("-", " ").strip() or "Check status"
 
 
 def _build_steps_panel(steps: list[dict[str, object]]) -> Panel:

--- a/tests/test_guard_render.py
+++ b/tests/test_guard_render.py
@@ -117,3 +117,105 @@ def test_guard_connect_render_clarifies_browser_approval_wait(capsys) -> None:
     assert "Browser paired" in output
     assert "Browser approval pending" in output
     assert "Waiting for browser approval" in output
+
+
+def test_guard_status_render_rewrites_internal_next_action_labels(capsys) -> None:
+    emit_guard_payload(
+        "status",
+        {
+            "managed_harnesses": 1,
+            "receipt_count": 3,
+            "pending_approvals": 1,
+            "sync_configured": False,
+            "cloud_state": "local_only",
+            "cloud_state_label": "Local only",
+            "cloud_state_detail": "Guard is protecting this machine locally.",
+            "dashboard_url": "https://hol.org/guard",
+            "connect_url": "https://hol.org/guard/connect",
+            "advisory_count": 0,
+            "harnesses": [
+                {
+                    "harness": "codex",
+                    "managed": False,
+                    "artifact_count": 2,
+                    "review_count": 0,
+                    "next_action": "install",
+                },
+                {
+                    "harness": "claude-code",
+                    "managed": True,
+                    "artifact_count": 4,
+                    "review_count": 2,
+                    "next_action": "review",
+                },
+                {
+                    "harness": "copilot",
+                    "managed": True,
+                    "artifact_count": 1,
+                    "review_count": 0,
+                    "next_action": "run",
+                },
+                {
+                    "harness": "cursor",
+                    "managed": False,
+                    "artifact_count": 0,
+                    "review_count": 0,
+                    "next_action": "install-harness",
+                },
+            ],
+        },
+        False,
+    )
+
+    output = capsys.readouterr().out
+    assert "Recommended action" in output
+    assert "Install Guard" in output
+    assert "Review 2 changes" in output
+    assert "Run through Guard" in output
+    assert "Install harness first" in output
+
+
+def test_guard_bootstrap_render_rewrites_skip_reason_labels(capsys) -> None:
+    emit_guard_payload(
+        "bootstrap",
+        {
+            "recommended_harness": "codex",
+            "approval_center_url": "http://127.0.0.1:4781",
+            "approval_center_reachable": True,
+            "bootstrap_install": {
+                "installed": False,
+                "harness": "codex",
+                "reason": "skipped_by_flag",
+            },
+            "shell_alias": {
+                "snippet": "alias guardp='hol-guard protect'",
+            },
+            "next_steps": [],
+        },
+        False,
+    )
+
+    output = capsys.readouterr().out
+    assert "Install skipped for now" in output
+    assert "skipped_by_flag" not in output
+
+
+def test_guard_bootstrap_render_rewrites_missing_harness_reason(capsys) -> None:
+    emit_guard_payload(
+        "bootstrap",
+        {
+            "recommended_harness": None,
+            "approval_center_url": "http://127.0.0.1:4781",
+            "approval_center_reachable": True,
+            "bootstrap_install": {
+                "installed": False,
+                "reason": "no_harness_detected",
+            },
+            "next_steps": [],
+        },
+        False,
+    )
+
+    output = capsys.readouterr().out
+    assert "No supported harness detected yet" in output
+    assert "no_harness_detected" not in output


### PR DESCRIPTION
## Summary
Polish guard setup and bootstrap summaries so setup flow output uses product-facing language.

## Changes Made
- setup-flow summary tables now use user-facing recommended-action labels
- bootstrap renderer now rewrites internal reason codes like skipped_by_flag/no_harness_detected into product copy

## Testing
- validation run: tests/test_guard_render.py, tests/test_guard_bootstrap.py, tests/test_guard_product_flow.py
- validation run: targeted setup/connect coverage from tests/test_guard_cli.py
- validation run: focused ruff check/format on touched files
- validation run: python -m build

## Related
- Branch: cli-dx-setup-flows-phase2