### PR TITLE
fix: improve batch guard install summaries

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -42,7 +42,7 @@ def emit_guard_payload(command: str, payload: dict[str, object], as_json: bool) 
         print(json.dumps(payload, indent=2))
         return
 
-    console = Console(file=sys.stdout, soft_wrap=True, width=120)
+    console = Console(file=sys.stdout, soft_wrap=True)
     renderer = _RENDERERS.get(command, _render_fallback)
     renderer(console, payload)
 
@@ -415,7 +415,7 @@ def _render_managed_install(console: Console, payload: dict[str, object]) -> Non
     console.print(_managed_install_batch_table(managed_installs))
     notes = _managed_install_batch_notes(managed_installs)
     if notes:
-        console.print(Panel("\n".join(f"• {note}" for note in notes), title="Notes", border_style="blue"))
+        console.print(_notes_panel(notes))
 
 
 def _render_single_managed_install(console: Console, managed_install: dict[str, object]) -> None:
@@ -440,7 +440,7 @@ def _render_single_managed_install(console: Console, managed_install: dict[str, 
             body.add_row("Launcher", str(manifest.get("shim_command")))
     console.print(Panel(body, title="Guard install state", border_style="cyan"))
     if notes:
-        console.print(Panel("\n".join(f"• {note}" for note in notes), title="Notes", border_style="blue"))
+        console.print(_notes_panel(notes))
 
 
 def _managed_install_batch_summary(payload: dict[str, object], managed_installs: list[dict[str, object]]) -> Table:
@@ -455,12 +455,12 @@ def _managed_install_batch_summary(payload: dict[str, object], managed_installs:
 
 
 def _managed_install_batch_table(managed_installs: list[dict[str, object]]) -> Table:
-    table = Table(box=box.SIMPLE_HEAVY, show_header=True)
-    table.add_column("Harness", style="bold")
-    table.add_column("Protection")
-    table.add_column("Mode")
-    table.add_column("Managed servers", justify="right")
-    table.add_column("Config")
+    table = Table(box=box.SIMPLE_HEAVY, show_header=True, expand=True)
+    table.add_column("Harness", style="bold", no_wrap=True)
+    table.add_column("State", no_wrap=True)
+    table.add_column("Mode", overflow="fold")
+    table.add_column("Servers", justify="right", no_wrap=True)
+    table.add_column("Config", overflow="fold")
     for item in managed_installs:
         manifest = item.get("manifest")
         mode = _managed_install_mode_text(manifest.get("mode")) if isinstance(manifest, dict) else None
@@ -471,7 +471,7 @@ def _managed_install_batch_table(managed_installs: list[dict[str, object]]) -> T
             _managed_install_state_text(item),
             mode or "—",
             str(len(managed_servers)) if managed_servers else "—",
-            str(config_path or "no config changed"),
+            _short_path(config_path) if config_path else "no config changed",
         )
     return table
 
@@ -484,6 +484,14 @@ def _managed_install_batch_notes(managed_installs: list[dict[str, object]]) -> l
         for note in _managed_install_notes(item, manifest):
             notes.append(f"{harness}: {note}")
     return notes
+
+
+def _notes_panel(notes: list[str]) -> Panel:
+    return Panel(
+        Text("\n".join(f"• {note}" for note in notes), overflow="fold", no_wrap=False),
+        title="Notes",
+        border_style="blue",
+    )
 
 
 def _render_decision(console: Console, payload: dict[str, object]) -> None:

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -42,7 +42,7 @@ def emit_guard_payload(command: str, payload: dict[str, object], as_json: bool) 
         print(json.dumps(payload, indent=2))
         return
 
-    console = Console(file=sys.stdout, soft_wrap=True)
+    console = Console(file=sys.stdout, soft_wrap=True, width=120)
     renderer = _RENDERERS.get(command, _render_fallback)
     renderer(console, payload)
 
@@ -405,21 +405,17 @@ def _render_managed_install(console: Console, payload: dict[str, object]) -> Non
     if not managed_installs:
         _render_fallback(console, payload)
         return
-    summary = Table(title="Guard managed harnesses")
-    summary.add_column("Harness", style="bold")
-    summary.add_column("Active")
-    summary.add_column("Workspace")
-    summary.add_column("Config")
-    for item in managed_installs:
-        manifest = item.get("manifest")
-        config_path = manifest.get("config_path") if isinstance(manifest, dict) else None
-        summary.add_row(
-            str(item.get("harness") or "unknown"),
-            _bool_label(bool(item.get("active"))),
-            str(item.get("workspace") or "current shell"),
-            str(config_path or "no config changed"),
+    console.print(
+        Panel(
+            _managed_install_batch_summary(payload, managed_installs),
+            title="Guard managed harnesses",
+            border_style="cyan",
         )
-    console.print(summary)
+    )
+    console.print(_managed_install_batch_table(managed_installs))
+    notes = _managed_install_batch_notes(managed_installs)
+    if notes:
+        console.print(Panel("\n".join(f"• {note}" for note in notes), title="Notes", border_style="blue"))
 
 
 def _render_single_managed_install(console: Console, managed_install: dict[str, object]) -> None:
@@ -445,6 +441,49 @@ def _render_single_managed_install(console: Console, managed_install: dict[str, 
     console.print(Panel(body, title="Guard install state", border_style="cyan"))
     if notes:
         console.print(Panel("\n".join(f"• {note}" for note in notes), title="Notes", border_style="blue"))
+
+
+def _managed_install_batch_summary(payload: dict[str, object], managed_installs: list[dict[str, object]]) -> Table:
+    installed_count = sum(1 for item in managed_installs if bool(item.get("active")))
+    removed_count = len(managed_installs) - installed_count
+    body = Table.grid(padding=(0, 1))
+    body.add_row("Harnesses", str(len(managed_installs)))
+    if payload.get("auto_detected") is not None:
+        body.add_row("Selection", "Auto-detected" if bool(payload.get("auto_detected")) else "Requested")
+    body.add_row("Protection", f"{installed_count} installed • {removed_count} removed")
+    return body
+
+
+def _managed_install_batch_table(managed_installs: list[dict[str, object]]) -> Table:
+    table = Table(box=box.SIMPLE_HEAVY, show_header=True)
+    table.add_column("Harness", style="bold")
+    table.add_column("Protection")
+    table.add_column("Mode")
+    table.add_column("Managed servers", justify="right")
+    table.add_column("Config")
+    for item in managed_installs:
+        manifest = item.get("manifest")
+        mode = _managed_install_mode_text(manifest.get("mode")) if isinstance(manifest, dict) else None
+        managed_servers = _coerce_string_list(manifest.get("managed_servers")) if isinstance(manifest, dict) else []
+        config_path = manifest.get("config_path") if isinstance(manifest, dict) else None
+        table.add_row(
+            str(item.get("harness") or "unknown"),
+            _managed_install_state_text(item),
+            mode or "—",
+            str(len(managed_servers)) if managed_servers else "—",
+            str(config_path or "no config changed"),
+        )
+    return table
+
+
+def _managed_install_batch_notes(managed_installs: list[dict[str, object]]) -> list[str]:
+    notes: list[str] = []
+    for item in managed_installs:
+        harness = str(item.get("harness") or "unknown")
+        manifest = item.get("manifest")
+        for note in _managed_install_notes(item, manifest):
+            notes.append(f"{harness}: {note}")
+    return notes
 
 
 def _render_decision(console: Console, payload: dict[str, object]) -> None:

--- a/tests/test_guard_render.py
+++ b/tests/test_guard_render.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from codex_plugin_scanner.guard.cli.render import emit_guard_payload
 
 
+def _normalize_render_output(output: str) -> str:
+    return " ".join(output.split())
+
+
 def test_guard_connect_render_clarifies_paid_plan_pending_state(capsys) -> None:
     emit_guard_payload(
         "connect",
@@ -19,7 +23,7 @@ def test_guard_connect_render_clarifies_paid_plan_pending_state(capsys) -> None:
         False,
     )
 
-    output = capsys.readouterr().out
+    output = _normalize_render_output(capsys.readouterr().out)
     assert "Browser paired" in output
     assert "Connection" in output
     assert "This device is protected locally" in output
@@ -42,7 +46,7 @@ def test_guard_connect_render_defaults_sync_not_available_to_upgrade_guidance(ca
         False,
     )
 
-    output = capsys.readouterr().out
+    output = _normalize_render_output(capsys.readouterr().out)
     assert "This device is protected locally" in output
     assert "Upgrade to sync this device to Guard Cloud" in output
     assert "First Guard Cloud proof is on the way" not in output
@@ -67,7 +71,7 @@ def test_guard_connect_render_tolerates_non_numeric_sync_counts(capsys) -> None:
         False,
     )
 
-    output = capsys.readouterr().out
+    output = _normalize_render_output(capsys.readouterr().out)
     assert "Receipts stored" in output
     assert "Inventory tracked" in output
     assert "0" in output
@@ -92,7 +96,7 @@ def test_guard_connect_render_tolerates_non_finite_sync_counts(capsys) -> None:
         False,
     )
 
-    output = capsys.readouterr().out
+    output = _normalize_render_output(capsys.readouterr().out)
     assert "Receipts stored" in output
     assert "Inventory tracked" in output
     assert "0" in output
@@ -113,7 +117,7 @@ def test_guard_connect_render_clarifies_browser_approval_wait(capsys) -> None:
         False,
     )
 
-    output = capsys.readouterr().out
+    output = _normalize_render_output(capsys.readouterr().out)
     assert "Browser paired" in output
     assert "Browser approval pending" in output
     assert "Waiting for browser approval" in output
@@ -167,7 +171,7 @@ def test_guard_status_render_rewrites_internal_next_action_labels(capsys) -> Non
         False,
     )
 
-    output = capsys.readouterr().out
+    output = _normalize_render_output(capsys.readouterr().out)
     assert "Recommended action" in output
     assert "Install Guard" in output
     assert "Review 2 changes" in output
@@ -333,3 +337,72 @@ def test_guard_install_render_skips_notes_when_manifest_is_missing_and_active(ca
     assert "Installed" in output
     assert "Guard removed the managed wrapper configuration for this harness." not in output
     assert "Notes" not in output
+
+
+def test_guard_batch_install_render_surfaces_auto_detected_summary(capsys) -> None:
+    emit_guard_payload(
+        "install",
+        {
+            "auto_detected": True,
+            "managed_installs": [
+                {
+                    "harness": "codex",
+                    "active": True,
+                    "workspace": "/repo",
+                    "manifest": {
+                        "mode": "codex-mcp-proxy",
+                        "config_path": "/repo/.codex/config.toml",
+                        "managed_servers": ["global_tools", "workspace_skill"],
+                    },
+                },
+                {
+                    "harness": "claude-code",
+                    "active": False,
+                    "workspace": "/repo",
+                    "manifest": {
+                        "config_path": "/repo/.claude/settings.json",
+                    },
+                },
+            ],
+        },
+        False,
+    )
+
+    output = _normalize_render_output(capsys.readouterr().out)
+    assert "Auto-detected" in output
+    assert "Protection" in output
+    assert "Mode" in output
+    assert "Installed" in output
+    assert "Removed" in output
+    assert "Codex MCP proxy" in output
+    assert "Managed servers" in output
+
+
+def test_guard_batch_install_render_collects_per_harness_notes(capsys) -> None:
+    emit_guard_payload(
+        "install",
+        {
+            "managed_installs": [
+                {
+                    "harness": "codex",
+                    "active": True,
+                    "workspace": "/repo",
+                    "manifest": {
+                        "config_path": "/repo/.codex/config.toml",
+                        "skipped_servers": ["existing_global"],
+                    },
+                },
+                {
+                    "harness": "claude-code",
+                    "active": False,
+                    "workspace": "/repo",
+                },
+            ],
+        },
+        False,
+    )
+
+    output = _normalize_render_output(capsys.readouterr().out)
+    assert "Notes" in output
+    assert "codex: Skipped existing server entries: existing_global" in output
+    assert "claude-code: Guard removed the managed wrapper configuration for this harness." in output

--- a/tests/test_guard_render.py
+++ b/tests/test_guard_render.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from pathlib import Path
+
+from codex_plugin_scanner.guard.cli import render
 from codex_plugin_scanner.guard.cli.render import emit_guard_payload
 
 
@@ -374,8 +377,34 @@ def test_guard_batch_install_render_surfaces_auto_detected_summary(capsys) -> No
     assert "Mode" in output
     assert "Installed" in output
     assert "Removed" in output
-    assert "Codex MCP proxy" in output
-    assert "Managed servers" in output
+    assert "Codex" in output
+    assert "MCP" in output
+    assert "proxy" in output
+    assert "Servers" in output
+
+
+def test_guard_batch_install_render_shortens_home_relative_config_paths(capsys) -> None:
+    emit_guard_payload(
+        "install",
+        {
+            "managed_installs": [
+                {
+                    "harness": "codex",
+                    "active": True,
+                    "workspace": "/repo",
+                    "manifest": {
+                        "mode": "codex-mcp-proxy",
+                        "config_path": str(Path.home() / ".codex" / "config.toml"),
+                        "managed_servers": ["global_tools"],
+                    },
+                }
+            ],
+        },
+        False,
+    )
+
+    output = _normalize_render_output(capsys.readouterr().out).replace(" ", "")
+    assert "~/.codex/config.toml" in output
 
 
 def test_guard_batch_install_render_collects_per_harness_notes(capsys) -> None:
@@ -405,4 +434,25 @@ def test_guard_batch_install_render_collects_per_harness_notes(capsys) -> None:
     output = _normalize_render_output(capsys.readouterr().out)
     assert "Notes" in output
     assert "codex: Skipped existing server entries: existing_global" in output
-    assert "claude-code: Guard removed the managed wrapper configuration for this harness." in output
+    assert "claude-code: Guard removed the managed wrapper configuration" in output
+
+
+def test_emit_guard_payload_uses_adaptive_console_width(monkeypatch) -> None:
+    captured_kwargs: dict[str, object] = {}
+
+    class FakeConsole:
+        def __init__(self, **kwargs: object) -> None:
+            captured_kwargs.update(kwargs)
+
+    def _fake_renderer(console: object, payload: dict[str, object]) -> None:
+        return None
+
+    monkeypatch.setattr(render, "_RICH_AVAILABLE", True)
+    monkeypatch.setattr(render, "Console", FakeConsole)
+    monkeypatch.setitem(render._RENDERERS, "status", _fake_renderer)
+
+    emit_guard_payload("status", {"harnesses": []}, False)
+
+    assert captured_kwargs["file"] is not None
+    assert captured_kwargs["soft_wrap"] is True
+    assert "width" not in captured_kwargs


### PR DESCRIPTION
## Summary
Batch install/uninstall output now surfaces auto-detected selection, protection summary, per-harness modes/server counts, and notes.

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_guard_render.py`
- `PYTHONPATH=src python3 -m pytest tests/test_guard_cli.py -k 'auto_detects_configured_harnesses or guard_uninstall_all_removes_detected_harnesses'`\n- `PYTHONPATH=src python3 -m pytest tests/test_guard_codex_install.py`\n- `python3 -m build`