### PR TITLE
feat(guard-approval): web recovery payloads for approval center error states

### DIFF
--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -24,6 +24,14 @@ GUARD_FLEET_URL = f"{GUARD_DASHBOARD_URL}/fleet"
 GUARD_CONNECT_URL = f"{GUARD_DASHBOARD_URL}/connect"
 
 
+class ApprovalRequestNotFoundError(ValueError):
+    """Raised when an approval request ID does not exist."""
+
+
+class ApprovalRequestAlreadyResolvedError(ValueError):
+    """Raised when an approval request was already resolved."""
+
+
 def queue_blocked_approvals(
     *,
     detection: HarnessDetection,
@@ -114,9 +122,9 @@ def apply_approval_resolution(
 ) -> dict[str, object]:
     request = store.get_approval_request(request_id)
     if request is None:
-        raise ValueError(f"Unknown approval request: {request_id}")
+        raise ApprovalRequestNotFoundError(f"Unknown approval request: {request_id}")
     if request["status"] != "pending":
-        raise ValueError(f"Approval request already resolved: {request_id}")
+        raise ApprovalRequestAlreadyResolvedError(f"Approval request already resolved: {request_id}")
     if scope == "workspace" and not workspace:
         raise ValueError(f"Approval request {request_id} requires --workspace for workspace scope.")
     if scope == "publisher" and not isinstance(request.get("publisher"), str):

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -183,7 +183,17 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if len(path_parts) == 3 and path_parts[:2] == ["v1", "requests"]:
             approval = store.get_approval_request(path_parts[2])
             if approval is None:
-                self._write_json({"error": "not_found"}, status=404)
+                self._write_json(
+                    {
+                        "error": "not_found",
+                        "recovery": {
+                            "code": "request_unknown",
+                            "title": "This request is no longer waiting.",
+                            "body": "The request was either already resolved or expired. You can close this tab.",
+                        },
+                    },
+                    status=404,
+                )
                 return
             self._write_json(approval)
             return
@@ -313,11 +323,29 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json({"error": "forbidden_origin"}, status=403)
             return
         if self._requires_header_token(parsed.path, path_parts) and not self._header_token_is_valid():
-            self._write_json(
-                {"error": "unauthorized"},
-                status=401,
-                extra_headers=self._cors_headers_for_request(),
-            )
+            if len(path_parts) == 4 and path_parts[:2] == ["v1", "requests"] and path_parts[3] in {"approve", "block"}:
+                host = self.server.server_address[0]  # type: ignore[attr-defined]
+                port = self.server.server_address[1]  # type: ignore[attr-defined]
+                reconnect_url = f"http://{host}:{port}/#/reconnect"
+                self._write_json(
+                    {
+                        "error": "unauthorized",
+                        "recovery": {
+                            "code": "session_stale",
+                            "title": "Your session with the local Guard daemon has expired.",
+                            "body": "Click the link below to reconnect, then retry your approval.",
+                            "reconnect_url": reconnect_url,
+                        },
+                    },
+                    status=401,
+                    extra_headers=self._cors_headers_for_request(),
+                )
+            else:
+                self._write_json(
+                    {"error": "unauthorized"},
+                    status=401,
+                    extra_headers=self._cors_headers_for_request(),
+                )
             return
         payload, body_error = self._load_request_body()
         if body_error is not None:
@@ -390,7 +418,38 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 reason=self._optional_string(payload.get("reason")),
             )
         except ValueError as error:
