### PR TITLE
fix(guard): redact protect output

### DIFF
--- a/src/codex_plugin_scanner/guard/advisory_model.py
+++ b/src/codex_plugin_scanner/guard/advisory_model.py
@@ -1,0 +1,133 @@
+"""Guard advisory identity helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
+_PACKAGE_URL_ECOSYSTEMS = {
+    "npm": "npm",
+    "pnpm": "npm",
+    "yarn": "npm",
+    "pip": "pypi",
+    "uv": "pypi",
+    "go": "golang",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ProtectTargetIdentity:
+    """Subset of install target data advisory matching needs."""
+
+    artifact_id: str
+    artifact_name: str
+    ecosystem: str
+    package_name: str | None
+    package_url: str | None
+    source_url: str | None
+
+
+def build_package_url(ecosystem: str, package_name: str | None, version: str | None) -> str | None:
+    """Build a simple purl-style identifier for registry package installs."""
+
+    if package_name is None:
+        return None
+    purl_type = _PACKAGE_URL_ECOSYSTEMS.get(ecosystem)
+    if purl_type is None:
+        return None
+    base = f"pkg:{purl_type}/{normalize_identity_value(package_name)}"
+    if version is None or not version.strip():
+        return base
+    return f"{base}@{version.strip()}"
+
+
+def advisory_matches_target(advisory: dict[str, object], target: ProtectTargetIdentity) -> bool:
+    """Match advisories against install targets using stable identities first."""
+
+    advisory_id = advisory.get("artifact_id")
+    if isinstance(advisory_id, str) and advisory_id == target.artifact_id:
+        return True
+
+    advisory_ecosystem = advisory.get("ecosystem")
+    if isinstance(advisory_ecosystem, str) and advisory_ecosystem not in {target.ecosystem, "*"}:
+        return False
+
+    package_url = advisory.get("package_url")
+    if isinstance(package_url, str) and _package_url_matches(package_url, target.package_url):
+        return True
+
+    if _normalized_membership(advisory.get("aliases"), target.package_name, target.artifact_name):
+        return True
+
+    advisory_package = advisory.get("package") or advisory.get("name")
+    if isinstance(advisory_package, str) and normalize_identity_value(advisory_package) in {
+        normalize_identity_value(target.package_name),
+        normalize_identity_value(target.artifact_name),
+    }:
+        return True
+
+    publisher = advisory.get("publisher")
+    if (
+        isinstance(publisher, str)
+        and normalize_identity_value(publisher) == normalize_identity_value(target.package_name)
+    ):
+        return True
+
+    if _normalized_membership(advisory.get("publisher_identities"), target.package_name):
+        return True
+
+    if _endpoint_indicator_matches(advisory.get("endpoint_indicators"), target.source_url):
+        return True
+
+    advisory_source_url = advisory.get("source_url")
+    return isinstance(advisory_source_url, str) and _normalized_url_indicator(
+        advisory_source_url
+    ) == _normalized_url_indicator(target.source_url)
+
+
+def normalize_identity_value(value: str | None) -> str:
+    return value.strip().lower() if isinstance(value, str) and value.strip() else ""
+
+
+def _normalized_membership(values: object, *candidates: str | None) -> bool:
+    if not isinstance(values, list):
+        return False
+    normalized_values = {normalize_identity_value(item) for item in values if isinstance(item, str)}
+    normalized_candidates = {normalize_identity_value(candidate) for candidate in candidates if candidate is not None}
+    normalized_candidates.discard("")
+    return bool(normalized_values & normalized_candidates)
+
+
+def _package_url_matches(advisory_url: str, target_url: str | None) -> bool:
+    if target_url is None:
+        return False
+    normalized_advisory = _package_url_base(advisory_url)
+    normalized_target = _package_url_base(target_url)
+    return normalized_advisory != "" and normalized_advisory == normalized_target
+
+
+def _package_url_base(package_url: str) -> str:
+    normalized = normalize_identity_value(package_url)
+    if "@" not in normalized:
+        return normalized
+    return normalized.rsplit("@", 1)[0]
+
+
+def _endpoint_indicator_matches(values: object, source_url: str | None) -> bool:
+    if source_url is None or not isinstance(values, list):
+        return False
+    normalized_source = _normalized_url_indicator(source_url)
+    return any(
+        isinstance(item, str) and normalize_identity_value(item) and normalize_identity_value(item) in normalized_source
+        for item in values
+    )
+
+
+def _normalized_url_indicator(value: str | None) -> str:
+    if value is None:
+        return ""
+    parsed = urlsplit(value)
+    if not parsed.scheme or not parsed.netloc:
+        return normalize_identity_value(value)
+    path = parsed.path.rstrip("/")
+    return normalize_identity_value(f"{parsed.netloc}{path}")

--- a/src/codex_plugin_scanner/guard/advisory_model.py
+++ b/src/codex_plugin_scanner/guard/advisory_model.py
@@ -67,9 +67,8 @@ def advisory_matches_target(advisory: dict[str, object], target: ProtectTargetId
         return True
 
     publisher = advisory.get("publisher")
-    if (
-        isinstance(publisher, str)
-        and normalize_identity_value(publisher) == normalize_identity_value(target.package_name)
+    if isinstance(publisher, str) and normalize_identity_value(publisher) == normalize_identity_value(
+        target.package_name
     ):
         return True
 

--- a/src/codex_plugin_scanner/guard/advisory_model.py
+++ b/src/codex_plugin_scanner/guard/advisory_model.py
@@ -60,16 +60,18 @@ def advisory_matches_target(advisory: dict[str, object], target: ProtectTargetId
         return True
 
     advisory_package = advisory.get("package") or advisory.get("name")
-    if isinstance(advisory_package, str) and normalize_identity_value(advisory_package) in {
+    normalized_advisory_package = (
+        normalize_identity_value(advisory_package) if isinstance(advisory_package, str) else ""
+    )
+    if normalized_advisory_package != "" and normalized_advisory_package in {
         normalize_identity_value(target.package_name),
         normalize_identity_value(target.artifact_name),
     }:
         return True
 
     publisher = advisory.get("publisher")
-    if isinstance(publisher, str) and normalize_identity_value(publisher) == normalize_identity_value(
-        target.package_name
-    ):
+    normalized_publisher = normalize_identity_value(publisher) if isinstance(publisher, str) else ""
+    if normalized_publisher != "" and normalized_publisher == normalize_identity_value(target.package_name):
         return True
 
     if _normalized_membership(advisory.get("publisher_identities"), target.package_name):

--- a/src/codex_plugin_scanner/guard/advisory_model.py
+++ b/src/codex_plugin_scanner/guard/advisory_model.py
@@ -79,9 +79,16 @@ def advisory_matches_target(advisory: dict[str, object], target: ProtectTargetId
         return True
 
     advisory_source_url = advisory.get("source_url")
-    return isinstance(advisory_source_url, str) and _normalized_url_indicator(
-        advisory_source_url
-    ) == _normalized_url_indicator(target.source_url)
+    if not isinstance(advisory_source_url, str):
+        return False
+
+    normalized_advisory_source = _normalized_url_indicator(advisory_source_url)
+    normalized_target_source = _normalized_url_indicator(target.source_url)
+    return (
+        normalized_advisory_source != ""
+        and normalized_target_source != ""
+        and normalized_advisory_source == normalized_target_source
+    )
 
 
 def normalize_identity_value(value: str | None) -> str:
@@ -107,9 +114,12 @@ def _package_url_matches(advisory_url: str, target_url: str | None) -> bool:
 
 def _package_url_base(package_url: str) -> str:
     normalized = normalize_identity_value(package_url)
-    if "@" not in normalized:
+    for separator in ("?", "#"):
+        normalized = normalized.split(separator, 1)[0]
+    last_at = normalized.rfind("@")
+    if last_at == -1 or last_at < normalized.rfind("/"):
         return normalized
-    return normalized.rsplit("@", 1)[0]
+    return normalized[:last_at]
 
 
 def _endpoint_indicator_matches(values: object, source_url: str | None) -> bool:
@@ -117,7 +127,9 @@ def _endpoint_indicator_matches(values: object, source_url: str | None) -> bool:
         return False
     normalized_source = _normalized_url_indicator(source_url)
     return any(
-        isinstance(item, str) and normalize_identity_value(item) and normalize_identity_value(item) in normalized_source
+        isinstance(item, str)
+        and _normalized_url_indicator(item) != ""
+        and _normalized_url_indicator(item) in normalized_source
         for item in values
     )
 

--- a/src/codex_plugin_scanner/guard/advisory_model.py
+++ b/src/codex_plugin_scanner/guard/advisory_model.py
@@ -129,9 +129,7 @@ def _endpoint_indicator_matches(values: object, source_url: str | None) -> bool:
         return False
     normalized_source = _normalized_url_indicator(source_url)
     return any(
-        isinstance(item, str)
-        and _normalized_url_indicator(item) != ""
-        and _normalized_url_indicator(item) in normalized_source
+        isinstance(item, str) and _url_indicator_matches(normalized_source, _normalized_url_indicator(item))
         for item in values
     )
 
@@ -144,3 +142,9 @@ def _normalized_url_indicator(value: str | None) -> str:
         return normalize_identity_value(value)
     path = parsed.path.rstrip("/")
     return normalize_identity_value(f"{parsed.netloc}{path}")
+
+
+def _url_indicator_matches(normalized_source: str, normalized_indicator: str) -> bool:
+    if normalized_source == "" or normalized_indicator == "":
+        return False
+    return normalized_source == normalized_indicator or normalized_source.startswith(f"{normalized_indicator}/")

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -285,6 +285,7 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     )
     _add_guard_common_args(protect_parser)
     protect_parser.add_argument("--dry-run", action="store_true")
+    protect_parser.add_argument("--unsafe-raw-output", action="store_true")
     protect_parser.add_argument("--json", action="store_true")
     protect_parser.add_argument("protect_command", nargs=argparse.REMAINDER)
 
@@ -659,6 +660,7 @@ def run_guard_command(
             workspace_dir=workspace or Path.cwd(),
             dry_run=bool(getattr(args, "dry_run", False)),
             now=_now(),
+            unsafe_raw_output=bool(getattr(args, "unsafe_raw_output", False)),
         )
         _emit("protect", payload, getattr(args, "json", False))
         return exit_code

--- a/src/codex_plugin_scanner/guard/protect.py
+++ b/src/codex_plugin_scanner/guard/protect.py
@@ -12,8 +12,10 @@ from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
 
+from .advisory_model import ProtectTargetIdentity, advisory_matches_target, build_package_url
 from .models import GuardReceipt
 from .receipts import build_receipt
+from .redaction import redact_text
 from .store import GuardStore
 
 ProtectAction = Literal["allow", "review", "block"]
@@ -38,6 +40,7 @@ class ProtectTarget:
     artifact_type: str
     ecosystem: str
     package_name: str | None
+    package_url: str | None
     raw_spec: str | None
     version: str | None
     source_url: str | None
@@ -50,6 +53,7 @@ class ProtectTarget:
             "artifact_type": self.artifact_type,
             "ecosystem": self.ecosystem,
             "package_name": self.package_name,
+            "package_url": self.package_url,
             "raw_spec": self.raw_spec,
             "version": self.version,
             "source_url": self.source_url,
@@ -109,6 +113,7 @@ def build_protect_payload(
     workspace_dir: Path,
     dry_run: bool,
     now: str,
+    unsafe_raw_output: bool = False,
 ) -> tuple[dict[str, object], int]:
     """Evaluate and optionally execute an install command."""
 
@@ -151,11 +156,16 @@ def build_protect_payload(
         text=True,
         timeout=_protect_command_timeout_seconds(),
     )
+    redacted_stdout = redact_text(execution.stdout)
+    redacted_stderr = redact_text(execution.stderr)
     payload["executed"] = True
     payload["execution"] = {
         "returncode": execution.returncode,
-        "stdout": execution.stdout,
-        "stderr": execution.stderr,
+        "stdout": execution.stdout if unsafe_raw_output else redacted_stdout.text,
+        "stderr": execution.stderr if unsafe_raw_output else redacted_stderr.text,
+        "stdout_redactions": redacted_stdout.to_dict(),
+        "stderr_redactions": redacted_stderr.to_dict(),
+        "raw_output_enabled": unsafe_raw_output,
     }
     if execution.returncode == 0:
         store.add_receipt(receipt)
@@ -287,6 +297,7 @@ def _parse_codex_request(command: list[str]) -> ProtectRequest:
             artifact_type="mcp_server",
             ecosystem="codex",
             package_name=name,
+            package_url=None,
             raw_spec=name,
             version=None,
             source_url=_option_value(command, "--url"),
@@ -309,6 +320,7 @@ def _parse_claude_request(command: list[str]) -> ProtectRequest:
             artifact_type="mcp_server",
             ecosystem="claude-code",
             package_name=name,
+            package_url=None,
             raw_spec=command_or_url,
             version=None,
             source_url=command_or_url if command_or_url.startswith(("http://", "https://")) else None,
@@ -334,6 +346,7 @@ def _parse_cursor_request(command: list[str]) -> ProtectRequest:
             artifact_type="mcp_server",
             ecosystem="cursor",
             package_name=name,
+            package_url=None,
             raw_spec=name,
             version=None,
             source_url=_option_value(command, "--url"),
@@ -352,6 +365,7 @@ def _parse_gemini_request(command: list[str]) -> ProtectRequest:
             artifact_type="extension",
             ecosystem="gemini",
             package_name=name,
+            package_url=None,
             raw_spec=name,
             version=None,
             source_url=_option_value(command, "--url"),
@@ -372,6 +386,7 @@ def _parse_gemini_request(command: list[str]) -> ProtectRequest:
             artifact_type=artifact_type,
             ecosystem="gemini",
             package_name=name if artifact_type == "extension" else None,
+            package_url=build_package_url("gemini", name if artifact_type == "extension" else None, None),
             raw_spec=spec,
             version=None,
             source_url=_spec_url(spec),
@@ -389,6 +404,7 @@ def _parse_gemini_request(command: list[str]) -> ProtectRequest:
             artifact_type="mcp_server",
             ecosystem="gemini",
             package_name=name,
+            package_url=None,
             raw_spec=command_or_url,
             version=None,
             source_url=source_url,
@@ -407,6 +423,7 @@ def _parse_antigravity_request(command: list[str]) -> ProtectRequest:
             artifact_type="extension",
             ecosystem="antigravity",
             package_name=extension_name,
+            package_url=build_package_url("antigravity", extension_name, None),
             raw_spec=extension_name,
             version=None,
             source_url=_spec_url(extension_name),
@@ -429,6 +446,7 @@ def _parse_opencode_request(command: list[str]) -> ProtectRequest:
             artifact_type="plugin" if command[1] == "plugin" else "skill",
             ecosystem="opencode",
             package_name=name,
+            package_url=None,
             raw_spec=name,
             version=None,
             source_url=_option_value(command, "--url"),
@@ -446,6 +464,7 @@ def _parse_custom_request(command: list[str]) -> ProtectRequest:
         artifact_type="custom_command",
         ecosystem="custom",
         package_name=None,
+        package_url=None,
         raw_spec=shlex.join(command),
         version=None,
         source_url=_first_url(command),
@@ -464,6 +483,7 @@ def _package_manager_request(command: list[str], ecosystem: str, specs: tuple[st
                 artifact_type="package_request",
                 ecosystem=ecosystem,
                 package_name=None,
+                package_url=None,
                 raw_spec=shlex.join(command),
                 version=None,
                 source_url=_first_url(command),
@@ -483,6 +503,7 @@ def _package_target(ecosystem: str, spec: str) -> ProtectTarget:
         artifact_type=f"{ecosystem}_package",
         ecosystem=ecosystem,
         package_name=package_name,
+        package_url=build_package_url(ecosystem, package_name, version),
         raw_spec=spec,
         version=version,
         source_url=source_url,
@@ -613,6 +634,7 @@ def _parse_antigravity_mcp_target(raw_payload: str) -> ProtectTarget:
         artifact_type="mcp_server",
         ecosystem="antigravity",
         package_name=name,
+        package_url=None,
         raw_spec=raw_payload,
         version=None,
         source_url=source_url,
@@ -640,6 +662,7 @@ def _parse_claude_mcp_target(name: str, raw_payload: str) -> ProtectTarget:
         artifact_type="mcp_server",
         ecosystem="claude-code",
         package_name=name,
+        package_url=None,
         raw_spec=raw_payload,
         version=None,
         source_url=source_url,
@@ -670,17 +693,17 @@ def _matching_advisories(
 
 
 def _advisory_matches_target(advisory: dict[str, object], target: ProtectTarget) -> bool:
-    advisory_id = advisory.get("artifact_id")
-    if isinstance(advisory_id, str) and advisory_id == target.artifact_id:
-        return True
-    advisory_ecosystem = advisory.get("ecosystem")
-    if isinstance(advisory_ecosystem, str) and advisory_ecosystem not in {target.ecosystem, "*"}:
-        return False
-    advisory_package = advisory.get("package") or advisory.get("name")
-    if isinstance(advisory_package, str):
-        return advisory_package == target.package_name or advisory_package == target.artifact_name
-    advisory_publisher = advisory.get("publisher")
-    return isinstance(advisory_publisher, str) and advisory_publisher == target.package_name
+    return advisory_matches_target(
+        advisory,
+        ProtectTargetIdentity(
+            artifact_id=target.artifact_id,
+            artifact_name=target.artifact_name,
+            ecosystem=target.ecosystem,
+            package_name=target.package_name,
+            package_url=target.package_url,
+            source_url=target.source_url,
+        ),
+    )
 
 
 def _advisory_severity(advisory: dict[str, object]) -> SeverityLabel:

--- a/src/codex_plugin_scanner/guard/redaction.py
+++ b/src/codex_plugin_scanner/guard/redaction.py
@@ -1,0 +1,93 @@
+"""Output redaction helpers for Guard command payloads."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class RedactedText:
+    """Safe text plus minimal metadata about removed secrets."""
+
+    text: str
+    count: int
+    classifiers: tuple[str, ...]
+    original_sha256: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "count": self.count,
+            "classifiers": list(self.classifiers),
+            "original_sha256": self.original_sha256,
+        }
+
+
+_REDACTION_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...] = (
+    (
+        "bearer-token",
+        re.compile(r"(?i)\b(Bearer)\s+([A-Za-z0-9._\-]{8,})"),
+        r"\1 *****",
+    ),
+    (
+        "github-token",
+        re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{8,}\b"),
+        "gh*****",
+    ),
+    (
+        "aws-access-key",
+        re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+        "AKIA****************",
+    ),
+    (
+        "npm-token",
+        re.compile(r"(?im)\b(_authToken|npm[_ -]?token)\s*[:=]\s*([^\s]+)"),
+        r"\1=*****",
+    ),
+    (
+        "private-key",
+        re.compile(
+            r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
+            re.DOTALL,
+        ),
+        "-----BEGIN PRIVATE KEY-----\n*****\n-----END PRIVATE KEY-----",
+    ),
+    (
+        "secret-env",
+        re.compile(
+            r"(?im)^([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|KEY|CREDENTIAL)[A-Z0-9_]*)=(.+)$",
+        ),
+        r"\1=*****",
+    ),
+    (
+        "connection-env",
+        re.compile(r"(?im)^([A-Z0-9_]*(?:URL|URI|DSN))=([A-Za-z][A-Za-z0-9+.-]*://.+)$"),
+        r"\1=*****",
+    ),
+    (
+        "connection-string",
+        re.compile(r"\b(?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis|amqp)://[^\s]+", re.IGNORECASE),
+        "*****",
+    ),
+)
+
+
+def redact_text(value: str) -> RedactedText:
+    """Redact common secret-like values before Guard prints or syncs them."""
+
+    redacted_value = value
+    classifiers: list[str] = []
+    total_count = 0
+    for classifier, pattern, replacement in _REDACTION_PATTERNS:
+        redacted_value, match_count = pattern.subn(replacement, redacted_value)
+        if match_count == 0:
+            continue
+        classifiers.extend([classifier] * match_count)
+        total_count += match_count
+    return RedactedText(
+        text=redacted_value,
+        count=total_count,
+        classifiers=tuple(dict.fromkeys(classifiers)),
+        original_sha256=hashlib.sha256(value.encode("utf-8")).hexdigest(),
+    )

