### PR TITLE
fix(actions): harden release and submission URLs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -205,8 +205,8 @@ jobs:
         id: release_exists
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.build.outputs.version }}
         run: |
-          VERSION="${{ needs.build.outputs.version }}"
           if gh release view "v${VERSION}" >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
@@ -215,10 +215,11 @@ jobs:
       - name: Generate changelog
         if: steps.release_exists.outputs.exists == 'false'
         id: changelog
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
         run: |
           # Get the range of commits since last tag
           LAST_TAG=$(git describe --tags --abbrev=0 --exclude="v${VERSION}" 2>/dev/null || echo "")
-          VERSION="${{ needs.build.outputs.version }}"
 
           if [ -n "$LAST_TAG" ]; then
             LOG=$(git log ${LAST_TAG}..HEAD --pretty=format:"- %s (%h)" --no-merges)
@@ -293,11 +294,11 @@ jobs:
         if: steps.release_exists.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.build.outputs.version }}
         run: |
           mapfile -t RELEASE_ASSETS <<'EOF'
           ${{ steps.release_assets.outputs.files }}
           EOF
-          VERSION="${{ needs.build.outputs.version }}"
           gh release create "v${VERSION}" \
             --title "v${VERSION}" \
             --target main \

--- a/src/codex_plugin_scanner/action_runner.py
+++ b/src/codex_plugin_scanner/action_runner.py
@@ -312,13 +312,16 @@ def main() -> int:
             event_name=github_event_name,
             pull_request_number=pull_request_number,
         ):
-            if github_repository and github_token and pr_comment_body:
+            if github_api_url_error is not None:
+                print(f"Warning: invalid GITHUB_API_URL: {github_api_url_error}", file=sys.stderr)
+                output_values["pr_comment_status"] = "failed"
+            elif github_repository and github_token and pr_comment_body:
                 try:
                     pr_comment_result = upsert_pr_comment(
                         repository=github_repository,
                         pull_request_number=pull_request_number if pull_request_number is not None else 0,
                         token=github_token,
-                        api_base_url=github_api_url,
+                        api_base_url=normalized_github_api_url,
                         body=pr_comment_body,
                     )
                     output_values["pr_comment_status"] = pr_comment_result.status

--- a/src/codex_plugin_scanner/action_runner.py
+++ b/src/codex_plugin_scanner/action_runner.py
@@ -31,6 +31,7 @@ from .submission import (
     build_submission_payload,
     create_submission_issue,
     find_existing_submission_issue,
+    normalize_github_api_base_url,
     resolve_submission_metadata,
 )
 from .verification import build_verification_payload, verify_plugin
@@ -261,6 +262,15 @@ def main() -> int:
     workflow_url = ""
     if github_repository and github_run_id:
         workflow_url = f"{github_server_url.rstrip('/')}/{github_repository}/actions/runs/{github_run_id}"
+    normalized_github_api_url = github_api_url
+    github_api_url_error: ValueError | None = None
+    try:
+        normalized_github_api_url = normalize_github_api_base_url(
+            github_api_url,
+            github_server_url=github_server_url,
+        )
+    except ValueError as error:
+        github_api_url_error = error
 
     report_path_value = ""
     registry_payload_path_value = ""
@@ -501,6 +511,9 @@ def main() -> int:
                 if not submission_token:
                     print("Submission is enabled but no submission token was provided.", file=sys.stderr)
                     return finish(1)
+                if github_api_url_error is not None:
+                    print(f"Invalid GITHUB_API_URL: {github_api_url_error}", file=sys.stderr)
+                    return finish(1)
                 if not metadata.plugin_url:
                     print("Submission metadata is missing a plugin repository URL.", file=sys.stderr)
                     return finish(1)
@@ -516,7 +529,7 @@ def main() -> int:
                         submission_repo,
                         metadata.plugin_url,
                         submission_token,
-                        api_base_url=github_api_url,
+                        api_base_url=normalized_github_api_url,
                     )
                     if existing is not None:
                         submission_issues.append(existing)
@@ -528,7 +541,7 @@ def main() -> int:
                             body,
                             submission_token,
                             labels=submission_labels,
-                            api_base_url=github_api_url,
+                            api_base_url=normalized_github_api_url,
                         )
                     )
 

--- a/src/codex_plugin_scanner/submission.py
+++ b/src/codex_plugin_scanner/submission.py
@@ -29,6 +29,8 @@ def expected_github_api_base_url(github_server_url: str = "https://github.com") 
         return "https://api.github.com"
     if parsed.netloc == "github.com":
         return "https://api.github.com"
