### PR TITLE
fix(guard): enforce Codex runtime risk hooks

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -203,11 +203,7 @@ def _is_managed_hook_command(command: object) -> bool:
         and re.search(r"['\"]--harness['\"]", code) is not None
         and re.search(r"['\"]codex['\"]", code) is not None
     )
-    return (
-        "codex_plugin_scanner.cli" in code
-        and "main([" in code
-        and has_guard_call
-    )
+    return "codex_plugin_scanner.cli" in code and "main([" in code and has_guard_call
 
 
 def _argv_targets_codex(argv: list[str]) -> bool:

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import shlex
 import sys
 from copy import deepcopy
@@ -43,11 +44,13 @@ def _read_toml(path: Path) -> dict[str, object]:
 _MANAGED_HOOK_STATUS_MESSAGE = "HOL Guard checking tool action"
 _MANAGED_PROMPT_HOOK_STATUS_MESSAGE = "HOL Guard checking prompt"
 _MANAGED_PERMISSION_HOOK_STATUS_MESSAGE = "HOL Guard checking Codex approval request"
+_MANAGED_POST_TOOL_HOOK_STATUS_MESSAGE = "HOL Guard checking tool result"
 _LEGACY_MANAGED_HOOK_STATUS_MESSAGES = {
     "HOL Guard checking Bash command",
     _MANAGED_HOOK_STATUS_MESSAGE,
     _MANAGED_PROMPT_HOOK_STATUS_MESSAGE,
     _MANAGED_PERMISSION_HOOK_STATUS_MESSAGE,
+    _MANAGED_POST_TOOL_HOOK_STATUS_MESSAGE,
 }
 
 
@@ -113,7 +116,7 @@ def _pre_tool_hook_group(context: HarnessContext) -> dict[str, object]:
             {
                 "type": "command",
                 "command": _hook_command(context),
-                "timeoutSec": 30,
+                "timeout": 30,
                 "statusMessage": _MANAGED_HOOK_STATUS_MESSAGE,
             }
         ],
@@ -126,7 +129,7 @@ def _prompt_hook_group(context: HarnessContext) -> dict[str, object]:
             {
                 "type": "command",
                 "command": _hook_command(context),
-                "timeoutSec": 30,
+                "timeout": 30,
                 "statusMessage": _MANAGED_PROMPT_HOOK_STATUS_MESSAGE,
             }
         ],
@@ -140,8 +143,22 @@ def _permission_request_hook_group(context: HarnessContext) -> dict[str, object]
             {
                 "type": "command",
                 "command": _hook_command(context),
-                "timeoutSec": 30,
+                "timeout": 30,
                 "statusMessage": _MANAGED_PERMISSION_HOOK_STATUS_MESSAGE,
+            }
+        ],
+    }
+
+
+def _post_tool_hook_group(context: HarnessContext) -> dict[str, object]:
+    return {
+        "matcher": "Bash",
+        "hooks": [
+            {
+                "type": "command",
+                "command": _hook_command(context),
+                "timeout": 30,
+                "statusMessage": _MANAGED_POST_TOOL_HOOK_STATUS_MESSAGE,
             }
         ],
     }
@@ -152,6 +169,7 @@ def _managed_hook_groups(context: HarnessContext) -> dict[str, dict[str, object]
         "PreToolUse": _pre_tool_hook_group(context),
         "PermissionRequest": _permission_request_hook_group(context),
         "UserPromptSubmit": _prompt_hook_group(context),
+        "PostToolUse": _post_tool_hook_group(context),
     }
 
 
@@ -179,13 +197,16 @@ def _is_managed_hook_command(command: object) -> bool:
     if tokens[1] != "-c":
         return False
     code = tokens[2]
+    has_guard_call = (
+        re.search(r"['\"]guard['\"]", code) is not None
+        and re.search(r"['\"]hook['\"]", code) is not None
+        and re.search(r"['\"]--harness['\"]", code) is not None
+        and re.search(r"['\"]codex['\"]", code) is not None
+    )
     return (
         "codex_plugin_scanner.cli" in code
         and "main([" in code
-        and "'guard'" in code
-        and "'hook'" in code
-        and "'--harness'" in code
-        and "'codex'" in code
+        and has_guard_call
     )
 
 
@@ -249,7 +270,7 @@ def _remove_hook_groups(groups: object) -> list[object]:
 def _remove_managed_hook_events(hooks: dict[str, object]) -> tuple[dict[str, object], bool]:
     updated_hooks = dict(hooks)
     changed = False
