### PR TITLE
feat(guard): add runtime action envelopes

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -71,6 +71,7 @@ _SENSITIVE_RAW_KEYS = frozenset(
         "tool_response",
     }
 )
+_SENSITIVE_RAW_KEY_ALIASES = frozenset(key.replace("_", "") for key in _SENSITIVE_RAW_KEYS)
 _HOOK_EVENT_NAME_MAP = {
     "userpromptsubmitted": "UserPromptSubmit",
     "pretooluse": "PreToolUse",
@@ -335,7 +336,7 @@ def _prompt_excerpt(value: object) -> str | None:
     stripped = " ".join(value.strip().split())
     if not stripped:
         return None
-    return stripped[:_PROMPT_EXCERPT_LIMIT]
+    return redact_text(stripped).text[:_PROMPT_EXCERPT_LIMIT]
 
 
 def _mcp_parts(tool_name: str | None) -> tuple[str | None, str | None]:
@@ -405,8 +406,8 @@ def _redacted_payload(payload: Mapping[str, object]) -> dict[str, object]:
 
 
 def _redacted_value(key: str, value: object) -> object:
-    normalized_key = key.lower().replace("-", "_")
-    if normalized_key in _SENSITIVE_RAW_KEYS:
+    normalized_key = _normalized_secret_key(key)
+    if normalized_key in _SENSITIVE_RAW_KEYS or normalized_key.replace("_", "") in _SENSITIVE_RAW_KEY_ALIASES:
         return "[redacted]"
     if isinstance(value, Mapping):
         return {
@@ -419,6 +420,12 @@ def _redacted_value(key: str, value: object) -> object:
     if isinstance(value, (bool, int, float)) or value is None:
         return value
     return str(value)
+
+
+def _normalized_secret_key(key: str) -> str:
+    normalized = key.replace("-", "_")
+    normalized = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", normalized)
+    return normalized.lower()
 
 
 def _normalized_command(command: str | None) -> str | None:

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -73,6 +73,7 @@ _SENSITIVE_RAW_KEYS = frozenset(
 )
 _SENSITIVE_RAW_KEY_ALIASES = frozenset(key.replace("_", "") for key in _SENSITIVE_RAW_KEYS)
 _HOOK_EVENT_NAME_MAP = {
+    "userpromptsubmit": "UserPromptSubmit",
     "userpromptsubmitted": "UserPromptSubmit",
     "pretooluse": "PreToolUse",
     "posttooluse": "PostToolUse",
@@ -334,10 +335,11 @@ def _command_from_payload(tool_input: Mapping[str, object]) -> str | None:
 def _prompt_excerpt(value: object) -> str | None:
     if not isinstance(value, str):
         return None
-    stripped = " ".join(value.strip().split())
-    if not stripped:
+    redacted = redact_text(value.strip()).text
+    collapsed = " ".join(redacted.split())
+    if not collapsed:
         return None
-    return redact_text(stripped).text[:_PROMPT_EXCERPT_LIMIT]
+    return collapsed[:_PROMPT_EXCERPT_LIMIT]
 
 
 def _mcp_parts(tool_name: str | None) -> tuple[str | None, str | None]:

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -231,8 +231,17 @@ def normalize_codex_hook_payload(
 
     normalized_payload = dict(payload)
     event_name = _hook_event_name(normalized_payload)
-    tool_name = _string_value(normalized_payload.get("tool_name")) or _string_value(normalized_payload.get("toolName"))
+    explicit_tool_name = _string_value(normalized_payload.get("tool_name")) or _string_value(
+        normalized_payload.get("toolName")
+    )
+    tool_call_name, tool_call_input = _tool_call_from_payload(
+        normalized_payload.get("toolCalls"),
+        expected_tool_name=explicit_tool_name,
+    )
+    tool_name = explicit_tool_name or tool_call_name
     tool_input = _tool_input_from_payload(normalized_payload)
+    if not tool_input and tool_call_input is not None:
+        tool_input = tool_call_input
     raw_command = _command_from_payload(tool_input)
     command = _command_detail(raw_command, home_dir=home_dir)
     prompt_text = _prompt_text(normalized_payload.get("prompt"))
@@ -322,17 +331,47 @@ def _mapping_value(value: object) -> Mapping[str, object]:
 
 def _tool_input_from_payload(payload: Mapping[str, object]) -> Mapping[str, object]:
     for key in ("tool_input", "toolInput", "toolArgs", "arguments"):
-        value = payload.get(key)
-        if isinstance(value, Mapping):
-            return value
-        if isinstance(value, str) and value.strip():
-            try:
-                parsed = json.loads(value)
-            except json.JSONDecodeError:
-                continue
-            if isinstance(parsed, Mapping):
-                return parsed
+        parsed = _mapping_from_value(payload.get(key))
+        if parsed is not None:
+            return parsed
     return {}
+
+
+def _tool_call_from_payload(
+    value: object,
+    *,
+    expected_tool_name: str | None,
+) -> tuple[str | None, Mapping[str, object] | None]:
+    if not isinstance(value, list):
+        return None, None
+    fallback_tool_call: tuple[str, Mapping[str, object] | None] | None = None
+    for item in value:
+        if not isinstance(item, Mapping):
+            continue
+        tool_name = _string_value(item.get("name"))
+        if tool_name is None:
+            continue
+        tool_input = _mapping_from_value(item.get("args"))
+        if fallback_tool_call is None:
+            fallback_tool_call = (tool_name, tool_input)
+        if expected_tool_name is None or tool_name == expected_tool_name:
+            return tool_name, tool_input
+    if fallback_tool_call is not None:
+        return fallback_tool_call
+    return None, None
+
+
+def _mapping_from_value(value: object) -> Mapping[str, object] | None:
+    if isinstance(value, Mapping):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return None
+        if isinstance(parsed, Mapping):
+            return parsed
+    return None
 
 
 def _hook_event_name(payload: Mapping[str, object]) -> str:

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -6,7 +6,7 @@ import hashlib
 import json
 import re
 from collections.abc import Mapping
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
@@ -78,7 +78,10 @@ _HOOK_EVENT_NAME_MAP = {
     "permissionrequest": "PermissionRequest",
 }
 _PROMPT_PATH_PATTERN = re.compile(
-    r"(?P<path>(?:~|\.{1,2})?/?[A-Za-z0-9_./-]*(?:\.npmrc|\.env(?:\.[A-Za-z0-9_-]+)?|id_rsa|id_ed25519|credentials)[A-Za-z0-9_./-]*)"
+    r"(?<![A-Za-z0-9_./-])"
+    r"(?P<path>(?:~|\.{1,2})?/?(?:[A-Za-z0-9_.-]+/)*"
+    r"(?:\.npmrc|\.env(?:\.[A-Za-z0-9_-]+)?|id_rsa|id_ed25519|credentials))"
+    r"(?![A-Za-z0-9_.-])"
 )
 _NETWORK_HOST_PATTERN = re.compile(r"(?:https?|wss?|grpcs?)://(?P<host>[A-Za-z0-9.-]+)(?::\d+)?(?:/|$)")
 _PROMPT_EXCERPT_LIMIT = 240
@@ -106,6 +109,10 @@ class GuardActionEnvelope:
     package_name: str | None
     script_name: str | None
     raw_payload_redacted: dict[str, object]
+
+    def __post_init__(self) -> None:
+        if not self.action_id:
+            object.__setattr__(self, "action_id", stable_action_hash(self))
 
     def to_dict(self) -> dict[str, object]:
         """Return the stable JSON payload stored with approvals and receipts."""
@@ -190,12 +197,8 @@ def redacted_workspace_label(workspace: Path | str | None, *, home_dir: Path | s
         return None
     workspace_path = Path(workspace).expanduser()
     home_path = Path(home_dir).expanduser() if home_dir is not None else Path.home()
-    try:
-        resolved_workspace = workspace_path.resolve()
-        resolved_home = home_path.resolve()
-    except OSError:
-        resolved_workspace = workspace_path.absolute()
-        resolved_home = home_path.absolute()
+    resolved_workspace = workspace_path.resolve(strict=False)
+    resolved_home = home_path.resolve(strict=False)
     if resolved_workspace.is_relative_to(resolved_home):
         relative = resolved_workspace.relative_to(resolved_home)
         return "~" if str(relative) == "." else f"~/{relative.as_posix()}"
@@ -224,16 +227,11 @@ def normalize_codex_hook_payload(
         prompt_excerpt=prompt_excerpt,
         mcp_server=mcp_server,
     )
-    target_paths = _target_paths(
-        action_type=action_type,
-        tool_input=tool_input,
-        command=command,
-        prompt_excerpt=prompt_excerpt,
-    )
+    target_paths = _target_paths(tool_input=tool_input, command=command, prompt_excerpt=prompt_excerpt)
     network_hosts = _network_hosts(command, prompt_excerpt)
     workspace_label = redacted_workspace_label(workspace, home_dir=home_dir)
     workspace_hash = _workspace_hash(workspace)
-    envelope = GuardActionEnvelope(
+    return GuardActionEnvelope(
         schema_version=_SCHEMA_VERSION,
         action_id="",
         harness="codex",
@@ -253,7 +251,6 @@ def normalize_codex_hook_payload(
         script_name=None,
         raw_payload_redacted=_redacted_payload(normalized_payload),
     )
-    return replace(envelope, action_id=stable_action_hash(envelope))
 
 
 def _required_int(payload: Mapping[str, object], key: str) -> int:
@@ -374,7 +371,6 @@ def _codex_action_type(
 
 def _target_paths(
     *,
-    action_type: GuardActionType,
     tool_input: Mapping[str, object],
     command: str | None,
     prompt_excerpt: str | None,

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -10,6 +10,8 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Literal
 
+from ..redaction import redact_text
+
 GuardActionType = Literal[
     "prompt",
     "shell_command",
@@ -215,7 +217,12 @@ def normalize_codex_hook_payload(
         prompt_excerpt=prompt_excerpt,
         mcp_server=mcp_server,
     )
-    target_paths = _target_paths(action_type=action_type, tool_input=tool_input, prompt_excerpt=prompt_excerpt)
+    target_paths = _target_paths(
+        action_type=action_type,
+        tool_input=tool_input,
+        command=command,
+        prompt_excerpt=prompt_excerpt,
+    )
     network_hosts = _network_hosts(command, prompt_excerpt)
     workspace_label = str(Path(workspace)) if workspace is not None else None
     workspace_hash = _workspace_hash(workspace)
@@ -347,6 +354,7 @@ def _target_paths(
     *,
     action_type: GuardActionType,
     tool_input: Mapping[str, object],
+    command: str | None,
     prompt_excerpt: str | None,
 ) -> tuple[str, ...]:
     paths: list[str] = []
@@ -355,8 +363,9 @@ def _target_paths(
             value = tool_input.get(key)
             if isinstance(value, str) and value.strip():
                 paths.append(value.strip())
-    if prompt_excerpt is not None:
-        paths.extend(match.group("path") for match in _PROMPT_PATH_PATTERN.finditer(prompt_excerpt))
+    for text in (command, prompt_excerpt):
+        if text is not None:
+            paths.extend(match.group("path") for match in _PROMPT_PATH_PATTERN.finditer(text))
     return tuple(dict.fromkeys(paths))
 
 
@@ -390,7 +399,7 @@ def _redacted_value(key: str, value: object) -> object:
     if isinstance(value, list):
         return [_redacted_value(key, item) for item in value]
     if isinstance(value, str):
-        return value[:_PROMPT_EXCERPT_LIMIT]
+        return redact_text(value).text[:_PROMPT_EXCERPT_LIMIT]
     if isinstance(value, (bool, int, float)) or value is None:
         return value
     return str(value)

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -203,7 +203,8 @@ def redacted_workspace_label(workspace: Path | str | None, *, home_dir: Path | s
     if resolved_workspace.is_relative_to(resolved_home):
         relative = resolved_workspace.relative_to(resolved_home)
         return "~" if str(relative) == "." else f"~/{relative.as_posix()}"
-    return resolved_workspace.as_posix()
+    workspace_name = resolved_workspace.name or "workspace"
+    return f".../{workspace_name}"
 
 
 def normalize_codex_hook_payload(

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -7,7 +7,7 @@ import json
 import re
 from collections.abc import Mapping
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Literal
 
 from ..redaction import redact_text
@@ -199,12 +199,12 @@ def redacted_workspace_label(workspace: Path | str | None, *, home_dir: Path | s
         return None
     workspace_path = Path(workspace).expanduser()
     home_path = Path(home_dir).expanduser() if home_dir is not None else Path.home()
-    resolved_workspace = workspace_path.resolve(strict=False)
-    resolved_home = home_path.resolve(strict=False)
+    resolved_workspace = _safe_resolve(workspace_path)
+    resolved_home = _safe_resolve(home_path)
     if resolved_workspace.is_relative_to(resolved_home):
         relative = resolved_workspace.relative_to(resolved_home)
         return "~" if str(relative) == "." else f"~/{relative.as_posix()}"
-    workspace_name = resolved_workspace.name or "workspace"
+    workspace_name = resolved_workspace.name or workspace_path.name or "workspace"
     return f".../{workspace_name}"
 
 
@@ -230,7 +230,12 @@ def normalize_codex_hook_payload(
         prompt_excerpt=prompt_excerpt,
         mcp_server=mcp_server,
     )
-    target_paths = _target_paths(tool_input=tool_input, command=command, prompt_excerpt=prompt_excerpt)
+    target_paths = _target_paths(
+        tool_input=tool_input,
+        command=command,
+        prompt_excerpt=prompt_excerpt,
+        home_dir=home_dir,
+    )
     network_hosts = _network_hosts(command, prompt_excerpt)
     workspace_label = redacted_workspace_label(workspace, home_dir=home_dir)
     workspace_hash = _workspace_hash(workspace)
@@ -378,6 +383,7 @@ def _target_paths(
     tool_input: Mapping[str, object],
     command: str | None,
     prompt_excerpt: str | None,
+    home_dir: Path | str | None,
 ) -> tuple[str, ...]:
     paths: list[str] = []
     for key in _PATH_KEYS:
@@ -387,7 +393,8 @@ def _target_paths(
     for text in (command, prompt_excerpt):
         if text is not None:
             paths.extend(match.group("path") for match in _PROMPT_PATH_PATTERN.finditer(text))
-    return tuple(dict.fromkeys(paths))
+    redacted_paths = (_redacted_target_path(path, home_dir=home_dir) for path in paths)
+    return tuple(dict.fromkeys(path for path in redacted_paths if path is not None))
 
 
 def _network_hosts(command: str | None, prompt_excerpt: str | None) -> tuple[str, ...]:
@@ -402,6 +409,35 @@ def _workspace_hash(workspace: Path | str | None) -> str | None:
         return None
     encoded = str(Path(workspace).expanduser()).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
+
+
+def _safe_resolve(path: Path) -> Path:
+    try:
+        return path.resolve(strict=False)
+    except (OSError, RuntimeError):
+        return path
+
+
+def _redacted_target_path(path: str, *, home_dir: Path | str | None) -> str | None:
+    stripped = path.strip()
+    if not stripped:
+        return None
+    if stripped == "~" or stripped.startswith("~/"):
+        return redact_text(stripped).text
+    if stripped.startswith("~"):
+        target_name = Path(stripped).name or "path"
+        return f".../{target_name}"
+    windows_path = PureWindowsPath(stripped)
+    if windows_path.is_absolute():
+        target_name = windows_path.name or "path"
+        return f".../{target_name}"
+    if _is_absolute_target_path(stripped):
+        return redacted_workspace_label(stripped, home_dir=home_dir)
+    return redact_text(stripped).text
+
+
+def _is_absolute_target_path(path: str) -> bool:
+    return Path(path).expanduser().is_absolute()
 
 
 def _redacted_payload(payload: Mapping[str, object]) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -81,8 +81,10 @@ _HOOK_EVENT_NAME_MAP = {
 }
 _PROMPT_PATH_PATTERN = re.compile(
     r"(?<![A-Za-z0-9_./-])"
-    r"(?P<path>(?:~|\.{1,2})?/?(?:[A-Za-z0-9_.-]+/)*"
-    r"(?:\.npmrc|\.env(?:\.[A-Za-z0-9_-]+)?|id_rsa|id_ed25519|credentials))"
+    r"(?P<path>(?:"
+    r"(?:~|\.{1,2})?/?(?:[A-Za-z0-9_.-]+/)*(?:\.npmrc|\.env(?:\.[A-Za-z0-9_-]+)?|id_rsa|id_ed25519)"
+    r"|(?:~|\.{1,2})?/?(?:[A-Za-z0-9_.-]+/)+credentials"
+    r"))"
     r"(?![A-Za-z0-9_.-])"
 )
 _NETWORK_HOST_PATTERN = re.compile(r"(?:https?|wss?|grpcs?)://(?P<host>[A-Za-z0-9.-]+)(?::\d+)?(?:/|$)")
@@ -221,7 +223,8 @@ def normalize_codex_hook_payload(
     tool_name = _string_value(normalized_payload.get("tool_name")) or _string_value(normalized_payload.get("toolName"))
     tool_input = _tool_input_from_payload(normalized_payload)
     command = _command_from_payload(tool_input)
-    prompt_excerpt = _prompt_excerpt(normalized_payload.get("prompt"))
+    prompt_text = _prompt_text(normalized_payload.get("prompt"))
+    prompt_excerpt = _prompt_excerpt(prompt_text)
     mcp_server, mcp_tool = _mcp_parts(tool_name)
     action_type = _codex_action_type(
         event_name=event_name,
@@ -233,10 +236,10 @@ def normalize_codex_hook_payload(
     target_paths = _target_paths(
         tool_input=tool_input,
         command=command,
-        prompt_excerpt=prompt_excerpt,
+        prompt_text=prompt_text,
         home_dir=home_dir,
     )
-    network_hosts = _network_hosts(command, prompt_excerpt)
+    network_hosts = _network_hosts(command, prompt_text)
     workspace_label = redacted_workspace_label(workspace, home_dir=home_dir)
     workspace_hash = _workspace_hash(workspace)
     return GuardActionEnvelope(
@@ -337,14 +340,20 @@ def _command_from_payload(tool_input: Mapping[str, object]) -> str | None:
     return None
 
 
-def _prompt_excerpt(value: object) -> str | None:
+def _prompt_text(value: object) -> str | None:
     if not isinstance(value, str):
         return None
     redacted = redact_text(value.strip()).text
     collapsed = " ".join(redacted.split())
     if not collapsed:
         return None
-    return collapsed[:_PROMPT_EXCERPT_LIMIT]
+    return collapsed
+
+
+def _prompt_excerpt(prompt_text: str | None) -> str | None:
+    if prompt_text is None:
+        return None
+    return prompt_text[:_PROMPT_EXCERPT_LIMIT]
 
 
 def _mcp_parts(tool_name: str | None) -> tuple[str | None, str | None]:
@@ -382,7 +391,7 @@ def _target_paths(
     *,
     tool_input: Mapping[str, object],
     command: str | None,
-    prompt_excerpt: str | None,
+    prompt_text: str | None,
     home_dir: Path | str | None,
 ) -> tuple[str, ...]:
     paths: list[str] = []
@@ -390,7 +399,7 @@ def _target_paths(
         value = tool_input.get(key)
         if isinstance(value, str) and value.strip():
             paths.append(value.strip())
-    for text in (command, prompt_excerpt):
+    for text in (command, prompt_text):
         if text is not None:
             paths.extend(match.group("path") for match in _PROMPT_PATH_PATTERN.finditer(text))
     redacted_paths = (_redacted_target_path(path, home_dir=home_dir) for path in paths)

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -87,7 +87,7 @@ _PROMPT_PATH_PATTERN = re.compile(
     r"))"
     r"(?![A-Za-z0-9_.-])"
 )
-_NETWORK_HOST_PATTERN = re.compile(r"(?:https?|wss?|grpcs?)://(?P<host>[A-Za-z0-9.-]+)(?::\d+)?(?:/|$)")
+_NETWORK_HOST_PATTERN = re.compile(r"(?:https?|wss?|grpcs?)://(?P<host>[A-Za-z0-9.-]+)(?::\d+)?(?:[/?#]|$)")
 _GENERIC_POSIX_ABSOLUTE_PATH_PATTERN = re.compile(
     r"(?<![:A-Za-z0-9_./-])(?P<path>/(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+)(?![A-Za-z0-9_.-])"
 )

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -88,6 +88,12 @@ _PROMPT_PATH_PATTERN = re.compile(
     r"(?![A-Za-z0-9_.-])"
 )
 _NETWORK_HOST_PATTERN = re.compile(r"(?:https?|wss?|grpcs?)://(?P<host>[A-Za-z0-9.-]+)(?::\d+)?(?:/|$)")
+_GENERIC_POSIX_ABSOLUTE_PATH_PATTERN = re.compile(
+    r"(?<![:A-Za-z0-9_./-])(?P<path>/(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+)(?![A-Za-z0-9_.-])"
+)
+_GENERIC_WINDOWS_ABSOLUTE_PATH_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_./\\:-])(?P<path>[A-Za-z]:\\(?:[^\\\s'\"<>|]+\\)+[^\\\s'\"<>|]+)"
+)
 _PROMPT_EXCERPT_LIMIT = 240
 
 
@@ -147,6 +153,8 @@ class GuardActionEnvelope:
         """Build an envelope from a persisted payload."""
 
         schema_version = _required_int(payload, "schema_version")
+        if schema_version != _SCHEMA_VERSION:
+            raise ValueError(f"Guard action envelope schema_version {schema_version} is not supported.")
         action_type = _required_action_type(payload.get("action_type"))
         return cls(
             schema_version=schema_version,
@@ -222,24 +230,25 @@ def normalize_codex_hook_payload(
     event_name = _hook_event_name(normalized_payload)
     tool_name = _string_value(normalized_payload.get("tool_name")) or _string_value(normalized_payload.get("toolName"))
     tool_input = _tool_input_from_payload(normalized_payload)
-    command = _command_from_payload(tool_input)
+    raw_command = _command_from_payload(tool_input)
+    command = _command_detail(raw_command, home_dir=home_dir)
     prompt_text = _prompt_text(normalized_payload.get("prompt"))
     prompt_excerpt = _prompt_excerpt(prompt_text)
     mcp_server, mcp_tool = _mcp_parts(tool_name)
     action_type = _codex_action_type(
         event_name=event_name,
         tool_name=tool_name,
-        command=command,
+        command=raw_command,
         prompt_excerpt=prompt_excerpt,
         mcp_server=mcp_server,
     )
     target_paths = _target_paths(
         tool_input=tool_input,
-        command=command,
+        command=raw_command,
         prompt_text=prompt_text,
         home_dir=home_dir,
     )
-    network_hosts = _network_hosts(command, prompt_text)
+    network_hosts = _network_hosts(raw_command, prompt_text)
     workspace_label = redacted_workspace_label(workspace, home_dir=home_dir)
     workspace_hash = _workspace_hash(workspace)
     return GuardActionEnvelope(
@@ -338,6 +347,12 @@ def _command_from_payload(tool_input: Mapping[str, object]) -> str | None:
         if isinstance(value, str) and value.strip():
             return value.strip()
     return None
+
+
+def _command_detail(command: str | None, *, home_dir: Path | str | None) -> str | None:
+    if command is None:
+        return None
+    return _redact_path_mentions(redact_text(command).text, home_dir=home_dir)
 
 
 def _prompt_text(value: object) -> str | None:
@@ -495,7 +510,9 @@ def _redact_path_mentions(text: str, *, home_dir: Path | str | None) -> str:
     def replace_path(match: re.Match[str]) -> str:
         return _redacted_target_path(match.group("path"), home_dir=home_dir) or match.group("path")
 
-    return _PROMPT_PATH_PATTERN.sub(replace_path, text)
+    redacted = _GENERIC_WINDOWS_ABSOLUTE_PATH_PATTERN.sub(replace_path, text)
+    redacted = _GENERIC_POSIX_ABSOLUTE_PATH_PATTERN.sub(replace_path, redacted)
+    return _PROMPT_PATH_PATTERN.sub(replace_path, redacted)
 
 
 def _normalized_secret_key(key: str) -> str:

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -49,15 +49,22 @@ _SENSITIVE_RAW_KEYS = frozenset(
     {
         "api_key",
         "apikey",
+        "access_token",
         "auth",
         "authorization",
+        "client_secret",
         "content",
+        "cookie",
         "credential",
         "credentials",
+        "id_token",
         "output",
         "password",
         "private_key",
+        "refresh_token",
         "secret",
+        "session_token",
+        "set_cookie",
         "stderr",
         "stdout",
         "token",
@@ -73,7 +80,7 @@ _HOOK_EVENT_NAME_MAP = {
 _PROMPT_PATH_PATTERN = re.compile(
     r"(?P<path>(?:~|\.{1,2})?/?[A-Za-z0-9_./-]*(?:\.npmrc|\.env(?:\.[A-Za-z0-9_-]+)?|id_rsa|id_ed25519|credentials)[A-Za-z0-9_./-]*)"
 )
-_NETWORK_HOST_PATTERN = re.compile(r"https?://(?P<host>[A-Za-z0-9.-]+)(?::\d+)?(?:/|$)")
+_NETWORK_HOST_PATTERN = re.compile(r"(?:https?|wss?|grpcs?)://(?P<host>[A-Za-z0-9.-]+)(?::\d+)?(?:/|$)")
 _PROMPT_EXCERPT_LIMIT = 240
 
 
@@ -189,7 +196,7 @@ def redacted_workspace_label(workspace: Path | str | None, *, home_dir: Path | s
     except OSError:
         resolved_workspace = workspace_path.absolute()
         resolved_home = home_path.absolute()
-    if _path_is_relative_to(resolved_workspace, resolved_home):
+    if resolved_workspace.is_relative_to(resolved_home):
         relative = resolved_workspace.relative_to(resolved_home)
         return "~" if str(relative) == "." else f"~/{relative.as_posix()}"
     return resolved_workspace.as_posix()
@@ -205,8 +212,8 @@ def normalize_codex_hook_payload(
 
     normalized_payload = dict(payload)
     event_name = _hook_event_name(normalized_payload)
-    tool_name = _string_value(normalized_payload.get("tool_name"))
-    tool_input = _mapping_value(normalized_payload.get("tool_input"))
+    tool_name = _string_value(normalized_payload.get("tool_name")) or _string_value(normalized_payload.get("toolName"))
+    tool_input = _tool_input_from_payload(normalized_payload)
     command = _command_from_payload(tool_input)
     prompt_excerpt = _prompt_excerpt(normalized_payload.get("prompt"))
     mcp_server, mcp_tool = _mcp_parts(tool_name)
@@ -224,7 +231,7 @@ def normalize_codex_hook_payload(
         prompt_excerpt=prompt_excerpt,
     )
     network_hosts = _network_hosts(command, prompt_excerpt)
-    workspace_label = str(Path(workspace)) if workspace is not None else None
+    workspace_label = redacted_workspace_label(workspace, home_dir=home_dir)
     workspace_hash = _workspace_hash(workspace)
     envelope = GuardActionEnvelope(
         schema_version=_SCHEMA_VERSION,
@@ -293,6 +300,21 @@ def _mapping_value(value: object) -> Mapping[str, object]:
     return {}
 
 
+def _tool_input_from_payload(payload: Mapping[str, object]) -> Mapping[str, object]:
+    for key in ("tool_input", "toolInput", "toolArgs", "arguments"):
+        value = payload.get(key)
+        if isinstance(value, Mapping):
+            return value
+        if isinstance(value, str) and value.strip():
+            try:
+                parsed = json.loads(value)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, Mapping):
+                return parsed
+    return {}
+
+
 def _hook_event_name(payload: Mapping[str, object]) -> str:
     for key in ("event", "hook_event_name", "hookEventName", "hook_name"):
         value = payload.get(key)
@@ -358,11 +380,10 @@ def _target_paths(
     prompt_excerpt: str | None,
 ) -> tuple[str, ...]:
     paths: list[str] = []
-    if action_type in {"file_read", "file_write"}:
-        for key in _PATH_KEYS:
-            value = tool_input.get(key)
-            if isinstance(value, str) and value.strip():
-                paths.append(value.strip())
+    for key in _PATH_KEYS:
+        value = tool_input.get(key)
+        if isinstance(value, str) and value.strip():
+            paths.append(value.strip())
     for text in (command, prompt_excerpt):
         if text is not None:
             paths.extend(match.group("path") for match in _PROMPT_PATH_PATTERN.finditer(text))
@@ -393,8 +414,7 @@ def _redacted_value(key: str, value: object) -> object:
         return "[redacted]"
     if isinstance(value, Mapping):
         return {
-            str(child_key): _redacted_value(str(child_key), child_value)
-            for child_key, child_value in value.items()
+            str(child_key): _redacted_value(str(child_key), child_value) for child_key, child_value in value.items()
         }
     if isinstance(value, list):
         return [_redacted_value(key, item) for item in value]
@@ -409,14 +429,6 @@ def _normalized_command(command: str | None) -> str | None:
     if command is None:
         return None
     return command.strip()
-
-
-def _path_is_relative_to(path: Path, root: Path) -> bool:
-    try:
-        path.relative_to(root)
-    except ValueError:
-        return False
-    return True
 
 
 __all__ = [

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -94,6 +94,9 @@ _GENERIC_POSIX_ABSOLUTE_PATH_PATTERN = re.compile(
 _GENERIC_WINDOWS_ABSOLUTE_PATH_PATTERN = re.compile(
     r"(?<![A-Za-z0-9_./\\:-])(?P<path>[A-Za-z]:\\(?:[^\\\s'\"<>|]+\\)+[^\\\s'\"<>|]+)"
 )
+_GENERIC_WINDOWS_UNC_PATH_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_./\\:-])(?P<path>\\\\[^\\\s'\"<>|]+\\[^\\\s'\"<>|]+(?:\\[^\\\s'\"<>|]+)+)"
+)
 _PROMPT_EXCERPT_LIMIT = 240
 
 
@@ -510,7 +513,8 @@ def _redact_path_mentions(text: str, *, home_dir: Path | str | None) -> str:
     def replace_path(match: re.Match[str]) -> str:
         return _redacted_target_path(match.group("path"), home_dir=home_dir) or match.group("path")
 
-    redacted = _GENERIC_WINDOWS_ABSOLUTE_PATH_PATTERN.sub(replace_path, text)
+    redacted = _GENERIC_WINDOWS_UNC_PATH_PATTERN.sub(replace_path, text)
+    redacted = _GENERIC_WINDOWS_ABSOLUTE_PATH_PATTERN.sub(replace_path, redacted)
     redacted = _GENERIC_POSIX_ABSOLUTE_PATH_PATTERN.sub(replace_path, redacted)
     return _PROMPT_PATH_PATTERN.sub(replace_path, redacted)
 

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -1,0 +1,419 @@
+"""Typed runtime action envelopes for Guard hook payloads."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Literal
+
+GuardActionType = Literal[
+    "prompt",
+    "shell_command",
+    "file_read",
+    "file_write",
+    "mcp_tool",
+    "package_script",
+    "network_request",
+    "config_change",
+    "browser_action",
+    "harness_start",
+]
+
+_VALID_ACTION_TYPES = frozenset(
+    {
+        "prompt",
+        "shell_command",
+        "file_read",
+        "file_write",
+        "mcp_tool",
+        "package_script",
+        "network_request",
+        "config_change",
+        "browser_action",
+        "harness_start",
+    }
+)
+_SCHEMA_VERSION = 1
+_SHELL_TOOL_NAMES = frozenset({"bash", "shell", "sh", "zsh", "terminal", "run_command", "run_terminal_command"})
+_FILE_READ_TOOL_NAMES = frozenset({"read", "read_file", "open_file", "view", "view_file", "cat_file"})
+_FILE_WRITE_TOOL_NAMES = frozenset({"write", "edit", "multiedit", "write_file", "edit_file"})
+_PATH_KEYS = ("path", "file_path", "filePath", "filepath", "file", "filename", "target_path", "targetPath")
+_COMMAND_KEYS = ("command", "cmd", "shell_command", "shellCommand")
+_SENSITIVE_RAW_KEYS = frozenset(
+    {
+        "api_key",
+        "apikey",
+        "auth",
+        "authorization",
+        "content",
+        "credential",
+        "credentials",
+        "output",
+        "password",
+        "private_key",
+        "secret",
+        "stderr",
+        "stdout",
+        "token",
+        "tool_response",
+    }
+)
+_HOOK_EVENT_NAME_MAP = {
+    "userpromptsubmitted": "UserPromptSubmit",
+    "pretooluse": "PreToolUse",
+    "posttooluse": "PostToolUse",
+    "permissionrequest": "PermissionRequest",
+}
+_PROMPT_PATH_PATTERN = re.compile(
+    r"(?P<path>(?:~|\.{1,2})?/?[A-Za-z0-9_./-]*(?:\.npmrc|\.env(?:\.[A-Za-z0-9_-]+)?|id_rsa|id_ed25519|credentials)[A-Za-z0-9_./-]*)"
+)
+_NETWORK_HOST_PATTERN = re.compile(r"https?://(?P<host>[A-Za-z0-9.-]+)(?::\d+)?(?:/|$)")
+_PROMPT_EXCERPT_LIMIT = 240
+
+
+@dataclass(frozen=True, slots=True)
+class GuardActionEnvelope:
+    """A redacted, typed view of one harness runtime action."""
+
+    schema_version: int
+    action_id: str
+    harness: str
+    event_name: str
+    action_type: GuardActionType
+    workspace: str | None
+    workspace_hash: str | None
+    tool_name: str | None
+    command: str | None
+    prompt_excerpt: str | None
+    target_paths: tuple[str, ...]
+    network_hosts: tuple[str, ...]
+    mcp_server: str | None
+    mcp_tool: str | None
+    package_manager: str | None
+    package_name: str | None
+    script_name: str | None
+    raw_payload_redacted: dict[str, object]
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the stable JSON payload stored with approvals and receipts."""
+
+        return {
+            "schema_version": self.schema_version,
+            "action_id": self.action_id,
+            "harness": self.harness,
+            "event_name": self.event_name,
+            "action_type": self.action_type,
+            "workspace": self.workspace,
+            "workspace_hash": self.workspace_hash,
+            "tool_name": self.tool_name,
+            "command": self.command,
+            "prompt_excerpt": self.prompt_excerpt,
+            "target_paths": list(self.target_paths),
+            "network_hosts": list(self.network_hosts),
+            "mcp_server": self.mcp_server,
+            "mcp_tool": self.mcp_tool,
+            "package_manager": self.package_manager,
+            "package_name": self.package_name,
+            "script_name": self.script_name,
+            "raw_payload_redacted": dict(self.raw_payload_redacted),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> GuardActionEnvelope:
+        """Build an envelope from a persisted payload."""
+
+        schema_version = _required_int(payload, "schema_version")
+        action_type = _required_action_type(payload.get("action_type"))
+        return cls(
+            schema_version=schema_version,
+            action_id=_string_value(payload.get("action_id")) or "",
+            harness=_required_string(payload, "harness"),
+            event_name=_required_string(payload, "event_name"),
+            action_type=action_type,
+            workspace=_string_value(payload.get("workspace")),
+            workspace_hash=_string_value(payload.get("workspace_hash")),
+            tool_name=_string_value(payload.get("tool_name")),
+            command=_string_value(payload.get("command")),
+            prompt_excerpt=_string_value(payload.get("prompt_excerpt")),
+            target_paths=_string_tuple(payload.get("target_paths")),
+            network_hosts=_string_tuple(payload.get("network_hosts")),
+            mcp_server=_string_value(payload.get("mcp_server")),
+            mcp_tool=_string_value(payload.get("mcp_tool")),
+            package_manager=_string_value(payload.get("package_manager")),
+            package_name=_string_value(payload.get("package_name")),
+            script_name=_string_value(payload.get("script_name")),
+            raw_payload_redacted=_dict_value(payload.get("raw_payload_redacted")),
+        )
+
+
+def stable_action_hash(envelope: GuardActionEnvelope) -> str:
+    """Return a deterministic action identity without raw payload content."""
+
+    payload = {
+        "schema_version": envelope.schema_version,
+        "harness": envelope.harness,
+        "event_name": envelope.event_name,
+        "action_type": envelope.action_type,
+        "workspace_hash": envelope.workspace_hash,
+        "tool_name": envelope.tool_name,
+        "command": _normalized_command(envelope.command),
+        "prompt_excerpt": envelope.prompt_excerpt,
+        "target_paths": list(envelope.target_paths),
+        "network_hosts": list(envelope.network_hosts),
+        "mcp_server": envelope.mcp_server,
+        "mcp_tool": envelope.mcp_tool,
+        "package_manager": envelope.package_manager,
+        "package_name": envelope.package_name,
+        "script_name": envelope.script_name,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def redacted_workspace_label(workspace: Path | str | None, *, home_dir: Path | str | None = None) -> str | None:
+    """Return a workspace label safe for local UI and persisted context."""
+
+    if workspace is None:
+        return None
+    workspace_path = Path(workspace).expanduser()
+    home_path = Path(home_dir).expanduser() if home_dir is not None else Path.home()
+    try:
+        resolved_workspace = workspace_path.resolve()
+        resolved_home = home_path.resolve()
+    except OSError:
+        resolved_workspace = workspace_path.absolute()
+        resolved_home = home_path.absolute()
+    if _path_is_relative_to(resolved_workspace, resolved_home):
+        relative = resolved_workspace.relative_to(resolved_home)
+        return "~" if str(relative) == "." else f"~/{relative.as_posix()}"
+    return resolved_workspace.as_posix()
+
+
+def normalize_codex_hook_payload(
+    payload: Mapping[str, object],
+    *,
+    workspace: Path | str | None = None,
+    home_dir: Path | str | None = None,
+) -> GuardActionEnvelope:
+    """Normalize a Codex hook payload into a typed action envelope."""
+
+    normalized_payload = dict(payload)
+    event_name = _hook_event_name(normalized_payload)
+    tool_name = _string_value(normalized_payload.get("tool_name"))
+    tool_input = _mapping_value(normalized_payload.get("tool_input"))
+    command = _command_from_payload(tool_input)
+    prompt_excerpt = _prompt_excerpt(normalized_payload.get("prompt"))
+    mcp_server, mcp_tool = _mcp_parts(tool_name)
+    action_type = _codex_action_type(
+        event_name=event_name,
+        tool_name=tool_name,
+        command=command,
+        prompt_excerpt=prompt_excerpt,
+        mcp_server=mcp_server,
+    )
+    target_paths = _target_paths(action_type=action_type, tool_input=tool_input, prompt_excerpt=prompt_excerpt)
+    network_hosts = _network_hosts(command, prompt_excerpt)
+    workspace_label = str(Path(workspace)) if workspace is not None else None
+    workspace_hash = _workspace_hash(workspace)
+    envelope = GuardActionEnvelope(
+        schema_version=_SCHEMA_VERSION,
+        action_id="",
+        harness="codex",
+        event_name=event_name,
+        action_type=action_type,
+        workspace=workspace_label,
+        workspace_hash=workspace_hash,
+        tool_name=tool_name,
+        command=command,
+        prompt_excerpt=prompt_excerpt,
+        target_paths=target_paths,
+        network_hosts=network_hosts,
+        mcp_server=mcp_server,
+        mcp_tool=mcp_tool,
+        package_manager=None,
+        package_name=None,
+        script_name=None,
+        raw_payload_redacted=_redacted_payload(normalized_payload),
+    )
+    return replace(envelope, action_id=stable_action_hash(envelope))
+
+
+def _required_int(payload: Mapping[str, object], key: str) -> int:
+    value = payload.get(key)
+    if not isinstance(value, int):
+        raise ValueError(f"Guard action envelope missing required integer {key}.")
+    return value
+
+
+def _required_string(payload: Mapping[str, object], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"Guard action envelope missing required string {key}.")
+    return value
+
+
+def _required_action_type(value: object) -> GuardActionType:
+    if not isinstance(value, str) or value not in _VALID_ACTION_TYPES:
+        raise ValueError("Guard action envelope missing valid action_type.")
+    return value
+
+
+def _string_value(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _string_tuple(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(item for item in value if isinstance(item, str) and item.strip())
+
+
+def _dict_value(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        return {}
+    return {str(key): item for key, item in value.items() if isinstance(key, str)}
+
+
+def _mapping_value(value: object) -> Mapping[str, object]:
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _hook_event_name(payload: Mapping[str, object]) -> str:
+    for key in ("event", "hook_event_name", "hookEventName", "hook_name"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            stripped = value.strip()
+            return _HOOK_EVENT_NAME_MAP.get(stripped.lower(), stripped)
+    return "PreToolUse"
+
+
+def _command_from_payload(tool_input: Mapping[str, object]) -> str | None:
+    for key in _COMMAND_KEYS:
+        value = tool_input.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _prompt_excerpt(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = " ".join(value.strip().split())
+    if not stripped:
+        return None
+    return stripped[:_PROMPT_EXCERPT_LIMIT]
+
+
+def _mcp_parts(tool_name: str | None) -> tuple[str | None, str | None]:
+    if tool_name is None or not tool_name.startswith("mcp__"):
+        return None, None
+    parts = tool_name.split("__", 2)
+    if len(parts) != 3 or not parts[1] or not parts[2]:
+        return None, None
+    return parts[1], parts[2]
+
+
+def _codex_action_type(
+    *,
+    event_name: str,
+    tool_name: str | None,
+    command: str | None,
+    prompt_excerpt: str | None,
+    mcp_server: str | None,
+) -> GuardActionType:
+    normalized_tool = tool_name.lower() if tool_name is not None else ""
+    if event_name == "UserPromptSubmit" and prompt_excerpt is not None:
+        return "prompt"
+    if mcp_server is not None:
+        return "mcp_tool"
+    if normalized_tool in _FILE_READ_TOOL_NAMES:
+        return "file_read"
+    if normalized_tool in _FILE_WRITE_TOOL_NAMES:
+        return "file_write"
+    if normalized_tool in _SHELL_TOOL_NAMES or command is not None:
+        return "shell_command"
+    return "config_change"
+
+
+def _target_paths(
+    *,
+    action_type: GuardActionType,
+    tool_input: Mapping[str, object],
+    prompt_excerpt: str | None,
+) -> tuple[str, ...]:
+    paths: list[str] = []
+    if action_type in {"file_read", "file_write"}:
+        for key in _PATH_KEYS:
+            value = tool_input.get(key)
+            if isinstance(value, str) and value.strip():
+                paths.append(value.strip())
+    if prompt_excerpt is not None:
+        paths.extend(match.group("path") for match in _PROMPT_PATH_PATTERN.finditer(prompt_excerpt))
+    return tuple(dict.fromkeys(paths))
+
+
+def _network_hosts(command: str | None, prompt_excerpt: str | None) -> tuple[str, ...]:
+    text = "\n".join(value for value in (command, prompt_excerpt) if value)
+    if not text:
+        return ()
+    return tuple(dict.fromkeys(match.group("host") for match in _NETWORK_HOST_PATTERN.finditer(text)))
+
+
+def _workspace_hash(workspace: Path | str | None) -> str | None:
+    if workspace is None:
+        return None
+    encoded = str(Path(workspace).expanduser()).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _redacted_payload(payload: Mapping[str, object]) -> dict[str, object]:
+    return {str(key): _redacted_value(str(key), value) for key, value in payload.items() if isinstance(key, str)}
+
+
+def _redacted_value(key: str, value: object) -> object:
+    normalized_key = key.lower().replace("-", "_")
+    if normalized_key in _SENSITIVE_RAW_KEYS:
+        return "[redacted]"
+    if isinstance(value, Mapping):
+        return {
+            str(child_key): _redacted_value(str(child_key), child_value)
+            for child_key, child_value in value.items()
+        }
+    if isinstance(value, list):
+        return [_redacted_value(key, item) for item in value]
+    if isinstance(value, str):
+        return value[:_PROMPT_EXCERPT_LIMIT]
+    if isinstance(value, (bool, int, float)) or value is None:
+        return value
+    return str(value)
+
+
+def _normalized_command(command: str | None) -> str | None:
+    if command is None:
+        return None
+    return command.strip()
+
+
+def _path_is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+__all__ = [
+    "GuardActionEnvelope",
+    "GuardActionType",
+    "normalize_codex_hook_payload",
+    "redacted_workspace_label",
+    "stable_action_hash",
+]

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -257,7 +257,7 @@ def normalize_codex_hook_payload(
         package_manager=None,
         package_name=None,
         script_name=None,
-        raw_payload_redacted=_redacted_payload(normalized_payload),
+        raw_payload_redacted=_redacted_payload(normalized_payload, home_dir=home_dir),
     )
 
 
@@ -440,25 +440,53 @@ def _is_absolute_target_path(path: str) -> bool:
     return Path(path).expanduser().is_absolute()
 
 
-def _redacted_payload(payload: Mapping[str, object]) -> dict[str, object]:
-    return {str(key): _redacted_value(str(key), value) for key, value in payload.items() if isinstance(key, str)}
+def _redacted_payload(payload: Mapping[str, object], *, home_dir: Path | str | None) -> dict[str, object]:
+    return {
+        str(key): _redacted_value(str(key), value, home_dir=home_dir)
+        for key, value in payload.items()
+        if isinstance(key, str)
+    }
 
 
-def _redacted_value(key: str, value: object) -> object:
+def _redacted_value(key: str, value: object, *, home_dir: Path | str | None) -> object:
     normalized_key = _normalized_secret_key(key)
     if normalized_key in _SENSITIVE_RAW_KEYS or normalized_key.replace("_", "") in _SENSITIVE_RAW_KEY_ALIASES:
         return "[redacted]"
     if isinstance(value, Mapping):
         return {
-            str(child_key): _redacted_value(str(child_key), child_value) for child_key, child_value in value.items()
+            str(child_key): _redacted_value(str(child_key), child_value, home_dir=home_dir)
+            for child_key, child_value in value.items()
         }
     if isinstance(value, list):
-        return [_redacted_value(key, item) for item in value]
+        return [_redacted_value(key, item, home_dir=home_dir) for item in value]
     if isinstance(value, str):
-        return redact_text(value).text[:_PROMPT_EXCERPT_LIMIT]
+        return _redacted_string_value(key, value, home_dir=home_dir)[:_PROMPT_EXCERPT_LIMIT]
     if isinstance(value, (bool, int, float)) or value is None:
         return value
     return str(value)
+
+
+def _redacted_string_value(key: str, value: str, *, home_dir: Path | str | None) -> str:
+    if _is_path_like_key(key):
+        redacted_path = _redacted_target_path(value, home_dir=home_dir)
+        if redacted_path is not None:
+            return redacted_path
+    return _redact_path_mentions(redact_text(value).text, home_dir=home_dir)
+
+
+def _is_path_like_key(key: str) -> bool:
+    normalized_key = _normalized_secret_key(key)
+    path_keys = {_normalized_secret_key(path_key) for path_key in _PATH_KEYS}
+    return normalized_key in path_keys or normalized_key.replace("_", "") in {
+        path_key.replace("_", "") for path_key in path_keys
+    }
+
+
+def _redact_path_mentions(text: str, *, home_dir: Path | str | None) -> str:
+    def replace_path(match: re.Match[str]) -> str:
+        return _redacted_target_path(match.group("path"), home_dir=home_dir) or match.group("path")
+
+    return _PROMPT_PATH_PATTERN.sub(replace_path, text)
 
 
 def _normalized_secret_key(key: str) -> str:

--- a/tests/test_guard_runtime_actions.py
+++ b/tests/test_guard_runtime_actions.py
@@ -196,6 +196,17 @@ def test_normalize_codex_prompt_extracts_late_path_and_host(tmp_path: Path) -> N
     assert envelope.network_hosts == ("api.example.test",)
 
 
+def test_normalize_codex_prompt_extracts_query_and_fragment_hosts(tmp_path: Path) -> None:
+    payload = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "Call https://api.example.test?token=abc and wss://relay.example.test#session.",
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.network_hosts == ("api.example.test", "relay.example.test")
+
+
 def test_normalize_codex_prompt_ignores_bare_credentials_word(tmp_path: Path) -> None:
     payload = {
         "hook_event_name": "UserPromptSubmit",

--- a/tests/test_guard_runtime_actions.py
+++ b/tests/test_guard_runtime_actions.py
@@ -105,6 +105,16 @@ def test_redacted_workspace_label_hides_home_directory(tmp_path: Path) -> None:
     assert str(home_dir) not in label
 
 
+def test_redacted_workspace_label_hides_non_home_absolute_path(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    workspace = tmp_path / "external" / "demo"
+
+    label = redacted_workspace_label(workspace, home_dir=home_dir)
+
+    assert label == ".../demo"
+    assert str(tmp_path) not in label
+
+
 def test_normalize_codex_pre_tool_bash_payload(tmp_path: Path) -> None:
     home_dir = tmp_path / "home"
     workspace = home_dir / "workspace"

--- a/tests/test_guard_runtime_actions.py
+++ b/tests/test_guard_runtime_actions.py
@@ -169,6 +169,43 @@ def test_normalize_codex_prompt_payload_extracts_prompt_excerpt(tmp_path: Path) 
     assert "prompt" in envelope.raw_payload_redacted
 
 
+def test_normalize_codex_prompt_extracts_late_path_and_host(tmp_path: Path) -> None:
+    prompt = f"{'Summarize guard behavior. ' * 12}Then inspect ~/.npmrc and call https://api.example.test/v1."
+    payload = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": prompt,
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.prompt_excerpt is not None
+    assert "~/.npmrc" not in envelope.prompt_excerpt
+    assert envelope.target_paths == ("~/.npmrc",)
+    assert envelope.network_hosts == ("api.example.test",)
+
+
+def test_normalize_codex_prompt_ignores_bare_credentials_word(tmp_path: Path) -> None:
+    payload = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "Please rotate credentials for the service owner.",
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.target_paths == ()
+
+
+def test_normalize_codex_prompt_extracts_credentials_path(tmp_path: Path) -> None:
+    payload = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "Please inspect ~/.aws/credentials before deploy.",
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.target_paths == ("~/.aws/credentials",)
+
+
 def test_normalize_codex_prompt_excerpt_redacts_secret_like_text(tmp_path: Path) -> None:
     payload = {
         "hook_event_name": "UserPromptSubmit",

--- a/tests/test_guard_runtime_actions.py
+++ b/tests/test_guard_runtime_actions.py
@@ -158,8 +158,20 @@ def test_normalize_codex_prompt_excerpt_redacts_secret_like_text(tmp_path: Path)
 
     envelope = normalize_codex_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
 
-    assert envelope.prompt_excerpt == "NPM_TOKEN=*****"
+    assert envelope.prompt_excerpt == "NPM_TOKEN=***** Please summarize this setup."
     assert envelope.raw_payload_redacted["prompt"] == "NPM_TOKEN=*****\nPlease summarize this setup."
+
+
+def test_normalize_codex_lower_camel_prompt_event(tmp_path: Path) -> None:
+    payload = {
+        "hook_event_name": "userPromptSubmit",
+        "prompt": "Please inspect ~/.npmrc.",
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.event_name == "UserPromptSubmit"
+    assert envelope.action_type == "prompt"
 
 
 def test_normalize_codex_mcp_payload_extracts_server_and_tool(tmp_path: Path) -> None:

--- a/tests/test_guard_runtime_actions.py
+++ b/tests/test_guard_runtime_actions.py
@@ -253,6 +253,21 @@ def test_normalize_codex_file_target_redacts_absolute_home_path(tmp_path: Path) 
     assert str(home_dir) not in envelope.target_paths[0]
 
 
+def test_normalize_codex_raw_payload_redacts_absolute_path_strings(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home" / "alice"
+    target_path = home_dir / ".ssh" / "id_rsa"
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Read",
+        "tool_input": {"path": str(target_path)},
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=home_dir / "workspace", home_dir=home_dir)
+
+    assert envelope.raw_payload_redacted["tool_input"] == {"path": "~/.ssh/id_rsa"}
+    assert str(home_dir) not in str(envelope.raw_payload_redacted)
+
+
 def test_normalize_codex_file_target_redacts_windows_absolute_path(tmp_path: Path) -> None:
     payload = {
         "hook_event_name": "PreToolUse",

--- a/tests/test_guard_runtime_actions.py
+++ b/tests/test_guard_runtime_actions.py
@@ -106,21 +106,22 @@ def test_redacted_workspace_label_hides_home_directory(tmp_path: Path) -> None:
 
 
 def test_normalize_codex_pre_tool_bash_payload(tmp_path: Path) -> None:
-    workspace = tmp_path / "workspace"
+    home_dir = tmp_path / "home"
+    workspace = home_dir / "workspace"
     payload = {
         "hook_event_name": "PreToolUse",
         "tool_name": "Bash",
         "tool_input": {"command": "printf ok"},
     }
 
-    envelope = normalize_codex_hook_payload(payload, workspace=workspace, home_dir=tmp_path)
+    envelope = normalize_codex_hook_payload(payload, workspace=workspace, home_dir=home_dir)
 
     assert envelope.harness == "codex"
     assert envelope.event_name == "PreToolUse"
     assert envelope.action_type == "shell_command"
     assert envelope.tool_name == "Bash"
     assert envelope.command == "printf ok"
-    assert envelope.workspace == str(workspace)
+    assert envelope.workspace == "~/workspace"
     assert envelope.workspace_hash is not None
     assert envelope.raw_payload_redacted["tool_input"] == {"command": "printf ok"}
 
@@ -199,3 +200,18 @@ def test_normalize_codex_raw_payload_redacts_secret_like_strings(tmp_path: Path)
         "command": "printf ok",
         "note": "NPM_TOKEN=*****",
     }
+
+
+def test_normalize_codex_camel_case_tool_payload(tmp_path: Path) -> None:
+    payload = {
+        "hookEventName": "PreToolUse",
+        "toolName": "Bash",
+        "toolInput": {"command": "cat ~/.npmrc"},
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.event_name == "PreToolUse"
+    assert envelope.tool_name == "Bash"
+    assert envelope.command == "cat ~/.npmrc"
+    assert envelope.target_paths == ("~/.npmrc",)

--- a/tests/test_guard_runtime_actions.py
+++ b/tests/test_guard_runtime_actions.py
@@ -168,3 +168,34 @@ def test_normalize_codex_post_tool_redacts_raw_output(tmp_path: Path) -> None:
     assert envelope.command == "cat fixture.txt"
     assert envelope.raw_payload_redacted["tool_response"] == "[redacted]"
     assert "secret output" not in str(envelope.raw_payload_redacted)
+
+
+def test_normalize_codex_shell_command_extracts_target_paths(tmp_path: Path) -> None:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "cat ~/.npmrc"},
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.action_type == "shell_command"
+    assert envelope.target_paths == ("~/.npmrc",)
+
+
+def test_normalize_codex_raw_payload_redacts_secret_like_strings(tmp_path: Path) -> None:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {
+            "command": "printf ok",
+            "note": "NPM_TOKEN=abc123456789",
+        },
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.raw_payload_redacted["tool_input"] == {
+        "command": "printf ok",
+        "note": "NPM_TOKEN=*****",
+    }

--- a/tests/test_guard_runtime_actions.py
+++ b/tests/test_guard_runtime_actions.py
@@ -140,6 +140,18 @@ def test_normalize_codex_prompt_payload_extracts_prompt_excerpt(tmp_path: Path) 
     assert "prompt" in envelope.raw_payload_redacted
 
 
+def test_normalize_codex_prompt_excerpt_redacts_secret_like_text(tmp_path: Path) -> None:
+    payload = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "NPM_TOKEN=abc123456789\nPlease summarize this setup.",
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.prompt_excerpt == "NPM_TOKEN=*****"
+    assert envelope.raw_payload_redacted["prompt"] == "NPM_TOKEN=*****\nPlease summarize this setup."
+
+
 def test_normalize_codex_mcp_payload_extracts_server_and_tool(tmp_path: Path) -> None:
     payload = {
         "hook_event_name": "PreToolUse",
@@ -199,6 +211,24 @@ def test_normalize_codex_raw_payload_redacts_secret_like_strings(tmp_path: Path)
     assert envelope.raw_payload_redacted["tool_input"] == {
         "command": "printf ok",
         "note": "NPM_TOKEN=*****",
+    }
+
+
+def test_normalize_codex_raw_payload_redacts_camel_case_secret_keys(tmp_path: Path) -> None:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {
+            "command": "printf ok",
+            "accessToken": "abc123456789",
+        },
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.raw_payload_redacted["tool_input"] == {
+        "command": "printf ok",
+        "accessToken": "[redacted]",
     }
 
 

--- a/tests/test_guard_runtime_actions.py
+++ b/tests/test_guard_runtime_actions.py
@@ -115,6 +115,25 @@ def test_redacted_workspace_label_hides_non_home_absolute_path(tmp_path: Path) -
     assert str(tmp_path) not in label
 
 
+def test_redacted_workspace_label_falls_back_when_resolution_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_resolve = Path.resolve
+
+    def failing_resolve(self: Path, strict: bool = False) -> Path:
+        if self.name == "blocked":
+            raise OSError("blocked path")
+        return original_resolve(self, strict=strict)
+
+    monkeypatch.setattr(Path, "resolve", failing_resolve)
+
+    label = redacted_workspace_label(tmp_path / "blocked", home_dir=tmp_path / "home")
+
+    assert label == ".../blocked"
+    assert str(tmp_path) not in label
+
+
 def test_normalize_codex_pre_tool_bash_payload(tmp_path: Path) -> None:
     home_dir = tmp_path / "home"
     workspace = home_dir / "workspace"
@@ -216,6 +235,35 @@ def test_normalize_codex_shell_command_extracts_target_paths(tmp_path: Path) -> 
 
     assert envelope.action_type == "shell_command"
     assert envelope.target_paths == ("~/.npmrc",)
+
+
+def test_normalize_codex_file_target_redacts_absolute_home_path(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home" / "alice"
+    target_path = home_dir / ".ssh" / "id_rsa"
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Read",
+        "tool_input": {"path": str(target_path)},
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=home_dir / "workspace", home_dir=home_dir)
+
+    assert envelope.action_type == "file_read"
+    assert envelope.target_paths == ("~/.ssh/id_rsa",)
+    assert str(home_dir) not in envelope.target_paths[0]
+
+
+def test_normalize_codex_file_target_redacts_windows_absolute_path(tmp_path: Path) -> None:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Read",
+        "tool_input": {"filePath": r"C:\Users\alice\.ssh\id_rsa"},
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.target_paths == (".../id_rsa",)
+    assert "alice" not in envelope.target_paths[0]
 
 
 def test_normalize_codex_raw_payload_redacts_secret_like_strings(tmp_path: Path) -> None:

--- a/tests/test_guard_runtime_actions.py
+++ b/tests/test_guard_runtime_actions.py
@@ -422,3 +422,46 @@ def test_normalize_codex_camel_case_tool_payload(tmp_path: Path) -> None:
     assert envelope.tool_name == "Bash"
     assert envelope.command == "cat ~/.npmrc"
     assert envelope.target_paths == ("~/.npmrc",)
+
+
+def test_normalize_codex_tool_calls_payload(tmp_path: Path) -> None:
+    payload = {
+        "hookEventName": "PreToolUse",
+        "toolCalls": [
+            {
+                "name": "Bash",
+                "args": {"command": "cat ~/.npmrc"},
+            }
+        ],
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.tool_name == "Bash"
+    assert envelope.action_type == "shell_command"
+    assert envelope.command == "cat ~/.npmrc"
+    assert envelope.target_paths == ("~/.npmrc",)
+
+
+def test_normalize_codex_tool_calls_matches_explicit_tool_name(tmp_path: Path) -> None:
+    payload = {
+        "hookEventName": "PreToolUse",
+        "toolName": "Read",
+        "toolCalls": [
+            {
+                "name": "Bash",
+                "args": {"command": "cat ~/.npmrc"},
+            },
+            {
+                "name": "Read",
+                "args": '{"path": "~/.npmrc"}',
+            },
+        ],
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.tool_name == "Read"
+    assert envelope.action_type == "file_read"
+    assert envelope.command is None
+    assert envelope.target_paths == ("~/.npmrc",)

--- a/tests/test_guard_runtime_actions.py
+++ b/tests/test_guard_runtime_actions.py
@@ -1,0 +1,170 @@
+"""Runtime action envelope tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.actions import (
+    GuardActionEnvelope,
+    normalize_codex_hook_payload,
+    redacted_workspace_label,
+    stable_action_hash,
+)
+
+
+def test_guard_action_envelope_round_trips_to_dict() -> None:
+    envelope = GuardActionEnvelope(
+        schema_version=1,
+        action_id="action-123",
+        harness="codex",
+        event_name="PreToolUse",
+        action_type="shell_command",
+        workspace="/workspace/demo",
+        workspace_hash="workspace-hash",
+        tool_name="Bash",
+        command="printf ok",
+        prompt_excerpt=None,
+        target_paths=("package.json",),
+        network_hosts=("example.com",),
+        mcp_server=None,
+        mcp_tool=None,
+        package_manager=None,
+        package_name=None,
+        script_name=None,
+        raw_payload_redacted={"tool_name": "Bash"},
+    )
+
+    payload = envelope.to_dict()
+    restored = GuardActionEnvelope.from_dict(payload)
+
+    assert payload == {
+        "schema_version": 1,
+        "action_id": "action-123",
+        "harness": "codex",
+        "event_name": "PreToolUse",
+        "action_type": "shell_command",
+        "workspace": "/workspace/demo",
+        "workspace_hash": "workspace-hash",
+        "tool_name": "Bash",
+        "command": "printf ok",
+        "prompt_excerpt": None,
+        "target_paths": ["package.json"],
+        "network_hosts": ["example.com"],
+        "mcp_server": None,
+        "mcp_tool": None,
+        "package_manager": None,
+        "package_name": None,
+        "script_name": None,
+        "raw_payload_redacted": {"tool_name": "Bash"},
+    }
+    assert restored == envelope
+
+
+def test_guard_action_envelope_from_dict_requires_schema_version() -> None:
+    with pytest.raises(ValueError, match="schema_version"):
+        GuardActionEnvelope.from_dict({"harness": "codex"})
+
+
+def test_stable_action_hash_trims_outer_command_whitespace_only() -> None:
+    base = GuardActionEnvelope(
+        schema_version=1,
+        action_id="",
+        harness="codex",
+        event_name="PreToolUse",
+        action_type="shell_command",
+        workspace=None,
+        workspace_hash=None,
+        tool_name="Bash",
+        command="printf ok",
+        prompt_excerpt=None,
+        target_paths=(),
+        network_hosts=(),
+        mcp_server=None,
+        mcp_tool=None,
+        package_manager=None,
+        package_name=None,
+        script_name=None,
+        raw_payload_redacted={},
+    )
+    padded = GuardActionEnvelope.from_dict({**base.to_dict(), "command": "  printf ok  "})
+    internally_changed = GuardActionEnvelope.from_dict({**base.to_dict(), "command": "printf  ok"})
+
+    assert stable_action_hash(base) == stable_action_hash(padded)
+    assert stable_action_hash(base) != stable_action_hash(internally_changed)
+
+
+def test_redacted_workspace_label_hides_home_directory(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    workspace = home_dir / "projects" / "demo"
+
+    label = redacted_workspace_label(workspace, home_dir=home_dir)
+
+    assert label == "~/projects/demo"
+    assert str(home_dir) not in label
+
+
+def test_normalize_codex_pre_tool_bash_payload(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "printf ok"},
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=workspace, home_dir=tmp_path)
+
+    assert envelope.harness == "codex"
+    assert envelope.event_name == "PreToolUse"
+    assert envelope.action_type == "shell_command"
+    assert envelope.tool_name == "Bash"
+    assert envelope.command == "printf ok"
+    assert envelope.workspace == str(workspace)
+    assert envelope.workspace_hash is not None
+    assert envelope.raw_payload_redacted["tool_input"] == {"command": "printf ok"}
+
+
+def test_normalize_codex_prompt_payload_extracts_prompt_excerpt(tmp_path: Path) -> None:
+    payload = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "Please inspect ~/.npmrc and summarize the token setup.",
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.action_type == "prompt"
+    assert envelope.prompt_excerpt == "Please inspect ~/.npmrc and summarize the token setup."
+    assert envelope.target_paths == ("~/.npmrc",)
+    assert "prompt" in envelope.raw_payload_redacted
+
+
+def test_normalize_codex_mcp_payload_extracts_server_and_tool(tmp_path: Path) -> None:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "mcp__danger_lab__dangerous_delete",
+        "tool_input": {"target": "workspace"},
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.action_type == "mcp_tool"
+    assert envelope.mcp_server == "danger_lab"
+    assert envelope.mcp_tool == "dangerous_delete"
+    assert envelope.tool_name == "mcp__danger_lab__dangerous_delete"
+
+
+def test_normalize_codex_post_tool_redacts_raw_output(tmp_path: Path) -> None:
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "cat fixture.txt"},
+        "tool_response": {"content": "secret output should not persist"},
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.action_type == "shell_command"
+    assert envelope.command == "cat fixture.txt"
+    assert envelope.raw_payload_redacted["tool_response"] == "[redacted]"
+    assert "secret output" not in str(envelope.raw_payload_redacted)

--- a/tests/test_guard_runtime_actions.py
+++ b/tests/test_guard_runtime_actions.py
@@ -67,6 +67,18 @@ def test_guard_action_envelope_from_dict_requires_schema_version() -> None:
         GuardActionEnvelope.from_dict({"harness": "codex"})
 
 
+def test_guard_action_envelope_from_dict_rejects_future_schema_version() -> None:
+    payload = {
+        "schema_version": 999,
+        "harness": "codex",
+        "event_name": "PreToolUse",
+        "action_type": "shell_command",
+    }
+
+    with pytest.raises(ValueError, match="schema_version"):
+        GuardActionEnvelope.from_dict(payload)
+
+
 def test_stable_action_hash_trims_outer_command_whitespace_only() -> None:
     base = GuardActionEnvelope(
         schema_version=1,
@@ -316,6 +328,22 @@ def test_normalize_codex_file_target_redacts_windows_absolute_path(tmp_path: Pat
 
     assert envelope.target_paths == (".../id_rsa",)
     assert "alice" not in envelope.target_paths[0]
+
+
+def test_normalize_codex_command_redacts_generic_absolute_path_strings(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home" / "alice"
+    target_path = home_dir / "project" / "package.json"
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": f"cat {target_path}"},
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=home_dir / "workspace", home_dir=home_dir)
+
+    assert envelope.command == "cat ~/project/package.json"
+    assert envelope.raw_payload_redacted["tool_input"] == {"command": "cat ~/project/package.json"}
+    assert str(home_dir) not in str(envelope.to_dict())
 
 
 def test_normalize_codex_raw_payload_redacts_secret_like_strings(tmp_path: Path) -> None:

--- a/tests/test_guard_runtime_actions.py
+++ b/tests/test_guard_runtime_actions.py
@@ -357,6 +357,22 @@ def test_normalize_codex_command_redacts_generic_absolute_path_strings(tmp_path:
     assert str(home_dir) not in str(envelope.to_dict())
 
 
+def test_normalize_codex_command_redacts_unc_path_strings(tmp_path: Path) -> None:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": r"type \\server\share\alice\secret.txt"},
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.command == "type .../secret.txt"
+    assert envelope.raw_payload_redacted["tool_input"] == {"command": "type .../secret.txt"}
+    assert "\\server" not in str(envelope.to_dict())
+    assert "share" not in str(envelope.to_dict())
+    assert "alice" not in str(envelope.to_dict())
+
+
 def test_normalize_codex_raw_payload_redacts_secret_like_strings(tmp_path: Path) -> None:
     payload = {
         "hook_event_name": "PreToolUse",


### PR DESCRIPTION
## Summary
Adds the first typed runtime action envelope layer for HOL Guard Local. The new backend-only module models redacted runtime actions, stable action hashing, home-prefixed workspace label redaction, and Codex hook normalization for shell commands, prompts, MCP tool calls, and post-tool events without persisting raw tool output.

## Completed task IDs
T046, T047, T048, T049, T050, T051, T052, T053, T054, T055

## Files changed
- src/codex_plugin_scanner/guard/runtime/actions.py
- tests/test_guard_runtime_actions.py

## Tests added before implementation
Added tests/test_guard_runtime_actions.py first to cover envelope serialization, missing-schema rejection, stable hash behavior, workspace redaction, and Codex hook normalization.

## Verification
- pytest tests/test_guard_runtime_actions.py -q -> 8 passed
- ruff check src/codex_plugin_scanner/guard/runtime/actions.py tests/test_guard_runtime_actions.py -> passed
- pytest tests/test_guard_runtime_actions.py tests/test_guard_runtime.py -q -> 327 passed

## Store migration notes
No SQLite schema changes in this PR.

## Dashboard note
No dashboard UI changes in this PR; screenshot/text snapshot not applicable.

## Privacy note
The new envelope stores a redacted payload view and intentionally omits raw post-tool output. No raw secrets, dotenv contents, full local paths, or raw command output leave the local machine by default.

## Harness compatibility
Codex gains typed normalization coverage in this PR. Claude Code, OpenCode, Copilot, Gemini, Cursor, Hermes, and OpenClaw runtime behavior is unchanged.

## Offline behavior
HOL Guard Local remains offline-first; this PR adds local-only data modeling and does not require Guard Cloud.