### PR TITLE
feat(guard): add guided app setup APIs

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/base.py
+++ b/src/codex_plugin_scanner/guard/adapters/base.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import subprocess
 from dataclasses import dataclass
+from functools import cached_property
 from pathlib import Path
 
 from ...path_support import resolves_within_root
@@ -119,11 +120,15 @@ class HarnessAdapter:
             **shim_manifest,
         }
 
-    def setup_contract(self) -> HarnessSetupContract:
+    @cached_property
+    def _setup_contract(self) -> HarnessSetupContract:
         contract = setup_contract_for(self.harness)
         if contract is None:
             raise ValueError(f"Unsupported harness setup contract: {self.harness}")
         return contract
+
+    def setup_contract(self) -> HarnessSetupContract:
+        return self._setup_contract
 
     def setup_steps(self) -> tuple[HarnessSetupStep, ...]:
         return self.setup_contract().setup_steps

--- a/src/codex_plugin_scanner/guard/adapters/base.py
+++ b/src/codex_plugin_scanner/guard/adapters/base.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from ...path_support import resolves_within_root
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
+from .contracts import HarnessCoverageSummary, HarnessSetupContract, HarnessSetupStep, setup_contract_for
 
 
 @dataclass(frozen=True, slots=True)
@@ -117,6 +118,24 @@ class HarnessAdapter:
             "config_path": shim_manifest["shim_path"],
             **shim_manifest,
         }
+
+    def setup_contract(self) -> HarnessSetupContract:
+        contract = setup_contract_for(self.harness)
+        if contract is None:
+            raise ValueError(f"Unsupported harness setup contract: {self.harness}")
+        return contract
+
+    def setup_steps(self) -> tuple[HarnessSetupStep, ...]:
+        return self.setup_contract().setup_steps
+
+    def verify_steps(self) -> tuple[HarnessSetupStep, ...]:
+        return self.setup_contract().verify_steps
+
+    def repair_steps(self) -> tuple[HarnessSetupStep, ...]:
+        return self.setup_contract().repair_steps
+
+    def coverage_summary(self) -> HarnessCoverageSummary:
+        return self.setup_contract().coverage
 
     def executable_candidates(self, context: HarnessContext) -> tuple[Path, ...]:
         del context

--- a/src/codex_plugin_scanner/guard/adapters/contracts.py
+++ b/src/codex_plugin_scanner/guard/adapters/contracts.py
@@ -322,12 +322,11 @@ def setup_contract_for(harness: str) -> HarnessSetupContract | None:
 def all_setup_contracts() -> tuple[HarnessSetupContract, ...]:
     """Return guided setup metadata for all supported harnesses."""
 
-    contracts: list[HarnessSetupContract] = []
-    for contract in HARNESS_CONTRACTS:
-        setup_contract = setup_contract_for(contract.harness)
-        if setup_contract is not None:
-            contracts.append(setup_contract)
-    return tuple(contracts)
+    return tuple(
+        setup_contract
+        for contract in HARNESS_CONTRACTS
+        if (setup_contract := setup_contract_for(contract.harness)) is not None
+    )
 
 
 def harness_contracts_table() -> str:

--- a/src/codex_plugin_scanner/guard/adapters/contracts.py
+++ b/src/codex_plugin_scanner/guard/adapters/contracts.py
@@ -44,6 +44,85 @@ class HarnessProtectionContract:
     smoke_command: str
 
 
