### PR TITLE
feat(guard): polish local secret display

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -4101,21 +4101,7 @@ def _codex_post_tool_output_artifact(
 
 
 def _codex_command_references_sensitive_local_source(command_text: str, *, cwd: Path | None) -> bool:
-    if _codex_sensitive_local_source_matches(command_text, cwd=cwd):
-        return True
-    try:
-        parts = shlex.split(command_text)
-    except ValueError:
-        return False
-    for part in parts:
-        stripped = part.strip()
-        if not stripped or stripped.startswith("-"):
-            continue
-        if _codex_token_is_url(stripped):
-            continue
-        if classify_secret_path(stripped, cwd=cwd) is not None:
-            return True
-    return False
+    return bool(_codex_sensitive_local_source_matches(command_text, cwd=cwd))
 
 
 def _codex_sensitive_local_source_matches(command_text: str, *, cwd: Path | None) -> list[SecretPathMatch]:
@@ -4289,6 +4275,8 @@ def _codex_command_parts_are_environment_dump(parts: list[str]) -> bool:
         return True
     if executable != "env":
         return False
+    if _codex_env_args_clear_environment(parts[1:]):
+        return False
     return not _codex_strip_env_wrapper(parts[1:])
 
 
@@ -4373,6 +4361,18 @@ def _codex_strip_env_wrapper(parts: list[str]) -> list[str]:
             continue
         return parts[index:]
     return []
+
+
+def _codex_env_args_clear_environment(parts: list[str]) -> bool:
+    for part in parts:
+        if part == "--":
+            return False
+        if part in {"-i", "--ignore-environment"}:
+            return True
+        if part.startswith("-") or ("=" in part and not part.startswith("=")):
+            continue
+        return False
+    return False
 
 
 def _codex_shell_split(command_text: str) -> list[str]:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -97,7 +97,12 @@ from ..runtime.secret_file_requests import (
     extract_sensitive_tool_action_request,
     is_explicitly_benign_tool_action_request,
 )
-from ..runtime.secret_sensitivity import SecretContentMatch, classify_secret_content, classify_secret_path
+from ..runtime.secret_sensitivity import (
+    SecretContentMatch,
+    SecretPathMatch,
+    classify_secret_content,
+    classify_secret_path,
+)
 from ..runtime.surface_server import GuardSurfaceRuntime
 from ..store import GuardStore
 from .approval_commands import add_approval_parser, run_approval_command
@@ -3236,6 +3241,12 @@ def _runtime_artifact_native_reason(artifact: GuardArtifact, response_payload: d
         trimmed_summary = risk_summary.strip()
         if len(trimmed_summary) > 180:
             trimmed_summary = f"{trimmed_summary[:177].rstrip()}..."
+        action_class = artifact.metadata.get("action_class")
+        if (
+            action_class == "credential exfiltration shell command"
+            and "credential-looking output" not in trimmed_summary.lower()
+        ):
+            trimmed_summary = f"{trimmed_summary} Guard also detected credential-looking output."
         return f"HOL Guard flagged this request: {trimmed_summary}"
     return "HOL Guard flagged this request for review."
 
@@ -4020,7 +4031,10 @@ def _codex_post_tool_output_artifact(
     command_text = _codex_post_tool_command_text(payload)
     if not command_text:
         command_text = tool_name
-    references_local_content = _codex_command_may_read_local_content(command_text, cwd=cwd)
+    local_source_matches = _codex_sensitive_local_source_matches(command_text, cwd=cwd)
+    references_local_content = bool(local_source_matches) or _codex_command_may_read_local_content(
+        command_text, cwd=cwd
+    )
     content_matches = classify_secret_content(response_text)
     if not content_matches and references_local_content:
         content_matches = classify_secret_content(response_text, suppress_samples=False)
@@ -4043,10 +4057,38 @@ def _codex_post_tool_output_artifact(
             sort_keys=True,
         ).encode("utf-8")
     ).hexdigest()
+    local_secret_source = _codex_local_secret_source_label(
+        local_source_matches,
+        command_text=command_text,
+    )
     runtime_default_action = "require-reapproval" if references_local_content else "warn"
     runtime_request_signals = ["tool output contains credential-looking material"]
     if references_local_content:
-        runtime_request_signals.append("command references a sensitive local source")
+        source_signal = "command references local secrets"
+        if local_secret_source is not None:
+            source_signal = f"command references local secrets from {local_secret_source}"
+        runtime_request_signals.append(source_signal)
+    request_summary = _codex_tool_output_request_summary(
+        tool_name=tool_name,
+        command_text=command_text,
+        local_secret_source=local_secret_source,
+    )
+    runtime_request_summary = _codex_tool_output_runtime_summary(local_secret_source)
+    metadata: dict[str, object] = {
+        "tool_name": tool_name,
+        "command_text": command_text,
+        "action_class": "credential exfiltration shell command",
+        "guard_default_action": runtime_default_action,
+        "request_summary": request_summary,
+        "runtime_request_signals": runtime_request_signals,
+        "runtime_request_summary": runtime_request_summary,
+        "runtime_request_reason": (
+            "Guard inspects supported Codex tool output before Codex uses it, so accidental secret reads can be "
+            "stopped even when the filename was not obviously sensitive."
+        ),
+    }
+    if local_secret_source is not None:
+        metadata["secret_source_family"] = local_secret_source
     return GuardArtifact(
         artifact_id=f"codex:{source_scope}:tool-output:{fingerprint}",
         name=f"{tool_name} credential-looking output",
@@ -4054,28 +4096,12 @@ def _codex_post_tool_output_artifact(
         artifact_type="tool_action_request",
         source_scope=source_scope,
         config_path=config_path,
-        metadata={
-            "tool_name": tool_name,
-            "command_text": command_text,
-            "action_class": "credential exfiltration shell command",
-            "guard_default_action": runtime_default_action,
-            "request_summary": (
-                f"Codex tool `{tool_name}` produced credential-looking output while running `{command_text}`."
-            ),
-            "runtime_request_signals": runtime_request_signals,
-            "runtime_request_summary": (
-                "Requests a sensitive native tool action: credential-looking output reached Codex."
-            ),
-            "runtime_request_reason": (
-                "Guard inspects supported Codex tool output before Codex uses it, so accidental secret reads can be "
-                "stopped even when the filename was not obviously sensitive."
-            ),
-        },
+        metadata=metadata,
     )
 
 
 def _codex_command_references_sensitive_local_source(command_text: str, *, cwd: Path | None) -> bool:
-    if _codex_text_contains_sensitive_path_token(command_text, cwd=cwd):
+    if _codex_sensitive_local_source_matches(command_text, cwd=cwd):
         return True
     try:
         parts = shlex.split(command_text)
@@ -4092,18 +4118,52 @@ def _codex_command_references_sensitive_local_source(command_text: str, *, cwd: 
     return False
 
 
+def _codex_sensitive_local_source_matches(command_text: str, *, cwd: Path | None) -> list[SecretPathMatch]:
+    matches = _codex_sensitive_path_matches_in_text(command_text, cwd=cwd)
+    try:
+        parts = shlex.split(command_text)
+    except ValueError:
+        return matches
+    for part in parts:
+        stripped = part.strip()
+        if not stripped or stripped.startswith("-") or _codex_token_is_url(stripped):
+            continue
+        path_match = classify_secret_path(stripped, cwd=cwd)
+        if path_match is not None:
+            matches.append(path_match)
+    return _dedupe_codex_secret_path_matches(matches)
+
+
+def _dedupe_codex_secret_path_matches(matches: list[SecretPathMatch]) -> list[SecretPathMatch]:
+    deduped: list[SecretPathMatch] = []
+    seen: set[tuple[str, str]] = set()
+    for match in matches:
+        key = (match.family, match.requested_path or match.path)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(match)
+    return deduped
+
+
 def _codex_token_is_url(token: str) -> bool:
     parsed = urllib.parse.urlparse(token)
     return bool(parsed.scheme and parsed.netloc)
 
 
 def _codex_text_contains_sensitive_path_token(text: str, *, cwd: Path | None) -> bool:
+    return bool(_codex_sensitive_path_matches_in_text(text, cwd=cwd))
+
+
+def _codex_sensitive_path_matches_in_text(text: str, *, cwd: Path | None) -> list[SecretPathMatch]:
+    matches: list[SecretPathMatch] = []
     for match in _PROMPT_PATH_TOKEN_PATTERN.finditer(text):
         if _codex_path_token_is_url_path(text, match.start()):
             continue
-        if classify_secret_path(match.group(0), cwd=cwd) is not None:
-            return True
-    return False
+        path_match = classify_secret_path(match.group(0), cwd=cwd)
+        if path_match is not None:
+            matches.append(path_match)
+    return matches
 
 
 def _codex_path_token_is_url_path(text: str, start: int) -> bool:
@@ -4150,7 +4210,10 @@ def _codex_pipeline_segment_may_read_local_content(segment: str, *, index: int, 
     if not parts:
         return False
     if index == 0:
-        return _codex_command_parts_may_read_local_content(parts, cwd=cwd)
+        return _codex_command_parts_are_environment_dump(parts) or _codex_command_parts_may_read_local_content(
+            parts,
+            cwd=cwd,
+        )
     return _codex_command_is_read_only_source_search(segment, cwd=cwd) or _codex_command_is_read_only_source_view(
         segment, cwd=cwd
     )
@@ -4205,6 +4268,63 @@ def _codex_command_sequence_starts_with_local_reader(parts: list[str], *, cwd: P
 
 def _codex_command_parts_are_git_grep(parts: list[str]) -> bool:
     return bool(parts) and Path(parts[0]).name.lower() == "git" and _git_grep_search_args(parts[1:]) is not None
+
+
+def _codex_command_reads_environment_pipeline(command_text: str) -> bool:
+    pipeline_segments = _split_codex_safe_read_only_pipeline(command_text)
+    if pipeline_segments is None:
+        return False
+    try:
+        first_parts = _codex_shell_split(pipeline_segments[0])
+    except ValueError:
+        return False
+    return _codex_command_parts_are_environment_dump(first_parts)
+
+
+def _codex_command_parts_are_environment_dump(parts: list[str]) -> bool:
+    if not parts:
+        return False
+    executable = Path(parts[0]).name.lower()
+    if executable == "printenv":
+        return True
+    if executable != "env":
+        return False
+    return not _codex_strip_env_wrapper(parts[1:])
+
+
+def _codex_local_secret_source_label(
+    matches: list[SecretPathMatch],
+    *,
+    command_text: str,
+) -> str | None:
+    families: list[str] = []
+    for match in matches:
+        if match.family not in families:
+            families.append(match.family)
+    if families:
+        if len(families) == 1:
+            return families[0]
+        return f"{families[0]} and other local secret files"
+    if _codex_command_reads_environment_pipeline(command_text):
+        return "environment variables"
+    return None
+
+
+def _codex_tool_output_request_summary(
+    *,
+    tool_name: str,
+    command_text: str,
+    local_secret_source: str | None,
+) -> str:
+    if local_secret_source is not None:
+        return f"Codex tool `{tool_name}` read local secrets from {local_secret_source} while running `{command_text}`."
+    return f"Codex tool `{tool_name}` produced credential-looking output while running `{command_text}`."
+
+
+def _codex_tool_output_runtime_summary(local_secret_source: str | None) -> str:
+    if local_secret_source is not None:
+        return f"Local secrets from {local_secret_source} reached Codex tool output."
+    return "Requests a sensitive native tool action: credential-looking output reached Codex."
 
 
 def _codex_unwrapped_command_parts(parts: list[str]) -> list[str]:

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -50,6 +50,7 @@ _SENSITIVE_STRING_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     ),
     (re.compile(r"(?i)(authorization:\s*)(bearer\s+)?[^\s,;]+"), r"\1*****"),
     (re.compile(r"(?i)(api[-_ ]?key:\s*)[^\s,;]+"), r"\1*****"),
+    (re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b"), "*****"),
     (re.compile(r"(?i)(bearer\s+)[^\s,;]+"), r"\1*****"),
     (re.compile(r"(?im)\b(?:_authToken|npm[_ -]?token)\s*[:=]\s*[^\s]+"), "npm token redacted"),
     (re.compile(r"\b(?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis|amqp)://[^\s]+", re.IGNORECASE), "*****"),
@@ -963,6 +964,8 @@ def _render_hook(console: Console, payload: dict[str, object]) -> None:
     body.add_row("Recorded", _bool_label(bool(payload.get("recorded"))))
     body.add_row("Artifact", str(payload.get("artifact_name") or payload.get("artifact_id") or "unknown"))
     body.add_row("Decision", _action_text(str(payload.get("policy_action", "warn"))))
+    if payload.get("risk_summary"):
+        body.add_row("Why", str(payload.get("risk_summary")))
     if payload.get("path_summary"):
         body.add_row("Path", str(payload.get("path_summary")))
     if payload.get("approval_center_url"):

--- a/tests/test_guard_render.py
+++ b/tests/test_guard_render.py
@@ -79,11 +79,7 @@ def test_guard_json_render_redacts_after_command_specific_payload_shape(capsys) 
 
 
 def test_guard_json_render_redacts_private_key_without_breaking_json(capsys) -> None:
-    private_key = (
-        "-----BEGIN PRIVATE KEY-----\n"
-        "super-secret-material\n"
-        "-----END PRIVATE KEY-----"
-    )
+    private_key = "-----BEGIN PRIVATE KEY-----\nsuper-secret-material\n-----END PRIVATE KEY-----"
 
     emit_guard_payload("status", {"details": private_key}, True)
 
@@ -157,6 +153,28 @@ def test_guard_settings_json_omits_billing_flag(capsys) -> None:
     output = json.loads(capsys.readouterr().out)
     assert output["settings"]["sync"] is True
     assert "billing" not in output["settings"]
+
+
+def test_guard_hook_render_shows_local_secrets_without_internal_jargon(capsys) -> None:
+    raw_secret = "sk-" + "A" * 32
+
+    emit_guard_payload(
+        "hook",
+        {
+            "recorded": True,
+            "artifact_name": "Bash local secret output",
+            "policy_action": "require-reapproval",
+            "risk_summary": f"Local secrets from local .env file. {raw_secret}",
+            "path_summary": ".env",
+        },
+        False,
+    )
+
+    output = _normalize_render_output(capsys.readouterr().out)
+    assert "local secrets" in output.lower()
+    assert ".env file" in output
+    assert raw_secret not in output
+    assert "credential-looking output" not in output.lower()
 
 
 def test_guard_connect_render_defaults_sync_not_available_to_upgrade_guidance(capsys) -> None:

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1763,6 +1763,47 @@ clearer UX and an implementation plan with technical references.
         assert output["approval_requests"]
         assert "environment variables" in output["risk_summary"].lower()
 
+    @pytest.mark.parametrize("command", ["env -i | grep TOKEN", "env --ignore-environment | grep TOKEN"])
+    def test_codex_post_tool_use_warns_for_cleared_env_pipe_token_output(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+        command,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        event = {
+            "event": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "tool_response": {
+                "stdout": "OPENAI_API_KEY=sk-" + "A" * 32,
+            },
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["policy_action"] == "warn"
+        assert "approval_requests" not in output
+
     @pytest.mark.parametrize(
         "command",
         [

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1226,6 +1226,50 @@ clearer UX and an implementation plan with technical references.
         assert output["continue"] is False
         assert "credential-looking output" in output["stopReason"]
 
+    def test_codex_post_tool_use_queues_secret_family_copy_for_local_secret_output(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        raw_secret = "sk-" + "A" * 32
+        event = {
+            "event": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "cat .env"},
+            "tool_response": {"stdout": f"OPENAI_API_KEY={raw_secret}\n"},
+            "source_scope": "project",
+        }
+        monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
+        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+        rendered = json.dumps(output)
+        approval = output["approval_requests"][0]
+
+        assert rc == 1
+        assert "local secrets" in approval["risk_summary"].lower()
+        assert ".env file" in approval["risk_summary"]
+        assert raw_secret not in rendered
+        assert "credential-looking output" not in approval["risk_summary"].lower()
+
     @pytest.mark.parametrize(
         "command",
         [
@@ -1677,6 +1721,47 @@ clearer UX and an implementation plan with technical references.
         assert rc == 1
         assert output["artifact_type"] == "tool_action_request"
         assert output["approval_requests"]
+
+    def test_codex_post_tool_use_asks_for_env_pipe_token_output_in_balanced(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        event = {
+            "event": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "env | grep TOKEN"},
+            "tool_response": {
+                "stdout": "OPENAI_API_KEY=sk-" + "A" * 32,
+            },
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 1
+        assert output["artifact_type"] == "tool_action_request"
+        assert output["approval_requests"]
+        assert "environment variables" in output["risk_summary"].lower()
 
     @pytest.mark.parametrize(
         "command",


### PR DESCRIPTION
## Summary
- ask for approval when Codex observes credential-like output from `env | grep TOKEN` in Balanced mode
- surface local secret source families such as local `.env` files and environment variables in approval-center and CLI hook copy
- extend output redaction for OpenAI-style keys before rich/JSON rendering

## Tests
- `pytest tests/test_guard_risk.py tests/test_guard_runtime_detectors.py tests/test_guard_runtime.py tests/test_guard_runtime_actions.py tests/test_guard_launch_env.py tests/test_guard_render.py -q`
- `ruff check src tests`
- `ruff format --check src tests/test_guard_risk.py tests/test_guard_runtime.py tests/test_guard_launch_env.py tests/test_guard_render.py`

## Safety
- No secrets or local absolute planning paths are included in code, tests, or this PR text.
- Approval copy names the local secret family without storing raw secret values in dashboard-facing summaries.