### PR TITLE
fix(guard): serialize daemon startup

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -7,9 +7,11 @@ import json
 import os
 import subprocess
 import sys
+import threading
 import time
 import urllib.error
 import urllib.request
+from contextlib import contextmanager
 from pathlib import Path
 
 from ...version import __version__
@@ -18,6 +20,11 @@ DEFAULT_GUARD_DAEMON_PORT = 4781
 GUARD_DAEMON_PORT_RANGE = 1000
 REQUIRED_DAEMON_TABLES = frozenset({"guard_connect_states"})
 GUARD_DAEMON_COMPATIBILITY_VERSION = 2
+GUARD_DAEMON_START_TIMEOUT_SECONDS = 5.0
+GUARD_DAEMON_POLL_INTERVAL_SECONDS = 0.1
+
+_START_LOCKS: dict[str, threading.Lock] = {}
+_START_LOCKS_GUARD = threading.Lock()
 
 
 def ensure_guard_daemon(guard_home: Path) -> str:
@@ -25,36 +32,41 @@ def ensure_guard_daemon(guard_home: Path) -> str:
     existing_url = load_guard_daemon_url(guard_home)
     if existing_url is not None:
         return existing_url
-    clear_guard_daemon_state(guard_home)
-    for candidate_port in _candidate_ports(guard_home):
-        command = [
-            sys.executable,
-            "-m",
-            "codex_plugin_scanner.cli",
-            "guard",
-            "daemon",
-            "--serve",
-            "--guard-home",
-            str(guard_home),
-            "--port",
-            str(candidate_port),
-        ]
-        kwargs: dict[str, object] = {
-            "stdin": subprocess.DEVNULL,
-            "stdout": subprocess.DEVNULL,
-            "stderr": subprocess.DEVNULL,
-        }
-        if os.name == "nt":
-            kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS
-        else:
-            kwargs["start_new_session"] = True
-        subprocess.Popen(command, **kwargs)
-        deadline = time.monotonic() + 1.5
-        while time.monotonic() < deadline:
-            url = load_guard_daemon_url(guard_home)
+    with _guard_daemon_start_lock(guard_home):
+        existing_url = load_guard_daemon_url(guard_home)
+        if existing_url is not None:
+            return existing_url
+        if _guard_daemon_start_in_progress(guard_home):
+            inflight_url = _wait_for_guard_daemon_url(guard_home, timeout=GUARD_DAEMON_START_TIMEOUT_SECONDS)
+            if inflight_url is not None:
+                return inflight_url
+        clear_guard_daemon_state(guard_home)
+        for candidate_port in _candidate_ports(guard_home):
+            command = [
+                sys.executable,
+                "-m",
+                "codex_plugin_scanner.cli",
+                "guard",
+                "daemon",
+                "--serve",
+                "--guard-home",
+                str(guard_home),
+                "--port",
+                str(candidate_port),
+            ]
+            kwargs: dict[str, object] = {
+                "stdin": subprocess.DEVNULL,
+                "stdout": subprocess.DEVNULL,
+                "stderr": subprocess.DEVNULL,
+            }
+            if os.name == "nt":
+                kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS
+            else:
+                kwargs["start_new_session"] = True
+            subprocess.Popen(command, **kwargs)
+            url = _wait_for_guard_daemon_url(guard_home, timeout=GUARD_DAEMON_START_TIMEOUT_SECONDS)
             if url is not None:
                 return url
-            time.sleep(0.1)
     raise RuntimeError(f"Guard approval center did not start. Expected state file at {state_path}.")
 
 
@@ -123,6 +135,83 @@ def _load_state(guard_home: Path) -> dict[str, object] | None:
 
 def _state_path(guard_home: Path) -> Path:
     return guard_home / "daemon-state.json"
