### PR TITLE
fix(guard): allow read-only source inspection output

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -4080,6 +4080,8 @@ def _codex_command_is_bounded_read_only_filter(command_text: str) -> bool:
         return False
     if not parts:
         return False
+    if _codex_command_uses_untrusted_search_binary(parts[0]):
+        return False
     executable = Path(parts[0]).name
     if executable not in _CODEX_READ_ONLY_PIPE_FILTERS:
         return False
@@ -4097,6 +4099,8 @@ def _codex_command_is_read_only_source_view(command_text: str, *, cwd: Path | No
     except ValueError:
         return False
     if not parts:
+        return False
+    if _codex_command_uses_untrusted_search_binary(parts[0]):
         return False
     executable = Path(parts[0]).name
     if executable not in _CODEX_READ_ONLY_VIEW_COMMANDS:
@@ -4161,30 +4165,21 @@ def _codex_cat_targets_are_source_like(args: list[str], *, cwd: Path | None) -> 
 
 
 def _codex_head_tail_args_are_bounded_filter(args: list[str]) -> bool:
-    skip_next = False
-    for arg in args:
-        if skip_next:
-            skip_next = False
-            if not _codex_count_arg_is_bounded(arg):
-                return False
-            continue
-        if arg in {"-n", "--lines", "-c", "--bytes"}:
-            skip_next = True
-            continue
-        if arg.startswith("--lines=") or arg.startswith("--bytes="):
-            _, value = arg.split("=", 1)
-            if not _codex_count_arg_is_bounded(value):
-                return False
-            continue
-        if re.fullmatch(r"-\d{1,6}", arg):
-            continue
-        if arg.startswith("-"):
-            return False
-        return False
-    return not skip_next
+    targets, valid, skip_next = _parse_codex_head_tail_args(args)
+    return valid and not skip_next and not targets
 
 
 def _codex_head_tail_targets_are_source_like(args: list[str], *, cwd: Path | None) -> bool:
+    targets, valid, skip_next = _parse_codex_head_tail_args(args)
+    return (
+        valid
+        and not skip_next
+        and bool(targets)
+        and all(_codex_search_target_is_source_like(target, cwd=cwd) for target in targets)
+    )
+
+
+def _parse_codex_head_tail_args(args: list[str]) -> tuple[list[str], bool, bool]:
     targets: list[str] = []
     skip_next = False
     after_option_terminator = False
@@ -4192,7 +4187,7 @@ def _codex_head_tail_targets_are_source_like(args: list[str], *, cwd: Path | Non
         if skip_next:
             skip_next = False
             if not _codex_count_arg_is_bounded(arg):
-                return False
+                return [], False, False
             continue
         if after_option_terminator:
             targets.append(arg)
@@ -4206,20 +4201,16 @@ def _codex_head_tail_targets_are_source_like(args: list[str], *, cwd: Path | Non
         if arg.startswith("--lines=") or arg.startswith("--bytes="):
             _, value = arg.split("=", 1)
             if not _codex_count_arg_is_bounded(value):
-                return False
+                return [], False, False
             continue
         if re.fullmatch(r"-\d{1,6}", arg):
             continue
         if arg == "-":
-            return False
+            return [], False, False
         if arg.startswith("-"):
-            return False
+            return [], False, False
         targets.append(arg)
-    return (
-        bool(targets)
-        and not skip_next
-        and all(_codex_search_target_is_source_like(target, cwd=cwd) for target in targets)
-    )
+    return targets, True, skip_next
 
 
 def _codex_sed_targets_are_read_only_source_like(args: list[str], *, cwd: Path | None) -> bool:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -4455,6 +4455,8 @@ def _codex_search_target_is_source_like(target: str, *, cwd: Path | None) -> boo
         return False
     if stripped.startswith(("~", "/")):
         return False
+    if any(char in stripped for char in ("*", "?", "[", "]", "{", "}")):
+        return False
     target_path = Path(stripped)
     base_dir = (cwd or Path.cwd()).resolve()
     unresolved_candidate = base_dir / target_path

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -4308,7 +4308,7 @@ def _codex_sed_targets_are_read_only_source_like(args: list[str], *, cwd: Path |
 
 
 def _codex_count_arg_is_bounded(value: str) -> bool:
-    normalized = value.strip().lstrip("+-")
+    normalized = value.strip()
     return bool(re.fullmatch(r"\d{1,6}", normalized))
 
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3990,6 +3990,8 @@ def _codex_command_is_read_only_source_inspection(command_text: str, *, cwd: Pat
     command = command_text.strip()
     if not command:
         return False
+    if _codex_command_has_unquoted_glob_metachar(command):
+        return False
     segments = _split_codex_safe_read_only_pipeline(command)
     if segments is None:
         return _codex_command_is_read_only_source_search(command, cwd=cwd) or _codex_command_is_read_only_source_view(
@@ -4004,6 +4006,28 @@ def _codex_command_is_read_only_source_inspection(command_text: str, *, cwd: Pat
     ):
         return False
     return all(_codex_command_is_bounded_read_only_filter(segment) for segment in filter_segments)
+
+
+def _codex_command_has_unquoted_glob_metachar(command: str) -> bool:
+    quote: str | None = None
+    escaped = False
+    for char in command:
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if quote is not None:
+            if char == quote:
+                quote = None
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            continue
+        if char in {"*", "?", "[", "]", "{", "}"}:
+            return True
+    return False
 
 
 def _split_codex_safe_read_only_pipeline(command: str) -> list[str] | None:
@@ -4455,7 +4479,7 @@ def _codex_search_target_is_source_like(target: str, *, cwd: Path | None) -> boo
         return False
     if stripped.startswith(("~", "/")):
         return False
-    if any(char in stripped for char in ("*", "?", "[", "]", "{", "}")):
+    if any(char in stripped for char in ("*", "?", "{", "}")):
         return False
     target_path = Path(stripped)
     base_dir = (cwd or Path.cwd()).resolve()

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -4011,7 +4011,7 @@ def _split_codex_safe_read_only_pipeline(command: str) -> list[str] | None:
     current: list[str] = []
     quote: str | None = None
     escaped = False
-    for index, char in enumerate(command):
+    for char in command:
         if escaped:
             current.append(char)
             escaped = False
@@ -4024,9 +4024,7 @@ def _split_codex_safe_read_only_pipeline(command: str) -> list[str] | None:
             current.append(char)
             if char == quote:
                 quote = None
-            elif quote == '"' and (
-                char == "`" or (char == "$" and index + 1 < len(command) and command[index + 1] in {"(", "{"})
-            ):
+            elif quote == '"' and (char == "`" or char == "$"):
                 return None
             continue
         if char in {"'", '"'}:
@@ -4035,7 +4033,7 @@ def _split_codex_safe_read_only_pipeline(command: str) -> list[str] | None:
             continue
         if char in {"\n", "\r", "&", ";", "<", "`"}:
             return None
-        if char == "$" and index + 1 < len(command) and command[index + 1] in {"(", "{"}:
+        if char == "$":
             return None
         if char == "|":
             segment = "".join(current).strip()
@@ -4361,7 +4359,7 @@ def _shell_wrapper_script_index(parts: list[str]) -> int | None:
 def _codex_command_has_unquoted_shell_control(command: str) -> bool:
     quote: str | None = None
     escaped = False
-    for index, char in enumerate(command):
+    for char in command:
         if escaped:
             escaped = False
             continue
@@ -4373,7 +4371,7 @@ def _codex_command_has_unquoted_shell_control(command: str) -> bool:
                 quote = None
             if quote == '"' and char == "`":
                 return True
-            if quote == '"' and char == "$" and index + 1 < len(command) and command[index + 1] in {"(", "{"}:
+            if quote == '"' and char == "$":
                 return True
             continue
         if char in {"'", '"'}:
@@ -4383,7 +4381,7 @@ def _codex_command_has_unquoted_shell_control(command: str) -> bool:
             return True
         if char in {"|", "&", ";", ">", "<", "`"}:
             return True
-        if char == "$" and index + 1 < len(command) and command[index + 1] in {"(", "{"}:
+        if char == "$":
             return True
     return False
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3751,6 +3751,8 @@ def _hook_runtime_artifact(
         )
         if output_artifact is not None:
             return output_artifact
+        if _codex_post_tool_command_is_read_only_source_inspection(payload=payload, cwd=workspace):
+            return None
     if event_name == "UserPromptSubmit":
         prompt_text = payload.get("prompt")
         if isinstance(prompt_text, str) and prompt_text.strip():
@@ -3840,12 +3842,7 @@ def _codex_post_tool_output_artifact(
     if not response_text or _CODEX_SECRET_OUTPUT_PATTERN.search(response_text) is None:
         return None
     tool_name = _coalesce_string(payload.get("tool_name"), "Bash")
-    tool_input = payload.get("tool_input")
-    command_text = ""
-    if isinstance(tool_input, dict):
-        command = tool_input.get("command")
-        if isinstance(command, str):
-            command_text = command.strip()
+    command_text = _codex_post_tool_command_text(payload)
     if not command_text:
         command_text = tool_name
     if _codex_command_is_read_only_source_inspection(command_text, cwd=cwd):
@@ -3884,6 +3881,24 @@ def _codex_post_tool_output_artifact(
             ),
         },
     )
+
+
+def _codex_post_tool_command_is_read_only_source_inspection(
+    *,
+    payload: dict[str, object],
+    cwd: Path | None,
+) -> bool:
+    command_text = _codex_post_tool_command_text(payload)
+    return bool(command_text) and _codex_command_is_read_only_source_inspection(command_text, cwd=cwd)
+
+
+def _codex_post_tool_command_text(payload: dict[str, object]) -> str:
+    tool_input = payload.get("tool_input")
+    if isinstance(tool_input, dict):
+        command = tool_input.get("command")
+        if isinstance(command, str):
+            return command.strip()
+    return ""
 
 
 _CODEX_READ_ONLY_SEARCH_COMMANDS = frozenset({"rg", "grep", "egrep", "fgrep"})
@@ -4010,7 +4025,7 @@ def _split_codex_safe_read_only_pipeline(command: str) -> list[str] | None:
             if char == quote:
                 quote = None
             elif quote == '"' and (
-                char == "`" or (char == "$" and index + 1 < len(command) and command[index + 1] == "(")
+                char == "`" or (char == "$" and index + 1 < len(command) and command[index + 1] in {"(", "{"})
             ):
                 return None
             continue
@@ -4020,7 +4035,7 @@ def _split_codex_safe_read_only_pipeline(command: str) -> list[str] | None:
             continue
         if char in {"\n", "\r", "&", ";", "<", "`"}:
             return None
-        if char == "$" and index + 1 < len(command) and command[index + 1] == "(":
+        if char == "$" and index + 1 < len(command) and command[index + 1] in {"(", "{"}:
             return None
         if char == "|":
             segment = "".join(current).strip()
@@ -4046,31 +4061,61 @@ def _split_codex_safe_read_only_pipeline(command: str) -> list[str] | None:
 
 
 def _strip_codex_safe_stderr_discard(segment: str) -> str | None:
+    cleaned_segment = _remove_codex_safe_stderr_discard(segment)
+    if cleaned_segment is None:
+        return None
     try:
-        parts = shlex.split(segment)
+        parts = shlex.split(cleaned_segment)
     except ValueError:
         return None
     if not parts:
         return None
+    return shlex.join(parts)
+
+
+def _remove_codex_safe_stderr_discard(segment: str) -> str | None:
     cleaned: list[str] = []
+    quote: str | None = None
+    escaped = False
     index = 0
-    while index < len(parts):
-        part = parts[index]
-        if part == "2>/dev/null":
+    while index < len(segment):
+        char = segment[index]
+        if escaped:
+            cleaned.append(char)
+            escaped = False
             index += 1
             continue
-        if part == "2>" and index + 1 < len(parts) and parts[index + 1] == "/dev/null":
-            index += 2
+        if char == "\\":
+            cleaned.append(char)
+            escaped = True
+            index += 1
             continue
-        if part.startswith("2>") and part != "2>/dev/null":
+        if quote is not None:
+            cleaned.append(char)
+            if char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in {"'", '"'}:
+            cleaned.append(char)
+            quote = char
+            index += 1
+            continue
+        if segment.startswith("2>", index):
+            after_redirect = index + 2
+            while after_redirect < len(segment) and segment[after_redirect].isspace():
+                after_redirect += 1
+            if segment.startswith("/dev/null", after_redirect):
+                after_target = after_redirect + len("/dev/null")
+                if after_target == len(segment) or segment[after_target].isspace():
+                    index = after_target
+                    continue
             return None
-        if ">" in part:
+        if char == ">":
             return None
-        cleaned.append(part)
+        cleaned.append(char)
         index += 1
-    if not cleaned:
-        return None
-    return shlex.join(cleaned)
+    return "".join(cleaned).strip()
 
 
 def _codex_command_is_bounded_read_only_filter(command_text: str) -> bool:
@@ -4326,7 +4371,7 @@ def _codex_command_has_unquoted_shell_control(command: str) -> bool:
                 quote = None
             if quote == '"' and char == "`":
                 return True
-            if quote == '"' and char == "$" and index + 1 < len(command) and command[index + 1] == "(":
+            if quote == '"' and char == "$" and index + 1 < len(command) and command[index + 1] in {"(", "{"}:
                 return True
             continue
         if char in {"'", '"'}:
@@ -4336,7 +4381,7 @@ def _codex_command_has_unquoted_shell_control(command: str) -> bool:
             return True
         if char in {"|", "&", ";", ">", "<", "`"}:
             return True
-        if char == "$" and index + 1 < len(command) and command[index + 1] == "(":
+        if char == "$" and index + 1 < len(command) and command[index + 1] in {"(", "{"}:
             return True
     return False
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3848,7 +3848,7 @@ def _codex_post_tool_output_artifact(
             command_text = command.strip()
     if not command_text:
         command_text = tool_name
-    if _codex_command_is_read_only_source_search(command_text, cwd=cwd):
+    if _codex_command_is_read_only_source_inspection(command_text, cwd=cwd):
         return None
     fingerprint = hashlib.sha256(
         json.dumps(
@@ -3887,6 +3887,8 @@ def _codex_post_tool_output_artifact(
 
 
 _CODEX_READ_ONLY_SEARCH_COMMANDS = frozenset({"rg", "grep", "egrep", "fgrep"})
+_CODEX_READ_ONLY_VIEW_COMMANDS = frozenset({"cat", "head", "tail", "sed"})
+_CODEX_READ_ONLY_PIPE_FILTERS = frozenset({"head", "tail"})
 _CODEX_READ_ONLY_SEARCH_WRAPPERS = frozenset({"bash", "sh", "zsh"})
 _CODEX_SEARCH_PATTERN_VALUE_FLAGS = frozenset({"-e", "--regexp", "-f", "--file"})
 _CODEX_SEARCH_OPTION_VALUE_FLAGS = frozenset(
@@ -3966,6 +3968,144 @@ _CODEX_SENSITIVE_SEARCH_BASENAMES = frozenset(
         "id_rsa",
     }
 )
+_CODEX_SED_PRINT_SCRIPT_PATTERN = re.compile(r"^\s*(?:\$|\d+)?(?:\s*,\s*(?:\$|\d+))?p\s*$")
+
+
+def _codex_command_is_read_only_source_inspection(command_text: str, *, cwd: Path | None) -> bool:
+    command = command_text.strip()
+    if not command:
+        return False
+    segments = _split_codex_safe_read_only_pipeline(command)
+    if segments is None:
+        return _codex_command_is_read_only_source_search(command, cwd=cwd) or _codex_command_is_read_only_source_view(
+            command, cwd=cwd
+        )
+    if not segments:
+        return False
+    first_segment, *filter_segments = segments
+    if not (
+        _codex_command_is_read_only_source_search(first_segment, cwd=cwd)
+        or _codex_command_is_read_only_source_view(first_segment, cwd=cwd)
+    ):
+        return False
+    return all(_codex_command_is_bounded_read_only_filter(segment) for segment in filter_segments)
+
+
+def _split_codex_safe_read_only_pipeline(command: str) -> list[str] | None:
+    segments: list[str] = []
+    current: list[str] = []
+    quote: str | None = None
+    escaped = False
+    for index, char in enumerate(command):
+        if escaped:
+            current.append(char)
+            escaped = False
+            continue
+        if char == "\\":
+            current.append(char)
+            escaped = True
+            continue
+        if quote is not None:
+            current.append(char)
+            if char == quote:
+                quote = None
+            elif quote == '"' and (
+                char == "`" or (char == "$" and index + 1 < len(command) and command[index + 1] == "(")
+            ):
+                return None
+            continue
+        if char in {"'", '"'}:
+            current.append(char)
+            quote = char
+            continue
+        if char in {"\n", "\r", "&", ";", "<", "`"}:
+            return None
+        if char == "$" and index + 1 < len(command) and command[index + 1] == "(":
+            return None
+        if char == "|":
+            segment = "".join(current).strip()
+            if not segment:
+                return None
+            stripped_segment = _strip_codex_safe_stderr_discard(segment)
+            if stripped_segment is None:
+                return None
+            segments.append(stripped_segment)
+            current = []
+            continue
+        current.append(char)
+    segment = "".join(current).strip()
+    if not segments:
+        return None
+    if not segment:
+        return None
+    stripped_segment = _strip_codex_safe_stderr_discard(segment)
+    if stripped_segment is None:
+        return None
+    segments.append(stripped_segment)
+    return segments
+
+
+def _strip_codex_safe_stderr_discard(segment: str) -> str | None:
+    try:
+        parts = shlex.split(segment)
+    except ValueError:
+        return None
+    if not parts:
+        return None
+    cleaned: list[str] = []
+    index = 0
+    while index < len(parts):
+        part = parts[index]
+        if part == "2>/dev/null":
+            index += 1
+            continue
+        if part == "2>" and index + 1 < len(parts) and parts[index + 1] == "/dev/null":
+            index += 2
+            continue
+        if part.startswith("2>") and part != "2>/dev/null":
+            return None
+        if ">" in part:
+            return None
+        cleaned.append(part)
+        index += 1
+    if not cleaned:
+        return None
+    return shlex.join(cleaned)
+
+
+def _codex_command_is_bounded_read_only_filter(command_text: str) -> bool:
+    try:
+        parts = shlex.split(command_text)
+    except ValueError:
+        return False
+    if not parts:
+        return False
+    executable = Path(parts[0]).name
+    if executable not in _CODEX_READ_ONLY_PIPE_FILTERS:
+        return False
+    return _codex_head_tail_args_are_bounded_filter(parts[1:])
+
+
+def _codex_command_is_read_only_source_view(command_text: str, *, cwd: Path | None) -> bool:
+    command = command_text.strip()
+    if not command:
+        return False
+    if _codex_command_has_unquoted_shell_control(command):
+        return False
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        return False
+    if not parts:
+        return False
+    executable = Path(parts[0]).name
+    if executable not in _CODEX_READ_ONLY_VIEW_COMMANDS:
+        return False
+    if executable == "sed":
+        return _codex_sed_targets_are_read_only_source_like(parts[1:], cwd=cwd)
+    if executable in {"head", "tail"}:
+        return _codex_head_tail_targets_are_source_like(parts[1:], cwd=cwd)
+    return _codex_cat_targets_are_source_like(parts[1:], cwd=cwd)
 
 
 def _codex_command_is_read_only_source_search(command_text: str, *, cwd: Path | None) -> bool:
@@ -4000,6 +4140,138 @@ def _codex_command_is_read_only_source_search(command_text: str, *, cwd: Path | 
 
 def _codex_command_uses_untrusted_search_binary(executable_token: str) -> bool:
     return executable_token.startswith(".") or "/" in executable_token or "\\" in executable_token
+
+
+def _codex_cat_targets_are_source_like(args: list[str], *, cwd: Path | None) -> bool:
+    targets: list[str] = []
+    after_option_terminator = False
+    for arg in args:
+        if after_option_terminator:
+            targets.append(arg)
+            continue
+        if arg == "--":
+            after_option_terminator = True
+            continue
+        if arg == "-":
+            return False
+        if arg.startswith("-"):
+            continue
+        targets.append(arg)
+    return bool(targets) and all(_codex_search_target_is_source_like(target, cwd=cwd) for target in targets)
+
+
+def _codex_head_tail_args_are_bounded_filter(args: list[str]) -> bool:
+    skip_next = False
+    for arg in args:
+        if skip_next:
+            skip_next = False
+            if not _codex_count_arg_is_bounded(arg):
+                return False
+            continue
+        if arg in {"-n", "--lines", "-c", "--bytes"}:
+            skip_next = True
+            continue
+        if arg.startswith("--lines=") or arg.startswith("--bytes="):
+            _, value = arg.split("=", 1)
+            if not _codex_count_arg_is_bounded(value):
+                return False
+            continue
+        if re.fullmatch(r"-\d{1,6}", arg):
+            continue
+        if arg.startswith("-"):
+            return False
+        return False
+    return not skip_next
+
+
+def _codex_head_tail_targets_are_source_like(args: list[str], *, cwd: Path | None) -> bool:
+    targets: list[str] = []
+    skip_next = False
+    after_option_terminator = False
+    for arg in args:
+        if skip_next:
+            skip_next = False
+            if not _codex_count_arg_is_bounded(arg):
+                return False
+            continue
+        if after_option_terminator:
+            targets.append(arg)
+            continue
+        if arg == "--":
+            after_option_terminator = True
+            continue
+        if arg in {"-n", "--lines", "-c", "--bytes"}:
+            skip_next = True
+            continue
+        if arg.startswith("--lines=") or arg.startswith("--bytes="):
+            _, value = arg.split("=", 1)
+            if not _codex_count_arg_is_bounded(value):
+                return False
+            continue
+        if re.fullmatch(r"-\d{1,6}", arg):
+            continue
+        if arg == "-":
+            return False
+        if arg.startswith("-"):
+            return False
+        targets.append(arg)
+    return (
+        bool(targets)
+        and not skip_next
+        and all(_codex_search_target_is_source_like(target, cwd=cwd) for target in targets)
+    )
+
+
+def _codex_sed_targets_are_read_only_source_like(args: list[str], *, cwd: Path | None) -> bool:
+    scripts: list[str] = []
+    targets: list[str] = []
+    skip_next_script = False
+    after_option_terminator = False
+    saw_print_suppression = False
+    for arg in args:
+        if skip_next_script:
+            skip_next_script = False
+            scripts.append(arg)
+            continue
+        if after_option_terminator:
+            targets.append(arg)
+            continue
+        if arg == "--":
+            after_option_terminator = True
+            continue
+        if arg in {"-i", "--in-place"} or arg.startswith(("-i", "--in-place=")):
+            return False
+        if arg == "-n" or arg == "--quiet" or arg == "--silent":
+            saw_print_suppression = True
+            continue
+        if arg == "-e" or arg == "--expression":
+            skip_next_script = True
+            continue
+        if arg.startswith("-e") and len(arg) > 2:
+            scripts.append(arg[2:])
+            continue
+        if arg.startswith("--expression="):
+            _, script = arg.split("=", 1)
+            scripts.append(script)
+            continue
+        if arg.startswith("-"):
+            return False
+        if not scripts:
+            scripts.append(arg)
+            continue
+        targets.append(arg)
+    if skip_next_script or not scripts or not targets:
+        return False
+    if not saw_print_suppression:
+        return False
+    if not all(_CODEX_SED_PRINT_SCRIPT_PATTERN.fullmatch(script.strip()) for script in scripts):
+        return False
+    return all(_codex_search_target_is_source_like(target, cwd=cwd) for target in targets)
+
+
+def _codex_count_arg_is_bounded(value: str) -> bool:
+    normalized = value.strip().lstrip("+-")
+    return bool(re.fullmatch(r"\d{1,6}", normalized))
 
 
 def _git_grep_search_args(args: list[str]) -> list[str] | None:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -4070,6 +4070,8 @@ def _strip_codex_safe_stderr_discard(segment: str) -> str | None:
         return None
     if not parts:
         return None
+    if _codex_command_uses_untrusted_search_binary(parts[0]):
+        return None
     return shlex.join(parts)
 
 

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -542,6 +542,83 @@ Please investigate the bug end to end, fix the publish flow, and make sure user-
         assert output["recorded"] is True
         assert "approval_requests" not in output
 
+    def test_codex_post_tool_use_allows_read_only_source_view_with_secret_like_output(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        source_file = workspace_dir / "__tests__" / "guard-connect-shell.test.tsx"
+        _write_text(source_file, "const label = 'credential-looking output';\n")
+        event = {
+            "event": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": ("sed -n '1,40p' __tests__/guard-connect-shell.test.tsx 2>/dev/null | head -40")},
+            "tool_response": {"stdout": "const label = 'credential-looking output';\n"},
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["recorded"] is True
+        assert "approval_requests" not in output
+
+    def test_codex_post_tool_use_blocks_hidden_file_view_with_secret_like_output(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        event = {
+            "event": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "sed -n '1,40p' .npmrc 2>/dev/null | head -40"},
+            "tool_response": {"stdout": "token = fixture-only\n"},
+            "source_scope": "project",
+        }
+        monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
+        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+            ]
+        )
+        payload = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert payload["continue"] is False
+        assert "credential-looking output" in payload["stopReason"]
+
     def test_codex_post_tool_use_allows_common_source_directory_searches(
         self,
         monkeypatch,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -11965,12 +11965,31 @@ def test_codex_read_only_source_inspection_rejects_globbed_targets(tmp_path: Pat
 
     commands = [
         "cat src/*.ts",
+        "cat src/[leak].ts",
         "sed -n '1,40p' src/*.ts | head -40",
         "rg safe src/*.ts",
     ]
 
     for command in commands:
         assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+            command,
+            cwd=workspace_dir,
+        )
+
+
+def test_codex_read_only_source_inspection_allows_quoted_bracket_targets(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    route_file = workspace_dir / "app" / "[slug]" / "page.tsx"
+    _write_text(route_file, "export default function Page() { return null; }\n")
+
+    commands = [
+        "cat 'app/[slug]/page.tsx'",
+        "sed -n '1,40p' 'app/[slug]/page.tsx' | head -40",
+        "rg Page 'app/[slug]/page.tsx'",
+    ]
+
+    for command in commands:
+        assert guard_commands_module._codex_command_is_read_only_source_inspection(
             command,
             cwd=workspace_dir,
         )

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -11956,3 +11956,21 @@ def test_sync_runtime_session_retries_once_after_read_timeout(tmp_path, monkeypa
 
     assert timeouts == [10, 90]
     assert payload["runtime_session_id"] == "session-read-timeout"
+
+
+def test_codex_read_only_source_inspection_rejects_globbed_targets(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    (workspace_dir / "src").mkdir(parents=True)
+    _write_text(workspace_dir / "src" / "safe.ts", "export const safe = true;\n")
+
+    commands = [
+        "cat src/*.ts",
+        "sed -n '1,40p' src/*.ts | head -40",
+        "rg safe src/*.ts",
+    ]
+
+    for command in commands:
+        assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+            command,
+            cwd=workspace_dir,
+        )

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -552,12 +552,12 @@ Please investigate the bug end to end, fix the publish flow, and make sure user-
         workspace_dir = tmp_path / "workspace"
         _build_guard_fixture(home_dir, workspace_dir)
         source_file = workspace_dir / "__tests__" / "guard-connect-shell.test.tsx"
-        _write_text(source_file, "const label = 'credential-looking output';\n")
+        _write_text(source_file, "const label = 'HOL_GUARD_FAKE_CREDENTIAL=fixture-only';\n")
         event = {
             "event": "PostToolUse",
             "tool_name": "Bash",
             "tool_input": {"command": ("sed -n '1,40p' __tests__/guard-connect-shell.test.tsx 2>/dev/null | head -40")},
-            "tool_response": {"stdout": "const label = 'credential-looking output';\n"},
+            "tool_response": {"stdout": "const label = 'HOL_GUARD_FAKE_CREDENTIAL=fixture-only';\n"},
             "source_scope": "project",
         }
         monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
@@ -595,6 +595,54 @@ Please investigate the bug end to end, fix the publish flow, and make sure user-
             "tool_name": "Bash",
             "tool_input": {"command": "sed -n '1,40p' .npmrc 2>/dev/null | head -40"},
             "tool_response": {"stdout": "token = fixture-only\n"},
+            "source_scope": "project",
+        }
+        monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
+        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+            ]
+        )
+        payload = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert payload["continue"] is False
+        assert "credential-looking output" in payload["stopReason"]
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "./sed -n '1,40p' __tests__/guard-connect-shell.test.tsx",
+            "sed -n '1,40p' __tests__/guard-connect-shell.test.tsx | ./head -40",
+        ],
+    )
+    def test_codex_post_tool_use_blocks_path_qualified_read_only_binaries(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+        command,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        source_file = workspace_dir / "__tests__" / "guard-connect-shell.test.tsx"
+        _write_text(source_file, "const label = 'HOL_GUARD_FAKE_CREDENTIAL=fixture-only';\n")
+        event = {
+            "event": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "tool_response": {"stdout": "const label = 'HOL_GUARD_FAKE_CREDENTIAL=fixture-only';\n"},
             "source_scope": "project",
         }
         monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -746,6 +746,48 @@ Please investigate the bug end to end, fix the publish flow, and make sure user-
         assert output["recorded"] is True
         assert "approval_requests" not in output
 
+    @pytest.mark.parametrize("filter_args", ["tail -n +1", "head -n -1"])
+    def test_codex_post_tool_use_blocks_unbounded_signed_head_tail_filters(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+        filter_args,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        source_file = workspace_dir / "__tests__" / "guard-connect-shell.test.tsx"
+        _write_text(source_file, "const label = 'HOL_GUARD_FAKE_CREDENTIAL=fixture-only';\n")
+        event = {
+            "event": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": f"sed -n '1,40p' __tests__/guard-connect-shell.test.tsx | {filter_args}"},
+            "tool_response": {"stdout": "const label = 'HOL_GUARD_FAKE_CREDENTIAL=fixture-only';\n"},
+            "source_scope": "project",
+        }
+        monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
+        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+            ]
+        )
+        payload = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert payload["continue"] is False
+        assert "credential-looking output" in payload["stopReason"]
+
     def test_codex_post_tool_use_allows_common_source_directory_searches(
         self,
         monkeypatch,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -707,6 +707,46 @@ Please investigate the bug end to end, fix the publish flow, and make sure user-
         assert payload["continue"] is False
         assert "credential-looking output" in payload["stopReason"]
 
+    def test_codex_post_tool_use_blocks_unbraced_env_expansion_source_view(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        source_file = workspace_dir / "__tests__" / "guard-connect-shell.test.tsx"
+        _write_text(source_file, "const label = 'HOL_GUARD_FAKE_CREDENTIAL=fixture-only';\n")
+        event = {
+            "event": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "sed -n '1,40p' $GUARD_SOURCE_FILE.tsx | head -40"},
+            "tool_response": {"stdout": "const label = 'HOL_GUARD_FAKE_CREDENTIAL=fixture-only';\n"},
+            "source_scope": "project",
+        }
+        monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
+        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+            ]
+        )
+        payload = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert payload["continue"] is False
+        assert "credential-looking output" in payload["stopReason"]
+
     def test_codex_post_tool_use_allows_quoted_greater_than_search_pipeline(
         self,
         monkeypatch,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -667,6 +667,85 @@ Please investigate the bug end to end, fix the publish flow, and make sure user-
         assert payload["continue"] is False
         assert "credential-looking output" in payload["stopReason"]
 
+    def test_codex_post_tool_use_blocks_parameter_expansion_source_view(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        source_file = workspace_dir / "__tests__" / "guard-connect-shell.test.tsx"
+        _write_text(source_file, "const label = 'HOL_GUARD_FAKE_CREDENTIAL=fixture-only';\n")
+        event = {
+            "event": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "sed -n '1,40p' ${GUARD_SOURCE_FILE}.tsx | head -40"},
+            "tool_response": {"stdout": "const label = 'HOL_GUARD_FAKE_CREDENTIAL=fixture-only';\n"},
+            "source_scope": "project",
+        }
+        monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
+        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+            ]
+        )
+        payload = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert payload["continue"] is False
+        assert "credential-looking output" in payload["stopReason"]
+
+    def test_codex_post_tool_use_allows_quoted_greater_than_search_pipeline(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        source_file = workspace_dir / "__tests__" / "guard-connect-shell.test.tsx"
+        _write_text(source_file, "const label = 'HOL_GUARD_FAKE_CREDENTIAL=fixture-only';\n")
+        event = {
+            "event": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "rg '>' __tests__/guard-connect-shell.test.tsx | head -40"},
+            "tool_response": {"stdout": "const label = 'HOL_GUARD_FAKE_CREDENTIAL=fixture-only';\n"},
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["recorded"] is True
+        assert "approval_requests" not in output
+
     def test_codex_post_tool_use_allows_common_source_directory_searches(
         self,
         monkeypatch,


### PR DESCRIPTION
## Summary
- Allow Codex PostToolUse credential-looking output when it came from narrow read-only source inspection commands.
- Keep hidden/sensitive paths, unsafe shell controls, writes, and unsafe pipes blocked.
- Add regression coverage for the sed-plus-head source-file flow that was creating noisy approvals.

## Verification
- ruff check src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_runtime.py
- ruff format --check src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_runtime.py
- pytest tests/test_guard_runtime.py -k 'codex_post_tool_use' -q
- pytest tests/test_guard_runtime.py -q
- pytest tests/test_guard_risk.py tests/test_guard_runtime.py -q
- pytest tests -q