+    if parsed.netloc.endswith(".ghe.com"):
+        return f"https://api.{parsed.netloc}"
     return f"https://{parsed.netloc}/api/v3"
 
 

--- a/src/codex_plugin_scanner/submission.py
+++ b/src/codex_plugin_scanner/submission.py
@@ -6,7 +6,7 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.error import HTTPError
-from urllib.parse import quote, urlencode
+from urllib.parse import quote, urlencode, urlparse
 from urllib.request import Request, urlopen
 
 from .checks.manifest import load_manifest
@@ -21,6 +21,31 @@ SUBMISSION_URL_MARKER_SUFFIX = " -->"
 def _repo_api_path(repo: str) -> str:
     owner, name = repo.split("/", 1)
     return f"{quote(owner, safe='')}/{quote(name, safe='')}"
+
+
+def expected_github_api_base_url(github_server_url: str = "https://github.com") -> str:
+    parsed = urlparse(github_server_url.strip() or "https://github.com")
+    if parsed.scheme != "https" or not parsed.netloc:
+        return "https://api.github.com"
+    if parsed.netloc == "github.com":
+        return "https://api.github.com"
+    return f"https://{parsed.netloc}/api/v3"
+
+
+def normalize_github_api_base_url(
+    api_base_url: str,
+    *,
+    github_server_url: str = "https://github.com",
+) -> str:
+    expected = expected_github_api_base_url(github_server_url)
+    candidate = api_base_url.strip() or expected
+    parsed = urlparse(candidate)
+    expected_parsed = urlparse(expected)
+    if parsed.scheme != "https" or not parsed.netloc or parsed.params or parsed.query or parsed.fragment:
+        raise ValueError("GITHUB_API_URL must be an HTTPS GitHub API URL.")
+    if parsed.netloc != expected_parsed.netloc or parsed.path.rstrip("/") != expected_parsed.path.rstrip("/"):
+        raise ValueError(f'GITHUB_API_URL must match "{expected}"')
+    return expected
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_action_runner.py
+++ b/tests/test_action_runner.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from typing import ClassVar
 from urllib.parse import parse_qs, urlsplit
 
+import yaml
+
 from codex_plugin_scanner.action_runner import _build_scan_args, main
 from codex_plugin_scanner.github_reporting import GitHubPrCommentResult, upsert_pr_comment
 
@@ -664,3 +666,38 @@ pr_comment = "off"
     assert exit_code == 0
     output_lines = output_path.read_text(encoding="utf-8").splitlines()
     assert "pr_comment_status=disabled" in output_lines
+
+
+def test_main_rejects_invalid_github_api_url_before_submission(monkeypatch, capsys) -> None:
+    def fail_submission_lookup(*args, **kwargs):
+        raise AssertionError("submission lookup should not run with an invalid GITHUB_API_URL")
+
+    monkeypatch.setattr("codex_plugin_scanner.action_runner.find_existing_submission_issue", fail_submission_lookup)
+    monkeypatch.setenv("MODE", "scan")
+    monkeypatch.setenv("PLUGIN_DIR", str(FIXTURES / "good-plugin"))
+    monkeypatch.setenv("FORMAT", "json")
+    monkeypatch.setenv("WRITE_STEP_SUMMARY", "false")
+    monkeypatch.setenv("SUBMISSION_ENABLED", "true")
+    monkeypatch.setenv("SUBMISSION_SCORE_THRESHOLD", "0")
+    monkeypatch.setenv("SUBMISSION_REPOS", "hashgraph-online/awesome-codex-plugins")
+    monkeypatch.setenv("SUBMISSION_TOKEN", "token-123")
+    monkeypatch.setenv("GITHUB_API_URL", "https://evil.example/api/v3")
+
+    return_code = main()
+
+    captured = capsys.readouterr()
+    assert return_code == 1
+    assert "Invalid GITHUB_API_URL" in captured.err
+
+
+def test_publish_workflow_does_not_inline_version_output_in_shell_scripts() -> None:
+    workflow = yaml.safe_load((Path(__file__).parent.parent / ".github" / "workflows" / "publish.yml").read_text())
+
+    run_blocks = [
+        step["run"]
+        for job in workflow["jobs"].values()
+        for step in job.get("steps", [])
+        if isinstance(step, dict) and isinstance(step.get("run"), str)
+    ]
+
+    assert all("${{ needs.build.outputs.version }}" not in run for run in run_blocks)

