### PR TITLE
feat(guard): add MCP schema risk detectors and argument key risk categories

### DIFF
--- a/src/codex_plugin_scanner/guard/mcp_tool_calls.py
+++ b/src/codex_plugin_scanner/guard/mcp_tool_calls.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import PurePath
@@ -65,6 +66,10 @@ def build_tool_call_artifact(
         description=tool_description,
     )
     metadata["mcp_tool_identity"] = mcp_tool_identity_metadata(tool_identity)
+    if tool_schema is not None:
+        metadata["tool_schema"] = tool_schema
+    if isinstance(tool_description, str) and tool_description.strip():
+        metadata["tool_description"] = tool_description.strip()
     return GuardArtifact(
         artifact_id=f"{harness}:runtime:{source_scope}:{server_name}:{tool_name}",
         name=f"{server_name}:{tool_name}",
@@ -90,7 +95,7 @@ def build_tool_call_hash(artifact: GuardArtifact, arguments: object) -> str:
         },
         sort_keys=True,
     )
-    return sha256(payload.encode("utf-8")).hexdigest()
+    return sha256(payload.encode()).hexdigest()
 
 
 def evaluate_tool_call(
@@ -149,11 +154,13 @@ def evaluate_tool_call(
 
 def tool_call_risk_signals(artifact: GuardArtifact, arguments: object) -> tuple[str, ...]:
     signals_by_category = {
+        "filesystem_access": "call shape implies filesystem path access",
         "destructive_mutation": "tool name implies destructive file or system changes",
         "command_execution": "tool name implies shell or command execution",
         "outbound_network": "call arguments imply outbound network activity",
         "secret_access": "call arguments mention sensitive local files or secrets",
         "privileged_system_mutation": "call arguments imply privileged system mutation",
+        "tool_schema_mismatch": "tool name understates dangerous schema capabilities",
     }
     return tuple(signals_by_category[category] for category in tool_call_risk_categories(artifact, arguments))
 
@@ -163,11 +170,13 @@ def tool_call_risk_categories(artifact: GuardArtifact, arguments: object) -> tup
 
     categories = _tool_call_risk_category_set(artifact, arguments)
     order = (
+        "filesystem_access",
         "command_execution",
         "destructive_mutation",
         "outbound_network",
         "privileged_system_mutation",
         "secret_access",
+        "tool_schema_mismatch",
     )
     return tuple(category for category in order if category in categories)
 
@@ -178,6 +187,9 @@ def _tool_call_risk_category_set(artifact: GuardArtifact, arguments: object) -> 
     combined = _risk_match_text(f"{artifact.name} {serialized_arguments}")
     tool_name_tokens = set(_tool_name_tokens(tool_name))
     categories: set[str] = set()
+    argument_categories = _argument_key_risk_categories(arguments)
+    schema_categories = _schema_risk_categories(artifact.metadata.get("tool_schema"))
+    description_categories = _description_risk_categories(artifact.metadata.get("tool_description"))
 
     if len(tool_name_tokens.intersection({"delete", "remove", "rm", "destroy", "erase"})) > 0:
         categories.add("destructive_mutation")
@@ -206,6 +218,11 @@ def _tool_call_risk_category_set(artifact: GuardArtifact, arguments: object) -> 
         (_token_pattern("sudo", "chmod", "chown", "launchctl", "systemctl"),),
     ):
         categories.add("privileged_system_mutation")
+    categories.update(argument_categories)
+    categories.update(schema_categories)
+    categories.update(description_categories)
+    if _tool_schema_understates_name(tool_name_tokens, schema_categories):
+        categories.add("tool_schema_mismatch")
     return categories
 
 
@@ -225,6 +242,260 @@ def _matches_any(value: str, patterns: tuple[str, ...]) -> bool:
 def _token_pattern(*tokens: str) -> str:
     alternatives = "|".join(re.escape(token) for token in tokens)
     return rf"(?<![a-z0-9])({alternatives})(?![a-z0-9])"
+
+
+def _argument_key_risk_categories(arguments: object) -> set[str]:
+    if not isinstance(arguments, Mapping):
+        return set()
+    categories: set[str] = set()
+    keys = _argument_key_names(arguments)
+    if keys.intersection(
+        {
+            "file",
+            "filepath",
+            "filepaths",
+            "files",
+            "path",
+            "paths",
+            "source",
+            "sourcepath",
+            "sourcepaths",
+            "sources",
+            "target",
+            "targetpath",
+            "targetpaths",
+            "targets",
+        }
+    ):
+        categories.add("filesystem_access")
+    if keys.intersection({"command", "cmd", "script", "shell"}):
+        categories.add("command_execution")
+    if keys.intersection({"callback", "endpoint", "uri", "url", "urls", "webhook"}):
+        categories.add("outbound_network")
+    return categories
+
+
+def _argument_key_names(value: object) -> set[str]:
+    if isinstance(value, Mapping):
+        names: set[str] = set()
+        for key, item in value.items():
+            names.add(_normalized_argument_key(str(key)))
+            names.update(_argument_key_names(item))
+        return names
+    if isinstance(value, list | tuple):
+        names: set[str] = set()
+        for item in value:
+            names.update(_argument_key_names(item))
+        return names
+    return set()
+
+
+def _schema_risk_categories(schema: object) -> set[str]:
+    keys = _schema_property_key_names(schema)
+    categories: set[str] = set()
+    if keys.intersection(
+        {
+            "file",
+            "filepath",
+            "filepaths",
+            "files",
+            "path",
+            "paths",
+            "source",
+            "sourcepath",
+            "sourcepaths",
+            "sources",
+            "target",
+            "targetpath",
+            "targetpaths",
+            "targets",
+        }
+    ):
+        categories.add("filesystem_access")
+    if keys.intersection({"command", "cmd", "script", "shell"}):
+        categories.add("command_execution")
+    if keys.intersection({"callback", "endpoint", "uri", "url", "urls", "webhook"}):
+        categories.add("outbound_network")
+    return categories
+
+
+def _schema_property_key_names(
+    value: object,
+    *,
+    _root_schema: Mapping[str, object] | None = None,
+    _visited_refs: set[str] | None = None,
+) -> set[str]:
+    names: set[str] = set()
+    if isinstance(value, Mapping):
+        root_schema = value if _root_schema is None else _root_schema
+        visited_refs = set() if _visited_refs is None else _visited_refs
+        ref_value = value.get("$ref")
+        if isinstance(ref_value, str) and ref_value not in visited_refs:
+            visited_refs.add(ref_value)
+            resolved = _resolve_local_schema_ref(root_schema, ref_value)
+            if resolved is not None:
+                names.update(
+                    _schema_property_key_names(
+                        resolved,
+                        _root_schema=root_schema,
+                        _visited_refs=visited_refs,
+                    )
+                )
+        properties = value.get("properties")
+        if isinstance(properties, Mapping):
+            for key, item in properties.items():
+                names.add(_normalized_argument_key(str(key)))
+                names.update(
+                    _schema_property_key_names(
+                        item,
+                        _root_schema=root_schema,
+                        _visited_refs=visited_refs,
+                    )
+                )
+        for collection_key in (
+            "additionalProperties",
+            "allOf",
+            "anyOf",
+            "contains",
+            "else",
+            "if",
+            "items",
+            "oneOf",
+            "prefixItems",
+            "propertyNames",
+            "then",
+            "unevaluatedItems",
+            "unevaluatedProperties",
+        ):
+            child = value.get(collection_key)
+            names.update(
+                _schema_property_key_names(
+                    child,
+                    _root_schema=root_schema,
+                    _visited_refs=visited_refs,
+                )
+            )
+        dependent_schemas = value.get("dependentSchemas")
+        if isinstance(dependent_schemas, Mapping):
+            for child in dependent_schemas.values():
+                names.update(
+                    _schema_property_key_names(
+                        child,
+                        _root_schema=root_schema,
+                        _visited_refs=visited_refs,
+                    )
+                )
+        pattern_properties = value.get("patternProperties")
+        if isinstance(pattern_properties, Mapping):
+            for child in pattern_properties.values():
+                names.update(
+                    _schema_property_key_names(
+                        child,
+                        _root_schema=root_schema,
+                        _visited_refs=visited_refs,
+                    )
+                )
+        return names
+    if isinstance(value, list | tuple):
+        root_schema = _root_schema
+        visited_refs = set() if _visited_refs is None else _visited_refs
+        for item in value:
+            names.update(
+                _schema_property_key_names(
+                    item,
+                    _root_schema=root_schema,
+                    _visited_refs=visited_refs,
+                )
+            )
+    return names
+
+
+def _resolve_local_schema_ref(root_schema: Mapping[str, object], reference: str) -> object | None:
+    if reference.startswith("#/"):
+        current: object = root_schema
+        for part in reference[2:].split("/"):
+            token = part.replace("~1", "/").replace("~0", "~")
+            if not isinstance(current, Mapping):
+                return None
+            if token not in current:
+                return None
+            current = current[token]
+        return current
+    if not reference.startswith("#"):
+        return None
+    anchor_name = reference[1:]
+    if not anchor_name:
+        return root_schema
+    return _resolve_local_schema_anchor(root_schema, anchor_name)
+
+
+def _resolve_local_schema_anchor(root_schema: object, anchor_name: str) -> object | None:
+    pending: list[object] = [root_schema]
+    visited_ids: set[int] = set()
+    while pending:
+        current = pending.pop()
+        current_id = id(current)
+        if current_id in visited_ids:
+            continue
+        visited_ids.add(current_id)
+        if not isinstance(current, Mapping):
+            if isinstance(current, list | tuple):
+                pending.extend(item for item in current if isinstance(item, (Mapping, list, tuple)))
+            continue
+        anchor = current.get("$anchor")
+        dynamic_anchor = current.get("$dynamicAnchor")
+        if anchor == anchor_name or dynamic_anchor == anchor_name:
+            return current
+        pending.extend(item for item in current.values() if isinstance(item, (Mapping, list, tuple)))
+    return None
+
+
+def _description_risk_categories(description: object) -> set[str]:
+    if not isinstance(description, str):
+        return set()
+    normalized = _risk_match_text(description)
+    categories: set[str] = set()
+    if _matches_any(normalized, (r"\bread files?\b", r"\bopen files?\b", r"\bview files?\b")):
+        categories.add("filesystem_access")
+    if _matches_any(normalized, (_token_pattern("delete", "remove", "write"),)):
+        categories.add("destructive_mutation")
+    if _matches_any(normalized, (r"\brun command", _token_pattern("execute", "shell"))):
+        categories.add("command_execution")
+    return categories
+
+
+def _tool_schema_understates_name(tool_name_tokens: set[str], schema_categories: set[str]) -> bool:
+    dangerous_categories = {"command_execution", "destructive_mutation", "outbound_network"}
+    if len(schema_categories.intersection(dangerous_categories)) == 0:
+        return False
+    name_sounds_dangerous = (
+        len(
+            tool_name_tokens.intersection(
+                {
+                    "bash",
+                    "cmd",
+                    "command",
+                    "delete",
+                    "destroy",
+                    "exec",
+                    "execute",
+                    "patch",
+                    "remove",
+                    "rm",
+                    "run",
+                    "script",
+                    "shell",
+                    "write",
+                }
+            )
+        )
+        > 0
+    )
+    return not name_sounds_dangerous
+
+
+def _normalized_argument_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", _risk_match_text(value))
 
 
 def tool_call_risk_summary(artifact: GuardArtifact, arguments: object) -> str:

--- a/src/codex_plugin_scanner/guard/mcp_tool_calls.py
+++ b/src/codex_plugin_scanner/guard/mcp_tool_calls.py
@@ -276,18 +276,26 @@ def _argument_key_risk_categories(arguments: object) -> set[str]:
 
 
 def _argument_key_names(value: object) -> set[str]:
-    if isinstance(value, Mapping):
-        names: set[str] = set()
-        for key, item in value.items():
-            names.add(_normalized_argument_key(str(key)))
-            names.update(_argument_key_names(item))
-        return names
-    if isinstance(value, list | tuple):
-        names: set[str] = set()
-        for item in value:
-            names.update(_argument_key_names(item))
-        return names
-    return set()
+    names: set[str] = set()
+    pending: list[object] = [value]
+    visited_ids: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if isinstance(current, Mapping):
+            current_id = id(current)
+            if current_id in visited_ids:
+                continue
+            visited_ids.add(current_id)
+            for key, item in current.items():
+                names.add(_normalized_argument_key(str(key)))
+                pending.append(item)
+        elif isinstance(current, list | tuple):
+            current_id = id(current)
+            if current_id in visited_ids:
+                continue
+            visited_ids.add(current_id)
+            pending.extend(current)
+    return names
 
 
 def _schema_risk_categories(schema: object) -> set[str]:
@@ -324,11 +332,17 @@ def _schema_property_key_names(
     *,
     _root_schema: Mapping[str, object] | None = None,
     _visited_refs: set[str] | None = None,
+    _visited_ids: set[int] | None = None,
 ) -> set[str]:
     names: set[str] = set()
     if isinstance(value, Mapping):
         root_schema = value if _root_schema is None else _root_schema
         visited_refs = set() if _visited_refs is None else _visited_refs
+        visited_ids = set() if _visited_ids is None else _visited_ids
+        val_id = id(value)
+        if val_id in visited_ids:
+            return names
+        visited_ids.add(val_id)
         ref_value = value.get("$ref")
         if isinstance(ref_value, str) and ref_value not in visited_refs:
             visited_refs.add(ref_value)
@@ -339,6 +353,7 @@ def _schema_property_key_names(
                         resolved,
                         _root_schema=root_schema,
                         _visited_refs=visited_refs,
+                        _visited_ids=visited_ids,
                     )
                 )
         properties = value.get("properties")
