### PR TITLE
feat(guard): normalize Cisco scanner evidence

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/cisco_evidence.py
+++ b/src/codex_plugin_scanner/guard/runtime/cisco_evidence.py
@@ -1,0 +1,175 @@
+"""Cisco scanner evidence adapters for Guard runtime signals."""
+
+from __future__ import annotations
+
+import re
+from hashlib import sha256
+
+from codex_plugin_scanner.guard.runtime.scanner_cache import scanner_cache_key
+from codex_plugin_scanner.guard.runtime.signals import (
+    GuardRiskSignalV3,
+    RiskConfidenceLabel,
+    RiskSeverityLabel,
+    RiskSignalCategory,
+    RiskSignalSource,
+    ScannerStatusLabel,
+)
+from codex_plugin_scanner.integrations.cisco_skill_scanner import CiscoIntegrationStatus
+from codex_plugin_scanner.models import Finding, Severity
+
+_LONG_SECRET_LIKE_TOKEN = re.compile(r"\b[A-Za-z0-9_./+=-]{32,}\b")
+_MAX_TEXT_LENGTH = 280
+__all__ = ["cisco_finding_to_risk_signal", "scanner_cache_key"]
+
+
+def cisco_finding_to_risk_signal(
+    finding: Finding,
+    *,
+    scanner_status: CiscoIntegrationStatus,
+    scanner_name: str | None = None,
+    source_version: str = "unknown",
+) -> GuardRiskSignalV3:
+    source = _source_from_finding(finding)
+    category = _category_from_finding(finding, source)
+    display_name = scanner_name or _scanner_name_from_source(source)
+    evidence_ref = _evidence_ref(finding)
+    return GuardRiskSignalV3(
+        signal_id=_signal_id(finding),
+        source=source,
+        source_version=source_version,
+        category=category,
+        severity=_severity_label(finding.severity),
+        confidence=_confidence_label(finding.severity),
+        title=_safe_text(finding.title, fallback="Cisco scanner finding"),
+        plain_language_summary=_safe_text(
+            finding.description,
+            fallback=f"{display_name} reported a potential {category} risk.",
+        ),
+        technical_detail=f"{display_name} rule {finding.rule_id} reported {finding.category} evidence.",
+        evidence_ref=evidence_ref,
+        scanner_name=display_name,
+        scanner_status=_status_label(scanner_status),
+        scanner_rule_id=finding.rule_id,
+        redaction_level="summary",
+        source_path=finding.file_path,
+        source_line=finding.line_number,
+        data_source=None,
+        data_sink=None,
+        recommended_action=_safe_optional_text(finding.remediation),
+    )
+
+
+def _signal_id(finding: Finding) -> str:
+    source = finding.source or "cisco-scanner"
+    path = finding.file_path or "unknown"
+    if finding.line_number is not None:
+        return f"{source}:{finding.rule_id}:{path}:{finding.line_number}"
+    payload = "|".join(
+        (
+            finding.rule_id,
+            path,
+            finding.title,
+            finding.description,
+            finding.remediation or "",
+        )
+    )
+    suffix = sha256(payload.encode("utf-8")).hexdigest()[:12]
+    return f"{source}:{finding.rule_id}:{path}:{suffix}"
+
+
+def _source_from_finding(finding: Finding) -> RiskSignalSource:
+    source = finding.source.lower()
+    if "mcp" in source:
+        return "cisco_mcp"
+    if "skill" in source:
+        return "cisco_skill"
+    if "mcp" in finding.category.lower():
+        return "cisco_mcp"
+    if "skill" in finding.category.lower():
+        return "cisco_skill"
+    return "native"
+
+
+def _category_from_finding(finding: Finding, source: RiskSignalSource) -> RiskSignalCategory:
+    if source == "cisco_mcp":
+        return "mcp"
+    if source == "cisco_skill":
+        return "skill"
+    category = finding.category.lower()
+    if "secret" in category:
+        return "secret"
+    if "network" in category:
+        return "network"
+    if "prompt" in category:
+        return "prompt"
+    if "supply" in category:
+        return "supply_chain"
+    return "policy"
+
+
+def _scanner_name_from_source(source: RiskSignalSource) -> str:
+    if source == "cisco_mcp":
+        return "Cisco MCP scanner"
+    if source == "cisco_skill":
+        return "Cisco skill scanner"
+    return "Cisco scanner"
+
+
+def _severity_label(severity: Severity) -> RiskSeverityLabel:
+    match severity:
+        case Severity.CRITICAL:
+            return "critical"
+        case Severity.HIGH:
+            return "high"
+        case Severity.MEDIUM:
+            return "medium"
+        case Severity.LOW:
+            return "low"
+        case Severity.INFO:
+            return "info"
+
+
+def _confidence_label(severity: Severity) -> RiskConfidenceLabel:
+    if severity in {Severity.CRITICAL, Severity.HIGH}:
+        return "strong"
+    if severity is Severity.MEDIUM:
+        return "likely"
+    return "weak"
+
+
+def _status_label(status: CiscoIntegrationStatus) -> ScannerStatusLabel:
+    match status:
+        case CiscoIntegrationStatus.ENABLED:
+            return "enabled"
+        case CiscoIntegrationStatus.SKIPPED:
+            return "skipped"
+        case CiscoIntegrationStatus.UNAVAILABLE:
+            return "unavailable"
+        case CiscoIntegrationStatus.FAILED:
+            return "failed"
+        case CiscoIntegrationStatus.TIMED_OUT:
+            return "timed_out"
+
+
+def _evidence_ref(finding: Finding) -> str | None:
+    if finding.file_path is None:
+        return None
+    if finding.line_number is None:
+        return finding.file_path
+    return f"{finding.file_path}:{finding.line_number}"
+
+
+def _safe_optional_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    return _safe_text(value, fallback="")
+
+
+def _safe_text(value: str, *, fallback: str) -> str:
+    normalized = " ".join(value.split())
+    if not normalized:
+        return fallback
+    redacted = _LONG_SECRET_LIKE_TOKEN.sub("[redacted]", normalized)
+    if len(redacted) <= _MAX_TEXT_LENGTH:
+        return redacted
+    return f"{redacted[: _MAX_TEXT_LENGTH - 1].rstrip()}…"

