### PR TITLE
fix(runtime): harden copilot and mcp execution

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/copilot.py
+++ b/src/codex_plugin_scanner/guard/adapters/copilot.py
@@ -109,11 +109,7 @@ def _is_managed_hook_command(command: str) -> bool:
 
 def _trusted_pythonpath_entries() -> list[str]:
     launcher_env = merge_guard_launcher_env()
-    path_entries = [
-        entry
-        for entry in launcher_env.get("PYTHONPATH", "").split(os.pathsep)
-        if entry.strip()
-    ]
+    path_entries = [entry for entry in launcher_env.get("PYTHONPATH", "").split(os.pathsep) if entry.strip()]
     package_root = _trusted_package_root()
     cli_entrypoint = package_root / "codex_plugin_scanner" / "cli.py"
     if not cli_entrypoint.is_file():

--- a/src/codex_plugin_scanner/guard/adapters/copilot.py
+++ b/src/codex_plugin_scanner/guard/adapters/copilot.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import ast
+import importlib.util
 import json
 import os
 import re
@@ -40,6 +42,7 @@ _LEGACY_MANAGED_HOOK_PATTERNS = (
     re.compile(r'(^|["\s])hook(["\s]|$)'),
     re.compile(r'--harness(?:["\s=]+)copilot(["\s]|$)'),
 )
+_INLINE_GUARD_ARGS_PATTERN = re.compile(r"json\.loads\((?P<payload>'(?:[^'\\]|\\.)*'|\"(?:[^\"\\]|\\.)*\")\)")
 
 
 def _hook_command_parts(context: HarnessContext, *, include_workspace: bool) -> tuple[str, ...]:
@@ -100,12 +103,8 @@ def _is_managed_hook_command(command: str) -> bool:
     if not executable.startswith("python") or tokens[1] != "-c":
         return False
     inline_code = tokens[2]
-    quoted_values = {match.group(2).lower() for match in re.finditer(r"([\"'])([^\"']+)\1", inline_code)}
-    return (
-        "codex_plugin_scanner.cli" in inline_code
-        and "main(" in inline_code
-        and {"guard", "hook", "--harness", "copilot"}.issubset(quoted_values)
-    )
+    inline_args = _inline_guard_args(inline_code)
+    return "codex_plugin_scanner.cli" in inline_code and _argv_targets_copilot(inline_args)
 
 
 def _trusted_pythonpath_entries() -> list[str]:
@@ -115,7 +114,7 @@ def _trusted_pythonpath_entries() -> list[str]:
         for entry in launcher_env.get("PYTHONPATH", "").split(os.pathsep)
         if entry.strip()
     ]
-    package_root = Path(__file__).resolve().parents[3]
+    package_root = _trusted_package_root()
     cli_entrypoint = package_root / "codex_plugin_scanner" / "cli.py"
     if not cli_entrypoint.is_file():
         raise RuntimeError(f"Guard could not locate the trusted CLI entrypoint at {cli_entrypoint}")
@@ -123,6 +122,45 @@ def _trusted_pythonpath_entries() -> list[str]:
     if package_root_str not in path_entries:
         path_entries.insert(0, package_root_str)
     return path_entries
+
+
+def _trusted_package_root() -> Path:
+    spec = importlib.util.find_spec("codex_plugin_scanner")
+    if spec is None:
+        raise RuntimeError("Guard could not locate the codex_plugin_scanner package")
+    if spec.submodule_search_locations:
+        return Path(next(iter(spec.submodule_search_locations))).resolve().parent
+    if spec.origin is None:
+        raise RuntimeError("Guard could not determine the codex_plugin_scanner package root")
+    return Path(spec.origin).resolve().parent.parent
+
+
+def _inline_guard_args(inline_code: str) -> tuple[str, ...]:
+    match = _INLINE_GUARD_ARGS_PATTERN.search(inline_code)
+    if match is None:
+        return ()
+    try:
+        payload = ast.literal_eval(match.group("payload"))
+    except (SyntaxError, ValueError):
+        return ()
+    if not isinstance(payload, str):
+        return ()
+    try:
+        guard_args = json.loads(payload)
+    except json.JSONDecodeError:
+        return ()
+    if not isinstance(guard_args, list) or any(not isinstance(item, str) for item in guard_args):
+        return ()
+    return tuple(item.lower() for item in guard_args)
+
+
+def _argv_targets_copilot(argv: tuple[str, ...]) -> bool:
+    for index, token in enumerate(argv):
+        if token == "--harness" and index + 1 < len(argv) and argv[index + 1] == "copilot":
+            return "guard" in argv and "hook" in argv
+        if token.startswith("--harness=") and token.split("=", 1)[1] == "copilot":
+            return "guard" in argv and "hook" in argv
+    return False
 
 
 def _is_managed_hook_entry(entry: object, bash_command: str, powershell_command: str) -> bool:

--- a/src/codex_plugin_scanner/guard/adapters/copilot.py
+++ b/src/codex_plugin_scanner/guard/adapters/copilot.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import shlex
 import subprocess
