### PR TITLE
feat(guard): cloud advisory threat intel — typed bundles, RSA-PSS signature, 10 matchers, SQLite cache

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1105,11 +1105,7 @@ def run_guard_command(
             all_advs = store.list_cached_advisories()
             target_id = getattr(args, "advisory_id", None)
             match = next(
-                (
-                    a
-                    for a in all_advs
-                    if a.get("advisory_id") == target_id or a.get("id") == target_id
-                ),
+                (a for a in all_advs if a.get("advisory_id") == target_id or a.get("id") == target_id),
                 None,
             )
             if match:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -480,14 +480,11 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
         choices=["low", "medium", "high", "critical"],
         help="Filter by minimum severity",
     )
-    _adv_list.add_argument("--json", action="store_true")
 
     _adv_sync = advisories_sub.add_parser("sync", help="Sync advisories from Guard Cloud")
-    _adv_sync.add_argument("--json", action="store_true")
 
     _adv_explain = advisories_sub.add_parser("explain", help="Explain a specific advisory by ID")
     _adv_explain.add_argument("advisory_id", help="Advisory ID to explain")
-    _adv_explain.add_argument("--json", action="store_true")
 
     events_parser = guard_subparsers.add_parser("events", help="List local Guard lifecycle events")
     _add_guard_common_args(events_parser)
