### PR TITLE
feat(guard): approval store scale with indexes, cursor pagination, bulk ops, and compaction - Phase 14

### DIFF
--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -175,6 +175,10 @@ def list_approval_requests(
     status: str | None = "pending",
     harness: str | None = None,
     limit: int | None = 50,
+    before_cursor: str | None = None,
+    search: str | None = None,
+    created_after: str | None = None,
+    created_before: str | None = None,
 ) -> list[dict[str, object]]:
     clauses = []
     params: list[object] = []
@@ -184,6 +188,24 @@ def list_approval_requests(
     if harness is not None:
         clauses.append("harness = ?")
         params.append(harness)
+    if before_cursor is not None:
+        clauses.append("created_at < ?")
+        params.append(before_cursor)
+    if created_after is not None:
+        clauses.append("created_at > ?")
+        params.append(created_after)
+    if created_before is not None:
+        clauses.append("created_at < ?")
+        params.append(created_before)
+    if search is not None:
+        search_clause = (
+            "(lower(artifact_name) like lower(?)"
+            " or lower(artifact_id) like lower(?)"
+            " or lower(coalesce(risk_summary, '')) like lower(?))"
+        )
+        clauses.append(search_clause)
+        pattern = f"%{search}%"
+        params.extend([pattern, pattern, pattern])
     where_clause = f"where {' and '.join(clauses)}" if clauses else ""
     query = f"""
         select request_id, harness, artifact_id, artifact_name, artifact_type, artifact_hash, publisher, policy_action,
@@ -243,14 +265,22 @@ def resolve_approval_request(
     )
 
 
-def count_approval_requests(connection: sqlite3.Connection, *, status: str | None = "pending") -> int:
-    if status is None:
-        row = connection.execute("select count(*) as total from approval_requests").fetchone()
-    else:
-        row = connection.execute(
-            "select count(*) as total from approval_requests where status = ?",
-            (status,),
-        ).fetchone()
+def count_approval_requests(
+    connection: sqlite3.Connection,
+    *,
+    status: str | None = "pending",
+    harness: str | None = None,
+) -> int:
+    clauses = []
+    params: list[object] = []
+    if status is not None:
+        clauses.append("status = ?")
+        params.append(status)
+    if harness is not None:
+        clauses.append("harness = ?")
+        params.append(harness)
+    where_clause = f"where {' and '.join(clauses)}" if clauses else ""
+    row = connection.execute(f"select count(*) as total from approval_requests {where_clause}", params).fetchone()
     return int(row["total"]) if row is not None else 0
 
 
@@ -265,14 +295,14 @@ def _row_to_payload(row: sqlite3.Row) -> dict[str, object]:
         "publisher": row["publisher"],
         "policy_action": str(row["policy_action"]),
         "recommended_scope": str(row["recommended_scope"]),
-        "changed_fields": json.loads(str(row["changed_fields_json"])),
+        "changed_fields": _safe_json_list(row["changed_fields_json"]),
         "source_scope": str(row["source_scope"]),
         "config_path": str(row["config_path"]),
         "workspace": row["workspace"],
         "launch_target": row["launch_target"],
         "transport": row["transport"],
         "risk_summary": row["risk_summary"],
-        "risk_signals": json.loads(str(row["risk_signals_json"])),
+        "risk_signals": _safe_json_list(row["risk_signals_json"]),
         "artifact_label": row["artifact_label"],
         "source_label": row["source_label"],
         "trigger_summary": row["trigger_summary"],
@@ -290,6 +320,111 @@ def _row_to_payload(row: sqlite3.Row) -> dict[str, object]:
         "created_at": str(row["created_at"]),
         "resolved_at": row["resolved_at"],
     }
+
+
+def _safe_json_list(value: object) -> list[object]:
+    if value is None:
+        return []
+    try:
+        parsed = json.loads(str(value))
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return []
+    return list(parsed) if isinstance(parsed, list) else []
+
+
+def approval_index_statements() -> list[str]:
+    return [
+        "create index if not exists idx_approval_status_created on approval_requests(status, created_at desc)",
+        "create index if not exists idx_approval_harness_status on approval_requests(harness, status)",
+        "create index if not exists idx_approval_artifact_hash on approval_requests(artifact_hash)",
+        "create index if not exists idx_approval_workspace_status on approval_requests(workspace, status)",
+        "create index if not exists idx_approval_policy_action on approval_requests(policy_action)",
+        "create index if not exists idx_approval_resolution on approval_requests(resolution_action, resolved_at)",
+    ]
+
+
+def bulk_resolve_approval_requests(
+    connection: sqlite3.Connection,
+    request_ids: list[str],
+    *,
+    resolution_action: str,
+    resolution_scope: str,
+    reason: str | None,
+    resolved_at: str,
+) -> None:
+    if not request_ids:
+        return
+    placeholders = ",".join("?" for _ in request_ids)
+    connection.execute(
+        f"""
+        update approval_requests
+        set status = 'resolved',
+            resolution_action = ?,
+            resolution_scope = ?,
+            reason = ?,
+            resolved_at = ?
+        where request_id in ({placeholders})
+          and status = 'pending'
+        """,
+        [resolution_action, resolution_scope, reason, resolved_at, *request_ids],
+    )
+
+
+def clear_approval_requests_by_harness(connection: sqlite3.Connection, harness: str) -> int:
+    cursor = connection.execute(
+        "delete from approval_requests where harness = ? and status = 'resolved'",
+        (harness,),
+    )
+    return cursor.rowcount
+
+
+def clear_approval_requests_by_workspace(connection: sqlite3.Connection, workspace: str) -> int:
+    cursor = connection.execute(
+        "delete from approval_requests where workspace = ? and status = 'resolved'",
+        (workspace,),
+    )
+    return cursor.rowcount
+
+
+def clear_approval_requests_by_scope(connection: sqlite3.Connection, source_scope: str) -> int:
+    cursor = connection.execute(
+        "delete from approval_requests where source_scope = ? and status = 'resolved'",
+        (source_scope,),
+    )
+    return cursor.rowcount
+
+
+def clear_resolved_approval_requests_before(connection: sqlite3.Connection, before_timestamp: str) -> int:
+    cursor = connection.execute(
+        "delete from approval_requests where status = 'resolved' and resolved_at < ?",
+        (before_timestamp,),
+    )
+    return cursor.rowcount
+
+
+def compact_approval_requests(connection: sqlite3.Connection) -> int:
+    rows = connection.execute(
+        """
+        select artifact_id, max(created_at) as latest_created
+        from approval_requests
+        where status = 'resolved'
+        group by artifact_id
+        having count(*) > 1
+        """
+    ).fetchall()
+    total_removed = 0
+    for row in rows:
+        cursor = connection.execute(
+            """
+            delete from approval_requests
+            where artifact_id = ?
+              and status = 'resolved'
+              and created_at < ?
+            """,
+            (row["artifact_id"], row["latest_created"]),
+        )
+        total_removed += cursor.rowcount
+    return total_removed
 
 
 def _optional_json_object(value: object) -> dict[str, object] | None:

--- a/tests/test_guard_approval_store_scale.py
+++ b/tests/test_guard_approval_store_scale.py
@@ -1,0 +1,510 @@
+"""Phase 14 — approval store scale: indexes, cursor pagination, bulk ops, and migrations."""
+
+from __future__ import annotations
+
+import dataclasses
+import sqlite3
+import uuid
+
+from codex_plugin_scanner.guard.models import GuardApprovalRequest
+from codex_plugin_scanner.guard.store_approvals import (
+    add_approval_request,
+    approval_index_statements,
+    approval_schema_statement,
+    bulk_resolve_approval_requests,
+    clear_approval_requests_by_harness,
+    clear_approval_requests_by_scope,
+    clear_approval_requests_by_workspace,
+    clear_resolved_approval_requests_before,
+    compact_approval_requests,
+    count_approval_requests,
+    get_approval_request,
+    list_approval_requests,
+    resolve_approval_request,
+)
+
+
+def _make_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("pragma journal_mode=wal")
+    conn.execute(approval_schema_statement())
+    for stmt in approval_index_statements():
+        conn.execute(stmt)
+    return conn
+
+
+def _make_request(
+    *,
+    harness: str = "codex",
+    workspace: str | None = "ws-a",
+    artifact_id: str | None = None,
+    policy_action: str = "require-reapproval",
+    source_scope: str = "project",
+) -> GuardApprovalRequest:
+    aid = artifact_id or f"codex:project:tool-{uuid.uuid4().hex[:8]}"
+    rid = str(uuid.uuid4())
+    return GuardApprovalRequest(
+        request_id=rid,
+        harness=harness,
+        artifact_id=aid,
+        artifact_name="tool",
+        artifact_type="mcp_server",
+        artifact_hash="abc123",
+        publisher=None,
+        policy_action=policy_action,
+        recommended_scope="session",
+        changed_fields=frozenset(["args"]),
+        source_scope=source_scope,
+        config_path="/tmp/config.toml",
+        workspace=workspace,
+        launch_target=None,
+        transport="stdio",
+        risk_summary="risk",
+        risk_signals=[],
+        artifact_label=None,
+        source_label=None,
+        trigger_summary=None,
+        why_now=None,
+        launch_summary=None,
+        risk_headline=None,
+        action_envelope_json=None,
+        decision_v2_json=None,
+        review_command=f"hol-guard review {rid}",
+        approval_url=f"http://localhost:4455/approve/{rid}",
+    )
+
+
+def _insert(conn: sqlite3.Connection, req: GuardApprovalRequest, now: str = "2026-01-01T00:00:00Z") -> str:
+    return add_approval_request(conn, req, now)
+
+
+class TestApprovalIndexStatements:
+    def test_index_statements_returns_nonempty_list(self) -> None:
+        stmts = approval_index_statements()
+        assert isinstance(stmts, list)
+        assert len(stmts) >= 6
+
+    def test_index_statements_are_create_index(self) -> None:
+        for stmt in approval_index_statements():
+            assert "create index" in stmt.lower()
+
+    def test_indexes_execute_without_error(self) -> None:
+        _make_conn()
+
+
+class TestCursorPagination:
+    def test_list_returns_all_when_no_cursor(self) -> None:
+        conn = _make_conn()
+        for i in range(5):
+            _insert(conn, _make_request(), f"2026-01-0{i + 1}T00:00:00Z")
+        rows = list_approval_requests(conn, status="pending", limit=10)
+        assert len(rows) == 5
+
+    def test_list_respects_limit(self) -> None:
+        conn = _make_conn()
+        for i in range(10):
+            _insert(conn, _make_request(), f"2026-01-{i + 1:02d}T00:00:00Z")
+        rows = list_approval_requests(conn, status="pending", limit=3)
+        assert len(rows) == 3
+
+    def test_cursor_after_skips_earlier_records(self) -> None:
+        conn = _make_conn()
+        for i in range(6):
+            _insert(conn, _make_request(), f"2026-01-{i + 1:02d}T00:00:00Z")
+        page1 = list_approval_requests(conn, status="pending", limit=3)
+        assert len(page1) == 3
+        cursor = page1[-1]["created_at"]
+        page2 = list_approval_requests(conn, status="pending", limit=3, before_cursor=cursor)
+        assert len(page2) == 3
+        dates_p1 = {r["created_at"] for r in page1}
+        dates_p2 = {r["created_at"] for r in page2}
+        assert dates_p1.isdisjoint(dates_p2)
+
+    def test_cursor_after_last_page_returns_empty(self) -> None:
+        conn = _make_conn()
+        for i in range(3):
+            _insert(conn, _make_request(), f"2026-01-0{i + 1}T00:00:00Z")
+        page1 = list_approval_requests(conn, status="pending", limit=3)
+        cursor = page1[-1]["created_at"]
+        page2 = list_approval_requests(conn, status="pending", limit=3, before_cursor=cursor)
+        assert page2 == []
+
+
+class TestSearchFilter:
+    def test_search_matches_artifact_name(self) -> None:
+        conn = _make_conn()
+        req = _make_request()
+        base = dataclasses.asdict(req)
+        req2 = GuardApprovalRequest(
+            **{
+                **base,
+                "request_id": str(uuid.uuid4()),
+                "artifact_name": "special-tool",
+                "artifact_id": "codex:project:special-tool",
+                "changed_fields": ("args",),
+            }
+        )
+        _insert(conn, req)
+        _insert(conn, req2)
+        results = list_approval_requests(conn, search="special")
+        assert len(results) == 1
+        assert results[0]["artifact_name"] == "special-tool"
+
+    def test_search_is_case_insensitive(self) -> None:
+        conn = _make_conn()
+        req = _make_request()
+        base = dataclasses.asdict(req)
+        mod = GuardApprovalRequest(
+            **{
+                **base,
+                "request_id": str(uuid.uuid4()),
+                "artifact_name": "SpecialTool",
+                "artifact_id": "codex:project:SpecialTool",
+                "changed_fields": ("args",),
+            }
+        )
+        _insert(conn, mod)
+        results = list_approval_requests(conn, search="specialtool")
+        assert len(results) == 1
+
+    def test_search_no_match_returns_empty(self) -> None:
+        conn = _make_conn()
+        _insert(conn, _make_request())
+        results = list_approval_requests(conn, search="xyznotfound")
+        assert results == []
+
+
+class TestStatusFilterList:
+    def test_multiple_statuses_returned(self) -> None:
+        conn = _make_conn()
+        req1 = _make_request()
+        req2 = _make_request()
+        _insert(conn, req1)
+        _insert(conn, req2)
+        resolve_approval_request(
+            conn,
+            req1.request_id,
+            resolution_action="allow",
+            resolution_scope="session",
+            reason=None,
+            resolved_at="2026-01-02T00:00:00Z",
+        )
+        rows = list_approval_requests(conn, status=None)
+        statuses = {r["status"] for r in rows}
+        assert "pending" in statuses
+        assert "resolved" in statuses
+
+    def test_status_list_filters_correctly(self) -> None:
+        conn = _make_conn()
+        req = _make_request()
+        _insert(conn, req)
+        resolve_approval_request(
+            conn,
+            req.request_id,
+            resolution_action="allow",
+            resolution_scope="session",
+            reason=None,
+            resolved_at="2026-01-02T00:00:00Z",
+        )
+        rows = list_approval_requests(conn, status="pending")
+        assert rows == []
+        rows = list_approval_requests(conn, status="resolved")
+        assert len(rows) == 1
+
+
+class TestHarnessFilter:
+    def test_harness_filter_excludes_other_harnesses(self) -> None:
+        conn = _make_conn()
+        _insert(conn, _make_request(harness="codex"))
+        _insert(conn, _make_request(harness="claude"))
+        rows = list_approval_requests(conn, harness="codex")
+        assert all(r["harness"] == "codex" for r in rows)
+        assert len(rows) == 1
+
+
+class TestDateRangeFilter:
+    def test_after_filter_excludes_older_rows(self) -> None:
+        conn = _make_conn()
+        _insert(conn, _make_request(), "2026-01-01T00:00:00Z")
+        _insert(conn, _make_request(), "2026-03-01T00:00:00Z")
+        rows = list_approval_requests(conn, created_after="2026-02-01T00:00:00Z")
+        assert len(rows) == 1
+        assert rows[0]["created_at"] == "2026-03-01T00:00:00Z"
+
+    def test_before_filter_excludes_newer_rows(self) -> None:
+        conn = _make_conn()
+        _insert(conn, _make_request(), "2026-01-01T00:00:00Z")
+        _insert(conn, _make_request(), "2026-03-01T00:00:00Z")
+        rows = list_approval_requests(conn, created_before="2026-02-01T00:00:00Z")
+        assert len(rows) == 1
+        assert rows[0]["created_at"] == "2026-01-01T00:00:00Z"
+
+
+class TestCountFilter:
+    def test_count_matches_status_filter(self) -> None:
+        conn = _make_conn()
+        req1 = _make_request()
+        req2 = _make_request()
+        _insert(conn, req1)
+        _insert(conn, req2)
+        resolve_approval_request(
+            conn,
+            req1.request_id,
+            resolution_action="allow",
+            resolution_scope="session",
+            reason=None,
+            resolved_at="2026-01-02T00:00:00Z",
+        )
+        pending_count = count_approval_requests(conn, status="pending")
+        resolved_count = count_approval_requests(conn, status="resolved")
+        assert pending_count == 1
+        assert resolved_count == 1
+
+    def test_count_with_harness_filter(self) -> None:
+        conn = _make_conn()
+        _insert(conn, _make_request(harness="codex"))
+        _insert(conn, _make_request(harness="claude"))
+        assert count_approval_requests(conn, status="pending", harness="codex") == 1
+        assert count_approval_requests(conn, status="pending", harness="claude") == 1
+
+
+class TestBulkResolve:
+    def test_bulk_resolve_marks_multiple_pending_resolved(self) -> None:
+        conn = _make_conn()
+        reqs = [_make_request() for _ in range(4)]
+        for r in reqs:
+            _insert(conn, r)
+        ids = [reqs[0].request_id, reqs[1].request_id]
+        bulk_resolve_approval_requests(
+            conn,
+            ids,
+            resolution_action="allow",
+            resolution_scope="session",
+            reason="bulk",
+            resolved_at="2026-01-10T00:00:00Z",
+        )
+        for rid in ids:
+            row = get_approval_request(conn, rid)
+            assert row is not None
+            assert row["status"] == "resolved"
+        assert get_approval_request(conn, reqs[2].request_id)["status"] == "pending"
+
+    def test_bulk_resolve_empty_list_is_noop(self) -> None:
+        conn = _make_conn()
+        bulk_resolve_approval_requests(
+            conn,
+            [],
+            resolution_action="allow",
+            resolution_scope="session",
+            reason=None,
+            resolved_at="2026-01-01T00:00:00Z",
+        )
+        assert count_approval_requests(conn) == 0
+
+
+class TestClearByHarness:
+    def test_clear_by_harness_removes_resolved_only(self) -> None:
+        conn = _make_conn()
+        pending = _make_request(harness="codex")
+        resolved = _make_request(harness="codex")
+        _insert(conn, pending)
+        _insert(conn, resolved)
+        resolve_approval_request(
+            conn,
+            resolved.request_id,
+            resolution_action="allow",
+            resolution_scope="session",
+            reason=None,
+            resolved_at="2026-01-02T00:00:00Z",
+        )
+        deleted = clear_approval_requests_by_harness(conn, "codex")
+        assert deleted == 1
+        assert get_approval_request(conn, pending.request_id) is not None
+        assert get_approval_request(conn, resolved.request_id) is None
+
+    def test_clear_by_harness_does_not_touch_other_harness(self) -> None:
+        conn = _make_conn()
+        req = _make_request(harness="claude")
+        _insert(conn, req)
+        resolve_approval_request(
+            conn,
+            req.request_id,
+            resolution_action="allow",
+            resolution_scope="session",
+            reason=None,
+            resolved_at="2026-01-02T00:00:00Z",
+        )
+        deleted = clear_approval_requests_by_harness(conn, "codex")
+        assert deleted == 0
+        assert get_approval_request(conn, req.request_id) is not None
+
+
+class TestClearByWorkspace:
+    def test_clear_by_workspace_removes_resolved_for_that_workspace(self) -> None:
+        conn = _make_conn()
+        req_a = _make_request(workspace="ws-a")
+        req_b = _make_request(workspace="ws-b")
+        _insert(conn, req_a)
+        _insert(conn, req_b)
+        resolve_approval_request(
+            conn,
+            req_a.request_id,
+            resolution_action="allow",
+            resolution_scope="session",
+            reason=None,
+            resolved_at="2026-01-02T00:00:00Z",
+        )
+        resolve_approval_request(
+            conn,
+            req_b.request_id,
+            resolution_action="allow",
+            resolution_scope="session",
+            reason=None,
+            resolved_at="2026-01-02T00:00:00Z",
+        )
+        deleted = clear_approval_requests_by_workspace(conn, "ws-a")
+        assert deleted == 1
+        assert get_approval_request(conn, req_a.request_id) is None
+        assert get_approval_request(conn, req_b.request_id) is not None
+
+
+class TestClearByScope:
+    def test_clear_by_scope_removes_resolved_for_that_scope(self) -> None:
+        conn = _make_conn()
+        req_proj = _make_request(source_scope="project")
+        req_home = _make_request(source_scope="home")
+        _insert(conn, req_proj)
+        _insert(conn, req_home)
+        resolve_approval_request(
+            conn,
+            req_proj.request_id,
+            resolution_action="allow",
+            resolution_scope="session",
+            reason=None,
+            resolved_at="2026-01-02T00:00:00Z",
+        )
+        resolve_approval_request(
+            conn,
+            req_home.request_id,
+            resolution_action="allow",
+            resolution_scope="session",
+            reason=None,
+            resolved_at="2026-01-02T00:00:00Z",
+        )
+        deleted = clear_approval_requests_by_scope(conn, "project")
+        assert deleted == 1
+        assert get_approval_request(conn, req_proj.request_id) is None
+        assert get_approval_request(conn, req_home.request_id) is not None
+
+
+class TestClearResolvedBefore:
+    def test_clear_before_date_removes_old_resolved(self) -> None:
+        conn = _make_conn()
+        old = _make_request()
+        new = _make_request()
+        _insert(conn, old)
+        _insert(conn, new)
+        resolve_approval_request(
+            conn,
+            old.request_id,
+            resolution_action="allow",
+            resolution_scope="session",
+            reason=None,
+            resolved_at="2026-01-01T00:00:00Z",
+        )
+        resolve_approval_request(
+            conn,
+            new.request_id,
+            resolution_action="allow",
+            resolution_scope="session",
+            reason=None,
+            resolved_at="2026-06-01T00:00:00Z",
+        )
+        deleted = clear_resolved_approval_requests_before(conn, "2026-03-01T00:00:00Z")
+        assert deleted == 1
+        assert get_approval_request(conn, old.request_id) is None
+        assert get_approval_request(conn, new.request_id) is not None
+
+
+class TestCompaction:
+    def test_compaction_keeps_latest_per_artifact_id(self) -> None:
+        conn = _make_conn()
+        aid = "codex:project:shared-tool"
+        req1 = _make_request(artifact_id=aid)
+        req2 = _make_request(artifact_id=aid)
+        _insert(conn, req1, "2026-01-01T00:00:00Z")
+        resolve_approval_request(
+            conn,
+            req1.request_id,
+            resolution_action="allow",
+            resolution_scope="session",
+            reason=None,
+            resolved_at="2026-01-02T00:00:00Z",
+        )
+        _insert(conn, req2, "2026-02-01T00:00:00Z")
+        resolve_approval_request(
+            conn,
+            req2.request_id,
+            resolution_action="deny",
+            resolution_scope="session",
+            reason=None,
+            resolved_at="2026-02-02T00:00:00Z",
+        )
+        removed = compact_approval_requests(conn)
+        assert removed == 1
+        assert get_approval_request(conn, req1.request_id) is None
+        assert get_approval_request(conn, req2.request_id) is not None
+
+    def test_compaction_does_not_remove_pending(self) -> None:
+        conn = _make_conn()
+        aid = "codex:project:pending-tool"
+        req = _make_request(artifact_id=aid)
+        _insert(conn, req)
+        removed = compact_approval_requests(conn)
+        assert removed == 0
+        assert get_approval_request(conn, req.request_id) is not None
+
+
+class TestMigrationFromOldSchema:
+    def test_migration_from_schema_without_indexes(self) -> None:
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.execute(approval_schema_statement())
+        req = _make_request()
+        add_approval_request(conn, req, "2026-01-01T00:00:00Z")
+        for stmt in approval_index_statements():
+            conn.execute(stmt)
+        rows = list_approval_requests(conn, status="pending")
+        assert len(rows) == 1
+
+    def test_migration_idempotent_double_index_creation(self) -> None:
+        conn = _make_conn()
+        for stmt in approval_index_statements():
+            conn.execute(stmt)
+
+
+class TestCorruptionRecovery:
+    def test_malformed_risk_signals_json_falls_back_gracefully(self) -> None:
+        conn = _make_conn()
+        req = _make_request()
+        _insert(conn, req)
+        conn.execute(
+            "update approval_requests set risk_signals_json = ? where request_id = ?",
+            ("not-valid-json", req.request_id),
+        )
+        row = get_approval_request(conn, req.request_id)
+        assert row is not None
+        assert isinstance(row["risk_signals"], list)
+
+    def test_malformed_changed_fields_json_falls_back_gracefully(self) -> None:
+        conn = _make_conn()
+        req = _make_request()
+        _insert(conn, req)
+        conn.execute(
+            "update approval_requests set changed_fields_json = ? where request_id = ?",
+            ("{bad json}", req.request_id),
+        )
+        row = get_approval_request(conn, req.request_id)
+        assert row is not None
+        assert isinstance(row["changed_fields"], list)


### PR DESCRIPTION
## Summary

Scales the approval queue persistence layer with database-level performance improvements, richer query capabilities, and operational tooling.

## Changes

- **`src/codex_plugin_scanner/guard/store_approvals.py`** — adds `approval_index_statements()` for performance indexes; 5 new bulk/clear functions (`bulk_resolve_approval_requests`, `clear_approval_requests_by_harness`, `clear_approval_requests_by_workspace`, `clear_approval_requests_by_scope`, `clear_resolved_approval_requests_before`); `compact_approval_requests()` for storage hygiene; enhanced `list_approval_requests` with cursor pagination, full-text search, and date range filters; enhanced `count_approval_requests` with harness filter; `_safe_json_list()` for corruption-resilient JSON parsing
- **`tests/test_guard_approval_store_scale.py`** — 30 new tests covering all new functionality including migration idempotency, corruption recovery, and edge cases

## Tests

30 new tests pass. All existing approval tests unaffected.

## Verification

```
pytest tests/test_guard_approval_store_scale.py -q
# 30 passed
ruff check src/codex_plugin_scanner/guard/store_approvals.py tests/test_guard_approval_store_scale.py
# All checks passed
```