### PR TITLE
fix: guard codex bash commands with hooks

### DIFF
--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -25,6 +25,8 @@ Use it when you want to protect a harness before local MCP servers, skills, hook
    hol-guard install codex
    ```
 
+   For Codex, install now enables Guard-owned `PreToolUse` Bash hooks in `.codex/hooks.json` and turns on the Codex hooks feature. That native hook path still runs when Codex itself is in YOLO mode, so Guard can pause sensitive Bash commands before execution instead of forcing a slower Codex approval mode.
+
    After upgrading later, run `hol-guard update` to update the installed `hol-guard` package in that environment.
 
 3. Run one dry pass so Guard records the current state:
@@ -218,14 +220,17 @@ For a real Codex canary, point `~/.codex/config.toml` or `<workspace>/.codex/con
 
 ## Codex-specific approval behavior
 
-Guard now has two real runtime paths for Codex MCP tool calls:
+Guard now has three real runtime paths for Codex:
 
-1. interactive Codex CLI and Codex App
+1. native Codex Bash tool calls
+   Guard installs a Codex `PreToolUse` hook in `.codex/hooks.json`, so sensitive Bash commands are denied before they run and routed into HOL Guard approval
+2. interactive Codex CLI and Codex App MCP tool calls
    Guard sends an MCP `elicitation/create` approval request, so the user can approve or deny in the same Codex chat
-2. noninteractive Codex runs such as `codex exec`
+3. noninteractive Codex runs such as `codex exec`
    if Codex does not answer the elicitation request, Guard queues a localhost approval request and returns the request id plus approval URL in the same tool-call error
 
-That means the user should never get a silent pass-through on a risky MCP tool call:
+That means the user should never get a silent pass-through on a risky Codex action that Guard manages:
 
-- same-chat approve or deny when Codex can render the inline prompt
+- native Bash deny plus HOL Guard approval-center recovery for sensitive shell actions
+- same-chat approve or deny when Codex can render the inline MCP prompt
 - explicit approval-center recovery when the session cannot

--- a/docs/guard/harness-support.md
+++ b/docs/guard/harness-support.md
@@ -4,7 +4,9 @@ Current Guard support in this repo:
 
 - `codex`
   - detects global and project `config.toml`
+  - detects Guard-managed `.codex/hooks.json` Bash hook entries
   - parses configured MCP servers
+  - installs Guard-owned Codex `PreToolUse` Bash hooks so native shell commands can be denied before execution even when Codex itself is running in YOLO mode
   - supports wrapper-mode `guard run codex`
   - uses same-chat MCP elicitation for live managed MCP tool approvals in the interactive CLI and Codex App
   - falls back to the local approval center only for nonresponsive or headless Codex sessions such as `codex exec`

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -161,25 +161,48 @@ def _is_managed_hook_group(group: object) -> bool:
     hooks = group.get("hooks")
     if not isinstance(hooks, list):
         return False
-    return any(
+    return any(_is_managed_hook_entry(entry) for entry in hooks)
+
+
+def _is_managed_hook_entry(entry: object) -> bool:
+    return (
         isinstance(entry, dict)
         and entry.get("type") == "command"
         and entry.get("statusMessage") == _MANAGED_HOOK_STATUS_MESSAGE
         and _is_managed_hook_command(entry.get("command"))
-        for entry in hooks
     )
 
 
+def _remove_managed_hook_entries(group: object) -> object | None:
+    if not isinstance(group, dict):
+        return group
+    matcher = group.get("matcher")
+    hooks = group.get("hooks")
+    if not isinstance(matcher, str) or matcher != "Bash" or not isinstance(hooks, list):
+        return group
+    remaining_hooks = [entry for entry in hooks if not _is_managed_hook_entry(entry)]
+    if len(remaining_hooks) == len(hooks):
+        return group
+    if not remaining_hooks:
+        return None
+    updated_group = dict(group)
+    updated_group["hooks"] = remaining_hooks
+    return updated_group
+
+
 def _merge_hook_groups(groups: object, managed_group: dict[str, object]) -> list[object]:
-    normalized = list(groups) if isinstance(groups, list) else []
-    preserved = [group for group in normalized if not _is_managed_hook_group(group)]
-    return [*preserved, managed_group]
+    return [*_remove_hook_groups(groups), managed_group]
 
 
 def _remove_hook_groups(groups: object) -> list[object]:
     if not isinstance(groups, list):
         return []
-    return [group for group in groups if not _is_managed_hook_group(group)]
+    remaining: list[object] = []
+    for group in groups:
+        cleaned_group = _remove_managed_hook_entries(group)
+        if cleaned_group is not None:
+            remaining.append(cleaned_group)
+    return remaining
 
 
 class CodexHarnessAdapter(HarnessAdapter):
@@ -318,6 +341,7 @@ class CodexHarnessAdapter(HarnessAdapter):
         managed_servers = managed_stdio_servers(detection)
         skipped_servers = skipped_stdio_server_names(detection)
         target_config_path = self._target_config_path(context)
+        hook_payloads = self._load_hook_payloads(context)
         original_text = target_config_path.read_text(encoding="utf-8") if target_config_path.is_file() else None
         backup_path = self._backup_path(context)
         if not backup_path.exists():
@@ -345,7 +369,7 @@ class CodexHarnessAdapter(HarnessAdapter):
             mcp_servers[server.name] = self._proxy_server_entry(context, server)
         payload["mcp_servers"] = mcp_servers
         write_toml_payload(target_config_path, payload)
-        hooks_path = self._install_hooks(context)
+        hooks_path = self._install_hooks(context, payloads=hook_payloads)
         shim_manifest = install_guard_shim(self.harness, context)
         return {
             "harness": self.harness,
@@ -364,6 +388,7 @@ class CodexHarnessAdapter(HarnessAdapter):
     def uninstall(self, context: HarnessContext) -> dict[str, object]:
         target_config_path = self._target_config_path(context)
         backup_path = self._backup_path(context)
+        hook_payloads = self._load_hook_payloads(context)
         if backup_path.is_file():
             original_text = backup_path.read_text(encoding="utf-8")
             if original_text:
@@ -372,7 +397,7 @@ class CodexHarnessAdapter(HarnessAdapter):
             elif target_config_path.is_file():
                 target_config_path.unlink()
             backup_path.unlink()
-        hooks_path = self._remove_hooks(context)
+        hooks_path = self._remove_hooks(context, payloads=hook_payloads)
         shim_manifest = remove_guard_shim(self.harness, context)
         return {
             "harness": self.harness,
@@ -427,17 +452,24 @@ class CodexHarnessAdapter(HarnessAdapter):
             return False
         return server.name in existing_workspace_server_names
 
-    def _install_hooks(self, context: HarnessContext) -> Path:
+    def _load_hook_payloads(self, context: HarnessContext) -> dict[Path, dict[str, object]]:
+        return {
+            hooks_path: _strict_json_object(hooks_path, label="Codex hooks file")
+            for hooks_path in self._all_hook_paths(context)
+        }
+
+    def _install_hooks(self, context: HarnessContext, *, payloads: dict[Path, dict[str, object]] | None = None) -> Path:
         target_hooks_path = self._hooks_path(context)
         managed_group = _hook_group(context)
+        hook_payloads = payloads or self._load_hook_payloads(context)
         for hooks_path in self._all_hook_paths(context):
-            payload = _strict_json_object(hooks_path, label="Codex hooks file")
+            payload = dict(hook_payloads.get(hooks_path, {}))
             hooks = payload.get("hooks")
             if not isinstance(hooks, dict):
                 hooks = {}
             remaining = _remove_hook_groups(hooks.get("PreToolUse"))
             if hooks_path == target_hooks_path:
-                hooks["PreToolUse"] = [*remaining, managed_group]
+                hooks["PreToolUse"] = _merge_hook_groups(remaining, managed_group)
                 payload["hooks"] = hooks
             else:
                 if remaining:
@@ -452,10 +484,11 @@ class CodexHarnessAdapter(HarnessAdapter):
             self._write_hooks_payload(hooks_path, payload)
         return target_hooks_path
 
-    def _remove_hooks(self, context: HarnessContext) -> Path:
+    def _remove_hooks(self, context: HarnessContext, *, payloads: dict[Path, dict[str, object]] | None = None) -> Path:
         target_hooks_path = self._hooks_path(context)
+        hook_payloads = payloads or self._load_hook_payloads(context)
         for hooks_path in self._all_hook_paths(context):
-            payload = _strict_json_object(hooks_path, label="Codex hooks file")
+            payload = dict(hook_payloads.get(hooks_path, {}))
             hooks = payload.get("hooks")
             if isinstance(hooks, dict):
                 remaining = _remove_hook_groups(hooks.get("PreToolUse"))

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -263,35 +263,40 @@ class CodexHarnessAdapter(HarnessAdapter):
                             },
                         )
                     )
