### PR TITLE
feat(guard): approval resolution copy field, event emission, and CLI retry commands

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/approval_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/approval_commands.py
@@ -170,7 +170,8 @@ def run_approval_retry_hint_command(
         return {"error": "not_resolved", "status": status, "request_id": request_id}, 1
     resolution_action = str(item.get("resolution_action", ""))
     harness = str(item.get("harness", ""))
-    return _build_retry_hint(resolution_action, harness), 0
+    hint: dict[str, object] = dict(_build_retry_hint(resolution_action, harness))
+    return hint, 0
 
 
 def _now() -> str:

--- a/src/codex_plugin_scanner/guard/cli/approval_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/approval_commands.py
@@ -10,6 +10,19 @@ from ..approvals import apply_approval_resolution, build_runtime_snapshot
 from ..daemon import load_guard_daemon_url
 from ..store import GuardStore
 
+_HARNESS_RETRY_COPY: dict[str, str] = {
+    "codex": "Return to Codex and retry",
+    "claude-code": "Return to Claude and retry",
+    "opencode": "Return to OpenCode and retry",
+    "copilot": "Return to Copilot and retry",
+}
+_DEFAULT_RETRY_COPY = "Return to your AI assistant and retry"
+
+
+def _build_retry_hint(action: str, harness: str) -> dict[str, str]:
+    title = "Approved. Retry in chat." if action == "allow" else "Blocked. Guard will remember this decision."
+    return {"title": title, "body": _HARNESS_RETRY_COPY.get(harness, _DEFAULT_RETRY_COPY)}
+
 
 def add_approval_parser(
     guard_subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
@@ -56,6 +69,22 @@ def add_approval_parser(
     )
     add_common_args(clear_history_parser)
     clear_history_parser.add_argument("--json", action="store_true")
+
+    open_parser = approvals_subparsers.add_parser(
+        "open",
+        help="Show the approval URL for a pending request",
+    )
+    open_parser.add_argument("request_id", help="The approval request ID to open")
+    add_common_args(open_parser)
+    open_parser.add_argument("--json", action="store_true")
+
+    retry_hint_parser = approvals_subparsers.add_parser(
+        "retry-hint",
+        help="Print the retry hint for a resolved approval request",
+    )
+    retry_hint_parser.add_argument("request_id", help="The approval request ID to get the retry hint for")
+    add_common_args(retry_hint_parser)
+    retry_hint_parser.add_argument("--json", action="store_true")
 
 
 def run_approval_command(
@@ -113,6 +142,35 @@ def run_approval_command(
         now=_now(),
     )
     return {"resolved": True, "item": item}
+
+
+def run_approval_open_command(
+    args: argparse.Namespace,
+    *,
+    store: GuardStore,
+) -> tuple[dict[str, object], int]:
+    request_id = args.request_id
+    item = store.get_approval_request(request_id)
+    if item is None:
+        return {"error": "not_found", "request_id": request_id}, 1
+    return {"request_id": request_id, "approval_url": str(item.get("approval_url", ""))}, 0
+
+
+def run_approval_retry_hint_command(
+    args: argparse.Namespace,
+    *,
+    store: GuardStore,
+) -> tuple[dict[str, object], int]:
+    request_id = args.request_id
+    item = store.get_approval_request(request_id)
+    if item is None:
+        return {"error": "not_found", "request_id": request_id}, 1
+    status = str(item.get("status", ""))
+    if status != "resolved":
+        return {"error": "not_resolved", "status": status, "request_id": request_id}, 1
+    resolution_action = str(item.get("resolution_action", ""))
+    harness = str(item.get("harness", ""))
+    return _build_retry_hint(resolution_action, harness), 0
 
 
 def _now() -> str:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -109,7 +109,12 @@ from ..runtime.secret_sensitivity import (
 from ..runtime.signals import RiskSignalV2
 from ..runtime.surface_server import GuardSurfaceRuntime
 from ..store import GuardStore
-from .approval_commands import add_approval_parser, run_approval_command
+from .approval_commands import (
+    add_approval_parser,
+    run_approval_command,
+    run_approval_open_command,
+    run_approval_retry_hint_command,
+)
 from .bootstrap import DEFAULT_ALIAS_NAME, build_guard_bootstrap_payload
 from .connect_flow import (
     DEFAULT_GUARD_CONNECT_URL,
@@ -1152,6 +1157,15 @@ def run_guard_command(
         return 0
 
     if args.guard_command == "approvals":
+        approvals_command = getattr(args, "approvals_command", None)
+        if approvals_command == "open":
+            payload, exit_code = run_approval_open_command(args, store=store)
+            _emit("approvals", payload, getattr(args, "json", False))
+            return exit_code
+        if approvals_command == "retry-hint":
+            payload, exit_code = run_approval_retry_hint_command(args, store=store)
+            _emit("approvals", payload, getattr(args, "json", False))
+            return exit_code
         payload = run_approval_command(args, store=store, workspace=workspace)
         _emit("approvals", payload, getattr(args, "json", False))
         return int(payload.get("exit_code", 0))

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -580,9 +580,7 @@ def _render_approvals(console: Console, payload: dict[str, object]) -> None:
         console.print(Panel(body, title="Approval resolved", border_style="green"))
         return
     if payload.get("error"):
-        console.print(
-            Panel(str(payload.get("error")), title="Approval error", border_style="red")
-        )
+        console.print(Panel(str(payload.get("error")), title="Approval error", border_style="red"))
         return
     if "history_cleared" in payload or "cleared_policies" in payload:
         error = payload.get("error")

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -566,6 +566,24 @@ def _render_events(console: Console, payload: dict[str, object]) -> None:
 
 
 def _render_approvals(console: Console, payload: dict[str, object]) -> None:
+    approval_url = payload.get("approval_url")
+    if isinstance(approval_url, str) and approval_url:
+        body = Table.grid(padding=(0, 1))
+        body.add_row("Request", str(payload.get("request_id", "")))
+        body.add_row("URL", f"[bold]{approval_url}[/bold]")
+        console.print(Panel(body, title="Open approval", border_style="cyan"))
+        return
+    if "title" in payload and "body" in payload:
+        body = Table.grid(padding=(0, 1))
+        body.add_row("Status", str(payload["title"]))
+        body.add_row("Next step", str(payload["body"]))
+        console.print(Panel(body, title="Approval resolved", border_style="green"))
+        return
+    if payload.get("error"):
+        console.print(
+            Panel(str(payload.get("error")), title="Approval error", border_style="red")
+        )
+        return
     if "history_cleared" in payload or "cleared_policies" in payload:
         error = payload.get("error")
         body = Table.grid(padding=(0, 1))

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -456,7 +456,13 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         except ValueError as error:
             self._write_json({"resolved": False, "error": str(error)}, status=400)
             return
-        self._write_json({"resolved": True, "item": updated})
+        self.server.store.add_event(  # type: ignore[attr-defined]
+            "approval_resolved",
+            {"request_id": request_id, "action": action, "scope": scope, "harness": str(updated.get("harness", ""))},
+            _now(),
+        )
+        harness = str(updated.get("harness", ""))
+        self._write_json({"resolved": True, "item": updated, "copy": _build_resolution_copy(action, harness)})
 
     def log_message(self, fmt: str, *args: Any) -> None:
         return
@@ -1386,6 +1392,20 @@ def _approval_center_browser_url(approval_center_url: str, auth_token: str) -> s
 def _build_local_url(host: str, port: int, path: str) -> str:
     host_part = f"[{host}]" if ":" in host else host
     return f"http://{host_part}:{port}{path}"
+
+
+_HARNESS_RETRY_COPY: dict[str, str] = {
+    "codex": "Return to Codex and retry",
+    "claude-code": "Return to Claude and retry",
+    "opencode": "Return to OpenCode and retry",
+    "copilot": "Return to Copilot and retry",
+}
+_DEFAULT_RETRY_COPY = "Return to your AI assistant and retry"
+
+
+def _build_resolution_copy(action: str, harness: str) -> dict[str, str]:
+    title = "Approved. Retry in chat." if action == "allow" else "Blocked. Guard will remember this decision."
+    return {"title": title, "body": _HARNESS_RETRY_COPY.get(harness, _DEFAULT_RETRY_COPY)}
 
 
 def _now() -> str:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -456,9 +456,11 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         except ValueError as error:
             self._write_json({"resolved": False, "error": str(error)}, status=400)
             return
+        normalized_scope = scope.strip()
+        harness_str = str(updated.get("harness", ""))
         self.server.store.add_event(  # type: ignore[attr-defined]
             "approval_resolved",
-            {"request_id": request_id, "action": action, "scope": scope, "harness": str(updated.get("harness", ""))},
+            {"request_id": request_id, "action": action, "scope": normalized_scope, "harness": harness_str},
             _now(),
         )
         harness = str(updated.get("harness", ""))

--- a/tests/test_guard_approval_copy_commands.py
+++ b/tests/test_guard_approval_copy_commands.py
@@ -1,0 +1,203 @@
+"""Tests for T732-T737: harness copy rule and approval CLI commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.approvals import approval_center_hint
+from codex_plugin_scanner.guard.models import GuardApprovalRequest
+from codex_plugin_scanner.guard.store import GuardStore
+
+_KNOWN_HARNESSES = ["codex", "claude-code", "opencode", "copilot", "gemini"]
+
+
+def _make_queue_item(harness: str, request_id: str) -> dict:
+    return {
+        "request_id": request_id,
+        "harness": harness,
+        "artifact_id": f"{harness}:project:tool",
+        "artifact_name": "Test tool",
+        "policy_action": "block",
+        "recommended_scope": "artifact",
+    }
+
+
+def _make_request(
+    *,
+    request_id: str,
+    harness: str = "codex",
+    status: str = "pending",
+) -> GuardApprovalRequest:
+    return GuardApprovalRequest(
+        request_id=request_id,
+        harness=harness,
+        artifact_id=f"{harness}:project:tool",
+        artifact_name="Test tool",
+        artifact_hash="hash-abc",
+        policy_action="require-reapproval",
+        recommended_scope="artifact",
+        changed_fields=("tool_action_request",),
+        source_scope="project",
+        config_path="/tmp/config.toml",
+        review_command=f"hol-guard approvals approve {request_id}",
+        approval_url=f"http://127.0.0.1:5474/approvals/{request_id}",
+    )
+
+
+class TestHarnessBlockMessageCopyRule:
+    """T732: harness block messages must never tell users to run 'hol-guard dashboard' as primary path."""
+
+    @pytest.mark.parametrize("harness", _KNOWN_HARNESSES)
+    def test_approval_center_hint_does_not_require_manual_dashboard_launch(
+        self, tmp_path: Path, harness: str
+    ) -> None:
+        """T732: approval_center_hint must not instruct users to run 'hol-guard dashboard'."""
+        context = HarnessContext(
+            home_dir=tmp_path,
+            guard_home=tmp_path / ".hol-guard",
+            workspace_dir=tmp_path / "workspace",
+        )
+        queued = [_make_queue_item(harness, "req-rule-01")]
+        hint = approval_center_hint(
+            context=context,
+            harness=harness,
+            approval_center_url="http://127.0.0.1:5474",
+            queued=queued,
+        )
+        assert "hol-guard dashboard" not in hint, (
+            f"Harness hint for '{harness}' must not tell users to run 'hol-guard dashboard' as primary path. "
+            f"Got: {hint!r}"
+        )
+
+
+class TestBlockMessageNoDashboardLaunchRequired:
+    """T733: CLI block message must not require manual dashboard launch."""
+
+    def test_block_approval_center_hint_no_manual_dashboard_command(self, tmp_path: Path) -> None:
+        """T733: block flow copy does not contain 'hol-guard dashboard' for any harness."""
+        context = HarnessContext(
+            home_dir=tmp_path,
+            guard_home=tmp_path / ".hol-guard",
+            workspace_dir=tmp_path / "workspace",
+        )
+        for harness in _KNOWN_HARNESSES:
+            queued = [_make_queue_item(harness, f"req-t733-{harness}")]
+            hint = approval_center_hint(
+                context=context,
+                harness=harness,
+                approval_center_url="http://127.0.0.1:5474",
+                queued=queued,
+            )
+            assert "hol-guard dashboard" not in hint, (
+                f"CLI block message for '{harness}' must not say 'hol-guard dashboard'. Got: {hint!r}"
+            )
+
+
+class TestApprovalsOpenCommand:
+    """T734-T735: 'hol-guard approvals open <request_id>' command."""
+
+    def test_approvals_open_returns_approval_url_for_known_request(self, tmp_path: Path, capsys) -> None:
+        """T734: approvals open prints the approval URL for an existing pending request."""
+        home_dir = tmp_path / "guard-home"
+        store = GuardStore(home_dir)
+        store.add_approval_request(_make_request(request_id="req-open-01"), "2026-01-01T00:00:00Z")
+
+        rc = main(["guard", "approvals", "open", "req-open-01", "--home", str(home_dir), "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["request_id"] == "req-open-01"
+        assert "approval_url" in output
+
+    def test_approvals_open_returns_error_for_missing_request(self, tmp_path: Path, capsys) -> None:
+        """T735: approvals open with daemon stopped returns a clear error, not a crash."""
+        home_dir = tmp_path / "guard-home"
+
+        rc = main(["guard", "approvals", "open", "req-missing", "--home", str(home_dir), "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc != 0
+        assert "error" in output
+
+
+class TestApprovalsRetryHintCommand:
+    """T736-T737: 'hol-guard approvals retry-hint <request_id>' command."""
+
+    def test_retry_hint_allow_resolution(self, tmp_path: Path, capsys) -> None:
+        """T737: retry-hint returns allow copy after approval."""
+        home_dir = tmp_path / "guard-home"
+        store = GuardStore(home_dir)
+        store.add_approval_request(_make_request(request_id="req-hint-allow"), "2026-01-01T00:00:00Z")
+        main(
+            [
+                "guard",
+                "approvals",
+                "approve",
+                "req-hint-allow",
+                "--home",
+                str(home_dir),
+                "--scope",
+                "artifact",
+                "--json",
+            ]
+        )
+        capsys.readouterr()
+
+        rc = main(["guard", "approvals", "retry-hint", "req-hint-allow", "--home", str(home_dir), "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["title"] == "Approved. Retry in chat."
+
+    def test_retry_hint_block_resolution(self, tmp_path: Path, capsys) -> None:
+        """T737: retry-hint returns block copy after block decision."""
+        home_dir = tmp_path / "guard-home"
+        store = GuardStore(home_dir)
+        store.add_approval_request(_make_request(request_id="req-hint-block"), "2026-01-01T00:00:00Z")
+        main(
+            [
+                "guard",
+                "approvals",
+                "deny",
+                "req-hint-block",
+                "--home",
+                str(home_dir),
+                "--scope",
+                "artifact",
+                "--json",
+            ]
+        )
+        capsys.readouterr()
+
+        rc = main(["guard", "approvals", "retry-hint", "req-hint-block", "--home", str(home_dir), "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["title"] == "Blocked. Guard will remember this decision."
+
+    def test_retry_hint_missing_request(self, tmp_path: Path, capsys) -> None:
+        """T737: retry-hint with unknown request_id returns error."""
+        home_dir = tmp_path / "guard-home"
+
+        rc = main(["guard", "approvals", "retry-hint", "req-hint-missing", "--home", str(home_dir), "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc != 0
+        assert "error" in output
+
+    def test_retry_hint_pending_request(self, tmp_path: Path, capsys) -> None:
+        """T737: retry-hint with still-pending request returns not_resolved status."""
+        home_dir = tmp_path / "guard-home"
+        store = GuardStore(home_dir)
+        store.add_approval_request(_make_request(request_id="req-hint-pending"), "2026-01-01T00:00:00Z")
+
+        rc = main(["guard", "approvals", "retry-hint", "req-hint-pending", "--home", str(home_dir), "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc != 0
+        assert output.get("status") == "pending" or "error" in output

--- a/tests/test_guard_render.py
+++ b/tests/test_guard_render.py
@@ -709,3 +709,34 @@ def test_emit_guard_payload_renders_sandbox_analysis_table(capsys, monkeypatch) 
     output = capsys.readouterr().out
     assert "Sandbox analysis" in output
     assert "1 result(s)" in output
+
+
+def test_approvals_open_render_shows_url(capsys) -> None:
+    emit_guard_payload(
+        "approvals",
+        {"request_id": "req-render-01", "approval_url": "http://127.0.0.1:5474/approvals/req-render-01"},
+        False,
+    )
+    output = capsys.readouterr().out
+    assert "http://127.0.0.1:5474/approvals/req-render-01" in output
+
+
+def test_approvals_retry_hint_render_shows_title_and_body(capsys) -> None:
+    emit_guard_payload(
+        "approvals",
+        {"title": "Approved. Retry in chat.", "body": "Return to Codex and retry"},
+        False,
+    )
+    output = capsys.readouterr().out
+    assert "Approved. Retry in chat." in output
+    assert "Return to Codex and retry" in output
+
+
+def test_approvals_render_error_shows_panel(capsys) -> None:
+    emit_guard_payload(
+        "approvals",
+        {"error": "not_found", "request_id": "req-missing"},
+        False,
+    )
+    output = capsys.readouterr().out
+    assert "not_found" in output

--- a/tests/test_guard_resolution_copy.py
+++ b/tests/test_guard_resolution_copy.py
@@ -1,0 +1,146 @@
+"""Tests for T725-T731: approval resolution copy field and approval_resolved event."""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+
+import pytest
+
+from codex_plugin_scanner.guard.daemon import GuardDaemonServer
+from codex_plugin_scanner.guard.models import GuardApprovalRequest
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _make_approval_request(
+    *,
+    request_id: str,
+    harness: str = "codex",
+    artifact_id: str = "codex:project:tool",
+    workspace: str | None = None,
+) -> GuardApprovalRequest:
+    return GuardApprovalRequest(
+        request_id=request_id,
+        harness=harness,
+        artifact_id=artifact_id,
+        artifact_name="Test tool",
+        artifact_hash="hash-abc",
+        policy_action="require-reapproval",
+        recommended_scope="artifact",
+        changed_fields=("tool_action_request",),
+        source_scope="project",
+        config_path="/tmp/config.toml",
+        workspace=workspace,
+        review_command=f"hol-guard approvals approve {request_id}",
+        approval_url=f"http://127.0.0.1:5474/approvals/{request_id}",
+    )
+
+
+def _post_resolution(port: int, request_id: str, endpoint: str, token: str) -> tuple[int, dict]:
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}/v1/requests/{request_id}/{endpoint}",
+        data=json.dumps({"scope": "artifact"}).encode("utf-8"),
+        headers={"Content-Type": "application/json", "X-Guard-Token": token},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        return resp.status, json.loads(resp.read().decode("utf-8"))
+
+
+class TestApprovalResolvedEvent:
+    """T725: approval_resolved event is emitted after resolution so SSE stream picks it up."""
+
+    def test_approve_emits_approval_resolved_event(self, tmp_path) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        store.add_approval_request(_make_approval_request(request_id="req-t725-allow"), "2026-01-01T00:00:00Z")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+        try:
+            _post_resolution(daemon.port, "req-t725-allow", "approve", daemon._server.auth_token)
+            events = store.list_events(event_name="approval_resolved")
+        finally:
+            daemon.stop()
+
+        assert len(events) == 1
+        payload = events[0]["payload"]
+        assert payload["request_id"] == "req-t725-allow"
+        assert payload["action"] == "allow"
+
+    def test_block_emits_approval_resolved_event(self, tmp_path) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        store.add_approval_request(_make_approval_request(request_id="req-t725-block"), "2026-01-01T00:00:00Z")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+        try:
+            _post_resolution(daemon.port, "req-t725-block", "block", daemon._server.auth_token)
+            events = store.list_events(event_name="approval_resolved")
+        finally:
+            daemon.stop()
+
+        assert len(events) == 1
+        payload = events[0]["payload"]
+        assert payload["request_id"] == "req-t725-block"
+        assert payload["action"] == "block"
+
+
+class TestApprovalResolutionCopyTitle:
+    """T726-T727: Resolution response includes copy field with action-specific titles."""
+
+    def test_approve_response_copy_title(self, tmp_path) -> None:
+        """T726: approve response has copy.title == 'Approved. Retry in chat.'"""
+        store = GuardStore(tmp_path / "guard-home")
+        store.add_approval_request(_make_approval_request(request_id="req-t726"), "2026-01-01T00:00:00Z")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+        try:
+            _, payload = _post_resolution(daemon.port, "req-t726", "approve", daemon._server.auth_token)
+        finally:
+            daemon.stop()
+
+        assert "copy" in payload, "Resolution response must include a 'copy' field"
+        assert payload["copy"]["title"] == "Approved. Retry in chat."
+
+    def test_block_response_copy_title(self, tmp_path) -> None:
+        """T727: block response has copy.title == 'Blocked. Guard will remember this decision.'"""
+        store = GuardStore(tmp_path / "guard-home")
+        store.add_approval_request(_make_approval_request(request_id="req-t727"), "2026-01-01T00:00:00Z")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+        try:
+            _, payload = _post_resolution(daemon.port, "req-t727", "block", daemon._server.auth_token)
+        finally:
+            daemon.stop()
+
+        assert "copy" in payload, "Resolution response must include a 'copy' field"
+        assert payload["copy"]["title"] == "Blocked. Guard will remember this decision."
+
+
+class TestApprovalResolutionCopyPerHarness:
+    """T728-T731: Per-harness retry hint in copy.body."""
+
+    @pytest.mark.parametrize(
+        "harness,expected_body",
+        [
+            ("codex", "Return to Codex and retry"),
+            ("claude-code", "Return to Claude and retry"),
+            ("opencode", "Return to OpenCode and retry"),
+            ("copilot", "Return to Copilot and retry"),
+            ("unknown-harness", "Return to your AI assistant and retry"),
+        ],
+    )
+    def test_approve_copy_body_per_harness(self, tmp_path, harness: str, expected_body: str) -> None:
+        """T728-T731: copy.body contains harness-specific retry hint after approval."""
+        store = GuardStore(tmp_path / "guard-home")
+        req_id = f"req-copy-{harness}"
+        store.add_approval_request(
+            _make_approval_request(request_id=req_id, harness=harness, artifact_id=f"{harness}:project:tool"),
+            "2026-01-01T00:00:00Z",
+        )
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+        try:
+            _, payload = _post_resolution(daemon.port, req_id, "approve", daemon._server.auth_token)
+        finally:
+            daemon.stop()
+
+        assert payload["copy"]["body"] == expected_body


### PR DESCRIPTION
## Summary

Adds post-resolution UX improvements: the approval daemon now emits an `approval_resolved` event after every resolution so the dashboard SSE stream can reflect the change without a page reload. The POST resolution response now includes a `copy` field with an action-specific title and per-harness retry hint.

Two new CLI subcommands are added: `hol-guard approvals open <request_id>` and `hol-guard approvals retry-hint <request_id>`.

## Changes

### `src/codex_plugin_scanner/guard/daemon/server.py`
- Added `_HARNESS_RETRY_COPY` map and `_build_resolution_copy(action, harness)` helper
- After successful resolution, emit `approval_resolved` event via `store.add_event`
- Include `copy` field in resolution response with `title` and `body`

### `src/codex_plugin_scanner/guard/cli/approval_commands.py`
- Added `open` and `retry-hint` subparsers to the approvals parser
- Added `run_approval_open_command` and `run_approval_retry_hint_command` handlers

### `src/codex_plugin_scanner/guard/cli/commands.py`
- Wired `open` and `retry-hint` subcommands into the approvals dispatch

### `tests/test_guard_resolution_copy.py` (new)
- T725: approve and block emit `approval_resolved` event with correct payload
- T726-T727: POST response `copy.title` is action-specific
- T728-T731: `copy.body` contains harness-specific retry hint

### `tests/test_guard_approval_copy_commands.py` (new)
- T732-T733: harness block hints never say `hol-guard dashboard`
- T734-T735: `approvals open` returns approval URL or error
- T736-T737: `approvals retry-hint` returns correct copy for allow/block/pending/missing