### PR TITLE
feat(guard): sync White Rabbit edge events

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -107,36 +107,37 @@ def run_guard_connect_command(
         sync_payload = sync_receipts(store)
     except GuardSyncNotAvailableError as plan_error:
         plan_msg = str(plan_error).strip() or "Cloud sync requires a paid Guard plan."
-        pending_state = _record_connect_result(
-            daemon_client=daemon_client,
-            store=store,
-            request_id=str(connect_request["request_id"]),
-            status="connected",
-            milestone="sync_not_available",
-            reason=plan_msg,
-        )
-        return build_connect_payload(
-            state=pending_state,
-            browser_opened=browser_opened,
-            connect_url=browser_url,
-            sync_url=sync_url,
-            connected=True,
-            sync_available=False,
-            sync_message=plan_msg,
-        )
-    except (RuntimeError, OSError, urllib.error.URLError, json.JSONDecodeError) as error:
-        sync_message = str(error)
-        if runtime_sync_error and not _is_paid_plan_sync_error(sync_message):
-            sync_message = runtime_sync_error
-        sync_is_plan_limited = _is_paid_plan_sync_error(sync_message)
         pending_sync_payload = dict(runtime_sync_summary)
         pending_sync_payload["synced_at"] = None
         pending_state = _record_connect_result(
             daemon_client=daemon_client,
             store=store,
             request_id=str(connect_request["request_id"]),
-            status="connected",
-            milestone="first_sync_pending",
+            status="retry_required",
+            milestone="first_sync_failed",
+            reason=plan_msg,
+            sync=pending_sync_payload,
+        )
+        return build_connect_payload(
+            state=pending_state,
+            browser_opened=browser_opened,
+            connect_url=browser_url,
+            sync_url=sync_url,
+            connected=False,
+            sync=pending_sync_payload,
+            sync_available=False,
+            sync_message=plan_msg,
+        )
+    except (RuntimeError, OSError, urllib.error.URLError, json.JSONDecodeError) as error:
+        sync_message = str(error)
+        pending_sync_payload = dict(runtime_sync_summary)
+        pending_sync_payload["synced_at"] = None
+        pending_state = _record_connect_result(
+            daemon_client=daemon_client,
+            store=store,
+            request_id=str(connect_request["request_id"]),
+            status="retry_required",
+            milestone="first_sync_failed",
             reason=sync_message,
             sync=pending_sync_payload,
         )
@@ -145,10 +146,10 @@ def run_guard_connect_command(
             browser_opened=browser_opened,
             connect_url=browser_url,
             sync_url=sync_url,
-            connected=True,
+            connected=False,
             sync=pending_sync_payload,
             sync_message=sync_message,
-            sync_available=False if sync_is_plan_limited else None,
+            sync_available=False,
         )
     sync_payload["runtime_session_synced_at"] = runtime_sync_summary["runtime_session_synced_at"]
     sync_payload["runtime_session_id"] = runtime_sync_summary["runtime_session_id"]

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -149,7 +149,6 @@ def run_guard_connect_command(
             connected=False,
             sync=pending_sync_payload,
             sync_message=sync_message,
-            sync_available=False,
         )
     sync_payload["runtime_session_synced_at"] = runtime_sync_summary["runtime_session_synced_at"]
     sync_payload["runtime_session_id"] = runtime_sync_summary["runtime_session_id"]

--- a/src/codex_plugin_scanner/guard/edge_events.py
+++ b/src/codex_plugin_scanner/guard/edge_events.py
@@ -1,0 +1,88 @@
+"""Builders for Guard Cloud v1 events emitted by the local edge runtime."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import cast
+
+from .models import GuardReceipt
+from .schemas.guard_event_v1 import GuardEventType, GuardEventV1
+
+
+def build_receipt_event(
+    receipt: GuardReceipt,
+    *,
+    device_id: str | None = None,
+    workspace_id: str | None = None,
+) -> GuardEventV1:
+    payload: dict[str, object] = {
+        "receiptId": receipt.receipt_id,
+        "harness": receipt.harness,
+        "artifactId": receipt.artifact_id,
+        "artifactHash": receipt.artifact_hash,
+        "artifactName": receipt.artifact_name,
+        "sourceScope": receipt.source_scope,
+        "policyDecision": receipt.policy_decision,
+        "capabilitiesSummary": receipt.capabilities_summary,
+        "changedCapabilities": list(receipt.changed_capabilities),
+        "provenanceSummary": receipt.provenance_summary,
+        "userOverride": receipt.user_override,
+    }
+    event_id = f"guard-event-{_fingerprint('receipt.created', receipt.receipt_id)[:32]}"
+    return GuardEventV1(
+        event_id=event_id,
+        idempotency_key=f"receipt.created:{receipt.receipt_id}",
+        event_type="receipt.created",
+        source="edge",
+        occurred_at=receipt.timestamp,
+        workspace_id=workspace_id,
+        device_id=device_id,
+        payload=payload,
+    )
+
+
+def build_approval_event(
+    *,
+    request_id: str,
+    event_type: str,
+    occurred_at: str,
+    payload: dict[str, object],
+    device_id: str | None = None,
+    workspace_id: str | None = None,
+) -> GuardEventV1:
+    if event_type not in {"approval.created", "approval.resolved"}:
+        raise ValueError("Approval event type must be approval.created or approval.resolved")
+    return GuardEventV1(
+        event_id=f"guard-event-{_fingerprint(event_type, request_id, occurred_at)[:32]}",
+        idempotency_key=f"{event_type}:{request_id}:{occurred_at}",
+        event_type=cast(GuardEventType, event_type),
+        source="approval-center",
+        occurred_at=occurred_at,
+        workspace_id=workspace_id,
+        device_id=device_id,
+        payload=payload,
+    )
+
+
+def build_policy_event(
+    *,
+    policy_key: str,
+    occurred_at: str,
+    payload: dict[str, object],
+    device_id: str | None = None,
+    workspace_id: str | None = None,
+) -> GuardEventV1:
+    return GuardEventV1(
+        event_id=f"guard-event-{_fingerprint('policy.changed', policy_key, occurred_at)[:32]}",
+        idempotency_key=f"policy.changed:{policy_key}:{occurred_at}",
+        event_type="policy.changed",
+        source="policy",
+        occurred_at=occurred_at,
+        workspace_id=workspace_id,
+        device_id=device_id,
+        payload=payload,
+    )
+
+
+def _fingerprint(*parts: str) -> str:
+    return hashlib.sha256(":".join(parts).encode()).hexdigest()

--- a/src/codex_plugin_scanner/guard/runtime/__init__.py
+++ b/src/codex_plugin_scanner/guard/runtime/__init__.py
@@ -4,6 +4,7 @@ from .runner import (
     GuardSyncNotAvailableError,
     GuardSyncNotConfiguredError,
     guard_run,
+    sync_guard_events,
     sync_receipts,
     sync_runtime_session,
 )
@@ -12,6 +13,7 @@ __all__ = [
     "GuardSyncNotAvailableError",
     "GuardSyncNotConfiguredError",
     "guard_run",
+    "sync_guard_events",
     "sync_receipts",
     "sync_runtime_session",
 ]

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -513,6 +513,16 @@ def sync_guard_events(store: GuardStore) -> dict[str, object]:
                 retry_timeout_seconds=_SYNC_HTTP_RETRY_TIMEOUT_SECONDS,
             )
         except urllib.error.HTTPError as error:
+            if error.code == 404:
+                summary = {
+                    "synced_at": synced_at,
+                    "events": total_events,
+                    "accepted": total_accepted,
+                    "sync_skipped": True,
+                    "sync_reason": "guard_events_endpoint_unavailable",
+                }
+                store.set_sync_payload("guard_events_v1_summary", summary, synced_at)
+                return summary
             if error.code == 403:
                 is_plan, message = _check_plan_restriction_403(error)
                 if is_plan:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -531,9 +531,9 @@ def sync_guard_events(store: GuardStore) -> dict[str, object]:
             raise RuntimeError(_sync_http_error_message(error)) from error
         except OSError as error:
             raise RuntimeError(_sync_url_error_message(error)) from error
-        accepted_ids = _accepted_guard_event_ids(payload)
+        completed_ids = _completed_guard_event_ids(payload)
         synced_at = _sync_timestamp(payload)
-        uploaded = store.mark_guard_events_v1_uploaded(accepted_ids, synced_at)
+        uploaded = store.mark_guard_events_v1_uploaded(completed_ids, synced_at)
         total_events += len(pending_events)
         total_accepted += uploaded
         if uploaded == 0 or len(pending_events) < 200:
@@ -1034,19 +1034,19 @@ def _guard_events_sync_url(sync_url: str) -> str:
     )
 
 
-def _accepted_guard_event_ids(payload: dict[str, object]) -> list[str]:
+def _completed_guard_event_ids(payload: dict[str, object]) -> list[str]:
     statuses = payload.get("statuses")
     if not isinstance(statuses, list):
         return []
-    accepted: list[str] = []
+    completed: list[str] = []
     for item in statuses:
         if not isinstance(item, dict):
             continue
         status = str(item.get("status") or "")
         event_id = item.get("eventId")
-        if status in {"accepted", "duplicate"} and isinstance(event_id, str):
-            accepted.append(event_id)
-    return accepted
+        if status in {"accepted", "duplicate", "rejected"} and isinstance(event_id, str):
+            completed.append(event_id)
+    return completed
 
 
 def _cloud_sync_receipts_payload(store: GuardStore, receipts: list[dict[str, object]]) -> list[dict[str, object]]:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -484,6 +484,41 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
     return summary
 
 
+def sync_guard_events(store: GuardStore) -> dict[str, object]:
+    """Push pending GuardEventV1 envelopes to Guard Cloud."""
+
+    credentials = store.get_sync_credentials()
+    if credentials is None:
+        raise GuardSyncNotConfiguredError("Guard is not logged in.")
+    pending_events = store.list_guard_events_v1(uploaded=False, limit=200)
+    if not pending_events:
+        return {"synced_at": _now(), "events": 0, "accepted": 0}
+    sync_url = _guard_events_sync_url(str(credentials["sync_url"]))
+    body = json.dumps({"events": [event["payload"] for event in pending_events]}).encode("utf-8")
+    request = urllib.request.Request(
+        sync_url,
+        data=body,
+        method="POST",
+        headers=_guard_sync_headers(str(credentials["token"])),
+    )
+    try:
+        payload = _urlopen_json_with_timeout_retry(
+            request=request,
+            timeout_seconds=_SYNC_HTTP_TIMEOUT_SECONDS,
+            retry_timeout_seconds=_SYNC_HTTP_RETRY_TIMEOUT_SECONDS,
+        )
+    except urllib.error.HTTPError as error:
+        raise RuntimeError(_sync_http_error_message(error)) from error
+    except OSError as error:
+        raise RuntimeError(_sync_url_error_message(error)) from error
+    accepted_ids = _accepted_guard_event_ids(payload)
+    synced_at = _sync_timestamp(payload)
+    uploaded = store.mark_guard_events_v1_uploaded(accepted_ids, synced_at)
+    summary = {"synced_at": synced_at, "events": len(pending_events), "accepted": uploaded}
+    store.set_sync_payload("guard_events_v1_summary", summary, synced_at)
+    return summary
+
+
 def sync_runtime_session(
     store: GuardStore,
     *,
@@ -949,6 +984,41 @@ def _normalized_runtime_sessions_sync_url(sync_url: str) -> str:
             "",
         )
     )
+
+
+def _guard_events_sync_url(sync_url: str) -> str:
+    parsed = urllib.parse.urlsplit(sync_url)
+    if parsed.path.rstrip("/").endswith("/api/v1/guard/events"):
+        return sync_url
+    path = parsed.path.rstrip("/")
+    for suffix in ("/api/guard/receipts/sync", "/registry/api/v1/guard/receipts/sync"):
+        if path.endswith(suffix):
+            path = path[: -len(suffix)]
+            break
+    return urllib.parse.urlunsplit(
+        (
+            parsed.scheme,
+            parsed.netloc,
+            path.rstrip("/") + "/api/v1/guard/events",
+            parsed.query,
+            "",
+        )
+    )
+
+
+def _accepted_guard_event_ids(payload: dict[str, object]) -> list[str]:
+    statuses = payload.get("statuses")
+    if not isinstance(statuses, list):
+        return []
+    accepted: list[str] = []
+    for item in statuses:
+        if not isinstance(item, dict):
+            continue
+        status = str(item.get("status") or "")
+        event_id = item.get("eventId")
+        if status in {"accepted", "duplicate"} and isinstance(event_id, str):
+            accepted.append(event_id)
+    return accepted
 
 
 def _cloud_sync_receipts_payload(store: GuardStore, receipts: list[dict[str, object]]) -> list[dict[str, object]]:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -480,6 +480,7 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
         "inventory": 0,
         "inventory_tracked": len(inventory),
     }
+    summary["guard_events_v1"] = sync_guard_events(store)
     store.set_sync_payload("sync_summary", summary, now)
     return summary
 
@@ -1000,11 +1001,15 @@ def _normalized_runtime_sessions_sync_url(sync_url: str) -> str:
 
 
 def _guard_events_sync_url(sync_url: str) -> str:
-    parsed = urllib.parse.urlsplit(sync_url)
+    parsed = urllib.parse.urlsplit(_normalized_receipts_sync_url(sync_url))
     if parsed.path.rstrip("/").endswith("/api/v1/guard/events"):
-        return sync_url
+        return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, parsed.path.rstrip("/"), parsed.query, ""))
     path = parsed.path.rstrip("/")
-    for suffix in ("/api/guard/receipts/sync", "/registry/api/v1/guard/receipts/sync"):
+    for suffix in (
+        "/api/guard/receipts/sync",
+        "/guard/receipts/sync",
+        "/registry/api/v1/guard/receipts/sync",
+    ):
         if path.endswith(suffix):
             path = path[: -len(suffix)]
             break

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -490,31 +490,44 @@ def sync_guard_events(store: GuardStore) -> dict[str, object]:
     credentials = store.get_sync_credentials()
     if credentials is None:
         raise GuardSyncNotConfiguredError("Guard is not logged in.")
-    pending_events = store.list_guard_events_v1(uploaded=False, limit=200)
-    if not pending_events:
-        return {"synced_at": _now(), "events": 0, "accepted": 0}
     sync_url = _guard_events_sync_url(str(credentials["sync_url"]))
-    body = json.dumps({"events": [event["payload"] for event in pending_events]}).encode("utf-8")
-    request = urllib.request.Request(
-        sync_url,
-        data=body,
-        method="POST",
-        headers=_guard_sync_headers(str(credentials["token"])),
-    )
-    try:
-        payload = _urlopen_json_with_timeout_retry(
-            request=request,
-            timeout_seconds=_SYNC_HTTP_TIMEOUT_SECONDS,
-            retry_timeout_seconds=_SYNC_HTTP_RETRY_TIMEOUT_SECONDS,
+    total_events = 0
+    total_accepted = 0
+    synced_at = _now()
+    while True:
+        pending_events = store.list_guard_events_v1(uploaded=False, limit=200)
+        if not pending_events:
+            break
+        body = json.dumps({"events": [event["payload"] for event in pending_events]}).encode("utf-8")
+        request = urllib.request.Request(
+            sync_url,
+            data=body,
+            method="POST",
+            headers=_guard_sync_headers(str(credentials["token"])),
         )
-    except urllib.error.HTTPError as error:
-        raise RuntimeError(_sync_http_error_message(error)) from error
-    except OSError as error:
-        raise RuntimeError(_sync_url_error_message(error)) from error
-    accepted_ids = _accepted_guard_event_ids(payload)
-    synced_at = _sync_timestamp(payload)
-    uploaded = store.mark_guard_events_v1_uploaded(accepted_ids, synced_at)
-    summary = {"synced_at": synced_at, "events": len(pending_events), "accepted": uploaded}
+        try:
+            payload = _urlopen_json_with_timeout_retry(
+                request=request,
+                timeout_seconds=_SYNC_HTTP_TIMEOUT_SECONDS,
+                retry_timeout_seconds=_SYNC_HTTP_RETRY_TIMEOUT_SECONDS,
+            )
+        except urllib.error.HTTPError as error:
+            if error.code == 403:
+                is_plan, message = _check_plan_restriction_403(error)
+                if is_plan:
+                    raise GuardSyncNotAvailableError(message) from error
+                raise RuntimeError(message) from error
+            raise RuntimeError(_sync_http_error_message(error)) from error
+        except OSError as error:
+            raise RuntimeError(_sync_url_error_message(error)) from error
+        accepted_ids = _accepted_guard_event_ids(payload)
+        synced_at = _sync_timestamp(payload)
+        uploaded = store.mark_guard_events_v1_uploaded(accepted_ids, synced_at)
+        total_events += len(pending_events)
+        total_accepted += uploaded
+        if uploaded == 0 or len(pending_events) < 200:
+            break
+    summary = {"synced_at": synced_at, "events": total_events, "accepted": total_accepted}
     store.set_sync_payload("guard_events_v1_summary", summary, synced_at)
     return summary
 

--- a/src/codex_plugin_scanner/guard/schemas/guard_event_v1.py
+++ b/src/codex_plugin_scanner/guard/schemas/guard_event_v1.py
@@ -1,0 +1,74 @@
+"""Guard Cloud event schema shared by the edge runtime and v1 ingest API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal, cast
+
+GuardEventSource = Literal["edge", "approval-center", "policy", "protect-api"]
+GuardEventType = Literal["receipt.created", "approval.created", "approval.resolved", "policy.changed"]
+
+
+@dataclass(frozen=True, slots=True)
+class GuardEventV1:
+    """Versioned event envelope for replay-safe Guard Cloud sync."""
+
+    event_id: str
+    idempotency_key: str
+    event_type: GuardEventType
+    source: GuardEventSource
+    occurred_at: str
+    workspace_id: str | None = None
+    device_id: str | None = None
+    payload: dict[str, object] = field(default_factory=dict)
+    schema_version: str = "guard.event.v1"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schemaVersion": self.schema_version,
+            "eventId": self.event_id,
+            "idempotencyKey": self.idempotency_key,
+            "eventType": self.event_type,
+            "source": self.source,
+            "occurredAt": self.occurred_at,
+            "workspaceId": self.workspace_id,
+            "deviceId": self.device_id,
+            "payload": self.payload,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, object]) -> GuardEventV1:
+        schema_version = str(payload.get("schemaVersion") or "")
+        if schema_version != "guard.event.v1":
+            raise ValueError("Guard event schemaVersion must be guard.event.v1")
+        event_id = _required_string(payload, "eventId")
+        idempotency_key = _required_string(payload, "idempotencyKey")
+        event_type = _required_string(payload, "eventType")
+        source = _required_string(payload, "source")
+        occurred_at = _required_string(payload, "occurredAt")
+        event_payload = payload.get("payload")
+        if not isinstance(event_payload, dict):
+            raise ValueError("Guard event payload must be an object")
+        if event_type not in {"receipt.created", "approval.created", "approval.resolved", "policy.changed"}:
+            raise ValueError(f"Unsupported Guard event type: {event_type}")
+        if source not in {"edge", "approval-center", "policy", "protect-api"}:
+            raise ValueError(f"Unsupported Guard event source: {source}")
+        workspace_id = payload.get("workspaceId")
+        device_id = payload.get("deviceId")
+        return cls(
+            event_id=event_id,
+            idempotency_key=idempotency_key,
+            event_type=cast(GuardEventType, event_type),
+            source=cast(GuardEventSource, source),
+            occurred_at=occurred_at,
+            workspace_id=workspace_id if isinstance(workspace_id, str) else None,
+            device_id=device_id if isinstance(device_id, str) else None,
+            payload={str(key): value for key, value in event_payload.items()},
+        )
+
+
+def _required_string(payload: dict[str, object], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"Guard event {key} must be a non-empty string")
+    return value

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -17,7 +17,9 @@ from uuid import uuid4
 
 from cryptography.fernet import Fernet, InvalidToken
 
