### PR TITLE
feat(guard): polish CLI guidance flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,32 +262,43 @@ The scanner evaluates only the surfaces a plugin actually exposes, then normaliz
 
 ```bash
 # Scan a plugin directory
-plugin-scanner ./my-plugin
+plugin-scanner scan ./my-plugin
 
 # Auto-detect all supported ecosystems inside a repo (default)
-plugin-scanner ./plugins-repo --ecosystem auto
+plugin-scanner scan ./plugins-repo --ecosystem auto
 
 # Scan only Claude package surfaces
-plugin-scanner ./plugins-repo --ecosystem claude
+plugin-scanner scan ./plugins-repo --ecosystem claude
 
 # List supported ecosystems
 plugin-scanner --list-ecosystems
 
 # Output JSON
-plugin-scanner ./my-plugin --json
+plugin-scanner scan ./my-plugin --format json
 
 # Write a SARIF report for GitHub code scanning
-plugin-scanner ./my-plugin --format sarif --output plugin-scanner.sarif
+plugin-scanner scan ./my-plugin --format sarif --output plugin-scanner.sarif
 
 # Fail CI on findings at or above high severity
-plugin-scanner ./my-plugin --fail-on-severity high
+plugin-scanner scan ./my-plugin --fail-on-severity high
 
 # Require Cisco skill scanning with a strict policy
-plugin-scanner ./my-plugin --cisco-skill-scan on --cisco-policy strict
+plugin-scanner scan ./my-plugin --cisco-skill-scan on --cisco-policy strict
 
 # Require optional Cisco MCP static analysis
-plugin-scanner ./my-plugin --cisco-mcp-scan on
+plugin-scanner scan ./my-plugin --cisco-mcp-scan on
 ```
+
+Use the bare `plugin-scanner ./my-plugin` form only for compatibility with older automation. New scripts and docs should
+prefer explicit subcommands so `scan`, `lint`, `verify`, `submit`, and `doctor` have predictable help, flags, and output.
+
+| Need | Command | Output contract |
+| :--- | :--- | :--- |
+| Human release summary | `plugin-scanner scan ./my-plugin` | terminal summary first, optional JSON/Markdown/SARIF with `--format` |
+| Rule-level authoring feedback | `plugin-scanner lint ./my-plugin` | human findings by default, JSON with `--format json` |
+| Runtime readiness details | `plugin-scanner verify ./my-plugin` | human pass/fail by default, JSON with `--format json` |
+| Publishable quality artifact | `plugin-scanner submit ./my-plugin --attest dist/plugin-quality.json` | writes one artifact for one plugin directory |
+| Troubleshooting bundle | `plugin-scanner doctor ./my-plugin --component mcp --bundle dist/doctor.zip` | diagnostic JSON and bundle artifacts |
 
 ## Quality Suite Commands
 