+@dataclass(frozen=True, slots=True)
+class HarnessSetupStep:
+    """Plain-language action for connecting or checking one harness."""
+
+    step_id: str
+    title: str
+    body: str
+    command: tuple[str, ...] = ()
+    writes_config: bool = False
+    requires_confirmation: bool = False
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "step_id": self.step_id,
+            "title": self.title,
+            "body": self.body,
+            "command": list(self.command),
+            "writes_config": self.writes_config,
+            "requires_confirmation": self.requires_confirmation,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessCoverageSummary:
+    """Summary of what Guard can and cannot observe for one harness."""
+
+    native_hooks: bool
+    browser_fallback: bool
+    mcp_proxy: bool
+    prompt_hooks: bool
+    blind_spots: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "native_hooks": self.native_hooks,
+            "browser_fallback": self.browser_fallback,
+            "mcp_proxy": self.mcp_proxy,
+            "prompt_hooks": self.prompt_hooks,
+            "blind_spots": list(self.blind_spots),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessSetupContract:
+    """Dashboard and CLI setup contract for one supported harness."""
+
+    harness: str
+    display_name: str
+    install_aliases: tuple[str, ...]
+    setup_steps: tuple[HarnessSetupStep, ...]
+    verify_steps: tuple[HarnessSetupStep, ...]
+    repair_steps: tuple[HarnessSetupStep, ...]
+    coverage: HarnessCoverageSummary
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "harness": self.harness,
+            "display_name": self.display_name,
+            "install_aliases": list(self.install_aliases),
+            "setup_steps": [step.to_dict() for step in self.setup_steps],
+            "verify_steps": [step.to_dict() for step in self.verify_steps],
+            "repair_steps": [step.to_dict() for step in self.repair_steps],
+            "coverage": self.coverage.to_dict(),
+        }
+
+
+_DISPLAY_NAMES = {
+    "codex": "Codex",
+    "claude-code": "Claude Code",
+    "opencode": "OpenCode",
+    "copilot": "Copilot",
+    "cursor": "Cursor",
+    "gemini": "Gemini",
+    "hermes": "Hermes",
+    "openclaw": "OpenClaw",
+    "antigravity": "Antigravity",
+}
+
+
 HARNESS_CONTRACTS: tuple[HarnessProtectionContract, ...] = (
     HarnessProtectionContract(
         harness="codex",
@@ -181,6 +260,74 @@ for _c in HARNESS_CONTRACTS:
 def contract_for(harness: str) -> HarnessProtectionContract | None:
     """Return the contract for a harness name or install alias, or None."""
     return _CONTRACT_BY_ALIAS.get(harness)
+
+
+def setup_contract_for(harness: str) -> HarnessSetupContract | None:
+    """Return guided setup metadata for a harness name or install alias."""
+
+    contract = contract_for(harness)
+    if contract is None:
+        return None
+    alias = contract.install_aliases[0] if contract.install_aliases else contract.harness
+    display_name = _DISPLAY_NAMES.get(contract.harness, contract.harness)
+    coverage = HarnessCoverageSummary(
+        native_hooks=contract.native_approval,
+        browser_fallback=contract.browser_fallback,
+        mcp_proxy="mcp_tool" in contract.event_surfaces,
+        prompt_hooks="prompt" in contract.event_surfaces,
+        blind_spots=(contract.known_blind_spots,),
+    )
+    setup_steps = (
+        HarnessSetupStep(
+            step_id="connect",
+            title=f"Connect {display_name}",
+            body=f"Add Guard's local protection hooks for {display_name}.",
+            command=("hol-guard", "apps", "connect", alias),
+            writes_config=True,
+        ),
+        HarnessSetupStep(
+            step_id="review-coverage",
+            title="Review what Guard can see",
+            body="Check covered events and known blind spots before relying on this app.",
+        ),
+    )
+    verify_steps = (
+        HarnessSetupStep(
+            step_id="safe-test",
+            title="Run a safe protection test",
+            body="Confirm Guard can detect the app without reading secrets or changing app config.",
+            command=("hol-guard", "apps", "test", alias),
+        ),
+    )
+    repair_steps = (
+        HarnessSetupStep(
+            step_id="repair",
+            title=f"Repair {display_name} protection",
+            body="Re-apply Guard managed config if hooks were removed or changed.",
+            command=("hol-guard", "apps", "repair", alias),
+            writes_config=True,
+        ),
+    )
+    return HarnessSetupContract(
+        harness=contract.harness,
+        display_name=display_name,
+        install_aliases=contract.install_aliases,
+        setup_steps=setup_steps,
+        verify_steps=verify_steps,
+        repair_steps=repair_steps,
+        coverage=coverage,
+    )
+
+
+def all_setup_contracts() -> tuple[HarnessSetupContract, ...]:
+    """Return guided setup metadata for all supported harnesses."""
+
+    contracts: list[HarnessSetupContract] = []
+    for contract in HARNESS_CONTRACTS:
+        setup_contract = setup_contract_for(contract.harness)
+        if setup_contract is not None:
+            contracts.append(setup_contract)
+    return tuple(contracts)
 
 
 def harness_contracts_table() -> str:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -274,8 +274,8 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     ):
         app_parser = apps_subparsers.add_parser(app_command, help=help_text)
         app_parser.add_argument("harness")
-        _add_guard_common_args(app_parser)
-        app_parser.add_argument("--json", action="store_true")
+        _add_guard_common_args(app_parser, suppress_defaults=True)
+        app_parser.add_argument("--json", action="store_true", default=argparse.SUPPRESS)
         if app_command in {"connect", "repair"}:
             app_parser.add_argument("--dry-run", action="store_true")
         if app_command == "disconnect":
@@ -706,10 +706,15 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     ]
 
 
-def _add_guard_common_args(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--home")
-    parser.add_argument("--guard-home")
-    parser.add_argument("--workspace")
+def _add_guard_common_args(
+    parser: argparse.ArgumentParser,
+    *,
+    suppress_defaults: bool = False,
+) -> None:
+    default = argparse.SUPPRESS if suppress_defaults else None
+    parser.add_argument("--home", default=default)
+    parser.add_argument("--guard-home", default=default)
+    parser.add_argument("--workspace", default=default)
 
 
 def _add_guard_cisco_mode_arg(parser: argparse.ArgumentParser) -> None:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -121,7 +121,13 @@ from .connect_flow import (
     DEFAULT_GUARD_SYNC_URL,
     run_guard_connect_command,
 )
-from .install_commands import apply_managed_install
+from .install_commands import (
+    apply_managed_install,
+    build_harness_setup_plan,
+    build_harness_verification,
+    list_harness_setup_items,
+    uninstall_confirmation_token,
+)
 from .product import build_guard_start_payload, build_guard_status_payload
 from .update_commands import run_guard_update
 
@@ -134,6 +140,7 @@ _GUARD_HELP_GROUPS = (
     "  start        First-run setup and the Guard operating loop\n"
     "  status       Current local protection state and next actions\n"
     "  dashboard    Open the local Guard dashboard in your browser\n"
+    "  apps         Connect, test, repair, or disconnect protected apps\n"
     "  run          Enforce Guard before a harness launch\n"
     "  approvals    Resolve the current request queue\n"
     "  receipts     Review recent local decisions\n"
@@ -235,7 +242,7 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
         required=True,
         parser_class=FriendlyArgumentParser,
         metavar=(
-            "{start,status,dashboard,bootstrap,detect,install,update,uninstall,run,protect,preflight,scan,diff,receipts,inventory,abom,"
+            "{start,status,dashboard,apps,bootstrap,detect,install,update,uninstall,run,protect,preflight,scan,diff,receipts,inventory,abom,"
             "approvals,explain,allow,deny,policies,exceptions,advisories,events,doctor,connect,login,sync,device,bridge}"
         ),
     )
@@ -254,6 +261,25 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     )
     _add_guard_common_args(dashboard_parser)
     dashboard_parser.add_argument("--json", action="store_true")
