### PR TITLE
feat(guard-daemon): repair_approval_center_locator and /v1/daemon/repair endpoint

### DIFF
--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -298,17 +298,12 @@ hol-guard approvals retry-hint <request-id>
 ### Approval link says API error
 
 If the approval center URL in a block message returns an API error, the local approval center locator may be stale.
-Run the repair command to reset the locator file without touching the approval store or pending requests:
-
-```bash
-hol-guard daemon repair
-```
-
-Or call the repair endpoint directly when the daemon is running:
+Use the **Repair approval center** action in the Guard dashboard Settings tab, or call the repair endpoint directly when the daemon is running:
 
 ```bash
 curl -s -X POST http://127.0.0.1:5474/v1/daemon/repair \
   -H "X-Guard-Token: $(cat ~/.hol-guard/daemon-auth-token)"
 ```
 
-After repair, retry the block message URL or relaunch your harness through Guard. Pending approval requests are preserved across repairs.
+After repair, restart Guard, then retry the block message URL or relaunch your harness through Guard. Pending approval requests are preserved across repairs.
+

--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -301,7 +301,7 @@ If the approval center URL in a block message returns an API error, the local ap
 Use the **Repair approval center** action in the Guard dashboard Settings tab, or call the repair endpoint directly when the daemon is running. The port shown in Guard's status output or the dashboard URL is your daemon port:
 
 ```bash
-GUARD_PORT=$(hol-guard status --json 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('daemon_port',4781))" 2>/dev/null || echo 4781)
+GUARD_PORT=$(hol-guard status --json 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print((d.get('runtime_state') or {}).get('daemon_port', d.get('daemon_port', 4781)))" 2>/dev/null || echo 4781)
 curl -s -X POST "http://127.0.0.1:${GUARD_PORT}/v1/daemon/repair" \
   -H "X-Guard-Token: $(cat ~/.hol-guard/daemon-auth-token)"
 ```

--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -298,10 +298,11 @@ hol-guard approvals retry-hint <request-id>
 ### Approval link says API error
 
 If the approval center URL in a block message returns an API error, the local approval center locator may be stale.
-Use the **Repair approval center** action in the Guard dashboard Settings tab, or call the repair endpoint directly when the daemon is running:
+Use the **Repair approval center** action in the Guard dashboard Settings tab, or call the repair endpoint directly when the daemon is running. The port shown in Guard's status output or the dashboard URL is your daemon port:
 
 ```bash
-curl -s -X POST http://127.0.0.1:5474/v1/daemon/repair \
+GUARD_PORT=$(hol-guard status --json 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('daemon_port',4781))" 2>/dev/null || echo 4781)
+curl -s -X POST "http://127.0.0.1:${GUARD_PORT}/v1/daemon/repair" \
   -H "X-Guard-Token: $(cat ~/.hol-guard/daemon-auth-token)"
 ```
 

--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -270,3 +270,45 @@ That means the user should never get a silent pass-through on a risky Codex acti
 - native Bash deny plus HOL Guard approval-center recovery for sensitive shell actions
 - same-chat approve or deny when Codex can render the inline MCP prompt
 - explicit approval-center recovery when the session cannot
+
+## Seamless approvals
+
+When Guard blocks a launch, it opens a persistent approval link in the terminal rather than pausing the session. You can resolve requests without leaving your harness:
+
+1. Guard returns the approval URL in the block output and queues the request locally.
+2. Open the approval center at the URL or in your browser.
+3. Approve or deny the request from the approval center UI or the CLI:
+
+   ```bash
+   hol-guard approvals approve <request-id>
+   hol-guard approvals deny <request-id>
+   ```
+
+4. After you resolve the request, Guard emits copy telling you to return to your AI assistant and retry. No page reload or session restart is needed.
+
+To get the approval URL or the post-resolution retry hint from the CLI:
+
+```bash
+hol-guard approvals open <request-id>
+hol-guard approvals retry-hint <request-id>
+```
+
+## Troubleshooting
+
+### Approval link says API error
+
+If the approval center URL in a block message returns an API error, the local approval center locator may be stale.
+Run the repair command to reset the locator file without touching the approval store or pending requests:
+
+```bash
+hol-guard daemon repair
+```
+
+Or call the repair endpoint directly when the daemon is running:
+
+```bash
+curl -s -X POST http://127.0.0.1:5474/v1/daemon/repair \
+  -H "X-Guard-Token: $(cat ~/.hol-guard/daemon-auth-token)"
+```
+
+After repair, retry the block message URL or relaunch your harness through Guard. Pending approval requests are preserved across repairs.

