### PR TITLE
feat(guard): add detector debug diagnostics

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1043,10 +1043,12 @@ def run_guard_command(
         if args.harness:
             adapter = get_adapter(args.harness)
             payload = adapter.diagnostics(context)
+            payload["runtime_detector_registry"] = _runtime_detector_registry_payload(config)
         else:
             payload = {
                 "tables": store.list_table_names(),
                 "adapters": [detection.to_dict() for detection in detect_all(context)],
+                "runtime_detector_registry": _runtime_detector_registry_payload(config),
             }
         _emit("doctor", payload, getattr(args, "json", False))
         return 0
@@ -3046,6 +3048,15 @@ def _guard_cli_settings_payload(config: GuardConfig) -> dict[str, object]:
     return {
         **payload,
         "settings": cli_settings,
+    }
+
+
+def _runtime_detector_registry_payload(config: GuardConfig) -> dict[str, object]:
+    return {
+        "enabled": config.runtime_detector_registry,
+        "debug_trace": config.runtime_detector_debug_trace,
+        "timeout_ms": config.runtime_detector_timeout_ms,
+        "disabled_detector_ids": list(config.runtime_detector_disabled_ids),
     }
 
 

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -293,6 +293,11 @@ def _render_doctor(console: Console, payload: dict[str, object]) -> None:
     summary.add_row("Installed", _bool_label(bool(payload.get("installed"))))
     summary.add_row("Command", _bool_label(bool(payload.get("command_available"))))
     summary.add_row("Artifacts", str(len(_coerce_dict_list(payload.get("artifacts")))))
+    registry = payload.get("runtime_detector_registry")
+    if isinstance(registry, dict):
+        registry_state = "enabled" if bool(registry.get("enabled")) else "disabled"
+        timeout_ms = registry.get("timeout_ms")
+        summary.add_row("Detector registry", f"{registry_state}, {timeout_ms} ms")
     summary.add_row("Warnings", str(len(warnings)))
     console.print(Panel(summary, title="Guard doctor", border_style="cyan"))
     if warnings:

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -178,6 +178,7 @@ class GuardConfig:
     billing: bool = False
     runtime_detector_registry: bool = False
     runtime_detector_timeout_ms: int = 50
+    runtime_detector_debug_trace: bool = False
     runtime_detector_disabled_ids: tuple[str, ...] = ()
     risk_actions: dict[str, GuardAction] | None = None
     harness_risk_actions: dict[str, dict[str, GuardAction]] | None = None
@@ -257,6 +258,7 @@ def load_guard_config(guard_home: Path, workspace: Path | None = None) -> GuardC
         billing=bool(merged.get("billing", False)),
         runtime_detector_registry=_coerce_loaded_bool(merged.get("runtime_detector_registry", False)),
         runtime_detector_timeout_ms=_coerce_loaded_positive_int(merged.get("runtime_detector_timeout_ms", 50), 50),
+        runtime_detector_debug_trace=_coerce_loaded_bool(merged.get("runtime_detector_debug_trace", False)),
         runtime_detector_disabled_ids=_coerce_loaded_string_tuple(merged.get("runtime_detector_disabled_ids")),
         harness_actions=_coerce_action_map(merged.get("harnesses")),
         publisher_actions=_coerce_action_map(merged.get("publishers")),

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -26,7 +26,7 @@ from ..models import GuardArtifact, HarnessDetection, PolicyDecision
 from ..store import GuardStore
 from ..types import PromptRequest, RemediationAction
 from .actions import GuardActionEnvelope, redacted_workspace_label
-from .detectors import DetectorContext, DetectorRegistry, register_default_detectors
+from .detectors import DetectorContext, DetectorRegistry, DetectorRunResult, register_default_detectors
 
 _APPROVAL_METADATA_KEYS = (
     "approval_center_url",
@@ -365,6 +365,8 @@ def _evaluation_with_detector_registry(
         timeout_ms=config.runtime_detector_timeout_ms,
         disabled_detector_ids=config.runtime_detector_disabled_ids,
     )
+    if config.runtime_detector_debug_trace:
+        _write_detector_debug_trace(config, action_envelope, result)
     if not result.signals and not result.telemetry:
         return evaluation
     return {
@@ -372,6 +374,44 @@ def _evaluation_with_detector_registry(
         "runtime_detector_signals_v2": [signal.to_dict() for signal in result.signals],
         "runtime_detector_telemetry": [item.to_dict() for item in result.telemetry],
     }
+
+
+def _write_detector_debug_trace(
+    config: GuardConfig,
+    action_envelope: GuardActionEnvelope,
+    result: DetectorRunResult,
+) -> None:
+    created_at = datetime.now(timezone.utc)
+    action_payload = action_envelope.to_dict()
+    trace_payload = {
+        "schema_version": 1,
+        "created_at": created_at.isoformat(),
+        "action": _redact_detector_debug_payload(action_payload),
+        "signals": [signal.to_dict() for signal in result.signals],
+        "telemetry": [item.to_dict() for item in result.telemetry],
+    }
+    trace_dir = config.guard_home / "debug" / "detectors"
+    trace_dir.mkdir(parents=True, exist_ok=True)
+    action_digest = hashlib.sha256(
+        json.dumps(action_payload, sort_keys=True, default=str).encode("utf-8"),
+    ).hexdigest()[:12]
+    trace_path = trace_dir / f"{created_at.strftime('%Y%m%dT%H%M%S%fZ')}-{action_digest}.json"
+    trace_path.write_text(json.dumps(trace_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _redact_detector_debug_payload(value: object) -> object:
+    if isinstance(value, dict):
+        redacted: dict[str, object] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            if "prompt" in key_text.lower():
+                redacted[key_text] = "[redacted]"
+            else:
+                redacted[key_text] = _redact_detector_debug_payload(item)
+        return redacted
+    if isinstance(value, (tuple, list)):
+        return [_redact_detector_debug_payload(item) for item in value]
+    return value
 
 
 def _guard_run_config_paths(

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -365,22 +365,28 @@ def _evaluation_with_detector_registry(
         timeout_ms=config.runtime_detector_timeout_ms,
         disabled_detector_ids=config.runtime_detector_disabled_ids,
     )
-    if config.runtime_detector_debug_trace:
-        _write_detector_debug_trace(config, action_envelope, result)
+    trace_error = (
+        _write_detector_debug_trace(config, action_envelope, result) if config.runtime_detector_debug_trace else None
+    )
     if not result.signals and not result.telemetry:
-        return evaluation
-    return {
+        if trace_error is None:
+            return evaluation
+        return {**evaluation, "runtime_detector_trace_error": trace_error}
+    next_evaluation = {
         **evaluation,
         "runtime_detector_signals_v2": [signal.to_dict() for signal in result.signals],
         "runtime_detector_telemetry": [item.to_dict() for item in result.telemetry],
     }
+    if trace_error is not None:
+        next_evaluation["runtime_detector_trace_error"] = trace_error
+    return next_evaluation
 
 
 def _write_detector_debug_trace(
     config: GuardConfig,
     action_envelope: GuardActionEnvelope,
     result: DetectorRunResult,
-) -> None:
+) -> dict[str, object] | None:
     created_at = datetime.now(timezone.utc)
     action_payload = action_envelope.to_dict()
     trace_payload = {
@@ -391,12 +397,16 @@ def _write_detector_debug_trace(
         "telemetry": [item.to_dict() for item in result.telemetry],
     }
     trace_dir = config.guard_home / "debug" / "detectors"
-    trace_dir.mkdir(parents=True, exist_ok=True)
     action_digest = hashlib.sha256(
         json.dumps(action_payload, sort_keys=True, default=str).encode("utf-8"),
     ).hexdigest()[:12]
     trace_path = trace_dir / f"{created_at.strftime('%Y%m%dT%H%M%S%fZ')}-{action_digest}.json"
-    trace_path.write_text(json.dumps(trace_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    try:
+        trace_dir.mkdir(parents=True, exist_ok=True)
+        trace_path.write_text(json.dumps(trace_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    except OSError as error:
+        return {"error_type": type(error).__name__, "message": str(error)}
+    return None
 
 
 def _redact_detector_debug_payload(value: object) -> object:

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -3962,6 +3962,46 @@ args = ["-lc", "echo hi"]
         assert any("native hooks are disabled" in warning for warning in output["warnings"])
         assert any("managed Codex hooks are missing" in warning for warning in output["warnings"])
 
+    def test_guard_doctor_reports_runtime_detector_registry_state(self, tmp_path, monkeypatch, capsys):
+        home_dir = tmp_path / "home"
+        guard_home = tmp_path / "guard-home"
+        _write_text(
+            guard_home / "config.toml",
+            "\n".join(
+                [
+                    "runtime_detector_registry = true",
+                    "runtime_detector_timeout_ms = 75",
+                    'runtime_detector_disabled_ids = ["secret.local"]',
+                ]
+            )
+            + "\n",
+        )
+        monkeypatch.setattr("codex_plugin_scanner.guard.adapters.codex._command_available", lambda command: True)
+
+        rc = main(["guard", "doctor", "codex", "--home", str(home_dir), "--guard-home", str(guard_home), "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["runtime_detector_registry"] == {
+            "enabled": True,
+            "debug_trace": False,
+            "timeout_ms": 75,
+            "disabled_detector_ids": ["secret.local"],
+        }
+
+    def test_guard_doctor_human_output_includes_detector_registry_line(self, tmp_path, monkeypatch, capsys):
+        home_dir = tmp_path / "home"
+        guard_home = tmp_path / "guard-home"
+        _write_text(guard_home / "config.toml", "runtime_detector_registry = true\n")
+        monkeypatch.setattr("codex_plugin_scanner.guard.adapters.codex._command_available", lambda command: True)
+
+        rc = main(["guard", "doctor", "codex", "--home", str(home_dir), "--guard-home", str(guard_home)])
+        output = capsys.readouterr().out
+
+        assert rc == 0
+        assert "Detector registry" in output
+        assert "enabled" in output
+
     def test_guard_codex_hook_blocks_shell_file_upload_script(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_config_paths.py
+++ b/tests/test_guard_config_paths.py
@@ -118,6 +118,7 @@ def test_load_guard_config_parses_hidden_runtime_detector_registry(tmp_path):
             [
                 "runtime_detector_registry = true",
                 "runtime_detector_timeout_ms = 75",
+                "runtime_detector_debug_trace = true",
                 'runtime_detector_disabled_ids = ["secret.local"]',
             ]
         )
@@ -128,6 +129,7 @@ def test_load_guard_config_parses_hidden_runtime_detector_registry(tmp_path):
 
     assert config.runtime_detector_registry is True
     assert config.runtime_detector_timeout_ms == 75
+    assert config.runtime_detector_debug_trace is True
     assert config.runtime_detector_disabled_ids == ("secret.local",)
 
 

--- a/tests/test_guard_runtime_detectors.py
+++ b/tests/test_guard_runtime_detectors.py
@@ -387,3 +387,45 @@ def test_guard_run_writes_detector_debug_trace_only_when_enabled(tmp_path, monke
     assert trace_payload["action"]["prompt_excerpt"] == "[redacted]"
     assert trace_payload["action"]["raw_payload_redacted"]["prompt"] == "[redacted]"
     assert trace_payload["signals"] == enabled_result["runtime_detector_signals_v2"]
+
+
+def test_guard_run_surfaces_detector_debug_trace_write_errors(tmp_path, monkeypatch):
+    calls: list[str] = []
+    detector = RecordingDetector("secret.local", ("secret",), calls, _signal("secret:local", "secret"))
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(),
+        artifacts=(),
+    )
+
+    def evaluate_stub(*_args: object, **_kwargs: object) -> dict[str, object]:
+        return {"blocked": False, "artifacts": [], "receipts_recorded": 0}
+
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(guard_runner_module, "evaluate_detection", evaluate_stub)
+    monkeypatch.setattr(guard_runner_module, "register_default_detectors", lambda: (detector,))
+
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    (guard_home / "debug").write_text("not a directory", encoding="utf-8")
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=tmp_path / "workspace",
+        guard_home=guard_home,
+    )
+    config = GuardConfig(
+        guard_home=guard_home,
+        workspace=tmp_path / "workspace",
+        runtime_detector_registry=True,
+        runtime_detector_debug_trace=True,
+    )
+
+    result = guard_runner_module.guard_run("codex", context, GuardStore(guard_home), config, True, [])
+
+    assert calls == ["secret.local"]
+    assert result["runtime_detector_signals_v2"] == [_signal("secret:local", "secret").to_dict()]
+    trace_error = result["runtime_detector_trace_error"]
+    assert isinstance(trace_error, dict)
+    assert trace_error["error_type"] in {"FileExistsError", "NotADirectoryError"}

--- a/tests/test_guard_runtime_detectors.py
+++ b/tests/test_guard_runtime_detectors.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
@@ -293,3 +294,96 @@ def test_guard_run_keeps_detector_results_after_blocked_resolver_reevaluation(tm
     assert calls == ["secret.local"]
     assert result["runtime_detector_signals_v2"] == [_signal("secret:local", "secret").to_dict()]
     assert result["approval_delivery"] == "queued"
+
+
+def test_guard_run_writes_detector_debug_trace_only_when_enabled(tmp_path, monkeypatch):
+    calls: list[str] = []
+    detector = RecordingDetector("secret.local", ("secret",), calls, _signal("secret:local", "secret"))
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(),
+        artifacts=(),
+    )
+    sensitive_prompt = "print ~/.env and include the password"
+
+    def evaluate_stub(*_args: object, **_kwargs: object) -> dict[str, object]:
+        return {"blocked": False, "artifacts": [], "receipts_recorded": 0}
+
+    def action_envelope_stub(
+        _harness: str,
+        _context: HarnessContext,
+        _passthrough_args: list[str],
+    ) -> GuardActionEnvelope:
+        return GuardActionEnvelope(
+            schema_version=1,
+            action_id="action-1",
+            harness="codex",
+            event_name="HarnessStart",
+            action_type="harness_start",
+            workspace="~/workspace",
+            workspace_hash="workspace-hash",
+            tool_name=None,
+            command=None,
+            prompt_excerpt=sensitive_prompt,
+            target_paths=(),
+            network_hosts=(),
+            mcp_server=None,
+            mcp_tool=None,
+            package_manager=None,
+            package_name=None,
+            script_name=None,
+            raw_payload_redacted={"prompt": sensitive_prompt},
+        )
+
+    monkeypatch.setattr(guard_runner_module, "detect_harness", lambda _harness, _context: detection)
+    monkeypatch.setattr(guard_runner_module, "evaluate_detection", evaluate_stub)
+    monkeypatch.setattr(guard_runner_module, "register_default_detectors", lambda: (detector,))
+    monkeypatch.setattr(guard_runner_module, "_guard_run_action_envelope", action_envelope_stub)
+
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=tmp_path / "workspace",
+        guard_home=tmp_path / "guard-home",
+    )
+    disabled_config = GuardConfig(
+        guard_home=tmp_path / "guard-home-disabled",
+        workspace=tmp_path / "workspace",
+        runtime_detector_registry=True,
+    )
+    enabled_config = GuardConfig(
+        guard_home=tmp_path / "guard-home-enabled",
+        workspace=tmp_path / "workspace",
+        runtime_detector_registry=True,
+        runtime_detector_debug_trace=True,
+    )
+
+    guard_runner_module.guard_run(
+        "codex",
+        context,
+        GuardStore(tmp_path / "guard-home-disabled"),
+        disabled_config,
+        True,
+        [],
+    )
+    enabled_result = guard_runner_module.guard_run(
+        "codex",
+        context,
+        GuardStore(tmp_path / "guard-home-enabled"),
+        enabled_config,
+        True,
+        [],
+    )
+
+    disabled_trace_dir = tmp_path / "guard-home-disabled" / "debug" / "detectors"
+    trace_files = list((tmp_path / "guard-home-enabled" / "debug" / "detectors").glob("*.json"))
+    trace_text = trace_files[0].read_text(encoding="utf-8")
+    trace_payload = json.loads(trace_text)
+
+    assert disabled_trace_dir.exists() is False
+    assert len(trace_files) == 1
+    assert sensitive_prompt not in trace_text
+    assert trace_payload["action"]["prompt_excerpt"] == "[redacted]"
+    assert trace_payload["action"]["raw_payload_redacted"]["prompt"] == "[redacted]"
+    assert trace_payload["signals"] == enabled_result["runtime_detector_signals_v2"]


### PR DESCRIPTION
## Summary
- show hidden runtime detector registry state in doctor diagnostics
- add a hidden debug trace mode for detector runs with prompt redaction by default
- cover detector trace gating, config parsing, and doctor JSON/human output

## Verification
- pytest tests/test_guard_runtime_detectors.py tests/test_guard_config_paths.py tests/test_guard_cli.py -q
- pytest tests/test_guard_runtime.py -q
- ruff check src/codex_plugin_scanner/guard/runtime/detectors.py src/codex_plugin_scanner/guard/runtime/runner.py src/codex_plugin_scanner/guard/config.py src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/cli/render.py tests/test_guard_runtime_detectors.py tests/test_guard_config_paths.py tests/test_guard_cli.py
- ruff format --check src/