+
+    apps_parser = guard_subparsers.add_parser("apps", help="Connect, test, repair, or disconnect protected apps")
+    _add_guard_common_args(apps_parser)
+    apps_parser.add_argument("--json", action="store_true")
+    apps_subparsers = apps_parser.add_subparsers(dest="apps_command", parser_class=FriendlyArgumentParser)
+    for app_command, help_text in (
+        ("connect", "Connect an app to local Guard protection"),
+        ("test", "Run a safe local Guard protection check"),
+        ("repair", "Repair Guard-managed app config"),
+        ("disconnect", "Remove Guard-managed app config"),
+    ):
+        app_parser = apps_subparsers.add_parser(app_command, help=help_text)
+        app_parser.add_argument("harness")
+        _add_guard_common_args(app_parser)
+        app_parser.add_argument("--json", action="store_true")
+        if app_command in {"connect", "repair"}:
+            app_parser.add_argument("--dry-run", action="store_true")
+        if app_command == "disconnect":
+            app_parser.add_argument("--confirm")
 
     admin_parser = guard_subparsers.add_parser("admin", help=argparse.SUPPRESS)
     _add_guard_common_args(admin_parser)
@@ -702,6 +728,82 @@ def _guard_http_url(value: str) -> str:
     return value
 
 
+def _run_apps_command(
+    args: argparse.Namespace,
+    context: HarnessContext,
+    store: GuardStore,
+    workspace: str | None,
+) -> int:
+    apps_command = getattr(args, "apps_command", None)
+    if apps_command is None:
+        _emit(
+            "apps",
+            {
+                "generated_at": _now(),
+                "items": list_harness_setup_items(context, store),
+            },
+            getattr(args, "json", False),
+        )
+        return 0
+
+    harness = str(getattr(args, "harness", "")).strip()
+    if not harness:
+        print("guard apps requires a harness.", file=sys.stderr)
+        return 2
+    if apps_command == "test":
+        try:
+            payload = build_harness_verification(harness, context, store)
+        except ValueError as error:
+            print(str(error), file=sys.stderr)
+            return 2
+        _emit("apps", payload, getattr(args, "json", False))
+        return 0
+
+    if apps_command in {"connect", "repair"} and bool(getattr(args, "dry_run", False)):
+        try:
+            payload = build_harness_setup_plan(apps_command, harness, context, dry_run=True)
+        except ValueError as error:
+            print(str(error), file=sys.stderr)
+            return 2
+        _emit("apps", payload, getattr(args, "json", False))
+        return 0
+
+    if apps_command == "disconnect":
+        try:
+            canonical_harness = get_adapter(harness).harness
+        except ValueError as error:
+            print(str(error), file=sys.stderr)
+            return 2
+        expected_confirmation = uninstall_confirmation_token(canonical_harness)
+        if getattr(args, "confirm", None) != expected_confirmation:
+            payload = {
+                "error": "confirmation_required",
+                "harness": canonical_harness,
+                "confirmation_phrase": expected_confirmation,
+                "confirm_command": f"hol-guard apps disconnect {canonical_harness} --confirm {expected_confirmation}",
+            }
+            _emit("apps", payload, getattr(args, "json", False))
+            return 2
+
+    install_command = "uninstall" if apps_command == "disconnect" else "install"
+    try:
+        payload = apply_managed_install(
+            install_command,
+            harness,
+            False,
+            context,
+            store,
+            workspace,
+            _now(),
+        )
+    except ValueError as error:
+        print(str(error), file=sys.stderr)
+        return 2
+    payload["action"] = apps_command
+    _emit("apps", payload, getattr(args, "json", False))
+    return 0
+
+
 def _build_cisco_scan_options(mode: str) -> ScanOptions:
     return ScanOptions(cisco_skill_scan=mode, cisco_mcp_scan=mode)
 
@@ -878,6 +980,9 @@ def run_guard_command(
         }
         _emit("detect", payload, getattr(args, "json", False))
         return 0
+
+    if args.guard_command == "apps":
+        return _run_apps_command(args, context, store, str(workspace) if workspace else None)
 
     if args.guard_command == "install":
         try:

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import glob as globlib
+import shutil
 from pathlib import Path
 
-from ..adapters import get_adapter
-from ..adapters.base import HarnessContext
+from ..adapters import get_adapter, list_adapters
+from ..adapters.base import HarnessAdapter, HarnessContext
+from ..adapters.contracts import contract_for
 from ..consumer import detect_all
 from ..runtime.skill_protection import build_skill_identity, detect_skill_content_risk
 from ..store import GuardStore