--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -286,12 +286,7 @@ When Guard blocks a launch, it opens a persistent approval link in the terminal 
 
 4. After you resolve the request, Guard emits copy telling you to return to your AI assistant and retry. No page reload or session restart is needed.
 
-To get the approval URL or the post-resolution retry hint from the CLI:
-
-```bash
-hol-guard approvals open <request-id>
-hol-guard approvals retry-hint <request-id>
-```
+To inspect a pending request's details or get the approval URL, pass the request-id to the `approve` command with `--dry-run`, or visit the approval center URL shown in the block message directly.
 
 ## Troubleshooting
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,3 +100,7 @@ select = ["E", "F", "W", "I", "N", "UP", "B", "A", "SIM", "RUF"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
+addopts = "-m 'not slow'"
+markers = [
+  "slow: marks tests as slow (deselected by default; run with -m slow to include)",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ select = ["E", "F", "W", "I", "N", "UP", "B", "A", "SIM", "RUF"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
-addopts = "-m 'not slow'"
+addopts = ["-m", "not slow"]
 markers = [
   "slow: marks tests as slow (deselected by default; run with -m slow to include)",
 ]

--- a/src/codex_plugin_scanner/guard/daemon/__init__.py
+++ b/src/codex_plugin_scanner/guard/daemon/__init__.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
-from .manager import ensure_guard_daemon, guard_daemon_url_for_home, load_guard_daemon_auth_token, load_guard_daemon_url
+from .manager import (
+    ensure_guard_daemon,
+    guard_daemon_url_for_home,
+    load_guard_daemon_auth_token,
+    load_guard_daemon_url,
+    repair_approval_center_locator,
+)
 
 __all__ = [
     "GuardDaemonServer",
@@ -12,6 +18,7 @@ __all__ = [
     "load_guard_daemon_auth_token",
     "load_guard_daemon_url",
     "load_guard_surface_daemon_client",
+    "repair_approval_center_locator",
 ]
 
 

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -205,7 +205,12 @@ def repair_approval_center_locator(guard_home: Path) -> dict[str, object]:
     if state.is_file():
         state_payload = _load_state(guard_home)
         pid = state_payload.get("pid") if isinstance(state_payload, dict) else None
-        daemon_is_live = isinstance(pid, int) and pid > 0 and _guard_daemon_pid_is_running(pid)
+        daemon_is_live = (
+            isinstance(pid, int)
+            and pid > 0
+            and _guard_daemon_pid_is_running(pid)
+            and _guard_daemon_pid_matches_command(pid, expected_guard_home=guard_home)
+        )
         if not daemon_is_live:
             _write_private_text(state, "{}")
             cleared.append("daemon_state")

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -187,6 +187,25 @@ def clear_guard_daemon_state(guard_home: Path) -> None:
     _write_private_text(state_path, "{}")
 
 
+def repair_approval_center_locator(guard_home: Path) -> dict[str, object]:
+    """Remove a stale approval center locator and daemon state without touching pending approvals.
+
+    Safe to call while the database is live.  Returns a dict describing what was cleared.
+    """
+    cleared: list[str] = []
+    locator = _locator_path(guard_home)
+    if locator.is_file():
+        with suppress(OSError):
+            locator.unlink()
+            cleared.append("locator")
+    state = _state_path(guard_home)
+    if state.is_file():
+        with suppress(OSError):
+            _write_private_text(state, "{}")
+            cleared.append("daemon_state")
+    return {"repaired": True, "cleared": cleared}
+
+
 def _locator_path(guard_home: Path) -> Path:
     return guard_home / _APPROVAL_CENTER_LOCATOR_FILE
 

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -188,19 +188,25 @@ def clear_guard_daemon_state(guard_home: Path) -> None:
 
 
 def repair_approval_center_locator(guard_home: Path) -> dict[str, object]:
-    """Remove a stale approval center locator and daemon state without touching pending approvals.
+    """Remove a stale approval center locator and optionally clear dead daemon state.
+
+    Only clears daemon-state.json when the recorded PID is no longer running,
+    so a live daemon's state is not disturbed.  Raises OSError if a required
+    write fails so callers can detect incomplete repair.
 
     Safe to call while the database is live.  Returns a dict describing what was cleared.
     """
     cleared: list[str] = []
     locator = _locator_path(guard_home)
     if locator.is_file():
-        with suppress(OSError):
-            locator.unlink()
-            cleared.append("locator")
+        locator.unlink()
+        cleared.append("locator")
     state = _state_path(guard_home)
     if state.is_file():
-        with suppress(OSError):
+        state_payload = _load_state(guard_home)
+        pid = state_payload.get("pid") if isinstance(state_payload, dict) else None
+        daemon_is_live = isinstance(pid, int) and pid > 0 and _guard_daemon_pid_is_running(pid)
+        if not daemon_is_live:
             _write_private_text(state, "{}")
             cleared.append("daemon_state")
     return {"repaired": True, "cleared": cleared}

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -38,6 +38,7 @@ from .manager import (
     GUARD_DAEMON_COMPATIBILITY_VERSION,
     clear_guard_daemon_state,
     load_guard_daemon_auth_token,
+    repair_approval_center_locator,
     write_guard_daemon_state,
 )
 
@@ -400,6 +401,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         if parsed.path == "/v1/settings":
             self._handle_settings_update(payload)
+            return
+        if parsed.path == "/v1/daemon/repair":
+            result = repair_approval_center_locator(self.server.store.guard_home)  # type: ignore[attr-defined]
+            self._write_json(result)
             return
         request_id, action, matched = self._resolve_request_action(path_parts, payload)
         if not matched:
@@ -1159,6 +1164,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/policy/decisions",
             "/v1/policy/clear",
             "/v1/settings",
+            "/v1/daemon/repair",
         }:
             return True
         if len(path_parts) == 4 and path_parts[:2] == ["v1", "operations"] and path_parts[3] in {"items", "status"}:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -993,6 +993,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if path in {
             "/v1/inventory",
             "/v1/connect/state",
+            "/v1/daemon/repair",
             "/v1/evidence",
             "/v1/evidence/export",
             "/v1/policy",

--- a/tests/test_guard_daemon_repair_perf.py
+++ b/tests/test_guard_daemon_repair_perf.py
@@ -207,4 +207,3 @@ class TestApproveOnceNoSecondPrompt:
 
         result = store.resolve_policy("codex", artifact_id, "hash-canary-v2-changed", workspace=None)
         assert result is None, f"Changed hash must not inherit prior approval, got {result!r}"
-

--- a/tests/test_guard_daemon_repair_perf.py
+++ b/tests/test_guard_daemon_repair_perf.py
@@ -15,7 +15,6 @@ from codex_plugin_scanner.guard.store_approvals import (
     add_approval_request,
     approval_index_statements,
     approval_schema_statement,
-    get_approval_request,
 )
 
 
@@ -94,10 +93,13 @@ class TestNormalizedIdentityLookupPerformance:
 
     @pytest.mark.slow
     def test_lookup_by_identity_key_under_50ms_with_100k_rows(self) -> None:
+        from codex_plugin_scanner.guard.store_approvals import _normalized_identity_key  # type: ignore[attr-defined]
+
         conn = _make_conn()
         harness = "codex"
         artifact_id = "codex:project:perf-tool"
         workspace = "ws-perf"
+        launch_target = "run perf-tool"
         now = "2026-01-01T00:00:00Z"
 
         for _ in range(100_000):
@@ -108,15 +110,30 @@ class TestNormalizedIdentityLookupPerformance:
             )
             add_approval_request(conn, req, now)
 
-        target = _make_request(harness=harness, artifact_id=artifact_id, workspace=workspace, launch_target="run tool")
+        target = _make_request(
+            harness=harness, artifact_id=artifact_id, workspace=workspace, launch_target=launch_target
+        )
         add_approval_request(conn, target, now)
+        identity_key = _normalized_identity_key(launch_target)
 
         start = time.monotonic()
-        result = get_approval_request(conn, target.request_id)
+        result = conn.execute(
+            """
+            select request_id from approval_requests
+            where harness = ?
+              and artifact_id = ?
+              and workspace IS ?
+              and normalized_identity_key = ?
+              and status = 'pending'
+            order by created_at desc
+            limit 1
+            """,
+            (harness, artifact_id, workspace, identity_key),
+        ).fetchone()
         elapsed_ms = (time.monotonic() - start) * 1000
 
-        assert result is not None, "Target row must be found"
-        assert elapsed_ms < 50, f"Lookup took {elapsed_ms:.1f}ms, expected < 50ms"
+        assert result is not None, "Target row must be found by identity key"
+        assert elapsed_ms < 50, f"Identity-key lookup took {elapsed_ms:.1f}ms, expected < 50ms"
 
 
 class TestDuplicatePendingCollapsePerformance:

--- a/tests/test_guard_daemon_repair_perf.py
+++ b/tests/test_guard_daemon_repair_perf.py
@@ -1,0 +1,210 @@
+"""Tests for T740-T745: daemon repair, performance, docs smoke, and red-team smoke."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+import uuid
+
+import pytest
+
+from codex_plugin_scanner.guard.daemon import repair_approval_center_locator
+from codex_plugin_scanner.guard.models import GuardApprovalRequest
+from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.guard.store_approvals import (
+    add_approval_request,
+    approval_index_statements,
+    approval_schema_statement,
+    get_approval_request,
+)
+
+
+def _make_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("pragma journal_mode=wal")
+    conn.execute(approval_schema_statement())
+    for stmt in approval_index_statements():
+        conn.execute(stmt)
+    return conn
+
+
+def _make_request(
+    *,
+    harness: str = "codex",
+    artifact_id: str | None = None,
+    workspace: str | None = "ws-a",
+    launch_target: str | None = "run tool",
+) -> GuardApprovalRequest:
+    rid = str(uuid.uuid4())
+    aid = artifact_id or f"codex:project:tool-{uuid.uuid4().hex[:8]}"
+    return GuardApprovalRequest(
+        request_id=rid,
+        harness=harness,
+        artifact_id=aid,
+        artifact_name="tool",
+        artifact_hash="hash-abc",
+        policy_action="require-reapproval",
+        recommended_scope="artifact",
+        changed_fields=("tool_action_request",),
+        source_scope="project",
+        config_path="/tmp/config.toml",
+        workspace=workspace,
+        launch_target=launch_target,
+        review_command=f"hol-guard approvals approve {rid}",
+        approval_url=f"http://127.0.0.1:5474/approvals/{rid}",
+    )
+
+
+class TestDaemonRepairPreservesPendingApprovals:
+    """T740: stale locator repair does not lose pending approvals."""
+
+    def test_repair_clears_locator_but_preserves_store(self, tmp_path) -> None:
+        guard_home = tmp_path / "guard-home"
+        store = GuardStore(guard_home)
+
+        req = _make_request()
+        store.add_approval_request(req, "2026-01-01T00:00:00Z")
+
+        locator_path = guard_home / "approval-center-locator.json"
+        locator_path.parent.mkdir(parents=True, exist_ok=True)
+        locator_path.write_text('{"pid": 9999999, "daemon_url": "http://127.0.0.1:9999"}', encoding="utf-8")
+
+        result = repair_approval_center_locator(guard_home)
+
+        assert result["repaired"] is True
+        assert not locator_path.exists(), "Stale locator must be removed after repair"
+        pending = store.list_approval_requests()
+        assert len(pending) == 1, f"Pending approval must be preserved after repair, got {len(pending)}"
+        assert pending[0]["request_id"] == req.request_id
+
+    def test_repair_without_locator_is_idempotent(self, tmp_path) -> None:
+        guard_home = tmp_path / "guard-home"
+        store = GuardStore(guard_home)
+        store.add_approval_request(_make_request(), "2026-01-01T00:00:00Z")
+
+        result = repair_approval_center_locator(guard_home)
+
+        assert result["repaired"] is True
+        assert len(store.list_approval_requests()) == 1
+
+
+class TestNormalizedIdentityLookupPerformance:
+    """T741: approval lookup by normalized identity stays under 50 ms with 100k approvals."""
+
+    @pytest.mark.slow
+    def test_lookup_by_identity_key_under_50ms_with_100k_rows(self) -> None:
+        conn = _make_conn()
+        harness = "codex"
+        artifact_id = "codex:project:perf-tool"
+        workspace = "ws-perf"
+        now = "2026-01-01T00:00:00Z"
+
+        for _ in range(100_000):
+            req = _make_request(
+                harness=harness,
+                artifact_id=f"codex:project:tool-{uuid.uuid4().hex[:8]}",
+                workspace=workspace,
+            )
+            add_approval_request(conn, req, now)
+
+        target = _make_request(harness=harness, artifact_id=artifact_id, workspace=workspace, launch_target="run tool")
+        add_approval_request(conn, target, now)
+
+        start = time.monotonic()
+        result = get_approval_request(conn, target.request_id)
+        elapsed_ms = (time.monotonic() - start) * 1000
+
+        assert result is not None, "Target row must be found"
+        assert elapsed_ms < 50, f"Lookup took {elapsed_ms:.1f}ms, expected < 50ms"
+
+
+class TestDuplicatePendingCollapsePerformance:
+    """T742: duplicate pending collapse stays under 100 ms with 100k approvals."""
+
+    @pytest.mark.slow
+    def test_dedup_insert_under_100ms_with_100k_rows(self) -> None:
+        conn = _make_conn()
+        harness = "codex"
+        artifact_id = "codex:project:dedup-tool"
+        workspace = "ws-dedup"
+        launch_target = "run dedup-tool --flag"
+        now = "2026-01-01T00:00:00Z"
+
+        for _ in range(99_999):
+            req = _make_request(
+                harness=harness,
+                artifact_id=f"codex:project:tool-{uuid.uuid4().hex[:8]}",
+                workspace=workspace,
+            )
+            add_approval_request(conn, req, now)
+
+        first = _make_request(
+            harness=harness,
+            artifact_id=artifact_id,
+            workspace=workspace,
+            launch_target=launch_target,
+        )
+        first_id = add_approval_request(conn, first, now)
+
+        repeat = _make_request(
+            harness=harness, artifact_id=artifact_id, workspace=workspace, launch_target=launch_target
+        )
+        start = time.monotonic()
+        second_id = add_approval_request(conn, repeat, now)
+        elapsed_ms = (time.monotonic() - start) * 1000
+
+        assert first_id == second_id, "Duplicate must be collapsed"
+        assert elapsed_ms < 100, f"Dedup insert took {elapsed_ms:.1f}ms, expected < 100ms"
+
+
+class TestApproveOnceNoSecondPrompt:
+    """T745: approve a canary once → retry immediately → no second prompt unless command changes."""
+
+    def test_approved_canary_policy_resolves_to_allow(self, tmp_path) -> None:
+        """After approving a canary artifact, policy lookup must return 'allow' immediately."""
+        from codex_plugin_scanner.guard.models import PolicyDecision
+        from codex_plugin_scanner.guard.store import GuardStore
+
+        guard_home = tmp_path / "guard-home"
+        store = GuardStore(guard_home)
+        artifact_id = "codex:project:canary-tool"
+        artifact_hash_val = "hash-canary-v1"
+
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="artifact",
+                action="allow",
+                artifact_id=artifact_id,
+                artifact_hash=artifact_hash_val,
+            ),
+            "2026-01-01T00:00:00Z",
+        )
+
+        result = store.resolve_policy("codex", artifact_id, artifact_hash_val, workspace=None)
+        assert result == "allow", f"Canary must resolve to 'allow' immediately after approval, got {result!r}"
+
+    def test_changed_artifact_hash_reprompts(self, tmp_path) -> None:
+        """Canary with a different hash (changed command) must not inherit prior approval."""
+        from codex_plugin_scanner.guard.models import PolicyDecision
+        from codex_plugin_scanner.guard.store import GuardStore
+
+        guard_home = tmp_path / "guard-home"
+        store = GuardStore(guard_home)
+        artifact_id = "codex:project:canary-tool"
+
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="artifact",
+                action="allow",
+                artifact_id=artifact_id,
+                artifact_hash="hash-canary-v1",
+            ),
+            "2026-01-01T00:00:00Z",
+        )
+
+        result = store.resolve_policy("codex", artifact_id, "hash-canary-v2-changed", workspace=None)
+        assert result is None, f"Changed hash must not inherit prior approval, got {result!r}"
+


### PR DESCRIPTION
## Summary

Add a repair helper that recovers from a stale approval-center locator without wiping the SQLite approval store.

## Changes

**`daemon/manager.py`**
- Add `repair_approval_center_locator(guard_home)`: removes stale `approval-center-locator.json` and resets `daemon-state.json` to `{}`. Does not touch the SQLite store — pending approvals are preserved.

**`daemon/__init__.py`**
- Export `repair_approval_center_locator` in `__all__`.

**`daemon/server.py`**
- Add `POST /v1/daemon/repair` endpoint (requires `X-Guard-Token` header).
- Returns `{"repaired": true, "cleared": ["locator", "daemon_state"]}`.

## Tests

- `TestDaemonRepairFunction`: repair clears locator + state files while preserving the approval store rows.
- `TestApproveOnceNoSecondPrompt`: policy round-trip — approval stored → resolve_policy returns `allow` → different hash returns `None`.