### PR TITLE
fix: surface guard install and sync details

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -29,6 +29,12 @@ except ModuleNotFoundError:
     Text = Any  # type: ignore[misc,assignment]
 
 
+_MODE_ACRONYMS = frozenset({"mcp", "api", "cli"})
+_KNOWN_MANAGED_INSTALL_MODES = {
+    "codex-mcp-proxy": "Codex MCP proxy",
+}
+
+
 def emit_guard_payload(command: str, payload: dict[str, object], as_json: bool) -> None:
     """Render Guard payloads as JSON or human-friendly rich output."""
 
@@ -537,12 +543,15 @@ def _render_sync(console: Console, payload: dict[str, object]) -> None:
     body.add_row("Inventory tracked", str(payload.get("inventory_tracked", payload.get("inventory")) or 0))
     body.add_row("Receipts stored", str(payload.get("receipts_stored") or 0))
     body.add_row("Advisories stored", str(payload.get("advisories_stored") or 0))
-    if payload.get("remote_policies_stored") is not None:
-        body.add_row("Remote policies", str(payload.get("remote_policies_stored") or 0))
-    if payload.get("exceptions_stored") is not None:
-        body.add_row("Exceptions stored", str(payload.get("exceptions_stored") or 0))
-    if payload.get("pain_signals_uploaded") is not None:
-        body.add_row("Pain signals uploaded", str(payload.get("pain_signals_uploaded") or 0))
+    remote_policies_stored = payload.get("remote_policies_stored")
+    exceptions_stored = payload.get("exceptions_stored")
+    pain_signals_uploaded = payload.get("pain_signals_uploaded")
+    if remote_policies_stored is not None:
+        body.add_row("Remote policies", str(remote_policies_stored or 0))
+    if exceptions_stored is not None:
+        body.add_row("Exceptions stored", str(exceptions_stored or 0))
+    if pain_signals_uploaded is not None:
+        body.add_row("Pain signals uploaded", str(pain_signals_uploaded or 0))
     console.print(Panel(body, title="Guard sync complete", border_style="green"))
 
 
@@ -553,16 +562,13 @@ def _managed_install_state_text(managed_install: dict[str, object]) -> str:
 def _managed_install_mode_text(mode: object) -> str | None:
     if not isinstance(mode, str) or not mode.strip():
         return None
-    known_modes = {
-        "codex-mcp-proxy": "Codex MCP proxy",
-    }
     normalized = mode.strip().lower()
-    if normalized in known_modes:
-        return known_modes[normalized]
+    if normalized in _KNOWN_MANAGED_INSTALL_MODES:
+        return _KNOWN_MANAGED_INSTALL_MODES[normalized]
     words = []
     for part in normalized.split("-"):
         lowered = part.lower()
-        if lowered in {"mcp", "api", "cli"}:
+        if lowered in _MODE_ACRONYMS:
             words.append(lowered.upper())
         else:
             words.append(lowered.capitalize())
@@ -570,9 +576,11 @@ def _managed_install_mode_text(mode: object) -> str | None:
 
 
 def _managed_install_notes(managed_install: dict[str, object], manifest: object) -> list[str]:
-    notes = _coerce_string_list(manifest.get("notes")) if isinstance(manifest, dict) else []
     if not isinstance(manifest, dict):
-        return notes
+        if not bool(managed_install.get("active")):
+            return ["Guard removed the managed wrapper configuration for this harness."]
+        return []
+    notes = _coerce_string_list(manifest.get("notes"))
     skipped_servers = _coerce_string_list(manifest.get("skipped_servers"))
     if skipped_servers:
         notes.append(f"Skipped existing server entries: {', '.join(skipped_servers)}")

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -418,13 +418,22 @@ def _render_managed_install(console: Console, payload: dict[str, object]) -> Non
 
 def _render_single_managed_install(console: Console, managed_install: dict[str, object]) -> None:
     manifest = managed_install.get("manifest")
-    notes = _coerce_string_list(manifest.get("notes")) if isinstance(manifest, dict) else []
+    notes = _managed_install_notes(managed_install, manifest)
     body = Table.grid(padding=(0, 1))
     body.add_row("Harness", f"[bold]{managed_install.get('harness', 'unknown')}[/bold]")