@@ -1107,7 +1104,14 @@ def run_guard_command(
         elif adv_sub == "explain":
             all_advs = store.list_cached_advisories()
             target_id = getattr(args, "advisory_id", None)
-            match = next((a for a in all_advs if a.get("advisory_id") == target_id), None)
+            match = next(
+                (
+                    a
+                    for a in all_advs
+                    if a.get("advisory_id") == target_id or a.get("id") == target_id
+                ),
+                None,
+            )
             if match:
                 _emit("advisory_explain", match, getattr(args, "json", False))
             else:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1113,8 +1113,8 @@ def run_guard_command(
                     getattr(args, "json", False),
                 )
         elif adv_sub == "explain":
-            all_advs = store.list_cached_advisories()
             target_id = getattr(args, "advisory_id", None)
+            all_advs = store.list_cached_advisories(limit=None)
             match = next(
                 (a for a in all_advs if a.get("advisory_id") == target_id or a.get("id") == target_id),
                 None,

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -472,6 +472,22 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     advisories_parser = guard_subparsers.add_parser("advisories", help="List cached Guard advisories and verdicts")
     _add_guard_common_args(advisories_parser)
     advisories_parser.add_argument("--json", action="store_true")
+    advisories_sub = advisories_parser.add_subparsers(dest="advisories_subcommand")
+
+    _adv_list = advisories_sub.add_parser("list", help="List cached advisories")
+    _adv_list.add_argument(
+        "--severity",
+        choices=["low", "medium", "high", "critical"],
+        help="Filter by minimum severity",
+    )
+    _adv_list.add_argument("--json", action="store_true")
+
+    _adv_sync = advisories_sub.add_parser("sync", help="Sync advisories from Guard Cloud")
+    _adv_sync.add_argument("--json", action="store_true")
+
+    _adv_explain = advisories_sub.add_parser("explain", help="Explain a specific advisory by ID")
+    _adv_explain.add_argument("advisory_id", help="Advisory ID to explain")
+    _adv_explain.add_argument("--json", action="store_true")
 
     events_parser = guard_subparsers.add_parser("events", help="List local Guard lifecycle events")
     _add_guard_common_args(events_parser)
@@ -1081,11 +1097,33 @@ def run_guard_command(
         return 0
 
     if args.guard_command == "advisories":
-        _emit(
-            "advisories",
-            {"generated_at": _now(), "items": store.list_cached_advisories()},
-            getattr(args, "json", False),
-        )
+        adv_sub = getattr(args, "advisories_subcommand", None)
+        if adv_sub == "sync":
+            _emit(
+                "advisories_sync",
+                {"generated_at": _now(), "status": "no_cloud_sync_configured"},
+                getattr(args, "json", False),
+            )
+        elif adv_sub == "explain":
+            all_advs = store.list_cached_advisories()
+            target_id = getattr(args, "advisory_id", None)
+            match = next((a for a in all_advs if a.get("advisory_id") == target_id), None)
+            if match:
+                _emit("advisory_explain", match, getattr(args, "json", False))
+            else:
+                _emit("advisory_explain", {"error": f"advisory {target_id!r} not found"}, getattr(args, "json", False))
+        else:
+            all_advs = store.list_cached_advisories()
+            sev_filter = getattr(args, "severity", None)
+            _sev_rank = {"low": 0, "medium": 1, "high": 2, "critical": 3}
+            if sev_filter and sev_filter in _sev_rank:
+                min_rank = _sev_rank[sev_filter]
+                all_advs = [a for a in all_advs if _sev_rank.get(str(a.get("severity", "")).lower(), -1) >= min_rank]
+            _emit(
+                "advisories",
+                {"generated_at": _now(), "items": all_advs},
+                getattr(args, "json", False),
+            )
         return 0
 
     if args.guard_command == "events":

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -475,7 +475,6 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     advisories_sub = advisories_parser.add_subparsers(dest="advisories_subcommand")
 
     _adv_list = advisories_sub.add_parser("list", help="List cached advisories")
-    _add_guard_common_args(_adv_list)
     _adv_list.add_argument("--json", action="store_true")
     _adv_list.add_argument(
         "--severity",
@@ -484,11 +483,9 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     )
 
     _adv_sync = advisories_sub.add_parser("sync", help="Sync advisories from Guard Cloud")
-    _add_guard_common_args(_adv_sync)
     _adv_sync.add_argument("--json", action="store_true")
 
     _adv_explain = advisories_sub.add_parser("explain", help="Explain a specific advisory by ID")
-    _add_guard_common_args(_adv_explain)
     _adv_explain.add_argument("--json", action="store_true")
     _adv_explain.add_argument("advisory_id", help="Advisory ID to explain")
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -475,6 +475,8 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     advisories_sub = advisories_parser.add_subparsers(dest="advisories_subcommand")
 
     _adv_list = advisories_sub.add_parser("list", help="List cached advisories")
+    _add_guard_common_args(_adv_list)
+    _adv_list.add_argument("--json", action="store_true")
     _adv_list.add_argument(
         "--severity",
         choices=["low", "medium", "high", "critical"],
@@ -482,8 +484,12 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     )
 
     _adv_sync = advisories_sub.add_parser("sync", help="Sync advisories from Guard Cloud")
+    _add_guard_common_args(_adv_sync)
+    _adv_sync.add_argument("--json", action="store_true")
 
     _adv_explain = advisories_sub.add_parser("explain", help="Explain a specific advisory by ID")
+    _add_guard_common_args(_adv_explain)
+    _adv_explain.add_argument("--json", action="store_true")
     _adv_explain.add_argument("advisory_id", help="Advisory ID to explain")
 
     events_parser = guard_subparsers.add_parser("events", help="List local Guard lifecycle events")
@@ -1096,11 +1102,19 @@ def run_guard_command(
     if args.guard_command == "advisories":
         adv_sub = getattr(args, "advisories_subcommand", None)
         if adv_sub == "sync":
-            _emit(
-                "advisories_sync",
-                {"generated_at": _now(), "status": "no_cloud_sync_configured"},
-                getattr(args, "json", False),
-            )
+            credentials = store.get_sync_credentials()
+            if credentials is None:
+                _emit(
+                    "advisories_sync",
+                    {"generated_at": _now(), "status": "no_cloud_sync_configured"},
+                    getattr(args, "json", False),
+                )
+            else:
+                _emit(
+                    "advisories_sync",
+                    {"generated_at": _now(), "status": "advisory_sync_not_available", "synced": False},
+                    getattr(args, "json", False),
+                )
         elif adv_sub == "explain":
             all_advs = store.list_cached_advisories()
             target_id = getattr(args, "advisory_id", None)

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -208,10 +208,12 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     limit=limit_v,
                 )
                 total = count_evidence(conn)
-            self._write_json({
-                "items": [vars(r) for r in records],
-                "total": total,
-            })
+            self._write_json(
+                {
+                    "items": [vars(r) for r in records],
+                    "total": total,
+                }
+            )
             return
         if parsed.path == "/v1/evidence/export":
             with store._connect() as conn:

--- a/src/codex_plugin_scanner/guard/runtime/advisory_escalation.py
+++ b/src/codex_plugin_scanner/guard/runtime/advisory_escalation.py
@@ -43,12 +43,12 @@ def escalate_for_advisories(
         return policy_action, None
 
     ranked = sorted(
-        (a for a in matched_advisories if a.severity in _ESCALATION_THRESHOLD_SEVERITIES),
-        key=lambda a: 0 if a.severity == "critical" else 1,
+        (a for a in matched_advisories if a.severity.lower() in _ESCALATION_THRESHOLD_SEVERITIES),
+        key=lambda a: 0 if a.severity.lower() == "critical" else 1,
     )
 
     for advisory in ranked:
-        escalation_map = _ESCALATION_TABLE.get(advisory.severity, {})
+        escalation_map = _ESCALATION_TABLE.get(advisory.severity.lower(), {})
         escalated = escalation_map.get(policy_action)
         if escalated is not None:
             return escalated, advisory.advisory_id  # type: ignore[return-value]
@@ -60,6 +60,6 @@ def advisory_match_summary(matched_advisories: tuple[ThreatAdvisory, ...]) -> st
     """Return a brief human-readable summary of matched advisories for logging."""
     if not matched_advisories:
         return "no advisory matches"
-    parts = [f"{a.advisory_id}({a.severity})" for a in matched_advisories[:5]]
+    parts = [f"{a.advisory_id}({a.severity.lower()})" for a in matched_advisories[:5]]
     suffix = f" +{len(matched_advisories) - 5} more" if len(matched_advisories) > 5 else ""
     return ", ".join(parts) + suffix

--- a/src/codex_plugin_scanner/guard/runtime/advisory_escalation.py
+++ b/src/codex_plugin_scanner/guard/runtime/advisory_escalation.py
@@ -1,0 +1,65 @@
+"""Advisory-driven policy escalation for Guard decisions.
+
+When a cached threat intelligence bundle contains a critical advisory that
+matches the current artifact, a lower-severity policy action such as ``allow``
+or ``warn`` can be escalated to ``ask`` or ``block`` to ensure the user
+reviews the risk before the action proceeds.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from codex_plugin_scanner.guard.models import GuardAction
+    from codex_plugin_scanner.guard.runtime.threat_intel import ThreatAdvisory
+
+_ESCALATION_TABLE: dict[str, dict[str, str]] = {
+    "critical": {
+        "allow": "ask",
+        "warn": "ask",
+        "review": "block",
+    },
+    "high": {
+        "allow": "ask",
+        "warn": "ask",
+    },
+}
+
+_ESCALATION_THRESHOLD_SEVERITIES = frozenset({"critical", "high"})
+
+
+def escalate_for_advisories(
+    policy_action: GuardAction,
+    matched_advisories: tuple[ThreatAdvisory, ...],
+) -> tuple[GuardAction, str | None]:
+    """Return the escalated policy action and the advisory id that triggered it.
+
+    If no advisory warrants escalation, returns the original action and None.
+    The most severe advisory match drives escalation; within the same severity
+    the first match in the input tuple wins.
+    """
+    if not matched_advisories:
+        return policy_action, None
+
+    ranked = sorted(
+        (a for a in matched_advisories if a.severity in _ESCALATION_THRESHOLD_SEVERITIES),
+        key=lambda a: 0 if a.severity == "critical" else 1,
+    )
+
+    for advisory in ranked:
+        escalation_map = _ESCALATION_TABLE.get(advisory.severity, {})
+        escalated = escalation_map.get(policy_action)
+        if escalated is not None:
+            return escalated, advisory.advisory_id  # type: ignore[return-value]
+
+    return policy_action, None
+
+
+def advisory_match_summary(matched_advisories: tuple[ThreatAdvisory, ...]) -> str:
+    """Return a brief human-readable summary of matched advisories for logging."""
+    if not matched_advisories:
+        return "no advisory matches"
+    parts = [f"{a.advisory_id}({a.severity})" for a in matched_advisories[:5]]
+    suffix = f" +{len(matched_advisories) - 5} more" if len(matched_advisories) > 5 else ""
+    return ", ".join(parts) + suffix

--- a/src/codex_plugin_scanner/guard/runtime/advisory_matchers.py
+++ b/src/codex_plugin_scanner/guard/runtime/advisory_matchers.py
@@ -37,8 +37,9 @@ def match_osv(advisory: ThreatAdvisory, target: dict[str, object]) -> bool:
     pkg_name = target.get("package_name")
     ecosystem = target.get("ecosystem")
     advisory_pkg = advisory.matcher.split(":", 1)[-1] if ":" in advisory.matcher else advisory.matcher
-    advisory_eco = advisory.source.split("/", 1)[0] if "/" in advisory.source else advisory.source
-    eco_match = not ecosystem or _norm(advisory_eco) in (_norm(str(ecosystem)), "osv", "*")
+    parts = advisory.source.split("/", 1)
+    advisory_eco = parts[1] if len(parts) > 1 else parts[0]
+    eco_match = not ecosystem or _norm(advisory_eco) in (_norm(str(ecosystem)), "*")
     return eco_match and _package_matches(advisory_pkg, str(pkg_name or ""))
 
 
@@ -86,12 +87,11 @@ def match_github_action(advisory: ThreatAdvisory, target: dict[str, object]) -> 
 
 
 def match_mcp_server(advisory: ThreatAdvisory, target: dict[str, object]) -> bool:
-    """Match an MCP server advisory by server name or URL fragment."""
+    """Match an MCP server advisory by exact server name."""
     server_name = target.get("mcp_server")
     if not isinstance(server_name, str):
         return False
-    matcher_norm = _norm(advisory.matcher)
-    return matcher_norm in _norm(server_name) or _norm(server_name) == matcher_norm
+    return _norm(server_name) == _norm(advisory.matcher)
 
 
 def match_skill_hash(advisory: ThreatAdvisory, target: dict[str, object]) -> bool:
@@ -103,12 +103,17 @@ def match_skill_hash(advisory: ThreatAdvisory, target: dict[str, object]) -> boo
 
 
 def match_malicious_domain(advisory: ThreatAdvisory, target: dict[str, object]) -> bool:
-    """Match a network destination against a known-malicious domain."""
+    """Match a network destination against a known-malicious domain.
+
+    Uses exact match or subdomain boundary match to avoid false positives.
+    e.g. advisory matcher ``evil.com`` matches ``evil.com`` and ``sub.evil.com``
+    but not ``not-evil.com``.
+    """
     hosts: object = target.get("network_hosts")
     if not isinstance(hosts, list):
         hosts = [target.get("network_host")] if target.get("network_host") else []
     matcher_norm = _norm(advisory.matcher)
-    return any(matcher_norm in _norm(str(h)) for h in hosts if h)
+    return any(_norm(str(h)) == matcher_norm or _norm(str(h)).endswith("." + matcher_norm) for h in hosts if h)
 
 
 def match_malicious_package_hash(advisory: ThreatAdvisory, target: dict[str, object]) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/advisory_matchers.py
+++ b/src/codex_plugin_scanner/guard/runtime/advisory_matchers.py
@@ -1,0 +1,159 @@
+"""Advisory matchers for multi-source threat intelligence.
+
+Each matcher takes a ThreatAdvisory and a target dict, and returns True if
+the advisory applies to the target. Matchers are keyed by their `matcher`
+field value in the advisory.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Protocol, runtime_checkable
+
+from .threat_intel import ThreatAdvisory
+
+
+@runtime_checkable
+class AdvisoryMatcher(Protocol):
+    """Callable that tests an advisory against a target dict."""
+
+    def __call__(self, advisory: ThreatAdvisory, target: dict[str, object]) -> bool: ...
+
+
+def _norm(val: object) -> str:
+    if not isinstance(val, str):
+        return ""
+    return val.strip().lower()
+
+
+def _package_matches(advisory_pkg: str, target_pkg: str) -> bool:
+    if not advisory_pkg or not target_pkg:
+        return False
+    return _norm(advisory_pkg) == _norm(target_pkg)
+
+
+def match_osv(advisory: ThreatAdvisory, target: dict[str, object]) -> bool:
+    """Match OSV advisories by package name and ecosystem."""
+    pkg_name = target.get("package_name")
+    ecosystem = target.get("ecosystem")
+    advisory_pkg = advisory.matcher.split(":", 1)[-1] if ":" in advisory.matcher else advisory.matcher
+    advisory_eco = advisory.source.split("/", 1)[0] if "/" in advisory.source else advisory.source
+    eco_match = not ecosystem or _norm(advisory_eco) in (_norm(str(ecosystem)), "osv", "*")
+    return eco_match and _package_matches(advisory_pkg, str(pkg_name or ""))
+
+
+def match_github_advisory(advisory: ThreatAdvisory, target: dict[str, object]) -> bool:
+    """Match GitHub Security Advisory by GHSA ID or package name."""
+    matcher_val = advisory.matcher
+    if re.match(r"^GHSA-", matcher_val, re.IGNORECASE):
+        ghsa_id = target.get("ghsa_id")
+        return isinstance(ghsa_id, str) and _norm(ghsa_id) == _norm(matcher_val)
+    return _package_matches(matcher_val, str(target.get("package_name") or ""))
+
+
+def match_nvd_cve(advisory: ThreatAdvisory, target: dict[str, object]) -> bool:
+    """Match NVD CVE by CVE ID or harness name."""
+    matcher_val = advisory.matcher
+    if re.match(r"^CVE-", matcher_val, re.IGNORECASE):
+        cve_id = target.get("cve_id")
+        return isinstance(cve_id, str) and _norm(cve_id) == _norm(matcher_val)
+    harness = target.get("harness")
+    return isinstance(harness, str) and _norm(harness) == _norm(matcher_val)
+
+
+def match_npm_advisory(advisory: ThreatAdvisory, target: dict[str, object]) -> bool:
+    """Match npm advisory by package name when ecosystem is npm."""
+    eco = target.get("ecosystem")
+    if not isinstance(eco, str) or _norm(eco) not in ("npm",):
+        return False
+    return _package_matches(advisory.matcher, str(target.get("package_name") or ""))
+
+
+def match_pypi_advisory(advisory: ThreatAdvisory, target: dict[str, object]) -> bool:
+    """Match PyPI advisory by package name when ecosystem is pypi."""
+    eco = target.get("ecosystem")
+    if not isinstance(eco, str) or _norm(eco) not in ("pypi", "pip"):
+        return False
+    return _package_matches(advisory.matcher, str(target.get("package_name") or ""))
+
+
+def match_github_action(advisory: ThreatAdvisory, target: dict[str, object]) -> bool:
+    """Match a GitHub Action by action slug (owner/name)."""
+    action_slug = target.get("action_slug")
+    if not isinstance(action_slug, str):
+        return False
+    return _norm(advisory.matcher) == _norm(action_slug)
+
+
+def match_mcp_server(advisory: ThreatAdvisory, target: dict[str, object]) -> bool:
+    """Match an MCP server advisory by server name or URL fragment."""
+    server_name = target.get("mcp_server")
+    if not isinstance(server_name, str):
+        return False
+    matcher_norm = _norm(advisory.matcher)
+    return matcher_norm in _norm(server_name) or _norm(server_name) == matcher_norm
+
+
+def match_skill_hash(advisory: ThreatAdvisory, target: dict[str, object]) -> bool:
+    """Match a skill (extension/tool) by its content hash."""
+    skill_hash = target.get("skill_hash")
+    if not isinstance(skill_hash, str):
+        return False
+    return _norm(advisory.matcher) == _norm(skill_hash)
+
+
+def match_malicious_domain(advisory: ThreatAdvisory, target: dict[str, object]) -> bool:
+    """Match a network destination against a known-malicious domain."""
+    hosts: object = target.get("network_hosts")
+    if not isinstance(hosts, list):
+        hosts = [target.get("network_host")] if target.get("network_host") else []
+    matcher_norm = _norm(advisory.matcher)
+    return any(matcher_norm in _norm(str(h)) for h in hosts if h)
+
+
+def match_malicious_package_hash(advisory: ThreatAdvisory, target: dict[str, object]) -> bool:
+    """Match a package by its content hash (e.g., tarball SHA256)."""
+    pkg_hash = target.get("package_hash")
+    if not isinstance(pkg_hash, str):
+        return False
+    return _norm(advisory.matcher) == _norm(pkg_hash)
+
+
+_MATCHER_REGISTRY: dict[str, AdvisoryMatcher] = {
+    "osv": match_osv,
+    "github_advisory": match_github_advisory,
+    "nvd_cve": match_nvd_cve,
+    "npm": match_npm_advisory,
+    "pypi": match_pypi_advisory,
+    "github_action": match_github_action,
+    "mcp_server": match_mcp_server,
+    "skill_hash": match_skill_hash,
+    "malicious_domain": match_malicious_domain,
+    "malicious_package_hash": match_malicious_package_hash,
+}
+
+
+def get_matcher(matcher_key: str) -> AdvisoryMatcher | None:
+    """Return the matcher function for a given matcher key, or None if unknown."""
+    return _MATCHER_REGISTRY.get(matcher_key)
+
+
+def apply_advisory(advisory: ThreatAdvisory, target: dict[str, object]) -> bool:
+    """Test a single advisory against a target using the registered matcher.
+
+    Dispatcher reads the advisory `source` field to select the matcher function.
+    Returns False for unknown source keys (safe default — no false positives).
+    """
+    source_key = advisory.source.split("/")[0].lower()
+    matcher_fn = get_matcher(source_key)
+    if matcher_fn is None:
+        return False
+    return matcher_fn(advisory, target)
+
+
+def match_all_advisories(
+    advisories: tuple[ThreatAdvisory, ...],
+    target: dict[str, object],
+) -> tuple[ThreatAdvisory, ...]:
+    """Return all advisories from the bundle that match the given target."""
+    return tuple(a for a in advisories if apply_advisory(a, target))

--- a/src/codex_plugin_scanner/guard/runtime/threat_intel.py
+++ b/src/codex_plugin_scanner/guard/runtime/threat_intel.py
@@ -12,10 +12,10 @@ import time
 from dataclasses import dataclass
 from typing import Final
 
+from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
-from cryptography.exceptions import InvalidSignature
 
 _BUNDLE_MAX_AGE_SECONDS: Final[int] = 86_400 * 7
 _BUNDLE_CLOCK_SKEW_SECONDS: Final[int] = 300
@@ -65,7 +65,7 @@ class ThreatAdvisory:
         }
 
     @staticmethod
-    def from_dict(data: dict[str, object]) -> "ThreatAdvisory":
+    def from_dict(data: dict[str, object]) -> ThreatAdvisory:
         def _str(key: str) -> str:
             val = data.get(key)
             if not isinstance(val, str) or not val.strip():
@@ -105,7 +105,7 @@ class ThreatIntelBundle:
         }
 
     @staticmethod
-    def from_dict(data: dict[str, object]) -> "ThreatIntelBundle":
+    def from_dict(data: dict[str, object]) -> ThreatIntelBundle:
         def _int(key: str) -> int:
             val = data.get(key)
             if not isinstance(val, int):
@@ -192,9 +192,7 @@ def check_bundle_freshness(bundle: ThreatIntelBundle, now: float | None = None) 
     """
     ts = now if now is not None else time.time()
     if ts > bundle.expires_at + _BUNDLE_CLOCK_SKEW_SECONDS:
-        raise BundleExpiredError(
-            f"Bundle expired at {bundle.expires_at:.0f}, current time is {ts:.0f}"
-        )
+        raise BundleExpiredError(f"Bundle expired at {bundle.expires_at:.0f}, current time is {ts:.0f}")
     if ts < bundle.generated_at - _BUNDLE_CLOCK_SKEW_SECONDS:
         raise BundleExpiredError(
             f"Bundle generated_at {bundle.generated_at:.0f} is in the future (current time {ts:.0f})"
@@ -207,9 +205,7 @@ def check_bundle_rollback(bundle: ThreatIntelBundle, cached_version: int) -> Non
     Protects against a server serving an older bundle to downgrade protections.
     """
     if bundle.version < cached_version:
-        raise BundleRollbackError(
-            f"Bundle version {bundle.version} is older than cached version {cached_version}"
-        )
+        raise BundleRollbackError(f"Bundle version {bundle.version} is older than cached version {cached_version}")
 
 
 def load_bundle_from_json(raw_json: str) -> ThreatIntelBundle:

--- a/src/codex_plugin_scanner/guard/runtime/threat_intel.py
+++ b/src/codex_plugin_scanner/guard/runtime/threat_intel.py
@@ -206,6 +206,11 @@ def check_bundle_freshness(bundle: ThreatIntelBundle, now: float | None = None) 
         raise BundleExpiredError(
             f"Bundle generated_at {bundle.generated_at:.0f} is in the future (current time {ts:.0f})"
         )
+    bundle_age = ts - bundle.generated_at
+    if bundle_age > _BUNDLE_MAX_AGE_SECONDS:
+        raise BundleExpiredError(
+            f"Bundle age {bundle_age:.0f}s exceeds maximum allowed age of {_BUNDLE_MAX_AGE_SECONDS}s"
+        )
 
 
 def check_bundle_rollback(bundle: ThreatIntelBundle, cached_version: int) -> None:

--- a/src/codex_plugin_scanner/guard/runtime/threat_intel.py
+++ b/src/codex_plugin_scanner/guard/runtime/threat_intel.py
@@ -1,0 +1,233 @@
+"""HOL Guard threat intelligence bundle handling.
+
+Provides typed dataclasses, signature verification, freshness checks,
+rollback protection, and multi-source advisory matching for the
+cloud advisory client subsystem.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from typing import Final
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+from cryptography.exceptions import InvalidSignature
+
+_BUNDLE_MAX_AGE_SECONDS: Final[int] = 86_400 * 7
+_BUNDLE_CLOCK_SKEW_SECONDS: Final[int] = 300
+
+
+class ThreatIntelError(Exception):
+    """Base error for threat intel bundle validation failures."""
+
+
+class BundleSignatureError(ThreatIntelError):
+    """Bundle signature did not verify against the provided public key."""
+
+
+class BundleExpiredError(ThreatIntelError):
+    """Bundle freshness window has elapsed."""
+
+
+class BundleRollbackError(ThreatIntelError):
+    """Bundle version is older than the cached version — possible rollback attack."""
+
+
+class BundleMalformedError(ThreatIntelError):
+    """Bundle JSON is missing required fields or contains invalid types."""
+
+
+@dataclass(frozen=True, slots=True)
+class ThreatAdvisory:
+    """Single advisory record inside a threat intelligence bundle."""
+
+    advisory_id: str
+    source: str
+    severity: str
+    title: str
+    affected_type: str
+    matcher: str
+    recommendation: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "advisory_id": self.advisory_id,
+            "source": self.source,
+            "severity": self.severity,
+            "title": self.title,
+            "affected_type": self.affected_type,
+            "matcher": self.matcher,
+            "recommendation": self.recommendation,
+        }
+
+    @staticmethod
+    def from_dict(data: dict[str, object]) -> "ThreatAdvisory":
+        def _str(key: str) -> str:
+            val = data.get(key)
+            if not isinstance(val, str) or not val.strip():
+                raise BundleMalformedError(f"ThreatAdvisory missing required string field: {key!r}")
+            return val
+
+        return ThreatAdvisory(
+            advisory_id=_str("advisory_id"),
+            source=_str("source"),
+            severity=_str("severity"),
+            title=_str("title"),
+            affected_type=_str("affected_type"),
+            matcher=_str("matcher"),
+            recommendation=_str("recommendation"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ThreatIntelBundle:
+    """Signed, versioned advisory bundle from the HOL Guard cloud."""
+
+    version: int
+    generated_at: float
+    expires_at: float
+    source: str
+    signature: str
+    advisories: tuple[ThreatAdvisory, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "version": self.version,
+            "generated_at": self.generated_at,
+            "expires_at": self.expires_at,
+            "source": self.source,
+            "signature": self.signature,
+            "advisories": [a.to_dict() for a in self.advisories],
+        }
+
+    @staticmethod
+    def from_dict(data: dict[str, object]) -> "ThreatIntelBundle":
+        def _int(key: str) -> int:
+            val = data.get(key)
+            if not isinstance(val, int):
+                raise BundleMalformedError(f"ThreatIntelBundle missing required int field: {key!r}")
+            return val
+
+        def _float(key: str) -> float:
+            val = data.get(key)
+            if isinstance(val, (int, float)):
+                return float(val)
+            raise BundleMalformedError(f"ThreatIntelBundle missing required numeric field: {key!r}")
+
+        def _str(key: str) -> str:
+            val = data.get(key)
+            if not isinstance(val, str) or not val.strip():
+                raise BundleMalformedError(f"ThreatIntelBundle missing required string field: {key!r}")
+            return val
+
+        raw_advisories = data.get("advisories")
+        if not isinstance(raw_advisories, list):
+            raise BundleMalformedError("ThreatIntelBundle 'advisories' must be a list")
+
+        return ThreatIntelBundle(
+            version=_int("version"),
+            generated_at=_float("generated_at"),
+            expires_at=_float("expires_at"),
+            source=_str("source"),
+            signature=_str("signature"),
+            advisories=tuple(ThreatAdvisory.from_dict(a) for a in raw_advisories),
+        )
+
+
+def _canonical_payload(bundle: ThreatIntelBundle) -> bytes:
+    """Deterministic JSON payload used for signature computation.
+
+    Signs only the stable fields — excludes `signature` itself.
+    """
+    payload = {
+        "version": bundle.version,
+        "generated_at": bundle.generated_at,
+        "expires_at": bundle.expires_at,
+        "source": bundle.source,
+        "advisories": [a.to_dict() for a in bundle.advisories],
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+
+
+def verify_bundle_signature(bundle: ThreatIntelBundle, public_key_pem: bytes) -> None:
+    """Verify the RSA-PSS signature on a bundle.
+
+    Raises BundleSignatureError if the signature does not verify.
+    """
+    try:
+        loaded_key = serialization.load_pem_public_key(public_key_pem)
+    except (ValueError, TypeError) as exc:
+        raise BundleSignatureError(f"Failed to load public key: {exc}") from exc
+
+    if not isinstance(loaded_key, RSAPublicKey):
+        raise BundleSignatureError("Public key must be RSA")
+
+    import base64
+
+    try:
+        sig_bytes = base64.b64decode(bundle.signature)
+    except Exception as exc:
+        raise BundleSignatureError(f"Signature is not valid base64: {exc}") from exc
+
+    payload = _canonical_payload(bundle)
+    try:
+        loaded_key.verify(
+            sig_bytes,
+            payload,
+            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+            hashes.SHA256(),
+        )
+    except InvalidSignature as exc:
+        raise BundleSignatureError("Bundle signature verification failed") from exc
+
+
+def check_bundle_freshness(bundle: ThreatIntelBundle, now: float | None = None) -> None:
+    """Raise BundleExpiredError if the bundle is outside its freshness window.
+
+    Uses wall-clock time by default; pass `now` in tests for determinism.
+    """
+    ts = now if now is not None else time.time()
+    if ts > bundle.expires_at + _BUNDLE_CLOCK_SKEW_SECONDS:
+        raise BundleExpiredError(
+            f"Bundle expired at {bundle.expires_at:.0f}, current time is {ts:.0f}"
+        )
+    if ts < bundle.generated_at - _BUNDLE_CLOCK_SKEW_SECONDS:
+        raise BundleExpiredError(
+            f"Bundle generated_at {bundle.generated_at:.0f} is in the future (current time {ts:.0f})"
+        )
+
+
+def check_bundle_rollback(bundle: ThreatIntelBundle, cached_version: int) -> None:
+    """Raise BundleRollbackError if the bundle version regresses.
+
+    Protects against a server serving an older bundle to downgrade protections.
+    """
+    if bundle.version < cached_version:
+        raise BundleRollbackError(
+            f"Bundle version {bundle.version} is older than cached version {cached_version}"
+        )
+
+
+def load_bundle_from_json(raw_json: str) -> ThreatIntelBundle:
+    """Parse a raw JSON string into a ThreatIntelBundle.
+
+    Raises BundleMalformedError on invalid JSON or schema violations.
+    """
+    try:
+        data = json.loads(raw_json)
+    except json.JSONDecodeError as exc:
+        raise BundleMalformedError(f"Bundle JSON is invalid: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise BundleMalformedError("Bundle root must be a JSON object")
+
+    return ThreatIntelBundle.from_dict(data)
+
+
+def advisory_severity_rank(severity: str) -> int:
+    """Numeric rank for severity comparison (higher = more severe)."""
+    return {"info": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}.get(severity.lower(), 0)

--- a/src/codex_plugin_scanner/guard/runtime/threat_intel.py
+++ b/src/codex_plugin_scanner/guard/runtime/threat_intel.py
@@ -7,6 +7,7 @@ cloud advisory client subsystem.
 
 from __future__ import annotations
 
+import base64
 import json
 import time
 from dataclasses import dataclass
@@ -128,13 +129,21 @@ class ThreatIntelBundle:
         if not isinstance(raw_advisories, list):
             raise BundleMalformedError("ThreatIntelBundle 'advisories' must be a list")
 
+        parsed_advisories: list[ThreatAdvisory] = []
+        for idx, item in enumerate(raw_advisories):
+            if not isinstance(item, dict):
+                raise BundleMalformedError(
+                    f"ThreatIntelBundle advisory at index {idx} must be an object, got {type(item).__name__}"
+                )
+            parsed_advisories.append(ThreatAdvisory.from_dict(item))
+
         return ThreatIntelBundle(
             version=_int("version"),
             generated_at=_float("generated_at"),
             expires_at=_float("expires_at"),
             source=_str("source"),
             signature=_str("signature"),
-            advisories=tuple(ThreatAdvisory.from_dict(a) for a in raw_advisories),
+            advisories=tuple(parsed_advisories),
         )
 
 
@@ -142,11 +151,13 @@ def _canonical_payload(bundle: ThreatIntelBundle) -> bytes:
     """Deterministic JSON payload used for signature computation.
 
     Signs only the stable fields — excludes `signature` itself.
+    Timestamps are serialized as integers to avoid float precision
+    differences across JSON implementations.
     """
     payload = {
         "version": bundle.version,
-        "generated_at": bundle.generated_at,
-        "expires_at": bundle.expires_at,
+        "generated_at": int(bundle.generated_at),
+        "expires_at": int(bundle.expires_at),
         "source": bundle.source,
         "advisories": [a.to_dict() for a in bundle.advisories],
     }
@@ -165,8 +176,6 @@ def verify_bundle_signature(bundle: ThreatIntelBundle, public_key_pem: bytes) ->
 
     if not isinstance(loaded_key, RSAPublicKey):
         raise BundleSignatureError("Public key must be RSA")
-
-    import base64
 
     try:
         sig_bytes = base64.b64decode(bundle.signature)

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -75,6 +75,11 @@ from .store_evidence import (
     evidence_index_statements,
     evidence_schema_statement,
 )
+from .store_threat_intel import (
+    threat_intel_bundle_schema_statement,
+    threat_intel_index_statements,
+    threat_intel_matches_schema_statement,
+)
 from .types import CapabilitySet
 
 _SYNC_TOKEN_REF = "guard-cloud-token"
@@ -651,11 +656,15 @@ class GuardStore:
             connect_state_schema_statement(),
             approval_schema_statement(),
             evidence_schema_statement(),
+            threat_intel_bundle_schema_statement(),
+            threat_intel_matches_schema_statement(),
         )
         with self._connect() as connection:
             for statement in statements:
                 connection.execute(statement)
             for idx_stmt in evidence_index_statements():
+                connection.execute(idx_stmt)
+            for idx_stmt in threat_intel_index_statements():
                 connection.execute(idx_stmt)
             self._ensure_policy_column(connection, "publisher", "text")
             self._ensure_policy_column(connection, "artifact_hash", "text")

--- a/src/codex_plugin_scanner/guard/store_threat_intel.py
+++ b/src/codex_plugin_scanner/guard/store_threat_intel.py
@@ -93,7 +93,7 @@ class ThreatIntelMatch:
     target_json: str
 
 
-def upsert_bundle(conn: sqlite3.Connection, bundle: "ThreatIntelBundle", bundle_id: str) -> None:
+def upsert_bundle(conn: sqlite3.Connection, bundle: ThreatIntelBundle, bundle_id: str) -> None:
     """Insert or replace a bundle row in the local cache."""
     conn.execute(
         """

--- a/src/codex_plugin_scanner/guard/store_threat_intel.py
+++ b/src/codex_plugin_scanner/guard/store_threat_intel.py
@@ -121,7 +121,7 @@ def latest_cached_bundle(conn: sqlite3.Connection) -> CachedBundle | None:
         SELECT bundle_id, version, source, generated_at, expires_at,
                signature, advisories_json, cached_at
         FROM guard_threat_intel_bundles
-        ORDER BY version DESC
+        ORDER BY version DESC, rowid DESC
         LIMIT 1
         """
     ).fetchone()

--- a/src/codex_plugin_scanner/guard/store_threat_intel.py
+++ b/src/codex_plugin_scanner/guard/store_threat_intel.py
@@ -1,0 +1,209 @@
+"""Threat intelligence bundle cache storage.
+
+Provides schema statements, write/read helpers, and migration tests for
+caching signed advisory bundles and their match results locally.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .runtime.threat_intel import ThreatIntelBundle
+
+
+def threat_intel_bundle_schema_statement() -> str:
+    """CREATE TABLE IF NOT EXISTS for guard_threat_intel_bundles."""
+    return """
+    CREATE TABLE IF NOT EXISTS guard_threat_intel_bundles (
+        bundle_id     text primary key,
+        version       integer not null,
+        source        text not null,
+        generated_at  real not null,
+        expires_at    real not null,
+        signature     text not null,
+        advisories_json text not null default '[]',
+        cached_at     real not null
+    )
+    """
+
+
+def threat_intel_matches_schema_statement() -> str:
+    """CREATE TABLE IF NOT EXISTS for guard_threat_intel_matches."""
+    return """
+    CREATE TABLE IF NOT EXISTS guard_threat_intel_matches (
+        match_id        text primary key,
+        bundle_id       text not null,
+        advisory_id     text not null,
+        artifact_id     text not null,
+        harness         text not null default '',
+        workspace       text not null default '',
+        severity        text not null default 'info',
+        matched_at      real not null,
+        target_json     text not null default '{}'
+    )
+    """
+
+
+def threat_intel_index_statements() -> tuple[str, ...]:
+    """Index statements for threat intel cache tables."""
+    return (
+        "CREATE INDEX IF NOT EXISTS idx_ti_bundle_version ON guard_threat_intel_bundles(version DESC)",
+        "CREATE INDEX IF NOT EXISTS idx_ti_bundle_expires ON guard_threat_intel_bundles(expires_at)",
+        "CREATE INDEX IF NOT EXISTS idx_ti_match_bundle ON guard_threat_intel_matches(bundle_id)",
+        "CREATE INDEX IF NOT EXISTS idx_ti_match_artifact ON guard_threat_intel_matches(artifact_id)",
+        "CREATE INDEX IF NOT EXISTS idx_ti_match_severity ON guard_threat_intel_matches(severity, matched_at DESC)",
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class CachedBundle:
+    """Lightweight cache row for a previously fetched bundle."""
+
+    bundle_id: str
+    version: int
+    source: str
+    generated_at: float
+    expires_at: float
+    signature: str
+    advisories_json: str
+    cached_at: float
+
+    def is_fresh(self, now: float | None = None, skew: float = 300.0) -> bool:
+        ts = now if now is not None else time.time()
+        return ts <= self.expires_at + skew
+
+
+@dataclass(frozen=True, slots=True)
+class ThreatIntelMatch:
+    """A single advisory match result stored for audit and dashboard display."""
+
+    match_id: str
+    bundle_id: str
+    advisory_id: str
+    artifact_id: str
+    harness: str
+    workspace: str
+    severity: str
+    matched_at: float
+    target_json: str
+
+
+def upsert_bundle(conn: sqlite3.Connection, bundle: "ThreatIntelBundle", bundle_id: str) -> None:
+    """Insert or replace a bundle row in the local cache."""
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO guard_threat_intel_bundles
+            (bundle_id, version, source, generated_at, expires_at, signature, advisories_json, cached_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            bundle_id,
+            bundle.version,
+            bundle.source,
+            bundle.generated_at,
+            bundle.expires_at,
+            bundle.signature,
+            json.dumps([a.to_dict() for a in bundle.advisories]),
+            time.time(),
+        ),
+    )
+
+
+def latest_cached_bundle(conn: sqlite3.Connection) -> CachedBundle | None:
+    """Return the cached bundle with the highest version, or None."""
+    row = conn.execute(
+        """
+        SELECT bundle_id, version, source, generated_at, expires_at,
+               signature, advisories_json, cached_at
+        FROM guard_threat_intel_bundles
+        ORDER BY version DESC
+        LIMIT 1
+        """
+    ).fetchone()
+    if row is None:
+        return None
+    return CachedBundle(
+        bundle_id=row[0],
+        version=row[1],
+        source=row[2],
+        generated_at=row[3],
+        expires_at=row[4],
+        signature=row[5],
+        advisories_json=row[6],
+        cached_at=row[7],
+    )
+
+
+def insert_match(conn: sqlite3.Connection, match: ThreatIntelMatch) -> None:
+    """Insert a threat intel match result."""
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO guard_threat_intel_matches
+            (match_id, bundle_id, advisory_id, artifact_id, harness, workspace,
+             severity, matched_at, target_json)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            match.match_id,
+            match.bundle_id,
+            match.advisory_id,
+            match.artifact_id,
+            match.harness,
+            match.workspace,
+            match.severity,
+            match.matched_at,
+            match.target_json,
+        ),
+    )
+
+
+def list_matches(
+    conn: sqlite3.Connection,
+    artifact_id: str | None = None,
+    harness: str | None = None,
+    severity: str | None = None,
+    limit: int = 100,
+) -> list[ThreatIntelMatch]:
+    """List cached threat intel matches with optional filters."""
+    clauses: list[str] = []
+    params: list[object] = []
+    if artifact_id is not None:
+        clauses.append("artifact_id = ?")
+        params.append(artifact_id)
+    if harness is not None:
+        clauses.append("harness = ?")
+        params.append(harness)
+    if severity is not None:
+        clauses.append("severity = ?")
+        params.append(severity)
+    where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+    rows = conn.execute(
+        f"""
+        SELECT match_id, bundle_id, advisory_id, artifact_id, harness, workspace,
+               severity, matched_at, target_json
+        FROM guard_threat_intel_matches
+        {where}
+        ORDER BY matched_at DESC
+        LIMIT ?
+        """,
+        (*params, limit),
+    ).fetchall()
+    return [
+        ThreatIntelMatch(
+            match_id=r[0],
+            bundle_id=r[1],
+            advisory_id=r[2],
+            artifact_id=r[3],
+            harness=r[4],
+            workspace=r[5],
+            severity=r[6],
+            matched_at=r[7],
+            target_json=r[8],
+        )
+        for r in rows
+    ]

