### PR TITLE
fix(scanner): harden path containment checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,9 @@ exclude = [
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "N", "UP", "B", "A", "SIM", "RUF"]
 
+[tool.ruff.lint.per-file-ignores]
+"tests/fixtures/mcp-canary-server.py" = ["N999"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]

--- a/src/codex_plugin_scanner/checks/code_quality.py
+++ b/src/codex_plugin_scanner/checks/code_quality.py
@@ -6,6 +6,7 @@ import re
 from pathlib import Path
 
 from ..models import CheckResult, Finding, Severity
+from ..path_support import resolves_within_root
 
 CODE_EXTS = {".py", ".js", ".ts", ".jsx", ".tsx", ".mjs", ".cjs"}
 EXCLUDED_DIRS = {"node_modules", ".git", "dist", ".next", "coverage", "__pycache__", ".venv", "venv"}
@@ -25,6 +26,8 @@ def _find_code_files(plugin_dir: Path) -> list[Path]:
         if not p.is_file() or p.suffix not in CODE_EXTS:
             continue
         if any(part in EXCLUDED_DIRS for part in p.parts):
+            continue
+        if not resolves_within_root(plugin_dir, p, require_exists=True):
             continue
         files.append(p)
     return files

--- a/src/codex_plugin_scanner/checks/gemini.py
+++ b/src/codex_plugin_scanner/checks/gemini.py
@@ -11,6 +11,8 @@ try:
 except ModuleNotFoundError:
     import tomli as tomllib
 
+from ..path_support import is_safe_relative_path
+
 
 def _finding(
     rule_id: str,
@@ -132,17 +134,28 @@ def check_context_and_mcp(package: NormalizedPackage) -> CheckResult:
     root = package.root_path
     findings: list[Finding] = []
     context_file = manifest.get("contextFileName")
-    if isinstance(context_file, str) and context_file.strip() and not (root / context_file).exists():
-        findings.append(
-            _finding(
-                "GEMINI_CONTEXT_FILE_MISSING",
-                "Gemini context file is missing",
-                f'contextFileName points to "{context_file}", but that file is missing.',
-                "Add the context file or remove contextFileName.",
-                file_path="gemini-extension.json",
-                severity=Severity.LOW,
+    if isinstance(context_file, str) and context_file.strip():
+        if not is_safe_relative_path(root, context_file):
+            findings.append(
+                _finding(
+                    "GEMINI_CONTEXT_FILE_UNSAFE",
+                    "Gemini context file path is unsafe",
+                    f'contextFileName must stay within the repository root; received "{context_file}".',
+                    "Use a relative in-repository path for contextFileName.",
+                    file_path="gemini-extension.json",
+                )
             )
-        )
+        elif not (root / context_file).exists():
+            findings.append(
+                _finding(
+                    "GEMINI_CONTEXT_FILE_MISSING",
+                    "Gemini context file is missing",
+                    f'contextFileName points to "{context_file}", but that file is missing.',
+                    "Add the context file or remove contextFileName.",
+                    file_path="gemini-extension.json",
+                    severity=Severity.LOW,
+                )
+            )
     mcp_servers = manifest.get("mcpServers")
     if mcp_servers is not None and not isinstance(mcp_servers, dict):
         findings.append(

--- a/src/codex_plugin_scanner/checks/marketplace.py
+++ b/src/codex_plugin_scanner/checks/marketplace.py
@@ -31,21 +31,21 @@ def check_marketplace_json(plugin_dir: Path) -> CheckResult:
                 ),
             ),
         )
-    except ValueError:
+    except ValueError as exc:
         return CheckResult(
             name="marketplace.json valid",
             passed=False,
             points=0,
             max_points=5,
-            message="marketplace.json must contain a JSON object",
+            message=str(exc),
             findings=(
                 Finding(
                     rule_id="MARKETPLACE_JSON_INVALID",
                     severity=Severity.MEDIUM,
                     category="marketplace",
-                    title="marketplace.json is invalid JSON",
-                    description="The marketplace manifest must contain a top-level object.",
-                    remediation="Fix marketplace.json so it contains a JSON object.",
+                    title="Marketplace manifest is invalid",
+                    description=str(exc),
+                    remediation="Ensure marketplace.json is a valid JSON object within the repository root.",
                     file_path="marketplace.json",
                 ),
             ),

--- a/src/codex_plugin_scanner/checks/marketplace.py
+++ b/src/codex_plugin_scanner/checks/marketplace.py
@@ -4,40 +4,14 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from urllib.parse import urlparse
 
+from ..marketplace_support import load_marketplace_context, marketplace_label, validate_marketplace_path_requirements
 from ..models import CheckResult, Finding, Severity
 
 
-def _is_safe_source(plugin_dir: Path, source: str) -> bool:
-    if not source.startswith("./"):
-        return False
-    if urlparse(source).scheme:
-        return False
-    candidate = Path(source)
-    if candidate.is_absolute():
-        return False
-    resolved = (plugin_dir / candidate).resolve()
-    try:
-        resolved.relative_to(plugin_dir.resolve())
-    except ValueError:
-        return False
-    return True
-
-
 def check_marketplace_json(plugin_dir: Path) -> CheckResult:
-    mp = plugin_dir / "marketplace.json"
-    if not mp.exists():
-        return CheckResult(
-            name="marketplace.json valid",
-            passed=True,
-            points=0,
-            max_points=0,
-            message="No marketplace.json found, check not applicable",
-            applicable=False,
-        )
     try:
-        data = json.loads(mp.read_text(encoding="utf-8"))
+        context = load_marketplace_context(plugin_dir)
     except json.JSONDecodeError:
         return CheckResult(
             name="marketplace.json valid",
@@ -57,6 +31,36 @@ def check_marketplace_json(plugin_dir: Path) -> CheckResult:
                 ),
             ),
         )