@@ -42,6 +45,145 @@ def apply_managed_install(
         if skill_scan:
             payload["skill_scan"] = skill_scan
     return payload
+
+
+def list_harness_setup_items(context: HarnessContext, store: GuardStore | None = None) -> list[dict[str, object]]:
+    items: list[dict[str, object]] = []
+    for adapter in list_adapters():
+        detection = _safe_setup_detection(adapter, context, store)
+        detected = (
+            bool(detection["installed"])
+            or bool(detection["command_available"])
+            or bool(detection["config_paths"])
+        )
+        if bool(detection["installed"]):
+            status = "protected"
+        elif detected:
+            status = "found"
+        else:
+            status = "not_found"
+        items.append(
+            {
+                "harness": adapter.harness,
+                "status": status,
+                "installed": detection["installed"],
+                "command_available": detection["command_available"],
+                "config_paths": detection["config_paths"],
+                "artifact_count": 0,
+                **adapter.setup_contract().to_dict(),
+            }
+        )
+    return items
+
+
+def build_harness_setup_plan(
+    action: str,
+    requested_harness: str,
+    context: HarnessContext,
+    *,
+    dry_run: bool,
+) -> dict[str, object]:
+    adapter = get_adapter(requested_harness)
+    contract = adapter.setup_contract()
+    if action == "repair":
+        steps = adapter.repair_steps()
+    elif action == "uninstall":
+        steps = ()
+    else:
+        steps = adapter.setup_steps()
+    payload: dict[str, object] = {
+        "harness": adapter.harness,
+        "action": action,
+        "dry_run": dry_run,
+        "contract": contract.to_dict(),
+        "steps": [step.to_dict() for step in steps],
+        "workspace": str(context.workspace_dir) if context.workspace_dir is not None else None,
+    }
+    if action == "uninstall":
+        confirmation_phrase = uninstall_confirmation_token(adapter.harness)
+        payload["confirmation_phrase"] = confirmation_phrase
+        payload["confirm_command"] = f"hol-guard apps disconnect {adapter.harness} --confirm {confirmation_phrase}"
+        payload["steps"] = [
+            {
+                "step_id": "disconnect",
+                "title": f"Disconnect {contract.display_name}",
+                "body": "Remove Guard managed config for this app.",
+                "command": ["hol-guard", "apps", "disconnect", adapter.harness],
+                "writes_config": True,
+                "requires_confirmation": True,
+            }
+        ]
+    return payload
+
+
+def build_harness_verification(
+    requested_harness: str,
+    context: HarnessContext,
+    store: GuardStore | None = None,
+) -> dict[str, object]:
+    adapter = get_adapter(requested_harness)
+    detection = _safe_setup_detection(adapter, context, store)
+    return {
+        "harness": adapter.harness,
+        "safe": True,
+        "contract": adapter.setup_contract().to_dict(),
+        "verification": {
+            "checked": True,
+            "writes_config": False,
+            "installed": detection["installed"],
+            "command_available": detection["command_available"],
+            "config_paths": detection["config_paths"],
+            "artifact_count": 0,
+            "warnings": [],
+            "steps": [step.to_dict() for step in adapter.verify_steps()],
+        },
+    }
+
+
+def uninstall_confirmation_token(harness: str) -> str:
+    return f"disconnect-{harness}"
+
+
+def _safe_setup_detection(
+    adapter: HarnessAdapter,
+    context: HarnessContext,
+    store: GuardStore | None,
+) -> dict[str, object]:
+    managed = store.get_managed_install(adapter.harness) if store is not None else None
+    protection_contract = contract_for(adapter.harness)
+    config_paths = protection_contract.config_paths if protection_contract is not None else ()
+    return {
+        "installed": bool(managed and managed.get("active")),
+        "command_available": bool(adapter.executable and shutil.which(adapter.executable)),
+        "config_paths": _existing_contract_config_paths(config_paths, context),
+    }
+
+
+def _existing_contract_config_paths(config_paths: tuple[str, ...], context: HarnessContext) -> list[str]:
+    existing: list[str] = []
+    for config_path in config_paths:
+        for candidate in _contract_config_path_candidates(config_path, context):
+            if candidate.exists():
+                existing.append(str(candidate))
+    return sorted(dict.fromkeys(existing))
+
+
+def _contract_config_path_candidates(config_path: str, context: HarnessContext) -> tuple[Path, ...]:
+    expanded_path = _expand_contract_config_path(config_path, context)
+    if globlib.has_magic(str(expanded_path)):
+        return tuple(sorted(Path(path) for path in globlib.glob(str(expanded_path))))
+    return (expanded_path,)
+
+
+def _expand_contract_config_path(config_path: str, context: HarnessContext) -> Path:
+    if config_path == "~":
+        return context.home_dir
+    if config_path.startswith("~/"):
+        return context.home_dir / config_path[2:]
+    path = Path(config_path)
+    if path.is_absolute():
+        return path
+    return context.home_dir / path
 
 
 def scan_workspace_skills(
@@ -128,4 +270,11 @@ def _resolve_targets(
     )
 
 
-__all__ = ["apply_managed_install", "scan_workspace_skills"]
+__all__ = [
+    "apply_managed_install",
+    "build_harness_setup_plan",
+    "build_harness_verification",
+    "list_harness_setup_items",
+    "scan_workspace_skills",
+    "uninstall_confirmation_token",
+]

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import glob as globlib
-import shutil
 from pathlib import Path
 
 from ..adapters import get_adapter, list_adapters
@@ -51,12 +50,8 @@ def list_harness_setup_items(context: HarnessContext, store: GuardStore | None =
     items: list[dict[str, object]] = []
     for adapter in list_adapters():
         detection = _safe_setup_detection(adapter, context, store)
-        detected = (
-            bool(detection["installed"])
-            or bool(detection["command_available"])
-            or bool(detection["config_paths"])
-        )
-        if bool(detection["installed"]):
+        detected = detection["installed"] or detection["command_available"] or bool(detection["config_paths"])
+        if detection["installed"]:
             status = "protected"
         elif detected:
             status = "found"
@@ -154,7 +149,7 @@ def _safe_setup_detection(
     config_paths = protection_contract.config_paths if protection_contract is not None else ()
     return {
         "installed": bool(managed and managed.get("active")),
-        "command_available": bool(adapter.executable and shutil.which(adapter.executable)),
+        "command_available": adapter.resolved_executable(context) is not None,
         "config_paths": _existing_contract_config_paths(config_paths, context),
     }
 
@@ -176,11 +171,9 @@ def _contract_config_path_candidates(config_path: str, context: HarnessContext) 
 
 
 def _expand_contract_config_path(config_path: str, context: HarnessContext) -> Path:
-    if config_path == "~":
-        return context.home_dir
-    if config_path.startswith("~/"):
-        return context.home_dir / config_path[2:]
     path = Path(config_path)
+    if path.parts and path.parts[0] == "~":
+        return context.home_dir.joinpath(*path.parts[1:])
     if path.is_absolute():
         return path
     return context.home_dir / path

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1142,12 +1142,17 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return True
         if len(path_parts) == 4 and path_parts[:2] == ["v1", "requests"] and path_parts[3] in {"approve", "block"}:
             return True
-        if len(path_parts) == 4 and path_parts[:2] == ["v1", "harnesses"] and path_parts[3] in {
-            "install",
-            "verify",
-            "repair",
-            "uninstall",
-        }:
+        if (
+            len(path_parts) == 4
+            and path_parts[:2] == ["v1", "harnesses"]
+            and path_parts[3]
+            in {
+                "install",
+                "verify",
+                "repair",
+                "uninstall",
+            }
+        ):
             return True
         return len(path_parts) == 4 and path_parts[:2] == ["v1", "artifacts"] and path_parts[3] == "diff"
 
@@ -1332,12 +1337,17 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return True
         if len(path_parts) == 4 and path_parts[:2] == ["v1", "requests"] and path_parts[3] in {"approve", "block"}:
             return True
-        if len(path_parts) == 4 and path_parts[:2] == ["v1", "harnesses"] and path_parts[3] in {
-            "install",
-            "verify",
-            "repair",
-            "uninstall",
-        }:
+        if (
+            len(path_parts) == 4
+            and path_parts[:2] == ["v1", "harnesses"]
+            and path_parts[3]
+            in {
+                "install",
+                "verify",
+                "repair",
+                "uninstall",
+            }
+        ):
             return True
         return len(path_parts) == 3 and path_parts[0] == "approvals" and path_parts[2] == "decision"
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -549,11 +549,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         )
 
     def _harness_context(self, payload: dict[str, object]) -> HarnessContext:
-        home = self._optional_string(payload.get("home"))
-        workspace = self._optional_string(payload.get("workspace"))
+        del payload
         return HarnessContext(
-            home_dir=Path(home).expanduser().resolve() if home is not None else Path.home().resolve(),
-            workspace_dir=Path(workspace).expanduser().resolve() if workspace is not None else None,
+            home_dir=Path.home().resolve(),
+            workspace_dir=None,
             guard_home=self.server.store.guard_home,  # type: ignore[attr-defined]
         )
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -18,11 +18,20 @@ from typing import Any
 from urllib.parse import parse_qs, parse_qsl, unquote, urlencode, urlparse, urlunparse
 
 from ...version import __version__
+from ..adapters import get_adapter
+from ..adapters.base import HarnessContext
 from ..approvals import (
     ApprovalRequestAlreadyResolvedError,
     ApprovalRequestNotFoundError,
     apply_approval_resolution,
     build_runtime_snapshot,
+)
+from ..cli.install_commands import (
+    apply_managed_install,
+    build_harness_setup_plan,
+    build_harness_verification,
+    list_harness_setup_items,
+    uninstall_confirmation_token,
 )
 from ..config import editable_guard_settings, load_guard_config, update_guard_settings
 from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES
@@ -126,6 +135,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 active_request_id=self._query_string(parsed.query, "active_request_id"),
             )
             self._write_json({**snapshot, "security_level": config.security_level})
+            return
+        if parsed.path == "/v1/harnesses":
+            context = self._harness_context({})
+            self._write_json({"items": list_harness_setup_items(context, self.server.store)})  # type: ignore[attr-defined]
             return
         if parsed.path == "/v1/inventory":
             from ..adapters.contracts import HARNESS_CONTRACTS
@@ -408,6 +421,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             result = repair_approval_center_locator(self.server.store.guard_home)  # type: ignore[attr-defined]
             self._write_json(result)
             return
+        if len(path_parts) == 4 and path_parts[:2] == ["v1", "harnesses"]:
+            self._handle_harness_action(path_parts[2], path_parts[3], payload)
+            return
         request_id, action, matched = self._resolve_request_action(path_parts, payload)
         if not matched:
             self.send_response(404)
@@ -531,6 +547,73 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 "source": source,
             }
         )
