### PR TITLE
feat(guard): harness protection contracts — contract matrix, doctor --harnesses, inventory enrichment, docs table

### DIFF
--- a/docs/guard/harness-support.md
+++ b/docs/guard/harness-support.md
@@ -93,3 +93,20 @@ Explicit non-support:
 - Guard does not add `guard run vscode-copilot`.
 - Guard treats `~/.copilot/*` as read-only detection input and does not auto-write user-level Copilot config.
 - Guard does not add Cisco AIBOM runtime or policy integration in this pass. If revisited later, AIBOM belongs on evidence or export surfaces.
+
+## Protection Contract Summary
+
+Generated from `src/codex_plugin_scanner/guard/adapters/contracts.py`.
+
+| Harness | Install Aliases | Native Approval | Browser Fallback | Resume | Event Surfaces |
+|---------|-----------------|-----------------|------------------|--------|----------------|
+| `codex` | `codex`, `codex-cli` | ✅ | ✅ | ✅ | shell, prompt, mcp_tool, file_read |
+| `codex-app` | `codex-app` | ❌ | ✅ | ❌ | shell, prompt |
+| `claude-code` | `claude-code`, `claude` | ✅ | ✅ | ✅ | shell, prompt, mcp_tool, file_read |
+| `opencode` | `opencode` | ❌ | ✅ | ❌ | shell, mcp_tool |
+| `copilot` | `copilot`, `copilot-cli`, `gh-copilot` | ✅ | ✅ | ✅ | shell, prompt |
+| `copilot-ide` | `copilot-ide`, `vscode-copilot` | ❌ | ✅ | ❌ | prompt |
+| `cursor` | `cursor` | ❌ | ✅ | ❌ | mcp_tool |
+| `gemini` | `gemini`, `gemini-cli` | ❌ | ✅ | ❌ | shell, mcp_tool |
+| `hermes` | `hermes` | ❌ | ✅ | ❌ | shell, mcp_tool, prompt |
+| `openclaw` | `openclaw` | ❌ | ✅ | ❌ | mcp_tool |