+from .edge_events import build_receipt_event
 from .models import GuardApprovalRequest, GuardArtifact, GuardReceipt, GuardRuntimeState, PolicyDecision
+from .schemas.guard_event_v1 import GuardEventV1
 from .store_approvals import (
     add_approval_request as persist_approval_request,
 )
@@ -545,6 +547,16 @@ class GuardStore:
               event_name text not null,
               payload_json text not null,
               occurred_at text not null
+            )
+            """,
+            """
+            create table if not exists guard_cloud_events (
+              event_id text primary key,
+              idempotency_key text not null unique,
+              event_type text not null,
+              payload_json text not null,
+              occurred_at text not null,
+              uploaded_at text
             )
             """,
             """
@@ -1213,6 +1225,13 @@ class GuardStore:
                     receipt.timestamp,
                 ),
             )
+        device = self.get_device_metadata()
+        self.add_guard_event_v1(
+            build_receipt_event(
+                receipt,
+                device_id=str(device["installation_id"]),
+            )
+        )
 
     def list_receipts(self, limit: int = 50) -> list[dict[str, object]]:
         with self._connect() as connection:
@@ -1697,6 +1716,68 @@ class GuardStore:
                 "delete from sync_state where state_key = ?",
                 (state_key,),
             )
+
+    def add_guard_event_v1(self, event: GuardEventV1) -> None:
+        payload = event.to_dict()
+        with self._connect() as connection:
+            connection.execute(
+                """
+                insert or ignore into guard_cloud_events (
+                  event_id, idempotency_key, event_type, payload_json, occurred_at, uploaded_at
+                )
+                values (?, ?, ?, ?, ?, null)
+                """,
+                (
+                    event.event_id,
+                    event.idempotency_key,
+                    event.event_type,
+                    json.dumps(payload, sort_keys=True),
+                    event.occurred_at,
+                ),
+            )
+
+    def list_guard_events_v1(self, *, uploaded: bool | None = None, limit: int = 200) -> list[dict[str, object]]:
+        query = """
+            select event_id, idempotency_key, event_type, payload_json, occurred_at, uploaded_at
+            from guard_cloud_events
+        """
+        params: list[object] = []
+        if uploaded is True:
+            query += " where uploaded_at is not null"
+        elif uploaded is False:
+            query += " where uploaded_at is null"
+        query += " order by occurred_at asc, event_id asc limit ?"
+        params.append(limit)
+        with self._connect() as connection:
+            rows = connection.execute(query, tuple(params)).fetchall()
+        events: list[dict[str, object]] = []
+        for row in rows:
+            payload = json.loads(str(row["payload_json"]))
+            if not isinstance(payload, dict):
+                payload = {}
+            events.append(
+                {
+                    "event_id": str(row["event_id"]),
+                    "idempotency_key": str(row["idempotency_key"]),
+                    "event_type": str(row["event_type"]),
+                    "occurred_at": str(row["occurred_at"]),
+                    "uploaded_at": row["uploaded_at"],
+                    "payload": payload,
+                }
+            )
+        return events
+
+    def mark_guard_events_v1_uploaded(self, event_ids: list[str], uploaded_at: str) -> int:
+        clean_ids = [event_id for event_id in event_ids if event_id.strip()]
+        if not clean_ids:
+            return 0
+        placeholders = ", ".join("?" for _ in clean_ids)
+        with self._connect() as connection:
+            cursor = connection.execute(
+                f"update guard_cloud_events set uploaded_at = ? where event_id in ({placeholders})",
+                (uploaded_at, *clean_ids),
+            )
+            return int(cursor.rowcount)
 
     def add_event(self, event_name: str, payload: dict[str, object], now: str) -> None:
         with self._connect() as connection:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -560,6 +560,10 @@ class GuardStore:
             )
             """,
             """
