### PR TITLE
fix(dashboard): restore favicon assets

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -13,10 +13,11 @@
     <meta property="og:description" content="Review blocked local harness launches with HOL Guard." />
     <meta property="og:image" content="/brand/Logo_Whole.png" />
     <meta property="og:type" content="website" />
-    <link rel="icon" href="/favicon.ico" sizes="48x48" />
-    <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+    <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -16,7 +16,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-    <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/dashboard/public/favicon.svg
+++ b/dashboard/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <path d="M16 2L4 7v9c0 6.6 5.1 12.8 12 14.4C22.9 28.8 28 22.6 28 16V7L16 2z" fill="#5599fe"/>
+  <path d="M11.5 16.5l3 3 6.5-6.5" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -49,6 +49,7 @@ _ROOT_STATIC_FILES = {
     "/favicon.ico",
     "/favicon-16x16.png",
     "/favicon-32x32.png",
+    "/apple-touch-icon.png",
 }
 _CLAUDE_HOOK_EXECUTION_LOCK = threading.Lock()
 _DEFAULT_GUARD_DAEMON_IDLE_TIMEOUT_SECONDS = 30 * 60

--- a/src/codex_plugin_scanner/guard/daemon/static/favicon.svg
+++ b/src/codex_plugin_scanner/guard/daemon/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <path d="M16 2L4 7v9c0 6.6 5.1 12.8 12 14.4C22.9 28.8 28 22.6 28 16V7L16 2z" fill="#5599fe"/>
+  <path d="M11.5 16.5l3 3 6.5-6.5" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/codex_plugin_scanner/guard/daemon/static/index.html
+++ b/src/codex_plugin_scanner/guard/daemon/static/index.html
@@ -13,10 +13,11 @@
     <meta property="og:description" content="Review blocked local harness launches with HOL Guard." />
     <meta property="og:image" content="/brand/Logo_Whole.png" />
     <meta property="og:type" content="website" />
-    <link rel="icon" href="/favicon.ico" sizes="48x48" />
-    <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+    <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/src/codex_plugin_scanner/guard/daemon/static/index.html
+++ b/src/codex_plugin_scanner/guard/daemon/static/index.html
@@ -16,7 +16,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-    <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary
- add the missing SVG favicon and correct the dashboard favicon link order
- serve the apple touch icon from the daemon root assets list
- regenerate the committed static dashboard shell with the favicon updates

## Verification
- npx vite build