-        hooks_path = self._hooks_path(context)
-        hooks_payload = _json_object(hooks_path)
-        hooks = hooks_payload.get("hooks")
-        if isinstance(hooks, dict):
+        hooks_paths = [context.home_dir / ".codex" / "hooks.json"]
+        if context.workspace_dir is not None:
+            hooks_paths.append(context.workspace_dir / ".codex" / "hooks.json")
+        for hooks_path in hooks_paths:
+            hooks_payload = _json_object(hooks_path)
+            hooks = hooks_payload.get("hooks")
+            if not isinstance(hooks, dict):
+                continue
             found_paths.append(str(hooks_path))
             scope = self._scope_for(context, hooks_path)
             hook_groups = hooks.get("PreToolUse")
-            if isinstance(hook_groups, list):
-                for group_index, group in enumerate(hook_groups):
-                    if not isinstance(group, dict):
+            if not isinstance(hook_groups, list):
+                continue
+            for group_index, group in enumerate(hook_groups):
+                if not isinstance(group, dict):
+                    continue
+                handlers = group.get("hooks")
+                if not isinstance(handlers, list):
+                    continue
+                for handler_index, handler in enumerate(handlers):
+                    if not isinstance(handler, dict):
                         continue
-                    handlers = group.get("hooks")
-                    if not isinstance(handlers, list):
-                        continue
-                    for handler_index, handler in enumerate(handlers):
-                        if not isinstance(handler, dict):
-                            continue
-                        command = handler.get("command")
-                        artifacts.append(
-                            GuardArtifact(
-                                artifact_id=f"codex:{scope}:pretooluse:{group_index}:{handler_index}",
-                                name="PreToolUse",
-                                harness=self.harness,
-                                artifact_type="hook",
-                                source_scope=scope,
-                                config_path=str(hooks_path),
-                                command=command if isinstance(command, str) else None,
-                            )
+                    command = handler.get("command")
+                    artifacts.append(
+                        GuardArtifact(
+                            artifact_id=f"codex:{scope}:pretooluse:{group_index}:{handler_index}",
+                            name="PreToolUse",
+                            harness=self.harness,
+                            artifact_type="hook",
+                            source_scope=scope,
+                            config_path=str(hooks_path),
+                            command=command if isinstance(command, str) else None,
                         )
+                    )
         return HarnessDetection(
             harness=self.harness,
             installed=bool(found_paths) or _command_available(self.executable),

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -54,6 +54,8 @@ def _json_object(path: Path) -> dict[str, object]:
 
 
 def _strict_json_object(path: Path, *, label: str) -> dict[str, object]:
+    if path.exists() and not path.is_file():
+        raise RuntimeError(f"Guard refused to overwrite non-file {label} at {path}")
     if not path.is_file():
         return {}
     try:

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -462,7 +462,8 @@ class CodexHarnessAdapter(HarnessAdapter):
         managed_group = _hook_group(context)
         hook_payloads = payloads or self._load_hook_payloads(context)
         for hooks_path in self._all_hook_paths(context):
-            payload = dict(hook_payloads.get(hooks_path, {}))
+            original_payload = dict(hook_payloads.get(hooks_path, {}))
+            payload = dict(original_payload)
             hooks = payload.get("hooks")
             if not isinstance(hooks, dict):
                 hooks = {}
@@ -480,14 +481,15 @@ class CodexHarnessAdapter(HarnessAdapter):
                         payload["hooks"] = hooks
                     else:
                         payload.pop("hooks", None)
-            self._write_hooks_payload(hooks_path, payload)
+            self._write_hooks_payload(hooks_path, payload, original_payload=original_payload)
         return target_hooks_path
 
     def _remove_hooks(self, context: HarnessContext, *, payloads: dict[Path, dict[str, object]] | None = None) -> Path:
         target_hooks_path = self._hooks_path(context)
         hook_payloads = payloads or {}
         for hooks_path in self._all_hook_paths(context):
-            payload = dict(hook_payloads.get(hooks_path, _json_object(hooks_path)))
+            original_payload = dict(hook_payloads.get(hooks_path, _json_object(hooks_path)))
+            payload = dict(original_payload)
             if not payload and hooks_path.exists():
                 continue
             hooks = payload.get("hooks")
@@ -502,11 +504,18 @@ class CodexHarnessAdapter(HarnessAdapter):
                         payload["hooks"] = hooks
                     else:
                         payload.pop("hooks", None)
-            self._write_hooks_payload(hooks_path, payload)
+            self._write_hooks_payload(hooks_path, payload, original_payload=original_payload)
         return target_hooks_path
 
     @staticmethod
-    def _write_hooks_payload(hooks_path: Path, payload: dict[str, object]) -> None:
+    def _write_hooks_payload(
+        hooks_path: Path,
+        payload: dict[str, object],
+        *,
+        original_payload: dict[str, object] | None = None,
+    ) -> None:
+        if original_payload is not None and payload == original_payload:
+            return
         if payload:
             hooks_path.parent.mkdir(parents=True, exist_ok=True)
             hooks_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -489,8 +489,6 @@ class CodexHarnessAdapter(HarnessAdapter):
         for hooks_path in self._all_hook_paths(context):
             payload = dict(hook_payloads.get(hooks_path, _json_object(hooks_path)))
             if not payload and hooks_path.exists():
-                if hooks_path == target_hooks_path:
-                    hooks_path.unlink()
                 continue
             hooks = payload.get("hooks")
             if isinstance(hooks, dict):

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -7,6 +7,7 @@ import json
 import os
 import shlex
 import sys
+from copy import deepcopy
 from pathlib import Path
 
 try:  # pragma: no cover - Python 3.11+
@@ -462,8 +463,8 @@ class CodexHarnessAdapter(HarnessAdapter):
         managed_group = _hook_group(context)
         hook_payloads = payloads or self._load_hook_payloads(context)
         for hooks_path in self._all_hook_paths(context):
-            original_payload = dict(hook_payloads.get(hooks_path, {}))
-            payload = dict(original_payload)
+            original_payload = deepcopy(hook_payloads.get(hooks_path, {}))
+            payload = deepcopy(original_payload)
             hooks = payload.get("hooks")
             if not isinstance(hooks, dict):
                 hooks = {}
@@ -488,8 +489,8 @@ class CodexHarnessAdapter(HarnessAdapter):
         target_hooks_path = self._hooks_path(context)
         hook_payloads = payloads or {}
         for hooks_path in self._all_hook_paths(context):
-            original_payload = dict(hook_payloads.get(hooks_path, _json_object(hooks_path)))
-            payload = dict(original_payload)
+            original_payload = deepcopy(hook_payloads.get(hooks_path, _json_object(hooks_path)))
+            payload = deepcopy(original_payload)
             if not payload and hooks_path.exists():
                 continue
             hooks = payload.get("hooks")

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -388,7 +388,6 @@ class CodexHarnessAdapter(HarnessAdapter):
     def uninstall(self, context: HarnessContext) -> dict[str, object]:
         target_config_path = self._target_config_path(context)
         backup_path = self._backup_path(context)
-        hook_payloads = self._load_hook_payloads(context)
         if backup_path.is_file():
             original_text = backup_path.read_text(encoding="utf-8")
             if original_text:
@@ -397,7 +396,7 @@ class CodexHarnessAdapter(HarnessAdapter):
             elif target_config_path.is_file():
                 target_config_path.unlink()
             backup_path.unlink()
-        hooks_path = self._remove_hooks(context, payloads=hook_payloads)
+        hooks_path = self._remove_hooks(context)
         shim_manifest = remove_guard_shim(self.harness, context)
         return {
             "harness": self.harness,
@@ -486,9 +485,13 @@ class CodexHarnessAdapter(HarnessAdapter):
 
     def _remove_hooks(self, context: HarnessContext, *, payloads: dict[Path, dict[str, object]] | None = None) -> Path:
         target_hooks_path = self._hooks_path(context)
-        hook_payloads = payloads or self._load_hook_payloads(context)
+        hook_payloads = payloads or {}
         for hooks_path in self._all_hook_paths(context):
-            payload = dict(hook_payloads.get(hooks_path, {}))
+            payload = dict(hook_payloads.get(hooks_path, _json_object(hooks_path)))
+            if not payload and hooks_path.exists():
+                if hooks_path == target_hooks_path:
+                    hooks_path.unlink()
+                continue
             hooks = payload.get("hooks")
             if isinstance(hooks, dict):
                 remaining = _remove_hook_groups(hooks.get("PreToolUse"))

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -468,10 +468,14 @@ class CodexHarnessAdapter(HarnessAdapter):
             hooks = payload.get("hooks")
             if not isinstance(hooks, dict):
                 hooks = {}
-            remaining = _remove_hook_groups(hooks.get("PreToolUse"))
+            original_groups = deepcopy(hooks.get("PreToolUse"))
+            remaining = _remove_hook_groups(original_groups)
+            managed_removed = isinstance(original_groups, list) and remaining != original_groups
             if hooks_path == target_hooks_path:
                 hooks["PreToolUse"] = _merge_hook_groups(remaining, managed_group)
                 payload["hooks"] = hooks
+            elif not managed_removed:
+                payload = deepcopy(original_payload)
             else:
                 if remaining:
                     hooks["PreToolUse"] = remaining
@@ -495,8 +499,12 @@ class CodexHarnessAdapter(HarnessAdapter):
                 continue
             hooks = payload.get("hooks")
             if isinstance(hooks, dict):
-                remaining = _remove_hook_groups(hooks.get("PreToolUse"))
-                if remaining:
+                original_groups = deepcopy(hooks.get("PreToolUse"))
+                remaining = _remove_hook_groups(original_groups)
+                managed_removed = isinstance(original_groups, list) and remaining != original_groups
+                if not managed_removed:
+                    payload = deepcopy(original_payload)
+                elif remaining:
                     hooks["PreToolUse"] = remaining
                     payload["hooks"] = hooks
                 else:

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import hashlib
+import json
+import os
+import shlex
 import sys
 from pathlib import Path
 
@@ -36,6 +39,149 @@ def _read_toml(path: Path) -> dict[str, object]:
         return {}
 
 
+_MANAGED_HOOK_STATUS_MESSAGE = "HOL Guard checking Bash command"
+
+
+def _json_object(path: Path) -> dict[str, object]:
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _strict_json_object(path: Path, *, label: str) -> dict[str, object]:
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"Guard refused to overwrite unreadable {label} at {path}") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Guard refused to overwrite non-object {label} at {path}")
+    return payload
+
+
+def _hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
+    guard_args = [
+        "guard",
+        "hook",
+        "--guard-home",
+        str(context.guard_home),
+        "--harness",
+        "codex",
+    ]
+    if context.home_dir.resolve() != Path.home().resolve():
+        guard_args.extend(["--home", str(context.home_dir)])
+    if context.workspace_dir is not None:
+        guard_args.extend(["--workspace", str(context.workspace_dir)])
+    launcher_env = merge_guard_launcher_env()
+    pythonpath = launcher_env.get("PYTHONPATH", "")
+    if not pythonpath.strip():
+        return (sys.executable, "-m", "codex_plugin_scanner.cli", *guard_args)
+    path_entries = [entry for entry in pythonpath.split(os.pathsep) if entry.strip()]
+    code = (
+        "import sys;"
+        f"sys.path[:0]={path_entries!r};"
+        "from codex_plugin_scanner.cli import main;"
+        f"raise SystemExit(main({guard_args!r}))"
+    )
+    return (sys.executable, "-c", code)
+
+
+def _hook_command(context: HarnessContext) -> str:
+    return shlex.join(_hook_command_parts(context))
+
+
+def _hook_group(context: HarnessContext) -> dict[str, object]:
+    return {
+        "matcher": "Bash",
+        "hooks": [
+            {
+                "type": "command",
+                "command": _hook_command(context),
+                "timeoutSec": 30,
+                "statusMessage": _MANAGED_HOOK_STATUS_MESSAGE,
+            }
+        ],
+    }
+
+
+def _is_managed_hook_command(command: object) -> bool:
+    if not isinstance(command, str):
+        return False
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return False
+    if len(tokens) < 3:
+        return False
+    executable = Path(tokens[0]).name.lower()
+    if not executable.startswith("python"):
+        return False
+    if tokens[1] == "-m":
+        if len(tokens) < 5:
+            return False
+        return (
+            tokens[2] == "codex_plugin_scanner.cli"
+            and tokens[3] == "guard"
+            and tokens[4] == "hook"
+            and _argv_targets_codex(tokens[5:])
+        )
+    if tokens[1] != "-c":
+        return False
+    code = tokens[2]
+    return (
+        "codex_plugin_scanner.cli" in code
+        and "main([" in code
+        and "'guard'" in code
+        and "'hook'" in code
+        and "'--harness'" in code
+        and "'codex'" in code
+    )
+
+
+def _argv_targets_codex(argv: list[str]) -> bool:
+    for index, token in enumerate(argv):
+        if token == "--harness" and index + 1 < len(argv) and argv[index + 1] == "codex":
+            return True
+        if token.startswith("--harness=") and token.split("=", 1)[1] == "codex":
+            return True
+    return False
+
+
+def _is_managed_hook_group(group: object) -> bool:
+    if not isinstance(group, dict):
+        return False
+    matcher = group.get("matcher")
+    if not isinstance(matcher, str) or matcher != "Bash":
+        return False
+    hooks = group.get("hooks")
+    if not isinstance(hooks, list):
+        return False
+    return any(
+        isinstance(entry, dict)
+        and entry.get("type") == "command"
+        and entry.get("statusMessage") == _MANAGED_HOOK_STATUS_MESSAGE
+        and _is_managed_hook_command(entry.get("command"))
+        for entry in hooks
+    )
+
+
+def _merge_hook_groups(groups: object, managed_group: dict[str, object]) -> list[object]:
+    normalized = list(groups) if isinstance(groups, list) else []
+    preserved = [group for group in normalized if not _is_managed_hook_group(group)]
+    return [*preserved, managed_group]
+
+
+def _remove_hook_groups(groups: object) -> list[object]:
+    if not isinstance(groups, list):
+        return []
+    return [group for group in groups if not _is_managed_hook_group(group)]
+
+
 class CodexHarnessAdapter(HarnessAdapter):
     """Discover Codex MCP servers and wrapper surfaces."""
 
@@ -43,12 +189,12 @@ class CodexHarnessAdapter(HarnessAdapter):
     executable = "codex"
     approval_tier = "native-or-center"
     approval_summary = (
-        "Guard prefers same-chat Codex approvals for live MCP tool calls and falls back to the "
-        "local approval center only when Codex cannot answer."
+        "Guard installs native Codex Bash hooks for shell interception, keeps same-chat approvals for "
+        "managed MCP tool calls, and falls back to the local approval center when Codex cannot answer."
     )
     fallback_hint = (
-        "If Codex cannot render or return the inline approval request, Guard will queue it in the "
-        "local approval center."
+        "If Codex cannot render or return the inline approval request, or a native Bash hook blocks a "
+        "sensitive command, Guard will queue it in the local approval center."
     )
     approval_prompt_channel = "native"
     approval_auto_open_browser = False
@@ -63,6 +209,12 @@ class CodexHarnessAdapter(HarnessAdapter):
         if context.workspace_dir is not None:
             return context.workspace_dir / ".codex" / "config.toml"
         return context.home_dir / ".codex" / "config.toml"
+
+    @staticmethod
+    def _hooks_path(context: HarnessContext) -> Path:
+        if context.workspace_dir is not None:
+            return context.workspace_dir / ".codex" / "hooks.json"
+        return context.home_dir / ".codex" / "hooks.json"
 
     def detect(self, context: HarnessContext) -> HarnessDetection:
         config_paths = [context.home_dir / ".codex" / "config.toml"]
@@ -111,6 +263,35 @@ class CodexHarnessAdapter(HarnessAdapter):
                             },
                         )
                     )
