### PR TITLE
fix(guard): route Claude approvals through tool prompts

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -23,7 +23,6 @@ CLAUDE_GUARD_POST_TOOL_MATCHER = f"{CLAUDE_GUARD_TOOL_MATCHER}|AskUserQuestion"
 CLAUDE_GUARD_NOTIFICATION_MATCHER = "permission_prompt"
 CLAUDE_GUARD_SESSION_START_MATCHERS = ("startup", "resume", "clear", "compact")
 CLAUDE_GUARD_TOOL_TIMEOUT_SECONDS = 30
-CLAUDE_GUARD_PROMPT_TIMEOUT_SECONDS = 20
 CLAUDE_GUARD_NOTIFICATION_TIMEOUT_SECONDS = 10
 CLAUDE_GUARD_SESSION_START_TIMEOUT_SECONDS = 10
 CLAUDE_GUARD_STOP_TIMEOUT_SECONDS = 10
@@ -47,7 +46,6 @@ def _sync_runtime_hook_groups(hooks: dict[str, object], hook_command: str) -> No
         ("PreToolUse", CLAUDE_GUARD_TOOL_MATCHER, CLAUDE_GUARD_TOOL_TIMEOUT_SECONDS),
         ("PermissionRequest", CLAUDE_GUARD_TOOL_MATCHER, CLAUDE_GUARD_NOTIFICATION_TIMEOUT_SECONDS),
         ("PostToolUse", CLAUDE_GUARD_POST_TOOL_MATCHER, CLAUDE_GUARD_TOOL_TIMEOUT_SECONDS),
-        ("UserPromptSubmit", None, CLAUDE_GUARD_PROMPT_TIMEOUT_SECONDS),
         ("Notification", CLAUDE_GUARD_NOTIFICATION_MATCHER, CLAUDE_GUARD_NOTIFICATION_TIMEOUT_SECONDS),
         ("Stop", None, CLAUDE_GUARD_STOP_TIMEOUT_SECONDS),
     ):
@@ -60,7 +58,7 @@ def _sync_runtime_hook_groups(hooks: dict[str, object], hook_command: str) -> No
 
 
 def _remove_unsupported_guard_hook_groups(hooks: dict[str, object]) -> None:
-    for key in ("PermissionDenied",):
+    for key in ("PermissionDenied", "UserPromptSubmit"):
         entries = hooks.get(key)
         if not isinstance(entries, list):
             continue

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -311,8 +311,11 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
         policy_parser.add_argument("--json", action="store_true")
         policy_parser.set_defaults(policy_action=action)
 
-    policies_parser = guard_subparsers.add_parser("policies", help="List stored Guard policy decisions")
+    policies_parser = guard_subparsers.add_parser("policies", help="List or clear stored Guard policy decisions")
+    policies_parser.add_argument("policies_command", nargs="?", choices=("clear",))
     policies_parser.add_argument("--harness")
+    policies_parser.add_argument("--source")
+    policies_parser.add_argument("--all", action="store_true", help="Clear decisions across every harness")
     _add_guard_common_args(policies_parser)
     policies_parser.add_argument("--json", action="store_true")
 