+
+
+def _guard_daemon_start_in_progress(guard_home: Path) -> bool:
+    payload = _load_state(guard_home)
+    if not isinstance(payload, dict):
+        return False
+    compatibility_version = payload.get("compatibility_version")
+    if compatibility_version != GUARD_DAEMON_COMPATIBILITY_VERSION:
+        return False
+    pid = payload.get("pid")
+    return isinstance(pid, int) and pid > 0 and _guard_daemon_pid_is_running(pid)
+
+
+def _guard_daemon_pid_is_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _wait_for_guard_daemon_url(guard_home: Path, *, timeout: float) -> str | None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        url = load_guard_daemon_url(guard_home)
+        if url is not None:
+            return url
+        time.sleep(GUARD_DAEMON_POLL_INTERVAL_SECONDS)
+    return None
+
+
+@contextmanager
+def _guard_daemon_start_lock(guard_home: Path):
+    lock_key = str(guard_home.resolve())
+    with _START_LOCKS_GUARD:
+        thread_lock = _START_LOCKS.setdefault(lock_key, threading.Lock())
+    with thread_lock:
+        lock_path = guard_home / "daemon-start.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with lock_path.open("a+b") as handle:
+            _lock_daemon_start_file(handle)
+            try:
+                yield
+            finally:
+                _unlock_daemon_start_file(handle)
+
+
+def _lock_daemon_start_file(handle) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        handle.seek(0)
+        if handle.tell() == 0:
+            handle.write(b"0")
+            handle.flush()
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+        return
+    import fcntl
+
+    fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+
+
+def _unlock_daemon_start_file(handle) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        return
+    import fcntl
+
+    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
 def _configured_port(guard_home: Path) -> int | None:

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -13,6 +13,7 @@ import urllib.error
 import urllib.request
 from contextlib import contextmanager
 from pathlib import Path
+from typing import BinaryIO
 
 from ...version import __version__
 
@@ -63,8 +64,12 @@ def ensure_guard_daemon(guard_home: Path) -> str:
                 kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS
             else:
                 kwargs["start_new_session"] = True
-            subprocess.Popen(command, **kwargs)
-            url = _wait_for_guard_daemon_url(guard_home, timeout=GUARD_DAEMON_START_TIMEOUT_SECONDS)
+            process = subprocess.Popen(command, **kwargs)
+            url = _wait_for_guard_daemon_url(
+                guard_home,
+                timeout=GUARD_DAEMON_START_TIMEOUT_SECONDS,
+                process=process,
+            )
             if url is not None:
                 return url
     raise RuntimeError(f"Guard approval center did not start. Expected state file at {state_path}.")
@@ -160,12 +165,19 @@ def _guard_daemon_pid_is_running(pid: int) -> bool:
     return True
 
 
-def _wait_for_guard_daemon_url(guard_home: Path, *, timeout: float) -> str | None:
+def _wait_for_guard_daemon_url(
+    guard_home: Path,
+    *,
+    timeout: float,
+    process: subprocess.Popen[bytes] | None = None,
+) -> str | None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         url = load_guard_daemon_url(guard_home)
         if url is not None:
             return url
+        if process is not None and process.poll() is not None:
+            return None
         time.sleep(GUARD_DAEMON_POLL_INTERVAL_SECONDS)
     return None
 
@@ -186,23 +198,28 @@ def _guard_daemon_start_lock(guard_home: Path):
                 _unlock_daemon_start_file(handle)
 
 
-def _lock_daemon_start_file(handle) -> None:
+def _lock_daemon_start_file(handle: BinaryIO) -> None:
     if os.name == "nt":
         import msvcrt
 
         handle.seek(0)
-        if handle.tell() == 0:
+        if os.fstat(handle.fileno()).st_size == 0:
             handle.write(b"0")
             handle.flush()
         handle.seek(0)
-        msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+        while True:
+            try:
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                return
+            except OSError:
+                time.sleep(GUARD_DAEMON_POLL_INTERVAL_SECONDS)
         return
     import fcntl
 
     fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
 
 
-def _unlock_daemon_start_file(handle) -> None:
+def _unlock_daemon_start_file(handle: BinaryIO) -> None:
     if os.name == "nt":
         import msvcrt
 

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -524,7 +524,7 @@ class TestGuardApprovals:
         launched_commands: list[list[str]] = []
         guard_home = tmp_path / "guard-home"
         expected_port = daemon_manager_module._configured_port(guard_home)
