### PR TITLE
feat(guard): add Cisco runtime scanner evidence

### DIFF
--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -98,6 +98,7 @@ def queue_blocked_approvals(
             risk_headline=incident["risk_headline"],
             action_envelope_json=_item_action_envelope_json(item),
             decision_v2_json=_item_decision_v2_json(item),
+            scanner_evidence=_item_scanner_evidence(item),
         )
         persisted_request_id = store.add_approval_request(request, timestamp)
         if persisted_request_id != request.request_id:
@@ -431,6 +432,13 @@ def _item_decision_v2_json(item: dict[str, object]) -> dict[str, object] | None:
     if not isinstance(value, Mapping):
         return None
     return {str(key): item_value for key, item_value in value.items() if isinstance(key, str)}
+
+
+def _item_scanner_evidence(item: dict[str, object]) -> tuple[dict[str, object], ...]:
+    value = item.get("scanner_evidence")
+    if not isinstance(value, list | tuple):
+        return ()
+    return tuple(dict(entry) for entry in value if isinstance(entry, Mapping))
 
 
 def _string_list(value: object) -> list[str]:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -757,7 +757,7 @@ def run_guard_command(
                 config=config,
             )
             payload["generated_at"] = _now()
-            _emit("scan", payload, getattr(args, "json", False))
+            _emit("deep-scan", payload, getattr(args, "json", False))
             return 0
         payload = _run_consumer_scan_with_mode(Path(args.target).resolve(), cisco_mode=args.cisco_mode)
         _emit("scan", payload, args.json or args.consumer_mode)
