### PR TITLE
feat(guard): evidence store with schema, indexes, CRUD, search, export, compaction, daemon API - Phase 15

### DIFF
--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -189,6 +189,7 @@ class GuardConfig:
     harness_actions: dict[str, GuardAction] | None = None
     publisher_actions: dict[str, GuardAction] | None = None
     artifact_actions: dict[str, GuardAction] | None = None
+    evidence_retain_days: int = 90
 
     def resolve_action_override(
         self,

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -23,6 +23,11 @@ from ..config import editable_guard_settings, load_guard_config, update_guard_se
 from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES
 from ..runtime.surface_server import GuardSurfaceRuntime
 from ..store import GuardStore
+from ..store_evidence import (
+    count_evidence,
+    export_evidence_json,
+    list_evidence,
+)
 from .manager import (
     GUARD_DAEMON_COMPATIBILITY_VERSION,
     clear_guard_daemon_state,
@@ -181,6 +186,40 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json(
                 {"items": store.list_policy_decisions(harness=harness if isinstance(harness, str) else None)}
             )
+            return
+        if parsed.path == "/v1/evidence":
+            query = parse_qs(parsed.query)
+            harness_q = query.get("harness", [None])[-1]
+            category_q = query.get("category", [None])[-1]
+            severity_q = query.get("severity", [None])[-1]
+            before_q = query.get("before", [None])[-1]
+            limit_q = query.get("limit", ["100"])[-1]
+            try:
+                limit_v = min(int(limit_q), 500)
+            except (ValueError, TypeError):
+                limit_v = 100
+            with store._connect() as conn:
+                records = list_evidence(
+                    conn,
+                    harness=harness_q if isinstance(harness_q, str) else None,
+                    category=category_q if isinstance(category_q, str) else None,
+                    severity=severity_q if isinstance(severity_q, str) else None,
+                    before_cursor=before_q if isinstance(before_q, str) else None,
+                    limit=limit_v,
+                )
+                total = count_evidence(conn)
+            self._write_json({
+                "items": [vars(r) for r in records],
+                "total": total,
+            })
+            return
+        if parsed.path == "/v1/evidence/export":
+            with store._connect() as conn:
+                payload = export_evidence_json(conn, limit=10_000)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(payload.encode("utf-8"))
             return
         if len(path_parts) == 4 and path_parts[:3] == ["v1", "artifacts", path_parts[2]] and path_parts[3] == "diff":
             query = parse_qs(parsed.query)

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -71,6 +71,10 @@ from .store_connect import (
 from .store_connect import (
     mark_connect_result as persist_connect_result,
 )
+from .store_evidence import (
+    evidence_index_statements,
+    evidence_schema_statement,
+)
 from .types import CapabilitySet
 
 _SYNC_TOKEN_REF = "guard-cloud-token"
@@ -646,10 +650,13 @@ class GuardStore:
             connect_request_schema_statement(),
             connect_state_schema_statement(),
             approval_schema_statement(),
+            evidence_schema_statement(),
         )
         with self._connect() as connection:
             for statement in statements:
                 connection.execute(statement)
+            for idx_stmt in evidence_index_statements():
+                connection.execute(idx_stmt)
             self._ensure_policy_column(connection, "publisher", "text")
             self._ensure_policy_column(connection, "artifact_hash", "text")
             self._ensure_policy_column(connection, "owner", "text")

--- a/src/codex_plugin_scanner/guard/store_evidence.py
+++ b/src/codex_plugin_scanner/guard/store_evidence.py
@@ -1,0 +1,217 @@
+"""Phase 15: Evidence store — table, indexes, CRUD, search, export, compaction."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceRecord:
+    evidence_id: str
+    action_id: str
+    request_id: str
+    harness: str
+    workspace: str
+    signal_id: str
+    category: str
+    severity: str
+    confidence: float
+    summary: str
+    details: dict[str, object] = field(default_factory=dict)
+    created_at: str = field(default_factory=_now_iso)
+
+
+def evidence_schema_statement() -> str:
+    return """
+    create table if not exists guard_evidence (
+      evidence_id text not null primary key,
+      action_id   text not null default '',
+      request_id  text not null default '',
+      harness     text not null default '',
+      workspace   text not null default '',
+      signal_id   text not null default '',
+      category    text not null default '',
+      severity    text not null default '',
+      confidence  real not null default 0.0,
+      summary     text not null default '',
+      details_json text not null default '{}',
+      created_at  text not null
+    )
+    """
+
+
+def evidence_index_statements() -> list[str]:
+    return [
+        "create index if not exists idx_evidence_created on guard_evidence(created_at desc)",
+        "create index if not exists idx_evidence_request on guard_evidence(request_id)",
+        "create index if not exists idx_evidence_action on guard_evidence(action_id)",
+        "create index if not exists idx_evidence_category_severity on guard_evidence(category, severity)",
+        "create index if not exists idx_evidence_harness_workspace on guard_evidence(harness, workspace)",
+    ]
+
+
+def _row_to_record(row: sqlite3.Row) -> EvidenceRecord:
+    try:
+        details: dict[str, object] = json.loads(row["details_json"])
+    except (json.JSONDecodeError, TypeError):
+        details = {}
+    return EvidenceRecord(
+        evidence_id=row["evidence_id"],
+        action_id=row["action_id"],
+        request_id=row["request_id"],
+        harness=row["harness"],
+        workspace=row["workspace"],
+        signal_id=row["signal_id"],
+        category=row["category"],
+        severity=row["severity"],
+        confidence=row["confidence"],
+        summary=row["summary"],
+        details=details,
+        created_at=row["created_at"],
+    )
+
+
+def store_evidence(conn: sqlite3.Connection, record: EvidenceRecord) -> EvidenceRecord:
+    conn.execute(
+        """
+        insert or replace into guard_evidence
+          (evidence_id, action_id, request_id, harness, workspace, signal_id,
+           category, severity, confidence, summary, details_json, created_at)
+        values (?,?,?,?,?,?,?,?,?,?,?,?)
+        """,
+        (
+            record.evidence_id,
+            record.action_id,
+            record.request_id,
+            record.harness,
+            record.workspace,
+            record.signal_id,
+            record.category,
+            record.severity,
+            record.confidence,
+            record.summary,
+            json.dumps(record.details),
+            record.created_at,
+        ),
+    )
+    conn.commit()
+    return record
+
+
+def list_evidence(
+    conn: sqlite3.Connection,
+    *,
+    harness: str | None = None,
+    category: str | None = None,
+    severity: str | None = None,
+    request_id: str | None = None,
+    before_cursor: str | None = None,
+    limit: int = 100,
+) -> list[EvidenceRecord]:
+    clauses: list[str] = []
+    params: list[object] = []
+
+    if harness is not None:
+        clauses.append("harness = ?")
+        params.append(harness)
+    if category is not None:
+        clauses.append("category = ?")
+        params.append(category)
+    if severity is not None:
+        clauses.append("severity = ?")
+        params.append(severity)
+    if request_id is not None:
+        clauses.append("request_id = ?")
+        params.append(request_id)
+    if before_cursor is not None:
+        clauses.append("created_at < ?")
+        params.append(before_cursor)
+
+    where = f"where {' and '.join(clauses)}" if clauses else ""
+    params.append(limit)
+    rows = conn.execute(
+        f"select * from guard_evidence {where} order by created_at desc limit ?",
+        params,
+    ).fetchall()
+    return [_row_to_record(r) for r in rows]
+
+
+def search_evidence(
+    conn: sqlite3.Connection,
+    query: str,
+    *,
+    limit: int = 100,
+) -> list[EvidenceRecord]:
+    pattern = f"%{query}%"
+    rows = conn.execute(
+        "select * from guard_evidence where lower(summary) like lower(?) order by created_at desc limit ?",
+        (pattern, limit),
+    ).fetchall()
+    return [_row_to_record(r) for r in rows]
+
+
+def count_evidence(
+    conn: sqlite3.Connection,
+    *,
+    harness: str | None = None,
+    category: str | None = None,
+) -> int:
+    clauses: list[str] = []
+    params: list[object] = []
+    if harness is not None:
+        clauses.append("harness = ?")
+        params.append(harness)
+    if category is not None:
+        clauses.append("category = ?")
+        params.append(category)
+    where = f"where {' and '.join(clauses)}" if clauses else ""
+    row = conn.execute(f"select count(*) from guard_evidence {where}", params).fetchone()
+    return int(row[0])
+
+
+def export_evidence_json(
+    conn: sqlite3.Connection,
+    *,
+    limit: int = 10_000,
+) -> str:
+    records = list_evidence(conn, limit=limit)
+    return json.dumps(
+        [
+            {
+                "evidence_id": r.evidence_id,
+                "action_id": r.action_id,
+                "request_id": r.request_id,
+                "harness": r.harness,
+                "workspace": r.workspace,
+                "signal_id": r.signal_id,
+                "category": r.category,
+                "severity": r.severity,
+                "confidence": r.confidence,
+                "summary": r.summary,
+                "created_at": r.created_at,
+            }
+            for r in records
+        ],
+        indent=2,
+    )
+
+
+def compact_evidence(conn: sqlite3.Connection, *, retain_days: int = 90) -> int:
+    cutoff = (
+        (datetime.now(timezone.utc) - timedelta(days=retain_days))
+        .isoformat(timespec="microseconds")
+        .replace("+00:00", "Z")
+    )
+    cursor = conn.execute(
+        "delete from guard_evidence where created_at < ?",
+        (cutoff,),
+    )
+    conn.commit()
+    return cursor.rowcount

--- a/tests/test_guard_evidence_store.py
+++ b/tests/test_guard_evidence_store.py
@@ -1,0 +1,286 @@
+"""Phase 15: Evidence store scale — TDD tests."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+
+from codex_plugin_scanner.guard.store_evidence import (
+    EvidenceRecord,
+    compact_evidence,
+    count_evidence,
+    evidence_index_statements,
+    evidence_schema_statement,
+    export_evidence_json,
+    list_evidence,
+    search_evidence,
+    store_evidence,
+)
+
+
+def _db(tmp_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(tmp_path / "guard.db"))
+    conn.row_factory = sqlite3.Row
+    conn.execute("pragma journal_mode=wal")
+    conn.execute(evidence_schema_statement())
+    for stmt in evidence_index_statements():
+        conn.execute(stmt)
+    conn.commit()
+    return conn
+
+
+def _rec(**kw: object) -> EvidenceRecord:
+    defaults: dict[str, object] = {
+        "evidence_id": "e1",
+        "action_id": "a1",
+        "request_id": "r1",
+        "harness": "codex",
+        "workspace": "/ws",
+        "signal_id": "s1",
+        "category": "exfiltration",
+        "severity": "high",
+        "confidence": 0.9,
+        "summary": "secret leaked",
+        "details": {"key": "val"},
+    }
+    defaults.update(kw)
+    return EvidenceRecord(**defaults)  # type: ignore[arg-type]
+
+
+class TestSchema:
+    def test_schema_creates_table(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        rows = conn.execute("select name from sqlite_master where type='table' and name='guard_evidence'").fetchall()
+        assert rows
+
+    def test_schema_idempotent(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        conn.execute(evidence_schema_statement())
+        rows = conn.execute("select name from sqlite_master where type='table' and name='guard_evidence'").fetchall()
+        assert len(rows) == 1
+
+    def test_indexes_created(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        names = {r[0] for r in conn.execute("select name from sqlite_master where type='index'")}
+        assert "idx_evidence_created" in names
+        assert "idx_evidence_request" in names
+        assert "idx_evidence_action" in names
+        assert "idx_evidence_category_severity" in names
+        assert "idx_evidence_harness_workspace" in names
+
+    def test_indexes_idempotent(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        for stmt in evidence_index_statements():
+            conn.execute(stmt)
+        names = [
+            r[0]
+            for r in conn.execute(
+                "select name from sqlite_master where type='index' and name like 'idx_evidence%'"
+            )
+        ]
+        assert len(names) == len(set(names))
+
+
+class TestStoreEvidence:
+    def test_store_basic(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        store_evidence(conn, _rec())
+        rows = conn.execute("select * from guard_evidence").fetchall()
+        assert len(rows) == 1
+
+    def test_store_returns_record(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        result = store_evidence(conn, _rec(evidence_id="ev-999"))
+        assert result.evidence_id == "ev-999"
+
+    def test_store_details_serialized(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        store_evidence(conn, _rec(details={"x": 1, "y": [2, 3]}))
+        row = conn.execute("select details_json from guard_evidence").fetchone()
+        assert json.loads(row[0]) == {"x": 1, "y": [2, 3]}
+
+    def test_store_multiple(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        for i in range(5):
+            store_evidence(conn, _rec(evidence_id=f"e{i}", action_id=f"a{i}"))
+        assert count_evidence(conn) == 5
+
+
+class TestListEvidence:
+    def test_list_all(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        for i in range(3):
+            store_evidence(conn, _rec(evidence_id=f"e{i}", action_id=f"a{i}"))
+        records = list_evidence(conn)
+        assert len(records) == 3
+
+    def test_list_limit(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        for i in range(10):
+            store_evidence(conn, _rec(evidence_id=f"e{i}", action_id=f"a{i}"))
+        records = list_evidence(conn, limit=3)
+        assert len(records) == 3
+
+    def test_list_filter_harness(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        store_evidence(conn, _rec(evidence_id="e1", harness="codex"))
+        store_evidence(conn, _rec(evidence_id="e2", harness="claude"))
+        records = list_evidence(conn, harness="codex")
+        assert len(records) == 1
+        assert records[0].harness == "codex"
+
+    def test_list_filter_category(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        store_evidence(conn, _rec(evidence_id="e1", category="exfiltration"))
+        store_evidence(conn, _rec(evidence_id="e2", category="injection"))
+        records = list_evidence(conn, category="injection")
+        assert len(records) == 1
+        assert records[0].category == "injection"
+
+    def test_list_filter_severity(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        store_evidence(conn, _rec(evidence_id="e1", severity="high"))
+        store_evidence(conn, _rec(evidence_id="e2", severity="low"))
+        records = list_evidence(conn, severity="high")
+        assert len(records) == 1
+
+    def test_list_cursor_pagination(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        for i in range(10):
+            store_evidence(conn, _rec(evidence_id=f"e{i:02d}", action_id=f"a{i}"))
+            time.sleep(0.01)
+        page1 = list_evidence(conn, limit=5)
+        assert len(page1) == 5
+        cursor = page1[-1].created_at
+        page2 = list_evidence(conn, limit=10, before_cursor=cursor)
+        assert len(page2) == 5
+        combined_ids = {r.evidence_id for r in page1} | {r.evidence_id for r in page2}
+        assert len(combined_ids) == 10
+
+    def test_list_filter_request_id(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        store_evidence(conn, _rec(evidence_id="e1", request_id="req-A"))
+        store_evidence(conn, _rec(evidence_id="e2", request_id="req-B"))
+        records = list_evidence(conn, request_id="req-A")
+        assert len(records) == 1
+
+    def test_list_order_desc(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        for i in range(5):
+            store_evidence(conn, _rec(evidence_id=f"e{i}", action_id=f"a{i}"))
+            time.sleep(0.01)
+        records = list_evidence(conn)
+        created_ats = [r.created_at for r in records]
+        assert created_ats == sorted(created_ats, reverse=True)
+
+
+class TestSearchEvidence:
+    def test_search_by_summary(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        store_evidence(conn, _rec(evidence_id="e1", summary="secret key leaked"))
+        store_evidence(conn, _rec(evidence_id="e2", summary="benign output"))
+        results = search_evidence(conn, "secret")
+        assert len(results) == 1
+        assert results[0].evidence_id == "e1"
+
+    def test_search_case_insensitive(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        store_evidence(conn, _rec(evidence_id="e1", summary="Secret Token Found"))
+        results = search_evidence(conn, "secret")
+        assert len(results) == 1
+
+    def test_search_no_match(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        store_evidence(conn, _rec(evidence_id="e1", summary="benign output"))
+        results = search_evidence(conn, "malware")
+        assert len(results) == 0
+
+    def test_search_does_not_expose_details_json(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        store_evidence(conn, _rec(evidence_id="e1", summary="clean", details={"password": "s3cr3t"}))
+        results = search_evidence(conn, "s3cr3t")
+        assert len(results) == 0
+
+
+class TestCountEvidence:
+    def test_count_zero(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        assert count_evidence(conn) == 0
+
+    def test_count_with_records(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        for i in range(7):
+            store_evidence(conn, _rec(evidence_id=f"e{i}", action_id=f"a{i}"))
+        assert count_evidence(conn) == 7
+
+    def test_count_filter_harness(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        store_evidence(conn, _rec(evidence_id="e1", harness="codex"))
+        store_evidence(conn, _rec(evidence_id="e2", harness="claude"))
+        store_evidence(conn, _rec(evidence_id="e3", harness="codex"))
+        assert count_evidence(conn, harness="codex") == 2
+
+    def test_count_filter_category(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        store_evidence(conn, _rec(evidence_id="e1", category="exfiltration"))
+        store_evidence(conn, _rec(evidence_id="e2", category="injection"))
+        assert count_evidence(conn, category="exfiltration") == 1
+
+
+class TestExportEvidence:
+    def test_export_returns_list(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        for i in range(3):
+            store_evidence(conn, _rec(evidence_id=f"e{i}", action_id=f"a{i}"))
+        exported = export_evidence_json(conn)
+        data = json.loads(exported)
+        assert isinstance(data, list)
+        assert len(data) == 3
+
+    def test_export_fields_present(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        store_evidence(conn, _rec(evidence_id="ev-X", category="exfil", summary="found token"))
+        data = json.loads(export_evidence_json(conn))
+        record = data[0]
+        assert record["evidence_id"] == "ev-X"
+        assert record["category"] == "exfil"
+        assert record["summary"] == "found token"
+
+    def test_export_limit(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        for i in range(20):
+            store_evidence(conn, _rec(evidence_id=f"e{i}", action_id=f"a{i}"))
+        data = json.loads(export_evidence_json(conn, limit=5))
+        assert len(data) == 5
+
+
+class TestCompactEvidence:
+    def test_compact_removes_old(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        store_evidence(conn, _rec(evidence_id="old"))
+        conn.execute("update guard_evidence set created_at = '2020-01-01T00:00:00Z' where evidence_id = 'old'")
+        conn.commit()
+        store_evidence(conn, _rec(evidence_id="new", action_id="a2"))
+        removed = compact_evidence(conn, retain_days=30)
+        assert removed >= 1
+        remaining = count_evidence(conn)
+        assert remaining == 1
+
+    def test_compact_keeps_recent(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        for i in range(5):
+            store_evidence(conn, _rec(evidence_id=f"e{i}", action_id=f"a{i}"))
+        removed = compact_evidence(conn, retain_days=90)
+        assert removed == 0
+        assert count_evidence(conn) == 5
+
+    def test_compact_idempotent(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        store_evidence(conn, _rec(evidence_id="e1"))
+        conn.execute("update guard_evidence set created_at = '2020-01-01T00:00:00Z'")
+        conn.commit()
+        compact_evidence(conn, retain_days=30)
+        removed2 = compact_evidence(conn, retain_days=30)
+        assert removed2 == 0


### PR DESCRIPTION
## Summary

Adds a first-class evidence persistence layer to HOL Guard Local with full query capabilities, daemon API endpoints, and operational tooling.

## Changes

- **`src/codex_plugin_scanner/guard/store_evidence.py`** — new module: `EvidenceRecord` dataclass; `evidence_schema_statement()` and `evidence_index_statements()` (5 indexes on created_at, request_id, action_id, category+severity, harness+workspace); `store_evidence()`, `list_evidence()` (harness/category/severity/request_id/cursor/limit filters), `search_evidence()` (summary-only, no details_json exposure), `count_evidence()`, `export_evidence_json()`, `compact_evidence()`
- **`src/codex_plugin_scanner/guard/store.py`** — integrates evidence schema and indexes into `_build_schema`
- **`src/codex_plugin_scanner/guard/config.py`** — adds `evidence_retain_days: int = 90` to `GuardConfig`
- **`src/codex_plugin_scanner/guard/daemon/server.py`** — adds `GET /v1/evidence` (with harness/category/severity/before/limit query params) and `GET /v1/evidence/export` endpoints
- **`tests/test_guard_evidence_store.py`** — 30 tests covering schema idempotency, CRUD, pagination, filters, search, count, export, compaction

## Tests

30 new tests pass. Existing server + config-paths tests unaffected.

## Verification

```
pytest tests/test_guard_evidence_store.py tests/test_guard_surface_server.py tests/test_guard_config_paths.py -q
# 100 passed
ruff check src/codex_plugin_scanner/guard/store_evidence.py
# All checks passed
```