--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -76,6 +76,30 @@ Use it when you want to protect a harness before local MCP servers, skills, hook
    hol-guard device rotate
    ```
 
+## Which command should I use?
+
+| Situation | Command | What it answers |
+| :--- | :--- | :--- |
+| I need the current protection posture | `hol-guard status` | What is Guard watching, is sync connected, and what is the next action? |
+| I need setup or runtime troubleshooting | `hol-guard doctor <harness>` | Why is this harness or Guard runtime not behaving correctly? |
+| A launch was blocked or changed | `hol-guard diff <harness>` | What changed since the last recorded snapshot? |
+| I need to resolve a queued block | `hol-guard approvals` | Which requests are waiting, and how do I approve or deny them? |
+| I need decision history | `hol-guard receipts` | What decisions did Guard record locally? |
+| I need the tracked catalog | `hol-guard inventory` | Which artifacts are currently tracked and present? |
+| I need an exportable evidence artifact | `hol-guard abom` | What local AI-BOM can I attach to an audit or handoff? |
+| I need the chronological log | `hol-guard events` | What happened over time on this machine? |
+
+## Troubleshooting
+
+| Symptom | Start here | Then try |
+| :--- | :--- | :--- |
+| Guard did not find my harness | `hol-guard detect --json` | `hol-guard doctor <harness> --json` for adapter-specific warnings |
+| `hol-guard run` paused a launch | `hol-guard diff <harness>` | `hol-guard approvals`, then retry `hol-guard run <harness>` |
+| I approved a prompt and want proof | `hol-guard receipts` | `hol-guard explain <artifact-id>` for the latest receipt and diff context |
+| I need audit or handoff evidence | `hol-guard inventory` | `hol-guard abom --format json` for machine-readable export |
+| I need to understand recent activity | `hol-guard events` | Use `--name <event>` to filter a noisy local timeline |
+| Cloud sync or pairing looks wrong | `hol-guard status` | `hol-guard connect` or `hol-guard sync --json` depending on the status output |
+
 ## Evidence-first decisions
 
 Guard now scores local decisions from structured evidence, not only string heuristics. Each changed artifact carries:

--- a/docs/guard/testing-matrix.md
+++ b/docs/guard/testing-matrix.md
@@ -10,6 +10,8 @@ Automated coverage in this phase includes:
 - consumer-mode JSON contract generation against scanner fixtures
 - local HTTP sync against a live in-process server instead of mocked transport
 - scheduled self-hosted harness smoke through `.github/workflows/harness-smoke.yml`
+- CLI DX contract tests for summary-first `run`, `explain`, `doctor`, `scan`, `lint`, and `verify` output
+- scanner command consistency tests for nonexistent target handling across `scan`, `lint`, `verify`, `doctor`, and `submit`
 
 Manual verification should include:
 
@@ -32,6 +34,14 @@ Manual verification should include:
 - `hol-guard install codex`
 - `hol-guard run codex --dry-run --default-action allow --json`
 - `hol-guard receipts`
+- `hol-guard explain codex:project:<artifact-name>`
+- `hol-guard diff codex`
+- `hol-guard events`
+- `hol-guard abom`
+- `plugin-scanner scan tests/fixtures/good-plugin --format json`
+- `plugin-scanner lint tests/fixtures/good-plugin --format json`
+- `plugin-scanner verify tests/fixtures/good-plugin --format json`
+- `plugin-scanner doctor tests/fixtures/good-plugin --component mcp --bundle dist/doctor.zip`
 - `codex mcp list`
 - `cursor-agent mcp list`
 - `antigravity --help`

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -149,7 +149,14 @@ _GUARD_HELP_GROUPS = (
     "  bootstrap    Detect, install, and launch the approval center\n"
     "  install      Enable Guard management for a harness\n"
     "  uninstall    Disable Guard management for a harness\n"
-    "  update       Update hol-guard in the current environment"
+    "  update       Update hol-guard in the current environment\n"
+    "\n"
+    "Command selection:\n"
+    "  Use status for current posture and the next safe step\n"
+    "  Use doctor for setup and runtime probes\n"
+    "  Use diff for changed artifacts after a blocked launch\n"
+    "  Use approvals for queued decisions and receipts for audit history\n"
+    "  Use events for the local timeline"
 )
 
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -155,6 +155,7 @@ _GUARD_HELP_GROUPS = (
     "  Use status for current posture and the next safe step\n"
     "  Use doctor for setup and runtime probes\n"
     "  Use diff for changed artifacts after a blocked launch\n"
+    "  Use explain for detailed artifact evidence\n"
     "  Use approvals for queued decisions and receipts for audit history\n"
     "  Use events for the local timeline"
 )

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -285,6 +285,7 @@ def _render_doctor(console: Console, payload: dict[str, object]) -> None:
         )
         adapters = _coerce_dict_list(payload.get("adapters"))
         console.print(_build_harness_table(adapters))
+        console.print(_build_diagnostic_command_panel())
         return
 
     warnings = _coerce_string_list(payload.get("warnings"))
@@ -316,6 +317,7 @@ def _render_doctor(console: Console, payload: dict[str, object]) -> None:
     artifacts = _coerce_dict_list(payload.get("artifacts"))
     if artifacts:
         console.print(_build_artifact_table(artifacts))
+    console.print(_build_diagnostic_command_panel())
 
 
 def _render_run(console: Console, payload: dict[str, object]) -> None:
@@ -494,6 +496,20 @@ def _render_advisories(console: Console, payload: dict[str, object]) -> None:
             str(item.get("updated_at") or "unknown"),
         )
     console.print(table)
+
+
+def _build_advisory_table(items: list[dict[str, object]]) -> Table:
+    table = Table(title="Matching advisories", box=box.SIMPLE_HEAVY, show_header=True)
+    table.add_column("Publisher", style="bold")
+    table.add_column("Severity")
+    table.add_column("Headline")
+    for item in items:
+        table.add_row(
+            str(item.get("publisher") or "unknown"),
+            str(item.get("severity") or "info"),
+            str(item.get("headline") or item.get("cache_key") or "advisory"),
+        )
+    return table
 
 
 def _render_events(console: Console, payload: dict[str, object]) -> None:
@@ -1077,6 +1093,38 @@ def _render_scan(console: Console, payload: dict[str, object]) -> None:
     _render_cisco_evidence(console, payload)
 
 
+def _render_explain(console: Console, payload: dict[str, object]) -> None:
+    if "artifact_snapshot" in payload:
+        console.print(Panel(_build_consumer_summary_table(payload), title="Path evidence", border_style="cyan"))
+        _render_consumer_evidence_panels(console, payload)
+        _render_cisco_evidence(console, payload)
+        return
+    artifact = payload.get("artifact")
+    if not isinstance(artifact, dict):
+        _render_fallback(console, payload)
+        return
+    latest_receipt = payload.get("latest_receipt")
+    latest_diff = payload.get("latest_diff")
+    advisories = _coerce_dict_list(payload.get("advisories"))
+    body = Table.grid(padding=(0, 1))
+    body.add_row("Artifact", str(artifact.get("artifact_name") or artifact.get("artifact_id") or "unknown"))
+    body.add_row("Harness", str(artifact.get("harness") or "unknown"))
+    body.add_row("Type", str(artifact.get("artifact_type") or "artifact"))
+    body.add_row("Scope", str(artifact.get("source_scope") or "unknown"))
+    body.add_row("Present", _bool_label(bool(artifact.get("present"))))
+    if isinstance(latest_receipt, dict):
+        body.add_row("Latest decision", _action_text(str(latest_receipt.get("policy_decision") or "warn")))
+        body.add_row("Receipt time", str(latest_receipt.get("timestamp") or "unknown"))
+    if isinstance(latest_diff, dict):
+        changed_fields = ", ".join(_coerce_string_list(latest_diff.get("changed_fields"))) or "no field changes"
+        body.add_row("Latest diff", changed_fields)
+        body.add_row("Current hash", str(latest_diff.get("current_hash") or "unknown"))
+    body.add_row("Advisories", str(len(advisories)))
+    console.print(Panel(body, title="Guard artifact evidence", border_style="cyan"))
+    if advisories:
+        console.print(_build_advisory_table(advisories))
+
+
 def _render_preflight(console: Console, payload: dict[str, object]) -> None:
     install_verdict = payload.get("install_verdict")
     install_target = payload.get("install_target")
@@ -1209,6 +1257,21 @@ def _build_steps_panel(steps: list[dict[str, object]]) -> Panel:
     return Panel("\n\n".join(lines), title="Next steps", border_style="green")
 
 
+def _build_diagnostic_command_panel() -> Panel:
+    return Panel(
+        "\n".join(
+            (
+                "Use status for current posture: hol-guard status",
+                "Use doctor for setup and runtime probes: hol-guard doctor <harness>",
+                "Use diff for changed artifacts: hol-guard diff <harness>",
+                "Use events for the local timeline: hol-guard events",
+            )
+        ),
+        title="Which diagnostic command?",
+        border_style="blue",
+    )
+
+
 def _render_harness_detail(console: Console, detection: dict[str, object]) -> None:
     artifacts = _coerce_dict_list(detection.get("artifacts"))
     warnings = _coerce_string_list(detection.get("warnings"))
@@ -1308,16 +1371,15 @@ def _build_run_steps(payload: dict[str, object], *, blocked: bool, dry_run: bool
     approvals_command = payload.get("approvals_command")
     if blocked and dry_run:
         review_command = (
-            str(approvals_command)
-            if approval_center_url and isinstance(approvals_command, str) and approvals_command
-            else "hol-guard approvals"
-            if approval_center_url
-            else str(rerun_command)
-            if isinstance(rerun_command, str) and rerun_command
-            else f"hol-guard run {harness}"
+            str(rerun_command) if isinstance(rerun_command, str) and rerun_command else f"hol-guard run {harness}"
         )
         inspect_command = (
             str(diff_command) if isinstance(diff_command, str) and diff_command else f"hol-guard diff {harness}"
+        )
+        approval_command = (
+            str(approvals_command)
+            if isinstance(approvals_command, str) and approvals_command
+            else "hol-guard approvals"
         )
         review_detail = (
             str(review_hint)
@@ -1331,6 +1393,13 @@ def _build_run_steps(payload: dict[str, object], *, blocked: bool, dry_run: bool
                 "detail": review_detail,
             },
             {
+                "title": "Open the approvals queue",
+                "command": approval_command,
+                "detail": (
+                    "Review any queued approval requests after the prompt appears, then retry the guarded command."
+                ),
+            },
+            {
                 "title": "Inspect only the changed config entries (optional)",
                 "command": inspect_command,
                 "detail": (
@@ -1342,7 +1411,7 @@ def _build_run_steps(payload: dict[str, object], *, blocked: bool, dry_run: bool
     if blocked and isinstance(review_hint, str) and review_hint:
         command = (
             str(approvals_command)
-            if approval_center_url and isinstance(approvals_command, str) and approvals_command
+            if isinstance(approvals_command, str) and approvals_command
             else "hol-guard approvals"
             if approval_center_url
             else str(rerun_command)
@@ -1749,5 +1818,5 @@ _RENDERERS: dict[str, Any] = {
     "protect": _render_protect,
     "preflight": _render_preflight,
     "scan": _render_scan,
-    "explain": _render_scan,
+    "explain": _render_explain,
 }

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -285,38 +285,36 @@ def _render_doctor(console: Console, payload: dict[str, object]) -> None:
         )
         adapters = _coerce_dict_list(payload.get("adapters"))
         console.print(_build_harness_table(adapters))
-        console.print(_build_diagnostic_command_panel())
-        return
-
-    warnings = _coerce_string_list(payload.get("warnings"))
-    summary = Table.grid(padding=(0, 1))
-    summary.add_row("Harness", f"[bold]{payload.get('harness', 'unknown')}[/bold]")
-    summary.add_row("Installed", _bool_label(bool(payload.get("installed"))))
-    summary.add_row("Command", _bool_label(bool(payload.get("command_available"))))
-    summary.add_row("Artifacts", str(len(_coerce_dict_list(payload.get("artifacts")))))
-    registry = payload.get("runtime_detector_registry")
-    if isinstance(registry, dict):
-        registry_state = "enabled" if bool(registry.get("enabled")) else "disabled"
-        timeout_ms = registry.get("timeout_ms")
-        summary.add_row("Detector registry", f"{registry_state}, {timeout_ms} ms")
-    summary.add_row("Warnings", str(len(warnings)))
-    console.print(Panel(summary, title="Guard doctor", border_style="cyan"))
-    if warnings:
-        warning_text = "\n".join(
-            textwrap.fill(
-                f"• {warning}",
-                width=72,
-                subsequent_indent="  ",
+    else:
+        warnings = _coerce_string_list(payload.get("warnings"))
+        summary = Table.grid(padding=(0, 1))
+        summary.add_row("Harness", f"[bold]{payload.get('harness', 'unknown')}[/bold]")
+        summary.add_row("Installed", _bool_label(bool(payload.get("installed"))))
+        summary.add_row("Command", _bool_label(bool(payload.get("command_available"))))
+        summary.add_row("Artifacts", str(len(_coerce_dict_list(payload.get("artifacts")))))
+        registry = payload.get("runtime_detector_registry")
+        if isinstance(registry, dict):
+            registry_state = "enabled" if bool(registry.get("enabled")) else "disabled"
+            timeout_ms = registry.get("timeout_ms")
+            summary.add_row("Detector registry", f"{registry_state}, {timeout_ms} ms")
+        summary.add_row("Warnings", str(len(warnings)))
+        console.print(Panel(summary, title="Guard doctor", border_style="cyan"))
+        if warnings:
+            warning_text = "\n".join(
+                textwrap.fill(
+                    f"• {warning}",
+                    width=72,
+                    subsequent_indent="  ",
+                )
+                for warning in warnings
             )
-            for warning in warnings
-        )
-        console.print(Panel(Text(warning_text), title="Attention", border_style="yellow"))
-    runtime_probe = payload.get("runtime_probe")
-    if isinstance(runtime_probe, dict):
-        console.print(_build_runtime_probe_panel(runtime_probe))
-    artifacts = _coerce_dict_list(payload.get("artifacts"))
-    if artifacts:
-        console.print(_build_artifact_table(artifacts))
+            console.print(Panel(Text(warning_text), title="Attention", border_style="yellow"))
+        runtime_probe = payload.get("runtime_probe")
+        if isinstance(runtime_probe, dict):
+            console.print(_build_runtime_probe_panel(runtime_probe))
+        artifacts = _coerce_dict_list(payload.get("artifacts"))
+        if artifacts:
+            console.print(_build_artifact_table(artifacts))
     console.print(_build_diagnostic_command_panel())
 
 
@@ -483,7 +481,11 @@ def _render_advisories(console: Console, payload: dict[str, object]) -> None:
             border_style="cyan",
         )
     )
-    table = Table(box=box.SIMPLE_HEAVY, show_header=True)
+    console.print(_build_advisory_table(items))
+
+
+def _build_advisory_table(items: list[dict[str, object]], *, title: str | None = None) -> Table:
+    table = Table(title=title, box=box.SIMPLE_HEAVY, show_header=True)
     table.add_column("Publisher", style="bold")
     table.add_column("Severity")
     table.add_column("Headline")
@@ -494,20 +496,6 @@ def _render_advisories(console: Console, payload: dict[str, object]) -> None:
             str(item.get("severity") or "info"),
             str(item.get("headline") or item.get("cache_key") or "advisory"),
             str(item.get("updated_at") or "unknown"),
-        )
-    console.print(table)
-
-
-def _build_advisory_table(items: list[dict[str, object]]) -> Table:
-    table = Table(title="Matching advisories", box=box.SIMPLE_HEAVY, show_header=True)
-    table.add_column("Publisher", style="bold")
-    table.add_column("Severity")
-    table.add_column("Headline")
-    for item in items:
-        table.add_row(
-            str(item.get("publisher") or "unknown"),
-            str(item.get("severity") or "info"),
-            str(item.get("headline") or item.get("cache_key") or "advisory"),
         )
     return table
 
@@ -1094,10 +1082,13 @@ def _render_scan(console: Console, payload: dict[str, object]) -> None:
 
 
 def _render_explain(console: Console, payload: dict[str, object]) -> None:
+    advisories = _coerce_dict_list(payload.get("advisories"))
     if "artifact_snapshot" in payload:
         console.print(Panel(_build_consumer_summary_table(payload), title="Path evidence", border_style="cyan"))
         _render_consumer_evidence_panels(console, payload)
         _render_cisco_evidence(console, payload)
+        if advisories:
+            console.print(_build_advisory_table(advisories, title="Matching advisories"))
         return
     artifact = payload.get("artifact")
     if not isinstance(artifact, dict):
@@ -1105,7 +1096,6 @@ def _render_explain(console: Console, payload: dict[str, object]) -> None:
         return
     latest_receipt = payload.get("latest_receipt")
     latest_diff = payload.get("latest_diff")
-    advisories = _coerce_dict_list(payload.get("advisories"))
     body = Table.grid(padding=(0, 1))
     body.add_row("Artifact", str(artifact.get("artifact_name") or artifact.get("artifact_id") or "unknown"))
     body.add_row("Harness", str(artifact.get("harness") or "unknown"))
@@ -1122,7 +1112,7 @@ def _render_explain(console: Console, payload: dict[str, object]) -> None:
     body.add_row("Advisories", str(len(advisories)))
     console.print(Panel(body, title="Guard artifact evidence", border_style="cyan"))
     if advisories:
-        console.print(_build_advisory_table(advisories))
+        console.print(_build_advisory_table(advisories, title="Matching advisories"))
 
 
 def _render_preflight(console: Console, payload: dict[str, object]) -> None:

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -1366,29 +1366,34 @@ def _build_run_steps(payload: dict[str, object], *, blocked: bool, dry_run: bool
         inspect_command = (
             str(diff_command) if isinstance(diff_command, str) and diff_command else f"hol-guard diff {harness}"
         )
-        approval_command = (
-            str(approvals_command)
-            if isinstance(approvals_command, str) and approvals_command
-            else "hol-guard approvals"
-        )
         review_detail = (
             str(review_hint)
             if isinstance(review_hint, str) and review_hint
             else "Rerun without --dry-run to review the full blocker set and continue into the harness launch."
         )
-        return [
+        steps = [
             {
                 "title": "Resolve the blocked launch",
                 "command": review_command,
                 "detail": review_detail,
             },
-            {
-                "title": "Open the approvals queue",
-                "command": approval_command,
-                "detail": (
-                    "Review any queued approval requests after the prompt appears, then retry the guarded command."
-                ),
-            },
+        ]
+        if approval_center_url:
+            approval_command = (
+                str(approvals_command)
+                if isinstance(approvals_command, str) and approvals_command
+                else "hol-guard approvals"
+            )
+            steps.append(
+                {
+                    "title": "Open the approvals queue",
+                    "command": approval_command,
+                    "detail": (
+                        "Review any queued approval requests after the prompt appears, then retry the guarded command."
+                    ),
+                }
+            )
+        steps.append(
             {
                 "title": "Inspect only the changed config entries (optional)",
                 "command": inspect_command,
@@ -1397,7 +1402,8 @@ def _build_run_steps(payload: dict[str, object], *, blocked: bool, dry_run: bool
                     "Guard still needs you to review."
                 ),
             },
-        ]
+        )
+        return steps
     if blocked and isinstance(review_hint, str) and review_hint:
         if approval_center_url:
             command = (

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -1409,15 +1409,16 @@ def _build_run_steps(payload: dict[str, object], *, blocked: bool, dry_run: bool
             },
         ]
     if blocked and isinstance(review_hint, str) and review_hint:
-        command = (
-            str(approvals_command)
-            if isinstance(approvals_command, str) and approvals_command
-            else "hol-guard approvals"
-            if approval_center_url
-            else str(rerun_command)
-            if isinstance(rerun_command, str) and rerun_command
-            else f"hol-guard run {harness}"
-        )
+        if approval_center_url:
+            command = (
+                str(approvals_command)
+                if isinstance(approvals_command, str) and approvals_command
+                else "hol-guard approvals"
+            )
+        elif isinstance(rerun_command, str) and rerun_command:
+            command = str(rerun_command)
+        else:
+            command = f"hol-guard run {harness}"
         return [{"title": "Resolve the blocked launch", "command": command, "detail": review_hint}]
     if dry_run:
         launch_command = (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -162,6 +162,42 @@ class TestMain:
         rc = main(["/nonexistent/path/that/does/not/exist"])
         assert rc == 1
 
+    def test_scan_and_lint_reject_nonexistent_directory_consistently(self, capsys):
+        scan_rc = main(["scan", str(NONEXISTENT_PLUGIN_DIR), "--format", "json"])
+        scan_captured = capsys.readouterr()
+
+        lint_rc = main(["lint", str(NONEXISTENT_PLUGIN_DIR), "--format", "json"])
+        lint_captured = capsys.readouterr()
+
+        expected = f'Error: "{NONEXISTENT_PLUGIN_DIR}" is not a directory.'
+        assert scan_rc == 1
+        assert lint_rc == 1
+        assert expected in scan_captured.err
+        assert expected in lint_captured.err
+        assert scan_captured.out == ""
+        assert lint_captured.out == ""
+
+    def test_scanner_human_outputs_stay_summary_first(self, capsys):
+        scan_rc = main(["scan", str(FIXTURES / "good-plugin")])
+        scan_output = capsys.readouterr().out
+
+        lint_rc = main(["lint", str(FIXTURES / "good-plugin")])
+        lint_output = capsys.readouterr().out
+
+        verify_rc = main(["verify", str(FIXTURES / "good-plugin")])
+        verify_output = capsys.readouterr().out
+
+        assert scan_rc == 0
+        assert lint_rc == 0
+        assert verify_rc == 0
+        assert "Plugin Scanner" in scan_output
+        assert "Final Score" in scan_output
+        assert "Lint profile" in lint_output
+        assert "Verification: PASS" in verify_output
+        assert '"schema_version"' not in scan_output
+        assert '"policy_pass"' not in lint_output
+        assert '"verify_pass"' not in verify_output
+
     def test_invalid_top_level_command_suggests_closest_match(self, capsys):
         with pytest.raises(SystemExit) as exc_info:
             main(["verfy"])

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -1647,7 +1647,7 @@ args = ["workspace-skill.js", "--changed"]
         assert "workspace_skill" in output
         assert "hol-guard run codex" in output
         assert "hol-guard diff codex" in output
-        assert "hol-guard approvals" in output
+        assert "hol-guard approvals" not in output
         assert '"artifacts"' not in output
 
     def test_guard_allow_supports_expiring_exception(self, tmp_path, capsys):

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -1594,6 +1594,62 @@ args = ["workspace-skill.js"]
         assert rc == 0
         assert "Recent Guard receipts" in output
 
+    def test_guard_run_blocked_human_output_lists_review_commands(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\n')
+
+        first_run = main(
+            [
+                "guard",
+                "run",
+                "codex",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--dry-run",
+                "--default-action",
+                "allow",
+                "--json",
+            ]
+        )
+        json.loads(capsys.readouterr().out)
+        _write_text(
+            workspace_dir / ".codex" / "config.toml",
+            """
+[mcp_servers.workspace_skill]
+command = "node"
+args = ["workspace-skill.js", "--changed"]
+""".strip()
+            + "\n",
+        )
+        _write_text(home_dir / "config.toml", 'changed_hash_action = "require-reapproval"\n')
+
+        rc = main(
+            [
+                "guard",
+                "run",
+                "codex",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--dry-run",
+            ]
+        )
+        output = capsys.readouterr().out
+
+        assert first_run == 0
+        assert rc == 1
+        assert "Dry run paused for review" in output
+        assert "workspace_skill" in output
+        assert "hol-guard run codex" in output
+        assert "hol-guard diff codex" in output
+        assert "hol-guard approvals" in output
+        assert '"artifacts"' not in output
+
     def test_guard_allow_supports_expiring_exception(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
@@ -1929,6 +1985,47 @@ args = ["workspace-skill.js"]
         assert explain_output["artifact"]["artifact_id"] == "codex:project:workspace_skill"
         assert explain_output["latest_receipt"]["policy_decision"] == "allow"
         assert explain_output["latest_diff"]["current_hash"]
+
+    def test_guard_explain_human_output_renders_tracked_artifact_context(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+
+        run_rc = main(
+            [
+                "guard",
+                "run",
+                "codex",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--dry-run",
+                "--default-action",
+                "allow",
+                "--json",
+            ]
+        )
+        json.loads(capsys.readouterr().out)
+
+        explain_rc = main(
+            [
+                "guard",
+                "explain",
+                "codex:project:workspace_skill",
+                "--home",
+                str(home_dir),
+            ]
+        )
+        output = capsys.readouterr().out
+
+        assert run_rc == 0
+        assert explain_rc == 0
+        assert "Guard artifact evidence" in output
+        assert "workspace_skill" in output
+        assert "Latest decision" in output
+        assert "Latest diff" in output
+        assert '"latest_receipt"' not in output
 
     def test_guard_diff_reports_config_changes(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -4001,6 +4098,9 @@ args = ["-lc", "echo hi"]
         assert rc == 0
         assert "Detector registry" in output
         assert "enabled" in output
+        assert "Use status for current posture" in output
+        assert "Use diff for changed artifacts" in output
+        assert "Use events for the local timeline" in output
 
     def test_guard_codex_hook_blocks_shell_file_upload_script(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -2027,6 +2027,63 @@ args = ["workspace-skill.js", "--changed"]
         assert "Latest diff" in output
         assert '"latest_receipt"' not in output
 
+    def test_guard_explain_human_output_renders_matching_advisories(self, capsys):
+        advisory = {
+            "publisher": "hashgraph-online",
+            "severity": "high",
+            "headline": "Rotate token",
+            "updated_at": "2026-05-06",
+        }
+
+        emit_guard_payload(
+            "explain",
+            {
+                "generated_at": "2026-05-06T03:49:00Z",
+                "artifact": {
+                    "artifact_id": "codex:project:workspace_skill",
+                    "artifact_name": "workspace_skill",
+                    "harness": "codex",
+                    "artifact_type": "mcp_server",
+                    "source_scope": "project",
+                    "present": True,
+                },
+                "latest_receipt": {
+                    "policy_decision": "warn",
+                    "timestamp": "2026-05-06T03:47:00Z",
+                },
+                "advisories": [advisory],
+            },
+            False,
+        )
+        tracked_output = capsys.readouterr().out
+
+        assert "Matching advisories" in tracked_output
+        assert "Rotate token" in tracked_output
+        assert "Updated" in tracked_output
+        assert "2026-05-06" in tracked_output
+
+        emit_guard_payload(
+            "explain",
+            {
+                "generated_at": "2026-05-06T03:49:00Z",
+                "artifact_snapshot": {"path": "/workspace/plugin"},
+                "capability_manifest": {"ecosystems": ["codex"]},
+                "policy_recommendation": {
+                    "action": "warn",
+                    "reason": "Review the path before adding it to a harness.",
+                },
+                "advisories": [advisory],
+            },
+            False,
+        )
+        path_output = capsys.readouterr().out
+
+        assert "Path evidence" in path_output
+        assert "Matching advisories" in path_output
+        assert "Rotate token" in path_output
+        assert "Updated" in path_output
+        assert "2026-05-06" in path_output
+
     def test_guard_diff_reports_config_changes(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_product_flow.py
+++ b/tests/test_guard_product_flow.py
@@ -67,6 +67,12 @@ class TestGuardProductFlow:
         assert "Scan plugin ecosystems for CI and publish readiness." in output
         assert "{scan,lint,verify,submit,doctor}" in output
         assert "guard" not in output
+        assert "protect" not in output
+        assert "preflight" not in output
+        assert "approvals" not in output
+        assert "receipts" not in output
+        assert "abom" not in output
+        assert "events" not in output
 
     def test_python_module_entry_keeps_combined_surface(self, capsys, monkeypatch):
         monkeypatch.setattr(sys, "argv", ["cli.py"])
@@ -263,6 +269,10 @@ class TestGuardProductFlow:
         assert "start        First-run setup and the Guard operating loop" in output
         assert "connect      Pair this machine to Guard Cloud" in output
         assert "doctor       Run local diagnostics" in output
+        assert "Use status for current posture" in output
+        assert "Use doctor for setup and runtime probes" in output
+        assert "Use diff for changed artifacts" in output
+        assert "Use events for the local timeline" in output
 
     def test_guard_start_human_output_highlights_guard_loop(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_product_flow.py
+++ b/tests/test_guard_product_flow.py
@@ -272,6 +272,7 @@ class TestGuardProductFlow:
         assert "Use status for current posture" in output
         assert "Use doctor for setup and runtime probes" in output
         assert "Use diff for changed artifacts" in output
+        assert "Use explain for detailed artifact evidence" in output
         assert "Use events for the local timeline" in output
 
     def test_guard_start_human_output_highlights_guard_loop(self, tmp_path, capsys):

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -9202,7 +9202,8 @@ def test_guard_run_renderer_uses_context_preserving_diff_command():
         dry_run=True,
     )
 
-    assert steps[1]["command"] == "hol-guard diff codex --home /guard-home --workspace /workspace"
+    assert steps[1]["command"] == "hol-guard approvals"
+    assert steps[2]["command"] == "hol-guard diff codex --home /guard-home --workspace /workspace"
 
 
 def test_guard_run_renderer_uses_context_preserving_launch_command_for_clean_dry_runs():

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -9253,6 +9253,21 @@ def test_guard_run_renderer_uses_context_preserving_approvals_command_for_blocke
     assert steps[0]["command"] == "hol-guard approvals --home /guard-home --workspace /workspace"
 
 
+def test_guard_run_renderer_uses_rerun_command_when_blocked_launch_has_no_approval_queue():
+    steps = guard_render_module._build_run_steps(
+        {
+            "harness": "codex",
+            "approvals_command": "hol-guard approvals --home /guard-home --workspace /workspace",
+            "rerun_command": "hol-guard run codex --home /guard-home --workspace /workspace",
+            "review_hint": "Approve the interactive prompt, then retry the guarded command.",
+        },
+        blocked=True,
+        dry_run=False,
+    )
+
+    assert steps[0]["command"] == "hol-guard run codex --home /guard-home --workspace /workspace"
+
+
 def test_guard_run_headless_allow_persists_state_when_approval_center_is_available(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -9202,8 +9202,10 @@ def test_guard_run_renderer_uses_context_preserving_diff_command():
         dry_run=True,
     )
 
-    assert steps[1]["command"] == "hol-guard approvals"
-    assert steps[2]["command"] == "hol-guard diff codex --home /guard-home --workspace /workspace"
+    assert [step["command"] for step in steps] == [
+        "hol-guard run codex",
+        "hol-guard diff codex --home /guard-home --workspace /workspace",
+    ]
 
 
 def test_guard_run_renderer_uses_context_preserving_launch_command_for_clean_dry_runs():
@@ -9251,6 +9253,27 @@ def test_guard_run_renderer_uses_context_preserving_approvals_command_for_blocke
     )
 
     assert steps[0]["command"] == "hol-guard approvals --home /guard-home --workspace /workspace"
+
+
+def test_guard_run_renderer_uses_approval_queue_for_blocked_dry_run_when_center_is_available():
+    steps = guard_render_module._build_run_steps(
+        {
+            "harness": "codex",
+            "blocked": True,
+            "dry_run": True,
+            "approval_center_url": "http://127.0.0.1:4455",
+            "approvals_command": "hol-guard approvals --home /guard-home --workspace /workspace",
+            "diff_command": "hol-guard diff codex --home /guard-home --workspace /workspace",
+        },
+        blocked=True,
+        dry_run=True,
+    )
+
+    assert [step["command"] for step in steps] == [
+        "hol-guard run codex",
+        "hol-guard approvals --home /guard-home --workspace /workspace",
+        "hol-guard diff codex --home /guard-home --workspace /workspace",
+    ]
 
 
 def test_guard_run_renderer_uses_rerun_command_when_blocked_launch_has_no_approval_queue():


### PR DESCRIPTION
## Summary
- clarify Guard run, explain, doctor, and top-level help guidance
- normalize scanner command documentation and CLI output contracts
- add regression coverage for blocked launch guidance, tracked artifact explain output, diagnostic command selection, and scanner command consistency

## Verification
- uv run --no-sync pytest tests/test_guard_runtime.py::test_guard_run_renderer_uses_context_preserving_diff_command -q
- uv run --no-sync pytest --tb=short -q
- uv run --no-sync ruff check .
- uv run --no-sync ruff format --check src tests/conftest.py tests/test_guard_cli.py tests/test_guard_product_flow.py tests/test_guard_runtime.py tests/test_cli.py
- git --no-pager diff --check