### PR TITLE
fix(guard): brand claude approval prompts

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -14,8 +14,10 @@ from ..shims import install_guard_shim, remove_guard_shim
 from .base import HarnessAdapter, HarnessContext, _json_payload, _run_command_probe
 
 CLAUDE_GUARD_TOOL_MATCHER = "Bash|Read|Write|Edit|MultiEdit|WebFetch|WebSearch|mcp__.*"
+CLAUDE_GUARD_NOTIFICATION_MATCHER = "permission_prompt"
 CLAUDE_GUARD_TOOL_TIMEOUT_SECONDS = 30
 CLAUDE_GUARD_PROMPT_TIMEOUT_SECONDS = 20
+CLAUDE_GUARD_NOTIFICATION_TIMEOUT_SECONDS = 10
 CLAUDE_SETTINGS_FILES = ("settings.json", "settings.local.json")
 
 
@@ -439,6 +441,15 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
             hook_command,
             timeout=CLAUDE_GUARD_PROMPT_TIMEOUT_SECONDS,
         )
+        notification_entries = _prune_guard_hook_entries(
+            hooks.get("Notification") if isinstance(hooks.get("Notification"), list) else []
+        )
+        hooks["Notification"] = _merge_hook_group(
+            notification_entries,
+            CLAUDE_GUARD_NOTIFICATION_MATCHER,
+            hook_command,
+            timeout=CLAUDE_GUARD_NOTIFICATION_TIMEOUT_SECONDS,
+        )
         settings_path.parent.mkdir(parents=True, exist_ok=True)
         settings_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
         return {
@@ -466,7 +477,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
         hook_command = self._hook_command(context)
         hooks = payload.get("hooks")
         if isinstance(hooks, dict):
-            for key in ("PreToolUse", "PostToolUse", "UserPromptSubmit"):
+            for key in ("PreToolUse", "PostToolUse", "UserPromptSubmit", "Notification"):
                 entries = hooks.get(key)
                 hooks[key] = _remove_hook_entry(
                     _prune_guard_hook_entries(entries if isinstance(entries, list) else []),

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1457,7 +1457,9 @@ def _should_emit_prequeue_native_hook_response(args: argparse.Namespace) -> bool
     return args.harness == "claude-code" and not getattr(args, "json", False)
 
 
-def _claude_permission_notice_state_key(session_id: str) -> str:
+def _claude_permission_notice_state_key(session_id: str, tool_name: str | None = None) -> str:
+    if tool_name is not None:
+        return f"claude_permission_notice:{session_id}:{tool_name}"
     return f"claude_permission_notice:{session_id}"
 
 
@@ -1480,14 +1482,31 @@ def _record_claude_permission_notice(
     }
     if tool_name is not None:
         notice_payload["tool_name"] = tool_name
-    store.set_sync_payload(_claude_permission_notice_state_key(session_id), notice_payload, _now())
+    try:
+        store.set_sync_payload(_claude_permission_notice_state_key(session_id, tool_name), notice_payload, _now())
+    except (OSError, sqlite3.Error):
+        return
 
 
 def _load_claude_permission_notice(store: GuardStore, payload: dict[str, object]) -> dict[str, object] | None:
     session_id = _optional_string(payload.get("session_id"))
     if session_id is None:
         return None
-    persisted = store.get_sync_payload(_claude_permission_notice_state_key(session_id))
+    tool_name = _optional_string(payload.get("tool_name"))
+    try:
+        persisted = store.get_sync_payload(_claude_permission_notice_state_key(session_id, tool_name))
+        loaded_generic = False
+        if persisted is None and tool_name is not None:
+            persisted = store.get_sync_payload(_claude_permission_notice_state_key(session_id))
+            loaded_generic = persisted is not None
+        if tool_name is not None:
+            store.delete_sync_payload(_claude_permission_notice_state_key(session_id, tool_name))
+            if loaded_generic:
+                store.delete_sync_payload(_claude_permission_notice_state_key(session_id))
+        else:
+            store.delete_sync_payload(_claude_permission_notice_state_key(session_id))
+    except (OSError, sqlite3.Error):
+        return None
     if isinstance(persisted, dict):
         return persisted
     return None

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1494,17 +1494,20 @@ def _load_claude_permission_notice(store: GuardStore, payload: dict[str, object]
         return None
     tool_name = _optional_string(payload.get("tool_name"))
     try:
-        persisted = store.get_sync_payload(_claude_permission_notice_state_key(session_id, tool_name))
-        loaded_generic = False
+        selected_key = _claude_permission_notice_state_key(session_id, tool_name)
+        persisted = store.get_sync_payload(selected_key)
         if persisted is None and tool_name is not None:
-            persisted = store.get_sync_payload(_claude_permission_notice_state_key(session_id))
-            loaded_generic = persisted is not None
-        if tool_name is not None:
-            store.delete_sync_payload(_claude_permission_notice_state_key(session_id, tool_name))
-            if loaded_generic:
-                store.delete_sync_payload(_claude_permission_notice_state_key(session_id))
-        else:
-            store.delete_sync_payload(_claude_permission_notice_state_key(session_id))
+            selected_key = _claude_permission_notice_state_key(session_id)
+            persisted = store.get_sync_payload(selected_key)
+        if persisted is None and tool_name is None:
+            prefix = f"{_claude_permission_notice_state_key(session_id)}:"
+            for candidate in store.list_sync_payloads_by_prefix(prefix, limit=1):
+                candidate_payload = candidate.get("payload")
+                if isinstance(candidate_payload, dict):
+                    persisted = candidate_payload
+                    selected_key = str(candidate["state_key"])
+                    break
+        store.delete_sync_payload(selected_key)
     except (OSError, sqlite3.Error):
         return None
     if isinstance(persisted, dict):

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1139,6 +1139,27 @@ def run_guard_command(args: argparse.Namespace) -> int:
             guard_home=context.guard_home,
             workspace=runtime_workspace,
         )
+        if _is_claude_permission_prompt_notification(args, payload):
+            notice = _load_claude_permission_notice(store, payload)
+            store.add_event(
+                "claude/permission_prompt",
+                {
+                    "session_id": payload.get("session_id"),
+                    "notification_type": payload.get("notification_type"),
+                    "tool_name": payload.get("tool_name"),
+                    "notice": notice or {},
+                },
+                _now(),
+            )
+            _emit_native_hook_response(
+                harness=args.harness,
+                policy_action="allow",
+                event_name="Notification",
+                reason="HOL Guard requested this Claude approval prompt.",
+                system_message=_claude_permission_prompt_system_message(payload=payload, notice=notice),
+                additional_context=_claude_permission_prompt_additional_context(notice),
+            )
+            return 0
         if runtime_artifact is not None:
             event_name = _hook_event_name(payload) or "PreToolUse"
             runtime_artifact_hash = artifact_hash(runtime_artifact)
@@ -1211,6 +1232,17 @@ def run_guard_command(args: argparse.Namespace) -> int:
                     artifact=runtime_artifact,
                     native_reason=native_reason,
                 )
+                if (
+                    args.harness == "claude-code"
+                    and event_name == "PreToolUse"
+                    and policy_action == "require-reapproval"
+                ):
+                    _record_claude_permission_notice(
+                        store=store,
+                        payload=payload,
+                        reason=native_reason,
+                        artifact=runtime_artifact,
+                    )
                 if _should_emit_copilot_hook_response(args):
                     _emit_copilot_hook_response(
                         policy_action=policy_action,
@@ -1425,6 +1457,80 @@ def _should_emit_prequeue_native_hook_response(args: argparse.Namespace) -> bool
     return args.harness == "claude-code" and not getattr(args, "json", False)
 
 
+def _claude_permission_notice_state_key(session_id: str) -> str:
+    return f"claude_permission_notice:{session_id}"
+
+
+def _record_claude_permission_notice(
+    *,
+    store: GuardStore,
+    payload: dict[str, object],
+    reason: str,
+    artifact: GuardArtifact,
+) -> None:
+    session_id = _optional_string(payload.get("session_id"))
+    if session_id is None:
+        return
+    tool_name = _optional_string(payload.get("tool_name"))
+    notice_payload: dict[str, object] = {
+        "saved_at": _now(),
+        "reason": reason,
+        "artifact_id": artifact.artifact_id,
+        "artifact_name": artifact.name,
+    }
+    if tool_name is not None:
+        notice_payload["tool_name"] = tool_name
+    store.set_sync_payload(_claude_permission_notice_state_key(session_id), notice_payload, _now())
+
+
+def _load_claude_permission_notice(store: GuardStore, payload: dict[str, object]) -> dict[str, object] | None:
+    session_id = _optional_string(payload.get("session_id"))
+    if session_id is None:
+        return None
+    persisted = store.get_sync_payload(_claude_permission_notice_state_key(session_id))
+    if isinstance(persisted, dict):
+        return persisted
+    return None
+
+
+def _is_claude_permission_prompt_notification(args: argparse.Namespace, payload: dict[str, object]) -> bool:
+    return (
+        args.harness == "claude-code"
+        and _hook_event_name(payload) == "Notification"
+        and _optional_string(payload.get("notification_type")) == "permission_prompt"
+    )
+
+
+def _claude_permission_prompt_system_message(
+    *,
+    payload: dict[str, object],
+    notice: dict[str, object] | None,
+) -> str:
+    tool_name = _optional_string(payload.get("tool_name"))
+    if tool_name is None and notice is not None:
+        tool_name = _optional_string(notice.get("tool_name"))
+    reason = _optional_string(notice.get("reason")) if notice is not None else None
+    intro = "HOL Guard requested this Claude approval prompt."
+    if tool_name is not None:
+        intro = f"HOL Guard requested this Claude approval prompt for {tool_name}."
+    if reason is not None:
+        return f"{intro} {reason}"
+    return f"{intro} Review the action details below before allowing it."
+
+
+def _claude_permission_prompt_additional_context(notice: dict[str, object] | None) -> str:
+    reason = _optional_string(notice.get("reason")) if notice is not None else None
+    if reason is not None:
+        return (
+            "HOL Guard requested the active approval prompt. "
+            f"{reason} If the user denies it, do not retry the same sensitive access."
+        )
+    return (
+        "HOL Guard requested the active approval prompt for a sensitive tool action. "
+        "If the user denies it, do not retry the same action."
+    )
+
+
 def _approval_delivery_payload(
     harness: str,
     *,
@@ -1603,6 +1709,7 @@ def _emit_native_hook_response(
     reason: str,
     event_name: str = "PreToolUse",
     additional_context: str | None = None,
+    system_message: str | None = None,
 ) -> None:
     if event_name == "UserPromptSubmit":
         payload: dict[str, object] = {}
@@ -1610,6 +1717,18 @@ def _emit_native_hook_response(
             payload["decision"] = "block"
             payload["reason"] = reason
         elif additional_context:
+            payload["hookSpecificOutput"] = {
+                "hookEventName": event_name,
+                "additionalContext": additional_context,
+            }
+        if payload:
+            print(json.dumps(payload, separators=(",", ":")))
+        return
+    if event_name == "Notification":
+        payload = {}
+        if isinstance(system_message, str) and system_message.strip():
+            payload["systemMessage"] = system_message.strip()
+        if additional_context:
             payload["hookSpecificOutput"] = {
                 "hookEventName": event_name,
                 "additionalContext": additional_context,

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1492,22 +1492,15 @@ def _load_claude_permission_notice(store: GuardStore, payload: dict[str, object]
     session_id = _optional_string(payload.get("session_id"))
     if session_id is None:
         return None
-    tool_name = _optional_string(payload.get("tool_name"))
+    tool_name = _claude_notification_tool_name(payload)
     try:
         selected_key = _claude_permission_notice_state_key(session_id, tool_name)
         persisted = store.get_sync_payload(selected_key)
         if persisted is None and tool_name is not None:
             selected_key = _claude_permission_notice_state_key(session_id)
             persisted = store.get_sync_payload(selected_key)
-        if persisted is None and tool_name is None:
-            prefix = f"{_claude_permission_notice_state_key(session_id)}:"
-            for candidate in store.list_sync_payloads_by_prefix(prefix, limit=1):
-                candidate_payload = candidate.get("payload")
-                if isinstance(candidate_payload, dict):
-                    persisted = candidate_payload
-                    selected_key = str(candidate["state_key"])
-                    break
-        store.delete_sync_payload(selected_key)
+        if persisted is not None:
+            store.delete_sync_payload(selected_key)
     except (OSError, sqlite3.Error):
         return None
     if isinstance(persisted, dict):
@@ -1528,7 +1521,7 @@ def _claude_permission_prompt_system_message(
     payload: dict[str, object],
     notice: dict[str, object] | None,
 ) -> str:
-    tool_name = _optional_string(payload.get("tool_name"))
+    tool_name = _claude_notification_tool_name(payload)
     if tool_name is None and notice is not None:
         tool_name = _optional_string(notice.get("tool_name"))
     reason = _optional_string(notice.get("reason")) if notice is not None else None
@@ -1551,6 +1544,20 @@ def _claude_permission_prompt_additional_context(notice: dict[str, object] | Non
         "HOL Guard requested the active approval prompt for a sensitive tool action. "
         "If the user denies it, do not retry the same action."
     )
+
+
+def _claude_notification_tool_name(payload: dict[str, object]) -> str | None:
+    direct_name = _optional_string(payload.get("tool_name"))
+    if direct_name is not None:
+        return direct_name
+    for key in ("message", "title"):
+        value = _optional_string(payload.get(key))
+        if value is None:
+            continue
+        match = re.search(r"\buse\s+([A-Za-z][A-Za-z0-9_]*)\b", value)
+        if match is not None:
+            return match.group(1)
+    return None
 
 
 def _approval_delivery_payload(

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1691,6 +1691,13 @@ class GuardStore:
             return payload
         return None
 
+    def delete_sync_payload(self, state_key: str) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                "delete from sync_state where state_key = ?",
+                (state_key,),
+            )
+
     def add_event(self, event_name: str, payload: dict[str, object], now: str) -> None:
         with self._connect() as connection:
             connection.execute(

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1698,6 +1698,32 @@ class GuardStore:
                 (state_key,),
             )
 
+    def list_sync_payloads_by_prefix(self, prefix: str, *, limit: int = 10) -> list[dict[str, object]]:
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                select state_key, payload_json, updated_at
+                from sync_state
+                where state_key like ?
+                order by updated_at desc, state_key desc
+                limit ?
+                """,
+                (f"{prefix}%", limit),
+            ).fetchall()
+        items: list[dict[str, object]] = []
+        for row in rows:
+            payload = json.loads(str(row["payload_json"]))
+            if not isinstance(payload, (dict, list)):
+                continue
+            items.append(
+                {
+                    "state_key": str(row["state_key"]),
+                    "payload": payload,
+                    "updated_at": str(row["updated_at"]),
+                }
+            )
+        return items
+
     def add_event(self, event_name: str, payload: dict[str, object], now: str) -> None:
         with self._connect() as connection:
             connection.execute(

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1698,32 +1698,6 @@ class GuardStore:
                 (state_key,),
             )
 
-    def list_sync_payloads_by_prefix(self, prefix: str, *, limit: int = 10) -> list[dict[str, object]]:
-        with self._connect() as connection:
-            rows = connection.execute(
-                """
-                select state_key, payload_json, updated_at
-                from sync_state
-                where state_key like ?
-                order by updated_at desc, state_key desc
-                limit ?
-                """,
-                (f"{prefix}%", limit),
-            ).fetchall()
-        items: list[dict[str, object]] = []
-        for row in rows:
-            payload = json.loads(str(row["payload_json"]))
-            if not isinstance(payload, (dict, list)):
-                continue
-            items.append(
-                {
-                    "state_key": str(row["state_key"]),
-                    "payload": payload,
-                    "updated_at": str(row["updated_at"]),
-                }
-            )
-        return items
-
     def add_event(self, event_name: str, payload: dict[str, object], now: str) -> None:
         with self._connect() as connection:
             connection.execute(

--- a/tests/test_guard_claude_adapter.py
+++ b/tests/test_guard_claude_adapter.py
@@ -107,6 +107,7 @@ def test_claude_install_writes_nested_hook_schema_and_is_idempotent(tmp_path):
     pre_tool_use = payload["hooks"]["PreToolUse"]
     post_tool_use = payload["hooks"]["PostToolUse"]
     prompt_submit = payload["hooks"]["UserPromptSubmit"]
+    notification = payload["hooks"]["Notification"]
 
     assert len(pre_tool_use) == 1
     assert pre_tool_use[0]["matcher"] == "Bash|Read|Write|Edit|MultiEdit|WebFetch|WebSearch|mcp__.*"
@@ -115,6 +116,9 @@ def test_claude_install_writes_nested_hook_schema_and_is_idempotent(tmp_path):
     assert len(post_tool_use) == 1
     assert len(prompt_submit) == 1
     assert "matcher" not in prompt_submit[0]
+    assert len(notification) == 1
+    assert notification[0]["matcher"] == "permission_prompt"
+    assert notification[0]["hooks"][0]["timeout"] == 10
 
 
 def test_claude_install_and_uninstall_preserve_unrelated_nested_hooks(tmp_path):

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -2079,9 +2079,12 @@ args = ["workspace-skill.js", "--changed"]
         )
         assert install_settings_payload["hooks"]["PreToolUse"][0]["hooks"][0]["command"] == expected_hook_command
         assert install_settings_payload["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"] == expected_hook_command
+        assert install_settings_payload["hooks"]["Notification"][0]["matcher"] == "permission_prompt"
+        assert install_settings_payload["hooks"]["Notification"][0]["hooks"][0]["command"] == expected_hook_command
         assert uninstall_rc == 0
         assert uninstall_output["managed_install"]["active"] is False
         assert settings_payload["hooks"]["PreToolUse"] == []
+        assert settings_payload["hooks"]["Notification"] == []
 
     def test_guard_uninstall_handles_non_dict_claude_hook_entries(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -2157,6 +2160,12 @@ args = ["workspace-skill.js", "--changed"]
                             "hooks": [{"type": "command", "command": legacy_command, "timeout": 20}],
                         }
                     ],
+                    "Notification": [
+                        {
+                            "matcher": "permission_prompt",
+                            "hooks": [{"type": "command", "command": legacy_command, "timeout": 10}],
+                        }
+                    ],
                 }
             },
         )
@@ -2181,6 +2190,7 @@ args = ["workspace-skill.js", "--changed"]
         assert len(payload["hooks"]["PreToolUse"]) == 1
         assert len(payload["hooks"]["PostToolUse"]) == 1
         assert len(payload["hooks"]["UserPromptSubmit"]) == 1
+        assert len(payload["hooks"]["Notification"]) == 1
         pretool_commands = [
             hook["command"]
             for hook in payload["hooks"]["PreToolUse"][0]["hooks"]
@@ -2188,6 +2198,13 @@ args = ["workspace-skill.js", "--changed"]
         ]
         assert len(pretool_commands) == 1
         assert legacy_command not in pretool_commands
+        notification_commands = [
+            hook["command"]
+            for hook in payload["hooks"]["Notification"][0]["hooks"]
+            if isinstance(hook, dict) and isinstance(hook.get("command"), str)
+        ]
+        assert len(notification_commands) == 1
+        assert legacy_command not in notification_commands
 
     def test_guard_install_auto_detects_configured_harnesses(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -4496,6 +4496,65 @@ def test_guard_hook_claude_notification_notice_is_tool_scoped_and_consumed(tmp_p
     )
 
 
+def test_guard_hook_claude_notification_notice_falls_back_when_tool_name_is_missing(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    pre_tool_event = {
+        "session_id": "session-claude-5",
+        "tool_name": "Read",
+        "tool_input": {"file_path": str(workspace_dir / ".env")},
+        "source_scope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(pre_tool_event)))
+
+    pre_tool_rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "claude-code",
+        ]
+    )
+    capsys.readouterr()
+
+    notification_event = {
+        "session_id": "session-claude-5",
+        "hook_event_name": "Notification",
+        "notification_type": "permission_prompt",
+        "title": "Permission needed",
+        "message": "Claude needs your permission to use Read",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(notification_event)))
+
+    notification_rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "claude-code",
+        ]
+    )
+    notification_output = json.loads(capsys.readouterr().out)
+
+    assert pre_tool_rc == 0
+    assert notification_rc == 0
+    assert "local secret access" in notification_output["systemMessage"]
+
+
 def test_guard_hook_claude_notice_storage_failures_fall_back_to_generic_prompt(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -6,6 +6,7 @@ import argparse
 import builtins
 import io
 import json
+import sqlite3
 import subprocess
 import sys
 import threading
@@ -4410,6 +4411,154 @@ def test_guard_hook_emits_generic_claude_notification_notice_without_cached_reas
         "Review the action details below before allowing it."
     )
     assert "sensitive tool action" in output["hookSpecificOutput"]["additionalContext"]
+
+
+def test_guard_hook_claude_notification_notice_is_tool_scoped_and_consumed(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    pre_tool_events = [
+        {
+            "session_id": "session-claude-3",
+            "tool_name": "Read",
+            "tool_input": {"file_path": str(workspace_dir / ".env")},
+            "source_scope": "project",
+        },
+        {
+            "session_id": "session-claude-3",
+            "tool_name": "Bash",
+            "tool_input": {"command": "docker run --rm alpine sh"},
+            "source_scope": "project",
+        },
+    ]
+    for event in pre_tool_events:
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "claude-code",
+            ]
+        )
+        assert rc == 0
+        capsys.readouterr()
+
+    read_notification = {
+        "session_id": "session-claude-3",
+        "hook_event_name": "Notification",
+        "notification_type": "permission_prompt",
+        "title": "Permission needed",
+        "message": "Claude needs your permission to use Read",
+        "tool_name": "Read",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(read_notification)))
+    first_rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "claude-code",
+        ]
+    )
+    first_output = json.loads(capsys.readouterr().out)
+
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(read_notification)))
+    second_rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "claude-code",
+        ]
+    )
+    second_output = json.loads(capsys.readouterr().out)
+
+    assert first_rc == 0
+    assert "local secret access" in first_output["systemMessage"]
+    assert second_rc == 0
+    assert second_output["systemMessage"] == (
+        "HOL Guard requested this Claude approval prompt for Read. "
+        "Review the action details below before allowing it."
+    )
+
+
+def test_guard_hook_claude_notice_storage_failures_fall_back_to_generic_prompt(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    def _raise_locked(*args, **kwargs):
+        raise sqlite3.Error("locked")
+
+    monkeypatch.setattr(GuardStore, "set_sync_payload", _raise_locked)
+    pre_tool_event = {
+        "session_id": "session-claude-4",
+        "tool_name": "Read",
+        "tool_input": {"file_path": str(workspace_dir / ".env")},
+        "source_scope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(pre_tool_event)))
+
+    pre_tool_rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "claude-code",
+        ]
+    )
+    pre_tool_output = json.loads(capsys.readouterr().out)
+
+    notification_event = {
+        "session_id": "session-claude-4",
+        "hook_event_name": "Notification",
+        "notification_type": "permission_prompt",
+        "title": "Permission needed",
+        "message": "Claude needs your permission to use Read",
+        "tool_name": "Read",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(notification_event)))
+
+    notification_rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "claude-code",
+        ]
+    )
+    notification_output = json.loads(capsys.readouterr().out)
+
+    assert pre_tool_rc == 0
+    assert pre_tool_output["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert notification_rc == 0
+    assert notification_output["systemMessage"] == (
+        "HOL Guard requested this Claude approval prompt for Read. "
+        "Review the action details below before allowing it."
+    )
 
 
 def test_guard_hook_emits_copilot_native_allow_response_for_safe_requests(tmp_path, capsys, monkeypatch):

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -4314,6 +4314,104 @@ def test_guard_hook_allows_claude_user_prompt_submit_without_hook_error(tmp_path
     assert output == ""
 
 
+def test_guard_hook_emits_claude_notification_notice_for_permission_prompt(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    pre_tool_event = {
+        "session_id": "session-claude-1",
+        "tool_name": "Read",
+        "tool_input": {"file_path": str(workspace_dir / ".env")},
+        "source_scope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(pre_tool_event)))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    pre_tool_rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "claude-code",
+        ]
+    )
+    pre_tool_output = json.loads(capsys.readouterr().out)
+
+    notification_event = {
+        "session_id": "session-claude-1",
+        "hook_event_name": "Notification",
+        "notification_type": "permission_prompt",
+        "title": "Permission needed",
+        "message": "Claude needs your permission to use Read",
+        "tool_name": "Read",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(notification_event)))
+
+    notification_rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "claude-code",
+        ]
+    )
+    notification_output = json.loads(capsys.readouterr().out)
+
+    assert pre_tool_rc == 0
+    assert pre_tool_output["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert notification_rc == 0
+    assert "HOL Guard requested this Claude approval prompt for Read." in notification_output["systemMessage"]
+    assert "local secret access" in notification_output["systemMessage"]
+    assert notification_output["hookSpecificOutput"]["hookEventName"] == "Notification"
+    assert "HOL Guard requested the active approval prompt." in (
+        notification_output["hookSpecificOutput"]["additionalContext"]
+    )
+
+
+def test_guard_hook_emits_generic_claude_notification_notice_without_cached_reason(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    notification_event = {
+        "session_id": "session-claude-2",
+        "hook_event_name": "Notification",
+        "notification_type": "permission_prompt",
+        "title": "Permission needed",
+        "message": "Claude needs your permission to use Bash",
+        "tool_name": "Bash",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(notification_event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "claude-code",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["systemMessage"] == (
+        "HOL Guard requested this Claude approval prompt for Bash. "
+        "Review the action details below before allowing it."
+    )
+    assert "sensitive tool action" in output["hookSpecificOutput"]["additionalContext"]
+
+
 def test_guard_hook_emits_copilot_native_allow_response_for_safe_requests(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"


### PR DESCRIPTION
## Summary
- add a Claude Notification(permission_prompt) Guard hook so native approval prompts explicitly say HOL Guard requested them
- persist the last Guard reason per Claude session and replay it into the user-visible system message/context when the permission prompt opens
- cover the new install/runtime behavior with focused adapter, CLI, and runtime tests

## Verification
- PYTHONPATH=src pytest tests/test_guard_claude_adapter.py tests/test_guard_cli.py tests/test_guard_runtime.py -k 'claude and (notification or user_prompt_submit or install_and_uninstall_manage_claude_hooks or install_replaces_legacy_claude_guard_hook_entries or nested_hook_schema)' -q
- ruff check src/codex_plugin_scanner/guard/adapters/claude_code.py src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_claude_adapter.py tests/test_guard_cli.py tests/test_guard_runtime.py
- installed hook command verification in /Users/michaelkantor/guard-claude-smoke showing PreToolUse ask plus Notification systemMessage output for a permission_prompt payload