-            self._write_json({"resolved": False, "error": str(error)}, status=400)
+            error_message = str(error)
+            if "Unknown approval request" in error_message:
+                self._write_json(
+                    {
+                        "resolved": False,
+                        "error": "not_found",
+                        "recovery": {
+                            "code": "request_unknown",
+                            "title": "This request is no longer waiting.",
+                            "body": "The request was either already resolved or expired. You can close this tab.",
+                        },
+                    },
+                    status=404,
+                )
+            elif "already resolved" in error_message:
+                self._write_json(
+                    {
+                        "resolved": False,
+                        "error": "already_resolved",
+                        "recovery": {
+                            "code": "request_resolved",
+                            "title": "This request has already been resolved.",
+                            "body": (
+                                "If the action is blocked and you believe it should be allowed, "
+                                "you can re-submit from your AI assistant."
+                            ),
+                        },
+                    },
+                    status=409,
+                )
+            else:
+                self._write_json({"resolved": False, "error": error_message}, status=400)
             return
         self._write_json({"resolved": True, "item": updated})
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -18,7 +18,12 @@ from typing import Any
 from urllib.parse import parse_qs, parse_qsl, unquote, urlencode, urlparse, urlunparse
 
 from ...version import __version__
-from ..approvals import apply_approval_resolution, build_runtime_snapshot
+from ..approvals import (
+    ApprovalRequestAlreadyResolvedError,
+    ApprovalRequestNotFoundError,
+    apply_approval_resolution,
+    build_runtime_snapshot,
+)
 from ..config import editable_guard_settings, load_guard_config, update_guard_settings
 from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES
 from ..runtime.surface_server import GuardSurfaceRuntime
@@ -326,7 +331,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             if len(path_parts) == 4 and path_parts[:2] == ["v1", "requests"] and path_parts[3] in {"approve", "block"}:
                 host = self.server.server_address[0]  # type: ignore[attr-defined]
                 port = self.server.server_address[1]  # type: ignore[attr-defined]
-                reconnect_url = f"http://{host}:{port}/#/reconnect"
+                reconnect_url = _build_local_url(host, port, "/#/reconnect")
                 self._write_json(
                     {
                         "error": "unauthorized",
@@ -417,39 +422,39 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 workspace=self._optional_string(payload.get("workspace")),
                 reason=self._optional_string(payload.get("reason")),
             )
+        except ApprovalRequestNotFoundError:
+            self._write_json(
+                {
+                    "resolved": False,
+                    "error": "not_found",
+                    "recovery": {
+                        "code": "request_unknown",
+                        "title": "This request is no longer waiting.",
+                        "body": "The request was either already resolved or expired. You can close this tab.",
+                    },
+                },
+                status=404,
+            )
+            return
+        except ApprovalRequestAlreadyResolvedError:
+            self._write_json(
+                {
+                    "resolved": False,
+                    "error": "already_resolved",
+                    "recovery": {
+                        "code": "request_resolved",
+                        "title": "This request has already been resolved.",
+                        "body": (
+                            "If the action is blocked and you believe it should be allowed, "
+                            "you can re-submit from your AI assistant."
+                        ),
+                    },
+                },
+                status=409,
+            )
+            return
         except ValueError as error:
-            error_message = str(error)
-            if "Unknown approval request" in error_message:
-                self._write_json(
-                    {
-                        "resolved": False,
-                        "error": "not_found",
-                        "recovery": {
-                            "code": "request_unknown",
-                            "title": "This request is no longer waiting.",
-                            "body": "The request was either already resolved or expired. You can close this tab.",
-                        },
-                    },
-                    status=404,
-                )
-            elif "already resolved" in error_message:
-                self._write_json(
-                    {
-                        "resolved": False,
-                        "error": "already_resolved",
-                        "recovery": {
-                            "code": "request_resolved",
-                            "title": "This request has already been resolved.",
-                            "body": (
-                                "If the action is blocked and you believe it should be allowed, "
-                                "you can re-submit from your AI assistant."
-                            ),
-                        },
-                    },
-                    status=409,
-                )
-            else:
-                self._write_json({"resolved": False, "error": error_message}, status=400)
+            self._write_json({"resolved": False, "error": str(error)}, status=400)
             return
         self._write_json({"resolved": True, "item": updated})
 
@@ -1376,6 +1381,11 @@ def _approval_center_browser_url(approval_center_url: str, auth_token: str) -> s
     ]
     fragment_pairs.append(("guard-token", auth_token))
     return urlunparse(parsed._replace(fragment=urlencode(fragment_pairs)))
