### PR TITLE
feat(guard): add harness action normalizers

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -101,21 +101,6 @@ _GENERIC_WINDOWS_UNC_PATH_PATTERN = re.compile(
     r"(?<![A-Za-z0-9_./\\:-])(?P<path>\\\\[^\\\s'\"<>|]+\\[^\\\s'\"<>|]+(?:\\[^\\\s'\"<>|]+)+)"
 )
 _PROMPT_EXCERPT_LIMIT = 240
-_SINGLE_TOKEN_MCP_TOOLS = frozenset(
-    {
-        "call",
-        "delete",
-        "get",
-        "inspect",
-        "list",
-        "lookup",
-        "query",
-        "read",
-        "run",
-        "search",
-        "write",
-    }
-)
 
 
 @dataclass(frozen=True, slots=True)
@@ -573,8 +558,8 @@ def _prompt_excerpt(prompt_text: str | None) -> str | None:
 def _mcp_details(payload: Mapping[str, object], tool_name: str | None) -> tuple[str | None, str | None]:
     explicit_server = _string_from_keys(payload, ("mcp_server", "mcpServer", "server", "serverName"))
     explicit_tool = _string_from_keys(payload, ("mcp_tool", "mcpTool", "tool"))
-    tool_name_value = _string_from_keys(payload, ("toolName",))
-    parts_server, parts_tool = _mcp_parts(tool_name)
+    tool_name_value = _string_from_keys(payload, ("tool_name", "toolName"))
+    parts_server, parts_tool = _mcp_parts(tool_name, known_servers=_known_mcp_servers(payload))
     server = explicit_server or parts_server
     tool = explicit_tool or parts_tool
     if tool is None and server is not None and tool_name_value is not None:
@@ -590,7 +575,18 @@ def _string_from_keys(payload: Mapping[str, object], keys: tuple[str, ...]) -> s
     return None
 
 
-def _mcp_parts(tool_name: str | None) -> tuple[str | None, str | None]:
+def _known_mcp_servers(payload: Mapping[str, object]) -> tuple[str, ...]:
+    servers: set[str] = set()
+    for key in ("mcp_servers", "mcpServers", "servers"):
+        value = payload.get(key)
+        if isinstance(value, Mapping):
+            servers.update(str(server_name).strip() for server_name in value if isinstance(server_name, str))
+        elif isinstance(value, list):
+            servers.update(item.strip() for item in value if isinstance(item, str) and item.strip())
+    return tuple(sorted((server for server in servers if server), key=len, reverse=True))
+
+
+def _mcp_parts(tool_name: str | None, *, known_servers: tuple[str, ...] = ()) -> tuple[str | None, str | None]:
     if tool_name is None:
         return None, None
     if "/" in tool_name:
@@ -603,22 +599,11 @@ def _mcp_parts(tool_name: str | None) -> tuple[str | None, str | None]:
         return None, None
     if tool_name.startswith("mcp_"):
         suffix = tool_name[len("mcp_") :]
-        if "_" not in suffix:
-            return None, None
-        parts = suffix.split("_")
-        if len(parts) >= 3 and parts[-1] in _SINGLE_TOKEN_MCP_TOOLS:
-            server = "_".join(parts[:-1])
-            tool = parts[-1]
-        elif len(parts) >= 3:
-            server = "_".join(parts[:-2])
-            tool = "_".join(parts[-2:])
-        elif len(parts) == 2:
-            server = parts[0]
-            tool = parts[1]
-        else:
-            return None, None
-        if server and tool:
-            return server, tool
+        for server in known_servers:
+            prefix = f"{server}_"
+            if suffix.startswith(prefix):
+                tool = suffix[len(prefix) :]
+                return (server, tool) if tool else (None, None)
         return None, None
     return None, None
 

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -73,9 +73,12 @@ _SENSITIVE_RAW_KEYS = frozenset(
 )
 _SENSITIVE_RAW_KEY_ALIASES = frozenset(key.replace("_", "") for key in _SENSITIVE_RAW_KEYS)
 _HOOK_EVENT_NAME_MAP = {
+    "prompt": "UserPromptSubmit",
     "userpromptsubmit": "UserPromptSubmit",
     "userpromptsubmitted": "UserPromptSubmit",
+    "pretool": "PreToolUse",
     "pretooluse": "PreToolUse",
+    "posttool": "PostToolUse",
     "posttooluse": "PostToolUse",
     "permissionrequest": "PermissionRequest",
 }
@@ -229,11 +232,122 @@ def normalize_codex_hook_payload(
 ) -> GuardActionEnvelope:
     """Normalize a Codex hook payload into a typed action envelope."""
 
