### PR TITLE
fix(guard-mcp): MCP catalog race condition, pip spec operators, absolute ref URIs

### DIFF
--- a/src/codex_plugin_scanner/guard/mcp_tool_calls.py
+++ b/src/codex_plugin_scanner/guard/mcp_tool_calls.py
@@ -451,9 +451,6 @@ def _resolve_local_schema_ref(root_schema: Mapping[str, object], reference: str)
                 return None
         return current
     if not reference.startswith("#"):
-        fragment_index = reference.find("#")
-        if fragment_index >= 0:
-            return _resolve_local_schema_ref(root_schema, reference[fragment_index:])
         return None
     anchor_name = reference[1:]
     if not anchor_name:

--- a/src/codex_plugin_scanner/guard/mcp_tool_calls.py
+++ b/src/codex_plugin_scanner/guard/mcp_tool_calls.py
@@ -451,6 +451,9 @@ def _resolve_local_schema_ref(root_schema: Mapping[str, object], reference: str)
                 return None
         return current
     if not reference.startswith("#"):
+        fragment_index = reference.find("#")
+        if fragment_index >= 0:
+            return _resolve_local_schema_ref(root_schema, reference[fragment_index:])
         return None
     anchor_name = reference[1:]
     if not anchor_name:

--- a/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
+++ b/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
@@ -186,6 +186,7 @@ class RuntimeMcpGuardProxy:
             event["decision"] = "forward-response"
             return None, event
         if method != "tools/call" or not isinstance(params, dict):
+            list_generation = self._tool_catalog_generation if method == "tools/list" else None
             response = self._forward_message(
                 message,
                 child_stdin,
@@ -195,7 +196,6 @@ class RuntimeMcpGuardProxy:
             )
             if method == "tools/list":
                 list_cursor = params.get("cursor") if isinstance(params, dict) else None
-                list_generation = self._tool_catalog_generation
                 self._capture_tools_catalog(
                     response,
                     request_cursor=list_cursor,

--- a/src/codex_plugin_scanner/guard/runtime/mcp_protection.py
+++ b/src/codex_plugin_scanner/guard/runtime/mcp_protection.py
@@ -216,7 +216,7 @@ def _command_name(value: str) -> str:
 def _split_pip_style_specifier(value: str) -> tuple[str | None, str | None]:
     if "://" in value:
         return None, None
-    for separator in ("===", "==", "=", "~=", "!=", "<=", ">=", "<", ">"):
+    for separator in ("===", "==", "~=", "!=", "<=", ">=", "<", ">", "="):
         name, matched, version = value.partition(separator)
         if not matched:
             continue


### PR DESCRIPTION
## Summary
- Snapshot `request_generation` before `_forward_message` to prevent race condition where a `tools/list_changed` notification during in-flight request bypasses catalog invalidation
- Reorder pip spec separator scan so multi-char operators (`~=`, `!=`, `<=`, `>=`) match before bare `=` — fixes `mypkg~=1.2` being split incorrectly
- Handle absolute URI `$ref` values in `_resolve_local_schema_ref` by extracting the fragment portion (e.g. `https://example.com/s.json#/$defs/X`)

## Verification
- pytest tests/test_guard_mcp_protection.py -q (68 passed)
- ruff check src/codex_plugin_scanner/guard/mcp_tool_calls.py src/codex_plugin_scanner/guard/proxy/runtime_mcp.py src/codex_plugin_scanner/guard/runtime/mcp_protection.py