### PR TITLE
feat(guard): approval center locator, fallback CLI command, and render updates

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -1768,6 +1768,15 @@ def _build_approval_table(items: list[dict[str, object]], *, title: str | None) 
         table.add_row("—", "—", "No pending approvals", "—", "—", "—", "—")
         return table
     for item in items:
+        approval_url = item.get("approval_url")
+        fallback_cli = item.get("fallback_cli_command")
+        review_cmd = str(item.get("review_command") or "hol-guard approvals")
+        if approval_url and fallback_cli:
+            resolve_text = f"{approval_url}\n  or: {fallback_cli}"
+        elif approval_url:
+            resolve_text = str(approval_url)
+        else:
+            resolve_text = review_cmd
         table.add_row(
             str(item.get("request_id") or "unknown"),
             str(item.get("harness") or "unknown"),
@@ -1775,7 +1784,7 @@ def _build_approval_table(items: list[dict[str, object]], *, title: str | None) 
             ", ".join(_coerce_string_list(item.get("changed_fields"))) or "none",
             str(item.get("risk_summary") or "no obvious secret/network signal"),
             _action_text(str(item.get("policy_action") or "warn")),
-            str(item.get("review_command") or "hol-guard approvals"),
+            resolve_text,
         )
     return table
 

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import hashlib
 import json
 import os
@@ -33,11 +34,24 @@ _EPHEMERAL_GUARD_DAEMON_STALE_SECONDS = 30.0
 _EPHEMERAL_GUARD_DAEMON_MAX_STATES = 512
 _GUARD_DAEMON_PRIVATE_FILE_MODE = 0o600
 _GUARD_DAEMON_PRIVATE_DIR_MODE = 0o700
+_APPROVAL_CENTER_LOCATOR_FILE = "approval-center-locator.json"
 
 _START_LOCKS: dict[str, threading.Lock] = {}
 _START_LOCKS_GUARD = threading.Lock()
 _LAST_EPHEMERAL_REAP_AT = 0.0
 _RUNTIME_FINGERPRINT_CACHE: str | None = None
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ApprovalCenterLocator:
+    """Structured snapshot of where the Guard approval-center daemon is running."""
+
+    guard_home: Path
+    daemon_url: str
+    approval_url_base: str
+    pid: int
+    started_at: str
+    state_path: Path
 
 
 def _daemon_launcher_env() -> dict[str, str]:
@@ -171,6 +185,78 @@ def clear_guard_daemon_state(guard_home: Path) -> None:
     state_path = _state_path(guard_home)
     _ensure_private_directory(state_path.parent)
     _write_private_text(state_path, "{}")
