### PR TITLE
fix(guard): add safe approval-history reset workflow

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/approval_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/approval_commands.py
@@ -41,13 +41,19 @@ def add_approval_parser(
         "clear-history",
         help="Clear saved allow/deny history so flows can be re-tested",
     )
-    clear_history_parser.add_argument("--harness")
+    clear_history_parser.add_argument(
+        "--harness",
+        help="The harness to clear history for (for example: codex, claude-code, opencode, copilot)",
+    )
     clear_history_parser.add_argument(
         "--all",
         action="store_true",
         help="Clear approval history across every harness; cannot be combined with --harness",
     )
-    clear_history_parser.add_argument("--source")
+    clear_history_parser.add_argument(
+        "--source",
+        help="Optional source filter for policy decisions (for example: manual, claude-ask-user-question)",
+    )
     add_common_args(clear_history_parser)
     clear_history_parser.add_argument("--json", action="store_true")
 
@@ -86,12 +92,15 @@ def run_approval_command(
             }
         target_harness = None if clear_all else harness
         source = getattr(args, "source", None)
+        cleared_resolved_requests = 0
+        if source is None:
+            cleared_resolved_requests = store.clear_approval_requests(harness=target_harness, status="resolved")
         return {
             "history_cleared": True,
             "harness": target_harness,
             "source": source,
             "cleared_policies": store.clear_policy_decisions(target_harness, source),
-            "cleared_resolved_requests": store.clear_approval_requests(harness=target_harness, status="resolved"),
+            "cleared_resolved_requests": cleared_resolved_requests,
             "exit_code": 0,
         }
     item = apply_approval_resolution(

--- a/src/codex_plugin_scanner/guard/cli/approval_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/approval_commands.py
@@ -15,7 +15,10 @@ def add_approval_parser(
     guard_subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
     add_common_args,
 ) -> None:
-    approvals_parser = guard_subparsers.add_parser("approvals", help="List or resolve pending Guard approvals")
+    approvals_parser = guard_subparsers.add_parser(
+        "approvals",
+        help="List, resolve, or clear Guard approval history",
+    )
     approvals_subparsers = approvals_parser.add_subparsers(dest="approvals_command")
 
     add_common_args(approvals_parser)
@@ -34,6 +37,20 @@ def add_approval_parser(
         decision_parser.add_argument("--json", action="store_true")
         decision_parser.set_defaults(approval_action=action)
 
+    clear_history_parser = approvals_subparsers.add_parser(
+        "clear-history",
+        help="Clear saved allow/deny history so flows can be re-tested",
+    )
+    clear_history_parser.add_argument("--harness")
+    clear_history_parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Clear approval history across every harness; cannot be combined with --harness",
+    )
+    clear_history_parser.add_argument("--source")
+    add_common_args(clear_history_parser)
+    clear_history_parser.add_argument("--json", action="store_true")
+
 
 def run_approval_command(
     args: argparse.Namespace,
@@ -41,12 +58,42 @@ def run_approval_command(
     store: GuardStore,
     workspace: Path | None,
 ) -> dict[str, object]:
-    if getattr(args, "approvals_command", None) is None:
+    command = getattr(args, "approvals_command", None)
+    if command is None:
         return build_runtime_snapshot(
             store=store,
             approval_center_url=load_guard_daemon_url(store.guard_home),
             now=_now(),
         )
+    if command == "clear-history":
+        harness = getattr(args, "harness", None)
+        clear_all = bool(getattr(args, "all", False))
+        if clear_all and harness is not None:
+            return {
+                "history_cleared": False,
+                "error": "Choose either --all or --harness <name> when clearing approval history.",
+                "cleared_policies": 0,
+                "cleared_resolved_requests": 0,
+                "exit_code": 2,
+            }
+        if not clear_all and harness is None:
+            return {
+                "history_cleared": False,
+                "error": "Choose --harness <name> or --all when clearing approval history.",
+                "cleared_policies": 0,
+                "cleared_resolved_requests": 0,
+                "exit_code": 2,
+            }
+        target_harness = None if clear_all else harness
+        source = getattr(args, "source", None)
+        return {
+            "history_cleared": True,
+            "harness": target_harness,
+            "source": source,
+            "cleared_policies": store.clear_policy_decisions(target_harness, source),
+            "cleared_resolved_requests": store.clear_approval_requests(harness=target_harness, status="resolved"),
+            "exit_code": 0,
+        }
     item = apply_approval_resolution(
         store=store,
         request_id=args.request_id,

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -855,7 +855,7 @@ def run_guard_command(
     if args.guard_command == "approvals":
         payload = run_approval_command(args, store=store, workspace=workspace)
         _emit("approvals", payload, getattr(args, "json", False))
-        return 0
+        return int(payload.get("exit_code", 0))
 
     if args.guard_command == "explain":
         payload = _build_explain_payload_with_mode(store, args.target, cisco_mode=args.cisco_mode)

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -392,6 +392,27 @@ def _render_events(console: Console, payload: dict[str, object]) -> None:
 
 
 def _render_approvals(console: Console, payload: dict[str, object]) -> None:
+    if "history_cleared" in payload or "cleared_policies" in payload:
+        error = payload.get("error")
+        body = Table.grid(padding=(0, 1))
+        body.add_row(
+            "Outcome",
+            str(error) if error else "approval history reset",
+        )
+        body.add_row("Harness", str(payload.get("harness") or "all harnesses"))
+        source = payload.get("source")
+        if source:
+            body.add_row("Source", str(source))
+        body.add_row("Policy decisions", str(int(payload.get("cleared_policies", 0) or 0)))
+        body.add_row("Resolved requests", str(int(payload.get("cleared_resolved_requests", 0) or 0)))
+        console.print(
+            Panel(
+                body,
+                title="Approval history",
+                border_style="red" if error else "green",
+            )
+        )
+        return
     if payload.get("resolved"):
         item = payload.get("item")
         if isinstance(item, dict):

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1526,6 +1526,22 @@ class GuardStore:
         with self._connect() as connection:
             return count_pending_approval_requests(connection, status=status)
 
+    def clear_approval_requests(self, *, harness: str | None = None, status: str | None = None) -> int:
+        conditions: list[str] = []
+        params: list[object] = []
+        if harness is not None:
+            conditions.append("harness = ?")
+            params.append(harness)
+        if status is not None:
+            conditions.append("status = ?")
+            params.append(status)
+        query = "delete from approval_requests"
+        if conditions:
+            query += " where " + " and ".join(conditions)
+        with self._connect() as connection:
+            cursor = connection.execute(query, tuple(params))
+            return int(cursor.rowcount if cursor.rowcount is not None else 0)
+
     def list_policy_decisions(self, harness: str | None = None) -> list[dict[str, object]]:
         query = """
             select harness, scope, artifact_id, artifact_hash, workspace, publisher, action, reason, owner, source,

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -1786,6 +1786,84 @@ class TestGuardApprovals:
         assert output["cleared_resolved_requests"] == 0
         assert "Choose --harness <name> or --all" in output["error"]
 
+    def test_guard_approvals_clear_history_with_source_only_clears_matching_policies(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        store = GuardStore(home_dir)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="claude-code",
+                scope="artifact",
+                action="block",
+                artifact_id="claude-code:runtime:file-read:.env",
+                artifact_hash="hash-env",
+                reason="blocked during local test",
+                source="claude-ask-user-question",
+            ),
+            "2026-04-23T00:00:00+00:00",
+        )
+        store.upsert_policy(
+            PolicyDecision(
+                harness="claude-code",
+                scope="artifact",
+                action="allow",
+                artifact_id="claude-code:runtime:file-read:.npmrc",
+                artifact_hash="hash-npmrc",
+                reason="keep manual allow",
+                source="manual",
+            ),
+            "2026-04-23T00:00:00+00:00",
+        )
+        store.add_approval_request(
+            GuardApprovalRequest(
+                request_id="req-claude-resolved-source",
+                harness="claude-code",
+                artifact_id="claude-code:runtime:file-read:.env",
+                artifact_name=".env",
+                artifact_hash="hash-env",
+                policy_action="require-reapproval",
+                recommended_scope="artifact",
+                changed_fields=("first_seen",),
+                source_scope="project",
+                config_path=str(tmp_path / "workspace" / ".claude" / "settings.local.json"),
+                review_command="hol-guard approvals approve req-claude-resolved-source",
+                approval_url="http://127.0.0.1/pending/req-claude-resolved-source",
+            ),
+            "2026-04-23T00:00:00+00:00",
+        )
+        store.resolve_approval_request(
+            "req-claude-resolved-source",
+            resolution_action="block",
+            resolution_scope="artifact",
+            reason="intentional block",
+            resolved_at="2026-04-23T00:01:00+00:00",
+        )
+
+        rc = main(
+            [
+                "guard",
+                "approvals",
+                "clear-history",
+                "--home",
+                str(home_dir),
+                "--harness",
+                "claude-code",
+                "--source",
+                "claude-ask-user-question",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["history_cleared"] is True
+        assert output["source"] == "claude-ask-user-question"
+        assert output["cleared_policies"] == 1
+        assert output["cleared_resolved_requests"] == 0
+        remaining = store.list_policy_decisions("claude-code")
+        assert len(remaining) == 1
+        assert remaining[0]["source"] == "manual"
+        assert len(store.list_approval_requests(status="resolved", harness="claude-code", limit=None)) == 1
+
     def test_guard_bridge_resolves_requests_against_guard_daemon_api(self, tmp_path, monkeypatch):
         store = GuardStore(tmp_path / "guard-home")
         bridge = GuardBridge(

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -1632,6 +1632,98 @@ class TestGuardApprovals:
         assert store.list_policy_decisions("claude-code") == []
         assert len(store.list_policy_decisions("codex")) == 1
 
+    def test_guard_approvals_clear_history_resets_saved_decisions(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        store = GuardStore(home_dir)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="claude-code",
+                scope="artifact",
+                action="block",
+                artifact_id="claude-code:runtime:file-read:.env",
+                artifact_hash="hash-env",
+                reason="blocked during local test",
+                source="claude-ask-user-question",
+            ),
+            "2026-04-23T00:00:00+00:00",
+        )
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="artifact",
+                action="allow",
+                artifact_id="codex:project:workspace_skill",
+                artifact_hash="hash-workspace",
+                reason="keep codex allow",
+                source="manual",
+            ),
+            "2026-04-23T00:00:00+00:00",
+        )
+        store.add_approval_request(
+            GuardApprovalRequest(
+                request_id="req-claude-resolved",
+                harness="claude-code",
+                artifact_id="claude-code:runtime:file-read:.env",
+                artifact_name=".env",
+                artifact_hash="hash-env",
+                policy_action="require-reapproval",
+                recommended_scope="artifact",
+                changed_fields=("first_seen",),
+                source_scope="project",
+                config_path=str(tmp_path / "workspace" / ".claude" / "settings.local.json"),
+                review_command="hol-guard approvals approve req-claude-resolved",
+                approval_url="http://127.0.0.1/pending/req-claude-resolved",
+            ),
+            "2026-04-23T00:00:00+00:00",
+        )
+        store.resolve_approval_request(
+            "req-claude-resolved",
+            resolution_action="block",
+            resolution_scope="artifact",
+            reason="intentional block",
+            resolved_at="2026-04-23T00:01:00+00:00",
+        )
+        store.add_approval_request(
+            GuardApprovalRequest(
+                request_id="req-claude-pending",
+                harness="claude-code",
+                artifact_id="claude-code:runtime:file-read:.npmrc",
+                artifact_name=".npmrc",
+                artifact_hash="hash-npmrc",
+                policy_action="require-reapproval",
+                recommended_scope="artifact",
+                changed_fields=("first_seen",),
+                source_scope="project",
+                config_path=str(tmp_path / "workspace" / ".claude" / "settings.local.json"),
+                review_command="hol-guard approvals approve req-claude-pending",
+                approval_url="http://127.0.0.1/pending/req-claude-pending",
+            ),
+            "2026-04-23T00:02:00+00:00",
+        )
+
+        rc = main(
+            [
+                "guard",
+                "approvals",
+                "clear-history",
+                "--home",
+                str(home_dir),
+                "--harness",
+                "claude-code",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["history_cleared"] is True
+        assert output["cleared_policies"] == 1
+        assert output["cleared_resolved_requests"] == 1
+        assert store.list_policy_decisions("claude-code") == []
+        assert len(store.list_policy_decisions("codex")) == 1
+        assert len(store.list_approval_requests(status="resolved", harness="claude-code", limit=None)) == 0
+        assert len(store.list_approval_requests(status="pending", harness="claude-code", limit=None)) == 1
+
     def test_guard_policies_clear_renders_non_json_result(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)
@@ -1683,6 +1775,16 @@ class TestGuardApprovals:
         assert rc == 2
         assert output["cleared"] == 0
         assert "Choose either --all or --harness <name>" in output["error"]
+
+    def test_guard_approvals_clear_history_requires_scope_selector(self, tmp_path, capsys):
+        rc = main(["guard", "approvals", "clear-history", "--home", str(tmp_path / "home"), "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 2
+        assert output["history_cleared"] is False
+        assert output["cleared_policies"] == 0
+        assert output["cleared_resolved_requests"] == 0
+        assert "Choose --harness <name> or --all" in output["error"]
 
     def test_guard_bridge_resolves_requests_against_guard_daemon_api(self, tmp_path, monkeypatch):
         store = GuardStore(tmp_path / "guard-home")


### PR DESCRIPTION
## Purpose
- Add an explicit `hol-guard approvals clear-history` command so users can safely reset saved allow/deny history and replay approval flows from a clean state.
- Keep reset scope explicit: require either `--harness <name>` or `--all`, and reject ambiguous combinations.
- Clear resolved approval request history alongside policy decisions while preserving pending approvals.

## What changed
- Added `guard approvals clear-history` parser and runtime handling.
- Added `GuardStore.clear_approval_requests(...)` for scoped request cleanup.
- Added approval-render output for clear-history success/error in non-JSON mode.
- Returned command-specific exit codes from `guard approvals` (for safe validation failures).
- Added regression tests for reset behavior and scope validation.

## Verification
- `pytest tests/test_guard_approvals.py -k 'clear_history or policies_clear' -q`
- `pytest tests/test_guard_approvals.py -q`
- `ruff check src/codex_plugin_scanner/guard/cli/approval_commands.py src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/cli/render.py src/codex_plugin_scanner/guard/store.py tests/test_guard_approvals.py`
- `ruff format --check src/codex_plugin_scanner/guard/cli/approval_commands.py src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/cli/render.py src/codex_plugin_scanner/guard/store.py tests/test_guard_approvals.py`
- `git diff --check`