+
+    def _harness_context(self, payload: dict[str, object]) -> HarnessContext:
+        home = self._optional_string(payload.get("home"))
+        workspace = self._optional_string(payload.get("workspace"))
+        return HarnessContext(
+            home_dir=Path(home).expanduser().resolve() if home is not None else Path.home().resolve(),
+            workspace_dir=Path(workspace).expanduser().resolve() if workspace is not None else None,
+            guard_home=self.server.store.guard_home,  # type: ignore[attr-defined]
+        )
+
+    def _handle_harness_action(self, harness: str, action: str, payload: dict[str, object]) -> None:
+        if action not in {"install", "verify", "repair", "uninstall"}:
+            self._write_json({"error": "not_found"}, status=404)
+            return
+        context = self._harness_context(payload)
+        if action == "verify":
+            try:
+                self._write_json(build_harness_verification(harness, context, self.server.store))  # type: ignore[attr-defined]
+            except ValueError as error:
+                self._write_json({"error": str(error)}, status=404)
+            return
+        try:
+            dry_run = self._optional_bool(payload.get("dry_run"), default=True)
+        except ValueError:
+            self._write_json({"error": "invalid_dry_run"}, status=400)
+            return
+        try:
+            adapter = get_adapter(harness)
+        except ValueError as error:
+            self._write_json({"error": str(error)}, status=404)
+            return
+        if action == "uninstall":
+            expected_confirmation = uninstall_confirmation_token(adapter.harness)
+            confirmation = self._optional_string(payload.get("confirmation_phrase")) or self._optional_string(
+                payload.get("confirmation_token")
+            )
+            if confirmation != expected_confirmation:
+                self._write_json(
+                    {
+                        "error": "confirmation_required",
+                        "harness": adapter.harness,
+                        "confirmation_phrase": expected_confirmation,
+                        "confirm_command": (
+                            f"hol-guard apps disconnect {adapter.harness} --confirm {expected_confirmation}"
+                        ),
+                    },
+                    status=400,
+                )
+                return
+        if dry_run:
+            self._write_json(build_harness_setup_plan(action, adapter.harness, context, dry_run=True))
+            return
+        install_command = "uninstall" if action == "uninstall" else "install"
+        try:
+            result = apply_managed_install(
+                install_command,
+                adapter.harness,
+                False,
+                context,
+                self.server.store,  # type: ignore[attr-defined]
+                str(context.workspace_dir) if context.workspace_dir is not None else None,
+                _now(),
+            )
+        except ValueError as error:
+            self._write_json({"error": str(error)}, status=400)
+            return
+        self._write_json({"harness": adapter.harness, "action": action, "dry_run": False, **result})
 
     def _handle_requests_list(self, query_string: str) -> None:
         limit = self._query_limit(query_string, default=200, maximum=200)