-    normalized_payload = dict(payload)
-    event_name = _hook_event_name(normalized_payload)
-    explicit_tool_name = _string_value(normalized_payload.get("tool_name")) or _string_value(
-        normalized_payload.get("toolName")
+    return _normalize_action_payload(
+        payload,
+        harness="codex",
+        default_event_name=None,
+        workspace=workspace,
+        home_dir=home_dir,
     )
+
+
+def normalize_claude_hook_payload(
+    payload: Mapping[str, object],
+    *,
+    workspace: Path | str | None = None,
+    home_dir: Path | str | None = None,
+) -> GuardActionEnvelope:
+    """Normalize a Claude Code hook payload into a typed action envelope."""
+
+    return _normalize_action_payload(
+        payload,
+        harness="claude-code",
+        default_event_name=None,
+        workspace=workspace,
+        home_dir=home_dir,
+    )
+
+
+def normalize_opencode_payload(
+    payload: Mapping[str, object],
+    *,
+    workspace: Path | str | None = None,
+    home_dir: Path | str | None = None,
+) -> GuardActionEnvelope:
+    """Normalize an OpenCode runtime payload into a typed action envelope."""
+
+    return _normalize_action_payload(
+        payload,
+        harness="opencode",
+        default_event_name=None,
+        workspace=workspace,
+        home_dir=home_dir,
+    )
+
+
+def normalize_copilot_payload(
+    payload: Mapping[str, object],
+    *,
+    workspace: Path | str | None = None,
+    home_dir: Path | str | None = None,
+) -> GuardActionEnvelope:
+    """Normalize a Copilot runtime payload into a typed action envelope."""
+
+    return _normalize_action_payload(
+        payload,
+        harness="copilot",
+        default_event_name=None,
+        workspace=workspace,
+        home_dir=home_dir,
+    )
+
+
+def normalize_gemini_payload(
+    payload: Mapping[str, object],
+    *,
+    workspace: Path | str | None = None,
+    home_dir: Path | str | None = None,
+) -> GuardActionEnvelope:
+    """Normalize a Gemini runtime payload into a typed action envelope."""
+
+    return _normalize_action_payload(
+        payload,
+        harness="gemini",
+        default_event_name=None,
+        workspace=workspace,
+        home_dir=home_dir,
+    )
+
+
+def normalize_harness_payload(
+    harness: str,
+    event_name: str,
+    payload: Mapping[str, object],
+    *,
+    workspace: Path | str | None = None,
+    home_dir: Path | str | None = None,
+) -> GuardActionEnvelope:
+    """Normalize any supported Guard harness payload into a typed action envelope."""
+
+    normalized_harness = harness.strip().lower()
+    normalizers = {
+        "codex": normalize_codex_hook_payload,
+        "claude": normalize_claude_hook_payload,
+        "claude-code": normalize_claude_hook_payload,
+        "opencode": normalize_opencode_payload,
+        "copilot": normalize_copilot_payload,
+        "gemini": normalize_gemini_payload,
+    }
+    normalizer = normalizers.get(normalized_harness)
+    if normalizer is None:
+        raise ValueError(f"Unsupported Guard harness for action normalization: {harness}")
+    normalized_payload = _payload_with_default_event(payload, event_name)
+    return normalizer(normalized_payload, workspace=workspace, home_dir=home_dir)
+
+
+def _normalize_action_payload(
+    payload: Mapping[str, object],
+    *,
+    harness: str,
+    default_event_name: str | None,
+    workspace: Path | str | None,
+    home_dir: Path | str | None,
+) -> GuardActionEnvelope:
+    normalized_payload = dict(payload)
+    if default_event_name is not None:
+        normalized_payload = _payload_with_default_event(normalized_payload, default_event_name)
+    event_name = _hook_event_name(normalized_payload)
+    explicit_tool_name = _tool_name_from_payload(normalized_payload)
     tool_call_name, tool_call_input = _tool_call_from_payload(
         normalized_payload.get("toolCalls"),
         expected_tool_name=explicit_tool_name,
@@ -244,10 +358,10 @@ def normalize_codex_hook_payload(
         tool_input = tool_call_input
     raw_command = _command_from_payload(tool_input)
     command = _command_detail(raw_command, home_dir=home_dir)
-    prompt_text = _prompt_text(normalized_payload.get("prompt"))
+    prompt_text = _prompt_text(_prompt_value(normalized_payload))
     prompt_excerpt = _prompt_excerpt(prompt_text)
-    mcp_server, mcp_tool = _mcp_parts(tool_name)
-    action_type = _codex_action_type(
+    mcp_server, mcp_tool = _mcp_details(normalized_payload, tool_name)
+    action_type = _action_type(
         event_name=event_name,
         tool_name=tool_name,
         command=raw_command,
@@ -266,7 +380,7 @@ def normalize_codex_hook_payload(
     return GuardActionEnvelope(
         schema_version=_SCHEMA_VERSION,
         action_id="",
-        harness="codex",
+        harness=harness,
         event_name=event_name,
         action_type=action_type,
         workspace=workspace_label,
@@ -329,6 +443,26 @@ def _mapping_value(value: object) -> Mapping[str, object]:
     return {}
 
 
+def _payload_with_default_event(payload: Mapping[str, object], event_name: str) -> dict[str, object]:
+    normalized_payload = dict(payload)
+    if not event_name.strip():
+        return normalized_payload
+    if any(
+        key in normalized_payload for key in ("event", "eventName", "hook_event_name", "hookEventName", "hook_name")
+    ):
+        return normalized_payload
+    normalized_payload["hook_event_name"] = event_name
+    return normalized_payload
+
+
+def _tool_name_from_payload(payload: Mapping[str, object]) -> str | None:
+    for key in ("tool_name", "toolName", "name", "tool"):
+        value = _string_value(payload.get(key))
+        if value is not None:
+            return value
+    return None
+
+
 def _tool_input_from_payload(payload: Mapping[str, object]) -> Mapping[str, object]:
     for key in ("tool_input", "toolInput", "toolArgs", "arguments"):
         parsed = _mapping_from_value(payload.get(key))
@@ -375,12 +509,20 @@ def _mapping_from_value(value: object) -> Mapping[str, object] | None:
 
 
 def _hook_event_name(payload: Mapping[str, object]) -> str:
-    for key in ("event", "hook_event_name", "hookEventName", "hook_name"):
+    for key in ("event", "eventName", "hook_event_name", "hookEventName", "hook_name"):
         value = payload.get(key)
         if isinstance(value, str) and value.strip():
             stripped = value.strip()
             return _HOOK_EVENT_NAME_MAP.get(stripped.lower(), stripped)
     return "PreToolUse"
+
+
+def _prompt_value(payload: Mapping[str, object]) -> object:
+    for key in ("prompt", "userPrompt", "user_prompt", "message", "text", "input"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
 
 
 def _command_from_payload(tool_input: Mapping[str, object]) -> str | None:
@@ -413,6 +555,22 @@ def _prompt_excerpt(prompt_text: str | None) -> str | None:
     return prompt_text[:_PROMPT_EXCERPT_LIMIT]
 
 
+def _mcp_details(payload: Mapping[str, object], tool_name: str | None) -> tuple[str | None, str | None]:
+    explicit_server = _string_from_keys(payload, ("mcp_server", "mcpServer", "server", "serverName"))
+    explicit_tool = _string_from_keys(payload, ("mcp_tool", "mcpTool", "tool", "toolName"))
+    if explicit_server is not None and explicit_tool is not None:
+        return explicit_server, explicit_tool
+    return _mcp_parts(tool_name)
+
+
+def _string_from_keys(payload: Mapping[str, object], keys: tuple[str, ...]) -> str | None:
+    for key in keys:
+        value = _string_value(payload.get(key))
+        if value is not None:
+            return value
+    return None
+
+
 def _mcp_parts(tool_name: str | None) -> tuple[str | None, str | None]:
     if tool_name is None or not tool_name.startswith("mcp__"):
         return None, None
@@ -422,7 +580,7 @@ def _mcp_parts(tool_name: str | None) -> tuple[str | None, str | None]:
     return parts[1], parts[2]
 
 
-def _codex_action_type(
+def _action_type(
     *,
     event_name: str,
     tool_name: str | None,
@@ -573,7 +731,12 @@ def _normalized_command(command: str | None) -> str | None:
 __all__ = [
     "GuardActionEnvelope",
     "GuardActionType",
+    "normalize_claude_hook_payload",
     "normalize_codex_hook_payload",
+    "normalize_copilot_payload",
+    "normalize_gemini_payload",
+    "normalize_harness_payload",
+    "normalize_opencode_payload",
     "redacted_workspace_label",
     "stable_action_hash",
 ]

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -101,6 +101,21 @@ _GENERIC_WINDOWS_UNC_PATH_PATTERN = re.compile(
     r"(?<![A-Za-z0-9_./\\:-])(?P<path>\\\\[^\\\s'\"<>|]+\\[^\\\s'\"<>|]+(?:\\[^\\\s'\"<>|]+)+)"
 )
 _PROMPT_EXCERPT_LIMIT = 240
+_SINGLE_TOKEN_MCP_TOOLS = frozenset(
+    {
+        "call",
+        "delete",
+        "get",
+        "inspect",
+        "list",
+        "lookup",
+        "query",
+        "read",
+        "run",
+        "search",
+        "write",
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -591,12 +606,17 @@ def _mcp_parts(tool_name: str | None) -> tuple[str | None, str | None]:
         if "_" not in suffix:
             return None, None
         parts = suffix.split("_")
-        if len(parts) >= 3:
-            server = "_".join(parts[:2])
-            tool = "_".join(parts[2:])
-        else:
+        if len(parts) >= 3 and parts[-1] in _SINGLE_TOKEN_MCP_TOOLS:
+            server = "_".join(parts[:-1])
+            tool = parts[-1]
+        elif len(parts) >= 3:
+            server = "_".join(parts[:-2])
+            tool = "_".join(parts[-2:])
+        elif len(parts) == 2:
             server = parts[0]
-            tool = "_".join(parts[1:])
+            tool = parts[1]
+        else:
+            return None, None
         if server and tool:
             return server, tool
         return None, None

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -447,10 +447,10 @@ def _payload_with_default_event(payload: Mapping[str, object], event_name: str) 
     normalized_payload = dict(payload)
     if not event_name.strip():
         return normalized_payload
-    if any(
-        key in normalized_payload for key in ("event", "eventName", "hook_event_name", "hookEventName", "hook_name")
-    ):
-        return normalized_payload
+    for key in ("event", "eventName", "hook_event_name", "hookEventName", "hook_name", "hookName"):
+        value = normalized_payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return normalized_payload
     normalized_payload["hook_event_name"] = event_name
     return normalized_payload
 
@@ -509,7 +509,7 @@ def _mapping_from_value(value: object) -> Mapping[str, object] | None:
 
 
 def _hook_event_name(payload: Mapping[str, object]) -> str:
-    for key in ("event", "eventName", "hook_event_name", "hookEventName", "hook_name"):
+    for key in ("event", "eventName", "hook_event_name", "hookEventName", "hook_name", "hookName"):
         value = payload.get(key)
         if isinstance(value, str) and value.strip():
             stripped = value.strip()
@@ -557,10 +557,14 @@ def _prompt_excerpt(prompt_text: str | None) -> str | None:
 
 def _mcp_details(payload: Mapping[str, object], tool_name: str | None) -> tuple[str | None, str | None]:
     explicit_server = _string_from_keys(payload, ("mcp_server", "mcpServer", "server", "serverName"))
-    explicit_tool = _string_from_keys(payload, ("mcp_tool", "mcpTool", "tool", "toolName"))
-    if explicit_server is not None and explicit_tool is not None:
-        return explicit_server, explicit_tool
-    return _mcp_parts(tool_name)
+    explicit_tool = _string_from_keys(payload, ("mcp_tool", "mcpTool", "tool"))
+    tool_name_value = _string_from_keys(payload, ("toolName",))
+    parts_server, parts_tool = _mcp_parts(tool_name)
+    server = explicit_server or parts_server
+    tool = explicit_tool or parts_tool
+    if tool is None and server is not None and tool_name_value is not None:
+        tool = tool_name_value
+    return server, tool
 
 
 def _string_from_keys(payload: Mapping[str, object], keys: tuple[str, ...]) -> str | None:
@@ -572,12 +576,25 @@ def _string_from_keys(payload: Mapping[str, object], keys: tuple[str, ...]) -> s
 
 
 def _mcp_parts(tool_name: str | None) -> tuple[str | None, str | None]:
-    if tool_name is None or not tool_name.startswith("mcp__"):
+    if tool_name is None:
         return None, None
-    parts = tool_name.split("__", 2)
-    if len(parts) != 3 or not parts[1] or not parts[2]:
+    if "/" in tool_name:
+        server, tool = tool_name.split("/", 1)
+        return (server, tool) if server and tool else (None, None)
+    if tool_name.startswith("mcp__"):
+        parts = tool_name.split("__", 2)
+        if len(parts) == 3 and parts[1] and parts[2]:
+            return parts[1], parts[2]
         return None, None
-    return parts[1], parts[2]
+    if tool_name.startswith("mcp_"):
+        suffix = tool_name[len("mcp_") :]
+        if "_" not in suffix:
+            return None, None
+        server, tool = suffix.split("_", 1)
+        if server and tool:
+            return server, tool
+        return None, None
+    return None, None
 
 
 def _action_type(

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -557,7 +557,7 @@ def _prompt_excerpt(prompt_text: str | None) -> str | None:
 
 def _mcp_details(payload: Mapping[str, object], tool_name: str | None) -> tuple[str | None, str | None]:
     explicit_server = _string_from_keys(payload, ("mcp_server", "mcpServer", "server", "serverName"))
-    explicit_tool = _string_from_keys(payload, ("mcp_tool", "mcpTool", "tool"))
+    explicit_tool = _string_from_keys(payload, ("mcp_tool", "mcpTool"))
     tool_name_value = _string_from_keys(payload, ("tool_name", "toolName"))
     parts_server, parts_tool = _mcp_parts(tool_name, known_servers=_known_mcp_servers(payload))
     server = explicit_server or parts_server
@@ -583,7 +583,11 @@ def _known_mcp_servers(payload: Mapping[str, object]) -> tuple[str, ...]:
             servers.update(str(server_name).strip() for server_name in value if isinstance(server_name, str))
         elif isinstance(value, list):
             servers.update(item.strip() for item in value if isinstance(item, str) and item.strip())
-    return tuple(sorted((server for server in servers if server), key=len, reverse=True))
+    return tuple(
+        sorted(
+            (server for server in servers if server), key=lambda server: len(_mcp_server_token(server)), reverse=True
+        )
+    )
 
 
 def _mcp_parts(tool_name: str | None, *, known_servers: tuple[str, ...] = ()) -> tuple[str | None, str | None]:
@@ -600,12 +604,18 @@ def _mcp_parts(tool_name: str | None, *, known_servers: tuple[str, ...] = ()) ->
     if tool_name.startswith("mcp_"):
         suffix = tool_name[len("mcp_") :]
         for server in known_servers:
-            prefix = f"{server}_"
+            server_token = _mcp_server_token(server)
+            prefix = f"{server_token}_"
             if suffix.startswith(prefix):
                 tool = suffix[len(prefix) :]
                 return (server, tool) if tool else (None, None)
         return None, None
     return None, None
+
+
+def _mcp_server_token(value: str) -> str:
+    token = re.sub(r"[^a-z0-9]+", "_", value.strip().lower())
+    return token.strip("_")
 
 
 def _action_type(

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -590,7 +590,13 @@ def _mcp_parts(tool_name: str | None) -> tuple[str | None, str | None]:
         suffix = tool_name[len("mcp_") :]
         if "_" not in suffix:
             return None, None
-        server, tool = suffix.split("_", 1)
+        parts = suffix.split("_")
+        if len(parts) >= 4:
+            server = "_".join(parts[:-2])
+            tool = "_".join(parts[-2:])
+        else:
+            server = parts[0]
+            tool = "_".join(parts[1:])
         if server and tool:
             return server, tool
         return None, None

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -591,9 +591,9 @@ def _mcp_parts(tool_name: str | None) -> tuple[str | None, str | None]:
         if "_" not in suffix:
             return None, None
         parts = suffix.split("_")
-        if len(parts) >= 4:
-            server = "_".join(parts[:-2])
-            tool = "_".join(parts[-2:])
+        if len(parts) >= 3:
+            server = "_".join(parts[:2])
+            tool = "_".join(parts[2:])
         else:
             server = parts[0]
             tool = "_".join(parts[1:])

--- a/tests/test_guard_runtime_action_harnesses.py
+++ b/tests/test_guard_runtime_action_harnesses.py
@@ -125,6 +125,7 @@ def test_normalize_copilot_prefixed_mcp_payload(tmp_path: Path) -> None:
         "hookName": "preToolUse",
         "toolName": "mcp_danger_lab_safe_echo",
         "toolInput": {"message": "hello"},
+        "mcpServers": {"danger_lab": {}},
     }
 
     envelope = normalize_copilot_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
@@ -139,6 +140,7 @@ def test_normalize_copilot_three_part_prefixed_mcp_payload(tmp_path: Path) -> No
         "hookName": "preToolUse",
         "toolName": "mcp_guard_lab_inspect",
         "toolInput": {"target": "workspace"},
+        "mcpServers": {"guard_lab": {}},
     }
 
     envelope = normalize_copilot_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
@@ -153,6 +155,7 @@ def test_normalize_copilot_long_server_prefixed_mcp_payload(tmp_path: Path) -> N
         "hookName": "preToolUse",
         "toolName": "mcp_my_server_name_my_tool",
         "toolInput": {"target": "workspace"},
+        "mcpServers": {"my_server_name": {}},
     }
 
     envelope = normalize_copilot_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
@@ -165,15 +168,30 @@ def test_normalize_copilot_long_server_prefixed_mcp_payload(tmp_path: Path) -> N
 def test_normalize_copilot_single_token_tool_prefixed_mcp_payload(tmp_path: Path) -> None:
     payload = {
         "hookName": "preToolUse",
-        "toolName": "mcp_guard_team_lab_inspect",
+        "toolName": "mcp_guard_team_lab_ping",
         "toolInput": {"target": "workspace"},
+        "mcpServers": {"guard_team_lab": {}},
     }
 
     envelope = normalize_copilot_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
 
     assert envelope.action_type == "mcp_tool"
     assert envelope.mcp_server == "guard_team_lab"
-    assert envelope.mcp_tool == "inspect"
+    assert envelope.mcp_tool == "ping"
+
+
+def test_normalize_copilot_unknown_prefixed_mcp_payload_stays_untyped(tmp_path: Path) -> None:
+    payload = {
+        "hookName": "preToolUse",
+        "toolName": "mcp_guard_team_lab_ping",
+        "toolInput": {"target": "workspace"},
+    }
+
+    envelope = normalize_copilot_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.action_type == "config_change"
+    assert envelope.mcp_server is None
+    assert envelope.mcp_tool is None
 
 
 def test_normalize_harness_payload_uses_default_for_empty_event(tmp_path: Path) -> None:
@@ -201,6 +219,21 @@ def test_normalize_opencode_merges_partial_mcp_details(tmp_path: Path) -> None:
         "server": "guard_lab",
         "toolName": "inspect",
         "toolInput": {"target": "workspace"},
+    }
+
+    envelope = normalize_opencode_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.action_type == "mcp_tool"
+    assert envelope.mcp_server == "guard_lab"
+    assert envelope.mcp_tool == "inspect"
+
+
+def test_normalize_opencode_merges_snake_case_partial_mcp_details(tmp_path: Path) -> None:
+    payload = {
+        "event": "permissionRequest",
+        "server": "guard_lab",
+        "tool_name": "inspect",
+        "tool_input": {"target": "workspace"},
     }
 
     envelope = normalize_opencode_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)

--- a/tests/test_guard_runtime_action_harnesses.py
+++ b/tests/test_guard_runtime_action_harnesses.py
@@ -194,6 +194,36 @@ def test_normalize_copilot_unknown_prefixed_mcp_payload_stays_untyped(tmp_path: 
     assert envelope.mcp_tool is None
 
 
+def test_normalize_copilot_tokenized_server_prefixed_mcp_payload(tmp_path: Path) -> None:
+    payload = {
+        "hookName": "preToolUse",
+        "toolName": "mcp_shared_tools_ping",
+        "toolInput": {"target": "workspace"},
+        "mcpServers": {"shared-tools": {}},
+    }
+
+    envelope = normalize_copilot_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.action_type == "mcp_tool"
+    assert envelope.mcp_server == "shared-tools"
+    assert envelope.mcp_tool == "ping"
+
+
+def test_normalize_generic_tool_alias_does_not_set_mcp_tool(tmp_path: Path) -> None:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool": "Read",
+        "tool_input": {"path": "~/.npmrc"},
+    }
+
+    envelope = normalize_claude_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.action_type == "file_read"
+    assert envelope.tool_name == "Read"
+    assert envelope.mcp_server is None
+    assert envelope.mcp_tool is None
+
+
 def test_normalize_harness_payload_uses_default_for_empty_event(tmp_path: Path) -> None:
     payload = {
         "event": "",

--- a/tests/test_guard_runtime_action_harnesses.py
+++ b/tests/test_guard_runtime_action_harnesses.py
@@ -148,6 +148,34 @@ def test_normalize_copilot_three_part_prefixed_mcp_payload(tmp_path: Path) -> No
     assert envelope.mcp_tool == "inspect"
 
 
+def test_normalize_copilot_long_server_prefixed_mcp_payload(tmp_path: Path) -> None:
+    payload = {
+        "hookName": "preToolUse",
+        "toolName": "mcp_my_server_name_my_tool",
+        "toolInput": {"target": "workspace"},
+    }
+
+    envelope = normalize_copilot_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.action_type == "mcp_tool"
+    assert envelope.mcp_server == "my_server_name"
+    assert envelope.mcp_tool == "my_tool"
+
+
+def test_normalize_copilot_single_token_tool_prefixed_mcp_payload(tmp_path: Path) -> None:
+    payload = {
+        "hookName": "preToolUse",
+        "toolName": "mcp_guard_team_lab_inspect",
+        "toolInput": {"target": "workspace"},
+    }
+
+    envelope = normalize_copilot_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.action_type == "mcp_tool"
+    assert envelope.mcp_server == "guard_team_lab"
+    assert envelope.mcp_tool == "inspect"
+
+
 def test_normalize_harness_payload_uses_default_for_empty_event(tmp_path: Path) -> None:
     payload = {
         "event": "",

--- a/tests/test_guard_runtime_action_harnesses.py
+++ b/tests/test_guard_runtime_action_harnesses.py
@@ -134,6 +134,20 @@ def test_normalize_copilot_prefixed_mcp_payload(tmp_path: Path) -> None:
     assert envelope.mcp_tool == "safe_echo"
 
 
+def test_normalize_copilot_three_part_prefixed_mcp_payload(tmp_path: Path) -> None:
+    payload = {
+        "hookName": "preToolUse",
+        "toolName": "mcp_guard_lab_inspect",
+        "toolInput": {"target": "workspace"},
+    }
+
+    envelope = normalize_copilot_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.action_type == "mcp_tool"
+    assert envelope.mcp_server == "guard_lab"
+    assert envelope.mcp_tool == "inspect"
+
+
 def test_normalize_harness_payload_uses_default_for_empty_event(tmp_path: Path) -> None:
     payload = {
         "event": "",

--- a/tests/test_guard_runtime_action_harnesses.py
+++ b/tests/test_guard_runtime_action_harnesses.py
@@ -93,6 +93,81 @@ def test_normalize_copilot_autopilot_shell_payload(tmp_path: Path) -> None:
     assert envelope.target_paths == ("~/.npmrc",)
 
 
+def test_normalize_copilot_hook_name_payload(tmp_path: Path) -> None:
+    payload = {
+        "hookName": "permissionRequest",
+        "toolName": "run_terminal_command",
+        "toolInput": {"command": "cat ~/.npmrc"},
+    }
+
+    envelope = normalize_copilot_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.event_name == "PermissionRequest"
+    assert envelope.action_type == "shell_command"
+
+
+def test_normalize_copilot_slash_mcp_payload(tmp_path: Path) -> None:
+    payload = {
+        "hookName": "preToolUse",
+        "toolName": "danger_lab/safe_echo",
+        "toolInput": {"message": "hello"},
+    }
+
+    envelope = normalize_copilot_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.action_type == "mcp_tool"
+    assert envelope.mcp_server == "danger_lab"
+    assert envelope.mcp_tool == "safe_echo"
+
+
+def test_normalize_copilot_prefixed_mcp_payload(tmp_path: Path) -> None:
+    payload = {
+        "hookName": "preToolUse",
+        "toolName": "mcp_danger_lab_safe_echo",
+        "toolInput": {"message": "hello"},
+    }
+
+    envelope = normalize_copilot_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.action_type == "mcp_tool"
+    assert envelope.mcp_server == "danger"
+    assert envelope.mcp_tool == "lab_safe_echo"
+
+
+def test_normalize_harness_payload_uses_default_for_empty_event(tmp_path: Path) -> None:
+    payload = {
+        "event": "",
+        "tool_name": "Bash",
+        "tool_input": {"command": "cat ~/.npmrc"},
+    }
+
+    envelope = normalize_harness_payload(
+        "claude-code",
+        "PermissionRequest",
+        payload,
+        workspace=tmp_path / "workspace",
+        home_dir=tmp_path,
+    )
+
+    assert envelope.event_name == "PermissionRequest"
+    assert envelope.action_type == "shell_command"
+
+
+def test_normalize_opencode_merges_partial_mcp_details(tmp_path: Path) -> None:
+    payload = {
+        "event": "permissionRequest",
+        "server": "guard_lab",
+        "toolName": "inspect",
+        "toolInput": {"target": "workspace"},
+    }
+
+    envelope = normalize_opencode_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.action_type == "mcp_tool"
+    assert envelope.mcp_server == "guard_lab"
+    assert envelope.mcp_tool == "inspect"
+
+
 def test_normalize_gemini_prompt_payload(tmp_path: Path) -> None:
     payload = {
         "event": "prompt",

--- a/tests/test_guard_runtime_action_harnesses.py
+++ b/tests/test_guard_runtime_action_harnesses.py
@@ -1,0 +1,136 @@
+"""Runtime action envelope harness normalizer tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.actions import (
+    normalize_claude_hook_payload,
+    normalize_copilot_payload,
+    normalize_gemini_payload,
+    normalize_harness_payload,
+    normalize_opencode_payload,
+)
+
+
+def test_normalize_claude_pre_tool_read_payload(tmp_path: Path) -> None:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Read",
+        "tool_input": {"file_path": "~/.npmrc"},
+    }
+
+    envelope = normalize_claude_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.harness == "claude-code"
+    assert envelope.event_name == "PreToolUse"
+    assert envelope.action_type == "file_read"
+    assert envelope.tool_name == "Read"
+    assert envelope.target_paths == ("~/.npmrc",)
+
+
+def test_normalize_claude_user_prompt_submit_payload(tmp_path: Path) -> None:
+    payload = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "Please print ~/.env to debug local setup.",
+    }
+
+    envelope = normalize_claude_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.harness == "claude-code"
+    assert envelope.action_type == "prompt"
+    assert envelope.prompt_excerpt == "Please print ~/.env to debug local setup."
+    assert envelope.target_paths == ("~/.env",)
+
+
+def test_normalize_claude_pre_tool_bash_payload(tmp_path: Path) -> None:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "cat ~/.npmrc"},
+    }
+
+    envelope = normalize_claude_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.harness == "claude-code"
+    assert envelope.action_type == "shell_command"
+    assert envelope.command == "cat ~/.npmrc"
+    assert envelope.target_paths == ("~/.npmrc",)
+
+
+def test_normalize_opencode_mcp_payload(tmp_path: Path) -> None:
+    payload = {
+        "event": "permissionRequest",
+        "tool_name": "mcp__guard_lab__inspect",
+        "tool_input": {"target": "workspace"},
+    }
+
+    envelope = normalize_opencode_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.harness == "opencode"
+    assert envelope.event_name == "PermissionRequest"
+    assert envelope.action_type == "mcp_tool"
+    assert envelope.mcp_server == "guard_lab"
+    assert envelope.mcp_tool == "inspect"
+
+
+def test_normalize_copilot_autopilot_shell_payload(tmp_path: Path) -> None:
+    payload = {
+        "eventName": "preToolUse",
+        "mode": "Autopilot",
+        "toolName": "run_terminal_command",
+        "toolInput": {"command": "cat ~/.npmrc"},
+    }
+
+    envelope = normalize_copilot_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.harness == "copilot"
+    assert envelope.event_name == "PreToolUse"
+    assert envelope.action_type == "shell_command"
+    assert envelope.command == "cat ~/.npmrc"
+    assert envelope.target_paths == ("~/.npmrc",)
+
+
+def test_normalize_gemini_prompt_payload(tmp_path: Path) -> None:
+    payload = {
+        "event": "prompt",
+        "prompt": "Inspect ~/.npmrc, then explain risk.",
+    }
+
+    envelope = normalize_gemini_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.harness == "gemini"
+    assert envelope.event_name == "UserPromptSubmit"
+    assert envelope.action_type == "prompt"
+    assert envelope.prompt_excerpt == "Inspect ~/.npmrc, then explain risk."
+    assert envelope.target_paths == ("~/.npmrc",)
+
+
+def test_normalize_harness_payload_dispatches_supported_harnesses(tmp_path: Path) -> None:
+    payload = {"tool_name": "Bash", "tool_input": {"command": "cat ~/.npmrc"}}
+
+    envelope = normalize_harness_payload(
+        "claude-code",
+        "PreToolUse",
+        payload,
+        workspace=tmp_path / "workspace",
+        home_dir=tmp_path,
+    )
+
+    assert envelope.harness == "claude-code"
+    assert envelope.event_name == "PreToolUse"
+    assert envelope.action_type == "shell_command"
+    assert envelope.target_paths == ("~/.npmrc",)
+
+
+def test_normalize_harness_payload_rejects_unknown_harness(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Unsupported Guard harness"):
+        normalize_harness_payload(
+            "unknown-harness",
+            "PreToolUse",
+            {},
+            workspace=tmp_path / "workspace",
+            home_dir=tmp_path,
+        )

--- a/tests/test_guard_runtime_action_harnesses.py
+++ b/tests/test_guard_runtime_action_harnesses.py
@@ -130,8 +130,8 @@ def test_normalize_copilot_prefixed_mcp_payload(tmp_path: Path) -> None:
     envelope = normalize_copilot_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
 
     assert envelope.action_type == "mcp_tool"
-    assert envelope.mcp_server == "danger"
-    assert envelope.mcp_tool == "lab_safe_echo"
+    assert envelope.mcp_server == "danger_lab"
+    assert envelope.mcp_tool == "safe_echo"
 
 
 def test_normalize_harness_payload_uses_default_for_empty_event(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary\n- add runtime action normalizers for Claude Code, OpenCode, Copilot, and Gemini payloads\n- add shared harness dispatcher for typed Guard action envelopes\n- cover read, prompt, shell, MCP, and unsupported-harness paths\n\n## Verification\n- ruff check src/codex_plugin_scanner/guard/runtime/actions.py tests/test_guard_runtime_actions.py tests/test_guard_runtime_action_harnesses.py\n- pytest tests/test_guard_runtime_actions.py tests/test_guard_runtime_action_harnesses.py tests/test_guard_runtime.py -q