+        hooks_path = self._hooks_path(context)
+        hooks_payload = _json_object(hooks_path)
+        hooks = hooks_payload.get("hooks")
+        if isinstance(hooks, dict):
+            found_paths.append(str(hooks_path))
+            scope = self._scope_for(context, hooks_path)
+            hook_groups = hooks.get("PreToolUse")
+            if isinstance(hook_groups, list):
+                for group_index, group in enumerate(hook_groups):
+                    if not isinstance(group, dict):
+                        continue
+                    handlers = group.get("hooks")
+                    if not isinstance(handlers, list):
+                        continue
+                    for handler_index, handler in enumerate(handlers):
+                        if not isinstance(handler, dict):
+                            continue
+                        command = handler.get("command")
+                        artifacts.append(
+                            GuardArtifact(
+                                artifact_id=f"codex:{scope}:pretooluse:{group_index}:{handler_index}",
+                                name="PreToolUse",
+                                harness=self.harness,
+                                artifact_type="hook",
+                                source_scope=scope,
+                                config_path=str(hooks_path),
+                                command=command if isinstance(command, str) else None,
+                            )
+                        )
         return HarnessDetection(
             harness=self.harness,
             installed=bool(found_paths) or _command_available(self.executable),
@@ -134,6 +315,11 @@ class CodexHarnessAdapter(HarnessAdapter):
         mcp_servers = payload.get("mcp_servers")
         if not isinstance(mcp_servers, dict):
             mcp_servers = {}
+        features = payload.get("features")
+        if not isinstance(features, dict):
+            features = {}
+        features["codex_hooks"] = True
+        payload["features"] = features
         existing_workspace_server_names = {
             name for name, value in mcp_servers.items() if isinstance(name, str) and isinstance(value, dict)
         }
@@ -147,6 +333,7 @@ class CodexHarnessAdapter(HarnessAdapter):
             mcp_servers[server.name] = self._proxy_server_entry(context, server)
         payload["mcp_servers"] = mcp_servers
         write_toml_payload(target_config_path, payload)
+        hooks_path = self._install_hooks(context)
         shim_manifest = install_guard_shim(self.harness, context)
         return {
             "harness": self.harness,
@@ -155,6 +342,7 @@ class CodexHarnessAdapter(HarnessAdapter):
             **shim_manifest,
             "mode": "codex-mcp-proxy",
             "managed_config_path": str(target_config_path),
+            "managed_hooks_path": str(hooks_path),
             "backup_path": str(backup_path),
             "managed_servers": [server.name for server in managed_servers],
             "skipped_servers": list(skipped_servers),
@@ -172,6 +360,7 @@ class CodexHarnessAdapter(HarnessAdapter):
             elif target_config_path.is_file():
                 target_config_path.unlink()
             backup_path.unlink()
+        hooks_path = self._remove_hooks(context)
         shim_manifest = remove_guard_shim(self.harness, context)
         return {
             "harness": self.harness,
@@ -180,6 +369,7 @@ class CodexHarnessAdapter(HarnessAdapter):
             **shim_manifest,
             "mode": "codex-mcp-proxy",
             "managed_config_path": str(target_config_path),
+            "managed_hooks_path": str(hooks_path),
             "backup_path": str(backup_path),
         }
 
@@ -224,3 +414,34 @@ class CodexHarnessAdapter(HarnessAdapter):
         if server.source_scope == "project":
             return False
         return server.name in existing_workspace_server_names
+
+    def _install_hooks(self, context: HarnessContext) -> Path:
+        hooks_path = self._hooks_path(context)
+        payload = _strict_json_object(hooks_path, label="Codex hooks file")
+        hooks = payload.get("hooks")
+        if not isinstance(hooks, dict):
+            hooks = {}
+        hooks["PreToolUse"] = _merge_hook_groups(hooks.get("PreToolUse"), _hook_group(context))
+        payload["hooks"] = hooks
+        hooks_path.parent.mkdir(parents=True, exist_ok=True)
+        hooks_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        return hooks_path
+
+    def _remove_hooks(self, context: HarnessContext) -> Path:
+        hooks_path = self._hooks_path(context)
+        payload = _strict_json_object(hooks_path, label="Codex hooks file")
+        hooks = payload.get("hooks")
+        if isinstance(hooks, dict):
+            remaining = _remove_hook_groups(hooks.get("PreToolUse"))
+            if remaining:
+                hooks["PreToolUse"] = remaining
+            else:
+                hooks.pop("PreToolUse", None)
+            if not hooks:
+                payload.pop("hooks", None)
+        if payload:
+            hooks_path.parent.mkdir(parents=True, exist_ok=True)
+            hooks_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        elif hooks_path.exists():
+            hooks_path.unlink()
+        return hooks_path

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -216,6 +216,13 @@ class CodexHarnessAdapter(HarnessAdapter):
             return context.workspace_dir / ".codex" / "hooks.json"
         return context.home_dir / ".codex" / "hooks.json"
 
+    @staticmethod
+    def _all_hook_paths(context: HarnessContext) -> tuple[Path, ...]:
+        paths = [context.home_dir / ".codex" / "hooks.json"]
+        if context.workspace_dir is not None:
+            paths.append(context.workspace_dir / ".codex" / "hooks.json")
+        return tuple(paths)
+
     def detect(self, context: HarnessContext) -> HarnessDetection:
         config_paths = [context.home_dir / ".codex" / "config.toml"]
         if context.workspace_dir is not None:
@@ -421,32 +428,53 @@ class CodexHarnessAdapter(HarnessAdapter):
         return server.name in existing_workspace_server_names
 
     def _install_hooks(self, context: HarnessContext) -> Path:
-        hooks_path = self._hooks_path(context)
-        payload = _strict_json_object(hooks_path, label="Codex hooks file")
-        hooks = payload.get("hooks")
-        if not isinstance(hooks, dict):
-            hooks = {}
-        hooks["PreToolUse"] = _merge_hook_groups(hooks.get("PreToolUse"), _hook_group(context))
-        payload["hooks"] = hooks
-        hooks_path.parent.mkdir(parents=True, exist_ok=True)
-        hooks_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-        return hooks_path
+        target_hooks_path = self._hooks_path(context)
+        managed_group = _hook_group(context)
+        for hooks_path in self._all_hook_paths(context):
+            payload = _strict_json_object(hooks_path, label="Codex hooks file")
+            hooks = payload.get("hooks")
+            if not isinstance(hooks, dict):
+                hooks = {}
+            remaining = _remove_hook_groups(hooks.get("PreToolUse"))
+            if hooks_path == target_hooks_path:
+                hooks["PreToolUse"] = [*remaining, managed_group]
+                payload["hooks"] = hooks
+            else:
+                if remaining:
+                    hooks["PreToolUse"] = remaining
+                    payload["hooks"] = hooks
+                else:
+                    hooks.pop("PreToolUse", None)
+                    if hooks:
+                        payload["hooks"] = hooks
+                    else:
+                        payload.pop("hooks", None)
+            self._write_hooks_payload(hooks_path, payload)
+        return target_hooks_path
 
     def _remove_hooks(self, context: HarnessContext) -> Path:
-        hooks_path = self._hooks_path(context)
-        payload = _strict_json_object(hooks_path, label="Codex hooks file")
-        hooks = payload.get("hooks")
-        if isinstance(hooks, dict):
-            remaining = _remove_hook_groups(hooks.get("PreToolUse"))
-            if remaining:
-                hooks["PreToolUse"] = remaining
-            else:
-                hooks.pop("PreToolUse", None)
-            if not hooks:
-                payload.pop("hooks", None)
+        target_hooks_path = self._hooks_path(context)
+        for hooks_path in self._all_hook_paths(context):
+            payload = _strict_json_object(hooks_path, label="Codex hooks file")
+            hooks = payload.get("hooks")
+            if isinstance(hooks, dict):
+                remaining = _remove_hook_groups(hooks.get("PreToolUse"))
+                if remaining:
+                    hooks["PreToolUse"] = remaining
+                    payload["hooks"] = hooks
+                else:
+                    hooks.pop("PreToolUse", None)
+                    if hooks:
+                        payload["hooks"] = hooks
+                    else:
+                        payload.pop("hooks", None)
+            self._write_hooks_payload(hooks_path, payload)
+        return target_hooks_path
+
+    @staticmethod
+    def _write_hooks_payload(hooks_path: Path, payload: dict[str, object]) -> None:
         if payload:
             hooks_path.parent.mkdir(parents=True, exist_ok=True)
             hooks_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
         elif hooks_path.exists():
             hooks_path.unlink()
-        return hooks_path

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1180,6 +1180,18 @@ def run_guard_command(args: argparse.Namespace) -> int:
                         ),
                     )
                     return 0
