### PR TITLE
fix(guard): defer Claude prompt approvals to tool calls

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2438,15 +2438,11 @@ def _claude_prompt_additional_context(
         return None
     if _prompt_requires_hard_block(artifact):
         return None
-    briefing_sentence = "HOL Guard will intercept the next sensitive action and open a branded approval question."
+    briefing_sentence = "HOL Guard will intercept Claude's next sensitive action and open a branded approval question."
     if "secret_read" in _prompt_request_classes(artifact):
         briefing_sentence = (
             "HOL Guard will intercept Claude's next attempt to access local secrets and open a branded approval "
             "question to protect you."
-        )
-    else:
-        briefing_sentence = (
-            "HOL Guard will intercept Claude's next sensitive action and open a branded approval question."
         )
     return (
         f"{_ensure_terminal_punctuation(native_reason)} "

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2438,22 +2438,21 @@ def _claude_prompt_additional_context(
         return None
     if _prompt_requires_hard_block(artifact):
         return None
-    briefing_sentence = "HOL Guard intercepted the next sensitive action and opened the approval dialog below."
+    briefing_sentence = "HOL Guard will intercept the next sensitive action and open a branded approval question."
     if "secret_read" in _prompt_request_classes(artifact):
         briefing_sentence = (
-            "HOL Guard intercepted Claude's next attempt to access local secrets and opened the approval dialog "
-            "shown below to protect you."
+            "HOL Guard will intercept Claude's next attempt to access local secrets and open a branded approval "
+            "question to protect you."
         )
     else:
         briefing_sentence = (
-            "HOL Guard intercepted Claude's next sensitive action and opened the approval dialog shown below."
+            "HOL Guard will intercept Claude's next sensitive action and open a branded approval question."
         )
     return (
         f"{_ensure_terminal_punctuation(native_reason)} "
-        "Before you use the first sensitive tool for this request, call AskUserQuestion with header 'HOL Guard', "
-        "question 'HOL Guard intercepted this sensitive action. What should Claude do?', and exactly these options: "
-        "'Allow once', 'Allow during this session', and 'Keep blocked'. If the user chooses Keep blocked, do not "
-        "retry the sensitive action. Then tell the user exactly: "
+        "Do not ask for approval at the prompt stage. Attempt the intended sensitive tool once so HOL Guard can "
+        "evaluate the exact tool, path, and arguments, then route that concrete action into a HOL Guard approval "
+        "question with Allow once, Allow during this session, and Keep blocked. First tell the user exactly: "
         f"'{briefing_sentence}' "
         "Attempt that sensitive tool at most once. If HOL Guard or Claude denies it, do not retry the same sensitive "
         "action automatically. Instead, tell the user approval is required in Claude to continue."

--- a/tests/test_guard_claude_adapter.py
+++ b/tests/test_guard_claude_adapter.py
@@ -399,7 +399,11 @@ def test_claude_daemon_hook_command_falls_back_without_blocking_prompt_on_daemon
     assert result.stderr == ""
     payload = json.loads(result.stdout)
     assert payload["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
-    assert "AskUserQuestion" in payload["hookSpecificOutput"]["additionalContext"]
+    assert "Do not ask for approval at the prompt stage" in payload["hookSpecificOutput"]["additionalContext"]
+    assert (
+        "route that concrete action into a HOL Guard approval question"
+        in payload["hookSpecificOutput"]["additionalContext"]
+    )
     assert "Keep blocked" in payload["hookSpecificOutput"]["additionalContext"]
 
 

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -4899,7 +4899,11 @@ def test_guard_hook_brands_claude_user_prompt_submit_before_native_approval(
 
     assert rc == 0
     assert payload["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
-    assert "AskUserQuestion" in payload["hookSpecificOutput"]["additionalContext"]
+    assert "Do not ask for approval at the prompt stage" in payload["hookSpecificOutput"]["additionalContext"]
+    assert (
+        "route that concrete action into a HOL Guard approval question"
+        in payload["hookSpecificOutput"]["additionalContext"]
+    )
     assert "Keep blocked" in payload["hookSpecificOutput"]["additionalContext"]
     assert any(receipt["artifact_id"].startswith("claude-code:session:prompt") for receipt in receipts)
 
@@ -4929,7 +4933,11 @@ def test_guard_hook_brands_generic_claude_user_prompt_submit_before_native_appro
 
     assert rc == 0
     assert payload["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
-    assert "AskUserQuestion" in payload["hookSpecificOutput"]["additionalContext"]
+    assert "Do not ask for approval at the prompt stage" in payload["hookSpecificOutput"]["additionalContext"]
+    assert (
+        "route that concrete action into a HOL Guard approval question"
+        in payload["hookSpecificOutput"]["additionalContext"]
+    )
     assert "Keep blocked" in payload["hookSpecificOutput"]["additionalContext"]
 
 

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -255,7 +255,11 @@ class TestGuardSurfaceServer:
 
         assert "HOL Guard intercepted this prompt" in hook_payload["systemMessage"]
         assert hook_payload["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
-        assert "AskUserQuestion" in hook_payload["hookSpecificOutput"]["additionalContext"]
+        assert "Do not ask for approval at the prompt stage" in hook_payload["hookSpecificOutput"]["additionalContext"]
+        assert (
+            "route that concrete action into a HOL Guard approval question"
+            in hook_payload["hookSpecificOutput"]["additionalContext"]
+        )
         assert "Allow once" in hook_payload["hookSpecificOutput"]["additionalContext"]
         assert "Keep blocked" in hook_payload["hookSpecificOutput"]["additionalContext"]
 


### PR DESCRIPTION
## Purpose
- Keep Claude prompt-stage HOL Guard context branded without asking for a decision before Guard has a concrete tool artifact.
- Route approval persistence through the actual tool-level HOL Guard approval question so allow/block choices can be saved correctly.
- Address the post-merge review finding from PR #166.

## Verification
- pytest tests/test_guard_surface_server.py tests/test_guard_claude_adapter.py tests/test_guard_runtime.py -q
- ruff check src/codex_plugin_scanner/guard/adapters/claude_code.py src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_claude_adapter.py tests/test_guard_runtime.py tests/test_guard_surface_server.py
- ruff format --check src/codex_plugin_scanner/guard/adapters/claude_code.py src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_claude_adapter.py tests/test_guard_runtime.py tests/test_guard_surface_server.py
- git diff --check