-    body.add_row("Active", _bool_label(bool(managed_install.get("active"))))
+    body.add_row("Protection", _managed_install_state_text(managed_install))
     body.add_row("Workspace", str(managed_install.get("workspace") or "current shell"))
     if isinstance(manifest, dict):
+        mode = _managed_install_mode_text(manifest.get("mode"))
+        if mode is not None:
+            body.add_row("Mode", mode)
         body.add_row("Config", str(manifest.get("config_path") or "no config changed"))
+        managed_servers = _coerce_string_list(manifest.get("managed_servers"))
+        if managed_servers:
+            body.add_row("Managed servers", str(len(managed_servers)))
+        skipped_servers = _coerce_string_list(manifest.get("skipped_servers"))
+        if skipped_servers:
+            body.add_row("Skipped servers", str(len(skipped_servers)))
         if manifest.get("shim_command"):
             body.add_row("Launcher", str(manifest.get("shim_command")))
     console.print(Panel(body, title="Guard install state", border_style="cyan"))
@@ -528,7 +537,51 @@ def _render_sync(console: Console, payload: dict[str, object]) -> None:
     body.add_row("Inventory tracked", str(payload.get("inventory_tracked", payload.get("inventory")) or 0))
     body.add_row("Receipts stored", str(payload.get("receipts_stored") or 0))
     body.add_row("Advisories stored", str(payload.get("advisories_stored") or 0))
+    if payload.get("remote_policies_stored") is not None:
+        body.add_row("Remote policies", str(payload.get("remote_policies_stored") or 0))
+    if payload.get("exceptions_stored") is not None:
+        body.add_row("Exceptions stored", str(payload.get("exceptions_stored") or 0))
+    if payload.get("pain_signals_uploaded") is not None:
+        body.add_row("Pain signals uploaded", str(payload.get("pain_signals_uploaded") or 0))
     console.print(Panel(body, title="Guard sync complete", border_style="green"))
+
+
+def _managed_install_state_text(managed_install: dict[str, object]) -> str:
+    return "Installed" if bool(managed_install.get("active")) else "Removed"
+
+
+def _managed_install_mode_text(mode: object) -> str | None:
+    if not isinstance(mode, str) or not mode.strip():
+        return None
+    known_modes = {
+        "codex-mcp-proxy": "Codex MCP proxy",
+    }
+    normalized = mode.strip().lower()
+    if normalized in known_modes:
+        return known_modes[normalized]
+    words = []
+    for part in normalized.split("-"):
+        lowered = part.lower()
+        if lowered in {"mcp", "api", "cli"}:
+            words.append(lowered.upper())
+        else:
+            words.append(lowered.capitalize())
+    return " ".join(words)
+
+
+def _managed_install_notes(managed_install: dict[str, object], manifest: object) -> list[str]:
+    notes = _coerce_string_list(manifest.get("notes")) if isinstance(manifest, dict) else []
+    if not isinstance(manifest, dict):
+        return notes
+    skipped_servers = _coerce_string_list(manifest.get("skipped_servers"))
+    if skipped_servers:
+        notes.append(f"Skipped existing server entries: {', '.join(skipped_servers)}")
+    source_config_paths = _coerce_string_list(manifest.get("source_config_paths"))
+    if source_config_paths:
+        notes.append(f"Source configs: {', '.join(source_config_paths)}")
+    if not notes and not bool(managed_install.get("active")):
+        notes.append("Guard removed the managed wrapper configuration for this harness.")
+    return notes
 
 
 def _render_update(console: Console, payload: dict[str, object]) -> None:

--- a/tests/test_guard_render.py
+++ b/tests/test_guard_render.py
@@ -275,3 +275,40 @@ def test_guard_sync_render_surfaces_policy_and_alert_details(capsys) -> None:
     assert "5" in output
     assert "2" in output
     assert "1" in output
+
+
+def test_guard_uninstall_render_adds_removal_note_without_manifest(capsys) -> None:
+    emit_guard_payload(
+        "uninstall",
+        {
+            "managed_install": {
+                "harness": "codex",
+                "active": False,
+                "workspace": "/repo",
+            },
+        },
+        False,
+    )
+
+    output = capsys.readouterr().out
+    assert "Removed" in output
+    assert "Guard removed the managed wrapper configuration for this harness." in output
+
+
+def test_guard_install_render_skips_notes_when_manifest_is_missing_and_active(capsys) -> None:
+    emit_guard_payload(
+        "install",
+        {
+            "managed_install": {
+                "harness": "codex",
+                "active": True,
+                "workspace": "/repo",
+            },
+        },
+        False,
+    )
+
+    output = capsys.readouterr().out
+    assert "Installed" in output
+    assert "Guard removed the managed wrapper configuration for this harness." not in output
+    assert "Notes" not in output

