### PR TITLE
feat(guard): add queue continuity contract

### DIFF
--- a/dashboard/src/approval-center-layout.tsx
+++ b/dashboard/src/approval-center-layout.tsx
@@ -139,7 +139,7 @@ export function ApprovalCenterLayout(props: LayoutProps) {
           <div className="mx-auto max-w-6xl">
             {props.view === "home" ? (
               <>
-                <RuntimeBanner runtime={props.runtime} />
+                <RuntimeBanner runtime={props.runtime} inventory={props.inventory} />
                 {props.homeContent}
               </>
             ) : props.view === "evidence" ? (
@@ -168,7 +168,7 @@ export function ApprovalCenterLayout(props: LayoutProps) {
   );
 }
 
-function RuntimeBanner(props: { runtime: RuntimeState }) {
+function RuntimeBanner(props: { runtime: RuntimeState; inventory: GuardInventoryItem[] }) {
   if (props.runtime.kind === "loading") {
     return <div className="mb-6 guard-skeleton h-20 w-full" />;
   }

--- a/dashboard/src/guard-api.test.ts
+++ b/dashboard/src/guard-api.test.ts
@@ -1,8 +1,11 @@
 import {
   buildDemoRuntimeSnapshot,
+  fetchApprovalPage,
+  fetchQueueSummary,
   normalizeApprovalRequest,
   parseActionEnvelope,
-  parseDecisionV2
+  parseDecisionV2,
+  resolveRequestWithQueueResult
 } from "./guard-api";
 import { resolveCloudSyncHealthCopy } from "./runtime-overview";
 import {
@@ -403,3 +406,175 @@ const requestWithMixedSignals: GuardApprovalRequest = {
 };
 const mixedEvidence = deriveDataFlowEvidence(requestWithMixedSignals);
 assert(mixedEvidence !== null && mixedEvidence.count === 2, "T094: count reflects only data-flow signals, not unrelated ones");
+
+type RecordedFetch = {
+  url: string;
+  init?: RequestInit;
+};
+
+type StorageShape = {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+  clear(): void;
+  key(index: number): string | null;
+  readonly length: number;
+};
+
+function installGuardWindow(search: string): void {
+  const storage = new Map<string, string>();
+  const sessionStorage: StorageShape = {
+    getItem(key: string): string | null {
+      return storage.get(key) ?? null;
+    },
+    setItem(key: string, value: string): void {
+      storage.set(key, value);
+    },
+    removeItem(key: string): void {
+      storage.delete(key);
+    },
+    clear(): void {
+      storage.clear();
+    },
+    key(index: number): string | null {
+      return Array.from(storage.keys())[index] ?? null;
+    },
+    get length(): number {
+      return storage.size;
+    }
+  };
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      location: {
+        origin: "http://127.0.0.1:4174",
+        pathname: "/",
+        search,
+        hash: ""
+      },
+      sessionStorage
+    }
+  });
+}
+
+function installFetchStub(payloads: Record<string, object>): RecordedFetch[] {
+  const calls: RecordedFetch[] = [];
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = input instanceof Request ? input.url : String(input);
+    calls.push({ url, init });
+    const parsed = new URL(url, "http://127.0.0.1:4174");
+    const payload = payloads[parsed.pathname] ?? payloads[`${parsed.pathname}${parsed.search}`];
+    if (!payload) {
+      return new Response(JSON.stringify({ error: "not_found" }), { status: 404 });
+    }
+    return new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "Content-Type": "application/json" }
+    });
+  };
+  return calls;
+}
+
+function headerValue(init: RequestInit | undefined, key: string): string | null {
+  return new Headers(init?.headers).get(key);
+}
+
+const pageItem: GuardApprovalRequest = {
+  ...BASE_REQUEST,
+  request_id: "req-page",
+  harness: "copilot",
+  action_envelope_json: BASE_ENVELOPE,
+  decision_v2_json: BASE_DECISION_V2
+};
+
+installGuardWindow("?guard-token=token-queue&guardDaemon=http%3A%2F%2F127.0.0.1%3A4781");
+const fetchApprovalCalls = installFetchStub({
+  "/v1/requests": {
+    items: [pageItem],
+    next_cursor: "cursor-two",
+    total_pending_count: 3,
+    total_count: 7,
+    status: "all"
+  }
+});
+
+const approvalPage = await fetchApprovalPage({
+  status: "all",
+  harness: "copilot",
+  search: "plugin secret",
+  cursor: "cursor-one",
+  limit: 25
+});
+const approvalUrl = new URL(fetchApprovalCalls[0].url);
+
+assert(approvalUrl.origin === "http://127.0.0.1:4781", "L078: fetchApprovalPage targets local Guard daemon origin");
+assert(approvalUrl.searchParams.get("status") === "all", "L078: fetchApprovalPage forwards status filter");
+assert(approvalUrl.searchParams.get("harness") === "copilot", "L078: fetchApprovalPage forwards harness filter");
+assert(approvalUrl.searchParams.get("search") === "plugin secret", "L078: fetchApprovalPage forwards search filter");
+assert(approvalUrl.searchParams.get("cursor") === "cursor-one", "L078: fetchApprovalPage forwards cursor");
+assert(approvalUrl.searchParams.get("limit") === "25", "L078: fetchApprovalPage forwards limit");
+assert(headerValue(fetchApprovalCalls[0].init, "X-Guard-Token") === "token-queue", "L078: fetchApprovalPage sends Guard token");
+assert(approvalPage.items[0].action_envelope_json?.action_id === "act-abc123", "L078: fetchApprovalPage normalizes action envelope");
+assert(approvalPage.items[0].decision_v2_json?.user_title === "Wants to read a credential file", "L078: fetchApprovalPage normalizes decision v2");
+assert(approvalPage.next_cursor === "cursor-two", "L078: fetchApprovalPage returns next cursor");
+assert(approvalPage.total_pending_count === 3, "L078: fetchApprovalPage returns pending total");
+assert(approvalPage.total_count === 7, "L078: fetchApprovalPage returns filtered total");
+
+installGuardWindow("?guard-token=token-runtime&guardDaemon=http%3A%2F%2F127.0.0.1%3A4781");
+const fetchQueueCalls = installFetchStub({
+  "/v1/runtime": {
+    ...snapshot,
+    queue_summary: {
+      active_request_id: "req-active",
+      next_request_id: "req-next",
+      remaining_pending_count: 2,
+      next_selectable_request_id: "req-next"
+    }
+  }
+});
+
+const queueSummary = await fetchQueueSummary({ activeRequestId: "req-active" });
+const runtimeUrl = new URL(fetchQueueCalls[0].url);
+
+assert(runtimeUrl.searchParams.get("active_request_id") === "req-active", "L079: fetchQueueSummary forwards active request id");
+assert(queueSummary.remaining_pending_count === 2, "L079: fetchQueueSummary returns queue count");
+assert(queueSummary.next_selectable_request_id === "req-next", "L079: fetchQueueSummary returns next selectable id");
+
+installGuardWindow("?guard-token=token-resolve&guardDaemon=http%3A%2F%2F127.0.0.1%3A4781");
+const fetchResolveCalls = installFetchStub({
+  "/v1/requests/req-active/approve": {
+    resolved: true,
+    item: { ...pageItem, request_id: "req-active", status: "resolved" },
+    resolved_request: { ...pageItem, request_id: "req-active", status: "resolved" },
+    remaining_pending_count: 1,
+    next_selectable_request_id: "req-next",
+    remaining_pending_summaries: [{ ...pageItem, request_id: "req-next" }],
+    resolved_duplicate_ids: ["req-dupe"],
+    resolution_summary: "Decision saved. 1 blocked action remains.",
+    retry_hint: "Retry the action in your AI assistant if you approved it.",
+    copy: {
+      title: "Approved. Retry in chat.",
+      body: "Return to Copilot and retry."
+    }
+  }
+});
+
+const resolution = await resolveRequestWithQueueResult({
+  requestId: "req-active",
+  action: "allow",
+  scope: "artifact",
+  workspace: "/workspace",
+  reason: "reviewed"
+});
+const resolveBody = JSON.parse(String(fetchResolveCalls[0].init?.body)) as Record<string, unknown>;
+
+assert(fetchResolveCalls[0].url === "http://127.0.0.1:4781/v1/requests/req-active/approve", "L077: resolveRequestWithQueueResult posts to approve route");
+assert(headerValue(fetchResolveCalls[0].init, "X-Guard-Token") === "token-resolve", "L077: resolveRequestWithQueueResult sends Guard token");
+assert(resolveBody["scope"] === "artifact", "L077: resolveRequestWithQueueResult sends scope");
+assert(resolveBody["workspace"] === "/workspace", "L077: resolveRequestWithQueueResult sends workspace");
+assert(resolveBody["reason"] === "reviewed", "L077: resolveRequestWithQueueResult sends reason");
+assert(resolution.remaining_pending_count === 1, "L077: resolveRequestWithQueueResult returns remaining count");
+assert(resolution.next_selectable_request_id === "req-next", "L077: resolveRequestWithQueueResult returns next selectable id");
+assert(resolution.remaining_pending_summaries[0].request_id === "req-next", "L077: resolveRequestWithQueueResult normalizes remaining summaries");
+assert(resolution.resolved_request?.status === "resolved", "L077: resolveRequestWithQueueResult normalizes resolved request");
+assert(resolution.resolved_duplicate_ids[0] === "req-dupe", "L077: resolveRequestWithQueueResult returns duplicate ids");

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -9,11 +9,17 @@ import {
 import type {
   GuardActionEnvelope,
   GuardActionType,
+  GuardApprovalPage,
+  GuardApprovalPageFilters,
+  GuardApprovalPageStatus,
   GuardApprovalRequest,
   GuardArtifactDiff,
   GuardDecisionV2,
   GuardInventoryItem,
   GuardPolicyDecision,
+  GuardQueueResolutionCopy,
+  GuardQueueResolutionResult,
+  GuardQueueSummary,
   GuardReceipt,
   GuardRuntimeSnapshot,
   GuardSettingsPayload,
@@ -42,10 +48,27 @@ type RawGuardApprovalRequest = Omit<GuardApprovalRequest, "action_envelope_json"
 
 type ApprovalRequestListPayload = {
   items?: RawGuardApprovalRequest[] | null;
+  next_cursor?: unknown;
+  total_pending_count?: unknown;
+  total_count?: unknown;
+  status?: unknown;
 };
 
 type RuntimeSnapshotPayload = Omit<GuardRuntimeSnapshot, "items"> & {
   items?: RawGuardApprovalRequest[] | null;
+  queue_summary?: unknown;
+};
+
+type QueueResolutionPayload = Omit<
+  GuardQueueResolutionResult,
+  "item" | "resolved_request" | "remaining_pending_summaries" | "resolved_duplicate_ids" | "resolved_scope_ids" | "copy"
+> & {
+  item?: RawGuardApprovalRequest | null;
+  resolved_request?: RawGuardApprovalRequest | null;
+  remaining_pending_summaries?: RawGuardApprovalRequest[] | null;
+  resolved_duplicate_ids?: unknown;
+  resolved_scope_ids?: unknown;
+  copy?: unknown;
 };
 
 async function readJson<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
@@ -171,8 +194,16 @@ function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((item): item is string => typeof item === "string");
 }
 
+function isNonNegativeNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
+}
+
+function isApprovalPageStatus(value: unknown): value is GuardApprovalPageStatus {
+  return value === "pending" || value === "resolved" || value === "all";
 }
 
 export function parseActionEnvelope(raw: unknown): GuardActionEnvelope | null {
@@ -350,12 +381,117 @@ function normalizeApprovalRequests(items: RawGuardApprovalRequest[] | null | und
   return items.map(normalizeApprovalRequest);
 }
 
+function normalizeOptionalApprovalRequest(item: RawGuardApprovalRequest | null | undefined): GuardApprovalRequest | null {
+  return isRecord(item) ? normalizeApprovalRequest(item) : null;
+}
+
+function normalizeApprovalPage(
+  payload: ApprovalRequestListPayload,
+  statusFallback: GuardApprovalPageStatus = "pending"
+): GuardApprovalPage {
+  return {
+    items: normalizeApprovalRequests(payload.items),
+    next_cursor: isStringOrNull(payload.next_cursor) ? payload.next_cursor : null,
+    total_pending_count: isNonNegativeNumber(payload.total_pending_count) ? payload.total_pending_count : 0,
+    total_count: isNonNegativeNumber(payload.total_count) ? payload.total_count : 0,
+    status: isApprovalPageStatus(payload.status) ? payload.status : statusFallback
+  };
+}
+
+function normalizeQueueSummary(raw: unknown, pendingCount: number): GuardQueueSummary {
+  if (!isRecord(raw)) {
+    return {
+      active_request_id: null,
+      next_request_id: null,
+      remaining_pending_count: pendingCount,
+      next_selectable_request_id: null
+    };
+  }
+  const remainingPendingCount = raw["remaining_pending_count"];
+  return {
+    active_request_id: isStringOrNull(raw["active_request_id"]) ? raw["active_request_id"] : null,
+    next_request_id: isStringOrNull(raw["next_request_id"]) ? raw["next_request_id"] : null,
+    remaining_pending_count: isNonNegativeNumber(remainingPendingCount) ? remainingPendingCount : pendingCount,
+    next_selectable_request_id: isStringOrNull(raw["next_selectable_request_id"]) ? raw["next_selectable_request_id"] : null
+  };
+}
+
+function normalizeQueueCopy(raw: unknown): GuardQueueResolutionCopy | null {
+  if (!isRecord(raw)) {
+    return null;
+  }
+  const title = raw["title"];
+  const body = raw["body"];
+  if (typeof title !== "string" || typeof body !== "string") {
+    return null;
+  }
+  return { title, body };
+}
+
+function normalizeQueueResolution(payload: QueueResolutionPayload): GuardQueueResolutionResult {
+  return {
+    resolved: payload.resolved === true,
+    item: normalizeOptionalApprovalRequest(payload.item),
+    resolved_request: normalizeOptionalApprovalRequest(payload.resolved_request),
+    remaining_pending_count: isNonNegativeNumber(payload.remaining_pending_count) ? payload.remaining_pending_count : 0,
+    next_selectable_request_id: isStringOrNull(payload.next_selectable_request_id)
+      ? payload.next_selectable_request_id
+      : null,
+    remaining_pending_summaries: normalizeApprovalRequests(payload.remaining_pending_summaries),
+    resolved_duplicate_ids: isStringArray(payload.resolved_duplicate_ids) ? payload.resolved_duplicate_ids : [],
+    resolved_scope_ids: isStringArray(payload.resolved_scope_ids) ? payload.resolved_scope_ids : undefined,
+    resolution_summary: typeof payload.resolution_summary === "string" ? payload.resolution_summary : "",
+    retry_hint: isStringOrNull(payload.retry_hint) ? payload.retry_hint : null,
+    copy: normalizeQueueCopy(payload.copy)
+  };
+}
+
+function queueSearchParams(input: GuardApprovalPageFilters): URLSearchParams {
+  const params = new URLSearchParams();
+  if (input.status) {
+    params.set("status", input.status);
+  }
+  if (input.harness) {
+    params.set("harness", input.harness);
+  }
+  if (input.search) {
+    params.set("search", input.search);
+  }
+  if (input.cursor) {
+    params.set("cursor", input.cursor);
+  }
+  if (typeof input.limit === "number") {
+    params.set("limit", String(input.limit));
+  }
+  return params;
+}
+
+function queuePath(basePath: string, params: URLSearchParams): string {
+  const query = params.toString();
+  return query ? `${basePath}?${query}` : basePath;
+}
+
 export async function fetchRequests(): Promise<GuardApprovalRequest[]> {
   if (isGuardDemoMode()) {
     return getDemoRequests();
   }
-  const payload = await readJson<ApprovalRequestListPayload>("/v1/requests");
-  return normalizeApprovalRequests(payload.items);
+  const page = await fetchApprovalPage();
+  return page.items;
+}
+
+export async function fetchApprovalPage(input: GuardApprovalPageFilters = {}): Promise<GuardApprovalPage> {
+  if (isGuardDemoMode()) {
+    const items = getDemoRequests();
+    return {
+      items,
+      next_cursor: null,
+      total_pending_count: items.filter((item) => item.status === "pending").length,
+      total_count: items.length,
+      status: input.status ?? "pending"
+    };
+  }
+  const payload = await readJson<ApprovalRequestListPayload>(queuePath("/v1/requests", queueSearchParams(input)));
+  return normalizeApprovalPage(payload, input.status ?? "pending");
 }
 
 export async function fetchRuntimeSnapshot(): Promise<GuardRuntimeSnapshot> {
@@ -363,7 +499,23 @@ export async function fetchRuntimeSnapshot(): Promise<GuardRuntimeSnapshot> {
     return buildDemoRuntimeSnapshot();
   }
   const snapshot = await readJson<RuntimeSnapshotPayload>("/v1/runtime");
-  return { ...snapshot, items: normalizeApprovalRequests(snapshot.items) };
+  return {
+    ...snapshot,
+    items: normalizeApprovalRequests(snapshot.items),
+    queue_summary: normalizeQueueSummary(snapshot.queue_summary, snapshot.pending_count)
+  };
+}
+
+export async function fetchQueueSummary(input: { activeRequestId?: string } = {}): Promise<GuardQueueSummary> {
+  if (isGuardDemoMode()) {
+    return buildDemoRuntimeSnapshot().queue_summary ?? normalizeQueueSummary(null, getDemoRequests().length);
+  }
+  const params = new URLSearchParams();
+  if (input.activeRequestId) {
+    params.set("active_request_id", input.activeRequestId);
+  }
+  const snapshot = await readJson<RuntimeSnapshotPayload>(queuePath("/v1/runtime", params));
+  return normalizeQueueSummary(snapshot.queue_summary, snapshot.pending_count);
 }
 
 export function buildDemoRuntimeSnapshot(): GuardRuntimeSnapshot {
@@ -424,6 +576,12 @@ export function buildDemoRuntimeSnapshot(): GuardRuntimeSnapshot {
     fleet_url: fleetUrl,
     connect_url: connectUrl,
     items: demoRequests,
+    queue_summary: {
+      active_request_id: null,
+      next_request_id: demoRequests[0]?.request_id ?? null,
+      remaining_pending_count: demoRequests.length,
+      next_selectable_request_id: demoRequests[0]?.request_id ?? null
+    },
     latest_receipts: demoReceipts.slice(0, 10)
   };
 }
@@ -592,11 +750,32 @@ export async function resolveRequest(input: {
   workspace?: string;
   reason: string;
 }): Promise<void> {
+  await resolveRequestWithQueueResult(input);
+}
+
+export async function resolveRequestWithQueueResult(input: {
+  requestId: string;
+  action: "allow" | "block";
+  scope: string;
+  workspace?: string;
+  reason: string;
+}): Promise<GuardQueueResolutionResult> {
   if (isGuardDemoMode()) {
-    return;
+    return {
+      resolved: true,
+      item: null,
+      resolved_request: null,
+      remaining_pending_count: 0,
+      next_selectable_request_id: null,
+      remaining_pending_summaries: [],
+      resolved_duplicate_ids: [],
+      resolution_summary: "Decision saved.",
+      retry_hint: null,
+      copy: null
+    };
   }
   const actionPath = input.action === "allow" ? "approve" : "block";
-  await readJson(`/v1/requests/${encodeURIComponent(input.requestId)}/${actionPath}`, {
+  const payload = await readJson<QueueResolutionPayload>(`/v1/requests/${encodeURIComponent(input.requestId)}/${actionPath}`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -609,6 +788,7 @@ export async function resolveRequest(input: {
       reason: input.reason || undefined
     })
   });
+  return normalizeQueueResolution(payload);
 }
 
 export async function clearEvidence(): Promise<void> {
@@ -642,4 +822,3 @@ export async function repairApprovalCenter(): Promise<{ repaired: boolean; clear
   }
   return response.json() as Promise<{ repaired: boolean; cleared: string[] }>;
 }
-

--- a/dashboard/src/guard-demo.ts
+++ b/dashboard/src/guard-demo.ts
@@ -112,7 +112,8 @@ const demoDiff: GuardArtifactDiff = {
 };
 
 export function isGuardDemoMode(): boolean {
-  if (!import.meta.env.DEV) {
+  const meta = import.meta as ImportMeta & { env?: { DEV?: boolean } };
+  if (meta.env?.DEV !== true) {
     return false;
   }
   return new URLSearchParams(window.location.search).get("demo") === "1";

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -131,6 +131,55 @@ export type GuardApprovalRequest = {
   resolved_at: string | null;
   action_envelope_json?: GuardActionEnvelope | null;
   decision_v2_json?: GuardDecisionV2 | null;
+  action_identity?: string | null;
+  queue_group_id?: string | null;
+  dedupe_count?: number;
+  last_seen_at?: string | null;
+  display_status?: string;
+};
+
+export type GuardApprovalPageStatus = "pending" | "resolved" | "all";
+
+export type GuardApprovalPageFilters = {
+  status?: GuardApprovalPageStatus;
+  harness?: string;
+  search?: string;
+  cursor?: string;
+  limit?: number;
+};
+
+export type GuardApprovalPage = {
+  items: GuardApprovalRequest[];
+  next_cursor: string | null;
+  total_pending_count: number;
+  total_count: number;
+  status: GuardApprovalPageStatus;
+};
+
+export type GuardQueueSummary = {
+  active_request_id: string | null;
+  next_request_id: string | null;
+  remaining_pending_count: number;
+  next_selectable_request_id: string | null;
+};
+
+export type GuardQueueResolutionCopy = {
+  title: string;
+  body: string;
+};
+
+export type GuardQueueResolutionResult = {
+  resolved: boolean;
+  item: GuardApprovalRequest | null;
+  resolved_request: GuardApprovalRequest | null;
+  remaining_pending_count: number;
+  next_selectable_request_id: string | null;
+  remaining_pending_summaries: GuardApprovalRequest[];
+  resolved_duplicate_ids: string[];
+  resolved_scope_ids?: string[];
+  resolution_summary: string;
+  retry_hint: string | null;
+  copy: GuardQueueResolutionCopy | null;
 };
 
 export type GuardRuntimeState = {
@@ -183,6 +232,7 @@ export type GuardRuntimeSnapshot = {
   fleet_url: string;
   connect_url: string;
   items: GuardApprovalRequest[];
+  queue_summary?: GuardQueueSummary;
   latest_receipts: GuardReceipt[];
   managed_installs?: GuardManagedInstall[];
   inventory?: GuardInventoryItem[];

--- a/dashboard/src/runtime-overview.test.ts
+++ b/dashboard/src/runtime-overview.test.ts
@@ -74,7 +74,16 @@ const baseSnapshot: GuardRuntimeSnapshot = {
   cloud_state: "local_only",
   cloud_state_label: "Offline",
   cloud_state_detail: "Running locally.",
-  cloud_pairing_state: { state: "local_only", label: "Offline", detail: "No cloud." },
+  cloud_pairing_state: {
+    state: "local_only",
+    label: "Offline",
+    detail: "No cloud.",
+    sync_configured: false,
+    dashboard_url: "http://localhost:7392",
+    inbox_url: "http://localhost:7392/inbox",
+    fleet_url: "http://localhost:7392/fleet",
+    connect_url: "http://localhost:7392/connect",
+  },
   cloud_sync_health: healthDisabled,
   dashboard_url: "http://localhost:7392",
   inbox_url: "http://localhost:7392/inbox",
@@ -104,4 +113,3 @@ const repairApproval = resolveApprovalCenterHealth(noUrlSnapshot);
 assert(repairApproval.state === "repair_needed", "T738: null approval_center_url should need repair");
 assert(repairApproval.label.toLowerCase().includes("unreachable"), "T738: repair label should mention unreachable");
 assert(repairApproval.detail.toLowerCase().includes("repair"), "T738: repair detail should suggest repair action");
-

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig(({ mode }) => {
       emptyOutDir: true,
       manifest: false,
       sourcemap: false,
+      minify: false,
       rollupOptions: {
         output: {
           entryFileNames: "assets/guard-dashboard.js",

--- a/docs/guard/approval-audit.md
+++ b/docs/guard/approval-audit.md
@@ -66,3 +66,85 @@ The next scanner-side UX upgrades should focus on:
 - richer approval-center presentation
 - live update transport
 - cleaner pause or resume semantics for harnesses that cannot prompt inline
+
+## Queue API contract
+
+`GET /v1/requests` returns a paginated queue page:
+
+```json
+{
+  "items": [
+    {
+      "request_id": "req_123",
+      "harness": "codex",
+      "artifact_id": "codex:project:tool",
+      "artifact_name": "tool",
+      "artifact_type": "mcp_server",
+      "policy_action": "require-reapproval",
+      "source_scope": "project",
+      "config_path": "/workspace/.codex/config.toml",
+      "workspace": "/workspace",
+      "launch_target": "cat ~/.npmrc",
+      "risk_summary": "Shell command can read a local secret file.",
+      "risk_headline": "Secret file access",
+      "action_identity": "{\"version\":\"v1\"}",
+      "queue_group_id": "approval-group:v1:...",
+      "dedupe_count": 1,
+      "created_at": "2026-05-08T10:00:00+00:00",
+      "last_seen_at": "2026-05-08T10:00:00+00:00",
+      "display_status": "pending"
+    }
+  ],
+  "next_cursor": null,
+  "total_pending_count": 1,
+  "total_count": 1,
+  "status": "pending"
+}
+```
+
+Supported query parameters:
+
+- `status`: `pending`, `resolved`, or `all`
+- `harness`: exact harness name
+- `search`: command, prompt excerpt, MCP server/tool, path, or evidence text
+- `cursor`: cursor returned by the previous page
+- `limit`: page size, capped at 200
+
+`POST /v1/requests/<request_id>/approve` and `POST /v1/requests/<request_id>/block` return a queue-aware resolution envelope:
+
+```json
+{
+  "resolved": true,
+  "item": {
+    "request_id": "req_123",
+    "status": "resolved",
+    "resolution_action": "allow",
+    "resolution_scope": "artifact"
+  },
+  "resolved_request": {
+    "request_id": "req_123",
+    "status": "resolved"
+  },
+  "remaining_pending_count": 2,
+  "next_selectable_request_id": "req_456",
+  "remaining_pending_summaries": [],
+  "resolved_duplicate_ids": [],
+  "resolution_summary": "Decision saved. 2 blocked actions remain.",
+  "retry_hint": "Retry the action in your AI assistant if you approved it.",
+  "copy": {
+    "title": "Approved. Retry in chat.",
+    "body": "Return to Codex and retry"
+  }
+}
+```
+
+`GET /v1/runtime` includes `queue_summary` with:
+
+```json
+{
+  "active_request_id": "req_123",
+  "next_request_id": "req_123",
+  "remaining_pending_count": 3,
+  "next_selectable_request_id": "req_123"
+}
+```

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -159,11 +159,11 @@ def apply_approval_resolution(
                 raise ApprovalRequestAlreadyResolvedError(f"Approval request already resolved: {request_id}")
             if error == "not_found":
                 raise ApprovalRequestNotFoundError(f"Unknown approval request: {request_id}")
-        if resolve_scope_matches and scope in {"workspace", "publisher", "harness", "global"}:
+        if resolve_scope_matches:
             resolved_scope_ids = store.resolve_matching_approval_requests(
                 harness=resolution_harness,
                 scope=scope,
-                artifact_id=None,
+                artifact_id=str(request["artifact_id"]) if scope == "artifact" else None,
                 workspace=workspace if scope == "workspace" else None,
                 publisher=(
                     str(request["publisher"])

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -120,6 +120,8 @@ def apply_approval_resolution(
     workspace: str | None,
     reason: str | None,
     now: str | None = None,
+    return_queue_result: bool = False,
+    resolve_scope_matches: bool = True,
 ) -> dict[str, object]:
     request = store.get_approval_request(request_id)
     if request is None:
@@ -143,19 +145,56 @@ def apply_approval_resolution(
     store.upsert_policy(decision, now or _now())
     resolved_at = now or _now()
     resolution_harness = None if scope == "global" else str(request["harness"])
-    resolved_ids = store.resolve_matching_approval_requests(
-        harness=resolution_harness,
-        scope=scope,
-        artifact_id=str(request["artifact_id"]) if scope == "artifact" else None,
-        workspace=workspace if scope == "workspace" else None,
-        publisher=(
-            str(request["publisher"]) if scope == "publisher" and isinstance(request.get("publisher"), str) else None
-        ),
-        resolution_action=action,
-        resolution_scope=scope,
-        reason=reason,
-        resolved_at=resolved_at,
-    )
+    if return_queue_result:
+        result = store.resolve_request_with_queue_result(
+            request_id,
+            resolution_action=action,
+            resolution_scope=scope,
+            reason=reason,
+            resolved_at=resolved_at,
+        )
+        if result.get("resolved") is not True:
+            error = result.get("error")
+            if error == "already_resolved":
+                raise ApprovalRequestAlreadyResolvedError(f"Approval request already resolved: {request_id}")
+            if error == "not_found":
+                raise ApprovalRequestNotFoundError(f"Unknown approval request: {request_id}")
+        if resolve_scope_matches and scope in {"workspace", "publisher", "harness", "global"}:
+            resolved_scope_ids = store.resolve_matching_approval_requests(
+                harness=resolution_harness,
+                scope=scope,
+                artifact_id=None,
+                workspace=workspace if scope == "workspace" else None,
+                publisher=(
+                    str(request["publisher"])
+                    if scope == "publisher" and isinstance(request.get("publisher"), str)
+                    else None
+                ),
+                resolution_action=action,
+                resolution_scope=scope,
+                reason=reason,
+                resolved_at=resolved_at,
+            )
+            if resolved_scope_ids:
+                _refresh_queue_result(store, result, resolved_scope_ids)
+        return result
+    resolved_ids: list[str] = []
+    if resolve_scope_matches:
+        resolved_ids = store.resolve_matching_approval_requests(
+            harness=resolution_harness,
+            scope=scope,
+            artifact_id=str(request["artifact_id"]) if scope == "artifact" else None,
+            workspace=workspace if scope == "workspace" else None,
+            publisher=(
+                str(request["publisher"])
+                if scope == "publisher" and isinstance(request.get("publisher"), str)
+                else None
+            ),
+            resolution_action=action,
+            resolution_scope=scope,
+            reason=reason,
+            resolved_at=resolved_at,
+        )
     if request_id not in resolved_ids:
         store.resolve_approval_request(
             request_id,
@@ -168,6 +207,26 @@ def apply_approval_resolution(
     if updated is None:
         raise ValueError(f"Approval request disappeared: {request_id}")
     return updated
+
+
+def _refresh_queue_result(
+    store: GuardStore,
+    result: dict[str, object],
+    resolved_scope_ids: list[str],
+) -> None:
+    page = store.list_pending_approval_summaries(limit=10)
+    next_request = store.get_next_pending_request()
+    remaining_count = int(page["total_pending_count"])
+    result["remaining_pending_count"] = remaining_count
+    result["next_selectable_request_id"] = next_request["request_id"] if next_request is not None else None
+    result["remaining_pending_summaries"] = page["items"]
+    result["resolved_scope_ids"] = resolved_scope_ids
+    if remaining_count == 0:
+        result["resolution_summary"] = "Decision saved. No blocked actions remain."
+    elif remaining_count == 1:
+        result["resolution_summary"] = "Decision saved. 1 blocked action remains."
+    else:
+        result["resolution_summary"] = f"Decision saved. {remaining_count} blocked actions remain."
 
 
 def approval_center_hint(
@@ -198,8 +257,15 @@ def build_runtime_snapshot(
     now: str | None = None,
     request_limit: int = 200,
     receipt_limit: int = 25,
+    active_request_id: str | None = None,
 ) -> dict[str, object]:
     pending_requests = store.list_approval_requests(limit=request_limit)
+    queue_page = store.list_pending_approval_summaries(limit=1)
+    queue_items = queue_page["items"] if isinstance(queue_page["items"], list) else []
+    active_request = store.get_approval_request(active_request_id) if active_request_id else None
+    active_is_pending = active_request is not None and active_request.get("status") == "pending"
+    first_request_id = str(queue_items[0]["request_id"]) if queue_items else None
+    next_request_id = active_request_id if active_is_pending else first_request_id
     latest_receipts = store.list_receipts(limit=receipt_limit)
     cloud_context = _build_runtime_cloud_context(store)
     headline_state = _resolve_runtime_headline_state(
@@ -212,6 +278,13 @@ def build_runtime_snapshot(
         "approval_center_url": approval_center_url,
         "runtime_state": store.get_runtime_state(),
         "pending_count": store.count_approval_requests(),
+        "queue_summary": {
+            "active_request_id": active_request_id if active_is_pending else None,
+            "next_request_id": next_request_id,
+            "remaining_pending_count": int(queue_page["total_pending_count"]),
+            "next_selectable_request_id": next_request_id,
+        },
+        "next_request_id": next_request_id,
         "receipt_count": store.count_receipts(),
         "headline_state": headline_state,
         "headline_label": _runtime_headline_label(headline_state),

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -28,6 +28,7 @@ from ..config import editable_guard_settings, load_guard_config, update_guard_se
 from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES
 from ..runtime.surface_server import GuardSurfaceRuntime
 from ..store import GuardStore
+from ..store_approvals import InvalidApprovalCursorError
 from ..store_evidence import (
     clear_evidence,
     count_evidence,
@@ -544,13 +545,27 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         else:
             self._write_json({"error": "invalid_status"}, status=400)
             return
-        page = self.server.store.list_approval_request_page(  # type: ignore[attr-defined]
-            status=status_filter,
-            limit=limit,
-            cursor=self._query_string(query_string, "cursor"),
-            harness=self._query_string(query_string, "harness"),
-            search=self._query_string(query_string, "search"),
-        )
+        try:
+            page = self.server.store.list_approval_request_page(  # type: ignore[attr-defined]
+                status=status_filter,
+                limit=limit,
+                cursor=self._query_string(query_string, "cursor"),
+                harness=self._query_string(query_string, "harness"),
+                search=self._query_string(query_string, "search"),
+            )
+        except InvalidApprovalCursorError:
+            self._write_json(
+                {
+                    "error": "invalid_cursor",
+                    "recovery": {
+                        "code": "refresh_queue",
+                        "title": "Refresh the blocked action list.",
+                        "body": "The queue position expired. Refresh the Review Queue to continue.",
+                    },
+                },
+                status=400,
+            )
+            return
         self._write_json(page)
 
     @staticmethod

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -122,6 +122,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             snapshot = build_runtime_snapshot(
                 store=store,
                 approval_center_url=f"http://{self.server.server_address[0]}:{self.server.server_address[1]}",
+                active_request_id=self._query_string(parsed.query, "active_request_id"),
             )
             self._write_json({**snapshot, "security_level": config.security_level})
             return
@@ -181,7 +182,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json({"items": store.list_events_after(_int_query_value(parsed.query, "cursor"), limit=200)})
             return
         if parsed.path == "/v1/requests":
-            self._write_json({"items": store.list_approval_requests(limit=200)})
+            self._handle_requests_list(parsed.query)
             return
         if parsed.path == "/v1/connect/state":
             self._handle_connect_state_read(parsed.query)
@@ -426,6 +427,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 scope=scope.strip(),
                 workspace=self._optional_string(payload.get("workspace")),
                 reason=self._optional_string(payload.get("reason")),
+                return_queue_result=True,
+                resolve_scope_matches=True,
             )
         except ApprovalRequestNotFoundError:
             self._write_json(
@@ -462,14 +465,16 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json({"resolved": False, "error": str(error)}, status=400)
             return
         normalized_scope = scope.strip()
-        harness_str = str(updated.get("harness", ""))
+        item = updated.get("item")
+        harness_str = str(item.get("harness", "")) if isinstance(item, dict) else ""
         self.server.store.add_event(  # type: ignore[attr-defined]
             "approval_resolved",
             {"request_id": request_id, "action": action, "scope": normalized_scope, "harness": harness_str},
             _now(),
         )
         harness = str(updated.get("harness", ""))
-        self._write_json({"resolved": True, "item": updated, "copy": _build_resolution_copy(action, harness)})
+        updated["copy"] = _build_resolution_copy(action, harness_str or harness)
+        self._write_json(updated)
 
     def log_message(self, fmt: str, *args: Any) -> None:
         return
@@ -525,6 +530,28 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 "source": source,
             }
         )
+
+    def _handle_requests_list(self, query_string: str) -> None:
+        limit = self._query_limit(query_string, default=200, maximum=200)
+        if limit is None:
+            self._write_json({"error": "invalid_limit"}, status=400)
+            return
+        status = self._query_string(query_string, "status") or "pending"
+        if status == "all":
+            status_filter = None
+        elif status in {"pending", "resolved"}:
+            status_filter = status
+        else:
+            self._write_json({"error": "invalid_status"}, status=400)
+            return
+        page = self.server.store.list_approval_request_page(  # type: ignore[attr-defined]
+            status=status_filter,
+            limit=limit,
+            cursor=self._query_string(query_string, "cursor"),
+            harness=self._query_string(query_string, "harness"),
+            search=self._query_string(query_string, "search"),
+        )
+        self._write_json(page)
 
     @staticmethod
     def _optional_bool(value: object, *, default: bool) -> bool:
@@ -1128,6 +1155,26 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if isinstance(value, str) and value.strip():
             return value.strip()
         return None
+
+    @staticmethod
+    def _query_string(query_string: str, key: str) -> str | None:
+        value = parse_qs(query_string).get(key, [None])[-1]
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        return None
+
+    @staticmethod
+    def _query_limit(query_string: str, *, default: int, maximum: int) -> int | None:
+        raw_value = parse_qs(query_string).get("limit", [None])[-1]
+        if raw_value is None:
+            return default
+        try:
+            value = int(raw_value)
+        except (TypeError, ValueError):
+            return None
+        if value < 1:
+            return None
+        return min(value, maximum)
 
     @staticmethod
     def _scope_target_is_valid(

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -12782,9 +12782,11 @@ const demoDiff = {
   recorded_at: now
 };
 function isGuardDemoMode() {
-  {
+  const meta = import.meta;
+  if (meta.env?.DEV !== true) {
     return false;
   }
+  return new URLSearchParams(window.location.search).get("demo") === "1";
 }
 function getDemoRequests() {
   return demoRequests;
@@ -12917,6 +12919,9 @@ function isStringOrNull(value) {
 function isStringArray(value) {
   return Array.isArray(value) && value.every((item) => typeof item === "string");
 }
+function isNonNegativeNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
 function isNonEmptyString(value) {
   return typeof value === "string" && value.trim().length > 0;
 }
@@ -13044,12 +13049,62 @@ function normalizeApprovalRequests(items) {
   }
   return items.map(normalizeApprovalRequest);
 }
+function normalizeOptionalApprovalRequest(item) {
+  return isRecord(item) ? normalizeApprovalRequest(item) : null;
+}
+function normalizeQueueSummary(raw, pendingCount) {
+  if (!isRecord(raw)) {
+    return {
+      active_request_id: null,
+      next_request_id: null,
+      remaining_pending_count: pendingCount,
+      next_selectable_request_id: null
+    };
+  }
+  const remainingPendingCount = raw["remaining_pending_count"];
+  return {
+    active_request_id: isStringOrNull(raw["active_request_id"]) ? raw["active_request_id"] : null,
+    next_request_id: isStringOrNull(raw["next_request_id"]) ? raw["next_request_id"] : null,
+    remaining_pending_count: isNonNegativeNumber(remainingPendingCount) ? remainingPendingCount : pendingCount,
+    next_selectable_request_id: isStringOrNull(raw["next_selectable_request_id"]) ? raw["next_selectable_request_id"] : null
+  };
+}
+function normalizeQueueCopy(raw) {
+  if (!isRecord(raw)) {
+    return null;
+  }
+  const title = raw["title"];
+  const body = raw["body"];
+  if (typeof title !== "string" || typeof body !== "string") {
+    return null;
+  }
+  return { title, body };
+}
+function normalizeQueueResolution(payload) {
+  return {
+    resolved: payload.resolved === true,
+    item: normalizeOptionalApprovalRequest(payload.item),
+    resolved_request: normalizeOptionalApprovalRequest(payload.resolved_request),
+    remaining_pending_count: isNonNegativeNumber(payload.remaining_pending_count) ? payload.remaining_pending_count : 0,
+    next_selectable_request_id: isStringOrNull(payload.next_selectable_request_id) ? payload.next_selectable_request_id : null,
+    remaining_pending_summaries: normalizeApprovalRequests(payload.remaining_pending_summaries),
+    resolved_duplicate_ids: isStringArray(payload.resolved_duplicate_ids) ? payload.resolved_duplicate_ids : [],
+    resolved_scope_ids: isStringArray(payload.resolved_scope_ids) ? payload.resolved_scope_ids : void 0,
+    resolution_summary: typeof payload.resolution_summary === "string" ? payload.resolution_summary : "",
+    retry_hint: isStringOrNull(payload.retry_hint) ? payload.retry_hint : null,
+    copy: normalizeQueueCopy(payload.copy)
+  };
+}
 async function fetchRuntimeSnapshot() {
   if (isGuardDemoMode()) {
     return buildDemoRuntimeSnapshot();
   }
   const snapshot = await readJson("/v1/runtime");
-  return { ...snapshot, items: normalizeApprovalRequests(snapshot.items) };
+  return {
+    ...snapshot,
+    items: normalizeApprovalRequests(snapshot.items),
+    queue_summary: normalizeQueueSummary(snapshot.queue_summary, snapshot.pending_count)
+  };
 }
 function buildDemoRuntimeSnapshot() {
   const demoRequests2 = getDemoRequests();
@@ -13105,6 +13160,12 @@ function buildDemoRuntimeSnapshot() {
     fleet_url: fleetUrl,
     connect_url: connectUrl,
     items: demoRequests2,
+    queue_summary: {
+      active_request_id: null,
+      next_request_id: demoRequests2[0]?.request_id ?? null,
+      remaining_pending_count: demoRequests2.length,
+      next_selectable_request_id: demoRequests2[0]?.request_id ?? null
+    },
     latest_receipts: demoReceipts.slice(0, 10)
   };
 }
@@ -13245,11 +13306,25 @@ function fetchGuardApi(input, init) {
   return fetch(guardApiInput(input), withGuardAuth(init));
 }
 async function resolveRequest(input) {
+  await resolveRequestWithQueueResult(input);
+}
+async function resolveRequestWithQueueResult(input) {
   if (isGuardDemoMode()) {
-    return;
+    return {
+      resolved: true,
+      item: null,
+      resolved_request: null,
+      remaining_pending_count: 0,
+      next_selectable_request_id: null,
+      remaining_pending_summaries: [],
+      resolved_duplicate_ids: [],
+      resolution_summary: "Decision saved.",
+      retry_hint: null,
+      copy: null
+    };
   }
   const actionPath = input.action === "allow" ? "approve" : "block";
-  await readJson(`/v1/requests/${encodeURIComponent(input.requestId)}/${actionPath}`, {
+  const payload = await readJson(`/v1/requests/${encodeURIComponent(input.requestId)}/${actionPath}`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -13262,6 +13337,7 @@ async function resolveRequest(input) {
       reason: input.reason || void 0
     })
   });
+  return normalizeQueueResolution(payload);
 }
 async function clearEvidence() {
   if (isGuardDemoMode()) {
@@ -14567,7 +14643,7 @@ function ApprovalCenterLayout(props) {
     ),
     /* @__PURE__ */ jsxRuntimeExports.jsx(ShellSidebar, { queuedCount: queuedItems.length, activeHarness, view: props.view }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex flex-col lg:pl-64", children: /* @__PURE__ */ jsxRuntimeExports.jsx("main", { className: "flex-1 p-6 lg:p-10", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mx-auto max-w-6xl", children: props.view === "home" ? /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(RuntimeBanner, { runtime: props.runtime }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(RuntimeBanner, { runtime: props.runtime, inventory: props.inventory }),
       props.homeContent
     ] }) : props.view === "evidence" ? /* @__PURE__ */ jsxRuntimeExports.jsx(ReceiptsWorkspace, { receipts: props.receipts }) : props.view === "fleet" ? props.fleetContent : props.view === "settings" ? props.settingsContent : /* @__PURE__ */ jsxRuntimeExports.jsx(
       QueueWorkspace,

--- a/src/codex_plugin_scanner/guard/models.py
+++ b/src/codex_plugin_scanner/guard/models.py
@@ -181,6 +181,10 @@ class GuardApprovalRequest:
     action_envelope_json: dict[str, object] | None = None
     decision_v2_json: dict[str, object] | None = None
     fallback_cli_command: str | None = None
+    action_identity: str | None = None
+    queue_group_id: str | None = None
+    dedupe_count: int = 1
+    last_seen_at: str | None = None
 
     def to_dict(self) -> dict[str, object]:
         payload = asdict(self)

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -726,7 +726,9 @@ class GuardStore:
             self._ensure_approval_column(connection, "dedupe_count", "integer not null default 1")
             self._ensure_approval_column(connection, "last_seen_at", "text")
             self._ensure_approval_column(connection, "fallback_cli_command", "text")
-            backfill_approval_queue_columns(connection)
+            if not self._schema_version_applied(connection, version=3):
+                backfill_approval_queue_columns(connection)
+                self._record_schema_version(connection, version=3)
             for idx_stmt in approval_index_statements():
                 connection.execute(idx_stmt)
             self._ensure_attachment_column(connection, "lease_id", "text not null default ''")
@@ -775,6 +777,14 @@ class GuardStore:
             """,
             (version, _now()),
         )
+
+    @staticmethod
+    def _schema_version_applied(connection: sqlite3.Connection, *, version: int) -> bool:
+        row = connection.execute(
+            "select 1 from schema_migrations where version = ?",
+            (version,),
+        ).fetchone()
+        return row is not None
 
     @staticmethod
     def _ensure_local_device(connection: sqlite3.Connection) -> None:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -26,7 +26,9 @@ from .store_approvals import (
     add_approval_request as persist_approval_request,
 )
 from .store_approvals import (
+    approval_index_statements,
     approval_schema_statement,
+    backfill_approval_queue_columns,
 )
 from .store_approvals import (
     count_approval_requests as count_pending_approval_requests,
@@ -35,10 +37,28 @@ from .store_approvals import (
     get_approval_request as load_approval_request,
 )
 from .store_approvals import (
+    get_next_pending_request as load_next_pending_request,
+)
+from .store_approvals import (
+    list_approval_request_page as load_approval_request_page,
+)
+from .store_approvals import (
     list_approval_requests as load_approval_requests,
 )
 from .store_approvals import (
+    list_pending_approval_summaries as load_pending_approval_summaries,
+)
+from .store_approvals import (
     resolve_approval_request as persist_approval_resolution,
+)
+from .store_approvals import (
+    resolve_matching_duplicate_requests as persist_duplicate_resolutions,
+)
+from .store_approvals import (
+    resolve_one_request_only as persist_one_resolution,
+)
+from .store_approvals import (
+    resolve_request_with_queue_result as persist_queue_resolution,
 )
 from .store_connect import (
     build_connect_request as build_pending_connect_request,
@@ -87,6 +107,7 @@ from .types import CapabilitySet
 _SYNC_TOKEN_REF = "guard-cloud-token"
 _SYNC_TOKEN_HASH_KEY = "token_sha256"
 _DEVICE_ROW_KEY = "local-device"
+_MAX_RESOLVED_SCOPE_IDS = 200
 
 
 def _token_sha256(value: str) -> str:
@@ -700,7 +721,14 @@ class GuardStore:
             self._ensure_approval_column(connection, "decision_v2_json", "text")
             self._ensure_approval_column(connection, "workspace", "text")
             self._ensure_approval_column(connection, "normalized_identity_key", "text")
+            self._ensure_approval_column(connection, "action_identity", "text")
+            self._ensure_approval_column(connection, "queue_group_id", "text")
+            self._ensure_approval_column(connection, "dedupe_count", "integer not null default 1")
+            self._ensure_approval_column(connection, "last_seen_at", "text")
             self._ensure_approval_column(connection, "fallback_cli_command", "text")
+            backfill_approval_queue_columns(connection)
+            for idx_stmt in approval_index_statements():
+                connection.execute(idx_stmt)
             self._ensure_attachment_column(connection, "lease_id", "text not null default ''")
             self._ensure_attachment_column(connection, "lease_expires_at", "text")
             self._ensure_local_device(connection)
@@ -1510,13 +1538,62 @@ class GuardStore:
         status: str | None = "pending",
         harness: str | None = None,
         limit: int | None = 50,
+        cursor: str | None = None,
+        search: str | None = None,
     ) -> list[dict[str, object]]:
         with self._connect() as connection:
-            return load_approval_requests(connection, status=status, harness=harness, limit=limit)
+            return load_approval_requests(
+                connection,
+                status=status,
+                harness=harness,
+                limit=limit,
+                cursor=cursor,
+                search=search,
+            )
+
+    def list_pending_approval_summaries(
+        self,
+        *,
+        limit: int = 50,
+        cursor: str | None = None,
+        harness: str | None = None,
+        search: str | None = None,
+    ) -> dict[str, object]:
+        with self._connect() as connection:
+            return load_pending_approval_summaries(
+                connection,
+                limit=limit,
+                cursor=cursor,
+                harness=harness,
+                search=search,
+            )
+
+    def list_approval_request_page(
+        self,
+        *,
+        status: str | None = "pending",
+        limit: int = 50,
+        cursor: str | None = None,
+        harness: str | None = None,
+        search: str | None = None,
+    ) -> dict[str, object]:
+        with self._connect() as connection:
+            return load_approval_request_page(
+                connection,
+                status=status,
+                limit=limit,
+                cursor=cursor,
+                harness=harness,
+                search=search,
+            )
 
     def get_approval_request(self, request_id: str) -> dict[str, object] | None:
         with self._connect() as connection:
             return load_approval_request(connection, request_id)
+
+    def get_next_pending_request(self, *, exclude_ids: set[str] | None = None) -> dict[str, object] | None:
+        with self._connect() as connection:
+            return load_next_pending_request(connection, exclude_ids=exclude_ids)
 
     def resolve_approval_request(
         self,
@@ -1537,10 +1614,69 @@ class GuardStore:
                 resolved_at=resolved_at,
             )
 
+    def resolve_one_request_only(
+        self,
+        request_id: str,
+        *,
+        resolution_action: str,
+        resolution_scope: str,
+        reason: str | None,
+        resolved_at: str,
+    ) -> bool:
+        with self._connect() as connection:
+            return persist_one_resolution(
+                connection,
+                request_id,
+                resolution_action=resolution_action,
+                resolution_scope=resolution_scope,
+                reason=reason,
+                resolved_at=resolved_at,
+            )
+
+    def resolve_matching_duplicate_requests(
+        self,
+        *,
+        queue_group_id: str | None,
+        request_id: str,
+        resolution_action: str,
+        resolution_scope: str,
+        reason: str | None,
+        resolved_at: str,
+    ) -> list[str]:
+        with self._connect() as connection:
+            return persist_duplicate_resolutions(
+                connection,
+                queue_group_id=queue_group_id,
+                request_id=request_id,
+                resolution_action=resolution_action,
+                resolution_scope=resolution_scope,
+                reason=reason,
+                resolved_at=resolved_at,
+            )
+
+    def resolve_request_with_queue_result(
+        self,
+        request_id: str,
+        *,
+        resolution_action: str,
+        resolution_scope: str,
+        reason: str | None,
+        resolved_at: str,
+    ) -> dict[str, object]:
+        with self._connect() as connection:
+            return persist_queue_resolution(
+                connection,
+                request_id,
+                resolution_action=resolution_action,
+                resolution_scope=resolution_scope,
+                reason=reason,
+                resolved_at=resolved_at,
+            )
+
     def resolve_matching_approval_requests(
         self,
         *,
-        harness: str,
+        harness: str | None,
         scope: str,
         artifact_id: str | None,
         workspace: str | None,
@@ -1550,27 +1686,74 @@ class GuardStore:
         reason: str | None,
         resolved_at: str,
     ) -> list[str]:
-        pending = self.list_approval_requests(status="pending", harness=harness, limit=None)
-        resolved_ids: list[str] = []
-        for item in pending:
-            if not self._matches_scope(
-                item,
-                scope=scope,
-                artifact_id=artifact_id,
-                workspace=workspace,
-                publisher=publisher,
-            ):
-                continue
-            request_id = str(item["request_id"])
-            self.resolve_approval_request(
-                request_id,
-                resolution_action=resolution_action,
-                resolution_scope=resolution_scope,
-                reason=reason,
-                resolved_at=resolved_at,
+        conditions, params = self._approval_scope_conditions(
+            harness=harness,
+            scope=scope,
+            artifact_id=artifact_id,
+            workspace=workspace,
+            publisher=publisher,
+        )
+        if conditions is None:
+            return []
+        where_clause = " and ".join(["status = 'pending'", *conditions])
+        with self._connect() as connection:
+            rows = connection.execute(
+                f"""
+                select request_id
+                from approval_requests
+                where {where_clause}
+                order by last_seen_at desc, request_id desc
+                limit ?
+                """,
+                (*params, _MAX_RESOLVED_SCOPE_IDS),
+            ).fetchall()
+            connection.execute(
+                f"""
+                update approval_requests
+                set status = 'resolved',
+                    resolution_action = ?,
+                    resolution_scope = ?,
+                    reason = ?,
+                    resolved_at = ?
+                where {where_clause}
+                """,
+                (resolution_action, resolution_scope, reason, resolved_at, *params),
             )
-            resolved_ids.append(request_id)
-        return resolved_ids
+        return [str(row["request_id"]) for row in rows]
+
+    @staticmethod
+    def _approval_scope_conditions(
+        *,
+        harness: str | None,
+        scope: str,
+        artifact_id: str | None,
+        workspace: str | None,
+        publisher: str | None,
+    ) -> tuple[list[str] | None, tuple[object, ...]]:
+        if scope == "global":
+            return [], ()
+        if scope == "harness":
+            if harness is None:
+                return None, ()
+            return ["harness = ?"], (harness,)
+        if scope == "artifact":
+            if harness is None or artifact_id is None:
+                return None, ()
+            return ["harness = ?", "artifact_id = ?"], (harness, artifact_id)
+        if scope == "publisher":
+            if harness is None or publisher is None:
+                return None, ()
+            return ["harness = ?", "publisher = ?"], (harness, publisher)
+        if scope == "workspace":
+            if harness is None or workspace is None:
+                return None, ()
+            workspace_prefix = f"{workspace.rstrip('/')}/%"
+            return ["harness = ?", "(config_path = ? or config_path like ?)"], (
+                harness,
+                workspace,
+                workspace_prefix,
+            )
+        return None, ()
 
     @staticmethod
     def _matches_scope(
@@ -1594,9 +1777,18 @@ class GuardStore:
             return _path_within_workspace(config_path, workspace)
         return False
 
-    def count_approval_requests(self, *, status: str | None = "pending") -> int:
+    def count_approval_requests(
+        self,
+        *,
+        status: str | None = "pending",
+        harness: str | None = None,
+        search: str | None = None,
+    ) -> int:
         with self._connect() as connection:
-            return count_pending_approval_requests(connection, status=status)
+            return count_pending_approval_requests(connection, status=status, harness=harness, search=search)
+
+    def count_pending_requests(self, *, harness: str | None = None, search: str | None = None) -> int:
+        return self.count_approval_requests(status="pending", harness=harness, search=search)
 
     def clear_approval_requests(self, *, harness: str | None = None, status: str | None = None) -> int:
         conditions: list[str] = []

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -108,6 +108,7 @@ _SYNC_TOKEN_REF = "guard-cloud-token"
 _SYNC_TOKEN_HASH_KEY = "token_sha256"
 _DEVICE_ROW_KEY = "local-device"
 _MAX_RESOLVED_SCOPE_IDS = 200
+_SQLITE_ID_BATCH_SIZE = 500
 
 
 def _token_sha256(value: str) -> str:
@@ -1696,6 +1697,17 @@ class GuardStore:
         reason: str | None,
         resolved_at: str,
     ) -> list[str]:
+        if scope == "workspace":
+            if harness is None or workspace is None:
+                return []
+            return self._resolve_workspace_matching_approval_requests(
+                harness=harness,
+                workspace=workspace,
+                resolution_action=resolution_action,
+                resolution_scope=resolution_scope,
+                reason=reason,
+                resolved_at=resolved_at,
+            )
         conditions, params = self._approval_scope_conditions(
             harness=harness,
             scope=scope,
@@ -1755,15 +1767,51 @@ class GuardStore:
                 return None, ()
             return ["harness = ?", "publisher = ?"], (harness, publisher)
         if scope == "workspace":
-            if harness is None or workspace is None:
-                return None, ()
-            workspace_prefix = f"{workspace.rstrip('/')}/%"
-            return ["harness = ?", "(config_path = ? or config_path like ?)"], (
-                harness,
-                workspace,
-                workspace_prefix,
-            )
+            return None, ()
         return None, ()
+
+    def _resolve_workspace_matching_approval_requests(
+        self,
+        *,
+        harness: str,
+        workspace: str,
+        resolution_action: str,
+        resolution_scope: str,
+        reason: str | None,
+        resolved_at: str,
+    ) -> list[str]:
+        with self._connect() as connection:
+            connection.execute("begin immediate")
+            rows = connection.execute(
+                """
+                select request_id, config_path
+                from approval_requests
+                where status = 'pending'
+                  and harness = ?
+                order by last_seen_at desc, request_id desc
+                """,
+                (harness,),
+            ).fetchall()
+            matching_ids = [
+                str(row["request_id"])
+                for row in rows
+                if _path_within_workspace(str(row["config_path"]), workspace)
+            ]
+            for chunk in _chunks(matching_ids, _SQLITE_ID_BATCH_SIZE):
+                placeholders = ", ".join("?" for _ in chunk)
+                connection.execute(
+                    f"""
+                    update approval_requests
+                    set status = 'resolved',
+                        resolution_action = ?,
+                        resolution_scope = ?,
+                        reason = ?,
+                        resolved_at = ?
+                    where request_id in ({placeholders})
+                    """,
+                    (resolution_action, resolution_scope, reason, resolved_at, *chunk),
+                )
+        return matching_ids[:_MAX_RESOLVED_SCOPE_IDS]
 
     @staticmethod
     def _matches_scope(
@@ -2955,9 +3003,23 @@ class GuardStore:
 
 
 def _path_within_workspace(config_path: str, workspace: str) -> bool:
-    config_path_obj = Path(config_path)
-    workspace_path_obj = Path(workspace)
-    return config_path_obj == workspace_path_obj or workspace_path_obj in config_path_obj.parents
+    normalized_config = _normalized_workspace_path(config_path)
+    normalized_workspace = _normalized_workspace_path(workspace)
+    if not normalized_config or not normalized_workspace:
+        return False
+    return normalized_config == normalized_workspace or normalized_config.startswith(f"{normalized_workspace}/")
+
+
+def _normalized_workspace_path(value: str) -> str:
+    normalized = value.strip().replace("\\", "/").rstrip("/")
+    if len(normalized) >= 2 and normalized[1] == ":":
+        normalized = normalized.lower()
+    return normalized
+
+
+def _chunks(values: list[str], size: int) -> Iterator[list[str]]:
+    for index in range(0, len(values), size):
+        yield values[index : index + size]
 
 
 def _now() -> str:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -3005,11 +3005,15 @@ def _path_within_workspace(config_path: str, workspace: str) -> bool:
     normalized_workspace = _normalized_workspace_path(workspace)
     if not normalized_config or not normalized_workspace:
         return False
+    if normalized_workspace == "/":
+        return normalized_config.startswith("/")
     return normalized_config == normalized_workspace or normalized_config.startswith(f"{normalized_workspace}/")
 
 
 def _normalized_workspace_path(value: str) -> str:
-    normalized = value.strip().replace("\\", "/").rstrip("/")
+    normalized = value.strip().replace("\\", "/")
+    while len(normalized) > 1 and normalized.endswith("/"):
+        normalized = normalized[:-1]
     if len(normalized) >= 2 and normalized[1] == ":":
         normalized = normalized.lower()
     return normalized

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1793,9 +1793,7 @@ class GuardStore:
                 (harness,),
             ).fetchall()
             matching_ids = [
-                str(row["request_id"])
-                for row in rows
-                if _path_within_workspace(str(row["config_path"]), workspace)
+                str(row["request_id"]) for row in rows if _path_within_workspace(str(row["config_path"]), workspace)
             ]
             for chunk in _chunks(matching_ids, _SQLITE_ID_BATCH_SIZE):
                 placeholders = ", ".join("?" for _ in chunk)

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -15,6 +15,10 @@ APPROVAL_QUEUE_BACKFILL_BATCH_SIZE = 500
 _QUEUE_IDENTITY_VERSION = "v1"
 
 
+class InvalidApprovalCursorError(ValueError):
+    pass
+
+
 def _normalized_identity_key(launch_target: str | None) -> str:
     return normalize_command_identity(launch_target or "")
 
@@ -342,13 +346,14 @@ def list_approval_requests(
         clauses.append("harness = ?")
         params.append(harness)
     if before_cursor is not None:
-        clauses.append("created_at < ?")
+        clauses.append("last_seen_at < ?")
         params.append(before_cursor)
     if cursor is not None:
         marker = _decode_page_cursor(cursor)
-        if marker is not None:
-            clauses.append("(last_seen_at < ? or (last_seen_at = ? and request_id < ?))")
-            params.extend([marker["last_seen_at"], marker["last_seen_at"], marker["request_id"]])
+        if marker is None:
+            raise InvalidApprovalCursorError("invalid approval queue cursor")
+        clauses.append("(last_seen_at < ? or (last_seen_at = ? and request_id < ?))")
+        params.extend([marker["last_seen_at"], marker["last_seen_at"], marker["request_id"]])
     if created_after is not None:
         clauses.append("created_at > ?")
         params.append(created_after)

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -11,7 +11,7 @@ from .models import GuardApprovalRequest
 from .runtime.action_identity import normalize_command_identity
 
 MAX_APPROVAL_PAGE_LIMIT = 200
-MAX_RESOLVED_DUPLICATE_IDS = 200
+APPROVAL_QUEUE_BACKFILL_BATCH_SIZE = 500
 _QUEUE_IDENTITY_VERSION = "v1"
 
 
@@ -660,6 +660,7 @@ def resolve_request_with_queue_result(
     reason: str | None,
     resolved_at: str,
 ) -> dict[str, object]:
+    _begin_immediate(connection)
     request = get_approval_request(connection, request_id)
     if request is None:
         return _unresolved_queue_result(connection, error="not_found")
@@ -703,46 +704,52 @@ def resolve_request_with_queue_result(
 
 
 def backfill_approval_queue_columns(connection: sqlite3.Connection) -> None:
-    rows = connection.execute(
-        """
-        select request_id, harness, artifact_id, workspace, launch_target, action_envelope_json,
-               action_identity, queue_group_id, dedupe_count, last_seen_at, created_at
-        from approval_requests
-        where action_identity is null
-           or queue_group_id is null
-           or last_seen_at is null
-           or dedupe_count is null
-           or dedupe_count < 1
-        """
-    ).fetchall()
-    for row in rows:
-        action_identity = row["action_identity"] or _build_action_identity(
-            launch_target=row["launch_target"],
-            action_envelope=_optional_json_object(row["action_envelope_json"]),
-        )
-        queue_group_id = row["queue_group_id"] or _build_queue_group_id(
-            harness=str(row["harness"]),
-            workspace=row["workspace"],
-            artifact_id=str(row["artifact_id"]),
-            action_identity=str(action_identity),
-        )
-        connection.execute(
+    while True:
+        rows = connection.execute(
             """
-            update approval_requests
-            set action_identity = ?,
-                queue_group_id = ?,
-                dedupe_count = ?,
-                last_seen_at = ?
-            where request_id = ?
+            select request_id, harness, artifact_id, workspace, launch_target, action_envelope_json,
+                   action_identity, queue_group_id, dedupe_count, last_seen_at, created_at
+            from approval_requests
+            where action_identity is null
+               or queue_group_id is null
+               or last_seen_at is null
+               or dedupe_count is null
+               or dedupe_count < 1
+            order by created_at asc, request_id asc
+            limit ?
             """,
-            (
-                action_identity,
-                queue_group_id,
-                max(1, int(row["dedupe_count"] or 1)),
-                row["last_seen_at"] or row["created_at"],
-                row["request_id"],
-            ),
-        )
+            (APPROVAL_QUEUE_BACKFILL_BATCH_SIZE,),
+        ).fetchall()
+        if not rows:
+            return
+        for row in rows:
+            action_identity = row["action_identity"] or _build_action_identity(
+                launch_target=row["launch_target"],
+                action_envelope=_optional_json_object(row["action_envelope_json"]),
+            )
+            queue_group_id = row["queue_group_id"] or _build_queue_group_id(
+                harness=str(row["harness"]),
+                workspace=row["workspace"],
+                artifact_id=str(row["artifact_id"]),
+                action_identity=str(action_identity),
+            )
+            connection.execute(
+                """
+                update approval_requests
+                set action_identity = ?,
+                    queue_group_id = ?,
+                    dedupe_count = ?,
+                    last_seen_at = ?
+                where request_id = ?
+                """,
+                (
+                    action_identity,
+                    queue_group_id,
+                    max(1, int(row["dedupe_count"] or 1)),
+                    row["last_seen_at"] or row["created_at"],
+                    row["request_id"],
+                ),
+            )
 
 
 def resolve_matching_duplicate_requests(
@@ -757,6 +764,7 @@ def resolve_matching_duplicate_requests(
 ) -> list[str]:
     if queue_group_id is None:
         return []
+    _begin_immediate(connection)
     rows = connection.execute(
         """
         select request_id
@@ -765,9 +773,8 @@ def resolve_matching_duplicate_requests(
           and request_id != ?
           and status = 'pending'
         order by last_seen_at desc, request_id desc
-        limit ?
         """,
-        (queue_group_id, request_id, MAX_RESOLVED_DUPLICATE_IDS),
+        (queue_group_id, request_id),
     ).fetchall()
     connection.execute(
         """

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -2,15 +2,99 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import json
 import sqlite3
 
 from .models import GuardApprovalRequest
 from .runtime.action_identity import normalize_command_identity
 
+MAX_APPROVAL_PAGE_LIMIT = 200
+MAX_RESOLVED_DUPLICATE_IDS = 200
+_QUEUE_IDENTITY_VERSION = "v1"
+
 
 def _normalized_identity_key(launch_target: str | None) -> str:
     return normalize_command_identity(launch_target or "")
+
+
+def _begin_immediate(connection: sqlite3.Connection) -> None:
+    if connection.in_transaction:
+        return
+    connection.execute("begin immediate")
+
+
+def approval_queue_identity_for_request(request: GuardApprovalRequest) -> tuple[str, str]:
+    action_identity = request.action_identity or _build_action_identity(
+        launch_target=request.launch_target,
+        action_envelope=request.action_envelope_json,
+    )
+    queue_group_id = request.queue_group_id or _build_queue_group_id(
+        harness=request.harness,
+        workspace=request.workspace,
+        artifact_id=request.artifact_id,
+        action_identity=action_identity,
+    )
+    return action_identity, queue_group_id
+
+
+def _build_action_identity(
+    *,
+    launch_target: str | None,
+    action_envelope: dict[str, object] | None,
+) -> str:
+    envelope = action_envelope or {}
+    command = _optional_text(envelope.get("command")) or launch_target or ""
+    payload = {
+        "version": _QUEUE_IDENTITY_VERSION,
+        "action_type": _optional_text(envelope.get("action_type")),
+        "tool_name": _optional_text(envelope.get("tool_name")),
+        "command": normalize_command_identity(command),
+        "prompt_excerpt": _optional_text(envelope.get("prompt_excerpt")),
+        "target_paths": _string_sequence(envelope.get("target_paths")),
+        "network_hosts": _string_sequence(envelope.get("network_hosts")),
+        "mcp_server": _optional_text(envelope.get("mcp_server")),
+        "mcp_tool": _optional_text(envelope.get("mcp_tool")),
+        "package_manager": _optional_text(envelope.get("package_manager")),
+        "package_name": _optional_text(envelope.get("package_name")),
+        "script_name": _optional_text(envelope.get("script_name")),
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def _build_queue_group_id(
+    *,
+    harness: str,
+    workspace: str | None,
+    artifact_id: str,
+    action_identity: str,
+) -> str:
+    payload = json.dumps(
+        {
+            "version": _QUEUE_IDENTITY_VERSION,
+            "harness": harness,
+            "workspace": workspace,
+            "artifact_id": artifact_id,
+            "action_identity": action_identity,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return f"approval-group:{_QUEUE_IDENTITY_VERSION}:{digest}"
+
+
+def _optional_text(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _string_sequence(value: object) -> list[str]:
+    if not isinstance(value, list | tuple):
+        return []
+    return sorted(str(item) for item in value if isinstance(item, str) and item.strip())
 
 
 def approval_schema_statement() -> str:
@@ -28,11 +112,15 @@ def approval_schema_statement() -> str:
           changed_fields_json text not null,
           source_scope text not null,
           config_path text not null,
-          workspace text,
-          launch_target text,
-          normalized_identity_key text,
-          transport text,
-          risk_summary text,
+           workspace text,
+           launch_target text,
+           normalized_identity_key text,
+           action_identity text,
+           queue_group_id text,
+           dedupe_count integer not null default 1,
+           last_seen_at text,
+           transport text,
+           risk_summary text,
           risk_signals_json text not null default '[]',
           artifact_label text,
           source_label text,
@@ -56,21 +144,36 @@ def approval_schema_statement() -> str:
 
 
 def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalRequest, now: str) -> str:
+    _begin_immediate(connection)
     identity_key = _normalized_identity_key(request.launch_target)
+    action_identity, queue_group_id = approval_queue_identity_for_request(request)
     existing = connection.execute(
         """
+        select request_id
+        from approval_requests
+        where queue_group_id = ?
+          and status = 'pending'
+        order by last_seen_at desc, request_id desc
+        limit 1
+        """,
+        (queue_group_id,),
+    ).fetchone()
+    if existing is None:
+        existing = connection.execute(
+            """
         select request_id
         from approval_requests
         where harness = ?
           and artifact_id = ?
           and workspace IS ?
           and normalized_identity_key = ?
+          and queue_group_id IS NULL
           and status = 'pending'
         order by created_at desc
         limit 1
         """,
-        (request.harness, request.artifact_id, request.workspace, identity_key),
-    ).fetchone()
+            (request.harness, request.artifact_id, request.workspace, identity_key),
+        ).fetchone()
     if existing is None:
         existing = connection.execute(
             """
@@ -81,6 +184,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
               and workspace IS ?
               and launch_target IS ?
               and normalized_identity_key IS NULL
+              and queue_group_id IS NULL
               and status = 'pending'
             order by created_at desc
             limit 1
@@ -96,10 +200,12 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
             update approval_requests
             set artifact_name = ?, artifact_type = ?, artifact_hash = ?, publisher = ?, policy_action = ?,
                 recommended_scope = ?, changed_fields_json = ?, source_scope = ?, config_path = ?, workspace = ?,
-                launch_target = ?, normalized_identity_key = ?, transport = ?, risk_summary = ?, risk_signals_json = ?,
+                launch_target = ?, normalized_identity_key = ?, action_identity = ?, queue_group_id = ?,
+                dedupe_count = coalesce(dedupe_count, 1) + 1, last_seen_at = ?,
+                transport = ?, risk_summary = ?, risk_signals_json = ?,
                 artifact_label = ?, source_label = ?, trigger_summary = ?, why_now = ?, launch_summary = ?,
                 risk_headline = ?, action_envelope_json = ?, decision_v2_json = ?, fallback_cli_command = ?,
-                review_command = ?, approval_url = ?, created_at = ?
+                review_command = ?, approval_url = ?
             where request_id = ?
             """,
             (
@@ -114,7 +220,10 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
                 request.config_path,
                 request.workspace,
                 request.launch_target,
-                _normalized_identity_key(request.launch_target),
+                identity_key,
+                action_identity,
+                queue_group_id,
+                now,
                 request.transport,
                 request.risk_summary,
                 json.dumps(list(request.risk_signals)),
@@ -133,7 +242,6 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
                 ),
                 review_command,
                 approval_url,
-                now,
                 request_id,
             ),
         )
@@ -142,15 +250,17 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
         """
         insert into approval_requests (
           request_id, harness, artifact_id, artifact_name, artifact_type, artifact_hash, publisher, policy_action,
-          recommended_scope, changed_fields_json, source_scope, config_path, workspace,
-           launch_target, normalized_identity_key, transport, risk_summary,
-           risk_signals_json, artifact_label, source_label, trigger_summary, why_now, launch_summary, risk_headline,
-            action_envelope_json, decision_v2_json, fallback_cli_command, review_command,
-            approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
-          )
-          values (
-            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
-          )
+           recommended_scope, changed_fields_json, source_scope, config_path, workspace,
+            launch_target, normalized_identity_key, action_identity, queue_group_id, dedupe_count, last_seen_at,
+            transport, risk_summary,
+            risk_signals_json, artifact_label, source_label, trigger_summary, why_now, launch_summary, risk_headline,
+             action_envelope_json, decision_v2_json, fallback_cli_command, review_command,
+             approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
+           )
+           values (
+                 ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                 ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
         """,
         (
             request.request_id,
@@ -167,7 +277,11 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
             request.config_path,
             request.workspace,
             request.launch_target,
-            _normalized_identity_key(request.launch_target),
+            identity_key,
+            action_identity,
+            queue_group_id,
+            max(1, int(request.dedupe_count)),
+            request.last_seen_at or now,
             request.transport,
             request.risk_summary,
             json.dumps(list(request.risk_signals)),
@@ -214,6 +328,7 @@ def list_approval_requests(
     harness: str | None = None,
     limit: int | None = 50,
     before_cursor: str | None = None,
+    cursor: str | None = None,
     search: str | None = None,
     created_after: str | None = None,
     created_before: str | None = None,
@@ -229,6 +344,11 @@ def list_approval_requests(
     if before_cursor is not None:
         clauses.append("created_at < ?")
         params.append(before_cursor)
+    if cursor is not None:
+        marker = _decode_page_cursor(cursor)
+        if marker is not None:
+            clauses.append("(last_seen_at < ? or (last_seen_at = ? and request_id < ?))")
+            params.extend([marker["last_seen_at"], marker["last_seen_at"], marker["request_id"]])
     if created_after is not None:
         clauses.append("created_at > ?")
         params.append(created_after)
@@ -239,22 +359,28 @@ def list_approval_requests(
         search_clause = (
             "(lower(artifact_name) like lower(?)"
             " or lower(artifact_id) like lower(?)"
-            " or lower(coalesce(risk_summary, '')) like lower(?))"
+            " or lower(coalesce(risk_summary, '')) like lower(?)"
+            " or lower(coalesce(launch_target, '')) like lower(?)"
+            " or lower(coalesce(action_identity, '')) like lower(?)"
+            " or lower(coalesce(action_envelope_json, '')) like lower(?)"
+            " or lower(coalesce(decision_v2_json, '')) like lower(?)"
+            " or lower(config_path) like lower(?))"
         )
         clauses.append(search_clause)
         pattern = f"%{search}%"
-        params.extend([pattern, pattern, pattern])
+        params.extend([pattern, pattern, pattern, pattern, pattern, pattern, pattern, pattern])
     where_clause = f"where {' and '.join(clauses)}" if clauses else ""
     query = f"""
         select request_id, harness, artifact_id, artifact_name, artifact_type, artifact_hash, publisher, policy_action,
-               recommended_scope, changed_fields_json, source_scope, config_path, workspace, launch_target, transport,
+               recommended_scope, changed_fields_json, source_scope, config_path, workspace, launch_target,
+                normalized_identity_key, action_identity, queue_group_id, dedupe_count, last_seen_at, transport,
                 risk_summary, risk_signals_json, artifact_label, source_label, trigger_summary, why_now,
                 launch_summary, risk_headline, action_envelope_json, decision_v2_json,
                 fallback_cli_command, review_command,
                 approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
         from approval_requests
         {where_clause}
-        order by created_at desc
+        order by last_seen_at desc, request_id desc
     """
     if limit is None:
         rows = connection.execute(query, params).fetchall()
@@ -264,13 +390,20 @@ def list_approval_requests(
 
 
 def get_approval_request(connection: sqlite3.Connection, request_id: str) -> dict[str, object] | None:
+    columns = _approval_columns(connection)
     row = connection.execute(
-        """
+        f"""
         select request_id, harness, artifact_id, artifact_name, artifact_type, artifact_hash, publisher, policy_action,
-               recommended_scope, changed_fields_json, source_scope, config_path, workspace, launch_target, transport,
+               recommended_scope, changed_fields_json, source_scope, config_path, workspace, launch_target,
+                {_column_expr(columns, "normalized_identity_key", "NULL")},
+                {_column_expr(columns, "action_identity", "NULL")},
+                {_column_expr(columns, "queue_group_id", "NULL")},
+                {_column_expr(columns, "dedupe_count", "1")},
+                {_column_expr(columns, "last_seen_at", "created_at")},
+                transport,
                 risk_summary, risk_signals_json, artifact_label, source_label, trigger_summary, why_now,
                 launch_summary, risk_headline, action_envelope_json, decision_v2_json,
-                fallback_cli_command, review_command,
+                {_column_expr(columns, "fallback_cli_command", "NULL")}, review_command,
                 approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
         from approval_requests
         where request_id = ?
@@ -280,6 +413,17 @@ def get_approval_request(connection: sqlite3.Connection, request_id: str) -> dic
     if row is None:
         return None
     return _row_to_payload(row)
+
+
+def _approval_columns(connection: sqlite3.Connection) -> set[str]:
+    rows = connection.execute("pragma table_info(approval_requests)").fetchall()
+    return {str(row["name"]) for row in rows}
+
+
+def _column_expr(existing: set[str], column_name: str, fallback_sql: str) -> str:
+    if column_name in existing:
+        return column_name
+    return f"{fallback_sql} as {column_name}"
 
 
 def resolve_approval_request(
@@ -310,6 +454,7 @@ def count_approval_requests(
     *,
     status: str | None = "pending",
     harness: str | None = None,
+    search: str | None = None,
 ) -> int:
     clauses = []
     params: list[object] = []
@@ -319,6 +464,19 @@ def count_approval_requests(
     if harness is not None:
         clauses.append("harness = ?")
         params.append(harness)
+    if search is not None:
+        clauses.append(
+            "(lower(artifact_name) like lower(?)"
+            " or lower(artifact_id) like lower(?)"
+            " or lower(coalesce(risk_summary, '')) like lower(?)"
+            " or lower(coalesce(launch_target, '')) like lower(?)"
+            " or lower(coalesce(action_identity, '')) like lower(?)"
+            " or lower(coalesce(action_envelope_json, '')) like lower(?)"
+            " or lower(coalesce(decision_v2_json, '')) like lower(?)"
+            " or lower(config_path) like lower(?))"
+        )
+        pattern = f"%{search}%"
+        params.extend([pattern, pattern, pattern, pattern, pattern, pattern, pattern, pattern])
     where_clause = f"where {' and '.join(clauses)}" if clauses else ""
     row = connection.execute(f"select count(*) as total from approval_requests {where_clause}", params).fetchone()
     return int(row["total"]) if row is not None else 0
@@ -340,6 +498,13 @@ def _row_to_payload(row: sqlite3.Row) -> dict[str, object]:
         "config_path": str(row["config_path"]),
         "workspace": row["workspace"],
         "launch_target": row["launch_target"],
+        "normalized_identity_key": row["normalized_identity_key"],
+        "action_identity": row["action_identity"],
+        "queue_group_id": row["queue_group_id"],
+        "dedupe_count": int(row["dedupe_count"] or 1),
+        "last_seen_at": row["last_seen_at"],
+        "display_status": str(row["status"]),
+        "resolution_intent": row["resolution_action"],
         "transport": row["transport"],
         "risk_summary": row["risk_summary"],
         "risk_signals": _safe_json_list(row["risk_signals_json"]),
@@ -376,12 +541,326 @@ def _safe_json_list(value: object) -> list[object]:
 def approval_index_statements() -> list[str]:
     return [
         "create index if not exists idx_approval_status_created on approval_requests(status, created_at desc)",
+        (
+            "create index if not exists idx_approval_status_harness_created "
+            "on approval_requests(status, harness, created_at desc)"
+        ),
+        (
+            "create index if not exists idx_approval_status_identity_workspace "
+            "on approval_requests(status, normalized_identity_key, workspace)"
+        ),
+        "create index if not exists idx_approval_group_status on approval_requests(queue_group_id, status)",
+        (
+            "create index if not exists idx_approval_status_last_seen "
+            "on approval_requests(status, last_seen_at desc, request_id desc)"
+        ),
+        (
+            "create index if not exists idx_approval_status_harness_last_seen "
+            "on approval_requests(status, harness, last_seen_at desc, request_id desc)"
+        ),
         "create index if not exists idx_approval_harness_status on approval_requests(harness, status)",
         "create index if not exists idx_approval_artifact_hash on approval_requests(artifact_hash)",
         "create index if not exists idx_approval_workspace_status on approval_requests(workspace, status)",
         "create index if not exists idx_approval_policy_action on approval_requests(policy_action)",
         "create index if not exists idx_approval_resolution on approval_requests(resolution_action, resolved_at)",
     ]
+
+
+def list_pending_approval_summaries(
+    connection: sqlite3.Connection,
+    *,
+    limit: int = 50,
+    cursor: str | None = None,
+    harness: str | None = None,
+    search: str | None = None,
+) -> dict[str, object]:
+    return list_approval_request_page(
+        connection,
+        status="pending",
+        limit=limit,
+        cursor=cursor,
+        harness=harness,
+        search=search,
+    )
+
+
+def list_approval_request_page(
+    connection: sqlite3.Connection,
+    *,
+    status: str | None = "pending",
+    limit: int = 50,
+    cursor: str | None = None,
+    harness: str | None = None,
+    search: str | None = None,
+) -> dict[str, object]:
+    page_limit = min(MAX_APPROVAL_PAGE_LIMIT, max(1, limit))
+    rows = list_approval_requests(
+        connection,
+        status=status,
+        harness=harness,
+        limit=page_limit + 1,
+        cursor=cursor,
+        search=search,
+    )
+    items = rows[:page_limit]
+    next_cursor = _encode_page_cursor(items[-1]) if len(rows) > page_limit and items else None
+    return {
+        "items": [_approval_summary(item) for item in items],
+        "next_cursor": next_cursor,
+        "total_pending_count": count_approval_requests(connection, status="pending", harness=harness, search=search),
+        "total_count": count_approval_requests(connection, status=status, harness=harness, search=search),
+        "status": status or "all",
+    }
+
+
+def get_next_pending_request(
+    connection: sqlite3.Connection,
+    *,
+    exclude_ids: set[str] | None = None,
+) -> dict[str, object] | None:
+    excluded = exclude_ids or set()
+    rows = list_approval_requests(connection, status="pending", limit=10)
+    for row in rows:
+        if str(row["request_id"]) not in excluded:
+            return row
+    return None
+
+
+def resolve_one_request_only(
+    connection: sqlite3.Connection,
+    request_id: str,
+    *,
+    resolution_action: str,
+    resolution_scope: str,
+    reason: str | None,
+    resolved_at: str,
+) -> bool:
+    cursor = connection.execute(
+        """
+        update approval_requests
+        set status = 'resolved',
+            resolution_action = ?,
+            resolution_scope = ?,
+            reason = ?,
+            resolved_at = ?
+        where request_id = ?
+          and status = 'pending'
+        """,
+        (resolution_action, resolution_scope, reason, resolved_at, request_id),
+    )
+    return int(cursor.rowcount if cursor.rowcount is not None else 0) == 1
+
+
+def resolve_request_with_queue_result(
+    connection: sqlite3.Connection,
+    request_id: str,
+    *,
+    resolution_action: str,
+    resolution_scope: str,
+    reason: str | None,
+    resolved_at: str,
+) -> dict[str, object]:
+    request = get_approval_request(connection, request_id)
+    if request is None:
+        return _unresolved_queue_result(connection, error="not_found")
+    if request["status"] != "pending":
+        return _unresolved_queue_result(connection, error="already_resolved", item=request)
+    did_resolve = resolve_one_request_only(
+        connection,
+        request_id,
+        resolution_action=resolution_action,
+        resolution_scope=resolution_scope,
+        reason=reason,
+        resolved_at=resolved_at,
+    )
+    if not did_resolve:
+        return _unresolved_queue_result(connection, error="already_resolved", item=request)
+    queue_group_id = request.get("queue_group_id")
+    duplicate_ids = resolve_matching_duplicate_requests(
+        connection,
+        queue_group_id=str(queue_group_id) if isinstance(queue_group_id, str) else None,
+        request_id=request_id,
+        resolution_action=resolution_action,
+        resolution_scope=resolution_scope,
+        reason=reason,
+        resolved_at=resolved_at,
+    )
+    updated = get_approval_request(connection, request_id)
+    next_request = get_next_pending_request(connection, exclude_ids={request_id, *duplicate_ids})
+    remaining_page = list_pending_approval_summaries(connection, limit=10)
+    remaining_count = int(remaining_page["total_pending_count"])
+    return {
+        "resolved": True,
+        "item": updated,
+        "resolved_request": updated,
+        "remaining_pending_count": remaining_count,
+        "next_selectable_request_id": next_request["request_id"] if next_request is not None else None,
+        "remaining_pending_summaries": remaining_page["items"],
+        "resolved_duplicate_ids": duplicate_ids,
+        "resolution_summary": _resolution_summary(remaining_count),
+        "retry_hint": "Retry the action in your AI assistant if you approved it.",
+    }
+
+
+def backfill_approval_queue_columns(connection: sqlite3.Connection) -> None:
+    rows = connection.execute(
+        """
+        select request_id, harness, artifact_id, workspace, launch_target, action_envelope_json,
+               action_identity, queue_group_id, dedupe_count, last_seen_at, created_at
+        from approval_requests
+        where action_identity is null
+           or queue_group_id is null
+           or last_seen_at is null
+           or dedupe_count is null
+           or dedupe_count < 1
+        """
+    ).fetchall()
+    for row in rows:
+        action_identity = row["action_identity"] or _build_action_identity(
+            launch_target=row["launch_target"],
+            action_envelope=_optional_json_object(row["action_envelope_json"]),
+        )
+        queue_group_id = row["queue_group_id"] or _build_queue_group_id(
+            harness=str(row["harness"]),
+            workspace=row["workspace"],
+            artifact_id=str(row["artifact_id"]),
+            action_identity=str(action_identity),
+        )
+        connection.execute(
+            """
+            update approval_requests
+            set action_identity = ?,
+                queue_group_id = ?,
+                dedupe_count = ?,
+                last_seen_at = ?
+            where request_id = ?
+            """,
+            (
+                action_identity,
+                queue_group_id,
+                max(1, int(row["dedupe_count"] or 1)),
+                row["last_seen_at"] or row["created_at"],
+                row["request_id"],
+            ),
+        )
+
+
+def resolve_matching_duplicate_requests(
+    connection: sqlite3.Connection,
+    *,
+    queue_group_id: str | None,
+    request_id: str,
+    resolution_action: str,
+    resolution_scope: str,
+    reason: str | None,
+    resolved_at: str,
+) -> list[str]:
+    if queue_group_id is None:
+        return []
+    rows = connection.execute(
+        """
+        select request_id
+        from approval_requests
+        where queue_group_id = ?
+          and request_id != ?
+          and status = 'pending'
+        order by last_seen_at desc, request_id desc
+        limit ?
+        """,
+        (queue_group_id, request_id, MAX_RESOLVED_DUPLICATE_IDS),
+    ).fetchall()
+    connection.execute(
+        """
+        update approval_requests
+        set status = 'resolved',
+            resolution_action = ?,
+            resolution_scope = ?,
+            reason = ?,
+            resolved_at = ?
+        where queue_group_id = ?
+          and request_id != ?
+          and status = 'pending'
+        """,
+        (resolution_action, resolution_scope, reason, resolved_at, queue_group_id, request_id),
+    )
+    return [str(row["request_id"]) for row in rows]
+
+
+def _approval_summary(item: dict[str, object]) -> dict[str, object]:
+    return {
+        "request_id": item["request_id"],
+        "harness": item["harness"],
+        "artifact_id": item["artifact_id"],
+        "artifact_name": item["artifact_name"],
+        "artifact_type": item["artifact_type"],
+        "policy_action": item["policy_action"],
+        "source_scope": item["source_scope"],
+        "config_path": item["config_path"],
+        "workspace": item["workspace"],
+        "launch_target": item["launch_target"],
+        "risk_summary": item["risk_summary"],
+        "risk_headline": item["risk_headline"],
+        "action_identity": item["action_identity"],
+        "queue_group_id": item["queue_group_id"],
+        "dedupe_count": item["dedupe_count"],
+        "created_at": item["created_at"],
+        "last_seen_at": item["last_seen_at"],
+        "display_status": item["display_status"],
+    }
+
+
+def _encode_page_cursor(item: dict[str, object]) -> str:
+    raw = json.dumps(
+        {"last_seen_at": item["last_seen_at"], "request_id": item["request_id"]},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _decode_page_cursor(cursor: str) -> dict[str, str] | None:
+    try:
+        padded = cursor + ("=" * (-len(cursor) % 4))
+        decoded = base64.urlsafe_b64decode(padded.encode("ascii")).decode("utf-8")
+        payload = json.loads(decoded)
+    except (ValueError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    last_seen_at = payload.get("last_seen_at")
+    request_id = payload.get("request_id")
+    if isinstance(last_seen_at, str) and isinstance(request_id, str):
+        return {"last_seen_at": last_seen_at, "request_id": request_id}
+    return None
+
+
+def _resolution_summary(remaining_count: int) -> str:
+    if remaining_count == 0:
+        return "Decision saved. No blocked actions remain."
+    if remaining_count == 1:
+        return "Decision saved. 1 blocked action remains."
+    return f"Decision saved. {remaining_count} blocked actions remain."
+
+
+def _unresolved_queue_result(
+    connection: sqlite3.Connection,
+    *,
+    error: str,
+    item: dict[str, object] | None = None,
+) -> dict[str, object]:
+    remaining_page = list_pending_approval_summaries(connection, limit=10)
+    next_request = get_next_pending_request(connection)
+    return {
+        "resolved": False,
+        "error": error,
+        "item": item,
+        "remaining_pending_count": int(remaining_page["total_pending_count"]),
+        "next_selectable_request_id": next_request["request_id"] if next_request is not None else None,
+        "remaining_pending_summaries": remaining_page["items"],
+        "resolved_duplicate_ids": [],
+        "resolution_summary": "Request was not resolved.",
+        "retry_hint": "Refresh the approval queue and choose an active request.",
+    }
 
 
 def bulk_resolve_approval_requests(

--- a/tests/test_guard_approval_store_scale.py
+++ b/tests/test_guard_approval_store_scale.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 import sqlite3
+import time
 import uuid
 
 from codex_plugin_scanner.guard.models import GuardApprovalRequest
@@ -20,7 +21,9 @@ from codex_plugin_scanner.guard.store_approvals import (
     count_approval_requests,
     get_approval_request,
     list_approval_requests,
+    list_pending_approval_summaries,
     resolve_approval_request,
+    resolve_request_with_queue_result,
 )
 
 
@@ -79,6 +82,72 @@ def _insert(conn: sqlite3.Connection, req: GuardApprovalRequest, now: str = "202
     return add_approval_request(conn, req, now)
 
 
+def _bulk_insert_pending(conn: sqlite3.Connection, total: int) -> None:
+    rows = []
+    for index in range(total):
+        timestamp = f"2026-01-01T00:00:00.{index:06d}Z"
+        rows.append(
+            (
+                f"req-{index:06d}",
+                "codex",
+                f"codex:project:tool-{index:06d}",
+                f"tool-{index:06d}",
+                "mcp_server",
+                f"hash-{index:06d}",
+                None,
+                "require-reapproval",
+                "session",
+                '["args"]',
+                "project",
+                "/tmp/config.toml",
+                "ws-a",
+                f"run tool {index:06d}",
+                f"run tool {index:06d}",
+                f"identity-{index:06d}",
+                f"approval-group:v1:{index:064d}",
+                1,
+                timestamp,
+                "stdio",
+                "risk",
+                "[]",
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                f'{{"command":"run tool {index:06d}"}}',
+                None,
+                None,
+                f"hol-guard review req-{index:06d}",
+                f"http://localhost:4455/approve/req-{index:06d}",
+                "pending",
+                None,
+                None,
+                None,
+                timestamp,
+                None,
+            )
+        )
+    conn.executemany(
+        """
+        insert into approval_requests (
+          request_id, harness, artifact_id, artifact_name, artifact_type, artifact_hash, publisher, policy_action,
+          recommended_scope, changed_fields_json, source_scope, config_path, workspace,
+          launch_target, normalized_identity_key, action_identity, queue_group_id, dedupe_count, last_seen_at,
+          transport, risk_summary, risk_signals_json, artifact_label, source_label, trigger_summary, why_now,
+          launch_summary, risk_headline, action_envelope_json, decision_v2_json, fallback_cli_command,
+          review_command, approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
+        )
+        values (
+          ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+          ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+        )
+        """,
+        rows,
+    )
+
+
 class TestApprovalIndexStatements:
     def test_index_statements_returns_nonempty_list(self) -> None:
         stmts = approval_index_statements()
@@ -129,6 +198,40 @@ class TestCursorPagination:
         cursor = page1[-1]["created_at"]
         page2 = list_approval_requests(conn, status="pending", limit=3, before_cursor=cursor)
         assert page2 == []
+
+
+class TestQueueScaleTargets:
+    def test_listing_first_queue_page_with_100k_rows_stays_under_100ms(self) -> None:
+        conn = _make_conn()
+        _bulk_insert_pending(conn, 100_000)
+
+        started = time.perf_counter()
+        page = list_pending_approval_summaries(conn, limit=25)
+        elapsed = time.perf_counter() - started
+
+        assert len(page["items"]) == 25
+        assert page["total_pending_count"] == 100_000
+        assert elapsed < 0.1
+
+    def test_resolving_one_request_with_100k_rows_stays_under_100ms(self) -> None:
+        conn = _make_conn()
+        _bulk_insert_pending(conn, 100_000)
+
+        started = time.perf_counter()
+        result = resolve_request_with_queue_result(
+            conn,
+            "req-099999",
+            resolution_action="allow",
+            resolution_scope="artifact",
+            reason="reviewed",
+            resolved_at="2026-01-02T00:00:00Z",
+        )
+        elapsed = time.perf_counter() - started
+
+        assert result["resolved"] is True
+        assert result["remaining_pending_count"] == 99_999
+        assert result["next_selectable_request_id"] == "req-099998"
+        assert elapsed < 0.1
 
 
 class TestSearchFilter:

--- a/tests/test_guard_queue_api_contract.py
+++ b/tests/test_guard_queue_api_contract.py
@@ -383,3 +383,25 @@ def test_request_list_limit_cursor_search_and_harness_filters(tmp_path: Path) ->
     assert {item["request_id"] for item in mcp_match["items"]} == {"req-codex-mcp"}
     assert {item["request_id"] for item in harness_match["items"]} == {"req-copilot"}
     assert bad_limit_status == 400
+
+
+def test_request_list_invalid_cursor_returns_recovery_error(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _populate(store, [_request("req-only")])
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+
+    try:
+        try:
+            _get_json(daemon.port, "/v1/requests?cursor=not-a-valid-cursor")
+        except urllib.error.HTTPError as error:
+            status = error.code
+            payload = json.loads(error.read().decode("utf-8"))
+        else:
+            raise AssertionError("expected HTTPError")
+    finally:
+        daemon.stop()
+
+    assert status == 400
+    assert payload["error"] == "invalid_cursor"
+    assert payload["recovery"]["code"] == "refresh_queue"

--- a/tests/test_guard_queue_api_contract.py
+++ b/tests/test_guard_queue_api_contract.py
@@ -1,0 +1,355 @@
+"""Guard queue API contract tests."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+from codex_plugin_scanner.guard.daemon import GuardDaemonServer
+from codex_plugin_scanner.guard.models import GuardApprovalRequest
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _request(
+    request_id: str,
+    *,
+    harness: str = "codex",
+    command: str = "cat ~/.npmrc",
+    prompt_excerpt: str | None = None,
+    mcp_server: str | None = None,
+    mcp_tool: str | None = None,
+    workspace: str = "workspace-a",
+) -> GuardApprovalRequest:
+    action_envelope = {
+        "action_type": "mcp_tool_call" if mcp_tool else "shell_command",
+        "tool_name": "mcp" if mcp_tool else "Bash",
+        "command": command,
+        "prompt_excerpt": prompt_excerpt,
+        "target_paths": ["~/.npmrc"] if "npmrc" in command else [],
+        "network_hosts": [],
+        "mcp_server": mcp_server,
+        "mcp_tool": mcp_tool,
+    }
+    return GuardApprovalRequest(
+        request_id=request_id,
+        harness=harness,
+        artifact_id=f"{harness}:project:{request_id}",
+        artifact_name=request_id,
+        artifact_hash=f"hash-{request_id}",
+        policy_action="require-reapproval",
+        recommended_scope="artifact",
+        changed_fields=("args",),
+        source_scope="project",
+        config_path=f"/{workspace}/.config/guard.toml",
+        workspace=workspace,
+        launch_target=command,
+        action_envelope_json=action_envelope,
+        decision_v2_json={"dashboard_primary_detail": prompt_excerpt} if prompt_excerpt else None,
+        review_command=f"hol-guard approvals approve {request_id}",
+        approval_url=f"http://127.0.0.1/pending/{request_id}",
+    )
+
+
+def _populate(store: GuardStore, requests: list[GuardApprovalRequest]) -> None:
+    for index, request in enumerate(requests):
+        store.add_approval_request(request, f"2026-05-08T10:0{index}:00+00:00")
+
+
+def _force_duplicate_row(store: GuardStore, request_id: str, source_request_id: str) -> None:
+    connection = sqlite3.connect(store.path)
+    try:
+        connection.execute(
+            """
+            insert into approval_requests (
+              request_id, harness, artifact_id, artifact_name, artifact_type, artifact_hash, publisher, policy_action,
+              recommended_scope, changed_fields_json, source_scope, config_path, workspace,
+              launch_target, normalized_identity_key, action_identity, queue_group_id, dedupe_count, last_seen_at,
+              transport, risk_summary, risk_signals_json, artifact_label, source_label, trigger_summary, why_now,
+              launch_summary, risk_headline, action_envelope_json, decision_v2_json, fallback_cli_command,
+              review_command, approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
+            )
+            select ?, harness, artifact_id, artifact_name, artifact_type, artifact_hash, publisher, policy_action,
+              recommended_scope, changed_fields_json, source_scope, config_path, workspace,
+              launch_target, normalized_identity_key, action_identity, queue_group_id, 1, last_seen_at,
+              transport, risk_summary, risk_signals_json, artifact_label, source_label, trigger_summary, why_now,
+              launch_summary, risk_headline, action_envelope_json, decision_v2_json, fallback_cli_command,
+              ?, ?, status, resolution_action, resolution_scope, reason, created_at, resolved_at
+            from approval_requests
+            where request_id = ?
+            """,
+            (
+                request_id,
+                f"hol-guard approvals approve {request_id}",
+                f"http://127.0.0.1/pending/{request_id}",
+                source_request_id,
+            ),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def _get_json(port: int, path: str) -> dict[str, object]:
+    with urllib.request.urlopen(f"http://127.0.0.1:{port}{path}", timeout=5) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _post_json(port: int, token: str, path: str, payload: dict[str, object]) -> dict[str, object]:
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{port}{path}",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json", "X-Guard-Token": token},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=5) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _post_error(port: int, token: str, path: str, payload: dict[str, object]) -> tuple[int, dict[str, object]]:
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{port}{path}",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json", "X-Guard-Token": token},
+        method="POST",
+    )
+    try:
+        urllib.request.urlopen(request, timeout=5)
+    except urllib.error.HTTPError as error:
+        return error.code, json.loads(error.read().decode("utf-8"))
+    raise AssertionError("expected HTTPError")
+
+
+def test_resolving_active_item_with_two_remaining_returns_next_hint(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _populate(
+        store,
+        [
+            _request("req-old", command="cat ~/.npmrc"),
+            _request("req-active", command="cat ~/.pypirc"),
+            _request("req-newest", command="curl https://metadata.example/health"),
+        ],
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+
+    try:
+        payload = _post_json(
+            daemon.port,
+            daemon._server.auth_token,
+            "/v1/requests/req-active/approve",
+            {"scope": "artifact", "reason": "reviewed"},
+        )
+    finally:
+        daemon.stop()
+
+    assert payload["remaining_pending_count"] == 2
+    assert payload["next_selectable_request_id"] == "req-newest"
+    assert {item["request_id"] for item in payload["remaining_pending_summaries"]} == {"req-newest", "req-old"}
+
+
+def test_resolving_last_item_returns_empty_queue_hint(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _populate(store, [_request("req-only")])
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+
+    try:
+        payload = _post_json(
+            daemon.port,
+            daemon._server.auth_token,
+            "/v1/requests/req-only/block",
+            {"scope": "artifact", "reason": "blocked"},
+        )
+    finally:
+        daemon.stop()
+
+    assert payload["remaining_pending_count"] == 0
+    assert payload["next_selectable_request_id"] is None
+    assert payload["remaining_pending_summaries"] == []
+
+
+def test_resolving_duplicate_group_reports_collapsed_ids(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _populate(store, [_request("req-active"), _request("req-unrelated", command="cat ~/.pypirc")])
+    _force_duplicate_row(store, "req-duplicate", "req-active")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+
+    try:
+        payload = _post_json(
+            daemon.port,
+            daemon._server.auth_token,
+            "/v1/requests/req-active/approve",
+            {"scope": "artifact", "reason": "reviewed"},
+        )
+    finally:
+        daemon.stop()
+
+    assert payload["resolved_duplicate_ids"] == ["req-duplicate"]
+    assert payload["remaining_pending_count"] == 1
+    assert payload["next_selectable_request_id"] == "req-unrelated"
+
+
+def test_broad_scope_resolution_refreshes_queue_envelope(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _populate(store, [_request("req-active"), _request("req-covered", command="cat ~/.pypirc")])
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+
+    try:
+        payload = _post_json(
+            daemon.port,
+            daemon._server.auth_token,
+            "/v1/requests/req-active/approve",
+            {"scope": "harness", "reason": "trust this harness"},
+        )
+    finally:
+        daemon.stop()
+
+    assert payload["remaining_pending_count"] == 0
+    assert payload["next_selectable_request_id"] is None
+    assert payload["resolved_scope_ids"] == ["req-covered"]
+
+
+def test_resolving_stale_item_returns_recovery_payload(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _populate(store, [_request("req-stale")])
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+
+    try:
+        _post_json(
+            daemon.port,
+            daemon._server.auth_token,
+            "/v1/requests/req-stale/approve",
+            {"scope": "artifact", "reason": "reviewed"},
+        )
+        status, payload = _post_error(
+            daemon.port,
+            daemon._server.auth_token,
+            "/v1/requests/req-stale/approve",
+            {"scope": "artifact", "reason": "reviewed again"},
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 409
+    assert payload["error"] == "already_resolved"
+    assert payload["recovery"]["code"] == "request_resolved"
+
+
+def test_resolving_missing_item_returns_recovery_payload(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+
+    try:
+        status, payload = _post_error(
+            daemon.port,
+            daemon._server.auth_token,
+            "/v1/requests/missing/approve",
+            {"scope": "artifact", "reason": "reviewed"},
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 404
+    assert payload["error"] == "not_found"
+    assert payload["recovery"]["code"] == "request_unknown"
+
+
+def test_request_resolution_without_auth_returns_session_recovery(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _populate(store, [_request("req-auth")])
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+
+    try:
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{daemon.port}/v1/requests/req-auth/approve",
+            data=json.dumps({"scope": "artifact"}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            urllib.request.urlopen(request, timeout=5)
+        except urllib.error.HTTPError as error:
+            status = error.code
+            payload = json.loads(error.read().decode("utf-8"))
+        else:
+            raise AssertionError("expected HTTPError")
+    finally:
+        daemon.stop()
+
+    assert status == 401
+    assert payload["error"] == "unauthorized"
+    assert payload["recovery"]["code"] == "session_stale"
+    assert "Request failed with 401" not in json.dumps(payload)
+
+
+def test_request_list_status_filter_includes_resolved_items(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _populate(store, [_request("req-resolved"), _request("req-pending")])
+    store.resolve_approval_request(
+        "req-resolved",
+        resolution_action="allow",
+        resolution_scope="artifact",
+        reason="reviewed",
+        resolved_at="2026-05-08T10:03:00+00:00",
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+
+    try:
+        resolved_page = _get_json(daemon.port, "/v1/requests?status=resolved")
+        all_page = _get_json(daemon.port, "/v1/requests?status=all")
+    finally:
+        daemon.stop()
+
+    assert [item["request_id"] for item in resolved_page["items"]] == ["req-resolved"]
+    assert {item["request_id"] for item in all_page["items"]} == {"req-pending", "req-resolved"}
+
+
+def test_request_list_limit_cursor_search_and_harness_filters(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _populate(
+        store,
+        [
+            _request("req-codex-command", command="cat ~/.npmrc"),
+            _request("req-codex-prompt", command="", prompt_excerpt="Review plugin prompt excerpt"),
+            _request("req-codex-mcp", command="", mcp_server="filesystem", mcp_tool="read_secret"),
+            _request("req-copilot", harness="copilot", command="cat ~/.npmrc"),
+        ],
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+
+    try:
+        first_page = _get_json(daemon.port, "/v1/requests?limit=2")
+        second_page = _get_json(
+            daemon.port,
+            f"/v1/requests?limit=2&cursor={urllib.parse.quote(str(first_page['next_cursor']))}",
+        )
+        command_match = _get_json(daemon.port, "/v1/requests?search=npmrc&harness=codex")
+        prompt_match = _get_json(daemon.port, "/v1/requests?search=plugin%20prompt")
+        mcp_match = _get_json(daemon.port, "/v1/requests?search=read_secret")
+        harness_match = _get_json(daemon.port, "/v1/requests?harness=copilot")
+        bad_limit_status = None
+        try:
+            _get_json(daemon.port, "/v1/requests?limit=banana")
+        except urllib.error.HTTPError as error:
+            bad_limit_status = error.code
+    finally:
+        daemon.stop()
+
+    assert [item["request_id"] for item in first_page["items"]] == ["req-copilot", "req-codex-mcp"]
+    assert [item["request_id"] for item in second_page["items"]] == ["req-codex-prompt", "req-codex-command"]
+    assert {item["request_id"] for item in command_match["items"]} == {"req-codex-command"}
+    assert {item["request_id"] for item in prompt_match["items"]} == {"req-codex-prompt"}
+    assert {item["request_id"] for item in mcp_match["items"]} == {"req-codex-mcp"}
+    assert {item["request_id"] for item in harness_match["items"]} == {"req-copilot"}
+    assert bad_limit_status == 400

--- a/tests/test_guard_queue_api_contract.py
+++ b/tests/test_guard_queue_api_contract.py
@@ -19,6 +19,7 @@ def _request(
     *,
     harness: str = "codex",
     command: str = "cat ~/.npmrc",
+    artifact_id: str | None = None,
     prompt_excerpt: str | None = None,
     mcp_server: str | None = None,
     mcp_tool: str | None = None,
@@ -37,7 +38,7 @@ def _request(
     return GuardApprovalRequest(
         request_id=request_id,
         harness=harness,
-        artifact_id=f"{harness}:project:{request_id}",
+        artifact_id=artifact_id or f"{harness}:project:{request_id}",
         artifact_name=request_id,
         artifact_hash=f"hash-{request_id}",
         policy_action="require-reapproval",
@@ -212,6 +213,35 @@ def test_broad_scope_resolution_refreshes_queue_envelope(tmp_path: Path) -> None
 
     assert payload["remaining_pending_count"] == 0
     assert payload["next_selectable_request_id"] is None
+    assert payload["resolved_scope_ids"] == ["req-covered"]
+
+
+def test_artifact_scope_resolution_refreshes_queue_envelope(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    shared_artifact = "codex:project:shared-tool"
+    _populate(
+        store,
+        [
+            _request("req-active", command="cat ~/.npmrc", artifact_id=shared_artifact),
+            _request("req-covered", command="cat ~/.pypirc", artifact_id=shared_artifact),
+            _request("req-unrelated", command="cat ~/.ssh/id_rsa", artifact_id="codex:project:other-tool"),
+        ],
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+
+    try:
+        payload = _post_json(
+            daemon.port,
+            daemon._server.auth_token,
+            "/v1/requests/req-active/approve",
+            {"scope": "artifact", "reason": "trust this artifact"},
+        )
+    finally:
+        daemon.stop()
+
+    assert payload["remaining_pending_count"] == 1
+    assert payload["next_selectable_request_id"] == "req-unrelated"
     assert payload["resolved_scope_ids"] == ["req-covered"]
 
 

--- a/tests/test_guard_queue_contract.py
+++ b/tests/test_guard_queue_contract.py
@@ -525,6 +525,33 @@ def test_workspace_scope_resolution_escapes_sql_wildcard_names(tmp_path: Path) -
     assert store.get_approval_request("req-neighbor")["status"] == "pending"
 
 
+def test_workspace_scope_resolution_preserves_root_workspace(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.add_approval_request(
+        replace(
+            _request("req-root", artifact_id="codex:project:root"),
+            workspace="/",
+            config_path="/repo/.codex/config.toml",
+        ),
+        "2026-05-08T10:00:00+00:00",
+    )
+
+    resolved_ids = store.resolve_matching_approval_requests(
+        harness="codex",
+        scope="workspace",
+        artifact_id=None,
+        workspace="/",
+        publisher=None,
+        resolution_action="allow",
+        resolution_scope="workspace",
+        reason="trusted root workspace",
+        resolved_at="2026-05-08T10:03:00+00:00",
+    )
+
+    assert resolved_ids == ["req-root"]
+    assert store.get_approval_request("req-root")["status"] == "resolved"
+
+
 def test_daemon_resolution_envelope_and_request_filters(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     for index, command in enumerate(("cat ~/.npmrc", "cat ~/.pypirc", "curl https://metadata.example/health")):

--- a/tests/test_guard_queue_contract.py
+++ b/tests/test_guard_queue_contract.py
@@ -6,6 +6,7 @@ import json
 import sqlite3
 import urllib.parse
 import urllib.request
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -450,6 +451,78 @@ def test_queue_backfill_runs_once_per_schema_version(tmp_path: Path, monkeypatch
     GuardStore(guard_home)
 
     assert calls == ["backfill"]
+
+
+def test_workspace_scope_resolution_matches_windows_paths(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.add_approval_request(
+        replace(
+            _request("req-win", artifact_id="codex:project:win"),
+            workspace=r"C:\repo",
+            config_path=r"C:\repo\.codex\config.toml",
+        ),
+        "2026-05-08T10:00:00+00:00",
+    )
+    store.add_approval_request(
+        replace(
+            _request("req-win-other", artifact_id="codex:project:win-other"),
+            workspace=r"C:\repo-other",
+            config_path=r"C:\repo-other\.codex\config.toml",
+        ),
+        "2026-05-08T10:01:00+00:00",
+    )
+
+    resolved_ids = store.resolve_matching_approval_requests(
+        harness="codex",
+        scope="workspace",
+        artifact_id=None,
+        workspace=r"C:\repo",
+        publisher=None,
+        resolution_action="allow",
+        resolution_scope="workspace",
+        reason="trusted workspace",
+        resolved_at="2026-05-08T10:03:00+00:00",
+    )
+
+    assert resolved_ids == ["req-win"]
+    assert store.get_approval_request("req-win")["status"] == "resolved"
+    assert store.get_approval_request("req-win-other")["status"] == "pending"
+
+
+def test_workspace_scope_resolution_escapes_sql_wildcard_names(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.add_approval_request(
+        replace(
+            _request("req-workspace", artifact_id="codex:project:wild"),
+            workspace="/tmp/work_%",
+            config_path="/tmp/work_%/.codex/config.toml",
+        ),
+        "2026-05-08T10:00:00+00:00",
+    )
+    store.add_approval_request(
+        replace(
+            _request("req-neighbor", artifact_id="codex:project:neighbor"),
+            workspace="/tmp/work-A",
+            config_path="/tmp/work-A/.codex/config.toml",
+        ),
+        "2026-05-08T10:01:00+00:00",
+    )
+
+    resolved_ids = store.resolve_matching_approval_requests(
+        harness="codex",
+        scope="workspace",
+        artifact_id=None,
+        workspace="/tmp/work_%",
+        publisher=None,
+        resolution_action="allow",
+        resolution_scope="workspace",
+        reason="trusted workspace",
+        resolved_at="2026-05-08T10:03:00+00:00",
+    )
+
+    assert resolved_ids == ["req-workspace"]
+    assert store.get_approval_request("req-workspace")["status"] == "resolved"
+    assert store.get_approval_request("req-neighbor")["status"] == "pending"
 
 
 def test_daemon_resolution_envelope_and_request_filters(tmp_path: Path) -> None:

--- a/tests/test_guard_queue_contract.py
+++ b/tests/test_guard_queue_contract.py
@@ -1,0 +1,441 @@
+"""Guard approval queue continuity contract tests."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+from codex_plugin_scanner.guard.daemon import GuardDaemonServer
+from codex_plugin_scanner.guard.models import GuardApprovalRequest
+from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.guard.store_approvals import (
+    add_approval_request,
+    approval_index_statements,
+    approval_schema_statement,
+    list_approval_requests,
+    list_pending_approval_summaries,
+    resolve_request_with_queue_result,
+)
+
+
+def _connection() -> sqlite3.Connection:
+    connection = sqlite3.connect(":memory:")
+    connection.row_factory = sqlite3.Row
+    connection.execute(approval_schema_statement())
+    for statement in approval_index_statements():
+        connection.execute(statement)
+    return connection
+
+
+def _request(
+    request_id: str,
+    *,
+    artifact_id: str = "codex:project:tool",
+    workspace: str = "workspace-a",
+    command: str = "cat ~/.npmrc",
+    target_paths: tuple[str, ...] = ("~/.npmrc",),
+    network_hosts: tuple[str, ...] = (),
+    mcp_server: str | None = None,
+    mcp_tool: str | None = None,
+    created_path: Path | None = None,
+) -> GuardApprovalRequest:
+    action_envelope = {
+        "action_type": "mcp_tool_call" if mcp_tool else "shell_command",
+        "tool_name": "mcp" if mcp_tool else "Bash",
+        "command": command,
+        "target_paths": list(target_paths),
+        "network_hosts": list(network_hosts),
+        "mcp_server": mcp_server,
+        "mcp_tool": mcp_tool,
+    }
+    config_path = str((created_path or Path("/workspace")) / ".codex" / "config.toml")
+    return GuardApprovalRequest(
+        request_id=request_id,
+        harness="codex",
+        artifact_id=artifact_id,
+        artifact_name=artifact_id.rsplit(":", maxsplit=1)[-1],
+        artifact_hash=f"hash-{request_id}",
+        policy_action="require-reapproval",
+        recommended_scope="artifact",
+        changed_fields=("args",),
+        source_scope="project",
+        config_path=config_path,
+        workspace=workspace,
+        launch_target=command,
+        action_envelope_json=action_envelope,
+        review_command=f"hol-guard approvals approve {request_id}",
+        approval_url=f"http://127.0.0.1/pending/{request_id}",
+    )
+
+
+def _post_json(port: int, token: str, path: str, payload: dict[str, object]) -> dict[str, object]:
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{port}{path}",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json", "X-Guard-Token": token},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=5) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _get_json(port: int, path: str) -> dict[str, object]:
+    with urllib.request.urlopen(f"http://127.0.0.1:{port}{path}", timeout=5) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def test_duplicate_requeue_preserves_first_seen_and_increments_dedupe_count() -> None:
+    connection = _connection()
+    first = _request("req-first")
+    duplicate = _request("req-duplicate")
+
+    first_id = add_approval_request(connection, first, "2026-05-08T10:00:00+00:00")
+    second_id = add_approval_request(connection, duplicate, "2026-05-08T10:01:00+00:00")
+    rows = list_approval_requests(connection, status="pending", limit=None)
+
+    assert first_id == "req-first"
+    assert second_id == "req-first"
+    assert len(rows) == 1
+    assert rows[0]["request_id"] == "req-first"
+    assert rows[0]["dedupe_count"] == 2
+    assert rows[0]["created_at"] == "2026-05-08T10:00:00+00:00"
+    assert rows[0]["last_seen_at"] == "2026-05-08T10:01:00+00:00"
+    assert isinstance(rows[0]["action_identity"], str)
+    assert str(rows[0]["queue_group_id"]).startswith("approval-group:v1:")
+
+
+def test_distinct_sensitive_paths_do_not_collapse() -> None:
+    connection = _connection()
+    npm = _request("req-npm", command="cat ~/.npmrc", target_paths=("~/.npmrc",))
+    pypi = _request("req-pypi", command="cat ~/.pypirc", target_paths=("~/.pypirc",))
+
+    add_approval_request(connection, npm, "2026-05-08T10:00:00+00:00")
+    add_approval_request(connection, pypi, "2026-05-08T10:01:00+00:00")
+    rows = list_approval_requests(connection, status="pending", limit=None)
+
+    assert {row["request_id"] for row in rows} == {"req-npm", "req-pypi"}
+    assert len({row["queue_group_id"] for row in rows}) == 2
+
+
+def test_distinct_mcp_tools_do_not_collapse() -> None:
+    connection = _connection()
+    read_tool = _request(
+        "req-read",
+        command="",
+        target_paths=(),
+        mcp_server="local-tools",
+        mcp_tool="read_secret",
+    )
+    write_tool = _request(
+        "req-write",
+        command="",
+        target_paths=(),
+        mcp_server="local-tools",
+        mcp_tool="write_file",
+    )
+
+    add_approval_request(connection, read_tool, "2026-05-08T10:00:00+00:00")
+    add_approval_request(connection, write_tool, "2026-05-08T10:01:00+00:00")
+    rows = list_approval_requests(connection, status="pending", limit=None)
+
+    assert {row["request_id"] for row in rows} == {"req-read", "req-write"}
+    assert len({row["action_identity"] for row in rows}) == 2
+
+
+def test_distinct_network_destinations_do_not_collapse() -> None:
+    connection = _connection()
+    first = _request(
+        "req-api",
+        command="curl https://api.example.test/health",
+        target_paths=(),
+        network_hosts=("api.example.test",),
+    )
+    second = _request(
+        "req-webhook",
+        command="curl https://webhook.example.test/health",
+        target_paths=(),
+        network_hosts=("webhook.example.test",),
+    )
+
+    add_approval_request(connection, first, "2026-05-08T10:00:00+00:00")
+    add_approval_request(connection, second, "2026-05-08T10:01:00+00:00")
+    rows = list_approval_requests(connection, status="pending", limit=None)
+
+    assert {row["request_id"] for row in rows} == {"req-api", "req-webhook"}
+    assert len({row["queue_group_id"] for row in rows}) == 2
+
+
+def _force_duplicate_row(connection: sqlite3.Connection, request_id: str, source_request_id: str) -> None:
+    connection.execute(
+        """
+        insert into approval_requests (
+          request_id, harness, artifact_id, artifact_name, artifact_type, artifact_hash, publisher, policy_action,
+          recommended_scope, changed_fields_json, source_scope, config_path, workspace,
+          launch_target, normalized_identity_key, action_identity, queue_group_id, dedupe_count, last_seen_at,
+          transport, risk_summary, risk_signals_json, artifact_label, source_label, trigger_summary, why_now,
+          launch_summary, risk_headline, action_envelope_json, decision_v2_json, fallback_cli_command,
+          review_command, approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
+        )
+        select ?, harness, artifact_id, artifact_name, artifact_type, artifact_hash, publisher, policy_action,
+          recommended_scope, changed_fields_json, source_scope, config_path, workspace,
+          launch_target, normalized_identity_key, action_identity, queue_group_id, 1, last_seen_at,
+          transport, risk_summary, risk_signals_json, artifact_label, source_label, trigger_summary, why_now,
+          launch_summary, risk_headline, action_envelope_json, decision_v2_json, fallback_cli_command,
+          ?, ?, status, resolution_action, resolution_scope, reason, created_at, resolved_at
+        from approval_requests
+        where request_id = ?
+        """,
+        (
+            request_id,
+            f"hol-guard approvals approve {request_id}",
+            f"http://127.0.0.1/pending/{request_id}",
+            source_request_id,
+        ),
+    )
+
+
+def test_resolve_queue_result_keeps_unrelated_pending_and_selects_next() -> None:
+    connection = _connection()
+    add_approval_request(connection, _request("req-old", command="cat ~/.npmrc"), "2026-05-08T10:00:00+00:00")
+    add_approval_request(connection, _request("req-active", command="cat ~/.pypirc"), "2026-05-08T10:01:00+00:00")
+    add_approval_request(
+        connection,
+        _request("req-newest", command="curl https://metadata.example/health", network_hosts=("metadata.example",)),
+        "2026-05-08T10:02:00+00:00",
+    )
+
+    result = resolve_request_with_queue_result(
+        connection,
+        "req-active",
+        resolution_action="allow",
+        resolution_scope="artifact",
+        reason="reviewed",
+        resolved_at="2026-05-08T10:03:00+00:00",
+    )
+
+    assert result["resolved"] is True
+    assert result["item"]["request_id"] == "req-active"
+    assert result["remaining_pending_count"] == 2
+    assert result["next_selectable_request_id"] == "req-newest"
+    assert result["resolved_duplicate_ids"] == []
+    assert {item["request_id"] for item in result["remaining_pending_summaries"]} == {"req-newest", "req-old"}
+
+
+def test_resolve_queue_result_returns_no_next_when_queue_empty() -> None:
+    connection = _connection()
+    add_approval_request(connection, _request("req-only"), "2026-05-08T10:00:00+00:00")
+
+    result = resolve_request_with_queue_result(
+        connection,
+        "req-only",
+        resolution_action="block",
+        resolution_scope="artifact",
+        reason="blocked",
+        resolved_at="2026-05-08T10:03:00+00:00",
+    )
+
+    assert result["resolved"] is True
+    assert result["remaining_pending_count"] == 0
+    assert result["next_selectable_request_id"] is None
+    assert result["remaining_pending_summaries"] == []
+
+
+def test_resolve_queue_result_reports_duplicate_ids_without_unrelated_items() -> None:
+    connection = _connection()
+    add_approval_request(connection, _request("req-active"), "2026-05-08T10:00:00+00:00")
+    _force_duplicate_row(connection, "req-duplicate", "req-active")
+    add_approval_request(
+        connection,
+        _request("req-unrelated", command="cat ~/.pypirc", target_paths=("~/.pypirc",)),
+        "2026-05-08T10:02:00+00:00",
+    )
+
+    result = resolve_request_with_queue_result(
+        connection,
+        "req-active",
+        resolution_action="allow",
+        resolution_scope="artifact",
+        reason="reviewed",
+        resolved_at="2026-05-08T10:03:00+00:00",
+    )
+
+    assert result["resolved_duplicate_ids"] == ["req-duplicate"]
+    assert result["remaining_pending_count"] == 1
+    assert result["next_selectable_request_id"] == "req-unrelated"
+    assert (
+        connection.execute("select status from approval_requests where request_id = 'req-unrelated'").fetchone()[
+            "status"
+        ]
+        == "pending"
+    )
+
+
+def test_pending_summary_pagination_uses_stable_cursor() -> None:
+    connection = _connection()
+    for index in range(3):
+        add_approval_request(
+            connection,
+            _request(f"req-{index}", artifact_id=f"codex:project:tool-{index}", command=f"run tool {index}"),
+            f"2026-05-08T10:0{index}:00+00:00",
+        )
+
+    first_page = list_pending_approval_summaries(connection, limit=2)
+    second_page = list_pending_approval_summaries(connection, limit=2, cursor=str(first_page["next_cursor"]))
+
+    assert [item["request_id"] for item in first_page["items"]] == ["req-2", "req-1"]
+    assert [item["request_id"] for item in second_page["items"]] == ["req-0"]
+    assert second_page["next_cursor"] is None
+
+
+def test_guard_store_migrates_database_missing_queue_columns(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    connection = sqlite3.connect(guard_home / "guard.db")
+    try:
+        connection.execute(
+            """
+            create table approval_requests (
+              request_id text primary key,
+              harness text not null,
+              artifact_id text not null,
+              artifact_name text not null,
+              artifact_type text not null,
+              artifact_hash text not null,
+              publisher text,
+              policy_action text not null,
+              recommended_scope text not null,
+              changed_fields_json text not null,
+              source_scope text not null,
+              config_path text not null,
+              workspace text,
+              launch_target text,
+              normalized_identity_key text,
+              transport text,
+              risk_summary text,
+              risk_signals_json text not null default '[]',
+              artifact_label text,
+              source_label text,
+              trigger_summary text,
+              why_now text,
+              launch_summary text,
+              risk_headline text,
+              action_envelope_json text,
+              decision_v2_json text,
+              fallback_cli_command text,
+              review_command text not null,
+              approval_url text not null,
+              status text not null,
+              resolution_action text,
+              resolution_scope text,
+              reason text,
+              created_at text not null,
+              resolved_at text
+            )
+            """
+        )
+        connection.execute(
+            """
+            insert into approval_requests (
+              request_id, harness, artifact_id, artifact_name, artifact_type, artifact_hash, publisher,
+              policy_action, recommended_scope, changed_fields_json, source_scope, config_path, workspace,
+              launch_target, normalized_identity_key, transport, risk_summary, risk_signals_json,
+              artifact_label, source_label, trigger_summary, why_now, launch_summary, risk_headline,
+              action_envelope_json, decision_v2_json, fallback_cli_command, review_command, approval_url,
+              status, resolution_action, resolution_scope, reason, created_at, resolved_at
+            )
+            values (
+              ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+              ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
+            """,
+            (
+                "req-old",
+                "codex",
+                "codex:project:tool",
+                "tool",
+                "mcp_server",
+                "hash-old",
+                None,
+                "require-reapproval",
+                "artifact",
+                '["args"]',
+                "project",
+                str(tmp_path / "workspace" / ".codex" / "config.toml"),
+                str(tmp_path / "workspace"),
+                "cat ~/.npmrc",
+                "cat ~/.npmrc",
+                "stdio",
+                "risk",
+                "[]",
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                '{"command":"cat ~/.npmrc","target_paths":["~/.npmrc"]}',
+                None,
+                None,
+                "hol-guard approvals approve req-old",
+                "http://127.0.0.1/pending/req-old",
+                "pending",
+                None,
+                None,
+                None,
+                "2026-05-08T10:00:00+00:00",
+                None,
+            ),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    store = GuardStore(guard_home)
+    migrated = store.get_approval_request("req-old")
+
+    assert migrated is not None
+    assert migrated["dedupe_count"] == 1
+    assert migrated["last_seen_at"] == "2026-05-08T10:00:00+00:00"
+    assert isinstance(migrated["action_identity"], str)
+    assert str(migrated["queue_group_id"]).startswith("approval-group:v1:")
+
+
+def test_daemon_resolution_envelope_and_request_filters(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    for index, command in enumerate(("cat ~/.npmrc", "cat ~/.pypirc", "curl https://metadata.example/health")):
+        target_path = "~/.npmrc" if "npmrc" in command else "~/.pypirc" if "pypirc" in command else ""
+        store.add_approval_request(
+            _request(
+                f"req-{index}",
+                artifact_id=f"codex:project:tool-{index}",
+                command=command,
+                target_paths=(target_path,) if target_path else (),
+                created_path=tmp_path / f"workspace-{index}",
+            ),
+            f"2026-05-08T10:0{index}:00+00:00",
+        )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+
+    try:
+        result = _post_json(
+            daemon.port,
+            daemon._server.auth_token,
+            "/v1/requests/req-2/approve",
+            {"scope": "artifact", "reason": "reviewed"},
+        )
+        filtered = _get_json(daemon.port, f"/v1/requests?search={urllib.parse.quote('npmrc')}&harness=codex&limit=1")
+        runtime = _get_json(daemon.port, "/v1/runtime?active_request_id=req-1")
+    finally:
+        daemon.stop()
+
+    assert result["resolved"] is True
+    assert result["remaining_pending_count"] == 2
+    assert result["next_selectable_request_id"] == "req-1"
+    assert [item["request_id"] for item in filtered["items"]] == ["req-0"]
+    assert filtered["total_pending_count"] == 1
+    assert runtime["queue_summary"]["active_request_id"] == "req-1"
+    assert runtime["queue_summary"]["next_request_id"] == "req-1"

--- a/tests/test_guard_queue_contract.py
+++ b/tests/test_guard_queue_contract.py
@@ -16,6 +16,7 @@ from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.models import GuardApprovalRequest
 from codex_plugin_scanner.guard.store import GuardStore
 from codex_plugin_scanner.guard.store_approvals import (
+    InvalidApprovalCursorError,
     add_approval_request,
     approval_index_statements,
     approval_schema_statement,
@@ -321,6 +322,30 @@ def test_pending_summary_pagination_uses_stable_cursor() -> None:
     assert [item["request_id"] for item in first_page["items"]] == ["req-2", "req-1"]
     assert [item["request_id"] for item in second_page["items"]] == ["req-0"]
     assert second_page["next_cursor"] is None
+
+
+def test_pending_summary_rejects_invalid_cursor() -> None:
+    connection = _connection()
+    add_approval_request(connection, _request("req-only"), "2026-05-08T10:00:00+00:00")
+
+    with pytest.raises(InvalidApprovalCursorError):
+        list_pending_approval_summaries(connection, limit=2, cursor="not-a-valid-cursor")
+
+
+def test_before_cursor_uses_last_seen_sort_order() -> None:
+    connection = _connection()
+    add_approval_request(connection, _request("req-old", command="cat ~/.npmrc"), "2026-05-08T10:00:00+00:00")
+    add_approval_request(connection, _request("req-middle", command="cat ~/.pypirc"), "2026-05-08T10:01:00+00:00")
+    add_approval_request(
+        connection,
+        _request("req-new", command="cat ~/.ssh/id_rsa", target_paths=("~/.ssh/id_rsa",)),
+        "2026-05-08T10:02:00+00:00",
+    )
+    add_approval_request(connection, _request("req-old-again", command="cat ~/.npmrc"), "2026-05-08T10:05:00+00:00")
+
+    rows = list_approval_requests(connection, limit=None, before_cursor="2026-05-08T10:02:00+00:00")
+
+    assert [row["request_id"] for row in rows] == ["req-middle"]
 
 
 def test_guard_store_migrates_database_missing_queue_columns(tmp_path: Path) -> None:

--- a/tests/test_guard_queue_contract.py
+++ b/tests/test_guard_queue_contract.py
@@ -8,6 +8,9 @@ import urllib.parse
 import urllib.request
 from pathlib import Path
 
+import pytest
+
+from codex_plugin_scanner.guard import store as store_module
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.models import GuardApprovalRequest
 from codex_plugin_scanner.guard.store import GuardStore
@@ -273,6 +276,35 @@ def test_resolve_queue_result_reports_duplicate_ids_without_unrelated_items() ->
     )
 
 
+def test_resolve_queue_result_reports_every_resolved_duplicate_id() -> None:
+    connection = _connection()
+    add_approval_request(connection, _request("req-active"), "2026-05-08T10:00:00+00:00")
+    for index in range(205):
+        _force_duplicate_row(connection, f"req-duplicate-{index:03d}", "req-active")
+
+    result = resolve_request_with_queue_result(
+        connection,
+        "req-active",
+        resolution_action="allow",
+        resolution_scope="artifact",
+        reason="reviewed",
+        resolved_at="2026-05-08T10:03:00+00:00",
+    )
+    pending_duplicates = connection.execute(
+        """
+        select count(*) as count
+        from approval_requests
+        where queue_group_id = (
+          select queue_group_id from approval_requests where request_id = 'req-active'
+        )
+          and status = 'pending'
+        """
+    ).fetchone()
+
+    assert len(result["resolved_duplicate_ids"]) == 205
+    assert pending_duplicates["count"] == 0
+
+
 def test_pending_summary_pagination_uses_stable_cursor() -> None:
     connection = _connection()
     for index in range(3):
@@ -401,6 +433,23 @@ def test_guard_store_migrates_database_missing_queue_columns(tmp_path: Path) -> 
     assert migrated["last_seen_at"] == "2026-05-08T10:00:00+00:00"
     assert isinstance(migrated["action_identity"], str)
     assert str(migrated["queue_group_id"]).startswith("approval-group:v1:")
+
+
+def test_queue_backfill_runs_once_per_schema_version(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    original = store_module.backfill_approval_queue_columns
+
+    def recording_backfill(connection: sqlite3.Connection) -> None:
+        calls.append("backfill")
+        original(connection)
+
+    monkeypatch.setattr(store_module, "backfill_approval_queue_columns", recording_backfill)
+
+    guard_home = tmp_path / "guard-home"
+    GuardStore(guard_home)
+    GuardStore(guard_home)
+
+    assert calls == ["backfill"]
 
 
 def test_daemon_resolution_envelope_and_request_filters(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary\n- add stable queue identity, dedupe metadata, and queue-aware approval resolution envelopes\n- add paginated/filterable request queue APIs and runtime queue hints\n- document the local queue API contract and expand migration, API, and scale coverage\n\n## Verification\n- uv run pytest -q\n- uv run ruff check src/codex_plugin_scanner tests\n- uv build