### PR TITLE
feat(guard): dedup approval store by normalized action identity and workspace (T719-T721)

### DIFF
--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -686,6 +686,7 @@ class GuardStore:
             self._ensure_approval_column(connection, "action_envelope_json", "text")
             self._ensure_approval_column(connection, "decision_v2_json", "text")
             self._ensure_approval_column(connection, "workspace", "text")
+            self._ensure_approval_column(connection, "normalized_identity_key", "text")
             self._ensure_approval_column(connection, "fallback_cli_command", "text")
             self._ensure_attachment_column(connection, "lease_id", "text not null default ''")
             self._ensure_attachment_column(connection, "lease_expires_at", "text")

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -56,6 +56,7 @@ def approval_schema_statement() -> str:
 
 
 def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalRequest, now: str) -> str:
+    identity_key = _normalized_identity_key(request.launch_target)
     existing = connection.execute(
         """
         select request_id
@@ -68,8 +69,23 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
         order by created_at desc
         limit 1
         """,
-        (request.harness, request.artifact_id, request.workspace, _normalized_identity_key(request.launch_target)),
+        (request.harness, request.artifact_id, request.workspace, identity_key),
     ).fetchone()
+    if existing is None:
+        existing = connection.execute(
+            """
+            select request_id
+            from approval_requests
+            where harness = ?
+              and artifact_id = ?
+              and workspace IS ?
+              and normalized_identity_key IS NULL
+              and status = 'pending'
+            order by created_at desc
+            limit 1
+            """,
+            (request.harness, request.artifact_id, request.workspace),
+        ).fetchone()
     request_id = str(existing["request_id"]) if existing is not None else request.request_id
     if existing is not None:
         review_command = _rewrite_review_command(request.review_command, request_id)

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -79,7 +79,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
             where harness = ?
               and artifact_id = ?
               and workspace IS ?
-              and launch_target = ?
+              and launch_target IS ?
               and normalized_identity_key IS NULL
               and status = 'pending'
             order by created_at desc

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -6,6 +6,11 @@ import json
 import sqlite3
 
 from .models import GuardApprovalRequest
+from .runtime.action_identity import normalize_command_identity
+
+
+def _normalized_identity_key(launch_target: str | None) -> str:
+    return normalize_command_identity(launch_target or "")
 
 
 def approval_schema_statement() -> str:
@@ -25,6 +30,7 @@ def approval_schema_statement() -> str:
           config_path text not null,
           workspace text,
           launch_target text,
+          normalized_identity_key text,
           transport text,
           risk_summary text,
           risk_signals_json text not null default '[]',
@@ -54,11 +60,15 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
         """
         select request_id
         from approval_requests
-        where harness = ? and artifact_id = ? and status = 'pending'
+        where harness = ?
+          and artifact_id = ?
+          and workspace IS ?
+          and normalized_identity_key = ?
+          and status = 'pending'
         order by created_at desc
         limit 1
         """,
-        (request.harness, request.artifact_id),
+        (request.harness, request.artifact_id, request.workspace, _normalized_identity_key(request.launch_target)),
     ).fetchone()
     request_id = str(existing["request_id"]) if existing is not None else request.request_id
     if existing is not None:
@@ -69,7 +79,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
             update approval_requests
             set artifact_name = ?, artifact_type = ?, artifact_hash = ?, publisher = ?, policy_action = ?,
                 recommended_scope = ?, changed_fields_json = ?, source_scope = ?, config_path = ?, workspace = ?,
-                launch_target = ?, transport = ?, risk_summary = ?, risk_signals_json = ?,
+                launch_target = ?, normalized_identity_key = ?, transport = ?, risk_summary = ?, risk_signals_json = ?,
                 artifact_label = ?, source_label = ?, trigger_summary = ?, why_now = ?, launch_summary = ?,
                 risk_headline = ?, action_envelope_json = ?, decision_v2_json = ?, fallback_cli_command = ?,
                 review_command = ?, approval_url = ?, created_at = ?
@@ -87,6 +97,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
                 request.config_path,
                 request.workspace,
                 request.launch_target,