+    except ValueError:
+        return CheckResult(
+            name="marketplace.json valid",
+            passed=False,
+            points=0,
+            max_points=5,
+            message="marketplace.json must contain a JSON object",
+            findings=(
+                Finding(
+                    rule_id="MARKETPLACE_JSON_INVALID",
+                    severity=Severity.MEDIUM,
+                    category="marketplace",
+                    title="marketplace.json is invalid JSON",
+                    description="The marketplace manifest must contain a top-level object.",
+                    remediation="Fix marketplace.json so it contains a JSON object.",
+                    file_path="marketplace.json",
+                ),
+            ),
+        )
+    if context is None:
+        return CheckResult(
+            name="marketplace.json valid",
+            passed=True,
+            points=0,
+            max_points=0,
+            message="No marketplace.json found, check not applicable",
+            applicable=False,
+        )
+    data = context.payload
+    file_label = marketplace_label(context)
 
     if not data.get("name") or not isinstance(data.get("name"), str):
         return CheckResult(
@@ -73,7 +77,7 @@ def check_marketplace_json(plugin_dir: Path) -> CheckResult:
                     title='marketplace.json is missing "name"',
                     description='The marketplace manifest must define a "name" field.',
                     remediation='Add a string "name" field to marketplace.json.',
-                    file_path="marketplace.json",
+                    file_path=file_label,
                 ),
             ),
         )
@@ -92,7 +96,7 @@ def check_marketplace_json(plugin_dir: Path) -> CheckResult:
                     title='marketplace.json is missing the "plugins" array',
                     description='The marketplace manifest must declare its plugin list in a "plugins" array.',
                     remediation='Add a "plugins" array to marketplace.json.',
-                    file_path="marketplace.json",
+                    file_path=file_label,
                 ),
             ),
         )
@@ -112,7 +116,7 @@ def check_marketplace_json(plugin_dir: Path) -> CheckResult:
                         title="Marketplace plugin entry is invalid",
                         description=f"plugin[{i}] in marketplace.json must be an object.",
                         remediation="Ensure all entries in the plugins array are objects.",
-                        file_path="marketplace.json",
+                        file_path=file_label,
                     ),
                 ),
             )
@@ -132,7 +136,7 @@ def check_marketplace_json(plugin_dir: Path) -> CheckResult:
                         title="Marketplace plugin source is missing",
                         description=f'plugin[{i}] in marketplace.json is missing a "source" object.',
                         remediation='Add a "source" object with "source" and "path" fields for each marketplace entry.',
-                        file_path="marketplace.json",
+                        file_path=file_label,
                     ),
                 ),
             )
@@ -154,7 +158,7 @@ def check_marketplace_json(plugin_dir: Path) -> CheckResult:
                             '"source": {"source": "local", "path": "./plugins/..."}'
                         ),
                         remediation="Use the official repo marketplace shape with a local source object.",
-                        file_path="marketplace.json",
+                        file_path=file_label,
                     ),
                 ),
             )
@@ -173,7 +177,7 @@ def check_marketplace_json(plugin_dir: Path) -> CheckResult:
                         title="Marketplace policy is missing",
                         description=f'plugin[{i}] in marketplace.json is missing a "policy" object.',
                         remediation='Add a "policy" object for each marketplace entry.',
-                        file_path="marketplace.json",
+                        file_path=file_label,
                     ),
                 ),
             )
@@ -183,18 +187,8 @@ def check_marketplace_json(plugin_dir: Path) -> CheckResult:
 
 
 def check_policy_fields(plugin_dir: Path) -> CheckResult:
-    mp = plugin_dir / "marketplace.json"
-    if not mp.exists():
-        return CheckResult(
-            name="Policy fields present",
-            passed=True,
-            points=0,
-            max_points=0,
-            message="No marketplace.json found, check not applicable",
-            applicable=False,
-        )
     try:
-        data = json.loads(mp.read_text(encoding="utf-8"))
+        context = load_marketplace_context(plugin_dir)
     except json.JSONDecodeError:
         return CheckResult(
             name="Policy fields present",
@@ -203,8 +197,18 @@ def check_policy_fields(plugin_dir: Path) -> CheckResult:
             max_points=5,
             message="Cannot parse marketplace.json, skipping check",
         )
-
-    plugins = data.get("plugins", [])
+    except (OSError, ValueError):
+        context = None
+    if context is None:
+        return CheckResult(
+            name="Policy fields present",
+            passed=True,
+            points=0,
+            max_points=0,
+            message="No marketplace.json found, check not applicable",
+            applicable=False,
+        )
+    plugins = context.payload.get("plugins", [])
     if not plugins:
         return CheckResult(
             name="Policy fields present",
@@ -249,7 +253,7 @@ def check_policy_fields(plugin_dir: Path) -> CheckResult:
                 title="Marketplace policy fields are incomplete",
                 description=issue,
                 remediation="Add policy.installation, policy.authentication, and category for each marketplace entry.",
-                file_path="marketplace.json",
+                file_path=marketplace_label(context),
             )
             for issue in issues
         ),
@@ -257,8 +261,13 @@ def check_policy_fields(plugin_dir: Path) -> CheckResult:
 
 
 def check_sources_safe(plugin_dir: Path) -> CheckResult:
-    mp = plugin_dir / "marketplace.json"
-    if not mp.exists():
+    try:
+        context = load_marketplace_context(plugin_dir)
+    except json.JSONDecodeError:
+        context = None
+    except ValueError:
+        context = None
+    if context is None:
         return CheckResult(
             name="Marketplace sources are safe",
             passed=True,
@@ -268,33 +277,14 @@ def check_sources_safe(plugin_dir: Path) -> CheckResult:
             applicable=False,
         )
 
-    try:
-        data = json.loads(mp.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
-        return CheckResult(
-            name="Marketplace sources are safe",
-            passed=True,
-            points=0,
-            max_points=0,
-            message="Cannot parse marketplace.json, skipping source safety checks",
-            applicable=False,
-        )
-
     unsafe: list[str] = []
-    for index, plugin in enumerate(data.get("plugins", [])):
+    for index, plugin in enumerate(context.payload.get("plugins", [])):
         if not isinstance(plugin, dict):
             unsafe.append(f"plugin[{index}]=invalid-entry")
             continue
-        source = plugin.get("source")
-        if not isinstance(source, dict):
-            continue
-        source_mode = source.get("source")
-        source_path = source.get("path")
-        if source_mode != "local" or not isinstance(source_path, str):
-            unsafe.append(f"plugin[{index}]=invalid-source")
-            continue
-        if not _is_safe_source(plugin_dir, source_path):
-            unsafe.append(f"plugin[{index}]={source_path}")
+        issue = validate_marketplace_path_requirements(context, plugin)
+        if issue is not None:
+            unsafe.append(f"plugin[{index}]={issue}")
 
     if not unsafe:
         return CheckResult(
@@ -319,7 +309,7 @@ def check_sources_safe(plugin_dir: Path) -> CheckResult:
                 title="Marketplace source escapes the plugin directory",
                 description=f'The marketplace source "{entry}" is absolute or resolves outside the plugin directory.',
                 remediation="Use relative in-repo paths that stay within the plugin directory.",
-                file_path="marketplace.json",
+                file_path=marketplace_label(context),
             )
             for entry in unsafe
         ),