@@ -775,6 +778,34 @@ def run_guard_command(
         return 0
 
     if args.guard_command == "policies":
+        if getattr(args, "policies_command", None) == "clear":
+            harness = getattr(args, "harness", None)
+            clear_all = bool(getattr(args, "all", False))
+            if not clear_all and harness is None:
+                _emit(
+                    "policies",
+                    {
+                        "error": "Choose --harness <name> or --all when clearing Guard policy decisions.",
+                        "cleared": 0,
+                    },
+                    getattr(args, "json", False),
+                )
+                return 2
+            cleared = store.clear_policy_decisions(
+                None if clear_all else harness,
+                getattr(args, "source", None),
+            )
+            _emit(
+                "policies",
+                {
+                    "generated_at": _now(),
+                    "cleared": cleared,
+                    "harness": None if clear_all else harness,
+                    "source": getattr(args, "source", None),
+                },
+                getattr(args, "json", False),
+            )
+            return 0
         policy_items = store.list_policy_decisions(getattr(args, "harness", None))
         items = _filter_policy_items(policy_items, active_only=True)
         _emit("policies", {"generated_at": _now(), "items": items}, getattr(args, "json", False))
@@ -1233,10 +1264,14 @@ def run_guard_command(
             )
             return 0
         if _canonical_harness_name(args.harness) == "claude-code" and _hook_event_name(payload) == "Stop":
-            denied = _persist_claude_pending_permission_denials(store, payload)
+            discarded = _discard_claude_pending_permissions(store, payload)
             store.add_event(
                 "claude/turn_stop",
-                {"session_id": payload.get("session_id"), "saved_denials": denied},
+                {
+                    "session_id": payload.get("session_id"),
+                    "discarded_pending_permissions": discarded,
+                    "saved_denials": 0,
+                },
                 _now(),
             )
             return 0
@@ -1371,6 +1406,14 @@ def run_guard_command(
                         artifact=runtime_artifact,
                         artifact_hash=runtime_artifact_hash,
                     )
+                if _should_allow_claude_user_prompt_submit_without_output(
+                    args,
+                    event_name=event_name,
+                    policy_action=policy_action,
+                    artifact=runtime_artifact,
+                    output_stream=output_stream,
+                ):
+                    return 0
                 if _should_emit_copilot_hook_response(args):
                     _emit_copilot_hook_response(
                         policy_action=policy_action,
@@ -1724,6 +1767,23 @@ def _should_emit_prequeue_native_hook_response(
     return output_stream is not None
 
 
+def _should_allow_claude_user_prompt_submit_without_output(
+    args: argparse.Namespace,
+    *,
+    event_name: str,
+    policy_action: str,
+    artifact: GuardArtifact,
+    output_stream: TextIO | None,
+) -> bool:
+    return (
+        _canonical_harness_name(args.harness) == "claude-code"
+        and event_name == "UserPromptSubmit"
+        and policy_action == "require-reapproval"
+        and not _prompt_requires_hard_block(artifact)
+        and (not getattr(args, "json", False) or output_stream is not None)
+    )
+
+
 def _emit_claude_permission_request_passthrough(*, output_stream: TextIO | None = None) -> None:
     if output_stream is not None:
         output_stream.write("")
@@ -2042,6 +2102,31 @@ def _persist_claude_native_permission_for_runtime_artifact(
             pending_key=_claude_pending_permission_state_key(session_id, artifact.artifact_id),
         )
     return True
+
+
+def _discard_claude_pending_permissions(store: GuardStore, payload: dict[str, object]) -> int:
+    session_id = _optional_string(payload.get("session_id"))
+    if session_id is None:
+        return 0
+    index_key = _claude_pending_permission_index_key(session_id)
+    try:
+        index_payload = store.get_sync_payload(index_key)
+    except (OSError, sqlite3.Error):
+        return 0
+    if not isinstance(index_payload, list):
+        return 0
+    pending_keys = [str(item) for item in index_payload]
+    if not pending_keys:
+        return 0
+    try:
+        with store._connect() as connection:
+            connection.execute("begin immediate")
+            for pending_key in pending_keys:
+                connection.execute("delete from sync_state where state_key = ?", (pending_key,))
+            connection.execute("delete from sync_state where state_key = ?", (index_key,))
+    except (OSError, sqlite3.Error):
+        return 0
+    return len(pending_keys)
 
 
 def _persist_claude_pending_permission_denials(store: GuardStore, payload: dict[str, object]) -> int:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1270,7 +1270,6 @@ def run_guard_command(
                 {
                     "session_id": payload.get("session_id"),
                     "discarded_pending_permissions": discarded,
-                    "saved_denials": 0,
                 },
                 _now(),
             )
@@ -2119,11 +2118,7 @@ def _discard_claude_pending_permissions(store: GuardStore, payload: dict[str, ob
     if not pending_keys:
         return 0
     try:
-        with store._connect() as connection:
-            connection.execute("begin immediate")
-            for pending_key in pending_keys:
-                connection.execute("delete from sync_state where state_key = ?", (pending_key,))
-            connection.execute("delete from sync_state where state_key = ?", (index_key,))
+        store.delete_sync_payloads([*pending_keys, index_key])
     except (OSError, sqlite3.Error):
         return 0
     return len(pending_keys)

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -315,7 +315,11 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     policies_parser.add_argument("policies_command", nargs="?", choices=("clear",))
     policies_parser.add_argument("--harness")
     policies_parser.add_argument("--source")
-    policies_parser.add_argument("--all", action="store_true", help="Clear decisions across every harness")
+    policies_parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Clear decisions across every harness; cannot be combined with --harness",
+    )
     _add_guard_common_args(policies_parser)
     policies_parser.add_argument("--json", action="store_true")
 
@@ -781,6 +785,18 @@ def run_guard_command(
         if getattr(args, "policies_command", None) == "clear":
             harness = getattr(args, "harness", None)
             clear_all = bool(getattr(args, "all", False))
+            if clear_all and harness is not None:
+                _emit(
+                    "policies",
+                    {
+                        "error": "Choose either --all or --harness <name> when clearing Guard policy decisions.",
+                        "cleared": 0,
+                        "harness": harness,
+                        "source": getattr(args, "source", None),
+                    },
+                    getattr(args, "json", False),
+                )
+                return 2
             if not clear_all and harness is None:
                 _emit(
                     "policies",

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2438,15 +2438,11 @@ def _claude_prompt_additional_context(
         return None
     if _prompt_requires_hard_block(artifact):
         return None
-    briefing_sentence = "HOL Guard will intercept the next sensitive action and open a branded approval question."
+    briefing_sentence = "HOL Guard will intercept Claude's next sensitive action and open a branded approval question."
     if "secret_read" in _prompt_request_classes(artifact):
         briefing_sentence = (
             "HOL Guard will intercept Claude's next attempt to access local secrets and open a branded approval "
             "question to protect you."
-        )
-    else:
-        briefing_sentence = (
-            "HOL Guard will intercept Claude's next sensitive action and open a branded approval question."
         )
     return (
         f"{_ensure_terminal_punctuation(native_reason)} "

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2438,22 +2438,21 @@ def _claude_prompt_additional_context(
         return None
     if _prompt_requires_hard_block(artifact):
         return None
-    briefing_sentence = "HOL Guard intercepted the next sensitive action and opened the approval dialog below."
+    briefing_sentence = "HOL Guard will intercept the next sensitive action and open a branded approval question."
     if "secret_read" in _prompt_request_classes(artifact):
         briefing_sentence = (
-            "HOL Guard intercepted Claude's next attempt to access local secrets and opened the approval dialog "
-            "shown below to protect you."
+            "HOL Guard will intercept Claude's next attempt to access local secrets and open a branded approval "
+            "question to protect you."
         )
     else:
         briefing_sentence = (
-            "HOL Guard intercepted Claude's next sensitive action and opened the approval dialog shown below."
+            "HOL Guard will intercept Claude's next sensitive action and open a branded approval question."
         )
     return (
         f"{_ensure_terminal_punctuation(native_reason)} "
-        "Before you use the first sensitive tool for this request, call AskUserQuestion with header 'HOL Guard', "
-        "question 'HOL Guard intercepted this sensitive action. What should Claude do?', and exactly these options: "
-        "'Allow once', 'Allow during this session', and 'Keep blocked'. If the user chooses Keep blocked, do not "
-        "retry the sensitive action. Then tell the user exactly: "
+        "Do not ask for approval at the prompt stage. Attempt the intended sensitive tool once so HOL Guard can "
+        "evaluate the exact tool, path, and arguments, then route that concrete action into a HOL Guard approval "
+        "question with Allow once, Allow during this session, and Keep blocked. First tell the user exactly: "
         f"'{briefing_sentence}' "
         "Attempt that sensitive tool at most once. If HOL Guard or Claude denies it, do not retry the same sensitive "
         "action automatically. Instead, tell the user approval is required in Claude to continue."

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -295,6 +295,24 @@ def _render_inventory(console: Console, payload: dict[str, object]) -> None:
 
 
 def _render_policies(console: Console, payload: dict[str, object]) -> None:
+    if "cleared" in payload or "error" in payload:
+        error = payload.get("error")
+        cleared = int(payload.get("cleared", 0) or 0)
+        scope = str(payload.get("harness") or "all harnesses")
+        source = payload.get("source")
+        body = Table.grid(padding=(0, 1))
+        body.add_row("Outcome", str(error) if error else f"cleared {cleared} decision{'s' if cleared != 1 else ''}")
+        body.add_row("Harness", scope)
+        if source:
+            body.add_row("Source", str(source))
+        console.print(
+            Panel(
+                body,
+                title="Guard policy clear",
+                border_style="red" if error else "green",
+            )
+        )
+        return
     items = _coerce_dict_list(payload.get("items"))
     console.print(
         Panel.fit(

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1528,6 +1528,22 @@ class GuardStore:
             for row in rows
         ]
 
+    def clear_policy_decisions(self, harness: str | None = None, source: str | None = None) -> int:
+        conditions: list[str] = []
+        params: list[object] = []
+        if harness is not None:
+            conditions.append("harness = ?")
+            params.append(harness)
+        if source is not None:
+            conditions.append("source = ?")
+            params.append(source)
+        query = "delete from policy_decisions"
+        if conditions:
+            query += " where " + " and ".join(conditions)
+        with self._connect() as connection:
+            cursor = connection.execute(query, tuple(params))
+            return int(cursor.rowcount if cursor.rowcount is not None else 0)
+
     def get_latest_diff(self, harness: str, artifact_id: str) -> dict[str, object] | None:
         with self._connect() as connection:
             row = connection.execute(

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1746,10 +1746,11 @@ class GuardStore:
     def delete_sync_payloads(self, state_keys: list[str]) -> int:
         if not state_keys:
             return 0
+        placeholders = ",".join("?" for _ in state_keys)
         with self._connect() as connection:
-            cursor = connection.executemany(
-                "delete from sync_state where state_key = ?",
-                [(state_key,) for state_key in state_keys],
+            cursor = connection.execute(
+                f"delete from sync_state where state_key in ({placeholders})",
+                tuple(state_keys),
             )
             return int(cursor.rowcount if cursor.rowcount is not None else 0)
 

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1743,6 +1743,16 @@ class GuardStore:
                 (state_key,),
             )
 
+    def delete_sync_payloads(self, state_keys: list[str]) -> int:
+        if not state_keys:
+            return 0
+        with self._connect() as connection:
+            cursor = connection.executemany(
+                "delete from sync_state where state_key = ?",
+                [(state_key,) for state_key in state_keys],
+            )
+            return int(cursor.rowcount if cursor.rowcount is not None else 0)
+
     def add_guard_event_v1(self, event: GuardEventV1) -> None:
         with self._connect() as connection:
             self._add_guard_event_v1(connection, event)

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -1664,6 +1664,26 @@ class TestGuardApprovals:
         assert "Guard policy clear" in output
         assert "Choose --harness <name> or --all" in output
 
+    def test_guard_policies_clear_rejects_all_with_harness(self, tmp_path, capsys):
+        rc = main(
+            [
+                "guard",
+                "policies",
+                "clear",
+                "--home",
+                str(tmp_path / "home"),
+                "--all",
+                "--harness",
+                "claude-code",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 2
+        assert output["cleared"] == 0
+        assert "Choose either --all or --harness <name>" in output["error"]
+
     def test_guard_bridge_resolves_requests_against_guard_daemon_api(self, tmp_path, monkeypatch):
         store = GuardStore(tmp_path / "guard-home")
         bridge = GuardBridge(

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -1598,6 +1598,40 @@ class TestGuardApprovals:
         assert approve_output["resolved"] is True
         assert store.resolve_policy("codex", "codex:project:workspace_skill", "hash-789") == "allow"
 
+    def test_guard_policies_cli_clears_local_decisions_for_harness(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        store = GuardStore(home_dir)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="claude-code",
+                scope="artifact",
+                action="block",
+                artifact_id="claude-code:runtime:file-read:.npmrc",
+                artifact_hash="hash-npmrc",
+                reason="blocked during local test",
+                source="claude-ask-user-question",
+            ),
+            "2026-04-23T00:00:00+00:00",
+        )
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="harness",
+                action="allow",
+                reason="keep codex decisions",
+                source="manual",
+            ),
+            "2026-04-23T00:00:00+00:00",
+        )
+
+        rc = main(["guard", "policies", "clear", "--home", str(home_dir), "--harness", "claude-code", "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["cleared"] == 1
+        assert store.list_policy_decisions("claude-code") == []
+        assert len(store.list_policy_decisions("codex")) == 1
+
     def test_guard_bridge_resolves_requests_against_guard_daemon_api(self, tmp_path, monkeypatch):
         store = GuardStore(tmp_path / "guard-home")
         bridge = GuardBridge(

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -1632,6 +1632,38 @@ class TestGuardApprovals:
         assert store.list_policy_decisions("claude-code") == []
         assert len(store.list_policy_decisions("codex")) == 1
 
+    def test_guard_policies_clear_renders_non_json_result(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        store = GuardStore(home_dir)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="claude-code",
+                scope="artifact",
+                action="block",
+                artifact_id="claude-code:runtime:file-read:.npmrc",
+                artifact_hash="hash-npmrc",
+                reason="blocked during local test",
+                source="claude-ask-user-question",
+            ),
+            "2026-04-23T00:00:00+00:00",
+        )
+
+        rc = main(["guard", "policies", "clear", "--home", str(home_dir), "--harness", "claude-code"])
+        output = capsys.readouterr().out
+
+        assert rc == 0
+        assert "Guard policy clear" in output
+        assert "cleared 1 decision" in output
+        assert store.list_policy_decisions("claude-code") == []
+
+    def test_guard_policies_clear_renders_non_json_validation_error(self, tmp_path, capsys):
+        rc = main(["guard", "policies", "clear", "--home", str(tmp_path / "home")])
+        output = capsys.readouterr().out
+
+        assert rc == 2
+        assert "Guard policy clear" in output
+        assert "Choose --harness <name> or --all" in output
+
     def test_guard_bridge_resolves_requests_against_guard_daemon_api(self, tmp_path, monkeypatch):
         store = GuardStore(tmp_path / "guard-home")
         bridge = GuardBridge(

--- a/tests/test_guard_claude_adapter.py
+++ b/tests/test_guard_claude_adapter.py
@@ -399,7 +399,11 @@ def test_claude_daemon_hook_command_falls_back_without_blocking_prompt_on_daemon
     assert result.stderr == ""
     payload = json.loads(result.stdout)
     assert payload["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
-    assert "AskUserQuestion" in payload["hookSpecificOutput"]["additionalContext"]
+    assert "Do not ask for approval at the prompt stage" in payload["hookSpecificOutput"]["additionalContext"]
+    assert (
+        "route that concrete action into a HOL Guard approval question"
+        in payload["hookSpecificOutput"]["additionalContext"]
+    )
     assert "Keep blocked" in payload["hookSpecificOutput"]["additionalContext"]
 
 

--- a/tests/test_guard_claude_adapter.py
+++ b/tests/test_guard_claude_adapter.py
@@ -47,8 +47,8 @@ def _runtime_hook_handlers(payload: dict[str, object]) -> list[dict[str, object]
     hooks = payload["hooks"]
     assert isinstance(hooks, dict)
     handlers: list[dict[str, object]] = []
-    for key in ("PreToolUse", "PermissionRequest", "PostToolUse", "UserPromptSubmit", "Notification", "Stop"):
-        entries = hooks[key]
+    for key in ("PreToolUse", "PermissionRequest", "PostToolUse", "Notification", "Stop"):
+        entries = hooks.get(key, [])
         assert isinstance(entries, list)
         for entry in entries:
             assert isinstance(entry, dict)
@@ -146,7 +146,6 @@ def test_claude_install_writes_session_start_and_command_hook_schema_and_is_idem
     pre_tool_use = payload["hooks"]["PreToolUse"]
     permission_request = payload["hooks"]["PermissionRequest"]
     post_tool_use = payload["hooks"]["PostToolUse"]
-    prompt_submit = payload["hooks"]["UserPromptSubmit"]
     notification = payload["hooks"]["Notification"]
     stop = payload["hooks"]["Stop"]
     assert len(session_start) == 4
@@ -165,9 +164,7 @@ def test_claude_install_writes_session_start_and_command_hook_schema_and_is_idem
     assert len(post_tool_use) == 1
     assert post_tool_use[0]["matcher"] == "Bash|Read|Write|Edit|MultiEdit|WebFetch|WebSearch|mcp__.*|AskUserQuestion"
     assert post_tool_use[0]["hooks"][0]["type"] == "command"
-    assert len(prompt_submit) == 1
-    assert "matcher" not in prompt_submit[0]
-    assert prompt_submit[0]["hooks"][0]["type"] == "command"
+    assert payload["hooks"].get("UserPromptSubmit", []) == []
     assert len(notification) == 1
     assert notification[0]["matcher"] == "permission_prompt"
     assert notification[0]["hooks"][0]["type"] == "command"
@@ -255,8 +252,8 @@ def test_claude_install_replaces_legacy_http_guard_hooks(tmp_path):
         "command",
         "command",
         "command",
-        "command",
     ]
+    assert payload["hooks"].get("UserPromptSubmit", []) == []
     assert all(CLAUDE_GUARD_DAEMON_HOOK_MARKER in str(handler.get("command", "")) for handler in installed_handlers)
     assert all("url" not in handler for handler in installed_handlers)
 
@@ -397,14 +394,7 @@ def test_claude_daemon_hook_command_falls_back_without_blocking_prompt_on_daemon
     )
     assert result.returncode == 0
     assert result.stderr == ""
-    payload = json.loads(result.stdout)
-    assert payload["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
-    assert "Do not ask for approval at the prompt stage" in payload["hookSpecificOutput"]["additionalContext"]
-    assert (
-        "route that concrete action into a HOL Guard approval question"
-        in payload["hookSpecificOutput"]["additionalContext"]
-    )
-    assert "Keep blocked" in payload["hookSpecificOutput"]["additionalContext"]
+    assert result.stdout == ""
 
 
 def test_claude_daemon_hook_command_falls_back_to_native_ask_on_daemon_miss(tmp_path):

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -2124,7 +2124,7 @@ args = ["workspace-skill.js", "--changed"]
         assert install_settings_payload["hooks"]["PreToolUse"][0]["hooks"][0]["type"] == "command"
         assert install_settings_payload["hooks"]["PreToolUse"][0]["hooks"][0]["command"] == expected_hook_command
         assert "url" not in install_settings_payload["hooks"]["PreToolUse"][0]["hooks"][0]
-        assert install_settings_payload["hooks"]["UserPromptSubmit"][0]["hooks"][0]["type"] == "command"
+        assert install_settings_payload["hooks"].get("UserPromptSubmit", []) == []
         assert install_settings_payload["hooks"]["Notification"][0]["matcher"] == "permission_prompt"
         assert install_settings_payload["hooks"]["Notification"][0]["hooks"][0]["type"] == "command"
         assert install_settings_payload["hooks"]["Notification"][0]["hooks"][0]["command"] == expected_hook_command
@@ -2222,7 +2222,7 @@ args = ["workspace-skill.js", "--changed"]
         assert uninstall_rc == 0
         assert output["managed_install"]["active"] is False
         assert payload["hooks"]["PreToolUse"] == []
-        assert payload["hooks"]["UserPromptSubmit"] == []
+        assert payload["hooks"].get("UserPromptSubmit", []) == []
         assert payload["hooks"]["Notification"] == []
         assert payload["hooks"]["Stop"] == []
 
@@ -2353,7 +2353,7 @@ args = ["workspace-skill.js", "--changed"]
         assert len(payload["hooks"]["SessionStart"]) == 4
         assert len(payload["hooks"]["PreToolUse"]) == 1
         assert len(payload["hooks"]["PostToolUse"]) == 1
-        assert len(payload["hooks"]["UserPromptSubmit"]) == 1
+        assert payload["hooks"].get("UserPromptSubmit", []) == []
         assert len(payload["hooks"]["Notification"]) == 1
         assert len(payload["hooks"]["Stop"]) == 1
         pretool_hook_commands = [

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -4899,7 +4899,11 @@ def test_guard_hook_brands_claude_user_prompt_submit_before_native_approval(
 
     assert rc == 0
     assert payload["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
-    assert "AskUserQuestion" in payload["hookSpecificOutput"]["additionalContext"]
+    assert "Do not ask for approval at the prompt stage" in payload["hookSpecificOutput"]["additionalContext"]
+    assert (
+        "route that concrete action into a HOL Guard approval question"
+        in payload["hookSpecificOutput"]["additionalContext"]
+    )
     assert "Keep blocked" in payload["hookSpecificOutput"]["additionalContext"]
     assert any(receipt["artifact_id"].startswith("claude-code:session:prompt") for receipt in receipts)
 
@@ -4929,7 +4933,11 @@ def test_guard_hook_brands_generic_claude_user_prompt_submit_before_native_appro
 
     assert rc == 0
     assert payload["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
-    assert "AskUserQuestion" in payload["hookSpecificOutput"]["additionalContext"]
+    assert "Do not ask for approval at the prompt stage" in payload["hookSpecificOutput"]["additionalContext"]
+    assert (
+        "route that concrete action into a HOL Guard approval question"
+        in payload["hookSpecificOutput"]["additionalContext"]
+    )
     assert "Keep blocked" in payload["hookSpecificOutput"]["additionalContext"]
 
 

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -4492,6 +4492,71 @@ def test_guard_hook_claude_ask_user_question_empty_answers_uses_explicit_fallbac
     assert guard_commands_module._claude_guard_approval_answer(payload) == "allow"
 
 
+def test_guard_hook_claude_native_cancel_does_not_persist_flat_block(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    first_event = {
+        "session_id": "session-claude-native-cancel",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Read",
+        "tool_input": {"file_path": str(workspace_dir / ".npmrc")},
+        "source_scope": "project",
+    }
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    first_rc, first_output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="claude-code",
+        event=first_event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    notification_rc, notification_output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="claude-code",
+        event={
+            **first_event,
+            "hook_event_name": "Notification",
+            "notification_type": "permission_prompt",
+            "message": "Claude needs your permission to use Read",
+        },
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    stop_rc, stop_output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="claude-code",
+        event={"session_id": "session-claude-native-cancel", "hook_event_name": "Stop"},
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    second_rc, second_output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="claude-code",
+        event={**first_event, "session_id": "session-claude-native-cancel-retry"},
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    first_payload = json.loads(first_output)
+    notification_payload = json.loads(notification_output)
+    second_payload = json.loads(second_output)
+
+    assert first_rc == 0
+    assert first_payload["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert notification_rc == 0
+    assert "HOL Guard approval question" in notification_payload["systemMessage"]
+    assert stop_rc == 0
+    assert stop_output == ""
+    assert GuardStore(home_dir).list_policy_decisions("claude-code") == []
+    assert second_rc == 0
+    assert second_payload["hookSpecificOutput"]["permissionDecision"] == "ask"
+
+
 def test_guard_hook_claude_alias_reuses_native_approval_policy_with_canonical_harness(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
@@ -4600,7 +4665,7 @@ def test_guard_hook_claude_alias_reuses_legacy_alias_policy_keys(tmp_path, capsy
     assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
 
 
-def test_guard_hook_claude_stop_persists_unapproved_native_prompt_as_denied(tmp_path, capsys, monkeypatch):
+def test_guard_hook_claude_stop_keeps_native_cancel_transient(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
@@ -4662,8 +4727,8 @@ def test_guard_hook_claude_stop_persists_unapproved_native_prompt_as_denied(tmp_
     assert stop_rc == 0
     assert stop_output == ""
     assert second_rc == 0
-    assert second_payload["hookSpecificOutput"]["permissionDecision"] == "deny"
-    assert "HOL Guard blocked Claude's attempt to use Read" in second_payload["systemMessage"]
+    assert second_payload["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert "HOL Guard intercepted Claude's attempt to use Read" in second_payload["systemMessage"]
 
 
 def test_guard_hook_claude_stop_does_not_persist_denial_without_visible_prompt(
@@ -4873,7 +4938,7 @@ def test_runtime_artifact_native_reason_truncates_long_risk_summaries() -> None:
     assert reason.endswith("...")
 
 
-def test_guard_hook_brands_claude_user_prompt_submit_before_native_approval(
+def test_guard_hook_allows_claude_user_prompt_submit_before_tool_approval(
     tmp_path,
     capsys,
     monkeypatch,
@@ -4895,20 +4960,13 @@ def test_guard_hook_brands_claude_user_prompt_submit_before_native_approval(
         monkeypatch=monkeypatch,
     )
     receipts = GuardStore(home_dir).list_receipts()
-    payload = json.loads(output)
 
     assert rc == 0
-    assert payload["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
-    assert "Do not ask for approval at the prompt stage" in payload["hookSpecificOutput"]["additionalContext"]
-    assert (
-        "route that concrete action into a HOL Guard approval question"
-        in payload["hookSpecificOutput"]["additionalContext"]
-    )
-    assert "Keep blocked" in payload["hookSpecificOutput"]["additionalContext"]
+    assert output == ""
     assert any(receipt["artifact_id"].startswith("claude-code:session:prompt") for receipt in receipts)
 
 
-def test_guard_hook_brands_generic_claude_user_prompt_submit_before_native_approval(
+def test_guard_hook_allows_generic_claude_user_prompt_submit_before_tool_approval(
     tmp_path,
     capsys,
     monkeypatch,
@@ -4929,16 +4987,9 @@ def test_guard_hook_brands_generic_claude_user_prompt_submit_before_native_appro
         capsys=capsys,
         monkeypatch=monkeypatch,
     )
-    payload = json.loads(output)
 
     assert rc == 0
-    assert payload["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
-    assert "Do not ask for approval at the prompt stage" in payload["hookSpecificOutput"]["additionalContext"]
-    assert (
-        "route that concrete action into a HOL Guard approval question"
-        in payload["hookSpecificOutput"]["additionalContext"]
-    )
-    assert "Keep blocked" in payload["hookSpecificOutput"]["additionalContext"]
+    assert output == ""
 
 
 def test_guard_hook_emits_json_for_claude_user_prompt_submit_overridable_prompts(

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -255,7 +255,11 @@ class TestGuardSurfaceServer:
 
         assert "HOL Guard intercepted this prompt" in hook_payload["systemMessage"]
         assert hook_payload["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
-        assert "AskUserQuestion" in hook_payload["hookSpecificOutput"]["additionalContext"]
+        assert "Do not ask for approval at the prompt stage" in hook_payload["hookSpecificOutput"]["additionalContext"]
+        assert (
+            "route that concrete action into a HOL Guard approval question"
+            in hook_payload["hookSpecificOutput"]["additionalContext"]
+        )
         assert "Allow once" in hook_payload["hookSpecificOutput"]["additionalContext"]
         assert "Keep blocked" in hook_payload["hookSpecificOutput"]["additionalContext"]
 

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -253,15 +253,7 @@ class TestGuardSurfaceServer:
         finally:
             daemon.stop()
 
-        assert "HOL Guard intercepted this prompt" in hook_payload["systemMessage"]
-        assert hook_payload["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
-        assert "Do not ask for approval at the prompt stage" in hook_payload["hookSpecificOutput"]["additionalContext"]
-        assert (
-            "route that concrete action into a HOL Guard approval question"
-            in hook_payload["hookSpecificOutput"]["additionalContext"]
-        )
-        assert "Allow once" in hook_payload["hookSpecificOutput"]["additionalContext"]
-        assert "Keep blocked" in hook_payload["hookSpecificOutput"]["additionalContext"]
+        assert hook_payload == {}
 
     def test_guard_daemon_claude_hook_endpoint_blocks_guard_bypass_user_prompt_submit(self, tmp_path) -> None:
         home_dir = tmp_path / "home"


### PR DESCRIPTION
## Purpose
- Stop installing Claude `UserPromptSubmit` Guard hooks that interrupt prompts before Claude can create a concrete tool permission request.
- Route sensitive Claude actions through branded HOL Guard tool permission prompts with allow-once, allow-session, keep-blocked, and chat options.
- Add a `hol-guard policies clear` command so stale local allow/deny decisions can be cleared during testing or recovery.

## Verification
- VSCode Terminal + local Claude harness: prompted Claude to `Read ./.env`; observed branded `HOL Guard` approval UI with `Allow once`, `Allow during this session`, `Keep blocked`, and `Chat about this`; selected `Keep blocked`; `.env` was not read.
- `pytest tests/test_guard_surface_server.py tests/test_guard_claude_adapter.py tests/test_guard_runtime.py tests/test_guard_approvals.py tests/test_guard_cli.py -q`
- `ruff check src/codex_plugin_scanner/guard/adapters/claude_code.py src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/store.py tests/test_guard_claude_adapter.py tests/test_guard_cli.py tests/test_guard_approvals.py tests/test_guard_runtime.py tests/test_guard_surface_server.py`
- `ruff format --check src/codex_plugin_scanner/guard/adapters/claude_code.py src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/store.py tests/test_guard_claude_adapter.py tests/test_guard_cli.py tests/test_guard_approvals.py tests/test_guard_runtime.py tests/test_guard_surface_server.py`
- `git diff --check`

## Notes
- No secrets were read during verification.
- The commit is GPG signed by the repository owner.