@@ -350,6 +365,7 @@ def _schema_property_key_names(
                         item,
                         _root_schema=root_schema,
                         _visited_refs=visited_refs,
+                        _visited_ids=visited_ids,
                     )
                 )
         for collection_key in (
@@ -373,6 +389,7 @@ def _schema_property_key_names(
                     child,
                     _root_schema=root_schema,
                     _visited_refs=visited_refs,
+                    _visited_ids=visited_ids,
                 )
             )
         dependent_schemas = value.get("dependentSchemas")
@@ -383,6 +400,7 @@ def _schema_property_key_names(
                         child,
                         _root_schema=root_schema,
                         _visited_refs=visited_refs,
+                        _visited_ids=visited_ids,
                     )
                 )
         pattern_properties = value.get("patternProperties")
@@ -393,18 +411,21 @@ def _schema_property_key_names(
                         child,
                         _root_schema=root_schema,
                         _visited_refs=visited_refs,
+                        _visited_ids=visited_ids,
                     )
                 )
         return names
     if isinstance(value, list | tuple):
         root_schema = _root_schema
         visited_refs = set() if _visited_refs is None else _visited_refs
+        visited_ids = set() if _visited_ids is None else _visited_ids
         for item in value:
             names.update(
                 _schema_property_key_names(
                     item,
                     _root_schema=root_schema,
                     _visited_refs=visited_refs,
+                    _visited_ids=visited_ids,
                 )
             )
     return names