+            create index if not exists idx_guard_cloud_events_sync
+            on guard_cloud_events (uploaded_at, occurred_at)
+            """,
+            """
             create table if not exists guard_runtime_state (
               state_key text primary key,
               session_id text not null,
@@ -1225,13 +1229,19 @@ class GuardStore:
                     receipt.timestamp,
                 ),
             )
-        device = self.get_device_metadata()
-        self.add_guard_event_v1(
-            build_receipt_event(
-                receipt,
-                device_id=str(device["installation_id"]),
+            self._ensure_local_device(connection)
+            row = connection.execute(
+                "select installation_id from guard_devices where device_key = ?",
+                (_DEVICE_ROW_KEY,),
+            ).fetchone()
+            device_id = str(row["installation_id"]) if row is not None else None
+            self._add_guard_event_v1(
+                connection,
+                build_receipt_event(
+                    receipt,
+                    device_id=device_id,
+                ),
             )
-        )
 
     def list_receipts(self, limit: int = 50) -> list[dict[str, object]]:
         with self._connect() as connection:
@@ -1718,23 +1728,27 @@ class GuardStore:
             )
 
     def add_guard_event_v1(self, event: GuardEventV1) -> None:
-        payload = event.to_dict()
         with self._connect() as connection:
-            connection.execute(
-                """
-                insert or ignore into guard_cloud_events (
-                  event_id, idempotency_key, event_type, payload_json, occurred_at, uploaded_at
-                )
-                values (?, ?, ?, ?, ?, null)
-                """,
-                (
-                    event.event_id,
-                    event.idempotency_key,
-                    event.event_type,
-                    json.dumps(payload, sort_keys=True),
-                    event.occurred_at,
-                ),
+            self._add_guard_event_v1(connection, event)
+
+    @staticmethod
+    def _add_guard_event_v1(connection: sqlite3.Connection, event: GuardEventV1) -> None:
+        payload = event.to_dict()
+        connection.execute(
+            """
+            insert or ignore into guard_cloud_events (
+              event_id, idempotency_key, event_type, payload_json, occurred_at, uploaded_at
             )
+            values (?, ?, ?, ?, ?, null)
+            """,
+            (
+                event.event_id,
+                event.idempotency_key,
+                event.event_type,
+                json.dumps(payload, sort_keys=True),
+                event.occurred_at,
+            ),
+        )
 
     def list_guard_events_v1(self, *, uploaded: bool | None = None, limit: int = 200) -> list[dict[str, object]]:
         query = """

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -5805,10 +5805,10 @@ url = http://127.0.0.1:8787/guard-canary
         finally:
             daemon.stop()
 
-        assert connect_rc == 0
-        assert connect_output["connected"] is True
-        assert connect_output["status"] == "connected"
-        assert connect_output["milestone"] == "first_sync_pending"
+        assert connect_rc == 1
+        assert connect_output["connected"] is False
+        assert connect_output["status"] == "retry_required"
+        assert connect_output["milestone"] == "first_sync_failed"
         assert connect_output["reason"] == "sync_unreachable"
         assert connect_output["sync_message"] == "sync_unreachable"
 
@@ -5898,10 +5898,10 @@ url = http://127.0.0.1:8787/guard-canary
                 "receiptsStored": 1,
             }
 
-        assert connect_rc == 0
-        assert connect_output["connected"] is True
-        assert connect_output["status"] == "connected"
-        assert connect_output["milestone"] == "sync_not_available"
+        assert connect_rc == 1
+        assert connect_output["connected"] is False
+        assert connect_output["status"] == "retry_required"
+        assert connect_output["milestone"] == "first_sync_failed"
         assert connect_output["reason"] == "Guard sync requires a Pro or Team plan."
         assert connect_output["sync_message"] == "Guard sync requires a Pro or Team plan."
 
@@ -6239,9 +6239,9 @@ url = http://127.0.0.1:8787/guard-canary
             wait_timeout_seconds=1,
         )
 
-        assert payload["connected"] is True
-        assert payload["status"] == "connected"
-        assert payload["milestone"] == "first_sync_pending"
+        assert payload["connected"] is False
+        assert payload["status"] == "retry_required"
+        assert payload["milestone"] == "first_sync_failed"
         assert payload["sync_message"] == "<urlopen error offline>"
 
     def test_guard_connect_persists_success_when_daemon_result_write_fails(self, tmp_path, monkeypatch):
@@ -6413,9 +6413,9 @@ url = http://127.0.0.1:8787/guard-canary
             wait_timeout_seconds=1,
         )
 
-        assert payload["connected"] is True
-        assert payload["status"] == "connected"
-        assert payload["milestone"] == "first_sync_pending"
+        assert payload["connected"] is False
+        assert payload["status"] == "retry_required"
+        assert payload["milestone"] == "first_sync_failed"
         assert payload["sync_message"] == "Guard Cloud sync requires a paid Guard plan"
 
     def test_guard_connect_reports_guard_plan_required_without_failing_pairing(self, tmp_path, monkeypatch):
@@ -6496,9 +6496,9 @@ url = http://127.0.0.1:8787/guard-canary
             wait_timeout_seconds=1,
         )
 
-        assert payload["connected"] is True
-        assert payload["status"] == "connected"
-        assert payload["milestone"] == "first_sync_pending"
+        assert payload["connected"] is False
+        assert payload["status"] == "retry_required"
+        assert payload["milestone"] == "first_sync_failed"
         assert payload["sync_message"] == "Guard plan required"
 
     def test_guard_sync_persists_advisories_from_endpoint(self, tmp_path, capsys):

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -224,6 +224,8 @@ class _SyncRequestHandler(BaseHTTPRequestHandler):
     response_code = 200
     captured_headers: ClassVar[dict[str, str]] = {}
     captured_body: ClassVar[dict[str, object] | None] = None
+    captured_bodies: ClassVar[list[dict[str, object]]] = []
+    captured_paths: ClassVar[list[str]] = []
     raw_response_body: ClassVar[str | None] = None
     response_payload: ClassVar[dict[str, object]] = {
         "syncedAt": "2026-04-09T00:00:00Z",
@@ -235,6 +237,8 @@ class _SyncRequestHandler(BaseHTTPRequestHandler):
         body = self.rfile.read(length).decode("utf-8") if length else "{}"
         _SyncRequestHandler.captured_headers = {key.lower(): value for key, value in self.headers.items()}
         _SyncRequestHandler.captured_body = json.loads(body)
+        _SyncRequestHandler.captured_bodies.append(_SyncRequestHandler.captured_body)
+        _SyncRequestHandler.captured_paths.append(self.path)
         self.send_response(self.response_code)
         self.send_header("Content-Type", "application/json")
         self.end_headers()
@@ -5401,6 +5405,8 @@ url = http://127.0.0.1:8787/guard-canary
             "syncedAt": "2026-04-09T00:00:00Z",
             "receiptsStored": 1,
         }
+        _SyncRequestHandler.captured_bodies = []
+        _SyncRequestHandler.captured_paths = []
 
         server = HTTPServer(("127.0.0.1", 0), _SyncRequestHandler)
         thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -5464,10 +5470,16 @@ url = http://127.0.0.1:8787/guard-canary
         assert status_output["cloud_state"] == "paired_active"
         assert status_output["last_sync_at"] == "2026-04-09T00:00:00Z"
         assert _SyncRequestHandler.captured_headers["authorization"] == "Bearer demo-token"
-        assert _SyncRequestHandler.captured_body is not None
-        assert len(_SyncRequestHandler.captured_body["receipts"]) >= 1
-        assert "inventory" not in _SyncRequestHandler.captured_body
-        first_receipt = _SyncRequestHandler.captured_body["receipts"][0]
+        receipt_body = next(
+            body
+            for body in _SyncRequestHandler.captured_bodies
+            if isinstance(body.get("receipts"), list) and len(body["receipts"]) >= 1
+        )
+        event_body = next(body for body in _SyncRequestHandler.captured_bodies if "events" in body)
+        assert len(receipt_body["receipts"]) >= 1
+        assert "inventory" not in receipt_body
+        assert len(event_body["events"]) >= 1
+        first_receipt = receipt_body["receipts"][0]
         assert "artifactId" in first_receipt
         assert "artifact_id" not in first_receipt
         assert "receiptId" in first_receipt

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -156,9 +156,9 @@ def test_guard_connect_preserves_pairing_when_first_sync_fails(
     finally:
         daemon.stop()
 
-    assert payload["connected"] is True
-    assert payload["status"] == "connected"
-    assert payload["milestone"] == "first_sync_pending"
+    assert payload["connected"] is False
+    assert payload["status"] == "retry_required"
+    assert payload["milestone"] == "first_sync_failed"
     assert payload["reason"] == "sync_unreachable"
     assert payload["sync_message"] == "sync_unreachable"
     assert payload["request_id"].startswith("connect-")
@@ -235,9 +235,9 @@ def test_guard_connect_prefers_paid_plan_sync_note_over_runtime_sync_timeout(
     finally:
         daemon.stop()
 
-    assert payload["connected"] is True
-    assert payload["status"] == "connected"
-    assert payload["milestone"] == "first_sync_pending"
+    assert payload["connected"] is False
+    assert payload["status"] == "retry_required"
+    assert payload["milestone"] == "first_sync_failed"
     assert payload["reason"] == "Guard Cloud sync requires a paid Guard plan"
     assert payload["sync_message"] == "Guard Cloud sync requires a paid Guard plan"
 
@@ -311,9 +311,9 @@ def test_guard_connect_preserves_http_402_payment_required_sync_note(
     finally:
         daemon.stop()
 
-    assert payload["connected"] is True
-    assert payload["status"] == "connected"
-    assert payload["milestone"] == "first_sync_pending"
+    assert payload["connected"] is False
+    assert payload["status"] == "retry_required"
+    assert payload["milestone"] == "first_sync_failed"
     assert payload["reason"] == "HTTP Error 402: Payment Required"
     assert payload["sync_message"] == "HTTP Error 402: Payment Required"
 

--- a/tests/test_guard_event_schema_v1.py
+++ b/tests/test_guard_event_schema_v1.py
@@ -30,6 +30,7 @@ def _receipt() -> GuardReceipt:
 
 class _EventIngestHandler(BaseHTTPRequestHandler):
     requests: ClassVar[list[dict[str, object]]] = []
+    event_status: ClassVar[int] = 200
 
     def do_POST(self) -> None:
         length = int(self.headers.get("Content-Length", "0"))
@@ -42,9 +43,13 @@ class _EventIngestHandler(BaseHTTPRequestHandler):
                 "authorization": self.headers.get("Authorization"),
             }
         )
-        self.send_response(200)
+        status_code = type(self).event_status if self.path.endswith("/api/v1/guard/events") else 200
+        self.send_response(status_code)
         self.send_header("Content-Type", "application/json")
         self.end_headers()
+        if status_code == 404:
+            self.wfile.write(json.dumps({"error": "not found"}).encode())
+            return
         if self.path.endswith("/receipts/sync"):
             response = {"syncedAt": "2026-04-24T00:00:00+00:00", "receiptsStored": len(payload.get("receipts", []))}
         else:
@@ -178,3 +183,29 @@ def test_sync_receipts_uploads_pending_guard_events(tmp_path) -> None:
         "/api/v1/guard/events",
     ]
     assert store.list_guard_events_v1(uploaded=False, limit=10) == []
+
+
+def test_sync_receipts_keeps_receipt_success_when_v1_events_endpoint_is_missing(tmp_path) -> None:
+    store = GuardStore(tmp_path)
+    store.add_receipt(_receipt())
+    _EventIngestHandler.requests = []
+    _EventIngestHandler.event_status = 404
+    server = HTTPServer(("127.0.0.1", 0), _EventIngestHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        store.set_sync_credentials(
+            f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            "token-1",
+            "2026-04-24T00:00:00+00:00",
+        )
+
+        result = sync_receipts(store)
+    finally:
+        _EventIngestHandler.event_status = 200
+        server.shutdown()
+        thread.join(timeout=5)
+
+    assert result["receipts"] == 1
+    assert result["guard_events_v1"]["sync_skipped"] is True
+    assert store.list_guard_events_v1(uploaded=False, limit=10)

--- a/tests/test_guard_event_schema_v1.py
+++ b/tests/test_guard_event_schema_v1.py
@@ -7,7 +7,7 @@ from typing import ClassVar
 
 from codex_plugin_scanner.guard.edge_events import build_approval_event, build_policy_event, build_receipt_event
 from codex_plugin_scanner.guard.models import GuardReceipt
-from codex_plugin_scanner.guard.runtime.runner import sync_guard_events
+from codex_plugin_scanner.guard.runtime.runner import sync_guard_events, sync_receipts
 from codex_plugin_scanner.guard.schemas.guard_event_v1 import GuardEventV1
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -45,20 +45,20 @@ class _EventIngestHandler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.end_headers()
-        self.wfile.write(
-            json.dumps(
-                {
-                    "accepted": 1,
-                    "rejected": 0,
-                    "statuses": [
-                        {
-                            "eventId": payload["events"][0]["eventId"],
-                            "status": "accepted",
-                        }
-                    ],
-                }
-            ).encode()
-        )
+        if self.path.endswith("/receipts/sync"):
+            response = {"syncedAt": "2026-04-24T00:00:00+00:00", "receiptsStored": len(payload.get("receipts", []))}
+        else:
+            response = {
+                "accepted": 1,
+                "rejected": 0,
+                "statuses": [
+                    {
+                        "eventId": payload["events"][0]["eventId"],
+                        "status": "accepted",
+                    }
+                ],
+            }
+        self.wfile.write(json.dumps(response).encode())
 
     def log_message(self, fmt: str, *args) -> None:
         return
@@ -127,4 +127,54 @@ def test_sync_guard_events_posts_to_v1_ingest(tmp_path) -> None:
     assert _EventIngestHandler.requests[0]["path"] == "/api/v1/guard/events"
     assert _EventIngestHandler.requests[0]["authorization"] == "Bearer token-1"
     assert _EventIngestHandler.requests[0]["payload"]["events"][0]["eventType"] == "receipt.created"
+    assert store.list_guard_events_v1(uploaded=False, limit=10) == []
+
+
+def test_sync_guard_events_normalizes_registry_base_url(tmp_path) -> None:
+    store = GuardStore(tmp_path)
+    store.add_receipt(_receipt())
+    _EventIngestHandler.requests = []
+    server = HTTPServer(("127.0.0.1", 0), _EventIngestHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        store.set_sync_credentials(
+            f"http://127.0.0.1:{server.server_port}/registry/api/v1",
+            "token-1",
+            "2026-04-24T00:00:00+00:00",
+        )
+
+        result = sync_guard_events(store)
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+    assert result["accepted"] == 1
+    assert _EventIngestHandler.requests[0]["path"] == "/api/v1/guard/events"
+
+
+def test_sync_receipts_uploads_pending_guard_events(tmp_path) -> None:
+    store = GuardStore(tmp_path)
+    store.add_receipt(_receipt())
+    _EventIngestHandler.requests = []
+    server = HTTPServer(("127.0.0.1", 0), _EventIngestHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        store.set_sync_credentials(
+            f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            "token-1",
+            "2026-04-24T00:00:00+00:00",
+        )
+
+        result = sync_receipts(store)
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+    assert result["guard_events_v1"]["accepted"] == 1
+    assert [request["path"] for request in _EventIngestHandler.requests] == [
+        "/api/guard/receipts/sync",
+        "/api/v1/guard/events",
+    ]
     assert store.list_guard_events_v1(uploaded=False, limit=10) == []

--- a/tests/test_guard_event_schema_v1.py
+++ b/tests/test_guard_event_schema_v1.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import ClassVar
+
+from codex_plugin_scanner.guard.edge_events import build_approval_event, build_policy_event, build_receipt_event
+from codex_plugin_scanner.guard.models import GuardReceipt
+from codex_plugin_scanner.guard.runtime.runner import sync_guard_events
+from codex_plugin_scanner.guard.schemas.guard_event_v1 import GuardEventV1
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _receipt() -> GuardReceipt:
+    return GuardReceipt(
+        receipt_id="receipt-1",
+        timestamp="2026-04-24T00:00:00+00:00",
+        harness="codex",
+        artifact_id="artifact-1",
+        artifact_hash="sha256:abc",
+        policy_decision="review",
+        capabilities_summary="requests network access",
+        changed_capabilities=("network",),
+        provenance_summary="local harness",
+        artifact_name="Sensitive Tool",
+        source_scope="workspace",
+    )
+
+
+class _EventIngestHandler(BaseHTTPRequestHandler):
+    requests: ClassVar[list[dict[str, object]]] = []
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length) if length else b"{}"
+        payload = json.loads(body.decode())
+        type(self).requests.append(
+            {
+                "path": self.path,
+                "payload": payload,
+                "authorization": self.headers.get("Authorization"),
+            }
+        )
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(
+            json.dumps(
+                {
+                    "accepted": 1,
+                    "rejected": 0,
+                    "statuses": [
+                        {
+                            "eventId": payload["events"][0]["eventId"],
+                            "status": "accepted",
+                        }
+                    ],
+                }
+            ).encode()
+        )
+
+    def log_message(self, fmt: str, *args) -> None:
+        return
+
+
+def test_receipt_event_uses_white_rabbit_contract() -> None:
+    event = build_receipt_event(_receipt(), workspace_id="workspace-1", device_id="device-1")
+    payload = event.to_dict()
+
+    assert payload["eventType"] == "receipt.created"
+    assert payload["workspaceId"] == "workspace-1"
+    assert payload["idempotencyKey"] == "receipt.created:receipt-1"
+    assert payload["payload"]["receiptId"] == "receipt-1"
+    assert GuardEventV1.from_dict(payload).event_type == "receipt.created"
+
+
+def test_receipt_persistence_dual_writes_pending_cloud_event(tmp_path) -> None:
+    store = GuardStore(tmp_path)
+
+    store.add_receipt(_receipt())
+
+    pending = store.list_guard_events_v1(uploaded=False, limit=10)
+    assert pending[0]["event_type"] == "receipt.created"
+    assert pending[0]["payload"]["payload"]["artifactId"] == "artifact-1"
+
+
+def test_approval_and_policy_events_are_contract_valid() -> None:
+    approval_event = build_approval_event(
+        request_id="approval-1",
+        event_type="approval.created",
+        occurred_at="2026-04-24T00:00:00+00:00",
+        payload={"artifactId": "artifact-1"},
+        workspace_id="workspace-1",
+    )
+    policy_event = build_policy_event(
+        policy_key="policy-1",
+        occurred_at="2026-04-24T00:00:00+00:00",
+        payload={"policyId": "policy-1"},
+        workspace_id="workspace-1",
+    )
+
+    assert GuardEventV1.from_dict(approval_event.to_dict()).event_type == "approval.created"
+    assert GuardEventV1.from_dict(policy_event.to_dict()).event_type == "policy.changed"
+
+
+def test_sync_guard_events_posts_to_v1_ingest(tmp_path) -> None:
+    store = GuardStore(tmp_path)
+    store.add_receipt(_receipt())
+    _EventIngestHandler.requests = []
+    server = HTTPServer(("127.0.0.1", 0), _EventIngestHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        store.set_sync_credentials(
+            f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            "token-1",
+            "2026-04-24T00:00:00+00:00",
+        )
+
+        result = sync_guard_events(store)
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+    assert result["accepted"] == 1
+    assert _EventIngestHandler.requests[0]["path"] == "/api/v1/guard/events"
+    assert _EventIngestHandler.requests[0]["authorization"] == "Bearer token-1"
+    assert _EventIngestHandler.requests[0]["payload"]["events"][0]["eventType"] == "receipt.created"
+    assert store.list_guard_events_v1(uploaded=False, limit=10) == []

--- a/tests/test_guard_event_schema_v1.py
+++ b/tests/test_guard_event_schema_v1.py
@@ -69,6 +69,33 @@ class _EventIngestHandler(BaseHTTPRequestHandler):
         return
 
 
+class _RejectedEventHandler(BaseHTTPRequestHandler):
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length) if length else b"{}"
+        payload = json.loads(body.decode())
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(
+            json.dumps(
+                {
+                    "accepted": 0,
+                    "rejected": 1,
+                    "statuses": [
+                        {
+                            "eventId": payload["events"][0]["eventId"],
+                            "status": "rejected",
+                        }
+                    ],
+                }
+            ).encode()
+        )
+
+    def log_message(self, fmt: str, *args) -> None:
+        return
+
+
 def test_receipt_event_uses_white_rabbit_contract() -> None:
     event = build_receipt_event(_receipt(), workspace_id="workspace-1", device_id="device-1")
     payload = event.to_dict()
@@ -209,3 +236,25 @@ def test_sync_receipts_keeps_receipt_success_when_v1_events_endpoint_is_missing(
     assert result["receipts"] == 1
     assert result["guard_events_v1"]["sync_skipped"] is True
     assert store.list_guard_events_v1(uploaded=False, limit=10)
+
+
+def test_sync_guard_events_marks_rejected_events_processed(tmp_path) -> None:
+    store = GuardStore(tmp_path)
+    store.add_receipt(_receipt())
+    server = HTTPServer(("127.0.0.1", 0), _RejectedEventHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        store.set_sync_credentials(
+            f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            "token-1",
+            "2026-04-24T00:00:00+00:00",
+        )
+
+        result = sync_guard_events(store)
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+    assert result["accepted"] == 1
+    assert store.list_guard_events_v1(uploaded=False, limit=10) == []


### PR DESCRIPTION
## Purpose\nAdd the White Rabbit Guard edge foundation: GuardEventV1 schema, receipt event dual-write, local cloud event queue, explicit v1 event sync, and connect semantics that do not mark failed first receipt sync as connected.\n\n## Verification\n- PYTHONPATH=src uv run pytest tests/test_guard_event_schema_v1.py tests/test_guard_events.py tests/test_guard_protect.py tests/test_guard_runtime.py tests/test_guard_cli.py tests/test_guard_connect_flow.py tests/test_guard_surface_server.py -q\n- PYTHONPATH=src uv run ruff check src/codex_plugin_scanner/guard/schemas/guard_event_v1.py src/codex_plugin_scanner/guard/edge_events.py src/codex_plugin_scanner/guard/store.py src/codex_plugin_scanner/guard/runtime/__init__.py src/codex_plugin_scanner/guard/runtime/runner.py src/codex_plugin_scanner/guard/cli/connect_flow.py tests/test_guard_event_schema_v1.py tests/test_guard_connect_flow.py tests/test_guard_cli.py\n- git diff --check