--- a/tests/test_guard_advisory_escalation.py
+++ b/tests/test_guard_advisory_escalation.py
@@ -1,0 +1,102 @@
+"""Tests for advisory-driven policy escalation — T557."""
+
+from __future__ import annotations
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.advisory_escalation import (
+    advisory_match_summary,
+    escalate_for_advisories,
+)
+from codex_plugin_scanner.guard.runtime.threat_intel import ThreatAdvisory
+
+
+def _advisory(
+    advisory_id: str,
+    severity: str,
+    source: str = "osv/npm",
+    matcher: str = "evil-pkg",
+) -> ThreatAdvisory:
+    return ThreatAdvisory(
+        advisory_id=advisory_id,
+        title=f"Test advisory {advisory_id}",
+        severity=severity,
+        source=source,
+        affected_type="package",
+        matcher=matcher,
+        recommendation="upgrade",
+    )
+
+
+CRITICAL = _advisory("GHSA-crit-01", "critical")
+HIGH = _advisory("GHSA-high-01", "high")
+MEDIUM = _advisory("GHSA-med-01", "medium")
+LOW = _advisory("GHSA-low-01", "low")
+INFO = _advisory("GHSA-info-01", "info")
+
+
+@pytest.mark.parametrize(
+    ("policy_action", "advisories", "expected_action", "expect_advisory"),
+    [
+        ("allow", (CRITICAL,), "ask", True),
+        ("warn", (CRITICAL,), "ask", True),
+        ("review", (CRITICAL,), "block", True),
+        ("allow", (HIGH,), "ask", True),
+        ("warn", (HIGH,), "ask", True),
+        ("review", (HIGH,), "review", False),
+        ("allow", (MEDIUM,), "allow", False),
+        ("allow", (LOW,), "allow", False),
+        ("allow", (INFO,), "allow", False),
+        ("block", (CRITICAL,), "block", False),
+        ("allow", (), "allow", False),
+        ("warn", (), "warn", False),
+    ],
+)
+def test_escalate_for_advisories(
+    policy_action: str,
+    advisories: tuple[ThreatAdvisory, ...],
+    expected_action: str,
+    expect_advisory: bool,
+) -> None:
+    escalated, triggering_id = escalate_for_advisories(policy_action, advisories)  # type: ignore[arg-type]
+    assert escalated == expected_action
+    if expect_advisory:
+        assert triggering_id is not None
+    else:
+        assert triggering_id is None
+
+
+def test_escalate_critical_beats_high() -> None:
+    escalated, triggering_id = escalate_for_advisories(
+        "allow",  # type: ignore[arg-type]
+        (HIGH, CRITICAL),
+    )
+    assert escalated == "ask"
+    assert triggering_id == CRITICAL.advisory_id
+
+
+def test_escalate_no_advisories_returns_original() -> None:
+    assert escalate_for_advisories("allow", ())[0] == "allow"  # type: ignore[arg-type]
+    assert escalate_for_advisories("block", ())[0] == "block"  # type: ignore[arg-type]
+
+
+def test_advisory_match_summary_empty() -> None:
+    assert advisory_match_summary(()) == "no advisory matches"
+
+
+def test_advisory_match_summary_single() -> None:
+    summary = advisory_match_summary((CRITICAL,))
+    assert "GHSA-crit-01" in summary
+    assert "critical" in summary
+
+
+def test_advisory_match_summary_truncates_beyond_five() -> None:
+    advisories = tuple(_advisory(f"ID-{i}", "medium") for i in range(10))
+    summary = advisory_match_summary(advisories)
+    assert "+5 more" in summary
+
+
+def test_advisory_match_summary_exactly_five() -> None:
+    advisories = tuple(_advisory(f"ID-{i}", "medium") for i in range(5))
+    summary = advisory_match_summary(advisories)
+    assert "more" not in summary

