### PR TITLE
fix(guard): avoid generic dotfile read false positives

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -4122,10 +4122,9 @@ _PROMPT_CONTENT_SCAN_SECRET_BASENAME_MARKERS = frozenset(
     {
         "auth",
         "credential",
-        "credentials",
+        "env",
         "key",
-        "passwd",
-        "password",
+        "pass",
         "secret",
         "token",
     }

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -4118,6 +4118,18 @@ _PROMPT_CONTENT_SCAN_SKIP_BASENAMES = frozenset(
         ".git-credentials",
     }
 )
+_PROMPT_CONTENT_SCAN_SECRET_BASENAME_MARKERS = frozenset(
+    {
+        "auth",
+        "credential",
+        "credentials",
+        "key",
+        "passwd",
+        "password",
+        "secret",
+        "token",
+    }
+)
 
 
 def _codex_prompt_credential_file_artifact(
@@ -4134,6 +4146,8 @@ def _codex_prompt_credential_file_artifact(
         if path is None or path.name in _PROMPT_CONTENT_SCAN_SKIP_BASENAMES:
             continue
         if not path.name.startswith("."):
+            continue
+        if not _prompt_path_looks_secret_bearing(path):
             continue
         if not path.is_file():
             continue
@@ -4179,6 +4193,11 @@ def _codex_prompt_credential_file_artifact(
             },
         )
     return None
+
+
+def _prompt_path_looks_secret_bearing(path: Path) -> bool:
+    lowered_name = path.name.lower()
+    return any(marker in lowered_name for marker in _PROMPT_CONTENT_SCAN_SECRET_BASENAME_MARKERS)
 
 
 def _with_codex_prompt_display_metadata(artifact: GuardArtifact, *, prompt_text: str) -> GuardArtifact:

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -413,10 +413,10 @@ Please investigate the bug end to end, fix the publish flow, and make sure user-
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         _build_guard_fixture(home_dir, workspace_dir)
-        _write_text(workspace_dir / ".nvmrc", "fake_credential=canary\n")
+        _write_text(workspace_dir / ".authrc", "fake_credential=canary\n")
         event = {
             "event": "UserPromptSubmit",
-            "prompt": "read .nvmrc",
+            "prompt": "read .authrc",
             "source_scope": "project",
         }
         monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
@@ -440,8 +440,8 @@ Please investigate the bug end to end, fix the publish flow, and make sure user-
 
         assert rc == 1
         assert output["artifact_type"] == "prompt_request"
-        assert "read .nvmrc" in output["launch_summary"]
-        assert approval_requests[0]["launch_target"] == "Codex prompt for `.nvmrc`: read .nvmrc"
+        assert "read .authrc" in output["launch_summary"]
+        assert approval_requests[0]["launch_target"] == "Codex prompt for `.authrc`: read .authrc"
 
     def test_codex_prompt_display_sanitizes_common_home_paths(self) -> None:
         display = guard_commands_module._codex_prompt_display_text(
@@ -10162,6 +10162,38 @@ def test_guard_hook_codex_user_prompt_submit_blocks_bare_credential_dotfile(
     event = {
         "hook_event_name": "UserPromptSubmit",
         "prompt": "read .authrc",
+        "source_scope": "project",
+    }
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc, output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event=event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    payload = json.loads(output)
+
+    assert rc == 0
+    assert payload["decision"] == "block"
+    assert "HOL Guard" in payload["reason"]
+    assert "credential-looking local file" in payload["reason"]
+
+
+def test_guard_hook_codex_user_prompt_submit_blocks_envrc_credential_dotfile(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(workspace_dir / ".envrc", "token = fixture-only\n")
+    event = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "read .envrc",
         "source_scope": "project",
     }
     monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -10096,10 +10096,10 @@ def test_guard_hook_codex_user_prompt_submit_blocks_credential_looking_dotfile(
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
-    _write_text(workspace_dir / ".nvmrc", "fake_credential\n")
+    _write_text(workspace_dir / ".authrc", "fake_credential\n")
     event = {
         "hook_event_name": "UserPromptSubmit",
-        "prompt": "Use bash to print the full contents of ./.nvmrc exactly.",
+        "prompt": "Use bash to print the full contents of ./.authrc exactly.",
         "source_scope": "project",
     }
     monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
@@ -10121,7 +10121,7 @@ def test_guard_hook_codex_user_prompt_submit_blocks_credential_looking_dotfile(
     assert "http://127.0.0.1:4455/approvals/" in payload["reason"]
 
 
-def test_guard_hook_codex_user_prompt_submit_blocks_bare_credential_dotfile(
+def test_guard_hook_codex_user_prompt_submit_allows_generic_dotfile_with_canary_text(
     tmp_path,
     capsys,
     monkeypatch,
@@ -10133,6 +10133,35 @@ def test_guard_hook_codex_user_prompt_submit_blocks_bare_credential_dotfile(
     event = {
         "hook_event_name": "UserPromptSubmit",
         "prompt": "read .nvmrc",
+        "source_scope": "project",
+    }
+
+    rc, output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event=event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    payload = json.loads(output)
+
+    assert rc == 0
+    assert payload == {"hookSpecificOutput": {"hookEventName": "UserPromptSubmit"}}
+
+
+def test_guard_hook_codex_user_prompt_submit_blocks_bare_credential_dotfile(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(workspace_dir / ".authrc", "fake_credential\n")
+    event = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "read .authrc",
         "source_scope": "project",
     }
     monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
@@ -10161,11 +10190,11 @@ def test_guard_hook_codex_prompt_dotfile_scan_uses_bounded_file_read(
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
-    _write_text(workspace_dir / ".nvmrc", "token = fixture-only\n")
+    _write_text(workspace_dir / ".authrc", "token = fixture-only\n")
     monkeypatch.setattr(Path, "read_bytes", lambda _path: (_ for _ in ()).throw(AssertionError("unbounded read")))
     event = {
         "hook_event_name": "UserPromptSubmit",
-        "prompt": "read .nvmrc",
+        "prompt": "read .authrc",
         "source_scope": "project",
     }
 
@@ -10184,7 +10213,7 @@ def test_guard_hook_codex_prompt_dotfile_scan_uses_bounded_file_read(
     assert "credential-looking local file" in payload["reason"]
 
 
-@pytest.mark.parametrize("prompt", ["read .nvmrc.", "print ./.nvmrc, please"])
+@pytest.mark.parametrize("prompt", ["read .authrc.", "print ./.authrc, please"])
 def test_guard_hook_codex_prompt_dotfile_scan_ignores_trailing_punctuation(
     prompt,
     tmp_path,
@@ -10194,7 +10223,7 @@ def test_guard_hook_codex_prompt_dotfile_scan_ignores_trailing_punctuation(
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
-    _write_text(workspace_dir / ".nvmrc", "token = fixture-only\n")
+    _write_text(workspace_dir / ".authrc", "token = fixture-only\n")
     event = {
         "hook_event_name": "UserPromptSubmit",
         "prompt": prompt,


### PR DESCRIPTION
## Summary
- stop Codex prompt pre-scan from treating every dotfile as secret-bearing
- keep content scanning for secret-looking dotfiles such as auth/token/key configs
- reinstall local Codex hooks away from stale worktree path during verification

## Verification
- pytest tests/test_guard_runtime.py -k 'credential_looking_dotfile or generic_dotfile_with_canary_text or bare_credential_dotfile or dotfile_scan' -q
- pytest tests/test_guard_runtime.py -k 'credential_looking_output or read_only_source_search or source_search' -q
- ruff check src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_runtime.py
- ruff format --check src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_runtime.py