+
+
+def _build_local_url(host: str, port: int, path: str) -> str:
+    host_part = f"[{host}]" if ":" in host else host
+    return f"http://{host_part}:{port}{path}"
 
 
 def _now() -> str:

--- a/tests/test_guard_web_recovery.py
+++ b/tests/test_guard_web_recovery.py
@@ -1,0 +1,190 @@
+"""Tests for approval web recovery screens (T695-T699)."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.daemon import GuardDaemonServer
+from codex_plugin_scanner.guard.models import GuardApprovalRequest
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _guard_json_headers(auth_token: str | None = None) -> dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    if auth_token is not None:
+        headers["X-Guard-Token"] = auth_token
+    return headers
+
+
+def _add_pending_request(store: GuardStore, request_id: str = "req-test-001") -> None:
+    store.add_approval_request(
+        GuardApprovalRequest(
+            request_id=request_id,
+            harness="codex",
+            artifact_id="codex:project:test_tool",
+            artifact_name="test_tool",
+            artifact_hash="hash-test",
+            policy_action="block",
+            recommended_scope="artifact",
+            changed_fields=(),
+            source_scope="local",
+            config_path="/tmp/config",
+            review_command=f"hol-guard approvals approve {request_id}",
+            approval_url=f"http://127.0.0.1:6174/#/approve/{request_id}",
+        ),
+        "2026-01-01T00:00:00+00:00",
+    )
+
+
+class TestApproveBlockRecoveryPayloads:
+    """T695-T697: approve/block endpoints return structured recovery payloads on error."""
+
+    def test_approve_unknown_request_returns_recovery_payload(self, tmp_path: Path) -> None:
+        """T695: Approving an unknown request ID returns recovery copy, not a bare error."""
+        store = GuardStore(tmp_path / "guard")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/requests/req-nonexistent/approve",
+                data=json.dumps({"scope": "artifact"}).encode("utf-8"),
+                headers=_guard_json_headers(daemon._server.auth_token),
+                method="POST",
+            )
+            try:
+                urllib.request.urlopen(request, timeout=5)
+                pytest.fail("Expected HTTP error")
+            except urllib.error.HTTPError as err:
+                payload = json.loads(err.read().decode("utf-8"))
+        finally:
+            daemon.stop()
+
+        assert payload.get("resolved") is False
+        recovery = payload.get("recovery")
+        assert isinstance(recovery, dict), "Recovery payload must be a dict"
+        assert recovery.get("code") == "request_unknown"
+        assert "no longer waiting" in recovery.get("title", "").lower()
+
+    def test_approve_already_resolved_request_returns_recovery_payload(self, tmp_path: Path) -> None:
+        """T696: Approving an already-resolved request returns recovery copy with decision info."""
+        store = GuardStore(tmp_path / "guard")
+        _add_pending_request(store, "req-resolved-001")
+        store.resolve_approval_request(
+            "req-resolved-001",
+            resolution_action="allow",
+            resolution_scope="artifact",
+            reason=None,
+            resolved_at="2026-01-01T01:00:00+00:00",
+        )
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/requests/req-resolved-001/approve",
+                data=json.dumps({"scope": "artifact"}).encode("utf-8"),
+                headers=_guard_json_headers(daemon._server.auth_token),
+                method="POST",
+            )
+            try:
+                urllib.request.urlopen(request, timeout=5)
+                pytest.fail("Expected HTTP error")
+            except urllib.error.HTTPError as err:
+                payload = json.loads(err.read().decode("utf-8"))
+        finally:
+            daemon.stop()
+
+        assert payload.get("resolved") is False
+        recovery = payload.get("recovery")
+        assert isinstance(recovery, dict), "Recovery payload must be a dict"
+        assert recovery.get("code") == "request_resolved"
+        title = recovery.get("title", "")
+        assert "already" in title.lower() or "resolved" in title.lower()
+
+    def test_approve_with_wrong_token_returns_recovery_payload_not_bare_401(self, tmp_path: Path) -> None:
+        """T697/T698: approve/block with wrong token returns structured recovery payload."""
+        store = GuardStore(tmp_path / "guard")
+        _add_pending_request(store, "req-auth-001")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/requests/req-auth-001/approve",
+                data=json.dumps({"scope": "artifact"}).encode("utf-8"),
+                headers=_guard_json_headers("wrong-token-xyz"),
+                method="POST",
+            )
+            try:
+                urllib.request.urlopen(request, timeout=5)
+                pytest.fail("Expected HTTP error")
+            except urllib.error.HTTPError as err:
+                assert err.code == 401
+                payload = json.loads(err.read().decode("utf-8"))
+        finally:
+            daemon.stop()
+
+        recovery = payload.get("recovery")
+        assert isinstance(recovery, dict), "401 response must include a recovery payload"
+        assert recovery.get("code") == "session_stale"
+        assert recovery.get("reconnect_url") is not None
+
+    def test_block_with_wrong_token_returns_recovery_payload(self, tmp_path: Path) -> None:
+        """T698: block with wrong token returns structured recovery payload."""
+        store = GuardStore(tmp_path / "guard")
+        _add_pending_request(store, "req-auth-002")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/requests/req-auth-002/block",
+                data=json.dumps({"scope": "artifact"}).encode("utf-8"),
+                headers=_guard_json_headers("bad-token"),
+                method="POST",
+            )
+            try:
+                urllib.request.urlopen(request, timeout=5)
+                pytest.fail("Expected HTTP error")
+            except urllib.error.HTTPError as err:
+                assert err.code == 401
+                payload = json.loads(err.read().decode("utf-8"))
+        finally:
+            daemon.stop()
+
+        recovery = payload.get("recovery")
+        assert isinstance(recovery, dict), "401 block response must include recovery payload"
+        assert recovery.get("code") == "session_stale"
+
+    def test_stale_approval_page_shows_recovery_copy_not_blank(self, tmp_path: Path) -> None:
+        """T699: GET on stale/nonexistent approval request returns recovery copy instead of bare 404."""
+        store = GuardStore(tmp_path / "guard")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            try:
+                with urllib.request.urlopen(
+                    urllib.request.Request(
+                        f"http://127.0.0.1:{daemon.port}/v1/requests/req-stale-999",
+                        headers=_guard_json_headers(daemon._server.auth_token),
+                        method="GET",
+                    ),
+                    timeout=5,
+                ):
+                    pytest.fail("Expected HTTP error")
+            except urllib.error.HTTPError as err:
+                payload = json.loads(err.read().decode("utf-8"))
+        finally:
+            daemon.stop()
+
+        recovery = payload.get("recovery")
+        assert isinstance(recovery, dict), "404 GET on stale request must include recovery payload"
+        assert recovery.get("code") in {"request_unknown", "not_found"}
+        assert recovery.get("title") is not None


### PR DESCRIPTION
## Summary

Adds structured recovery payloads to the Guard daemon approval center API so that when an approval URL becomes stale, users see actionable copy instead of blank errors or raw JSON.

## Changes

### Backend — `server.py`
- `GET /v1/requests/{id}` now returns `{"error": "not_found", "recovery": {...}}` when the request is unknown
- `POST /v1/requests/{id}/approve|block` now returns typed recovery payloads:
  - Unknown request: `code=request_unknown`, copy: "This request is no longer waiting."
  - Already-resolved request: `code=request_resolved`, copy + retry guidance
  - Wrong auth token (401): `code=session_stale` with `reconnect_url` for one-click reconnect

### Tests — `test_guard_web_recovery.py` (5 new tests)
- T695: approve unknown request → recovery payload with `request_unknown` code
- T696: approve already-resolved → recovery payload with `request_resolved` code
- T697/T698: approve/block with wrong token → recovery payload with `session_stale` + reconnect URL
- T699: GET stale request → recovery payload instead of bare 404

## Verification
```
pytest tests/test_guard_web_recovery.py tests/test_guard_approvals.py -q
# 70 passed
```