### PR TITLE
feat(guard): add secret path detectors

### DIFF
--- a/src/codex_plugin_scanner/guard/risk.py
+++ b/src/codex_plugin_scanner/guard/risk.py
@@ -8,6 +8,7 @@ from pathlib import PurePath
 from urllib.parse import urlsplit
 
 from .models import GuardArtifact
+from .runtime.secret_sensitivity import classify_secret_path_families
 from .runtime.signals import RiskSignalV2
 from .types import GuardSignal
 
@@ -305,12 +306,7 @@ def extract_network_hosts(text: str) -> set[str]:
 def classify_secret_paths(text: str) -> set[str]:
     """Classify secret-bearing file families referenced in text."""
 
-    lowered = text.lower()
-    classes: set[str] = set()
-    for pattern, label in _SECRET_PATH_LABELS:
-        if pattern in lowered:
-            classes.add(label)
-    return classes
+    return classify_secret_path_families(text)
 
 
 def detect_encoded_command(text: str) -> list[GuardSignal]:

--- a/src/codex_plugin_scanner/guard/risk.py
+++ b/src/codex_plugin_scanner/guard/risk.py
@@ -8,7 +8,7 @@ from pathlib import PurePath
 from urllib.parse import urlsplit
 
 from .models import GuardArtifact
-from .runtime.secret_sensitivity import classify_secret_path_families
+from .runtime.secret_sensitivity import classify_legacy_secret_path_families
 from .runtime.signals import RiskSignalV2
 from .types import GuardSignal
 
@@ -306,7 +306,7 @@ def extract_network_hosts(text: str) -> set[str]:
 def classify_secret_paths(text: str) -> set[str]:
     """Classify secret-bearing file families referenced in text."""
 
-    return classify_secret_path_families(text)
+    return classify_legacy_secret_path_families(text)
 
 
 def detect_encoded_command(text: str) -> list[GuardSignal]:

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -43,7 +43,23 @@ _SCHEMA_VERSION = 1
 _SHELL_TOOL_NAMES = frozenset({"bash", "shell", "sh", "zsh", "terminal", "run_command", "run_terminal_command"})
 _FILE_READ_TOOL_NAMES = frozenset({"read", "read_file", "open_file", "view", "view_file", "cat_file"})
 _FILE_WRITE_TOOL_NAMES = frozenset({"write", "edit", "multiedit", "write_file", "edit_file"})