@@ -1046,6 +1129,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/daemon/repair",
             "/v1/evidence",
             "/v1/evidence/export",
+            "/v1/harnesses",
             "/v1/policy",
             "/v1/policy/clear",
             "/v1/receipts",
@@ -1058,6 +1142,13 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if len(path_parts) == 3 and path_parts[:2] in (["v1", "requests"], ["v1", "receipts"]):
             return True
         if len(path_parts) == 4 and path_parts[:2] == ["v1", "requests"] and path_parts[3] in {"approve", "block"}:
+            return True
+        if len(path_parts) == 4 and path_parts[:2] == ["v1", "harnesses"] and path_parts[3] in {
+            "install",
+            "verify",
+            "repair",
+            "uninstall",
+        }:
             return True
         return len(path_parts) == 4 and path_parts[:2] == ["v1", "artifacts"] and path_parts[3] == "diff"
 
@@ -1241,6 +1332,13 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if len(path_parts) == 4 and path_parts[:2] == ["v1", "operations"] and path_parts[3] in {"items", "status"}:
             return True
         if len(path_parts) == 4 and path_parts[:2] == ["v1", "requests"] and path_parts[3] in {"approve", "block"}:
+            return True
+        if len(path_parts) == 4 and path_parts[:2] == ["v1", "harnesses"] and path_parts[3] in {
+            "install",
+            "verify",
+            "repair",
+            "uninstall",
+        }:
             return True
         return len(path_parts) == 3 and path_parts[0] == "approvals" and path_parts[2] == "decision"
 

