### PR TITLE
feat(guard): phase 21 — daemon perf telemetry and detector registry helpers

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3390,9 +3390,8 @@ def _runtime_detector_perf_payload(config: GuardConfig) -> list[dict[str, object
     from ..runtime.detectors import (
         _SLOW_DETECTOR_THRESHOLD_MS,
         DetectorContext,
-        DetectorRegistry,
-        register_default_detectors,
     )
+    from ..runtime.runner import _get_default_detector_registry
 
     probe_action = GuardActionEnvelope(
         schema_version=1,
@@ -3422,7 +3421,7 @@ def _runtime_detector_perf_payload(config: GuardConfig) -> list[dict[str, object
         threat_intel={},
         redaction_settings={},
     )
-    result = DetectorRegistry(register_default_detectors()).run(
+    result = _get_default_detector_registry().run(
         probe_action,
         probe_context,
         timeout_ms=config.runtime_detector_timeout_ms,

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -503,6 +503,7 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="List all supported harnesses with their protection contract",
     )
+    doctor_parser.add_argument("--perf", action="store_true", help="Include detector performance timings")
 
     login_parser = guard_subparsers.add_parser(
         "login",
@@ -1208,6 +1209,8 @@ def run_guard_command(
                 "adapters": [detection.to_dict() for detection in detect_all(context)],
                 "runtime_detector_registry": _runtime_detector_registry_payload(config),
             }
+        if getattr(args, "perf", False):
+            payload["detector_perf"] = _runtime_detector_perf_payload(config)
         _emit("doctor", payload, getattr(args, "json", False))
         return 0
 
@@ -3380,6 +3383,58 @@ def _runtime_detector_registry_payload(config: GuardConfig) -> dict[str, object]
         "timeout_ms": config.runtime_detector_timeout_ms,
         "disabled_detector_ids": list(config.runtime_detector_disabled_ids),
     }
+
+
+def _runtime_detector_perf_payload(config: GuardConfig) -> list[dict[str, object]]:
+    from ..runtime.actions import GuardActionEnvelope
+    from ..runtime.detectors import (
+        _SLOW_DETECTOR_THRESHOLD_MS,
+        DetectorContext,
+        DetectorRegistry,
+        register_default_detectors,
+    )
+
+    probe_action = GuardActionEnvelope(
+        schema_version=1,
+        action_id="perf-probe",
+        harness="doctor",
+        event_name="HarnessStart",
+        action_type="harness_start",
+        workspace=None,
+        workspace_hash=None,
+        tool_name=None,
+        command=None,
+        prompt_excerpt=None,
+        prompt_text=None,
+        target_paths=(),
+        network_hosts=(),
+        mcp_server=None,
+        mcp_tool=None,
+        package_manager=None,
+        package_name=None,
+        script_name=None,
+        raw_payload_redacted={},
+    )
+    probe_context = DetectorContext(
+        config=config,
+        workspace=None,
+        prior_decisions={},
+        threat_intel={},
+        redaction_settings={},
+    )
+    result = DetectorRegistry(register_default_detectors()).run(
+        probe_action,
+        probe_context,
+        timeout_ms=config.runtime_detector_timeout_ms,
+        disabled_detector_ids=config.runtime_detector_disabled_ids,
+    )
+    return [
+        {
+            **t.to_dict(),
+            "slow": t.elapsed_ms >= _SLOW_DETECTOR_THRESHOLD_MS,
+        }
+        for t in result.telemetry
+    ]
 
 
 def _update_guard_cli_settings(*, args: argparse.Namespace, config: GuardConfig, guard_home: Path) -> GuardConfig:

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -339,7 +339,7 @@ def _render_doctor(console: Console, payload: dict[str, object]) -> None:
             console.print(_build_artifact_table(artifacts))
     perf_items = payload.get("detector_perf")
     if isinstance(perf_items, list) and perf_items:
-        perf_table = Table(title="Detector performance", box=box.SIMPLE, show_header=True)
+        perf_table = Table(title="Detector performance", box=box.SIMPLE_HEAVY, show_header=True)
         perf_table.add_column("Detector", style="bold")
         perf_table.add_column("Status")
         perf_table.add_column("ms", justify="right")

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -337,6 +337,22 @@ def _render_doctor(console: Console, payload: dict[str, object]) -> None:
         artifacts = _coerce_dict_list(payload.get("artifacts"))
         if artifacts:
             console.print(_build_artifact_table(artifacts))
+    perf_items = payload.get("detector_perf")
+    if isinstance(perf_items, list) and perf_items:
+        perf_table = Table(title="Detector performance", box=box.SIMPLE, show_header=True)
+        perf_table.add_column("Detector", style="bold")
+        perf_table.add_column("Status")
+        perf_table.add_column("ms", justify="right")
+        perf_table.add_column("Slow?")
+        for item in perf_items:
+            slow = bool(item.get("slow"))
+            perf_table.add_row(
+                str(item.get("detector_id", "")),
+                str(item.get("status", "")),
+                str(item.get("elapsed_ms", 0)),
+                "[red]yes[/red]" if slow else "no",
+            )
+        console.print(perf_table)
     console.print(_build_diagnostic_command_panel())
 
 

--- a/src/codex_plugin_scanner/guard/daemon/client.py
+++ b/src/codex_plugin_scanner/guard/daemon/client.py
@@ -160,7 +160,7 @@ class GuardSurfaceDaemonClient:
             method="GET",
         )
         try:
-            with urllib.request.urlopen(request, timeout=_DEFAULT_REQUEST_TIMEOUT_S) as response:
+            with urllib.request.urlopen(request, timeout=_STATUS_REQUEST_TIMEOUT_S) as response:
                 payload = self._decode_json_response(response.read().decode("utf-8"))
         except urllib.error.HTTPError as error:
             try:

--- a/src/codex_plugin_scanner/guard/daemon/client.py
+++ b/src/codex_plugin_scanner/guard/daemon/client.py
@@ -24,6 +24,10 @@ class GuardDaemonTransportError(GuardDaemonRequestError):
     """Raised when the Guard daemon request fails due to transport issues."""
 
 
+_DEFAULT_REQUEST_TIMEOUT_S: float = 5.0
+_STATUS_REQUEST_TIMEOUT_S: float = 0.25
+
+
 class GuardSurfaceDaemonClient:
     """Small authenticated client for the local Guard daemon."""
 
@@ -156,7 +160,7 @@ class GuardSurfaceDaemonClient:
             method="GET",
         )
         try:
-            with urllib.request.urlopen(request, timeout=5) as response:
+            with urllib.request.urlopen(request, timeout=_DEFAULT_REQUEST_TIMEOUT_S) as response:
                 payload = self._decode_json_response(response.read().decode("utf-8"))
         except urllib.error.HTTPError as error:
             try:
@@ -196,7 +200,13 @@ class GuardSurfaceDaemonClient:
             return state
         return response
 
-    def _post(self, path: str, payload: dict[str, object]) -> dict[str, object]:
+    def _post(
+        self,
+        path: str,
+        payload: dict[str, object],
+        *,
+        timeout: float = _DEFAULT_REQUEST_TIMEOUT_S,
+    ) -> dict[str, object]:
         request = urllib.request.Request(
             f"{self.daemon_url}{path}",
             data=json.dumps(payload).encode("utf-8"),
@@ -207,7 +217,7 @@ class GuardSurfaceDaemonClient:
             method="POST",
         )
         try:
-            with urllib.request.urlopen(request, timeout=5) as response:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
                 return self._decode_json_response(response.read().decode("utf-8"))
         except urllib.error.HTTPError as error:
             try:

--- a/src/codex_plugin_scanner/guard/runtime/detectors.py
+++ b/src/codex_plugin_scanner/guard/runtime/detectors.py
@@ -41,6 +41,7 @@ DETECTOR_CATEGORY_TAGS: tuple[RiskSignalCategory, ...] = (
     "execution",
 )
 DetectorRunStatus = Literal["ok", "disabled", "filtered", "timeout", "error"]
+_SLOW_DETECTOR_THRESHOLD_MS: int = 100
 
 
 @dataclass(frozen=True, slots=True)
@@ -90,6 +91,10 @@ class DetectorRunResult:
 
     signals: tuple[RiskSignalV2, ...]
     telemetry: tuple[DetectorTelemetry, ...]
+
+    def slow_detectors(self, threshold_ms: int = _SLOW_DETECTOR_THRESHOLD_MS) -> tuple[DetectorTelemetry, ...]:
+        """Return telemetry entries that exceeded *threshold_ms*."""
+        return tuple(t for t in self.telemetry if t.elapsed_ms >= threshold_ms)
 
 
 class DetectorRegistry:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -38,6 +38,12 @@ _APPROVAL_METADATA_KEYS = (
     "approval_wait",
     "review_hint",
 )
+
+
+def _get_default_detector_registry() -> DetectorRegistry:
+    return DetectorRegistry(register_default_detectors())
+
+
 _PAIN_SIGNAL_EVENTS = frozenset(
     {
         "changed_artifact_caught",
@@ -364,7 +370,7 @@ def _evaluation_with_detector_registry(
         threat_intel={},
         redaction_settings={},
     )
-    result = DetectorRegistry(register_default_detectors()).run(
+    result = _get_default_detector_registry().run(
         action_envelope,
         detector_context,
         timeout_ms=config.runtime_detector_timeout_ms,

--- a/tests/test_guard_daemon_perf.py
+++ b/tests/test_guard_daemon_perf.py
@@ -1,0 +1,178 @@
+"""Tests for Phase 21 daemon performance and detector lazy-init."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.runtime.detectors import (
+    _SLOW_DETECTOR_THRESHOLD_MS,
+    DetectorContext,
+    DetectorRegistry,
+    DetectorRunResult,
+    DetectorTelemetry,
+)
+from codex_plugin_scanner.guard.runtime.runner import _get_default_detector_registry
+
+
+def _make_config(tmp_path: Path) -> GuardConfig:
+    return GuardConfig(guard_home=tmp_path / "guard-home", workspace=tmp_path / "workspace")
+
+
+def _make_harness_start_action() -> object:
+    from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope
+
+    return GuardActionEnvelope(
+        schema_version=1,
+        action_id="perf-test-action",
+        harness="codex",
+        event_name="HarnessStart",
+        action_type="harness_start",
+        workspace=None,
+        workspace_hash=None,
+        tool_name=None,
+        command=None,
+        prompt_excerpt=None,
+        prompt_text=None,
+        target_paths=(),
+        network_hosts=(),
+        mcp_server=None,
+        mcp_tool=None,
+        package_manager=None,
+        package_name=None,
+        script_name=None,
+        raw_payload_redacted={},
+    )
+
+
+def _make_detector_context(tmp_path: Path) -> DetectorContext:
+    return DetectorContext(
+        config=_make_config(tmp_path),
+        workspace=None,
+        prior_decisions={},
+        threat_intel={},
+        redaction_settings={},
+    )
+
+
+class TestSlowDetectorThreshold:
+    def test_slow_detector_threshold_is_100ms(self) -> None:
+        assert _SLOW_DETECTOR_THRESHOLD_MS == 100
+
+    def test_slow_detectors_returns_empty_when_all_fast(self, tmp_path: Path) -> None:
+        action = _make_harness_start_action()
+        context = _make_detector_context(tmp_path)
+        clock_values = iter([0.0, 0.001])
+
+        def fast_clock() -> float:
+            try:
+                return next(clock_values)
+            except StopIteration:
+                return 0.001
+
+        registry = DetectorRegistry((), clock=fast_clock)
+        result = registry.run(action, context)
+        assert result.slow_detectors() == ()
+
+    def test_slow_detectors_flags_entries_at_or_above_threshold(self) -> None:
+        fast_entry = DetectorTelemetry(
+            detector_id="fast.detector",
+            categories=("secret",),
+            status="ok",
+            elapsed_ms=50,
+        )
+        slow_entry = DetectorTelemetry(
+            detector_id="slow.detector",
+            categories=("network",),
+            status="ok",
+            elapsed_ms=100,
+        )
+        very_slow_entry = DetectorTelemetry(
+            detector_id="very.slow.detector",
+            categories=("prompt",),
+            status="ok",
+            elapsed_ms=250,
+        )
+        result = DetectorRunResult(
+            signals=(),
+            telemetry=(fast_entry, slow_entry, very_slow_entry),
+        )
+        slow = result.slow_detectors()
+        assert len(slow) == 2
+        assert slow[0].detector_id == "slow.detector"
+        assert slow[1].detector_id == "very.slow.detector"
+
+    def test_slow_detectors_custom_threshold(self) -> None:
+        entry = DetectorTelemetry(
+            detector_id="medium.detector",
+            categories=("secret",),
+            status="ok",
+            elapsed_ms=75,
+        )
+        result = DetectorRunResult(signals=(), telemetry=(entry,))
+        assert result.slow_detectors(threshold_ms=50) == (entry,)
+        assert result.slow_detectors(threshold_ms=100) == ()
+
+
+class TestLazyDetectorRegistry:
+    def test_get_default_registry_returns_registry_instance(self) -> None:
+        registry = _get_default_detector_registry()
+        assert isinstance(registry, DetectorRegistry)
+
+    def test_get_default_registry_returns_fresh_instance_each_call(self) -> None:
+        first = _get_default_detector_registry()
+        second = _get_default_detector_registry()
+        assert isinstance(first, DetectorRegistry)
+        assert isinstance(second, DetectorRegistry)
+
+    def test_cached_registry_runs_without_error(self, tmp_path: Path) -> None:
+        action = _make_harness_start_action()
+        context = _make_detector_context(tmp_path)
+        registry = _get_default_detector_registry()
+        result = registry.run(action, context, timeout_ms=200)
+        assert isinstance(result, DetectorRunResult)
+
+
+class TestClientTimeoutConstants:
+    def test_default_request_timeout_is_five_seconds(self) -> None:
+        from codex_plugin_scanner.guard.daemon.client import _DEFAULT_REQUEST_TIMEOUT_S
+
+        assert _DEFAULT_REQUEST_TIMEOUT_S == 5.0
+
+    def test_status_request_timeout_is_250ms(self) -> None:
+        from codex_plugin_scanner.guard.daemon.client import _STATUS_REQUEST_TIMEOUT_S
+
+        assert pytest.approx(0.25) == _STATUS_REQUEST_TIMEOUT_S
+
+
+class TestDoctorPerfPayload:
+    def test_perf_payload_includes_all_detectors(self, tmp_path: Path) -> None:
+        from codex_plugin_scanner.guard.cli.commands import _runtime_detector_perf_payload
+
+        config = _make_config(tmp_path)
+        perf = _runtime_detector_perf_payload(config)
+        assert isinstance(perf, list)
+        assert len(perf) >= 1
+
+    def test_perf_payload_items_have_required_fields(self, tmp_path: Path) -> None:
+        from codex_plugin_scanner.guard.cli.commands import _runtime_detector_perf_payload
+
+        config = _make_config(tmp_path)
+        perf = _runtime_detector_perf_payload(config)
+        for item in perf:
+            assert "detector_id" in item
+            assert "status" in item
+            assert "elapsed_ms" in item
+            assert "slow" in item
+            assert isinstance(item["slow"], bool)
+
+    def test_perf_payload_slow_field_matches_threshold(self, tmp_path: Path) -> None:
+        from codex_plugin_scanner.guard.cli.commands import _runtime_detector_perf_payload
+
+        config = _make_config(tmp_path)
+        perf = _runtime_detector_perf_payload(config)
+        for item in perf:
+            expected_slow = int(item["elapsed_ms"]) >= _SLOW_DETECTOR_THRESHOLD_MS
+            assert item["slow"] == expected_slow


### PR DESCRIPTION
## Summary

Phase 21: perf telemetry and detector registry helpers.

- Add `_SLOW_DETECTOR_THRESHOLD_MS = 100` constant to detectors module
- Add `DetectorRunResult.slow_detectors()` helper to filter slow telemetry
- Add `_get_default_detector_registry()` non-caching factory in runner.py
- Add `_DEFAULT_REQUEST_TIMEOUT_S` / `_STATUS_REQUEST_TIMEOUT_S` constants in client.py
- Wire `_post()` timeout as configurable parameter (default 5s)
- `get_connect_state()` uses 250ms timeout (not 5s) to match poll cadence
- Add `--perf` flag to `hol-guard doctor`; emit per-detector timing table
- Add `_runtime_detector_perf_payload()` using `_get_default_detector_registry()` factory
- Render detector performance table using `box.SIMPLE_HEAVY` for consistency
- Add 12 tests covering timing, slow-detector filtering, and CLI perf output

## Verification

```
pytest tests/test_guard_daemon_perf.py -q   # 12 passed
ruff check src/...                           # All checks passed
```