### PR TITLE
fix(guard): restore valid claude hook schema

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import shlex
 import subprocess
 import sys
 from collections.abc import Callable
@@ -24,17 +25,14 @@ CLAUDE_GUARD_PROMPT_TIMEOUT_SECONDS = 20
 CLAUDE_GUARD_NOTIFICATION_TIMEOUT_SECONDS = 10
 CLAUDE_GUARD_SESSION_START_TIMEOUT_SECONDS = 10
 CLAUDE_SETTINGS_FILES = ("settings.json", "settings.local.json")
+CLAUDE_GUARD_DAEMON_HOOK_MARKER = "HOL_GUARD_CLAUDE_DAEMON_HOOK"
 
 
 def _guard_command_handler(command: str, *, timeout: int) -> dict[str, object]:
     return {"type": "command", "command": command, "timeout": timeout}
 
 
-def _guard_http_handler(url: str, *, timeout: int) -> dict[str, object]:
-    return {"type": "http", "url": url, "timeout": timeout}
-
-
-def _sync_runtime_hook_groups(hooks: dict[str, object], hook_url: str) -> None:
+def _sync_runtime_hook_groups(hooks: dict[str, object], hook_command: str) -> None:
     for key, matcher, timeout in (
         ("PreToolUse", CLAUDE_GUARD_TOOL_MATCHER, CLAUDE_GUARD_TOOL_TIMEOUT_SECONDS),
         ("PostToolUse", CLAUDE_GUARD_TOOL_MATCHER, CLAUDE_GUARD_TOOL_TIMEOUT_SECONDS),
@@ -45,7 +43,7 @@ def _sync_runtime_hook_groups(hooks: dict[str, object], hook_url: str) -> None:
         hooks[key] = _merge_hook_group(
             _prune_guard_hook_entries(existing_entries if isinstance(existing_entries, list) else []),
             matcher,
-            _guard_http_handler(hook_url, timeout=timeout),
+            _guard_command_handler(hook_command, timeout=timeout),
         )
 
 
@@ -59,6 +57,8 @@ def _guard_hook_group(matcher: str | None, handler: dict[str, object]) -> dict[s
 def _is_guard_hook_command(command: object) -> bool:
     if not isinstance(command, str):
         return False
+    if CLAUDE_GUARD_DAEMON_HOOK_MARKER in command:
+        return True
     if "codex_plugin_scanner.cli" in command:
         return "guard hook" in command or "'guard', 'hook'" in command or '"guard", "hook"' in command
     return "ensure_guard_daemon(" in command and "HOL Guard protection is active for this workspace." in command
@@ -441,6 +441,11 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
         return subprocess.list2cmdline(list(command))
 
     @staticmethod
+    def _daemon_hook_command(context: HarnessContext) -> str:
+        command = ClaudeCodeHarnessAdapter._daemon_hook_command_parts(context)
+        return shlex.join(command)
+
+    @staticmethod
     def _session_start_command(context: HarnessContext) -> str:
         command = ClaudeCodeHarnessAdapter._session_start_command_parts(context)
         return subprocess.list2cmdline(list(command))
@@ -454,6 +459,60 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
         if context.workspace_dir is not None:
             query["workspace"] = str(context.workspace_dir)
         return f"{daemon_url}/v1/hooks/claude-code?{urlencode(query)}"
+
+    @staticmethod
+    def _daemon_hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
+        fallback_daemon_url = load_guard_daemon_url(context.guard_home) or guard_daemon_url_for_home(context.guard_home)
+        state_path = context.guard_home / "daemon-state.json"
+        query: dict[str, str] = {"guard-home": str(context.guard_home)}
+        if context.home_dir.resolve() != Path.home().resolve():
+            query["home"] = str(context.home_dir)
+        if context.workspace_dir is not None:
+            query["workspace"] = str(context.workspace_dir)
+        js = (
+            f"const MARKER={CLAUDE_GUARD_DAEMON_HOOK_MARKER!r};"
+            "void MARKER;"
+            "const fs=require('fs');"
+            "const http=require('http');"
+            "const {URL}=require('url');"
+            f"const statePath={str(state_path)!r};"
+            f"const fallbackUrl={fallback_daemon_url!r};"
+            f"const query={urlencode(query)!r};"
+            "function daemonUrl(){"
+            "try{"
+            "const payload=JSON.parse(fs.readFileSync(statePath,'utf8'));"
+            "if(Number.isInteger(payload.port))return `http://127.0.0.1:${payload.port}`;"
+            "}catch(_error){}"
+            "return fallbackUrl;"
+            "}"
+            "function fail(reason){"
+            "const message=`HOL Guard could not evaluate this action: ${reason}`;"
+            "process.stdout.write(JSON.stringify({decision:'block',reason:message}));"
+            "process.exit(0);"
+            "}"
+            "let body='';"
+            "process.stdin.setEncoding('utf8');"
+            "process.stdin.on('data',chunk=>{body+=chunk;});"
+            "process.stdin.on('end',()=>{"
+            "let endpoint;"
+            "try{endpoint=new URL('/v1/hooks/claude-code?'+query,daemonUrl());}"
+            "catch(error){fail(error.message);return;}"
+            "const data=body.trim()?body:'{}';"
+            "const headers={'content-type':'application/json','content-length':Buffer.byteLength(data)};"
+            "const request=http.request(endpoint,{method:'POST',headers},response=>{"
+            "let responseBody='';"
+            "response.setEncoding('utf8');"
+            "response.on('data',chunk=>{responseBody+=chunk;});"
+            "response.on('end',()=>{"
+            "if(response.statusCode>=200&&response.statusCode<300){process.stdout.write(responseBody);process.exit(0);}"
+            "fail(`daemon returned HTTP ${response.statusCode||0}`);"
+            "});"
+            "});"
+            "request.on('error',error=>{fail(error.message);});"
+            "request.end(data);"
+            "});"
+        )
+        return ("node", "-e", js)
 
     @staticmethod
     def _hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
@@ -509,7 +568,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
         hooks = payload.get("hooks")
         if not isinstance(hooks, dict):
             return
-        _sync_runtime_hook_groups(hooks, self._hook_http_url(context))
+        _sync_runtime_hook_groups(hooks, self._daemon_hook_command(context))
         settings_path.parent.mkdir(parents=True, exist_ok=True)
         settings_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
@@ -537,7 +596,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
         _ensure_path_within_root(context.workspace_dir, settings_path, label="Claude Code")
         payload = _json_payload(settings_path)
         session_start_command = self._session_start_command(context)
-        hook_url = self._hook_http_url(context)
+        hook_command = self._daemon_hook_command(context)
         hooks = payload.setdefault("hooks", {})
         if not isinstance(hooks, dict):
             hooks = {}
@@ -552,7 +611,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
         for matcher in CLAUDE_GUARD_SESSION_START_MATCHERS:
             session_start_entries = _merge_hook_group(session_start_entries, matcher, session_start_handler)
         hooks["SessionStart"] = session_start_entries
-        _sync_runtime_hook_groups(hooks, hook_url)
+        _sync_runtime_hook_groups(hooks, hook_command)
         settings_path.parent.mkdir(parents=True, exist_ok=True)
         settings_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
         return {

--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import shlex
 import subprocess
 import sys
@@ -30,6 +31,13 @@ CLAUDE_GUARD_DAEMON_HOOK_MARKER = "HOL_GUARD_CLAUDE_DAEMON_HOOK"
 
 def _guard_command_handler(command: str, *, timeout: int) -> dict[str, object]:
     return {"type": "command", "command": command, "timeout": timeout}
+
+
+def _shell_command(command: tuple[str, ...], *, windows: bool | None = None) -> str:
+    is_windows = os.name == "nt" if windows is None else windows
+    if is_windows:
+        return subprocess.list2cmdline(list(command))
+    return shlex.join(command)
 
 
 def _sync_runtime_hook_groups(hooks: dict[str, object], hook_command: str) -> None:
@@ -443,7 +451,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
     @staticmethod
     def _daemon_hook_command(context: HarnessContext) -> str:
         command = ClaudeCodeHarnessAdapter._daemon_hook_command_parts(context)
-        return shlex.join(command)
+        return _shell_command(command)
 
     @staticmethod
     def _session_start_command(context: HarnessContext) -> str:

--- a/tests/test_guard_claude_adapter.py
+++ b/tests/test_guard_claude_adapter.py
@@ -14,6 +14,7 @@ from codex_plugin_scanner.guard.adapters.claude_code import (
     CLAUDE_GUARD_DAEMON_HOOK_MARKER,
     CLAUDE_GUARD_TOOL_MATCHER,
     ClaudeCodeHarnessAdapter,
+    _shell_command,
 )
 
 
@@ -331,6 +332,12 @@ def test_claude_daemon_hook_command_is_identified_as_guard_hook(tmp_path):
 
     assert CLAUDE_GUARD_DAEMON_HOOK_MARKER in command
     assert claude_code._is_guard_hook_command(command) is True
+
+
+def test_claude_shell_command_uses_list2cmdline_on_windows():
+    command = ("node", "-e", "console.log('hello')")
+
+    assert _shell_command(command, windows=True) == subprocess.list2cmdline(list(command))
 
 
 def test_claude_daemon_hook_command_survives_shell_execution(tmp_path):

--- a/tests/test_guard_claude_adapter.py
+++ b/tests/test_guard_claude_adapter.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
-from urllib.parse import quote
 
 import pytest
 
 from codex_plugin_scanner.guard.adapters import claude_code, get_adapter
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
-from codex_plugin_scanner.guard.adapters.claude_code import CLAUDE_GUARD_TOOL_MATCHER, ClaudeCodeHarnessAdapter
+from codex_plugin_scanner.guard.adapters.claude_code import (
+    CLAUDE_GUARD_DAEMON_HOOK_MARKER,
+    CLAUDE_GUARD_TOOL_MATCHER,
+    ClaudeCodeHarnessAdapter,
+)
 
 
 def _write_json(path: Path, payload: dict[str, object]) -> None:
@@ -36,6 +40,23 @@ def _build_context(tmp_path: Path) -> HarnessContext:
         workspace_dir=workspace_dir,
         guard_home=guard_home,
     )
+
+
+def _runtime_hook_handlers(payload: dict[str, object]) -> list[dict[str, object]]:
+    hooks = payload["hooks"]
+    assert isinstance(hooks, dict)
+    handlers: list[dict[str, object]] = []
+    for key in ("PreToolUse", "PostToolUse", "UserPromptSubmit", "Notification"):
+        entries = hooks[key]
+        assert isinstance(entries, list)
+        for entry in entries:
+            assert isinstance(entry, dict)
+            entry_hooks = entry["hooks"]
+            assert isinstance(entry_hooks, list)
+            for hook in entry_hooks:
+                assert isinstance(hook, dict)
+                handlers.append(hook)
+    return handlers
 
 
 def test_claude_detect_marks_local_cli_install_as_available_when_not_on_path(monkeypatch, tmp_path):
@@ -114,7 +135,6 @@ def test_claude_install_bakes_current_source_root_into_session_start_command(tmp
 def test_claude_install_writes_session_start_and_command_hook_schema_and_is_idempotent(tmp_path):
     context = _build_context(tmp_path)
     adapter = ClaudeCodeHarnessAdapter()
-    expected_hook_url = adapter._hook_http_url(context)
 
     adapter.install(context)
     adapter.install(context)
@@ -131,18 +151,20 @@ def test_claude_install_writes_session_start_and_command_hook_schema_and_is_idem
     assert all(entry["hooks"][0]["type"] == "command" for entry in session_start)
     assert len(pre_tool_use) == 1
     assert pre_tool_use[0]["matcher"] == "Bash|Read|Write|Edit|MultiEdit|WebFetch|WebSearch|mcp__.*"
-    assert pre_tool_use[0]["hooks"][0]["type"] == "http"
-    assert pre_tool_use[0]["hooks"][0]["url"] == expected_hook_url
+    assert pre_tool_use[0]["hooks"][0]["type"] == "command"
+    assert CLAUDE_GUARD_DAEMON_HOOK_MARKER in pre_tool_use[0]["hooks"][0]["command"]
+    assert "url" not in pre_tool_use[0]["hooks"][0]
     assert pre_tool_use[0]["hooks"][0]["timeout"] == 30
     assert len(post_tool_use) == 1
-    assert post_tool_use[0]["hooks"][0]["type"] == "http"
+    assert post_tool_use[0]["hooks"][0]["type"] == "command"
     assert len(prompt_submit) == 1
     assert "matcher" not in prompt_submit[0]
-    assert prompt_submit[0]["hooks"][0]["type"] == "http"
+    assert prompt_submit[0]["hooks"][0]["type"] == "command"
     assert len(notification) == 1
     assert notification[0]["matcher"] == "permission_prompt"
-    assert notification[0]["hooks"][0]["type"] == "http"
+    assert notification[0]["hooks"][0]["type"] == "command"
     assert notification[0]["hooks"][0]["timeout"] == 10
+    assert all("url" not in handler for handler in _runtime_hook_handlers(payload))
 
 
 def test_get_adapter_accepts_claude_alias():
@@ -213,19 +235,11 @@ def test_claude_install_replaces_legacy_http_guard_hooks(tmp_path):
     adapter.install(context)
 
     payload = json.loads(settings_path.read_text(encoding="utf-8"))
-    installed_hook_types = [
-        hook["type"]
-        for group in (
-            payload["hooks"]["PreToolUse"]
-            + payload["hooks"]["PostToolUse"]
-            + payload["hooks"]["UserPromptSubmit"]
-            + payload["hooks"]["Notification"]
-        )
-        for hook in group["hooks"]
-        if isinstance(hook, dict)
-    ]
+    installed_handlers = _runtime_hook_handlers(payload)
 
-    assert installed_hook_types == ["http", "http", "http", "http"]
+    assert [handler["type"] for handler in installed_handlers] == ["command", "command", "command", "command"]
+    assert all(CLAUDE_GUARD_DAEMON_HOOK_MARKER in str(handler.get("command", "")) for handler in installed_handlers)
+    assert all("url" not in handler for handler in installed_handlers)
 
 
 def test_claude_refresh_runtime_hook_urls_rewrites_stale_daemon_port(tmp_path):
@@ -266,17 +280,12 @@ def test_claude_refresh_runtime_hook_urls_rewrites_stale_daemon_port(tmp_path):
         claude_code.load_guard_daemon_url = original_load_guard_daemon_url
 
     payload = json.loads(settings_path.read_text(encoding="utf-8"))
-    expected_hook_url = (
-        "http://127.0.0.1:5999/v1/hooks/claude-code?"
-        f"guard-home={quote(str(context.guard_home), safe='')}"
-        f"&home={quote(str(context.home_dir), safe='')}"
-        f"&workspace={quote(str(context.workspace_dir), safe='')}"
-    )
+    installed_handlers = _runtime_hook_handlers(payload)
 
-    assert payload["hooks"]["PreToolUse"][0]["hooks"][0]["url"] == expected_hook_url
-    assert payload["hooks"]["PostToolUse"][0]["hooks"][0]["url"] == expected_hook_url
-    assert payload["hooks"]["UserPromptSubmit"][0]["hooks"][0]["url"] == expected_hook_url
-    assert payload["hooks"]["Notification"][0]["hooks"][0]["url"] == expected_hook_url
+    assert all(handler["type"] == "command" for handler in installed_handlers)
+    assert all("url" not in handler for handler in installed_handlers)
+    assert all("http://127.0.0.1:5999" in str(handler["command"]) for handler in installed_handlers)
+    assert all(CLAUDE_GUARD_DAEMON_HOOK_MARKER in str(handler["command"]) for handler in installed_handlers)
 
 
 def test_claude_install_rejects_symlinked_settings_file(tmp_path):
@@ -315,6 +324,37 @@ def test_claude_handler_identity_uses_http_url_for_http_hooks():
     )
 
 
+def test_claude_daemon_hook_command_is_identified_as_guard_hook(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = ClaudeCodeHarnessAdapter()
+    command = adapter._daemon_hook_command(context)
+
+    assert CLAUDE_GUARD_DAEMON_HOOK_MARKER in command
+    assert claude_code._is_guard_hook_command(command) is True
+
+
+def test_claude_daemon_hook_command_survives_shell_execution(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = ClaudeCodeHarnessAdapter()
+    command = adapter._daemon_hook_command(context)
+
+    result = subprocess.run(
+        ["/bin/sh", "-c", command],
+        input=json.dumps({"hook_event_name": "UserPromptSubmit", "prompt": "hello"}),
+        text=True,
+        capture_output=True,
+        timeout=5,
+        check=False,
+    )
+
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert payload["decision"] == "block"
+    assert "HOL Guard could not evaluate this action" in payload["reason"]
+
+
 def test_claude_install_replaces_prior_session_start_guard_handlers_when_context_changes(tmp_path):
     initial_context = _build_context(tmp_path)
     changed_context = HarnessContext(
@@ -323,7 +363,6 @@ def test_claude_install_replaces_prior_session_start_guard_handlers_when_context
         guard_home=tmp_path / "different-guard-home",
     )
     adapter = ClaudeCodeHarnessAdapter()
-    expected_hook_url = adapter._hook_http_url(changed_context)
 
     adapter.install(initial_context)
     adapter.install(changed_context)
@@ -332,23 +371,17 @@ def test_claude_install_replaces_prior_session_start_guard_handlers_when_context
     payload = json.loads(settings_path.read_text(encoding="utf-8"))
     session_start = payload["hooks"]["SessionStart"]
     hook_commands = [entry["hooks"][0]["command"] for entry in session_start]
-    operational_urls = [
-        group["hooks"][0]["url"]
-        for group in (
-            payload["hooks"]["PreToolUse"]
-            + payload["hooks"]["PostToolUse"]
-            + payload["hooks"]["UserPromptSubmit"]
-            + payload["hooks"]["Notification"]
-        )
-    ]
+    operational_handlers = _runtime_hook_handlers(payload)
+    operational_commands = [str(handler["command"]) for handler in operational_handlers]
 
     assert len(session_start) == 4
     assert all(len(entry["hooks"]) == 1 for entry in session_start)
     assert all(str(changed_context.guard_home) in command for command in hook_commands)
     assert all(str(initial_context.guard_home) not in command for command in hook_commands)
-    assert all(url == expected_hook_url for url in operational_urls)
-    assert all(quote(str(changed_context.guard_home), safe="") in url for url in operational_urls)
-    assert all(quote(str(initial_context.guard_home), safe="") not in url for url in operational_urls)
+    assert all(handler["type"] == "command" for handler in operational_handlers)
+    assert all(CLAUDE_GUARD_DAEMON_HOOK_MARKER in command for command in operational_commands)
+    assert all(str(changed_context.guard_home) in command for command in operational_commands)
+    assert all(str(initial_context.guard_home) not in command for command in operational_commands)
 
 
 def test_claude_install_and_uninstall_preserve_unrelated_nested_hooks(tmp_path):
@@ -410,9 +443,11 @@ def test_claude_install_migrates_legacy_flat_guard_hook_entries(tmp_path):
     post_tool_use = payload["hooks"]["PostToolUse"]
 
     assert len(pre_tool_use) == 1
-    assert pre_tool_use[0]["hooks"][0]["type"] == "http"
+    assert pre_tool_use[0]["hooks"][0]["type"] == "command"
+    assert CLAUDE_GUARD_DAEMON_HOOK_MARKER in pre_tool_use[0]["hooks"][0]["command"]
     assert len(post_tool_use) == 1
-    assert post_tool_use[0]["hooks"][0]["type"] == "http"
+    assert post_tool_use[0]["hooks"][0]["type"] == "command"
+    assert CLAUDE_GUARD_DAEMON_HOOK_MARKER in post_tool_use[0]["hooks"][0]["command"]
 
 
 def test_claude_detect_discovers_nested_hooks_skills_commands_and_rules(tmp_path):

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -20,7 +20,7 @@ from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.adapters import claude_code as claude_adapter_module
 from codex_plugin_scanner.guard.adapters import cursor as cursor_adapter_module
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
-from codex_plugin_scanner.guard.adapters.claude_code import ClaudeCodeHarnessAdapter
+from codex_plugin_scanner.guard.adapters.claude_code import CLAUDE_GUARD_DAEMON_HOOK_MARKER, ClaudeCodeHarnessAdapter
 from codex_plugin_scanner.guard.adapters.opencode import OpenCodeHarnessAdapter
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
 from codex_plugin_scanner.guard.cli import connect_flow as guard_connect_flow_module
@@ -2114,19 +2114,21 @@ args = ["workspace-skill.js", "--changed"]
             install_settings_payload["hooks"]["SessionStart"][0]["hooks"][0]["command"]
             == expected_session_start_command
         )
-        expected_hook_url = ClaudeCodeHarnessAdapter._hook_http_url(
+        expected_hook_command = ClaudeCodeHarnessAdapter._daemon_hook_command(
             HarnessContext(
                 home_dir=home_dir,
                 workspace_dir=workspace_dir,
                 guard_home=home_dir,
             )
         )
-        assert install_settings_payload["hooks"]["PreToolUse"][0]["hooks"][0]["type"] == "http"
-        assert install_settings_payload["hooks"]["PreToolUse"][0]["hooks"][0]["url"] == expected_hook_url
-        assert install_settings_payload["hooks"]["UserPromptSubmit"][0]["hooks"][0]["type"] == "http"
+        assert install_settings_payload["hooks"]["PreToolUse"][0]["hooks"][0]["type"] == "command"
+        assert install_settings_payload["hooks"]["PreToolUse"][0]["hooks"][0]["command"] == expected_hook_command
+        assert "url" not in install_settings_payload["hooks"]["PreToolUse"][0]["hooks"][0]
+        assert install_settings_payload["hooks"]["UserPromptSubmit"][0]["hooks"][0]["type"] == "command"
         assert install_settings_payload["hooks"]["Notification"][0]["matcher"] == "permission_prompt"
-        assert install_settings_payload["hooks"]["Notification"][0]["hooks"][0]["type"] == "http"
-        assert install_settings_payload["hooks"]["Notification"][0]["hooks"][0]["url"] == expected_hook_url
+        assert install_settings_payload["hooks"]["Notification"][0]["hooks"][0]["type"] == "command"
+        assert install_settings_payload["hooks"]["Notification"][0]["hooks"][0]["command"] == expected_hook_command
+        assert "url" not in install_settings_payload["hooks"]["Notification"][0]["hooks"][0]
         assert uninstall_rc == 0
         assert uninstall_output["managed_install"]["active"] is False
         assert settings_payload["hooks"]["SessionStart"] == []
@@ -2350,20 +2352,22 @@ args = ["workspace-skill.js", "--changed"]
         assert len(payload["hooks"]["PostToolUse"]) == 1
         assert len(payload["hooks"]["UserPromptSubmit"]) == 1
         assert len(payload["hooks"]["Notification"]) == 1
-        pretool_hook_urls = [
-            hook["url"]
+        pretool_hook_commands = [
+            hook["command"]
             for hook in payload["hooks"]["PreToolUse"][0]["hooks"]
-            if isinstance(hook, dict) and isinstance(hook.get("url"), str)
+            if isinstance(hook, dict) and isinstance(hook.get("command"), str)
         ]
-        assert len(pretool_hook_urls) == 1
-        assert "legacy-guard-home" not in pretool_hook_urls[0]
-        notification_hook_urls = [
-            hook["url"]
+        assert len(pretool_hook_commands) == 1
+        assert CLAUDE_GUARD_DAEMON_HOOK_MARKER in pretool_hook_commands[0]
+        assert "legacy-guard-home" not in pretool_hook_commands[0]
+        notification_hook_commands = [
+            hook["command"]
             for hook in payload["hooks"]["Notification"][0]["hooks"]
-            if isinstance(hook, dict) and isinstance(hook.get("url"), str)
+            if isinstance(hook, dict) and isinstance(hook.get("command"), str)
         ]
-        assert len(notification_hook_urls) == 1
-        assert "legacy-guard-home" not in notification_hook_urls[0]
+        assert len(notification_hook_commands) == 1
+        assert CLAUDE_GUARD_DAEMON_HOOK_MARKER in notification_hook_commands[0]
+        assert "legacy-guard-home" not in notification_hook_commands[0]
 
     def test_guard_install_auto_detects_configured_harnesses(self, tmp_path, capsys):
         home_dir = tmp_path / "home"


### PR DESCRIPTION
## Purpose
- Restore Claude Code install compatibility with Claude 2.1.x hook schemas.
- Replace invalid runtime `type: http` hook handlers with valid `type: command` handlers that delegate to the existing HOL Guard daemon.
- Preserve legacy HTTP hook cleanup and add shell-execution regression coverage for the command bridge.

## Verification
- `ruff check src/codex_plugin_scanner/guard/adapters/claude_code.py tests/test_guard_claude_adapter.py`
- `PYTHONPATH=src pytest tests/test_guard_claude_adapter.py tests/test_guard_daemon_manager.py -q`
- Local Claude Code 2.1.116 smoke: `claude -p ... --output-format stream-json --include-hook-events --verbose` from `/Users/michaelkantor/guard-claude-smoke` showed SessionStart/UserPromptSubmit/PreToolUse hooks succeeding and HOL Guard-branded permission text for guarded .env access.

## Setup notes
- No new dependencies.