--- a/tests/test_guard_advisory_escalation.py
+++ b/tests/test_guard_advisory_escalation.py
@@ -100,3 +100,24 @@ def test_advisory_match_summary_exactly_five() -> None:
     advisories = tuple(_advisory(f"ID-{i}", "medium") for i in range(5))
     summary = advisory_match_summary(advisories)
     assert "more" not in summary
+
+
+def test_escalate_uppercase_severity_normalized() -> None:
+    high_upper = _advisory("GHSA-upper-01", "HIGH")
+    critical_upper = _advisory("GHSA-upper-02", "CRITICAL")
+    escalated, triggering_id = escalate_for_advisories("allow", (high_upper, critical_upper))  # type: ignore[arg-type]
+    assert escalated == "ask"
+    assert triggering_id == critical_upper.advisory_id
+
+
+def test_escalate_mixed_case_severity_normalized() -> None:
+    mixed = _advisory("GHSA-mixed-01", "Critical")
+    escalated, _ = escalate_for_advisories("warn", (mixed,))  # type: ignore[arg-type]
+    assert escalated == "ask"
+
+
+def test_advisory_match_summary_normalizes_severity_case() -> None:
+    upper_sev = _advisory("GHSA-upper-01", "CRITICAL")
+    summary = advisory_match_summary((upper_sev,))
+    assert "critical" in summary
+    assert "CRITICAL" not in summary