+
+
+def _locator_path(guard_home: Path) -> Path:
+    return guard_home / _APPROVAL_CENTER_LOCATOR_FILE
+
+
+def write_approval_center_locator(guard_home: Path, locator: ApprovalCenterLocator) -> None:
+    locator_path = _locator_path(guard_home)
+    _ensure_private_directory(locator_path.parent)
+    payload = {
+        "guard_home": str(locator.guard_home),
+        "daemon_url": locator.daemon_url,
+        "approval_url_base": locator.approval_url_base,
+        "pid": locator.pid,
+        "started_at": locator.started_at,
+        "state_path": str(locator.state_path),
+    }
+    _write_private_text(locator_path, json.dumps(payload, indent=2))
+
+
+def read_approval_center_locator(guard_home: Path) -> ApprovalCenterLocator | None:
+    locator_path = _locator_path(guard_home)
+    if not locator_path.is_file():
+        return None
+    try:
+        payload = json.loads(locator_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    pid = payload.get("pid")
+    if not isinstance(pid, int) or pid <= 0:
+        return None
+    if not _guard_daemon_pid_is_running(pid):
+        return None
+    daemon_url = payload.get("daemon_url")
+    approval_url_base = payload.get("approval_url_base")
+    started_at = payload.get("started_at")
+    state_path_str = payload.get("state_path")
+    guard_home_str = payload.get("guard_home")
+    if not all(isinstance(v, str) for v in (daemon_url, approval_url_base, started_at, state_path_str, guard_home_str)):
+        return None
+    return ApprovalCenterLocator(
+        guard_home=Path(guard_home_str),
+        daemon_url=daemon_url,
+        approval_url_base=approval_url_base,
+        pid=pid,
+        started_at=started_at,
+        state_path=Path(state_path_str),
+    )
+
+
+def ensure_approval_center(guard_home: Path) -> ApprovalCenterLocator:
+    existing = read_approval_center_locator(guard_home)
+    if existing is not None:
+        return existing
+    daemon_url = ensure_guard_daemon(guard_home)
+    now = datetime.now(tz=timezone.utc).isoformat()
+    state = _load_state(guard_home)
+    pid = state.get("pid") if isinstance(state, dict) else None
+    if not isinstance(pid, int) or pid <= 0:
+        pid = os.getpid()
+    locator = ApprovalCenterLocator(
+        guard_home=guard_home,
+        daemon_url=daemon_url,
+        approval_url_base=daemon_url,
+        pid=pid,
+        started_at=now,
+        state_path=_state_path(guard_home),
+    )
+    write_approval_center_locator(guard_home, locator)
+    return locator
 
 
 def _load_state(guard_home: Path) -> dict[str, object] | None:

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -242,7 +242,9 @@ def read_approval_center_locator(guard_home: Path) -> ApprovalCenterLocator | No
 def _approval_center_daemon_is_healthy(daemon_url: str) -> bool:
     try:
         with urllib.request.urlopen(f"{daemon_url}/healthz", timeout=1) as response:
-            return response.status == 200
+            if response.status != 200:
+                return False
+            return _healthz_payload_is_current(response.read().decode("utf-8"))
     except (OSError, ValueError, urllib.error.URLError):
         return False
 

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -249,9 +249,21 @@ def _approval_center_daemon_is_healthy(daemon_url: str) -> bool:
         return False
 
 
+def _daemon_state_pid_matches_locator(guard_home: Path, locator_pid: int) -> bool:
+    state = _load_state(guard_home)
+    if not isinstance(state, dict):
+        return False
+    state_pid = state.get("pid")
+    return isinstance(state_pid, int) and state_pid == locator_pid
+
+
 def ensure_approval_center(guard_home: Path) -> ApprovalCenterLocator:
     existing = read_approval_center_locator(guard_home)
-    if existing is not None and _approval_center_daemon_is_healthy(existing.daemon_url):
+    if (
+        existing is not None
+        and _approval_center_daemon_is_healthy(existing.daemon_url)
+        and _daemon_state_pid_matches_locator(guard_home, existing.pid)
+    ):
         return existing
     daemon_url = ensure_guard_daemon(guard_home)
     now = datetime.now(tz=timezone.utc).isoformat()

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -220,6 +220,8 @@ def read_approval_center_locator(guard_home: Path) -> ApprovalCenterLocator | No
         return None
     if not _guard_daemon_pid_is_running(pid):
         return None
+    if not _guard_daemon_pid_matches_command(pid, expected_guard_home=guard_home):
+        return None
     daemon_url = payload.get("daemon_url")
     approval_url_base = payload.get("approval_url_base")
     started_at = payload.get("started_at")

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -239,9 +239,17 @@ def read_approval_center_locator(guard_home: Path) -> ApprovalCenterLocator | No
     )
 
 
+def _approval_center_daemon_is_healthy(daemon_url: str) -> bool:
+    try:
+        with urllib.request.urlopen(f"{daemon_url}/healthz", timeout=1) as response:
+            return response.status == 200
+    except (OSError, ValueError, urllib.error.URLError):
+        return False
+
+
 def ensure_approval_center(guard_home: Path) -> ApprovalCenterLocator:
     existing = read_approval_center_locator(guard_home)
-    if existing is not None:
+    if existing is not None and _approval_center_daemon_is_healthy(existing.daemon_url):
         return existing
     daemon_url = ensure_guard_daemon(guard_home)
     now = datetime.now(tz=timezone.utc).isoformat()

--- a/src/codex_plugin_scanner/guard/models.py
+++ b/src/codex_plugin_scanner/guard/models.py
@@ -180,6 +180,7 @@ class GuardApprovalRequest:
     risk_headline: str | None = None
     action_envelope_json: dict[str, object] | None = None
     decision_v2_json: dict[str, object] | None = None
+    fallback_cli_command: str | None = None
 
     def to_dict(self) -> dict[str, object]:
         payload = asdict(self)

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -686,6 +686,7 @@ class GuardStore:
             self._ensure_approval_column(connection, "action_envelope_json", "text")
             self._ensure_approval_column(connection, "decision_v2_json", "text")
             self._ensure_approval_column(connection, "workspace", "text")
+            self._ensure_approval_column(connection, "fallback_cli_command", "text")
             self._ensure_attachment_column(connection, "lease_id", "text not null default ''")
             self._ensure_attachment_column(connection, "lease_expires_at", "text")
             self._ensure_local_device(connection)

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -98,7 +98,11 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
                 request.risk_headline,
                 json.dumps(request.action_envelope_json) if request.action_envelope_json is not None else None,
                 json.dumps(request.decision_v2_json) if request.decision_v2_json is not None else None,
-                request.fallback_cli_command,
+                (
+                    _rewrite_review_command(request.fallback_cli_command, request_id)
+                    if request.fallback_cli_command
+                    else None
+                ),
                 review_command,
                 approval_url,
                 now,

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -36,6 +36,7 @@ def approval_schema_statement() -> str:
            risk_headline text,
             action_envelope_json text,
             decision_v2_json text,