@@ -42,7 +43,6 @@ _LEGACY_MANAGED_HOOK_PATTERNS = (
 
 
 def _hook_command_parts(context: HarnessContext, *, include_workspace: bool) -> tuple[str, ...]:
-    package_root = Path(__file__).resolve().parents[3]
     guard_args = [
         "guard",
         "hook",
@@ -55,11 +55,13 @@ def _hook_command_parts(context: HarnessContext, *, include_workspace: bool) -> 
         guard_args.extend(["--home", str(context.home_dir)])
     if include_workspace and context.workspace_dir is not None:
         guard_args.extend(["--workspace", str(context.workspace_dir)])
+    trusted_path_entries = _trusted_pythonpath_entries()
+    guard_args_json = json.dumps(guard_args)
     code = (
-        "import sys;"
-        f"sys.path.insert(0, {str(package_root)!r});"
+        "import json,sys;"
+        f"sys.path[:0]={trusted_path_entries!r};"
         "from codex_plugin_scanner.cli import main;"
-        f"raise SystemExit(main({guard_args!r}))"
+        f"raise SystemExit(main(json.loads({guard_args_json!r})))"
     )
     return (sys.executable, "-c", code)
 
@@ -88,12 +90,39 @@ def _is_managed_hook_command(command: str) -> bool:
     normalized_command = command.lower()
     if all(pattern.search(normalized_command) is not None for pattern in _LEGACY_MANAGED_HOOK_PATTERNS):
         return True
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return False
+    if len(tokens) < 3:
+        return False
+    executable = Path(tokens[0]).name.lower()
+    if not executable.startswith("python") or tokens[1] != "-c":
+        return False
+    inline_code = tokens[2]
+    quoted_values = {match.group(2).lower() for match in re.finditer(r"([\"'])([^\"']+)\1", inline_code)}
     return (
-        "codex_plugin_scanner.cli" in normalized_command
-        and "copilot" in normalized_command
-        and "'guard'" in normalized_command
-        and "'hook'" in normalized_command
+        "codex_plugin_scanner.cli" in inline_code
+        and "main(" in inline_code
+        and {"guard", "hook", "--harness", "copilot"}.issubset(quoted_values)
     )
+
+
+def _trusted_pythonpath_entries() -> list[str]:
+    launcher_env = merge_guard_launcher_env()
+    path_entries = [
+        entry
+        for entry in launcher_env.get("PYTHONPATH", "").split(os.pathsep)
+        if entry.strip()
+    ]
+    package_root = Path(__file__).resolve().parents[3]
+    cli_entrypoint = package_root / "codex_plugin_scanner" / "cli.py"
+    if not cli_entrypoint.is_file():
+        raise RuntimeError(f"Guard could not locate the trusted CLI entrypoint at {cli_entrypoint}")
+    package_root_str = str(package_root)
+    if package_root_str not in path_entries:
+        path_entries.insert(0, package_root_str)
+    return path_entries
 
 
 def _is_managed_hook_entry(entry: object, bash_command: str, powershell_command: str) -> bool:

--- a/src/codex_plugin_scanner/guard/adapters/copilot.py
+++ b/src/codex_plugin_scanner/guard/adapters/copilot.py
@@ -33,7 +33,7 @@ _DETECTABLE_HOOK_EVENTS = (
     "errorOccurred",
 )
 _MANAGED_HOOK_FILENAME = "hol-guard-copilot.json"
-_MANAGED_HOOK_COMMAND_PATTERNS = (
+_LEGACY_MANAGED_HOOK_PATTERNS = (
     re.compile(r'(^|["\s])-m["\s]+codex_plugin_scanner\.cli(["\s]|$)'),
     re.compile(r'(^|["\s])guard(["\s]|$)'),
     re.compile(r'(^|["\s])hook(["\s]|$)'),
@@ -42,10 +42,8 @@ _MANAGED_HOOK_COMMAND_PATTERNS = (
 
 
 def _hook_command_parts(context: HarnessContext, *, include_workspace: bool) -> tuple[str, ...]:
-    command = [
-        sys.executable,
-        "-m",
-        "codex_plugin_scanner.cli",
+    package_root = Path(__file__).resolve().parents[3]
+    guard_args = [
         "guard",
         "hook",
         "--guard-home",
@@ -54,10 +52,16 @@ def _hook_command_parts(context: HarnessContext, *, include_workspace: bool) -> 
         "copilot",
     ]
     if context.home_dir.resolve() != Path.home().resolve():
-        command.extend(["--home", str(context.home_dir)])
+        guard_args.extend(["--home", str(context.home_dir)])
     if include_workspace and context.workspace_dir is not None:
-        command.extend(["--workspace", str(context.workspace_dir)])
-    return tuple(command)
+        guard_args.extend(["--workspace", str(context.workspace_dir)])
+    code = (
+        "import sys;"
+        f"sys.path.insert(0, {str(package_root)!r});"
+        "from codex_plugin_scanner.cli import main;"
+        f"raise SystemExit(main({guard_args!r}))"
+    )
+    return (sys.executable, "-c", code)
 
 
 def _hook_shell_commands(context: HarnessContext, *, include_workspace: bool) -> tuple[str, str]:
@@ -71,7 +75,7 @@ def _hook_entry(context: HarnessContext, *, include_workspace: bool) -> dict[str
         "type": "command",
         "bash": bash_command,
         "powershell": powershell_command,
-        "cwd": ".",
+        "cwd": str(context.guard_home),
         "timeoutSec": 30,
     }
     env = merge_guard_launcher_env()
@@ -82,7 +86,14 @@ def _hook_entry(context: HarnessContext, *, include_workspace: bool) -> dict[str
 
 def _is_managed_hook_command(command: str) -> bool:
     normalized_command = command.lower()
-    return all(pattern.search(normalized_command) is not None for pattern in _MANAGED_HOOK_COMMAND_PATTERNS)
+    if all(pattern.search(normalized_command) is not None for pattern in _LEGACY_MANAGED_HOOK_PATTERNS):
+        return True
+    return (
+        "codex_plugin_scanner.cli" in normalized_command
+        and "copilot" in normalized_command
+        and "'guard'" in normalized_command
+        and "'hook'" in normalized_command
+    )
 
 
 def _is_managed_hook_entry(entry: object, bash_command: str, powershell_command: str) -> bool:

--- a/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
@@ -9,6 +9,7 @@ import sys
 from collections.abc import Awaitable
 from dataclasses import dataclass
 from importlib import metadata as importlib_metadata
+from importlib.metadata import Distribution
 from pathlib import Path
 from threading import Thread
 from typing import TypeVar
@@ -102,7 +103,7 @@ def _load_distribution_module(distribution_name: str, module_name: str) -> objec
     return module
 
 
-def _distribution_module_spec(distribution: importlib_metadata.Distribution, module_name: str):
+def _distribution_module_spec(distribution: Distribution, module_name: str):
     files = distribution.files or ()
     package_init_relative = f"{module_name}/__init__.py"
     module_relative = f"{module_name}.py"

--- a/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import importlib.util
 import os
+import sys
 from collections.abc import Awaitable
 from dataclasses import dataclass
+from importlib import metadata as importlib_metadata
 from pathlib import Path
 from threading import Thread
 from typing import TypeVar
@@ -70,9 +73,50 @@ def _build_summary(
 
 
 def _load_mcp_scanner_components() -> dict[str, object]:
-    from mcpscanner import YaraAnalyzer
+    module = _load_distribution_module("cisco-ai-mcp-scanner", "mcpscanner")
+    analyzer = getattr(module, "YaraAnalyzer", None)
+    if analyzer is None:
+        raise ImportError("cisco-ai-mcp-scanner does not expose mcpscanner.YaraAnalyzer")
+    return {"YaraAnalyzer": analyzer}
 
-    return {"YaraAnalyzer": YaraAnalyzer}
+
+def _load_distribution_module(distribution_name: str, module_name: str) -> object:
+    try:
+        distribution = importlib_metadata.distribution(distribution_name)
+    except importlib_metadata.PackageNotFoundError as exc:
+        raise ImportError(f"{distribution_name} is not installed") from exc
+    spec = _distribution_module_spec(distribution, module_name)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to resolve {module_name} from {distribution_name}")
+    module = importlib.util.module_from_spec(spec)
+    previous_module = sys.modules.get(module_name)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        if previous_module is None:
+            sys.modules.pop(module_name, None)
+        else:
+            sys.modules[module_name] = previous_module
+    return module
+
+
+def _distribution_module_spec(distribution: object, module_name: str):
+    locate_file = getattr(distribution, "locate_file", None)
+    if not callable(locate_file):
+        return None
+    package_dir = Path(locate_file(module_name))
+    package_init = package_dir / "__init__.py"
+    if package_init.is_file():
+        return importlib.util.spec_from_file_location(
+            module_name,
+            package_init,
+            submodule_search_locations=[str(package_dir)],
+        )
+    module_file = Path(locate_file(f"{module_name}.py"))
+    if module_file.is_file():
+        return importlib.util.spec_from_file_location(module_name, module_file)
+    return None
 
 
 def _relative_path(plugin_dir: Path, file_path: Path) -> str:

--- a/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
@@ -73,20 +73,27 @@ def _build_summary(
     )
 
 
-def _load_mcp_scanner_components() -> dict[str, object]:
-    module = _load_distribution_module("cisco-ai-mcp-scanner", "mcpscanner")
+def _load_mcp_scanner_components(*, blocked_root: Path | None = None) -> dict[str, object]:
+    module = _load_distribution_module("cisco-ai-mcp-scanner", "mcpscanner", blocked_root=blocked_root)
     analyzer = getattr(module, "YaraAnalyzer", None)
     if analyzer is None:
         raise ImportError("cisco-ai-mcp-scanner does not expose mcpscanner.YaraAnalyzer")
     return {"YaraAnalyzer": analyzer}
 
 
-def _load_distribution_module(distribution_name: str, module_name: str) -> object:
+def _load_distribution_module(
+    distribution_name: str,
+    module_name: str,
+    *,
+    blocked_root: Path | None = None,
+) -> object:
     try:
         distribution = importlib_metadata.distribution(distribution_name)
     except importlib_metadata.PackageNotFoundError as exc:
         raise ImportError(f"{distribution_name} is not installed") from exc
     spec = _distribution_module_spec(distribution, module_name)
+    if spec is None:
+        spec = _editable_distribution_spec(module_name, blocked_root=blocked_root)
     if spec is None or spec.loader is None:
         raise ImportError(f"Unable to resolve {module_name} from {distribution_name}")
     module = importlib.util.module_from_spec(spec)
@@ -139,6 +146,35 @@ def _distribution_module_spec(distribution: Distribution, module_name: str):
     if module_file.is_file():
         return importlib.util.spec_from_file_location(module_name, module_file)
     return None
+
+
+def _editable_distribution_spec(module_name: str, *, blocked_root: Path | None) -> object | None:
+    spec = importlib.util.find_spec(module_name)
+    if spec is None or spec.loader is None:
+        return None
+    if blocked_root is not None and not _spec_outside_blocked_root(spec, blocked_root):
+        return None
+    return spec
+
+
+def _spec_outside_blocked_root(spec: object, blocked_root: Path) -> bool:
+    blocked_root_resolved = blocked_root.resolve()
+    candidate_paths: list[Path] = []
+    spec_origin = getattr(spec, "origin", None)
+    if isinstance(spec_origin, str) and spec_origin not in {"built-in", "frozen"}:
+        candidate_paths.append(Path(spec_origin).resolve())
+    search_locations = getattr(spec, "submodule_search_locations", None)
+    if search_locations is not None:
+        candidate_paths.extend(Path(location).resolve() for location in search_locations)
+    return all(not _path_within_root(candidate_path, blocked_root_resolved) for candidate_path in candidate_paths)
+
+
+def _path_within_root(candidate_path: Path, root: Path) -> bool:
+    try:
+        candidate_path.relative_to(root)
+    except ValueError:
+        return False
+    return True
 
 
 def _relative_path(plugin_dir: Path, file_path: Path) -> str:
@@ -290,7 +326,12 @@ def run_cisco_mcp_scan(plugin_dir: Path, mode: str = "auto") -> CiscoMcpScanSumm
         )
 
     try:
-        components = _load_mcp_scanner_components()
+        try:
+            components = _load_mcp_scanner_components(blocked_root=plugin_dir)
+        except TypeError as exc:
+            if "blocked_root" not in str(exc):
+                raise
+            components = _load_mcp_scanner_components()
     except ImportError:
         if mode == "on":
             return _build_summary(

--- a/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
@@ -92,6 +92,8 @@ def _load_distribution_module(
     except importlib_metadata.PackageNotFoundError as exc:
         raise ImportError(f"{distribution_name} is not installed") from exc
     spec = _distribution_module_spec(distribution, module_name)
+    if spec is not None and blocked_root is not None and not _spec_outside_blocked_root(spec, blocked_root):
+        spec = None
     if spec is None:
         spec = _editable_distribution_spec(module_name, blocked_root=blocked_root)
     if spec is None or spec.loader is None:

--- a/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
@@ -93,27 +93,48 @@ def _load_distribution_module(distribution_name: str, module_name: str) -> objec
     sys.modules[module_name] = module
     try:
         spec.loader.exec_module(module)
-    finally:
+    except Exception:
         if previous_module is None:
             sys.modules.pop(module_name, None)
         else:
             sys.modules[module_name] = previous_module
+        raise
     return module
 
 
-def _distribution_module_spec(distribution: object, module_name: str):
+def _distribution_module_spec(distribution: importlib_metadata.Distribution, module_name: str):
+    files = distribution.files or ()
+    package_init_relative = f"{module_name}/__init__.py"
+    module_relative = f"{module_name}.py"
+    for package_file in files:
+        if str(package_file).replace("\\", "/") != package_init_relative:
+            continue
+        package_init = Path(package_file.locate())
+        if package_init.is_file():
+            return importlib.util.spec_from_file_location(
+                module_name,
+                package_init,
+                submodule_search_locations=[str(package_init.parent)],
+            )
+    for package_file in files:
+        if str(package_file).replace("\\", "/") != module_relative:
+            continue
+        module_file = Path(package_file.locate())
+        if module_file.is_file():
+            return importlib.util.spec_from_file_location(module_name, module_file)
     locate_file = getattr(distribution, "locate_file", None)
     if not callable(locate_file):
         return None
     package_dir = Path(locate_file(module_name))
-    package_init = package_dir / "__init__.py"
-    if package_init.is_file():
-        return importlib.util.spec_from_file_location(
-            module_name,
-            package_init,
-            submodule_search_locations=[str(package_dir)],
-        )
-    module_file = Path(locate_file(f"{module_name}.py"))
+    if package_dir.is_dir():
+        package_init = package_dir / "__init__.py"
+        if package_init.is_file():
+            return importlib.util.spec_from_file_location(
+                module_name,
+                package_init,
+                submodule_search_locations=[str(package_dir)],
+            )
+    module_file = Path(locate_file(module_relative))
     if module_file.is_file():
         return importlib.util.spec_from_file_location(module_name, module_file)
     return None

--- a/src/codex_plugin_scanner/verification.py
+++ b/src/codex_plugin_scanner/verification.py
@@ -452,7 +452,7 @@ def _check_mcp_http(remotes: list[dict], *, online: bool) -> list[VerificationCa
     return cases
 
 
-def _check_mcp_stdio(servers: dict) -> tuple[list[VerificationCase], list[RuntimeTrace]]:
+def _check_mcp_stdio(servers: dict) -> list[VerificationCase]:
     cases: list[VerificationCase] = []
     for name, server in servers.items():
         cmd = server.get("command") if isinstance(server, dict) else None
@@ -462,12 +462,12 @@ def _check_mcp_stdio(servers: dict) -> tuple[list[VerificationCase], list[Runtim
             VerificationCase(
                 "mcp",
                 f"stdio execution:{name}",
-                True,
-                "Skipped stdio command execution for safety; review the MCP command manually before trusting it.",
+                False,
+                "Skipped stdio command execution for safety; manual review is required before trusting it.",
                 "safety-skip",
             )
         )
-    return cases, []
+    return cases
 
 
 def _check_mcp(plugin_dir: Path, *, online: bool) -> tuple[list[VerificationCase], list[RuntimeTrace]]:
@@ -491,7 +491,8 @@ def _check_mcp(plugin_dir: Path, *, online: bool) -> tuple[list[VerificationCase
         cases.append(VerificationCase("mcp", "server registry", False, "mcpServers must be an object", "schema"))
         servers = {}
     cases.extend(_check_mcp_http(remotes, online=online))
-    stdio_cases, traces = _check_mcp_stdio(servers)
+    stdio_cases = _check_mcp_stdio(servers)
+    traces: list[RuntimeTrace] = []
     cases.extend(stdio_cases)
     if len(cases) == 1:
         cases.append(VerificationCase("mcp", "mcp config", True, "No remote or stdio MCP surfaces declared"))

--- a/src/codex_plugin_scanner/verification.py
+++ b/src/codex_plugin_scanner/verification.py
@@ -3,19 +3,13 @@
 from __future__ import annotations
 
 import json
-import os
-import queue
 import re
-import subprocess
-import threading
 import urllib.error
 import urllib.parse
 import urllib.request
-from contextlib import suppress
 from dataclasses import dataclass, replace
 from pathlib import Path
 
-from . import __version__
 from .checks.manifest import load_manifest
 from .checks.manifest_support import safe_manifest_path
 from .marketplace_support import (
@@ -119,26 +113,6 @@ def _read_json(path: Path) -> dict | list | None:
 
 def _is_safe_relative_asset(plugin_dir: Path, value: str) -> bool:
     return is_safe_relative_path(plugin_dir, value, require_prefix=True, require_exists=True)
-
-
-def _readline_with_timeout(stream, *, timeout: float, command: list[str], transcript: list[str]) -> str:
-    result_queue: queue.Queue[str | BaseException] = queue.Queue(maxsize=1)
-
-    def _reader() -> None:
-        try:
-            result_queue.put(stream.readline())
-        except BaseException as exc:  # pragma: no cover - defensive worker handoff
-            result_queue.put(exc)
-
-    thread = threading.Thread(target=_reader, daemon=True)
-    thread.start()
-    try:
-        result = result_queue.get(timeout=timeout)
-    except queue.Empty as exc:
-        raise subprocess.TimeoutExpired(command, timeout, output="\n".join(transcript)) from exc
-    if isinstance(result, BaseException):
-        raise result
-    return result
 
 
 def _check_manifest(plugin_dir: Path) -> list[VerificationCase]:
@@ -480,176 +454,20 @@ def _check_mcp_http(remotes: list[dict], *, online: bool) -> list[VerificationCa
 
 def _check_mcp_stdio(servers: dict) -> tuple[list[VerificationCase], list[RuntimeTrace]]:
     cases: list[VerificationCase] = []
-    traces: list[RuntimeTrace] = []
     for name, server in servers.items():
         cmd = server.get("command") if isinstance(server, dict) else None
-        args = server.get("args", []) if isinstance(server, dict) and isinstance(server.get("args", []), list) else []
         if not cmd:
             continue
-        command = [str(cmd), *[str(arg) for arg in args]]
-        try:
-            proc = subprocess.Popen(
-                command,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-                env=os.environ.copy(),
+        cases.append(
+            VerificationCase(
+                "mcp",
+                f"stdio execution:{name}",
+                True,
+                "Skipped stdio command execution for safety; review the MCP command manually before trusting it.",
+                "safety-skip",
             )
-        except Exception as exc:
-            cases.append(VerificationCase("mcp", f"stdio spawn:{name}", False, str(exc), "spawn-failure"))
-            traces.append(
-                RuntimeTrace(
-                    component="mcp",
-                    name=f"stdio spawn:{name}",
-                    command=tuple(command),
-                    returncode=None,
-                    stdout="",
-                    stderr=str(exc),
-                )
-            )
-            continue
-        transcript: list[str] = []
-        try:
-            if proc.stdin is None or proc.stdout is None or proc.stderr is None:
-                raise RuntimeError("stdio server did not expose all pipes")
-            initialize_request = {
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "initialize",
-                "params": {
-                    "protocolVersion": "2024-11-05",
-                    "capabilities": {"tools": {}, "resources": {}, "prompts": {}},
-                    "clientInfo": {"name": "plugin-scanner", "version": __version__},
-                },
-            }
-            proc.stdin.write(json.dumps(initialize_request) + "\n")
-            proc.stdin.flush()
-            transcript.append("> " + json.dumps(initialize_request))
-
-            initialize_response_line = _readline_with_timeout(
-                proc.stdout,
-                timeout=2,
-                command=command,
-                transcript=transcript,
-            )
-            if not initialize_response_line:
-                raise RuntimeError("server did not respond to initialize")
-            transcript.append("< " + initialize_response_line.strip())
-            initialize_response = json.loads(initialize_response_line)
-            result_payload = initialize_response.get("result")
-            if not isinstance(result_payload, dict):
-                raise RuntimeError("server returned an invalid initialize result")
-
-            initialized_notification = {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}
-            proc.stdin.write(json.dumps(initialized_notification) + "\n")
-            proc.stdin.flush()
-            transcript.append("> " + json.dumps(initialized_notification))
-
-            capabilities = result_payload.get("capabilities")
-            probe_methods = (
-                ("tools/list", "tools"),
-                ("resources/list", "resources"),
-                ("prompts/list", "prompts"),
-            )
-            request_id = 2
-            if isinstance(capabilities, dict):
-                for method, key in probe_methods:
-                    if key not in capabilities:
-                        continue
-                    request = {"jsonrpc": "2.0", "id": request_id, "method": method, "params": {}}
-                    request_id += 1
-                    proc.stdin.write(json.dumps(request) + "\n")
-                    proc.stdin.flush()
-                    transcript.append("> " + json.dumps(request))
-                    response_line = _readline_with_timeout(
-                        proc.stdout,
-                        timeout=2,
-                        command=command,
-                        transcript=transcript,
-                    )
-                    if not response_line:
-                        raise RuntimeError(f"server did not respond to {method}")
-                    transcript.append("< " + response_line.strip())
-                    json.loads(response_line)
-
-            proc.stdin.close()
-            proc.wait(timeout=2)
-            stdout = proc.stdout.read()
-            stderr = proc.stderr.read()
-            transcript_output = "\n".join(transcript)
-            if stdout:
-                transcript_output = f"{transcript_output}\n{stdout}".strip()
-            traces.append(
-                RuntimeTrace(
-                    component="mcp",
-                    name=f"stdio lifecycle:{name}",
-                    command=tuple(command),
-                    returncode=proc.returncode,
-                    stdout=transcript_output,
-                    stderr=stderr,
-                )
-            )
-            if proc.returncode not in (0, None):
-                cases.append(
-                    VerificationCase(
-                        "mcp",
-                        f"stdio initialize:{name}",
-                        False,
-                        stderr or "non-zero exit",
-                        "spawn-failure",
-                    )
-                )
-            elif "error" in transcript_output.lower():
-                cases.append(
-                    VerificationCase(
-                        "mcp",
-                        f"stdio initialize:{name}",
-                        False,
-                        transcript_output.strip(),
-                        "protocol-failure",
-                    )
-                )
-            else:
-                cases.append(VerificationCase("mcp", f"stdio initialize:{name}", True, "initialize completed"))
-        except subprocess.TimeoutExpired as exc:
-            proc.kill()
-            stdout = exc.stdout if isinstance(exc.stdout, str) else ""
-            stderr = exc.stderr if isinstance(exc.stderr, str) else ""
-            traces.append(
-                RuntimeTrace(
-                    component="mcp",
-                    name=f"stdio timeout:{name}",
-                    command=tuple(command),
-                    returncode=None,
-                    stdout=stdout,
-                    stderr=stderr,
-                    timed_out=True,
-                )
-            )
-            cases.append(VerificationCase("mcp", f"stdio timeout:{name}", False, "process timed out", "timeout"))
-        except Exception as exc:
-            if proc.poll() is None:
-                proc.kill()
-                with suppress(Exception):
-                    proc.wait(timeout=1)
-            stdout = proc.stdout.read() if proc.stdout is not None else ""
-            stderr = proc.stderr.read() if proc.stderr is not None else ""
-            transcript_output = "\n".join(transcript)
-            if stdout:
-                transcript_output = f"{transcript_output}\n{stdout}".strip()
-            traces.append(
-                RuntimeTrace(
-                    component="mcp",
-                    name=f"stdio lifecycle:{name}",
-                    command=tuple(command),
-                    returncode=proc.returncode,
-                    stdout=transcript_output,
-                    stderr=stderr or str(exc),
-                )
-            )
-            cases.append(VerificationCase("mcp", f"stdio run:{name}", False, str(exc), "spawn-failure"))
-    return cases, traces
+        )
+    return cases, []
 
 
 def _check_mcp(plugin_dir: Path, *, online: bool) -> tuple[list[VerificationCase], list[RuntimeTrace]]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SRC_PATH = Path(__file__).resolve().parents[1] / "src"
+
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -437,11 +437,13 @@ baseline_file = "baseline.txt"
 
         assert rc == 0
         with zipfile.ZipFile(bundle) as archive:
+            report = json.loads(archive.read("doctor-report.json").decode("utf-8"))
             stderr_log = archive.read("stderr.log").decode("utf-8")
             stdout_log = archive.read("stdout.log").decode("utf-8")
             timeout_markers = archive.read("timeout-markers.txt").decode("utf-8")
-        assert "doctor-err" in stderr_log
-        assert "doctor-out" in stdout_log
+        assert any(case["classification"] == "safety-skip" for case in report["cases"])
+        assert stderr_log == ""
+        assert stdout_log == ""
         assert "none" in timeout_markers
 
     def test_submit_writes_artifact(self, tmp_path):

--- a/tests/test_guard_copilot_adapter.py
+++ b/tests/test_guard_copilot_adapter.py
@@ -223,15 +223,15 @@ def test_copilot_install_and_uninstall_manage_inline_config_hooks_idempotently(t
         assert len(managed_hooks["postToolUse"]) == 1
         assert len(managed_hooks["permissionRequest"]) == 1
         assert managed_hooks["preToolUse"][0]["type"] == "command"
-        assert managed_hooks["preToolUse"][0]["cwd"] == "."
+        assert managed_hooks["preToolUse"][0]["cwd"] == str(context.guard_home)
         assert managed_hooks["preToolUse"][0]["timeoutSec"] == 30
         assert managed_hooks["preToolUse"][0]["env"]["PYTHONPATH"] == original_pythonpath
-        assert "guard hook" in managed_hooks["preToolUse"][0]["bash"]
-        assert "--harness copilot" in managed_hooks["preToolUse"][0]["bash"]
+        assert "from codex_plugin_scanner.cli import main" in managed_hooks["preToolUse"][0]["bash"]
+        assert "copilot" in managed_hooks["preToolUse"][0]["bash"]
         assert "--workspace" not in managed_hooks["preToolUse"][0]["bash"]
-        assert "guard hook" in managed_hooks["preToolUse"][0]["powershell"]
+        assert "from codex_plugin_scanner.cli import main" in managed_hooks["preToolUse"][0]["powershell"]
         assert managed_hooks["postToolUse"][0]["type"] == "command"
-        assert "guard hook" in managed_hooks["postToolUse"][0]["bash"]
+        assert "from codex_plugin_scanner.cli import main" in managed_hooks["postToolUse"][0]["bash"]
         assert len(managed_workspace_hooks["preToolUse"]) == 1
         assert len(managed_workspace_hooks["postToolUse"]) == 1
         assert len(managed_workspace_hooks["permissionRequest"]) == 1
@@ -372,7 +372,7 @@ def test_copilot_install_and_uninstall_match_inline_hooks_after_path_changes(tmp
                             "--guard-home C:\\old-guard --harness copilot --home C:\\old-home "
                             "--workspace C:\\old-workspace"
                         ),
-                        "cwd": ".",
+                        "cwd": "/tmp/old-workspace",
                         "timeoutSec": 30,
                     }
                 ],
@@ -389,7 +389,7 @@ def test_copilot_install_and_uninstall_match_inline_hooks_after_path_changes(tmp
                             "--guard-home C:\\old-guard --harness copilot --home C:\\old-home "
                             "--workspace C:\\old-workspace"
                         ),
-                        "cwd": ".",
+                        "cwd": "/tmp/old-workspace",
                         "timeoutSec": 30,
                     }
                 ],
@@ -405,6 +405,7 @@ def test_copilot_install_and_uninstall_match_inline_hooks_after_path_changes(tmp
     assert len(managed_payload["hooks"]["permissionRequest"]) == 1
     assert "--workspace /tmp/old-workspace" not in managed_payload["hooks"]["preToolUse"][0]["bash"]
     assert "--workspace" not in managed_payload["hooks"]["preToolUse"][0]["bash"]
+    assert managed_payload["hooks"]["preToolUse"][0]["cwd"] == str(context.guard_home)
 
     uninstall_payload = adapter.uninstall(context)
 

--- a/tests/test_guard_copilot_adapter.py
+++ b/tests/test_guard_copilot_adapter.py
@@ -355,6 +355,9 @@ def test_copilot_install_and_uninstall_match_inline_hooks_after_path_changes(tmp
     context = _build_context(tmp_path)
     adapter = CopilotHarnessAdapter()
     config_path = context.home_dir / ".copilot" / "config.json"
+    old_workspace_dir = tmp_path / "old-workspace"
+    old_guard_home = tmp_path / "old-guard"
+    old_home_dir = tmp_path / "old-home"
     _write_json(
         config_path,
         {
@@ -364,15 +367,15 @@ def test_copilot_install_and_uninstall_match_inline_hooks_after_path_changes(tmp
                         "type": "command",
                         "bash": (
                             "/opt/python/bin/python -m codex_plugin_scanner.cli guard hook "
-                            "--guard-home /tmp/old-guard --harness copilot --home /tmp/old-home "
-                            "--workspace /tmp/old-workspace"
+                            f"--guard-home {old_guard_home} --harness copilot --home {old_home_dir} "
+                            f"--workspace {old_workspace_dir}"
                         ),
                         "powershell": (
                             '"C:\\Python\\python.exe" -m codex_plugin_scanner.cli guard hook '
                             "--guard-home C:\\old-guard --harness copilot --home C:\\old-home "
                             "--workspace C:\\old-workspace"
                         ),
-                        "cwd": "/tmp/old-workspace",
+                        "cwd": str(old_workspace_dir),
                         "timeoutSec": 30,
                     }
                 ],
@@ -381,15 +384,15 @@ def test_copilot_install_and_uninstall_match_inline_hooks_after_path_changes(tmp
                         "type": "command",
                         "bash": (
                             "/opt/python/bin/python -m codex_plugin_scanner.cli guard hook "
-                            "--guard-home /tmp/old-guard --harness copilot --home /tmp/old-home "
-                            "--workspace /tmp/old-workspace"
+                            f"--guard-home {old_guard_home} --harness copilot --home {old_home_dir} "
+                            f"--workspace {old_workspace_dir}"
                         ),
                         "powershell": (
                             '"C:\\Python\\python.exe" -m codex_plugin_scanner.cli guard hook '
                             "--guard-home C:\\old-guard --harness copilot --home C:\\old-home "
                             "--workspace C:\\old-workspace"
                         ),
-                        "cwd": "/tmp/old-workspace",
+                        "cwd": str(old_workspace_dir),
                         "timeoutSec": 30,
                     }
                 ],
@@ -403,7 +406,7 @@ def test_copilot_install_and_uninstall_match_inline_hooks_after_path_changes(tmp
     assert len(managed_payload["hooks"]["preToolUse"]) == 1
     assert len(managed_payload["hooks"]["postToolUse"]) == 1
     assert len(managed_payload["hooks"]["permissionRequest"]) == 1
-    assert "--workspace /tmp/old-workspace" not in managed_payload["hooks"]["preToolUse"][0]["bash"]
+    assert str(old_workspace_dir) not in managed_payload["hooks"]["preToolUse"][0]["bash"]
     assert "--workspace" not in managed_payload["hooks"]["preToolUse"][0]["bash"]
     assert managed_payload["hooks"]["preToolUse"][0]["cwd"] == str(context.guard_home)
 

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -200,6 +200,7 @@ def test_mcp_security_loads_mcpscanner_from_installed_distribution(monkeypatch, 
         "distribution",
         lambda name: _FakeDistribution(trusted_root),
     )
+    monkeypatch.syspath_prepend(str(plugin_dir))
 
     components = cisco_mcp_module._load_mcp_scanner_components()
 

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import importlib.util
 import json
 import sys
 from pathlib import Path
@@ -206,6 +207,50 @@ def test_mcp_security_loads_mcpscanner_from_installed_distribution(monkeypatch, 
 
     assert components["YaraAnalyzer"].__module__ == "mcpscanner"
     assert Path(sys.modules["mcpscanner"].__file__).resolve() == (trusted_package / "__init__.py").resolve()
+
+
+def test_mcp_security_supports_editable_distribution_outside_plugin_root(monkeypatch, tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugin"
+    _write_plugin(plugin_dir)
+    trusted_root = tmp_path / "editable-src"
+    trusted_package = trusted_root / "mcpscanner"
+    trusted_package.mkdir(parents=True)
+    trusted_init = trusted_package / "__init__.py"
+    trusted_init.write_text("class YaraAnalyzer:\n    pass\n", encoding="utf-8")
+    (plugin_dir / "mcpscanner.py").write_text(
+        "raise RuntimeError('workspace import hijack executed')\n",
+        encoding="utf-8",
+    )
+
+    class _EditableDistribution:
+        files: tuple[()] = ()
+
+    editable_spec = importlib.util.spec_from_file_location(
+        "mcpscanner",
+        trusted_init,
+        submodule_search_locations=[str(trusted_package)],
+    )
+
+    monkeypatch.setattr(
+        cisco_mcp_module.importlib_metadata,
+        "distribution",
+        lambda name: _EditableDistribution(),
+    )
+    monkeypatch.setattr(
+        cisco_mcp_module.importlib.util,
+        "find_spec",
+        lambda name: editable_spec if name == "mcpscanner" else None,
+    )
+    monkeypatch.syspath_prepend(str(plugin_dir))
+
+    module = cisco_mcp_module._load_distribution_module(
+        "cisco-ai-mcp-scanner",
+        "mcpscanner",
+        blocked_root=plugin_dir,
+    )
+
+    assert module.__file__ == str(trusted_init)
+    assert Path(sys.modules["mcpscanner"].__file__).resolve() == trusted_init.resolve()
 
 
 def test_scan_plugin_includes_cisco_mcp_findings(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from codex_plugin_scanner.checks.mcp_security import resolve_mcp_security_context, run_mcp_security_checks
+from codex_plugin_scanner.integrations import cisco_mcp_scanner as cisco_mcp_module
 from codex_plugin_scanner.integrations.cisco_mcp_scanner import run_cisco_mcp_scan
 from codex_plugin_scanner.integrations.cisco_skill_scanner import CiscoIntegrationStatus
 from codex_plugin_scanner.models import ScanOptions
@@ -157,6 +158,39 @@ def test_mcp_security_handles_loader_failures(monkeypatch, tmp_path: Path) -> No
 
     assert summary.status == CiscoIntegrationStatus.FAILED
     assert "loader boom" in summary.message
+
+
+def test_mcp_security_loads_mcpscanner_from_installed_distribution(monkeypatch, tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugin"
+    _write_plugin(plugin_dir)
+    trusted_root = tmp_path / "trusted-site"
+    trusted_package = trusted_root / "mcpscanner"
+    trusted_package.mkdir(parents=True)
+    (trusted_package / "__init__.py").write_text(
+        "class YaraAnalyzer:\n    pass\n",
+        encoding="utf-8",
+    )
+    (plugin_dir / "mcpscanner.py").write_text(
+        "raise RuntimeError('workspace import hijack executed')\n",
+        encoding="utf-8",
+    )
+
+    class _FakeDistribution:
+        def __init__(self, package_root: Path) -> None:
+            self._package_root = package_root
+
+        def locate_file(self, path: str) -> Path:
+            return self._package_root / path
+
+    monkeypatch.setattr(
+        cisco_mcp_module.importlib_metadata,
+        "distribution",
+        lambda name: _FakeDistribution(trusted_root),
+    )
+
+    components = cisco_mcp_module._load_mcp_scanner_components()
+
+    assert components["YaraAnalyzer"].__module__ == "mcpscanner"
 
 
 def test_scan_plugin_includes_cisco_mcp_findings(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -178,9 +179,21 @@ def test_mcp_security_loads_mcpscanner_from_installed_distribution(monkeypatch, 
     class _FakeDistribution:
         def __init__(self, package_root: Path) -> None:
             self._package_root = package_root
+            self.files = (_FakeDistributionFile("mcpscanner/__init__.py", package_root / "mcpscanner" / "__init__.py"),)
 
         def locate_file(self, path: str) -> Path:
             return self._package_root / path
+
+    class _FakeDistributionFile:
+        def __init__(self, relative_path: str, absolute_path: Path) -> None:
+            self._relative_path = relative_path
+            self._absolute_path = absolute_path
+
+        def __str__(self) -> str:
+            return self._relative_path
+
+        def locate(self) -> Path:
+            return self._absolute_path
 
     monkeypatch.setattr(
         cisco_mcp_module.importlib_metadata,
@@ -191,6 +204,7 @@ def test_mcp_security_loads_mcpscanner_from_installed_distribution(monkeypatch, 
     components = cisco_mcp_module._load_mcp_scanner_components()
 
     assert components["YaraAnalyzer"].__module__ == "mcpscanner"
+    assert Path(sys.modules["mcpscanner"].__file__).resolve() == (trusted_package / "__init__.py").resolve()
 
 
 def test_scan_plugin_includes_cisco_mcp_findings(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -253,6 +253,45 @@ def test_mcp_security_supports_editable_distribution_outside_plugin_root(monkeyp
     assert Path(sys.modules["mcpscanner"].__file__).resolve() == trusted_init.resolve()
 
 
+def test_mcp_security_rejects_distribution_spec_inside_plugin_root(monkeypatch, tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugin"
+    _write_plugin(plugin_dir)
+    plugin_package = plugin_dir / "mcpscanner"
+    plugin_package.mkdir()
+    plugin_init = plugin_package / "__init__.py"
+    plugin_init.write_text("class YaraAnalyzer:\n    pass\n", encoding="utf-8")
+
+    class _PluginDistributionFile:
+        def __str__(self) -> str:
+            return "mcpscanner/__init__.py"
+
+        def locate(self) -> Path:
+            return plugin_init
+
+    class _PluginDistribution:
+        files = (_PluginDistributionFile(),)
+
+    monkeypatch.setattr(
+        cisco_mcp_module.importlib_metadata,
+        "distribution",
+        lambda name: _PluginDistribution(),
+    )
+    monkeypatch.setattr(cisco_mcp_module.importlib.util, "find_spec", lambda name: None)
+
+    try:
+        cisco_mcp_module._load_distribution_module(
+            "cisco-ai-mcp-scanner",
+            "mcpscanner",
+            blocked_root=plugin_dir,
+        )
+    except ImportError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("expected plugin-root distribution spec to be rejected")
+
+    assert "Unable to resolve mcpscanner" in message
+
+
 def test_scan_plugin_includes_cisco_mcp_findings(monkeypatch, tmp_path: Path) -> None:
     plugin_dir = tmp_path / "plugin"
     _write_plugin(plugin_dir)

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -1,11 +1,8 @@
 """Tests for runtime verification engine."""
 
 import json
-import os
-import sys
 from pathlib import Path
 
-from codex_plugin_scanner import verification as verification_module
 from codex_plugin_scanner.verification import build_doctor_report, verify_plugin
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -63,94 +60,12 @@ def test_verify_plugin_checks_skill_frontmatter_from_manifest(tmp_path: Path):
     assert any(case.component == "skills" and case.classification == "frontmatter" for case in result.cases)
 
 
-def test_verify_plugin_stdio_inherits_process_environment(tmp_path: Path, monkeypatch):
-    captured_env: dict[str, str] = {}
-
-    class StubInput:
-        def __init__(self):
-            self.writes: list[str] = []
-
-        def write(self, payload: str):
-            self.writes.append(payload)
-            return len(payload)
-
-        def flush(self):
-            return None
-
-        def close(self):
-            return None
-
-    class StubOutput:
-        def __init__(self, lines: list[str]):
-            self._lines = lines
-
-        def readline(self):
-            return self._lines.pop(0) if self._lines else ""
-
-        def read(self):
-            return ""
-
-    class StubProcess:
-        returncode = 0
-
-        def __init__(self):
-            self.stdin = StubInput()
-            self.stdout = StubOutput(
-                [
-                    '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{},"serverInfo":{"name":"stub","version":"1.0.0"}}}\n'
-                ]
-            )
-            self.stderr = StubOutput([])
-
-        def wait(self, timeout: int):
-            return 0
-
-    def fake_popen(*args, **kwargs):
-        nonlocal captured_env
-        captured_env = kwargs["env"]
-        return StubProcess()
-
-    monkeypatch.setattr(verification_module.subprocess, "Popen", fake_popen)
-    (tmp_path / ".mcp.json").write_text(
-        '{"mcpServers":{"demo":{"command":"python","args":["-c","print(1)"]}}}',
+def test_verify_plugin_skips_stdio_execution_for_untrusted_servers(tmp_path: Path):
+    (tmp_path / ".codex-plugin").mkdir()
+    (tmp_path / ".codex-plugin" / "plugin.json").write_text(
+        '{"name":"demo","version":"1.0.0","description":"demo"}',
         encoding="utf-8",
     )
-
-    verify_plugin(tmp_path)
-
-    assert captured_env
-    assert captured_env["PATH"] == os.environ["PATH"]
-
-
-def test_verify_plugin_kills_stdio_process_on_runtime_exception(tmp_path: Path, monkeypatch):
-    killed = False
-
-    class StubStdin:
-        def write(self, payload: str):
-            return len(payload)
-
-        def flush(self):
-            raise BrokenPipeError("broken pipe")
-
-    class StubProcess:
-        returncode = None
-
-        def __init__(self):
-            self.stdin = StubStdin()
-            self.stdout = None
-            self.stderr = None
-
-        def kill(self):
-            nonlocal killed
-            killed = True
-
-        def poll(self):
-            return None
-
-        def wait(self, timeout=None):
-            return None
-
-    monkeypatch.setattr(verification_module.subprocess, "Popen", lambda *args, **kwargs: StubProcess())
     (tmp_path / ".mcp.json").write_text(
         '{"mcpServers":{"demo":{"command":"python","args":["-c","print(1)"]}}}',
         encoding="utf-8",
@@ -158,9 +73,30 @@ def test_verify_plugin_kills_stdio_process_on_runtime_exception(tmp_path: Path, 
 
     result = verify_plugin(tmp_path)
 
-    assert killed is True
-    assert result.verify_pass is False
-    assert any(case.classification == "spawn-failure" for case in result.cases)
+    assert result.verify_pass is True
+    assert any(case.name == "stdio execution:demo" for case in result.cases)
+    assert any(case.classification == "safety-skip" for case in result.cases)
+    assert all(not trace.name.startswith("stdio") for trace in result.traces)
+
+
+def test_verify_plugin_reports_stdio_servers_without_spawning_them(tmp_path: Path):
+    (tmp_path / ".codex-plugin").mkdir()
+    (tmp_path / ".codex-plugin" / "plugin.json").write_text(
+        '{"name":"demo","version":"1.0.0","description":"demo"}',
+        encoding="utf-8",
+    )
+    (tmp_path / ".mcp.json").write_text(
+        '{"mcpServers":{"demo":{"command":"python","args":["-c","print(1)"]}}}',
+        encoding="utf-8",
+    )
+
+    result = verify_plugin(tmp_path)
+
+    assert result.verify_pass is True
+    expected_message = (
+        "Skipped stdio command execution for safety; review the MCP command manually before trusting it."
+    )
+    assert any(case.message == expected_message for case in result.cases)
 
 
 def test_doctor_report_filters_component():
@@ -169,35 +105,7 @@ def test_doctor_report_filters_component():
     assert isinstance(report["cases"], list)
 
 
-def test_verify_plugin_performs_mcp_initialize_lifecycle(tmp_path: Path):
-    script = """
-import json
-import sys
-
-init = json.loads(sys.stdin.readline())
-assert init["method"] == "initialize"
-assert init["params"]["protocolVersion"]
-assert init["params"]["clientInfo"]["name"] == "plugin-scanner"
-sys.stdout.write(json.dumps({
-    "jsonrpc": "2.0",
-    "id": init["id"],
-    "result": {
-        "protocolVersion": init["params"]["protocolVersion"],
-        "capabilities": {"tools": {}, "resources": {}, "prompts": {}},
-        "serverInfo": {"name": "stub", "version": "1.0.0"}
-    }
-}) + "\\n")
-sys.stdout.flush()
-
-initialized = json.loads(sys.stdin.readline())
-assert initialized["method"] == "notifications/initialized"
-
-for method, key in (("tools/list", "tools"), ("resources/list", "resources"), ("prompts/list", "prompts")):
-    request = json.loads(sys.stdin.readline())
-    assert request["method"] == method
-    sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": request["id"], "result": {key: []}}) + "\\n")
-    sys.stdout.flush()
-"""
+def test_doctor_report_explains_when_stdio_execution_is_skipped(tmp_path: Path):
     (tmp_path / ".codex-plugin").mkdir()
     (tmp_path / ".codex-plugin" / "plugin.json").write_text(
         '{"name":"mcp-demo","version":"1.0.0","description":"demo"}',
@@ -208,8 +116,8 @@ for method, key in (("tools/list", "tools"), ("resources/list", "resources"), ("
             {
                 "mcpServers": {
                     "stub": {
-                        "command": sys.executable,
-                        "args": ["-u", "-c", script],
+                        "command": "python",
+                        "args": ["-u", "-c", "print('unsafe')"],
                     }
                 }
             }
@@ -217,10 +125,8 @@ for method, key in (("tools/list", "tools"), ("resources/list", "resources"), ("
         encoding="utf-8",
     )
 
-    result = verify_plugin(tmp_path)
     report = build_doctor_report(tmp_path, "mcp")
 
-    assert result.verify_pass is True
-    assert any(case.name == "stdio initialize:stub" and case.passed for case in result.cases)
-    assert "notifications/initialized" in report["stdout_log"]
-    assert "tools/list" in report["stdout_log"]
+    assert report["verify_pass"] is True
+    assert report["stdout_log"] == ""
+    assert any(case["classification"] == "safety-skip" for case in report["cases"])

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -73,7 +73,7 @@ def test_verify_plugin_skips_stdio_execution_for_untrusted_servers(tmp_path: Pat
 
     result = verify_plugin(tmp_path)
 
-    assert result.verify_pass is True
+    assert result.verify_pass is False
     assert any(case.name == "stdio execution:demo" for case in result.cases)
     assert any(case.classification == "safety-skip" for case in result.cases)
     assert all(not trace.name.startswith("stdio") for trace in result.traces)
@@ -92,9 +92,9 @@ def test_verify_plugin_reports_stdio_servers_without_spawning_them(tmp_path: Pat
 
     result = verify_plugin(tmp_path)
 
-    assert result.verify_pass is True
+    assert result.verify_pass is False
     expected_message = (
-        "Skipped stdio command execution for safety; review the MCP command manually before trusting it."
+        "Skipped stdio command execution for safety; manual review is required before trusting it."
     )
     assert any(case.message == expected_message for case in result.cases)
 
@@ -127,6 +127,6 @@ def test_doctor_report_explains_when_stdio_execution_is_skipped(tmp_path: Path):
 
     report = build_doctor_report(tmp_path, "mcp")
 
-    assert report["verify_pass"] is True
+    assert report["verify_pass"] is False
     assert report["stdout_log"] == ""
     assert any(case["classification"] == "safety-skip" for case in report["cases"])


### PR DESCRIPTION
## Summary
- harden Copilot hook launchers to run Guard from a trusted inline entrypoint with a safe working directory
- load Cisco MCP scanner components from the installed distribution instead of ambient workspace import order
- stop doctor/verify from executing untrusted stdio MCP commands and report them as manual-review safety skips

## Verification
- pytest tests/test_verification.py tests/test_mcp_security.py tests/test_guard_copilot_adapter.py -q
- ruff check src tests/conftest.py tests/test_verification.py tests/test_mcp_security.py tests/test_guard_copilot_adapter.py tests/test_cli.py
- pytest -q