### PR TITLE
fix(guard): harden symlink source scans

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3816,7 +3816,13 @@ _CODEX_SEARCH_OPTION_VALUE_FLAGS = frozenset(
 _CODEX_SEARCH_OPTION_VALUE_FLAGS_BY_EXECUTABLE = {
     "rg": frozenset({"-T"}),
 }
-_CODEX_SEARCH_UNSAFE_FLAGS = frozenset({"--pre"})
+_CODEX_SEARCH_UNSAFE_FLAGS = frozenset({"--dereference-recursive", "--follow", "--pre"})
+_CODEX_SEARCH_UNSAFE_SHORT_FLAGS_BY_EXECUTABLE = {
+    "egrep": frozenset({"R"}),
+    "fgrep": frozenset({"R"}),
+    "grep": frozenset({"R"}),
+    "rg": frozenset({"L"}),
+}
 _CODEX_GIT_GLOBAL_VALUE_FLAGS = frozenset(
     {"-c", "--config-env", "--exec-path", "--git-dir", "--work-tree", "--namespace"}
 )
@@ -3995,7 +4001,7 @@ def _codex_search_targets_are_source_like(args: list[str], *, cwd: Path | None, 
         if skip_next:
             skip_next = False
             continue
-        if arg in _CODEX_SEARCH_UNSAFE_FLAGS or any(arg.startswith(f"{flag}=") for flag in _CODEX_SEARCH_UNSAFE_FLAGS):
+        if _codex_search_arg_is_unsafe(arg, executable=executable):
             return False
         if arg in _CODEX_SEARCH_PATTERN_VALUE_FLAGS:
             pattern_from_option = True
@@ -4024,6 +4030,17 @@ def _codex_search_targets_are_source_like(args: list[str], *, cwd: Path | None, 
     else:
         return False
     return bool(targets) and all(_codex_search_target_is_source_like(target, cwd=cwd) for target in targets)
+
+
+def _codex_search_arg_is_unsafe(arg: str, *, executable: str) -> bool:
+    if arg in _CODEX_SEARCH_UNSAFE_FLAGS:
+        return True
+    if any(arg.startswith(f"{flag}=") for flag in _CODEX_SEARCH_UNSAFE_FLAGS if flag.startswith("--")):
+        return True
+    if not arg.startswith("-") or arg.startswith("--"):
+        return False
+    unsafe_short_flags = _CODEX_SEARCH_UNSAFE_SHORT_FLAGS_BY_EXECUTABLE.get(executable, frozenset())
+    return any(flag in unsafe_short_flags for flag in arg[1:])
 
 
 def _codex_search_target_is_source_like(target: str, *, cwd: Path | None) -> bool:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -4001,7 +4001,7 @@ def _codex_search_targets_are_source_like(args: list[str], *, cwd: Path | None, 
         if skip_next:
             skip_next = False
             continue
-        if _codex_search_arg_is_unsafe(arg, executable=executable):
+        if _codex_search_arg_is_unsafe(arg, executable=executable, option_value_flags=option_value_flags):
             return False
         if arg in _CODEX_SEARCH_PATTERN_VALUE_FLAGS:
             pattern_from_option = True
@@ -4032,15 +4032,20 @@ def _codex_search_targets_are_source_like(args: list[str], *, cwd: Path | None, 
     return bool(targets) and all(_codex_search_target_is_source_like(target, cwd=cwd) for target in targets)
 
 
-def _codex_search_arg_is_unsafe(arg: str, *, executable: str) -> bool:
+def _codex_search_arg_is_unsafe(arg: str, *, executable: str, option_value_flags: frozenset[str]) -> bool:
     if arg in _CODEX_SEARCH_UNSAFE_FLAGS:
         return True
-    if any(arg.startswith(f"{flag}=") for flag in _CODEX_SEARCH_UNSAFE_FLAGS if flag.startswith("--")):
+    if any(arg.startswith(f"{flag}=") for flag in _CODEX_SEARCH_UNSAFE_FLAGS):
         return True
     if not arg.startswith("-") or arg.startswith("--"):
         return False
     unsafe_short_flags = _CODEX_SEARCH_UNSAFE_SHORT_FLAGS_BY_EXECUTABLE.get(executable, frozenset())
-    return any(flag in unsafe_short_flags for flag in arg[1:])
+    for flag in arg[1:]:
+        if flag in unsafe_short_flags:
+            return True
+        if f"-{flag}" in option_value_flags:
+            return False
+    return False
 
 
 def _codex_search_target_is_source_like(target: str, *, cwd: Path | None) -> bool:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3994,12 +3994,19 @@ def _codex_search_targets_are_source_like(args: list[str], *, cwd: Path | None, 
     positional: list[str] = []
     skip_next = False
     pattern_from_option = False
+    after_option_terminator = False
     option_value_flags = _CODEX_SEARCH_OPTION_VALUE_FLAGS | _CODEX_SEARCH_OPTION_VALUE_FLAGS_BY_EXECUTABLE.get(
         executable, frozenset()
     )
     for arg in args:
         if skip_next:
             skip_next = False
+            continue
+        if after_option_terminator:
+            positional.append(arg)
+            continue
+        if arg == "--":
+            after_option_terminator = True
             continue
         if _codex_search_arg_is_unsafe(arg, executable=executable, option_value_flags=option_value_flags):
             return False
@@ -4017,8 +4024,6 @@ def _codex_search_targets_are_source_like(args: list[str], *, cwd: Path | None, 
             pattern_from_option = True
             continue
         if any(arg.startswith(f"{flag}=") for flag in option_value_flags):
-            continue
-        if arg == "--":
             continue
         if arg.startswith("-"):
             continue

--- a/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
@@ -47,6 +47,13 @@ class CiscoMcpScanSummary:
     scan_mode: str = "static"
 
 
+@dataclass(frozen=True, slots=True)
+class _StaticScanTarget:
+    read_path: Path
+    tool_name: str
+    content_type: str
+
+
 def _empty_counts() -> dict[str, int]:
     return {severity.value: 0 for severity in Severity}
 
@@ -235,17 +242,23 @@ def _normalize_finding(plugin_dir: Path, file_path: Path, finding: object) -> Fi
     )
 
 
-def _collect_static_targets(plugin_dir: Path) -> tuple[Path, ...]:
+def _collect_static_targets(plugin_dir: Path) -> tuple[_StaticScanTarget, ...]:
     config_path = plugin_dir / ".mcp.json"
     resolved_config_path = _safe_resolved_static_target(plugin_dir, config_path)
     if resolved_config_path is None:
         return ()
 
-    targets: list[Path] = []
+    targets: list[_StaticScanTarget] = []
     seen_targets: set[Path] = set()
     try:
         if resolved_config_path.stat().st_size <= _MAX_TARGET_SIZE_BYTES:
-            targets.append(resolved_config_path)
+            targets.append(
+                _StaticScanTarget(
+                    read_path=resolved_config_path,
+                    tool_name=config_path.name,
+                    content_type="mcp-config",
+                )
+            )
             seen_targets.add(resolved_config_path)
     except OSError:
         pass
@@ -264,7 +277,13 @@ def _collect_static_targets(plugin_dir: Path) -> tuple[Path, ...]:
                     continue
             except OSError:
                 continue
-            targets.append(resolved_file_path)
+            targets.append(
+                _StaticScanTarget(
+                    read_path=resolved_file_path,
+                    tool_name=resolved_file_path.name,
+                    content_type="mcp-source",
+                )
+            )
             seen_targets.add(resolved_file_path)
     return tuple(targets)
 
@@ -310,27 +329,26 @@ def _run_awaitable(awaitable: Awaitable[T]) -> T:
 
 
 async def _scan_targets(
-    plugin_dir: Path, targets: tuple[Path, ...], analyzer: object
+    plugin_dir: Path, targets: tuple[_StaticScanTarget, ...], analyzer: object
 ) -> tuple[tuple[Finding, ...], int]:
     findings: list[Finding] = []
     targets_scanned = 0
     for target in targets:
         try:
-            content = target.read_text(encoding="utf-8", errors="ignore")
+            content = target.read_path.read_text(encoding="utf-8", errors="ignore")
         except OSError:
             continue
-        content_type = "mcp-config" if target.name == ".mcp.json" else "mcp-source"
         external_findings = await analyzer.analyze(
             content,
             {
-                "tool_name": target.name,
-                "content_type": content_type,
-                "file_path": str(target),
+                "tool_name": target.tool_name,
+                "content_type": target.content_type,
+                "file_path": str(target.read_path),
             },
         )
         targets_scanned += 1
         for finding in external_findings:
-            findings.append(_normalize_finding(plugin_dir, target, finding))
+            findings.append(_normalize_finding(plugin_dir, target.read_path, finding))
     return tuple(findings), targets_scanned
 
 

--- a/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
@@ -15,7 +15,6 @@ from threading import Thread
 from typing import TypeVar
 
 from ..models import Finding, Severity, severity_from_value
-from ..path_support import resolves_within_root
 from .cisco_skill_scanner import CiscoIntegrationStatus
 
 _EXCLUDED_DIRS = {
@@ -238,13 +237,16 @@ def _normalize_finding(plugin_dir: Path, file_path: Path, finding: object) -> Fi
 
 def _collect_static_targets(plugin_dir: Path) -> tuple[Path, ...]:
     config_path = plugin_dir / ".mcp.json"
-    if not _is_safe_static_target(plugin_dir, config_path):
+    resolved_config_path = _safe_resolved_static_target(plugin_dir, config_path)
+    if resolved_config_path is None:
         return ()
 
     targets: list[Path] = []
+    seen_targets: set[Path] = set()
     try:
-        if config_path.stat().st_size <= _MAX_TARGET_SIZE_BYTES:
-            targets.append(config_path)
+        if resolved_config_path.stat().st_size <= _MAX_TARGET_SIZE_BYTES:
+            targets.append(resolved_config_path)
+            seen_targets.add(resolved_config_path)
     except OSError:
         pass
     for root, dirs, files in os.walk(plugin_dir, topdown=True):
@@ -254,24 +256,32 @@ def _collect_static_targets(plugin_dir: Path) -> tuple[Path, ...]:
             file_path = current_dir / file_name
             if file_path == config_path or file_path.suffix.lower() not in _SOURCE_SUFFIXES:
                 continue
-            if not _is_safe_static_target(plugin_dir, file_path):
+            resolved_file_path = _safe_resolved_static_target(plugin_dir, file_path)
+            if resolved_file_path is None or resolved_file_path in seen_targets:
                 continue
             try:
-                if file_path.stat().st_size > _MAX_TARGET_SIZE_BYTES:
+                if resolved_file_path.stat().st_size > _MAX_TARGET_SIZE_BYTES:
                     continue
             except OSError:
                 continue
-            targets.append(file_path)
+            targets.append(resolved_file_path)
+            seen_targets.add(resolved_file_path)
     return tuple(targets)
 
 
-def _is_safe_static_target(plugin_dir: Path, target: Path) -> bool:
+def _safe_resolved_static_target(plugin_dir: Path, target: Path) -> Path | None:
     try:
-        if not target.is_file():
-            return False
-    except OSError:
-        return False
-    return resolves_within_root(plugin_dir, target, require_exists=True)
+        resolved_root = plugin_dir.resolve(strict=True)
+        resolved_target = target.resolve(strict=True)
+        if not resolved_target.is_file():
+            return None
+    except (OSError, RuntimeError):
+        return None
+    try:
+        resolved_target.relative_to(resolved_root)
+    except ValueError:
+        return None
+    return resolved_target
 
 
 def _run_awaitable(awaitable: Awaitable[T]) -> T:
@@ -335,7 +345,7 @@ def run_cisco_mcp_scan(plugin_dir: Path, mode: str = "auto") -> CiscoMcpScanSumm
             message="Cisco MCP scanning disabled by configuration.",
         )
 
-    if not _is_safe_static_target(plugin_dir, config_path):
+    if _safe_resolved_static_target(plugin_dir, config_path) is None:
         return _build_summary(
             status=CiscoIntegrationStatus.SKIPPED,
             message="No .mcp.json found; Cisco MCP scan skipped.",

--- a/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
@@ -15,6 +15,7 @@ from threading import Thread
 from typing import TypeVar
 
 from ..models import Finding, Severity, severity_from_value
+from ..path_support import resolves_within_root
 from .cisco_skill_scanner import CiscoIntegrationStatus
 
 _EXCLUDED_DIRS = {
@@ -237,7 +238,7 @@ def _normalize_finding(plugin_dir: Path, file_path: Path, finding: object) -> Fi
 
 def _collect_static_targets(plugin_dir: Path) -> tuple[Path, ...]:
     config_path = plugin_dir / ".mcp.json"
-    if not config_path.is_file():
+    if not _is_safe_static_target(plugin_dir, config_path):
         return ()
 
     targets: list[Path] = []
@@ -253,6 +254,8 @@ def _collect_static_targets(plugin_dir: Path) -> tuple[Path, ...]:
             file_path = current_dir / file_name
             if file_path == config_path or file_path.suffix.lower() not in _SOURCE_SUFFIXES:
                 continue
+            if not _is_safe_static_target(plugin_dir, file_path):
+                continue
             try:
                 if file_path.stat().st_size > _MAX_TARGET_SIZE_BYTES:
                     continue
@@ -260,6 +263,15 @@ def _collect_static_targets(plugin_dir: Path) -> tuple[Path, ...]:
                 continue
             targets.append(file_path)
     return tuple(targets)
+
+
+def _is_safe_static_target(plugin_dir: Path, target: Path) -> bool:
+    try:
+        if not target.is_file():
+            return False
+    except OSError:
+        return False
+    return resolves_within_root(plugin_dir, target, require_exists=True)
 
 
 def _run_awaitable(awaitable: Awaitable[T]) -> T:
@@ -315,13 +327,15 @@ async def _scan_targets(
 def run_cisco_mcp_scan(plugin_dir: Path, mode: str = "auto") -> CiscoMcpScanSummary:
     """Run Cisco MCP scanner static analysis when available."""
 
+    config_path = plugin_dir / ".mcp.json"
+
     if mode == "off":
         return _build_summary(
             status=CiscoIntegrationStatus.SKIPPED,
             message="Cisco MCP scanning disabled by configuration.",
         )
 
-    if not (plugin_dir / ".mcp.json").is_file():
+    if not _is_safe_static_target(plugin_dir, config_path):
         return _build_summary(
             status=CiscoIntegrationStatus.SKIPPED,
             message="No .mcp.json found; Cisco MCP scan skipped.",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -541,6 +541,59 @@ Please investigate the bug end to end, fix the publish flow, and make sure user-
         assert output["recorded"] is True
         assert "approval_requests" not in output
 
+    @pytest.mark.parametrize(
+        "command",
+        (
+            "rg --follow TOKEN src",
+            "rg -L TOKEN src",
+            "grep -R TOKEN src",
+        ),
+    )
+    def test_codex_post_tool_use_blocks_symlink_following_source_search_flags(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+        command: str,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        secret_file = home_dir / ".aws" / "credentials"
+        _write_text(secret_file, "auth_token=outside-secret\n")
+        src_dir = workspace_dir / "src"
+        src_dir.mkdir()
+        (src_dir / "config.ts").symlink_to(secret_file)
+        event = {
+            "event": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "tool_response": {
+                "stdout": "src/config.ts:1:auth_token=outside-secret",
+            },
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 1
+        assert output["artifact_type"] == "tool_action_request"
+        assert output["approval_requests"]
+
     def test_codex_post_tool_use_allows_ripgrep_type_not_source_search(
         self,
         monkeypatch,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -541,6 +541,45 @@ Please investigate the bug end to end, fix the publish flow, and make sure user-
         assert output["recorded"] is True
         assert "approval_requests" not in output
 
+    def test_codex_post_tool_use_allows_short_option_value_payloads(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        event = {
+            "event": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "rg -gLICENSE TOKEN src"},
+            "tool_response": {
+                "stdout": "src/config.ts:1:const auth_token = process.env.TOKEN",
+            },
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["recorded"] is True
+        assert "approval_requests" not in output
+
     @pytest.mark.parametrize(
         "command",
         (

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -580,6 +580,45 @@ Please investigate the bug end to end, fix the publish flow, and make sure user-
         assert output["recorded"] is True
         assert "approval_requests" not in output
 
+    def test_codex_post_tool_use_allows_double_dash_terminated_literal_pattern(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        event = {
+            "event": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "rg -- --follow src"},
+            "tool_response": {
+                "stdout": "src/config.ts:1:const auth_token = process.env.TOKEN",
+            },
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["recorded"] is True
+        assert "approval_requests" not in output
+
     @pytest.mark.parametrize(
         "command",
         (

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -103,6 +103,68 @@ def test_scan_includes_dist_descendants(monkeypatch, tmp_path: Path) -> None:
     assert any(path.endswith("dist/server.js") for path in analyzed_paths)
 
 
+def test_scan_skips_source_symlink_resolving_outside_plugin_root(monkeypatch, tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugin"
+    _write_plugin(plugin_dir)
+    outside_secret = tmp_path / "outside.py"
+    outside_secret.write_text("auth_token = 'outside-secret'\n", encoding="utf-8")
+    (plugin_dir / "leak.py").symlink_to(outside_secret)
+    analyzed_paths: list[str] = []
+    analyzed_contents: list[str] = []
+
+    class RecordingYaraAnalyzer:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        async def analyze(self, content: str, context: dict[str, Any] | None = None) -> list[FakeCiscoFinding]:
+            analyzed_paths.append(str((context or {}).get("file_path", "")))
+            analyzed_contents.append(content)
+            return []
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.integrations.cisco_mcp_scanner._load_mcp_scanner_components",
+        lambda: {"YaraAnalyzer": RecordingYaraAnalyzer},
+    )
+
+    summary = run_cisco_mcp_scan(plugin_dir, mode="on")
+
+    assert summary.status == CiscoIntegrationStatus.ENABLED
+    assert summary.targets_scanned == 2
+    assert str(plugin_dir / "leak.py") not in analyzed_paths
+    assert all("outside-secret" not in content for content in analyzed_contents)
+
+
+def test_scan_skips_symlinked_mcp_config_outside_plugin_root(monkeypatch, tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugin"
+    _write_plugin(plugin_dir)
+    (plugin_dir / ".mcp.json").unlink()
+    outside_config = tmp_path / "outside-mcp.json"
+    outside_config.write_text(
+        json.dumps({"mcpServers": {"outside": {"command": "python", "args": ["secret.py"]}}}),
+        encoding="utf-8",
+    )
+    (plugin_dir / ".mcp.json").symlink_to(outside_config)
+    loader_state = {"called": False}
+
+    class RecordingYaraAnalyzer:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            return None
+
+    def _loader() -> dict[str, type[RecordingYaraAnalyzer]]:
+        loader_state["called"] = True
+        return {"YaraAnalyzer": RecordingYaraAnalyzer}
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.integrations.cisco_mcp_scanner._load_mcp_scanner_components",
+        _loader,
+    )
+
+    summary = run_cisco_mcp_scan(plugin_dir, mode="on")
+
+    assert summary.status == CiscoIntegrationStatus.SKIPPED
+    assert loader_state["called"] is False
+
+
 def test_mcp_security_auto_mode_unavailable_is_not_applicable(monkeypatch, tmp_path: Path) -> None:
     plugin_dir = tmp_path / "plugin"
     _write_plugin(plugin_dir)

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -194,6 +194,39 @@ def test_scan_resolves_in_root_symlink_targets_before_analysis(monkeypatch, tmp_
     assert str(plugin_dir / "link.py") not in analyzed_paths
 
 
+def test_scan_preserves_symlinked_mcp_config_identity(monkeypatch, tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugin"
+    _write_plugin(plugin_dir)
+    real_config = plugin_dir / "configs" / "base.json"
+    real_config.parent.mkdir()
+    real_config.write_text(
+        json.dumps({"mcpServers": {"demo": {"command": "python", "args": ["server.py"]}}}),
+        encoding="utf-8",
+    )
+    (plugin_dir / ".mcp.json").unlink()
+    (plugin_dir / ".mcp.json").symlink_to(real_config)
+    analyzed_contexts: list[dict[str, Any]] = []
+
+    class RecordingYaraAnalyzer:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        async def analyze(self, content: str, context: dict[str, Any] | None = None) -> list[FakeCiscoFinding]:
+            analyzed_contexts.append(dict(context or {}))
+            return []
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.integrations.cisco_mcp_scanner._load_mcp_scanner_components",
+        lambda: {"YaraAnalyzer": RecordingYaraAnalyzer},
+    )
+
+    summary = run_cisco_mcp_scan(plugin_dir, mode="on")
+
+    assert summary.status == CiscoIntegrationStatus.ENABLED
+    assert analyzed_contexts[0]["tool_name"] == ".mcp.json"
+    assert analyzed_contexts[0]["content_type"] == "mcp-config"
+
+
 def test_mcp_security_auto_mode_unavailable_is_not_applicable(monkeypatch, tmp_path: Path) -> None:
     plugin_dir = tmp_path / "plugin"
     _write_plugin(plugin_dir)

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -165,6 +165,35 @@ def test_scan_skips_symlinked_mcp_config_outside_plugin_root(monkeypatch, tmp_pa
     assert loader_state["called"] is False
 
 
+def test_scan_resolves_in_root_symlink_targets_before_analysis(monkeypatch, tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugin"
+    _write_plugin(plugin_dir)
+    real_source = plugin_dir / "real.py"
+    real_source.write_text("print('real')\n", encoding="utf-8")
+    (plugin_dir / "link.py").symlink_to(real_source)
+    analyzed_paths: list[str] = []
+
+    class RecordingYaraAnalyzer:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        async def analyze(self, content: str, context: dict[str, Any] | None = None) -> list[FakeCiscoFinding]:
+            analyzed_paths.append(str((context or {}).get("file_path", "")))
+            return []
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.integrations.cisco_mcp_scanner._load_mcp_scanner_components",
+        lambda: {"YaraAnalyzer": RecordingYaraAnalyzer},
+    )
+
+    summary = run_cisco_mcp_scan(plugin_dir, mode="on")
+
+    assert summary.status == CiscoIntegrationStatus.ENABLED
+    assert summary.targets_scanned == 3
+    assert str(real_source.resolve()) in analyzed_paths
+    assert str(plugin_dir / "link.py") not in analyzed_paths
+
+
 def test_mcp_security_auto_mode_unavailable_is_not_applicable(monkeypatch, tmp_path: Path) -> None:
     plugin_dir = tmp_path / "plugin"
     _write_plugin(plugin_dir)


### PR DESCRIPTION
## Summary
- skip Cisco MCP targets and configs that resolve outside plugin root
- treat symlink-following search flags as unsafe for Codex read-only source-search fast path
- add regressions for out-of-root symlink scans and follow-flag bypasses

## Testing
- ruff check .
- pytest -q
- python3 -m build