-    for event_name in ("PreToolUse", "PermissionRequest", "UserPromptSubmit"):
+    for event_name in ("PreToolUse", "PermissionRequest", "UserPromptSubmit", "PostToolUse"):
         original_groups = deepcopy(updated_hooks.get(event_name))
         remaining = _remove_hook_groups(original_groups)
         managed_removed = isinstance(original_groups, list) and remaining != original_groups
@@ -273,6 +294,7 @@ def codex_native_hook_state(context: HarnessContext) -> dict[str, object]:
     pre_tool_groups = hooks.get("PreToolUse") if isinstance(hooks, dict) else None
     permission_groups = hooks.get("PermissionRequest") if isinstance(hooks, dict) else None
     prompt_groups = hooks.get("UserPromptSubmit") if isinstance(hooks, dict) else None
+    post_tool_groups = hooks.get("PostToolUse") if isinstance(hooks, dict) else None
     pre_tool_hook_installed = isinstance(pre_tool_groups, list) and any(
         _is_managed_hook_group(group) for group in pre_tool_groups
     )
@@ -282,7 +304,12 @@ def codex_native_hook_state(context: HarnessContext) -> dict[str, object]:
     prompt_hook_installed = isinstance(prompt_groups, list) and any(
         _is_managed_hook_group(group) for group in prompt_groups
     )