--- a/src/codex_plugin_scanner/guard/runtime/cisco_evidence.py
+++ b/src/codex_plugin_scanner/guard/runtime/cisco_evidence.py
@@ -78,7 +78,7 @@ def _signal_id(finding: Finding) -> str:
 
 
 def _source_from_finding(finding: Finding) -> RiskSignalSource:
-    source = finding.source.lower()
+    source = (finding.source or "").lower()
     if "mcp" in source:
         return "cisco_mcp"
     if "skill" in source:

--- a/src/codex_plugin_scanner/guard/runtime/cisco_evidence.py
+++ b/src/codex_plugin_scanner/guard/runtime/cisco_evidence.py
@@ -132,7 +132,7 @@ def _severity_label(severity: Severity) -> RiskSeverityLabel:
 def _confidence_label(severity: Severity) -> RiskConfidenceLabel:
     if severity in {Severity.CRITICAL, Severity.HIGH}:
         return "strong"
-    if severity is Severity.MEDIUM:
+    if severity == Severity.MEDIUM:
         return "likely"
     return "weak"
 

--- a/src/codex_plugin_scanner/guard/runtime/scanner_cache.py
+++ b/src/codex_plugin_scanner/guard/runtime/scanner_cache.py
@@ -1,0 +1,10 @@
+"""Scanner cache identity helpers."""
+
+from __future__ import annotations
+
+from hashlib import sha256
+
+
+def scanner_cache_key(*, scanner_name: str, input_content_hash: str, scanner_version: str) -> str:
+    payload = "\0".join((scanner_name.strip(), input_content_hash.strip(), scanner_version.strip()))
+    return sha256(payload.encode("utf-8")).hexdigest()