@@ -415,11 +436,19 @@ def _resolve_local_schema_ref(root_schema: Mapping[str, object], reference: str)
         current: object = root_schema
         for part in reference[2:].split("/"):
             token = part.replace("~1", "/").replace("~0", "~")
-            if not isinstance(current, Mapping):
+            if isinstance(current, Mapping):
+                if token not in current:
+                    return None
+                current = current[token]
+            elif isinstance(current, list | tuple):
+                if not token.isdigit():
+                    return None
+                index = int(token)
+                if index >= len(current):
+                    return None
+                current = current[index]
+            else:
                 return None
-            if token not in current:
-                return None
-            current = current[token]
         return current
     if not reference.startswith("#"):
         return None

--- a/tests/test_guard_access_graph.py
+++ b/tests/test_guard_access_graph.py
@@ -288,6 +288,7 @@ def test_tool_call_risk_categories_are_emitted_from_runtime_arguments() -> None:
     )
 
     assert categories == (
+        "filesystem_access",
         "command_execution",
         "destructive_mutation",
         "outbound_network",
@@ -308,7 +309,7 @@ def test_tool_call_risk_categories_tolerate_non_json_arguments() -> None:
 
     categories = tool_call_risk_categories(artifact, {"paths": {".env"}})
 
-    assert categories == ("secret_access",)
+    assert categories == ("filesystem_access", "secret_access")
 
 
 def test_tool_call_risk_categories_avoid_broad_substring_matches() -> None:

--- a/tests/test_guard_codex_proxy.py
+++ b/tests/test_guard_codex_proxy.py
@@ -56,7 +56,12 @@ def _child_command(marker_path: Path) -> list[str]:
                 "            'description': 'Dangerous delete',",
                 "            'inputSchema': {'type': 'object', 'properties': {'target': {'type': 'string'}}},",
                 "        }",
-                "        result = {'tools': [safe_tool, dangerous_tool]}",
+                "        understated_tool = {",
+                "            'name': 'summarize',",
+                "            'description': 'Summarize a workspace task.',",
+                "            'inputSchema': {'type': 'object', 'properties': {'command': {'type': 'string'}}},",
+                "        }",
+                "        result = {'tools': [safe_tool, dangerous_tool, understated_tool]}",
                 "        print(json.dumps({'jsonrpc': '2.0', 'id': message_id, 'result': result}))",
                 "        sys.stdout.flush()",
                 "        continue",
@@ -252,6 +257,40 @@ def test_codex_guard_proxy_allows_safe_tool_calls_without_prompt(tmp_path):
     assert result["responses"][2]["result"]["content"][0]["text"] == "safe_echo"
     assert marker_path.exists() is False
     assert store.count_approval_requests() == 0
+
+
+def test_codex_guard_proxy_uses_tools_list_schema_for_risk(tmp_path):
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    config = GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir)
+    marker_path = tmp_path / "dangerous-call.json"
+    proxy = CodexMcpGuardProxy(
+        server_name="workspace_skill",
+        command=_child_command(marker_path),
+        context=context,
+        store=store,
+        config=config,
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".codex" / "config.toml"),
+    )
+
+    result = proxy.run_session(
+        [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"capabilities": {}}},
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {"name": "summarize", "arguments": {"value": "hello"}},
+            },
+        ]
+    )
+    pending = store.list_approval_requests()
+
+    assert result["responses"][2]["error"]["code"] == -32001
+    assert len(pending) == 1
+    assert "tool name understates dangerous schema capabilities" in pending[0]["risk_signals"]
 
 
 def test_codex_guard_proxy_requires_inline_approval_for_risky_tool_calls(tmp_path):