@@ -1766,7 +1766,11 @@ def run_guard_command(
                 return 0
             changed_capabilities = [runtime_artifact.artifact_type]
             data_flow_signals = _runtime_action_data_flow_signals(action_envelope, workspace=runtime_workspace)
-            scanner_evidence = scan_action_for_cisco_evidence(action_envelope, workspace=runtime_workspace)
+            scanner_evidence = (
+                scan_action_for_cisco_evidence(action_envelope, workspace=runtime_workspace)
+                if action_envelope is not None
+                else ()
+            )
             scanner_evidence_payload = [signal.to_dict() for signal in scanner_evidence]
             if data_flow_signals and requested_policy_action not in VALID_GUARD_ACTIONS:
                 data_flow_action = resolve_risk_action(
@@ -1776,6 +1780,7 @@ def run_guard_command(
                 )
                 if _guard_action_severity(data_flow_action) > _guard_action_severity(policy_action):
                     policy_action = data_flow_action
+            _pre_scanner_policy_action = policy_action
             if scanner_evidence and requested_policy_action not in VALID_GUARD_ACTIONS:
                 scanner_action = policy_action_for_cisco_signals(
                     scanner_evidence,
@@ -1784,6 +1789,9 @@ def run_guard_command(
                 )
                 if _guard_action_severity(scanner_action) > _guard_action_severity(policy_action):
                     policy_action = scanner_action
+            scanner_raised_to_block = (
+                policy_action == "block" and _pre_scanner_policy_action != "block" and bool(scanner_evidence)
+            )
             base_decision_signals = data_flow_signals or artifact_risk_signals_v2(runtime_artifact)
             scanner_decision_signals = tuple(cisco_risk_signal_v3_to_v2(signal) for signal in scanner_evidence)
             decision_signals = (*base_decision_signals, *scanner_decision_signals)
@@ -1796,7 +1804,7 @@ def run_guard_command(
                 risk_summary = artifact_risk_summary(runtime_artifact)
             if scanner_risk_signals:
                 risk_signals.extend(scanner_risk_signals)
-                if policy_action == "block":
+                if scanner_raised_to_block:
                     risk_summary = scanner_risk_signals[0]
             decision_v2 = build_decision_v2(policy_action, reason=policy_action, signals=decision_signals)
             incident = build_incident_context(

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -83,6 +83,12 @@ from ..proxy import (
 from ..receipts import build_receipt
 from ..risk import artifact_risk_signals, artifact_risk_signals_v2, artifact_risk_summary
 from ..runtime.actions import GuardActionEnvelope, normalize_harness_payload
+from ..runtime.cisco_preflight import (
+    build_cisco_deep_scan_payload,
+    cisco_risk_signal_v3_to_v2,
+    policy_action_for_cisco_signals,
+    scan_action_for_cisco_evidence,
+)
 from ..runtime.data_flow_rules import detect_data_flow_exfiltration
 from ..runtime.runner import (
     GuardSyncNotConfiguredError,
@@ -333,6 +339,8 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     scan_parser.add_argument("target", nargs="?", default=".")
     scan_parser.add_argument("--consumer-mode", action="store_true")
     scan_parser.add_argument("--json", action="store_true")
+    scan_parser.add_argument("--deep", action="store_true", help="Run first-class local Cisco scanner evidence.")
+    _add_guard_common_args(scan_parser)
     _add_guard_cisco_mode_arg(scan_parser)
 
     diff_parser = guard_subparsers.add_parser("diff", help="Compare current harness artifacts to stored snapshots")
@@ -733,6 +741,24 @@ def run_guard_command(
     """Execute a Guard subcommand."""
 
     if args.guard_command == "scan":
+        if getattr(args, "deep", False):
+            scan_type = str(args.target)
+            if scan_type not in {"skills", "mcp"}:
+                print("guard scan --deep supports 'skills' or 'mcp'.", file=sys.stderr)
+                return 2
+            home_override = getattr(args, "home", None)
+            guard_home = resolve_guard_home(getattr(args, "guard_home", None) or home_override)
+            workspace = Path(args.workspace).resolve() if getattr(args, "workspace", None) else Path.cwd().resolve()
+            config = load_guard_config(guard_home, workspace=workspace)
+            payload = build_cisco_deep_scan_payload(
+                scan_type=scan_type,
+                target=workspace,
+                mode=args.cisco_mode,
+                config=config,
+            )
+            payload["generated_at"] = _now()
+            _emit("scan", payload, getattr(args, "json", False))
+            return 0
         payload = _run_consumer_scan_with_mode(Path(args.target).resolve(), cisco_mode=args.cisco_mode)
         _emit("scan", payload, args.json or args.consumer_mode)
         return 0
@@ -1740,6 +1766,8 @@ def run_guard_command(
                 return 0
             changed_capabilities = [runtime_artifact.artifact_type]
             data_flow_signals = _runtime_action_data_flow_signals(action_envelope, workspace=runtime_workspace)
+            scanner_evidence = scan_action_for_cisco_evidence(action_envelope, workspace=runtime_workspace)
+            scanner_evidence_payload = [signal.to_dict() for signal in scanner_evidence]
             if data_flow_signals and requested_policy_action not in VALID_GUARD_ACTIONS:
                 data_flow_action = resolve_risk_action(
                     config,
@@ -1748,17 +1776,28 @@ def run_guard_command(
                 )
                 if _guard_action_severity(data_flow_action) > _guard_action_severity(policy_action):
                     policy_action = data_flow_action
-            decision_signals = data_flow_signals or artifact_risk_signals_v2(runtime_artifact)
-            risk_signals = (
-                [signal.plain_reason for signal in data_flow_signals]
-                if data_flow_signals
-                else list(artifact_risk_signals(runtime_artifact))
-            )
-            risk_summary = (
-                _runtime_data_flow_summary(data_flow_signals)
-                if data_flow_signals
-                else artifact_risk_summary(runtime_artifact)
-            )
+            if scanner_evidence and requested_policy_action not in VALID_GUARD_ACTIONS:
+                scanner_action = policy_action_for_cisco_signals(
+                    scanner_evidence,
+                    config=config,
+                    harness=policy_harness,
+                )
+                if _guard_action_severity(scanner_action) > _guard_action_severity(policy_action):
+                    policy_action = scanner_action
+            base_decision_signals = data_flow_signals or artifact_risk_signals_v2(runtime_artifact)
+            scanner_decision_signals = tuple(cisco_risk_signal_v3_to_v2(signal) for signal in scanner_evidence)
+            decision_signals = (*base_decision_signals, *scanner_decision_signals)
+            scanner_risk_signals = [signal.plain_language_summary for signal in scanner_evidence]
+            if data_flow_signals:
+                risk_signals = [signal.plain_reason for signal in data_flow_signals]
+                risk_summary = _runtime_data_flow_summary(data_flow_signals)
+            else:
+                risk_signals = list(artifact_risk_signals(runtime_artifact))
+                risk_summary = artifact_risk_summary(runtime_artifact)
+            if scanner_risk_signals:
+                risk_signals.extend(scanner_risk_signals)
+                if policy_action == "block":
+                    risk_summary = scanner_risk_signals[0]
             decision_v2 = build_decision_v2(policy_action, reason=policy_action, signals=decision_signals)
             incident = build_incident_context(
                 harness=args.harness,
@@ -1784,6 +1823,7 @@ def run_guard_command(
                 artifact_name=artifact_name,
                 source_scope=runtime_artifact.source_scope,
                 user_override=_optional_string(payload.get("user_override")),
+                scanner_evidence=scanner_evidence_payload,
             )
             store.add_receipt(receipt)
             response_payload = {
@@ -1795,6 +1835,7 @@ def run_guard_command(
                 "policy_action": policy_action,
                 "risk_signals": risk_signals,
                 "risk_summary": risk_summary,
+                "scanner_evidence": scanner_evidence_payload,
                 "decision_v2_json": decision_v2.to_dict(),
                 "artifact_label": incident["artifact_label"],
                 "source_label": incident["source_label"],
@@ -1881,6 +1922,7 @@ def run_guard_command(
                                 "launch_target": _runtime_request_summary(runtime_artifact),
                                 "action_envelope_json": _action_envelope_json(action_envelope),
                                 "decision_v2_json": decision_v2.to_dict(),
+                                "scanner_evidence": scanner_evidence_payload,
                             }
                         ]
                     }

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -1253,6 +1253,37 @@ def _render_scan(console: Console, payload: dict[str, object]) -> None:
     _render_cisco_evidence(console, payload)
 
 
+def _render_deep_scan(console: Console, payload: dict[str, object]) -> None:
+    scan_type = str(payload.get("scan_type") or "unknown")
+    status = str(payload.get("status") or "unknown")
+    body = Table.grid(padding=(0, 1))
+    body.add_row("Type", scan_type)
+    body.add_row("Status", _cisco_status_text(status))
+    body.add_row("Mode", str(payload.get("mode") or "auto"))
+    body.add_row("Findings", str(payload.get("total_findings") or 0))
+    body.add_row("Targets", str(payload.get("targets_scanned") or 0))
+    body.add_row("Analyzers", str(payload.get("analyzers_used") or 0))
+    if payload.get("message"):
+        body.add_row("Message", str(payload["message"]))
+    console.print(Panel(body, title=f"Deep scan — {scan_type}", border_style="cyan"))
+    findings = _coerce_dict_list(payload.get("findings"))
+    if findings:
+        table = Table(box=box.SIMPLE_HEAVY, show_header=True)
+        table.add_column("Severity", style="bold")
+        table.add_column("Title")
+        table.add_column("Category")
+        for finding in findings[:50]:
+            sev = str(finding.get("severity") or "info")
+            table.add_row(
+                sev,
+                str(finding.get("title") or finding.get("rule_id") or "unknown"),
+                str(finding.get("category") or ""),
+            )
+        if len(findings) > 50:
+            table.add_row("…", f"and {len(findings) - 50} more", "")
+        console.print(table)
+
+
 def _render_explain(console: Console, payload: dict[str, object]) -> None:
     advisories = _coerce_dict_list(payload.get("advisories"))
     if "artifact_snapshot" in payload:
@@ -1996,5 +2027,6 @@ _RENDERERS: dict[str, Any] = {
     "protect": _render_protect,
     "preflight": _render_preflight,
     "scan": _render_scan,
+    "deep-scan": _render_deep_scan,
     "explain": _render_explain,
 }

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -1260,13 +1260,13 @@ def _render_deep_scan(console: Console, payload: dict[str, object]) -> None:
     body.add_row("Type", scan_type)
     body.add_row("Status", _cisco_status_text(status))
     body.add_row("Mode", str(payload.get("mode") or "auto"))
-    body.add_row("Findings", str(payload.get("total_findings") or 0))
+    body.add_row("Findings", str(payload.get("finding_count") or 0))
     body.add_row("Targets", str(payload.get("targets_scanned") or 0))
     body.add_row("Analyzers", str(payload.get("analyzers_used") or 0))
     if payload.get("message"):
         body.add_row("Message", str(payload["message"]))
     console.print(Panel(body, title=f"Deep scan — {scan_type}", border_style="cyan"))
-    findings = _coerce_dict_list(payload.get("findings"))
+    findings = _coerce_dict_list(payload.get("scanner_evidence") or payload.get("findings"))
     if findings:
         table = Table(box=box.SIMPLE_HEAVY, show_header=True)
         table.add_column("Severity", style="bold")

--- a/src/codex_plugin_scanner/guard/models.py
+++ b/src/codex_plugin_scanner/guard/models.py
@@ -142,10 +142,12 @@ class GuardReceipt:
     artifact_name: str | None = None
     source_scope: str | None = None
     action_envelope_json: dict[str, object] | None = None
+    scanner_evidence: tuple[dict[str, object], ...] = ()
 
     def to_dict(self) -> dict[str, object]:
         payload = asdict(self)
         payload["changed_capabilities"] = list(self.changed_capabilities)
+        payload["scanner_evidence"] = [dict(item) for item in self.scanner_evidence]
         return payload
 
 
@@ -185,11 +187,13 @@ class GuardApprovalRequest:
     queue_group_id: str | None = None
     dedupe_count: int = 1
     last_seen_at: str | None = None
+    scanner_evidence: tuple[dict[str, object], ...] = ()
 
     def to_dict(self) -> dict[str, object]:
         payload = asdict(self)
         payload["changed_fields"] = list(self.changed_fields)
         payload["risk_signals"] = list(self.risk_signals)
+        payload["scanner_evidence"] = [dict(item) for item in self.scanner_evidence]
         return payload
 
 

--- a/src/codex_plugin_scanner/guard/receipts/manager.py
+++ b/src/codex_plugin_scanner/guard/receipts/manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from uuid import uuid4
 
@@ -19,6 +20,7 @@ def build_receipt(
     artifact_name: str | None,
     source_scope: str | None,
     user_override: str | None = None,
+    scanner_evidence: Sequence[Mapping[str, object]] = (),
 ) -> GuardReceipt:
     """Create a runtime receipt."""
 
@@ -35,4 +37,5 @@ def build_receipt(
         user_override=user_override,
         artifact_name=artifact_name,
         source_scope=source_scope,
+        scanner_evidence=tuple(dict(item) for item in scanner_evidence),
     )

--- a/src/codex_plugin_scanner/guard/runtime/cisco_preflight.py
+++ b/src/codex_plugin_scanner/guard/runtime/cisco_preflight.py
@@ -1,0 +1,267 @@
+"""Cisco scanner preflight helpers for local Guard runtime actions."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+from codex_plugin_scanner.guard.config import GuardConfig, resolve_risk_action
+from codex_plugin_scanner.guard.models import GuardAction
+from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope
+from codex_plugin_scanner.guard.runtime.cisco_evidence import cisco_finding_to_risk_signal
+from codex_plugin_scanner.guard.runtime.signals import GuardRiskSignalV3, RiskSignalV2
+from codex_plugin_scanner.integrations import cisco_mcp_scanner, cisco_skill_scanner
+from codex_plugin_scanner.integrations.cisco_skill_scanner import CiscoIntegrationStatus
+from codex_plugin_scanner.models import Finding
+
+_DEFAULT_SCANNER_TIMEOUT_SECONDS = 5.0
+_ACTION_RANK: dict[GuardAction, int] = {
+    "allow": 0,
+    "warn": 1,
+    "review": 2,
+    "require-reapproval": 3,
+    "sandbox-required": 4,
+    "block": 5,
+}
+_SEVERITY_RANK = {"info": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
+
+
+class CiscoSkillPreflightDetector:
+    """Detector wrapper for changed local skill files."""
+
+    detector_id = "cisco.skill"
+    categories = ("skill",)
+
+    def detect(self, action: GuardActionEnvelope, context: object) -> tuple[RiskSignalV2, ...]:
+        workspace = getattr(context, "workspace", None)
+        signals = scan_action_for_cisco_evidence(action, workspace=workspace, sources=("skill",))
+        return tuple(cisco_risk_signal_v3_to_v2(signal) for signal in signals)
+
+
+class CiscoMcpPreflightDetector:
+    """Detector wrapper for changed local MCP config."""
+
+    detector_id = "cisco.mcp"
+    categories = ("mcp",)
+
+    def detect(self, action: GuardActionEnvelope, context: object) -> tuple[RiskSignalV2, ...]:
+        workspace = getattr(context, "workspace", None)
+        signals = scan_action_for_cisco_evidence(action, workspace=workspace, sources=("mcp",))
+        return tuple(cisco_risk_signal_v3_to_v2(signal) for signal in signals)
+
+
+def scan_action_for_cisco_evidence(
+    action: GuardActionEnvelope,
+    *,
+    workspace: Path | str | None,
+    mode: str = "auto",
+    sources: Iterable[str] = ("skill", "mcp"),
+    timeout_seconds: float = _DEFAULT_SCANNER_TIMEOUT_SECONDS,
+) -> tuple[GuardRiskSignalV3, ...]:
+    """Run Cisco preflight scans for changed skill or MCP files referenced by an action."""
+
+    if action.action_type not in {"file_write", "config_change"}:
+        return ()
+    workspace_path = Path(workspace).expanduser().resolve() if workspace is not None else Path.cwd().resolve()
+    requested_sources = frozenset(sources)
+    signals: list[GuardRiskSignalV3] = []
+    scanned_skill_roots: set[Path] = set()
+    scanned_mcp_roots: set[Path] = set()
+    for target_path in _resolve_target_paths(action, workspace_path):
+        if "skill" in requested_sources and _is_skill_file(target_path):
+            skill_root = _skill_scan_root_for_file(target_path, workspace_path)
+            if skill_root not in scanned_skill_roots:
+                scanned_skill_roots.add(skill_root)
+                signals.extend(
+                    _skill_findings_to_signals(
+                        cisco_skill_scanner.run_cisco_skill_scan(
+                            skill_root,
+                            mode=mode,
+                            timeout_seconds=timeout_seconds,
+                        )
+                    )
+                )
+        if "mcp" in requested_sources and target_path.name == ".mcp.json":
+            mcp_root = target_path.parent
+            if mcp_root not in scanned_mcp_roots:
+                scanned_mcp_roots.add(mcp_root)
+                signals.extend(
+                    _mcp_findings_to_signals(
+                        cisco_mcp_scanner.run_cisco_mcp_scan(
+                            mcp_root,
+                            mode=mode,
+                            timeout_seconds=timeout_seconds,
+                        )
+                    )
+                )
+    return tuple(signals)
+
+
+def build_cisco_deep_scan_payload(
+    *,
+    scan_type: str,
+    target: Path,
+    mode: str,
+    config: GuardConfig,
+    harness: str | None = None,
+    timeout_seconds: float = _DEFAULT_SCANNER_TIMEOUT_SECONDS,
+) -> dict[str, object]:
+    """Build a stable CLI payload for deep Cisco scanner evidence."""
+
+    if scan_type == "skills":
+        scan_root = _skill_scan_root_for_workspace(target)
+        summary = cisco_skill_scanner.run_cisco_skill_scan(
+            scan_root,
+            mode=mode,
+            timeout_seconds=timeout_seconds,
+        )
+        signals = tuple(_skill_findings_to_signals(summary))
+        return {
+            "scan_type": "skills",
+            "scanner": "cisco-skill-scanner",
+            "target": str(scan_root),
+            "status": summary.status.value,
+            "message": summary.message,
+            "finding_count": len(signals),
+            "target_count": summary.skills_scanned,
+            "analyzers_used": list(summary.analyzers_used),
+            "scanner_evidence": [signal.to_dict() for signal in signals],
+            "policy_action": policy_action_for_cisco_signals(signals, config=config, harness=harness),
+        }
+    if scan_type == "mcp":
+        summary = cisco_mcp_scanner.run_cisco_mcp_scan(
+            target,
+            mode=mode,
+            timeout_seconds=timeout_seconds,
+        )
+        signals = tuple(_mcp_findings_to_signals(summary))
+        return {
+            "scan_type": "mcp",
+            "scanner": "cisco-mcp-scanner",
+            "target": str(target),
+            "status": summary.status.value,
+            "message": summary.message,
+            "finding_count": len(signals),
+            "target_count": summary.targets_scanned,
+            "analyzers_used": list(summary.analyzers_used),
+            "scanner_evidence": [signal.to_dict() for signal in signals],
+            "policy_action": policy_action_for_cisco_signals(signals, config=config, harness=harness),
+        }
+    raise ValueError(f"Unsupported deep scan type: {scan_type}")
+
+
+def cisco_risk_signal_v3_to_v2(signal: GuardRiskSignalV3) -> RiskSignalV2:
+    """Adapt scanner-aware evidence into the existing decision signal contract."""
+
+    return RiskSignalV2(
+        signal_id=signal.signal_id,
+        category=signal.category,
+        severity=signal.severity,
+        confidence=signal.confidence,
+        detector=signal.source,
+        title=signal.title,
+        plain_reason=signal.plain_language_summary,
+        technical_detail=signal.technical_detail,
+        evidence_ref=signal.evidence_ref,
+        redaction_level=signal.redaction_level,
+        false_positive_hint=signal.recommended_action,
+        advisory_id=None,
+    )
+
+
+def policy_action_for_cisco_signals(
+    signals: tuple[GuardRiskSignalV3, ...],
+    *,
+    config: GuardConfig,
+    harness: str | None,
+) -> GuardAction:
+    """Resolve the policy effect of Cisco scanner evidence."""
+
+    if not signals:
+        return "allow"
+    if any(signal.severity == "critical" and signal.confidence == "strong" for signal in signals):
+        return "block"
+    if all(
+        _SEVERITY_RANK[signal.severity] <= _SEVERITY_RANK["low"] or signal.confidence == "weak" for signal in signals
+    ):
+        return "warn"
+    action: GuardAction = "warn"
+    for signal in signals:
+        risk_class = "malicious_skill" if signal.source == "cisco_skill" else "mcp_dangerous_tool"
+        resolved = resolve_risk_action(config, risk_class, harness=harness)
+        if resolved is not None and _ACTION_RANK[resolved] > _ACTION_RANK[action]:
+            action = resolved
+    return action
+
+
+def _resolve_target_paths(action: GuardActionEnvelope, workspace: Path) -> tuple[Path, ...]:
+    paths: list[Path] = []
+    for target in action.target_paths:
+        candidate = Path(target).expanduser()
+        if not candidate.is_absolute():
+            candidate = workspace / candidate
+        paths.append(candidate.resolve())
+    return tuple(paths)
+
+
+def _is_skill_file(path: Path) -> bool:
+    return path.name == "SKILL.md"
+
+
+def _skill_scan_root_for_file(path: Path, workspace: Path) -> Path:
+    parent = path.parent
+    if parent.parent.name == "skills":
+        return parent.parent
+    if parent.name == "skills":
+        return parent
+    if parent == workspace:
+        return parent
+    return parent
+
+
+def _skill_scan_root_for_workspace(target: Path) -> Path:
+    skills_dir = target / "skills"
+    if skills_dir.is_dir():
+        return skills_dir
+    return target
+
+
+def _skill_findings_to_signals(summary: object) -> tuple[GuardRiskSignalV3, ...]:
+    status = getattr(summary, "status", CiscoIntegrationStatus.FAILED)
+    findings = getattr(summary, "findings", ())
+    return _findings_to_signals(
+        findings,
+        scanner_status=status,
+        scanner_name="Cisco skill scanner",
+    )
+
+
+def _mcp_findings_to_signals(summary: object) -> tuple[GuardRiskSignalV3, ...]:
+    status = getattr(summary, "status", CiscoIntegrationStatus.FAILED)
+    findings = getattr(summary, "findings", ())
+    return _findings_to_signals(
+        findings,
+        scanner_status=status,
+        scanner_name="Cisco MCP scanner",
+    )
+
+
+def _findings_to_signals(
+    findings: object,
+    *,
+    scanner_status: CiscoIntegrationStatus,
+    scanner_name: str,
+) -> tuple[GuardRiskSignalV3, ...]:
+    if not isinstance(findings, tuple | list):
+        return ()
+    signals: list[GuardRiskSignalV3] = []
+    for finding in findings:
+        if isinstance(finding, Finding):
+            signals.append(
+                cisco_finding_to_risk_signal(
+                    finding,
+                    scanner_status=scanner_status,
+                    scanner_name=scanner_name,
+                )
+            )
+    return tuple(signals)

--- a/src/codex_plugin_scanner/guard/runtime/cisco_preflight.py
+++ b/src/codex_plugin_scanner/guard/runtime/cisco_preflight.py
@@ -33,6 +33,9 @@ _SOURCE_RISK_CLASS: dict[str, str] = {
 }
 
 
+_CISCO_DETECTOR_MIN_BUDGET_SECONDS = 0.5
+
+
 class CiscoSkillPreflightDetector:
     """Detector wrapper for changed local skill files."""
 
@@ -41,7 +44,14 @@ class CiscoSkillPreflightDetector:
 
     def detect(self, action: GuardActionEnvelope, context: object) -> tuple[RiskSignalV2, ...]:
         workspace = getattr(context, "workspace", None)
-        signals = scan_action_for_cisco_evidence(action, workspace=workspace, sources=("skill",))
+        config = getattr(context, "config", None)
+        timeout_ms: int = getattr(config, "runtime_detector_timeout_ms", 5000) if config is not None else 5000
+        budget_seconds = timeout_ms / 1000.0
+        if budget_seconds < _CISCO_DETECTOR_MIN_BUDGET_SECONDS:
+            return ()
+        signals = scan_action_for_cisco_evidence(
+            action, workspace=workspace, sources=("skill",), timeout_seconds=budget_seconds
+        )
         return tuple(cisco_risk_signal_v3_to_v2(signal) for signal in signals)
 
 
@@ -53,7 +63,14 @@ class CiscoMcpPreflightDetector:
 
     def detect(self, action: GuardActionEnvelope, context: object) -> tuple[RiskSignalV2, ...]:
         workspace = getattr(context, "workspace", None)
-        signals = scan_action_for_cisco_evidence(action, workspace=workspace, sources=("mcp",))
+        config = getattr(context, "config", None)
+        timeout_ms: int = getattr(config, "runtime_detector_timeout_ms", 5000) if config is not None else 5000
+        budget_seconds = timeout_ms / 1000.0
+        if budget_seconds < _CISCO_DETECTOR_MIN_BUDGET_SECONDS:
+            return ()
+        signals = scan_action_for_cisco_evidence(
+            action, workspace=workspace, sources=("mcp",), timeout_seconds=budget_seconds
+        )
         return tuple(cisco_risk_signal_v3_to_v2(signal) for signal in signals)
 
 

--- a/src/codex_plugin_scanner/guard/runtime/cisco_preflight.py
+++ b/src/codex_plugin_scanner/guard/runtime/cisco_preflight.py
@@ -57,6 +57,11 @@ class CiscoMcpPreflightDetector:
         return tuple(cisco_risk_signal_v3_to_v2(signal) for signal in signals)
 
 
+def _is_redacted_path(path_str: str) -> bool:
+    """Return True when a target path is a redacted placeholder (starts with .../)."""
+    return path_str.startswith(".../")
+
+
 def scan_action_for_cisco_evidence(
     action: GuardActionEnvelope,
     *,
@@ -74,33 +79,58 @@ def scan_action_for_cisco_evidence(
     signals: list[GuardRiskSignalV3] = []
     scanned_skill_roots: set[Path] = set()
     scanned_mcp_roots: set[Path] = set()
-    for target_path in _resolve_target_paths(action, workspace_path):
+    skill_via_path = False
+    mcp_via_path = False
+    for target_str, target_path in zip(action.target_paths, _resolve_target_paths(action, workspace_path), strict=True):
         if "skill" in requested_sources and _is_skill_file(target_path):
-            skill_root = _skill_scan_root_for_file(target_path, workspace_path)
-            if skill_root not in scanned_skill_roots:
-                scanned_skill_roots.add(skill_root)
-                signals.extend(
-                    _skill_findings_to_signals(
-                        cisco_skill_scanner.run_cisco_skill_scan(
-                            skill_root,
-                            mode=mode,
-                            timeout_seconds=timeout_seconds,
+            if _is_redacted_path(target_str):
+                skill_via_path = True
+            else:
+                skill_via_path = True
+                skill_root = _skill_scan_root_for_file(target_path, workspace_path)
+                if skill_root not in scanned_skill_roots:
+                    scanned_skill_roots.add(skill_root)
+                    signals.extend(
+                        _skill_findings_to_signals(
+                            cisco_skill_scanner.run_cisco_skill_scan(
+                                skill_root,
+                                mode=mode,
+                                timeout_seconds=timeout_seconds,
+                            )
                         )
                     )
-                )
         if "mcp" in requested_sources and target_path.name == ".mcp.json":
-            mcp_root = target_path.parent
-            if mcp_root not in scanned_mcp_roots:
-                scanned_mcp_roots.add(mcp_root)
-                signals.extend(
-                    _mcp_findings_to_signals(
-                        cisco_mcp_scanner.run_cisco_mcp_scan(
-                            mcp_root,
-                            mode=mode,
-                            timeout_seconds=timeout_seconds,
+            if _is_redacted_path(target_str):
+                mcp_via_path = True
+            else:
+                mcp_via_path = True
+                mcp_root = target_path.parent
+                if mcp_root not in scanned_mcp_roots:
+                    scanned_mcp_roots.add(mcp_root)
+                    signals.extend(
+                        _mcp_findings_to_signals(
+                            cisco_mcp_scanner.run_cisco_mcp_scan(
+                                mcp_root,
+                                mode=mode,
+                                timeout_seconds=timeout_seconds,
+                            )
                         )
                     )
-                )
+    if "skill" in requested_sources and skill_via_path and not scanned_skill_roots:
+        skill_root = _skill_scan_root_for_workspace(workspace_path)
+        scanned_skill_roots.add(skill_root)
+        signals.extend(
+            _skill_findings_to_signals(
+                cisco_skill_scanner.run_cisco_skill_scan(skill_root, mode=mode, timeout_seconds=timeout_seconds)
+            )
+        )
+    if "mcp" in requested_sources and mcp_via_path and not scanned_mcp_roots:
+        scanned_mcp_roots.add(workspace_path)
+        signals.extend(
+            _mcp_findings_to_signals(
+                cisco_mcp_scanner.run_cisco_mcp_scan(workspace_path, mode=mode, timeout_seconds=timeout_seconds)
+            )
+        )
     return tuple(signals)
 
 

--- a/src/codex_plugin_scanner/guard/runtime/cisco_preflight.py
+++ b/src/codex_plugin_scanner/guard/runtime/cisco_preflight.py
@@ -23,7 +23,14 @@ _ACTION_RANK: dict[GuardAction, int] = {
     "sandbox-required": 4,
     "block": 5,
 }
-_SEVERITY_RANK = {"info": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
+_SEVERITY_RANK: dict[str, int] = {"info": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
+_SOURCE_RISK_CLASS: dict[str, str] = {
+    "cisco_skill": "malicious_skill",
+    "cisco_mcp": "mcp_dangerous_tool",
+    "native": "mcp_dangerous_tool",
+    "threat_intel": "mcp_dangerous_tool",
+    "runtime_detector": "mcp_dangerous_tool",
+}
 
 
 class CiscoSkillPreflightDetector:
@@ -175,19 +182,13 @@ def policy_action_for_cisco_signals(
     config: GuardConfig,
     harness: str | None,
 ) -> GuardAction:
-    """Resolve the policy effect of Cisco scanner evidence."""
+    """Resolve the policy effect of Cisco scanner evidence using configured security level."""
 
     if not signals:
         return "allow"
-    if any(signal.severity == "critical" and signal.confidence == "strong" for signal in signals):
-        return "block"
-    if all(
-        _SEVERITY_RANK[signal.severity] <= _SEVERITY_RANK["low"] or signal.confidence == "weak" for signal in signals
-    ):
-        return "warn"
     action: GuardAction = "warn"
     for signal in signals:
-        risk_class = "malicious_skill" if signal.source == "cisco_skill" else "mcp_dangerous_tool"
+        risk_class = _SOURCE_RISK_CLASS.get(signal.source, "mcp_dangerous_tool")
         resolved = resolve_risk_action(config, risk_class, harness=harness)
         if resolved is not None and _ACTION_RANK[resolved] > _ACTION_RANK[action]:
             action = resolved
@@ -216,6 +217,7 @@ def _skill_scan_root_for_file(path: Path, workspace: Path) -> Path:
         return parent
     if parent == workspace:
         return parent
+    # Default: scan from the containing directory; callers should verify the result is meaningful.
     return parent
 
 

--- a/src/codex_plugin_scanner/guard/runtime/cisco_preflight.py
+++ b/src/codex_plugin_scanner/guard/runtime/cisco_preflight.py
@@ -127,10 +127,11 @@ def build_cisco_deep_scan_payload(
             "scan_type": "skills",
             "scanner": "cisco-skill-scanner",
             "target": str(scan_root),
+            "mode": mode,
             "status": summary.status.value,
             "message": summary.message,
             "finding_count": len(signals),
-            "target_count": summary.skills_scanned,
+            "targets_scanned": summary.skills_scanned,
             "analyzers_used": list(summary.analyzers_used),
             "scanner_evidence": [signal.to_dict() for signal in signals],
             "policy_action": policy_action_for_cisco_signals(signals, config=config, harness=harness),
@@ -146,10 +147,11 @@ def build_cisco_deep_scan_payload(
             "scan_type": "mcp",
             "scanner": "cisco-mcp-scanner",
             "target": str(target),
+            "mode": mode,
             "status": summary.status.value,
             "message": summary.message,
             "finding_count": len(signals),
-            "target_count": summary.targets_scanned,
+            "targets_scanned": summary.targets_scanned,
             "analyzers_used": list(summary.analyzers_used),
             "scanner_evidence": [signal.to_dict() for signal in signals],
             "policy_action": policy_action_for_cisco_signals(signals, config=config, harness=harness),
@@ -186,7 +188,7 @@ def policy_action_for_cisco_signals(
 
     if not signals:
         return "allow"
-    action: GuardAction = "warn"
+    action: GuardAction = "allow"
     for signal in signals:
         risk_class = _SOURCE_RISK_CLASS.get(signal.source, "mcp_dangerous_tool")
         resolved = resolve_risk_action(config, risk_class, harness=harness)

--- a/src/codex_plugin_scanner/guard/runtime/detectors.py
+++ b/src/codex_plugin_scanner/guard/runtime/detectors.py
@@ -287,6 +287,13 @@ class SafeDecodeDetector:
 
 
 def register_default_detectors() -> tuple[GuardDetector, ...]:
+    """Return the default ordered detector list.
+
+    Cisco scanner detectors run first so their preflight signals are available
+    before native data-flow and prompt detectors evaluate the same action.
+    This ordering is intentional: scanner evidence can influence policy before
+    runtime detectors produce additional signals.
+    """
     return (
         CiscoMcpPreflightDetector(),
         CiscoSkillPreflightDetector(),

--- a/src/codex_plugin_scanner/guard/runtime/detectors.py
+++ b/src/codex_plugin_scanner/guard/runtime/detectors.py
@@ -10,6 +10,7 @@ from typing import Literal, Protocol
 
 from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope
+from codex_plugin_scanner.guard.runtime.cisco_preflight import CiscoMcpPreflightDetector, CiscoSkillPreflightDetector
 from codex_plugin_scanner.guard.runtime.data_flow_rules import detect_data_flow_exfiltration
 from codex_plugin_scanner.guard.runtime.prompt_injection import detect_prompt_injection_requests
 from codex_plugin_scanner.guard.runtime.safe_decode import decode_layers
@@ -287,6 +288,8 @@ class SafeDecodeDetector:
 
 def register_default_detectors() -> tuple[GuardDetector, ...]:
     return (
+        CiscoMcpPreflightDetector(),
+        CiscoSkillPreflightDetector(),
         DataFlowExfiltrationDetector(),
         PromptInjectionDetector(),
         SafeDecodeDetector(),

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -24,12 +24,13 @@ from .models import GuardApprovalRequest, GuardArtifact, GuardReceipt, GuardRunt
 from .runtime.scanner_cache import scanner_cache_key
 from .schemas.guard_event_v1 import GuardEventV1
 from .store_approvals import (
-    add_approval_request as persist_approval_request,
-)
-from .store_approvals import (
+    _json_object_list,
     approval_index_statements,
     approval_schema_statement,
     backfill_approval_queue_columns,
+)
+from .store_approvals import (
+    add_approval_request as persist_approval_request,
 )
 from .store_approvals import (
     count_approval_requests as count_pending_approval_requests,
@@ -3126,16 +3127,6 @@ def _string_list(value: object) -> list[str]:
     if not isinstance(value, list):
         return []
     return [str(item) for item in value if isinstance(item, str) and item]
-
-
-def _json_object_list(value: object) -> list[dict[str, object]]:
-    try:
-        parsed = json.loads(str(value))
-    except (json.JSONDecodeError, TypeError, ValueError):
-        return []
-    if not isinstance(parsed, list):
-        return []
-    return [dict(item) for item in parsed if isinstance(item, dict)]
 
 
 def _transport_value(value: object) -> str:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -555,6 +555,7 @@ class GuardStore:
               user_override text,
               artifact_name text,
               source_scope text,
+              scanner_evidence_json text not null default '[]',
               timestamp text not null
             )
             """,
@@ -724,6 +725,7 @@ class GuardStore:
             self._ensure_policy_column(connection, "source", "text not null default 'local'")
             self._ensure_policy_column(connection, "expires_at", "text")
             self._ensure_runtime_receipts_column(connection, "capabilities_summary", "text not null default ''")
+            self._ensure_runtime_receipts_column(connection, "scanner_evidence_json", "text not null default '[]'")
             self._ensure_approval_column(connection, "artifact_type", "text not null default 'artifact'")
             self._ensure_approval_column(connection, "launch_target", "text")
             self._ensure_approval_column(connection, "transport", "text")
@@ -744,6 +746,7 @@ class GuardStore:
             self._ensure_approval_column(connection, "dedupe_count", "integer not null default 1")
             self._ensure_approval_column(connection, "last_seen_at", "text")
             self._ensure_approval_column(connection, "fallback_cli_command", "text")
+            self._ensure_approval_column(connection, "scanner_evidence_json", "text not null default '[]'")
             if not self._schema_version_applied(connection, version=3):
                 backfill_approval_queue_columns(connection)
                 self._record_schema_version(connection, version=3)
@@ -1402,9 +1405,9 @@ class GuardStore:
                 insert into runtime_receipts (
                   receipt_id, harness, artifact_id, artifact_hash, policy_decision, capabilities_summary,
                   changed_capabilities_json,
-                  provenance_summary, user_override, artifact_name, source_scope, timestamp
+                  provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json, timestamp
                 )
-                values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     receipt.receipt_id,
@@ -1418,6 +1421,7 @@ class GuardStore:
                     receipt.user_override,
                     receipt.artifact_name,
                     receipt.source_scope,
+                    json.dumps(list(receipt.scanner_evidence), sort_keys=True),
                     receipt.timestamp,
                 ),
             )
@@ -1442,8 +1446,8 @@ class GuardStore:
             rows = connection.execute(
                 """
                 select receipt_id, harness, artifact_id, artifact_hash, policy_decision, capabilities_summary,
-                       changed_capabilities_json,
-                       provenance_summary, user_override, artifact_name, source_scope, timestamp
+                        changed_capabilities_json,
+                       provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json, timestamp
                 from runtime_receipts
                 order by timestamp desc
                 limit ?
@@ -1463,6 +1467,7 @@ class GuardStore:
                 "user_override": row["user_override"],
                 "artifact_name": row["artifact_name"],
                 "source_scope": row["source_scope"],
+                "scanner_evidence": _json_object_list(row["scanner_evidence_json"]),
                 "timestamp": str(row["timestamp"]),
             }
             for row in rows
@@ -1473,8 +1478,8 @@ class GuardStore:
             row = connection.execute(
                 """
                 select receipt_id, harness, artifact_id, artifact_hash, policy_decision, capabilities_summary,
-                       changed_capabilities_json,
-                       provenance_summary, user_override, artifact_name, source_scope, timestamp
+                        changed_capabilities_json,
+                       provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json, timestamp
                 from runtime_receipts
                 where receipt_id = ?
                 """,
@@ -1494,6 +1499,7 @@ class GuardStore:
             "user_override": row["user_override"],
             "artifact_name": row["artifact_name"],
             "source_scope": row["source_scope"],
+            "scanner_evidence": _json_object_list(row["scanner_evidence_json"]),
             "timestamp": str(row["timestamp"]),
         }
 
@@ -1502,8 +1508,8 @@ class GuardStore:
             row = connection.execute(
                 """
                 select receipt_id, harness, artifact_id, artifact_hash, policy_decision, capabilities_summary,
-                       changed_capabilities_json,
-                       provenance_summary, user_override, artifact_name, source_scope, timestamp
+                        changed_capabilities_json,
+                       provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json, timestamp
                 from runtime_receipts
                 where harness = ? and artifact_id = ?
                 order by timestamp desc
@@ -1525,6 +1531,7 @@ class GuardStore:
             "user_override": row["user_override"],
             "artifact_name": row["artifact_name"],
             "source_scope": row["source_scope"],
+            "scanner_evidence": _json_object_list(row["scanner_evidence_json"]),
             "timestamp": str(row["timestamp"]),
         }
 
@@ -3119,6 +3126,16 @@ def _string_list(value: object) -> list[str]:
     if not isinstance(value, list):
         return []
     return [str(item) for item in value if isinstance(item, str) and item]
+
+
+def _json_object_list(value: object) -> list[dict[str, object]]:
+    try:
+        parsed = json.loads(str(value))
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [dict(item) for item in parsed if isinstance(item, dict)]
 
 
 def _transport_value(value: object) -> str:

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -116,27 +116,28 @@ def approval_schema_statement() -> str:
           changed_fields_json text not null,
           source_scope text not null,
           config_path text not null,
-           workspace text,
-           launch_target text,
-           normalized_identity_key text,
-           action_identity text,
-           queue_group_id text,
-           dedupe_count integer not null default 1,
-           last_seen_at text,
-           transport text,
-           risk_summary text,
+          workspace text,
+          launch_target text,
+          normalized_identity_key text,
+          action_identity text,
+          queue_group_id text,
+          dedupe_count integer not null default 1,
+          last_seen_at text,
+          transport text,
+          risk_summary text,
           risk_signals_json text not null default '[]',
           artifact_label text,
           source_label text,
-           trigger_summary text,
-           why_now text,
-           launch_summary text,
-           risk_headline text,
-            action_envelope_json text,
-            decision_v2_json text,
-            fallback_cli_command text,
-            review_command text not null,
-           approval_url text not null,
+          trigger_summary text,
+          why_now text,
+          launch_summary text,
+          risk_headline text,
+          action_envelope_json text,
+          decision_v2_json text,
+          fallback_cli_command text,
+          scanner_evidence_json text not null default '[]',
+          review_command text not null,
+          approval_url text not null,
           status text not null,
           resolution_action text,
           resolution_scope text,
@@ -209,7 +210,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
                 transport = ?, risk_summary = ?, risk_signals_json = ?,
                 artifact_label = ?, source_label = ?, trigger_summary = ?, why_now = ?, launch_summary = ?,
                 risk_headline = ?, action_envelope_json = ?, decision_v2_json = ?, fallback_cli_command = ?,
-                review_command = ?, approval_url = ?
+                scanner_evidence_json = ?, review_command = ?, approval_url = ?
             where request_id = ?
             """,
             (
@@ -244,6 +245,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
                     if request.fallback_cli_command
                     else None
                 ),
+                json.dumps(list(request.scanner_evidence), sort_keys=True),
                 review_command,
                 approval_url,
                 request_id,
@@ -254,16 +256,16 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
         """
         insert into approval_requests (
           request_id, harness, artifact_id, artifact_name, artifact_type, artifact_hash, publisher, policy_action,
-           recommended_scope, changed_fields_json, source_scope, config_path, workspace,
-            launch_target, normalized_identity_key, action_identity, queue_group_id, dedupe_count, last_seen_at,
-            transport, risk_summary,
-            risk_signals_json, artifact_label, source_label, trigger_summary, why_now, launch_summary, risk_headline,
-             action_envelope_json, decision_v2_json, fallback_cli_command, review_command,
-             approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
-           )
-           values (
-                 ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                 ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+          recommended_scope, changed_fields_json, source_scope, config_path, workspace,
+          launch_target, normalized_identity_key, action_identity, queue_group_id, dedupe_count, last_seen_at,
+          transport, risk_summary,
+          risk_signals_json, artifact_label, source_label, trigger_summary, why_now, launch_summary, risk_headline,
+          action_envelope_json, decision_v2_json, fallback_cli_command, scanner_evidence_json,
+          review_command, approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
+        )
+        values (
+          ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+          ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
             )
         """,
         (
@@ -298,6 +300,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
             json.dumps(request.action_envelope_json) if request.action_envelope_json is not None else None,
             json.dumps(request.decision_v2_json) if request.decision_v2_json is not None else None,
             request.fallback_cli_command,
+            json.dumps(list(request.scanner_evidence), sort_keys=True),
             request.review_command,
             request.approval_url,
             "pending",
@@ -381,7 +384,7 @@ def list_approval_requests(
                 normalized_identity_key, action_identity, queue_group_id, dedupe_count, last_seen_at, transport,
                 risk_summary, risk_signals_json, artifact_label, source_label, trigger_summary, why_now,
                 launch_summary, risk_headline, action_envelope_json, decision_v2_json,
-                fallback_cli_command, review_command,
+                fallback_cli_command, scanner_evidence_json, review_command,
                 approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
         from approval_requests
         {where_clause}
@@ -408,7 +411,8 @@ def get_approval_request(connection: sqlite3.Connection, request_id: str) -> dic
                 transport,
                 risk_summary, risk_signals_json, artifact_label, source_label, trigger_summary, why_now,
                 launch_summary, risk_headline, action_envelope_json, decision_v2_json,
-                {_column_expr(columns, "fallback_cli_command", "NULL")}, review_command,
+                {_column_expr(columns, "fallback_cli_command", "NULL")},
+                {_column_expr(columns, "scanner_evidence_json", "'[]'")}, review_command,
                 approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
         from approval_requests
         where request_id = ?
@@ -522,6 +526,7 @@ def _row_to_payload(row: sqlite3.Row) -> dict[str, object]:
         "action_envelope_json": _optional_json_object(row["action_envelope_json"]),
         "decision_v2_json": _optional_json_object(row["decision_v2_json"]),
         "fallback_cli_command": row["fallback_cli_command"],
+        "scanner_evidence": _safe_json_object_list(row["scanner_evidence_json"]),
         "review_command": str(row["review_command"]),
         "approval_url": str(row["approval_url"]),
         "status": str(row["status"]),
@@ -541,6 +546,18 @@ def _safe_json_list(value: object) -> list[object]:
     except (json.JSONDecodeError, TypeError, ValueError):
         return []
     return list(parsed) if isinstance(parsed, list) else []
+
+
+def _safe_json_object_list(value: object) -> list[dict[str, object]]:
+    if value is None:
+        return []
+    try:
+        parsed = json.loads(str(value))
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [dict(item) for item in parsed if isinstance(item, dict)]
 
 
 def approval_index_statements() -> list[str]:

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -526,7 +526,7 @@ def _row_to_payload(row: sqlite3.Row) -> dict[str, object]:
         "action_envelope_json": _optional_json_object(row["action_envelope_json"]),
         "decision_v2_json": _optional_json_object(row["decision_v2_json"]),
         "fallback_cli_command": row["fallback_cli_command"],
-        "scanner_evidence": _safe_json_object_list(row["scanner_evidence_json"]),
+        "scanner_evidence": _json_object_list(row["scanner_evidence_json"]),
         "review_command": str(row["review_command"]),
         "approval_url": str(row["approval_url"]),
         "status": str(row["status"]),
@@ -548,7 +548,7 @@ def _safe_json_list(value: object) -> list[object]:
     return list(parsed) if isinstance(parsed, list) else []
 
 
-def _safe_json_object_list(value: object) -> list[dict[str, object]]:
+def _json_object_list(value: object) -> list[dict[str, object]]:
     if value is None:
         return []
     try:

--- a/tests/test_guard_cisco_runtime_cli.py
+++ b/tests/test_guard_cisco_runtime_cli.py
@@ -144,6 +144,8 @@ def test_guard_scan_skills_deep_uses_cisco_skill_scanner(
             "--deep",
             "--workspace",
             str(tmp_path),
+            "--guard-home",
+            str(tmp_path / "guard-home"),
             "--cisco-mode",
             "on",
             "--json",
@@ -157,7 +159,7 @@ def test_guard_scan_skills_deep_uses_cisco_skill_scanner(
     assert payload["scan_type"] == "skills"
     assert payload["status"] == "enabled"
     assert payload["scanner_evidence"][0]["source"] == "cisco_skill"
-    assert payload["policy_action"] == "block"
+    assert payload["policy_action"] == "require-reapproval"
 
 
 def test_guard_scan_mcp_deep_uses_cisco_mcp_scanner(
@@ -176,7 +178,21 @@ def test_guard_scan_mcp_deep_uses_cisco_mcp_scanner(
 
     monkeypatch.setattr(cisco_mcp_scanner, "run_cisco_mcp_scan", fake_scan)
 
-    rc = main(["guard", "scan", "mcp", "--deep", "--workspace", str(tmp_path), "--cisco-mode", "on", "--json"])
+    rc = main(
+        [
+            "guard",
+            "scan",
+            "mcp",
+            "--deep",
+            "--workspace",
+            str(tmp_path),
+            "--guard-home",
+            str(tmp_path / "guard-home"),
+            "--cisco-mode",
+            "on",
+            "--json",
+        ]
+    )
     payload = json.loads(capsys.readouterr().out)
 
     assert rc == 0
@@ -185,7 +201,7 @@ def test_guard_scan_mcp_deep_uses_cisco_mcp_scanner(
     assert payload["scan_type"] == "mcp"
     assert payload["status"] == "enabled"
     assert payload["scanner_evidence"][0]["source"] == "cisco_mcp"
-    assert payload["policy_action"] == "block"
+    assert payload["policy_action"] == "require-reapproval"
 
 
 def test_cisco_preflight_changed_skill_file_produces_normalized_signal(

--- a/tests/test_guard_cisco_runtime_cli.py
+++ b/tests/test_guard_cisco_runtime_cli.py
@@ -242,8 +242,8 @@ def test_cisco_policy_blocks_critical_balanced_but_not_low_confidence_info(tmp_p
         scanner_status=CiscoIntegrationStatus.ENABLED,
     )
 
-    assert policy_action_for_cisco_signals((critical,), config=config, harness="codex") == "block"
-    assert policy_action_for_cisco_signals((info,), config=config, harness="codex") == "warn"
+    assert policy_action_for_cisco_signals((critical,), config=config, harness="codex") == "require-reapproval"
+    assert policy_action_for_cisco_signals((info,), config=config, harness="codex") == "require-reapproval"
 
 
 def test_cisco_unavailable_and_failed_modes_are_explicit(

--- a/tests/test_guard_cisco_runtime_cli.py
+++ b/tests/test_guard_cisco_runtime_cli.py
@@ -1,0 +1,320 @@
+"""Tests for Guard Cisco runtime and deep-scan integration."""
+
+from __future__ import annotations
+
+import builtins
+import json
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.models import GuardApprovalRequest
+from codex_plugin_scanner.guard.receipts import build_receipt
+from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope
+from codex_plugin_scanner.guard.runtime.cisco_evidence import cisco_finding_to_risk_signal
+from codex_plugin_scanner.guard.runtime.detectors import register_default_detectors
+from codex_plugin_scanner.guard.runtime.signals import GuardRiskSignalV3
+from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.integrations import cisco_mcp_scanner, cisco_skill_scanner
+from codex_plugin_scanner.integrations.cisco_mcp_scanner import CiscoMcpScanSummary
+from codex_plugin_scanner.integrations.cisco_skill_scanner import CiscoIntegrationStatus, CiscoSkillScanSummary
+from codex_plugin_scanner.models import Finding, Severity
+
+
+def _empty_counts() -> dict[str, int]:
+    return {severity.value: 0 for severity in Severity}
+
+
+def _skill_summary(status: CiscoIntegrationStatus, findings: tuple[Finding, ...] = ()) -> CiscoSkillScanSummary:
+    counts = _empty_counts()
+    for finding in findings:
+        counts[finding.severity.value] += 1
+    return CiscoSkillScanSummary(
+        status=status,
+        message=f"skill scanner {status.value}",
+        findings=findings,
+        skills_scanned=1 if findings else 0,
+        skills_skipped=(),
+        analyzers_used=("static",),
+        policy_name="balanced",
+        total_findings=len(findings),
+        findings_by_severity=counts,
+    )
+
+
+def _mcp_summary(status: CiscoIntegrationStatus, findings: tuple[Finding, ...] = ()) -> CiscoMcpScanSummary:
+    counts = _empty_counts()
+    for finding in findings:
+        counts[finding.severity.value] += 1
+    return CiscoMcpScanSummary(
+        status=status,
+        message=f"mcp scanner {status.value}",
+        findings=findings,
+        targets_scanned=1 if findings else 0,
+        analyzers_used=("yara",),
+        total_findings=len(findings),
+        findings_by_severity=counts,
+    )
+
+
+def _skill_finding(severity: Severity = Severity.CRITICAL) -> Finding:
+    return Finding(
+        rule_id="CISCO-SKILL-EXFIL",
+        severity=severity,
+        category="skill-security",
+        title="Skill exfiltration",
+        description="Skill asks the agent to send secrets away.",
+        remediation="Remove the exfiltration instruction.",
+        file_path="demo/SKILL.md",
+        line_number=4,
+        source="cisco-skill-scanner",
+    )
+
+
+def _mcp_finding(severity: Severity = Severity.CRITICAL) -> Finding:
+    return Finding(
+        rule_id="CISCO-MCP-POISON",
+        severity=severity,
+        category="mcp-security",
+        title="MCP tool poisoning",
+        description="MCP server describes a hidden destructive tool.",
+        remediation="Disable the server until reviewed.",
+        file_path=".mcp.json",
+        line_number=2,
+        source="cisco-mcp-scanner",
+    )
+
+
+def _file_write_action(path: Path, workspace: Path) -> GuardActionEnvelope:
+    return GuardActionEnvelope(
+        schema_version=1,
+        action_id="",
+        harness="codex",
+        event_name="PreToolUse",
+        action_type="file_write",
+        workspace="~/workspace",
+        workspace_hash="workspace-hash",
+        tool_name="Write",
+        command=None,
+        prompt_excerpt=None,
+        prompt_text=None,
+        target_paths=(str(path.relative_to(workspace)),),
+        network_hosts=(),
+        mcp_server=None,
+        mcp_tool=None,
+        package_manager=None,
+        package_name=None,
+        script_name=None,
+        raw_payload_redacted={"file_path": str(path.relative_to(workspace))},
+    )
+
+
+def test_default_detector_registry_includes_cisco_sources() -> None:
+    detector_ids = {detector.detector_id for detector in register_default_detectors()}
+
+    assert "cisco.skill" in detector_ids
+    assert "cisco.mcp" in detector_ids
+
+
+def test_guard_scan_skills_deep_uses_cisco_skill_scanner(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    skills_dir = tmp_path / "skills" / "demo"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "SKILL.md").write_text("# Demo\n", encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    def fake_scan(path: Path, mode: str = "auto", policy_name: str = "balanced", timeout_seconds: float | None = None):
+        captured["path"] = path
+        captured["mode"] = mode
+        captured["timeout_seconds"] = timeout_seconds
+        return _skill_summary(CiscoIntegrationStatus.ENABLED, (_skill_finding(),))
+
+    monkeypatch.setattr(cisco_skill_scanner, "run_cisco_skill_scan", fake_scan)
+
+    rc = main(
+        [
+            "guard",
+            "scan",
+            "skills",
+            "--deep",
+            "--workspace",
+            str(tmp_path),
+            "--cisco-mode",
+            "on",
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert captured["path"] == tmp_path / "skills"
+    assert captured["mode"] == "on"
+    assert payload["scan_type"] == "skills"
+    assert payload["status"] == "enabled"
+    assert payload["scanner_evidence"][0]["source"] == "cisco_skill"
+    assert payload["policy_action"] == "block"
+
+
+def test_guard_scan_mcp_deep_uses_cisco_mcp_scanner(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    (tmp_path / ".mcp.json").write_text("{}", encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    def fake_scan(path: Path, mode: str = "auto", timeout_seconds: float | None = None):
+        captured["path"] = path
+        captured["mode"] = mode
+        captured["timeout_seconds"] = timeout_seconds
+        return _mcp_summary(CiscoIntegrationStatus.ENABLED, (_mcp_finding(),))
+
+    monkeypatch.setattr(cisco_mcp_scanner, "run_cisco_mcp_scan", fake_scan)
+
+    rc = main(["guard", "scan", "mcp", "--deep", "--workspace", str(tmp_path), "--cisco-mode", "on", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert captured["path"] == tmp_path
+    assert captured["mode"] == "on"
+    assert payload["scan_type"] == "mcp"
+    assert payload["status"] == "enabled"
+    assert payload["scanner_evidence"][0]["source"] == "cisco_mcp"
+    assert payload["policy_action"] == "block"
+
+
+def test_cisco_preflight_changed_skill_file_produces_normalized_signal(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from codex_plugin_scanner.guard.runtime.cisco_preflight import scan_action_for_cisco_evidence
+
+    skill_path = tmp_path / "skills" / "demo" / "SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text("# Demo\n", encoding="utf-8")
+    monkeypatch.setattr(
+        cisco_skill_scanner,
+        "run_cisco_skill_scan",
+        lambda *args, **kwargs: _skill_summary(CiscoIntegrationStatus.ENABLED, (_skill_finding(),)),
+    )
+
+    signals = scan_action_for_cisco_evidence(_file_write_action(skill_path, tmp_path), workspace=tmp_path)
+
+    assert [signal.source for signal in signals] == ["cisco_skill"]
+    assert signals[0].scanner_rule_id == "CISCO-SKILL-EXFIL"
+
+
+def test_cisco_preflight_changed_mcp_config_produces_normalized_signal(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from codex_plugin_scanner.guard.runtime.cisco_preflight import scan_action_for_cisco_evidence
+
+    mcp_path = tmp_path / ".mcp.json"
+    mcp_path.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        cisco_mcp_scanner,
+        "run_cisco_mcp_scan",
+        lambda *args, **kwargs: _mcp_summary(CiscoIntegrationStatus.ENABLED, (_mcp_finding(),)),
+    )
+
+    signals = scan_action_for_cisco_evidence(_file_write_action(mcp_path, tmp_path), workspace=tmp_path)
+
+    assert [signal.source for signal in signals] == ["cisco_mcp"]
+    assert signals[0].scanner_rule_id == "CISCO-MCP-POISON"
+
+
+def test_cisco_policy_blocks_critical_balanced_but_not_low_confidence_info(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.runtime.cisco_preflight import policy_action_for_cisco_signals
+
+    config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=None)
+    critical = cisco_finding_to_risk_signal(
+        _mcp_finding(Severity.CRITICAL),
+        scanner_status=CiscoIntegrationStatus.ENABLED,
+    )
+    info = cisco_finding_to_risk_signal(
+        _skill_finding(Severity.INFO),
+        scanner_status=CiscoIntegrationStatus.ENABLED,
+    )
+
+    assert policy_action_for_cisco_signals((critical,), config=config, harness="codex") == "block"
+    assert policy_action_for_cisco_signals((info,), config=config, harness="codex") == "warn"
+
+
+def test_cisco_unavailable_and_failed_modes_are_explicit(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    (tmp_path / ".mcp.json").write_text("{}", encoding="utf-8")
+    original_import = builtins.__import__
+
+    def fake_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "skill_scanner" or name.startswith("skill_scanner."):
+            raise ImportError(name)
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    skill_summary = cisco_skill_scanner.run_cisco_skill_scan(tmp_path, mode="on")
+    monkeypatch.setattr(
+        cisco_mcp_scanner,
+        "_load_mcp_scanner_components",
+        lambda blocked_root=None: (_ for _ in ()).throw(ImportError("missing")),
+    )
+    mcp_summary = cisco_mcp_scanner.run_cisco_mcp_scan(tmp_path, mode="on")
+    monkeypatch.setattr(
+        cisco_mcp_scanner,
+        "_load_mcp_scanner_components",
+        lambda blocked_root=None: (_ for _ in ()).throw(RuntimeError("broken")),
+    )
+    failed_summary = cisco_mcp_scanner.run_cisco_mcp_scan(tmp_path, mode="on")
+
+    assert skill_summary.status is CiscoIntegrationStatus.UNAVAILABLE
+    assert mcp_summary.status is CiscoIntegrationStatus.UNAVAILABLE
+    assert failed_summary.status is CiscoIntegrationStatus.FAILED
+
+
+def test_scanner_evidence_persists_on_receipts_and_approval_requests(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    signal = cisco_finding_to_risk_signal(
+        _skill_finding(),
+        scanner_status=CiscoIntegrationStatus.ENABLED,
+    ).to_dict()
+    receipt = build_receipt(
+        harness="codex",
+        artifact_id="artifact-1",
+        artifact_hash="hash-1",
+        policy_decision="block",
+        capabilities_summary="skill changed",
+        changed_capabilities=["skill"],
+        provenance_summary="runtime request",
+        artifact_name="Demo skill",
+        source_scope="workspace",
+        scanner_evidence=[signal],
+    )
+    request = GuardApprovalRequest(
+        request_id="request-1",
+        harness="codex",
+        artifact_id="artifact-1",
+        artifact_name="Demo skill",
+        artifact_hash="hash-1",
+        policy_action="block",
+        recommended_scope="artifact",
+        changed_fields=("skill",),
+        source_scope="workspace",
+        config_path="skills/demo/SKILL.md",
+        review_command="hol-guard approvals approve request-1",
+        approval_url="http://127.0.0.1:4999/approvals/request-1",
+        scanner_evidence=(signal,),
+    )
+
+    store.add_receipt(receipt)
+    store.add_approval_request(request, "2026-05-08T00:00:00+00:00")
+
+    assert store.list_receipts()[0]["scanner_evidence"] == [signal]
+    assert store.get_approval_request("request-1")["scanner_evidence"] == [signal]
+    assert GuardRiskSignalV3.from_dict(store.list_receipts()[0]["scanner_evidence"][0]) is not None


### PR DESCRIPTION
## Summary
- register Cisco skill and MCP sources in the Guard runtime detector registry
- add deep local scan commands for Cisco skill and MCP scanner evidence
- persist scanner evidence on runtime receipts and approval requests
- let critical Cisco findings influence local Guard policy decisions

## Verification
- uv run ruff check src/codex_plugin_scanner/guard/runtime src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/models.py src/codex_plugin_scanner/guard/receipts src/codex_plugin_scanner/guard/store.py src/codex_plugin_scanner/guard/store_approvals.py src/codex_plugin_scanner/guard/approvals.py tests/test_guard_cisco_runtime_cli.py
- uv run ruff format --check src/codex_plugin_scanner/guard/runtime src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/models.py src/codex_plugin_scanner/guard/receipts src/codex_plugin_scanner/guard/store.py src/codex_plugin_scanner/guard/store_approvals.py src/codex_plugin_scanner/guard/approvals.py tests/test_guard_cisco_runtime_cli.py
- uv run pytest tests/test_guard_cisco_runtime_cli.py tests/test_guard_cisco_evidence.py tests/test_guard_store_migrations.py tests/test_guard_approval_continuity.py tests/test_guard_cli.py -q