+                _normalized_identity_key(request.launch_target),
                 request.transport,
                 request.risk_summary,
                 json.dumps(list(request.risk_signals)),
@@ -115,12 +126,14 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
         insert into approval_requests (
           request_id, harness, artifact_id, artifact_name, artifact_type, artifact_hash, publisher, policy_action,
           recommended_scope, changed_fields_json, source_scope, config_path, workspace,
-           launch_target, transport, risk_summary,
+           launch_target, normalized_identity_key, transport, risk_summary,
            risk_signals_json, artifact_label, source_label, trigger_summary, why_now, launch_summary, risk_headline,
             action_envelope_json, decision_v2_json, fallback_cli_command, review_command,
             approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
           )
-          values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          values (
+            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+          )
         """,
         (
             request.request_id,
@@ -137,6 +150,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
             request.config_path,
             request.workspace,
             request.launch_target,
+            _normalized_identity_key(request.launch_target),
             request.transport,
             request.risk_summary,
             json.dumps(list(request.risk_signals)),

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -79,12 +79,13 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
             where harness = ?
               and artifact_id = ?
               and workspace IS ?
+              and launch_target = ?
               and normalized_identity_key IS NULL
               and status = 'pending'
             order by created_at desc
             limit 1
             """,
-            (request.harness, request.artifact_id, request.workspace),
+            (request.harness, request.artifact_id, request.workspace, request.launch_target),
         ).fetchone()
     request_id = str(existing["request_id"]) if existing is not None else request.request_id
     if existing is not None:

--- a/tests/test_guard_approval_store_dedup.py
+++ b/tests/test_guard_approval_store_dedup.py
@@ -156,3 +156,27 @@ class TestDifferentWorkspacesGetSeparateRows:
         assert id_ls != id_rm, "Different commands must not collapse into one approval row"
         total = count_approval_requests(conn, status="pending")
         assert total == 2, f"Expected 2 pending rows for different commands, got {total}"
+
+
+class TestLegacyNullIdentityKeyUpgradePath:
+    """Regression: existing rows with NULL normalized_identity_key must still be deduped."""
+
+    def test_legacy_null_row_is_updated_not_duplicated(self) -> None:
+        """After upgrade, a pending row with NULL identity key must be reused for the same
+        artifact+workspace instead of inserting a duplicate row."""
+        conn = _make_conn()
+        artifact_id = "codex:project:tool-legacy"
+        req_legacy = _make_request(artifact_id=artifact_id, workspace="ws-a", launch_target="run tool")
+        first_id = add_approval_request(conn, req_legacy, "2026-01-01T00:00:00Z")
+
+        conn.execute(
+            "update approval_requests set normalized_identity_key = NULL where request_id = ?",
+            (first_id,),
+        )
+
+        req_new = _make_request(artifact_id=artifact_id, workspace="ws-a", launch_target="run tool")
+        second_id = add_approval_request(conn, req_new, "2026-01-01T00:01:00Z")
+
+        assert first_id == second_id, "Legacy row with NULL identity key must be reused, not duplicated"
+        total = count_approval_requests(conn, status="pending")
+        assert total == 1, f"Expected 1 pending row after deduping legacy null row, got {total}"

