### PR TITLE
feat(guard): integrate decision v2 payloads

### DIFF
--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -88,6 +88,7 @@ def queue_blocked_approvals(
             launch_summary=incident["launch_summary"],
             risk_headline=incident["risk_headline"],
             action_envelope_json=_item_action_envelope_json(item),
+            decision_v2_json=_item_decision_v2_json(item),
         )
         persisted_request_id = store.add_approval_request(request, timestamp)
         if persisted_request_id != request.request_id:
@@ -337,6 +338,13 @@ def _item_risk_signals(item: dict[str, object], artifact) -> tuple[str, ...]:
 
 def _item_action_envelope_json(item: dict[str, object]) -> dict[str, object] | None:
     value = item.get("action_envelope_json")
+    if not isinstance(value, Mapping):
+        return None
+    return {str(key): item_value for key, item_value in value.items() if isinstance(key, str)}
+
+
+def _item_decision_v2_json(item: dict[str, object]) -> dict[str, object] | None:
+    value = item.get("decision_v2_json")
     if not isinstance(value, Mapping):
         return None
     return {str(key): item_value for key, item_value in value.items() if isinstance(key, str)}

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -15,6 +15,7 @@ import sys
 import urllib.error
 import urllib.parse
 import webbrowser
+from collections.abc import Mapping
 from contextlib import suppress
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
@@ -3130,6 +3131,9 @@ def _native_prompt_context(artifact: GuardArtifact) -> str:
 
 
 def _runtime_artifact_native_reason(artifact: GuardArtifact, response_payload: dict[str, object]) -> str:
+    decision_message = _decision_v2_harness_message(response_payload)
+    if decision_message is not None:
+        return decision_message
     if artifact.artifact_type == "prompt_request":
         harness = response_payload.get("harness")
         prompt_classes = _prompt_request_classes(artifact)
