### PR TITLE
fix(guard): improve claude approval attribution

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1615,7 +1615,8 @@ def _native_prompt_context(artifact: GuardArtifact) -> str:
     }
     if "secret_read" in prompt_classes:
         return (
-            "HOL Guard flagged this prompt because it asks for direct local secret access. "
+            "HOL Guard flagged this prompt because it asks for direct local secret access and is protecting your "
+            "local secrets. "
             "If that is intentional, continue and Guard will ask again on the actual tool call."
         )
     return (
@@ -1634,8 +1635,8 @@ def _runtime_artifact_native_reason(artifact: GuardArtifact, response_payload: d
     tool_name = artifact.metadata.get("tool_name")
     if isinstance(path_class, str) and isinstance(tool_name, str):
         return (
-            f"HOL Guard flagged this as local secret access via {tool_name} ({path_class}). "
-            "Approve only if you intended to expose it."
+            f"HOL Guard is protecting your local secrets from local secret access via {tool_name} ({path_class}). "
+            "Approve only if you intended to expose them."
         )
     risk_summary = response_payload.get("risk_summary")
     if isinstance(risk_summary, str) and risk_summary.strip():

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1529,13 +1529,9 @@ def _claude_permission_prompt_system_message(
     if tool_name is not None:
         intro = f"HOL Guard requested this Claude approval prompt for {tool_name}."
     if reason is not None:
-        return (
-            f"{intro} This is not Claude's default permission prompt. "
-            f"{_ensure_terminal_punctuation(reason)}"
-        )
+        return f"{intro} This is not Claude's default permission prompt. {_ensure_terminal_punctuation(reason)}"
     return (
-        f"{intro} This is not Claude's default permission prompt. "
-        "Review the action details below before allowing it."
+        f"{intro} This is not Claude's default permission prompt. Review the action details below before allowing it."
     )
 
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1529,7 +1529,10 @@ def _claude_permission_prompt_system_message(
     if tool_name is not None:
         intro = f"HOL Guard requested this Claude approval prompt for {tool_name}."
     if reason is not None:
-        return f"{intro} This is not Claude's default permission prompt. {reason}"
+        return (
+            f"{intro} This is not Claude's default permission prompt. "
+            f"{_ensure_terminal_punctuation(reason)}"
+        )
     return (
         f"{intro} This is not Claude's default permission prompt. "
         "Review the action details below before allowing it."
@@ -1541,7 +1544,7 @@ def _claude_permission_prompt_additional_context(notice: dict[str, object] | Non
     if reason is not None:
         return (
             "HOL Guard requested the active approval prompt. This is not Claude's default permission prompt. "
-            f"{reason} If the user denies it, do not retry the same sensitive access."
+            f"{_ensure_terminal_punctuation(reason)} If the user denies it, do not retry the same sensitive access."
         )
     return (
         "HOL Guard requested the active approval prompt for a sensitive tool action. "
@@ -1582,6 +1585,13 @@ def _native_hook_reason(*values: object | None) -> str:
     if messages:
         return " ".join(messages)
     return "HOL Guard flagged this tool call for review."
+
+
+def _ensure_terminal_punctuation(message: str) -> str:
+    trimmed = message.strip()
+    if trimmed.endswith((".", "!", "?")):
+        return trimmed
+    return f"{trimmed}."
 
 
 def _native_hook_reason_for_harness(harness: str, *values: object | None) -> str:
@@ -1664,11 +1674,11 @@ def _claude_prompt_additional_context(
     if _prompt_requires_hard_block(artifact):
         return None
     return (
-        f"{native_reason} "
-        "Before you use the first sensitive tool for this request, tell the user in one short sentence that HOL Guard "
-        "is requesting approval for the next sensitive action. Attempt that sensitive tool at most once. If HOL Guard "
-        "or Claude denies it, do not retry the same sensitive action automatically. Instead, tell the user approval "
-        "is required in Claude to continue."
+        f"{_ensure_terminal_punctuation(native_reason)} "
+        "Before you use the first sensitive tool for this request, tell the user exactly: "
+        "'HOL Guard is protecting your local secrets and is requesting approval for the next sensitive action.' "
+        "Attempt that sensitive tool at most once. If HOL Guard or Claude denies it, do not retry the same sensitive "
+        "action automatically. Instead, tell the user approval is required in Claude to continue."
     )
 
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1611,18 +1611,16 @@ def _prompt_requires_hard_block(artifact: GuardArtifact) -> bool:
     return isinstance(prompt_class, str) and prompt_class == "guard_bypass_intent"
 
 
+def _prompt_request_classes(artifact: GuardArtifact) -> set[str]:
+    prompt_classes = artifact.metadata.get("prompt_request_classes")
+    values = prompt_classes if isinstance(prompt_classes, list) else [artifact.metadata.get("prompt_request_class")]
+    return {str(item) for item in values if isinstance(item, str) and item.strip()}
+
+
 def _native_prompt_context(artifact: GuardArtifact) -> str:
     if _prompt_requires_hard_block(artifact):
         return "HOL Guard blocked this prompt because it asks to bypass or disable Guard."
-    prompt_classes = {
-        str(item)
-        for item in (
-            artifact.metadata.get("prompt_request_classes")
-            if isinstance(artifact.metadata.get("prompt_request_classes"), list)
-            else [artifact.metadata.get("prompt_request_class")]
-        )
-        if isinstance(item, str) and item.strip()
-    }
+    prompt_classes = _prompt_request_classes(artifact)
     if "secret_read" in prompt_classes:
         return (
             "HOL Guard flagged this prompt because it asks for direct local secret access and is protecting your "
@@ -1673,10 +1671,15 @@ def _claude_prompt_additional_context(
         return None
     if _prompt_requires_hard_block(artifact):
         return None
+    briefing_sentence = "HOL Guard is requesting approval for the next sensitive action."
+    if "secret_read" in _prompt_request_classes(artifact):
+        briefing_sentence = (
+            "HOL Guard is protecting your local secrets and is requesting approval for the next sensitive action."
+        )
     return (
         f"{_ensure_terminal_punctuation(native_reason)} "
         "Before you use the first sensitive tool for this request, tell the user exactly: "
-        "'HOL Guard is protecting your local secrets and is requesting approval for the next sensitive action.' "
+        f"'{briefing_sentence}' "
         "Attempt that sensitive tool at most once. If HOL Guard or Claude denies it, do not retry the same sensitive "
         "action automatically. Instead, tell the user approval is required in Claude to continue."
     )

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1529,19 +1529,23 @@ def _claude_permission_prompt_system_message(
     if tool_name is not None:
         intro = f"HOL Guard requested this Claude approval prompt for {tool_name}."
     if reason is not None:
-        return f"{intro} {reason}"
-    return f"{intro} Review the action details below before allowing it."
+        return f"{intro} This is not Claude's default permission prompt. {reason}"
+    return (
+        f"{intro} This is not Claude's default permission prompt. "
+        "Review the action details below before allowing it."
+    )
 
 
 def _claude_permission_prompt_additional_context(notice: dict[str, object] | None) -> str:
     reason = _optional_string(notice.get("reason")) if notice is not None else None
     if reason is not None:
         return (
-            "HOL Guard requested the active approval prompt. "
+            "HOL Guard requested the active approval prompt. This is not Claude's default permission prompt. "
             f"{reason} If the user denies it, do not retry the same sensitive access."
         )
     return (
         "HOL Guard requested the active approval prompt for a sensitive tool action. "
+        "This is not Claude's default permission prompt. "
         "If the user denies it, do not retry the same action."
     )
 
@@ -1658,7 +1662,13 @@ def _claude_prompt_additional_context(
         return None
     if _prompt_requires_hard_block(artifact):
         return None
-    return native_reason
+    return (
+        f"{native_reason} "
+        "Before you use the first sensitive tool for this request, tell the user in one short sentence that HOL Guard "
+        "is requesting approval for the next sensitive action. Attempt that sensitive tool at most once. If HOL Guard "
+        "or Claude denies it, do not retry the same sensitive action automatically. Instead, tell the user approval "
+        "is required in Claude to continue."
+    )
 
 
 def _copilot_hook_reason(*values: object | None) -> str:

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -4181,6 +4181,10 @@ def test_guard_hook_emits_claude_user_prompt_submit_context_for_overridable_prom
     assert "direct local secret access" in output["hookSpecificOutput"]["additionalContext"]
     assert "protecting your local secrets" in output["hookSpecificOutput"]["additionalContext"].lower()
     assert "before you use the first sensitive tool" in output["hookSpecificOutput"]["additionalContext"].lower()
+    assert "tell the user exactly" in output["hookSpecificOutput"]["additionalContext"].lower()
+    assert "hol guard is protecting your local secrets and is requesting approval" in (
+        output["hookSpecificOutput"]["additionalContext"].lower()
+    )
     assert "do not retry the same sensitive action automatically" in (
         output["hookSpecificOutput"]["additionalContext"].lower()
     )

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -4179,6 +4179,10 @@ def test_guard_hook_emits_claude_user_prompt_submit_context_for_overridable_prom
     assert output["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
     assert "additionalContext" in output["hookSpecificOutput"]
     assert "direct local secret access" in output["hookSpecificOutput"]["additionalContext"]
+    assert "before you use the first sensitive tool" in output["hookSpecificOutput"]["additionalContext"].lower()
+    assert "do not retry the same sensitive action automatically" in (
+        output["hookSpecificOutput"]["additionalContext"].lower()
+    )
     assert any(receipt["artifact_id"].startswith("claude-code:session:prompt") for receipt in receipts)
 
 
@@ -4370,11 +4374,13 @@ def test_guard_hook_emits_claude_notification_notice_for_permission_prompt(tmp_p
     assert pre_tool_output["hookSpecificOutput"]["permissionDecision"] == "ask"
     assert notification_rc == 0
     assert "HOL Guard requested this Claude approval prompt for Read." in notification_output["systemMessage"]
+    assert "not Claude's default permission prompt" in notification_output["systemMessage"]
     assert "local secret access" in notification_output["systemMessage"]
     assert notification_output["hookSpecificOutput"]["hookEventName"] == "Notification"
     assert "HOL Guard requested the active approval prompt." in (
         notification_output["hookSpecificOutput"]["additionalContext"]
     )
+    assert "not Claude's default permission prompt" in notification_output["hookSpecificOutput"]["additionalContext"]
 
 
 def test_guard_hook_emits_generic_claude_notification_notice_without_cached_reason(tmp_path, capsys, monkeypatch):
@@ -4408,6 +4414,7 @@ def test_guard_hook_emits_generic_claude_notification_notice_without_cached_reas
     assert rc == 0
     assert output["systemMessage"] == (
         "HOL Guard requested this Claude approval prompt for Bash. "
+        "This is not Claude's default permission prompt. "
         "Review the action details below before allowing it."
     )
     assert "sensitive tool action" in output["hookSpecificOutput"]["additionalContext"]
@@ -4492,6 +4499,7 @@ def test_guard_hook_claude_notification_notice_is_tool_scoped_and_consumed(tmp_p
     assert second_rc == 0
     assert second_output["systemMessage"] == (
         "HOL Guard requested this Claude approval prompt for Read. "
+        "This is not Claude's default permission prompt. "
         "Review the action details below before allowing it."
     )
 
@@ -4616,6 +4624,7 @@ def test_guard_hook_claude_notice_storage_failures_fall_back_to_generic_prompt(t
     assert notification_rc == 0
     assert notification_output["systemMessage"] == (
         "HOL Guard requested this Claude approval prompt for Read. "
+        "This is not Claude's default permission prompt. "
         "Review the action details below before allowing it."
     )
 

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -4191,6 +4191,42 @@ def test_guard_hook_emits_claude_user_prompt_submit_context_for_overridable_prom
     assert any(receipt["artifact_id"].startswith("claude-code:session:prompt") for receipt in receipts)
 
 
+def test_guard_hook_emits_generic_claude_user_prompt_submit_context_for_non_secret_prompts(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "Use Bash to run rm -rf ./dist and then stop.",
+        "source_scope": "project",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "claude-code",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert "protecting your local secrets" not in output["hookSpecificOutput"]["additionalContext"].lower()
+    assert "hol guard is requesting approval for the next sensitive action" in (
+        output["hookSpecificOutput"]["additionalContext"].lower()
+    )
+
+
 def test_guard_hook_emits_claude_user_prompt_submit_block_reason_without_continue_guidance(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -4179,6 +4179,7 @@ def test_guard_hook_emits_claude_user_prompt_submit_context_for_overridable_prom
     assert output["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
     assert "additionalContext" in output["hookSpecificOutput"]
     assert "direct local secret access" in output["hookSpecificOutput"]["additionalContext"]
+    assert "protecting your local secrets" in output["hookSpecificOutput"]["additionalContext"].lower()
     assert "before you use the first sensitive tool" in output["hookSpecificOutput"]["additionalContext"].lower()
     assert "do not retry the same sensitive action automatically" in (
         output["hookSpecificOutput"]["additionalContext"].lower()
@@ -4375,6 +4376,7 @@ def test_guard_hook_emits_claude_notification_notice_for_permission_prompt(tmp_p
     assert notification_rc == 0
     assert "HOL Guard requested this Claude approval prompt for Read." in notification_output["systemMessage"]
     assert "not Claude's default permission prompt" in notification_output["systemMessage"]
+    assert "protecting your local secrets" in notification_output["systemMessage"].lower()
     assert "local secret access" in notification_output["systemMessage"]
     assert notification_output["hookSpecificOutput"]["hookEventName"] == "Notification"
     assert "HOL Guard requested the active approval prompt." in (
@@ -4495,6 +4497,7 @@ def test_guard_hook_claude_notification_notice_is_tool_scoped_and_consumed(tmp_p
     second_output = json.loads(capsys.readouterr().out)
 
     assert first_rc == 0
+    assert "protecting your local secrets" in first_output["systemMessage"].lower()
     assert "local secret access" in first_output["systemMessage"]
     assert second_rc == 0
     assert second_output["systemMessage"] == (


### PR DESCRIPTION
## Summary
- make Claude prompt-hook guidance explicitly tell Claude to attribute the next sensitive approval to HOL Guard and avoid retry loops after denial
- make Claude permission-prompt notification copy explicitly say the approval prompt comes from HOL Guard, not Claude default permissions
- extend runtime coverage for the stronger Guard-owned Claude copy

## Verification
- PYTHONPATH=src pytest tests/test_guard_runtime.py -k 'claude and (user_prompt_submit_context_for_overridable_prompts or notification_notice_for_permission_prompt or generic_claude_notification_notice_without_cached_reason or claude_notification_notice_is_tool_scoped_and_consumed or claude_notification_notice_falls_back_when_tool_name_is_missing or claude_notice_storage_failures_fall_back_to_generic_prompt)' -q\n- PYTHONPATH=src pytest tests/test_guard_runtime.py tests/test_guard_cli.py tests/test_guard_claude_adapter.py -k 'claude and (user_prompt_submit or notification or install_and_uninstall_manage_claude_hooks or install_replaces_legacy_claude_guard_hook_entries or nested_hook_schema)' -q\n- ruff check src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_runtime.py tests/test_guard_cli.py tests/test_guard_claude_adapter.py\n- claude -p --verbose --output-format stream-json --include-hook-events ... against /Users/michaelkantor/guard-claude-smoke to confirm a single Guard-branded denial flow with no repeated .env read loop\n- direct invocation of the installed /Users/michaelkantor/guard-claude-smoke/.claude/settings.local.json hook command to verify the Notification(permission_prompt) systemMessage and additionalContext are explicitly HOL Guard-owned