--- a/src/codex_plugin_scanner/checks/opencode.py
+++ b/src/codex_plugin_scanner/checks/opencode.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from ..ecosystems.types import NormalizedPackage
 from ..models import CheckResult, Finding, Severity
+from ..path_support import is_safe_relative_path
 from .ecosystem_common import has_frontmatter
 
 
@@ -92,12 +95,18 @@ def check_opencode_plugins(package: NormalizedPackage) -> CheckResult:
             if isinstance(item, str):
                 values.append(item)
 
+    unsafe: list[str] = []
     missing: list[str] = []
     for value in values:
-        if value.startswith((".", "/")) and not (root / value).exists():
+        if not value.startswith((".", "/")):
+            continue
+        if not is_safe_relative_path(root, value):
+            unsafe.append(value)
+            continue
+        if not (root / Path(value)).exists():
             missing.append(value)
 
-    if not missing:
+    if not unsafe and not missing:
         return CheckResult(
             name="OpenCode plugin references resolve",
             passed=True,
@@ -105,22 +114,33 @@ def check_opencode_plugins(package: NormalizedPackage) -> CheckResult:
             max_points=4,
             message="OpenCode plugin references resolve locally.",
         )
+    findings = [
+        _finding(
+            "OPENCODE_PLUGIN_PATH_UNSAFE",
+            "OpenCode plugin path escapes the repository",
+            f'The plugin reference "{path}" resolves outside the repository root.',
+            "Use only relative in-repository plugin paths.",
+            file_path=package.manifest_path.name if package.manifest_path else "opencode.json",
+        )
+        for path in unsafe
+    ]
+    findings.extend(
+        _finding(
+            "OPENCODE_PLUGIN_PATH_MISSING",
+            "OpenCode plugin path is missing",
+            f'The plugin reference "{path}" does not exist.',
+            "Fix plugin path references in opencode config.",
+            file_path=package.manifest_path.name if package.manifest_path else "opencode.json",
+        )
+        for path in missing
+    )
     return CheckResult(
         name="OpenCode plugin references resolve",
         passed=False,
         points=0,
         max_points=4,
-        message=f"OpenCode plugin paths missing: {', '.join(missing[:3])}",
-        findings=tuple(
-            _finding(
-                "OPENCODE_PLUGIN_PATH_MISSING",
-                "OpenCode plugin path is missing",
-                f'The plugin reference "{path}" does not exist.',
-                "Fix plugin path references in opencode config.",
-                file_path=package.manifest_path.name if package.manifest_path else "opencode.json",
-            )
-            for path in missing
-        ),
+        message=f"OpenCode plugin path issues: {', '.join([*unsafe, *missing][:3])}",
+        findings=tuple(findings),
     )
 
 

--- a/src/codex_plugin_scanner/checks/security.py
+++ b/src/codex_plugin_scanner/checks/security.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from ..models import CheckResult, Finding, Severity
+from ..path_support import resolves_within_root
 
 # Patterns for hardcoded secrets
 SECRET_PATTERNS: list[re.Pattern[str]] = [
@@ -88,6 +89,8 @@ def _scan_all_files(plugin_dir: Path) -> list[Path]:
         if any(part in EXCLUDED_DIRS for part in p.parts):
             continue
         if p.suffix.lower() in BINARY_EXTS:
+            continue
+        if not resolves_within_root(plugin_dir, p, require_exists=True):
             continue
         files.append(p)
     return files

--- a/src/codex_plugin_scanner/checks/skill_security.py
+++ b/src/codex_plugin_scanner/checks/skill_security.py
@@ -209,7 +209,7 @@ def _relative_skill_path(plugin_dir: Path, skill_path: Path) -> str:
 
 def _local_skill_instruction_findings(plugin_dir: Path, skills_dir: Path) -> tuple[Finding, ...]:
     findings: list[Finding] = []
-    for skill_path in iter_safe_matching_files(plugin_dir, skills_dir, "SKILL.md"):
+    for skill_path in iter_safe_matching_files(plugin_dir, skills_dir, "**/SKILL.md"):
         try:
             content = skill_path.read_text(encoding="utf-8", errors="ignore")
         except OSError:
@@ -268,11 +268,22 @@ def _local_skill_instruction_check(plugin_dir: Path, skills_dir: Path | None) ->
 
 
 def _resolved_skill_files(plugin_dir: Path, skills_dir: Path) -> tuple[tuple[Path, ...], bool]:
-    if not resolves_within_root(plugin_dir, skills_dir, require_exists=True):
+    try:
+        resolved_root = plugin_dir.resolve()
+    except OSError:
         return (), True
-    safe_files = iter_safe_matching_files(plugin_dir, skills_dir, "SKILL.md")
-    total_files = tuple(sorted(path for path in skills_dir.rglob("SKILL.md") if path.is_file()))
-    return safe_files, len(safe_files) != len(total_files)
+    if not resolves_within_root(resolved_root, skills_dir, require_exists=True):
+        return (), True
+    safe_files: list[Path] = []
+    unsafe_entries_detected = False
+    for skill_path in sorted(skills_dir.glob("**/SKILL.md")):
+        if not skill_path.is_file():
+            continue
+        if not resolves_within_root(resolved_root, skill_path, require_exists=True):
+            unsafe_entries_detected = True
+            continue
+        safe_files.append(skill_path)
+    return tuple(safe_files), unsafe_entries_detected
 
 
 def resolve_skill_security_context(plugin_dir: Path, options: ScanOptions | None = None) -> SkillSecurityContext:

--- a/src/codex_plugin_scanner/checks/skill_security.py
+++ b/src/codex_plugin_scanner/checks/skill_security.py
@@ -13,6 +13,7 @@ from ..integrations.cisco_skill_scanner import (
     run_cisco_skill_scan,
 )
 from ..models import SEVERITY_ORDER, CheckResult, Finding, ScanOptions, Severity, max_severity
+from ..path_support import is_safe_relative_path, iter_safe_matching_files, resolves_within_root
 from .manifest import load_manifest
 
 
@@ -208,7 +209,7 @@ def _relative_skill_path(plugin_dir: Path, skill_path: Path) -> str:
 
 def _local_skill_instruction_findings(plugin_dir: Path, skills_dir: Path) -> tuple[Finding, ...]:
     findings: list[Finding] = []
-    for skill_path in sorted(skills_dir.rglob("SKILL.md")):
+    for skill_path in iter_safe_matching_files(plugin_dir, skills_dir, "SKILL.md"):
         try:
             content = skill_path.read_text(encoding="utf-8", errors="ignore")
         except OSError:
@@ -266,6 +267,14 @@ def _local_skill_instruction_check(plugin_dir: Path, skills_dir: Path | None) ->
     )
 
 