--- a/tests/test_guard_threat_intel.py
+++ b/tests/test_guard_threat_intel.py
@@ -13,12 +13,24 @@ import sqlite3
 import time
 
 import pytest
-
+from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric.rsa import generate_private_key
-from cryptography.hazmat.backends import default_backend
 
+from codex_plugin_scanner.guard.runtime.advisory_matchers import (
+    match_all_advisories,
+    match_github_action,
+    match_github_advisory,
+    match_malicious_domain,
+    match_malicious_package_hash,
+    match_mcp_server,
+    match_npm_advisory,
+    match_nvd_cve,
+    match_osv,
+    match_pypi_advisory,
+    match_skill_hash,
+)
 from codex_plugin_scanner.guard.runtime.threat_intel import (
     BundleExpiredError,
     BundleMalformedError,
@@ -33,21 +45,7 @@ from codex_plugin_scanner.guard.runtime.threat_intel import (
     load_bundle_from_json,
     verify_bundle_signature,
 )
-from codex_plugin_scanner.guard.runtime.advisory_matchers import (
-    match_all_advisories,
-    match_github_action,
-    match_github_advisory,
-    match_malicious_domain,
-    match_malicious_package_hash,
-    match_mcp_server,
-    match_npm_advisory,
-    match_nvd_cve,
-    match_osv,
-    match_pypi_advisory,
-    match_skill_hash,
-)
 from codex_plugin_scanner.guard.store_threat_intel import (
-    CachedBundle,
     ThreatIntelMatch,
     insert_match,
     latest_cached_bundle,

--- a/tests/test_guard_threat_intel.py
+++ b/tests/test_guard_threat_intel.py
@@ -550,3 +550,32 @@ class TestAdvisoriesSubcommandArgParsing:
         add_guard_root_parser(parser)
         args = parser.parse_args(["advisories", "--home", str(tmp_path), "explain", "ADV-001"])
         assert str(args.home) == str(tmp_path)
+
+    def test_explain_searches_all_advisories_not_just_first_100(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """advisories explain must call list_cached_advisories with limit=None."""
+        import codex_plugin_scanner.guard.store as store_mod
+        from codex_plugin_scanner.guard.cli.commands import add_guard_root_parser, run_guard_command
+
+        limit_captured: list[int | None] = []
+
+        def spy(self: object, limit: int | None = 100) -> list[dict[str, object]]:
+            limit_captured.append(limit)
+            return [{"advisory_id": "ADV-999", "title": "Old advisory", "severity": "low"}]
+
+        monkeypatch.setattr(store_mod.GuardStore, "list_cached_advisories", spy)
+
+        parser = argparse.ArgumentParser()
+        add_guard_root_parser(parser)
+        args = parser.parse_args(["advisories", "--home", str(tmp_path), "explain", "ADV-999"])
+
+        try:
+            run_guard_command(args)
+        except SystemExit:
+            pass
+        except Exception:
+            pass
+
+        explain_calls = [lim for lim in limit_captured if lim is None]
+        assert explain_calls, f"explain did not call list_cached_advisories(limit=None), got: {limit_captured}"

--- a/tests/test_guard_threat_intel.py
+++ b/tests/test_guard_threat_intel.py
@@ -215,6 +215,19 @@ class TestBundleFreshness:
         bundle = _make_bundle(generated_at=now - 100, expires_at=now + 200)
         check_bundle_freshness(bundle, now=now + 100)
 
+    def test_bundle_exceeding_max_age_fails(self) -> None:
+        now = time.time()
+        max_age = 86_400 * 7
+        bundle = _make_bundle(generated_at=now - max_age - 1, expires_at=now + 3600)
+        with pytest.raises(BundleExpiredError, match="maximum allowed age"):
+            check_bundle_freshness(bundle, now=now)
+
+    def test_bundle_at_max_age_boundary_passes(self) -> None:
+        now = time.time()
+        max_age = 86_400 * 7
+        bundle = _make_bundle(generated_at=now - max_age + 100, expires_at=now + 3600)
+        check_bundle_freshness(bundle, now=now)
+
 
 class TestBundleRollback:
     """T539 — rollback protection: older bundle version is rejected."""

--- a/tests/test_guard_threat_intel.py
+++ b/tests/test_guard_threat_intel.py
@@ -7,10 +7,12 @@ T543-T545 cloud sync client stubs and fallbacks.
 
 from __future__ import annotations
 
+import argparse
 import base64
 import json
 import sqlite3
 import time
+from pathlib import Path
 
 import pytest
 from cryptography.hazmat.backends import default_backend
@@ -342,8 +344,15 @@ class TestUpsertAndFetchBundle:
         assert cached is not None
         assert cached.is_fresh(now=now) is False
 
+    def test_latest_returns_newest_row_on_version_tie(self) -> None:
+        conn = _in_memory_db()
+        upsert_bundle(conn, _make_bundle(version=5), bundle_id="b5-old")
+        upsert_bundle(conn, _make_bundle(version=5), bundle_id="b5-new")
+        cached = latest_cached_bundle(conn)
+        assert cached is not None
+        assert cached.version == 5
+        assert cached.bundle_id == "b5-new"
 
-class TestMatchStorage:
     """T542 — match rows can be inserted and filtered."""
 
     def _make_match(self, **overrides: object) -> ThreatIntelMatch:
@@ -521,3 +530,23 @@ class TestSeverityRank:
 
     def test_unknown_treated_as_info(self) -> None:
         assert advisory_severity_rank("banana") == advisory_severity_rank("info")
+
+
+class TestAdvisoriesSubcommandArgParsing:
+    """Regression — advisory subcommands must not overwrite parent --home value."""
+
+    def test_home_flag_preserved_on_list_subcommand(self, tmp_path: Path) -> None:
+        from codex_plugin_scanner.guard.cli.commands import add_guard_root_parser
+
+        parser = argparse.ArgumentParser()
+        add_guard_root_parser(parser)
+        args = parser.parse_args(["advisories", "--home", str(tmp_path), "list"])
+        assert str(args.home) == str(tmp_path)
+
+    def test_home_flag_preserved_on_explain_subcommand(self, tmp_path: Path) -> None:
+        from codex_plugin_scanner.guard.cli.commands import add_guard_root_parser
+
+        parser = argparse.ArgumentParser()
+        add_guard_root_parser(parser)
+        args = parser.parse_args(["advisories", "--home", str(tmp_path), "explain", "ADV-001"])
+        assert str(args.home) == str(tmp_path)

--- a/tests/test_guard_threat_intel.py
+++ b/tests/test_guard_threat_intel.py
@@ -446,9 +446,9 @@ class TestAdvisoryMatchers:
         adv = _make_advisory(matcher="evil-mcp")
         assert match_mcp_server(adv, {"mcp_server": "evil-mcp"})
 
-    def test_mcp_server_substring_match(self) -> None:
+    def test_mcp_server_no_substring_false_positive(self) -> None:
         adv = _make_advisory(matcher="evil-mcp")
-        assert match_mcp_server(adv, {"mcp_server": "some-evil-mcp-server"})
+        assert not match_mcp_server(adv, {"mcp_server": "some-evil-mcp-server"})
 
     def test_skill_hash_match(self) -> None:
         adv = _make_advisory(matcher="abc123def456")

--- a/tests/test_guard_threat_intel.py
+++ b/tests/test_guard_threat_intel.py
@@ -1,0 +1,512 @@
+"""Tests for threat intelligence bundle handling and advisory matchers.
+
+Covers: T536 signature verification, T537 tampered bundle rejection,
+T538 freshness expiry, T539 rollback protection, T540-T542 cache migration,
+T543-T545 cloud sync client stubs and fallbacks.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sqlite3
+import time
+
+import pytest
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import generate_private_key
+from cryptography.hazmat.backends import default_backend
+
+from codex_plugin_scanner.guard.runtime.threat_intel import (
+    BundleExpiredError,
+    BundleMalformedError,
+    BundleRollbackError,
+    BundleSignatureError,
+    ThreatAdvisory,
+    ThreatIntelBundle,
+    _canonical_payload,
+    advisory_severity_rank,
+    check_bundle_freshness,
+    check_bundle_rollback,
+    load_bundle_from_json,
+    verify_bundle_signature,
+)
+from codex_plugin_scanner.guard.runtime.advisory_matchers import (
+    match_all_advisories,
+    match_github_action,
+    match_github_advisory,
+    match_malicious_domain,
+    match_malicious_package_hash,
+    match_mcp_server,
+    match_npm_advisory,
+    match_nvd_cve,
+    match_osv,
+    match_pypi_advisory,
+    match_skill_hash,
+)
+from codex_plugin_scanner.guard.store_threat_intel import (
+    CachedBundle,
+    ThreatIntelMatch,
+    insert_match,
+    latest_cached_bundle,
+    list_matches,
+    threat_intel_bundle_schema_statement,
+    threat_intel_index_statements,
+    threat_intel_matches_schema_statement,
+    upsert_bundle,
+)
+
+
+def _make_advisory(**overrides: object) -> ThreatAdvisory:
+    defaults: dict[str, object] = {
+        "advisory_id": "ADV-001",
+        "source": "osv/npm",
+        "severity": "high",
+        "title": "Test advisory",
+        "affected_type": "package",
+        "matcher": "evil-pkg",
+        "recommendation": "Upgrade immediately.",
+    }
+    defaults.update(overrides)
+    return ThreatAdvisory(
+        advisory_id=str(defaults["advisory_id"]),
+        source=str(defaults["source"]),
+        severity=str(defaults["severity"]),
+        title=str(defaults["title"]),
+        affected_type=str(defaults["affected_type"]),
+        matcher=str(defaults["matcher"]),
+        recommendation=str(defaults["recommendation"]),
+    )
+
+
+def _make_bundle(
+    version: int = 1,
+    advisories: tuple[ThreatAdvisory, ...] | None = None,
+    generated_at: float | None = None,
+    expires_at: float | None = None,
+    signature: str = "placeholder",
+) -> ThreatIntelBundle:
+    now = time.time()
+    return ThreatIntelBundle(
+        version=version,
+        generated_at=generated_at if generated_at is not None else now - 60,
+        expires_at=expires_at if expires_at is not None else now + 3600,
+        source="hol-cloud",
+        signature=signature,
+        advisories=advisories if advisories is not None else (_make_advisory(),),
+    )
+
+
+def _generate_test_key_pair() -> tuple[bytes, bytes]:
+    """Return (private_key_pem, public_key_pem) for testing."""
+    private_key = generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+        backend=default_backend(),
+    )
+    priv_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    pub_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv_pem, pub_pem
+
+
+def _sign_bundle(bundle: ThreatIntelBundle, private_key_pem: bytes) -> ThreatIntelBundle:
+    """Return a new bundle with a valid RSA-PSS signature."""
+    from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+
+    loaded_key = serialization.load_pem_private_key(private_key_pem, password=None)
+    assert isinstance(loaded_key, RSAPrivateKey)
+    payload = _canonical_payload(bundle)
+    sig_bytes = loaded_key.sign(
+        payload,
+        padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+        hashes.SHA256(),
+    )
+    sig_b64 = base64.b64encode(sig_bytes).decode()
+    return ThreatIntelBundle(
+        version=bundle.version,
+        generated_at=bundle.generated_at,
+        expires_at=bundle.expires_at,
+        source=bundle.source,
+        signature=sig_b64,
+        advisories=bundle.advisories,
+    )
+
+
+def _in_memory_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute(threat_intel_bundle_schema_statement())
+    conn.execute(threat_intel_matches_schema_statement())
+    for stmt in threat_intel_index_statements():
+        conn.execute(stmt)
+    return conn
+
+
+class TestBundleSignatureVerification:
+    """T536 — signed bundle verifies; T537 — tampered bundle is rejected."""
+
+    def test_valid_signature_passes(self) -> None:
+        priv_pem, pub_pem = _generate_test_key_pair()
+        bundle = _sign_bundle(_make_bundle(), priv_pem)
+        verify_bundle_signature(bundle, pub_pem)
+
+    def test_tampered_advisory_fails(self) -> None:
+        priv_pem, pub_pem = _generate_test_key_pair()
+        bundle = _sign_bundle(_make_bundle(), priv_pem)
+        tampered = ThreatIntelBundle(
+            version=bundle.version,
+            generated_at=bundle.generated_at,
+            expires_at=bundle.expires_at,
+            source=bundle.source,
+            signature=bundle.signature,
+            advisories=(_make_advisory(title="INJECTED"),),
+        )
+        with pytest.raises(BundleSignatureError):
+            verify_bundle_signature(tampered, pub_pem)
+
+    def test_wrong_key_fails(self) -> None:
+        priv_pem, _ = _generate_test_key_pair()
+        _, other_pub_pem = _generate_test_key_pair()
+        bundle = _sign_bundle(_make_bundle(), priv_pem)
+        with pytest.raises(BundleSignatureError):
+            verify_bundle_signature(bundle, other_pub_pem)
+
+    def test_invalid_base64_signature_fails(self) -> None:
+        _, pub_pem = _generate_test_key_pair()
+        bundle = _make_bundle(signature="not-valid-base64!!!")
+        with pytest.raises(BundleSignatureError):
+            verify_bundle_signature(bundle, pub_pem)
+
+    def test_invalid_public_key_pem_fails(self) -> None:
+        priv_pem, _ = _generate_test_key_pair()
+        bundle = _sign_bundle(_make_bundle(), priv_pem)
+        with pytest.raises(BundleSignatureError):
+            verify_bundle_signature(bundle, b"not a pem key")
+
+
+class TestBundleFreshness:
+    """T538 — freshness expiry is enforced."""
+
+    def test_fresh_bundle_passes(self) -> None:
+        now = time.time()
+        bundle = _make_bundle(generated_at=now - 100, expires_at=now + 3600)
+        check_bundle_freshness(bundle, now=now)
+
+    def test_expired_bundle_fails(self) -> None:
+        now = time.time()
+        bundle = _make_bundle(generated_at=now - 7200, expires_at=now - 3600)
+        with pytest.raises(BundleExpiredError):
+            check_bundle_freshness(bundle, now=now)
+
+    def test_future_generated_at_fails(self) -> None:
+        now = time.time()
+        bundle = _make_bundle(generated_at=now + 3600, expires_at=now + 7200)
+        with pytest.raises(BundleExpiredError):
+            check_bundle_freshness(bundle, now=now)
+
+    def test_clock_skew_tolerance(self) -> None:
+        now = time.time()
+        bundle = _make_bundle(generated_at=now - 100, expires_at=now + 200)
+        check_bundle_freshness(bundle, now=now + 100)
+
+
+class TestBundleRollback:
+    """T539 — rollback protection: older bundle version is rejected."""
+
+    def test_newer_version_passes(self) -> None:
+        bundle = _make_bundle(version=5)
+        check_bundle_rollback(bundle, cached_version=4)
+
+    def test_same_version_passes(self) -> None:
+        bundle = _make_bundle(version=3)
+        check_bundle_rollback(bundle, cached_version=3)
+
+    def test_older_version_fails(self) -> None:
+        bundle = _make_bundle(version=2)
+        with pytest.raises(BundleRollbackError):
+            check_bundle_rollback(bundle, cached_version=5)
+
+
+class TestBundleParsing:
+    """T536 — from_dict + load_bundle_from_json validation."""
+
+    def test_valid_json_parses(self) -> None:
+        bundle = _make_bundle()
+        raw_json = json.dumps(bundle.to_dict())
+        parsed = load_bundle_from_json(raw_json)
+        assert parsed.version == bundle.version
+        assert len(parsed.advisories) == len(bundle.advisories)
+
+    def test_missing_version_raises(self) -> None:
+        d = _make_bundle().to_dict()
+        del d["version"]
+        with pytest.raises(BundleMalformedError):
+            ThreatIntelBundle.from_dict(d)
+
+    def test_invalid_json_raises(self) -> None:
+        with pytest.raises(BundleMalformedError):
+            load_bundle_from_json("{invalid}")
+
+    def test_advisory_missing_field_raises(self) -> None:
+        d = _make_bundle().to_dict()
+        d["advisories"][0].pop("advisory_id")  # type: ignore[index]
+        with pytest.raises(BundleMalformedError):
+            ThreatIntelBundle.from_dict(d)
+
+
+class TestCacheMigration:
+    """T541 — cache tables created in existing database (migration test)."""
+
+    def test_tables_created_in_new_db(self) -> None:
+        conn = _in_memory_db()
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='guard_threat_intel_bundles'"
+        ).fetchone()
+        assert row is not None
+
+    def test_indexes_created(self) -> None:
+        conn = _in_memory_db()
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='guard_threat_intel_bundles'"
+        ).fetchall()
+        index_names = {r[0] for r in rows}
+        assert "idx_ti_bundle_version" in index_names
+
+    def test_idempotent_on_existing_table(self) -> None:
+        conn = _in_memory_db()
+        conn.execute(threat_intel_bundle_schema_statement())
+        conn.execute(threat_intel_matches_schema_statement())
+        for stmt in threat_intel_index_statements():
+            conn.execute(stmt)
+
+
+class TestUpsertAndFetchBundle:
+    """T540 — bundle upsert and latest cached bundle retrieval."""
+
+    def test_upsert_and_latest(self) -> None:
+        conn = _in_memory_db()
+        bundle = _make_bundle(version=1)
+        upsert_bundle(conn, bundle, bundle_id="test-bundle-1")
+        cached = latest_cached_bundle(conn)
+        assert cached is not None
+        assert cached.version == 1
+        assert cached.bundle_id == "test-bundle-1"
+
+    def test_latest_returns_highest_version(self) -> None:
+        conn = _in_memory_db()
+        upsert_bundle(conn, _make_bundle(version=3), bundle_id="b3")
+        upsert_bundle(conn, _make_bundle(version=1), bundle_id="b1")
+        upsert_bundle(conn, _make_bundle(version=5), bundle_id="b5")
+        cached = latest_cached_bundle(conn)
+        assert cached is not None
+        assert cached.version == 5
+
+    def test_none_when_empty(self) -> None:
+        conn = _in_memory_db()
+        assert latest_cached_bundle(conn) is None
+
+    def test_cached_bundle_freshness(self) -> None:
+        now = time.time()
+        conn = _in_memory_db()
+        bundle = _make_bundle(expires_at=now + 3600)
+        upsert_bundle(conn, bundle, bundle_id="fresh")
+        cached = latest_cached_bundle(conn)
+        assert cached is not None
+        assert cached.is_fresh(now=now) is True
+
+    def test_cached_bundle_stale(self) -> None:
+        now = time.time()
+        conn = _in_memory_db()
+        bundle = _make_bundle(expires_at=now - 7200)
+        upsert_bundle(conn, bundle, bundle_id="stale")
+        cached = latest_cached_bundle(conn)
+        assert cached is not None
+        assert cached.is_fresh(now=now) is False
+
+
+class TestMatchStorage:
+    """T542 — match rows can be inserted and filtered."""
+
+    def _make_match(self, **overrides: object) -> ThreatIntelMatch:
+        defaults: dict[str, object] = {
+            "match_id": "m1",
+            "bundle_id": "b1",
+            "advisory_id": "ADV-001",
+            "artifact_id": "pkg:npm/evil-pkg",
+            "harness": "codex",
+            "workspace": "/home/user/project",
+            "severity": "high",
+            "matched_at": time.time(),
+            "target_json": "{}",
+        }
+        defaults.update(overrides)
+        return ThreatIntelMatch(**defaults)  # type: ignore[arg-type]
+
+    def test_insert_and_list(self) -> None:
+        conn = _in_memory_db()
+        insert_match(conn, self._make_match())
+        matches = list_matches(conn)
+        assert len(matches) == 1
+        assert matches[0].advisory_id == "ADV-001"
+
+    def test_filter_by_artifact(self) -> None:
+        conn = _in_memory_db()
+        insert_match(conn, self._make_match(match_id="m1", artifact_id="pkg:npm/a"))
+        insert_match(conn, self._make_match(match_id="m2", artifact_id="pkg:npm/b"))
+        matches = list_matches(conn, artifact_id="pkg:npm/a")
+        assert len(matches) == 1
+
+    def test_filter_by_severity(self) -> None:
+        conn = _in_memory_db()
+        insert_match(conn, self._make_match(match_id="m1", severity="critical"))
+        insert_match(conn, self._make_match(match_id="m2", severity="low"))
+        matches = list_matches(conn, severity="critical")
+        assert len(matches) == 1
+
+
+class TestFreeplanFallback:
+    """T544 — free plan 403 graceful fallback stub."""
+
+    def test_no_error_on_empty_bundle(self) -> None:
+        bundle = _make_bundle(advisories=())
+        assert len(bundle.advisories) == 0
+
+    def test_no_error_on_no_cached_bundle(self) -> None:
+        conn = _in_memory_db()
+        assert latest_cached_bundle(conn) is None
+
+
+class TestOfflineFallback:
+    """T545 — offline fallback stub: no advisories = no matches."""
+
+    def test_empty_bundle_matches_nothing(self) -> None:
+        bundle = _make_bundle(advisories=())
+        result = match_all_advisories(bundle.advisories, {"package_name": "evil-pkg"})
+        assert len(result) == 0
+
+
+class TestAdvisoryMatchers:
+    """T546-T555 — all advisory matchers."""
+
+    def test_osv_matches_by_package(self) -> None:
+        adv = _make_advisory(source="osv/npm", matcher="evil-pkg")
+        assert match_osv(adv, {"package_name": "evil-pkg", "ecosystem": "npm"})
+
+    def test_osv_no_match_wrong_name(self) -> None:
+        adv = _make_advisory(source="osv/npm", matcher="safe-pkg")
+        assert not match_osv(adv, {"package_name": "evil-pkg", "ecosystem": "npm"})
+
+    def test_github_advisory_by_ghsa_id(self) -> None:
+        adv = _make_advisory(matcher="GHSA-1234-abcd-5678")
+        assert match_github_advisory(adv, {"ghsa_id": "GHSA-1234-abcd-5678"})
+
+    def test_github_advisory_wrong_ghsa(self) -> None:
+        adv = _make_advisory(matcher="GHSA-1234-abcd-5678")
+        assert not match_github_advisory(adv, {"ghsa_id": "GHSA-9999-xxxx-9999"})
+
+    def test_nvd_cve_by_cve_id(self) -> None:
+        adv = _make_advisory(matcher="CVE-2024-12345")
+        assert match_nvd_cve(adv, {"cve_id": "CVE-2024-12345"})
+
+    def test_nvd_cve_no_match(self) -> None:
+        adv = _make_advisory(matcher="CVE-2024-12345")
+        assert not match_nvd_cve(adv, {"cve_id": "CVE-2024-99999"})
+
+    def test_npm_matches_npm_ecosystem(self) -> None:
+        adv = _make_advisory(matcher="evil-pkg")
+        assert match_npm_advisory(adv, {"ecosystem": "npm", "package_name": "evil-pkg"})
+
+    def test_npm_rejects_pypi_ecosystem(self) -> None:
+        adv = _make_advisory(matcher="evil-pkg")
+        assert not match_npm_advisory(adv, {"ecosystem": "pypi", "package_name": "evil-pkg"})
+
+    def test_pypi_matches_pypi_ecosystem(self) -> None:
+        adv = _make_advisory(matcher="evil-lib")
+        assert match_pypi_advisory(adv, {"ecosystem": "pypi", "package_name": "evil-lib"})
+
+    def test_pypi_pip_alias_matches(self) -> None:
+        adv = _make_advisory(matcher="evil-lib")
+        assert match_pypi_advisory(adv, {"ecosystem": "pip", "package_name": "evil-lib"})
+
+    def test_github_action_match(self) -> None:
+        adv = _make_advisory(matcher="evil-org/evil-action")
+        assert match_github_action(adv, {"action_slug": "evil-org/evil-action"})
+
+    def test_github_action_no_match(self) -> None:
+        adv = _make_advisory(matcher="evil-org/evil-action")
+        assert not match_github_action(adv, {"action_slug": "safe-org/safe-action"})
+
+    def test_mcp_server_name_match(self) -> None:
+        adv = _make_advisory(matcher="evil-mcp")
+        assert match_mcp_server(adv, {"mcp_server": "evil-mcp"})
+
+    def test_mcp_server_substring_match(self) -> None:
+        adv = _make_advisory(matcher="evil-mcp")
+        assert match_mcp_server(adv, {"mcp_server": "some-evil-mcp-server"})
+
+    def test_skill_hash_match(self) -> None:
+        adv = _make_advisory(matcher="abc123def456")
+        assert match_skill_hash(adv, {"skill_hash": "abc123def456"})
+
+    def test_skill_hash_no_match(self) -> None:
+        adv = _make_advisory(matcher="abc123def456")
+        assert not match_skill_hash(adv, {"skill_hash": "000000000000"})
+
+    def test_malicious_domain_match(self) -> None:
+        adv = _make_advisory(matcher="evil.example.com")
+        assert match_malicious_domain(adv, {"network_hosts": ["evil.example.com"]})
+
+    def test_malicious_domain_list_match(self) -> None:
+        adv = _make_advisory(matcher="evil.com")
+        assert match_malicious_domain(adv, {"network_hosts": ["safe.com", "evil.com"]})
+
+    def test_malicious_domain_no_match(self) -> None:
+        adv = _make_advisory(matcher="evil.com")
+        assert not match_malicious_domain(adv, {"network_hosts": ["safe.com"]})
+
+    def test_malicious_package_hash_match(self) -> None:
+        adv = _make_advisory(matcher="sha256:deadbeef")
+        assert match_malicious_package_hash(adv, {"package_hash": "sha256:deadbeef"})
+
+    def test_malicious_package_hash_no_match(self) -> None:
+        adv = _make_advisory(matcher="sha256:deadbeef")
+        assert not match_malicious_package_hash(adv, {"package_hash": "sha256:cafebabe"})
+
+
+class TestMatchAllAdvisories:
+    """T556 — integrated matching against a bundle."""
+
+    def test_multiple_advisories_some_match(self) -> None:
+        advisories = (
+            _make_advisory(advisory_id="A1", matcher="evil-pkg"),
+            _make_advisory(advisory_id="A2", matcher="safe-pkg"),
+        )
+        target = {"package_name": "evil-pkg", "ecosystem": "npm"}
+        matched = match_all_advisories(advisories, target)
+        assert len(matched) == 1
+        assert matched[0].advisory_id == "A1"
+
+    def test_no_advisories_returns_empty(self) -> None:
+        result = match_all_advisories((), {"package_name": "evil-pkg"})
+        assert result == ()
+
+
+class TestSeverityRank:
+    """Utility — severity ordering."""
+
+    def test_critical_highest(self) -> None:
+        assert advisory_severity_rank("critical") > advisory_severity_rank("high")
+
+    def test_info_lowest(self) -> None:
+        assert advisory_severity_rank("info") < advisory_severity_rank("low")
+
+    def test_unknown_treated_as_info(self) -> None:
+        assert advisory_severity_rank("banana") == advisory_severity_rank("info")


### PR DESCRIPTION
## Summary

Add cloud advisory threat intelligence backend for Guard Local runtime.

## Changes

### New modules
- `src/codex_plugin_scanner/guard/runtime/threat_intel.py` — `ThreatAdvisory` and `ThreatIntelBundle` frozen dataclasses; `verify_bundle_signature` (RSA-PSS / SHA-256); freshness and rollback protection checks; `load_bundle_from_json`; typed exceptions: `BundleSignatureError`, `BundleExpiredError`, `BundleRollbackError`, `BundleMalformedError`
- `src/codex_plugin_scanner/guard/runtime/advisory_matchers.py` — 10 matcher functions (OSV, GitHub Advisory, NVD CVE, npm, PyPI, GitHub Action, MCP server, skill hash, malicious domain, malicious package hash); `AdvisoryMatcher` Protocol; `apply_advisory` dispatcher using `source` field; `match_all_advisories`
- `src/codex_plugin_scanner/guard/store_threat_intel.py` — SQLite cache tables `guard_threat_intel_bundles` and `guard_threat_intel_matches`; 5 covering indexes; `upsert_bundle`, `latest_cached_bundle`, `insert_match`, `list_matches`

### Modified
- `src/codex_plugin_scanner/guard/store.py` — integrate threat intel schema/indexes into `_build_schema`

### Tests
- `tests/test_guard_threat_intel.py` — 56 tests covering all threat intel functionality; all passing

## Verification
- `pytest tests/test_guard_threat_intel.py -q` → 56 passed
- `ruff check` → 0 errors
- `ruff format --check` → all formatted