### PR TITLE
feat(guard): persist action envelopes on approvals

### DIFF
--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import time
 import uuid
+from collections.abc import Mapping
 from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
@@ -86,6 +87,7 @@ def queue_blocked_approvals(
             why_now=incident["why_now"],
             launch_summary=incident["launch_summary"],
             risk_headline=incident["risk_headline"],
+            action_envelope_json=_item_action_envelope_json(item),
         )
         persisted_request_id = store.add_approval_request(request, timestamp)
         if persisted_request_id != request.request_id:
@@ -331,6 +333,13 @@ def _item_risk_signals(item: dict[str, object], artifact) -> tuple[str, ...]:
         if normalized:
             return normalized
     return artifact_risk_signals(artifact) if artifact is not None else ()
+
+
+def _item_action_envelope_json(item: dict[str, object]) -> dict[str, object] | None:
+    value = item.get("action_envelope_json")
+    if not isinstance(value, Mapping):
+        return None
+    return {str(key): item_value for key, item_value in value.items() if isinstance(key, str)}
 
 
 def _string_list(value: object) -> list[str]:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -80,6 +80,7 @@ from ..proxy import (
 )
 from ..receipts import build_receipt
 from ..risk import artifact_risk_signals, artifact_risk_summary
+from ..runtime.actions import GuardActionEnvelope, normalize_harness_payload
 from ..runtime.runner import (
     GuardSyncNotConfiguredError,
     extract_prompt_requests,
@@ -1206,6 +1207,12 @@ def run_guard_command(
                     runtime_workspace = current_workspace
         if args.harness == "copilot":
             runtime_workspace = _resolve_copilot_workspace_root(runtime_workspace)
+        action_envelope = _hook_action_envelope(
+            harness=args.harness,
+            payload=payload,
+            home_dir=context.home_dir,
+            workspace=runtime_workspace,
+        )
         copilot_hook_stage = _copilot_hook_stage(payload) if args.harness == "copilot" else None
         copilot_runtime_tool_call = (
             _copilot_runtime_tool_call(
@@ -1309,6 +1316,7 @@ def run_guard_command(
                         "launch_target": json.dumps(runtime_arguments, sort_keys=True)
                         if runtime_arguments is not None
                         else runtime_artifact.command,
+                        "action_envelope_json": _action_envelope_json(action_envelope),
                     }
                 ]
             }
@@ -1667,6 +1675,7 @@ def run_guard_command(
                                 "source_scope": runtime_artifact.source_scope,
                                 "config_path": runtime_artifact.config_path,
                                 "launch_target": _runtime_request_summary(runtime_artifact),
+                                "action_envelope_json": _action_envelope_json(action_envelope),
                             }
                         ]
                     }
@@ -3617,6 +3626,32 @@ def _load_hook_payload(event_file: str | None, *, input_text: str | None = None)
         return {}
     payload = json.loads(raw)
     return _normalize_hook_payload(payload) if isinstance(payload, dict) else {}
+
+
+_ACTION_ENVELOPE_HARNESSES = frozenset({"codex", "claude-code", "opencode", "copilot", "gemini"})
+
+
+def _hook_action_envelope(
+    *,
+    harness: str,
+    payload: dict[str, object],
+    home_dir: Path,
+    workspace: Path | None,
+) -> GuardActionEnvelope | None:
+    canonical_harness = _canonical_harness_name(harness)
+    if canonical_harness not in _ACTION_ENVELOPE_HARNESSES:
+        return None
+    return normalize_harness_payload(
+        canonical_harness,
+        _hook_event_name(payload) or "PreToolUse",
+        payload,
+        workspace=workspace,
+        home_dir=home_dir,
+    )
+
+
+def _action_envelope_json(envelope: GuardActionEnvelope | None) -> dict[str, object] | None:
+    return envelope.to_dict() if envelope is not None else None
 
 
 def _normalize_hook_payload(payload: dict[str, object]) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/models.py
+++ b/src/codex_plugin_scanner/guard/models.py
@@ -141,6 +141,7 @@ class GuardReceipt:
     user_override: str | None = None
     artifact_name: str | None = None
     source_scope: str | None = None
+    action_envelope_json: dict[str, object] | None = None
 
     def to_dict(self) -> dict[str, object]:
         payload = asdict(self)
@@ -177,6 +178,7 @@ class GuardApprovalRequest:
     why_now: str | None = None
     launch_summary: str | None = None
     risk_headline: str | None = None