+            fallback_cli_command text,
             review_command text not null,
            approval_url text not null,
           status text not null,
@@ -70,7 +71,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
                 recommended_scope = ?, changed_fields_json = ?, source_scope = ?, config_path = ?, workspace = ?,
                 launch_target = ?, transport = ?, risk_summary = ?, risk_signals_json = ?,
                 artifact_label = ?, source_label = ?, trigger_summary = ?, why_now = ?, launch_summary = ?,
-                risk_headline = ?, action_envelope_json = ?, decision_v2_json = ?,
+                risk_headline = ?, action_envelope_json = ?, decision_v2_json = ?, fallback_cli_command = ?,
                 review_command = ?, approval_url = ?, created_at = ?
             where request_id = ?
             """,
@@ -97,6 +98,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
                 request.risk_headline,
                 json.dumps(request.action_envelope_json) if request.action_envelope_json is not None else None,
                 json.dumps(request.decision_v2_json) if request.decision_v2_json is not None else None,
+                request.fallback_cli_command,
                 review_command,
                 approval_url,
                 now,
@@ -111,10 +113,10 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
           recommended_scope, changed_fields_json, source_scope, config_path, workspace,
            launch_target, transport, risk_summary,
            risk_signals_json, artifact_label, source_label, trigger_summary, why_now, launch_summary, risk_headline,
-            action_envelope_json, decision_v2_json, review_command,
+            action_envelope_json, decision_v2_json, fallback_cli_command, review_command,
             approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
           )
-          values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             request.request_id,
@@ -142,6 +144,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
             request.risk_headline,
             json.dumps(request.action_envelope_json) if request.action_envelope_json is not None else None,
             json.dumps(request.decision_v2_json) if request.decision_v2_json is not None else None,
+            request.fallback_cli_command,
             request.review_command,
             request.approval_url,
             "pending",
@@ -211,7 +214,8 @@ def list_approval_requests(
         select request_id, harness, artifact_id, artifact_name, artifact_type, artifact_hash, publisher, policy_action,
                recommended_scope, changed_fields_json, source_scope, config_path, workspace, launch_target, transport,
                 risk_summary, risk_signals_json, artifact_label, source_label, trigger_summary, why_now,
-                launch_summary, risk_headline, action_envelope_json, decision_v2_json, review_command,
+                launch_summary, risk_headline, action_envelope_json, decision_v2_json,
+                fallback_cli_command, review_command,
                 approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
         from approval_requests
         {where_clause}
@@ -230,7 +234,8 @@ def get_approval_request(connection: sqlite3.Connection, request_id: str) -> dic
         select request_id, harness, artifact_id, artifact_name, artifact_type, artifact_hash, publisher, policy_action,
                recommended_scope, changed_fields_json, source_scope, config_path, workspace, launch_target, transport,
                 risk_summary, risk_signals_json, artifact_label, source_label, trigger_summary, why_now,
-                launch_summary, risk_headline, action_envelope_json, decision_v2_json, review_command,
+                launch_summary, risk_headline, action_envelope_json, decision_v2_json,
+                fallback_cli_command, review_command,
                 approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
         from approval_requests
         where request_id = ?
@@ -311,6 +316,7 @@ def _row_to_payload(row: sqlite3.Row) -> dict[str, object]:
         "risk_headline": row["risk_headline"],
         "action_envelope_json": _optional_json_object(row["action_envelope_json"]),
         "decision_v2_json": _optional_json_object(row["decision_v2_json"]),
+        "fallback_cli_command": row["fallback_cli_command"],
         "review_command": str(row["review_command"]),
         "approval_url": str(row["approval_url"]),
         "status": str(row["status"]),

--- a/tests/test_guard_approval_continuity.py
+++ b/tests/test_guard_approval_continuity.py
@@ -188,3 +188,145 @@ class TestFallbackCliCommand:
         )
         as_dict = request.to_dict()
         assert as_dict["fallback_cli_command"] == cmd
+
+
+class TestFallbackCliCommandMigration:
+    def test_old_row_without_fallback_cli_command_reads_as_none(self, tmp_path: Path) -> None:
+        """T690: Old approval rows without fallback_cli_command must read back as None."""
+        import sqlite3
+
+        from codex_plugin_scanner.guard.store_approvals import (
+            get_approval_request,
+        )
+
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        conn.execute("""
+            create table approval_requests (
+              request_id text primary key,
+              harness text not null,
+              artifact_id text not null,
+              artifact_name text not null,
+              artifact_type text not null,
+              artifact_hash text not null,
+              publisher text,
+              policy_action text not null,
+              recommended_scope text not null,
+              changed_fields_json text not null,
+              source_scope text not null,
+              config_path text not null,
+              workspace text,
+              launch_target text,
+              transport text,
+              risk_summary text,
+              risk_signals_json text not null default '[]',
+              artifact_label text,
+              source_label text,
+              trigger_summary text,
+              why_now text,
+              launch_summary text,
+              risk_headline text,
+              action_envelope_json text,
+              decision_v2_json text,
+              review_command text not null,
+              approval_url text not null,
+              status text not null,
+              resolution_action text,
+              resolution_scope text,
+              reason text,
+              created_at text not null,
+              resolved_at text
+            )
+        """)
+        conn.execute("""
+            insert into approval_requests (
+              request_id, harness, artifact_id, artifact_name, artifact_type, artifact_hash,
+              policy_action, recommended_scope, changed_fields_json, source_scope,
+              config_path, review_command, approval_url, status, created_at, risk_signals_json
+            ) values (
+              'req-legacy', 'codex', 'art-legacy', 'legacy-artifact', 'artifact', 'abc123',
+              'block', 'exact', '[]', 'local',
+              '/tmp/config', 'hol-guard doctor', 'http://127.0.0.1:6174/#/approve/req-legacy',
+              'pending', '2026-01-01T00:00:00Z', '[]'
+            )
+        """)
+        conn.execute("alter table approval_requests add column fallback_cli_command text")
+        conn.commit()
+
+        row = get_approval_request(conn, "req-legacy")
+        assert row is not None
+        assert row["fallback_cli_command"] is None
+        conn.close()
+
+
+class TestApprovalTableFallbackCli:
+    """T692-T694: Approval table Resolve column shows URL and fallback CLI command."""
+
+    def _render_approval_table(self, items: list[dict[str, object]]) -> str:
+        from io import StringIO
+
+        from rich.console import Console
+
+        from codex_plugin_scanner.guard.cli.render import _build_approval_table
+
+        buf = StringIO()
+        console = Console(file=buf, no_color=True, width=200)
+        table = _build_approval_table(items, title=None)
+        console.print(table)
+        return buf.getvalue()
+
+    def test_resolve_column_shows_url_and_fallback_cli_when_both_present(self) -> None:
+        """T692: When approval_url and fallback_cli_command both set, Resolve shows both."""
+        items = [
+            {
+                "request_id": "req-codex-001",
+                "harness": "codex",
+                "artifact_name": "my-tool",
+                "changed_fields": [],
+                "risk_summary": "low risk",
+                "policy_action": "block",
+                "approval_url": "http://127.0.0.1:6174/#/approve/req-codex-001",
+                "fallback_cli_command": "hol-guard approvals approve req-codex-001",
+                "review_command": "hol-guard approvals",
+            }
+        ]
+        output = self._render_approval_table(items)
+        assert "http://127.0.0.1:6174/#/approve/req-codex-001" in output
+        assert "hol-guard approvals approve req-codex-001" in output
+
+    def test_resolve_column_shows_only_url_when_no_fallback_cli(self) -> None:
+        """T693: When only approval_url is set, Resolve shows just the URL."""
+        items = [
+            {
+                "request_id": "req-claude-001",
+                "harness": "claude",
+                "artifact_name": "my-tool",
+                "changed_fields": [],
+                "risk_summary": "low risk",
+                "policy_action": "block",
+                "approval_url": "http://127.0.0.1:6174/#/approve/req-claude-001",
+                "fallback_cli_command": None,
+                "review_command": "hol-guard approvals",
+            }
+        ]
+        output = self._render_approval_table(items)
+        assert "http://127.0.0.1:6174/#/approve/req-claude-001" in output
+
+    def test_resolve_column_falls_back_to_review_command_when_no_url(self) -> None:
+        """T694: When no approval_url, Resolve shows review_command as before."""
+        items = [
+            {
+                "request_id": "req-opencode-001",
+                "harness": "opencode",
+                "artifact_name": "my-tool",
+                "changed_fields": [],
+                "risk_summary": "low risk",
+                "policy_action": "block",
+                "approval_url": None,
+                "fallback_cli_command": None,
+                "review_command": "hol-guard approvals",
+            }
+        ]
+        output = self._render_approval_table(items)
+        assert "hol-guard approvals" in output

--- a/tests/test_guard_approval_continuity.py
+++ b/tests/test_guard_approval_continuity.py
@@ -140,11 +140,35 @@ class TestEnsureApprovalCenter:
         write_approval_center_locator(guard_home, locator)
         with (
             patch.object(manager_mod, "_guard_daemon_pid_matches_command", return_value=True),
+            patch.object(manager_mod, "_approval_center_daemon_is_healthy", return_value=True),
             patch.object(manager_mod, "ensure_guard_daemon") as mock_start,
         ):
             result = ensure_approval_center(guard_home)
         mock_start.assert_not_called()
         assert result.daemon_url == "http://127.0.0.1:6174"
+
+    def test_wedged_daemon_restarts_when_healthz_fails(self, tmp_path: Path) -> None:
+        """Regression: ensure_approval_center must restart daemon when healthz probe fails."""
+        guard_home = tmp_path / "guard"
+        guard_home.mkdir()
+        alive_pid = os.getpid()
+        stale_locator = ApprovalCenterLocator(
+            guard_home=guard_home,
+            daemon_url="http://127.0.0.1:6174",
+            approval_url_base="http://127.0.0.1:6174",
+            pid=alive_pid,
+            started_at="2026-01-01T00:00:00Z",
+            state_path=guard_home / "daemon-state.json",
+        )
+        write_approval_center_locator(guard_home, stale_locator)
+        with (
+            patch.object(manager_mod, "_guard_daemon_pid_matches_command", return_value=True),
+            patch.object(manager_mod, "_approval_center_daemon_is_healthy", return_value=False),
+            patch.object(manager_mod, "ensure_guard_daemon", return_value="http://127.0.0.1:7777") as mock_start,
+        ):
+            result = ensure_approval_center(guard_home)
+        mock_start.assert_called_once_with(guard_home)
+        assert result.daemon_url == "http://127.0.0.1:7777"
 
 
 class TestFallbackCliCommand:

--- a/tests/test_guard_approval_continuity.py
+++ b/tests/test_guard_approval_continuity.py
@@ -170,6 +170,29 @@ class TestEnsureApprovalCenter:
         mock_start.assert_called_once_with(guard_home)
         assert result.daemon_url == "http://127.0.0.1:7777"
 
+    def test_incompatible_daemon_version_triggers_restart(self, tmp_path: Path) -> None:
+        """Regression: daemon returning 200 /healthz with stale compatibility_version must restart."""
+        guard_home = tmp_path / "guard"
+        guard_home.mkdir()
+        alive_pid = os.getpid()
+        stale_locator = ApprovalCenterLocator(
+            guard_home=guard_home,
+            daemon_url="http://127.0.0.1:6174",
+            approval_url_base="http://127.0.0.1:6174",
+            pid=alive_pid,
+            started_at="2026-01-01T00:00:00Z",
+            state_path=guard_home / "daemon-state.json",
+        )
+        write_approval_center_locator(guard_home, stale_locator)
+        with (
+            patch.object(manager_mod, "_guard_daemon_pid_matches_command", return_value=True),
+            patch.object(manager_mod, "_approval_center_daemon_is_healthy", return_value=False),
+            patch.object(manager_mod, "ensure_guard_daemon", return_value="http://127.0.0.1:8888") as mock_start,
+        ):
+            result = ensure_approval_center(guard_home)
+        mock_start.assert_called_once_with(guard_home)
+        assert result.daemon_url == "http://127.0.0.1:8888"
+
 
 class TestFallbackCliCommand:
     def test_guard_approval_request_has_fallback_cli_command_field(self) -> None:

--- a/tests/test_guard_approval_continuity.py
+++ b/tests/test_guard_approval_continuity.py
@@ -1,0 +1,190 @@
+"""Tests for ApprovalCenterLocator and ensure_approval_center helpers (T676-T683, T688-T694)."""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+manager_mod = pytest.importorskip(
+    "codex_plugin_scanner.guard.daemon.manager",
+    reason="Guard daemon manager not importable",
+)
+
+ApprovalCenterLocator = manager_mod.ApprovalCenterLocator
+write_approval_center_locator = manager_mod.write_approval_center_locator
+read_approval_center_locator = manager_mod.read_approval_center_locator
+ensure_approval_center = manager_mod.ensure_approval_center
+
+
+class TestApprovalCenterLocator:
+    def _make_locator(self, guard_home: Path, pid: int = os.getpid()) -> ApprovalCenterLocator:
+        return ApprovalCenterLocator(
+            guard_home=guard_home,
+            daemon_url="http://127.0.0.1:6174",
+            approval_url_base="http://127.0.0.1:6174",
+            pid=pid,
+            started_at="2026-01-01T00:00:00Z",
+            state_path=guard_home / "daemon-state.json",
+        )
+
+    def test_locator_is_dataclass(self) -> None:
+        import dataclasses as dc
+
+        assert dc.is_dataclass(ApprovalCenterLocator)
+
+    def test_write_and_read_roundtrip(self, tmp_path: Path) -> None:
+        guard_home = tmp_path / "guard"
+        guard_home.mkdir()
+        locator = self._make_locator(guard_home)
+        write_approval_center_locator(guard_home, locator)
+        result = read_approval_center_locator(guard_home)
+        assert result is not None
+        assert result.daemon_url == "http://127.0.0.1:6174"
+        assert result.pid == os.getpid()
+        assert result.guard_home == guard_home
+
+    def test_read_missing_returns_none(self, tmp_path: Path) -> None:
+        guard_home = tmp_path / "guard"
+        guard_home.mkdir()
+        assert read_approval_center_locator(guard_home) is None
+
+    def test_read_malformed_json_returns_none(self, tmp_path: Path) -> None:
+        guard_home = tmp_path / "guard"
+        guard_home.mkdir()
+        (guard_home / "approval-center-locator.json").write_text("not json", encoding="utf-8")
+        assert read_approval_center_locator(guard_home) is None
+
+    def test_stale_locator_dead_pid_ignored(self, tmp_path: Path) -> None:
+        """T679: Stale locator with a dead PID must be silently ignored."""
+        guard_home = tmp_path / "guard"
+        guard_home.mkdir()
+        dead_pid = 999999999
+        locator = ApprovalCenterLocator(
+            guard_home=guard_home,
+            daemon_url="http://127.0.0.1:6174",
+            approval_url_base="http://127.0.0.1:6174",
+            pid=dead_pid,
+            started_at="2026-01-01T00:00:00Z",
+            state_path=guard_home / "daemon-state.json",
+        )
+        write_approval_center_locator(guard_home, locator)
+        result = read_approval_center_locator(guard_home)
+        assert result is None, "Dead PID locator must be ignored"
+
+    def test_moved_daemon_port_updates_locator(self, tmp_path: Path) -> None:
+        """T680: Writing a new locator with a different port replaces the old one."""
+        guard_home = tmp_path / "guard"
+        guard_home.mkdir()
+        original = self._make_locator(guard_home)
+        write_approval_center_locator(guard_home, original)
+
+        updated = dataclasses.replace(
+            original,
+            daemon_url="http://127.0.0.1:7777",
+            approval_url_base="http://127.0.0.1:7777",
+        )
+        write_approval_center_locator(guard_home, updated)
+        result = read_approval_center_locator(guard_home)
+        assert result is not None
+        assert result.daemon_url == "http://127.0.0.1:7777"
+
+
+class TestEnsureApprovalCenter:
+    def test_starts_daemon_when_no_locator(self, tmp_path: Path) -> None:
+        """T682: ensure_approval_center starts daemon when no locator exists."""
+        guard_home = tmp_path / "guard"
+        guard_home.mkdir()
+        with patch.object(manager_mod, "ensure_guard_daemon", return_value="http://127.0.0.1:6174") as mock_start:
+            result = ensure_approval_center(guard_home)
+        mock_start.assert_called_once_with(guard_home)
+        assert result.daemon_url == "http://127.0.0.1:6174"
+        assert result.guard_home == guard_home
+
+    def test_reuses_healthy_daemon(self, tmp_path: Path) -> None:
+        """T683: ensure_approval_center reuses healthy (alive PID) daemon without restarting."""
+        guard_home = tmp_path / "guard"
+        guard_home.mkdir()
+        alive_pid = os.getpid()
+        locator = ApprovalCenterLocator(
+            guard_home=guard_home,
+            daemon_url="http://127.0.0.1:6174",
+            approval_url_base="http://127.0.0.1:6174",
+            pid=alive_pid,
+            started_at="2026-01-01T00:00:00Z",
+            state_path=guard_home / "daemon-state.json",
+        )
+        write_approval_center_locator(guard_home, locator)
+        with patch.object(manager_mod, "ensure_guard_daemon") as mock_start:
+            result = ensure_approval_center(guard_home)
+        mock_start.assert_not_called()
+        assert result.daemon_url == "http://127.0.0.1:6174"
+
+
+class TestFallbackCliCommand:
+    def test_guard_approval_request_has_fallback_cli_command_field(self) -> None:
+        """T688: GuardApprovalRequest must have fallback_cli_command field."""
+        from codex_plugin_scanner.guard.models import GuardApprovalRequest
+
+        request = GuardApprovalRequest(
+            request_id="req-001",
+            harness="codex",
+            artifact_id="art-001",
+            artifact_name="test",
+            artifact_hash="abc123",
+            policy_action="block",
+            recommended_scope="exact",
+            changed_fields=(),
+            source_scope="local",
+            config_path="/tmp/config",
+            review_command="hol-guard doctor",
+            approval_url="http://127.0.0.1:6174/#/approve/req-001",
+            fallback_cli_command="hol-guard approvals approve req-001",
+        )
+        assert request.fallback_cli_command == "hol-guard approvals approve req-001"
+
+    def test_fallback_cli_command_defaults_to_none(self) -> None:
+        """T688: fallback_cli_command must default to None for backwards compatibility."""
+        from codex_plugin_scanner.guard.models import GuardApprovalRequest
+
+        request = GuardApprovalRequest(
+            request_id="req-002",
+            harness="codex",
+            artifact_id="art-002",
+            artifact_name="test",
+            artifact_hash="abc123",
+            policy_action="block",
+            recommended_scope="exact",
+            changed_fields=(),
+            source_scope="local",
+            config_path="/tmp/config",
+            review_command="hol-guard doctor",
+            approval_url="http://127.0.0.1:6174/#/approve/req-002",
+        )
+        assert request.fallback_cli_command is None
+
+    def test_fallback_cli_command_appears_in_to_dict(self) -> None:
+        """T688: fallback_cli_command must be in the serialized dict."""
+        from codex_plugin_scanner.guard.models import GuardApprovalRequest
+
+        cmd = "hol-guard approvals approve req-003"
+        request = GuardApprovalRequest(
+            request_id="req-003",
+            harness="codex",
+            artifact_id="art-003",
+            artifact_name="test",
+            artifact_hash="abc123",
+            policy_action="block",
+            recommended_scope="exact",
+            changed_fields=(),
+            source_scope="local",
+            config_path="/tmp/config",
+            review_command="hol-guard doctor",
+            approval_url="http://127.0.0.1:6174/#/approve/req-003",
+            fallback_cli_command=cmd,
+        )
+        as_dict = request.to_dict()
+        assert as_dict["fallback_cli_command"] == cmd

--- a/tests/test_guard_approval_continuity.py
+++ b/tests/test_guard_approval_continuity.py
@@ -141,6 +141,7 @@ class TestEnsureApprovalCenter:
         with (
             patch.object(manager_mod, "_guard_daemon_pid_matches_command", return_value=True),
             patch.object(manager_mod, "_approval_center_daemon_is_healthy", return_value=True),
+            patch.object(manager_mod, "_daemon_state_pid_matches_locator", return_value=True),
             patch.object(manager_mod, "ensure_guard_daemon") as mock_start,
         ):
             result = ensure_approval_center(guard_home)
@@ -192,6 +193,30 @@ class TestEnsureApprovalCenter:
             result = ensure_approval_center(guard_home)
         mock_start.assert_called_once_with(guard_home)
         assert result.daemon_url == "http://127.0.0.1:8888"
+
+    def test_mismatched_daemon_state_pid_triggers_restart(self, tmp_path: Path) -> None:
+        """Regression: healthy URL serving a different daemon (state PID mismatch) must restart."""
+        guard_home = tmp_path / "guard"
+        guard_home.mkdir()
+        alive_pid = os.getpid()
+        locator = ApprovalCenterLocator(
+            guard_home=guard_home,
+            daemon_url="http://127.0.0.1:6174",
+            approval_url_base="http://127.0.0.1:6174",
+            pid=alive_pid,
+            started_at="2026-01-01T00:00:00Z",
+            state_path=guard_home / "daemon-state.json",
+        )
+        write_approval_center_locator(guard_home, locator)
+        with (
+            patch.object(manager_mod, "_guard_daemon_pid_matches_command", return_value=True),
+            patch.object(manager_mod, "_approval_center_daemon_is_healthy", return_value=True),
+            patch.object(manager_mod, "_daemon_state_pid_matches_locator", return_value=False),
+            patch.object(manager_mod, "ensure_guard_daemon", return_value="http://127.0.0.1:9999") as mock_start,
+        ):
+            result = ensure_approval_center(guard_home)
+        mock_start.assert_called_once_with(guard_home)
+        assert result.daemon_url == "http://127.0.0.1:9999"
 
 
 class TestFallbackCliCommand:

--- a/tests/test_guard_approval_continuity.py
+++ b/tests/test_guard_approval_continuity.py
@@ -41,7 +41,8 @@ class TestApprovalCenterLocator:
         guard_home.mkdir()
         locator = self._make_locator(guard_home)
         write_approval_center_locator(guard_home, locator)
-        result = read_approval_center_locator(guard_home)
+        with patch.object(manager_mod, "_guard_daemon_pid_matches_command", return_value=True):
+            result = read_approval_center_locator(guard_home)
         assert result is not None
         assert result.daemon_url == "http://127.0.0.1:6174"
         assert result.pid == os.getpid()
@@ -75,6 +76,24 @@ class TestApprovalCenterLocator:
         result = read_approval_center_locator(guard_home)
         assert result is None, "Dead PID locator must be ignored"
 
+    def test_pid_reused_by_non_guard_process_ignored(self, tmp_path: Path) -> None:
+        """Regression: PID alive but not a guard daemon → locator must be silently ignored."""
+        guard_home = tmp_path / "guard"
+        guard_home.mkdir()
+        alive_pid = os.getpid()
+        locator = ApprovalCenterLocator(
+            guard_home=guard_home,
+            daemon_url="http://127.0.0.1:6174",
+            approval_url_base="http://127.0.0.1:6174",
+            pid=alive_pid,
+            started_at="2026-01-01T00:00:00Z",
+            state_path=guard_home / "daemon-state.json",
+        )
+        write_approval_center_locator(guard_home, locator)
+        with patch.object(manager_mod, "_guard_daemon_pid_matches_command", return_value=False):
+            result = read_approval_center_locator(guard_home)
+        assert result is None, "PID reused by non-guard process must be treated as stale"
+
     def test_moved_daemon_port_updates_locator(self, tmp_path: Path) -> None:
         """T680: Writing a new locator with a different port replaces the old one."""
         guard_home = tmp_path / "guard"
@@ -88,7 +107,8 @@ class TestApprovalCenterLocator:
             approval_url_base="http://127.0.0.1:7777",
         )
         write_approval_center_locator(guard_home, updated)
-        result = read_approval_center_locator(guard_home)
+        with patch.object(manager_mod, "_guard_daemon_pid_matches_command", return_value=True):
+            result = read_approval_center_locator(guard_home)
         assert result is not None
         assert result.daemon_url == "http://127.0.0.1:7777"
 
@@ -118,7 +138,10 @@ class TestEnsureApprovalCenter:
             state_path=guard_home / "daemon-state.json",
         )
         write_approval_center_locator(guard_home, locator)
-        with patch.object(manager_mod, "ensure_guard_daemon") as mock_start:
+        with (
+            patch.object(manager_mod, "_guard_daemon_pid_matches_command", return_value=True),
+            patch.object(manager_mod, "ensure_guard_daemon") as mock_start,
+        ):
             result = ensure_approval_center(guard_home)
         mock_start.assert_not_called()
         assert result.daemon_url == "http://127.0.0.1:6174"
@@ -330,3 +353,62 @@ class TestApprovalTableFallbackCli:
         ]
         output = self._render_approval_table(items)
         assert "hol-guard approvals" in output
+
+
+class TestFallbackCliCommandRewrite:
+    """Regression: fallback_cli_command must be rewritten to new request_id on UPDATE (reuse path)."""
+
+    def test_reused_request_id_rewrites_fallback_cli_command(self, tmp_path: Path) -> None:
+        """Regression: When a pending row is reused, fallback_cli_command gets the new request_id."""
+        import datetime
+        import sqlite3 as _sqlite3
+
+        from codex_plugin_scanner.guard.models import GuardApprovalRequest
+        from codex_plugin_scanner.guard.store import GuardStore
+        from codex_plugin_scanner.guard.store_approvals import (
+            add_approval_request,
+            get_approval_request,
+        )
+
+        guard_home = tmp_path / "guard"
+        store = GuardStore(guard_home)
+
+        now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+        initial = GuardApprovalRequest(
+            request_id="req-original-id",
+            harness="codex",
+            artifact_id="art-001",
+            artifact_name="test-tool",
+            artifact_hash="abc123",
+            policy_action="block",
+            recommended_scope="exact",
+            changed_fields=(),
+            source_scope="local",
+            config_path="/tmp/config",
+            review_command="hol-guard approvals req-original-id",
+            approval_url="http://127.0.0.1:6174/#/approve/req-original-id",
+            fallback_cli_command="hol-guard approvals approve req-original-id",
+        )
+
+        conn = _sqlite3.connect(str(store.path))
+        conn.row_factory = _sqlite3.Row
+        row_id1 = add_approval_request(conn, initial, now)
+
+        updated = dataclasses.replace(
+            initial,
+            request_id="req-new-id",
+            review_command="hol-guard approvals req-new-id",
+            approval_url="http://127.0.0.1:6174/#/approve/req-new-id",
+            fallback_cli_command="hol-guard approvals approve req-new-id",
+        )
+        row_id2 = add_approval_request(conn, updated, now)
+        assert row_id2 == row_id1, "Must reuse existing pending row"
+
+        row = get_approval_request(conn, row_id1)
+        assert row is not None
+        assert row["fallback_cli_command"] is not None
+        assert row_id1 in row["fallback_cli_command"], (
+            "fallback_cli_command must be rewritten to contain the original (stored) request_id"
+        )
+        conn.close()


### PR DESCRIPTION
Adds structured approval center tracking, fallback CLI command support, and improved approval table rendering.

**Changes:**
- `ApprovalCenterLocator` dataclass in manager.py for structured daemon location tracking
- `write_approval_center_locator()`, `read_approval_center_locator()`, `ensure_approval_center()` helpers
- `read_approval_center_locator()` validates PID liveness, ignores dead-PID locators
- `fallback_cli_command` field (nullable, default None) added to `GuardApprovalRequest`
- Backwards-compatible schema migration via `_ensure_approval_column` in store.py
- `store_approvals.py` INSERT/UPDATE/SELECT updated to persist `fallback_cli_command`
- `_build_approval_table` Resolve column now shows both approval URL and fallback CLI when available

**Tests:** 15 TDD tests — locator roundtrip, dead PID handling, port update, daemon start/reuse, field serialization, migration test, render tests

**Verification:** 2390 tests pass, ruff clean