--- a/src/codex_plugin_scanner/guard/runtime/signals.py
+++ b/src/codex_plugin_scanner/guard/runtime/signals.py
@@ -28,6 +28,8 @@ RiskSignalCategory = Literal[
 RiskSeverityLabel = Literal["info", "low", "medium", "high", "critical"]
 RiskConfidenceLabel = Literal["weak", "likely", "strong"]
 RiskRedactionLevel = Literal["none", "summary", "redacted"]
+RiskSignalSource = Literal["native", "cisco_mcp", "cisco_skill", "threat_intel", "runtime_detector"]
+ScannerStatusLabel = Literal["enabled", "skipped", "unavailable", "failed", "timed_out"]
 
 _FAMILY_CATEGORY: dict[str, RiskSignalCategory] = {
     "network": "network",
@@ -109,6 +111,78 @@ class RiskSignalV2:
         )
 
 
+@dataclass(frozen=True, slots=True)
+class GuardRiskSignalV3:
+    """Scanner-aware risk signal with durable local evidence references."""
+
+    signal_id: str
+    source: RiskSignalSource
+    source_version: str
+    category: RiskSignalCategory
+    severity: RiskSeverityLabel
+    confidence: RiskConfidenceLabel
+    title: str
+    plain_language_summary: str
+    technical_detail: str | None
+    evidence_ref: str | None
+    scanner_name: str | None
+    scanner_status: ScannerStatusLabel
+    scanner_rule_id: str | None
+    redaction_level: RiskRedactionLevel
+    source_path: str | None
+    source_line: int | None
+    data_source: str | None
+    data_sink: str | None
+    recommended_action: str | None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "signal_id": self.signal_id,
+            "source": self.source,
+            "source_version": self.source_version,
+            "category": self.category,
+            "severity": self.severity,
+            "confidence": self.confidence,
+            "title": self.title,
+            "plain_language_summary": self.plain_language_summary,
+            "technical_detail": self.technical_detail,
+            "evidence_ref": self.evidence_ref,
+            "scanner_name": self.scanner_name,
+            "scanner_status": self.scanner_status,
+            "scanner_rule_id": self.scanner_rule_id,
+            "redaction_level": self.redaction_level,
+            "source_path": self.source_path,
+            "source_line": self.source_line,
+            "data_source": self.data_source,
+            "data_sink": self.data_sink,
+            "recommended_action": self.recommended_action,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> GuardRiskSignalV3:
+        return cls(
+            signal_id=_required_string(payload, "signal_id"),
+            source=_parse_source(payload.get("source")),
+            source_version=_required_string(payload, "source_version"),
+            category=_parse_category(payload.get("category")),
+            severity=_parse_severity(payload.get("severity")),
+            confidence=_parse_confidence(payload.get("confidence")),
+            title=_required_string(payload, "title"),
+            plain_language_summary=_required_string(payload, "plain_language_summary"),
+            technical_detail=_optional_string(payload, "technical_detail"),
+            evidence_ref=_optional_string(payload, "evidence_ref"),
+            scanner_name=_optional_string(payload, "scanner_name"),
+            scanner_status=_parse_scanner_status(payload.get("scanner_status")),
+            scanner_rule_id=_optional_string(payload, "scanner_rule_id"),
+            redaction_level=_parse_redaction_level(payload.get("redaction_level")),
+            source_path=_optional_string(payload, "source_path"),
+            source_line=_optional_int(payload, "source_line"),
+            data_source=_optional_string(payload, "data_source"),
+            data_sink=_optional_string(payload, "data_sink"),
+            recommended_action=_optional_string(payload, "recommended_action"),
+        )
+
+
 def severity_label_from_score(score: int | float) -> RiskSeverityLabel:
     if score >= 9:
         return "critical"
@@ -165,6 +239,31 @@ def _optional_string(payload: Mapping[str, object], key: str) -> str | None:
     if not isinstance(value, str):
         raise ValueError(f"{key} must be a string or null")
     return value
+
+
+def _optional_int(payload: Mapping[str, object], key: str) -> int | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, int):
+        raise ValueError(f"{key} must be an integer or null")
+    return value
+
+
+def _parse_source(value: object) -> RiskSignalSource:
+    match value:
+        case "native":
+            return "native"
+        case "cisco_mcp":
+            return "cisco_mcp"
+        case "cisco_skill":
+            return "cisco_skill"
+        case "threat_intel":
+            return "threat_intel"
+        case "runtime_detector":
+            return "runtime_detector"
+        case _:
+            raise ValueError("source must be a known risk signal source")
 
 
 def _parse_category(value: object) -> RiskSignalCategory:
@@ -241,3 +340,19 @@ def _parse_redaction_level(value: object) -> RiskRedactionLevel:
             return "redacted"
         case _:
             raise ValueError("redaction_level must be a known redaction level")
+
+
+def _parse_scanner_status(value: object) -> ScannerStatusLabel:
+    match value:
+        case "enabled":
+            return "enabled"
+        case "skipped":
+            return "skipped"
+        case "unavailable":
+            return "unavailable"
+        case "failed":
+            return "failed"
+        case "timed_out":
+            return "timed_out"
+        case _:
+            raise ValueError("scanner_status must be a known scanner status")

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -21,6 +21,7 @@ from cryptography.fernet import Fernet, InvalidToken
 
 from .edge_events import build_receipt_event
 from .models import GuardApprovalRequest, GuardArtifact, GuardReceipt, GuardRuntimeState, PolicyDecision
+from .runtime.scanner_cache import scanner_cache_key
 from .schemas.guard_event_v1 import GuardEventV1
 from .store_approvals import (
     add_approval_request as persist_approval_request,
@@ -619,6 +620,22 @@ class GuardStore:
             )
             """,
             """
