### PR TITLE
feat(guard): approval center locator and fallback CLI command

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import hashlib
 import json
 import os
@@ -33,11 +34,24 @@ _EPHEMERAL_GUARD_DAEMON_STALE_SECONDS = 30.0
 _EPHEMERAL_GUARD_DAEMON_MAX_STATES = 512
 _GUARD_DAEMON_PRIVATE_FILE_MODE = 0o600
 _GUARD_DAEMON_PRIVATE_DIR_MODE = 0o700
+_APPROVAL_CENTER_LOCATOR_FILE = "approval-center-locator.json"
 
 _START_LOCKS: dict[str, threading.Lock] = {}
 _START_LOCKS_GUARD = threading.Lock()
 _LAST_EPHEMERAL_REAP_AT = 0.0
 _RUNTIME_FINGERPRINT_CACHE: str | None = None
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ApprovalCenterLocator:
+    """Structured snapshot of where the Guard approval-center daemon is running."""
+
+    guard_home: Path
+    daemon_url: str
+    approval_url_base: str
+    pid: int
+    started_at: str
+    state_path: Path
 
 
 def _daemon_launcher_env() -> dict[str, str]:
@@ -171,6 +185,78 @@ def clear_guard_daemon_state(guard_home: Path) -> None:
     state_path = _state_path(guard_home)
     _ensure_private_directory(state_path.parent)
     _write_private_text(state_path, "{}")