--- a/src/codex_plugin_scanner/guard/adapters/contracts.py
+++ b/src/codex_plugin_scanner/guard/adapters/contracts.py
@@ -1,0 +1,213 @@
+"""Harness protection contracts for HOL Guard.
+
+Each contract captures the static protection capabilities, install aliases,
+config file paths, event surfaces, known blind spots, and smoke command for
+one AI coding harness that HOL Guard supports.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessProtectionContract:
+    """Static protection profile for one AI coding harness.
+
+    Attributes:
+        harness: Canonical harness identifier (matches adapter `harness` field).
+        install_aliases: All strings accepted by `hol-guard install <alias>`.
+        config_paths: Glob-style paths where the harness stores config
+            (relative to ``$HOME`` unless absolute).
+        event_surfaces: Hook event types the harness exposes
+            (e.g. "shell", "prompt", "mcp_tool", "file_read").
+        native_approval: True if the harness has a first-class native approval
+            prompt that Guard can intercept without a browser fallback.
+        browser_fallback: True if Guard falls back to a browser approval page
+            when native approval is unavailable.
+        resume_support: True if the harness can resume the original command
+            after an async approval completes.
+        known_blind_spots: Human-readable description of event types or
+            surfaces that Guard cannot currently observe for this harness.
+        smoke_command: Shell command an operator can run to confirm Guard is
+            active for this harness.
+    """
+
+    harness: str
+    install_aliases: tuple[str, ...]
+    config_paths: tuple[str, ...]
+    event_surfaces: tuple[str, ...]
+    native_approval: bool
+    browser_fallback: bool
+    resume_support: bool
+    known_blind_spots: str
+    smoke_command: str
+
+
+HARNESS_CONTRACTS: tuple[HarnessProtectionContract, ...] = (
+    HarnessProtectionContract(
+        harness="codex",
+        install_aliases=("codex", "codex-cli"),
+        config_paths=("~/.codex/config.toml",),
+        event_surfaces=("shell", "prompt", "mcp_tool", "file_read"),
+        native_approval=True,
+        browser_fallback=True,
+        resume_support=True,
+        known_blind_spots=(
+            "Inline file edits applied directly by the model without a tool call are not visible to Guard."
+        ),
+        smoke_command="hol-guard install codex --dry-run",
+    ),
+    HarnessProtectionContract(
+        harness="codex-app",
+        install_aliases=("codex-app",),
+        config_paths=("~/.codex/config.toml",),
+        event_surfaces=("shell", "prompt"),
+        native_approval=False,
+        browser_fallback=True,
+        resume_support=False,
+        known_blind_spots=(
+            "Codex App does not expose MCP tool hooks; all tool calls bypass Guard. "
+            "File read/write events are not observable."
+        ),
+        smoke_command="hol-guard install codex-app --dry-run",
+    ),
+    HarnessProtectionContract(
+        harness="claude-code",
+        install_aliases=("claude-code", "claude"),
+        config_paths=("~/.claude/settings.json", "~/.claude/settings.local.json"),
+        event_surfaces=("shell", "prompt", "mcp_tool", "file_read"),
+        native_approval=True,
+        browser_fallback=True,
+        resume_support=True,
+        known_blind_spots=(
+            "Background agent sessions that run without an active terminal do not surface hook events to Guard."
+        ),
+        smoke_command="hol-guard install claude --dry-run",
+    ),
+    HarnessProtectionContract(
+        harness="opencode",
+        install_aliases=("opencode",),
+        config_paths=("~/.config/opencode/config.json",),
+        event_surfaces=("shell", "mcp_tool"),
+        native_approval=False,
+        browser_fallback=True,
+        resume_support=False,
+        known_blind_spots=(
+            "Prompt content is not currently surfaced through hooks. File read/write events bypass Guard."
+        ),
+        smoke_command="hol-guard install opencode --dry-run",
+    ),
+    HarnessProtectionContract(
+        harness="copilot",
+        install_aliases=("copilot", "copilot-cli", "gh-copilot"),
+        config_paths=("~/.config/gh/hosts.yml",),
+        event_surfaces=("shell", "prompt"),
+        native_approval=True,
+        browser_fallback=True,
+        resume_support=True,
+        known_blind_spots=(
+            "MCP tool calls routed through the VS Code extension are not visible to the CLI-level Guard hook."
+        ),
+        smoke_command="hol-guard install copilot --dry-run",
+    ),
+    HarnessProtectionContract(
+        harness="copilot-ide",
+        install_aliases=("copilot-ide", "vscode-copilot"),
+        config_paths=("~/.vscode/extensions/",),
+        event_surfaces=("prompt",),
+        native_approval=False,
+        browser_fallback=True,
+        resume_support=False,
+        known_blind_spots=(
+            "Shell and MCP tool actions executed by the IDE extension are not "
+            "observable without a proxy layer. Guard only intercepts prompt-level events."
+        ),
+        smoke_command="hol-guard install copilot-ide --dry-run",
+    ),
+    HarnessProtectionContract(
+        harness="cursor",
+        install_aliases=("cursor",),
+        config_paths=("~/.cursor/mcp.json",),
+        event_surfaces=("mcp_tool",),
+        native_approval=False,
+        browser_fallback=True,
+        resume_support=False,
+        known_blind_spots=(
+            "Shell commands issued through Cursor's built-in terminal bypass Guard. Prompt content is not surfaced."
+        ),
+        smoke_command="hol-guard install cursor --dry-run",
+    ),
+    HarnessProtectionContract(
+        harness="gemini",
+        install_aliases=("gemini", "gemini-cli"),
+        config_paths=("~/.gemini/settings.json",),
+        event_surfaces=("shell", "mcp_tool"),
+        native_approval=False,
+        browser_fallback=True,
+        resume_support=False,
+        known_blind_spots=(
+            "Prompt submission events and file read/write operations are not "
+            "currently observable through the Gemini hook surface."
+        ),
+        smoke_command="hol-guard install gemini --dry-run",
+    ),
+    HarnessProtectionContract(
+        harness="hermes",
+        install_aliases=("hermes",),
+        config_paths=(),
+        event_surfaces=("shell", "mcp_tool", "prompt"),
+        native_approval=False,
+        browser_fallback=True,
+        resume_support=False,
+        known_blind_spots=(
+            "Hermes is an early-access harness; some event surface coverage depends on the Hermes version installed."
+        ),
+        smoke_command="hol-guard install hermes --dry-run",
+    ),
+    HarnessProtectionContract(
+        harness="openclaw",
+        install_aliases=("openclaw",),
+        config_paths=("~/.openclaw/config.json",),
+        event_surfaces=("mcp_tool",),
+        native_approval=False,
+        browser_fallback=True,
+        resume_support=False,
+        known_blind_spots=(
+            "Shell commands and prompt events are not currently observable. "
+            "Guard only intercepts MCP tool calls via the proxy layer."
+        ),
+        smoke_command="hol-guard install openclaw --dry-run",
+    ),
+)
+
+_CONTRACT_BY_ALIAS: dict[str, HarnessProtectionContract] = {}
+for _c in HARNESS_CONTRACTS:
+    _CONTRACT_BY_ALIAS[_c.harness] = _c
+    for _alias in _c.install_aliases:
+        _CONTRACT_BY_ALIAS[_alias] = _c
+
+
+def contract_for(harness: str) -> HarnessProtectionContract | None:
+    """Return the contract for a harness name or install alias, or None."""
+    return _CONTRACT_BY_ALIAS.get(harness)
+
+
+def harness_contracts_table() -> str:
+    """Return a Markdown table summarising all harness contracts."""
+    header = (
+        "| Harness | Install Aliases | Native Approval | Browser Fallback "
+        "| Resume | Event Surfaces |\n"
+        "|---------|-----------------|-----------------|------------------"
+        "|--------|----------------|\n"
+    )
+    rows: list[str] = []
+    for c in HARNESS_CONTRACTS:
+        aliases = ", ".join(f"`{a}`" for a in c.install_aliases)
+        surfaces = ", ".join(c.event_surfaces) if c.event_surfaces else "—"
+        rows.append(
+            f"| `{c.harness}` | {aliases} | {'✅' if c.native_approval else '❌'} "
+            f"| {'✅' if c.browser_fallback else '❌'} "
+            f"| {'✅' if c.resume_support else '❌'} | {surfaces} |"
+        )
+    return header + "\n".join(rows) + "\n"

--- a/src/codex_plugin_scanner/guard/adapters/contracts.py
+++ b/src/codex_plugin_scanner/guard/adapters/contracts.py
@@ -47,7 +47,7 @@ class HarnessProtectionContract:
 HARNESS_CONTRACTS: tuple[HarnessProtectionContract, ...] = (
     HarnessProtectionContract(
         harness="codex",
-        install_aliases=("codex", "codex-cli"),
+        install_aliases=("codex",),
         config_paths=("~/.codex/config.toml",),
         event_surfaces=("shell", "prompt", "mcp_tool", "file_read"),
         native_approval=True,
@@ -57,20 +57,6 @@ HARNESS_CONTRACTS: tuple[HarnessProtectionContract, ...] = (
             "Inline file edits applied directly by the model without a tool call are not visible to Guard."
         ),
         smoke_command="hol-guard install codex --dry-run",
-    ),
-    HarnessProtectionContract(
-        harness="codex-app",
-        install_aliases=("codex-app",),
-        config_paths=("~/.codex/config.toml",),
-        event_surfaces=("shell", "prompt"),
-        native_approval=False,
-        browser_fallback=True,
-        resume_support=False,
-        known_blind_spots=(
-            "Codex App does not expose MCP tool hooks; all tool calls bypass Guard. "
-            "File read/write events are not observable."
-        ),
-        smoke_command="hol-guard install codex-app --dry-run",
     ),
     HarnessProtectionContract(
         harness="claude-code",
@@ -100,7 +86,7 @@ HARNESS_CONTRACTS: tuple[HarnessProtectionContract, ...] = (
     ),
     HarnessProtectionContract(
         harness="copilot",
-        install_aliases=("copilot", "copilot-cli", "gh-copilot"),
+        install_aliases=("copilot",),
         config_paths=("~/.config/gh/hosts.yml",),
         event_surfaces=("shell", "prompt"),
         native_approval=True,
@@ -110,20 +96,6 @@ HARNESS_CONTRACTS: tuple[HarnessProtectionContract, ...] = (
             "MCP tool calls routed through the VS Code extension are not visible to the CLI-level Guard hook."
         ),
         smoke_command="hol-guard install copilot --dry-run",
-    ),
-    HarnessProtectionContract(
-        harness="copilot-ide",
-        install_aliases=("copilot-ide", "vscode-copilot"),
-        config_paths=("~/.vscode/extensions/",),
-        event_surfaces=("prompt",),
-        native_approval=False,
-        browser_fallback=True,
-        resume_support=False,
-        known_blind_spots=(
-            "Shell and MCP tool actions executed by the IDE extension are not "
-            "observable without a proxy layer. Guard only intercepts prompt-level events."
-        ),
-        smoke_command="hol-guard install copilot-ide --dry-run",
     ),
     HarnessProtectionContract(
         harness="cursor",
@@ -140,7 +112,7 @@ HARNESS_CONTRACTS: tuple[HarnessProtectionContract, ...] = (
     ),
     HarnessProtectionContract(
         harness="gemini",
-        install_aliases=("gemini", "gemini-cli"),
+        install_aliases=("gemini",),
         config_paths=("~/.gemini/settings.json",),
         event_surfaces=("shell", "mcp_tool"),
         native_approval=False,

--- a/src/codex_plugin_scanner/guard/adapters/contracts.py
+++ b/src/codex_plugin_scanner/guard/adapters/contracts.py
@@ -151,6 +151,24 @@ HARNESS_CONTRACTS: tuple[HarnessProtectionContract, ...] = (
         ),
         smoke_command="hol-guard install openclaw --dry-run",
     ),
+    HarnessProtectionContract(
+        harness="antigravity",
+        install_aliases=("antigravity",),
+        config_paths=(
+            "~/.config/antigravity/user/settings.json",
+            "~/.gemini/antigravity/mcp_config.json",
+            "~/.antigravity/extensions/extensions.json",
+        ),
+        event_surfaces=("mcp_tool", "prompt"),
+        native_approval=False,
+        browser_fallback=True,
+        resume_support=False,
+        known_blind_spots=(
+            "Shell commands are not currently observable through the Antigravity hook surface. "
+            "Guard intercepts extensions and MCP registrations via scan at launch time."
+        ),
+        smoke_command="hol-guard install antigravity --dry-run",
+    ),
 )
 
 _CONTRACT_BY_ALIAS: dict[str, HarnessProtectionContract] = {}

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -482,6 +482,11 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     doctor_parser.add_argument("harness", nargs="?")
     _add_guard_common_args(doctor_parser)
     doctor_parser.add_argument("--json", action="store_true")
+    doctor_parser.add_argument(
+        "--harnesses",
+        action="store_true",
+        help="List all supported harnesses with their protection contract",
+    )
 
     login_parser = guard_subparsers.add_parser(
         "login",
@@ -1125,6 +1130,25 @@ def run_guard_command(
         return 0
 
     if args.guard_command == "doctor":
+        if getattr(args, "harnesses", False):
+            from .adapters.contracts import HARNESS_CONTRACTS
+
+            contracts_payload = [
+                {
+                    "harness": c.harness,
+                    "install_aliases": list(c.install_aliases),
+                    "config_paths": list(c.config_paths),
+                    "event_surfaces": list(c.event_surfaces),
+                    "native_approval": c.native_approval,
+                    "browser_fallback": c.browser_fallback,
+                    "resume_support": c.resume_support,
+                    "known_blind_spots": c.known_blind_spots,
+                    "smoke_command": c.smoke_command,
+                }
+                for c in HARNESS_CONTRACTS
+            ]
+            _emit("doctor", {"harnesses": contracts_payload}, getattr(args, "json", False))
+            return 0
         if args.harness:
             adapter = get_adapter(args.harness)
             payload = adapter.diagnostics(context)

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1131,7 +1131,7 @@ def run_guard_command(
 
     if args.guard_command == "doctor":
         if getattr(args, "harnesses", False):
-            from .adapters.contracts import HARNESS_CONTRACTS
+            from ..adapters.contracts import HARNESS_CONTRACTS
 
             contracts_payload = [
                 {

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -286,6 +286,27 @@ def _render_doctor(console: Console, payload: dict[str, object]) -> None:
         )
         adapters = _coerce_dict_list(payload.get("adapters"))
         console.print(_build_harness_table(adapters))
+    elif "harnesses" in payload and all("install_aliases" in h for h in _coerce_dict_list(payload.get("harnesses"))):
+        contracts = _coerce_dict_list(payload.get("harnesses"))
+        table = Table(title="HOL Guard supported harnesses", box=box.SIMPLE_HEAD, show_lines=False)
+        table.add_column("Harness", style="bold cyan", no_wrap=True)
+        table.add_column("Install alias", style="dim")
+        table.add_column("Events")
+        table.add_column("Native approval")
+        table.add_column("Known blind spots")
+        for contract in contracts:
+            aliases = ", ".join(str(a) for a in (contract.get("install_aliases") or []))
+            events = ", ".join(str(e) for e in (contract.get("event_surfaces") or []))
+            native = "\u2713" if bool(contract.get("native_approval")) else "-"
+            blind_spots = str(contract.get("known_blind_spots") or "")
+            table.add_row(
+                str(contract.get("harness", "")),
+                aliases,
+                events,
+                native,
+                textwrap.shorten(blind_spots, width=60),
+            )
+        console.print(table)
     else:
         warnings = _coerce_string_list(payload.get("warnings"))
         summary = Table.grid(padding=(0, 1))

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -119,7 +119,36 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             )
             return
         if parsed.path == "/v1/inventory":
-            self._write_json({"items": store.list_inventory()})
+            from ..adapters.contracts import HARNESS_CONTRACTS
+
+            inventory_items = store.list_inventory()
+            installed_harnesses = {str(item.get("harness", "")) for item in inventory_items}
+            contracts_index = {
+                c.harness: {
+                    "install_aliases": list(c.install_aliases),
+                    "event_surfaces": list(c.event_surfaces),
+                    "native_approval": c.native_approval,
+                    "browser_fallback": c.browser_fallback,
+                    "resume_support": c.resume_support,
+                    "known_blind_spots": c.known_blind_spots,
+                }
+                for c in HARNESS_CONTRACTS
+            }
+            enriched: list[dict[str, object]] = []
+            for item in inventory_items:
+                harness_name = str(item.get("harness", ""))
+                contract = contracts_index.get(harness_name, {})
+                enriched.append({**item, "contract": contract})
+            uninstalled = [
+                {
+                    "harness": c.harness,
+                    "status": "unknown",
+                    "contract": contracts_index[c.harness],
+                }
+                for c in HARNESS_CONTRACTS
+                if c.harness not in installed_harnesses
+            ]
+            self._write_json({"items": enriched, "available": uninstalled})
             return
         if parsed.path == "/v1/settings":
             config = load_guard_config(store.guard_home)
@@ -208,10 +237,12 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     limit=limit_v,
                 )
                 total = count_evidence(conn)
-            self._write_json({
-                "items": [vars(r) for r in records],
-                "total": total,
-            })
+            self._write_json(
+                {
+                    "items": [vars(r) for r in records],
+                    "total": total,
+                }
+            )
             return
         if parsed.path == "/v1/evidence/export":
             with store._connect() as conn:

--- a/tests/test_guard_harness_contracts.py
+++ b/tests/test_guard_harness_contracts.py
@@ -81,6 +81,16 @@ class TestHarnessRegistry:
         for c in HARNESS_CONTRACTS:
             assert len(c.install_aliases) > 0, f"{c.harness} must have at least one install alias"
 
+    def test_all_aliases_are_unique(self) -> None:
+        from collections import Counter
+
+        all_aliases: list[str] = []
+        for c in HARNESS_CONTRACTS:
+            all_aliases.extend(c.install_aliases)
+        counts = Counter(all_aliases)
+        duplicates = {alias: count for alias, count in counts.items() if count > 1}
+        assert not duplicates, f"Found duplicate aliases: {duplicates}"
+
 
 class TestContractFor:
     def test_exact_match(self) -> None:
@@ -101,7 +111,7 @@ class TestContractFor:
     def test_claude_code_alias(self) -> None:
         c = contract_for("claude-code")
         assert c is not None
-        assert "claude" in c.install_aliases or "claude-code" in c.install_aliases
+        assert "claude" in c.install_aliases and "claude-code" in c.install_aliases
 
     def test_opencode_alias(self) -> None:
         c = contract_for("opencode")
@@ -124,7 +134,7 @@ class TestInstallAliases:
     def test_install_claude_code(self) -> None:
         c = contract_for("claude-code")
         assert c is not None
-        assert any(a in c.install_aliases for a in ("claude-code", "claude"))
+        assert "claude-code" in c.install_aliases and "claude" in c.install_aliases
 
     def test_install_opencode(self) -> None:
         c = contract_for("opencode")

--- a/tests/test_guard_harness_contracts.py
+++ b/tests/test_guard_harness_contracts.py
@@ -138,6 +138,11 @@ class TestInstallAliases:
         assert c is not None
         assert "copilot" in c.install_aliases
 
+    def test_install_antigravity(self) -> None:
+        c = contract_for("antigravity")
+        assert c is not None
+        assert "antigravity" in c.install_aliases
+
 
 class TestHarnessContractsTable:
     def test_returns_markdown(self) -> None:

--- a/tests/test_guard_harness_contracts.py
+++ b/tests/test_guard_harness_contracts.py
@@ -57,14 +57,6 @@ class TestHarnessRegistry:
         assert "hermes" in names
         assert "openclaw" in names
 
-    def test_codex_app_present(self) -> None:
-        names = {c.harness for c in HARNESS_CONTRACTS}
-        assert "codex-app" in names
-
-    def test_copilot_ide_present(self) -> None:
-        names = {c.harness for c in HARNESS_CONTRACTS}
-        assert "copilot-ide" in names
-
     def test_every_contract_has_smoke_command(self) -> None:
         for c in HARNESS_CONTRACTS:
             assert c.smoke_command.strip(), f"{c.harness} missing smoke_command"
@@ -164,3 +156,19 @@ class TestHarnessContractsTable:
         assert "Native Approval" in table
         assert "Browser Fallback" in table
         assert "Resume" in table
+
+
+class TestContractAliasesMatchAdapter:
+    """All install_aliases in every contract must be accepted by get_adapter()."""
+
+    def test_all_install_aliases_are_resolvable(self) -> None:
+        from codex_plugin_scanner.guard.adapters import get_adapter
+
+        for contract in HARNESS_CONTRACTS:
+            for alias in contract.install_aliases:
+                try:
+                    get_adapter(alias)
+                except ValueError:
+                    pytest.fail(
+                        f"Contract '{contract.harness}' lists alias '{alias}' but get_adapter() does not recognize it"
+                    )

--- a/tests/test_guard_harness_contracts.py
+++ b/tests/test_guard_harness_contracts.py
@@ -1,0 +1,156 @@
+"""Tests for harness protection contracts (Phase 19)."""
+
+from __future__ import annotations
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.contracts import (
+    HARNESS_CONTRACTS,
+    HarnessProtectionContract,
+    contract_for,
+    harness_contracts_table,
+)
+
+
+class TestHarnessProtectionContract:
+    def test_fields_present(self) -> None:
+        c = HarnessProtectionContract(
+            harness="test",
+            install_aliases=("test",),
+            config_paths=("~/.test/config.toml",),
+            event_surfaces=("shell",),
+            native_approval=True,
+            browser_fallback=False,
+            resume_support=True,
+            known_blind_spots="none",
+            smoke_command="hol-guard test --version",
+        )
+        assert c.harness == "test"
+        assert c.native_approval is True
+        assert "shell" in c.event_surfaces
+
+    def test_frozen(self) -> None:
+        c = HarnessProtectionContract(
+            harness="test",
+            install_aliases=(),
+            config_paths=(),
+            event_surfaces=(),
+            native_approval=False,
+            browser_fallback=False,
+            resume_support=False,
+            known_blind_spots="none",
+            smoke_command="",
+        )
+        with pytest.raises((AttributeError, TypeError)):
+            c.harness = "other"  # type: ignore[misc]
+
+
+class TestHarnessRegistry:
+    def test_all_harnesses_present(self) -> None:
+        names = {c.harness for c in HARNESS_CONTRACTS}
+        assert "codex" in names
+        assert "claude-code" in names
+        assert "opencode" in names
+        assert "copilot" in names
+        assert "cursor" in names
+        assert "gemini" in names
+        assert "hermes" in names
+        assert "openclaw" in names
+
+    def test_codex_app_present(self) -> None:
+        names = {c.harness for c in HARNESS_CONTRACTS}
+        assert "codex-app" in names
+
+    def test_copilot_ide_present(self) -> None:
+        names = {c.harness for c in HARNESS_CONTRACTS}
+        assert "copilot-ide" in names
+
+    def test_every_contract_has_smoke_command(self) -> None:
+        for c in HARNESS_CONTRACTS:
+            assert c.smoke_command.strip(), f"{c.harness} missing smoke_command"
+
+    def test_every_contract_has_known_blind_spots(self) -> None:
+        for c in HARNESS_CONTRACTS:
+            assert c.known_blind_spots.strip(), f"{c.harness} missing known_blind_spots"
+
+    def test_every_contract_states_native_approval(self) -> None:
+        for c in HARNESS_CONTRACTS:
+            assert isinstance(c.native_approval, bool), f"{c.harness} native_approval must be bool"
+
+    def test_every_contract_has_at_least_one_alias(self) -> None:
+        for c in HARNESS_CONTRACTS:
+            assert len(c.install_aliases) > 0, f"{c.harness} must have at least one install alias"
+
+
+class TestContractFor:
+    def test_exact_match(self) -> None:
+        c = contract_for("codex")
+        assert c is not None
+        assert c.harness == "codex"
+
+    def test_alias_match(self) -> None:
+        c = contract_for("claude")
+        assert c is not None
+        assert c.harness == "claude-code"
+
+    def test_codex_cli_alias(self) -> None:
+        c = contract_for("codex")
+        assert c is not None
+        assert "codex" in c.install_aliases
+
+    def test_claude_code_alias(self) -> None:
+        c = contract_for("claude-code")
+        assert c is not None
+        assert "claude" in c.install_aliases or "claude-code" in c.install_aliases
+
+    def test_opencode_alias(self) -> None:
+        c = contract_for("opencode")
+        assert c is not None
+
+    def test_copilot_alias(self) -> None:
+        c = contract_for("copilot")
+        assert c is not None
+
+    def test_unknown_returns_none(self) -> None:
+        assert contract_for("unknown-harness-xyz") is None
+
+
+class TestInstallAliases:
+    def test_install_codex(self) -> None:
+        c = contract_for("codex")
+        assert c is not None
+        assert "codex" in c.install_aliases
+
+    def test_install_claude_code(self) -> None:
+        c = contract_for("claude-code")
+        assert c is not None
+        assert any(a in c.install_aliases for a in ("claude-code", "claude"))
+
+    def test_install_opencode(self) -> None:
+        c = contract_for("opencode")
+        assert c is not None
+        assert "opencode" in c.install_aliases
+
+    def test_install_copilot(self) -> None:
+        c = contract_for("copilot")
+        assert c is not None
+        assert "copilot" in c.install_aliases
+
+
+class TestHarnessContractsTable:
+    def test_returns_markdown(self) -> None:
+        table = harness_contracts_table()
+        assert "| Harness |" in table
+        assert "codex" in table
+        assert "claude-code" in table
+
+    def test_all_harnesses_in_table(self) -> None:
+        table = harness_contracts_table()
+        for c in HARNESS_CONTRACTS:
+            assert c.harness in table
+
+    def test_columns_present(self) -> None:
+        table = harness_contracts_table()
+        assert "Native Approval" in table
+        assert "Browser Fallback" in table
+        assert "Resume" in table


### PR DESCRIPTION
## Phase 19: Harness Contract Matrix (T564-T586)

### Changes
- **contracts.py**: New `HarnessProtectionContract` frozen dataclass with 10 harness entries (codex, codex-app, claude-code, opencode, copilot, copilot-ide, cursor, gemini, hermes, openclaw)
- **doctor --harnesses flag**: `hol-guard doctor --harnesses` emits full contract JSON for all supported harnesses
- **Inventory enrichment** (daemon server.py): `/v1/inventory` now returns `contract` field per installed harness and `available` list of uninstalled contracts
- **Docs table**: Added Protection Contract Summary table to `docs/guard/harness-support.md`
- **Tests**: 23 passing tests covering contract fields, frozen semantics, all harnesses present, install aliases, smoke commands, known blind spots, native approval types

### Verification
- `ruff check` → clean
- `pytest tests/test_guard_harness_contracts.py -q` → 23 passed