### PR TITLE
fix(daemon): stop leaking dashboard auth token

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1019,19 +1019,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
 
     def _write_dashboard_shell(self) -> None:
         if _INDEX_PATH.is_file() and _ENTRY_PATH.is_file():
-            body = _INDEX_PATH.read_text(encoding="utf-8")
-            token_script = (
-                "<script>"
-                "try{window.sessionStorage.setItem("
-                f"{json.dumps('guard-token')},{json.dumps(self.server.auth_token)}"  # type: ignore[attr-defined]
-                ");}catch(_error){}"
-                "</script>"
-            )
-            if "</head>" in body:
-                body = body.replace("</head>", f"{token_script}</head>", 1)
-            else:
-                body = f"{token_script}{body}"
-            encoded = body.encode("utf-8")
+            encoded = _INDEX_PATH.read_bytes()
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.send_header("Content-Length", str(len(encoded)))

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -39,6 +39,9 @@ class TestGuardSurfaceServer:
                 assert response.status == 200
                 assert "text/html" in response.headers.get("Content-Type", "")
                 assert "Loading Local approval center" in body
+                assert "sessionStorage.setItem" not in body
+                assert "guard-token" not in body
+                assert daemon._server.auth_token not in body
         finally:
             daemon.stop()
 
@@ -68,7 +71,7 @@ class TestGuardSurfaceServer:
         assert favicon_response.status == 200
         assert favicon_response.headers.get("Cache-Control") == "no-store, max-age=0"
 
-    def test_guard_daemon_dashboard_shell_seeds_local_auth_token(self, tmp_path) -> None:
+    def test_guard_daemon_dashboard_shell_omits_local_auth_token(self, tmp_path) -> None:
         store = GuardStore(tmp_path / "guard-home")
         store.add_approval_request(
             GuardApprovalRequest(
@@ -112,9 +115,9 @@ class TestGuardSurfaceServer:
             daemon.stop()
 
         assert response.status == 200
-        assert "sessionStorage.setItem" in body
-        assert "guard-token" in body
-        assert daemon._server.auth_token in body
+        assert "sessionStorage.setItem" not in body
+        assert "guard-token" not in body
+        assert daemon._server.auth_token not in body
         assert approval_response.status == 200
         assert approval_payload["resolved"] is True
 


### PR DESCRIPTION
## Summary
- serve the dashboard shell without injecting the daemon auth token into HTML
- prove unauthenticated dashboard routes no longer expose the live token across root and section pages
- preserve authenticated follow-up behavior and existing initialize/connect bootstrap flow

## Validation
- ruff check .
- pytest -q
- python3 -m build