+
+
+def _locator_path(guard_home: Path) -> Path:
+    return guard_home / _APPROVAL_CENTER_LOCATOR_FILE
+
+
+def write_approval_center_locator(guard_home: Path, locator: ApprovalCenterLocator) -> None:
+    locator_path = _locator_path(guard_home)
+    _ensure_private_directory(locator_path.parent)
+    payload = {
+        "guard_home": str(locator.guard_home),
+        "daemon_url": locator.daemon_url,
+        "approval_url_base": locator.approval_url_base,
+        "pid": locator.pid,
+        "started_at": locator.started_at,
+        "state_path": str(locator.state_path),
+    }
+    _write_private_text(locator_path, json.dumps(payload, indent=2))
+
+
+def read_approval_center_locator(guard_home: Path) -> ApprovalCenterLocator | None:
+    locator_path = _locator_path(guard_home)
+    if not locator_path.is_file():
+        return None
+    try:
+        payload = json.loads(locator_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    pid = payload.get("pid")
+    if not isinstance(pid, int) or pid <= 0:
+        return None
+    if not _guard_daemon_pid_is_running(pid):
+        return None
+    daemon_url = payload.get("daemon_url")
+    approval_url_base = payload.get("approval_url_base")
+    started_at = payload.get("started_at")
+    state_path_str = payload.get("state_path")
+    guard_home_str = payload.get("guard_home")
+    if not all(isinstance(v, str) for v in (daemon_url, approval_url_base, started_at, state_path_str, guard_home_str)):
+        return None
+    return ApprovalCenterLocator(
+        guard_home=Path(guard_home_str),
+        daemon_url=daemon_url,
+        approval_url_base=approval_url_base,
+        pid=pid,
+        started_at=started_at,
+        state_path=Path(state_path_str),
+    )
+
+
+def ensure_approval_center(guard_home: Path) -> ApprovalCenterLocator:
+    existing = read_approval_center_locator(guard_home)
+    if existing is not None:
+        return existing
+    daemon_url = ensure_guard_daemon(guard_home)
+    now = datetime.now(tz=timezone.utc).isoformat()
+    state = _load_state(guard_home)
+    pid = state.get("pid") if isinstance(state, dict) else None
+    if not isinstance(pid, int) or pid <= 0:
+        pid = os.getpid()
+    locator = ApprovalCenterLocator(
+        guard_home=guard_home,
+        daemon_url=daemon_url,
+        approval_url_base=daemon_url,
+        pid=pid,
+        started_at=now,
+        state_path=_state_path(guard_home),
+    )
+    write_approval_center_locator(guard_home, locator)
+    return locator
 
 
 def _load_state(guard_home: Path) -> dict[str, object] | None:

--- a/src/codex_plugin_scanner/guard/models.py
+++ b/src/codex_plugin_scanner/guard/models.py
@@ -180,6 +180,7 @@ class GuardApprovalRequest:
     risk_headline: str | None = None
     action_envelope_json: dict[str, object] | None = None
     decision_v2_json: dict[str, object] | None = None
+    fallback_cli_command: str | None = None
 
     def to_dict(self) -> dict[str, object]:
         payload = asdict(self)

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -686,6 +686,7 @@ class GuardStore:
             self._ensure_approval_column(connection, "action_envelope_json", "text")
             self._ensure_approval_column(connection, "decision_v2_json", "text")
             self._ensure_approval_column(connection, "workspace", "text")
+            self._ensure_approval_column(connection, "fallback_cli_command", "text")
             self._ensure_attachment_column(connection, "lease_id", "text not null default ''")
             self._ensure_attachment_column(connection, "lease_expires_at", "text")
             self._ensure_local_device(connection)

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -36,6 +36,7 @@ def approval_schema_statement() -> str:
            risk_headline text,
             action_envelope_json text,
             decision_v2_json text,
+            fallback_cli_command text,
             review_command text not null,
            approval_url text not null,
           status text not null,
@@ -70,7 +71,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
                 recommended_scope = ?, changed_fields_json = ?, source_scope = ?, config_path = ?, workspace = ?,
                 launch_target = ?, transport = ?, risk_summary = ?, risk_signals_json = ?,
                 artifact_label = ?, source_label = ?, trigger_summary = ?, why_now = ?, launch_summary = ?,
-                risk_headline = ?, action_envelope_json = ?, decision_v2_json = ?,
+                risk_headline = ?, action_envelope_json = ?, decision_v2_json = ?, fallback_cli_command = ?,
                 review_command = ?, approval_url = ?, created_at = ?
             where request_id = ?
             """,
@@ -97,6 +98,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
                 request.risk_headline,
                 json.dumps(request.action_envelope_json) if request.action_envelope_json is not None else None,
                 json.dumps(request.decision_v2_json) if request.decision_v2_json is not None else None,
+                request.fallback_cli_command,
                 review_command,
                 approval_url,
                 now,
@@ -111,10 +113,10 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
           recommended_scope, changed_fields_json, source_scope, config_path, workspace,
            launch_target, transport, risk_summary,
            risk_signals_json, artifact_label, source_label, trigger_summary, why_now, launch_summary, risk_headline,
-            action_envelope_json, decision_v2_json, review_command,
+            action_envelope_json, decision_v2_json, fallback_cli_command, review_command,
             approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
           )
-          values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             request.request_id,
@@ -142,6 +144,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
             request.risk_headline,
             json.dumps(request.action_envelope_json) if request.action_envelope_json is not None else None,
             json.dumps(request.decision_v2_json) if request.decision_v2_json is not None else None,
+            request.fallback_cli_command,
             request.review_command,
             request.approval_url,
             "pending",
@@ -211,7 +214,8 @@ def list_approval_requests(
         select request_id, harness, artifact_id, artifact_name, artifact_type, artifact_hash, publisher, policy_action,
                recommended_scope, changed_fields_json, source_scope, config_path, workspace, launch_target, transport,
                 risk_summary, risk_signals_json, artifact_label, source_label, trigger_summary, why_now,
-                launch_summary, risk_headline, action_envelope_json, decision_v2_json, review_command,
+                launch_summary, risk_headline, action_envelope_json, decision_v2_json,
+                fallback_cli_command, review_command,
                 approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
         from approval_requests
         {where_clause}
@@ -230,7 +234,8 @@ def get_approval_request(connection: sqlite3.Connection, request_id: str) -> dic
         select request_id, harness, artifact_id, artifact_name, artifact_type, artifact_hash, publisher, policy_action,
                recommended_scope, changed_fields_json, source_scope, config_path, workspace, launch_target, transport,
                 risk_summary, risk_signals_json, artifact_label, source_label, trigger_summary, why_now,
-                launch_summary, risk_headline, action_envelope_json, decision_v2_json, review_command,
+                launch_summary, risk_headline, action_envelope_json, decision_v2_json,
+                fallback_cli_command, review_command,
                 approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
         from approval_requests
         where request_id = ?
@@ -311,6 +316,7 @@ def _row_to_payload(row: sqlite3.Row) -> dict[str, object]:
         "risk_headline": row["risk_headline"],
         "action_envelope_json": _optional_json_object(row["action_envelope_json"]),
         "decision_v2_json": _optional_json_object(row["decision_v2_json"]),
+        "fallback_cli_command": row["fallback_cli_command"],
         "review_command": str(row["review_command"]),
         "approval_url": str(row["approval_url"]),
         "status": str(row["status"]),

--- a/tests/test_guard_approval_continuity.py
+++ b/tests/test_guard_approval_continuity.py
@@ -1,0 +1,190 @@
+"""Tests for ApprovalCenterLocator and ensure_approval_center helpers (T676-T683, T688-T694)."""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+manager_mod = pytest.importorskip(
+    "codex_plugin_scanner.guard.daemon.manager",
+    reason="Guard daemon manager not importable",
+)
+
+ApprovalCenterLocator = manager_mod.ApprovalCenterLocator
+write_approval_center_locator = manager_mod.write_approval_center_locator
+read_approval_center_locator = manager_mod.read_approval_center_locator
+ensure_approval_center = manager_mod.ensure_approval_center
+
+
+class TestApprovalCenterLocator:
+    def _make_locator(self, guard_home: Path, pid: int = os.getpid()) -> ApprovalCenterLocator:
+        return ApprovalCenterLocator(
+            guard_home=guard_home,
+            daemon_url="http://127.0.0.1:6174",
+            approval_url_base="http://127.0.0.1:6174",
+            pid=pid,
+            started_at="2026-01-01T00:00:00Z",
+            state_path=guard_home / "daemon-state.json",
+        )
+
+    def test_locator_is_dataclass(self) -> None:
+        import dataclasses as dc
+
+        assert dc.is_dataclass(ApprovalCenterLocator)
+
+    def test_write_and_read_roundtrip(self, tmp_path: Path) -> None:
+        guard_home = tmp_path / "guard"
+        guard_home.mkdir()
+        locator = self._make_locator(guard_home)
+        write_approval_center_locator(guard_home, locator)
+        result = read_approval_center_locator(guard_home)
+        assert result is not None
+        assert result.daemon_url == "http://127.0.0.1:6174"
+        assert result.pid == os.getpid()
+        assert result.guard_home == guard_home
+
+    def test_read_missing_returns_none(self, tmp_path: Path) -> None:
+        guard_home = tmp_path / "guard"
+        guard_home.mkdir()
+        assert read_approval_center_locator(guard_home) is None
+
+    def test_read_malformed_json_returns_none(self, tmp_path: Path) -> None:
+        guard_home = tmp_path / "guard"
+        guard_home.mkdir()
+        (guard_home / "approval-center-locator.json").write_text("not json", encoding="utf-8")
+        assert read_approval_center_locator(guard_home) is None
+
+    def test_stale_locator_dead_pid_ignored(self, tmp_path: Path) -> None:
+        """T679: Stale locator with a dead PID must be silently ignored."""
+        guard_home = tmp_path / "guard"
+        guard_home.mkdir()
+        dead_pid = 999999999
+        locator = ApprovalCenterLocator(
+            guard_home=guard_home,
+            daemon_url="http://127.0.0.1:6174",
+            approval_url_base="http://127.0.0.1:6174",
+            pid=dead_pid,
+            started_at="2026-01-01T00:00:00Z",
+            state_path=guard_home / "daemon-state.json",
+        )
+        write_approval_center_locator(guard_home, locator)
+        result = read_approval_center_locator(guard_home)
+        assert result is None, "Dead PID locator must be ignored"
+
+    def test_moved_daemon_port_updates_locator(self, tmp_path: Path) -> None:
+        """T680: Writing a new locator with a different port replaces the old one."""
+        guard_home = tmp_path / "guard"
+        guard_home.mkdir()
+        original = self._make_locator(guard_home)
+        write_approval_center_locator(guard_home, original)
+
+        updated = dataclasses.replace(
+            original,
+            daemon_url="http://127.0.0.1:7777",
+            approval_url_base="http://127.0.0.1:7777",
+        )
+        write_approval_center_locator(guard_home, updated)
+        result = read_approval_center_locator(guard_home)
+        assert result is not None
+        assert result.daemon_url == "http://127.0.0.1:7777"
+
+
+class TestEnsureApprovalCenter:
+    def test_starts_daemon_when_no_locator(self, tmp_path: Path) -> None:
+        """T682: ensure_approval_center starts daemon when no locator exists."""
+        guard_home = tmp_path / "guard"
+        guard_home.mkdir()
+        with patch.object(manager_mod, "ensure_guard_daemon", return_value="http://127.0.0.1:6174") as mock_start:
+            result = ensure_approval_center(guard_home)
+        mock_start.assert_called_once_with(guard_home)
+        assert result.daemon_url == "http://127.0.0.1:6174"
+        assert result.guard_home == guard_home
+
+    def test_reuses_healthy_daemon(self, tmp_path: Path) -> None:
+        """T683: ensure_approval_center reuses healthy (alive PID) daemon without restarting."""
+        guard_home = tmp_path / "guard"
+        guard_home.mkdir()
+        alive_pid = os.getpid()
+        locator = ApprovalCenterLocator(
+            guard_home=guard_home,
+            daemon_url="http://127.0.0.1:6174",
+            approval_url_base="http://127.0.0.1:6174",
+            pid=alive_pid,
+            started_at="2026-01-01T00:00:00Z",
+            state_path=guard_home / "daemon-state.json",
+        )
+        write_approval_center_locator(guard_home, locator)
+        with patch.object(manager_mod, "ensure_guard_daemon") as mock_start:
+            result = ensure_approval_center(guard_home)
+        mock_start.assert_not_called()
+        assert result.daemon_url == "http://127.0.0.1:6174"
+
+
+class TestFallbackCliCommand:
+    def test_guard_approval_request_has_fallback_cli_command_field(self) -> None:
+        """T688: GuardApprovalRequest must have fallback_cli_command field."""
+        from codex_plugin_scanner.guard.models import GuardApprovalRequest
+
+        request = GuardApprovalRequest(
+            request_id="req-001",
+            harness="codex",
+            artifact_id="art-001",
+            artifact_name="test",
+            artifact_hash="abc123",
+            policy_action="block",
+            recommended_scope="exact",
+            changed_fields=(),
+            source_scope="local",
+            config_path="/tmp/config",
+            review_command="hol-guard doctor",
+            approval_url="http://127.0.0.1:6174/#/approve/req-001",
+            fallback_cli_command="hol-guard approvals approve req-001",
+        )
+        assert request.fallback_cli_command == "hol-guard approvals approve req-001"
+
+    def test_fallback_cli_command_defaults_to_none(self) -> None:
+        """T688: fallback_cli_command must default to None for backwards compatibility."""
+        from codex_plugin_scanner.guard.models import GuardApprovalRequest
+
+        request = GuardApprovalRequest(
+            request_id="req-002",
+            harness="codex",
+            artifact_id="art-002",
+            artifact_name="test",
+            artifact_hash="abc123",
+            policy_action="block",
+            recommended_scope="exact",
+            changed_fields=(),
+            source_scope="local",
+            config_path="/tmp/config",
+            review_command="hol-guard doctor",
+            approval_url="http://127.0.0.1:6174/#/approve/req-002",
+        )
+        assert request.fallback_cli_command is None
+
+    def test_fallback_cli_command_appears_in_to_dict(self) -> None:
+        """T688: fallback_cli_command must be in the serialized dict."""
+        from codex_plugin_scanner.guard.models import GuardApprovalRequest
+
+        cmd = "hol-guard approvals approve req-003"
+        request = GuardApprovalRequest(
+            request_id="req-003",
+            harness="codex",
+            artifact_id="art-003",
+            artifact_name="test",
+            artifact_hash="abc123",
+            policy_action="block",
+            recommended_scope="exact",
+            changed_fields=(),
+            source_scope="local",
+            config_path="/tmp/config",
+            review_command="hol-guard doctor",
+            approval_url="http://127.0.0.1:6174/#/approve/req-003",
+            fallback_cli_command=cmd,
+        )
+        as_dict = request.to_dict()
+        assert as_dict["fallback_cli_command"] == cmd


### PR DESCRIPTION
Adds structured approval center tracking and fallback CLI command support for continuity.

**Changes:**
- `ApprovalCenterLocator` dataclass in manager.py for structured daemon location tracking
- `write_approval_center_locator()`, `read_approval_center_locator()`, `ensure_approval_center()` helpers
- `read_approval_center_locator()` validates PID liveness, ignores dead-PID locators
- `fallback_cli_command` field (nullable, default None) added to `GuardApprovalRequest`
- Backwards-compatible schema migration via `_ensure_approval_column` in store.py
- `store_approvals.py` INSERT/UPDATE/SELECT updated to persist `fallback_cli_command`

**Tests:** 11 TDD tests — locator roundtrip, dead PID handling, port update, daemon start/reuse, field serialization

**Verification:** 2390 tests pass, ruff clean