--- a/src/codex_plugin_scanner/guard/redaction.py
+++ b/src/codex_plugin_scanner/guard/redaction.py
@@ -56,14 +56,14 @@ _REDACTION_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...] = (
     (
         "secret-env",
         re.compile(
-            r"(?im)^([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|KEY|CREDENTIAL)[A-Z0-9_]*)=(.+)$",
+            r"(?im)^([ \t]*)([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|KEY|CREDENTIAL)[A-Z0-9_]*)=(.+)$",
         ),
-        r"\1=*****",
+        r"\1\2=*****",
     ),
     (
         "connection-env",
-        re.compile(r"(?im)^([A-Z0-9_]*(?:URL|URI|DSN))=([A-Za-z][A-Za-z0-9+.-]*://.+)$"),
-        r"\1=*****",
+        re.compile(r"(?im)^([ \t]*)([A-Z0-9_]*(?:URL|URI|DSN))=([A-Za-z][A-Za-z0-9+.-]*://.+)$"),
+        r"\1\2=*****",
     ),
     (
         "connection-string",

--- a/tests/test_guard_protect.py
+++ b/tests/test_guard_protect.py
@@ -787,6 +787,42 @@ class TestGuardProtect:
 
         assert advisory_matches_target(advisory, target) is False
 
+    def test_guard_protect_does_not_match_blank_package_advisory(self) -> None:
+        advisory = {
+            "id": "adv-blank-package",
+            "ecosystem": "*",
+            "package": "   ",
+            "action": "review",
+        }
+        target = ProtectTargetIdentity(
+            artifact_id="install:claude-code:mcp:remote-risk",
+            artifact_name="remote-risk",
+            ecosystem="claude-code",
+            package_name=None,
+            package_url=None,
+            source_url="https://evil.example/mcp",
+        )
+
+        assert advisory_matches_target(advisory, target) is False
+
+    def test_guard_protect_does_not_match_blank_publisher_advisory(self) -> None:
+        advisory = {
+            "id": "adv-blank-publisher",
+            "ecosystem": "*",
+            "publisher": "   ",
+            "action": "review",
+        }
+        target = ProtectTargetIdentity(
+            artifact_id="install:claude-code:mcp:remote-risk",
+            artifact_name="remote-risk",
+            ecosystem="claude-code",
+            package_name=None,
+            package_url=None,
+            source_url="https://evil.example/mcp",
+        )
+
+        assert advisory_matches_target(advisory, target) is False
+
     def test_guard_protect_redacts_indented_secret_and_connection_env_lines(self) -> None:
         output = redact_text("  API_TOKEN=super-secret-token\n\tDATABASE_URL=postgres://user:pass@db.internal/app\n")
 

--- a/tests/test_guard_protect.py
+++ b/tests/test_guard_protect.py
@@ -12,6 +12,8 @@ from typing import ClassVar
 
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard import protect
+from codex_plugin_scanner.guard.advisory_model import ProtectTargetIdentity, advisory_matches_target
+from codex_plugin_scanner.guard.redaction import redact_text
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -635,6 +637,46 @@ class TestGuardProtect:
         assert output["verdict"]["action"] == "block"
         assert output["matched_advisories"][0]["id"] == "adv-purl-block"
 
+    def test_guard_protect_matches_blocking_advisory_by_scoped_package_url(self, tmp_path, capsys) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir(parents=True)
+        store = GuardStore(home_dir)
+        store.cache_advisories(
+            [
+                {
+                    "id": "adv-purl-scoped-block",
+                    "ecosystem": "npm",
+                    "package_url": "pkg:npm/@scope/badpkg",
+                    "severity": "high",
+                    "action": "block",
+                    "headline": "Known scoped package URL match.",
+                }
+            ],
+            _now(),
+        )
+
+        rc = main(
+            [
+                "guard",
+                "protect",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+                "npm",
+                "install",
+                "@scope/badpkg@1.2.3",
+            ]
+        )
+
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 2
+        assert output["verdict"]["action"] == "block"
+        assert output["matched_advisories"][0]["id"] == "adv-purl-scoped-block"
+
     def test_guard_protect_matches_review_advisory_by_remote_endpoint_indicator(
         self,
         tmp_path,
@@ -680,6 +722,75 @@ class TestGuardProtect:
         assert rc == 2
         assert output["verdict"]["action"] == "review"
         assert output["matched_advisories"][0]["id"] == "adv-endpoint-review"
+
+    def test_guard_protect_matches_review_advisory_by_remote_endpoint_indicator_url(
+        self,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir(parents=True)
+        store = GuardStore(home_dir)
+        store.cache_advisories(
+            [
+                {
+                    "id": "adv-endpoint-url-review",
+                    "ecosystem": "claude-code",
+                    "endpoint_indicators": ["https://evil.example/mcp/"],
+                    "severity": "medium",
+                    "action": "review",
+                    "headline": "Known risky endpoint URL.",
+                }
+            ],
+            _now(),
+        )
+
+        rc = main(
+            [
+                "guard",
+                "protect",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+                "claude",
+                "mcp",
+                "add",
+                "remote-risk",
+                "https://evil.example/mcp",
+            ]
+        )
+
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 2
+        assert output["verdict"]["action"] == "review"
+        assert output["matched_advisories"][0]["id"] == "adv-endpoint-url-review"
+
+    def test_guard_protect_does_not_match_blank_source_url_advisory(self) -> None:
+        advisory = {
+            "id": "adv-blank-source",
+            "ecosystem": "npm",
+            "source_url": "   ",
+            "action": "review",
+        }
+        target = ProtectTargetIdentity(
+            artifact_id="install:npm:package:safe",
+            artifact_name="safe",
+            ecosystem="npm",
+            package_name="safe",
+            package_url="pkg:npm/safe",
+            source_url=None,
+        )
+
+        assert advisory_matches_target(advisory, target) is False
+
+    def test_guard_protect_redacts_indented_secret_and_connection_env_lines(self) -> None:
+        output = redact_text("  API_TOKEN=super-secret-token\n\tDATABASE_URL=postgres://user:pass@db.internal/app\n")
+
+        assert output.text == "  API_TOKEN=*****\n\tDATABASE_URL=*****\n"
 
     def test_guard_store_keeps_distinct_advisories_without_ids(self, tmp_path) -> None:
         store = GuardStore(tmp_path / "guard-home")

--- a/tests/test_guard_protect.py
+++ b/tests/test_guard_protect.py
@@ -109,6 +109,54 @@ class TestGuardProtect:
         assert output["execution"]["returncode"] == 0
         assert output_path.read_text(encoding="utf-8") == "ok"
 
+    def test_guard_protect_redacts_execution_output_before_json_payload(
+        self,
+        tmp_path,
+        capsys,
+        monkeypatch,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir(parents=True)
+        stdout_value = "Bearer sk-live-secret-token\nDATABASE_URL=postgres://user:pass@db.internal/app\n"
+        stderr_value = "npm token=npm_super_secret_value\n"
+
+        def fake_run(*args, **kwargs) -> CompletedProcess[str]:
+            return CompletedProcess(
+                args[0],
+                0,
+                stdout=stdout_value,
+                stderr=stderr_value,
+            )
+
+        monkeypatch.setattr(protect.subprocess, "run", fake_run)
+
+        rc = main(
+            [
+                "guard",
+                "protect",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+                sys.executable,
+                "-c",
+                "print('ok')",
+            ]
+        )
+
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["execution"]["stdout"] != stdout_value
+        assert output["execution"]["stderr"] != stderr_value
+        assert "sk-live-secret-token" not in output["execution"]["stdout"]
+        assert "postgres://user:pass@db.internal/app" not in output["execution"]["stdout"]
+        assert "npm_super_secret_value" not in output["execution"]["stderr"]
+        assert output["execution"]["stdout_redactions"]["count"] >= 2
+        assert output["execution"]["stderr_redactions"]["count"] >= 1
+
     def test_guard_protect_does_not_persist_allow_receipt_when_execution_fails(
         self,
         tmp_path,
@@ -546,6 +594,92 @@ class TestGuardProtect:
         assert rc == 2
         assert output["verdict"]["action"] == "block"
         assert any(item["id"] == "adv-block-tail" for item in output["matched_advisories"])
+
+    def test_guard_protect_matches_blocking_advisory_by_package_url(self, tmp_path, capsys) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir(parents=True)
+        store = GuardStore(home_dir)
+        store.cache_advisories(
+            [
+                {
+                    "id": "adv-purl-block",
+                    "ecosystem": "npm",
+                    "package_url": "pkg:npm/badpkg",
+                    "severity": "high",
+                    "action": "block",
+                    "headline": "Known package URL match.",
+                }
+            ],
+            _now(),
+        )
+
+        rc = main(
+            [
+                "guard",
+                "protect",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+                "npm",
+                "install",
+                "badpkg@1.2.3",
+            ]
+        )
+
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 2
+        assert output["verdict"]["action"] == "block"
+        assert output["matched_advisories"][0]["id"] == "adv-purl-block"
+
+    def test_guard_protect_matches_review_advisory_by_remote_endpoint_indicator(
+        self,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir(parents=True)
+        store = GuardStore(home_dir)
+        store.cache_advisories(
+            [
+                {
+                    "id": "adv-endpoint-review",
+                    "ecosystem": "claude-code",
+                    "endpoint_indicators": ["evil.example/mcp"],
+                    "severity": "medium",
+                    "action": "review",
+                    "headline": "Known risky endpoint.",
+                }
+            ],
+            _now(),
+        )
+
+        rc = main(
+            [
+                "guard",
+                "protect",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+                "claude",
+                "mcp",
+                "add",
+                "remote-risk",
+                "https://evil.example/mcp",
+            ]
+        )
+
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 2
+        assert output["verdict"]["action"] == "review"
+        assert output["matched_advisories"][0]["id"] == "adv-endpoint-review"
 
     def test_guard_store_keeps_distinct_advisories_without_ids(self, tmp_path) -> None:
         store = GuardStore(tmp_path / "guard-home")

--- a/tests/test_guard_protect.py
+++ b/tests/test_guard_protect.py
@@ -823,6 +823,51 @@ class TestGuardProtect:
 
         assert advisory_matches_target(advisory, target) is False
 
+    def test_guard_protect_matches_endpoint_indicators_on_url_boundaries(self) -> None:
+        advisory = {
+            "id": "adv-endpoint-boundary",
+            "ecosystem": "claude-code",
+            "endpoint_indicators": ["evil.example/mcp"],
+            "action": "review",
+        }
+        exact_target = ProtectTargetIdentity(
+            artifact_id="install:claude-code:mcp:exact",
+            artifact_name="exact",
+            ecosystem="claude-code",
+            package_name=None,
+            package_url=None,
+            source_url="https://evil.example/mcp",
+        )
+        child_target = ProtectTargetIdentity(
+            artifact_id="install:claude-code:mcp:child",
+            artifact_name="child",
+            ecosystem="claude-code",
+            package_name=None,
+            package_url=None,
+            source_url="https://evil.example/mcp/subpath",
+        )
+        sibling_target = ProtectTargetIdentity(
+            artifact_id="install:claude-code:mcp:sibling",
+            artifact_name="sibling",
+            ecosystem="claude-code",
+            package_name=None,
+            package_url=None,
+            source_url="https://evil.example/mcp-backup",
+        )
+        prefix_target = ProtectTargetIdentity(
+            artifact_id="install:claude-code:mcp:prefix",
+            artifact_name="prefix",
+            ecosystem="claude-code",
+            package_name=None,
+            package_url=None,
+            source_url="https://safe-evil.example/mcp",
+        )
+
+        assert advisory_matches_target(advisory, exact_target) is True
+        assert advisory_matches_target(advisory, child_target) is True
+        assert advisory_matches_target(advisory, sibling_target) is False
+        assert advisory_matches_target(advisory, prefix_target) is False
+
     def test_guard_protect_redacts_indented_secret_and_connection_env_lines(self) -> None:
         output = redact_text("  API_TOKEN=super-secret-token\n\tDATABASE_URL=postgres://user:pass@db.internal/app\n")
 


### PR DESCRIPTION
## Summary
- redact install-time protect stdout/stderr by default while preserving optional raw debug output
- match advisories by package URL and remote endpoint indicators instead of package name only
- add focused regressions for protect payload leakage and richer advisory identity matching

## Verification
- uv run ruff check .
- uv run pytest tests/test_guard_protect.py -q
- uv build