### PR TITLE
feat(guard): daemon status/repair/stop CLI subcommands

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -6574,8 +6574,13 @@ def _handle_daemon_status(guard_home: Path, as_json: bool) -> int:
             state = _json.loads(state_path.read_text())
             pid = state.get("pid") if isinstance(state, dict) else None
             port = state.get("port") if isinstance(state, dict) else None
-            if isinstance(pid, int) and pid > 0:
-                running = _guard_daemon_pid_is_running(pid)
+            if (
+                isinstance(pid, int)
+                and pid > 0
+                and _guard_daemon_pid_is_running(pid)
+                and _guard_daemon_pid_matches_command(pid, expected_guard_home=guard_home)
+            ):
+                running = True
         except Exception:
             pass
     payload: dict[str, object] = {
@@ -6619,7 +6624,7 @@ def _handle_daemon_stop(guard_home: Path, as_json: bool) -> int:
             ):
                 os.kill(pid, _signal.SIGTERM)
                 stopped = True
-        except (ProcessLookupError, PermissionError, OSError):
+        except (ProcessLookupError, PermissionError, OSError, _json.JSONDecodeError, ValueError):
             pass
     from codex_plugin_scanner.guard.daemon.manager import clear_guard_daemon_state
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -60,8 +60,13 @@ from ..consumer import (
     record_policy,
     run_consumer_scan,
 )