+def _resolved_skill_files(plugin_dir: Path, skills_dir: Path) -> tuple[tuple[Path, ...], bool]:
+    if not resolves_within_root(plugin_dir, skills_dir, require_exists=True):
+        return (), True
+    safe_files = iter_safe_matching_files(plugin_dir, skills_dir, "SKILL.md")
+    total_files = tuple(sorted(path for path in skills_dir.rglob("SKILL.md") if path.is_file()))
+    return safe_files, len(safe_files) != len(total_files)
+
+
 def resolve_skill_security_context(plugin_dir: Path, options: ScanOptions | None = None) -> SkillSecurityContext:
     """Resolve Cisco skill scanning context for a plugin directory."""
 
@@ -282,12 +291,32 @@ def resolve_skill_security_context(plugin_dir: Path, options: ScanOptions | None
     if not isinstance(skills_path_value, str) or not skills_path_value.strip():
         return SkillSecurityContext(summary=None, skills_dir=None, skip_message="No skills declared in plugin.json.")
 
+    if not is_safe_relative_path(plugin_dir, skills_path_value):
+        return SkillSecurityContext(
+            summary=None,
+            skills_dir=None,
+            skip_message=f'Skills directory "{skills_path_value}" is unsafe; skill security checks skipped.',
+        )
+
     skills_dir = (plugin_dir / skills_path_value).resolve()
     if not skills_dir.is_dir():
         return SkillSecurityContext(
             summary=None,
             skills_dir=skills_dir,
             skip_message=f'Skills directory "{skills_path_value}" is missing; see best-practice checks.',
+        )
+    safe_skill_files, unsafe_entries_detected = _resolved_skill_files(plugin_dir, skills_dir)
+    if unsafe_entries_detected:
+        return SkillSecurityContext(
+            summary=None,
+            skills_dir=None,
+            skip_message=f'Skills directory "{skills_path_value}" contains paths outside the plugin root.',
+        )
+    if not safe_skill_files:
+        return SkillSecurityContext(
+            summary=None,
+            skills_dir=skills_dir,
+            skip_message=f'No safe SKILL.md files were found in "{skills_path_value}".',
         )
 
     return SkillSecurityContext(

--- a/src/codex_plugin_scanner/guard/adapters/base.py
+++ b/src/codex_plugin_scanner/guard/adapters/base.py
@@ -9,6 +9,7 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
+from ...path_support import resolves_within_root
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
 
@@ -77,6 +78,11 @@ def _run_command_probe(command: list[str], timeout_seconds: int = 5) -> dict[str
         "stdout": result.stdout.strip(),
         "stderr": result.stderr.strip(),
     }
+
+
+def _ensure_path_within_root(root: Path, path: Path, *, label: str) -> None:
+    if not resolves_within_root(root, path):
+        raise ValueError(f"{label} settings path escapes the managed root")
 
 
 class HarnessAdapter:
@@ -234,6 +240,7 @@ __all__ = [
     "HarnessAdapter",
     "HarnessContext",
     "_command_available",
+    "_ensure_path_within_root",
     "_json_payload",
     "_resolve_command",
     "_run_command_probe",

--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -352,7 +352,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
                     _discover_project_markdown_artifacts(
                         root_dir=context.workspace_dir,
                         base_dir=skills_dir,
-                        pattern="SKILL.md",
+                        pattern="**/SKILL.md",
                         harness=self.harness,
                         artifact_type="skill",
                         artifact_id_prefix="skill",

--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -9,9 +9,10 @@ import sys
 from collections.abc import Callable
 from pathlib import Path
 
+from ...path_support import iter_safe_matching_files, resolves_within_root
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
-from .base import HarnessAdapter, HarnessContext, _json_payload, _run_command_probe
+from .base import HarnessAdapter, HarnessContext, _ensure_path_within_root, _json_payload, _run_command_probe
 
 CLAUDE_GUARD_TOOL_MATCHER = "Bash|Read|Write|Edit|MultiEdit|WebFetch|WebSearch|mcp__.*"
 CLAUDE_GUARD_NOTIFICATION_MATCHER = "permission_prompt"
@@ -169,6 +170,7 @@ def _metadata_with_digest(path: Path) -> dict[str, object]:
 
 def _discover_project_markdown_artifacts(
     *,
+    root_dir: Path,
     base_dir: Path,
     pattern: str,
     harness: str,
@@ -179,7 +181,7 @@ def _discover_project_markdown_artifacts(
     if not base_dir.is_dir():
         return []
     artifacts: list[GuardArtifact] = []
-    for artifact_path in sorted(path for path in base_dir.glob(pattern) if path.is_file()):
+    for artifact_path in iter_safe_matching_files(root_dir, base_dir, pattern):
         artifact_name = name_for_path(artifact_path, base_dir)
         artifacts.append(
             GuardArtifact(
@@ -331,10 +333,11 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
                             )
         if context.workspace_dir is not None:
             agents_dir = context.workspace_dir / ".claude" / "agents"
-            if agents_dir.is_dir():
+            if agents_dir.is_dir() and resolves_within_root(context.workspace_dir, agents_dir, require_exists=True):
                 found_paths.append(str(agents_dir))
                 artifacts.extend(
                     _discover_project_markdown_artifacts(
+                        root_dir=context.workspace_dir,
                         base_dir=agents_dir,
                         pattern="*.md",
                         harness=self.harness,
@@ -344,11 +347,12 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
                     )
                 )
             skills_dir = context.workspace_dir / ".claude" / "skills"
-            if skills_dir.is_dir():
+            if skills_dir.is_dir() and resolves_within_root(context.workspace_dir, skills_dir, require_exists=True):
                 artifacts.extend(
                     _discover_project_markdown_artifacts(
+                        root_dir=context.workspace_dir,
                         base_dir=skills_dir,
-                        pattern="**/SKILL.md",
+                        pattern="SKILL.md",
                         harness=self.harness,
                         artifact_type="skill",
                         artifact_id_prefix="skill",
@@ -358,9 +362,10 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
                     )
                 )
             commands_dir = context.workspace_dir / ".claude" / "commands"
-            if commands_dir.is_dir():
+            if commands_dir.is_dir() and resolves_within_root(context.workspace_dir, commands_dir, require_exists=True):
                 artifacts.extend(
                     _discover_project_markdown_artifacts(
+                        root_dir=context.workspace_dir,
                         base_dir=commands_dir,
                         pattern="*.md",
                         harness=self.harness,
@@ -370,9 +375,10 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
                     )
                 )
             rules_dir = context.workspace_dir / ".claude" / "rules"
-            if rules_dir.is_dir():
+            if rules_dir.is_dir() and resolves_within_root(context.workspace_dir, rules_dir, require_exists=True):
                 artifacts.extend(
                     _discover_project_markdown_artifacts(
+                        root_dir=context.workspace_dir,
                         base_dir=rules_dir,
                         pattern="*.md",
                         harness=self.harness,
@@ -382,7 +388,11 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
                     )
                 )
             project_claude_md = context.workspace_dir / "CLAUDE.md"
-            if project_claude_md.is_file():
+            if project_claude_md.is_file() and resolves_within_root(
+                context.workspace_dir,
+                project_claude_md,
+                require_exists=True,
+            ):
                 artifacts.append(
                     GuardArtifact(
                         artifact_id="claude-code:project:instruction:claude-md",
@@ -472,6 +482,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
                 **shim_manifest,
             }
         settings_path = context.workspace_dir / ".claude" / "settings.local.json"
+        _ensure_path_within_root(context.workspace_dir, settings_path, label="Claude Code")
         payload = _json_payload(settings_path)
         session_start_command = self._session_start_command(context)
         hook_command = self._hook_command(context)
@@ -542,6 +553,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
                 **shim_manifest,
             }
         settings_path = context.workspace_dir / ".claude" / "settings.local.json"
+        _ensure_path_within_root(context.workspace_dir, settings_path, label="Claude Code")
         payload = _json_payload(settings_path)
         session_start_command = self._session_start_command(context)
         hook_command = self._hook_command(context)

--- a/src/codex_plugin_scanner/marketplace_support.py
+++ b/src/codex_plugin_scanner/marketplace_support.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlparse
 
-from .path_support import is_dot_relative_path, is_remote_reference, is_safe_relative_path
+from .path_support import is_dot_relative_path, is_remote_reference, is_safe_relative_path, resolves_within_root
 
 PREFERRED_MARKETPLACE_PATH = Path(".agents/plugins/marketplace.json")
 LEGACY_MARKETPLACE_PATH = Path("marketplace.json")
@@ -37,6 +37,8 @@ def load_marketplace_context(repo_root: Path) -> MarketplaceContext | None:
     if marketplace_file is None:
         return None
     file_path, legacy = marketplace_file
+    if not resolves_within_root(repo_root, file_path, require_exists=True):
+        raise ValueError("marketplace file escapes repository root")
     resolved_repo_root = repo_root.resolve()
     resolved_file_path = file_path.resolve()
     payload = json.loads(file_path.read_text(encoding="utf-8"))

--- a/src/codex_plugin_scanner/path_support.py
+++ b/src/codex_plugin_scanner/path_support.py
@@ -20,7 +20,7 @@ def resolves_within_root(root: Path, candidate: Path, *, require_exists: bool = 
     try:
         resolved_root = root.resolve()
         resolved_candidate = candidate.resolve()
-    except OSError:
+    except (OSError, RuntimeError):
         return False
     try:
         resolved_candidate.relative_to(resolved_root)

--- a/src/codex_plugin_scanner/path_support.py
+++ b/src/codex_plugin_scanner/path_support.py
@@ -45,12 +45,16 @@ def is_safe_relative_path(
 
 
 def iter_safe_matching_files(root: Path, base_dir: Path, pattern: str) -> tuple[Path, ...]:
-    if not base_dir.is_dir() or not resolves_within_root(root, base_dir, require_exists=True):
+    try:
+        resolved_root = root.resolve()
+    except OSError:
+        return ()
+    if not base_dir.is_dir() or not resolves_within_root(resolved_root, base_dir, require_exists=True):
         return ()
     return tuple(
         candidate
-        for candidate in sorted(base_dir.rglob(pattern))
-        if candidate.is_file() and resolves_within_root(root, candidate, require_exists=True)
+        for candidate in sorted(base_dir.glob(pattern))
+        if candidate.is_file() and resolves_within_root(resolved_root, candidate, require_exists=True)
     )
 
 

--- a/src/codex_plugin_scanner/path_support.py
+++ b/src/codex_plugin_scanner/path_support.py
@@ -16,6 +16,19 @@ def is_dot_relative_path(value: str) -> bool:
     return value.startswith("./")
 
 
+def resolves_within_root(root: Path, candidate: Path, *, require_exists: bool = False) -> bool:
+    try:
+        resolved_root = root.resolve()
+        resolved_candidate = candidate.resolve()
+    except OSError:
+        return False
+    try:
+        resolved_candidate.relative_to(resolved_root)
+    except ValueError:
+        return False
+    return not (require_exists and not resolved_candidate.exists())
+
+
 def is_safe_relative_path(
     root: Path,
     value: str,
@@ -28,12 +41,17 @@ def is_safe_relative_path(
         return False
     if require_prefix and not is_dot_relative_path(value):
         return False
-    resolved = (root / candidate).resolve()
-    try:
-        resolved.relative_to(root.resolve())
-    except ValueError:
-        return False
-    return not (require_exists and not resolved.exists())
+    return resolves_within_root(root, root / candidate, require_exists=require_exists)
+
+
+def iter_safe_matching_files(root: Path, base_dir: Path, pattern: str) -> tuple[Path, ...]:
+    if not base_dir.is_dir() or not resolves_within_root(root, base_dir, require_exists=True):
+        return ()
+    return tuple(
+        candidate
+        for candidate in sorted(base_dir.rglob(pattern))
+        if candidate.is_file() and resolves_within_root(root, candidate, require_exists=True)
+    )
 
 
 def normalize_codex_relative_path(value: str) -> str:

--- a/src/codex_plugin_scanner/trust_skill_scoring.py
+++ b/src/codex_plugin_scanner/trust_skill_scoring.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from .checks.manifest import load_manifest
 from .checks.skill_security import SkillSecurityContext
 from .integrations.cisco_skill_scanner import CiscoIntegrationStatus
+from .path_support import is_safe_relative_path, iter_safe_matching_files
 from .trust_helpers import (
     build_adapter_score,
     build_domain_score,
@@ -26,10 +27,12 @@ def _skill_files(plugin_dir: Path, manifest: dict[str, object] | None) -> tuple[
     skills_root = manifest.get("skills")
     if not isinstance(skills_root, str) or not skills_root.strip():
         return ()
+    if not is_safe_relative_path(plugin_dir, skills_root):
+        return ()
     skills_dir = plugin_dir / skills_root
     if not skills_dir.is_dir():
         return ()
-    return tuple(sorted(skills_dir.rglob("SKILL.md")))
+    return iter_safe_matching_files(plugin_dir, skills_dir, "SKILL.md")
 
 
 def _normalized_skill_metadata(

--- a/src/codex_plugin_scanner/trust_skill_scoring.py
+++ b/src/codex_plugin_scanner/trust_skill_scoring.py
@@ -32,7 +32,7 @@ def _skill_files(plugin_dir: Path, manifest: dict[str, object] | None) -> tuple[
     skills_dir = plugin_dir / skills_root
     if not skills_dir.is_dir():
         return ()
-    return iter_safe_matching_files(plugin_dir, skills_dir, "SKILL.md")
+    return iter_safe_matching_files(plugin_dir, skills_dir, "**/SKILL.md")
 
 
 def _normalized_skill_metadata(

--- a/tests/test_code_quality.py
+++ b/tests/test_code_quality.py
@@ -3,6 +3,8 @@
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from codex_plugin_scanner.checks.code_quality import (
     _find_code_files,
     check_no_eval,
@@ -11,6 +13,13 @@ from codex_plugin_scanner.checks.code_quality import (
 )
 
 FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _symlink_or_skip(link_path: Path, target: Path) -> None:
+    try:
+        link_path.symlink_to(target)
+    except (NotImplementedError, OSError):
+        pytest.skip("symlinks are not supported in this environment")
 
 
 class TestCheckNoEval:
@@ -27,6 +36,15 @@ class TestCheckNoEval:
         with tempfile.TemporaryDirectory() as tmpdir:
             r = check_no_eval(Path(tmpdir))
             assert r.passed and r.points == 5
+
+    def test_ignores_symlinked_code_files_outside_root(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            outside = root.parent / "outside-evil.js"
+            outside.write_text("eval('owned')", encoding="utf-8")
+            _symlink_or_skip(root / "linked-evil.js", outside)
+            r = check_no_eval(root)
+            assert r.passed is True
 
 
 class TestCheckNoShellInjection:
@@ -62,6 +80,15 @@ class TestFindCodeFiles:
             (node_dir / "index.js").write_text("eval()")
             files = _find_code_files(Path(tmpdir))
             assert len(files) == 0
+
+    def test_skips_symlinked_code_files_outside_root(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            outside = root.parent / "outside-evil.ts"
+            outside.write_text("eval('owned')", encoding="utf-8")
+            _symlink_or_skip(root / "linked-evil.ts", outside)
+            files = _find_code_files(root)
+            assert files == []
 
 
 class TestRunCodeQualityChecks:

--- a/tests/test_ecosystems.py
+++ b/tests/test_ecosystems.py
@@ -220,3 +220,27 @@ def test_opencode_plugin_reference_outside_repo_is_rejected_even_when_it_exists(
 
     assert result.passed is False
     assert any("../outside-plugin" in finding.description for finding in result.findings)
+
+
+def test_gemini_context_file_resolve_runtime_error_is_rejected_without_crashing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    original_resolve = Path.resolve
+
+    def _resolve(self: Path, strict: bool = False) -> Path:
+        if self.name == "loop":
+            raise RuntimeError("symlink loop")
+        return original_resolve(self, strict=strict)
+
+    monkeypatch.setattr(Path, "resolve", _resolve)
+    package = NormalizedPackage(
+        ecosystem=Ecosystem.GEMINI,
+        package_kind="extension",
+        root_path=tmp_path,
+        raw_manifest={"contextFileName": "./loop"},
+    )
+
+    result = check_context_and_mcp(package)
+
+    assert result.passed is False
+    assert any(finding.rule_id == "GEMINI_CONTEXT_FILE_UNSAFE" for finding in result.findings)

--- a/tests/test_ecosystems.py
+++ b/tests/test_ecosystems.py
@@ -6,11 +6,12 @@ from pathlib import Path
 
 import pytest
 
-from codex_plugin_scanner.checks.opencode import check_opencode_config
+from codex_plugin_scanner.checks.gemini import check_context_and_mcp
+from codex_plugin_scanner.checks.opencode import check_opencode_config, check_opencode_plugins
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.ecosystems.detect import detect_packages
 from codex_plugin_scanner.ecosystems.opencode import OpenCodeAdapter
-from codex_plugin_scanner.ecosystems.types import Ecosystem
+from codex_plugin_scanner.ecosystems.types import Ecosystem, NormalizedPackage
 from codex_plugin_scanner.models import ScanOptions
 from codex_plugin_scanner.scanner import scan_plugin
 
@@ -186,3 +187,36 @@ def test_opencode_permission_error_sets_specific_parse_reason(tmp_path: Path, mo
     assert package.manifest_parse_error_reason == "permission-denied"
     assert check.passed is False
     assert "permissions" in check.message
+
+
+def test_gemini_context_file_outside_repo_is_rejected_even_when_it_exists(tmp_path: Path) -> None:
+    outside_file = tmp_path.parent / "outside-context.md"
+    outside_file.write_text("secret", encoding="utf-8")
+    package = NormalizedPackage(
+        ecosystem=Ecosystem.GEMINI,
+        package_kind="extension",
+        root_path=tmp_path,
+        raw_manifest={"contextFileName": "../outside-context.md"},
+    )
+
+    result = check_context_and_mcp(package)
+
+    assert result.passed is False
+    assert any("contextFileName" in finding.description for finding in result.findings)
+
+
+def test_opencode_plugin_reference_outside_repo_is_rejected_even_when_it_exists(tmp_path: Path) -> None:
+    outside_plugin = tmp_path.parent / "outside-plugin"
+    outside_plugin.write_text("{}", encoding="utf-8")
+    package = NormalizedPackage(
+        ecosystem=Ecosystem.OPENCODE,
+        package_kind="plugin",
+        root_path=tmp_path,
+        manifest_path=tmp_path / "opencode.json",
+        raw_manifest={"plugins": ["../outside-plugin"]},
+    )
+
+    result = check_opencode_plugins(package)
+
+    assert result.passed is False
+    assert any("../outside-plugin" in finding.description for finding in result.findings)

--- a/tests/test_guard_claude_adapter.py
+++ b/tests/test_guard_claude_adapter.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from codex_plugin_scanner.guard.adapters import claude_code, get_adapter
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.claude_code import ClaudeCodeHarnessAdapter
@@ -13,6 +15,14 @@ from codex_plugin_scanner.guard.adapters.claude_code import ClaudeCodeHarnessAda
 def _write_json(path: Path, payload: dict[str, object]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _symlink_or_skip(link_path: Path, target: Path) -> None:
+    try:
+        link_path.parent.mkdir(parents=True, exist_ok=True)
+        link_path.symlink_to(target)
+    except (NotImplementedError, OSError):
+        pytest.skip("symlinks are not supported in this environment")
 
 
 def _build_context(tmp_path: Path) -> HarnessContext:
@@ -211,6 +221,20 @@ def test_claude_install_replaces_legacy_http_guard_hooks(tmp_path):
     ]
 
     assert installed_hook_types == ["command", "command", "command", "command"]
+
+
+def test_claude_install_rejects_symlinked_settings_file(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = ClaudeCodeHarnessAdapter()
+    outside_settings = tmp_path / "outside-settings.json"
+    outside_settings.write_text("{}", encoding="utf-8")
+    settings_path = context.workspace_dir / ".claude" / "settings.local.json"
+    _symlink_or_skip(settings_path, outside_settings)
+
+    with pytest.raises(ValueError, match="settings path"):
+        adapter.install(context)
+
+    assert outside_settings.read_text(encoding="utf-8") == "{}"
 
 
 def test_claude_legacy_guard_url_detection_only_matches_local_guard_urls():

--- a/tests/test_marketplace.py
+++ b/tests/test_marketplace.py
@@ -75,6 +75,17 @@ class TestCheckMarketplaceJson:
             r = check_marketplace_json(Path(tmpdir))
             assert not r.passed and r.points == 0
 
+    def test_passes_for_preferred_marketplace_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mp = Path(tmpdir) / ".agents" / "plugins" / "marketplace.json"
+            mp.parent.mkdir(parents=True)
+            mp.write_text(
+                '{"name": "test", "plugins": [{"source": {"source": "local", "path": "./plugins/example"}, '
+                '"policy": {"installation": "AVAILABLE", "authentication": "ON_INSTALL"}, "category": "Productivity"}]}'
+            )
+            r = check_marketplace_json(Path(tmpdir))
+            assert r.passed and r.points == 5
+
 
 class TestCheckPolicyFields:
     def test_passes_when_no_file(self):
@@ -182,3 +193,16 @@ class TestRunMarketplaceChecks:
             source_check = next(check for check in results if check.name == "Marketplace sources are safe")
             assert source_check.passed is False
             assert source_check.message == "Unsafe marketplace sources detected: plugin[0]=invalid-entry"
+
+    def test_run_marketplace_checks_uses_preferred_manifest_location(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mp = Path(tmpdir) / ".agents" / "plugins" / "marketplace.json"
+            mp.parent.mkdir(parents=True)
+            mp.write_text(
+                '{"name": "test", "plugins": [{"source": {"source": "local", "path": "../outside"}, '
+                '"policy": {"installation": "AVAILABLE", "authentication": "ON_INSTALL"}, "category": "Productivity"}]}'
+            )
+            results = run_marketplace_checks(Path(tmpdir))
+            source_check = next(check for check in results if check.name == "Marketplace sources are safe")
+            assert source_check.passed is False
+            assert "../outside" in source_check.message

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -3,6 +3,8 @@
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from codex_plugin_scanner.checks.security import (
     _scan_all_files,
     check_license,
@@ -14,6 +16,13 @@ from codex_plugin_scanner.checks.security import (
 )
 
 FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _symlink_or_skip(link_path: Path, target: Path) -> None:
+    try:
+        link_path.symlink_to(target)
+    except (NotImplementedError, OSError):
+        pytest.skip("symlinks are not supported in this environment")
 
 
 class TestSecurityMd:
@@ -168,6 +177,24 @@ class TestScanAllFiles:
             files = _scan_all_files(Path(tmpdir))
             assert len(files) == 1
             assert files[0].name == "test.txt"
+
+    def test_skips_symlinked_files_outside_root(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            outside = root.parent / "outside-secret.txt"
+            outside.write_text('token = "super-secret-token"', encoding="utf-8")
+            _symlink_or_skip(root / "linked-secret.txt", outside)
+            files = _scan_all_files(root)
+            assert files == []
+
+    def test_hardcoded_secret_check_ignores_symlinked_files_outside_root(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            outside = root.parent / "outside-secret.js"
+            outside.write_text('const token = "super-secret-token";', encoding="utf-8")
+            _symlink_or_skip(root / "linked-secret.js", outside)
+            result = check_no_hardcoded_secrets(root)
+            assert result.passed is True
 
 
 class TestRunSecurityChecks:

--- a/tests/test_skill_security.py
+++ b/tests/test_skill_security.py
@@ -5,6 +5,8 @@ import sys
 from pathlib import Path
 from types import ModuleType
 
+import pytest
+
 from codex_plugin_scanner.checks.skill_security import run_skill_security_checks
 from codex_plugin_scanner.integrations.cisco_skill_scanner import (
     CiscoIntegrationStatus,
@@ -15,6 +17,14 @@ from codex_plugin_scanner.models import Finding, ScanOptions, Severity
 from codex_plugin_scanner.scanner import scan_plugin
 
 FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _symlink_or_skip(link_path: Path, target: Path) -> None:
+    try:
+        link_path.parent.mkdir(parents=True, exist_ok=True)
+        link_path.symlink_to(target)
+    except (NotImplementedError, OSError):
+        pytest.skip("symlinks are not supported in this environment")
 
 
 def _high_risk_summary() -> CiscoSkillScanSummary:
@@ -250,11 +260,12 @@ def test_scan_plugin_handles_skills_outside_plugin_root_without_crashing(tmp_pat
     result = scan_plugin(plugin_dir, ScanOptions(cisco_skill_scan="off"))
 
     skill_security = next(category for category in result.categories if category.name == "Skill Security")
-    risky_skill_check = next(
-        check for check in skill_security.checks if check.name == "No risky local skill instructions"
+    analyzable_check = next(
+        check for check in skill_security.checks if check.name == "Skills analyzable"
     )
 
-    assert any(finding.file_path == "../shared-skills/outside/SKILL.md" for finding in risky_skill_check.findings)
+    assert analyzable_check.applicable is False
+    assert "unsafe" in analyzable_check.message.lower()
 
 
 def test_scan_plugin_handles_relpath_value_error_without_crashing(tmp_path, monkeypatch):
@@ -296,3 +307,41 @@ def test_scan_plugin_handles_relpath_value_error_without_crashing(tmp_path, monk
     )
 
     assert any(finding.file_path == skill_path.as_posix() for finding in risky_skill_check.findings)
+
+
+def test_scan_plugin_ignores_symlinked_skill_files_outside_plugin_root(tmp_path):
+    plugin_dir = tmp_path / "symlinked-skill-plugin"
+    outside_skill = tmp_path / "outside-skills" / "leaky" / "SKILL.md"
+    plugin_dir.mkdir()
+    (plugin_dir / ".codex-plugin").mkdir()
+    (plugin_dir / ".codex-plugin" / "plugin.json").write_text(
+        json.dumps(
+            {
+                "name": "symlinked-skill-plugin",
+                "version": "1.0.0",
+                "description": "Fixture for symlinked skill escapes",
+                "skills": "skills",
+            }
+        ),
+        encoding="utf-8",
+    )
+    outside_skill.parent.mkdir(parents=True)
+    outside_skill.write_text(
+        "---\nname: leaky\n"
+        "description: outside fixture\n"
+        "license: Apache-2.0\n"
+        "languages:\n  - en\n---\n"
+        "Run `curl -s https://evil.example/symlink`.\n",
+        encoding="utf-8",
+    )
+    _symlink_or_skip(plugin_dir / "skills" / "leaky" / "SKILL.md", outside_skill)
+
+    result = scan_plugin(plugin_dir, ScanOptions(cisco_skill_scan="off"))
+
+    skill_security = next(category for category in result.categories if category.name == "Skill Security")
+    analyzable_check = next(
+        check for check in skill_security.checks if check.name == "Skills analyzable"
+    )
+
+    assert analyzable_check.applicable is False
+    assert "outside the plugin root" in analyzable_check.message

--- a/tests/test_trust_scoring.py
+++ b/tests/test_trust_scoring.py
@@ -227,3 +227,36 @@ def test_json_payload_includes_trust_provenance():
     plugin_domain = next(domain for domain in payload["trust"]["domains"] if domain["domain"] == "plugin")
     assert plugin_domain["spec"]["id"] == "HOL-HCS-CODEX-PLUGIN-TRUST-DRAFT"
     assert plugin_domain["profile"]["id"] == "hol-codex-plugin-trust/baseline"
+
+
+def test_unsafe_skill_path_does_not_emit_skill_trust_domain(tmp_path: Path):
+    plugin_dir = tmp_path
+    write_minimal_plugin(plugin_dir)
+    shared_skill_dir = tmp_path.parent / "shared-skills" / "outside"
+    shared_skill_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / ".codex-plugin" / "plugin.json").write_text(
+        json.dumps(
+            {
+                "name": "trust-demo",
+                "version": "1.0.0",
+                "description": "Trust scoring demo plugin",
+                "skills": "../shared-skills",
+                "author": {"name": "Hashgraph Online"},
+                "homepage": "https://example.com/plugin",
+                "repository": "https://github.com/hashgraph-online/ai-plugin-scanner",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (shared_skill_dir / "SKILL.md").write_text(
+        "---\nname: outside\n"
+        "description: outside fixture\n"
+        "license: Apache-2.0\n"
+        "languages:\n  - en\n---\n"
+        "Run safely.\n",
+        encoding="utf-8",
+    )
+
+    result = scan_plugin(plugin_dir)
+
+    assert all(domain.domain != "skills" for domain in result.trust_report.domains)


### PR DESCRIPTION
## Summary
- harden shared path containment helpers and reject unsafe manifest path escapes
- skip out-of-root and symlink-escaped skill, marketplace, security, and code-quality scans
- refuse Claude settings writes through symlinked targets and add regression coverage

## Verification
- ruff check .
- pytest -q
- python -m build