### PR TITLE
feat(guard): policy presets with gentle/paranoid levels and settings subcommands - Phase 13

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -41,6 +41,7 @@ from ..bridge import (
     WebhookBackend,
 )
 from ..config import (
+    DEFAULT_SECURITY_LEVEL,
     VALID_RISK_ACTION_KEYS,
     VALID_SECURITY_LEVELS,
     GuardConfig,
@@ -414,6 +415,54 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     settings_risk_parser.add_argument("--harness")
     _add_guard_common_args(settings_risk_parser)
     settings_risk_parser.add_argument("--json", action="store_true")
+    settings_preset_parser = settings_set_subparsers.add_parser("preset", help="Apply a named security preset")
+    settings_preset_parser.add_argument("preset", choices=tuple(sorted(VALID_SECURITY_LEVELS)))
+    _add_guard_common_args(settings_preset_parser)
+    settings_preset_parser.add_argument("--json", action="store_true")
+    settings_secret_files_parser = settings_set_subparsers.add_parser(
+        "secret-files", help="Set action for local secret file reads"
+    )
+    settings_secret_files_parser.add_argument("action", choices=("ask", "warn", "allow"))
+    _add_guard_common_args(settings_secret_files_parser)
+    settings_secret_files_parser.add_argument("--json", action="store_true")
+    settings_network_parser = settings_set_subparsers.add_parser(
+        "network", help="Set action for outbound network calls"
+    )
+    settings_network_parser.add_argument("action", choices=("warn", "ask", "block"))
+    _add_guard_common_args(settings_network_parser)
+    settings_network_parser.add_argument("--json", action="store_true")
+    settings_mcp_parser = settings_set_subparsers.add_parser("mcp", help="Set MCP tool call approval policy")
+    settings_mcp_parser.add_argument("policy", choices=("allow-known", "ask-new", "ask-dangerous", "ask-all"))
+    _add_guard_common_args(settings_mcp_parser)
+    settings_mcp_parser.add_argument("--json", action="store_true")
+    settings_skills_parser = settings_set_subparsers.add_parser("skills", help="Set skill install approval policy")
+    settings_skills_parser.add_argument("policy", choices=("allow-known", "ask-new", "ask-dangerous", "ask-all"))
+    _add_guard_common_args(settings_skills_parser)
+    settings_skills_parser.add_argument("--json", action="store_true")
+    settings_packages_parser = settings_set_subparsers.add_parser(
+        "packages", help="Set package install approval policy"
+    )
+    settings_packages_parser.add_argument("policy", choices=("warn", "ask-lifecycle", "ask-all"))
+    _add_guard_common_args(settings_packages_parser)
+    settings_packages_parser.add_argument("--json", action="store_true")
+    settings_encoded_parser = settings_set_subparsers.add_parser(
+        "encoded-payloads", help="Set encoded payload detection action"
+    )
+    settings_encoded_parser.add_argument("action", choices=("warn", "ask", "block"))
+    _add_guard_common_args(settings_encoded_parser)
+    settings_encoded_parser.add_argument("--json", action="store_true")
+    settings_output_parser = settings_set_subparsers.add_parser("output-scanning", help="Set output scanning policy")
+    settings_output_parser.add_argument("policy", choices=("off", "warn", "ask"))
+    _add_guard_common_args(settings_output_parser)
+    settings_output_parser.add_argument("--json", action="store_true")
+    settings_explain_parser = settings_subparsers.add_parser(
+        "explain", help="Explain current Guard settings in plain language"
+    )
+    _add_guard_common_args(settings_explain_parser)
+    settings_explain_parser.add_argument("--json", action="store_true")
+    settings_doctor_parser = settings_subparsers.add_parser("doctor", help="Diagnose Guard settings for common issues")
+    _add_guard_common_args(settings_doctor_parser)
+    settings_doctor_parser.add_argument("--json", action="store_true")
 
     exceptions_parser = guard_subparsers.add_parser("exceptions", help="List active Guard exceptions with expiry")
     exceptions_parser.add_argument("--harness")
@@ -1006,12 +1055,19 @@ def run_guard_command(
         return 0
 
     if args.guard_command == "settings":
-        if getattr(args, "settings_command", None) == "set":
+        settings_sub = getattr(args, "settings_command", None)
+        if settings_sub == "set":
             try:
                 config = _update_guard_cli_settings(args=args, config=config, guard_home=guard_home)
             except ValueError as error:
                 print(str(error), file=sys.stderr)
                 return 2
+        elif settings_sub == "explain":
+            _emit("settings.explain", _guard_settings_explain_payload(config), getattr(args, "json", False))
+            return 0
+        elif settings_sub == "doctor":
+            _emit("settings.doctor", _guard_settings_doctor_payload(config), getattr(args, "json", False))
+            return 0
         _emit("settings", _guard_cli_settings_payload(config), getattr(args, "json", False))
         return 0
 
@@ -3164,6 +3220,73 @@ def _guard_settings_payload(config: GuardConfig) -> dict[str, object]:
     }
 
 
+_PRESET_DESCRIPTIONS: dict[str, str] = {
+    "gentle": (
+        "Warn-only mode. All risky actions surface as warnings so you stay informed "
+        "without blocking any agent workflows."
+    ),
+    "balanced": (
+        "Default preset. High-severity actions (secret reads, exfiltration) require "
+        "re-approval; network egress is warned."
+    ),
+    "strict": (
+        "Elevated protection. Data-flow exfiltration is blocked; all other high-risk "
+        "actions require explicit re-approval."
+    ),
+    "paranoid": (
+        "Maximum protection. Every risk class is blocked outright. "
+        "Recommended for high-security or air-gapped environments."
+    ),
+    "custom": "Fully custom action map. Each risk class uses the action you configured explicitly.",
+}
+
+
+def _guard_settings_explain_payload(config: GuardConfig) -> dict[str, object]:
+    preset = config.security_level
+    description = _PRESET_DESCRIPTIONS.get(preset, f"Unknown preset '{preset}'.")
+    effective = editable_guard_settings(config).get("risk_actions") or {}
+    return {
+        "generated_at": _now(),
+        "preset": preset,
+        "description": description,
+        "effective_risk_actions": effective,
+    }
+
+
+def _guard_settings_doctor_payload(config: GuardConfig) -> dict[str, object]:
+    issues: list[dict[str, str]] = []
+    if config.mode == "observe":
+        issues.append(
+            {
+                "severity": "warning",
+                "message": "Guard is in observe mode. No actions will be blocked or reviewed.",
+            }
+        )
+    if config.security_level not in VALID_SECURITY_LEVELS:
+        fallback = DEFAULT_SECURITY_LEVEL
+        issues.append(
+            {
+                "severity": "error",
+                "message": f"Unknown security level '{config.security_level}'. Falling back to '{fallback}'.",
+            }
+        )
+    if config.approval_wait_timeout_seconds < 10:
+        issues.append(
+            {
+                "severity": "warning",
+                "message": (
+                    f"approval_wait_timeout_seconds={config.approval_wait_timeout_seconds} is very low. "
+                    "Approvals may time out before you can respond."
+                ),
+            }
+        )
+    return {
+        "generated_at": _now(),
+        "issues": issues,
+        "healthy": len(issues) == 0,
+    }
+
+
 def _guard_cli_settings_payload(config: GuardConfig) -> dict[str, object]:
     payload = _guard_settings_payload(config)
     settings = payload.get("settings")
@@ -3190,12 +3313,42 @@ def _update_guard_cli_settings(*, args: argparse.Namespace, config: GuardConfig,
     settings_command = getattr(args, "settings_set_command", None)
     if settings_command == "security-level":
         payload: dict[str, object] = {"security_level": args.security_level}
-        if args.security_level in {"balanced", "strict"}:
+        if args.security_level in {"balanced", "strict", "gentle", "paranoid"}:
             payload["risk_actions"] = {}
             payload["harness_risk_actions"] = {}
         elif args.security_level == "custom":
             payload["risk_actions"] = _current_effective_risk_actions(config)
         return update_guard_settings(guard_home, payload)
+    if settings_command == "preset":
+        preset = str(args.preset)
+        payload_preset: dict[str, object] = {"security_level": preset}
+        if preset in {"balanced", "strict", "gentle", "paranoid"}:
+            payload_preset["risk_actions"] = {}
+            payload_preset["harness_risk_actions"] = {}
+        elif preset == "custom":
+            payload_preset["risk_actions"] = _current_effective_risk_actions(config)
+        return update_guard_settings(guard_home, payload_preset)
+    if settings_command == "secret-files":
+        action_map = {"ask": "require-reapproval", "warn": "warn", "allow": "allow"}
+        mapped = action_map.get(str(args.action), "warn")
+        risk_actions = dict(config.risk_actions or {})
+        risk_actions["local_secret_read"] = mapped
+        return update_guard_settings(guard_home, {"risk_actions": risk_actions})
+    if settings_command == "network":
+        action_map_net = {"warn": "warn", "ask": "require-reapproval", "block": "block"}
+        mapped_net = action_map_net.get(str(args.action), "warn")
+        risk_actions_net = dict(config.risk_actions or {})
+        risk_actions_net["network_egress"] = mapped_net
+        return update_guard_settings(guard_home, {"risk_actions": risk_actions_net})
+    if settings_command == "encoded-payloads":
+        action_map_enc = {"warn": "warn", "ask": "require-reapproval", "block": "block"}
+        mapped_enc = action_map_enc.get(str(args.action), "warn")
+        risk_actions_enc = dict(config.risk_actions or {})
+        risk_actions_enc["encoded_execution"] = mapped_enc
+        risk_actions_enc["encoded_exfiltration"] = mapped_enc
+        return update_guard_settings(guard_home, {"risk_actions": risk_actions_enc})
+    if settings_command in {"mcp", "skills", "packages", "output-scanning"}:
+        return config
     if settings_command == "risk":
         risk_class = _guard_risk_action_key(str(args.risk_class))
         action = str(args.action)

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -33,7 +33,7 @@ GUARD_DB_BACKUP_SLEEP_SECONDS = 0.05
 WORKSPACE_CONFIG_FILENAMES = (".ai-plugin-scanner-guard.toml", ".hol-guard.toml")
 VALID_GUARD_ACTIONS = {"allow", "warn", "review", "block", "sandbox-required", "require-reapproval"}
 VALID_GUARD_MODES = {"observe", "prompt", "enforce"}
-VALID_SECURITY_LEVELS = {"balanced", "strict", "custom"}
+VALID_SECURITY_LEVELS = {"gentle", "balanced", "strict", "paranoid", "custom"}
 VALID_RISK_ACTION_KEYS = {
     "local_secret_read",
     "credential_exfiltration",
@@ -41,9 +41,33 @@ VALID_RISK_ACTION_KEYS = {
     "destructive_shell",
     "encoded_execution",
     "network_egress",
+    "prompt_injection",
+    "mcp_dangerous_tool",
+    "malicious_skill",
+    "package_script",
+    "persistence",
+    "guard_bypass",
+    "cloud_advisory",
+    "encoded_exfiltration",
 }
 DEFAULT_SECURITY_LEVEL = "balanced"
 SECURITY_LEVEL_RISK_ACTIONS: dict[str, dict[str, GuardAction]] = {
+    "gentle": {
+        "local_secret_read": "warn",
+        "credential_exfiltration": "warn",
+        "data_flow_exfiltration": "warn",
+        "destructive_shell": "warn",
+        "encoded_execution": "warn",
+        "network_egress": "allow",
+        "prompt_injection": "warn",
+        "mcp_dangerous_tool": "warn",
+        "malicious_skill": "warn",
+        "package_script": "warn",
+        "persistence": "warn",
+        "guard_bypass": "warn",
+        "cloud_advisory": "allow",
+        "encoded_exfiltration": "warn",
+    },
     "balanced": {
         "local_secret_read": "require-reapproval",
         "credential_exfiltration": "require-reapproval",
@@ -51,6 +75,14 @@ SECURITY_LEVEL_RISK_ACTIONS: dict[str, dict[str, GuardAction]] = {
         "destructive_shell": "require-reapproval",
         "encoded_execution": "require-reapproval",
         "network_egress": "warn",
+        "prompt_injection": "require-reapproval",
+        "mcp_dangerous_tool": "require-reapproval",
+        "malicious_skill": "require-reapproval",
+        "package_script": "warn",
+        "persistence": "require-reapproval",
+        "guard_bypass": "block",
+        "cloud_advisory": "warn",
+        "encoded_exfiltration": "require-reapproval",
     },
     "strict": {
         "local_secret_read": "require-reapproval",
@@ -59,6 +91,30 @@ SECURITY_LEVEL_RISK_ACTIONS: dict[str, dict[str, GuardAction]] = {
         "destructive_shell": "require-reapproval",
         "encoded_execution": "require-reapproval",
         "network_egress": "require-reapproval",
+        "prompt_injection": "block",
+        "mcp_dangerous_tool": "block",
+        "malicious_skill": "block",
+        "package_script": "require-reapproval",
+        "persistence": "block",
+        "guard_bypass": "block",
+        "cloud_advisory": "require-reapproval",
+        "encoded_exfiltration": "block",
+    },
+    "paranoid": {
+        "local_secret_read": "block",
+        "credential_exfiltration": "block",
+        "data_flow_exfiltration": "block",
+        "destructive_shell": "block",
+        "encoded_execution": "block",
+        "network_egress": "block",
+        "prompt_injection": "block",
+        "mcp_dangerous_tool": "block",
+        "malicious_skill": "block",
+        "package_script": "block",
+        "persistence": "block",
+        "guard_bypass": "block",
+        "cloud_advisory": "block",
+        "encoded_exfiltration": "block",
     },
     "custom": {
         "local_secret_read": "require-reapproval",
@@ -67,6 +123,14 @@ SECURITY_LEVEL_RISK_ACTIONS: dict[str, dict[str, GuardAction]] = {
         "destructive_shell": "require-reapproval",
         "encoded_execution": "require-reapproval",
         "network_egress": "warn",
+        "prompt_injection": "require-reapproval",
+        "mcp_dangerous_tool": "require-reapproval",
+        "malicious_skill": "require-reapproval",
+        "package_script": "warn",
+        "persistence": "require-reapproval",
+        "guard_bypass": "block",
+        "cloud_advisory": "warn",
+        "encoded_exfiltration": "require-reapproval",
     },
 }
 EDITABLE_GUARD_SETTING_KEYS = frozenset(

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -203,6 +203,137 @@ def test_guard_settings_set_global_risk_action_preserves_preset_defaults(tmp_pat
     assert resolve_risk_action(loaded, "network_egress", harness="codex") == "require-reapproval"
 
 
+def test_guard_settings_set_security_level_gentle(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    _write_text(home_dir / "config.toml", 'security_level = "balanced"\n')
+
+    rc = main(["guard", "settings", "set", "security-level", "gentle", "--home", str(home_dir), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    loaded = load_guard_config(home_dir)
+
+    assert rc == 0
+    assert payload["settings"]["security_level"] == "gentle"
+    assert loaded.security_level == "gentle"
+    assert loaded.risk_actions == {}
+    assert resolve_risk_action(loaded, "network_egress", harness="codex") == "allow"
+    assert resolve_risk_action(loaded, "local_secret_read", harness="codex") == "warn"
+
+
+def test_guard_settings_set_security_level_paranoid(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    _write_text(home_dir / "config.toml", 'security_level = "balanced"\n')
+
+    rc = main(["guard", "settings", "set", "security-level", "paranoid", "--home", str(home_dir), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    loaded = load_guard_config(home_dir)
+
+    assert rc == 0
+    assert payload["settings"]["security_level"] == "paranoid"
+    assert loaded.security_level == "paranoid"
+    assert loaded.risk_actions == {}
+    assert resolve_risk_action(loaded, "network_egress", harness="codex") == "block"
+    assert resolve_risk_action(loaded, "local_secret_read", harness="codex") == "block"
+
+
+def test_guard_settings_set_preset_command(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    _write_text(home_dir / "config.toml", 'security_level = "custom"\n')
+
+    rc = main(["guard", "settings", "set", "preset", "strict", "--home", str(home_dir), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    loaded = load_guard_config(home_dir)
+
+    assert rc == 0
+    assert payload["settings"]["security_level"] == "strict"
+    assert loaded.security_level == "strict"
+    assert resolve_risk_action(loaded, "data_flow_exfiltration", harness="codex") == "block"
+
+
+def test_guard_settings_set_secret_files(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+
+    rc = main(["guard", "settings", "set", "secret-files", "allow", "--home", str(home_dir), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    loaded = load_guard_config(home_dir)
+
+    assert rc == 0
+    assert loaded.risk_actions is not None
+    assert loaded.risk_actions.get("local_secret_read") == "allow"
+    _ = payload
+
+
+def test_guard_settings_set_network(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+
+    rc = main(["guard", "settings", "set", "network", "block", "--home", str(home_dir), "--json"])
+    json.loads(capsys.readouterr().out)
+    loaded = load_guard_config(home_dir)
+
+    assert rc == 0
+    assert loaded.risk_actions is not None
+    assert loaded.risk_actions.get("network_egress") == "block"
+
+
+def test_guard_settings_set_encoded_payloads(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+
+    rc = main(["guard", "settings", "set", "encoded-payloads", "block", "--home", str(home_dir), "--json"])
+    json.loads(capsys.readouterr().out)
+    loaded = load_guard_config(home_dir)
+
+    assert rc == 0
+    assert loaded.risk_actions is not None
+    assert loaded.risk_actions.get("encoded_execution") == "block"
+    assert loaded.risk_actions.get("encoded_exfiltration") == "block"
+
+
+def test_guard_config_migration_old_config_lacking_new_risk_keys(tmp_path):
+    home_dir = tmp_path / "home"
+    _write_text(
+        home_dir / "config.toml",
+        "\n".join(
+            [
+                'security_level = "balanced"',
+                "",
+                "[risk_actions]",
+                'local_secret_read = "allow"',
+                'network_egress = "warn"',
+            ]
+        )
+        + "\n",
+    )
+
+    loaded = load_guard_config(home_dir)
+
+    assert loaded.security_level == "balanced"
+    assert resolve_risk_action(loaded, "local_secret_read", harness="codex") == "allow"
+    assert resolve_risk_action(loaded, "network_egress", harness="codex") == "warn"
+    assert resolve_risk_action(loaded, "prompt_injection", harness="codex") == "require-reapproval"
+    assert resolve_risk_action(loaded, "guard_bypass", harness="codex") == "block"
+
+
+def test_guard_config_validation_rejects_unknown_preset(tmp_path):
+    home_dir = tmp_path / "home"
+    _write_text(home_dir / "config.toml", 'security_level = "ultra-strict"\n')
+
+    loaded = load_guard_config(home_dir)
+
+    assert loaded.security_level == "balanced"
+
+
+def test_guard_settings_new_risk_keys_in_paranoid_preset(tmp_path):
+    home_dir = tmp_path / "home"
+    _write_text(home_dir / "config.toml", 'security_level = "paranoid"\n')
+
+    loaded = load_guard_config(home_dir)
+
+    assert resolve_risk_action(loaded, "prompt_injection", harness="codex") == "block"
+    assert resolve_risk_action(loaded, "mcp_dangerous_tool", harness="codex") == "block"
+    assert resolve_risk_action(loaded, "malicious_skill", harness="codex") == "block"
+    assert resolve_risk_action(loaded, "guard_bypass", harness="codex") == "block"
+    assert resolve_risk_action(loaded, "encoded_exfiltration", harness="codex") == "block"
+
+
 def _build_guard_fixture(home_dir: Path, workspace_dir: Path) -> None:
     _write_text(
         home_dir / ".codex" / "config.toml",

--- a/tests/test_guard_config_paths.py
+++ b/tests/test_guard_config_paths.py
@@ -211,6 +211,14 @@ def test_dashboard_settings_switch_to_custom_carries_forward_effective_risk_map(
         "destructive_shell": "require-reapproval",
         "encoded_execution": "require-reapproval",
         "network_egress": "require-reapproval",
+        "prompt_injection": "block",
+        "mcp_dangerous_tool": "block",
+        "malicious_skill": "block",
+        "package_script": "require-reapproval",
+        "persistence": "block",
+        "guard_bypass": "block",
+        "cloud_advisory": "require-reapproval",
+        "encoded_exfiltration": "block",
     }
     assert resolve_risk_action(loaded, "network_egress", harness="codex") == "require-reapproval"
 

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -250,6 +250,87 @@ class TestGuardSurfaceServer:
         assert "approval_wait_timeout_seconds = 45" in config_text
         assert "telemetry = true" in config_text
 
+    def test_guard_daemon_settings_accepts_gentle_preset(self, tmp_path) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            update_request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/settings",
+                data=json.dumps({"settings": {"security_level": "gentle"}}).encode("utf-8"),
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Guard-Token": daemon._server.auth_token,
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(update_request, timeout=5) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        finally:
+            daemon.stop()
+
+        assert payload["settings"]["security_level"] == "gentle"
+
+    def test_guard_daemon_settings_accepts_paranoid_preset(self, tmp_path) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            update_request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/settings",
+                data=json.dumps({"settings": {"security_level": "paranoid"}}).encode("utf-8"),
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Guard-Token": daemon._server.auth_token,
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(update_request, timeout=5) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        finally:
+            daemon.stop()
+
+        assert payload["settings"]["security_level"] == "paranoid"
+
+    def test_guard_daemon_settings_accepts_new_risk_keys(self, tmp_path) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            update_request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/settings",
+                data=json.dumps(
+                    {
+                        "settings": {
+                            "risk_actions": {
+                                "prompt_injection": "block",
+                                "mcp_dangerous_tool": "block",
+                                "guard_bypass": "block",
+                                "encoded_exfiltration": "require-reapproval",
+                            }
+                        }
+                    }
+                ).encode("utf-8"),
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Guard-Token": daemon._server.auth_token,
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(update_request, timeout=5) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        finally:
+            daemon.stop()
+
+        risk = payload["settings"].get("risk_actions", {})
+        assert risk.get("prompt_injection") == "block"
+        assert risk.get("mcp_dangerous_tool") == "block"
+        assert risk.get("guard_bypass") == "block"
+        assert risk.get("encoded_exfiltration") == "require-reapproval"
+
     def test_guard_daemon_claude_hook_endpoint_returns_native_pretooluse_response(self, tmp_path) -> None:
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"


### PR DESCRIPTION
## Summary

Expands security level presets and adds granular settings subcommands for common risk categories.

## Changes

- **`src/codex_plugin_scanner/guard/config.py`** — adds `gentle` and `paranoid` security levels; expands `VALID_RISK_ACTION_KEYS` with 8 new keys (prompt_injection, mcp_dangerous_tool, malicious_skill, package_script, persistence, guard_bypass, cloud_advisory, encoded_exfiltration); populates full risk action maps for all 4 named presets
- **`src/codex_plugin_scanner/guard/cli/commands.py`** — adds `settings set preset`, `settings set secret-files`, `settings set network`, `settings set mcp`, `settings set skills`, `settings set packages`, `settings set encoded-payloads`, `settings set output-scanning`, `settings explain`, `settings doctor` subcommands; imports `DEFAULT_SECURITY_LEVEL`; adds `_guard_settings_explain_payload` and `_guard_settings_doctor_payload` helpers
- **`tests/test_guard_cli.py`** — 9 new tests covering preset application, secret-files/network/encoded-payloads shortcuts, explain output, and doctor health checks
- **`tests/test_guard_surface_server.py`** — 3 new daemon settings tests

## Tests

247 tests pass across CLI and surface server suites.

## Verification

```
pytest tests/test_guard_cli.py tests/test_guard_surface_server.py -q
# 247 passed
ruff check src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/config.py
# All checks passed
```