### PR TITLE
feat(guard): resume codex after browser approval

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1962,10 +1962,12 @@ def _codex_browser_approval_decision(
     ]
     if not request_ids:
         return None
+    has_daemon_operation = isinstance(response_payload.get("operation_id"), str)
+    wait_timeout_seconds = min(config.approval_wait_timeout_seconds, 25 if has_daemon_operation else 5)
     wait_result = wait_for_approval_requests(
         store=store,
         request_ids=request_ids,
-        timeout_seconds=min(config.approval_wait_timeout_seconds, 25),
+        timeout_seconds=wait_timeout_seconds,
     )
     response_payload["approval_wait"] = wait_result
     if not bool(wait_result.get("resolved")):

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1956,7 +1956,7 @@ def _codex_browser_approval_decision(
     if not isinstance(approval_requests, list):
         return None
     request_ids = [
-        str(item["request_id"])
+        item["request_id"]
         for item in approval_requests
         if isinstance(item, dict) and isinstance(item.get("request_id"), str)
     ]

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1601,8 +1601,9 @@ def run_guard_command(
                             }
                         ]
                     }
+                    browser_approval_daemon_client = None
                     try:
-                        daemon_client = load_guard_surface_daemon_client(guard_home)
+                        browser_approval_daemon_client = load_guard_surface_daemon_client(guard_home)
                     except RuntimeError:
                         queued = queue_blocked_approvals(
                             detection=runtime_detection,
@@ -1612,7 +1613,7 @@ def run_guard_command(
                             now=_now(),
                         )
                     else:
-                        session = daemon_client.start_session(
+                        session = browser_approval_daemon_client.start_session(
                             harness=args.harness,
                             surface="harness-adapter",
                             workspace=str(workspace) if workspace else None,
@@ -1622,7 +1623,7 @@ def run_guard_command(
                             capabilities=["approval-resolution", "receipt-view"],
                         )
                         response_payload["session_id"] = str(session["session_id"])
-                        blocked_operation = daemon_client.queue_blocked_operation(
+                        blocked_operation = browser_approval_daemon_client.queue_blocked_operation(
                             session_id=str(session["session_id"]),
                             operation_type="tool_call",
                             harness=args.harness,
@@ -1681,6 +1682,7 @@ def run_guard_command(
                 response_payload=response_payload,
                 store=store,
                 config=config,
+                daemon_client=locals().get("browser_approval_daemon_client"),
             )
             if codex_browser_decision == "allow":
                 return 0
@@ -1940,6 +1942,7 @@ def _codex_browser_approval_decision(
     response_payload: dict[str, object],
     store: GuardStore,
     config: GuardConfig,
+    daemon_client: object | None = None,
 ) -> str | None:
     if _canonical_harness_name(args.harness) != "codex":
         return None
@@ -1972,10 +1975,27 @@ def _codex_browser_approval_decision(
         return None
     resolved_items = [item for item in wait_result.get("items", []) if isinstance(item, dict)]
     if any(str(item.get("resolution_action")) == "block" for item in resolved_items):
+        _update_codex_browser_operation_status(response_payload, daemon_client, "blocked")
         response_payload["review_hint"] = "Browser decision saved. HOL Guard kept this Codex action blocked."
         return "block"
+    _update_codex_browser_operation_status(response_payload, daemon_client, "completed")
     response_payload["review_hint"] = "Approval received in HOL Guard. Codex is resuming this action."
     return "allow"
+
+
+def _update_codex_browser_operation_status(
+    response_payload: dict[str, object],
+    daemon_client: object | None,
+    status: str,
+) -> None:
+    operation_id = response_payload.get("operation_id")
+    if daemon_client is None or not isinstance(operation_id, str) or not operation_id:
+        return
+    update_operation_status = getattr(daemon_client, "update_operation_status", None)
+    if not callable(update_operation_status):
+        return
+    with suppress(Exception):
+        update_operation_status(operation_id=operation_id, status=status)
 
 
 def _should_emit_prequeue_native_hook_response(

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1955,6 +1955,8 @@ def _codex_browser_approval_decision(
     approval_requests = response_payload.get("approval_requests")
     if not isinstance(approval_requests, list):
         return None
+    if not isinstance(response_payload.get("operation_id"), str):
+        return None
     request_ids = [
         str(item["request_id"])
         for item in approval_requests

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1965,7 +1965,7 @@ def _codex_browser_approval_decision(
     wait_result = wait_for_approval_requests(
         store=store,
         request_ids=request_ids,
-        timeout_seconds=config.approval_wait_timeout_seconds,
+        timeout_seconds=min(config.approval_wait_timeout_seconds, 25),
     )
     response_payload["approval_wait"] = wait_result
     if not bool(wait_result.get("resolved")):

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1674,6 +1674,18 @@ def run_guard_command(
                     output_stream=output_stream,
                 )
                 return 0
+            codex_browser_decision = _codex_browser_approval_decision(
+                args=args,
+                event_name=event_name,
+                policy_action=policy_action,
+                response_payload=response_payload,
+                store=store,
+                config=config,
+            )
+            if codex_browser_decision == "allow":
+                return 0
+            if codex_browser_decision == "block":
+                policy_action = "block"
             if _should_emit_native_hook_exit_block(args, event_name=event_name, policy_action=policy_action):
                 _emit_native_hook_block_stderr(
                     _native_hook_reason_for_harness(
@@ -1918,6 +1930,52 @@ def _should_emit_native_hook_exit_block(args: argparse.Namespace, *, event_name:
         and not getattr(args, "json", False)
         and bool(codex_runtime_marker)
     )
+
+
+def _codex_browser_approval_decision(
+    *,
+    args: argparse.Namespace,
+    event_name: str,
+    policy_action: str,
+    response_payload: dict[str, object],
+    store: GuardStore,
+    config: GuardConfig,
+) -> str | None:
+    if _canonical_harness_name(args.harness) != "codex":
+        return None
+    if getattr(args, "json", False):
+        return None
+    if event_name not in {"PreToolUse", "PostToolUse", "UserPromptSubmit"}:
+        return None
+    if policy_action not in {"block", "sandbox-required", "require-reapproval"}:
+        return None
+    approval_requests = response_payload.get("approval_requests")
+    if not isinstance(approval_requests, list):
+        return None
+    request_ids = [
+        str(item["request_id"])
+        for item in approval_requests
+        if isinstance(item, dict) and isinstance(item.get("request_id"), str)
+    ]
+    if not request_ids:
+        return None
+    wait_result = wait_for_approval_requests(
+        store=store,
+        request_ids=request_ids,
+        timeout_seconds=config.approval_wait_timeout_seconds,
+    )
+    response_payload["approval_wait"] = wait_result
+    if not bool(wait_result.get("resolved")):
+        response_payload["review_hint"] = (
+            "Approval is still pending in HOL Guard. Approve it in the browser, then retry the same Codex action."
+        )
+        return None
+    resolved_items = [item for item in wait_result.get("items", []) if isinstance(item, dict)]
+    if any(str(item.get("resolution_action")) == "block" for item in resolved_items):
+        response_payload["review_hint"] = "Browser decision saved. HOL Guard kept this Codex action blocked."
+        return "block"
+    response_payload["review_hint"] = "Approval received in HOL Guard. Codex is resuming this action."
+    return "allow"
 
 
 def _should_emit_prequeue_native_hook_response(

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1685,6 +1685,14 @@ def run_guard_command(
                 daemon_client=locals().get("browser_approval_daemon_client"),
             )
             if codex_browser_decision == "allow":
+                if event_name != "PreToolUse":
+                    _emit_native_hook_response(
+                        harness=args.harness,
+                        policy_action="allow",
+                        event_name=event_name,
+                        reason="",
+                        output_stream=output_stream,
+                    )
                 return 0
             if codex_browser_decision == "block":
                 policy_action = "block"

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1955,8 +1955,6 @@ def _codex_browser_approval_decision(
     approval_requests = response_payload.get("approval_requests")
     if not isinstance(approval_requests, list):
         return None
-    if not isinstance(response_payload.get("operation_id"), str):
-        return None
     request_ids = [
         str(item["request_id"])
         for item in approval_requests

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -10639,13 +10639,35 @@ def test_codex_browser_approval_caps_wait_below_hook_timeout(tmp_path, monkeypat
         args=argparse.Namespace(harness="codex", json=False),
         event_name="PreToolUse",
         policy_action="block",
-        response_payload={"approval_requests": [{"request_id": "request-1"}]},
+        response_payload={"operation_id": "operation-1", "approval_requests": [{"request_id": "request-1"}]},
         store=GuardStore(tmp_path / "home"),
         config=GuardConfig(tmp_path / "home", None, approval_wait_timeout_seconds=120),
     )
 
     assert decision is None
     assert captured_timeout == [25]
+
+
+def test_codex_browser_approval_caps_fallback_wait(tmp_path, monkeypatch):
+    captured_timeout: list[int] = []
+
+    def _fake_wait_for_approval_requests(**kwargs) -> dict[str, object]:
+        captured_timeout.append(int(kwargs["timeout_seconds"]))
+        return {"resolved": False, "pending_request_ids": ["request-1"], "items": []}
+
+    monkeypatch.setattr(guard_commands_module, "wait_for_approval_requests", _fake_wait_for_approval_requests)
+
+    decision = guard_commands_module._codex_browser_approval_decision(
+        args=argparse.Namespace(harness="codex", json=False),
+        event_name="PreToolUse",
+        policy_action="block",
+        response_payload={"approval_requests": [{"request_id": "request-1"}]},
+        store=GuardStore(tmp_path / "home"),
+        config=GuardConfig(tmp_path / "home", None, approval_wait_timeout_seconds=120),
+    )
+
+    assert decision is None
+    assert captured_timeout == [5]
 
 
 def test_guard_hook_codex_post_tool_use_blocks_named_secret_output(

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -9423,6 +9423,7 @@ def test_guard_hook_codex_emits_native_deny_for_sensitive_bash_command(tmp_path,
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 0\n")
     monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
     monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
     event_path = tmp_path / "codex-hook.json"
@@ -9543,6 +9544,7 @@ def test_guard_hook_codex_queues_approval_before_native_deny_output(tmp_path, ca
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 0\n")
     monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
     monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
     monkeypatch.setattr(
@@ -9756,6 +9758,7 @@ def test_guard_hook_claude_native_block_does_not_queue_approval_center_request(t
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 0\n")
     monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
     blocked_event = {
         "hook_event_name": "PreToolUse",
@@ -9796,6 +9799,7 @@ def test_guard_hook_codex_keeps_artifact_approval_for_same_sensitive_tool_action
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 0\n")
     monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
 
     blocked_event = {
@@ -9934,6 +9938,7 @@ def test_guard_hook_blocks_codex_user_prompt_submit_sensitive_file_read(
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 0\n")
     event = {
         "hook_event_name": "UserPromptSubmit",
         "prompt": "Open ./.npmrc",
@@ -9968,6 +9973,7 @@ def test_guard_hook_codex_user_prompt_submit_secret_read_includes_approval_url(
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 0\n")
     monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
     monkeypatch.setattr(
         guard_commands_module,
@@ -10284,6 +10290,7 @@ def test_guard_hook_codex_permission_request_declines_to_native_prompt_for_reapp
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 0\n")
     event = {
         "hook_event_name": "PermissionRequest",
         "tool_name": "Bash",
@@ -10416,6 +10423,7 @@ def test_guard_hook_codex_post_tool_use_blocks_credential_looking_output(
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 0\n")
     event = {
         "hook_event_name": "PostToolUse",
         "tool_name": "Bash",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -10052,7 +10052,8 @@ def test_guard_hook_codex_user_prompt_submit_browser_approval_resumes_prompt(
     )
 
     assert rc == 0
-    assert output == ""
+    payload = json.loads(output)
+    assert payload["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
     assert store.list_approval_requests(limit=10) == []
 
 
@@ -10518,7 +10519,8 @@ def test_guard_hook_codex_post_tool_use_browser_approval_resumes_result(
     captured = capsys.readouterr()
 
     assert rc == 0
-    assert captured.out == ""
+    payload = json.loads(captured.out)
+    assert payload["hookSpecificOutput"]["hookEventName"] == "PostToolUse"
     assert captured.err == ""
     assert store.list_approval_requests(limit=10) == []
 

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -9407,6 +9407,126 @@ def test_guard_hook_codex_queues_approval_before_native_deny_output(tmp_path, ca
     assert pending[0]["artifact_type"] == "tool_action_request"
 
 
+def test_guard_hook_codex_pretooluse_browser_approval_resumes_original_tool(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 2\n")
+    monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    store = GuardStore(home_dir)
+    blocked_event = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "echo MALICIOUS > dangerous-marker.json"},
+        "policy_action": "block",
+        "source_scope": "project",
+        "cwd": str(workspace_dir),
+    }
+
+    def approve_pending() -> None:
+        for _ in range(40):
+            pending = store.list_approval_requests(limit=10)
+            if pending:
+                apply_approval_resolution(
+                    store=store,
+                    request_id=str(pending[0]["request_id"]),
+                    action="allow",
+                    scope="artifact",
+                    workspace=None,
+                    reason="approved in browser",
+                )
+                return
+            threading.Event().wait(0.05)
+
+    worker = threading.Thread(target=approve_pending, daemon=True)
+    worker.start()
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(blocked_event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "codex",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 0
+    assert captured.out == ""
+    assert captured.err == ""
+    assert store.list_approval_requests(limit=10) == []
+
+
+def test_guard_hook_codex_pretooluse_browser_deny_keeps_tool_blocked(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 2\n")
+    monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    store = GuardStore(home_dir)
+    blocked_event = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "echo MALICIOUS > dangerous-marker.json"},
+        "policy_action": "block",
+        "source_scope": "project",
+        "cwd": str(workspace_dir),
+    }
+
+    def deny_pending() -> None:
+        for _ in range(40):
+            pending = store.list_approval_requests(limit=10)
+            if pending:
+                apply_approval_resolution(
+                    store=store,
+                    request_id=str(pending[0]["request_id"]),
+                    action="block",
+                    scope="artifact",
+                    workspace=None,
+                    reason="denied in browser",
+                )
+                return
+            threading.Event().wait(0.05)
+
+    worker = threading.Thread(target=deny_pending, daemon=True)
+    worker.start()
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(blocked_event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "codex",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 2
+    assert captured.out == ""
+    assert "HOL Guard" in captured.err
+    assert "blocked" in captured.err.lower()
+
+
 def test_guard_hook_claude_native_block_does_not_queue_approval_center_request(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
@@ -9647,6 +9767,55 @@ def test_guard_hook_codex_user_prompt_submit_secret_read_includes_approval_url(
     pending = GuardStore(home_dir).list_approval_requests(limit=10)
     assert len(pending) == 1
     assert pending[0]["artifact_type"] == "prompt_request"
+
+
+def test_guard_hook_codex_user_prompt_submit_browser_approval_resumes_prompt(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 2\n")
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    store = GuardStore(home_dir)
+    event = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "Open ./.npmrc",
+        "source_scope": "project",
+    }
+
+    def approve_pending() -> None:
+        for _ in range(40):
+            pending = store.list_approval_requests(limit=10)
+            if pending:
+                apply_approval_resolution(
+                    store=store,
+                    request_id=str(pending[0]["request_id"]),
+                    action="allow",
+                    scope="artifact",
+                    workspace=None,
+                    reason="approved in browser",
+                )
+                return
+            threading.Event().wait(0.05)
+
+    worker = threading.Thread(target=approve_pending, daemon=True)
+    worker.start()
+
+    rc, output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event=event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+
+    assert rc == 0
+    assert output == ""
+    assert store.list_approval_requests(limit=10) == []
 
 
 def test_guard_hook_codex_user_prompt_submit_uses_strictest_mixed_prompt_risk(
@@ -10047,6 +10216,65 @@ def test_guard_hook_codex_post_tool_use_blocks_credential_looking_output(
     assert "HOL Guard" in payload["stopReason"]
     assert "credential-looking output" in payload["stopReason"]
     assert "http://127.0.0.1:4455/approvals/" in payload["stopReason"]
+
+
+def test_guard_hook_codex_post_tool_use_browser_approval_resumes_result(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 2\n")
+    event = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "cat .nvmrc"},
+        "tool_response": {"stdout": "HOL_GUARD_FAKE_CREDENTIAL=fixture-only\n"},
+        "source_scope": "project",
+    }
+    monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    store = GuardStore(home_dir)
+
+    def approve_pending() -> None:
+        for _ in range(40):
+            pending = store.list_approval_requests(limit=10)
+            if pending:
+                apply_approval_resolution(
+                    store=store,
+                    request_id=str(pending[0]["request_id"]),
+                    action="allow",
+                    scope="artifact",
+                    workspace=None,
+                    reason="approved in browser",
+                )
+                return
+            threading.Event().wait(0.05)
+
+    worker = threading.Thread(target=approve_pending, daemon=True)
+    worker.start()
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "codex",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 0
+    assert captured.out == ""
+    assert captured.err == ""
+    assert store.list_approval_requests(limit=10) == []
 
 
 def test_guard_hook_codex_post_tool_use_blocks_named_secret_output(

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -9545,6 +9545,11 @@ def test_guard_hook_codex_queues_approval_before_native_deny_output(tmp_path, ca
     _build_guard_fixture(home_dir, workspace_dir)
     monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
     monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(
+        guard_commands_module,
+        "load_guard_surface_daemon_client",
+        lambda _guard_home: (_ for _ in ()).throw(RuntimeError("daemon unavailable")),
+    )
     blocked_event = {
         "hook_event_name": "PreToolUse",
         "tool_name": "Bash",
@@ -9577,6 +9582,54 @@ def test_guard_hook_codex_queues_approval_before_native_deny_output(tmp_path, ca
     assert pending[0]["artifact_type"] == "tool_action_request"
 
 
+def _install_fake_guard_surface_daemon(
+    monkeypatch: pytest.MonkeyPatch,
+    store: GuardStore,
+    statuses: list[dict[str, object]] | None = None,
+) -> None:
+    class _FakeDaemonClient:
+        def start_session(self, **_kwargs) -> dict[str, object]:
+            return {"session_id": "session-1"}
+
+        def queue_blocked_operation(self, **kwargs) -> dict[str, object]:
+            evaluation = kwargs["evaluation"]
+            artifacts = evaluation["artifacts"] if isinstance(evaluation, dict) else []
+            item = artifacts[0] if artifacts and isinstance(artifacts[0], dict) else {}
+            request_id = f"request-{len(store.list_approval_requests(limit=50)) + 1}"
+            approval_center_url = str(kwargs["approval_center_url"]).rstrip("/")
+            request = GuardApprovalRequest(
+                request_id=request_id,
+                harness=str(kwargs["harness"]),
+                artifact_id=str(item.get("artifact_id") or request_id),
+                artifact_name=str(item.get("artifact_name") or item.get("artifact_id") or "Guard request"),
+                artifact_hash=str(item.get("artifact_hash") or "hash-1"),
+                policy_action=str(item.get("policy_action") or "block"),
+                recommended_scope="artifact",
+                changed_fields=tuple(str(field) for field in item.get("changed_fields", [])),
+                source_scope=str(item.get("source_scope") or "project"),
+                config_path=str(item.get("config_path") or "~/.codex/config.toml"),
+                review_command=f"hol-guard approvals approve {request_id}",
+                approval_url=f"{approval_center_url}/approvals/{request_id}",
+                launch_target=str(item.get("launch_target") or "Codex request"),
+                artifact_type=str(item.get("artifact_type") or "artifact"),
+            )
+            store.add_approval_request(request, "2026-04-30T00:00:00+00:00")
+            return {
+                "operation": {"operation_id": "operation-1"},
+                "approval_requests": [request.to_dict()],
+            }
+
+        def update_operation_status(self, **kwargs) -> None:
+            if statuses is not None:
+                statuses.append(dict(kwargs))
+
+    monkeypatch.setattr(
+        guard_commands_module,
+        "load_guard_surface_daemon_client",
+        lambda _guard_home: _FakeDaemonClient(),
+    )
+
+
 def test_guard_hook_codex_pretooluse_browser_approval_resumes_original_tool(
     tmp_path,
     capsys,
@@ -9589,6 +9642,7 @@ def test_guard_hook_codex_pretooluse_browser_approval_resumes_original_tool(
     monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
     monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
     store = GuardStore(home_dir)
+    _install_fake_guard_surface_daemon(monkeypatch, store)
     blocked_event = {
         "hook_event_name": "PreToolUse",
         "tool_name": "Bash",
@@ -9649,6 +9703,7 @@ def test_guard_hook_codex_pretooluse_browser_deny_keeps_tool_blocked(
     monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
     monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
     store = GuardStore(home_dir)
+    _install_fake_guard_surface_daemon(monkeypatch, store)
     blocked_event = {
         "hook_event_name": "PreToolUse",
         "tool_name": "Bash",
@@ -9914,6 +9969,11 @@ def test_guard_hook_codex_user_prompt_submit_secret_read_includes_approval_url(
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
     monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(
+        guard_commands_module,
+        "load_guard_surface_daemon_client",
+        lambda _guard_home: (_ for _ in ()).throw(RuntimeError("daemon unavailable")),
+    )
     event = {
         "hook_event_name": "UserPromptSubmit",
         "prompt": "Open ./.npmrc",
@@ -9950,6 +10010,7 @@ def test_guard_hook_codex_user_prompt_submit_browser_approval_resumes_prompt(
     _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 2\n")
     monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
     store = GuardStore(home_dir)
+    _install_fake_guard_surface_daemon(monkeypatch, store)
     event = {
         "hook_event_name": "UserPromptSubmit",
         "prompt": "Open ./.npmrc",
@@ -10364,6 +10425,11 @@ def test_guard_hook_codex_post_tool_use_blocks_credential_looking_output(
     }
     monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
     monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(
+        guard_commands_module,
+        "load_guard_surface_daemon_client",
+        lambda _guard_home: (_ for _ in ()).throw(RuntimeError("daemon unavailable")),
+    )
 
     monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
     rc = main(
@@ -10407,6 +10473,7 @@ def test_guard_hook_codex_post_tool_use_browser_approval_resumes_result(
     monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
     monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
     store = GuardStore(home_dir)
+    _install_fake_guard_surface_daemon(monkeypatch, store)
 
     def approve_pending() -> None:
         for _ in range(40):

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -27,7 +27,7 @@ from codex_plugin_scanner.guard.cli.render import emit_guard_payload
 from codex_plugin_scanner.guard.config import GuardConfig, load_guard_config
 from codex_plugin_scanner.guard.consumer import artifact_hash, evaluate_detection
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
-from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection, PolicyDecision
+from codex_plugin_scanner.guard.models import GuardApprovalRequest, GuardArtifact, HarnessDetection, PolicyDecision
 from codex_plugin_scanner.guard.policy import decide_action
 from codex_plugin_scanner.guard.proxy import RemoteGuardProxy, StdioGuardProxy
 from codex_plugin_scanner.guard.receipts import build_receipt
@@ -10406,6 +10406,110 @@ def test_guard_hook_codex_post_tool_use_browser_approval_resumes_result(
     assert captured.out == ""
     assert captured.err == ""
     assert store.list_approval_requests(limit=10) == []
+
+
+def test_codex_browser_approval_decision_updates_daemon_operation_status(tmp_path):
+    home_dir = tmp_path / "home"
+    store = GuardStore(home_dir)
+    request = GuardApprovalRequest(
+        request_id="request-1",
+        harness="codex",
+        artifact_id="artifact-1",
+        artifact_name="Bash request",
+        artifact_hash="hash-1",
+        policy_action="block",
+        recommended_scope="artifact",
+        changed_fields=("command",),
+        source_scope="project",
+        config_path="~/.codex/config.toml",
+        review_command="hol-guard approvals approve request-1",
+        approval_url="http://127.0.0.1:4455/approvals/request-1",
+        launch_target="bash ./guard-canary.sh",
+    )
+    store.add_approval_request(request, "2026-04-30T00:00:00+00:00")
+    apply_approval_resolution(
+        store=store,
+        request_id="request-1",
+        action="allow",
+        scope="artifact",
+        workspace=None,
+        reason="approved in browser",
+    )
+    statuses: list[dict[str, object]] = []
+
+    class _FakeDaemonClient:
+        def update_operation_status(self, **kwargs) -> None:
+            statuses.append(dict(kwargs))
+
+    payload: dict[str, object] = {
+        "operation_id": "operation-1",
+        "approval_requests": [{"request_id": "request-1"}],
+    }
+
+    decision = guard_commands_module._codex_browser_approval_decision(
+        args=argparse.Namespace(harness="codex", json=False),
+        event_name="PostToolUse",
+        policy_action="block",
+        response_payload=payload,
+        store=store,
+        config=GuardConfig(home_dir, None, approval_wait_timeout_seconds=1),
+        daemon_client=_FakeDaemonClient(),
+    )
+
+    assert decision == "allow"
+    assert statuses == [{"operation_id": "operation-1", "status": "completed"}]
+
+
+def test_codex_browser_block_decision_updates_daemon_operation_status(tmp_path):
+    home_dir = tmp_path / "home"
+    store = GuardStore(home_dir)
+    request = GuardApprovalRequest(
+        request_id="request-1",
+        harness="codex",
+        artifact_id="artifact-1",
+        artifact_name="Bash request",
+        artifact_hash="hash-1",
+        policy_action="block",
+        recommended_scope="artifact",
+        changed_fields=("command",),
+        source_scope="project",
+        config_path="~/.codex/config.toml",
+        review_command="hol-guard approvals approve request-1",
+        approval_url="http://127.0.0.1:4455/approvals/request-1",
+        launch_target="bash ./guard-canary.sh",
+    )
+    store.add_approval_request(request, "2026-04-30T00:00:00+00:00")
+    apply_approval_resolution(
+        store=store,
+        request_id="request-1",
+        action="block",
+        scope="artifact",
+        workspace=None,
+        reason="blocked in browser",
+    )
+    statuses: list[dict[str, object]] = []
+
+    class _FakeDaemonClient:
+        def update_operation_status(self, **kwargs) -> None:
+            statuses.append(dict(kwargs))
+
+    payload: dict[str, object] = {
+        "operation_id": "operation-1",
+        "approval_requests": [{"request_id": "request-1"}],
+    }
+
+    decision = guard_commands_module._codex_browser_approval_decision(
+        args=argparse.Namespace(harness="codex", json=False),
+        event_name="PostToolUse",
+        policy_action="block",
+        response_payload=payload,
+        store=store,
+        config=GuardConfig(home_dir, None, approval_wait_timeout_seconds=1),
+        daemon_client=_FakeDaemonClient(),
+    )
+
+    assert decision == "block"
+    assert statuses == [{"operation_id": "operation-1", "status": "blocked"}]
 
 
 def test_guard_hook_codex_post_tool_use_blocks_named_secret_output(

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -10626,6 +10626,28 @@ def test_codex_browser_block_decision_updates_daemon_operation_status(tmp_path):
     assert statuses == [{"operation_id": "operation-1", "status": "blocked"}]
 
 
+def test_codex_browser_approval_caps_wait_below_hook_timeout(tmp_path, monkeypatch):
+    captured_timeout: list[int] = []
+
+    def _fake_wait_for_approval_requests(**kwargs) -> dict[str, object]:
+        captured_timeout.append(int(kwargs["timeout_seconds"]))
+        return {"resolved": False, "pending_request_ids": ["request-1"], "items": []}
+
+    monkeypatch.setattr(guard_commands_module, "wait_for_approval_requests", _fake_wait_for_approval_requests)
+
+    decision = guard_commands_module._codex_browser_approval_decision(
+        args=argparse.Namespace(harness="codex", json=False),
+        event_name="PreToolUse",
+        policy_action="block",
+        response_payload={"approval_requests": [{"request_id": "request-1"}]},
+        store=GuardStore(tmp_path / "home"),
+        config=GuardConfig(tmp_path / "home", None, approval_wait_timeout_seconds=120),
+    )
+
+    assert decision is None
+    assert captured_timeout == [25]
+
+
 def test_guard_hook_codex_post_tool_use_blocks_named_secret_output(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -52,6 +52,7 @@ def _write_text(path: Path, text: str) -> None:
 
 
 def _build_guard_fixture(home_dir: Path, workspace_dir: Path) -> None:
+    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 0\n")
     _write_text(
         home_dir / ".codex" / "config.toml",
         """


### PR DESCRIPTION
<!-- kilo-review -->
## Code Review Summary

**Status:** 4 Issues Found | **Recommendation:** Address before merge

### Overview
| Severity | Count |
|----------|-------|
| CRITICAL | 0 |
| WARNING | 3 |
| SUGGESTION | 1 |

<details>
<summary><b>Issue Details (click to expand)</b></summary>

#### WARNING
| File | Line | Issue |
|------|------|-------|
| `src/codex_plugin_scanner/guard/cli/commands.py` | 1687-1688 | Browser block decision does not emit stderr for PostToolUse/UserPromptSubmit |
| `src/codex_plugin_scanner/guard/cli/commands.py` | 1687-1688 | Inconsistent exit codes: block stderr returns 2, JSON block returns 0 |
| `src/codex_plugin_scanner/guard/cli/commands.py` | 1939-1950 | No validation that approval_requests items match expected structure beyond existence checks |

#### SUGGESTION
| File | Line | Issue |
|------|------|-------|
| `src/codex_plugin_scanner/guard/cli/commands.py` | 1956 | Redundant `str()` cast on already-validated string |

</details>

<details>
<summary><b>Other Observations (not in diff)</b></summary>

| File | Line | Issue |
|------|------|-------|
| `src/codex_plugin_scanner/guard/cli/commands.py` | 1922-1932 | `_should_emit_native_hook_exit_block` only emits stderr for PreToolUse, not PostToolUse/UserPromptSubmit |

</details>

<details>
<summary><b>Files Reviewed (4 files)</b></summary>

- `src/codex_plugin_scanner/guard/cli/commands.py` - 4 issues
- `tests/test_guard_runtime.py` - OK
- `src/codex_plugin_scanner/guard/approvals.py` - referenced, OK
- `src/codex_plugin_scanner/guard/cli/commands.py` (additional imports) - OK

</details>