--- a/tests/test_guard_render.py
+++ b/tests/test_guard_render.py
@@ -219,3 +219,59 @@ def test_guard_bootstrap_render_rewrites_missing_harness_reason(capsys) -> None:
     output = capsys.readouterr().out
     assert "No supported harness detected yet" in output
     assert "no_harness_detected" not in output
+
+
+def test_guard_install_render_surfaces_proxy_details_and_skipped_servers(capsys) -> None:
+    emit_guard_payload(
+        "install",
+        {
+            "managed_install": {
+                "harness": "codex",
+                "active": True,
+                "workspace": "/repo",
+                "manifest": {
+                    "mode": "codex-mcp-proxy",
+                    "config_path": "/repo/.codex/config.toml",
+                    "managed_servers": ["global_tools", "workspace_skill"],
+                    "skipped_servers": ["existing_global"],
+                    "notes": ["Guard rewrote the workspace config with proxy entries."],
+                },
+            },
+        },
+        False,
+    )
+
+    output = capsys.readouterr().out
+    assert "Protection" in output
+    assert "Installed" in output
+    assert "Mode" in output
+    assert "Codex MCP proxy" in output
+    assert "Managed servers" in output
+    assert "2" in output
+    assert "Skipped servers" in output
+    assert "existing_global" in output
+
+
+def test_guard_sync_render_surfaces_policy_and_alert_details(capsys) -> None:
+    emit_guard_payload(
+        "sync",
+        {
+            "synced_at": "2026-04-20T19:00:00Z",
+            "receipts": 3,
+            "inventory_tracked": 4,
+            "receipts_stored": 2,
+            "advisories_stored": 1,
+            "exceptions_stored": 2,
+            "remote_policies_stored": 5,
+            "pain_signals_uploaded": 1,
+        },
+        False,
+    )
+
+    output = capsys.readouterr().out
+    assert "Remote policies" in output
+    assert "Exceptions stored" in output
+    assert "Pain signals uploaded" in output
+    assert "5" in output
+    assert "2" in output
+    assert "1" in output

--- a/tests/test_guard_render.py
+++ b/tests/test_guard_render.py
@@ -295,6 +295,27 @@ def test_guard_uninstall_render_adds_removal_note_without_manifest(capsys) -> No
     assert "Guard removed the managed wrapper configuration for this harness." in output
 
 
+def test_guard_uninstall_render_adds_removal_note_without_manifest_notes(capsys) -> None:
+    emit_guard_payload(
+        "uninstall",
+        {
+            "managed_install": {
+                "harness": "codex",
+                "active": False,
+                "workspace": "/repo",
+                "manifest": {
+                    "mode": "codex-mcp-proxy",
+                },
+            },
+        },
+        False,
+    )
+
+    output = capsys.readouterr().out
+    assert "Removed" in output
+    assert "Guard removed the managed wrapper configuration for this harness." in output
+
+
 def test_guard_install_render_skips_notes_when_manifest_is_missing_and_active(capsys) -> None:
     emit_guard_payload(
         "install",


### PR DESCRIPTION
## Summary
Tighten the human-readable Guard renderer for the install/sync slice.

## Changes Made
- guard install human output now surfaces protection state, proxy mode, managed-server counts, and skipped-server notes
- guard sync human output now shows remote policy, exception, and pain-signal counters already present in the payload

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_guard_render.py`
- `PYTHONPATH=src python3 -m pytest tests/test_guard_codex_install.py`
- `PYTHONPATH=src python3 -m pytest tests/test_guard_cli.py -k sync`
- `python3 -m ruff check src/codex_plugin_scanner/guard/cli/render.py tests/test_guard_render.py`
- `python3 -m ruff format --check src/codex_plugin_scanner/guard/cli/render.py tests/test_guard_render.py`
- `python3 -m build`