### PR TITLE
fix(guard): brand Claude native approvals

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -25,6 +25,7 @@ CLAUDE_GUARD_TOOL_TIMEOUT_SECONDS = 30
 CLAUDE_GUARD_PROMPT_TIMEOUT_SECONDS = 20
 CLAUDE_GUARD_NOTIFICATION_TIMEOUT_SECONDS = 10
 CLAUDE_GUARD_SESSION_START_TIMEOUT_SECONDS = 10
+CLAUDE_GUARD_STOP_TIMEOUT_SECONDS = 10
 CLAUDE_SETTINGS_FILES = ("settings.json", "settings.local.json")
 CLAUDE_GUARD_DAEMON_HOOK_MARKER = "HOL_GUARD_CLAUDE_DAEMON_HOOK"
 
@@ -46,6 +47,7 @@ def _sync_runtime_hook_groups(hooks: dict[str, object], hook_command: str) -> No
         ("PostToolUse", CLAUDE_GUARD_TOOL_MATCHER, CLAUDE_GUARD_TOOL_TIMEOUT_SECONDS),
         ("UserPromptSubmit", None, CLAUDE_GUARD_PROMPT_TIMEOUT_SECONDS),
         ("Notification", CLAUDE_GUARD_NOTIFICATION_MATCHER, CLAUDE_GUARD_NOTIFICATION_TIMEOUT_SECONDS),
+        ("Stop", None, CLAUDE_GUARD_STOP_TIMEOUT_SECONDS),
     ):
         existing_entries = hooks.get(key)
         hooks[key] = _merge_hook_group(
@@ -53,6 +55,18 @@ def _sync_runtime_hook_groups(hooks: dict[str, object], hook_command: str) -> No
             matcher,
             _guard_command_handler(hook_command, timeout=timeout),
         )
+
+
+def _remove_unsupported_guard_hook_groups(hooks: dict[str, object]) -> None:
+    for key in ("PermissionDenied",):
+        entries = hooks.get(key)
+        if not isinstance(entries, list):
+            continue
+        remaining = _prune_guard_hook_entries(entries)
+        if remaining:
+            hooks[key] = remaining
+        else:
+            hooks.pop(key, None)
 
 
 def _guard_hook_group(matcher: str | None, handler: dict[str, object]) -> dict[str, object]:
@@ -577,6 +591,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
         if not isinstance(hooks, dict):
             return
         _sync_runtime_hook_groups(hooks, self._daemon_hook_command(context))
+        _remove_unsupported_guard_hook_groups(hooks)
         settings_path.parent.mkdir(parents=True, exist_ok=True)
         settings_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
@@ -620,6 +635,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
             session_start_entries = _merge_hook_group(session_start_entries, matcher, session_start_handler)
         hooks["SessionStart"] = session_start_entries
         _sync_runtime_hook_groups(hooks, hook_command)