-from ..daemon import GuardDaemonServer, ensure_guard_daemon, load_guard_surface_daemon_client
-from ..daemon.manager import load_guard_daemon_auth_token
+from ..daemon import (
+    GuardDaemonServer,
+    ensure_guard_daemon,
+    load_guard_surface_daemon_client,
+    repair_approval_center_locator,
+)
+from ..daemon.manager import _guard_daemon_pid_is_running, load_guard_daemon_auth_token, load_guard_daemon_url
 from ..incident import build_incident_context
 from ..mcp_tool_calls import (
     allow_tool_call,
@@ -662,6 +667,16 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     daemon_parser.add_argument("--serve", action="store_true")
     daemon_parser.add_argument("--port", type=int)
     daemon_parser.add_argument("--json", action="store_true")
+    daemon_subparsers = daemon_parser.add_subparsers(dest="daemon_command")
+    daemon_status_parser = daemon_subparsers.add_parser("status", help="Show local Guard daemon status")
+    _add_guard_common_args(daemon_status_parser)
+    daemon_status_parser.add_argument("--json", action="store_true")
+    daemon_repair_parser = daemon_subparsers.add_parser("repair", help="Repair stale Guard daemon state")
+    _add_guard_common_args(daemon_repair_parser)
+    daemon_repair_parser.add_argument("--json", action="store_true")
+    daemon_stop_parser = daemon_subparsers.add_parser("stop", help="Stop a running Guard daemon")
+    _add_guard_common_args(daemon_stop_parser)
+    daemon_stop_parser.add_argument("--json", action="store_true")
 
     codex_proxy_parser = guard_subparsers.add_parser("codex-mcp-proxy", help=argparse.SUPPRESS)
     _add_guard_common_args(codex_proxy_parser)
@@ -1502,6 +1517,13 @@ def run_guard_command(
         return 2
 
     if args.guard_command == "daemon":
+        daemon_command = getattr(args, "daemon_command", None)
+        if daemon_command == "status":
+            return _handle_daemon_status(guard_home, getattr(args, "json", False))
+        if daemon_command == "repair":
+            return _handle_daemon_repair(guard_home, getattr(args, "json", False))
+        if daemon_command == "stop":
+            return _handle_daemon_stop(guard_home, getattr(args, "json", False))
         daemon = GuardDaemonServer(store, port=args.port or 0)
         if args.serve:
             daemon.serve()
@@ -6531,3 +6553,71 @@ def _matching_advisories(store: GuardStore, publisher: object) -> list[dict[str,
     if not isinstance(publisher, str) or not publisher.strip():
         return []
     return [item for item in store.list_cached_advisories() if item.get("publisher") == publisher]
+
+
+def _handle_daemon_status(guard_home: Path, as_json: bool) -> int:
+    from codex_plugin_scanner.version import __version__
+
+    url = load_guard_daemon_url(guard_home)
+    running = False
+    port: int | None = None
+    pid: int | None = None
+    state_path = guard_home / "daemon-state.json"
+    if state_path.is_file():
+        import json as _json
+
+        try:
+            state = _json.loads(state_path.read_text())
+            pid = state.get("pid") if isinstance(state, dict) else None
+            port = state.get("port") if isinstance(state, dict) else None
+            if isinstance(pid, int) and pid > 0:
+                running = _guard_daemon_pid_is_running(pid)
+        except Exception:
+            pass
+    payload: dict[str, object] = {
+        "running": running,
+        "guard_home": str(guard_home),
+        "version": __version__,
+    }
+    if port is not None:
+        payload["port"] = port
+    if pid is not None:
+        payload["pid"] = pid
+    if url is not None:
+        payload["url"] = url
+    _emit("daemon", payload, as_json)
+    return 0
+
+
+def _handle_daemon_repair(guard_home: Path, as_json: bool) -> int:
+    result = repair_approval_center_locator(guard_home)
+    _emit("daemon", result, as_json)
+    return 0
+
+
+def _handle_daemon_stop(guard_home: Path, as_json: bool) -> int:
+    import json as _json
+    import os
+    import signal as _signal
+
+    state_path = guard_home / "daemon-state.json"
+    stopped = False
+    pid: int | None = None
+    if state_path.is_file():
+        try:
+            state = _json.loads(state_path.read_text())
+            pid = state.get("pid") if isinstance(state, dict) else None
+            if isinstance(pid, int) and pid > 0 and _guard_daemon_pid_is_running(pid):
+                os.kill(pid, _signal.SIGTERM)
+                stopped = True
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+    from codex_plugin_scanner.guard.daemon.manager import clear_guard_daemon_state
+
+    with suppress(OSError):
+        clear_guard_daemon_state(guard_home)
+    payload: dict[str, object] = {"stopped": stopped, "running": False}
+    if pid is not None:
+        payload["pid"] = pid
+    _emit("daemon", payload, as_json)
+    return 0

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -66,7 +66,12 @@ from ..daemon import (
     load_guard_surface_daemon_client,
     repair_approval_center_locator,
 )
-from ..daemon.manager import _guard_daemon_pid_is_running, load_guard_daemon_auth_token, load_guard_daemon_url
+from ..daemon.manager import (
+    _guard_daemon_pid_is_running,
+    _guard_daemon_pid_matches_command,
+    load_guard_daemon_auth_token,
+    load_guard_daemon_url,
+)
 from ..incident import build_incident_context
 from ..mcp_tool_calls import (
     allow_tool_call,
@@ -666,17 +671,16 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     _add_guard_common_args(daemon_parser)
     daemon_parser.add_argument("--serve", action="store_true")
     daemon_parser.add_argument("--port", type=int)
-    daemon_parser.add_argument("--json", action="store_true")
     daemon_subparsers = daemon_parser.add_subparsers(dest="daemon_command")
-    daemon_status_parser = daemon_subparsers.add_parser("status", help="Show local Guard daemon status")
-    _add_guard_common_args(daemon_status_parser)
-    daemon_status_parser.add_argument("--json", action="store_true")
-    daemon_repair_parser = daemon_subparsers.add_parser("repair", help="Repair stale Guard daemon state")
-    _add_guard_common_args(daemon_repair_parser)
-    daemon_repair_parser.add_argument("--json", action="store_true")
-    daemon_stop_parser = daemon_subparsers.add_parser("stop", help="Stop a running Guard daemon")
-    _add_guard_common_args(daemon_stop_parser)
-    daemon_stop_parser.add_argument("--json", action="store_true")
+    status_p = daemon_subparsers.add_parser("status", help="Show local Guard daemon status")
+    _add_guard_common_args(status_p)
+    status_p.add_argument("--json", action="store_true")
+    repair_p = daemon_subparsers.add_parser("repair", help="Repair stale Guard daemon state")
+    _add_guard_common_args(repair_p)
+    repair_p.add_argument("--json", action="store_true")
+    stop_p = daemon_subparsers.add_parser("stop", help="Stop a running Guard daemon")
+    _add_guard_common_args(stop_p)
+    stop_p.add_argument("--json", action="store_true")
 
     codex_proxy_parser = guard_subparsers.add_parser("codex-mcp-proxy", help=argparse.SUPPRESS)
     _add_guard_common_args(codex_proxy_parser)
@@ -6607,7 +6611,12 @@ def _handle_daemon_stop(guard_home: Path, as_json: bool) -> int:
         try:
             state = _json.loads(state_path.read_text())
             pid = state.get("pid") if isinstance(state, dict) else None
-            if isinstance(pid, int) and pid > 0 and _guard_daemon_pid_is_running(pid):
+            if (
+                isinstance(pid, int)
+                and pid > 0
+                and _guard_daemon_pid_is_running(pid)
+                and _guard_daemon_pid_matches_command(pid, expected_guard_home=guard_home)
+            ):
                 os.kill(pid, _signal.SIGTERM)
                 stopped = True
         except (ProcessLookupError, PermissionError, OSError):

--- a/tests/test_guard_daemon_cli.py
+++ b/tests/test_guard_daemon_cli.py
@@ -1,0 +1,123 @@
+"""Tests for hol-guard daemon status/repair/stop subcommands.
+
+Covers L311-L313: daemon CLI management commands.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _run(args: list[str], guard_home: Path) -> tuple[int, dict]:
+    result = subprocess.run(
+        ["hol-guard", *args, f"--guard-home={guard_home}", "--json"],
+        capture_output=True,
+        text=True,
+    )
+    try:
+        payload = json.loads(result.stdout or result.stderr or "{}")
+    except json.JSONDecodeError:
+        payload = {"raw": result.stdout or result.stderr}
+    return result.returncode, payload
+
+
+class TestDaemonStatusCommand:
+    """L311: hol-guard daemon status."""
+
+    def test_status_returns_not_running_when_no_daemon_state(self, tmp_path: Path) -> None:
+        code, payload = _run(["daemon", "status"], tmp_path)
+        assert code == 0
+        assert payload.get("running") is False
+
+    def test_status_json_has_required_keys(self, tmp_path: Path) -> None:
+        code, payload = _run(["daemon", "status"], tmp_path)
+        assert code == 0
+        for key in ("running", "guard_home"):
+            assert key in payload, f"missing key: {key}"
+
+    def test_status_shows_guard_home_path(self, tmp_path: Path) -> None:
+        code, payload = _run(["daemon", "status"], tmp_path)
+        assert code == 0
+        assert payload.get("guard_home") == str(tmp_path)
+
+    def test_status_includes_version_when_present(self, tmp_path: Path) -> None:
+        code, payload = _run(["daemon", "status"], tmp_path)
+        assert code == 0
+        assert "version" in payload
+
+    def test_status_running_true_when_live_state(self, tmp_path: Path) -> None:
+        from codex_plugin_scanner.guard.daemon.manager import write_guard_daemon_state
+
+        write_guard_daemon_state(tmp_path, port=19999, auth_token="test-token-abc")
+        state_path = tmp_path / "daemon-state.json"
+        import json as _json
+
+        state = _json.loads(state_path.read_text())
+        pid = os.getpid()
+        state["pid"] = pid
+        state_path.write_text(_json.dumps(state))
+
+        code, payload = _run(["daemon", "status"], tmp_path)
+        assert code == 0
+        assert "guard_home" in payload
+
+
+class TestDaemonRepairCommand:
+    """L312: hol-guard daemon repair."""
+
+    def test_repair_succeeds_with_no_daemon_state(self, tmp_path: Path) -> None:
+        code, payload = _run(["daemon", "repair"], tmp_path)
+        assert code == 0
+        assert payload.get("repaired") is True
+
+    def test_repair_removes_stale_locator(self, tmp_path: Path) -> None:
+        locator_path = tmp_path / "approval-center-locator.json"
+        locator_path.write_text('{"port": 0, "pid": 99999999}')
+        assert locator_path.exists()
+
+        code, payload = _run(["daemon", "repair"], tmp_path)
+        assert code == 0
+        assert not locator_path.exists(), "stale locator should be removed"
+
+    def test_repair_reports_cleared_items(self, tmp_path: Path) -> None:
+        locator_path = tmp_path / "approval-center-locator.json"
+        locator_path.write_text('{"port": 0, "pid": 99999999}')
+
+        code, payload = _run(["daemon", "repair"], tmp_path)
+        assert code == 0
+        cleared = payload.get("cleared", [])
+        assert "locator" in cleared
+
+    def test_repair_is_idempotent(self, tmp_path: Path) -> None:
+        code1, _ = _run(["daemon", "repair"], tmp_path)
+        code2, _ = _run(["daemon", "repair"], tmp_path)
+        assert code1 == 0
+        assert code2 == 0
+
+
+class TestDaemonStopCommand:
+    """L313: hol-guard daemon stop."""
+
+    def test_stop_succeeds_when_no_daemon_running(self, tmp_path: Path) -> None:
+        code, payload = _run(["daemon", "stop"], tmp_path)
+        assert code == 0
+        assert payload.get("stopped") is True or payload.get("running") is False
+
+    def test_stop_clears_daemon_state(self, tmp_path: Path) -> None:
+        from codex_plugin_scanner.guard.daemon.manager import write_guard_daemon_state
+
+        write_guard_daemon_state(tmp_path, port=0, auth_token="x")
+
+        code, payload = _run(["daemon", "stop"], tmp_path)
+        assert code == 0
+
+    def test_stop_json_has_stopped_key(self, tmp_path: Path) -> None:
+        code, payload = _run(["daemon", "stop"], tmp_path)
+        assert code == 0
+        assert "stopped" in payload or "running" in payload

--- a/tests/test_guard_daemon_cli.py
+++ b/tests/test_guard_daemon_cli.py
@@ -8,10 +8,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-import sys
 from pathlib import Path
-
-import pytest
 
 
 def _run(args: list[str], guard_home: Path) -> tuple[int, dict]:
@@ -81,7 +78,7 @@ class TestDaemonRepairCommand:
         locator_path.write_text('{"port": 0, "pid": 99999999}')
         assert locator_path.exists()
 
-        code, payload = _run(["daemon", "repair"], tmp_path)
+        code, _payload = _run(["daemon", "repair"], tmp_path)
         assert code == 0
         assert not locator_path.exists(), "stale locator should be removed"
 
@@ -114,7 +111,7 @@ class TestDaemonStopCommand:
 
         write_guard_daemon_state(tmp_path, port=0, auth_token="x")
 
-        code, payload = _run(["daemon", "stop"], tmp_path)
+        code, _payload = _run(["daemon", "stop"], tmp_path)
         assert code == 0
 
     def test_stop_json_has_stopped_key(self, tmp_path: Path) -> None:

--- a/tests/test_guard_daemon_cli.py
+++ b/tests/test_guard_daemon_cli.py
@@ -118,3 +118,27 @@ class TestDaemonStopCommand:
         code, payload = _run(["daemon", "stop"], tmp_path)
         assert code == 0
         assert "stopped" in payload or "running" in payload
+
+    def test_stop_handles_corrupted_state_file(self, tmp_path: Path) -> None:
+        """Regression: corrupted daemon-state.json must not raise."""
+        state_path = tmp_path / "daemon-state.json"
+        state_path.write_text("{this is not valid json!!")
+        code, _payload = _run(["daemon", "stop"], tmp_path)
+        assert code == 0
+
+    def test_status_with_pid_reuse_returns_not_running(self, tmp_path: Path) -> None:
+        """Regression: status must verify daemon identity, not just PID liveness."""
+        import json as _json
+
+        from codex_plugin_scanner.guard.daemon.manager import write_guard_daemon_state
+
+        write_guard_daemon_state(tmp_path, port=19998, auth_token="tok")
+        state_path = tmp_path / "daemon-state.json"
+        state = _json.loads(state_path.read_text())
+        state["pid"] = os.getpid()
+        state["guard_home"] = "/some/other/guard/home"
+        state_path.write_text(_json.dumps(state))
+
+        code, payload = _run(["daemon", "status"], tmp_path)
+        assert code == 0
+        assert payload.get("running") is False, "PID reuse must not be reported as running"


### PR DESCRIPTION
Adds three operator subcommands under `hol-guard daemon`:

- `daemon status` — shows running state, PID, URL, version, guard home path; supports `--json`
- `daemon repair` — clears stale approval-center locator and dead daemon state; idempotent
- `daemon stop` — sends SIGTERM to the running daemon process; no-op when daemon not running

All subcommands respect `--guard-home` override and `--json` output mode.

12 tests added covering all subcommands and edge cases.