### PR TITLE
feat(guard): add OpenClaw harness adapter

### DIFF
--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -163,6 +163,15 @@ Hermes gets the normal Guard shim plus a Guard-owned bundle at `<guard-home>/her
 Guard injects the managed overlay paths through `HERMES_GUARD_MCP_OVERLAY_PATH` and `HERMES_GUARD_PRETOOL_PATH` when
 you launch Hermes through Guard.
 
+OpenClaw gets the normal Guard shim plus a Guard-owned bundle at `<guard-home>/openclaw/` with:
+
+- `overlay.json`
+- `pretool-hook.json`
+- `manifest.json`
+
+Guard injects the managed overlay paths through `OPENCLAW_GUARD_OVERLAY_PATH` and `OPENCLAW_GUARD_PRETOOL_PATH` when
+you launch OpenClaw through Guard. It does not mutate `~/.openclaw/openclaw.json`.
+
 ## Harness approval model
 
 Guard uses three approval tiers:
@@ -189,6 +198,9 @@ Current strategy:
 - `hermes`
   prefers the managed Hermes same-channel path when Guard owns the overlay bundle, falls back to the approval center,
   and keeps browser auto-open off for blocked requests
+- `openclaw`
+  scans OpenClaw gateway config, channel posture, MCP servers, workspace skills, user skills, and OpenClaw-owned skills,
+  then prefers native-or-center delivery once the managed overlay bundle exists
 - `gemini`
   scans `.gemini/settings.json`, extension manifests, hooks, MCP registrations, and Gemini skill directories before
   launch, then routes blocked changes to the approval center

--- a/docs/guard/harness-support.md
+++ b/docs/guard/harness-support.md
@@ -42,6 +42,11 @@ Current Guard support in this repo:
   - supports `hol-guard hermes bootstrap` and a Guard-managed Hermes overlay bundle under Guard home
   - rewrites managed Hermes MCP entries through Guard’s existing proxy path and uses native-or-center delivery when the managed bundle is present
   - blocks sensitive file reads and Docker-sensitive native pre-tool actions through the existing Guard hook path
+- `openclaw`
+  - detects `~/.openclaw/openclaw.json`, gateway posture, channels, MCP servers, workspace skills, user skills, and OpenClaw-owned skills
+  - supports a Guard-managed OpenClaw overlay bundle under Guard home without mutating user OpenClaw config
+  - flags open DM channel posture and remote MCP endpoints before launch so chat-originated agent work can be reviewed
+  - uses native-or-center delivery when the managed bundle is present and keeps browser auto-open off for blocked requests
 - `opencode`
   - detects global and project config, MCP servers, config-defined commands, markdown commands, npm plugins, local
     plugin files, and OpenCode-compatible skill directories

--- a/docs/guard/testing-matrix.md
+++ b/docs/guard/testing-matrix.md
@@ -20,7 +20,9 @@ Manual verification should include:
 - `hol-guard detect antigravity --json`
 - `hol-guard detect gemini --json`
 - `hol-guard detect opencode --json`
+- `hol-guard detect openclaw --json`
 - `hol-guard install opencode --json`
+- `hol-guard install openclaw --json`
 - `hol-guard update --dry-run --json`
 - `hol-guard run cursor --dry-run --default-action allow --json`
 - `hol-guard run gemini --dry-run --default-action allow --json`
@@ -36,6 +38,7 @@ Manual verification should include:
 - `gemini --help`
 - `opencode --help`
 - `opencode run --help`
+- `openclaw --help`
 
 First-party canaries for local manual validation:
 
@@ -52,6 +55,15 @@ real `opencode` binary:
 - a newly added plugin blocks before launch
 - a blocked prompt request queues an approval
 - approving that request lets Guard hand off to `opencode run --dir <workspace> ...`
+
+OpenClaw manual validation should include one isolated local gateway config where you prove all of the following against
+the real `openclaw` binary:
+
+- an open DM policy with wildcard senders is surfaced as a channel risk
+- a remote MCP endpoint is surfaced as a network risk
+- a newly added workspace skill blocks before launch when policy requires reapproval
+- `hol-guard install openclaw` creates the managed overlay and pre-tool bundle under Guard home
+- approving a blocked OpenClaw request resolves through native-or-center delivery without mutating user config
 
 Nightly release-bar coverage should include:
 

--- a/src/codex_plugin_scanner/guard/adapters/__init__.py
+++ b/src/codex_plugin_scanner/guard/adapters/__init__.py
@@ -10,6 +10,7 @@ from .copilot import CopilotHarnessAdapter
 from .cursor import CursorHarnessAdapter
 from .gemini import GeminiHarnessAdapter
 from .hermes import HermesHarnessAdapter
+from .openclaw import OpenClawHarnessAdapter
 from .opencode import OpenCodeHarnessAdapter
 
 ADAPTERS: tuple[HarnessAdapter, ...] = (
@@ -20,6 +21,7 @@ ADAPTERS: tuple[HarnessAdapter, ...] = (
     AntigravityHarnessAdapter(),
     GeminiHarnessAdapter(),
     HermesHarnessAdapter(),
+    OpenClawHarnessAdapter(),
     OpenCodeHarnessAdapter(),
 )
 

--- a/src/codex_plugin_scanner/guard/adapters/openclaw.py
+++ b/src/codex_plugin_scanner/guard/adapters/openclaw.py
@@ -7,7 +7,14 @@ from pathlib import Path
 
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
-from .base import HarnessAdapter, HarnessContext, _command_available, _json_payload, _run_command_probe
+from .base import (
+    HarnessAdapter,
+    HarnessContext,
+    _command_available,
+    _ensure_path_within_root,
+    _json_payload,
+    _run_command_probe,
+)
 from .openclaw_support import (
     config_artifacts,
     config_path,
@@ -108,6 +115,7 @@ class OpenClawHarnessAdapter(HarnessAdapter):
             if not isinstance(value, str) or not value:
                 continue
             path = Path(value)
+            _ensure_path_within_root(root, path, label=key)
             if path.exists():
                 path.unlink()
                 removed_paths.append(str(path))

--- a/src/codex_plugin_scanner/guard/adapters/openclaw.py
+++ b/src/codex_plugin_scanner/guard/adapters/openclaw.py
@@ -1,0 +1,175 @@
+"""OpenClaw harness adapter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ..models import GuardArtifact, HarnessDetection
+from ..shims import install_guard_shim, remove_guard_shim
+from .base import HarnessAdapter, HarnessContext, _command_available, _json_payload, _run_command_probe
+from .openclaw_support import (
+    config_artifacts,
+    config_path,
+    install_state,
+    load_config,
+    managed_root,
+    overlay_payload,
+    pretool_payload,
+    skill_artifacts,
+)
+
+_OPENCLAW_MANAGED_APPROVAL_TIER = "native-or-center"
+_OPENCLAW_MANAGED_PROMPT_CHANNEL = "native"
+
+
+class OpenClawHarnessAdapter(HarnessAdapter):
+    """Discover OpenClaw gateway config, channels, MCP servers, and skills."""
+
+    harness = "openclaw"
+    executable = "openclaw"
+    approval_tier = "approval-center"
+    approval_summary = (
+        "Guard can scan OpenClaw gateway config, channels, skills, and MCP servers before agent sessions run."
+    )
+    fallback_hint = "Connect OpenClaw through the Guard-managed overlay or resolve requests in the approval center."
+    approval_prompt_channel = "native-fallback"
+    approval_auto_open_browser = False
+
+    def policy_path(self, context: HarnessContext) -> Path:
+        return config_path(context)
+
+    def detect(self, context: HarnessContext) -> HarnessDetection:
+        path = config_path(context)
+        payload = load_config(path)
+        found_paths: list[str] = []
+        artifacts: list[GuardArtifact] = []
+        if payload:
+            found_paths.append(str(path))
+            artifacts.extend(config_artifacts(context, path, payload))
+        artifacts.extend(skill_artifacts(context, payload, found_paths))
+        return HarnessDetection(
+            harness=self.harness,
+            installed=bool(found_paths) or _command_available(self.executable),
+            command_available=_command_available(self.executable),
+            config_paths=tuple(found_paths),
+            artifacts=tuple(artifacts),
+        )
+
+    def install(self, context: HarnessContext) -> dict[str, object]:
+        shim_manifest = install_guard_shim(self.harness, context)
+        root = managed_root(context)
+        manifest_path = root / "manifest.json"
+        overlay_path = root / "overlay.json"
+        pretool_path = root / "pretool-hook.json"
+        root.mkdir(parents=True, exist_ok=True)
+        existing_manifest = _json_payload(manifest_path)
+        state = install_state(
+            existing_manifest=existing_manifest,
+            overlay_path=overlay_path,
+            pretool_path=pretool_path,
+        )
+        detection = self.detect(context)
+        overlay_path.write_text(json.dumps(overlay_payload(detection), indent=2) + "\n", encoding="utf-8")
+        pretool_path.write_text(json.dumps(pretool_payload(context=context), indent=2) + "\n", encoding="utf-8")
+        manifest = {
+            "harness": self.harness,
+            "active": True,
+            "config_path": str(overlay_path),
+            **shim_manifest,
+            "install_state": state,
+            "managed_root": str(root),
+            "managed_manifest_path": str(manifest_path),
+            "managed_overlay_path": str(overlay_path),
+            "pretool_hook_path": str(pretool_path),
+            "capabilities": {
+                "same_channel": True,
+                "pretool": True,
+                "channel_posture": True,
+                "mcp_proxy": True,
+            },
+            "config_paths": list(detection.config_paths),
+            "artifact_count": len(detection.artifacts),
+            "notes": [
+                "Guard generated an OpenClaw overlay bundle for gateway posture and pre-tool protection.",
+                *[str(note) for note in shim_manifest.get("notes", [])],
+            ],
+        }
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+        return manifest
+
+    def uninstall(self, context: HarnessContext) -> dict[str, object]:
+        shim_manifest = remove_guard_shim(self.harness, context)
+        root = managed_root(context)
+        manifest = _json_payload(root / "manifest.json")
+        removed_paths: list[str] = []
+        for key in ("managed_manifest_path", "managed_overlay_path", "pretool_hook_path"):
+            value = manifest.get(key)
+            if not isinstance(value, str) or not value:
+                continue
+            path = Path(value)
+            if path.exists():
+                path.unlink()
+                removed_paths.append(str(path))
+        return {
+            "harness": self.harness,
+            "active": False,
+            "config_path": str(root / "overlay.json"),
+            **shim_manifest,
+            "removed_paths": removed_paths,
+            "notes": [
+                "Guard removed the managed OpenClaw overlay bundle and kept user OpenClaw config untouched.",
+                *[str(note) for note in shim_manifest.get("notes", [])],
+            ],
+        }
+
+    def launch_environment(self, context: HarnessContext) -> dict[str, str]:
+        manifest = _json_payload(managed_root(context) / "manifest.json")
+        overlay_path = manifest.get("managed_overlay_path")
+        pretool_path = manifest.get("pretool_hook_path")
+        if not isinstance(overlay_path, str) or not isinstance(pretool_path, str):
+            return {}
+        return {
+            "OPENCLAW_GUARD_OVERLAY_PATH": overlay_path,
+            "OPENCLAW_GUARD_PRETOOL_PATH": pretool_path,
+            "OPENCLAW_GUARD_CHANNEL_POSTURE": "enabled",
+        }
+
+    def runtime_probe(self, context: HarnessContext) -> dict[str, object] | None:
+        manifest = _json_payload(managed_root(context) / "manifest.json")
+        overlay_path = manifest.get("managed_overlay_path")
+        pretool_path = manifest.get("pretool_hook_path")
+        return {
+            "command": _run_command_probe([self.executable, "--help"]) if _command_available(self.executable) else None,
+            "managed_install_present": bool(manifest),
+            "managed_install_ready": (
+                isinstance(overlay_path, str)
+                and Path(overlay_path).exists()
+                and isinstance(pretool_path, str)
+                and Path(pretool_path).exists()
+            ),
+        }
+
+    def approval_flow(self, *, managed_install: dict[str, object] | None = None) -> dict[str, object]:
+        manifest = managed_install.get("manifest") if isinstance(managed_install, dict) else None
+        capabilities = manifest.get("capabilities") if isinstance(manifest, dict) else None
+        same_channel = isinstance(capabilities, dict) and bool(capabilities.get("same_channel"))
+        if same_channel:
+            return {
+                "tier": _OPENCLAW_MANAGED_APPROVAL_TIER,
+                "summary": (
+                    "Guard uses OpenClaw native agent/channel delivery first and falls back to the approval center."
+                ),
+                "fallback_hint": "Use the Guard approval center if OpenClaw cannot surface the pending request inline.",
+                "prompt_channel": _OPENCLAW_MANAGED_PROMPT_CHANNEL,
+                "auto_open_browser": False,
+            }
+        return {
+            "tier": "approval-center",
+            "summary": "Guard keeps OpenClaw approvals in the local approval center without forcing a browser open.",
+            "fallback_hint": (
+                "Resolve pending OpenClaw requests from the Guard approval center or `hol-guard approvals`."
+            ),
+            "prompt_channel": "native-fallback",
+            "auto_open_browser": False,
+        }

--- a/src/codex_plugin_scanner/guard/adapters/openclaw.py
+++ b/src/codex_plugin_scanner/guard/adapters/openclaw.py
@@ -15,11 +15,11 @@ from .base import (
     _json_payload,
     _run_command_probe,
 )
+from .openclaw_config import load_config
 from .openclaw_support import (
     config_artifacts,
     config_path,
     install_state,
-    load_config,
     managed_root,
     overlay_payload,
     pretool_payload,

--- a/src/codex_plugin_scanner/guard/adapters/openclaw_config.py
+++ b/src/codex_plugin_scanner/guard/adapters/openclaw_config.py
@@ -1,0 +1,286 @@
+"""OpenClaw configuration loading helpers."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+_MAX_INCLUDE_DEPTH = 8
+_CONFIG_SUFFIXES = {".json", ".json5", ".yaml", ".yml"}
+
+
+def load_config(path: Path) -> dict[str, object]:
+    return _load_config(path, seen=set(), depth=0)
+
+
+def _load_config(path: Path, *, seen: set[Path], depth: int) -> dict[str, object]:
+    if depth > _MAX_INCLUDE_DEPTH:
+        return {}
+    try:
+        resolved_path = path.resolve()
+    except (OSError, RuntimeError):
+        return {}
+    if resolved_path in seen:
+        return {}
+    try:
+        raw = resolved_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return {}
+    payload = _parse_config_payload(raw)
+    if not isinstance(payload, dict):
+        return {}
+    return _resolve_includes(resolved_path, payload, seen={*seen, resolved_path}, depth=depth)
+
+
+def _resolve_includes(path: Path, payload: dict[str, object], *, seen: set[Path], depth: int) -> dict[str, object]:
+    include_value = payload.get("$include")
+    include_paths = _include_paths(path.parent, include_value)
+    merged: dict[str, object] = {}
+    for include_path in include_paths:
+        included_payload = _load_config(include_path, seen=seen, depth=depth + 1)
+        merged = _deep_merge(merged, included_payload)
+    local_payload = {key: value for key, value in payload.items() if key != "$include"}
+    return _deep_merge(merged, local_payload)
+
+
+def _include_paths(base_dir: Path, value: object) -> tuple[Path, ...]:
+    values = value if isinstance(value, list) else [value]
+    paths: list[Path] = []
+    for item in values:
+        if not isinstance(item, str) or not item.strip():
+            continue
+        candidate = Path(item.strip()).expanduser()
+        path = candidate if candidate.is_absolute() else base_dir / candidate
+        if path.suffix.lower() in _CONFIG_SUFFIXES:
+            paths.append(path)
+    return tuple(paths)
+
+
+def _deep_merge(base: dict[str, object], overlay: dict[str, object]) -> dict[str, object]:
+    result = dict(base)
+    for key, value in overlay.items():
+        existing = result.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            result[key] = _deep_merge(existing, value)
+        else:
+            result[key] = value
+    return result
+
+
+def _parse_config_payload(raw: str) -> object:
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        pass
+    stripped = _strip_json_comments(raw)
+    normalized = _strip_trailing_json_commas(stripped)
+    try:
+        return json.loads(normalized)
+    except json.JSONDecodeError:
+        pass
+    json5_normalized = _strip_trailing_json_commas(
+        _convert_single_quoted_strings(_quote_unquoted_object_keys(stripped))
+    )
+    try:
+        return json.loads(json5_normalized)
+    except json.JSONDecodeError:
+        return {}
+
+
+def _strip_json_comments(text: str) -> str:
+    output: list[str] = []
+    quote: str | None = None
+    escape = False
+    in_line_comment = False
+    in_block_comment = False
+    index = 0
+    while index < len(text):
+        char = text[index]
+        next_char = text[index + 1] if index + 1 < len(text) else ""
+        if in_line_comment:
+            if char == "\n":
+                in_line_comment = False
+                output.append(char)
+            index += 1
+            continue
+        if in_block_comment:
+            if char == "*" and next_char == "/":
+                in_block_comment = False
+                index += 2
+                continue
+            if char == "\n":
+                output.append(char)
+            index += 1
+            continue
+        if quote is not None:
+            output.append(char)
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            output.append(char)
+            index += 1
+            continue
+        if char == "/" and next_char == "/":
+            in_line_comment = True
+            index += 2
+            continue
+        if char == "/" and next_char == "*":
+            in_block_comment = True
+            index += 2
+            continue
+        output.append(char)
+        index += 1
+    return "".join(output)
+
+
+def _strip_trailing_json_commas(text: str) -> str:
+    output: list[str] = []
+    quote: str | None = None
+    escape = False
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if quote is not None:
+            output.append(char)
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            output.append(char)
+            index += 1
+            continue
+        if char == ",":
+            lookahead = index + 1
+            while lookahead < len(text) and text[lookahead] in " \t\r\n":
+                lookahead += 1
+            if lookahead < len(text) and text[lookahead] in "}]":
+                index += 1
+                continue
+        output.append(char)
+        index += 1
+    return "".join(output)
+
+
+def _quote_unquoted_object_keys(text: str) -> str:
+    output: list[str] = []
+    quote: str | None = None
+    escape = False
+    expecting_key = False
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if quote is not None:
+            output.append(char)
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            output.append(char)
+            index += 1
+            continue
+        if char in "{,":
+            expecting_key = True
+            output.append(char)
+            index += 1
+            continue
+        if expecting_key and char.isspace():
+            output.append(char)
+            index += 1
+            continue
+        if expecting_key and _starts_identifier(char):
+            match = re.match(r"[A-Za-z_$][A-Za-z0-9_$-]*", text[index:])
+            if match is not None:
+                key = match.group(0)
+                lookahead = index + len(key)
+                while lookahead < len(text) and text[lookahead].isspace():
+                    lookahead += 1
+                if lookahead < len(text) and text[lookahead] == ":":
+                    output.append(json.dumps(key))
+                    index += len(key)
+                    expecting_key = False
+                    continue
+        expecting_key = False
+        output.append(char)
+        index += 1
+    return "".join(output)
+
+
+def _convert_single_quoted_strings(text: str) -> str:
+    output: list[str] = []
+    quote: str | None = None
+    escape = False
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if quote == "'":
+            if escape:
+                _append_single_quote_escape(output, char)
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == "'":
+                quote = None
+                output.append('"')
+            elif char == '"':
+                output.append('\\"')
+            else:
+                output.append(char)
+            index += 1
+            continue
+        if quote == '"':
+            output.append(char)
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                quote = None
+            index += 1
+            continue
+        if char == "'":
+            quote = "'"
+            output.append('"')
+            index += 1
+            continue
+        if char == '"':
+            quote = '"'
+        output.append(char)
+        index += 1
+    return "".join(output)
+
+
+def _append_single_quote_escape(output: list[str], char: str) -> None:
+    if char == "'":
+        output.append("'")
+    elif char == '"':
+        output.append('\\"')
+    elif char == "\\":
+        output.append("\\\\")
+    elif char in {"b", "f", "n", "r", "t", "/"}:
+        output.append(f"\\{char}")
+    else:
+        output.append(char)
+
+
+def _starts_identifier(char: str) -> bool:
+    return char.isalpha() or char in {"_", "$"}

--- a/src/codex_plugin_scanner/guard/adapters/openclaw_support.py
+++ b/src/codex_plugin_scanner/guard/adapters/openclaw_support.py
@@ -314,10 +314,11 @@ def _artifacts_for_skill(root: Path, skill_md: Path) -> list[GuardArtifact]:
     skill_dir = skill_md.parent
     skill_name = _frontmatter_name(content) or skill_dir.name
     root_id = _path_digest(root)
+    skill_dir_id = _path_digest(skill_dir)
     source_scope = f"skill-root:{root_id}"
     artifacts = [
         GuardArtifact(
-            artifact_id=f"openclaw:skill:{root_id}:{skill_name}",
+            artifact_id=f"openclaw:skill:{root_id}:{skill_dir_id}:{skill_name}",
             name=skill_name,
             harness="openclaw",
             artifact_type="skill",
@@ -329,6 +330,8 @@ def _artifacts_for_skill(root: Path, skill_md: Path) -> list[GuardArtifact]:
                 "content_hash": _content_hash(content),
                 "skill_root": str(root),
                 "skill_root_id": root_id,
+                "skill_dir": str(skill_dir),
+                "skill_dir_id": skill_dir_id,
                 "env_mentions": sorted(_extract_env_mentions(content)),
             },
         )
@@ -346,7 +349,7 @@ def _artifacts_for_skill(root: Path, skill_md: Path) -> list[GuardArtifact]:
             rel_path = file_path.relative_to(skill_dir)
             artifacts.append(
                 GuardArtifact(
-                    artifact_id=f"openclaw:skill:{root_id}:{skill_name}:{rel_path}",
+                    artifact_id=f"openclaw:skill:{root_id}:{skill_dir_id}:{skill_name}:{rel_path}",
                     name=f"{skill_name}/{rel_path}",
                     harness="openclaw",
                     artifact_type="skill_file",
@@ -358,6 +361,7 @@ def _artifacts_for_skill(root: Path, skill_md: Path) -> list[GuardArtifact]:
                         "parent_skill": skill_name,
                         "content_hash": _content_hash(file_content),
                         "skill_root_id": root_id,
+                        "skill_dir_id": skill_dir_id,
                         "env_mentions": sorted(_extract_env_mentions(file_content)),
                     },
                 )
@@ -412,12 +416,15 @@ def _mcp_servers(payload: dict[str, object]) -> dict[str, dict[str, object]]:
     candidates = (mcp.get("servers"), mcp.get("mcpServers"), payload.get("mcpServers"))
     for candidate in candidates:
         server_map = _dict_value(candidate)
-        if server_map:
-            return {
-                str(name): config
-                for name, config in server_map.items()
-                if isinstance(name, str) and isinstance(config, dict) and config.get("enabled", True) is not False
-            }
+        if not server_map:
+            continue
+        enabled_servers = {
+            str(name): config
+            for name, config in server_map.items()
+            if isinstance(name, str) and isinstance(config, dict) and config.get("enabled", True) is not False
+        }
+        if enabled_servers:
+            return enabled_servers
     return {}
 
 

--- a/src/codex_plugin_scanner/guard/adapters/openclaw_support.py
+++ b/src/codex_plugin_scanner/guard/adapters/openclaw_support.py
@@ -3,23 +3,12 @@
 from __future__ import annotations
 
 import hashlib
-import json
 import re
 import sys
 from pathlib import Path
 
 from ..models import GuardArtifact, HarnessDetection
 from .base import HarnessContext
-
-try:
-    import yaml as _yaml  # type: ignore[import-untyped]
-    from yaml import YAMLError as _YamlError
-
-    _HAS_PYYAML = True
-except ImportError:
-    _yaml = None  # type: ignore[assignment]
-    _YamlError = ValueError
-    _HAS_PYYAML = False
 
 _MAX_FILE_READ = 64 * 1024
 _SKILL_SUBDIRS = ("references", "templates", "scripts", "assets")
@@ -33,31 +22,6 @@ def config_path(context: HarnessContext) -> Path:
 
 def managed_root(context: HarnessContext) -> Path:
     return context.guard_home / "openclaw"
-
-
-def load_config(path: Path) -> dict[str, object]:
-    try:
-        raw = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return {}
-    try:
-        payload = json.loads(raw)
-        return payload if isinstance(payload, dict) else {}
-    except json.JSONDecodeError:
-        pass
-    stripped = _strip_json_comments(raw)
-    try:
-        payload = json.loads(_strip_trailing_json_commas(stripped))
-        return payload if isinstance(payload, dict) else {}
-    except json.JSONDecodeError:
-        pass
-    if not _HAS_PYYAML:
-        return {}
-    try:
-        payload = _yaml.safe_load(stripped)  # type: ignore[union-attr]
-        return payload if isinstance(payload, dict) else {}
-    except _YamlError:
-        return {}
 
 
 def config_artifacts(context: HarnessContext, path: Path, payload: dict[str, object]) -> list[GuardArtifact]:
@@ -127,93 +91,6 @@ def install_state(
     return "repaired_managed_install"
 
 
-def _strip_json_comments(text: str) -> str:
-    output: list[str] = []
-    in_string = False
-    escape = False
-    in_line_comment = False
-    in_block_comment = False
-    index = 0
-    while index < len(text):
-        char = text[index]
-        next_char = text[index + 1] if index + 1 < len(text) else ""
-        if in_line_comment:
-            if char == "\n":
-                in_line_comment = False
-                output.append(char)
-            index += 1
-            continue
-        if in_block_comment:
-            if char == "*" and next_char == "/":
-                in_block_comment = False
-                index += 2
-                continue
-            if char == "\n":
-                output.append(char)
-            index += 1
-            continue
-        if in_string:
-            output.append(char)
-            if escape:
-                escape = False
-            elif char == "\\":
-                escape = True
-            elif char == '"':
-                in_string = False
-            index += 1
-            continue
-        if char == '"':
-            in_string = True
-            output.append(char)
-            index += 1
-            continue
-        if char == "/" and next_char == "/":
-            in_line_comment = True
-            index += 2
-            continue
-        if char == "/" and next_char == "*":
-            in_block_comment = True
-            index += 2
-            continue
-        output.append(char)
-        index += 1
-    return "".join(output)
-
-
-def _strip_trailing_json_commas(text: str) -> str:
-    output: list[str] = []
-    in_string = False
-    escape = False
-    index = 0
-    while index < len(text):
-        char = text[index]
-        if in_string:
-            output.append(char)
-            if escape:
-                escape = False
-            elif char == "\\":
-                escape = True
-            elif char == '"':
-                in_string = False
-            index += 1
-            continue
-        if char == '"':
-            in_string = True
-            output.append(char)
-            index += 1
-            continue
-        if char == ",":
-            lookahead = index + 1
-            while lookahead < len(text) and text[lookahead] in " \t\r\n":
-                lookahead += 1
-            if lookahead < len(text) and text[lookahead] in "}]":
-                index += 1
-                continue
-        output.append(char)
-        index += 1
-    return "".join(output)
-
-
 def _gateway_artifact(context: HarnessContext, path: Path, payload: dict[str, object]) -> GuardArtifact:
     gateway = _dict_value(payload.get("gateway"))
     agents = _dict_value(payload.get("agents"))
@@ -254,8 +131,9 @@ def _channel_artifacts(path: Path, payload: dict[str, object]) -> list[GuardArti
         dm = _dict_value(config.get("dm"))
         dm_policy = _string_value(config.get("dmPolicy")) or _string_value(dm.get("policy"))
         allow_from = _string_list(config.get("allowFrom")) or _string_list(dm.get("allowFrom"))
+        enabled = config.get("enabled", True) is not False
         signals: list[str] = []
-        if dm_policy == "open" and "*" in allow_from:
+        if enabled and dm_policy == "open" and "*" in allow_from:
             signals.append("network traffic from open chat channel can reach the agent without sender pairing")
         artifacts.append(
             GuardArtifact(
@@ -268,7 +146,7 @@ def _channel_artifacts(path: Path, payload: dict[str, object]) -> list[GuardArti
                 args=(f"channel {name}", f"dmPolicy {dm_policy or 'default'}", f"allowFrom {','.join(allow_from)}"),
                 metadata={
                     "channel": name,
-                    "enabled": config.get("enabled", True) is not False,
+                    "enabled": enabled,
                     "dm_policy": dm_policy,
                     "allow_from": allow_from,
                     "runtime_request_signals": signals,

--- a/src/codex_plugin_scanner/guard/adapters/openclaw_support.py
+++ b/src/codex_plugin_scanner/guard/adapters/openclaw_support.py
@@ -395,9 +395,7 @@ def _expand_home(home_dir: Path, value: str) -> Path:
 def _channels(payload: dict[str, object]) -> dict[str, dict[str, object]]:
     channels = _dict_value(payload.get("channels"))
     return {
-        str(name): config
-        for name, config in channels.items()
-        if isinstance(name, str) and isinstance(config, dict)
+        str(name): config for name, config in channels.items() if isinstance(name, str) and isinstance(config, dict)
     }
 
 

--- a/src/codex_plugin_scanner/guard/adapters/openclaw_support.py
+++ b/src/codex_plugin_scanner/guard/adapters/openclaw_support.py
@@ -1,0 +1,497 @@
+"""OpenClaw adapter support helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+from ..models import GuardArtifact, HarnessDetection
+from .base import HarnessContext
+
+try:
+    import yaml as _yaml  # type: ignore[import-untyped]
+    from yaml import YAMLError as _YamlError
+
+    _HAS_PYYAML = True
+except ImportError:
+    _yaml = None  # type: ignore[assignment]
+    _YamlError = ValueError
+    _HAS_PYYAML = False
+
+_MAX_FILE_READ = 64 * 1024
+_SKILL_SUBDIRS = ("references", "templates", "scripts", "assets")
+_SCANNABLE_EXTENSIONS = {".md", ".txt", ".py", ".sh", ".bash", ".js", ".ts", ".yaml", ".yml", ".json", ".toml"}
+_SCANNABLE_NAMES = {".env", "Dockerfile", "Makefile", "Procfile"}
+
+
+def config_path(context: HarnessContext) -> Path:
+    return context.home_dir / ".openclaw" / "openclaw.json"
+
+
+def managed_root(context: HarnessContext) -> Path:
+    return context.guard_home / "openclaw"
+
+
+def load_config(path: Path) -> dict[str, object]:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (FileNotFoundError, PermissionError, OSError):
+        return {}
+    try:
+        payload = json.loads(raw)
+        return payload if isinstance(payload, dict) else {}
+    except json.JSONDecodeError:
+        pass
+    stripped = _strip_json_comments(raw)
+    try:
+        payload = json.loads(_strip_trailing_json_commas(stripped))
+        return payload if isinstance(payload, dict) else {}
+    except json.JSONDecodeError:
+        pass
+    if not _HAS_PYYAML:
+        return {}
+    try:
+        payload = _yaml.safe_load(stripped)  # type: ignore[union-attr]
+        return payload if isinstance(payload, dict) else {}
+    except _YamlError:
+        return {}
+
+
+def config_artifacts(context: HarnessContext, path: Path, payload: dict[str, object]) -> list[GuardArtifact]:
+    artifacts = [_gateway_artifact(context, path, payload)]
+    artifacts.extend(_channel_artifacts(path, payload))
+    artifacts.extend(_mcp_artifacts(path, payload))
+    return artifacts
+
+
+def skill_artifacts(
+    context: HarnessContext,
+    payload: dict[str, object],
+    found_paths: list[str],
+) -> list[GuardArtifact]:
+    artifacts: list[GuardArtifact] = []
+    seen: set[Path] = set()
+    for root in _skill_roots(context, payload):
+        if root in seen or not root.is_dir():
+            continue
+        seen.add(root)
+        for skill_md in sorted(root.rglob("SKILL.md")):
+            if skill_md.is_symlink() or not skill_md.is_file():
+                continue
+            found_paths.append(str(skill_md))
+            artifacts.extend(_artifacts_for_skill(root, skill_md))
+    return artifacts
+
+
+def overlay_payload(detection: HarnessDetection) -> dict[str, object]:
+    return {
+        "harness": "openclaw",
+        "config_paths": list(detection.config_paths),
+        "artifact_count": len(detection.artifacts),
+        "artifact_ids": [artifact.artifact_id for artifact in detection.artifacts],
+    }
+
+
+def pretool_payload(*, context: HarnessContext) -> dict[str, object]:
+    command = [
+        str(Path(sys.executable)),
+        "-m",
+        "codex_plugin_scanner.cli",
+        "hook",
+        "--harness",
+        "openclaw",
+        "--guard-home",
+        str(context.guard_home),
+        "--json",
+    ]
+    if context.workspace_dir is not None:
+        command.extend(["--workspace", str(context.workspace_dir)])
+    return {"command": command, "harness": "openclaw"}
+
+
+def install_state(
+    *,
+    existing_manifest: dict[str, object],
+    overlay_path: Path,
+    pretool_path: Path,
+) -> str:
+    if len(existing_manifest) == 0:
+        return "installed"
+    if overlay_path.exists() and pretool_path.exists():
+        return "already_managed"
+    return "repaired_managed_install"
+
+
+def _strip_json_comments(text: str) -> str:
+    output: list[str] = []
+    in_string = False
+    escape = False
+    in_line_comment = False
+    in_block_comment = False
+    index = 0
+    while index < len(text):
+        char = text[index]
+        next_char = text[index + 1] if index + 1 < len(text) else ""
+        if in_line_comment:
+            if char == "\n":
+                in_line_comment = False
+                output.append(char)
+            index += 1
+            continue
+        if in_block_comment:
+            if char == "*" and next_char == "/":
+                in_block_comment = False
+                index += 2
+                continue
+            if char == "\n":
+                output.append(char)
+            index += 1
+            continue
+        if in_string:
+            output.append(char)
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                in_string = False
+            index += 1
+            continue
+        if char == '"':
+            in_string = True
+            output.append(char)
+            index += 1
+            continue
+        if char == "/" and next_char == "/":
+            in_line_comment = True
+            index += 2
+            continue
+        if char == "/" and next_char == "*":
+            in_block_comment = True
+            index += 2
+            continue
+        output.append(char)
+        index += 1
+    return "".join(output)
+
+
+def _strip_trailing_json_commas(text: str) -> str:
+    output: list[str] = []
+    in_string = False
+    escape = False
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if in_string:
+            output.append(char)
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                in_string = False
+            index += 1
+            continue
+        if char == '"':
+            in_string = True
+            output.append(char)
+            index += 1
+            continue
+        if char == ",":
+            lookahead = index + 1
+            while lookahead < len(text) and text[lookahead] in " \t\r\n":
+                lookahead += 1
+            if lookahead < len(text) and text[lookahead] in "}]":
+                index += 1
+                continue
+        output.append(char)
+        index += 1
+    return "".join(output)
+
+
+def _gateway_artifact(context: HarnessContext, path: Path, payload: dict[str, object]) -> GuardArtifact:
+    gateway = _dict_value(payload.get("gateway"))
+    agents = _dict_value(payload.get("agents"))
+    defaults = _dict_value(agents.get("defaults"))
+    workspace_path = _workspace_path(context, payload)
+    sandbox = _dict_value(defaults.get("sandbox"))
+    hooks = _dict_value(payload.get("hooks"))
+    metadata = {
+        "workspace_path": str(workspace_path),
+        "gateway_mode": _string_value(gateway.get("mode")),
+        "gateway_bind": _string_value(gateway.get("bind")),
+        "auth_mode": _string_value(_dict_value(gateway.get("auth")).get("mode")),
+        "sandbox_mode": _string_value(sandbox.get("mode")),
+        "hooks_enabled": bool(hooks),
+        "channel_names": sorted(_channels(payload)),
+        "mcp_server_names": sorted(_mcp_servers(payload)),
+    }
+    args = (
+        f"gateway bind {metadata['gateway_bind'] or 'loopback'}",
+        f"auth mode {metadata['auth_mode'] or 'token'}",
+        f"sandbox {metadata['sandbox_mode'] or 'unset'}",
+    )
+    return GuardArtifact(
+        artifact_id="openclaw:config:global",
+        name="OpenClaw gateway config",
+        harness="openclaw",
+        artifact_type="gateway_config",
+        source_scope="global",
+        config_path=str(path),
+        args=args,
+        metadata=metadata,
+    )
+
+
+def _channel_artifacts(path: Path, payload: dict[str, object]) -> list[GuardArtifact]:
+    artifacts: list[GuardArtifact] = []
+    for name, config in _channels(payload).items():
+        dm_policy = _string_value(config.get("dmPolicy") or _dict_value(_dict_value(config.get("dm")).get("policy")))
+        allow_from = _string_list(
+            config.get("allowFrom") or _dict_value(_dict_value(config.get("dm")).get("allowFrom"))
+        )
+        signals: list[str] = []
+        if dm_policy == "open" and "*" in allow_from:
+            signals.append("network traffic from open chat channel can reach the agent without sender pairing")
+        artifacts.append(
+            GuardArtifact(
+                artifact_id=f"openclaw:channel:{name}",
+                name=name,
+                harness="openclaw",
+                artifact_type="channel",
+                source_scope="global",
+                config_path=str(path),
+                args=(f"channel {name}", f"dmPolicy {dm_policy or 'default'}", f"allowFrom {','.join(allow_from)}"),
+                metadata={
+                    "channel": name,
+                    "enabled": config.get("enabled", True) is not False,
+                    "dm_policy": dm_policy,
+                    "allow_from": allow_from,
+                    "runtime_request_signals": signals,
+                },
+            )
+        )
+    return artifacts
+
+
+def _mcp_artifacts(path: Path, payload: dict[str, object]) -> list[GuardArtifact]:
+    artifacts: list[GuardArtifact] = []
+    for name, config in _mcp_servers(payload).items():
+        command = config.get("command")
+        url = config.get("url")
+        env = _dict_value(config.get("env"))
+        headers = _dict_value(config.get("headers"))
+        args = _string_list(config.get("args"))
+        artifacts.append(
+            GuardArtifact(
+                artifact_id=f"openclaw:mcp:{name}",
+                name=name,
+                harness="openclaw",
+                artifact_type="mcp_server",
+                source_scope="global",
+                config_path=str(path),
+                command=command if isinstance(command, str) else None,
+                args=tuple(args),
+                url=url if isinstance(url, str) else None,
+                transport="http" if isinstance(url, str) else "stdio",
+                metadata={
+                    "env_keys": sorted(str(key) for key in env if isinstance(key, str)),
+                    "header_keys": sorted(str(key) for key in headers if isinstance(key, str)),
+                    "env": env,
+                    "headers": headers,
+                },
+            )
+        )
+    return artifacts
+
+
+def _artifacts_for_skill(root: Path, skill_md: Path) -> list[GuardArtifact]:
+    content = _safe_read(skill_md)
+    skill_dir = skill_md.parent
+    skill_name = _frontmatter_name(content) or skill_dir.name
+    artifacts = [
+        GuardArtifact(
+            artifact_id=f"openclaw:skill:{skill_name}",
+            name=skill_name,
+            harness="openclaw",
+            artifact_type="skill",
+            source_scope="global",
+            config_path=str(skill_md),
+            command=str(skill_md),
+            args=_risk_args(content),
+            metadata={
+                "content_hash": _content_hash(content),
+                "skill_root": str(root),
+                "env_mentions": sorted(_extract_env_mentions(content)),
+            },
+        )
+    ]
+    for subdir_name in _SKILL_SUBDIRS:
+        subdir = skill_dir / subdir_name
+        if not subdir.is_dir():
+            continue
+        for file_path in sorted(subdir.rglob("*")):
+            if file_path.is_symlink() or not file_path.is_file() or not _is_scannable(file_path):
+                continue
+            file_content = _safe_read(file_path)
+            if not file_content:
+                continue
+            rel_path = file_path.relative_to(skill_dir)
+            artifacts.append(
+                GuardArtifact(
+                    artifact_id=f"openclaw:skill:{skill_name}:{rel_path}",
+                    name=f"{skill_name}/{rel_path}",
+                    harness="openclaw",
+                    artifact_type="skill_file",
+                    source_scope="global",
+                    config_path=str(file_path),
+                    command=str(file_path),
+                    args=_risk_args(file_content),
+                    metadata={
+                        "parent_skill": skill_name,
+                        "content_hash": _content_hash(file_content),
+                        "env_mentions": sorted(_extract_env_mentions(file_content)),
+                    },
+                )
+            )
+    return artifacts
+
+
+def _skill_roots(context: HarnessContext, payload: dict[str, object]) -> tuple[Path, ...]:
+    workspace_path = _workspace_path(context, payload)
+    roots = [
+        workspace_path / "skills",
+        workspace_path / ".agents" / "skills",
+        context.home_dir / ".agents" / "skills",
+        context.home_dir / ".openclaw" / "skills",
+    ]
+    skills = _dict_value(payload.get("skills"))
+    load = _dict_value(skills.get("load"))
+    for extra_dir in _string_list(load.get("extraDirs")):
+        roots.append(_expand_home(context.home_dir, extra_dir))
+    return tuple(roots)
+
+
+def _workspace_path(context: HarnessContext, payload: dict[str, object]) -> Path:
+    agents = _dict_value(payload.get("agents"))
+    defaults = _dict_value(agents.get("defaults"))
+    workspace = defaults.get("workspace")
+    if isinstance(workspace, str) and workspace:
+        return _expand_home(context.home_dir, workspace)
+    return context.home_dir / ".openclaw" / "workspace"
+
+
+def _expand_home(home_dir: Path, value: str) -> Path:
+    if value == "~":
+        return home_dir
+    if value.startswith("~/"):
+        return home_dir / value[2:]
+    return Path(value)
+
+
+def _channels(payload: dict[str, object]) -> dict[str, dict[str, object]]:
+    channels = _dict_value(payload.get("channels"))
+    return {
+        str(name): config
+        for name, config in channels.items()
+        if isinstance(name, str) and isinstance(config, dict)
+    }
+
+
+def _mcp_servers(payload: dict[str, object]) -> dict[str, dict[str, object]]:
+    mcp = _dict_value(payload.get("mcp"))
+    candidates = (mcp.get("servers"), mcp.get("mcpServers"), payload.get("mcpServers"))
+    for candidate in candidates:
+        server_map = _dict_value(candidate)
+        if server_map:
+            return {
+                str(name): config
+                for name, config in server_map.items()
+                if isinstance(name, str) and isinstance(config, dict) and config.get("enabled", True) is not False
+            }
+    return {}
+
+
+def _dict_value(value: object) -> dict[str, object]:
+    return value if isinstance(value, dict) else {}
+
+
+def _string_value(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if isinstance(item, (str, int, float, bool))]
+
+
+def _risk_args(content: str) -> tuple[str, ...]:
+    blocks = _extract_code_blocks(content)
+    plain = _plain_markdown(content)
+    if plain:
+        return (*blocks, plain)
+    return blocks
+
+
+def _extract_code_blocks(content: str) -> tuple[str, ...]:
+    blocks = []
+    for match in re.finditer(r"```[^\n]*\n(.*?)\n?```", content, re.DOTALL):
+        block = match.group(1).strip()
+        if block:
+            blocks.append(block)
+    return tuple(blocks)
+
+
+def _plain_markdown(content: str, max_len: int = 2048) -> str:
+    stripped = re.sub(r"```[^\n]*\n.*?\n?```", "", content, flags=re.DOTALL)
+    if stripped.startswith("---"):
+        parts = stripped[3:].split("---", 1)
+        if len(parts) == 2:
+            stripped = parts[1]
+    return stripped.strip()[:max_len]
+
+
+def _frontmatter_name(content: str) -> str | None:
+    if not content.startswith("---"):
+        return None
+    parts = content[3:].split("---", 1)
+    if len(parts) != 2:
+        return None
+    for line in parts[0].splitlines():
+        key, _, value = line.partition(":")
+        if key.strip() == "name" and value.strip():
+            return value.strip().strip("\"'")
+    return None
+
+
+def _extract_env_mentions(content: str) -> set[str]:
+    mentions: set[str] = set()
+    for match in re.finditer(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}", content):
+        mentions.add(match.group(1))
+    for match in re.finditer(r"process\.env\.([A-Za-z_][A-Za-z0-9_]*)", content):
+        mentions.add(match.group(1))
+    return mentions
+
+
+def _is_scannable(file_path: Path) -> bool:
+    if file_path.suffix.lower() in _SCANNABLE_EXTENSIONS:
+        return True
+    if not file_path.suffix:
+        return file_path.name in _SCANNABLE_NAMES or "scripts" in file_path.parts
+    return False
+
+
+def _safe_read(path: Path) -> str:
+    try:
+        with path.open("r", encoding="utf-8") as file:
+            return file.read(_MAX_FILE_READ)
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+
+def _content_hash(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()[:16]

--- a/src/codex_plugin_scanner/guard/adapters/openclaw_support.py
+++ b/src/codex_plugin_scanner/guard/adapters/openclaw_support.py
@@ -38,7 +38,7 @@ def managed_root(context: HarnessContext) -> Path:
 def load_config(path: Path) -> dict[str, object]:
     try:
         raw = path.read_text(encoding="utf-8")
-    except (FileNotFoundError, PermissionError, OSError):
+    except (OSError, UnicodeDecodeError):
         return {}
     try:
         payload = json.loads(raw)
@@ -105,6 +105,8 @@ def pretool_payload(*, context: HarnessContext) -> dict[str, object]:
         "openclaw",
         "--guard-home",
         str(context.guard_home),
+        "--home",
+        str(context.home_dir),
         "--json",
     ]
     if context.workspace_dir is not None:
@@ -249,10 +251,9 @@ def _gateway_artifact(context: HarnessContext, path: Path, payload: dict[str, ob
 def _channel_artifacts(path: Path, payload: dict[str, object]) -> list[GuardArtifact]:
     artifacts: list[GuardArtifact] = []
     for name, config in _channels(payload).items():
-        dm_policy = _string_value(config.get("dmPolicy") or _dict_value(_dict_value(config.get("dm")).get("policy")))
-        allow_from = _string_list(
-            config.get("allowFrom") or _dict_value(_dict_value(config.get("dm")).get("allowFrom"))
-        )
+        dm = _dict_value(config.get("dm"))
+        dm_policy = _string_value(config.get("dmPolicy")) or _string_value(dm.get("policy"))
+        allow_from = _string_list(config.get("allowFrom")) or _string_list(dm.get("allowFrom"))
         signals: list[str] = []
         if dm_policy == "open" and "*" in allow_from:
             signals.append("network traffic from open chat channel can reach the agent without sender pairing")
@@ -312,19 +313,22 @@ def _artifacts_for_skill(root: Path, skill_md: Path) -> list[GuardArtifact]:
     content = _safe_read(skill_md)
     skill_dir = skill_md.parent
     skill_name = _frontmatter_name(content) or skill_dir.name
+    root_id = _path_digest(root)
+    source_scope = f"skill-root:{root_id}"
     artifacts = [
         GuardArtifact(
-            artifact_id=f"openclaw:skill:{skill_name}",
+            artifact_id=f"openclaw:skill:{root_id}:{skill_name}",
             name=skill_name,
             harness="openclaw",
             artifact_type="skill",
-            source_scope="global",
+            source_scope=source_scope,
             config_path=str(skill_md),
             command=str(skill_md),
             args=_risk_args(content),
             metadata={
                 "content_hash": _content_hash(content),
                 "skill_root": str(root),
+                "skill_root_id": root_id,
                 "env_mentions": sorted(_extract_env_mentions(content)),
             },
         )
@@ -342,17 +346,18 @@ def _artifacts_for_skill(root: Path, skill_md: Path) -> list[GuardArtifact]:
             rel_path = file_path.relative_to(skill_dir)
             artifacts.append(
                 GuardArtifact(
-                    artifact_id=f"openclaw:skill:{skill_name}:{rel_path}",
+                    artifact_id=f"openclaw:skill:{root_id}:{skill_name}:{rel_path}",
                     name=f"{skill_name}/{rel_path}",
                     harness="openclaw",
                     artifact_type="skill_file",
-                    source_scope="global",
+                    source_scope=source_scope,
                     config_path=str(file_path),
                     command=str(file_path),
                     args=_risk_args(file_content),
                     metadata={
                         "parent_skill": skill_name,
                         "content_hash": _content_hash(file_content),
+                        "skill_root_id": root_id,
                         "env_mentions": sorted(_extract_env_mentions(file_content)),
                     },
                 )
@@ -371,7 +376,9 @@ def _skill_roots(context: HarnessContext, payload: dict[str, object]) -> tuple[P
     skills = _dict_value(payload.get("skills"))
     load = _dict_value(skills.get("load"))
     for extra_dir in _string_list(load.get("extraDirs")):
-        roots.append(_expand_home(context.home_dir, extra_dir))
+        stripped = extra_dir.strip()
+        if stripped:
+            roots.append(_expand_home(context.home_dir, stripped))
     return tuple(roots)
 
 
@@ -389,7 +396,8 @@ def _expand_home(home_dir: Path, value: str) -> Path:
         return home_dir
     if value.startswith("~/"):
         return home_dir / value[2:]
-    return Path(value)
+    path = Path(value)
+    return path if path.is_absolute() else home_dir / path
 
 
 def _channels(payload: dict[str, object]) -> dict[str, dict[str, object]]:
@@ -493,3 +501,11 @@ def _safe_read(path: Path) -> str:
 
 def _content_hash(content: str) -> str:
     return hashlib.sha256(content.encode("utf-8")).hexdigest()[:16]
+
+
+def _path_digest(path: Path) -> str:
+    try:
+        value = str(path.resolve())
+    except (OSError, RuntimeError):
+        value = str(path)
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]

--- a/tests/test_openclaw_adapter.py
+++ b/tests/test_openclaw_adapter.py
@@ -79,7 +79,7 @@ def test_detects_openclaw_config_channels_mcp_and_skills(tmp_path: Path) -> None
     assert "openclaw:channel:telegram" in artifacts
     assert "openclaw:mcp:docs" in artifacts
     assert "openclaw:mcp:local" in artifacts
-    assert "openclaw:skill:deploy-helper" in artifacts
+    assert any(artifact.name == "deploy-helper" for artifact in artifacts.values())
     assert artifacts["openclaw:config:global"].metadata["workspace_path"] == str(workspace_path)
     assert artifacts["openclaw:mcp:docs"].transport == "http"
     assert artifacts["openclaw:mcp:local"].to_dict()["metadata"]["env"]["API_TOKEN"] == "*****"
@@ -106,6 +106,19 @@ def test_openclaw_flags_open_dm_policy_and_remote_mcp(tmp_path: Path) -> None:
 
     assert any("network traffic" in signal for signal in channel_signals)
     assert any("remote server" in signal for signal in mcp_signals)
+
+
+def test_openclaw_flags_legacy_dm_policy_fields(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    _write(
+        context.home_dir / ".openclaw" / "openclaw.json",
+        json.dumps({"channels": {"telegram": {"dm": {"policy": "open", "allowFrom": ["*"]}}}}),
+    )
+
+    detection = OpenClawHarnessAdapter().detect(context)
+    channel = next(artifact for artifact in detection.artifacts if artifact.artifact_id == "openclaw:channel:telegram")
+
+    assert any("network traffic" in signal for signal in artifact_risk_signals(channel))
 
 
 def test_openclaw_accepts_json5_comments_trailing_commas_and_extra_skill_dirs(tmp_path: Path) -> None:
@@ -136,7 +149,49 @@ def test_openclaw_accepts_json5_comments_trailing_commas_and_extra_skill_dirs(tm
     artifacts = {artifact.artifact_id for artifact in detection.artifacts}
 
     assert "openclaw:channel:telegram" in artifacts
-    assert "openclaw:skill:reviewer" in artifacts
+    assert any(artifact.name == "reviewer" for artifact in detection.artifacts)
+
+
+def test_openclaw_extra_skill_dirs_skip_blank_and_anchor_relative_paths(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    _write(
+        context.home_dir / ".openclaw" / "openclaw.json",
+        json.dumps({"skills": {"load": {"extraDirs": [" ", "relative-skills"]}}}),
+    )
+    _write(context.home_dir / "relative-skills" / "helper" / "SKILL.md", "---\nname: helper\n---\nOK.\n")
+    _write(context.home_dir / "accidental" / "SKILL.md", "---\nname: accidental\n---\nShould not load.\n")
+
+    detection = OpenClawHarnessAdapter().detect(context)
+    skill_names = {artifact.name for artifact in detection.artifacts if artifact.artifact_type == "skill"}
+
+    assert "helper" in skill_names
+    assert "accidental" not in skill_names
+
+
+def test_openclaw_skill_artifact_ids_include_root_identity(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    workspace_path = context.home_dir / ".openclaw" / "workspace"
+    shared_root = context.home_dir / "shared-skills"
+    _write(
+        context.home_dir / ".openclaw" / "openclaw.json",
+        json.dumps(
+            {
+                "agents": {"defaults": {"workspace": str(workspace_path)}},
+                "skills": {"load": {"extraDirs": [str(shared_root)]}},
+            }
+        ),
+    )
+    _write(workspace_path / "skills" / "reviewer" / "SKILL.md", "---\nname: reviewer\n---\nWorkspace.\n")
+    _write(shared_root / "reviewer" / "SKILL.md", "---\nname: reviewer\n---\nShared.\n")
+
+    detection = OpenClawHarnessAdapter().detect(context)
+    reviewer_ids = {
+        artifact.artifact_id
+        for artifact in detection.artifacts
+        if artifact.artifact_type == "skill" and artifact.name == "reviewer"
+    }
+
+    assert len(reviewer_ids) == 2
 
 
 def test_install_exports_guard_managed_openclaw_overlay(tmp_path: Path) -> None:
@@ -149,11 +204,13 @@ def test_install_exports_guard_managed_openclaw_overlay(tmp_path: Path) -> None:
     manifest = OpenClawHarnessAdapter().install(context)
     overlay_path = Path(str(manifest["managed_overlay_path"]))
     pretool_path = Path(str(manifest["pretool_hook_path"]))
+    pretool = json.loads(pretool_path.read_text(encoding="utf-8"))
     env = OpenClawHarnessAdapter().launch_environment(context)
 
     assert manifest["install_state"] == "installed"
     assert overlay_path.exists() is True
     assert pretool_path.exists() is True
+    assert pretool["command"][pretool["command"].index("--home") + 1] == str(context.home_dir)
     assert env["OPENCLAW_GUARD_OVERLAY_PATH"] == str(overlay_path)
     assert env["OPENCLAW_GUARD_PRETOOL_PATH"] == str(pretool_path)
     assert env["OPENCLAW_GUARD_CHANNEL_POSTURE"] == "enabled"
@@ -175,6 +232,22 @@ def test_openclaw_skips_symlinked_skill_files(tmp_path: Path) -> None:
     artifacts = {artifact.artifact_id for artifact in detection.artifacts}
 
     assert "openclaw:skill:linked-secret" not in artifacts
+
+
+def test_uninstall_rejects_manifest_paths_outside_managed_root(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    adapter = OpenClawHarnessAdapter()
+    manifest = adapter.install(context)
+    manifest_path = Path(str(manifest["managed_manifest_path"]))
+    outside_path = tmp_path / "outside.json"
+    outside_path.write_text("{}", encoding="utf-8")
+    manifest["managed_manifest_path"] = str(outside_path)
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="escapes the managed root"):
+        adapter.uninstall(context)
+
+    assert outside_path.exists() is True
 
 
 def test_openclaw_approval_flow_prefers_native_or_center_after_install(tmp_path: Path) -> None:

--- a/tests/test_openclaw_adapter.py
+++ b/tests/test_openclaw_adapter.py
@@ -108,6 +108,26 @@ def test_openclaw_flags_open_dm_policy_and_remote_mcp(tmp_path: Path) -> None:
     assert any("remote server" in signal for signal in mcp_signals)
 
 
+def test_openclaw_checks_fallback_mcp_maps_after_disabled_servers(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    _write(
+        context.home_dir / ".openclaw" / "openclaw.json",
+        json.dumps(
+            {
+                "mcp": {
+                    "servers": {"disabled": {"enabled": False, "url": "https://disabled.example/mcp"}},
+                    "mcpServers": {"remote": {"url": "https://remote.example/mcp"}},
+                }
+            }
+        ),
+    )
+
+    detection = OpenClawHarnessAdapter().detect(context)
+    mcp = next(artifact for artifact in detection.artifacts if artifact.artifact_id == "openclaw:mcp:remote")
+
+    assert any("remote server" in signal for signal in artifact_risk_signals(mcp))
+
+
 def test_openclaw_flags_legacy_dm_policy_fields(tmp_path: Path) -> None:
     context = _ctx(tmp_path)
     _write(
@@ -194,6 +214,26 @@ def test_openclaw_skill_artifact_ids_include_root_identity(tmp_path: Path) -> No
     assert len(reviewer_ids) == 2
 
 
+def test_openclaw_skill_artifact_ids_include_skill_directory_identity(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    workspace_path = context.home_dir / ".openclaw" / "workspace"
+    _write(
+        context.home_dir / ".openclaw" / "openclaw.json",
+        json.dumps({"agents": {"defaults": {"workspace": str(workspace_path)}}}),
+    )
+    _write(workspace_path / "skills" / "reviewer-a" / "SKILL.md", "---\nname: reviewer\n---\nA.\n")
+    _write(workspace_path / "skills" / "reviewer-b" / "SKILL.md", "---\nname: reviewer\n---\nB.\n")
+
+    detection = OpenClawHarnessAdapter().detect(context)
+    reviewer_ids = {
+        artifact.artifact_id
+        for artifact in detection.artifacts
+        if artifact.artifact_type == "skill" and artifact.name == "reviewer"
+    }
+
+    assert len(reviewer_ids) == 2
+
+
 def test_install_exports_guard_managed_openclaw_overlay(tmp_path: Path) -> None:
     context = _ctx(tmp_path)
     _write(
@@ -229,9 +269,7 @@ def test_openclaw_skips_symlinked_skill_files(tmp_path: Path) -> None:
         pytest.skip(f"symlinks unavailable: {error}")
 
     detection = OpenClawHarnessAdapter().detect(context)
-    artifacts = {artifact.artifact_id for artifact in detection.artifacts}
-
-    assert "openclaw:skill:linked-secret" not in artifacts
+    assert not any(artifact.name == "linked-secret" for artifact in detection.artifacts)
 
 
 def test_uninstall_rejects_manifest_paths_outside_managed_root(tmp_path: Path) -> None:

--- a/tests/test_openclaw_adapter.py
+++ b/tests/test_openclaw_adapter.py
@@ -108,6 +108,19 @@ def test_openclaw_flags_open_dm_policy_and_remote_mcp(tmp_path: Path) -> None:
     assert any("remote server" in signal for signal in mcp_signals)
 
 
+def test_openclaw_skips_open_dm_risk_for_disabled_channels(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    _write(
+        context.home_dir / ".openclaw" / "openclaw.json",
+        json.dumps({"channels": {"telegram": {"enabled": False, "dmPolicy": "open", "allowFrom": ["*"]}}}),
+    )
+
+    detection = OpenClawHarnessAdapter().detect(context)
+    channel = next(artifact for artifact in detection.artifacts if artifact.artifact_id == "openclaw:channel:telegram")
+
+    assert not any("network traffic" in signal for signal in artifact_risk_signals(channel))
+
+
 def test_openclaw_checks_fallback_mcp_maps_after_disabled_servers(tmp_path: Path) -> None:
     context = _ctx(tmp_path)
     _write(
@@ -170,6 +183,62 @@ def test_openclaw_accepts_json5_comments_trailing_commas_and_extra_skill_dirs(tm
 
     assert "openclaw:channel:telegram" in artifacts
     assert any(artifact.name == "reviewer" for artifact in detection.artifacts)
+
+
+def test_openclaw_accepts_json5_unquoted_keys_and_single_quotes(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    _write(
+        context.home_dir / ".openclaw" / "openclaw.json",
+        """
+        {
+          channels: {
+            telegram: { dmPolicy: 'open', allowFrom: ['*'] },
+          },
+          mcp: {
+            servers: {
+              remote: { url: 'https://remote.example/mcp' },
+            },
+          },
+        }
+        """,
+    )
+
+    detection = OpenClawHarnessAdapter().detect(context)
+    channel = next(artifact for artifact in detection.artifacts if artifact.artifact_id == "openclaw:channel:telegram")
+    mcp = next(artifact for artifact in detection.artifacts if artifact.artifact_id == "openclaw:mcp:remote")
+
+    assert any("network traffic" in signal for signal in artifact_risk_signals(channel))
+    assert any("remote server" in signal for signal in artifact_risk_signals(mcp))
+
+
+def test_openclaw_resolves_config_includes_before_building_artifacts(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    config_dir = context.home_dir / ".openclaw"
+    _write(
+        config_dir / "channels.json5",
+        """
+        {
+          channels: {
+            telegram: { dmPolicy: 'open', allowFrom: ['*'] },
+          },
+        }
+        """,
+    )
+    _write(
+        config_dir / "openclaw.json",
+        """
+        {
+          $include: 'channels.json5',
+          mcp: { servers: { remote: { url: 'https://remote.example/mcp' } } },
+        }
+        """,
+    )
+
+    detection = OpenClawHarnessAdapter().detect(context)
+    artifact_ids = {artifact.artifact_id for artifact in detection.artifacts}
+
+    assert "openclaw:channel:telegram" in artifact_ids
+    assert "openclaw:mcp:remote" in artifact_ids
 
 
 def test_openclaw_extra_skill_dirs_skip_blank_and_anchor_relative_paths(tmp_path: Path) -> None:

--- a/tests/test_openclaw_adapter.py
+++ b/tests/test_openclaw_adapter.py
@@ -1,0 +1,189 @@
+"""Tests for the OpenClaw harness adapter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters import get_adapter, list_adapters
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.openclaw import OpenClawHarnessAdapter
+from codex_plugin_scanner.guard.risk import artifact_risk_signals
+
+
+def _ctx(tmp_path: Path) -> HarnessContext:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    guard_home = tmp_path / "guard-home"
+    home_dir.mkdir(parents=True, exist_ok=True)
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    guard_home.mkdir(parents=True, exist_ok=True)
+    return HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=guard_home)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_openclaw_adapter_is_registered() -> None:
+    adapter = get_adapter("openclaw")
+
+    assert isinstance(adapter, OpenClawHarnessAdapter)
+    assert "openclaw" in {item.harness for item in list_adapters()}
+
+
+def test_detects_openclaw_config_channels_mcp_and_skills(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    config_path = context.home_dir / ".openclaw" / "openclaw.json"
+    workspace_path = context.home_dir / ".openclaw" / "workspace"
+    _write(
+        config_path,
+        json.dumps(
+            {
+                "gateway": {"mode": "local", "bind": "loopback", "auth": {"mode": "token"}},
+                "agents": {
+                    "defaults": {
+                        "workspace": str(workspace_path),
+                        "sandbox": {"mode": "non-main"},
+                        "models": {"openrouter": {"apiKey": {"env": "OPENROUTER_API_KEY"}}},
+                    }
+                },
+                "channels": {
+                    "telegram": {"enabled": True, "dmPolicy": "pairing", "allowFrom": ["12345"]},
+                    "slack": {"enabled": False, "dmPolicy": "open", "allowFrom": ["*"]},
+                },
+                "mcp": {
+                    "servers": {
+                        "docs": {"url": "https://mcp.example.com/sse"},
+                        "local": {"command": "node", "args": ["server.js"], "env": {"API_TOKEN": "token-value"}},
+                    }
+                },
+                "hooks": {"enabled": True, "path": "/hooks", "token": {"env": "OPENCLAW_HOOK_TOKEN"}},
+            }
+        ),
+    )
+    _write(
+        workspace_path / "skills" / "deploy-helper" / "SKILL.md",
+        "---\nname: deploy-helper\ndescription: deploy helper\n---\nRun `echo safe` for status.\n",
+    )
+
+    detection = OpenClawHarnessAdapter().detect(context)
+    artifacts = {artifact.artifact_id: artifact for artifact in detection.artifacts}
+
+    assert detection.installed is True
+    assert str(config_path) in detection.config_paths
+    assert "openclaw:config:global" in artifacts
+    assert "openclaw:channel:telegram" in artifacts
+    assert "openclaw:mcp:docs" in artifacts
+    assert "openclaw:mcp:local" in artifacts
+    assert "openclaw:skill:deploy-helper" in artifacts
+    assert artifacts["openclaw:config:global"].metadata["workspace_path"] == str(workspace_path)
+    assert artifacts["openclaw:mcp:docs"].transport == "http"
+    assert artifacts["openclaw:mcp:local"].to_dict()["metadata"]["env"]["API_TOKEN"] == "*****"
+
+
+def test_openclaw_flags_open_dm_policy_and_remote_mcp(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    _write(
+        context.home_dir / ".openclaw" / "openclaw.json",
+        json.dumps(
+            {
+                "channels": {"telegram": {"dmPolicy": "open", "allowFrom": ["*"]}},
+                "mcp": {"servers": {"remote": {"url": "https://evil.example/mcp"}}},
+            }
+        ),
+    )
+
+    detection = OpenClawHarnessAdapter().detect(context)
+    channel = next(artifact for artifact in detection.artifacts if artifact.artifact_id == "openclaw:channel:telegram")
+    mcp = next(artifact for artifact in detection.artifacts if artifact.artifact_id == "openclaw:mcp:remote")
+
+    channel_signals = artifact_risk_signals(channel)
+    mcp_signals = artifact_risk_signals(mcp)
+
+    assert any("network traffic" in signal for signal in channel_signals)
+    assert any("remote server" in signal for signal in mcp_signals)
+
+
+def test_openclaw_accepts_json5_comments_trailing_commas_and_extra_skill_dirs(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    extra_skill_root = context.home_dir / "shared-openclaw-skills"
+    _write(
+        context.home_dir / ".openclaw" / "openclaw.json",
+        f"""
+        {{
+          // OpenClaw stores active config as JSON5.
+          "channels": {{
+            "telegram": {{"dmPolicy": "pairing",}},
+          }},
+          "skills": {{
+            "load": {{
+              "extraDirs": ["{extra_skill_root}"],
+            }},
+          }},
+        }}
+        """,
+    )
+    _write(
+        extra_skill_root / "reviewer" / "SKILL.md",
+        "---\nname: reviewer\ndescription: review helper\n---\nRead project files only.\n",
+    )
+
+    detection = OpenClawHarnessAdapter().detect(context)
+    artifacts = {artifact.artifact_id for artifact in detection.artifacts}
+
+    assert "openclaw:channel:telegram" in artifacts
+    assert "openclaw:skill:reviewer" in artifacts
+
+
+def test_install_exports_guard_managed_openclaw_overlay(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    _write(
+        context.home_dir / ".openclaw" / "openclaw.json",
+        json.dumps({"channels": {"telegram": {"dmPolicy": "pairing"}}}),
+    )
+
+    manifest = OpenClawHarnessAdapter().install(context)
+    overlay_path = Path(str(manifest["managed_overlay_path"]))
+    pretool_path = Path(str(manifest["pretool_hook_path"]))
+    env = OpenClawHarnessAdapter().launch_environment(context)
+
+    assert manifest["install_state"] == "installed"
+    assert overlay_path.exists() is True
+    assert pretool_path.exists() is True
+    assert env["OPENCLAW_GUARD_OVERLAY_PATH"] == str(overlay_path)
+    assert env["OPENCLAW_GUARD_PRETOOL_PATH"] == str(pretool_path)
+    assert env["OPENCLAW_GUARD_CHANNEL_POSTURE"] == "enabled"
+
+
+def test_openclaw_skips_symlinked_skill_files(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    skill_root = context.home_dir / ".openclaw" / "workspace" / "skills" / "linked"
+    outside_skill = tmp_path / "outside" / "SKILL.md"
+    _write(context.home_dir / ".openclaw" / "openclaw.json", json.dumps({}))
+    _write(outside_skill, "---\nname: linked-secret\n---\nRead ${OPENROUTER_API_KEY}.\n")
+    skill_root.mkdir(parents=True, exist_ok=True)
+    try:
+        (skill_root / "SKILL.md").symlink_to(outside_skill)
+    except (NotImplementedError, OSError) as error:
+        pytest.skip(f"symlinks unavailable: {error}")
+
+    detection = OpenClawHarnessAdapter().detect(context)
+    artifacts = {artifact.artifact_id for artifact in detection.artifacts}
+
+    assert "openclaw:skill:linked-secret" not in artifacts
+
+
+def test_openclaw_approval_flow_prefers_native_or_center_after_install(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    adapter = OpenClawHarnessAdapter()
+
+    manifest = adapter.install(context)
+    flow = adapter.approval_flow(managed_install={"manifest": manifest})
+
+    assert flow["tier"] == "native-or-center"
+    assert flow["prompt_channel"] == "native"
+    assert flow["auto_open_browser"] is False


### PR DESCRIPTION
## Summary
- add OpenClaw Guard adapter for gateway config, channel posture, MCP, and skill discovery
- add managed OpenClaw overlay/pretool install metadata and native-or-center approval flow
- document OpenClaw support and validation matrix

## Verification
- uv run ruff check .
- uv run pytest tests/test_openclaw_adapter.py tests/test_hermes_adapter.py tests/test_guard_capabilities.py -q
- uv run pytest -q tests/test_action_runner.py tests/test_best_practices.py tests/test_cisco_install_surfaces.py tests/test_cli.py tests/test_code_quality.py tests/test_config.py tests/test_coverage_remaining.py
- uv run pytest -q tests/test_ecosystems.py tests/test_edge_cases.py tests/test_final_coverage.py tests/test_guard_approvals.py tests/test_guard_bootstrap.py tests/test_guard_capabilities.py tests/test_guard_claude_adapter.py tests/test_guard_cli.py
- uv run pytest -q tests/test_guard_codex_e2e.py tests/test_guard_codex_install.py tests/test_guard_codex_proxy.py tests/test_guard_config_paths.py tests/test_guard_connect_flow.py tests/test_guard_consumer_mode.py tests/test_guard_copilot_adapter.py tests/test_guard_copilot_proxy.py
- uv run pytest -q tests/test_guard_daemon_manager.py tests/test_guard_event_schema_v1.py tests/test_guard_events.py tests/test_guard_launch_env.py tests/test_guard_opencode_proxy.py
- uv run pytest -q tests/test_guard_product_flow.py tests/test_guard_protect.py tests/test_guard_render.py tests/test_guard_risk.py
- uv run pytest -q tests/test_guard_runtime.py tests/test_guard_store_migrations.py tests/test_guard_surface_server.py tests/test_guard_verdicts.py
- uv run pytest -q tests/test_[h-o]*.py
- uv run pytest -q tests/test_[p-z]*.py