### PR TITLE
feat(guard-perf): lazy detector registry cache and daemon start-lock regression tests

### DIFF
--- a/docs/guard/release-notes.md
+++ b/docs/guard/release-notes.md
@@ -1,0 +1,37 @@
+# HOL Guard Release Notes
+
+Release notes document user-visible changes, false-positive improvements, and paid-feature additions.
+Update this file for every release that touches a Guard integration path.
+
+---
+
+## Unreleased
+
+### False-positive improvements (T647)
+
+- **Supply-chain artifact fallback** — `SupplyChainRiskCard` now matches `package_request`
+  and any `*_package` artifact type in addition to the original `supply_chain` value,
+  eliminating spurious "no risk signals" cards for npm/PyPI requests.
+- **Encoded-layer count** — `DecodedLayerCard` now reads the true layer count from the
+  detector `plain_reason` field (e.g., "Decoded 3 encoding layer(s)") instead of counting
+  signal list length, so multi-layer exfil is accurately reported rather than shown as
+  "0 additional layers".
+- **Detector registry cached across hook calls** — The default detector registry is now
+  lazily initialised once per process and reused, reducing per-hook construction overhead.
+
+### Cloud advisory paid sync (T648)
+
+Advisory bundles are signed by the HOL advisory service and verified locally before use.
+The free plan receives a graceful 403 fallback with a local-only warning; no advisory data
+is sent to the server during sync. Run `hol-guard advisories sync` to pull the latest bundle.
+
+### Settings presets (T649)
+
+Four one-click security presets — **Gentle**, **Balanced**, **Strict**, and **Paranoid** —
+are available from the Settings page. Choosing a preset applies a curated `risk_actions`
+profile. Custom overrides survive a preset switch unless explicitly cleared.
+
+### Dashboard scale (T650)
+
+The approval center and evidence log now paginate at 50 items per page. Large workspaces
+with thousands of receipts will no longer cause the dashboard to stall on load.

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -8,6 +8,7 @@ import os
 import re
 import socket
 import subprocess
+import threading
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -40,8 +41,8 @@ _APPROVAL_METADATA_KEYS = (
 )
 
 
-_DEFAULT_DETECTOR_REGISTRY: tuple[object, DetectorRegistry] | None = None
-_DEFAULT_DETECTOR_REGISTRY_LOCK = __import__("threading").Lock()
+_DEFAULT_DETECTOR_REGISTRY: tuple[Callable[[], tuple[Any, ...]], DetectorRegistry] | None = None
+_DEFAULT_DETECTOR_REGISTRY_LOCK = threading.Lock()
 
 
 def _get_default_detector_registry() -> DetectorRegistry:
@@ -53,8 +54,9 @@ def _get_default_detector_registry() -> DetectorRegistry:
     with _DEFAULT_DETECTOR_REGISTRY_LOCK:
         cached = _DEFAULT_DETECTOR_REGISTRY
         if cached is None or cached[0] is not factory:
-            _DEFAULT_DETECTOR_REGISTRY = (factory, DetectorRegistry(factory()))
-    return _DEFAULT_DETECTOR_REGISTRY[1]
+            cached = (factory, DetectorRegistry(factory()))
+            _DEFAULT_DETECTOR_REGISTRY = cached
+    return cached[1]
 
 
 _PAIN_SIGNAL_EVENTS = frozenset(

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -40,8 +40,21 @@ _APPROVAL_METADATA_KEYS = (
 )
 
 
+_DEFAULT_DETECTOR_REGISTRY: tuple[object, DetectorRegistry] | None = None
+_DEFAULT_DETECTOR_REGISTRY_LOCK = __import__("threading").Lock()
+
+
 def _get_default_detector_registry() -> DetectorRegistry:
-    return DetectorRegistry(register_default_detectors())
+    global _DEFAULT_DETECTOR_REGISTRY
+    factory = register_default_detectors
+    cached = _DEFAULT_DETECTOR_REGISTRY
+    if cached is not None and cached[0] is factory:
+        return cached[1]
+    with _DEFAULT_DETECTOR_REGISTRY_LOCK:
+        cached = _DEFAULT_DETECTOR_REGISTRY
+        if cached is None or cached[0] is not factory:
+            _DEFAULT_DETECTOR_REGISTRY = (factory, DetectorRegistry(factory()))
+    return _DEFAULT_DETECTOR_REGISTRY[1]
 
 
 _PAIN_SIGNAL_EVENTS = frozenset(

--- a/tests/test_guard_daemon_manager.py
+++ b/tests/test_guard_daemon_manager.py
@@ -593,19 +593,20 @@ def test_guard_daemon_start_lock_prevents_concurrent_starts(tmp_path):
 
     events: list[str] = []
     errors: list[Exception] = []
-    release_event = threading.Event()
+    t1_entered = threading.Event()
+    release_holder = threading.Event()
 
     def holder() -> None:
         try:
             with daemon_manager_module._guard_daemon_start_lock(guard_home):
                 events.append("t1-entered")
-                release_event.wait(timeout=5)
+                t1_entered.set()
+                release_holder.wait(timeout=5)
                 events.append("t1-exited")
         except Exception as exc:
             errors.append(exc)
 
     def waiter() -> None:
-        release_event.wait(timeout=1)
         try:
             with daemon_manager_module._guard_daemon_start_lock(guard_home):
                 events.append("t2-entered")
@@ -613,13 +614,11 @@ def test_guard_daemon_start_lock_prevents_concurrent_starts(tmp_path):
             errors.append(exc)
 
     t1 = threading.Thread(target=holder)
-    t2 = threading.Thread(target=waiter)
     t1.start()
-    import time
-    time.sleep(0.1)
+    t1_entered.wait(timeout=5)
+    t2 = threading.Thread(target=waiter)
     t2.start()
-    time.sleep(0.05)
-    release_event.set()
+    release_holder.set()
     t1.join(timeout=10)
     t2.join(timeout=10)
 

--- a/tests/test_guard_daemon_manager.py
+++ b/tests/test_guard_daemon_manager.py
@@ -585,3 +585,78 @@ def test_guard_daemon_pid_matches_command_validates_guard_home_on_windows(tmp_pa
         12345,
         expected_guard_home=tmp_path / "other-home",
     )
+
+
+def test_guard_daemon_start_lock_prevents_concurrent_starts(tmp_path):
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(parents=True)
+
+    events: list[str] = []
+    errors: list[Exception] = []
+    release_event = threading.Event()
+
+    def holder() -> None:
+        try:
+            with daemon_manager_module._guard_daemon_start_lock(guard_home):
+                events.append("t1-entered")
+                release_event.wait(timeout=5)
+                events.append("t1-exited")
+        except Exception as exc:
+            errors.append(exc)
+
+    def waiter() -> None:
+        release_event.wait(timeout=1)
+        try:
+            with daemon_manager_module._guard_daemon_start_lock(guard_home):
+                events.append("t2-entered")
+        except Exception as exc:
+            errors.append(exc)
+
+    t1 = threading.Thread(target=holder)
+    t2 = threading.Thread(target=waiter)
+    t1.start()
+    import time
+    time.sleep(0.1)
+    t2.start()
+    time.sleep(0.05)
+    release_event.set()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert not errors, f"Lock worker raised: {errors}"
+    assert events.index("t1-exited") < events.index("t2-entered"), (
+        "Second thread entered before first released the lock"
+    )
+
+
+def test_guard_daemon_start_lock_file_created_and_released(tmp_path):
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(parents=True)
+    lock_path = guard_home / "daemon-start.lock"
+
+    assert not lock_path.exists()
+
+    with daemon_manager_module._guard_daemon_start_lock(guard_home):
+        assert lock_path.exists()
+
+    assert lock_path.exists()
+
+
+def test_guard_daemon_start_lock_recovers_after_exception(tmp_path):
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(parents=True)
+
+    raised = False
+    try:
+        with daemon_manager_module._guard_daemon_start_lock(guard_home):
+            raised = True
+            raise RuntimeError("simulated crash")
+    except RuntimeError:
+        pass
+
+    assert raised
+
+    acquired = False
+    with daemon_manager_module._guard_daemon_start_lock(guard_home):
+        acquired = True
+    assert acquired, "Lock was not released after exception; stale lock not recoverable"


### PR DESCRIPTION
Improves hot-path performance and adds regression tests for the daemon start lock.

Changes:
- **Lazy detector registry** (`runner.py`): `_get_default_detector_registry()` now caches the `DetectorRegistry` instance keyed by the factory function identity. First call pays the construction cost; subsequent calls return the cached instance immediately. Cache is automatically invalidated when `register_default_detectors` is monkeypatched in tests, so test isolation is preserved.

Regression tests:
- `test_guard_daemon_start_lock_prevents_concurrent_starts`: verifies thread 2 cannot enter the critical section while thread 1 holds the file lock
- `test_guard_daemon_start_lock_file_created_and_released`: verifies lock file is created on entry and remains after exit
- `test_guard_daemon_start_lock_recovers_after_exception`: verifies the lock is always released via context manager even when an exception is raised inside the block (stale lock recovery)