--- a/tests/test_action_runner.py
+++ b/tests/test_action_runner.py
@@ -376,51 +376,55 @@ def test_action_runner_creates_pr_comment_for_pull_request_event(monkeypatch, tm
     output_path = tmp_path / "github-output.txt"
     event_path = tmp_path / "event.json"
     event_path.write_text(json.dumps({"pull_request": {"number": 12}}), encoding="utf-8")
-    _GitHubHandler.comments = []
-    _GitHubHandler.comment_pages = None
-    server, api_base_url = _start_github_server()
-    try:
-        monkeypatch.setenv("PLUGIN_DIR", str(FIXTURES / "good-plugin"))
-        monkeypatch.setenv("FORMAT", "json")
-        monkeypatch.setenv("OUTPUT", "")
-        monkeypatch.setenv("MIN_SCORE", "0")
-        monkeypatch.setenv("FAIL_ON", "none")
-        monkeypatch.setenv("CISCO_SCAN", "off")
-        monkeypatch.setenv("CISCO_POLICY", "balanced")
-        monkeypatch.setenv("SUBMISSION_ENABLED", "false")
-        monkeypatch.setenv("SUBMISSION_SCORE_THRESHOLD", "80")
-        monkeypatch.setenv("SUBMISSION_REPOS", "hashgraph-online/awesome-codex-plugins")
-        monkeypatch.setenv("SUBMISSION_TOKEN", "")
-        monkeypatch.setenv("SUBMISSION_LABELS", "plugin-submission")
-        monkeypatch.setenv("SUBMISSION_CATEGORY", "Community Plugins")
-        monkeypatch.setenv("SUBMISSION_PLUGIN_NAME", "")
-        monkeypatch.setenv("SUBMISSION_PLUGIN_URL", "")
-        monkeypatch.setenv("SUBMISSION_PLUGIN_DESCRIPTION", "")
-        monkeypatch.setenv("SUBMISSION_AUTHOR", "")
-        monkeypatch.setenv("WRITE_STEP_SUMMARY", "false")
-        monkeypatch.setenv("REGISTRY_PAYLOAD_OUTPUT", "")
-        monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
-        monkeypatch.setenv("GITHUB_TOKEN", "test-token")
-        monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
-        monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
-        monkeypatch.setenv("GITHUB_REPOSITORY", "hashgraph-online/example-good-plugin")
-        monkeypatch.setenv("GITHUB_API_URL", api_base_url)
+    captured: dict[str, str] = {}
 
-        exit_code = main()
-
-        assert exit_code == 0
-        output_lines = output_path.read_text(encoding="utf-8").splitlines()
-        assert "pr_comment_status=created" in output_lines
-        assert "pr_comment_id=101" in output_lines
-        assert (
-            "pr_comment_url=https://github.com/hashgraph-online/example-good-plugin/pull/12#issuecomment-101"
-            in output_lines
+    def _capture_comment(**kwargs: object) -> GitHubPrCommentResult:
+        body = kwargs.get("body")
+        if isinstance(body, str):
+            captured["body"] = body
+        return GitHubPrCommentResult(
+            status="created",
+            comment_id="101",
+            comment_url="https://github.com/hashgraph-online/example-good-plugin/pull/12#issuecomment-101",
         )
-        assert _GitHubHandler.comments
-        assert "## Guard repo scan" in str(_GitHubHandler.comments[0]["body"])
-    finally:
-        server.shutdown()
-        server.server_close()
+
+    monkeypatch.setenv("PLUGIN_DIR", str(FIXTURES / "good-plugin"))
+    monkeypatch.setenv("FORMAT", "json")
+    monkeypatch.setenv("OUTPUT", "")
+    monkeypatch.setenv("MIN_SCORE", "0")
+    monkeypatch.setenv("FAIL_ON", "none")
+    monkeypatch.setenv("CISCO_SCAN", "off")
+    monkeypatch.setenv("CISCO_POLICY", "balanced")
+    monkeypatch.setenv("SUBMISSION_ENABLED", "false")
+    monkeypatch.setenv("SUBMISSION_SCORE_THRESHOLD", "80")
+    monkeypatch.setenv("SUBMISSION_REPOS", "hashgraph-online/awesome-codex-plugins")
+    monkeypatch.setenv("SUBMISSION_TOKEN", "")
+    monkeypatch.setenv("SUBMISSION_LABELS", "plugin-submission")
+    monkeypatch.setenv("SUBMISSION_CATEGORY", "Community Plugins")
+    monkeypatch.setenv("SUBMISSION_PLUGIN_NAME", "")
+    monkeypatch.setenv("SUBMISSION_PLUGIN_URL", "")
+    monkeypatch.setenv("SUBMISSION_PLUGIN_DESCRIPTION", "")
+    monkeypatch.setenv("SUBMISSION_AUTHOR", "")
+    monkeypatch.setenv("WRITE_STEP_SUMMARY", "false")
+    monkeypatch.setenv("REGISTRY_PAYLOAD_OUTPUT", "")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+    monkeypatch.setenv("GITHUB_REPOSITORY", "hashgraph-online/example-good-plugin")
+    monkeypatch.setattr("codex_plugin_scanner.action_runner.upsert_pr_comment", _capture_comment)
+
+    exit_code = main()
+
+    assert exit_code == 0
+    output_lines = output_path.read_text(encoding="utf-8").splitlines()
+    assert "pr_comment_status=created" in output_lines
+    assert "pr_comment_id=101" in output_lines
+    assert (
+        "pr_comment_url=https://github.com/hashgraph-online/example-good-plugin/pull/12#issuecomment-101"
+        in output_lines
+    )
+    assert "## Guard repo scan" in captured["body"]
 
 
 def test_action_runner_pr_comment_failure_is_nonfatal(monkeypatch, tmp_path, capsys) -> None:
@@ -452,7 +456,7 @@ def test_action_runner_pr_comment_failure_is_nonfatal(monkeypatch, tmp_path, cap
     monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
     monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
     monkeypatch.setenv("GITHUB_REPOSITORY", "hashgraph-online/example-good-plugin")
-    monkeypatch.setenv("GITHUB_API_URL", "https://api.github.test")
+    monkeypatch.setenv("GITHUB_API_URL", "https://api.github.com")
     monkeypatch.setattr(
         "codex_plugin_scanner.action_runner.upsert_pr_comment",
         lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
@@ -571,7 +575,7 @@ def test_action_runner_updates_pr_comment_before_gate_failure(monkeypatch, tmp_p
     monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
     monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
     monkeypatch.setenv("GITHUB_REPOSITORY", "hashgraph-online/example-good-plugin")
-    monkeypatch.setenv("GITHUB_API_URL", "https://api.github.test")
+    monkeypatch.setenv("GITHUB_API_URL", "https://api.github.com")
 
     def _capture_comment(**kwargs: object) -> GitHubPrCommentResult:
         body = kwargs.get("body")

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -274,6 +274,16 @@ def test_normalize_github_api_base_url_accepts_matching_enterprise_api() -> None
     )
 
 
+def test_normalize_github_api_base_url_accepts_matching_ghe_com_api() -> None:
+    assert (
+        normalize_github_api_base_url(
+            "https://api.octocorp.ghe.com",
+            github_server_url="https://octocorp.ghe.com",
+        )
+        == "https://api.octocorp.ghe.com"
+    )
+
+
 def test_normalize_github_api_base_url_rejects_untrusted_host() -> None:
     try:
         normalize_github_api_base_url("https://evil.example/api/v3")

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -12,6 +12,7 @@ from codex_plugin_scanner.submission import (
     build_submission_payload,
     create_submission_issue,
     find_existing_submission_issue,
+    normalize_github_api_base_url,
     resolve_submission_metadata,
 )
 
@@ -257,3 +258,26 @@ def test_create_submission_issue_rejects_missing_issue_fields(monkeypatch) -> No
         assert "required fields" in str(error)
     else:
         raise AssertionError("Expected create_submission_issue to reject incomplete responses.")
+
+
+def test_normalize_github_api_base_url_accepts_github_dot_com_default() -> None:
+    assert normalize_github_api_base_url("https://api.github.com") == "https://api.github.com"
+
+
+def test_normalize_github_api_base_url_accepts_matching_enterprise_api() -> None:
+    assert (
+        normalize_github_api_base_url(
+            "https://github.enterprise.example/api/v3",
+            github_server_url="https://github.enterprise.example",
+        )
+        == "https://github.enterprise.example/api/v3"
+    )
+
+
+def test_normalize_github_api_base_url_rejects_untrusted_host() -> None:
+    try:
+        normalize_github_api_base_url("https://evil.example/api/v3")
+    except ValueError as error:
+        assert 'GITHUB_API_URL must match "https://api.github.com"' in str(error)
+    else:
+        raise AssertionError("Expected normalize_github_api_base_url to reject untrusted hosts.")


### PR DESCRIPTION
## Summary
- stop inlining workflow version outputs into publish shell scripts
- validate submission API base URLs against the active GitHub server before sending tokens
- add workflow and action-runner regressions for the release and submission paths

## Verification
- ruff check .
- pytest -q
- python -m build