+    action_envelope_json: dict[str, object] | None = None
 
     def to_dict(self) -> dict[str, object]:
         payload = asdict(self)

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -12,6 +12,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from collections.abc import Callable
+from contextlib import suppress
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -24,6 +25,7 @@ from ..consumer import detect_harness, evaluate_detection
 from ..models import GuardArtifact, HarnessDetection, PolicyDecision
 from ..store import GuardStore
 from ..types import PromptRequest, RemediationAction
+from .actions import GuardActionEnvelope, redacted_workspace_label
 
 _APPROVAL_METADATA_KEYS = (
     "approval_center_url",
@@ -233,12 +235,18 @@ def guard_run(
         if not evaluation["blocked"]:
             evaluation = evaluate_detection(detection, store, config, default_action=default_action, persist=True)
 
+    action_envelope = _guard_run_action_envelope(harness, context, passthrough_args)
+    if evaluation["blocked"]:
+        evaluation = _evaluation_with_action_envelope(evaluation, action_envelope)
+
     if not dry_run and interactive_resolver is not None and evaluation["blocked"]:
         evaluation = interactive_resolver(detection, evaluation)
     elif not dry_run and blocked_resolver is not None and evaluation["blocked"]:
         pending_evaluation = blocked_resolver(detection, evaluation)
         detection = _detection_with_prompt_artifacts(detect_harness(harness, context), context, passthrough_args)
         reevaluated = evaluate_detection(detection, store, config, default_action=default_action, persist=True)
+        if reevaluated["blocked"]:
+            reevaluated = _evaluation_with_action_envelope(reevaluated, action_envelope)
         for key in _APPROVAL_METADATA_KEYS:
             if key in pending_evaluation:
                 reevaluated[key] = pending_evaluation[key]
@@ -272,6 +280,61 @@ def guard_run(
     evaluation["launched"] = True
     evaluation["return_code"] = result.returncode
     return evaluation
+
+
+def _guard_run_action_envelope(
+    harness: str,
+    context: HarnessContext,
+    passthrough_args: list[str],
+) -> GuardActionEnvelope:
+    workspace = context.workspace_dir
+    workspace_hash = None
+    if workspace is not None:
+        workspace_path = workspace.expanduser()
+        with suppress(OSError):
+            workspace_path = workspace_path.resolve()
+        workspace_hash = hashlib.sha256(str(workspace_path).encode("utf-8")).hexdigest()
+    return GuardActionEnvelope(
+        schema_version=1,
+        action_id="",
+        harness=harness,
+        event_name="HarnessStart",
+        action_type="harness_start",
+        workspace=redacted_workspace_label(workspace, home_dir=context.home_dir),
+        workspace_hash=workspace_hash,
+        tool_name=None,
+        command=None,
+        prompt_excerpt=None,
+        target_paths=(),
+        network_hosts=(),
+        mcp_server=None,
+        mcp_tool=None,
+        package_manager=None,
+        package_name=None,
+        script_name=None,
+        raw_payload_redacted={"passthrough_arg_count": len(passthrough_args)},
+    )
+
+
+def _evaluation_with_action_envelope(
+    evaluation: dict[str, Any],
+    action_envelope: GuardActionEnvelope,
+) -> dict[str, Any]:
+    artifacts = evaluation.get("artifacts")
+    if not isinstance(artifacts, list):
+        return evaluation
+    action_payload = action_envelope.to_dict()
+    normalized_artifacts: list[object] = []
+    changed = False
+    for item in artifacts:
+        if isinstance(item, dict) and "action_envelope_json" not in item:
+            normalized_artifacts.append({**item, "action_envelope_json": action_payload})
+            changed = True
+        else:
+            normalized_artifacts.append(item)
+    if not changed:
+        return evaluation
+    return {**evaluation, "artifacts": normalized_artifacts}
 
 
 def _guard_run_config_paths(

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -666,6 +666,7 @@ class GuardStore:
             self._ensure_approval_column(connection, "why_now", "text")
             self._ensure_approval_column(connection, "launch_summary", "text")
             self._ensure_approval_column(connection, "risk_headline", "text")
+            self._ensure_approval_column(connection, "action_envelope_json", "text")
             self._ensure_approval_column(connection, "workspace", "text")
             self._ensure_attachment_column(connection, "lease_id", "text not null default ''")
             self._ensure_attachment_column(connection, "lease_expires_at", "text")

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -30,12 +30,13 @@ def approval_schema_statement() -> str:
           risk_signals_json text not null default '[]',
           artifact_label text,
           source_label text,
-          trigger_summary text,
-          why_now text,
-          launch_summary text,
-          risk_headline text,
-          review_command text not null,
-          approval_url text not null,
+           trigger_summary text,
+           why_now text,
+           launch_summary text,
+           risk_headline text,
+           action_envelope_json text,
+           review_command text not null,
+           approval_url text not null,
           status text not null,
           resolution_action text,
           resolution_scope text,
@@ -68,7 +69,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
                 recommended_scope = ?, changed_fields_json = ?, source_scope = ?, config_path = ?, workspace = ?,
                 launch_target = ?, transport = ?, risk_summary = ?, risk_signals_json = ?,
                 artifact_label = ?, source_label = ?, trigger_summary = ?, why_now = ?, launch_summary = ?,
-                risk_headline = ?,
+                risk_headline = ?, action_envelope_json = ?,
                 review_command = ?, approval_url = ?, created_at = ?
             where request_id = ?
             """,
@@ -93,6 +94,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
                 request.why_now,
                 request.launch_summary,
                 request.risk_headline,
+                json.dumps(request.action_envelope_json) if request.action_envelope_json is not None else None,
                 review_command,
                 approval_url,
                 now,
@@ -105,12 +107,12 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
         insert into approval_requests (
           request_id, harness, artifact_id, artifact_name, artifact_type, artifact_hash, publisher, policy_action,
           recommended_scope, changed_fields_json, source_scope, config_path, workspace,
-          launch_target, transport, risk_summary,
-          risk_signals_json, artifact_label, source_label, trigger_summary, why_now, launch_summary, risk_headline,
-          review_command,
-          approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
-        )
-        values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           launch_target, transport, risk_summary,
+           risk_signals_json, artifact_label, source_label, trigger_summary, why_now, launch_summary, risk_headline,
+           action_envelope_json, review_command,
+           approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
+         )
+         values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             request.request_id,
@@ -136,6 +138,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
             request.why_now,
             request.launch_summary,
             request.risk_headline,
+            json.dumps(request.action_envelope_json) if request.action_envelope_json is not None else None,
             request.review_command,
             request.approval_url,
             "pending",
@@ -182,9 +185,9 @@ def list_approval_requests(
     query = f"""
         select request_id, harness, artifact_id, artifact_name, artifact_type, artifact_hash, publisher, policy_action,
                recommended_scope, changed_fields_json, source_scope, config_path, workspace, launch_target, transport,
-               risk_summary, risk_signals_json, artifact_label, source_label, trigger_summary, why_now,
-               launch_summary, risk_headline, review_command,
-               approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
+                risk_summary, risk_signals_json, artifact_label, source_label, trigger_summary, why_now,
+                launch_summary, risk_headline, action_envelope_json, review_command,
+                approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
         from approval_requests
         {where_clause}
         order by created_at desc
@@ -201,9 +204,9 @@ def get_approval_request(connection: sqlite3.Connection, request_id: str) -> dic
         """
         select request_id, harness, artifact_id, artifact_name, artifact_type, artifact_hash, publisher, policy_action,
                recommended_scope, changed_fields_json, source_scope, config_path, workspace, launch_target, transport,
-               risk_summary, risk_signals_json, artifact_label, source_label, trigger_summary, why_now,
-               launch_summary, risk_headline, review_command,
-               approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
+                risk_summary, risk_signals_json, artifact_label, source_label, trigger_summary, why_now,
+                launch_summary, risk_headline, action_envelope_json, review_command,
+                approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
         from approval_requests
         where request_id = ?
         """,
@@ -273,6 +276,7 @@ def _row_to_payload(row: sqlite3.Row) -> dict[str, object]:
         "why_now": row["why_now"],
         "launch_summary": row["launch_summary"],
         "risk_headline": row["risk_headline"],
+        "action_envelope_json": _optional_json_object(row["action_envelope_json"]),
         "review_command": str(row["review_command"]),
         "approval_url": str(row["approval_url"]),
         "status": str(row["status"]),
@@ -282,3 +286,12 @@ def _row_to_payload(row: sqlite3.Row) -> dict[str, object]:
         "created_at": str(row["created_at"]),
         "resolved_at": row["resolved_at"],
     }
+
+
+def _optional_json_object(value: object) -> dict[str, object] | None:
+    if value is None:
+        return None
+    parsed = json.loads(str(value))
+    if isinstance(parsed, dict):
+        return {str(key): item for key, item in parsed.items() if isinstance(key, str)}
+    return None

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -291,7 +291,10 @@ def _row_to_payload(row: sqlite3.Row) -> dict[str, object]:
 def _optional_json_object(value: object) -> dict[str, object] | None:
     if value is None:
         return None
-    parsed = json.loads(str(value))
+    try:
+        parsed = json.loads(str(value))
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None
     if isinstance(parsed, dict):
         return {str(key): item for key, item in parsed.items() if isinstance(key, str)}
     return None

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -226,6 +226,65 @@ class TestGuardApprovals:
         assert request["request_id"] == "req-old"
         assert request["action_envelope_json"] is None
 
+    def test_guard_store_ignores_malformed_action_envelope_json(self, tmp_path):
+        store = GuardStore(tmp_path / "guard-home")
+        connection = sqlite3.connect(store.path)
+        try:
+            connection.execute(
+                """
+                insert into approval_requests (
+                  request_id, harness, artifact_id, artifact_name, artifact_type, artifact_hash, publisher,
+                  policy_action, recommended_scope, changed_fields_json, source_scope, config_path, workspace,
+                  launch_target, transport, risk_summary, risk_signals_json, artifact_label, source_label,
+                  trigger_summary, why_now, launch_summary, risk_headline, action_envelope_json, review_command,
+                  approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
+                )
+                values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "req-bad-envelope",
+                    "codex",
+                    "codex:project:workspace_skill",
+                    "workspace_skill",
+                    "artifact",
+                    "hash-bad-envelope",
+                    None,
+                    "require-reapproval",
+                    "artifact",
+                    json.dumps(["args"]),
+                    "project",
+                    str(tmp_path / "workspace" / ".codex" / "config.toml"),
+                    None,
+                    None,
+                    None,
+                    None,
+                    "[]",
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    "{not-json",
+                    "hol-guard approvals approve req-bad-envelope",
+                    "http://127.0.0.1/pending",
+                    "pending",
+                    None,
+                    None,
+                    None,
+                    "2026-04-11T00:00:00+00:00",
+                    None,
+                ),
+            )
+            connection.commit()
+        finally:
+            connection.close()
+
+        request = store.get_approval_request("req-bad-envelope")
+
+        assert request is not None
+        assert request["action_envelope_json"] is None
+
     def test_guard_surface_daemon_client_recovers_missing_auth_token(self, tmp_path, monkeypatch):
         guard_home = tmp_path / "guard-home"
         cleared: list[Path] = []

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -69,6 +70,26 @@ class TestGuardApprovals:
     def test_guard_store_persists_and_resolves_approval_requests(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
         workspace_dir = tmp_path / "workspace"
+        action_envelope_json = {
+            "schema_version": 1,
+            "action_id": "action-123",
+            "harness": "codex",
+            "event_name": "PreToolUse",
+            "action_type": "shell_command",
+            "workspace": "~/workspace",
+            "workspace_hash": "workspace-hash",
+            "tool_name": "Bash",
+            "command": "cat ~/.npmrc",
+            "prompt_excerpt": None,
+            "target_paths": ["~/.npmrc"],
+            "network_hosts": [],
+            "mcp_server": None,
+            "mcp_tool": None,
+            "package_manager": None,
+            "package_name": None,
+            "script_name": None,
+            "raw_payload_redacted": {"tool_name": "Bash"},
+        }
         request = GuardApprovalRequest(
             request_id="req-123",
             harness="codex",
@@ -83,6 +104,7 @@ class TestGuardApprovals:
             workspace=str(workspace_dir),
             review_command="hol-guard approvals approve req-123",
             approval_url="http://127.0.0.1:4455/approvals/req-123",
+            action_envelope_json=action_envelope_json,
         )
 
         store.add_approval_request(request, "2026-04-11T00:00:00+00:00")
@@ -99,10 +121,110 @@ class TestGuardApprovals:
         assert pending[0]["status"] == "pending"
         assert pending[0]["approval_url"] == "http://127.0.0.1:4455/approvals/req-123"
         assert pending[0]["workspace"] == str(workspace_dir)
+        assert pending[0]["action_envelope_json"] == action_envelope_json
         assert resolved is not None
         assert resolved["status"] == "resolved"
         assert resolved["resolution_action"] == "allow"
         assert resolved["resolution_scope"] == "artifact"
+        assert resolved["action_envelope_json"] == action_envelope_json
+
+    def test_guard_store_loads_old_approval_rows_without_action_envelope(self, tmp_path):
+        guard_home = tmp_path / "guard-home"
+        guard_home.mkdir(parents=True, exist_ok=True)
+        connection = sqlite3.connect(guard_home / "guard.db")
+        try:
+            connection.execute(
+                """
+                create table approval_requests (
+                  request_id text primary key,
+                  harness text not null,
+                  artifact_id text not null,
+                  artifact_name text not null,
+                  artifact_type text not null,
+                  artifact_hash text not null,
+                  publisher text,
+                  policy_action text not null,
+                  recommended_scope text not null,
+                  changed_fields_json text not null,
+                  source_scope text not null,
+                  config_path text not null,
+                  workspace text,
+                  launch_target text,
+                  transport text,
+                  risk_summary text,
+                  risk_signals_json text not null default '[]',
+                  artifact_label text,
+                  source_label text,
+                  trigger_summary text,
+                  why_now text,
+                  launch_summary text,
+                  risk_headline text,
+                  review_command text not null,
+                  approval_url text not null,
+                  status text not null,
+                  resolution_action text,
+                  resolution_scope text,
+                  reason text,
+                  created_at text not null,
+                  resolved_at text
+                )
+                """
+            )
+            connection.execute(
+                """
+                insert into approval_requests (
+                  request_id, harness, artifact_id, artifact_name, artifact_type, artifact_hash, publisher,
+                  policy_action, recommended_scope, changed_fields_json, source_scope, config_path, workspace,
+                  launch_target, transport, risk_summary, risk_signals_json, artifact_label, source_label,
+                  trigger_summary, why_now, launch_summary, risk_headline, review_command, approval_url, status,
+                  resolution_action, resolution_scope, reason, created_at, resolved_at
+                )
+                values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "req-old",
+                    "codex",
+                    "codex:project:workspace_skill",
+                    "workspace_skill",
+                    "artifact",
+                    "hash-old",
+                    None,
+                    "require-reapproval",
+                    "artifact",
+                    json.dumps(["args"]),
+                    "project",
+                    str(tmp_path / "workspace" / ".codex" / "config.toml"),
+                    None,
+                    None,
+                    None,
+                    None,
+                    "[]",
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    "hol-guard approvals approve req-old",
+                    "http://127.0.0.1/pending",
+                    "pending",
+                    None,
+                    None,
+                    None,
+                    "2026-04-11T00:00:00+00:00",
+                    None,
+                ),
+            )
+            connection.commit()
+        finally:
+            connection.close()
+
+        store = GuardStore(guard_home)
+        request = store.get_approval_request("req-old")
+
+        assert request is not None
+        assert request["request_id"] == "req-old"
+        assert request["action_envelope_json"] is None
 
     def test_guard_surface_daemon_client_recovers_missing_auth_token(self, tmp_path, monkeypatch):
         guard_home = tmp_path / "guard-home"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -492,6 +492,8 @@ clearer UX and an implementation plan with technical references.
         assert output["artifact_type"] == "prompt_request"
         assert "read .authrc" in output["launch_summary"]
         assert approval_requests[0]["launch_target"] == "Codex prompt for `.authrc`: read .authrc"
+        assert approval_requests[0]["action_envelope_json"]["action_type"] == "prompt"
+        assert approval_requests[0]["action_envelope_json"]["prompt_excerpt"] == "read .authrc"
 
     def test_codex_prompt_display_sanitizes_common_home_paths(self) -> None:
         display = guard_commands_module._codex_prompt_display_text(
@@ -9418,6 +9420,8 @@ def test_guard_headless_blocked_run_persists_receipts_and_diffs(tmp_path, monkey
     latest_receipt = store.get_latest_receipt("claude-code", baseline.artifact_id)
 
     assert result["blocked"] is True
+    assert result["artifacts"][0]["action_envelope_json"]["action_type"] == "harness_start"
+    assert result["artifacts"][0]["action_envelope_json"]["harness"] == "claude-code"
     assert latest_diff is not None
     assert latest_diff["current_hash"] == artifact_hash(changed)
     assert latest_receipt is not None


### PR DESCRIPTION
## Summary
- persist typed Guard action envelopes with approval requests
- normalize hook payloads before legacy runtime approval checks
- keep old approval databases loadable when the envelope column is absent

## Tests
- ruff check src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/models.py src/codex_plugin_scanner/guard/store.py src/codex_plugin_scanner/guard/store_approvals.py src/codex_plugin_scanner/guard/approvals.py src/codex_plugin_scanner/guard/runtime/runner.py tests/test_guard_approvals.py tests/test_guard_runtime.py
- pytest tests/test_guard_approvals.py tests/test_guard_runtime.py -q
- pytest tests/test_guard_runtime_actions.py tests/test_guard_runtime_action_harnesses.py tests/test_guard_runtime.py tests/test_guard_approvals.py -q