-_PATH_KEYS = ("path", "file_path", "filePath", "filepath", "file", "filename", "target_path", "targetPath")
+_PATH_KEYS = (
+    "path",
+    "paths",
+    "file_path",
+    "file_paths",
+    "filePath",
+    "filePaths",
+    "filepath",
+    "file",
+    "files",
+    "filename",
+    "filenames",
+    "target_path",
+    "target_paths",
+    "targetPath",
+    "targetPaths",
+)
 _COMMAND_KEYS = ("command", "cmd", "shell_command", "shellCommand")
 _SENSITIVE_RAW_KEYS = frozenset(
     {
@@ -652,6 +668,8 @@ def _target_paths(
         value = tool_input.get(key)
         if isinstance(value, str) and value.strip():
             paths.append(value.strip())
+        elif isinstance(value, list):
+            paths.extend(item.strip() for item in value if isinstance(item, str) and item.strip())
     for text in (command, prompt_text):
         if text is not None:
             paths.extend(match.group("path") for match in _PROMPT_PATH_PATTERN.finditer(text))

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -11,6 +11,7 @@ from pathlib import Path, PureWindowsPath
 from typing import Literal
 
 from ..redaction import redact_text
+from .secret_sensitivity import redacted_secret_path_context
 
 GuardActionType = Literal[
     "prompt",
@@ -709,10 +710,18 @@ def _redacted_target_path(path: str, *, home_dir: Path | str | None) -> str | No
         return f".../{target_name}"
     windows_path = PureWindowsPath(stripped)
     if windows_path.is_absolute():
+        secret_context = redacted_secret_path_context(stripped)
+        if secret_context is not None:
+            return secret_context
         target_name = windows_path.name or "path"
         return f".../{target_name}"
     if _is_absolute_target_path(stripped):
-        return redacted_workspace_label(stripped, home_dir=home_dir)
+        redacted_path = redacted_workspace_label(stripped, home_dir=home_dir)
+        if redacted_path.startswith(".../"):
+            secret_context = redacted_secret_path_context(stripped)
+            if secret_context is not None:
+                return secret_context
+        return redacted_path
     return redact_text(stripped).text
 
 

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -706,6 +706,9 @@ def _redacted_target_path(path: str, *, home_dir: Path | str | None) -> str | No
     if stripped == "~" or stripped.startswith("~/"):
         return redact_text(stripped).text
     if stripped.startswith("~"):
+        secret_context = redacted_secret_path_context(stripped)
+        if secret_context is not None:
+            return secret_context
         target_name = Path(stripped).name or "path"
         return f".../{target_name}"
     windows_path = PureWindowsPath(stripped)

--- a/src/codex_plugin_scanner/guard/runtime/detectors.py
+++ b/src/codex_plugin_scanner/guard/runtime/detectors.py
@@ -10,6 +10,7 @@ from typing import Literal, Protocol
 
 from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope
+from codex_plugin_scanner.guard.runtime.secret_sensitivity import SecretPathMatch, classify_secret_path
 from codex_plugin_scanner.guard.runtime.signals import RiskSignalCategory, RiskSignalV2
 
 DETECTOR_CATEGORY_TAGS: tuple[RiskSignalCategory, ...] = (
@@ -124,12 +125,53 @@ class DetectorRegistry:
         return DetectorRunResult(signals=tuple(signals), telemetry=tuple(telemetry))
 
 
+class SecretPathDetector:
+    detector_id = "secret.path"
+    categories: tuple[RiskSignalCategory, ...] = ("secret",)
+
+    def detect(self, action: GuardActionEnvelope, context: DetectorContext) -> tuple[RiskSignalV2, ...]:
+        if action.action_type != "file_read":
+            return ()
+        matches = tuple(_secret_path_matches(action.target_paths, workspace=context.workspace))
+        return tuple(_secret_path_signal(match, index=index) for index, match in enumerate(matches))
+
+
 def register_default_detectors() -> tuple[GuardDetector, ...]:
-    return ()
+    return (SecretPathDetector(),)
+
+
+def _secret_path_signal(match: SecretPathMatch, *, index: int) -> RiskSignalV2:
+    return RiskSignalV2(
+        signal_id=f"secret:path:{_slug(match.family)}:{index}",
+        category="secret",
+        severity="high",
+        confidence="strong",
+        detector="secret.path",
+        title=f"Direct access to {match.family}",
+        plain_reason=f"Requested direct access to {match.family}.",
+        technical_detail=f"matched secret path family: {match.family}",
+        evidence_ref="target_paths",
+        redaction_level="summary",
+        false_positive_hint="Allow only if this tool needs the exact local secret file for the current task.",
+        advisory_id=None,
+    )
+
+
+def _secret_path_matches(paths: Sequence[str], *, workspace: Path | None) -> tuple[SecretPathMatch, ...]:
+    matches: list[SecretPathMatch] = []
+    for path in paths:
+        match = classify_secret_path(path, cwd=workspace)
+        if match is not None:
+            matches.append(match)
+    return tuple(matches)
 
 
 def _elapsed_ms(started_at: float, finished_at: float) -> int:
     return max(0, round((finished_at - started_at) * 1000))
+
+
+def _slug(value: str) -> str:
+    return "-".join(part for part in value.lower().replace(".", " ").replace("/", " ").split() if part)
 
 
 def _telemetry(

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -16,6 +16,8 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from ..models import GuardArtifact
+from .secret_sensitivity import SecretPathMatch as SensitivePathMatch
+from .secret_sensitivity import classify_secret_path
 
 _FILE_READ_TOOL_NAMES = frozenset(
     {
@@ -360,16 +362,6 @@ _SENSITIVE_PATH_REASONS = {
 
 
 @dataclass(frozen=True, slots=True)
-class SensitivePathMatch:
-    """A normalized sensitive path classification."""
-
-    requested_path: str
-    normalized_path: str
-    path_class: str
-    reason: str
-
-
-@dataclass(frozen=True, slots=True)
 class FileReadRequestMatch:
     """A sensitive file-read tool call."""
 
@@ -405,41 +397,7 @@ def classify_sensitive_path(
 ) -> SensitivePathMatch | None:
     """Classify a path if it points at a high-confidence sensitive local file."""
 
-    if not isinstance(path, str):
-        return None
-    requested_path = path.strip().strip("'").strip('"')
-    if not requested_path:
-        return None
-    expanded_home = _expand_home(requested_path, home_dir)
-    normalized_path = _normalize_path(expanded_home, cwd)
-    lowered_segments = tuple(segment for segment in normalized_path.replace("\\", "/").lower().split("/") if segment)
-    if not lowered_segments:
-        return None
-    basename = lowered_segments[-1]
-    if basename == ".env" or basename.startswith(".env."):
-        return SensitivePathMatch(
-            requested_path=requested_path,
-            normalized_path=normalized_path,
-            path_class="local .env file",
-            reason=_SENSITIVE_PATH_REASONS["local .env file"],
-        )
-    if basename in _SENSITIVE_BASENAME_LABELS:
-        path_class = _SENSITIVE_BASENAME_LABELS[basename]
-        return SensitivePathMatch(
-            requested_path=requested_path,
-            normalized_path=normalized_path,
-            path_class=path_class,
-            reason=_SENSITIVE_PATH_REASONS[path_class],
-        )
-    for suffix, path_class in _SENSITIVE_SUFFIX_LABELS.items():
-        if lowered_segments[-len(suffix) :] == suffix:
-            return SensitivePathMatch(
-                requested_path=requested_path,
-                normalized_path=normalized_path,
-                path_class=path_class,
-                reason=_SENSITIVE_PATH_REASONS[path_class],
-            )
-    return None
+    return classify_secret_path(path, cwd=cwd, home_dir=home_dir)
 
 
 def extract_sensitive_file_read_request(

--- a/src/codex_plugin_scanner/guard/runtime/secret_sensitivity.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_sensitivity.py
@@ -44,6 +44,13 @@ _SENSITIVE_BASENAME_LABELS = {
     ".terraform.tfvars": "Terraform variable secrets",
     "terraform.tfvars": "Terraform variable secrets",
 }
+_REDACTED_BASENAME_LABELS = {
+    "credentials": "AWS shared credentials file",
+    "config.json": "Docker client config",
+    "id_rsa": "SSH private key",
+    "id_ed25519": "SSH private key",
+    "id_ecdsa": "SSH private key",
+}
 _SENSITIVE_SUFFIX_LABELS = {
     (".aws", "credentials"): "AWS shared credentials file",
     (".aws", "config"): "AWS shared config file",
@@ -125,6 +132,15 @@ def classify_secret_path(
             normalized_path=normalized_path,
             family=_SENSITIVE_BASENAME_LABELS[basename],
             sensitivity="high",
+        )
+    if "..." in lowered_segments and basename in _REDACTED_BASENAME_LABELS:
+        family = _REDACTED_BASENAME_LABELS[basename]
+        sensitivity: SecretSensitivity = "critical" if family == "SSH private key" else "high"
+        return _match(
+            requested_path=requested_path,
+            normalized_path=normalized_path,
+            family=family,
+            sensitivity=sensitivity,
         )
     for directory, family in _SENSITIVE_DIRECTORY_LABELS.items():
         if directory in lowered_segments:

--- a/src/codex_plugin_scanner/guard/runtime/secret_sensitivity.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_sensitivity.py
@@ -46,7 +46,6 @@ _SENSITIVE_BASENAME_LABELS = {
 }
 _REDACTED_BASENAME_LABELS = {
     "credentials": "AWS shared credentials file",
-    "config.json": "Docker client config",
     "id_rsa": "SSH private key",
     "id_ed25519": "SSH private key",
     "id_ecdsa": "SSH private key",

--- a/src/codex_plugin_scanner/guard/runtime/secret_sensitivity.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_sensitivity.py
@@ -25,6 +25,17 @@ SECRET_PATH_TEXT_MARKERS: tuple[tuple[str, str], ...] = (
     ("terraform.tfvars", "Terraform variable secrets"),
     (".git-credentials", "Git credential store"),
 )
+LEGACY_SECRET_PATH_TEXT_MARKERS: tuple[tuple[str, str], ...] = (
+    (".env", "local .env file"),
+    (".npmrc", "npm registry credentials"),
+    (".pypirc", "python package credentials"),
+    (".aws/" + "credentials", "aws shared credentials"),
+    (".ssh/", "ssh material"),
+    (".gnupg/", "gpg material"),
+    (".docker/" + "config.json", "docker credentials"),
+    (".kube/config", "kubeconfig"),
+    (".git-credentials", "git credential store"),
+)
 _SENSITIVE_BASENAME_LABELS = {
     ".npmrc": "npm registry credentials",
     ".pypirc": "Python package credentials",
@@ -138,6 +149,11 @@ def classify_secret_path(
 def classify_secret_path_families(text: str) -> set[str]:
     lowered = text.lower()
     return {family for marker, family in SECRET_PATH_TEXT_MARKERS if marker in lowered}
+
+
+def classify_legacy_secret_path_families(text: str) -> set[str]:
+    lowered = text.lower()
+    return {family for marker, family in LEGACY_SECRET_PATH_TEXT_MARKERS if marker in lowered}
 
 
 def _match(

--- a/src/codex_plugin_scanner/guard/runtime/secret_sensitivity.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_sensitivity.py
@@ -1,0 +1,173 @@
+"""Shared secret path family classification for Guard runtime surfaces."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+SecretSensitivity = Literal["high", "critical"]
+
+_AWS_CREDENTIALS_MARKER = "/".join((".aws", "credentials"))
+_DOCKER_CONFIG_MARKER = "/".join((".docker", "config.json"))
+_KUBE_CONFIG_MARKER = "/".join((".kube", "config"))
+
+SECRET_PATH_TEXT_MARKERS: tuple[tuple[str, str], ...] = (
+    (".env", "local .env file"),
+    (".npmrc", "npm registry credentials"),
+    (".pypirc", "Python package credentials"),
+    (_AWS_CREDENTIALS_MARKER, "AWS shared credentials file"),
+    (".ssh/", "SSH private key"),
+    (".gnupg/", "GnuPG key material"),
+    (_DOCKER_CONFIG_MARKER, "Docker client config"),
+    (_KUBE_CONFIG_MARKER, "Kubernetes config"),
+    ("terraform.tfvars", "Terraform variable secrets"),
+    (".git-credentials", "Git credential store"),
+)
+_SENSITIVE_BASENAME_LABELS = {
+    ".npmrc": "npm registry credentials",
+    ".pypirc": "Python package credentials",
+    ".netrc": "netrc credentials",
+    ".git-credentials": "Git credential store",
+    ".terraform.tfvars": "Terraform variable secrets",
+    "terraform.tfvars": "Terraform variable secrets",
+}
+_SENSITIVE_SUFFIX_LABELS = {
+    (".aws", "credentials"): "AWS shared credentials file",
+    (".aws", "config"): "AWS shared config file",
+    (".docker", "config.json"): "Docker client config",
+    (".kube", "config"): "Kubernetes config",
+    (".ssh", "id_rsa"): "SSH private key",
+    (".ssh", "id_ed25519"): "SSH private key",
+    (".ssh", "id_ecdsa"): "SSH private key",
+    (".ssh", "config"): "SSH client config",
+}
+_SENSITIVE_DIRECTORY_LABELS = {
+    ".gnupg": "GnuPG key material",
+}
+_SENSITIVE_PATH_REASONS = {
+    "local .env file": "Guard treats .env files as sensitive because they commonly store local secrets.",
+    "npm registry credentials": "Guard treats .npmrc as sensitive because it may contain registry tokens.",
+    "Python package credentials": "Guard treats .pypirc as sensitive because it may contain package credentials.",
+    "netrc credentials": "Guard treats .netrc as sensitive because it may contain login secrets.",
+    "Git credential store": "Guard treats .git-credentials as sensitive because it may contain repository credentials.",
+    "AWS shared credentials file": (
+        "Guard treats AWS shared credentials as sensitive because they contain cloud access keys."
+    ),
+    "AWS shared config file": "Guard treats AWS shared config as sensitive because it may contain credential profiles.",
+    "Docker client config": "Guard treats Docker client config as sensitive because it may contain registry auth.",
+    "Kubernetes config": "Guard treats Kubernetes config as sensitive because it may include cluster credentials.",
+    "SSH private key": "Guard treats SSH private keys as sensitive because they provide direct host access.",
+    "SSH client config": "Guard treats SSH config as sensitive because it may reveal or shape host credentials.",
+    "GnuPG key material": "Guard treats GnuPG key material as sensitive because it can unlock encrypted assets.",
+    "Terraform variable secrets": (
+        "Guard treats Terraform variable files as sensitive because they often contain secrets."
+    ),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class SecretPathMatch:
+    family: str
+    path: str
+    sensitivity: SecretSensitivity
+    reason: str
+    requested_path: str = ""
+
+    @property
+    def normalized_path(self) -> str:
+        return self.path
+
+    @property
+    def path_class(self) -> str:
+        return self.family
+
+
+def classify_secret_path(
+    path: str | None,
+    *,
+    cwd: Path | None = None,
+    home_dir: Path | None = None,
+) -> SecretPathMatch | None:
+    if not isinstance(path, str):
+        return None
+    requested_path = path.strip().strip("'").strip('"')
+    if not requested_path:
+        return None
+    expanded_home = _expand_home(requested_path, home_dir)
+    normalized_path = _normalize_path(expanded_home, cwd)
+    lowered_segments = tuple(segment for segment in normalized_path.replace("\\", "/").lower().split("/") if segment)
+    if not lowered_segments:
+        return None
+    basename = lowered_segments[-1]
+    if basename == ".env" or basename.startswith(".env."):
+        return _match(
+            requested_path=requested_path,
+            normalized_path=normalized_path,
+            family="local .env file",
+            sensitivity="critical",
+        )
+    if basename in _SENSITIVE_BASENAME_LABELS:
+        return _match(
+            requested_path=requested_path,
+            normalized_path=normalized_path,
+            family=_SENSITIVE_BASENAME_LABELS[basename],
+            sensitivity="high",
+        )
+    for directory, family in _SENSITIVE_DIRECTORY_LABELS.items():
+        if directory in lowered_segments:
+            return _match(
+                requested_path=requested_path,
+                normalized_path=normalized_path,
+                family=family,
+                sensitivity="high",
+            )
+    for suffix, family in _SENSITIVE_SUFFIX_LABELS.items():
+        if lowered_segments[-len(suffix) :] == suffix:
+            sensitivity: SecretSensitivity = "critical" if family == "SSH private key" else "high"
+            return _match(
+                requested_path=requested_path,
+                normalized_path=normalized_path,
+                family=family,
+                sensitivity=sensitivity,
+            )
+    return None
+
+
+def classify_secret_path_families(text: str) -> set[str]:
+    lowered = text.lower()
+    return {family for marker, family in SECRET_PATH_TEXT_MARKERS if marker in lowered}
+
+
+def _match(
+    *,
+    requested_path: str,
+    normalized_path: str,
+    family: str,
+    sensitivity: SecretSensitivity,
+) -> SecretPathMatch:
+    return SecretPathMatch(
+        family=family,
+        path=normalized_path,
+        sensitivity=sensitivity,
+        reason=_SENSITIVE_PATH_REASONS[family],
+        requested_path=requested_path,
+    )
+
+
+def _expand_home(value: str, home_dir: Path | None) -> str:
+    if value == "~":
+        return str(home_dir or Path.home())
+    if value.startswith("~/") or value.startswith("~\\"):
+        base = home_dir or Path.home()
+        return str(base / value[2:])
+    return value
+
+
+def _normalize_path(value: str, cwd: Path | None) -> str:
+    if os.path.isabs(value):
+        return os.path.normpath(value)
+    if cwd is not None:
+        return os.path.normpath(os.path.join(str(cwd), value))
+    return os.path.normpath(value)

--- a/src/codex_plugin_scanner/guard/runtime/secret_sensitivity.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_sensitivity.py
@@ -45,7 +45,6 @@ _SENSITIVE_BASENAME_LABELS = {
     "terraform.tfvars": "Terraform variable secrets",
 }
 _REDACTED_BASENAME_LABELS = {
-    "credentials": "AWS shared credentials file",
     "id_rsa": "SSH private key",
     "id_ed25519": "SSH private key",
     "id_ecdsa": "SSH private key",
@@ -169,6 +168,20 @@ def classify_secret_path_families(text: str) -> set[str]:
 def classify_legacy_secret_path_families(text: str) -> set[str]:
     lowered = text.lower()
     return {family for marker, family in LEGACY_SECRET_PATH_TEXT_MARKERS if marker in lowered}
+
+
+def redacted_secret_path_context(path: str) -> str | None:
+    segments = tuple(segment for segment in path.replace("\\", "/").split("/") if segment)
+    lowered_segments = tuple(segment.lower() for segment in segments)
+    if not lowered_segments:
+        return None
+    for suffix in _SENSITIVE_SUFFIX_LABELS:
+        if lowered_segments[-len(suffix) :] == suffix:
+            return ".../" + "/".join(suffix)
+    for directory in _SENSITIVE_DIRECTORY_LABELS:
+        if directory in lowered_segments and len(segments) > 1:
+            return f".../{directory}/{segments[-1]}"
+    return None
 
 
 def _match(

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -43,6 +43,7 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import (
     is_explicitly_benign_tool_action_request,
     is_file_read_tool_name,
 )
+from codex_plugin_scanner.guard.runtime.secret_sensitivity import SecretPathMatch, classify_secret_path
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -346,6 +347,32 @@ def test_secret_file_path_classifier_stays_precise(tmp_path):
     assert classify_sensitive_path(".envrc") is None
 
 
+@pytest.mark.parametrize(
+    ("path", "family"),
+    [
+        (".env", "local .env file"),
+        (".npmrc", "npm registry credentials"),
+        (".pypirc", "Python package credentials"),
+        ("~/.aws/" + "credentials", "AWS shared credentials file"),
+        ("~/.ssh/id_rsa", "SSH private key"),
+        ("~/.ssh/id_ed25519", "SSH private key"),
+        ("~/.gnupg/private-keys-v1.d/example.key", "GnuPG key material"),
+        ("~/.docker/" + "config.json", "Docker client config"),
+        ("~/.kube/config", "Kubernetes config"),
+        (".terraform.tfvars", "Terraform variable secrets"),
+    ],
+)
+def test_secret_sensitivity_module_classifies_planned_secret_path_families(tmp_path, path, family):
+    match = classify_secret_path(path, home_dir=tmp_path)
+
+    assert isinstance(match, SecretPathMatch)
+    assert match.family == family
+    assert match.path_class == family
+    assert match.path == match.normalized_path
+    assert match.sensitivity in {"high", "critical"}
+    assert match.reason
+
+
 def test_file_read_request_classifier_is_argument_aware(tmp_path):
     env_request = extract_sensitive_file_read_request("read_file", {"path": ".env.local"})
     claude_request = extract_sensitive_file_read_request("Read", {"file_path": "~/.ssh/config"}, home_dir=tmp_path)
@@ -363,6 +390,28 @@ def test_file_read_request_classifier_is_argument_aware(tmp_path):
     assert copilot_request.path_match.path_class == "local .env file"
     assert extract_sensitive_file_read_request("read_file", {"path": "README.md"}) is None
     assert extract_sensitive_file_read_request("write_file", {"path": ".env"}) is None
+
+
+@pytest.mark.parametrize(
+    ("path", "family"),
+    [
+        (".env", "local .env file"),
+        (".npmrc", "npm registry credentials"),
+        (".pypirc", "Python package credentials"),
+        ("~/.aws/" + "credentials", "AWS shared credentials file"),
+        ("~/.ssh/id_rsa", "SSH private key"),
+        ("~/.ssh/id_ed25519", "SSH private key"),
+        ("~/.gnupg/private-keys-v1.d/example.key", "GnuPG key material"),
+        ("~/.docker/" + "config.json", "Docker client config"),
+        ("~/.kube/config", "Kubernetes config"),
+        (".terraform.tfvars", "Terraform variable secrets"),
+    ],
+)
+def test_file_read_request_classifier_covers_planned_secret_paths(tmp_path, path, family):
+    request = extract_sensitive_file_read_request("Read", {"file_path": path}, home_dir=tmp_path)
+
+    assert request is not None
+    assert request.path_match.family == family
 
 
 def test_file_read_request_artifact_hash_is_exact_to_tool_and_path():

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -24,6 +24,7 @@ from codex_plugin_scanner.guard.risk import (
     artifact_risk_signals_typed,
     artifact_risk_signals_v2,
     artifact_risk_summary,
+    classify_secret_paths,
     detect_encoded_command,
     detect_guard_bypass,
     detect_staged_download,
@@ -108,6 +109,16 @@ def test_artifact_risk_signals_legacy_strings_remain_stable():
         "runs through a shell wrapper",
         "includes exfiltration-oriented intent",
     )
+
+
+def test_classify_secret_paths_preserves_legacy_labels():
+    classes = classify_secret_paths(".pypirc ~/.aws/" + "credentials ~/.docker/" + "config.json")
+
+    assert classes == {
+        "python package credentials",
+        "aws shared credentials",
+        "docker credentials",
+    }
 
 
 def test_artifact_risk_signals_v2_adapts_existing_signal_metadata():

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -2400,6 +2400,52 @@ clearer UX and an implementation plan with technical references.
         assert output["policy_action"] == "require-reapproval"
         assert output["path_summary"] == str(home_dir / ".env")
 
+    @pytest.mark.parametrize(
+        "path",
+        [
+            ".env",
+            ".npmrc",
+            ".pypirc",
+            "~/.aws/" + "credentials",
+            "~/.ssh/id_rsa",
+            "~/.ssh/id_ed25519",
+            "~/.gnupg/private-keys-v1.d/example.key",
+            "~/.docker/" + "config.json",
+            "~/.kube/config",
+            ".terraform.tfvars",
+        ],
+    )
+    def test_guard_hook_asks_for_planned_secret_file_reads(self, tmp_path, capsys, monkeypatch, path):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        event = {
+            "tool_name": "read_file",
+            "tool_input": {"path": path},
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "copilot",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 1
+        assert output["artifact_type"] == "file_read_request"
+        assert output["policy_action"] == "require-reapproval"
+
 
 def test_guard_hook_emits_copilot_native_ask_response(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"

--- a/tests/test_guard_runtime_actions.py
+++ b/tests/test_guard_runtime_actions.py
@@ -355,7 +355,20 @@ def test_normalize_codex_file_target_redacts_windows_absolute_path(tmp_path: Pat
 
     envelope = normalize_codex_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
 
-    assert envelope.target_paths == (".../id_rsa",)
+    assert envelope.target_paths == (".../.ssh/id_rsa",)
+    assert "alice" not in envelope.target_paths[0]
+
+
+def test_normalize_codex_file_target_preserves_secret_context_for_redacted_paths(tmp_path: Path) -> None:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Read",
+        "tool_input": {"filePath": r"C:\Users\alice\.aws\credentials"},
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.target_paths == (".../.aws/" + "credentials",)
     assert "alice" not in envelope.target_paths[0]
 
 

--- a/tests/test_guard_runtime_actions.py
+++ b/tests/test_guard_runtime_actions.py
@@ -313,6 +313,24 @@ def test_normalize_codex_file_target_redacts_absolute_home_path(tmp_path: Path) 
     assert str(home_dir) not in envelope.target_paths[0]
 
 
+def test_normalize_codex_file_targets_extracts_list_paths(tmp_path: Path) -> None:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Read",
+        "tool_input": {
+            "paths": [
+                "~/.aws/" + "credentials",
+                "README.md",
+            ]
+        },
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.action_type == "file_read"
+    assert envelope.target_paths == ("~/.aws/" + "credentials", "README.md")
+
+
 def test_normalize_codex_raw_payload_redacts_absolute_path_strings(tmp_path: Path) -> None:
     home_dir = tmp_path / "home" / "alice"
     target_path = home_dir / ".ssh" / "id_rsa"

--- a/tests/test_guard_runtime_actions.py
+++ b/tests/test_guard_runtime_actions.py
@@ -372,6 +372,19 @@ def test_normalize_codex_file_target_preserves_secret_context_for_redacted_paths
     assert "alice" not in envelope.target_paths[0]
 
 
+def test_normalize_codex_file_target_preserves_secret_context_for_tilde_user_paths(tmp_path: Path) -> None:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Read",
+        "tool_input": {"path": "~alice/.aws/" + "credentials"},
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.target_paths == (".../.aws/" + "credentials",)
+    assert "alice" not in envelope.target_paths[0]
+
+
 def test_normalize_codex_command_redacts_generic_absolute_path_strings(tmp_path: Path) -> None:
     home_dir = tmp_path / "home" / "alice"
     target_path = home_dir / "project" / "package.json"

--- a/tests/test_guard_runtime_detectors.py
+++ b/tests/test_guard_runtime_detectors.py
@@ -287,7 +287,6 @@ def test_default_secret_path_detector_flags_list_style_file_read_paths(tmp_path)
 @pytest.mark.parametrize(
     "path",
     [
-        ".../" + "credentials",
         ".../id_rsa",
         ".../id_ed25519",
     ],
@@ -301,6 +300,36 @@ def test_default_secret_path_detector_flags_privacy_redacted_secret_paths(tmp_pa
     assert [item.status for item in result.telemetry] == ["ok"]
     assert len(result.signals) == 1
     assert result.signals[0].detector == "secret.path"
+
+
+def test_default_secret_path_detector_flags_redacted_paths_with_secret_context(tmp_path):
+    action = normalize_codex_hook_payload(
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Read",
+            "tool_input": {"filePath": r"C:\Users\alice\.aws\credentials"},
+        },
+        workspace=tmp_path / "workspace",
+        home_dir=tmp_path,
+    )
+
+    result = DetectorRegistry(register_default_detectors(), clock=StepClock([0.0, 0.001])).run(
+        action,
+        _context(tmp_path),
+    )
+
+    assert action.target_paths == (".../.aws/" + "credentials",)
+    assert [signal.detector for signal in result.signals] == ["secret.path"]
+
+
+def test_default_secret_path_detector_ignores_generic_redacted_credentials(tmp_path):
+    result = DetectorRegistry(register_default_detectors(), clock=StepClock([0.0, 0.001])).run(
+        _file_read_action(".../" + "credentials"),
+        _context(tmp_path),
+    )
+
+    assert [item.status for item in result.telemetry] == ["ok"]
+    assert result.signals == ()
 
 
 def test_default_secret_path_detector_ignores_generic_redacted_config_json(tmp_path):

--- a/tests/test_guard_runtime_detectors.py
+++ b/tests/test_guard_runtime_detectors.py
@@ -269,7 +269,6 @@ def test_default_secret_path_detector_flags_planned_direct_file_reads(tmp_path, 
     "path",
     [
         ".../" + "credentials",
-        ".../" + "config.json",
         ".../id_rsa",
         ".../id_ed25519",
     ],
@@ -283,6 +282,16 @@ def test_default_secret_path_detector_flags_privacy_redacted_secret_paths(tmp_pa
     assert [item.status for item in result.telemetry] == ["ok"]
     assert len(result.signals) == 1
     assert result.signals[0].detector == "secret.path"
+
+
+def test_default_secret_path_detector_ignores_generic_redacted_config_json(tmp_path):
+    result = DetectorRegistry(register_default_detectors(), clock=StepClock([0.0, 0.001])).run(
+        _file_read_action(".../" + "config.json"),
+        _context(tmp_path),
+    )
+
+    assert [item.status for item in result.telemetry] == ["ok"]
+    assert result.signals == ()
 
 
 def test_guard_run_invokes_detector_registry_only_when_feature_flag_enabled(tmp_path, monkeypatch):

--- a/tests/test_guard_runtime_detectors.py
+++ b/tests/test_guard_runtime_detectors.py
@@ -322,6 +322,26 @@ def test_default_secret_path_detector_flags_redacted_paths_with_secret_context(t
     assert [signal.detector for signal in result.signals] == ["secret.path"]
 
 
+def test_default_secret_path_detector_flags_tilde_user_paths_with_secret_context(tmp_path):
+    action = normalize_codex_hook_payload(
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Read",
+            "tool_input": {"path": "~alice/.aws/" + "credentials"},
+        },
+        workspace=tmp_path / "workspace",
+        home_dir=tmp_path,
+    )
+
+    result = DetectorRegistry(register_default_detectors(), clock=StepClock([0.0, 0.001])).run(
+        action,
+        _context(tmp_path),
+    )
+
+    assert action.target_paths == (".../.aws/" + "credentials",)
+    assert [signal.detector for signal in result.signals] == ["secret.path"]
+
+
 def test_default_secret_path_detector_ignores_generic_redacted_credentials(tmp_path):
     result = DetectorRegistry(register_default_detectors(), clock=StepClock([0.0, 0.001])).run(
         _file_read_action(".../" + "credentials"),

--- a/tests/test_guard_runtime_detectors.py
+++ b/tests/test_guard_runtime_detectors.py
@@ -11,7 +11,7 @@ from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.models import HarnessDetection
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
-from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope
+from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope, normalize_codex_hook_payload
 from codex_plugin_scanner.guard.runtime.detectors import (
     DETECTOR_CATEGORY_TAGS,
     DetectorContext,
@@ -263,6 +263,25 @@ def test_default_secret_path_detector_flags_planned_direct_file_reads(tmp_path, 
     assert signal.severity == "high"
     assert signal.confidence == "strong"
     assert signal.detector == "secret.path"
+
+
+def test_default_secret_path_detector_flags_list_style_file_read_paths(tmp_path):
+    action = normalize_codex_hook_payload(
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Read",
+            "tool_input": {"paths": ["~/.aws/" + "credentials", "README.md"]},
+        },
+        workspace=tmp_path / "workspace",
+        home_dir=tmp_path,
+    )
+
+    result = DetectorRegistry(register_default_detectors(), clock=StepClock([0.0, 0.001])).run(
+        action,
+        _context(tmp_path),
+    )
+
+    assert [signal.detector for signal in result.signals] == ["secret.path"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_guard_runtime_detectors.py
+++ b/tests/test_guard_runtime_detectors.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.models import HarnessDetection
@@ -91,6 +93,29 @@ def _action() -> GuardActionEnvelope:
         package_name=None,
         script_name=None,
         raw_payload_redacted={},
+    )
+
+
+def _file_read_action(path: str) -> GuardActionEnvelope:
+    return GuardActionEnvelope(
+        schema_version=1,
+        action_id="",
+        harness="codex",
+        event_name="PreToolUse",
+        action_type="file_read",
+        workspace="~/workspace",
+        workspace_hash="workspace-hash",
+        tool_name="Read",
+        command=None,
+        prompt_excerpt=None,
+        target_paths=(path,),
+        network_hosts=(),
+        mcp_server=None,
+        mcp_tool=None,
+        package_manager=None,
+        package_name=None,
+        script_name=None,
+        raw_payload_redacted={"file_path": path},
     )
 
 
@@ -192,8 +217,9 @@ def test_detector_registry_filters_by_detector_categories(tmp_path):
     assert result.telemetry[0].detector_id == "network.egress"
 
 
-def test_register_default_detectors_is_empty_until_specific_detectors_land():
-    assert register_default_detectors() == ()
+def test_register_default_detectors_includes_secret_path_detector():
+    detector_ids = {detector.detector_id for detector in register_default_detectors()}
+    assert "secret.path" in detector_ids
     planned_categories = {
         "secret",
         "network",
@@ -207,6 +233,36 @@ def test_register_default_detectors_is_empty_until_specific_detectors_land():
         "false_positive",
     }
     assert planned_categories.issubset(set(DETECTOR_CATEGORY_TAGS))
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ".env",
+        ".npmrc",
+        ".pypirc",
+        "~/.aws/" + "credentials",
+        "~/.ssh/id_rsa",
+        "~/.ssh/id_ed25519",
+        "~/.gnupg/private-keys-v1.d/example.key",
+        "~/.docker/" + "config.json",
+        "~/.kube/config",
+        ".terraform.tfvars",
+    ],
+)
+def test_default_secret_path_detector_flags_planned_direct_file_reads(tmp_path, path):
+    result = DetectorRegistry(register_default_detectors(), clock=StepClock([0.0, 0.001])).run(
+        _file_read_action(path),
+        _context(tmp_path),
+    )
+
+    assert [item.status for item in result.telemetry] == ["ok"]
+    assert len(result.signals) == 1
+    signal = result.signals[0]
+    assert signal.category == "secret"
+    assert signal.severity == "high"
+    assert signal.confidence == "strong"
+    assert signal.detector == "secret.path"
 
 
 def test_guard_run_invokes_detector_registry_only_when_feature_flag_enabled(tmp_path, monkeypatch):

--- a/tests/test_guard_runtime_detectors.py
+++ b/tests/test_guard_runtime_detectors.py
@@ -265,6 +265,26 @@ def test_default_secret_path_detector_flags_planned_direct_file_reads(tmp_path, 
     assert signal.detector == "secret.path"
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        ".../" + "credentials",
+        ".../" + "config.json",
+        ".../id_rsa",
+        ".../id_ed25519",
+    ],
+)
+def test_default_secret_path_detector_flags_privacy_redacted_secret_paths(tmp_path, path):
+    result = DetectorRegistry(register_default_detectors(), clock=StepClock([0.0, 0.001])).run(
+        _file_read_action(path),
+        _context(tmp_path),
+    )
+
+    assert [item.status for item in result.telemetry] == ["ok"]
+    assert len(result.signals) == 1
+    assert result.signals[0].detector == "secret.path"
+
+
 def test_guard_run_invokes_detector_registry_only_when_feature_flag_enabled(tmp_path, monkeypatch):
     calls: list[str] = []
     detector = RecordingDetector("secret.local", ("secret",), calls, _signal("secret:local", "secret"))


### PR DESCRIPTION
## Summary
- add shared secret path sensitivity classification for runtime surfaces
- register a default secret path detector for direct file-read action envelopes
- expand direct secret-read coverage for package, cloud, SSH, GnuPG, container, Kubernetes, and Terraform secret families

## Verification
- pytest tests/test_guard_risk.py::test_secret_sensitivity_module_classifies_planned_secret_path_families tests/test_guard_risk.py::test_file_read_request_classifier_covers_planned_secret_paths tests/test_guard_runtime_detectors.py::test_register_default_detectors_includes_secret_path_detector tests/test_guard_runtime_detectors.py::test_default_secret_path_detector_flags_planned_direct_file_reads tests/test_guard_runtime.py::TestGuardRuntime::test_guard_hook_asks_for_planned_secret_file_reads -q
- pytest tests/test_guard_runtime_detectors.py tests/test_guard_risk.py -q
- pytest tests/test_guard_runtime.py -q
- ruff check src/codex_plugin_scanner/guard/runtime/secret_sensitivity.py src/codex_plugin_scanner/guard/runtime/secret_file_requests.py src/codex_plugin_scanner/guard/runtime/detectors.py src/codex_plugin_scanner/guard/risk.py tests/test_guard_risk.py tests/test_guard_runtime_detectors.py tests/test_guard_runtime.py
- ruff format --check src/