-    managed_hook_installed = pre_tool_hook_installed and permission_hook_installed and prompt_hook_installed
+    post_tool_hook_installed = isinstance(post_tool_groups, list) and any(
+        _is_managed_hook_group(group) for group in post_tool_groups
+    )
+    managed_hook_installed = (
+        pre_tool_hook_installed and permission_hook_installed and prompt_hook_installed and post_tool_hook_installed
+    )
     return {
         "config_path": str(config_path),
         "config_present": config_path.is_file(),
@@ -292,6 +319,7 @@ def codex_native_hook_state(context: HarnessContext) -> dict[str, object]:
         "managed_pre_tool_hook_installed": pre_tool_hook_installed,
         "managed_permission_request_hook_installed": permission_hook_installed,
         "managed_prompt_hook_installed": prompt_hook_installed,
+        "managed_post_tool_hook_installed": post_tool_hook_installed,
         "managed_hook_installed": managed_hook_installed,
         "protection_active": isinstance(features, dict)
         and features.get("codex_hooks") is True

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1419,11 +1419,13 @@ def run_guard_command(
             artifact_id = runtime_artifact.artifact_id
             artifact_name = runtime_artifact.name
             policy_harness = _canonical_harness_name(args.harness)
-            stored_policy_action = store.resolve_policy(
-                policy_harness,
-                artifact_id,
-                runtime_artifact_hash,
-                str(runtime_workspace) if runtime_workspace else None,
+            stored_policy_action = _runtime_stored_policy_action(
+                store=store,
+                harness=policy_harness,
+                artifact=runtime_artifact,
+                artifact_id=artifact_id,
+                artifact_hash=runtime_artifact_hash,
+                workspace=str(runtime_workspace) if runtime_workspace else None,
             )
             if stored_policy_action is None:
                 legacy_artifact = _legacy_claude_alias_runtime_artifact(
@@ -1433,11 +1435,13 @@ def run_guard_command(
                     workspace=runtime_workspace,
                 )
                 if legacy_artifact is not None:
-                    stored_policy_action = store.resolve_policy(
-                        args.harness,
-                        legacy_artifact.artifact_id,
-                        artifact_hash(legacy_artifact),
-                        str(runtime_workspace) if runtime_workspace else None,
+                    stored_policy_action = _runtime_stored_policy_action(
+                        store=store,
+                        harness=args.harness,
+                        artifact=legacy_artifact,
+                        artifact_id=legacy_artifact.artifact_id,
+                        artifact_hash=artifact_hash(legacy_artifact),
+                        workspace=str(runtime_workspace) if runtime_workspace else None,
                     )
             policy_action = _coalesce_string(
                 getattr(args, "policy_action", None),
@@ -2771,6 +2775,37 @@ def _native_approval_center_context(response_payload: dict[str, object], *, harn
     )
 
 
+def _runtime_stored_policy_action(
+    *,
+    store: GuardStore,
+    harness: str,
+    artifact: GuardArtifact,
+    artifact_id: str,
+    artifact_hash: str,
+    workspace: str | None,
+) -> str | None:
+    decision = store.resolve_policy_decision(
+        harness,
+        artifact_id,
+        artifact_hash,
+        workspace,
+        artifact.publisher,
+    )
+    if decision is None:
+        return None
+    action = _optional_string(decision.get("action"))
+    if action is None:
+        return None
+    scope = _optional_string(decision.get("scope"))
+    if (
+        action in {"allow", "warn", "review"}
+        and scope in {"publisher", "harness", "global"}
+        and _runtime_artifact_risk_classes(artifact)
+    ):
+        return None
+    return action
+
+
 def _runtime_artifact_policy_action(config: GuardConfig, artifact: GuardArtifact, harness: str) -> str:
     if _prompt_requires_hard_block(artifact):
         return "block"
@@ -2933,6 +2968,13 @@ def _runtime_artifact_native_reason(artifact: GuardArtifact, response_payload: d
         harness = response_payload.get("harness")
         prompt_classes = _prompt_request_classes(artifact)
         if harness == "codex" and "secret_read" in prompt_classes:
+            prompt_summary = artifact.metadata.get("prompt_summary")
+            if isinstance(prompt_summary, str) and "credential-looking local file" in prompt_summary:
+                return (
+                    "HOL Guard stopped this Codex prompt before Codex could open a credential-looking local file. "
+                    "Codex does not expose native approval prompts for Read-tool file reads, so Guard blocks this "
+                    "request at prompt time."
+                )
             return (
                 "HOL Guard stopped this Codex prompt before Codex could open a sensitive local file. Codex does not "
                 "expose native approval prompts for Read-tool file reads, so Guard blocks this request at prompt time."
@@ -3163,6 +3205,13 @@ def _emit_native_hook_response(
             }
         if payload:
             _write_json_line(payload, output_stream=output_stream)
+        return
+    if event_name == "PostToolUse" and policy_action in {"block", "sandbox-required", "require-reapproval"}:
+        payload["decision"] = "block"
+        payload["reason"] = reason
+        payload["continue"] = False
+        payload["stopReason"] = reason
+        _write_json_line(payload, output_stream=output_stream)
         return
     permission_decision = _native_hook_permission_decision(policy_action, harness=harness)
     if harness == "codex" and event_name == "PreToolUse" and permission_decision is None:
@@ -3594,6 +3643,14 @@ def _hook_runtime_artifact(
 ) -> GuardArtifact | None:
     harness = _canonical_harness_name(harness)
     event_name = _hook_event_name(payload)
+    if harness == "codex" and event_name == "PostToolUse":
+        output_artifact = _codex_post_tool_output_artifact(
+            payload=payload,
+            config_path=str(_runtime_policy_path(harness, home_dir, workspace)),
+            source_scope=_coalesce_string(payload.get("source_scope"), "project"),
+        )
+        if output_artifact is not None:
+            return output_artifact
     if event_name == "UserPromptSubmit":
         prompt_text = payload.get("prompt")
         if isinstance(prompt_text, str) and prompt_text.strip():
@@ -3619,6 +3676,13 @@ def _hook_runtime_artifact(
                 )
                 if prompt_artifacts:
                     return _merged_prompt_runtime_artifact(harness, prompt_artifacts)
+            prompt_file_artifact = _codex_prompt_credential_file_artifact(
+                prompt_text=prompt_text,
+                cwd=workspace,
+                config_path=config_path,
+            )
+            if prompt_file_artifact is not None:
+                return prompt_file_artifact
     request = extract_sensitive_file_read_request(
         payload.get("tool_name"),
         payload.get("tool_input", payload.get("arguments")),
@@ -3648,6 +3712,174 @@ def _hook_runtime_artifact(
         config_path=config_path,
         source_scope=source_scope,
     )
+
+
+_CODEX_SECRET_OUTPUT_PATTERN = re.compile(
+    r"(?i)(?:fake[_-]?credential|fake[_-]?secret|"
+    r"(?:api[_-]?key|auth[_-]?token|credential|npm[_-]?token|private[_-]?key|secret|token|password)\\s*[:=])"
+)
+
+
+def _codex_post_tool_output_artifact(
+    *,
+    payload: dict[str, object],
+    config_path: str,
+    source_scope: str,
+) -> GuardArtifact | None:
+    response_text = _collect_codex_tool_response_text(payload.get("tool_response"))
+    if not response_text or _CODEX_SECRET_OUTPUT_PATTERN.search(response_text) is None:
+        return None
+    tool_name = _coalesce_string(payload.get("tool_name"), "Bash")
+    tool_input = payload.get("tool_input")
+    command_text = ""
+    if isinstance(tool_input, dict):
+        command = tool_input.get("command")
+        if isinstance(command, str):
+            command_text = command.strip()
+    if not command_text:
+        command_text = tool_name
+    fingerprint = hashlib.sha256(
+        json.dumps(
+            {
+                "tool_name": tool_name,
+                "command_text": command_text,
+                "output_class": "credential-looking output",
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+    ).hexdigest()
+    return GuardArtifact(
+        artifact_id=f"codex:{source_scope}:tool-output:{fingerprint}",
+        name=f"{tool_name} credential-looking output",
+        harness="codex",
+        artifact_type="tool_action_request",
+        source_scope=source_scope,
+        config_path=config_path,
+        metadata={
+            "tool_name": tool_name,
+            "command_text": command_text,
+            "action_class": "credential exfiltration shell command",
+            "request_summary": (
+                f"Codex tool `{tool_name}` produced credential-looking output while running `{command_text}`."
+            ),
+            "runtime_request_signals": ["tool output contains credential-looking material"],
+            "runtime_request_summary": (
+                "Requests a sensitive native tool action: credential-looking output reached Codex."
+            ),
+            "runtime_request_reason": (
+                "Guard inspects supported Codex tool output before Codex uses it, so accidental secret reads can be "
+                "stopped even when the filename was not obviously sensitive."
+            ),
+        },
+    )
+
+
+def _collect_codex_tool_response_text(value: object, *, depth: int = 0) -> str:
+    if depth > 5:
+        return ""
+    if isinstance(value, str):
+        return value[:20000]
+    if isinstance(value, dict):
+        parts: list[str] = []
+        for key, child in value.items():
+            key_text = str(key).lower()
+            if key_text in {"stdout", "stderr", "output", "text", "content", "result", "message"} or depth > 0:
+                text = _collect_codex_tool_response_text(child, depth=depth + 1)
+                if text:
+                    parts.append(text)
+        return "\n".join(parts)[:20000]
+    if isinstance(value, list):
+        return "\n".join(_collect_codex_tool_response_text(item, depth=depth + 1) for item in value)[:20000]
+    return ""
+
+
+_PROMPT_PATH_TOKEN_PATTERN = re.compile(
+    r"(?P<path>(?:~|\.{1,2}|/)[A-Za-z0-9_./@%+=:,~-]*\.[A-Za-z0-9_.-]+|"
+    r"(?<![\w/.-])\.[A-Za-z0-9][A-Za-z0-9_.-]*)"
+)
+_PROMPT_FILE_READ_VERB_PATTERN = re.compile(r"\b(?:read|open|print|show|dump|cat|head|tail|less|view|display)\b", re.I)
+_PROMPT_CONTENT_SCAN_MAX_BYTES = 64 * 1024
+_PROMPT_CONTENT_SCAN_SKIP_BASENAMES = frozenset(
+    {
+        ".env",
+        ".npmrc",
+        ".pypirc",
+        ".netrc",
+        ".git-credentials",
+    }
+)
+
+
+def _codex_prompt_credential_file_artifact(
+    *,
+    prompt_text: str,
+    cwd: Path | None,
+    config_path: str,
+) -> GuardArtifact | None:
+    if _PROMPT_FILE_READ_VERB_PATTERN.search(prompt_text) is None:
+        return None
+    for match in _PROMPT_PATH_TOKEN_PATTERN.finditer(prompt_text):
+        requested_path = match.group("path")
+        path = _resolve_prompt_scan_path(requested_path, cwd=cwd)
+        if path is None or path.name in _PROMPT_CONTENT_SCAN_SKIP_BASENAMES:
+            continue
+        if not path.name.startswith("."):
+            continue
+        if not path.is_file():
+            continue
+        try:
+            content = path.read_bytes()[:_PROMPT_CONTENT_SCAN_MAX_BYTES].decode("utf-8", errors="ignore")
+        except OSError:
+            continue
+        if _CODEX_SECRET_OUTPUT_PATTERN.search(content) is None:
+            continue
+        normalized_path = str(path)
+        fingerprint = hashlib.sha256(
+            json.dumps(
+                {
+                    "harness": "codex",
+                    "prompt_path": normalized_path,
+                    "content_class": "credential-looking local file",
+                },
+                sort_keys=True,
+            ).encode("utf-8")
+        ).hexdigest()[:24]
+        return GuardArtifact(
+            artifact_id=f"codex:project:prompt-file:{fingerprint}",
+            name=f"credential-looking local file {path.name}",
+            harness="codex",
+            artifact_type="prompt_request",
+            source_scope="project",
+            config_path=config_path,
+            metadata={
+                "prompt_signals": ["requested file content contains credential-looking material"],
+                "prompt_summary": "Prompt asks Codex to read a credential-looking local file.",
+                "prompt_matched_text": requested_path,
+                "prompt_request_class": "secret_read",
+                "prompt_request_classes": ["secret_read"],
+                "runtime_request_summary": "Prompt requests direct access to a credential-looking local file.",
+                "runtime_request_reason": (
+                    "Guard scanned a small local dotfile before Codex read it and found credential-looking text."
+                ),
+                "normalized_path": normalized_path,
+            },
+        )
+    return None
+
+
+def _resolve_prompt_scan_path(requested_path: str, *, cwd: Path | None) -> Path | None:
+    stripped = requested_path.strip().strip("'\"")
+    if not stripped:
+        return None
+    try:
+        expanded = Path(stripped).expanduser()
+    except RuntimeError:
+        return None
+    if not expanded.is_absolute():
+        expanded = (cwd or Path.cwd()) / expanded
+    with suppress(OSError):
+        return expanded.resolve(strict=False)
+    return expanded
 
 
 def _legacy_claude_alias_runtime_artifact(

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3874,7 +3874,7 @@ def _codex_prompt_credential_file_artifact(
 
 
 def _resolve_prompt_scan_path(requested_path: str, *, cwd: Path | None) -> Path | None:
-    stripped = requested_path.strip().strip("'\"")
+    stripped = requested_path.strip().strip("'\"").rstrip(".,;:!?)]}")
     if not stripped:
         return None
     try:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3833,7 +3833,8 @@ def _codex_prompt_credential_file_artifact(
         if not path.is_file():
             continue
         try:
-            content = path.read_bytes()[:_PROMPT_CONTENT_SCAN_MAX_BYTES].decode("utf-8", errors="ignore")
+            with path.open("rb") as handle:
+                content = handle.read(_PROMPT_CONTENT_SCAN_MAX_BYTES).decode("utf-8", errors="ignore")
         except OSError:
             continue
         if _CODEX_SECRET_OUTPUT_PATTERN.search(content) is None:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3716,8 +3716,11 @@ def _hook_runtime_artifact(
 
 _CODEX_SECRET_OUTPUT_PATTERN = re.compile(
     r"(?i)(?:fake[_-]?credential|fake[_-]?secret|"
-    r"(?:api[_-]?key|auth[_-]?token|credential|npm[_-]?token|private[_-]?key|secret|token|password)\\s*[:=])"
+    r"(?:api[_-]?key|auth[_-]?token|credential|npm[_-]?token|private[_-]?key|secret|token|password)\s*[:=])"
 )
+_CODEX_TOOL_RESPONSE_MAX_DEPTH = 5
+_CODEX_TOOL_RESPONSE_TEXT_LIMIT = 20000
+_CODEX_PROMPT_FILE_FINGERPRINT_LENGTH = 24
 
 
 def _codex_post_tool_output_artifact(
@@ -3775,10 +3778,10 @@ def _codex_post_tool_output_artifact(
 
 
 def _collect_codex_tool_response_text(value: object, *, depth: int = 0) -> str:
-    if depth > 5:
+    if depth > _CODEX_TOOL_RESPONSE_MAX_DEPTH:
         return ""
     if isinstance(value, str):
-        return value[:20000]
+        return value[:_CODEX_TOOL_RESPONSE_TEXT_LIMIT]
     if isinstance(value, dict):
         parts: list[str] = []
         for key, child in value.items():
@@ -3787,15 +3790,17 @@ def _collect_codex_tool_response_text(value: object, *, depth: int = 0) -> str:
                 text = _collect_codex_tool_response_text(child, depth=depth + 1)
                 if text:
                     parts.append(text)
-        return "\n".join(parts)[:20000]
+        return "\n".join(parts)[:_CODEX_TOOL_RESPONSE_TEXT_LIMIT]
     if isinstance(value, list):
-        return "\n".join(_collect_codex_tool_response_text(item, depth=depth + 1) for item in value)[:20000]
+        return "\n".join(_collect_codex_tool_response_text(item, depth=depth + 1) for item in value)[
+            :_CODEX_TOOL_RESPONSE_TEXT_LIMIT
+        ]
     return ""
 
 
 _PROMPT_PATH_TOKEN_PATTERN = re.compile(
-    r"(?P<path>(?:~|\.{1,2}|/)[A-Za-z0-9_./@%+=:,~-]*\.[A-Za-z0-9_.-]+|"
-    r"(?<![\w/.-])\.[A-Za-z0-9][A-Za-z0-9_.-]*)"
+    r"(?<![\w/.-])\.[A-Za-z0-9][A-Za-z0-9_.-]{0,255}|"
+    r"(?:~|\.{1,2}|/)[^\s'\"`<>|;(){}\[\]]{0,255}"
 )
 _PROMPT_FILE_READ_VERB_PATTERN = re.compile(r"\b(?:read|open|print|show|dump|cat|head|tail|less|view|display)\b", re.I)
 _PROMPT_CONTENT_SCAN_MAX_BYTES = 64 * 1024
@@ -3819,7 +3824,7 @@ def _codex_prompt_credential_file_artifact(
     if _PROMPT_FILE_READ_VERB_PATTERN.search(prompt_text) is None:
         return None
     for match in _PROMPT_PATH_TOKEN_PATTERN.finditer(prompt_text):
-        requested_path = match.group("path")
+        requested_path = match.group(0)
         path = _resolve_prompt_scan_path(requested_path, cwd=cwd)
         if path is None or path.name in _PROMPT_CONTENT_SCAN_SKIP_BASENAMES:
             continue
@@ -3843,7 +3848,7 @@ def _codex_prompt_credential_file_artifact(
                 },
                 sort_keys=True,
             ).encode("utf-8")
-        ).hexdigest()[:24]
+        ).hexdigest()[:_CODEX_PROMPT_FILE_FINGERPRINT_LENGTH]
         return GuardArtifact(
             artifact_id=f"codex:project:prompt-file:{fingerprint}",
             name=f"credential-looking local file {path.name}",

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2799,7 +2799,7 @@ def _runtime_stored_policy_action(
     scope = _optional_string(decision.get("scope"))
     if (
         action in {"allow", "warn", "review"}
-        and scope in {"publisher", "harness", "global"}
+        and scope in {"workspace", "publisher", "harness", "global"}
         and _runtime_artifact_risk_classes(artifact)
     ):
         return None

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1170,11 +1170,31 @@ class GuardStore:
         publisher: str | None = None,
         now: str | None = None,
     ) -> str | None:
+        decision = self.resolve_policy_decision(
+            harness,
+            artifact_id,
+            artifact_hash,
+            workspace,
+            publisher,
+            now,
+        )
+        return str(decision["action"]) if decision is not None else None
+
+    def resolve_policy_decision(
+        self,
+        harness: str,
+        artifact_id: str | None,
+        artifact_hash: str | None = None,
+        workspace: str | None = None,
+        publisher: str | None = None,
+        now: str | None = None,
+    ) -> dict[str, str | None] | None:
         current_time = now or _now()
         with self._connect() as connection:
             rows = connection.execute(
                 """
-                select scope, action, artifact_hash from policy_decisions
+                select harness, scope, artifact_id, action, artifact_hash, workspace, publisher, source
+                from policy_decisions
                 where (harness = ? or harness = '*') and (
                   (
                     scope = 'artifact' and artifact_id = ? and (
@@ -1193,7 +1213,19 @@ class GuardStore:
                 """,
                 (harness, artifact_id, artifact_hash, artifact_hash, workspace, publisher, current_time),
             ).fetchall()
-        return str(rows[0]["action"]) if rows else None
+        if not rows:
+            return None
+        row = rows[0]
+        return {
+            "harness": row["harness"],
+            "scope": row["scope"],
+            "artifact_id": row["artifact_id"],
+            "artifact_hash": row["artifact_hash"],
+            "workspace": row["workspace"],
+            "publisher": row["publisher"],
+            "action": row["action"],
+            "source": row["source"],
+        }
 
     @staticmethod
     def _normalized_policy_keys(decision: PolicyDecision) -> tuple[str | None, str | None, str | None, str | None]:

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import subprocess
+import sys
 from pathlib import Path
 
 try:
@@ -269,6 +271,85 @@ def test_guard_install_codex_migrates_legacy_bash_only_managed_hook(tmp_path, ca
     assert hooks_payload["hooks"]["PreToolUse"][0]["matcher"] == "Bash"
     assert hooks_payload["hooks"]["PreToolUse"][0]["hooks"][0]["statusMessage"] == "HOL Guard checking tool action"
     assert len(hooks_payload["hooks"]["UserPromptSubmit"]) == 1
+
+
+def test_guard_install_codex_migrates_stale_python_c_managed_hooks(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    stale_worktree = tmp_path / "deleted-worktree"
+    _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
+    stale_command = (
+        f"{sys.executable} -c "
+        + shlex.quote(
+            "import sys;"
+            f"sys.path[:0]=[{str(stale_worktree / 'src')!r}];"
+            "from codex_plugin_scanner.cli import main;"
+            "raise SystemExit(main(["
+            '"guard", "hook", "--guard-home", '
+            f"{str(home_dir / '.hol-guard')!r}, "
+            '"--harness", "codex"'
+            "]))"
+        )
+    )
+    _write_text(
+        workspace_dir / ".codex" / "hooks.json",
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": stale_command,
+                                    "timeoutSec": 30,
+                                    "statusMessage": "HOL Guard checking tool action",
+                                }
+                            ],
+                        }
+                    ],
+                    "UserPromptSubmit": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": stale_command,
+                                    "timeoutSec": 30,
+                                    "statusMessage": "HOL Guard checking prompt",
+                                }
+                            ]
+                        }
+                    ],
+                }
+            },
+            indent=2,
+        )
+        + "\n",
+    )
+
+    install_rc = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+    hooks_payload = json.loads((workspace_dir / ".codex" / "hooks.json").read_text(encoding="utf-8"))
+
+    assert install_rc == 0
+    assert len(hooks_payload["hooks"]["PreToolUse"]) == 1
+    assert len(hooks_payload["hooks"]["UserPromptSubmit"]) == 1
+    assert len(hooks_payload["hooks"]["PermissionRequest"]) == 1
+    assert len(hooks_payload["hooks"]["PostToolUse"]) == 1
+    all_commands = json.dumps(hooks_payload)
+    assert str(stale_worktree) not in all_commands
 
 
 def test_guard_install_codex_workspace_cleans_stale_global_managed_hook(tmp_path, capsys):

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -9020,6 +9020,162 @@ PY
     assert "http://127.0.0.1:4455/approvals/" in captured.err
 
 
+def test_guard_hook_codex_post_tool_use_blocks_credential_looking_output(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "cat .nvmrc"},
+        "tool_response": {"stdout": "HOL_GUARD_FAKE_CREDENTIAL=fixture-only\n"},
+        "source_scope": "project",
+    }
+    monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "codex",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 0
+    payload = json.loads(captured.out)
+    assert payload["continue"] is False
+    assert "HOL Guard" in payload["stopReason"]
+    assert "credential-looking output" in payload["stopReason"]
+    assert "http://127.0.0.1:4455/approvals/" in payload["stopReason"]
+
+
+def test_guard_hook_codex_user_prompt_submit_blocks_credential_looking_dotfile(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(workspace_dir / ".nvmrc", "fake_credential\n")
+    event = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "Use bash to print the full contents of ./.nvmrc exactly.",
+        "source_scope": "project",
+    }
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc, output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event=event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    payload = json.loads(output)
+
+    assert rc == 0
+    assert payload["decision"] == "block"
+    assert "HOL Guard" in payload["reason"]
+    assert "credential-looking local file" in payload["reason"]
+    assert "http://127.0.0.1:4455/approvals/" in payload["reason"]
+
+
+def test_guard_hook_codex_user_prompt_submit_blocks_bare_credential_dotfile(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(workspace_dir / ".nvmrc", "fake_credential\n")
+    event = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "read .nvmrc",
+        "source_scope": "project",
+    }
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc, output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event=event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    payload = json.loads(output)
+
+    assert rc == 0
+    assert payload["decision"] == "block"
+    assert "HOL Guard" in payload["reason"]
+    assert "credential-looking local file" in payload["reason"]
+
+
+def test_guard_hook_codex_runtime_risk_ignores_broad_allow_policy(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    store = GuardStore(home_dir)
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="global",
+            action="allow",
+            reason="broad local allow must not bypass runtime risk",
+        ),
+        "2026-04-30T00:00:00+00:00",
+    )
+    event = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "sed -n '1,20p' .nvmrc"},
+        "tool_response": "fake_credential\n",
+        "source_scope": "project",
+    }
+    monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "codex",
+        ]
+    )
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert rc == 0
+    assert payload["continue"] is False
+    assert "HOL Guard" in payload["stopReason"]
+    assert "credential-looking output" in payload["stopReason"]
+
+
 def test_guard_hook_allows_codex_safe_user_prompt_submit_without_output(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -9061,6 +9061,45 @@ def test_guard_hook_codex_post_tool_use_blocks_credential_looking_output(
     assert "http://127.0.0.1:4455/approvals/" in payload["stopReason"]
 
 
+def test_guard_hook_codex_post_tool_use_blocks_named_secret_output(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "sed -n '1,20p' .npmrc"},
+        "tool_response": "token = fixture-only\n",
+        "source_scope": "project",
+    }
+    monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "codex",
+        ]
+    )
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert rc == 0
+    assert payload["continue"] is False
+    assert "credential-looking output" in payload["stopReason"]
+
+
 def test_guard_hook_codex_user_prompt_submit_blocks_credential_looking_dotfile(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -9228,7 +9228,9 @@ def test_guard_hook_codex_prompt_dotfile_scan_ignores_trailing_punctuation(
     assert "credential-looking local file" in payload["reason"]
 
 
+@pytest.mark.parametrize("scope", ["workspace", "global"])
 def test_guard_hook_codex_runtime_risk_ignores_broad_allow_policy(
+    scope,
     tmp_path,
     capsys,
     monkeypatch,
@@ -9240,8 +9242,9 @@ def test_guard_hook_codex_runtime_risk_ignores_broad_allow_policy(
     store.upsert_policy(
         PolicyDecision(
             harness="codex",
-            scope="global",
+            scope=scope,
             action="allow",
+            workspace=str(workspace_dir) if scope == "workspace" else None,
             reason="broad local allow must not bypass runtime risk",
         ),
         "2026-04-30T00:00:00+00:00",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -9165,6 +9165,37 @@ def test_guard_hook_codex_user_prompt_submit_blocks_bare_credential_dotfile(
     assert "credential-looking local file" in payload["reason"]
 
 
+def test_guard_hook_codex_prompt_dotfile_scan_uses_bounded_file_read(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(workspace_dir / ".nvmrc", "token = fixture-only\n")
+    monkeypatch.setattr(Path, "read_bytes", lambda _path: (_ for _ in ()).throw(AssertionError("unbounded read")))
+    event = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "read .nvmrc",
+        "source_scope": "project",
+    }
+
+    rc, output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event=event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    payload = json.loads(output)
+
+    assert rc == 0
+    assert payload["decision"] == "block"
+    assert "credential-looking local file" in payload["reason"]
+
+
 def test_guard_hook_codex_runtime_risk_ignores_broad_allow_policy(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -9196,6 +9196,38 @@ def test_guard_hook_codex_prompt_dotfile_scan_uses_bounded_file_read(
     assert "credential-looking local file" in payload["reason"]
 
 
+@pytest.mark.parametrize("prompt", ["read .nvmrc.", "print ./.nvmrc, please"])
+def test_guard_hook_codex_prompt_dotfile_scan_ignores_trailing_punctuation(
+    prompt,
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(workspace_dir / ".nvmrc", "token = fixture-only\n")
+    event = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": prompt,
+        "source_scope": "project",
+    }
+
+    rc, output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event=event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    payload = json.loads(output)
+
+    assert rc == 0
+    assert payload["decision"] == "block"
+    assert "credential-looking local file" in payload["reason"]
+
+
 def test_guard_hook_codex_runtime_risk_ignores_broad_allow_policy(
     tmp_path,
     capsys,


### PR DESCRIPTION
## Summary
- install Codex PostToolUse hooks and migrate stale managed hook commands
- block credential-looking Codex prompt/tool output even when broad allow policies exist
- support bare credential-looking dotfile prompts such as .nvmrc and surface HOL Guard approval links

## Verification
- pytest tests/test_guard_runtime.py -k codex -q
- pytest tests/test_guard_codex_install.py -q
- ruff check src/codex_plugin_scanner/guard/adapters/codex.py src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/store.py tests/test_guard_codex_install.py tests/test_guard_runtime.py
- local Codex TUI: read .nvmrc blocked by HOL Guard with approval URL