### PR TITLE
fix(guard): harden local approval auth

### DIFF
--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -119,7 +119,7 @@ def apply_approval_resolution(
     if scope == "publisher" and not isinstance(request.get("publisher"), str):
         raise ValueError(f"Approval request {request_id} has no publisher scope to approve.")
     decision = PolicyDecision(
-        harness=str(request["harness"]),
+        harness="*" if scope == "global" else str(request["harness"]),
         scope=scope,
         action="allow" if action == "allow" else "block",
         artifact_id=str(request["artifact_id"]) if scope == "artifact" else None,
@@ -131,7 +131,7 @@ def apply_approval_resolution(
     store.upsert_policy(decision, now or _now())
     resolved_at = now or _now()
     resolved_ids = store.resolve_matching_approval_requests(
-        harness=str(request["harness"]),
+        harness="*" if scope == "global" else str(request["harness"]),
         scope=scope,
         artifact_id=str(request["artifact_id"]) if scope == "artifact" else None,
         workspace=workspace if scope == "workspace" else None,

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -130,8 +130,9 @@ def apply_approval_resolution(
     )
     store.upsert_policy(decision, now or _now())
     resolved_at = now or _now()
+    resolution_harness = None if scope == "global" else str(request["harness"])
     resolved_ids = store.resolve_matching_approval_requests(
-        harness="*" if scope == "global" else str(request["harness"]),
+        harness=resolution_harness,
         scope=scope,
         artifact_id=str(request["artifact_id"]) if scope == "artifact" else None,
         workspace=workspace if scope == "workspace" else None,

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -26,6 +26,7 @@ from ..store import GuardStore
 from .manager import (
     GUARD_DAEMON_COMPATIBILITY_VERSION,
     clear_guard_daemon_state,
+    load_guard_daemon_auth_token,
     write_guard_daemon_state,
 )
 
@@ -59,18 +60,19 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
     _MAX_BODY_BYTES = 1_000_000
 
     def do_OPTIONS(self) -> None:
-        parsed = urlparse(self.path)
-        if parsed.path in {"/v1/connect/complete", "/v1/connect/state"}:
-            origin = self._normalize_origin(self.headers.get("Origin"))
-            if origin is None:
-                self._write_empty(status=400)
-                return
-            self._write_empty(
-                status=200,
-                extra_headers=self._cors_headers(origin, allow_methods="GET, POST, OPTIONS"),
-            )
+        origin = self._normalize_origin(self.headers.get("Origin"))
+        if origin is None:
+            self._write_empty(status=400)
             return
-        self._write_empty(status=404)
+        if not self._origin_is_allowed():
+            self._write_empty(status=403)
+            return
+        self._write_empty(
+            status=200,
+            extra_headers=self._cors_headers(
+                origin, allow_methods="GET, POST, OPTIONS", allow_headers="Content-Type, X-Guard-Token"
+            ),
+        )
 
     def do_GET(self) -> None:
         store = self.server.store  # type: ignore[attr-defined]
@@ -205,11 +207,14 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if parsed.path != "/v1/connect/complete" and not self._origin_is_allowed():
             self._write_json({"error": "forbidden_origin"}, status=403)
             return
+        path_parts = [part for part in parsed.path.split("/") if part]
+        if self._requires_header_token(parsed.path, path_parts) and not self._header_token_is_valid():
+            self._write_json({"error": "unauthorized"}, status=401)
+            return
         payload, body_error = self._load_request_body()
         if body_error is not None:
             self._write_json({"error": body_error}, status=400)
             return
-        path_parts = [part for part in parsed.path.split("/") if part]
         if parsed.path == "/v1/initialize":
             self._handle_initialize(payload)
             return
@@ -868,11 +873,16 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         return f"{parsed.scheme}://{host}{port_suffix}"
 
     @staticmethod
-    def _cors_headers(origin: str, *, allow_methods: str = "POST, OPTIONS") -> dict[str, str]:
+    def _cors_headers(
+        origin: str,
+        *,
+        allow_methods: str = "POST, OPTIONS",
+        allow_headers: str = "Content-Type, X-Guard-Token",
+    ) -> dict[str, str]:
         return {
             "Access-Control-Allow-Origin": origin,
             "Access-Control-Allow-Methods": allow_methods,
-            "Access-Control-Allow-Headers": "Content-Type",
+            "Access-Control-Allow-Headers": allow_headers,
             "Vary": "Origin",
         }
 
@@ -958,6 +968,14 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 return path_parts[1], None, True
             return path_parts[1], action.strip(), True
         return None, None, False
+
+    @staticmethod
+    def _requires_header_token(path: str, path_parts: list[str]) -> bool:
+        if path in {"/v1/policy/decisions", "/v1/policy/clear"}:
+            return True
+        if len(path_parts) == 4 and path_parts[:2] == ["v1", "requests"] and path_parts[3] in {"approve", "block"}:
+            return True
+        return len(path_parts) == 3 and path_parts[0] == "approvals" and path_parts[2] == "decision"
 
     def _write_json(
         self,
@@ -1080,7 +1098,7 @@ class GuardDaemonServer:
         self._server = _GuardDaemonHttpServer((host, port), _GuardDaemonHandler)
         self._server.store = store
         self._server.runtime = GuardSurfaceRuntime(store)
-        self._server.auth_token = uuid.uuid4().hex
+        self._server.auth_token = load_guard_daemon_auth_token(store.guard_home) or uuid.uuid4().hex
         self._server.runtime_host = host
         self._server.runtime_session_id = uuid.uuid4().hex
         self._server.runtime_started_at = _now()

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -209,7 +209,12 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         path_parts = [part for part in parsed.path.split("/") if part]
         if self._requires_header_token(parsed.path, path_parts) and not self._header_token_is_valid():
-            self._write_json({"error": "unauthorized"}, status=401)
+            origin = self._normalize_origin(self.headers.get("Origin"))
+            self._write_json(
+                {"error": "unauthorized"},
+                status=401,
+                extra_headers=self._cors_headers(origin) if origin is not None else None,
+            )
             return
         payload, body_error = self._load_request_body()
         if body_error is not None:
@@ -222,87 +227,48 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._handle_claude_hook(payload, parsed.query)
             return
         if parsed.path == "/v1/clients/attach":
-            if not self._header_token_is_valid():
-                self._write_json({"error": "unauthorized"}, status=401)
-                return
             self._handle_client_attach(payload)
             return
         if parsed.path == "/v1/clients/heartbeat":
-            if not self._header_token_is_valid():
-                self._write_json({"error": "unauthorized"}, status=401)
-                return
             self._handle_client_heartbeat(payload)
             return
         if parsed.path == "/v1/sessions/start":
-            if not self._header_token_is_valid():
-                self._write_json({"error": "unauthorized"}, status=401)
-                return
             self._handle_session_start(payload)
             return
         if parsed.path == "/v1/operations/start":
-            if not self._header_token_is_valid():
-                self._write_json({"error": "unauthorized"}, status=401)
-                return
             self._handle_operation_start(payload)
             return
         if parsed.path == "/v1/connect/requests":
-            if not self._header_token_is_valid():
-                self._write_json({"error": "unauthorized"}, status=401)
-                return
             self._handle_connect_request_create(payload)
             return
         if parsed.path == "/v1/connect/complete":
             self._handle_connect_complete(payload)
             return
         if parsed.path == "/v1/connect/result":
-            if not self._header_token_is_valid():
-                self._write_json({"error": "unauthorized"}, status=401)
-                return
             self._handle_connect_result_update(payload)
             return
         if parsed.path == "/v1/operations/block":
-            if not self._header_token_is_valid():
-                self._write_json({"error": "unauthorized"}, status=401)
-                return
             self._handle_operation_block(payload)
             return
         if len(path_parts) == 4 and path_parts[:2] == ["v1", "operations"] and path_parts[3] == "items":
-            if not self._header_token_is_valid():
-                self._write_json({"error": "unauthorized"}, status=401)
-                return
             self._handle_operation_item(path_parts[2], payload)
             return
         if len(path_parts) == 4 and path_parts[:2] == ["v1", "operations"] and path_parts[3] == "status":
-            if not self._header_token_is_valid():
-                self._write_json({"error": "unauthorized"}, status=401)
-                return
             self._handle_operation_status(path_parts[2], payload)
             return
         if parsed.path == "/v1/policy/decisions":
-            if not self._header_token_is_valid():
-                self._write_json({"error": "unauthorized"}, status=401)
-                return
             self._handle_policy_upsert(payload)
             return
         if parsed.path == "/v1/policy/clear":
-            if not self._header_token_is_valid():
-                self._write_json({"error": "unauthorized"}, status=401)
-                return
             self._handle_policy_clear(payload)
             return
         if parsed.path == "/v1/settings":
-            if not self._header_token_is_valid():
-                self._write_json({"error": "unauthorized"}, status=401)
-                return
             self._handle_settings_update(payload)
             return
         request_id, action, matched = self._resolve_request_action(path_parts, payload)
         if not matched:
             self.send_response(404)
             self.end_headers()
-            return
-        if not self._header_token_is_valid():
-            self._write_json({"error": "unauthorized"}, status=401)
             return
         if action is None:
             self._write_json({"resolved": False, "error": "missing_required_fields"}, status=400)
@@ -971,7 +937,20 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
 
     @staticmethod
     def _requires_header_token(path: str, path_parts: list[str]) -> bool:
-        if path in {"/v1/policy/decisions", "/v1/policy/clear"}:
+        if path in {
+            "/v1/clients/attach",
+            "/v1/clients/heartbeat",
+            "/v1/sessions/start",
+            "/v1/operations/start",
+            "/v1/connect/requests",
+            "/v1/connect/result",
+            "/v1/operations/block",
+            "/v1/policy/decisions",
+            "/v1/policy/clear",
+            "/v1/settings",
+        }:
+            return True
+        if len(path_parts) == 4 and path_parts[:2] == ["v1", "operations"] and path_parts[3] in {"items", "status"}:
             return True
         if len(path_parts) == 4 and path_parts[:2] == ["v1", "requests"] and path_parts[3] in {"approve", "block"}:
             return True

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -418,6 +418,44 @@ class TestGuardApprovals:
         assert resolved["status"] == "resolved"
         assert store.get_approval_request("req-b")["status"] == "resolved"
 
+    def test_guard_global_scope_resolution_clears_pending_requests_across_harnesses(self, tmp_path):
+        store = GuardStore(tmp_path / "guard-home")
+        for request_id, harness in (("req-codex", "codex"), ("req-copilot", "copilot")):
+            store.add_approval_request(
+                GuardApprovalRequest(
+                    request_id=request_id,
+                    harness=harness,
+                    artifact_id=f"{harness}:project:item",
+                    artifact_name=f"{harness}-item",
+                    artifact_hash=f"hash-{request_id}",
+                    policy_action="require-reapproval",
+                    recommended_scope="global",
+                    changed_fields=("args",),
+                    source_scope="project",
+                    config_path=str(tmp_path / harness / ".config" / "guard.toml"),
+                    review_command=f"hol-guard approvals approve {request_id}",
+                    approval_url=f"http://127.0.0.1:4455/approvals/{request_id}",
+                ),
+                "2026-04-11T00:00:00+00:00",
+            )
+
+        resolved = apply_approval_resolution(
+            store=store,
+            request_id="req-codex",
+            action="allow",
+            scope="global",
+            workspace=None,
+            reason="trusted globally",
+            now="2026-04-11T00:02:00+00:00",
+        )
+
+        pending = store.list_approval_requests(status="pending", limit=None)
+        decisions = store.list_policy_decisions()
+
+        assert resolved["status"] == "resolved"
+        assert pending == []
+        assert decisions[0]["harness"] == "*"
+
     def test_guard_broad_scope_resolution_clears_more_than_default_pending_page(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
         for index in range(520):
@@ -1429,6 +1467,36 @@ class TestGuardApprovals:
 
         assert status == 200
         assert allow_headers == "Content-Type, X-Guard-Token"
+
+    def test_guard_daemon_includes_cors_headers_on_unauthorized_local_post(self, tmp_path):
+        store = GuardStore(tmp_path / "guard-home")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/requests/missing/approve",
+                data=json.dumps({"scope": "artifact"}).encode("utf-8"),
+                headers={
+                    "Content-Type": "application/json",
+                    "Origin": f"http://127.0.0.1:{daemon.port}",
+                },
+                method="POST",
+            )
+            try:
+                urllib.request.urlopen(request, timeout=5)
+            except urllib.error.HTTPError as error:
+                status = error.code
+                payload = json.loads(error.read().decode("utf-8"))
+                allow_origin = error.headers.get("Access-Control-Allow-Origin")
+            else:
+                raise AssertionError("expected HTTPError for missing auth token")
+        finally:
+            daemon.stop()
+
+        assert status == 401
+        assert payload["error"] == "unauthorized"
+        assert allow_origin == f"http://127.0.0.1:{daemon.port}"
 
     def test_guard_daemon_rejects_spoofed_localhost_origin_post_requests(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -692,6 +692,20 @@ class TestGuardApprovals:
 
         assert daemon_manager_module.load_guard_daemon_url(guard_home) is None
 
+    def test_guard_daemon_server_reuses_existing_auth_token(self, tmp_path):
+        store = GuardStore(tmp_path / "guard-home")
+        token_path = store.guard_home / "daemon-auth-token"
+        token_path.parent.mkdir(parents=True, exist_ok=True)
+        token_path.write_text("persisted-token", encoding="utf-8")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+
+        try:
+            daemon.start()
+            assert daemon._server.auth_token == "persisted-token"
+            assert token_path.read_text(encoding="utf-8").strip() == "persisted-token"
+        finally:
+            daemon.stop()
+
     def test_guard_daemon_serves_approval_queue_and_resolves_requests(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
         store.add_approval_request(
@@ -1290,7 +1304,7 @@ class TestGuardApprovals:
             request = urllib.request.Request(
                 f"http://127.0.0.1:{daemon.port}/approvals/missing/decision",
                 data=b"{not-json",
-                headers={"Content-Type": "application/json"},
+                headers=_guard_json_headers(daemon._server.auth_token),
                 method="POST",
             )
             try:
@@ -1373,6 +1387,48 @@ class TestGuardApprovals:
 
         assert status == 403
         assert payload["error"] == "forbidden_origin"
+
+    def test_guard_daemon_rejects_cross_origin_options_requests(self, tmp_path):
+        store = GuardStore(tmp_path / "guard-home")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/requests/missing/approve",
+                headers={"Origin": "https://evil.example"},
+                method="OPTIONS",
+            )
+            try:
+                urllib.request.urlopen(request, timeout=5)
+            except urllib.error.HTTPError as error:
+                status = error.code
+            else:
+                raise AssertionError("expected HTTPError for disallowed preflight origin")
+        finally:
+            daemon.stop()
+
+        assert status == 403
+
+    def test_guard_daemon_allows_local_options_requests_with_guard_headers(self, tmp_path):
+        store = GuardStore(tmp_path / "guard-home")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/requests/missing/approve",
+                headers={"Origin": f"http://127.0.0.1:{daemon.port}"},
+                method="OPTIONS",
+            )
+            with urllib.request.urlopen(request, timeout=5) as response:
+                allow_headers = response.headers.get("Access-Control-Allow-Headers")
+                status = response.status
+        finally:
+            daemon.stop()
+
+        assert status == 200
+        assert allow_headers == "Content-Type, X-Guard-Token"
 
     def test_guard_daemon_rejects_spoofed_localhost_origin_post_requests(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")


### PR DESCRIPTION
## Summary
- preserve the local daemon auth token across restarts so open dashboard sessions do not break
- require `X-Guard-Token` before parsing privileged approval/policy POST bodies
- cover localhost-only OPTIONS preflight behavior and tokenized approval regressions

## Affected paths
- `src/codex_plugin_scanner/guard/approvals.py`
- `src/codex_plugin_scanner/guard/daemon/server.py`
- `tests/test_guard_approvals.py`

## Verification
- `python3 -m pytest tests/test_guard_approvals.py tests/test_guard_connect_flow.py tests/test_guard_event_schema_v1.py tests/test_guard_consumer_mode.py tests/test_mcp_security.py tests/test_cisco_install_surfaces.py`
- `python3 -m pytest tests/test_guard_approvals.py -k "guard_daemon_server_reuses_existing_auth_token or rejects_cross_origin_options_requests or allows_local_options_requests_with_guard_headers or guard_daemon_serves_approval_queue_and_resolves_requests or approve_route_requires_auth_token or approve_route_requires_workspace_for_workspace_scope"`
- `ruff check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_approvals.py`
- dashboard `pnpm install` and `pnpm run build`

## Local note
- verified live daemon on `127.0.0.1:5474` now uses repo source and accepts tokenized local preflights without 401/CORS failure