### PR TITLE
fix(guard): add claude install alias

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/__init__.py
+++ b/src/codex_plugin_scanner/guard/adapters/__init__.py
@@ -30,6 +30,8 @@ def get_adapter(harness: str) -> HarnessAdapter:
     for adapter in ADAPTERS:
         if adapter.harness == harness:
             return adapter
+        if harness in getattr(adapter, "aliases", ()):
+            return adapter
     raise ValueError(f"Unsupported harness: {harness}")
 
 

--- a/src/codex_plugin_scanner/guard/adapters/base.py
+++ b/src/codex_plugin_scanner/guard/adapters/base.py
@@ -83,6 +83,7 @@ class HarnessAdapter:
     """Common interface shared by harness adapters."""
 
     harness = ""
+    aliases: tuple[str, ...] = ()
     executable = ""
     approval_tier = "approval-center"
     approval_summary = "Guard pauses the launch and routes approval through the local approval center."

--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -40,6 +40,21 @@ def _is_guard_hook_command(command: object) -> bool:
     return "guard hook" in command or "'guard', 'hook'" in command or '"guard", "hook"' in command
 
 
+def _is_guard_hook_url(url: object) -> bool:
+    return isinstance(url, str) and "/v1/hooks/claude-code" in url
+
+
+def _is_guard_hook_handler(handler: object) -> bool:
+    if not isinstance(handler, dict):
+        return False
+    handler_type = handler.get("type")
+    if handler_type == "command":
+        return _is_guard_hook_command(handler.get("command"))
+    if handler_type == "http":
+        return _is_guard_hook_url(handler.get("url"))
+    return False
+
+
 def _merge_hook_group(
     entries: list[object],
     matcher: str | None,
@@ -96,9 +111,7 @@ def _prune_guard_hook_entries(entries: list[object]) -> list[object]:
         if not isinstance(hooks, list):
             remaining.append(entry)
             continue
-        filtered_hooks = [
-            item for item in hooks if not (isinstance(item, dict) and _is_guard_hook_command(item.get("command")))
-        ]
+        filtered_hooks = [item for item in hooks if not _is_guard_hook_handler(item)]
         if filtered_hooks:
             updated_entry = dict(entry)
             updated_entry["hooks"] = filtered_hooks
@@ -176,6 +189,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
 
     harness = "claude-code"
     executable = "claude"
+    aliases = ("claude",)
     approval_tier = "native-or-center"
     approval_summary = (
         "Guard uses Claude hooks first and falls back to the local approval center when the shell cannot prompt."
@@ -408,7 +422,12 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
         return _run_command_probe([resolved_executable, "--help"], timeout_seconds=5)
 
     def install(self, context: HarnessContext) -> dict[str, object]:
-        shim_manifest = install_guard_shim(self.harness, context)
+        shim_manifest = install_guard_shim(
+            self.harness,
+            context,
+            launcher_name="claude",
+            display_name="claude",
+        )
         if context.workspace_dir is None:
             return {
                 "harness": self.harness,
@@ -464,7 +483,12 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
         }
 
     def uninstall(self, context: HarnessContext) -> dict[str, object]:
-        shim_manifest = remove_guard_shim(self.harness, context)
+        shim_manifest = remove_guard_shim(
+            self.harness,
+            context,
+            launcher_name="claude",
+            display_name="claude",
+        )
         if context.workspace_dir is None:
             return {
                 "harness": self.harness,

--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import subprocess
 import sys
+import urllib.parse
 from collections.abc import Callable
 from pathlib import Path
 
@@ -41,7 +42,10 @@ def _is_guard_hook_command(command: object) -> bool:
 
 
 def _is_guard_hook_url(url: object) -> bool:
-    return isinstance(url, str) and "/v1/hooks/claude-code" in url
+    if not isinstance(url, str):
+        return False
+    parsed = urllib.parse.urlparse(url)
+    return parsed.scheme == "http" and parsed.hostname == "127.0.0.1" and parsed.path == "/v1/hooks/claude-code"
 
 
 def _is_guard_hook_handler(handler: object) -> bool:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -148,7 +148,7 @@ def add_guard_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPar
             f"  {program_name} guard detect\n"
             f"  {program_name} guard doctor cursor\n"
             f"  {program_name} guard run codex --dry-run\n"
-            f"  {program_name} guard install claude-code --workspace .\n\n"
+            f"  {program_name} guard install claude --workspace .\n\n"
             f"{_GUARD_HELP_GROUPS}"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -12,13 +12,21 @@ if TYPE_CHECKING:
     from .adapters.base import HarnessContext
 
 
-def install_guard_shim(harness: str, context: HarnessContext) -> dict[str, object]:
+def install_guard_shim(
+    harness: str,
+    context: HarnessContext,
+    *,
+    launcher_name: str | None = None,
+    display_name: str | None = None,
+) -> dict[str, object]:
     """Create a local launcher shim that routes harness launches through Guard."""
 
     shim_dir = context.guard_home / "bin"
     shim_dir.mkdir(parents=True, exist_ok=True)
-    posix_path = shim_dir / f"guard-{harness}"
-    windows_path = shim_dir / f"guard-{harness}.cmd"
+    shim_name = launcher_name or harness
+    harness_label = display_name or harness
+    posix_path = shim_dir / f"guard-{shim_name}"
+    windows_path = shim_dir / f"guard-{shim_name}.cmd"
     workspace_args = []
     if context.workspace_dir is not None:
         workspace_args = ["--workspace", str(context.workspace_dir)]
@@ -31,18 +39,26 @@ def install_guard_shim(harness: str, context: HarnessContext) -> dict[str, objec
         "shim_command": posix_path.name,
         "windows_shim_path": str(windows_path),
         "notes": [
-            f"Launch {harness} through {posix_path.name} so Guard checks changes before the harness starts.",
+            f"Launch {harness_label} through {posix_path.name} so Guard checks changes before the harness starts.",
             f"Add {shim_dir} to PATH to use the wrapper command from any shell.",
         ],
     }
 
 
-def remove_guard_shim(harness: str, context: HarnessContext) -> dict[str, object]:
+def remove_guard_shim(
+    harness: str,
+    context: HarnessContext,
+    *,
+    launcher_name: str | None = None,
+    display_name: str | None = None,
+) -> dict[str, object]:
     """Remove a previously installed Guard launcher shim."""
 
     shim_dir = context.guard_home / "bin"
-    posix_path = shim_dir / f"guard-{harness}"
-    windows_path = shim_dir / f"guard-{harness}.cmd"
+    shim_name = launcher_name or harness
+    harness_label = display_name or harness
+    posix_path = shim_dir / f"guard-{shim_name}"
+    windows_path = shim_dir / f"guard-{shim_name}.cmd"
     removed_paths: list[str] = []
     for path in (posix_path, windows_path):
         if path.exists():
@@ -53,7 +69,7 @@ def remove_guard_shim(harness: str, context: HarnessContext) -> dict[str, object
         "shim_dir": str(shim_dir),
         "removed_paths": removed_paths,
         "shim_command": posix_path.name,
-        "notes": [f"Removed the Guard launcher shim for {harness}."],
+        "notes": [f"Removed the Guard launcher shim for {harness_label}."],
     }
 
 

--- a/tests/test_guard_claude_adapter.py
+++ b/tests/test_guard_claude_adapter.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from codex_plugin_scanner.guard.adapters import get_adapter
+from codex_plugin_scanner.guard.adapters import claude_code, get_adapter
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.claude_code import ClaudeCodeHarnessAdapter
 
@@ -203,6 +203,17 @@ def test_claude_install_replaces_legacy_http_guard_hooks(tmp_path):
     ]
 
     assert installed_hook_types == ["command", "command", "command", "command"]
+
+
+def test_claude_legacy_guard_url_detection_only_matches_local_guard_urls():
+    assert (
+        claude_code._is_guard_hook_url(
+            "http://127.0.0.1:5371/v1/hooks/claude-code?guard-home=%2Fold&workspace=%2Fworkspace"
+        )
+        is True
+    )
+    assert claude_code._is_guard_hook_url("https://hol.org/v1/hooks/claude-code") is False
+    assert claude_code._is_guard_hook_url("http://localhost:5371/v1/hooks/claude-code") is False
 
 
 def test_claude_install_and_uninstall_preserve_unrelated_nested_hooks(tmp_path):

--- a/tests/test_guard_claude_adapter.py
+++ b/tests/test_guard_claude_adapter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from codex_plugin_scanner.guard.adapters import get_adapter
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.claude_code import ClaudeCodeHarnessAdapter
 
@@ -119,6 +120,89 @@ def test_claude_install_writes_nested_hook_schema_and_is_idempotent(tmp_path):
     assert len(notification) == 1
     assert notification[0]["matcher"] == "permission_prompt"
     assert notification[0]["hooks"][0]["timeout"] == 10
+
+
+def test_get_adapter_accepts_claude_alias():
+    adapter = get_adapter("claude")
+
+    assert isinstance(adapter, ClaudeCodeHarnessAdapter)
+
+
+def test_claude_install_replaces_legacy_http_guard_hooks(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = ClaudeCodeHarnessAdapter()
+    settings_path = context.workspace_dir / ".claude" / "settings.local.json"
+    _write_json(
+        settings_path,
+        {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash|Read|Write|Edit|MultiEdit|WebFetch|WebSearch|mcp__.*",
+                        "hooks": [
+                            {
+                                "type": "http",
+                                "url": "http://127.0.0.1:5371/v1/hooks/claude-code?guard-home=%2Fold",
+                                "timeout": 30,
+                            }
+                        ],
+                    }
+                ],
+                "PostToolUse": [
+                    {
+                        "matcher": "Bash|Read|Write|Edit|MultiEdit|WebFetch|WebSearch|mcp__.*",
+                        "hooks": [
+                            {
+                                "type": "http",
+                                "url": "http://127.0.0.1:5371/v1/hooks/claude-code?guard-home=%2Fold",
+                                "timeout": 30,
+                            }
+                        ],
+                    }
+                ],
+                "UserPromptSubmit": [
+                    {
+                        "hooks": [
+                            {
+                                "type": "http",
+                                "url": "http://127.0.0.1:5371/v1/hooks/claude-code?guard-home=%2Fold",
+                                "timeout": 20,
+                            }
+                        ],
+                    }
+                ],
+                "Notification": [
+                    {
+                        "matcher": "permission_prompt",
+                        "hooks": [
+                            {
+                                "type": "http",
+                                "url": "http://127.0.0.1:5371/v1/hooks/claude-code?guard-home=%2Fold",
+                                "timeout": 10,
+                            }
+                        ],
+                    }
+                ],
+            }
+        },
+    )
+
+    adapter.install(context)
+
+    payload = json.loads(settings_path.read_text(encoding="utf-8"))
+    installed_hook_types = [
+        hook["type"]
+        for group in (
+            payload["hooks"]["PreToolUse"]
+            + payload["hooks"]["PostToolUse"]
+            + payload["hooks"]["UserPromptSubmit"]
+            + payload["hooks"]["Notification"]
+        )
+        for hook in group["hooks"]
+        if isinstance(hook, dict)
+    ]
+
+    assert installed_hook_types == ["command", "command", "command", "command"]
 
 
 def test_claude_install_and_uninstall_preserve_unrelated_nested_hooks(tmp_path):

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -2034,7 +2034,7 @@ args = ["workspace-skill.js", "--changed"]
             [
                 "guard",
                 "install",
-                "claude-code",
+                "claude",
                 "--home",
                 str(home_dir),
                 "--workspace",
@@ -2063,6 +2063,7 @@ args = ["workspace-skill.js", "--changed"]
 
         assert install_rc == 0
         assert install_output["managed_install"]["active"] is True
+        assert install_output["managed_install"]["manifest"]["shim_command"] == "guard-claude"
         assert settings_local.exists()
         assert len(install_settings_payload["hooks"]["PreToolUse"]) == 1
         assert install_output["managed_install"]["manifest"]["notes"][0]
@@ -3685,9 +3686,7 @@ curl --data-binary @"$1" http://127.0.0.1:8787/guard-canary
         assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
         assert "Approve it in HOL Guard, then retry." in output["hookSpecificOutput"]["permissionDecisionReason"]
 
-    def test_guard_codex_hook_exits_with_block_status_in_actual_codex_runtime(
-        self, tmp_path, monkeypatch, capsys
-    ):
+    def test_guard_codex_hook_exits_with_block_status_in_actual_codex_runtime(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         payload_path = workspace_dir / "hook-event.json"


### PR DESCRIPTION
## Summary
- accept  as a first-class alias for the Claude Code harness
- write the shorter  launcher while still targeting the canonical  runtime
- replace broken legacy Claude Guard  hook entries with valid  hooks during install

## Verification
- .................                                                        [100%]
17 passed, 163 deselected in 0.67s
- All checks passed!
- 7 files already formatted
- real local Claude smoke from  after repairing the workspace hook config to the new command-hook schema