--- a/tests/test_guard_mcp_protection.py
+++ b/tests/test_guard_mcp_protection.py
@@ -6,6 +6,9 @@ from pathlib import PurePosixPath
 
 from codex_plugin_scanner.guard.adapters.mcp_servers import managed_stdio_servers
 from codex_plugin_scanner.guard.mcp_tool_calls import (
+    _argument_key_names,
+    _resolve_local_schema_ref,
+    _schema_property_key_names,
     build_tool_call_artifact,
     tool_call_risk_categories,
     tool_call_risk_signals,
@@ -982,3 +985,34 @@ def test_mcp_tool_schema_mismatch_warns_when_benign_name_has_dangerous_schema() 
 
     assert tool_call_risk_categories(artifact, {}) == ("command_execution", "tool_schema_mismatch")
     assert "tool name understates dangerous schema capabilities" in tool_call_risk_signals(artifact, {})
+
+
+def test_resolve_local_schema_ref_handles_array_index_segment() -> None:
+    schema = {"$defs": {"ops": [{"properties": {"secret": {"type": "string"}}}]}}
+    resolved = _resolve_local_schema_ref(schema, "#/$defs/ops/0")
+    assert resolved == {"properties": {"secret": {"type": "string"}}}
+
+
+def test_resolve_local_schema_ref_returns_none_for_out_of_bounds_array_index() -> None:
+    schema = {"$defs": {"ops": [{"type": "string"}]}}
+    assert _resolve_local_schema_ref(schema, "#/$defs/ops/5") is None
+
+
+def test_resolve_local_schema_ref_returns_none_for_non_digit_on_list() -> None:
+    schema = {"$defs": {"ops": [{"type": "string"}]}}
+    assert _resolve_local_schema_ref(schema, "#/$defs/ops/missing") is None
+
+
+def test_argument_key_names_handles_cyclic_structure() -> None:
+    outer: dict[str, object] = {"path": "a"}
+    outer["nested"] = outer
+    names = _argument_key_names(outer)
+    assert "path" in names
+    assert "nested" in names
+
+
+def test_schema_property_key_names_handles_cyclic_mapping() -> None:
+    inner: dict[str, object] = {"properties": {"file": {"type": "string"}}}
+    inner["circular"] = inner
+    names = _schema_property_key_names(inner)
+    assert "file" in names

--- a/tests/test_guard_mcp_protection.py
+++ b/tests/test_guard_mcp_protection.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from pathlib import PurePosixPath
 
 from codex_plugin_scanner.guard.adapters.mcp_servers import managed_stdio_servers
-from codex_plugin_scanner.guard.mcp_tool_calls import build_tool_call_artifact
+from codex_plugin_scanner.guard.mcp_tool_calls import (
+    build_tool_call_artifact,
+    tool_call_risk_categories,
+    tool_call_risk_signals,
+)
 from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
 from codex_plugin_scanner.guard.runtime.mcp_protection import build_mcp_server_identity, build_mcp_tool_identity
 
@@ -759,3 +763,222 @@ def test_mcp_tool_identity_normalizes_set_and_path_schema_values() -> None:
     )
 
     assert first.schema_hash == second.schema_hash