@@ -3171,6 +3175,16 @@ def _runtime_artifact_native_reason(artifact: GuardArtifact, response_payload: d
             trimmed_summary = f"{trimmed_summary[:177].rstrip()}..."
         return f"HOL Guard flagged this request: {trimmed_summary}"
     return "HOL Guard flagged this request for review."
+
+
+def _decision_v2_harness_message(response_payload: dict[str, object]) -> str | None:
+    decision_v2 = response_payload.get("decision_v2_json")
+    if not isinstance(decision_v2, Mapping):
+        return None
+    message = decision_v2.get("harness_message")
+    if isinstance(message, str) and message.strip():
+        return message.strip()
+    return None
 
 
 def _claude_prompt_additional_context(

--- a/src/codex_plugin_scanner/guard/consumer/service.py
+++ b/src/codex_plugin_scanner/guard/consumer/service.py
@@ -15,9 +15,10 @@ from ..capabilities import compute_capability_delta, normalize_artifact_capabili
 from ..config import GuardConfig
 from ..incident import build_incident_context
 from ..models import GuardArtifact, HarnessDetection, PolicyDecision
-from ..policy import decide_action
+from ..policy import build_decision_v2, decide_action
 from ..receipts import build_receipt
 from ..risk import artifact_risk_signals_typed, artifact_risk_summary, summarize_signals
+from ..runtime.signals import RiskSignalV2
 from ..schemas import build_consumer_mode_contract
 from ..store import GuardStore
 from ..types import (
@@ -384,6 +385,7 @@ def evaluate_detection(
         current_capabilities = normalize_artifact_capabilities(artifact)
         capability_delta = compute_capability_delta(previous_capabilities, current_capabilities)
         structured_signals = artifact_risk_signals_typed(artifact)
+        risk_signals_v2 = tuple(RiskSignalV2.from_guard_signal(signal) for signal in structured_signals)
         history_context = build_history_context(store, detection.harness, artifact.artifact_id, artifact.publisher)
         provenance_bundle = build_provenance_bundle(store, artifact.publisher)
         verdict = score_verdict(structured_signals, capability_delta, provenance_bundle, history_context)
@@ -405,6 +407,7 @@ def evaluate_detection(
             )
         if _is_blocking_action(policy_action):
             blocked = True
+        decision_v2 = build_decision_v2(policy_action, reason=policy_action, signals=risk_signals_v2)
         risk_signals = tuple(signal.explanation for signal in structured_signals)
         risk_summary = artifact_risk_summary(artifact) if structured_signals else summarize_signals(())
         changed_capabilities = [delta.delta_type for delta in capability_delta] or list(diff["changed_fields"])
@@ -495,6 +498,7 @@ def evaluate_detection(
                 "changed": diff["changed"],
                 "changed_fields": diff["changed_fields"],
                 "policy_action": policy_action,
+                "decision_v2_json": decision_v2.to_dict(),
                 "artifact_hash": diff["current_hash"],
                 "risk_signals": list(risk_signals),
                 "risk_summary": risk_summary,
@@ -536,6 +540,7 @@ def evaluate_detection(
         )
         if _is_blocking_action(policy_action):
             blocked = True
+        decision_v2 = build_decision_v2(policy_action, reason=policy_action)
         artifact_name = previous.get("name")
         source_scope = previous.get("source_scope")
         config_path = previous.get("config_path")
@@ -605,6 +610,7 @@ def evaluate_detection(
                 "changed": True,
                 "changed_fields": ["removed"],
                 "policy_action": policy_action,
+                "decision_v2_json": decision_v2.to_dict(),
                 "artifact_hash": previous_hash,
                 "removed": True,
                 "risk_signals": ["artifact removed from local harness configuration"],

--- a/src/codex_plugin_scanner/guard/models.py
+++ b/src/codex_plugin_scanner/guard/models.py
@@ -179,6 +179,7 @@ class GuardApprovalRequest:
     launch_summary: str | None = None
     risk_headline: str | None = None
     action_envelope_json: dict[str, object] | None = None
+    decision_v2_json: dict[str, object] | None = None
 
     def to_dict(self) -> dict[str, object]:
         payload = asdict(self)

--- a/src/codex_plugin_scanner/guard/policy/__init__.py
+++ b/src/codex_plugin_scanner/guard/policy/__init__.py
@@ -1,5 +1,5 @@
 """Guard policy helpers."""
 
-from .engine import decide_action
+from .engine import build_decision_v2, decide_action, decide_action_with_v2
 
-__all__ = ["decide_action"]
+__all__ = ["build_decision_v2", "decide_action", "decide_action_with_v2"]

--- a/src/codex_plugin_scanner/guard/policy/engine.py
+++ b/src/codex_plugin_scanner/guard/policy/engine.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from ..config import GuardConfig
 from ..models import GuardAction
+from ..runtime.decisions import GuardDecisionV2, decision_from_legacy_policy_action
+from ..runtime.signals import RiskSignalV2
 
 VALID_GUARD_ACTIONS = {"allow", "warn", "review", "block", "sandbox-required", "require-reapproval"}
 SAFE_CHANGED_HASH_ACTION: GuardAction = "require-reapproval"
@@ -29,3 +33,30 @@ def decide_action(
     if config.default_action in VALID_GUARD_ACTIONS:
         return config.default_action
     return SAFE_DEFAULT_ACTION
+
+
+def build_decision_v2(
+    policy_action: GuardAction,
+    *,
+    reason: str,
+    signals: Sequence[RiskSignalV2] = (),
+) -> GuardDecisionV2:
+    return decision_from_legacy_policy_action(policy_action, reason=reason, signals=signals)
+
+
+def decide_action_with_v2(
+    configured_action: str | None,
+    default_action: str | None,
+    config: GuardConfig,
+    changed: bool,
+    *,
+    reason: str,
+    signals: Sequence[RiskSignalV2] = (),
+) -> tuple[GuardAction, GuardDecisionV2]:
+    action = decide_action(
+        configured_action=configured_action,
+        default_action=default_action,
+        config=config,
+        changed=changed,
+    )
+    return action, build_decision_v2(action, reason=reason, signals=signals)

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -667,6 +667,7 @@ class GuardStore:
             self._ensure_approval_column(connection, "launch_summary", "text")
             self._ensure_approval_column(connection, "risk_headline", "text")
             self._ensure_approval_column(connection, "action_envelope_json", "text")
+            self._ensure_approval_column(connection, "decision_v2_json", "text")
             self._ensure_approval_column(connection, "workspace", "text")
             self._ensure_attachment_column(connection, "lease_id", "text not null default ''")
             self._ensure_attachment_column(connection, "lease_expires_at", "text")

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -34,8 +34,9 @@ def approval_schema_statement() -> str:
            why_now text,
            launch_summary text,
            risk_headline text,
-           action_envelope_json text,
-           review_command text not null,
+            action_envelope_json text,
+            decision_v2_json text,
+            review_command text not null,
            approval_url text not null,
           status text not null,
           resolution_action text,
@@ -69,7 +70,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
                 recommended_scope = ?, changed_fields_json = ?, source_scope = ?, config_path = ?, workspace = ?,
                 launch_target = ?, transport = ?, risk_summary = ?, risk_signals_json = ?,
                 artifact_label = ?, source_label = ?, trigger_summary = ?, why_now = ?, launch_summary = ?,
-                risk_headline = ?, action_envelope_json = ?,
+                risk_headline = ?, action_envelope_json = ?, decision_v2_json = ?,
                 review_command = ?, approval_url = ?, created_at = ?
             where request_id = ?
             """,
@@ -95,6 +96,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
                 request.launch_summary,
                 request.risk_headline,
                 json.dumps(request.action_envelope_json) if request.action_envelope_json is not None else None,
+                json.dumps(request.decision_v2_json) if request.decision_v2_json is not None else None,
                 review_command,
                 approval_url,
                 now,
@@ -109,10 +111,10 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
           recommended_scope, changed_fields_json, source_scope, config_path, workspace,
            launch_target, transport, risk_summary,
            risk_signals_json, artifact_label, source_label, trigger_summary, why_now, launch_summary, risk_headline,
-           action_envelope_json, review_command,
-           approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
-         )
-         values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            action_envelope_json, decision_v2_json, review_command,
+            approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
+          )
+          values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             request.request_id,
@@ -139,6 +141,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
             request.launch_summary,
             request.risk_headline,
             json.dumps(request.action_envelope_json) if request.action_envelope_json is not None else None,
+            json.dumps(request.decision_v2_json) if request.decision_v2_json is not None else None,
             request.review_command,
             request.approval_url,
             "pending",
@@ -186,7 +189,7 @@ def list_approval_requests(
         select request_id, harness, artifact_id, artifact_name, artifact_type, artifact_hash, publisher, policy_action,
                recommended_scope, changed_fields_json, source_scope, config_path, workspace, launch_target, transport,
                 risk_summary, risk_signals_json, artifact_label, source_label, trigger_summary, why_now,
-                launch_summary, risk_headline, action_envelope_json, review_command,
+                launch_summary, risk_headline, action_envelope_json, decision_v2_json, review_command,
                 approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
         from approval_requests
         {where_clause}
@@ -205,7 +208,7 @@ def get_approval_request(connection: sqlite3.Connection, request_id: str) -> dic
         select request_id, harness, artifact_id, artifact_name, artifact_type, artifact_hash, publisher, policy_action,
                recommended_scope, changed_fields_json, source_scope, config_path, workspace, launch_target, transport,
                 risk_summary, risk_signals_json, artifact_label, source_label, trigger_summary, why_now,
-                launch_summary, risk_headline, action_envelope_json, review_command,
+                launch_summary, risk_headline, action_envelope_json, decision_v2_json, review_command,
                 approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
         from approval_requests
         where request_id = ?
@@ -277,6 +280,7 @@ def _row_to_payload(row: sqlite3.Row) -> dict[str, object]:
         "launch_summary": row["launch_summary"],
         "risk_headline": row["risk_headline"],
         "action_envelope_json": _optional_json_object(row["action_envelope_json"]),
+        "decision_v2_json": _optional_json_object(row["decision_v2_json"]),
         "review_command": str(row["review_command"]),
         "approval_url": str(row["approval_url"]),
         "status": str(row["status"]),

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -90,6 +90,18 @@ class TestGuardApprovals:
             "script_name": None,
             "raw_payload_redacted": {"tool_name": "Bash"},
         }
+        decision_v2_json = {
+            "action": "ask",
+            "reason": "require-reapproval",
+            "user_title": "Review workspace_skill",
+            "user_body": "HOL Guard needs approval before this action continues.",
+            "harness_message": "HOL Guard paused this action for approval.",
+            "dashboard_primary_detail": "Shell command can read a local secret file.",
+            "approval_scopes": ["artifact", "workspace"],
+            "retry_instruction": "Approve it in HOL Guard, then retry.",
+            "signals": [],
+            "confidence": "likely",
+        }
         request = GuardApprovalRequest(
             request_id="req-123",
             harness="codex",
@@ -105,6 +117,7 @@ class TestGuardApprovals:
             review_command="hol-guard approvals approve req-123",
             approval_url="http://127.0.0.1:4455/approvals/req-123",
             action_envelope_json=action_envelope_json,
+            decision_v2_json=decision_v2_json,
         )
 
         store.add_approval_request(request, "2026-04-11T00:00:00+00:00")
@@ -122,11 +135,13 @@ class TestGuardApprovals:
         assert pending[0]["approval_url"] == "http://127.0.0.1:4455/approvals/req-123"
         assert pending[0]["workspace"] == str(workspace_dir)
         assert pending[0]["action_envelope_json"] == action_envelope_json
+        assert pending[0]["decision_v2_json"] == decision_v2_json
         assert resolved is not None
         assert resolved["status"] == "resolved"
         assert resolved["resolution_action"] == "allow"
         assert resolved["resolution_scope"] == "artifact"
         assert resolved["action_envelope_json"] == action_envelope_json
+        assert resolved["decision_v2_json"] == decision_v2_json
 
     def test_guard_store_loads_old_approval_rows_without_action_envelope(self, tmp_path):
         guard_home = tmp_path / "guard-home"
@@ -225,8 +240,9 @@ class TestGuardApprovals:
         assert request is not None
         assert request["request_id"] == "req-old"
         assert request["action_envelope_json"] is None
+        assert request["decision_v2_json"] is None
 
-    def test_guard_store_ignores_malformed_action_envelope_json(self, tmp_path):
+    def test_guard_store_ignores_malformed_action_and_decision_json(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
         connection = sqlite3.connect(store.path)
         try:
@@ -236,10 +252,13 @@ class TestGuardApprovals:
                   request_id, harness, artifact_id, artifact_name, artifact_type, artifact_hash, publisher,
                   policy_action, recommended_scope, changed_fields_json, source_scope, config_path, workspace,
                   launch_target, transport, risk_summary, risk_signals_json, artifact_label, source_label,
-                  trigger_summary, why_now, launch_summary, risk_headline, action_envelope_json, review_command,
+                  trigger_summary, why_now, launch_summary, risk_headline, action_envelope_json, decision_v2_json,
+                  review_command,
                   approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
                 )
-                values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                values (
+                  ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+                )
                 """,
                 (
                     "req-bad-envelope",
@@ -266,6 +285,7 @@ class TestGuardApprovals:
                     None,
                     None,
                     "{not-json",
+                    "{also-not-json",
                     "hol-guard approvals approve req-bad-envelope",
                     "http://127.0.0.1/pending",
                     "pending",
@@ -284,6 +304,7 @@ class TestGuardApprovals:
 
         assert request is not None
         assert request["action_envelope_json"] is None
+        assert request["decision_v2_json"] is None
 
     def test_guard_surface_daemon_client_recovers_missing_auth_token(self, tmp_path, monkeypatch):
         guard_home = tmp_path / "guard-home"
@@ -1960,6 +1981,11 @@ class TestGuardApprovals:
         assert output["approval_center_url"].startswith("http://127.0.0.1:")
         assert approvals[0]["harness"] == "codex"
         assert approvals[0]["status"] == "pending"
+        assert approvals[0]["decision_v2_json"]["action"] == "ask"
+        assert (
+            approvals[0]["decision_v2_json"]["harness_message"]
+            == "HOL Guard needs a fresh approval because this action changed."
+        )
 
     def test_guard_approvals_cli_lists_and_resolves_requests(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -28,7 +28,7 @@ from codex_plugin_scanner.guard.config import GuardConfig, load_guard_config
 from codex_plugin_scanner.guard.consumer import artifact_hash, evaluate_detection
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.models import GuardApprovalRequest, GuardArtifact, HarnessDetection, PolicyDecision
-from codex_plugin_scanner.guard.policy import decide_action
+from codex_plugin_scanner.guard.policy import decide_action, decide_action_with_v2
 from codex_plugin_scanner.guard.proxy import RemoteGuardProxy, StdioGuardProxy
 from codex_plugin_scanner.guard.receipts import build_receipt
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
@@ -2023,6 +2023,8 @@ clearer UX and an implementation plan with technical references.
 
         assert evaluation["blocked"] is True
         assert evaluation["artifacts"][0]["policy_action"] == "block"
+        assert evaluation["artifacts"][0]["decision_v2_json"]["action"] == "block"
+        assert evaluation["artifacts"][0]["decision_v2_json"]["harness_message"] == "HOL Guard blocked this action."
         assert receipts[0]["capabilities_summary"] == "mcp server • stdio • node"
 
     def test_guard_evaluate_detection_blocks_for_sandbox_required_override(self, tmp_path):
@@ -7132,6 +7134,30 @@ def test_runtime_artifact_native_reason_truncates_long_risk_summaries() -> None:
     assert reason.endswith("...")
 
 
+def test_runtime_artifact_native_reason_prefers_decision_v2_harness_message() -> None:
+    artifact = GuardArtifact(
+        artifact_id="claude-code:project:tool-action:test",
+        name="destructive shell command",
+        harness="claude-code",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path="/tmp/settings.local.json",
+        metadata={},
+    )
+
+    reason = guard_commands_module._runtime_artifact_native_reason(
+        artifact,
+        {
+            "decision_v2_json": {
+                "harness_message": "HOL Guard stopped this exact shell command before it touched secrets.",
+            },
+            "risk_summary": "Generic fallback summary.",
+        },
+    )
+
+    assert reason == "HOL Guard stopped this exact shell command before it touched secrets."
+
+
 def test_native_approval_center_context_uses_harness_specific_retry_copy() -> None:
     payload = {
         "approval_center_url": "http://127.0.0.1:4455",
@@ -9489,6 +9515,27 @@ def test_guard_invalid_default_action_falls_back_to_reapproval(tmp_path):
     action = decide_action(configured_action=None, default_action=None, config=config, changed=False)
 
     assert action == "require-reapproval"
+
+
+def test_decide_action_with_v2_preserves_legacy_action_and_adds_decision(tmp_path):
+    config = GuardConfig(
+        guard_home=tmp_path / "guard-home",
+        workspace=None,
+        default_action="block",
+    )
+
+    action, decision = decide_action_with_v2(
+        configured_action=None,
+        default_action=None,
+        config=config,
+        changed=False,
+        reason="invalid-default-fallback",
+    )
+
+    assert action == "block"
+    assert decision.action == "block"
+    assert decision.reason == "invalid-default-fallback"
+    assert decision.harness_message == "HOL Guard blocked this action."
 
 
 def test_guard_hook_invalid_policy_action_falls_back_to_reapproval(tmp_path, capsys, monkeypatch):


### PR DESCRIPTION
## Summary
- add a non-breaking policy helper that pairs legacy Guard actions with typed decision payloads
- carry decision payloads into evaluation artifacts and queued approval records
- persist nullable decision payload JSON on approval requests and prefer harness copy when present

## Verification
- pytest tests/test_guard_approvals.py tests/test_guard_runtime.py tests/test_guard_runtime_decisions.py -q
- ruff check src/codex_plugin_scanner/guard/models.py src/codex_plugin_scanner/guard/store.py src/codex_plugin_scanner/guard/store_approvals.py src/codex_plugin_scanner/guard/approvals.py src/codex_plugin_scanner/guard/policy/engine.py src/codex_plugin_scanner/guard/policy/__init__.py src/codex_plugin_scanner/guard/consumer/service.py src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_approvals.py tests/test_guard_runtime.py