+        _remove_unsupported_guard_hook_groups(hooks)
         settings_path.parent.mkdir(parents=True, exist_ok=True)
         settings_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
         return {
@@ -653,9 +669,17 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
         payload = _json_payload(settings_path)
         hooks = payload.get("hooks")
         if isinstance(hooks, dict):
-            for key in ("SessionStart", "PreToolUse", "PostToolUse", "UserPromptSubmit", "Notification"):
+            for key in (
+                "SessionStart",
+                "PreToolUse",
+                "PostToolUse",
+                "UserPromptSubmit",
+                "Notification",
+                "Stop",
+            ):
                 entries = hooks.get(key)
                 hooks[key] = _prune_guard_hook_entries(entries if isinstance(entries, list) else [])
+            _remove_unsupported_guard_hook_groups(hooks)
             settings_path.parent.mkdir(parents=True, exist_ok=True)
             settings_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
         return {

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -14,6 +14,7 @@ import sys
 import urllib.error
 import urllib.parse
 import webbrowser
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TextIO
@@ -1235,6 +1236,20 @@ def run_guard_command(
                 runtime_artifact_hash,
                 str(runtime_workspace) if runtime_workspace else None,
             )
+            if stored_policy_action is None:
+                legacy_artifact = _legacy_claude_alias_runtime_artifact(
+                    artifact=runtime_artifact,
+                    requested_harness=args.harness,
+                    home_dir=context.home_dir,
+                    workspace=runtime_workspace,
+                )
+                if legacy_artifact is not None:
+                    stored_policy_action = store.resolve_policy(
+                        args.harness,
+                        legacy_artifact.artifact_id,
+                        artifact_hash(legacy_artifact),
+                        str(runtime_workspace) if runtime_workspace else None,
+                    )
             policy_action = _coalesce_string(
                 getattr(args, "policy_action", None),
                 stored_policy_action,
@@ -2822,6 +2837,28 @@ def _hook_runtime_artifact(
         request=tool_request,
         config_path=config_path,
         source_scope=source_scope,
+    )
+
+
+def _legacy_claude_alias_runtime_artifact(
+    *,
+    artifact: GuardArtifact,
+    requested_harness: str,
+    home_dir: Path,
+    workspace: Path | None,
+) -> GuardArtifact | None:
+    if requested_harness == artifact.harness:
+        return None
+    if requested_harness != "claude" or artifact.harness != "claude-code":
+        return None
+    legacy_prefix = "claude-code:"
+    if not artifact.artifact_id.startswith(legacy_prefix):
+        return None
+    return replace(
+        artifact,
+        artifact_id=f"claude:{artifact.artifact_id[len(legacy_prefix):]}",
+        harness="claude",
+        config_path=str(_runtime_policy_path("claude", home_dir, workspace)),
     )
 
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1256,7 +1256,7 @@ def run_guard_command(
                 )
                 if saved:
                     receipt = build_receipt(
-                        harness=args.harness,
+                        harness=policy_harness,
                         artifact_id=artifact_id,
                         artifact_hash=runtime_artifact_hash,
                         policy_decision="allow",

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2692,6 +2692,7 @@ def _hook_runtime_artifact(
     guard_home: Path,
     workspace: Path | None,
 ) -> GuardArtifact | None:
+    harness = _canonical_harness_name(harness)
     event_name = _hook_event_name(payload)
     if event_name == "UserPromptSubmit":
         prompt_text = payload.get("prompt")

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1228,8 +1228,9 @@ def run_guard_command(
             runtime_artifact_hash = artifact_hash(runtime_artifact)
             artifact_id = runtime_artifact.artifact_id
             artifact_name = runtime_artifact.name
+            policy_harness = _canonical_harness_name(args.harness)
             stored_policy_action = store.resolve_policy(
-                args.harness,
+                policy_harness,
                 artifact_id,
                 runtime_artifact_hash,
                 str(runtime_workspace) if runtime_workspace else None,
@@ -1265,30 +1266,6 @@ def run_guard_command(
                         artifact_name=artifact_name,
                         source_scope=runtime_artifact.source_scope,
                         user_override="claude-native-approve",
-                    )
-                    store.add_receipt(receipt)
-                return 0
-            if _canonical_harness_name(args.harness) == "claude-code" and event_name == "PermissionDenied":
-                saved = _persist_claude_native_permission_for_runtime_artifact(
-                    store=store,
-                    payload=payload,
-                    artifact=runtime_artifact,
-                    artifact_hash=runtime_artifact_hash,
-                    action="block",
-                    reason=_coalesce_string(payload.get("reason"), "Denied by Claude permission classifier."),
-                )
-                if saved:
-                    receipt = build_receipt(
-                        harness=args.harness,
-                        artifact_id=artifact_id,
-                        artifact_hash=runtime_artifact_hash,
-                        policy_decision="block",
-                        capabilities_summary=_runtime_capabilities_summary(runtime_artifact),
-                        changed_capabilities=[runtime_artifact.artifact_type, "claude-native-denied"],
-                        provenance_summary=f"runtime tool request denied from {runtime_artifact.config_path}",
-                        artifact_name=artifact_name,
-                        source_scope=runtime_artifact.source_scope,
-                        user_override="claude-native-deny",
                     )
                     store.add_receipt(receipt)
                 return 0
@@ -1904,8 +1881,10 @@ def _persist_claude_pending_permission_denials(store: GuardStore, payload: dict[
         return 0
     if not isinstance(index_payload, list):
         return 0
+    pending_keys = [str(item) for item in index_payload]
+    processed_keys: list[str] = []
     denied = 0
-    for pending_key in [str(item) for item in index_payload]:
+    for pending_key in pending_keys:
         try:
             pending = store.get_sync_payload(pending_key)
         except (OSError, sqlite3.Error):
@@ -1925,8 +1904,20 @@ def _persist_claude_pending_permission_denials(store: GuardStore, payload: dict[
             reason=f"Denied in Claude native approval prompt. {reason}",
             now=_now(),
         )
-        _remove_claude_pending_permission(store, session_id=session_id, pending_key=pending_key)
+        processed_keys.append(pending_key)
         denied += 1
+    if processed_keys:
+        processed_set = set(processed_keys)
+        try:
+            for pending_key in processed_keys:
+                store.delete_sync_payload(pending_key)
+            remaining_keys = [pending_key for pending_key in pending_keys if pending_key not in processed_set]
+            if remaining_keys:
+                store.set_sync_payload(index_key, remaining_keys, _now())
+            else:
+                store.delete_sync_payload(index_key)
+        except (OSError, sqlite3.Error):
+            return denied
     return denied
 
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1704,6 +1704,46 @@ def _claude_pending_permission_state_key(session_id: str, artifact_id: str) -> s
     return f"claude_pending_permission:{session_id}:{fingerprint}"
 
 
+def _sync_payload_list_from_row(row: sqlite3.Row | None) -> list[str]:
+    if row is None:
+        return []
+    try:
+        payload = json.loads(str(row["payload_json"]))
+    except json.JSONDecodeError:
+        return []
+    return [str(item) for item in payload] if isinstance(payload, list) else []
+
+
+def _append_claude_pending_permission_key(
+    store: GuardStore,
+    *,
+    session_id: str,
+    pending_key: str,
+    now: str,
+) -> None:
+    index_key = _claude_pending_permission_index_key(session_id)
+    with store._connect() as connection:
+        connection.execute("begin immediate")
+        row = connection.execute(
+            "select payload_json from sync_state where state_key = ?",
+            (index_key,),
+        ).fetchone()
+        pending_keys = _sync_payload_list_from_row(row)
+        if pending_key in pending_keys:
+            return
+        pending_keys.append(pending_key)
+        connection.execute(
+            """
+            insert into sync_state (state_key, payload_json, updated_at)
+            values (?, ?, ?)
+            on conflict(state_key) do update set
+              payload_json = excluded.payload_json,
+              updated_at = excluded.updated_at
+            """,
+            (index_key, json.dumps(pending_keys), now),
+        )
+
+
 def _record_claude_permission_notice(
     *,
     store: GuardStore,
@@ -1732,12 +1772,7 @@ def _record_claude_permission_notice(
         store.set_sync_payload(_claude_permission_notice_state_key(session_id, tool_name), notice_payload, _now())
         pending_key = _claude_pending_permission_state_key(session_id, artifact.artifact_id)
         store.set_sync_payload(pending_key, notice_payload, _now())
-        index_key = _claude_pending_permission_index_key(session_id)
-        index_payload = store.get_sync_payload(index_key)
-        pending_keys = [str(item) for item in index_payload] if isinstance(index_payload, list) else []
-        if pending_key not in pending_keys:
-            pending_keys.append(pending_key)
-            store.set_sync_payload(index_key, pending_keys, _now())
+        _append_claude_pending_permission_key(store, session_id=session_id, pending_key=pending_key, now=_now())
     except (OSError, sqlite3.Error):
         return
 
@@ -1785,15 +1820,28 @@ def _remove_claude_pending_permission(
     pending_key: str,
 ) -> None:
     try:
-        store.delete_sync_payload(pending_key)
         index_key = _claude_pending_permission_index_key(session_id)
-        index_payload = store.get_sync_payload(index_key)
-        if isinstance(index_payload, list):
-            remaining = [str(item) for item in index_payload if str(item) != pending_key]
+        with store._connect() as connection:
+            connection.execute("begin immediate")
+            connection.execute("delete from sync_state where state_key = ?", (pending_key,))
+            row = connection.execute(
+                "select payload_json from sync_state where state_key = ?",
+                (index_key,),
+            ).fetchone()
+            remaining = [key for key in _sync_payload_list_from_row(row) if key != pending_key]
             if remaining:
-                store.set_sync_payload(index_key, remaining, _now())
+                connection.execute(
+                    """
+                    insert into sync_state (state_key, payload_json, updated_at)
+                    values (?, ?, ?)
+                    on conflict(state_key) do update set
+                      payload_json = excluded.payload_json,
+                      updated_at = excluded.updated_at
+                    """,
+                    (index_key, json.dumps(remaining), _now()),
+                )
             else:
-                store.delete_sync_payload(index_key)
+                connection.execute("delete from sync_state where state_key = ?", (index_key,))
     except (OSError, sqlite3.Error):
         return
 
@@ -1806,29 +1854,33 @@ def _persist_claude_native_permission_policy(
     action: str,
     reason: str,
     now: str,
-) -> None:
-    store.upsert_policy(
-        PolicyDecision(
-            harness="claude-code",
-            scope="artifact",
-            action="allow" if action == "allow" else "block",
-            artifact_id=artifact_id,
-            artifact_hash=artifact_hash,
-            reason=reason,
-            source="claude-native-approval",
-        ),
-        now,
-    )
-    store.add_event(
-        "claude/native_permission_saved",
-        {
-            "artifact_id": artifact_id,
-            "artifact_hash": artifact_hash,
-            "action": action,
-            "reason": reason,
-        },
-        now,
-    )
+) -> bool:
+    try:
+        store.upsert_policy(
+            PolicyDecision(
+                harness="claude-code",
+                scope="artifact",
+                action="allow" if action == "allow" else "block",
+                artifact_id=artifact_id,
+                artifact_hash=artifact_hash,
+                reason=reason,
+                source="claude-native-approval",
+            ),
+            now,
+        )
+        store.add_event(
+            "claude/native_permission_saved",
+            {
+                "artifact_id": artifact_id,
+                "artifact_hash": artifact_hash,
+                "action": action,
+                "reason": reason,
+            },
+            now,
+        )
+    except (OSError, sqlite3.Error):
+        return False
+    return True
 
 
 def _persist_claude_native_permission_for_runtime_artifact(
@@ -1844,7 +1896,7 @@ def _persist_claude_native_permission_for_runtime_artifact(
     if pending is None:
         return False
     now = _now()
-    _persist_claude_native_permission_policy(
+    saved_policy = _persist_claude_native_permission_policy(
         store=store,
         artifact_id=artifact.artifact_id,
         artifact_hash=artifact_hash,
@@ -1852,14 +1904,19 @@ def _persist_claude_native_permission_for_runtime_artifact(
         reason=reason,
         now=now,
     )
-    store.record_inventory_artifact(
-        artifact=artifact,
-        artifact_hash=artifact_hash,
-        policy_action="allow" if action == "allow" else "block",
-        changed=False,
-        now=now,
-        approved=action == "allow",
-    )
+    if not saved_policy:
+        return False
+    try:
+        store.record_inventory_artifact(
+            artifact=artifact,
+            artifact_hash=artifact_hash,
+            policy_action="allow" if action == "allow" else "block",
+            changed=False,
+            now=now,
+            approved=action == "allow",
+        )
+    except (OSError, sqlite3.Error):
+        return False
     session_id = _optional_string(payload.get("session_id"))
     if session_id is not None:
         _remove_claude_pending_permission(
@@ -1896,7 +1953,7 @@ def _persist_claude_pending_permission_denials(store: GuardStore, payload: dict[
         if artifact_id is None or artifact_hash_value is None:
             continue
         reason = _optional_string(pending.get("reason")) or "Denied in Claude's native approval prompt."
-        _persist_claude_native_permission_policy(
+        saved_policy = _persist_claude_native_permission_policy(
             store=store,
             artifact_id=artifact_id,
             artifact_hash=artifact_hash_value,
@@ -1904,18 +1961,36 @@ def _persist_claude_pending_permission_denials(store: GuardStore, payload: dict[
             reason=f"Denied in Claude native approval prompt. {reason}",
             now=_now(),
         )
+        if not saved_policy:
+            continue
         processed_keys.append(pending_key)
         denied += 1
     if processed_keys:
         processed_set = set(processed_keys)
         try:
-            for pending_key in processed_keys:
-                store.delete_sync_payload(pending_key)
-            remaining_keys = [pending_key for pending_key in pending_keys if pending_key not in processed_set]
-            if remaining_keys:
-                store.set_sync_payload(index_key, remaining_keys, _now())
-            else:
-                store.delete_sync_payload(index_key)
+            with store._connect() as connection:
+                connection.execute("begin immediate")
+                for pending_key in processed_keys:
+                    connection.execute("delete from sync_state where state_key = ?", (pending_key,))
+                row = connection.execute(
+                    "select payload_json from sync_state where state_key = ?",
+                    (index_key,),
+                ).fetchone()
+                current_keys = _sync_payload_list_from_row(row)
+                remaining_keys = [pending_key for pending_key in current_keys if pending_key not in processed_set]
+                if remaining_keys:
+                    connection.execute(
+                        """
+                        insert into sync_state (state_key, payload_json, updated_at)
+                        values (?, ?, ?)
+                        on conflict(state_key) do update set
+                          payload_json = excluded.payload_json,
+                          updated_at = excluded.updated_at
+                        """,
+                        (index_key, json.dumps(remaining_keys), _now()),
+                    )
+                else:
+                    connection.execute("delete from sync_state where state_key = ?", (index_key,))
         except (OSError, sqlite3.Error):
             return denied
     return denied

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2856,7 +2856,7 @@ def _legacy_claude_alias_runtime_artifact(
         return None
     return replace(
         artifact,
-        artifact_id=f"claude:{artifact.artifact_id[len(legacy_prefix):]}",
+        artifact_id=f"claude:{artifact.artifact_id[len(legacy_prefix) :]}",
         harness="claude",
         config_path=str(_runtime_policy_path("claude", home_dir, workspace)),
     )

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -55,7 +55,7 @@ from ..mcp_tool_calls import (
     build_tool_call_hash,
     evaluate_tool_call,
 )
-from ..models import GuardArtifact, HarnessDetection
+from ..models import GuardArtifact, HarnessDetection, PolicyDecision
 from ..policy.engine import SAFE_CHANGED_HASH_ACTION, VALID_GUARD_ACTIONS
 from ..protect import build_protect_payload
 from ..proxy import (
@@ -1215,6 +1215,14 @@ def run_guard_command(
                 output_stream=output_stream,
             )
             return 0
+        if _canonical_harness_name(args.harness) == "claude-code" and _hook_event_name(payload) == "Stop":
+            denied = _persist_claude_pending_permission_denials(store, payload)
+            store.add_event(
+                "claude/turn_stop",
+                {"session_id": payload.get("session_id"), "saved_denials": denied},
+                _now(),
+            )
+            return 0
         if runtime_artifact is not None:
             event_name = _hook_event_name(payload) or "PreToolUse"
             runtime_artifact_hash = artifact_hash(runtime_artifact)
@@ -1233,6 +1241,57 @@ def run_guard_command(
             )
             if policy_action not in VALID_GUARD_ACTIONS:
                 policy_action = SAFE_CHANGED_HASH_ACTION
+            if _canonical_harness_name(args.harness) == "claude-code" and event_name in {
+                "PostToolUse",
+                "PostToolUseFailure",
+            }:
+                saved = _persist_claude_native_permission_for_runtime_artifact(
+                    store=store,
+                    payload=payload,
+                    artifact=runtime_artifact,
+                    artifact_hash=runtime_artifact_hash,
+                    action="allow",
+                    reason="Approved in Claude native approval prompt.",
+                )
+                if saved:
+                    receipt = build_receipt(
+                        harness=args.harness,
+                        artifact_id=artifact_id,
+                        artifact_hash=runtime_artifact_hash,
+                        policy_decision="allow",
+                        capabilities_summary=_runtime_capabilities_summary(runtime_artifact),
+                        changed_capabilities=[runtime_artifact.artifact_type, "claude-native-approved"],
+                        provenance_summary=f"runtime tool request approved from {runtime_artifact.config_path}",
+                        artifact_name=artifact_name,
+                        source_scope=runtime_artifact.source_scope,
+                        user_override="claude-native-approve",
+                    )
+                    store.add_receipt(receipt)
+                return 0
+            if _canonical_harness_name(args.harness) == "claude-code" and event_name == "PermissionDenied":
+                saved = _persist_claude_native_permission_for_runtime_artifact(
+                    store=store,
+                    payload=payload,
+                    artifact=runtime_artifact,
+                    artifact_hash=runtime_artifact_hash,
+                    action="block",
+                    reason=_coalesce_string(payload.get("reason"), "Denied by Claude permission classifier."),
+                )
+                if saved:
+                    receipt = build_receipt(
+                        harness=args.harness,
+                        artifact_id=artifact_id,
+                        artifact_hash=runtime_artifact_hash,
+                        policy_decision="block",
+                        capabilities_summary=_runtime_capabilities_summary(runtime_artifact),
+                        changed_capabilities=[runtime_artifact.artifact_type, "claude-native-denied"],
+                        provenance_summary=f"runtime tool request denied from {runtime_artifact.config_path}",
+                        artifact_name=artifact_name,
+                        source_scope=runtime_artifact.source_scope,
+                        user_override="claude-native-deny",
+                    )
+                    store.add_receipt(receipt)
+                return 0
             changed_capabilities = [runtime_artifact.artifact_type]
             risk_signals = list(artifact_risk_signals(runtime_artifact))
             risk_summary = artifact_risk_summary(runtime_artifact)
@@ -1290,16 +1349,6 @@ def run_guard_command(
                 )
                 if (
                     _canonical_harness_name(args.harness) == "claude-code"
-                    and event_name == "UserPromptSubmit"
-                    and policy_action == "require-reapproval"
-                    and not _prompt_requires_hard_block(runtime_artifact)
-                    and (output_stream is not None or not getattr(args, "json", False))
-                ):
-                    if getattr(args, "json", False) and output_stream is not None:
-                        _write_json_line({}, output_stream=output_stream)
-                    return 0
-                if (
-                    _canonical_harness_name(args.harness) == "claude-code"
                     and event_name == "PreToolUse"
                     and policy_action == "require-reapproval"
                 ):
@@ -1308,6 +1357,7 @@ def run_guard_command(
                         payload=payload,
                         reason=native_reason,
                         artifact=runtime_artifact,
+                        artifact_hash=runtime_artifact_hash,
                     )
                 if _should_emit_copilot_hook_response(args):
                     _emit_copilot_hook_response(
@@ -1668,12 +1718,22 @@ def _claude_permission_notice_state_key(session_id: str, tool_name: str | None =
     return f"claude_permission_notice:{session_id}"
 
 
+def _claude_pending_permission_index_key(session_id: str) -> str:
+    return f"claude_pending_permissions:{session_id}"
+
+
+def _claude_pending_permission_state_key(session_id: str, artifact_id: str) -> str:
+    fingerprint = hashlib.sha256(artifact_id.encode("utf-8")).hexdigest()[:24]
+    return f"claude_pending_permission:{session_id}:{fingerprint}"
+
+
 def _record_claude_permission_notice(
     *,
     store: GuardStore,
     payload: dict[str, object],
     reason: str,
     artifact: GuardArtifact,
+    artifact_hash: str,
 ) -> None:
     session_id = _optional_string(payload.get("session_id"))
     if session_id is None:
@@ -1683,12 +1743,24 @@ def _record_claude_permission_notice(
         "saved_at": _now(),
         "reason": reason,
         "artifact_id": artifact.artifact_id,
+        "artifact_hash": artifact_hash,
         "artifact_name": artifact.name,
+        "artifact_type": artifact.artifact_type,
+        "config_path": artifact.config_path,
+        "source_scope": artifact.source_scope,
     }
     if tool_name is not None:
         notice_payload["tool_name"] = tool_name
     try:
         store.set_sync_payload(_claude_permission_notice_state_key(session_id, tool_name), notice_payload, _now())
+        pending_key = _claude_pending_permission_state_key(session_id, artifact.artifact_id)
+        store.set_sync_payload(pending_key, notice_payload, _now())
+        index_key = _claude_pending_permission_index_key(session_id)
+        index_payload = store.get_sync_payload(index_key)
+        pending_keys = [str(item) for item in index_payload] if isinstance(index_payload, list) else []
+        if pending_key not in pending_keys:
+            pending_keys.append(pending_key)
+            store.set_sync_payload(index_key, pending_keys, _now())
     except (OSError, sqlite3.Error):
         return
 
@@ -1711,6 +1783,151 @@ def _load_claude_permission_notice(store: GuardStore, payload: dict[str, object]
     if isinstance(persisted, dict):
         return persisted
     return None
+
+
+def _load_claude_pending_permission(
+    store: GuardStore,
+    payload: dict[str, object],
+    artifact: GuardArtifact,
+) -> dict[str, object] | None:
+    session_id = _optional_string(payload.get("session_id"))
+    if session_id is None:
+        return None
+    pending_key = _claude_pending_permission_state_key(session_id, artifact.artifact_id)
+    try:
+        persisted = store.get_sync_payload(pending_key)
+    except (OSError, sqlite3.Error):
+        return None
+    return persisted if isinstance(persisted, dict) else None
+
+
+def _remove_claude_pending_permission(
+    store: GuardStore,
+    *,
+    session_id: str,
+    pending_key: str,
+) -> None:
+    try:
+        store.delete_sync_payload(pending_key)
+        index_key = _claude_pending_permission_index_key(session_id)
+        index_payload = store.get_sync_payload(index_key)
+        if isinstance(index_payload, list):
+            remaining = [str(item) for item in index_payload if str(item) != pending_key]
+            if remaining:
+                store.set_sync_payload(index_key, remaining, _now())
+            else:
+                store.delete_sync_payload(index_key)
+    except (OSError, sqlite3.Error):
+        return
+
+
+def _persist_claude_native_permission_policy(
+    *,
+    store: GuardStore,
+    artifact_id: str,
+    artifact_hash: str,
+    action: str,
+    reason: str,
+    now: str,
+) -> None:
+    store.upsert_policy(
+        PolicyDecision(
+            harness="claude-code",
+            scope="artifact",
+            action="allow" if action == "allow" else "block",
+            artifact_id=artifact_id,
+            artifact_hash=artifact_hash,
+            reason=reason,
+            source="claude-native-approval",
+        ),
+        now,
+    )
+    store.add_event(
+        "claude/native_permission_saved",
+        {
+            "artifact_id": artifact_id,
+            "artifact_hash": artifact_hash,
+            "action": action,
+            "reason": reason,
+        },
+        now,
+    )
+
+
+def _persist_claude_native_permission_for_runtime_artifact(
+    *,
+    store: GuardStore,
+    payload: dict[str, object],
+    artifact: GuardArtifact,
+    artifact_hash: str,
+    action: str,
+    reason: str,
+) -> bool:
+    pending = _load_claude_pending_permission(store, payload, artifact)
+    if pending is None:
+        return False
+    now = _now()
+    _persist_claude_native_permission_policy(
+        store=store,
+        artifact_id=artifact.artifact_id,
+        artifact_hash=artifact_hash,
+        action=action,
+        reason=reason,
+        now=now,
+    )
+    store.record_inventory_artifact(
+        artifact=artifact,
+        artifact_hash=artifact_hash,
+        policy_action="allow" if action == "allow" else "block",
+        changed=False,
+        now=now,
+        approved=action == "allow",
+    )
+    session_id = _optional_string(payload.get("session_id"))
+    if session_id is not None:
+        _remove_claude_pending_permission(
+            store,
+            session_id=session_id,
+            pending_key=_claude_pending_permission_state_key(session_id, artifact.artifact_id),
+        )
+    return True
+
+
+def _persist_claude_pending_permission_denials(store: GuardStore, payload: dict[str, object]) -> int:
+    session_id = _optional_string(payload.get("session_id"))
+    if session_id is None:
+        return 0
+    index_key = _claude_pending_permission_index_key(session_id)
+    try:
+        index_payload = store.get_sync_payload(index_key)
+    except (OSError, sqlite3.Error):
+        return 0
+    if not isinstance(index_payload, list):
+        return 0
+    denied = 0
+    for pending_key in [str(item) for item in index_payload]:
+        try:
+            pending = store.get_sync_payload(pending_key)
+        except (OSError, sqlite3.Error):
+            continue
+        if not isinstance(pending, dict):
+            continue
+        artifact_id = _optional_string(pending.get("artifact_id"))
+        artifact_hash_value = _optional_string(pending.get("artifact_hash"))
+        if artifact_id is None or artifact_hash_value is None:
+            continue
+        reason = _optional_string(pending.get("reason")) or "Denied in Claude's native approval prompt."
+        _persist_claude_native_permission_policy(
+            store=store,
+            artifact_id=artifact_id,
+            artifact_hash=artifact_hash_value,
+            action="block",
+            reason=f"Denied in Claude native approval prompt. {reason}",
+            now=_now(),
+        )
+        _remove_claude_pending_permission(store, session_id=session_id, pending_key=pending_key)
+        denied += 1
+    return denied
 
 
 def _is_claude_permission_prompt_notification(args: argparse.Namespace, payload: dict[str, object]) -> bool:

--- a/tests/test_guard_claude_adapter.py
+++ b/tests/test_guard_claude_adapter.py
@@ -47,7 +47,7 @@ def _runtime_hook_handlers(payload: dict[str, object]) -> list[dict[str, object]
     hooks = payload["hooks"]
     assert isinstance(hooks, dict)
     handlers: list[dict[str, object]] = []
-    for key in ("PreToolUse", "PostToolUse", "UserPromptSubmit", "Notification"):
+    for key in ("PreToolUse", "PostToolUse", "UserPromptSubmit", "Notification", "Stop"):
         entries = hooks[key]
         assert isinstance(entries, list)
         for entry in entries:
@@ -147,6 +147,7 @@ def test_claude_install_writes_session_start_and_command_hook_schema_and_is_idem
     post_tool_use = payload["hooks"]["PostToolUse"]
     prompt_submit = payload["hooks"]["UserPromptSubmit"]
     notification = payload["hooks"]["Notification"]
+    stop = payload["hooks"]["Stop"]
     assert len(session_start) == 4
     assert {entry["matcher"] for entry in session_start} == {"startup", "resume", "clear", "compact"}
     assert all(entry["hooks"][0]["type"] == "command" for entry in session_start)
@@ -165,6 +166,10 @@ def test_claude_install_writes_session_start_and_command_hook_schema_and_is_idem
     assert notification[0]["matcher"] == "permission_prompt"
     assert notification[0]["hooks"][0]["type"] == "command"
     assert notification[0]["hooks"][0]["timeout"] == 10
+    assert len(stop) == 1
+    assert "matcher" not in stop[0]
+    assert stop[0]["hooks"][0]["type"] == "command"
+    assert stop[0]["hooks"][0]["timeout"] == 10
     assert all("url" not in handler for handler in _runtime_hook_handlers(payload))
 
 
@@ -238,7 +243,13 @@ def test_claude_install_replaces_legacy_http_guard_hooks(tmp_path):
     payload = json.loads(settings_path.read_text(encoding="utf-8"))
     installed_handlers = _runtime_hook_handlers(payload)
 
-    assert [handler["type"] for handler in installed_handlers] == ["command", "command", "command", "command"]
+    assert [handler["type"] for handler in installed_handlers] == [
+        "command",
+        "command",
+        "command",
+        "command",
+        "command",
+    ]
     assert all(CLAUDE_GUARD_DAEMON_HOOK_MARKER in str(handler.get("command", "")) for handler in installed_handlers)
     assert all("url" not in handler for handler in installed_handlers)
 

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -2129,11 +2129,13 @@ args = ["workspace-skill.js", "--changed"]
         assert install_settings_payload["hooks"]["Notification"][0]["hooks"][0]["type"] == "command"
         assert install_settings_payload["hooks"]["Notification"][0]["hooks"][0]["command"] == expected_hook_command
         assert "url" not in install_settings_payload["hooks"]["Notification"][0]["hooks"][0]
+        assert install_settings_payload["hooks"]["Stop"][0]["hooks"][0]["command"] == expected_hook_command
         assert uninstall_rc == 0
         assert uninstall_output["managed_install"]["active"] is False
         assert settings_payload["hooks"]["SessionStart"] == []
         assert settings_payload["hooks"]["PreToolUse"] == []
         assert settings_payload["hooks"]["Notification"] == []
+        assert settings_payload["hooks"]["Stop"] == []
 
     def test_guard_uninstall_handles_non_dict_claude_hook_entries(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -2222,6 +2224,7 @@ args = ["workspace-skill.js", "--changed"]
         assert payload["hooks"]["PreToolUse"] == []
         assert payload["hooks"]["UserPromptSubmit"] == []
         assert payload["hooks"]["Notification"] == []
+        assert payload["hooks"]["Stop"] == []
 
     def test_guard_install_claude_alias_persists_canonical_managed_install(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -2352,6 +2355,7 @@ args = ["workspace-skill.js", "--changed"]
         assert len(payload["hooks"]["PostToolUse"]) == 1
         assert len(payload["hooks"]["UserPromptSubmit"]) == 1
         assert len(payload["hooks"]["Notification"]) == 1
+        assert len(payload["hooks"]["Stop"]) == 1
         pretool_hook_commands = [
             hook["command"]
             for hook in payload["hooks"]["PreToolUse"][0]["hooks"]

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -4231,6 +4231,7 @@ def test_guard_hook_claude_alias_reuses_native_approval_policy_with_canonical_ha
     )
     first_payload = json.loads(first_output)
     second_payload = json.loads(second_output)
+    receipts = GuardStore(home_dir).list_receipts(limit=20)
 
     assert first_rc == 0
     assert first_payload["hookSpecificOutput"]["permissionDecision"] == "ask"
@@ -4238,6 +4239,7 @@ def test_guard_hook_claude_alias_reuses_native_approval_policy_with_canonical_ha
     assert post_output == ""
     assert second_rc == 0
     assert second_payload["hookSpecificOutput"]["permissionDecision"] == "allow"
+    assert any(receipt["harness"] == "claude-code" for receipt in receipts)
 
 
 def test_guard_hook_claude_stop_persists_unapproved_native_prompt_as_denied(tmp_path, capsys, monkeypatch):

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -4133,6 +4133,110 @@ def test_guard_hook_emits_claude_native_pretooluse_notice_on_stderr(tmp_path, ca
     assert "Yes during this session" in captured_notice[0]
 
 
+def test_guard_hook_claude_posttooluse_persists_native_approval(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    first_event = {
+        "session_id": "session-claude-approval",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Read",
+        "tool_input": {"file_path": str(workspace_dir / ".env")},
+        "source_scope": "project",
+    }
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    first_rc, first_output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="claude-code",
+        event=first_event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    post_event = {
+        **first_event,
+        "hook_event_name": "PostToolUse",
+        "tool_response": {"filePath": str(workspace_dir / ".env"), "success": True},
+    }
+    post_rc, post_output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="claude-code",
+        event=post_event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    second_rc, second_output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="claude-code",
+        event={**first_event, "session_id": "session-claude-next"},
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    first_payload = json.loads(first_output)
+    second_payload = json.loads(second_output)
+    receipts = GuardStore(home_dir).list_receipts(limit=20)
+
+    assert first_rc == 0
+    assert first_payload["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert post_rc == 0
+    assert post_output == ""
+    assert second_rc == 0
+    assert second_payload["hookSpecificOutput"]["permissionDecision"] == "allow"
+    assert any(receipt["user_override"] == "claude-native-approve" for receipt in receipts)
+
+
+def test_guard_hook_claude_stop_persists_unapproved_native_prompt_as_denied(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    first_event = {
+        "session_id": "session-claude-deny",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Read",
+        "tool_input": {"file_path": str(workspace_dir / ".env")},
+        "source_scope": "project",
+    }
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    first_rc, first_output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="claude-code",
+        event=first_event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    stop_rc, stop_output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="claude-code",
+        event={"session_id": "session-claude-deny", "hook_event_name": "Stop", "stop_hook_active": False},
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    second_rc, second_output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="claude-code",
+        event={**first_event, "session_id": "session-claude-deny-next"},
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    first_payload = json.loads(first_output)
+    second_payload = json.loads(second_output)
+
+    assert first_rc == 0
+    assert first_payload["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert stop_rc == 0
+    assert stop_output == ""
+    assert second_rc == 0
+    assert second_payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "HOL Guard blocked Claude's attempt to use Read" in second_payload["systemMessage"]
+
+
 def test_guard_hook_emits_claude_native_ask_response_for_claude_alias(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
@@ -4287,7 +4391,7 @@ def test_runtime_artifact_native_reason_truncates_long_risk_summaries() -> None:
     assert reason.endswith("...")
 
 
-def test_guard_hook_allows_claude_user_prompt_submit_for_overridable_prompts_without_output(
+def test_guard_hook_brands_claude_user_prompt_submit_before_native_approval(
     tmp_path,
     capsys,
     monkeypatch,
@@ -4309,13 +4413,19 @@ def test_guard_hook_allows_claude_user_prompt_submit_for_overridable_prompts_wit
         monkeypatch=monkeypatch,
     )
     receipts = GuardStore(home_dir).list_receipts()
+    payload = json.loads(output)
+    hook_output = payload["hookSpecificOutput"]
 
     assert rc == 0
-    assert output == ""
+    assert "decision" not in payload
+    assert "HOL Guard intercepted this prompt" in payload["systemMessage"]
+    assert hook_output["hookEventName"] == "UserPromptSubmit"
+    assert "HOL Guard intercepted Claude's next attempt to access local secrets" in hook_output["additionalContext"]
+    assert "approval dialog" in hook_output["additionalContext"]
     assert any(receipt["artifact_id"].startswith("claude-code:session:prompt") for receipt in receipts)
 
 
-def test_guard_hook_allows_generic_claude_user_prompt_submit_for_overridable_prompts_without_output(
+def test_guard_hook_brands_generic_claude_user_prompt_submit_before_native_approval(
     tmp_path,
     capsys,
     monkeypatch,
@@ -4336,9 +4446,15 @@ def test_guard_hook_allows_generic_claude_user_prompt_submit_for_overridable_pro
         capsys=capsys,
         monkeypatch=monkeypatch,
     )
+    payload = json.loads(output)
+    hook_output = payload["hookSpecificOutput"]
 
     assert rc == 0
-    assert output == ""
+    assert "decision" not in payload
+    assert "HOL Guard intercepted this prompt" in payload["systemMessage"]
+    assert hook_output["hookEventName"] == "UserPromptSubmit"
+    assert "HOL Guard intercepted Claude's next sensitive action" in hook_output["additionalContext"]
+    assert "approval dialog" in hook_output["additionalContext"]
 
 
 def test_guard_hook_emits_json_for_claude_user_prompt_submit_overridable_prompts(

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -25,7 +25,7 @@ from codex_plugin_scanner.guard.cli.render import emit_guard_payload
 from codex_plugin_scanner.guard.config import GuardConfig, load_guard_config
 from codex_plugin_scanner.guard.consumer import artifact_hash, evaluate_detection
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
-from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
+from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection, PolicyDecision
 from codex_plugin_scanner.guard.policy import decide_action
 from codex_plugin_scanner.guard.proxy import RemoteGuardProxy, StdioGuardProxy
 from codex_plugin_scanner.guard.receipts import build_receipt
@@ -4240,6 +4240,60 @@ def test_guard_hook_claude_alias_reuses_native_approval_policy_with_canonical_ha
     assert second_rc == 0
     assert second_payload["hookSpecificOutput"]["permissionDecision"] == "allow"
     assert any(receipt["harness"] == "claude-code" for receipt in receipts)
+
+
+def test_guard_hook_claude_alias_reuses_legacy_alias_policy_keys(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "session_id": "session-claude-legacy-alias",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Read",
+        "tool_input": {"file_path": str(workspace_dir / ".env")},
+        "source_scope": "project",
+    }
+    canonical_artifact = guard_commands_module._hook_runtime_artifact(
+        harness="claude",
+        payload=event,
+        home_dir=home_dir,
+        guard_home=home_dir,
+        workspace=workspace_dir,
+    )
+    assert canonical_artifact is not None
+    legacy_artifact = guard_commands_module._legacy_claude_alias_runtime_artifact(
+        artifact=canonical_artifact,
+        requested_harness="claude",
+        home_dir=home_dir,
+        workspace=workspace_dir,
+    )
+    assert legacy_artifact is not None
+    GuardStore(home_dir).upsert_policy(
+        PolicyDecision(
+            harness="claude",
+            scope="artifact",
+            action="block",
+            artifact_id=legacy_artifact.artifact_id,
+            artifact_hash=artifact_hash(legacy_artifact),
+            reason="Legacy alias block",
+            source="claude-native-approval",
+        ),
+        "2026-04-23T00:00:00+00:00",
+    )
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc, output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="claude",
+        event=event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    payload = json.loads(output)
+
+    assert rc == 0
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
 
 
 def test_guard_hook_claude_stop_persists_unapproved_native_prompt_as_denied(tmp_path, capsys, monkeypatch):

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -4887,9 +4887,10 @@ def test_guard_hook_emits_generic_claude_notification_notice_without_cached_reas
         "HOL Guard intercepted the sensitive request and opened the Claude approval dialog"
         in (output["hookSpecificOutput"]["additionalContext"])
     )
-    assert "the user can choose yes, yes during this session, or no" in (
-        output["hookSpecificOutput"]["additionalContext"]
-    ).lower()
+    assert (
+        "the user can choose yes, yes during this session, or no"
+        in (output["hookSpecificOutput"]["additionalContext"]).lower()
+    )
 
 
 def test_guard_hook_claude_notification_notice_is_tool_scoped_and_consumed(tmp_path, capsys, monkeypatch):

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -4188,7 +4188,7 @@ def test_guard_hook_claude_posttooluse_persists_native_approval(tmp_path, capsys
     assert any(receipt["user_override"] == "claude-native-approve" for receipt in receipts)
 
 
-def test_guard_hook_claude_alias_reuses_native_approval_policy(tmp_path, capsys, monkeypatch):
+def test_guard_hook_claude_alias_reuses_native_approval_policy_with_canonical_harness(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
@@ -4224,7 +4224,7 @@ def test_guard_hook_claude_alias_reuses_native_approval_policy(tmp_path, capsys,
     second_rc, second_output = _run_guard_hook(
         home_dir=home_dir,
         workspace_dir=workspace_dir,
-        harness="claude",
+        harness="claude-code",
         event={**first_event, "session_id": "session-claude-alias-next"},
         capsys=capsys,
         monkeypatch=monkeypatch,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -4188,6 +4188,58 @@ def test_guard_hook_claude_posttooluse_persists_native_approval(tmp_path, capsys
     assert any(receipt["user_override"] == "claude-native-approve" for receipt in receipts)
 
 
+def test_guard_hook_claude_alias_reuses_native_approval_policy(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    first_event = {
+        "session_id": "session-claude-alias-approval",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Read",
+        "tool_input": {"file_path": str(workspace_dir / ".env")},
+        "source_scope": "project",
+    }
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    first_rc, first_output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="claude",
+        event=first_event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    post_rc, post_output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="claude",
+        event={
+            **first_event,
+            "hook_event_name": "PostToolUse",
+            "tool_response": {"filePath": str(workspace_dir / ".env"), "success": True},
+        },
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    second_rc, second_output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="claude",
+        event={**first_event, "session_id": "session-claude-alias-next"},
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    first_payload = json.loads(first_output)
+    second_payload = json.loads(second_output)
+
+    assert first_rc == 0
+    assert first_payload["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert post_rc == 0
+    assert post_output == ""
+    assert second_rc == 0
+    assert second_payload["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+
 def test_guard_hook_claude_stop_persists_unapproved_native_prompt_as_denied(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -221,7 +221,7 @@ class TestGuardSurfaceServer:
 
         assert hook_payload == {}
 
-    def test_guard_daemon_claude_hook_endpoint_allows_overridable_user_prompt_submit_without_error(
+    def test_guard_daemon_claude_hook_endpoint_brands_overridable_user_prompt_submit_without_blocking(
         self, tmp_path
     ) -> None:
         home_dir = tmp_path / "home"
@@ -251,7 +251,14 @@ class TestGuardSurfaceServer:
         finally:
             daemon.stop()
 
-        assert hook_payload == {}
+        assert "decision" not in hook_payload
+        assert "HOL Guard intercepted this prompt" in hook_payload["systemMessage"]
+        assert hook_payload["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+        assert (
+            "HOL Guard intercepted Claude's next attempt to access local secrets"
+            in hook_payload["hookSpecificOutput"]["additionalContext"]
+        )
+        assert "approval dialog" in hook_payload["hookSpecificOutput"]["additionalContext"]
 
     def test_guard_daemon_claude_hook_endpoint_returns_native_user_prompt_submit_block(
         self, tmp_path


### PR DESCRIPTION
## Purpose
- Make Claude Code visibly attribute sensitive prompts and permission dialogs to HOL Guard.
- Persist Claude native approvals as allow policies and unresolved/denied prompts as block policies.
- Prune the obsolete Guard-managed PermissionDenied hook group that breaks current Claude Code settings.

## Verification
- pytest tests/test_guard_runtime.py -k 'claude_user_prompt_submit or claude_posttooluse_persists_native_approval or claude_stop_persists_unapproved_native_prompt_as_denied or emits_claude_native_ask_response or emits_claude_native_pretooluse_notice' -q\n- pytest tests/test_guard_claude_adapter.py tests/test_guard_cli.py -k 'claude' -q\n- pytest tests/test_guard_surface_server.py -k 'claude_hook_endpoint' -q\n- pytest tests/test_guard_runtime.py tests/test_guard_claude_adapter.py tests/test_guard_cli.py tests/test_guard_surface_server.py -q\n- ruff check src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/adapters/claude_code.py tests/test_guard_runtime.py tests/test_guard_claude_adapter.py tests/test_guard_cli.py tests/test_guard_surface_server.py\n- git diff --check\n\n## Real harness smoke\n- Claude Code v2.1.116 in /Users/michaelkantor/guard-claude-smoke emitted UserPromptSubmit HOL Guard attribution before the tool call.\n- Claude PreToolUse returned native permissionDecision=ask with HOL Guard branded reason.\n- Stop persisted a claude-native-approval block policy for an unapproved prompt.\n- Daemon hook sequence PreToolUse -> PostToolUseFailure -> PreToolUse persisted allow and returned allow on the next identical action.