-        responses = iter([None, f"http://127.0.0.1:{expected_port}"])
+        responses = iter([None, None, f"http://127.0.0.1:{expected_port}"])
 
         monkeypatch.delenv("GUARD_DAEMON_PORT", raising=False)
         monkeypatch.setattr(

--- a/tests/test_guard_daemon_manager.py
+++ b/tests/test_guard_daemon_manager.py
@@ -1,0 +1,82 @@
+"""Focused tests for Guard daemon startup coordination."""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+from codex_plugin_scanner.guard.daemon import manager as daemon_manager_module
+
+
+def test_ensure_guard_daemon_reuses_inflight_pid_before_respawning(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    responses = iter((None, None, "http://127.0.0.1:5409"))
+
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "load_guard_daemon_url",
+        lambda _guard_home: next(responses, "http://127.0.0.1:5409"),
+    )
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "_load_state",
+        lambda _guard_home: {
+            "pid": 12345,
+            "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
+        },
+    )
+    monkeypatch.setattr(daemon_manager_module, "_guard_daemon_pid_is_running", lambda _pid: True)
+    monkeypatch.setattr(daemon_manager_module.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        daemon_manager_module.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("should not spawn a new daemon")),
+    )
+
+    url = daemon_manager_module.ensure_guard_daemon(guard_home)
+
+    assert url == "http://127.0.0.1:5409"
+
+
+def test_ensure_guard_daemon_serializes_parallel_start_attempts(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    launched_commands: list[list[str]] = []
+    launched_event = threading.Event()
+    barrier = threading.Barrier(8)
+
+    def fake_load_guard_daemon_url(_guard_home):
+        if launched_event.is_set():
+            return "http://127.0.0.1:5410"
+        return None
+
+    def fake_popen(command, **_kwargs):
+        launched_commands.append(list(command))
+        launched_event.set()
+        return SimpleNamespace()
+
+    monkeypatch.setattr(daemon_manager_module, "load_guard_daemon_url", fake_load_guard_daemon_url)
+    monkeypatch.setattr(daemon_manager_module, "_load_state", lambda _guard_home: None)
+    monkeypatch.setattr(daemon_manager_module, "_candidate_ports", lambda _guard_home: [5410])
+    monkeypatch.setattr(daemon_manager_module.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(daemon_manager_module.time, "sleep", lambda _seconds: None)
+
+    results: list[str] = []
+    failures: list[str] = []
+
+    def worker() -> None:
+        try:
+            barrier.wait()
+            results.append(daemon_manager_module.ensure_guard_daemon(guard_home))
+        except Exception as exc:  # pragma: no cover - test assertion path
+            failures.append(str(exc))
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert failures == []
+    assert results == ["http://127.0.0.1:5410"] * 8
+    assert len(launched_commands) == 1
+    assert launched_commands[0][-2:] == ["--port", "5410"]

--- a/tests/test_guard_daemon_manager.py
+++ b/tests/test_guard_daemon_manager.py
@@ -80,3 +80,39 @@ def test_ensure_guard_daemon_serializes_parallel_start_attempts(tmp_path, monkey
     assert results == ["http://127.0.0.1:5410"] * 8
     assert len(launched_commands) == 1
     assert launched_commands[0][-2:] == ["--port", "5410"]
+
+
+def test_ensure_guard_daemon_advances_ports_after_early_process_exit(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    launched_commands: list[list[str]] = []
+    poll_count = {"value": 0}
+
+    class FakeProcess:
+        def __init__(self, *, alive: bool) -> None:
+            self._alive = alive
+
+        def poll(self) -> int | None:
+            if self._alive:
+                return None
+            return 1
+
+    def fake_load_guard_daemon_url(_guard_home):
+        if poll_count["value"] < 4:
+            poll_count["value"] += 1
+            return None
+        return "http://127.0.0.1:5411"
+
+    def fake_popen(command, **_kwargs):
+        launched_commands.append(list(command))
+        return FakeProcess(alive=len(launched_commands) > 1)
+
+    monkeypatch.setattr(daemon_manager_module, "load_guard_daemon_url", fake_load_guard_daemon_url)
+    monkeypatch.setattr(daemon_manager_module, "_load_state", lambda _guard_home: None)
+    monkeypatch.setattr(daemon_manager_module, "_candidate_ports", lambda _guard_home: [5410, 5411])
+    monkeypatch.setattr(daemon_manager_module.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(daemon_manager_module.time, "sleep", lambda _seconds: None)
+
+    url = daemon_manager_module.ensure_guard_daemon(guard_home)
+
+    assert url == "http://127.0.0.1:5411"
+    assert [command[-1] for command in launched_commands] == ["5410", "5411"]


### PR DESCRIPTION
## Summary
- serialize `ensure_guard_daemon()` startup so concurrent callers reuse the same in-flight daemon
- wait for an already-starting compatible daemon before clearing state or spawning another process
- add regression coverage for both in-flight reuse and parallel startup attempts

## Verification
- `PYTHONPATH=src pytest tests/test_guard_daemon_manager.py`
- `PYTHONPATH=src pytest tests/test_guard_approvals.py -k "ensure_guard_daemon or load_guard_daemon_url"`
- `ruff check src/codex_plugin_scanner/guard/daemon/manager.py tests/test_guard_daemon_manager.py tests/test_guard_approvals.py`
- bounded local smoke: repeated and parallel `ensure_guard_daemon()` calls converged on one live daemon process