### PR TITLE
feat(guard): add agent identity hints

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/cloud_identity.py
+++ b/src/codex_plugin_scanner/guard/adapters/cloud_identity.py
@@ -1,0 +1,88 @@
+"""Guard Cloud agent identity hints for local harness adapters."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from .base import HarnessContext
+
+_SERVICE_RUNTIME_PROFILE_STATE_KEY = "service_runtime_profile"
+_PROFILE_FIELDS = (
+    "runtime",
+    "label",
+    "workspace",
+    "surface",
+    "client_name",
+    "client_title",
+    "client_version",
+    "agent_id",
+    "principal_id",
+)
+_ENV_FIELDS = {
+    "runtime": "RUNTIME",
+    "label": "LABEL",
+    "workspace": "WORKSPACE",
+    "agent_id": "AGENT_ID",
+    "principal_id": "PRINCIPAL_ID",
+}
+
+
+def cloud_agent_identity_hints(
+    context: HarnessContext,
+    *,
+    runtime: str,
+) -> dict[str, str] | None:
+    payload = _read_service_runtime_profile(context.guard_home / "guard.db")
+    if payload is None or _string_field(payload, "runtime") != runtime:
+        return None
+    hints = {
+        field: value
+        for field in _PROFILE_FIELDS
+        if (value := _string_field(payload, field)) is not None
+    }
+    return hints if hints else None
+
+
+def cloud_agent_identity_environment(
+    identity: object,
+    *,
+    prefix: str,
+) -> dict[str, str]:
+    if not isinstance(identity, dict):
+        return {}
+    env: dict[str, str] = {}
+    for field, suffix in _ENV_FIELDS.items():
+        value = identity.get(field)
+        if isinstance(value, str) and value:
+            env[f"{prefix}_GUARD_CLOUD_{suffix}"] = value
+    return env
+
+
+def _read_service_runtime_profile(db_path: Path) -> dict[str, object] | None:
+    if not db_path.exists():
+        return None
+    try:
+        with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as connection:
+            row = connection.execute(
+                "select payload_json from sync_state where state_key = ?",
+                (_SERVICE_RUNTIME_PROFILE_STATE_KEY,),
+            ).fetchone()
+    except (OSError, sqlite3.Error):
+        return None
+    if row is None:
+        return None
+    try:
+        payload = json.loads(str(row[0]))
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _string_field(payload: dict[str, object], field: str) -> str | None:
+    value = payload.get(field)
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None

--- a/src/codex_plugin_scanner/guard/adapters/cloud_identity.py
+++ b/src/codex_plugin_scanner/guard/adapters/cloud_identity.py
@@ -64,11 +64,15 @@ def _read_service_runtime_profile(db_path: Path) -> dict[str, object] | None:
     if not db_path.exists():
         return None
     try:
-        with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as connection:
+        db_uri = f"{db_path.resolve().as_uri()}?mode=ro"
+        connection = sqlite3.connect(db_uri, uri=True)
+        try:
             row = connection.execute(
                 "select payload_json from sync_state where state_key = ?",
                 (_SERVICE_RUNTIME_PROFILE_STATE_KEY,),
             ).fetchone()
+        finally:
+            connection.close()
     except (OSError, sqlite3.Error):
         return None
     if row is None:

--- a/src/codex_plugin_scanner/guard/adapters/cloud_identity.py
+++ b/src/codex_plugin_scanner/guard/adapters/cloud_identity.py
@@ -37,11 +37,7 @@ def cloud_agent_identity_hints(
     payload = _read_service_runtime_profile(context.guard_home / "guard.db")
     if payload is None or _string_field(payload, "runtime") != runtime:
         return None
-    hints = {
-        field: value
-        for field in _PROFILE_FIELDS
-        if (value := _string_field(payload, field)) is not None
-    }
+    hints = {field: value for field in _PROFILE_FIELDS if (value := _string_field(payload, field)) is not None}
     return hints if hints else None
 
 

--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
 from .base import HarnessAdapter, HarnessContext, _command_available, _json_payload, _run_command_probe
+from .cloud_identity import cloud_agent_identity_environment, cloud_agent_identity_hints
 
 # Optional: PyYAML is preferred when available for robust YAML parsing.
 # The adapter works without it via a line-based fallback parser.
@@ -83,6 +84,7 @@ class HermesHarnessAdapter(HarnessAdapter):
         )
         source_configs = _load_mcp_server_sources(context.home_dir / ".hermes")
         overlay_servers = _overlay_servers(context=context, source_configs=source_configs)
+        cloud_identity = cloud_agent_identity_hints(context, runtime=self.harness)
         overlay_path.write_text(json.dumps(overlay_servers, indent=2) + "\n", encoding="utf-8")
         pretool_path.write_text(
             json.dumps(_pretool_payload(context=context), indent=2) + "\n",
@@ -109,6 +111,8 @@ class HermesHarnessAdapter(HarnessAdapter):
                 *[str(note) for note in shim_manifest.get("notes", [])],
             ],
         }
+        if cloud_identity is not None:
+            manifest["cloud_agent_identity"] = cloud_identity
         manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
         return manifest
 
@@ -147,10 +151,12 @@ class HermesHarnessAdapter(HarnessAdapter):
         pretool_path = manifest.get("pretool_hook_path")
         if not isinstance(overlay_path, str) or not isinstance(pretool_path, str):
             return {}
-        return {
+        environment = {
             "HERMES_GUARD_MCP_OVERLAY_PATH": overlay_path,
             "HERMES_GUARD_PRETOOL_PATH": pretool_path,
         }
+        environment.update(cloud_agent_identity_environment(manifest.get("cloud_agent_identity"), prefix="HERMES"))
+        return environment
 
     def runtime_probe(self, context: HarnessContext) -> dict[str, object] | None:
         manifest = _json_payload(_managed_root(context) / "manifest.json")
@@ -165,6 +171,7 @@ class HermesHarnessAdapter(HarnessAdapter):
                 and isinstance(pretool_path, str)
                 and Path(pretool_path).exists()
             ),
+            "cloud_agent_identity_configured": bool(manifest.get("cloud_agent_identity")),
         }
 
     def approval_flow(self, *, managed_install: dict[str, object] | None = None) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -155,7 +155,12 @@ class HermesHarnessAdapter(HarnessAdapter):
             "HERMES_GUARD_MCP_OVERLAY_PATH": overlay_path,
             "HERMES_GUARD_PRETOOL_PATH": pretool_path,
         }
-        environment.update(cloud_agent_identity_environment(manifest.get("cloud_agent_identity"), prefix="HERMES"))
+        environment.update(
+            cloud_agent_identity_environment(
+                cloud_agent_identity_hints(context, runtime=self.harness),
+                prefix="HERMES",
+            )
+        )
         return environment
 
     def runtime_probe(self, context: HarnessContext) -> dict[str, object] | None:
@@ -171,7 +176,9 @@ class HermesHarnessAdapter(HarnessAdapter):
                 and isinstance(pretool_path, str)
                 and Path(pretool_path).exists()
             ),
-            "cloud_agent_identity_configured": bool(manifest.get("cloud_agent_identity")),
+            "cloud_agent_identity_configured": bool(
+                cloud_agent_identity_hints(context, runtime=self.harness)
+            ),
         }
 
     def approval_flow(self, *, managed_install: dict[str, object] | None = None) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -176,9 +176,7 @@ class HermesHarnessAdapter(HarnessAdapter):
                 and isinstance(pretool_path, str)
                 and Path(pretool_path).exists()
             ),
-            "cloud_agent_identity_configured": bool(
-                cloud_agent_identity_hints(context, runtime=self.harness)
-            ),
+            "cloud_agent_identity_configured": bool(cloud_agent_identity_hints(context, runtime=self.harness)),
         }
 
     def approval_flow(self, *, managed_install: dict[str, object] | None = None) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/adapters/openclaw.py
+++ b/src/codex_plugin_scanner/guard/adapters/openclaw.py
@@ -15,6 +15,7 @@ from .base import (
     _json_payload,
     _run_command_probe,
 )
+from .cloud_identity import cloud_agent_identity_environment, cloud_agent_identity_hints
 from .openclaw_config import load_config
 from .openclaw_support import (
     config_artifacts,
@@ -77,6 +78,7 @@ class OpenClawHarnessAdapter(HarnessAdapter):
             pretool_path=pretool_path,
         )
         detection = self.detect(context)
+        cloud_identity = cloud_agent_identity_hints(context, runtime=self.harness)
         overlay_path.write_text(json.dumps(overlay_payload(detection), indent=2) + "\n", encoding="utf-8")
         pretool_path.write_text(json.dumps(pretool_payload(context=context), indent=2) + "\n", encoding="utf-8")
         manifest = {
@@ -102,6 +104,8 @@ class OpenClawHarnessAdapter(HarnessAdapter):
                 *[str(note) for note in shim_manifest.get("notes", [])],
             ],
         }
+        if cloud_identity is not None:
+            manifest["cloud_agent_identity"] = cloud_identity
         manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
         return manifest
 
@@ -137,11 +141,13 @@ class OpenClawHarnessAdapter(HarnessAdapter):
         pretool_path = manifest.get("pretool_hook_path")
         if not isinstance(overlay_path, str) or not isinstance(pretool_path, str):
             return {}
-        return {
+        environment = {
             "OPENCLAW_GUARD_OVERLAY_PATH": overlay_path,
             "OPENCLAW_GUARD_PRETOOL_PATH": pretool_path,
             "OPENCLAW_GUARD_CHANNEL_POSTURE": "enabled",
         }
+        environment.update(cloud_agent_identity_environment(manifest.get("cloud_agent_identity"), prefix="OPENCLAW"))
+        return environment
 
     def runtime_probe(self, context: HarnessContext) -> dict[str, object] | None:
         manifest = _json_payload(managed_root(context) / "manifest.json")
@@ -156,6 +162,7 @@ class OpenClawHarnessAdapter(HarnessAdapter):
                 and isinstance(pretool_path, str)
                 and Path(pretool_path).exists()
             ),
+            "cloud_agent_identity_configured": bool(manifest.get("cloud_agent_identity")),
         }
 
     def approval_flow(self, *, managed_install: dict[str, object] | None = None) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/adapters/openclaw.py
+++ b/src/codex_plugin_scanner/guard/adapters/openclaw.py
@@ -146,7 +146,12 @@ class OpenClawHarnessAdapter(HarnessAdapter):
             "OPENCLAW_GUARD_PRETOOL_PATH": pretool_path,
             "OPENCLAW_GUARD_CHANNEL_POSTURE": "enabled",
         }
-        environment.update(cloud_agent_identity_environment(manifest.get("cloud_agent_identity"), prefix="OPENCLAW"))
+        environment.update(
+            cloud_agent_identity_environment(
+                cloud_agent_identity_hints(context, runtime=self.harness),
+                prefix="OPENCLAW",
+            )
+        )
         return environment
 
     def runtime_probe(self, context: HarnessContext) -> dict[str, object] | None:
@@ -162,7 +167,9 @@ class OpenClawHarnessAdapter(HarnessAdapter):
                 and isinstance(pretool_path, str)
                 and Path(pretool_path).exists()
             ),
-            "cloud_agent_identity_configured": bool(manifest.get("cloud_agent_identity")),
+            "cloud_agent_identity_configured": bool(
+                cloud_agent_identity_hints(context, runtime=self.harness)
+            ),
         }
 
     def approval_flow(self, *, managed_install: dict[str, object] | None = None) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/adapters/openclaw.py
+++ b/src/codex_plugin_scanner/guard/adapters/openclaw.py
@@ -167,9 +167,7 @@ class OpenClawHarnessAdapter(HarnessAdapter):
                 and isinstance(pretool_path, str)
                 and Path(pretool_path).exists()
             ),
-            "cloud_agent_identity_configured": bool(
-                cloud_agent_identity_hints(context, runtime=self.harness)
-            ),
+            "cloud_agent_identity_configured": bool(cloud_agent_identity_hints(context, runtime=self.harness)),
         }
 
     def approval_flow(self, *, managed_install: dict[str, object] | None = None) -> dict[str, object]:

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -13,6 +13,7 @@ from codex_plugin_scanner.guard.adapters.hermes import (
     _looks_like_secret,
 )
 from codex_plugin_scanner.guard.risk import artifact_risk_signals
+from codex_plugin_scanner.guard.store import GuardStore
 
 FIXTURES = Path(__file__).parent / "fixtures" / "hermes-plugin-evil"
 
@@ -28,6 +29,26 @@ def _ctx(tmp_path: Path) -> HarnessContext:
 def _write(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
+
+
+def _seed_cloud_profile(context: HarnessContext, runtime: str = "hermes") -> None:
+    GuardStore(context.guard_home).set_sync_payload(
+        "service_runtime_profile",
+        {
+            "runtime": runtime,
+            "label": "Hermes Telegram agent",
+            "workspace": "workspace_ops",
+            "surface": "agent-sdk",
+            "client_name": "hol-guard",
+            "client_title": "Hermes Telegram agent",
+            "client_version": "2.0.95",
+            "agent_id": "agent_123",
+            "principal_id": "principal_123",
+            "sync_url": "https://hol.org/api/guard/receipts/sync",
+            "token": "guard_live_secret",
+        },
+        "2026-05-05T00:00:00.000Z",
+    )
 
 
 def test_install_generates_guard_managed_overlay_and_pretool_files(tmp_path: Path):
@@ -63,6 +84,42 @@ def test_install_generates_guard_managed_overlay_and_pretool_files(tmp_path: Pat
     assert overlay_payload["remote-docs"]["args"][-3:] == ["--server", "yaml:remote-docs", "--stdio"]
     assert manifest["servers"]["yaml:remote-docs"]["env"] == {"GITHUB_TOKEN": "ghp_test_token"}
     assert manifest["servers"]["yaml:remote-docs"]["headers"] == {"Authorization": "Bearer test-token"}
+
+
+def test_install_includes_non_secret_cloud_identity_hints_when_configured(tmp_path: Path):
+    context = _ctx(tmp_path)
+    _seed_cloud_profile(context)
+
+    manifest = HermesHarnessAdapter().install(context)
+    identity = manifest["cloud_agent_identity"]
+    env = HermesHarnessAdapter().launch_environment(context)
+
+    assert identity == {
+        "runtime": "hermes",
+        "label": "Hermes Telegram agent",
+        "workspace": "workspace_ops",
+        "surface": "agent-sdk",
+        "client_name": "hol-guard",
+        "client_title": "Hermes Telegram agent",
+        "client_version": "2.0.95",
+        "agent_id": "agent_123",
+        "principal_id": "principal_123",
+    }
+    assert "token" not in identity
+    assert "sync_url" not in identity
+    assert env["HERMES_GUARD_CLOUD_WORKSPACE"] == "workspace_ops"
+    assert env["HERMES_GUARD_CLOUD_AGENT_ID"] == "agent_123"
+
+
+def test_install_omits_cloud_identity_hints_for_other_runtimes(tmp_path: Path):
+    context = _ctx(tmp_path)
+    _seed_cloud_profile(context, runtime="openclaw")
+
+    manifest = HermesHarnessAdapter().install(context)
+    env = HermesHarnessAdapter().launch_environment(context)
+
+    assert "cloud_agent_identity" not in manifest
+    assert "HERMES_GUARD_CLOUD_WORKSPACE" not in env
 
 
 def test_install_stringifies_typed_env_values_in_managed_manifest(tmp_path: Path):

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -122,6 +122,17 @@ def test_install_omits_cloud_identity_hints_for_other_runtimes(tmp_path: Path):
     assert "HERMES_GUARD_CLOUD_WORKSPACE" not in env
 
 
+def test_launch_environment_recomputes_cloud_identity_hints(tmp_path: Path):
+    context = _ctx(tmp_path)
+    _seed_cloud_profile(context)
+
+    HermesHarnessAdapter().install(context)
+    _seed_cloud_profile(context, runtime="openclaw")
+    env = HermesHarnessAdapter().launch_environment(context)
+
+    assert "HERMES_GUARD_CLOUD_WORKSPACE" not in env
+
+
 def test_install_stringifies_typed_env_values_in_managed_manifest(tmp_path: Path):
     _write(
         tmp_path / ".hermes" / "config.yaml",

--- a/tests/test_openclaw_adapter.py
+++ b/tests/test_openclaw_adapter.py
@@ -11,6 +11,7 @@ from codex_plugin_scanner.guard.adapters import get_adapter, list_adapters
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.openclaw import OpenClawHarnessAdapter
 from codex_plugin_scanner.guard.risk import artifact_risk_signals
+from codex_plugin_scanner.guard.store import GuardStore
 
 
 def _ctx(tmp_path: Path) -> HarnessContext:
@@ -26,6 +27,26 @@ def _ctx(tmp_path: Path) -> HarnessContext:
 def _write(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
+
+
+def _seed_cloud_profile(context: HarnessContext, runtime: str = "openclaw") -> None:
+    GuardStore(context.guard_home).set_sync_payload(
+        "service_runtime_profile",
+        {
+            "runtime": runtime,
+            "label": "OpenClaw runtime",
+            "workspace": "workspace_ops",
+            "surface": "agent-sdk",
+            "client_name": "hol-guard",
+            "client_title": "OpenClaw runtime",
+            "client_version": "2.0.95",
+            "agent_id": "agent_456",
+            "principal_id": "principal_456",
+            "token": "guard_live_secret",
+            "sync_url": "https://hol.org/api/guard/receipts/sync",
+        },
+        "2026-05-05T00:00:00.000Z",
+    )
 
 
 def test_openclaw_adapter_is_registered() -> None:
@@ -323,6 +344,42 @@ def test_install_exports_guard_managed_openclaw_overlay(tmp_path: Path) -> None:
     assert env["OPENCLAW_GUARD_OVERLAY_PATH"] == str(overlay_path)
     assert env["OPENCLAW_GUARD_PRETOOL_PATH"] == str(pretool_path)
     assert env["OPENCLAW_GUARD_CHANNEL_POSTURE"] == "enabled"
+
+
+def test_install_exports_cloud_identity_hints_without_secret_values(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    _seed_cloud_profile(context)
+
+    manifest = OpenClawHarnessAdapter().install(context)
+    identity = manifest["cloud_agent_identity"]
+    env = OpenClawHarnessAdapter().launch_environment(context)
+
+    assert identity == {
+        "runtime": "openclaw",
+        "label": "OpenClaw runtime",
+        "workspace": "workspace_ops",
+        "surface": "agent-sdk",
+        "client_name": "hol-guard",
+        "client_title": "OpenClaw runtime",
+        "client_version": "2.0.95",
+        "agent_id": "agent_456",
+        "principal_id": "principal_456",
+    }
+    assert "token" not in identity
+    assert "sync_url" not in identity
+    assert env["OPENCLAW_GUARD_CLOUD_WORKSPACE"] == "workspace_ops"
+    assert env["OPENCLAW_GUARD_CLOUD_AGENT_ID"] == "agent_456"
+
+
+def test_install_ignores_cloud_identity_hints_for_other_runtimes(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    _seed_cloud_profile(context, runtime="hermes")
+
+    manifest = OpenClawHarnessAdapter().install(context)
+    env = OpenClawHarnessAdapter().launch_environment(context)
+
+    assert "cloud_agent_identity" not in manifest
+    assert "OPENCLAW_GUARD_CLOUD_WORKSPACE" not in env
 
 
 def test_openclaw_skips_symlinked_skill_files(tmp_path: Path) -> None:

--- a/tests/test_openclaw_adapter.py
+++ b/tests/test_openclaw_adapter.py
@@ -382,6 +382,17 @@ def test_install_ignores_cloud_identity_hints_for_other_runtimes(tmp_path: Path)
     assert "OPENCLAW_GUARD_CLOUD_WORKSPACE" not in env
 
 
+def test_launch_environment_recomputes_cloud_identity_hints(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    _seed_cloud_profile(context)
+
+    OpenClawHarnessAdapter().install(context)
+    _seed_cloud_profile(context, runtime="hermes")
+    env = OpenClawHarnessAdapter().launch_environment(context)
+
+    assert "OPENCLAW_GUARD_CLOUD_WORKSPACE" not in env
+
+
 def test_openclaw_skips_symlinked_skill_files(tmp_path: Path) -> None:
     context = _ctx(tmp_path)
     skill_root = context.home_dir / ".openclaw" / "workspace" / "skills" / "linked"


### PR DESCRIPTION
## Summary
- Adds local Guard Cloud identity hint loading for Hermes and OpenClaw managed manifests.
- Emits allowlisted, non-secret runtime identity environment variables when the local service runtime profile matches the adapter.
- Adds regression tests proving secrets and mismatched runtimes are excluded.

## Verification
- pytest tests/test_hermes_adapter.py tests/test_openclaw_adapter.py
- ruff check .
- git --no-pager diff --check

## Security / compatibility
- Reads the local Guard store in SQLite read-only mode.
- Explicit allowlist excludes token, sync URL, and unrecognized profile fields.
- No Cloud connectivity is required for managed runtime launch hints.