+                if _should_emit_prequeue_native_hook_response(args):
+                    _emit_native_hook_response(
+                        harness=args.harness,
+                        policy_action=policy_action,
+                        reason=_native_hook_reason_for_harness(
+                            args.harness,
+                            response_payload.get("why_now"),
+                            response_payload.get("risk_headline"),
+                            response_payload.get("path_summary"),
+                        ),
+                    )
+                    return 0
                 approval_flow = get_adapter(args.harness).approval_flow(managed_install=managed_install)
                 approval_center_url = ensure_guard_daemon(guard_home)
                 runtime_detection = _runtime_detection(args.harness, runtime_artifact)
@@ -1369,6 +1381,10 @@ def _should_emit_copilot_hook_response(args: argparse.Namespace) -> bool:
 
 def _should_emit_native_hook_response(args: argparse.Namespace) -> bool:
     return args.harness in {"claude-code", "codex"} and not getattr(args, "json", False)
+
+
+def _should_emit_prequeue_native_hook_response(args: argparse.Namespace) -> bool:
+    return args.harness == "claude-code" and not getattr(args, "json", False)
 
 
 def _approval_delivery_payload(

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1180,10 +1180,12 @@ def run_guard_command(args: argparse.Namespace) -> int:
                         ),
                     )
                     return 0