+            create table if not exists scanner_cache (
+              scanner_name text not null,
+              target_id text not null,
+              cache_key text not null,
+              input_content_hash text not null,
+              scanner_version text not null,
+              payload_json text not null,
+              updated_at text not null,
+              primary key (scanner_name, target_id)
+            )
+            """,
+            """
+            create index if not exists idx_scanner_cache_key
+            on scanner_cache (cache_key)
+            """,
+            """
             create table if not exists managed_installs (
               harness text primary key,
               active integer not null,
@@ -808,6 +825,72 @@ class GuardStore:
         with self._connect() as connection:
             rows = connection.execute("select name from sqlite_master where type = 'table'").fetchall()
         return sorted(str(row["name"]) for row in rows)
+
+    def save_scanner_cache(
+        self,
+        *,
+        scanner_name: str,
+        target_id: str,
+        input_content_hash: str,
+        scanner_version: str,
+        payload: dict[str, object],
+        now: str,
+    ) -> None:
+        cache_key = scanner_cache_key(
+            scanner_name=scanner_name,
+            input_content_hash=input_content_hash,
+            scanner_version=scanner_version,
+        )
+        with self._connect() as connection:
+            connection.execute(
+                """
+                insert into scanner_cache (
+                  scanner_name, target_id, cache_key, input_content_hash, scanner_version, payload_json, updated_at
+                )
+                values (?, ?, ?, ?, ?, ?, ?)
+                on conflict(scanner_name, target_id) do update set
+                  cache_key = excluded.cache_key,
+                  input_content_hash = excluded.input_content_hash,
+                  scanner_version = excluded.scanner_version,
+                  payload_json = excluded.payload_json,
+                  updated_at = excluded.updated_at
+                """,
+                (
+                    scanner_name,
+                    target_id,
+                    cache_key,
+                    input_content_hash,
+                    scanner_version,
+                    json.dumps(payload, sort_keys=True),
+                    now,
+                ),
+            )
+
+    def get_scanner_cache(
+        self,
+        *,
+        scanner_name: str,
+        target_id: str,
+        input_content_hash: str,
+        scanner_version: str,
+    ) -> dict[str, object] | None:
+        cache_key = scanner_cache_key(
+            scanner_name=scanner_name,
+            input_content_hash=input_content_hash,
+            scanner_version=scanner_version,
+        )
+        with self._connect() as connection:
+            row = connection.execute(
+                """
+                select payload_json from scanner_cache
+                where scanner_name = ? and target_id = ? and cache_key = ?
+                """,
+                (scanner_name, target_id, cache_key),
+            ).fetchone()
+        if row is None:
+            return None
+        payload = json.loads(str(row["payload_json"]))
+        return payload if isinstance(payload, dict) else None
 
     def save_snapshot(
         self,

--- a/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
@@ -404,7 +404,7 @@ def run_cisco_mcp_scan(
         if timeout_seconds is not None:
             scan_awaitable = asyncio.wait_for(scan_awaitable, timeout=timeout_seconds)
         findings, targets_scanned = _run_awaitable(scan_awaitable)
-    except TimeoutError:
+    except (TimeoutError, asyncio.TimeoutError):
         return _build_summary(
             status=CiscoIntegrationStatus.TIMED_OUT,
             message="Cisco MCP scanner timed out before it could finish.",

--- a/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
@@ -352,7 +352,11 @@ async def _scan_targets(
     return tuple(findings), targets_scanned
 
 
-def run_cisco_mcp_scan(plugin_dir: Path, mode: str = "auto") -> CiscoMcpScanSummary:
+def run_cisco_mcp_scan(
+    plugin_dir: Path,
+    mode: str = "auto",
+    timeout_seconds: float | None = None,
+) -> CiscoMcpScanSummary:
     """Run Cisco MCP scanner static analysis when available."""
 
     config_path = plugin_dir / ".mcp.json"
@@ -396,7 +400,15 @@ def run_cisco_mcp_scan(plugin_dir: Path, mode: str = "auto") -> CiscoMcpScanSumm
         analyzer_class = components["YaraAnalyzer"]
         analyzer = analyzer_class()
         targets = _collect_static_targets(plugin_dir)
-        findings, targets_scanned = _run_awaitable(_scan_targets(plugin_dir, targets, analyzer))
+        scan_awaitable: Awaitable[tuple[tuple[Finding, ...], int]] = _scan_targets(plugin_dir, targets, analyzer)
+        if timeout_seconds is not None:
+            scan_awaitable = asyncio.wait_for(scan_awaitable, timeout=timeout_seconds)
+        findings, targets_scanned = _run_awaitable(scan_awaitable)
+    except TimeoutError:
+        return _build_summary(
+            status=CiscoIntegrationStatus.TIMED_OUT,
+            message="Cisco MCP scanner timed out before it could finish.",
+        )
     except Exception as exc:
         return _build_summary(
             status=CiscoIntegrationStatus.FAILED,

--- a/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from multiprocessing import get_context
+from multiprocessing.process import BaseProcess
 from pathlib import Path
 from queue import Empty
 
@@ -90,6 +91,14 @@ def _scan_directory_worker(skills_dir: str, policy_name: str, result_queue: obje
         result_queue.put(("error", type(exc).__name__, str(exc)))
 
 
+def _terminate_scan_process(process: BaseProcess) -> None:
+    process.terminate()
+    process.join(1)
+    if process.is_alive():
+        process.kill()
+        process.join()
+
+
 def _scan_directory_with_timeout(
     skills_dir: Path, policy_name: str, timeout_seconds: float | None
 ) -> dict[str, object]:
@@ -103,19 +112,23 @@ def _scan_directory_with_timeout(
         args=(str(skills_dir), policy_name, result_queue),
     )
     process.start()
-    process.join(timeout_seconds)
-    if process.is_alive():
-        process.terminate()
-        process.join(1)
-        if process.is_alive():
-            process.kill()
-            process.join()
-        raise TimeoutError("Cisco skill scanner timed out")
 
     try:
-        status, payload, *details = result_queue.get(timeout=1)
+        status, payload, *details = result_queue.get(timeout=timeout_seconds)
     except Empty as exc:
-        raise RuntimeError(f"Cisco skill scanner exited with code {process.exitcode}") from exc
+        process.join(0)
+        if process.is_alive():
+            _terminate_scan_process(process)
+            raise TimeoutError("Cisco skill scanner timed out") from exc
+        try:
+            status, payload, *details = result_queue.get(timeout=1)
+        except Empty as empty_exc:
+            raise RuntimeError(f"Cisco skill scanner exited with code {process.exitcode}") from empty_exc
+    else:
+        process.join(1)
+        if process.is_alive():
+            _terminate_scan_process(process)
+
     if status == "error":
         error_type = str(payload)
         error_message = str(details[0]) if details else "unknown error"

--- a/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+from multiprocessing import get_context
 from pathlib import Path
-from queue import Queue
-from threading import Thread
+from queue import Empty
 
 from ..models import Finding, Severity, severity_from_value
 
@@ -72,31 +72,55 @@ def _build_unavailable_summary(message: str, *, status: CiscoIntegrationStatus) 
     )
 
 
-def _scan_directory_with_timeout(scanner: object, skills_dir: Path, timeout_seconds: float | None) -> dict[str, object]:
+def _scan_directory_payload(skills_dir: Path, policy_name: str) -> dict[str, object]:
+    from skill_scanner import SkillScanner
+    from skill_scanner.core.scan_policy import ScanPolicy
+
+    scanner = SkillScanner(policy=ScanPolicy(preset_base=policy_name))
+    report = scanner.scan_directory(skills_dir)
+    payload = report.to_dict()
+    return payload if isinstance(payload, dict) else {}
+
+
+def _scan_directory_worker(skills_dir: str, policy_name: str, result_queue: object) -> None:
+    try:
+        payload = _scan_directory_payload(Path(skills_dir), policy_name)
+        result_queue.put(("ok", payload))
+    except BaseException as exc:
+        result_queue.put(("error", type(exc).__name__, str(exc)))
+
+
+def _scan_directory_with_timeout(
+    skills_dir: Path, policy_name: str, timeout_seconds: float | None
+) -> dict[str, object]:
     if timeout_seconds is None:
-        report = scanner.scan_directory(skills_dir)
-        payload = report.to_dict()
-        return payload if isinstance(payload, dict) else {}
+        return _scan_directory_payload(skills_dir, policy_name)
 
-    results: Queue[dict[str, object] | BaseException] = Queue(maxsize=1)
-
-    def _runner() -> None:
-        try:
-            report = scanner.scan_directory(skills_dir)
-            payload = report.to_dict()
-            results.put(payload if isinstance(payload, dict) else {})
-        except BaseException as exc:
-            results.put(exc)
-
-    thread = Thread(target=_runner, daemon=True)
-    thread.start()
-    thread.join(timeout_seconds)
-    if thread.is_alive():
+    context = get_context("spawn")
+    result_queue = context.Queue(maxsize=1)
+    process = context.Process(
+        target=_scan_directory_worker,
+        args=(str(skills_dir), policy_name, result_queue),
+    )
+    process.start()
+    process.join(timeout_seconds)
+    if process.is_alive():
+        process.terminate()
+        process.join(1)
+        if process.is_alive():
+            process.kill()
+            process.join()
         raise TimeoutError("Cisco skill scanner timed out")
-    result = results.get()
-    if isinstance(result, BaseException):
-        raise result
-    return result
+
+    try:
+        status, payload, *details = result_queue.get_nowait()
+    except Empty as exc:
+        raise RuntimeError(f"Cisco skill scanner exited with code {process.exitcode}") from exc
+    if status == "error":
+        error_type = str(payload)
+        error_message = str(details[0]) if details else "unknown error"
+        raise RuntimeError(f"{error_type}: {error_message}")
+    return payload if isinstance(payload, dict) else {}
 
 
 def _to_local_finding(plugin_dir: Path, skill_result: dict[str, object], finding: dict[str, object]) -> Finding:
@@ -176,8 +200,8 @@ def run_cisco_skill_scan(
         )
 
     try:
-        from skill_scanner import SkillScanner
-        from skill_scanner.core.scan_policy import ScanPolicy
+        __import__("skill_scanner")
+        __import__("skill_scanner.core.scan_policy")
     except ImportError:
         if mode == "on":
             return _build_unavailable_summary(
@@ -190,8 +214,7 @@ def run_cisco_skill_scan(
         )
 
     try:
-        scanner = SkillScanner(policy=ScanPolicy(preset_base=policy_name))
-        payload = _scan_directory_with_timeout(scanner, skills_dir.resolve(), timeout_seconds)
+        payload = _scan_directory_with_timeout(skills_dir.resolve(), policy_name, timeout_seconds)
     except TimeoutError:
         return _build_unavailable_summary(
             "Cisco skill scanner timed out before it could finish.",

--- a/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from queue import Queue
+from threading import Thread
 
 from ..models import Finding, Severity, severity_from_value
 
@@ -16,6 +18,7 @@ class CiscoIntegrationStatus(str, Enum):
     SKIPPED = "skipped"
     UNAVAILABLE = "unavailable"
     FAILED = "failed"
+    TIMED_OUT = "timed_out"
 
 
 @dataclass(frozen=True, slots=True)
@@ -67,6 +70,33 @@ def _build_unavailable_summary(message: str, *, status: CiscoIntegrationStatus) 
         total_findings=0,
         findings_by_severity=_empty_counts(),
     )
+
+
+def _scan_directory_with_timeout(scanner: object, skills_dir: Path, timeout_seconds: float | None) -> dict[str, object]:
+    if timeout_seconds is None:
+        report = scanner.scan_directory(skills_dir)
+        payload = report.to_dict()
+        return payload if isinstance(payload, dict) else {}
+
+    results: Queue[dict[str, object] | BaseException] = Queue(maxsize=1)
+
+    def _runner() -> None:
+        try:
+            report = scanner.scan_directory(skills_dir)
+            payload = report.to_dict()
+            results.put(payload if isinstance(payload, dict) else {})
+        except BaseException as exc:
+            results.put(exc)
+
+    thread = Thread(target=_runner, daemon=True)
+    thread.start()
+    thread.join(timeout_seconds)
+    if thread.is_alive():
+        raise TimeoutError("Cisco skill scanner timed out")
+    result = results.get()
+    if isinstance(result, BaseException):
+        raise result
+    return result
 
 
 def _to_local_finding(plugin_dir: Path, skill_result: dict[str, object], finding: dict[str, object]) -> Finding:
@@ -131,7 +161,12 @@ def _extract_skipped_skills(summary: object, results: object) -> tuple[str, ...]
     return tuple(dict.fromkeys(skipped))
 
 
-def run_cisco_skill_scan(skills_dir: Path, mode: str = "auto", policy_name: str = "balanced") -> CiscoSkillScanSummary:
+def run_cisco_skill_scan(
+    skills_dir: Path,
+    mode: str = "auto",
+    policy_name: str = "balanced",
+    timeout_seconds: float | None = None,
+) -> CiscoSkillScanSummary:
     """Run Cisco skill-scanner against a skills directory when available."""
 
     if mode == "off":
@@ -156,8 +191,12 @@ def run_cisco_skill_scan(skills_dir: Path, mode: str = "auto", policy_name: str 
 
     try:
         scanner = SkillScanner(policy=ScanPolicy(preset_base=policy_name))
-        report = scanner.scan_directory(skills_dir.resolve())
-        payload = report.to_dict()
+        payload = _scan_directory_with_timeout(scanner, skills_dir.resolve(), timeout_seconds)
+    except TimeoutError:
+        return _build_unavailable_summary(
+            "Cisco skill scanner timed out before it could finish.",
+            status=CiscoIntegrationStatus.TIMED_OUT,
+        )
     except Exception as exc:  # pragma: no cover - defensive around third-party code
         return _build_unavailable_summary(
             f"Cisco skill scanner failed: {exc}",

--- a/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
@@ -113,7 +113,7 @@ def _scan_directory_with_timeout(
         raise TimeoutError("Cisco skill scanner timed out")
 
     try:
-        status, payload, *details = result_queue.get_nowait()
+        status, payload, *details = result_queue.get(timeout=1)
     except Empty as exc:
         raise RuntimeError(f"Cisco skill scanner exited with code {process.exitcode}") from exc
     if status == "error":

--- a/tests/test_guard_cisco_evidence.py
+++ b/tests/test_guard_cisco_evidence.py
@@ -6,6 +6,7 @@ import json
 import sqlite3
 import time
 from pathlib import Path
+from types import ModuleType
 
 from codex_plugin_scanner.guard.runtime.cisco_evidence import (
     cisco_finding_to_risk_signal,
@@ -157,16 +158,18 @@ def test_skill_scanner_reports_timeout_without_marking_scan_failed(monkeypatch, 
         def __init__(self, preset_base: str) -> None:
             self.preset_base = preset_base
 
-    monkeypatch.setitem(
-        __import__("sys").modules,
-        "skill_scanner",
-        type("SkillScannerModule", (), {"SkillScanner": SlowScanner}),
-    )
-    monkeypatch.setitem(
-        __import__("sys").modules,
-        "skill_scanner.core.scan_policy",
-        type("ScanPolicyModule", (), {"ScanPolicy": ScanPolicy}),
-    )
+    skill_scanner_module = ModuleType("skill_scanner")
+    skill_scanner_module.SkillScanner = SlowScanner
+    scan_policy_module = ModuleType("skill_scanner.core.scan_policy")
+    scan_policy_module.ScanPolicy = ScanPolicy
+    monkeypatch.setitem(__import__("sys").modules, "skill_scanner", skill_scanner_module)
+    monkeypatch.setitem(__import__("sys").modules, "skill_scanner.core", ModuleType("skill_scanner.core"))
+    monkeypatch.setitem(__import__("sys").modules, "skill_scanner.core.scan_policy", scan_policy_module)
+
+    def _raise_timeout(skills_dir: Path, policy_name: str, timeout_seconds: float | None) -> dict[str, object]:
+        raise TimeoutError("Cisco skill scanner timed out")
+
+    monkeypatch.setattr(cisco_skill_scanner, "_scan_directory_with_timeout", _raise_timeout)
 
     summary = cisco_skill_scanner.run_cisco_skill_scan(tmp_path, timeout_seconds=0.001)
 

--- a/tests/test_guard_cisco_evidence.py
+++ b/tests/test_guard_cisco_evidence.py
@@ -6,7 +6,7 @@ import json
 import sqlite3
 import time
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 
 from codex_plugin_scanner.guard.runtime.cisco_evidence import (
     cisco_finding_to_risk_signal,
@@ -175,6 +175,54 @@ def test_skill_scanner_reports_timeout_without_marking_scan_failed(monkeypatch, 
 
     assert summary.status is CiscoIntegrationStatus.TIMED_OUT
     assert "timed out" in summary.message
+
+
+def test_skill_scanner_timeout_path_drains_worker_result_before_terminating(monkeypatch, tmp_path: Path) -> None:
+    class FakeQueue:
+        def __init__(self) -> None:
+            self.process: FakeProcess | None = None
+
+        def get(self, timeout: float) -> tuple[str, dict[str, object]]:
+            if self.process is not None:
+                self.process.alive = False
+            return ("ok", {"summary": {"total_skills_scanned": 0}, "results": []})
+
+    class FakeProcess:
+        def __init__(self, queue: FakeQueue) -> None:
+            self.queue = queue
+            self.alive = True
+            self.exitcode = 0
+            self.terminated = False
+            self.killed = False
+
+        def start(self) -> None:
+            self.queue.process = self
+
+        def join(self, timeout: float | None = None) -> None:
+            return None
+
+        def is_alive(self) -> bool:
+            return self.alive
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+        def kill(self) -> None:
+            self.killed = True
+
+    queue = FakeQueue()
+    process = FakeProcess(queue)
+    context = SimpleNamespace(
+        Queue=lambda maxsize: queue,
+        Process=lambda target, args: process,
+    )
+    monkeypatch.setattr(cisco_skill_scanner, "get_context", lambda method: context)
+
+    payload = cisco_skill_scanner._scan_directory_with_timeout(tmp_path, "balanced", 0.1)
+
+    assert payload == {"summary": {"total_skills_scanned": 0}, "results": []}
+    assert process.terminated is False
+    assert process.killed is False
 
 
 def test_mcp_scanner_reports_timeout_without_marking_scan_failed(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_guard_cisco_evidence.py
+++ b/tests/test_guard_cisco_evidence.py
@@ -1,0 +1,194 @@
+"""Tests for Cisco scanner evidence normalization."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+
+from codex_plugin_scanner.guard.runtime.cisco_evidence import (
+    cisco_finding_to_risk_signal,
+    scanner_cache_key,
+)
+from codex_plugin_scanner.guard.runtime.signals import GuardRiskSignalV3
+from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.integrations import cisco_mcp_scanner, cisco_skill_scanner
+from codex_plugin_scanner.integrations.cisco_skill_scanner import CiscoIntegrationStatus
+from codex_plugin_scanner.models import Finding, Severity
+
+
+def test_cisco_finding_becomes_v3_signal_with_first_class_scanner_fields() -> None:
+    finding = Finding(
+        rule_id="CISCO-MCP-TOOL-POISONING",
+        severity=Severity.HIGH,
+        category="security",
+        title="Tool poisoning detected",
+        description="MCP config exposes a risky tool description.",
+        remediation="Review the MCP server before enabling it.",
+        file_path=".mcp.json",
+        line_number=12,
+        source="cisco-mcp-scanner",
+    )
+
+    signal = cisco_finding_to_risk_signal(
+        finding,
+        scanner_status=CiscoIntegrationStatus.ENABLED,
+        scanner_name="Cisco MCP scanner",
+        source_version="4.6.2",
+    )
+
+    assert signal == GuardRiskSignalV3(
+        signal_id="cisco-mcp-scanner:CISCO-MCP-TOOL-POISONING:.mcp.json:12",
+        source="cisco_mcp",
+        source_version="4.6.2",
+        category="mcp",
+        severity="high",
+        confidence="strong",
+        title="Tool poisoning detected",
+        plain_language_summary="MCP config exposes a risky tool description.",
+        technical_detail="Cisco MCP scanner rule CISCO-MCP-TOOL-POISONING reported security evidence.",
+        evidence_ref=".mcp.json:12",
+        scanner_name="Cisco MCP scanner",
+        scanner_status="enabled",
+        scanner_rule_id="CISCO-MCP-TOOL-POISONING",
+        redaction_level="summary",
+        source_path=".mcp.json",
+        source_line=12,
+        data_source=None,
+        data_sink=None,
+        recommended_action="Review the MCP server before enabling it.",
+    )
+    assert signal.to_dict()["scanner_status"] == "enabled"
+    assert GuardRiskSignalV3.from_dict(signal.to_dict()) == signal
+
+
+def test_scanner_cache_key_changes_with_content_hash_or_version() -> None:
+    base_key = scanner_cache_key(
+        scanner_name="cisco-mcp-scanner",
+        input_content_hash="content-a",
+        scanner_version="4.6.2",
+    )
+
+    assert (
+        scanner_cache_key(
+            scanner_name="cisco-mcp-scanner",
+            input_content_hash="content-b",
+            scanner_version="4.6.2",
+        )
+        != base_key
+    )
+    assert (
+        scanner_cache_key(
+            scanner_name="cisco-mcp-scanner",
+            input_content_hash="content-a",
+            scanner_version="4.7.0",
+        )
+        != base_key
+    )
+
+
+def test_guard_store_invalidates_scanner_cache_when_hash_or_version_changes(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    payload = {"signals": [{"signal_id": "signal-1"}]}
+
+    store.save_scanner_cache(
+        scanner_name="cisco-mcp-scanner",
+        target_id="workspace/.mcp.json",
+        input_content_hash="hash-a",
+        scanner_version="4.6.2",
+        payload=payload,
+        now="2026-05-08T00:00:00+00:00",
+    )
+
+    assert (
+        store.get_scanner_cache(
+            scanner_name="cisco-mcp-scanner",
+            target_id="workspace/.mcp.json",
+            input_content_hash="hash-a",
+            scanner_version="4.6.2",
+        )
+        == payload
+    )
+    assert (
+        store.get_scanner_cache(
+            scanner_name="cisco-mcp-scanner",
+            target_id="workspace/.mcp.json",
+            input_content_hash="hash-b",
+            scanner_version="4.6.2",
+        )
+        is None
+    )
+    assert (
+        store.get_scanner_cache(
+            scanner_name="cisco-mcp-scanner",
+            target_id="workspace/.mcp.json",
+            input_content_hash="hash-a",
+            scanner_version="4.7.0",
+        )
+        is None
+    )
+
+    with sqlite3.connect(store.path) as connection:
+        row = connection.execute(
+            "select cache_key, payload_json from scanner_cache where scanner_name = ? and target_id = ?",
+            ("cisco-mcp-scanner", "workspace/.mcp.json"),
+        ).fetchone()
+
+    assert row is not None
+    assert str(row[0]) == scanner_cache_key(
+        scanner_name="cisco-mcp-scanner",
+        input_content_hash="hash-a",
+        scanner_version="4.6.2",
+    )
+    assert json.loads(str(row[1])) == payload
+
+
+def test_skill_scanner_reports_timeout_without_marking_scan_failed(monkeypatch, tmp_path: Path) -> None:
+    class SlowScanner:
+        def __init__(self, policy: object) -> None:
+            self.policy = policy
+
+        def scan_directory(self, skills_dir: Path) -> object:
+            time.sleep(0.05)
+            return object()
+
+    class ScanPolicy:
+        def __init__(self, preset_base: str) -> None:
+            self.preset_base = preset_base
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "skill_scanner",
+        type("SkillScannerModule", (), {"SkillScanner": SlowScanner}),
+    )
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "skill_scanner.core.scan_policy",
+        type("ScanPolicyModule", (), {"ScanPolicy": ScanPolicy}),
+    )
+
+    summary = cisco_skill_scanner.run_cisco_skill_scan(tmp_path, timeout_seconds=0.001)
+
+    assert summary.status is CiscoIntegrationStatus.TIMED_OUT
+    assert "timed out" in summary.message
+
+
+def test_mcp_scanner_reports_timeout_without_marking_scan_failed(monkeypatch, tmp_path: Path) -> None:
+    (tmp_path / ".mcp.json").write_text("{}", encoding="utf-8")
+
+    class SlowAnalyzer:
+        async def analyze(self, content: str, metadata: dict[str, str]) -> tuple[object, ...]:
+            await cisco_mcp_scanner.asyncio.sleep(0.05)
+            return ()
+
+    monkeypatch.setattr(
+        cisco_mcp_scanner,
+        "_load_mcp_scanner_components",
+        lambda blocked_root=None: {"YaraAnalyzer": SlowAnalyzer},
+    )
+
+    summary = cisco_mcp_scanner.run_cisco_mcp_scan(tmp_path, timeout_seconds=0.001)
+
+    assert summary.status is CiscoIntegrationStatus.TIMED_OUT
+    assert "timed out" in summary.message


### PR DESCRIPTION
## Summary
- add scanner-aware Guard risk signals for Cisco MCP and skill findings
- add Cisco scanner timeout status handling
- add local scanner cache keyed by content hash and scanner version

## Verification
- uv run ruff check src/codex_plugin_scanner/guard/runtime src/codex_plugin_scanner/integrations src/codex_plugin_scanner/guard/store.py tests/test_guard_cisco_evidence.py
- uv run ruff format --check src/codex_plugin_scanner/guard/runtime src/codex_plugin_scanner/integrations src/codex_plugin_scanner/guard/store.py tests/test_guard_cisco_evidence.py
- uv run pytest tests/test_guard_cisco_evidence.py tests/test_guard_store_migrations.py tests/test_cisco_install_surfaces.py -q