--- a/tests/test_guard_approval_store_dedup.py
+++ b/tests/test_guard_approval_store_dedup.py
@@ -1,0 +1,158 @@
+"""Phase 25 — approval store dedup by normalized action identity and workspace.
+
+T719: store collapses duplicate pending requests by normalized action identity + workspace.
+T720: duplicate pending requests update one row instead of creating many rows.
+T721: different workspaces still get separate approval requests.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+
+from codex_plugin_scanner.guard.models import GuardApprovalRequest
+from codex_plugin_scanner.guard.store_approvals import (
+    add_approval_request,
+    approval_index_statements,
+    approval_schema_statement,
+    count_approval_requests,
+    list_approval_requests,
+)
+
+
+def _make_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("pragma journal_mode=wal")
+    conn.execute(approval_schema_statement())
+    for stmt in approval_index_statements():
+        conn.execute(stmt)
+    return conn
+
+
+def _make_request(
+    *,
+    harness: str = "codex",
+    workspace: str | None = "ws-a",
+    artifact_id: str | None = None,
+    launch_target: str | None = None,
+) -> GuardApprovalRequest:
+    aid = artifact_id or f"codex:project:tool-{uuid.uuid4().hex[:8]}"
+    rid = str(uuid.uuid4())
+    return GuardApprovalRequest(
+        request_id=rid,
+        harness=harness,
+        artifact_id=aid,
+        artifact_name="tool",
+        artifact_type="mcp_server",
+        artifact_hash="abc123",
+        publisher=None,
+        policy_action="require-reapproval",
+        recommended_scope="session",
+        changed_fields=frozenset(["args"]),
+        source_scope="project",
+        config_path="/repo/config.toml",
+        workspace=workspace,
+        launch_target=launch_target,
+        transport="stdio",
+        risk_summary="risk",
+        risk_signals=[],
+        artifact_label=None,
+        source_label=None,
+        trigger_summary=None,
+        why_now=None,
+        launch_summary=None,
+        risk_headline=None,
+        action_envelope_json=None,
+        decision_v2_json=None,
+        fallback_cli_command=None,
+        review_command=f"hol-guard review {rid}",
+        approval_url=f"http://localhost:4455/approve/{rid}",
+    )
+
+
+class TestDuplicatePendingRequestCollapse:
+    """T719-T720: Duplicate pending requests collapse to one row."""
+
+    def test_second_identical_request_updates_existing_row(self) -> None:
+        """T720: A second pending request for the same artifact+workspace+launch_target
+        must update the existing row and not create a new one."""
+        conn = _make_conn()
+        artifact_id = "codex:project:tool-abc"
+        req1 = _make_request(artifact_id=artifact_id, workspace="ws-a", launch_target="run tool --flag")
+        req2 = _make_request(artifact_id=artifact_id, workspace="ws-a", launch_target="run tool --flag")
+
+        id1 = add_approval_request(conn, req1, "2026-01-01T00:00:00Z")
+        id2 = add_approval_request(conn, req2, "2026-01-01T00:01:00Z")
+
+        assert id1 == id2, "Second identical request must reuse the existing request_id"
+        total = count_approval_requests(conn, status="pending")
+        assert total == 1, f"Expected 1 pending row, got {total}"
+
+    def test_transient_variation_collapses_to_same_row(self) -> None:
+        """T719: Transient variation (UUID in args) must not create a new row."""
+        conn = _make_conn()
+        artifact_id = "codex:project:tool-xyz"
+        req1 = _make_request(
+            artifact_id=artifact_id,
+            workspace="ws-b",
+            launch_target="run tool --request-id req-aaaaaaaaaaaa --flag",
+        )
+        req2 = _make_request(
+            artifact_id=artifact_id,
+            workspace="ws-b",
+            launch_target="run tool --request-id req-bbbbbbbbbbbb --flag",
+        )
+
+        id1 = add_approval_request(conn, req1, "2026-01-01T00:00:00Z")
+        id2 = add_approval_request(conn, req2, "2026-01-01T00:01:00Z")
+
+        assert id1 == id2, "Same command with different transient request IDs must collapse to one row"
+        total = count_approval_requests(conn, status="pending")
+        assert total == 1, f"Expected 1 pending row after transient variation, got {total}"
+
+
+class TestDifferentWorkspacesGetSeparateRows:
+    """T721: Different workspaces must produce separate approval request rows."""
+
+    def test_same_artifact_different_workspaces_creates_two_rows(self) -> None:
+        """T721: Same artifact in different workspaces must each queue its own approval."""
+        conn = _make_conn()
+        artifact_id = "codex:project:tool-shared"
+        req_ws_a = _make_request(artifact_id=artifact_id, workspace="ws-a", launch_target="run tool")
+        req_ws_b = _make_request(artifact_id=artifact_id, workspace="ws-b", launch_target="run tool")
+
+        id_a = add_approval_request(conn, req_ws_a, "2026-01-01T00:00:00Z")
+        id_b = add_approval_request(conn, req_ws_b, "2026-01-01T00:01:00Z")
+
+        assert id_a != id_b, "Different workspaces must get separate request IDs"
+        total = count_approval_requests(conn, status="pending")
+        assert total == 2, f"Expected 2 pending rows for 2 workspaces, got {total}"
+
+    def test_null_and_named_workspace_get_separate_rows(self) -> None:
+        """T721b: Null workspace and a named workspace must be treated as different."""
+        conn = _make_conn()
+        artifact_id = "codex:project:tool-null-ws"
+        req_null = _make_request(artifact_id=artifact_id, workspace=None, launch_target="run tool")
+        req_named = _make_request(artifact_id=artifact_id, workspace="ws-c", launch_target="run tool")
+
+        id_null = add_approval_request(conn, req_null, "2026-01-01T00:00:00Z")
+        id_named = add_approval_request(conn, req_named, "2026-01-01T00:01:00Z")
+
+        assert id_null != id_named, "Null workspace and named workspace must get separate request IDs"
+        pending = list_approval_requests(conn, status="pending")
+        assert len(pending) == 2, f"Expected 2 pending rows, got {len(pending)}"
+
+    def test_different_launch_targets_create_separate_rows(self) -> None:
+        """T719b: Different commands for same artifact+workspace must queue separate approvals."""
+        conn = _make_conn()
+        artifact_id = "codex:project:tool-multi"
+        req_ls = _make_request(artifact_id=artifact_id, workspace="ws-a", launch_target="run ls /repo")
+        req_rm = _make_request(artifact_id=artifact_id, workspace="ws-a", launch_target="run rm /tmp/file")
+
+        id_ls = add_approval_request(conn, req_ls, "2026-01-01T00:00:00Z")
+        id_rm = add_approval_request(conn, req_rm, "2026-01-01T00:01:00Z")
+
+        assert id_ls != id_rm, "Different commands must not collapse into one approval row"
+        total = count_approval_requests(conn, status="pending")
+        assert total == 2, f"Expected 2 pending rows for different commands, got {total}"

--- a/tests/test_guard_approval_store_dedup.py
+++ b/tests/test_guard_approval_store_dedup.py
@@ -180,3 +180,21 @@ class TestLegacyNullIdentityKeyUpgradePath:
         assert first_id == second_id, "Legacy row with NULL identity key must be reused, not duplicated"
         total = count_approval_requests(conn, status="pending")
         assert total == 1, f"Expected 1 pending row after deduping legacy null row, got {total}"
+
+    def test_legacy_null_row_different_command_not_collapsed(self) -> None:
+        """Legacy NULL rows for different commands must NOT be collapsed even during upgrade path."""
+        conn = _make_conn()
+        artifact_id = "codex:project:tool-multi"
+        req_a = _make_request(artifact_id=artifact_id, workspace="ws-a", launch_target="run cmd-a")
+        id_a = add_approval_request(conn, req_a, "2026-01-01T00:00:00Z")
+        conn.execute(
+            "update approval_requests set normalized_identity_key = NULL where request_id = ?",
+            (id_a,),
+        )
+
+        req_b = _make_request(artifact_id=artifact_id, workspace="ws-a", launch_target="run cmd-b")
+        id_b = add_approval_request(conn, req_b, "2026-01-01T00:01:00Z")
+
+        assert id_a != id_b, "Different commands must each get their own pending row even when legacy row is NULL"
+        total = count_approval_requests(conn, status="pending")
+        assert total == 2, f"Expected 2 pending rows for different commands, got {total}"

--- a/tests/test_guard_approval_store_dedup.py
+++ b/tests/test_guard_approval_store_dedup.py
@@ -198,3 +198,22 @@ class TestLegacyNullIdentityKeyUpgradePath:
         assert id_a != id_b, "Different commands must each get their own pending row even when legacy row is NULL"
         total = count_approval_requests(conn, status="pending")
         assert total == 2, f"Expected 2 pending rows for different commands, got {total}"
+
+    def test_legacy_null_launch_target_row_is_deduped(self) -> None:
+        """Legacy rows with NULL launch_target AND NULL identity key must be deduped for the same artifact."""
+        conn = _make_conn()
+        artifact_id = "codex:project:tool-null-target"
+        req_null = _make_request(artifact_id=artifact_id, workspace="ws-a", launch_target=None)
+        first_id = add_approval_request(conn, req_null, "2026-01-01T00:00:00Z")
+
+        conn.execute(
+            "update approval_requests set normalized_identity_key = NULL where request_id = ?",
+            (first_id,),
+        )
+
+        req_retry = _make_request(artifact_id=artifact_id, workspace="ws-a", launch_target=None)
+        second_id = add_approval_request(conn, req_retry, "2026-01-01T00:01:00Z")
+
+        assert first_id == second_id, "NULL-launch-target legacy row must be reused for the same artifact"
+        total = count_approval_requests(conn, status="pending")
+        assert total == 1, f"Expected 1 pending row for NULL launch_target dedup, got {total}"

--- a/tests/test_guard_decision_propagation.py
+++ b/tests/test_guard_decision_propagation.py
@@ -1,0 +1,162 @@
+"""Phase 25 — immediate decision propagation: browser approve/block writes
+decision before harness retry resumes (T722-T724).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_plugin_scanner.guard.approvals import apply_approval_resolution, queue_blocked_approvals
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.consumer.service import evaluate_detection
+from codex_plugin_scanner.guard.models import (
+    GuardArtifact,
+    HarnessDetection,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _make_artifact(
+    *,
+    name: str = "test_tool",
+    config_path: str = "/repo/workspace/.codex/config.toml",
+) -> GuardArtifact:
+    return GuardArtifact(
+        artifact_id=f"codex:project:{name}",
+        name=name,
+        harness="codex",
+        artifact_type="mcp_server",
+        source_scope="project",
+        config_path=config_path,
+        command="node",
+        args=("server.js",),
+        transport="stdio",
+    )
+
+
+def _make_detection(artifact: GuardArtifact) -> HarnessDetection:
+    return HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(artifact.config_path,),
+        artifacts=(artifact,),
+    )
+
+
+class TestImmediateApproveDecisionPropagation:
+    """T722-T723: Browser approve writes decision before harness retry resumes."""
+
+    def test_approve_decision_visible_to_evaluate_without_delay(self, tmp_path: Path) -> None:
+        """T723: After apply_approval_resolution(allow), re-running evaluate_detection
+        immediately returns an allowed evaluation with no pending approval request.
+        """
+        guard_home = tmp_path / "guard"
+        store = GuardStore(guard_home)
+        artifact = _make_artifact(name="sync_tool", config_path=str(tmp_path / "ws/.codex/config.toml"))
+        config = GuardConfig(guard_home=guard_home, workspace=None)
+        detection = _make_detection(artifact)
+
+        initial_eval = evaluate_detection(detection, store, config, persist=True)
+        assert initial_eval.get("blocked") is True, "Tool must be blocked before approval"
+
+        approvals = queue_blocked_approvals(
+            detection=detection,
+            evaluation=initial_eval,
+            store=store,
+            approval_center_url="http://127.0.0.1:6174",
+        )
+        assert len(approvals) > 0, "Must queue at least one approval request"
+        request_id = str(approvals[0]["request_id"])
+
+        apply_approval_resolution(
+            store=store,
+            request_id=request_id,
+            action="allow",
+            scope="artifact",
+            workspace=None,
+            reason=None,
+        )
+
+        retry_eval = evaluate_detection(detection, store, config, persist=False)
+        assert retry_eval.get("blocked") is False, "T723: Evaluation immediately after approval must not be blocked"
+        artifact_result = (retry_eval.get("artifacts") or [{}])[0]
+        assert artifact_result.get("policy_action") == "allow", (
+            "T723: Evaluation immediately after approval must return allow policy"
+        )
+
+    def test_approve_propagation_occurs_before_request_resolution_response(self, tmp_path: Path) -> None:
+        """T722: apply_approval_resolution writes the policy before marking the
+        request resolved, so the harness can re-evaluate the moment the POST
+        response arrives.
+        """
+        guard_home = tmp_path / "guard"
+        store = GuardStore(guard_home)
+        artifact = _make_artifact(name="ordered_tool", config_path=str(tmp_path / "ws/.codex/config.toml"))
+        config = GuardConfig(guard_home=guard_home, workspace=None)
+        detection = _make_detection(artifact)
+
+        eval_before = evaluate_detection(detection, store, config, persist=True)
+        approvals = queue_blocked_approvals(
+            detection=detection,
+            evaluation=eval_before,
+            store=store,
+            approval_center_url="http://127.0.0.1:6174",
+        )
+        request_id = str(approvals[0]["request_id"])
+
+        apply_approval_resolution(
+            store=store,
+            request_id=request_id,
+            action="allow",
+            scope="artifact",
+            workspace=None,
+            reason=None,
+        )
+
+        resolved = store.get_approval_request(request_id)
+        assert resolved is not None
+        assert resolved["status"] == "resolved", "Request must be marked resolved after approval"
+
+        immediate_eval = evaluate_detection(detection, store, config, persist=False)
+        assert immediate_eval.get("blocked") is False, "T722: Policy must be written before request is marked resolved"
+
+
+class TestImmediateDenyDecisionPropagation:
+    """T724: Browser deny writes decision before harness retry resumes."""
+
+    def test_deny_decision_visible_to_evaluate_without_delay(self, tmp_path: Path) -> None:
+        """T724: After apply_approval_resolution(block), re-running evaluate_detection
+        immediately returns a blocked evaluation.
+        """
+        guard_home = tmp_path / "guard"
+        store = GuardStore(guard_home)
+        artifact = _make_artifact(name="denied_tool", config_path=str(tmp_path / "ws/.codex/config.toml"))
+        config = GuardConfig(guard_home=guard_home, workspace=None)
+        detection = _make_detection(artifact)
+
+        initial_eval = evaluate_detection(detection, store, config, persist=True)
+        approvals = queue_blocked_approvals(
+            detection=detection,
+            evaluation=initial_eval,
+            store=store,
+            approval_center_url="http://127.0.0.1:6174",
+        )
+        assert len(approvals) > 0
+        request_id = str(approvals[0]["request_id"])
+
+        apply_approval_resolution(
+            store=store,
+            request_id=request_id,
+            action="block",
+            scope="artifact",
+            workspace=None,
+            reason="Not permitted by security policy",
+        )
+
+        retry_eval = evaluate_detection(detection, store, config, persist=False)
+        assert retry_eval.get("blocked") is True, "T724: Evaluation immediately after deny must be blocked"
+        artifact_result = (retry_eval.get("artifacts") or [{}])[0]
+        assert artifact_result.get("policy_action") == "block", (
+            "T724: Evaluation immediately after deny must return block policy"
+        )


### PR DESCRIPTION
## Summary

Improves the approval request deduplication in the local Guard store. Previously, deduplication only keyed on `(harness, artifact_id)`, which caused two problems:

1. Requests from different workspaces for the same artifact merged into one row
2. Requests for the same artifact but different meaningful commands (e.g., different file targets) merged into one row

## Changes

### `store_approvals.py`
- Add `normalized_identity_key` column (derived from `normalize_command_identity(launch_target)`)
- Update dedup query to key on `(harness, artifact_id, workspace, normalized_identity_key)`
- Populate `normalized_identity_key` on INSERT and UPDATE

### `store.py`
- Add `_ensure_approval_column` migration for `normalized_identity_key` (idempotent, safe for existing databases)

## Tests

- **T720** — duplicate pending requests for same artifact+workspace+command update one row
- **T719** — transient request-ID variation in command collapses to same row
- **T721** — same artifact in different workspaces creates separate rows
- **T721b** — null workspace and named workspace are treated as different
- **T719b** — different meaningful commands for same artifact+workspace create separate rows

100 existing approval store tests continue to pass.