### PR TITLE
feat(guard): add hosted runtime cloud cli

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5327,7 +5327,7 @@ def _guard_service_login_payload(
     now = _now()
     label = str(args.label).strip()
     workspace = _optional_string(args.workspace) or ""
-    sync_url = str(args.sync_url)
+    sync_url = str(args.sync_url).strip()
     token = str(args.token).strip()
     if not token:
         return {

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -86,6 +86,7 @@ from ..runtime.runner import (
     guard_run,
     prompt_requests_to_artifacts,
     sync_receipts,
+    sync_runtime_session,
 )
 from ..runtime.secret_file_requests import (
     build_file_read_request_artifact,
@@ -108,6 +109,9 @@ from .product import build_guard_start_payload, build_guard_status_payload
 from .update_commands import run_guard_update
 
 _GUARD_CLIENT_VERSION = "2.0.0"
+_SERVICE_RUNTIME_PROFILE_STATE_KEY = "service_runtime_profile"
+_SERVICE_RUNTIME_CHOICES = ("hermes", "openclaw", "custom")
+_SERVICE_RUNTIME_SURFACE = "agent-sdk"
 _GUARD_HELP_GROUPS = (
     "Everyday protection:\n"
     "  start        First-run setup and the Guard operating loop\n"
@@ -121,6 +125,7 @@ _GUARD_HELP_GROUPS = (
     "  connect      Pair this machine to Guard Cloud\n"
     "  login        Compatibility alias for browser pairing\n"
     "  sync         Send local decisions to Guard Cloud\n"
+    "  service      Manage hosted-runtime Guard Cloud login and sync\n"
     "  device       Inspect or rotate this machine identity\n"
     "  bridge       Forward Guard signals to external channels\n"
     "\n"
@@ -436,6 +441,41 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     sync_parser.add_argument("--home")
     sync_parser.add_argument("--guard-home")
     sync_parser.add_argument("--json", action="store_true")
+
+    service_parser = guard_subparsers.add_parser(
+        "service",
+        help="Manage headless hosted-runtime Guard Cloud login, sync, and status",
+    )
+    service_subparsers = service_parser.add_subparsers(
+        dest="service_command",
+        required=True,
+        parser_class=FriendlyArgumentParser,
+    )
+
+    service_login_parser = service_subparsers.add_parser(
+        "login",
+        help="Save a hosted-runtime Guard Cloud token and runtime profile",
+    )
+    _add_guard_common_args(service_login_parser)
+    service_login_parser.add_argument("--runtime", choices=_SERVICE_RUNTIME_CHOICES, required=True)
+    service_login_parser.add_argument("--label", required=True)
+    service_login_parser.add_argument("--sync-url", required=True, type=_guard_http_url)
+    service_login_parser.add_argument("--token", required=True)
+    service_login_parser.add_argument("--json", action="store_true")
+
+    service_sync_parser = service_subparsers.add_parser(
+        "sync",
+        help="Publish the hosted runtime session, then sync receipts",
+    )
+    _add_guard_common_args(service_sync_parser)
+    service_sync_parser.add_argument("--json", action="store_true")
+
+    service_status_parser = service_subparsers.add_parser(
+        "status",
+        help="Show hosted-runtime Guard Cloud login state and latest sync summaries",
+    )
+    _add_guard_common_args(service_status_parser)
+    service_status_parser.add_argument("--json", action="store_true")
 
     device_parser = guard_subparsers.add_parser("device", help="Manage local Guard installation identity")
     _add_guard_common_args(device_parser)
@@ -1092,6 +1132,37 @@ def run_guard_command(
             return 1
         _emit("sync", payload, getattr(args, "json", False))
         return 0
+
+    if args.guard_command == "service":
+        service_command = getattr(args, "service_command", None)
+        if service_command == "login":
+            payload, exit_code = _guard_service_login_payload(args=args, store=store)
+            _emit("service-login", payload, getattr(args, "json", False))
+            return exit_code
+        if service_command == "sync":
+            try:
+                payload = _guard_service_sync_payload(store)
+            except GuardSyncNotConfiguredError:
+                message = _guard_service_sync_prerequisite_message()
+                if getattr(args, "json", False):
+                    _emit("service-sync", {"synced": False, "error": message}, True)
+                else:
+                    print(message, file=sys.stderr)
+                return 1
+            except RuntimeError as error:
+                if getattr(args, "json", False):
+                    _emit("service-sync", {"synced": False, "error": str(error)}, True)
+                else:
+                    print(str(error), file=sys.stderr)
+                return 1
+            _emit("service-sync", payload, getattr(args, "json", False))
+            return 0
+        if service_command == "status":
+            payload = _guard_service_status_payload(store)
+            _emit("service-status", payload, getattr(args, "json", False))
+            return 0
+        print("service subcommand is required", file=sys.stderr)
+        return 2
 
     if args.guard_command == "device":
         command = getattr(args, "device_command", None)
@@ -5216,6 +5287,137 @@ def _manual_guard_login_payload(
     store.set_sync_credentials(manual_sync_url, manual_token, _now())
     store.add_event("sign_in", {"sync_url": manual_sync_url, "source": "local-cli"}, _now())
     return {"logged_in": True, "sync_url": manual_sync_url}, 0
+
+
+def _guard_service_runtime_profile(
+    store: GuardStore,
+) -> dict[str, str] | None:
+    payload = store.get_sync_payload(_SERVICE_RUNTIME_PROFILE_STATE_KEY)
+    if not isinstance(payload, dict):
+        return None
+    runtime = _optional_string(payload.get("runtime"))
+    label = _optional_string(payload.get("label"))
+    surface = _optional_string(payload.get("surface"))
+    client_name = _optional_string(payload.get("client_name"))
+    client_title = _optional_string(payload.get("client_title"))
+    client_version = _optional_string(payload.get("client_version"))
+    if (
+        runtime not in _SERVICE_RUNTIME_CHOICES
+        or label is None
+        or surface is None
+        or client_name is None
+        or client_title is None
+        or client_version is None
+    ):
+        return None
+    return {
+        "runtime": runtime,
+        "label": label,
+        "workspace": _optional_string(payload.get("workspace")) or "",
+        "surface": surface,
+        "client_name": client_name,
+        "client_title": client_title,
+        "client_version": client_version,
+    }
+
+
+def _guard_service_login_payload(
+    *,
+    args: argparse.Namespace,
+    store: GuardStore,
+) -> tuple[dict[str, object], int]:
+    now = _now()
+    label = str(args.label).strip()
+    workspace = _optional_string(args.workspace) or ""
+    sync_url = str(args.sync_url)
+    runtime = str(args.runtime)
+    service_profile = {
+        "runtime": runtime,
+        "label": label,
+        "workspace": workspace,
+        "surface": _SERVICE_RUNTIME_SURFACE,
+        "client_name": "hol-guard",
+        "client_title": label,
+        "client_version": _GUARD_CLIENT_VERSION,
+    }
+    store.set_sync_credentials(sync_url, str(args.token).strip(), now)
+    store.set_sync_payload(_SERVICE_RUNTIME_PROFILE_STATE_KEY, service_profile, now)
+    device = store.set_device_label(label, now)
+    store.add_event(
+        "service_sign_in",
+        {
+            "runtime": runtime,
+            "label": label,
+            "workspace": workspace or None,
+            "sync_url": sync_url,
+            "source": "hosted-runtime-cli",
+        },
+        now,
+    )
+    return {
+        "logged_in": True,
+        "sync_url": sync_url,
+        "service": service_profile,
+        "device": device,
+    }, 0
+
+
+def _guard_service_sync_prerequisite_message() -> str:
+    return (
+        "Hosted Guard runtime is not configured yet. Run `hol-guard service login --runtime <runtime> "
+        "--label \"<label>\" --sync-url \"<url>\" --token \"<token>\"` first."
+    )
+
+
+def _guard_service_status_payload(store: GuardStore) -> dict[str, object]:
+    credentials = store.get_sync_credentials()
+    service_profile = _guard_service_runtime_profile(store)
+    return {
+        "configured": credentials is not None and service_profile is not None,
+        "connection": {
+            "configured": credentials is not None,
+            "sync_url": credentials["sync_url"] if credentials is not None else None,
+        },
+        "service": service_profile,
+        "runtime": store.get_sync_payload("runtime_session_summary") or {},
+        "receipts": store.get_sync_payload("sync_summary") or {},
+    }
+
+
+def _guard_service_sync_payload(store: GuardStore) -> dict[str, object]:
+    service_profile = _guard_service_runtime_profile(store)
+    if service_profile is None:
+        raise GuardSyncNotConfiguredError(_guard_service_sync_prerequisite_message())
+    runtime_summary = sync_runtime_session(
+        store,
+        session={
+            "harness": service_profile["runtime"],
+            "surface": service_profile["surface"],
+            "status": "active",
+            "client_name": service_profile["client_name"],
+            "client_title": service_profile["client_title"],
+            "client_version": service_profile["client_version"],
+            "workspace": service_profile["workspace"] or None,
+            "capabilities": ["hosted-runtime", "guard-cloud-sync"],
+        },
+    )
+    receipts_summary = sync_receipts(store)
+    store.add_event(
+        "service_sync",
+        {
+            "runtime": service_profile["runtime"],
+            "workspace": service_profile["workspace"] or None,
+            "runtime_session_id": runtime_summary.get("runtime_session_id"),
+            "synced_at": receipts_summary.get("synced_at"),
+        },
+        _now(),
+    )
+    return {
+        "synced": True,
+        "service": service_profile,
+        "runtime": runtime_summary,
+        "receipts": receipts_summary,
+    }
 
 
 def _guard_sync_prerequisite_message() -> str:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5401,7 +5401,7 @@ def _guard_service_sync_payload(store: GuardStore) -> dict[str, object]:
             "client_name": service_profile["client_name"],
             "client_title": service_profile["client_title"],
             "client_version": service_profile["client_version"],
-            "workspace": service_profile["workspace"] or None,
+            "workspace": service_profile["workspace"],
             "capabilities": ["hosted-runtime", "guard-cloud-sync"],
         },
     )

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1142,18 +1142,16 @@ def run_guard_command(
         if service_command == "sync":
             try:
                 payload = _guard_service_sync_payload(store)
-            except GuardSyncNotConfiguredError:
-                message = _guard_service_sync_prerequisite_message()
+            except (GuardSyncNotConfiguredError, RuntimeError) as error:
+                message = (
+                    _guard_service_sync_prerequisite_message()
+                    if isinstance(error, GuardSyncNotConfiguredError)
+                    else str(error)
+                )
                 if getattr(args, "json", False):
                     _emit("service-sync", {"synced": False, "error": message}, True)
                 else:
                     print(message, file=sys.stderr)
-                return 1
-            except RuntimeError as error:
-                if getattr(args, "json", False):
-                    _emit("service-sync", {"synced": False, "error": str(error)}, True)
-                else:
-                    print(str(error), file=sys.stderr)
                 return 1
             _emit("service-sync", payload, getattr(args, "json", False))
             return 0
@@ -5330,6 +5328,12 @@ def _guard_service_login_payload(
     label = str(args.label).strip()
     workspace = _optional_string(args.workspace) or ""
     sync_url = str(args.sync_url)
+    token = str(args.token).strip()
+    if not token:
+        return {
+            "logged_in": False,
+            "error": "Hosted Guard runtime token cannot be empty.",
+        }, 2
     runtime = str(args.runtime)
     service_profile = {
         "runtime": runtime,
@@ -5340,7 +5344,7 @@ def _guard_service_login_payload(
         "client_title": label,
         "client_version": _GUARD_CLIENT_VERSION,
     }
-    store.set_sync_credentials(sync_url, str(args.token).strip(), now)
+    store.set_sync_credentials(sync_url, token, now)
     store.set_sync_payload(_SERVICE_RUNTIME_PROFILE_STATE_KEY, service_profile, now)
     device = store.set_device_label(label, now)
     store.add_event(
@@ -5365,7 +5369,7 @@ def _guard_service_login_payload(
 def _guard_service_sync_prerequisite_message() -> str:
     return (
         "Hosted Guard runtime is not configured yet. Run `hol-guard service login --runtime <runtime> "
-        "--label \"<label>\" --sync-url \"<url>\" --token \"<token>\"` first."
+        '--label "<label>" --sync-url "<url>" --token "<token>"` first.'
     )
 
 

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -5883,6 +5883,154 @@ url = http://127.0.0.1:8787/guard-canary
         assert login_rc == 2
         assert "Pass both --sync-url and --token to save credentials manually" in capsys.readouterr().err
 
+    def test_guard_service_login_stores_hosted_runtime_profile(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+
+        login_rc = main(
+            [
+                "guard",
+                "service",
+                "login",
+                "--home",
+                str(home_dir),
+                "--runtime",
+                "hermes",
+                "--label",
+                "Hermes Telegram agent",
+                "--workspace",
+                "workspace_ops",
+                "--sync-url",
+                "https://hol.org/api/guard/receipts/sync",
+                "--token",
+                "guard_live_secretvalue",
+                "--json",
+            ]
+        )
+        payload = json.loads(capsys.readouterr().out)
+        store = GuardStore(home_dir)
+
+        assert login_rc == 0
+        assert payload["logged_in"] is True
+        assert payload["service"]["runtime"] == "hermes"
+        assert payload["service"]["label"] == "Hermes Telegram agent"
+        assert payload["service"]["workspace"] == "workspace_ops"
+        assert store.get_sync_credentials() == {
+            "sync_url": "https://hol.org/api/guard/receipts/sync",
+            "token": "guard_live_secretvalue",
+        }
+        assert store.get_sync_payload("service_runtime_profile") == {
+            "runtime": "hermes",
+            "label": "Hermes Telegram agent",
+            "workspace": "workspace_ops",
+            "surface": "agent-sdk",
+            "client_name": "hol-guard",
+            "client_title": "Hermes Telegram agent",
+            "client_version": guard_commands_module._GUARD_CLIENT_VERSION,
+        }
+        assert store.get_device_metadata()["device_label"] == "Hermes Telegram agent"
+
+    def test_guard_service_sync_publishes_runtime_session_before_receipts(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        store = GuardStore(home_dir)
+        now = "2026-05-01T00:00:00Z"
+        store.set_sync_credentials("https://hol.org/api/guard/receipts/sync", "guard_live_secretvalue", now)
+        store.set_sync_payload(
+            "service_runtime_profile",
+            {
+                "runtime": "openclaw",
+                "label": "OpenClaw Runner",
+                "workspace": "workspace_ops",
+                "surface": "agent-sdk",
+                "client_name": "hol-guard",
+                "client_title": "OpenClaw Runner",
+                "client_version": "2.0.0",
+            },
+            now,
+        )
+
+        captured_session: dict[str, object] = {}
+
+        def fake_sync_runtime_session(current_store: GuardStore, *, session: dict[str, object]) -> dict[str, object]:
+            assert current_store is not None
+            captured_session.update(session)
+            return {
+                "synced_at": now,
+                "runtime_session_synced_at": now,
+                "runtime_session_id": "runtime-session-1",
+                "runtime_sessions_visible": 1,
+            }
+
+        def fake_sync_receipts(current_store: GuardStore) -> dict[str, object]:
+            assert current_store is not None
+            return {
+                "synced_at": now,
+                "receipts_stored": 0,
+                "inventory_stored": 0,
+                "guard_events_v1": {"accepted": 0, "events": 0, "synced_at": now},
+            }
+
+        monkeypatch.setattr(guard_commands_module, "sync_runtime_session", fake_sync_runtime_session)
+        monkeypatch.setattr(guard_commands_module, "sync_receipts", fake_sync_receipts)
+
+        sync_rc = main(["guard", "service", "sync", "--home", str(home_dir), "--json"])
+        payload = json.loads(capsys.readouterr().out)
+
+        assert sync_rc == 0
+        assert payload["service"]["runtime"] == "openclaw"
+        assert payload["runtime"]["runtime_session_id"] == "runtime-session-1"
+        assert payload["receipts"]["receipts_stored"] == 0
+        assert captured_session["harness"] == "openclaw"
+        assert captured_session["surface"] == "agent-sdk"
+        assert captured_session["workspace"] == "workspace_ops"
+        assert captured_session["client_title"] == "OpenClaw Runner"
+
+    def test_guard_service_status_reports_hosted_runtime_state(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        store = GuardStore(home_dir)
+        now = "2026-05-01T00:00:00Z"
+        store.set_sync_credentials("https://hol.org/api/guard/receipts/sync", "guard_live_secretvalue", now)
+        store.set_sync_payload(
+            "service_runtime_profile",
+            {
+                "runtime": "hermes",
+                "label": "Hermes Telegram agent",
+                "workspace": "workspace_ops",
+                "surface": "agent-sdk",
+                "client_name": "hol-guard",
+                "client_title": "Hermes Telegram agent",
+                "client_version": "2.0.0",
+            },
+            now,
+        )
+        store.set_sync_payload(
+            "runtime_session_summary",
+            {
+                "runtime_session_id": "runtime-session-1",
+                "runtime_session_synced_at": now,
+                "runtime_sessions_visible": 1,
+            },
+            now,
+        )
+        store.set_sync_payload(
+            "sync_summary",
+            {
+                "synced_at": now,
+                "receipts_stored": 2,
+            },
+            now,
+        )
+
+        status_rc = main(["guard", "service", "status", "--home", str(home_dir), "--json"])
+        payload = json.loads(capsys.readouterr().out)
+
+        assert status_rc == 0
+        assert payload["configured"] is True
+        assert payload["service"]["runtime"] == "hermes"
+        assert payload["service"]["label"] == "Hermes Telegram agent"
+        assert payload["runtime"]["runtime_session_id"] == "runtime-session-1"
+        assert payload["receipts"]["receipts_stored"] == 2
+        assert payload["connection"]["sync_url"] == "https://hol.org/api/guard/receipts/sync"
+
     def test_guard_connect_preserves_pairing_when_first_sync_fails(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6018,10 +6018,16 @@ url = http://127.0.0.1:8787/guard-canary
         assert payload["service"]["runtime"] == "openclaw"
         assert payload["runtime"]["runtime_session_id"] == "runtime-session-1"
         assert payload["receipts"]["receipts_stored"] == 0
-        assert captured_session["harness"] == "openclaw"
-        assert captured_session["surface"] == "agent-sdk"
-        assert captured_session["workspace"] == "workspace_ops"
-        assert captured_session["client_title"] == "OpenClaw Runner"
+        assert captured_session == {
+            "harness": "openclaw",
+            "surface": "agent-sdk",
+            "status": "active",
+            "client_name": "hol-guard",
+            "client_title": "OpenClaw Runner",
+            "client_version": "2.0.0",
+            "workspace": "workspace_ops",
+            "capabilities": ["hosted-runtime", "guard-cloud-sync"],
+        }
 
     def test_guard_service_status_reports_hosted_runtime_state(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -6064,8 +6070,15 @@ url = http://127.0.0.1:8787/guard-canary
 
         assert status_rc == 0
         assert payload["configured"] is True
-        assert payload["service"]["runtime"] == "hermes"
-        assert payload["service"]["label"] == "Hermes Telegram agent"
+        assert payload["service"] == {
+            "runtime": "hermes",
+            "label": "Hermes Telegram agent",
+            "workspace": "workspace_ops",
+            "surface": "agent-sdk",
+            "client_name": "hol-guard",
+            "client_title": "Hermes Telegram agent",
+            "client_version": "2.0.0",
+        }
         assert payload["runtime"]["runtime_session_id"] == "runtime-session-1"
         assert payload["receipts"]["receipts_stored"] == 2
         assert payload["connection"]["sync_url"] == "https://hol.org/api/guard/receipts/sync"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6062,6 +6062,56 @@ url = http://127.0.0.1:8787/guard-canary
             "capabilities": ["hosted-runtime", "guard-cloud-sync"],
         }
 
+    def test_guard_service_sync_preserves_empty_workspace(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        store = GuardStore(home_dir)
+        now = "2026-05-01T00:00:00Z"
+        store.set_sync_credentials("https://hol.org/api/guard/receipts/sync", "guard_live_secretvalue", now)
+        store.set_sync_payload(
+            "service_runtime_profile",
+            {
+                "runtime": "openclaw",
+                "label": "OpenClaw Runner",
+                "workspace": "",
+                "surface": "agent-sdk",
+                "client_name": "hol-guard",
+                "client_title": "OpenClaw Runner",
+                "client_version": "2.0.0",
+            },
+            now,
+        )
+
+        captured_session: dict[str, object] = {}
+
+        def fake_sync_runtime_session(current_store: GuardStore, *, session: dict[str, object]) -> dict[str, object]:
+            assert current_store is not None
+            captured_session.update(session)
+            return {
+                "synced_at": now,
+                "runtime_session_synced_at": now,
+                "runtime_session_id": "runtime-session-1",
+                "runtime_sessions_visible": 1,
+            }
+
+        def fake_sync_receipts(current_store: GuardStore) -> dict[str, object]:
+            assert current_store is not None
+            return {
+                "synced_at": now,
+                "receipts_stored": 0,
+                "inventory_stored": 0,
+                "guard_events_v1": {"accepted": 0, "events": 0, "synced_at": now},
+            }
+
+        monkeypatch.setattr(guard_commands_module, "sync_runtime_session", fake_sync_runtime_session)
+        monkeypatch.setattr(guard_commands_module, "sync_receipts", fake_sync_receipts)
+
+        sync_rc = main(["guard", "service", "sync", "--home", str(home_dir), "--json"])
+        payload = json.loads(capsys.readouterr().out)
+
+        assert sync_rc == 0
+        assert payload["runtime"]["runtime_session_id"] == "runtime-session-1"
+        assert captured_session["workspace"] == ""
+
     def test_guard_service_status_reports_hosted_runtime_state(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -5911,9 +5911,15 @@ url = http://127.0.0.1:8787/guard-canary
 
         assert login_rc == 0
         assert payload["logged_in"] is True
-        assert payload["service"]["runtime"] == "hermes"
-        assert payload["service"]["label"] == "Hermes Telegram agent"
-        assert payload["service"]["workspace"] == "workspace_ops"
+        assert payload["service"] == {
+            "runtime": "hermes",
+            "label": "Hermes Telegram agent",
+            "workspace": "workspace_ops",
+            "surface": "agent-sdk",
+            "client_name": "hol-guard",
+            "client_title": "Hermes Telegram agent",
+            "client_version": guard_commands_module._GUARD_CLIENT_VERSION,
+        }
         assert store.get_sync_credentials() == {
             "sync_url": "https://hol.org/api/guard/receipts/sync",
             "token": "guard_live_secretvalue",
@@ -5928,6 +5934,39 @@ url = http://127.0.0.1:8787/guard-canary
             "client_version": guard_commands_module._GUARD_CLIENT_VERSION,
         }
         assert store.get_device_metadata()["device_label"] == "Hermes Telegram agent"
+
+    def test_guard_service_login_rejects_blank_token(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+
+        login_rc = main(
+            [
+                "guard",
+                "service",
+                "login",
+                "--home",
+                str(home_dir),
+                "--runtime",
+                "hermes",
+                "--label",
+                "Hermes Telegram agent",
+                "--workspace",
+                "workspace_ops",
+                "--sync-url",
+                "https://hol.org/api/guard/receipts/sync",
+                "--token",
+                "   ",
+                "--json",
+            ]
+        )
+        payload = json.loads(capsys.readouterr().out)
+        store = GuardStore(home_dir)
+
+        assert login_rc == 2
+        assert payload == {
+            "logged_in": False,
+            "error": "Hosted Guard runtime token cannot be empty.",
+        }
+        assert store.get_sync_credentials() is None
 
     def test_guard_service_sync_publishes_runtime_session_before_receipts(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -5935,6 +5935,39 @@ url = http://127.0.0.1:8787/guard-canary
         }
         assert store.get_device_metadata()["device_label"] == "Hermes Telegram agent"
 
+    def test_guard_service_login_trims_sync_url(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+
+        login_rc = main(
+            [
+                "guard",
+                "service",
+                "login",
+                "--home",
+                str(home_dir),
+                "--runtime",
+                "hermes",
+                "--label",
+                "Hermes Telegram agent",
+                "--workspace",
+                "workspace_ops",
+                "--sync-url",
+                "https://hol.org/api/guard/receipts/sync ",
+                "--token",
+                "guard_live_secretvalue",
+                "--json",
+            ]
+        )
+        payload = json.loads(capsys.readouterr().out)
+        store = GuardStore(home_dir)
+
+        assert login_rc == 0
+        assert payload["sync_url"] == "https://hol.org/api/guard/receipts/sync"
+        assert store.get_sync_credentials() == {
+            "sync_url": "https://hol.org/api/guard/receipts/sync",
+            "token": "guard_live_secretvalue",
+        }
+
     def test_guard_service_login_rejects_blank_token(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
 


### PR DESCRIPTION
## Summary
- add hosted-runtime Guard Cloud login, sync, and status commands
- publish runtime sessions before receipt sync so Hermes/OpenClaw service principals show up in Guard Cloud
- cover the new CLI flow with focused regression tests

## Validation
- pytest tests/test_guard_cli.py
- pytest tests/test_guard_cli.py -k "service_login or service_sync or service_status"
- ruff check src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_cli.py