-                if _should_emit_claude_hook_response(args):
-                    _emit_claude_hook_response(
+                if _should_emit_native_hook_response(args):
+                    _emit_native_hook_response(
+                        harness=args.harness,
                         policy_action=policy_action,
-                        reason=_native_hook_reason(
+                        reason=_native_hook_reason_for_harness(
+                            args.harness,
                             response_payload.get("why_now"),
                             response_payload.get("risk_headline"),
                             response_payload.get("path_summary"),
@@ -1278,10 +1280,12 @@ def run_guard_command(args: argparse.Namespace) -> int:
                     ),
                 )
                 return 0
-            if _should_emit_claude_hook_response(args):
-                _emit_claude_hook_response(
+            if _should_emit_native_hook_response(args):
+                _emit_native_hook_response(
+                    harness=args.harness,
                     policy_action=policy_action,
-                    reason=_native_hook_reason(
+                    reason=_native_hook_reason_for_harness(
+                        args.harness,
                         response_payload.get("why_now"),
                         response_payload.get("review_hint"),
                         response_payload.get("risk_headline"),
@@ -1343,10 +1347,11 @@ def run_guard_command(args: argparse.Namespace) -> int:
                 reason=_copilot_hook_reason(payload.get("permission_decision_reason")),
             )
             return 0
-        if _should_emit_claude_hook_response(args):
-            _emit_claude_hook_response(
+        if _should_emit_native_hook_response(args):
+            _emit_native_hook_response(
+                harness=args.harness,
                 policy_action=policy_action,
-                reason=_native_hook_reason(payload.get("permission_decision_reason")),
+                reason=_native_hook_reason_for_harness(args.harness, payload.get("permission_decision_reason")),
             )
             return 0
         _emit(
@@ -1374,8 +1379,8 @@ def _should_emit_copilot_hook_response(args: argparse.Namespace) -> bool:
     return args.harness == "copilot" and not getattr(args, "json", False)
 
 
-def _should_emit_claude_hook_response(args: argparse.Namespace) -> bool:
-    return args.harness == "claude-code" and not getattr(args, "json", False)
+def _should_emit_native_hook_response(args: argparse.Namespace) -> bool:
+    return args.harness in {"claude-code", "codex"} and not getattr(args, "json", False)
 
 
 def _approval_delivery_payload(
@@ -1396,6 +1401,13 @@ def _native_hook_reason(*values: object | None) -> str:
     if messages:
         return " ".join(messages)
     return "HOL Guard flagged this tool call for review."
+
+
+def _native_hook_reason_for_harness(harness: str, *values: object | None) -> str:
+    reason = _native_hook_reason(*values)
+    if harness != "codex" or "approve" in reason.lower():
+        return reason
+    return f"{reason} Approve it in HOL Guard, then retry."
 
 
 def _copilot_hook_reason(*values: object | None) -> str:
@@ -1468,11 +1480,11 @@ def _emit_copilot_permission_request_response(
     print(json.dumps(payload, separators=(",", ":")))
 
 
-def _emit_claude_hook_response(*, policy_action: str, reason: str) -> None:
+def _emit_native_hook_response(*, harness: str, policy_action: str, reason: str) -> None:
     payload = {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
-            "permissionDecision": _native_hook_permission_decision(policy_action),
+            "permissionDecision": _native_hook_permission_decision(policy_action, harness=harness),
         }
     }
     if payload["hookSpecificOutput"]["permissionDecision"] != "allow":
@@ -1480,10 +1492,12 @@ def _emit_claude_hook_response(*, policy_action: str, reason: str) -> None:
     print(json.dumps(payload, separators=(",", ":")))
 
 
-def _native_hook_permission_decision(policy_action: str) -> str:
+def _native_hook_permission_decision(policy_action: str, *, harness: str) -> str:
     if policy_action in {"block", "sandbox-required"}:
         return "deny"
     if policy_action == "require-reapproval":
+        if harness == "codex":
+            return "deny"
         return "ask"
     return "allow"
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1180,18 +1180,6 @@ def run_guard_command(args: argparse.Namespace) -> int:
                         ),
                     )
                     return 0
-                if _should_emit_native_hook_response(args):
-                    _emit_native_hook_response(
-                        harness=args.harness,
-                        policy_action=policy_action,
-                        reason=_native_hook_reason_for_harness(
-                            args.harness,
-                            response_payload.get("why_now"),
-                            response_payload.get("risk_headline"),
-                            response_payload.get("path_summary"),
-                        ),
-                    )
-                    return 0
                 approval_flow = get_adapter(args.harness).approval_flow(managed_install=managed_install)
                 approval_center_url = ensure_guard_daemon(guard_home)
                 runtime_detection = _runtime_detection(args.harness, runtime_artifact)

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -258,6 +258,81 @@ def test_guard_install_codex_workspace_cleans_stale_global_managed_hook(tmp_path
     assert "codex_plugin_scanner.cli" in managed_group["hooks"][0]["command"]
 
 
+def test_guard_uninstall_codex_preserves_user_hooks_in_managed_bash_group(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
+
+    install_rc = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+    hooks_path = workspace_dir / ".codex" / "hooks.json"
+    hooks_payload = json.loads(hooks_path.read_text(encoding="utf-8"))
+    hooks_payload["hooks"]["PreToolUse"][0]["hooks"].append({"type": "command", "command": "python3 custom-pre.py"})
+    hooks_path.write_text(json.dumps(hooks_payload, indent=2) + "\n", encoding="utf-8")
+
+    uninstall_rc = main(
+        [
+            "guard",
+            "uninstall",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+    restored_hooks = json.loads(hooks_path.read_text(encoding="utf-8"))
+
+    assert install_rc == 0
+    assert uninstall_rc == 0
+    assert restored_hooks["hooks"]["PreToolUse"] == [
+        {
+            "matcher": "Bash",
+            "hooks": [{"type": "command", "command": "python3 custom-pre.py"}],
+        }
+    ]
+
+
+def test_guard_install_codex_refuses_invalid_alternate_hook_file_before_config_write(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    original_config = 'approval_policy = "never"\n'
+    _write_text(workspace_dir / ".codex" / "config.toml", original_config)
+    _write_text(home_dir / ".codex" / "hooks.json", '{"hooks": ')
+
+    rc = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert "Guard refused to overwrite unreadable Codex hooks file" in captured.err
+    assert (workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8") == original_config
+    assert (home_dir / ".codex" / "hooks.json").read_text(encoding="utf-8") == '{"hooks": '
+
+
 def test_guard_detect_codex_collects_global_and_workspace_hooks(tmp_path):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -333,6 +333,33 @@ def test_guard_install_codex_refuses_invalid_alternate_hook_file_before_config_w
     assert (home_dir / ".codex" / "hooks.json").read_text(encoding="utf-8") == '{"hooks": '
 
 
+def test_guard_install_codex_refuses_non_file_alternate_hook_path_before_config_write(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    original_config = 'approval_policy = "never"\n'
+    _write_text(workspace_dir / ".codex" / "config.toml", original_config)
+    (home_dir / ".codex" / "hooks.json").mkdir(parents=True)
+
+    rc = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert "Guard refused to overwrite non-file Codex hooks file" in captured.err
+    assert (workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8") == original_config
+    assert (home_dir / ".codex" / "hooks.json").is_dir() is True
+
+
 def test_guard_uninstall_codex_succeeds_when_alternate_hook_file_is_invalid(tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -376,6 +376,48 @@ def test_guard_uninstall_codex_succeeds_when_alternate_hook_file_is_invalid(tmp_
     assert (home_dir / ".codex" / "hooks.json").read_text(encoding="utf-8") == '{"hooks": '
 
 
+def test_guard_uninstall_codex_preserves_invalid_target_hook_file(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    original_config = 'approval_policy = "never"\n'
+    _write_text(workspace_dir / ".codex" / "config.toml", original_config)
+
+    install_rc = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+    _write_text(workspace_dir / ".codex" / "hooks.json", '{"hooks": ')
+
+    uninstall_rc = main(
+        [
+            "guard",
+            "uninstall",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    uninstall_output = json.loads(capsys.readouterr().out)
+
+    assert install_rc == 0
+    assert uninstall_rc == 0
+    assert uninstall_output["managed_install"]["active"] is False
+    assert (workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8") == original_config
+    assert (workspace_dir / ".codex" / "hooks.json").read_text(encoding="utf-8") == '{"hooks": '
+
+
 def test_guard_detect_codex_collects_global_and_workspace_hooks(tmp_path):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -418,6 +418,99 @@ def test_guard_uninstall_codex_preserves_invalid_target_hook_file(tmp_path, caps
     assert (workspace_dir / ".codex" / "hooks.json").read_text(encoding="utf-8") == '{"hooks": '
 
 
+def test_guard_install_codex_skips_unchanged_read_only_alternate_hook_file(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
+    home_hooks_path = home_dir / ".codex" / "hooks.json"
+    original_hooks = json.dumps(
+        {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{"type": "command", "command": "python3 custom-pre.py"}],
+                    }
+                ]
+            }
+        },
+        indent=2,
+    )
+    _write_text(home_hooks_path, original_hooks + "\n")
+    os.chmod(home_hooks_path, 0o444)
+
+    install_rc = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+
+    assert install_rc == 0
+    assert home_hooks_path.read_text(encoding="utf-8") == original_hooks + "\n"
+
+
+def test_guard_uninstall_codex_skips_unchanged_read_only_alternate_hook_file(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
+    home_hooks_path = home_dir / ".codex" / "hooks.json"
+    original_hooks = json.dumps(
+        {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [{"type": "command", "command": "python3 custom-pre.py"}],
+                    }
+                ]
+            }
+        },
+        indent=2,
+    )
+    _write_text(home_hooks_path, original_hooks + "\n")
+
+    install_rc = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+    os.chmod(home_hooks_path, 0o444)
+
+    uninstall_rc = main(
+        [
+            "guard",
+            "uninstall",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+
+    assert install_rc == 0
+    assert uninstall_rc == 0
+    assert home_hooks_path.read_text(encoding="utf-8") == original_hooks + "\n"
+
+
 def test_guard_detect_codex_collects_global_and_workspace_hooks(tmp_path):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -210,6 +210,54 @@ def test_guard_install_codex_merges_managed_hooks_without_removing_existing_entr
     ]
 
 
+def test_guard_install_codex_workspace_cleans_stale_global_managed_hook(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _write_text(
+        home_dir / ".codex" / "config.toml",
+        '[mcp_servers.global_tools]\ncommand = "python3"\nargs = ["-m", "http.server", "9000"]\n',
+    )
+    _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
+
+    global_install_rc = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+
+    workspace_install_rc = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+
+    home_hooks_path = home_dir / ".codex" / "hooks.json"
+    workspace_hooks_path = workspace_dir / ".codex" / "hooks.json"
+    workspace_hooks = json.loads(workspace_hooks_path.read_text(encoding="utf-8"))
+
+    assert global_install_rc == 0
+    assert workspace_install_rc == 0
+    assert home_hooks_path.exists() is False
+    assert len(workspace_hooks["hooks"]["PreToolUse"]) == 1
+    managed_group = workspace_hooks["hooks"]["PreToolUse"][0]
+    assert managed_group["matcher"] == "Bash"
+    assert "codex_plugin_scanner.cli" in managed_group["hooks"][0]["command"]
+
+
 def test_guard_detect_codex_collects_global_and_workspace_hooks(tmp_path):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -511,6 +511,73 @@ def test_guard_uninstall_codex_skips_unchanged_read_only_alternate_hook_file(tmp
     assert home_hooks_path.read_text(encoding="utf-8") == original_hooks + "\n"
 
 
+def test_guard_install_codex_preserves_unchanged_empty_alternate_hook_file(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
+    home_hooks_path = home_dir / ".codex" / "hooks.json"
+    original_hooks = '{\n  "hooks": {}\n}\n'
+    _write_text(home_hooks_path, original_hooks)
+
+    install_rc = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+
+    assert install_rc == 0
+    assert home_hooks_path.read_text(encoding="utf-8") == original_hooks
+
+
+def test_guard_uninstall_codex_preserves_unchanged_empty_alternate_hook_file(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
+    home_hooks_path = home_dir / ".codex" / "hooks.json"
+    original_hooks = '{\n  "hooks": {}\n}\n'
+    _write_text(home_hooks_path, original_hooks)
+
+    install_rc = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+
+    uninstall_rc = main(
+        [
+            "guard",
+            "uninstall",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+
+    assert install_rc == 0
+    assert uninstall_rc == 0
+    assert home_hooks_path.read_text(encoding="utf-8") == original_hooks
+
+
 def test_guard_detect_codex_collects_global_and_workspace_hooks(tmp_path):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -11,6 +11,8 @@ except ModuleNotFoundError:
     import tomli as tomllib  # type: ignore[no-redef]
 
 from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.codex import CodexHarnessAdapter
 
 
 def _write_text(path: Path, text: str) -> None:
@@ -206,6 +208,65 @@ def test_guard_install_codex_merges_managed_hooks_without_removing_existing_entr
             "hooks": [{"type": "command", "command": "python3 custom-start.py"}],
         }
     ]
+
+
+def test_guard_detect_codex_collects_global_and_workspace_hooks(tmp_path):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _write_text(
+        home_dir / ".codex" / "hooks.json",
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [{"type": "command", "command": "python3 global-pre.py"}],
+                        }
+                    ]
+                }
+            },
+            indent=2,
+        )
+        + "\n",
+    )
+    _write_text(
+        workspace_dir / ".codex" / "hooks.json",
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [{"type": "command", "command": "python3 workspace-pre.py"}],
+                        }
+                    ]
+                }
+            },
+            indent=2,
+        )
+        + "\n",
+    )
+
+    detection = CodexHarnessAdapter().detect(
+        HarnessContext(
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+            guard_home=tmp_path / "guard-home",
+        )
+    )
+
+    hook_artifacts = [artifact for artifact in detection.artifacts if artifact.artifact_type == "hook"]
+
+    assert {artifact.command for artifact in hook_artifacts} == {
+        "python3 global-pre.py",
+        "python3 workspace-pre.py",
+    }
+    assert {artifact.source_scope for artifact in hook_artifacts} == {"global", "project"}
+    assert set(detection.config_paths) == {
+        str(home_dir / ".codex" / "hooks.json"),
+        str(workspace_dir / ".codex" / "hooks.json"),
+    }
 
 
 def test_guard_install_codex_encodes_dash_prefixed_server_args_safely(tmp_path, capsys):

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -63,18 +63,28 @@ def test_guard_install_codex_rewrites_workspace_config_with_proxy_entries(tmp_pa
     managed_install = output["managed_install"]
     manifest = managed_install["manifest"]
     config_text = (workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8")
+    hooks_path = workspace_dir / ".codex" / "hooks.json"
+    hooks_payload = json.loads(hooks_path.read_text(encoding="utf-8"))
 
     assert rc == 0
     assert managed_install["active"] is True
     assert manifest["mode"] == "codex-mcp-proxy"
     assert manifest["managed_config_path"] == str(workspace_dir / ".codex" / "config.toml")
+    assert manifest["managed_hooks_path"] == str(hooks_path)
     assert set(manifest["managed_servers"]) == {"global_tools", "workspace_skill"}
     assert "--server-name" in config_text
     assert "guard" in config_text
     assert "codex-mcp-proxy" in config_text
     assert 'approval_policy = "never"' in config_text
+    assert "codex_hooks = true" in config_text
     assert 'API_BASE = "https://hol.org"' in config_text
     assert 'FEATURE_FLAG = "1"' in config_text
+    assert hooks_payload["hooks"]["PreToolUse"][0]["matcher"] == "Bash"
+    handler = hooks_payload["hooks"]["PreToolUse"][0]["hooks"][0]
+    assert handler["type"] == "command"
+    assert "codex_plugin_scanner.cli" in handler["command"]
+    assert "hook" in handler["command"]
+    assert "codex" in handler["command"]
 
 
 def test_guard_uninstall_codex_restores_original_workspace_config(tmp_path, capsys):
@@ -114,6 +124,88 @@ def test_guard_uninstall_codex_restores_original_workspace_config(tmp_path, caps
     assert uninstall_rc == 0
     assert uninstall_output["managed_install"]["active"] is False
     assert (workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8") == original_text
+    assert (workspace_dir / ".codex" / "hooks.json").exists() is False
+
+
+def test_guard_install_codex_merges_managed_hooks_without_removing_existing_entries(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
+    _write_text(
+        workspace_dir / ".codex" / "hooks.json",
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [{"type": "command", "command": "python3 custom-pre.py"}],
+                        }
+                    ],
+                    "SessionStart": [
+                        {
+                            "matcher": "startup|resume",
+                            "hooks": [{"type": "command", "command": "python3 custom-start.py"}],
+                        }
+                    ],
+                }
+            },
+            indent=2,
+        )
+        + "\n",
+    )
+
+    install_rc = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+    hooks_payload = json.loads((workspace_dir / ".codex" / "hooks.json").read_text(encoding="utf-8"))
+
+    uninstall_rc = main(
+        [
+            "guard",
+            "uninstall",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+    restored_hooks = json.loads((workspace_dir / ".codex" / "hooks.json").read_text(encoding="utf-8"))
+
+    assert install_rc == 0
+    assert uninstall_rc == 0
+    assert len(hooks_payload["hooks"]["PreToolUse"]) == 2
+    assert hooks_payload["hooks"]["PreToolUse"][0]["hooks"][0]["command"] == "python3 custom-pre.py"
+    managed_group = hooks_payload["hooks"]["PreToolUse"][1]
+    assert managed_group["matcher"] == "Bash"
+    assert "codex_plugin_scanner.cli" in managed_group["hooks"][0]["command"]
+    assert "hook" in managed_group["hooks"][0]["command"]
+    assert "codex" in managed_group["hooks"][0]["command"]
+    assert restored_hooks["hooks"]["PreToolUse"] == [
+        {
+            "matcher": "Bash",
+            "hooks": [{"type": "command", "command": "python3 custom-pre.py"}],
+        }
+    ]
+    assert restored_hooks["hooks"]["SessionStart"] == [
+        {
+            "matcher": "startup|resume",
+            "hooks": [{"type": "command", "command": "python3 custom-start.py"}],
+        }
+    ]
 
 
 def test_guard_install_codex_encodes_dash_prefixed_server_args_safely(tmp_path, capsys):

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -333,6 +333,49 @@ def test_guard_install_codex_refuses_invalid_alternate_hook_file_before_config_w
     assert (home_dir / ".codex" / "hooks.json").read_text(encoding="utf-8") == '{"hooks": '
 
 
+def test_guard_uninstall_codex_succeeds_when_alternate_hook_file_is_invalid(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    original_config = 'approval_policy = "never"\n'
+    _write_text(workspace_dir / ".codex" / "config.toml", original_config)
+
+    install_rc = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+    _write_text(home_dir / ".codex" / "hooks.json", '{"hooks": ')
+
+    uninstall_rc = main(
+        [
+            "guard",
+            "uninstall",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    uninstall_output = json.loads(capsys.readouterr().out)
+
+    assert install_rc == 0
+    assert uninstall_rc == 0
+    assert uninstall_output["managed_install"]["active"] is False
+    assert (workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8") == original_config
+    assert (workspace_dir / ".codex" / "hooks.json").exists() is False
+    assert (home_dir / ".codex" / "hooks.json").read_text(encoding="utf-8") == '{"hooks": '
+
+
 def test_guard_detect_codex_collects_global_and_workspace_hooks(tmp_path):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_product_flow.py
+++ b/tests/test_guard_product_flow.py
@@ -108,7 +108,8 @@ class TestGuardProductFlow:
         assert codex_summary["next_action"] == "install"
         assert codex_summary["approval_flow"]["prompt_channel"] == "native"
         assert codex_summary["approval_flow"]["auto_open_browser"] is False
-        assert "same-chat Codex approvals" in codex_summary["approval_flow"]["summary"]
+        assert "native Codex Bash hooks" in codex_summary["approval_flow"]["summary"]
+        assert "same-chat approvals" in codex_summary["approval_flow"]["summary"]
         assert output["next_steps"][0]["command"] == "hol-guard install codex"
         assert output["next_steps"][1]["command"] == "hol-guard run codex --dry-run"
 

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -5831,10 +5831,11 @@ def test_guard_hook_keeps_artifact_approval_for_same_sensitive_tool_action_retry
     assert len(third_output["approval_requests"]) == 1
 
 
-def test_guard_hook_codex_emits_native_deny_for_sensitive_bash_command(tmp_path, capsys):
+def test_guard_hook_codex_emits_native_deny_for_sensitive_bash_command(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
     event_path = tmp_path / "codex-hook.json"
     _write_json(
         event_path,
@@ -5867,6 +5868,44 @@ def test_guard_hook_codex_emits_native_deny_for_sensitive_bash_command(tmp_path,
     assert '"hookEventName":"PreToolUse"' in output
     assert '"permissionDecision":"deny"' in output
     assert "Approve it in HOL Guard, then retry." in output
+
+
+def test_guard_hook_codex_queues_approval_before_native_deny_output(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    blocked_event = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "echo MALICIOUS > dangerous-marker.json"},
+        "policy_action": "block",
+        "source_scope": "project",
+        "cwd": str(workspace_dir),
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(blocked_event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "codex",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+    pending = GuardStore(home_dir).list_approval_requests(limit=10)
+
+    assert rc == 0
+    assert output["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+    assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "Approve it in HOL Guard, then retry." in output["hookSpecificOutput"]["permissionDecisionReason"]
+    assert len(pending) == 1
+    assert pending[0]["artifact_type"] == "tool_action_request"
 
 
 def test_guard_hook_codex_keeps_artifact_approval_for_same_sensitive_tool_action_retry(

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -5831,6 +5831,149 @@ def test_guard_hook_keeps_artifact_approval_for_same_sensitive_tool_action_retry
     assert len(third_output["approval_requests"]) == 1
 
 
+def test_guard_hook_codex_emits_native_deny_for_sensitive_bash_command(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event_path = tmp_path / "codex-hook.json"
+    _write_json(
+        event_path,
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "echo MALICIOUS > dangerous-marker.json"},
+            "policy_action": "require-reapproval",
+            "cwd": str(workspace_dir),
+        },
+    )
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "codex",
+            "--event-file",
+            str(event_path),
+        ]
+    )
+    output = capsys.readouterr().out.strip()
+
+    assert rc == 0
+    assert '"hookEventName":"PreToolUse"' in output
+    assert '"permissionDecision":"deny"' in output
+    assert "Approve it in HOL Guard, then retry." in output
+
+
+def test_guard_hook_codex_keeps_artifact_approval_for_same_sensitive_tool_action_retry(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    blocked_event = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "echo MALICIOUS > dangerous-marker.json"},
+        "policy_action": "block",
+        "source_scope": "project",
+        "cwd": str(workspace_dir),
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(blocked_event)))
+
+    first_rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "codex",
+            "--json",
+        ]
+    )
+    first_output = json.loads(capsys.readouterr().out)
+    approval_request = first_output["approval_requests"][0]
+
+    approval_rc = main(
+        [
+            "guard",
+            "approvals",
+            "approve",
+            str(approval_request["request_id"]),
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(blocked_event)))
+    second_rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "codex",
+            "--json",
+        ]
+    )
+    second_output = json.loads(capsys.readouterr().out)
+
+    different_event = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "echo MALICIOUS > danger-two.json"},
+        "policy_action": "block",
+        "source_scope": "project",
+        "cwd": str(workspace_dir),
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(different_event)))
+    third_rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "codex",
+            "--json",
+        ]
+    )
+    third_output = json.loads(capsys.readouterr().out)
+
+    assert first_rc == 1
+    assert first_output["policy_action"] == "block"
+    assert first_output["artifact_type"] == "tool_action_request"
+    assert "destructive shell command" in first_output["risk_summary"].lower()
+    assert approval_request["recommended_scope"] == "artifact"
+    assert approval_rc == 0
+    assert second_rc == 0
+    assert second_output["policy_action"] == "allow"
+    assert second_output.get("approval_requests") in (None, [])
+    assert third_rc == 1
+    assert third_output["policy_action"] == "block"
+    assert len(third_output["approval_requests"]) == 1
+
+
 def test_guard_hook_allows_non_sensitive_read_file_requests(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -5908,6 +5908,42 @@ def test_guard_hook_codex_queues_approval_before_native_deny_output(tmp_path, ca
     assert pending[0]["artifact_type"] == "tool_action_request"
 
 
+def test_guard_hook_claude_native_block_does_not_queue_approval_center_request(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    blocked_event = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "echo MALICIOUS > dangerous-marker.json"},
+        "policy_action": "block",
+        "source_scope": "project",
+        "cwd": str(workspace_dir),
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(blocked_event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "claude-code",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+    pending = GuardStore(home_dir).list_approval_requests(limit=10)
+
+    assert rc == 0
+    assert output["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+    assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert pending == []
+
+
 def test_guard_hook_codex_keeps_artifact_approval_for_same_sensitive_tool_action_retry(
     tmp_path,
     capsys,


### PR DESCRIPTION
## Summary
- install Guard-managed Codex `PreToolUse` Bash hooks alongside Codex MCP management
- keep Codex `approval_policy = \"never\"` intact while enabling `features.codex_hooks = true`
- emit native Codex hook deny responses through the existing Guard approval pipeline and add regressions for install/uninstall and exact approval replay

## Verification
- `python3 -m pytest tests/test_guard_codex_install.py tests/test_guard_runtime.py -k 'codex or hook_keeps_artifact_approval_for_same_sensitive_tool_action_retry'`
- `python3 -m ruff check src/codex_plugin_scanner/guard/adapters/codex.py src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_codex_install.py tests/test_guard_runtime.py`
- `python3 -m build`

## Notes
- Current-source Guard install + native hook wiring verified locally.
- Real Codex canary proof was attempted multiple ways, but authenticated Codex runs were blocked upstream by Codex service availability (`We're currently experiencing high demand`) and throwaway-HOME runs hit auth bootstrap (`401 Unauthorized`).