--- a/tests/test_guard_harness_setup.py
+++ b/tests/test_guard_harness_setup.py
@@ -13,7 +13,7 @@ import pytest
 from codex_plugin_scanner.guard.adapters import get_adapter, list_adapters
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.contracts import HarnessSetupContract
-from codex_plugin_scanner.guard.cli.commands import run_guard_command
+from codex_plugin_scanner.guard.cli.commands import add_guard_root_parser, run_guard_command
 from codex_plugin_scanner.guard.cli.install_commands import list_harness_setup_items
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.store import GuardStore
@@ -220,6 +220,32 @@ def test_apps_test_alias_uses_safe_verification(tmp_path: Path, capsys: pytest.C
     assert payload["harness"] == "codex"
     assert payload["safe"] is True
     assert payload["verification"]["writes_config"] is False
+
+
+def test_apps_subcommand_preserves_parent_flags(tmp_path: Path) -> None:
+    parser = argparse.ArgumentParser()
+    add_guard_root_parser(parser)
+
+    args = parser.parse_args(
+        [
+            "apps",
+            "--home",
+            str(tmp_path / "home"),
+            "--guard-home",
+            str(tmp_path / "guard-home"),
+            "--workspace",
+            str(tmp_path / "workspace"),
+            "--json",
+            "connect",
+            "codex",
+        ]
+    )
+
+    assert args.home == str(tmp_path / "home")
+    assert args.guard_home == str(tmp_path / "guard-home")
+    assert args.workspace == str(tmp_path / "workspace")
+    assert args.json is True
+    assert args.apps_command == "connect"
 
 
 def test_apps_inventory_uses_adapter_command_resolution(

--- a/tests/test_guard_harness_setup.py
+++ b/tests/test_guard_harness_setup.py
@@ -14,6 +14,7 @@ from codex_plugin_scanner.guard.adapters import get_adapter, list_adapters
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.contracts import HarnessSetupContract
 from codex_plugin_scanner.guard.cli.commands import run_guard_command
+from codex_plugin_scanner.guard.cli.install_commands import list_harness_setup_items
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -219,6 +220,24 @@ def test_apps_test_alias_uses_safe_verification(tmp_path: Path, capsys: pytest.C
     assert payload["harness"] == "codex"
     assert payload["safe"] is True
     assert payload["verification"]["writes_config"] is False
+
+
+def test_apps_inventory_uses_adapter_command_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    adapter = get_adapter("claude-code")
+
+    def resolved_executable(_context: HarnessContext) -> str | None:
+        return str(tmp_path / "home" / ".claude" / "local" / "claude")
+
+    monkeypatch.setattr(adapter, "resolved_executable", resolved_executable)
+
+    items = list_harness_setup_items(context, GuardStore(tmp_path / "guard-home"))
+
+    claude = next(item for item in items if item["harness"] == "claude-code")
+    assert claude["command_available"] is True
 
 
 def test_apps_disconnect_confirmation_phrase_is_visible(

--- a/tests/test_guard_harness_setup.py
+++ b/tests/test_guard_harness_setup.py
@@ -1,0 +1,290 @@
+"""Tests for guided Guard harness setup contracts and app aliases."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters import get_adapter, list_adapters
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.contracts import HarnessSetupContract
+from codex_plugin_scanner.guard.cli.commands import run_guard_command
+from codex_plugin_scanner.guard.daemon import GuardDaemonServer
+from codex_plugin_scanner.guard.store import GuardStore
+
+SUPPORTED_HARNESSES = (
+    "codex",
+    "claude-code",
+    "opencode",
+    "copilot",
+    "gemini",
+    "cursor",
+    "hermes",
+    "openclaw",
+)
+
+
+def _context(tmp_path: Path) -> HarnessContext:
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    guard_home = tmp_path / "guard-home"
+    workspace.mkdir(parents=True, exist_ok=True)
+    return HarnessContext(home_dir=home, workspace_dir=workspace, guard_home=guard_home)
+
+
+def _read_json_response(request: urllib.request.Request) -> tuple[int, dict[str, object]]:
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            return response.status, json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        return error.code, json.loads(error.read().decode("utf-8"))
+
+
+def _request(
+    port: int,
+    path: str,
+    *,
+    token: str | None = None,
+    payload: dict[str, object] | None = None,
+) -> urllib.request.Request:
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    headers = {"Content-Type": "application/json"}
+    if token is not None:
+        headers["X-Guard-Token"] = token
+    return urllib.request.Request(
+        f"http://127.0.0.1:{port}{path}",
+        data=data,
+        headers=headers,
+        method="POST" if payload is not None else "GET",
+    )
+
+
+@pytest.mark.parametrize("harness", SUPPORTED_HARNESSES)
+def test_adapter_exposes_guided_setup_contract(harness: str) -> None:
+    adapter = get_adapter(harness)
+
+    contract = adapter.setup_contract()
+
+    assert isinstance(contract, HarnessSetupContract)
+    assert contract.harness == adapter.harness
+    assert contract.setup_steps
+    assert contract.verify_steps
+    assert contract.repair_steps
+    assert contract.coverage.native_hooks in {True, False}
+    assert contract.coverage.browser_fallback in {True, False}
+    assert contract.coverage.mcp_proxy in {True, False}
+    assert contract.coverage.prompt_hooks in {True, False}
+    assert contract.coverage.blind_spots
+    assert all(step.title and step.body for step in contract.setup_steps)
+    assert all(step.command[0] == "hol-guard" for step in contract.verify_steps)
+
+
+def test_every_adapter_has_setup_methods() -> None:
+    for adapter in list_adapters():
+        assert adapter.setup_steps()
+        assert adapter.verify_steps()
+        assert adapter.repair_steps()
+        assert adapter.coverage_summary().blind_spots
+
+
+def test_daemon_lists_harness_setup_contracts(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, payload = _read_json_response(_request(daemon.port, "/v1/harnesses"))
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    items = payload["items"]
+    assert isinstance(items, list)
+    harnesses = {item["harness"] for item in items if isinstance(item, dict)}
+    assert set(SUPPORTED_HARNESSES).issubset(harnesses)
+    codex = next(item for item in items if isinstance(item, dict) and item["harness"] == "codex")
+    assert codex["setup_steps"]
+    assert codex["verify_steps"]
+    assert codex["repair_steps"]
+    assert codex["coverage"]["browser_fallback"] is True
+
+
+def test_daemon_install_endpoint_defaults_to_dry_run(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/harnesses/codex/install",
+                token=daemon._server.auth_token,
+                payload={},
+            )
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert payload["dry_run"] is True
+    assert payload["action"] == "install"
+    assert payload["contract"]["harness"] == "codex"
+    assert store.get_managed_install("codex") is None
+
+
+def test_daemon_verify_endpoint_runs_safe_local_detection(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/harnesses/codex/verify",
+                token=daemon._server.auth_token,
+                payload={},
+            )
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert payload["harness"] == "codex"
+    assert payload["safe"] is True
+    assert payload["verification"]["checked"] is True
+    assert payload["verification"]["writes_config"] is False
+
+
+def test_daemon_uninstall_requires_confirmation_token(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/harnesses/codex/uninstall",
+                token=daemon._server.auth_token,
+                payload={},
+            )
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 400
+    assert payload["error"] == "confirmation_required"
+    assert payload["confirmation_phrase"] == "disconnect-codex"
+    assert payload["confirm_command"] == "hol-guard apps disconnect codex --confirm disconnect-codex"
+
+
+def test_apps_alias_lists_harnesses_as_plain_inventory(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    args = argparse.Namespace(
+        guard_command="apps",
+        apps_command=None,
+        harness=None,
+        home=str(tmp_path / "home"),
+        guard_home=str(tmp_path / "guard-home"),
+        workspace=str(tmp_path / "workspace"),
+        json=True,
+    )
+
+    exit_code = run_guard_command(args)
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["items"]
+    assert payload["items"][0]["setup_steps"]
+    assert payload["items"][0]["coverage"]["blind_spots"]
+
+
+def test_apps_test_alias_uses_safe_verification(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    args = argparse.Namespace(
+        guard_command="apps",
+        apps_command="test",
+        harness="codex",
+        home=str(tmp_path / "home"),
+        guard_home=str(tmp_path / "guard-home"),
+        workspace=str(tmp_path / "workspace"),
+        json=True,
+    )
+
+    exit_code = run_guard_command(args)
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["harness"] == "codex"
+    assert payload["safe"] is True
+    assert payload["verification"]["writes_config"] is False
+
+
+def test_apps_disconnect_confirmation_phrase_is_visible(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    args = argparse.Namespace(
+        guard_command="apps",
+        apps_command="disconnect",
+        harness="codex",
+        confirm=None,
+        home=str(tmp_path / "home"),
+        guard_home=str(tmp_path / "guard-home"),
+        workspace=str(tmp_path / "workspace"),
+        json=True,
+    )
+
+    exit_code = run_guard_command(args)
+
+    assert exit_code == 2
+    output = capsys.readouterr().out
+    assert "disconnect-codex" in output
+    payload = json.loads(output)
+    assert payload["confirmation_phrase"] == "disconnect-codex"
+    assert payload["confirm_command"] == "hol-guard apps disconnect codex --confirm disconnect-codex"
+
+
+def test_apps_safe_setup_does_not_read_skill_env_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    home = tmp_path / "home"
+    skill_env = home / ".agents" / "skills" / "network-helper" / "references" / ".env"
+    skill_env.parent.mkdir(parents=True, exist_ok=True)
+    skill_env.write_text("API_TOKEN=secret\n", encoding="utf-8")
+    original_read_text = Path.read_text
+
+    def guarded_read_text(path: Path, *args: object, **kwargs: object) -> str:
+        if path.name == ".env":
+            raise AssertionError("safe setup flow must not read .env files")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", guarded_read_text)
+    list_args = argparse.Namespace(
+        guard_command="apps",
+        apps_command=None,
+        harness=None,
+        home=str(home),
+        guard_home=str(tmp_path / "guard-home"),
+        workspace=str(tmp_path / "workspace"),
+        json=True,
+    )
+    test_args = argparse.Namespace(
+        guard_command="apps",
+        apps_command="test",
+        harness="hermes",
+        home=str(home),
+        guard_home=str(tmp_path / "guard-home"),
+        workspace=str(tmp_path / "workspace"),
+        json=True,
+    )
+
+    assert run_guard_command(list_args) == 0
+    list_payload = json.loads(capsys.readouterr().out)
+    assert run_guard_command(test_args) == 0
+    test_payload = json.loads(capsys.readouterr().out)
+    assert list_payload["items"]
+    assert test_payload["safe"] is True


### PR DESCRIPTION
## Summary
- add guided app setup contracts and safe verification metadata
- expose local harness setup APIs for install, verify, repair, and disconnect flows
- add plain hol-guard apps aliases for app inventory and setup actions

## Verification
- uv run ruff check src/codex_plugin_scanner/guard/adapters src/codex_plugin_scanner/guard/cli src/codex_plugin_scanner/guard/daemon tests/test_guard_harness_setup.py
- uv run pytest tests/test_guard_harness_setup.py -q
- uv run pytest tests/test_guard_claude_adapter.py tests/test_guard_copilot_adapter.py tests/test_guard_harness_setup.py -q
- git --no-pager diff --check