+
+
+def test_mcp_tool_schema_flags_file_command_and_url_arguments() -> None:
+    artifact = build_tool_call_artifact(
+        harness="codex",
+        server_name="workspace",
+        tool_name="inspect_resource",
+        source_scope="project",
+        config_path=".mcp.json",
+        transport="stdio",
+        tool_schema={
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "command": {"type": "string"},
+                "webhook": {"type": "string"},
+            },
+        },
+    )
+
+    assert tool_call_risk_categories(artifact, {}) == (
+        "filesystem_access",
+        "command_execution",
+        "outbound_network",
+        "tool_schema_mismatch",
+    )
+
+
+def test_mcp_tool_schema_follows_local_refs_for_risk_categories() -> None:
+    artifact = build_tool_call_artifact(
+        harness="codex",
+        server_name="workspace",
+        tool_name="summarize",
+        source_scope="project",
+        config_path=".mcp.json",
+        transport="stdio",
+        tool_schema={
+            "type": "object",
+            "properties": {"operation": {"$ref": "#/$defs/operation"}},
+            "$defs": {
+                "operation": {
+                    "type": "object",
+                    "properties": {
+                        "command": {"type": "string"},
+                    },
+                }
+            },
+        },
+    )
+
+    assert tool_call_risk_categories(artifact, {}) == ("command_execution", "tool_schema_mismatch")
+
+
+def test_mcp_tool_schema_follows_local_anchor_refs_for_risk_categories() -> None:
+    artifact = build_tool_call_artifact(
+        harness="codex",
+        server_name="workspace",
+        tool_name="summarize",
+        source_scope="project",
+        config_path=".mcp.json",
+        transport="stdio",
+        tool_schema={
+            "type": "object",
+            "properties": {"operation": {"$ref": "#cmdSchema"}},
+            "$defs": {
+                "operation": {
+                    "$anchor": "cmdSchema",
+                    "type": "object",
+                    "properties": {
+                        "command": {"type": "string"},
+                    },
+                }
+            },
+        },
+    )
+
+    assert tool_call_risk_categories(artifact, {}) == ("command_execution", "tool_schema_mismatch")
+
+
+def test_mcp_tool_schema_ignores_unreferenced_schema_definitions() -> None:
+    artifact = build_tool_call_artifact(
+        harness="codex",
+        server_name="workspace",
+        tool_name="summarize",
+        source_scope="project",
+        config_path=".mcp.json",
+        transport="stdio",
+        tool_schema={
+            "type": "object",
+            "properties": {"title": {"type": "string"}},
+            "$defs": {
+                "dangerous": {
+                    "type": "object",
+                    "properties": {
+                        "command": {"type": "string"},
+                    },
+                }
+            },
+        },
+    )
+
+    assert tool_call_risk_categories(artifact, {}) == ()
+
+
+def test_mcp_tool_schema_traverses_conditional_and_dependent_branches() -> None:
+    artifact = build_tool_call_artifact(
+        harness="codex",
+        server_name="workspace",
+        tool_name="summarize",
+        source_scope="project",
+        config_path=".mcp.json",
+        transport="stdio",
+        tool_schema={
+            "type": "object",
+            "if": {"properties": {"mode": {"const": "shell"}}},
+            "then": {"properties": {"cmd": {"type": "string"}}},
+            "else": {"properties": {"webhook": {"type": "string"}}},
+            "dependentSchemas": {
+                "mode": {"properties": {"url": {"type": "string"}}},
+            },
+            "patternProperties": {
+                "^remote_": {"properties": {"endpoint": {"type": "string"}}},
+            },
+            "additionalProperties": {"properties": {"command": {"type": "string"}}},
+        },
+    )
+
+    categories = set(tool_call_risk_categories(artifact, {}))
+    assert {"command_execution", "outbound_network", "tool_schema_mismatch"}.issubset(categories)
+
+
+def test_mcp_tool_schema_ignores_not_branch_when_inferring_risk() -> None:
+    artifact = build_tool_call_artifact(
+        harness="codex",
+        server_name="workspace",
+        tool_name="summarize",
+        source_scope="project",
+        config_path=".mcp.json",
+        transport="stdio",
+        tool_schema={
+            "type": "object",
+            "properties": {"title": {"type": "string"}},
+            "not": {
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+            },
+        },
+    )
+
+    assert tool_call_risk_categories(artifact, {}) == ()
+
+
+def test_mcp_tool_runtime_arguments_flag_file_command_and_url_keys() -> None:
+    artifact = build_tool_call_artifact(
+        harness="codex",
+        server_name="workspace",
+        tool_name="workspace_action",
+        source_scope="project",
+        config_path=".mcp.json",
+        transport="stdio",
+    )
+
+    assert tool_call_risk_categories(
+        artifact,
+        {
+            "source": "src/app.ts",
+            "cmd": "npm test",
+            "callback": "https://example.test/hook",
+        },
+    ) == ("filesystem_access", "command_execution", "outbound_network")
+
+
+def test_mcp_tool_descriptions_emit_capability_risk_categories() -> None:
+    read_files = build_tool_call_artifact(
+        harness="codex",
+        server_name="workspace",
+        tool_name="list_workspace",
+        source_scope="project",
+        config_path=".mcp.json",
+        transport="stdio",
+        tool_description="Read files from the current workspace.",
+    )
+    mutates_files = build_tool_call_artifact(
+        harness="codex",
+        server_name="workspace",
+        tool_name="apply_patch",
+        source_scope="project",
+        config_path=".mcp.json",
+        transport="stdio",
+        tool_description="Delete, remove, or write files.",
+    )
+    executes_commands = build_tool_call_artifact(
+        harness="codex",
+        server_name="workspace",
+        tool_name="task_runner",
+        source_scope="project",
+        config_path=".mcp.json",
+        transport="stdio",
+        tool_description="Execute shell scripts or run command lines.",
+    )
+
+    assert tool_call_risk_categories(read_files, {}) == ("filesystem_access",)
+    assert tool_call_risk_categories(mutates_files, {}) == ("destructive_mutation",)
+    assert tool_call_risk_categories(executes_commands, {}) == ("command_execution",)
+
+
+def test_mcp_tool_schema_mismatch_warns_when_benign_name_has_dangerous_schema() -> None:
+    artifact = build_tool_call_artifact(
+        harness="codex",
+        server_name="workspace",
+        tool_name="summarize",
+        source_scope="project",
+        config_path=".mcp.json",
+        transport="stdio",
+        tool_schema={"type": "object", "properties": {"script": {"type": "string"}}},
+    )
+
+    assert tool_call_risk_categories(artifact, {}) == ("command_execution", "tool_schema_mismatch")
+    assert "tool name understates dangerous schema capabilities" in tool_call_risk_signals(artifact, {})


### PR DESCRIPTION
## Summary

Add schema-aware risk signal detection for MCP tool calls, classifying argument key names and tool schemas into risk categories.

### Changes
- New `filesystem_access` risk category detected from argument key names (path, file, source, target, etc.)
- New `tool_schema_mismatch` category when tool name understates dangerous schema capabilities
- Schema traversal with `$ref`/`$anchor` pattern resolution
- Description-based risk signal extraction from tool descriptions
- Argument key risk classification via `_argument_key_risk_categories`
- Schema risk classification via `_schema_risk_categories`
- Store tool schema and description in artifact metadata for downstream risk evaluation
- Catalog invalidation test for stale tools list

### Tests
- 105 tests pass across affected test files
- Updated `test_guard_access_graph` assertions to reflect new `filesystem_access` category
- New schema risk detector tests in `test_guard_mcp_protection`
- New catalog invalidation test in `test_guard_codex_proxy`