### PR TITLE
test(guard): add daemon wake and log redaction tests

### DIFF
--- a/tests/test_guard_daemon_wake.py
+++ b/tests/test_guard_daemon_wake.py
@@ -1,0 +1,176 @@
+"""L314: No-dashboard approval URL wake tests.
+
+Verifies that Guard starts the daemon and surfaces the approval URL even when
+no browser dashboard is open (e.g., CLI-only or headless environments).
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+
+from codex_plugin_scanner.guard.daemon import manager as daemon_manager_module
+
+
+def _make_start_mock(guard_home: Path, port: int = 5700):
+    """Return a Popen-compatible fake that writes a valid state file immediately."""
+
+    import os
+
+    state_dir = guard_home / ".guard"
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    class FakeProcess:
+        pid = 12345
+        returncode = None
+
+        def poll(self):
+            return None
+
+    def _popen(*_args, **_kwargs):
+        state = {
+            "port": port,
+            "pid": FakeProcess.pid,
+            "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
+            "source_root": daemon_manager_module._current_guard_daemon_source_root(),
+            "runtime_fingerprint": daemon_manager_module._current_guard_daemon_runtime_fingerprint(),
+        }
+        state_path = state_dir / "daemon-state.json"
+        state_path.write_text(json.dumps(state), encoding="utf-8")
+        os.chmod(state_path, stat.S_IRUSR | stat.S_IWUSR)
+        return FakeProcess()
+
+    return _popen
+
+
+class TestNoDashboardApprovalURLWake:
+    """L314: daemon must start and expose the approval URL with no browser open."""
+
+    def test_ensure_guard_daemon_returns_url_when_no_daemon_running(self, tmp_path, monkeypatch) -> None:
+        """When no daemon is running and the dashboard is closed, ensure_guard_daemon
+        starts the daemon and returns a usable approval URL."""
+        guard_home = tmp_path / "guard-home"
+        port = 5700
+
+        monkeypatch.setattr(daemon_manager_module, "_reap_stale_ephemeral_guard_daemons", lambda **_: None)
+
+        url_iter = iter([None, None, f"http://127.0.0.1:{port}"])
+        monkeypatch.setattr(
+            daemon_manager_module,
+            "load_guard_daemon_url",
+            lambda _gh: next(url_iter, f"http://127.0.0.1:{port}"),
+        )
+
+        monkeypatch.setattr(daemon_manager_module, "_load_state", lambda _gh: None)
+        monkeypatch.setattr(daemon_manager_module, "_guard_daemon_start_in_progress", lambda _gh: False)
+        monkeypatch.setattr(daemon_manager_module.time, "sleep", lambda _: None)
+        monkeypatch.setattr(daemon_manager_module.subprocess, "Popen", _make_start_mock(guard_home, port))
+        monkeypatch.setattr(
+            daemon_manager_module,
+            "_wait_for_guard_daemon_url",
+            lambda _gh, **_kw: f"http://127.0.0.1:{port}",
+        )
+
+        url = daemon_manager_module.ensure_guard_daemon(guard_home)
+
+        assert url == f"http://127.0.0.1:{port}"
+        assert url.startswith("http://127.0.0.1:")
+
+    def test_ensure_guard_daemon_does_not_spawn_second_daemon_when_already_running(self, tmp_path, monkeypatch) -> None:
+        """If the daemon state file is already present and healthy, ensure_guard_daemon
+        must return the existing URL without spawning a new process."""
+        guard_home = tmp_path / "guard-home"
+        port = 5701
+        spawn_calls: list[str] = []
+
+        monkeypatch.setattr(daemon_manager_module, "_reap_stale_ephemeral_guard_daemons", lambda **_: None)
+        monkeypatch.setattr(
+            daemon_manager_module,
+            "load_guard_daemon_url",
+            lambda _gh: f"http://127.0.0.1:{port}",
+        )
+
+        def _boom(*_args, **_kwargs):
+            spawn_calls.append("spawn")
+            raise AssertionError("daemon must not be spawned when already running")
+
+        monkeypatch.setattr(daemon_manager_module.subprocess, "Popen", _boom)
+
+        url = daemon_manager_module.ensure_guard_daemon(guard_home)
+
+        assert url == f"http://127.0.0.1:{port}"
+        assert spawn_calls == []
+
+    def test_approval_url_has_expected_structure(self, tmp_path, monkeypatch) -> None:
+        """The returned approval URL must be a valid localhost HTTP URL."""
+        guard_home = tmp_path / "guard-home"
+        port = 5702
+
+        monkeypatch.setattr(daemon_manager_module, "_reap_stale_ephemeral_guard_daemons", lambda **_: None)
+        monkeypatch.setattr(
+            daemon_manager_module,
+            "load_guard_daemon_url",
+            lambda _gh: f"http://127.0.0.1:{port}",
+        )
+
+        url = daemon_manager_module.ensure_guard_daemon(guard_home)
+
+        assert url.startswith("http://"), "URL must be HTTP"
+        assert "127.0.0.1" in url or "localhost" in url, "URL must be local"
+        assert str(port) in url, "URL must include the daemon port"
+
+    def test_approval_url_exposed_without_browser_open(self, tmp_path, monkeypatch) -> None:
+        """Guard must provide an approval URL for CLI/headless consumers
+        even when webbrowser.open is never called."""
+        guard_home = tmp_path / "guard-home"
+        port = 5703
+        browser_opens: list[str] = []
+
+        monkeypatch.setattr(daemon_manager_module, "_reap_stale_ephemeral_guard_daemons", lambda **_: None)
+        monkeypatch.setattr(
+            daemon_manager_module,
+            "load_guard_daemon_url",
+            lambda _gh: f"http://127.0.0.1:{port}",
+        )
+
+        url = daemon_manager_module.ensure_guard_daemon(guard_home)
+
+        assert url is not None
+        assert len(browser_opens) == 0, "No browser should have been opened by ensure_guard_daemon"
+
+    def test_daemon_wake_survives_stale_state_file(self, tmp_path, monkeypatch) -> None:
+        """When the state file references a dead process, the daemon must be retired
+        and a new daemon started to handle the approval URL."""
+        guard_home = tmp_path / "guard-home"
+        port = 5704
+
+        monkeypatch.setattr(daemon_manager_module, "_reap_stale_ephemeral_guard_daemons", lambda **_: None)
+
+        stale_state = {
+            "pid": 99999,
+            "port": 4000,
+            "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
+            "source_root": daemon_manager_module._current_guard_daemon_source_root(),
+            "runtime_fingerprint": daemon_manager_module._current_guard_daemon_runtime_fingerprint(),
+        }
+        url_iter = iter([None, None, f"http://127.0.0.1:{port}"])
+        monkeypatch.setattr(daemon_manager_module, "_load_state", lambda _gh: stale_state)
+        monkeypatch.setattr(
+            daemon_manager_module,
+            "load_guard_daemon_url",
+            lambda _gh: next(url_iter, f"http://127.0.0.1:{port}"),
+        )
+        monkeypatch.setattr(daemon_manager_module, "_retire_guard_daemon_process", lambda _state: None)
+        monkeypatch.setattr(daemon_manager_module, "_guard_daemon_start_in_progress", lambda _gh: False)
+        monkeypatch.setattr(daemon_manager_module.time, "sleep", lambda _: None)
+        monkeypatch.setattr(daemon_manager_module.subprocess, "Popen", _make_start_mock(guard_home, port))
+        monkeypatch.setattr(
+            daemon_manager_module,
+            "_wait_for_guard_daemon_url",
+            lambda _gh, **_kw: f"http://127.0.0.1:{port}",
+        )
+
+        url = daemon_manager_module.ensure_guard_daemon(guard_home)
+
+        assert url == f"http://127.0.0.1:{port}"

--- a/tests/test_guard_daemon_wake.py
+++ b/tests/test_guard_daemon_wake.py
@@ -123,10 +123,16 @@ class TestNoDashboardApprovalURLWake:
     def test_approval_url_exposed_without_browser_open(self, tmp_path, monkeypatch) -> None:
         """Guard must provide an approval URL for CLI/headless consumers
         even when webbrowser.open is never called."""
+        import webbrowser
+
         guard_home = tmp_path / "guard-home"
         port = 5703
         browser_opens: list[str] = []
 
+        def _fake_browser_open(url: str, *_args, **_kwargs) -> None:
+            browser_opens.append(url)
+
+        monkeypatch.setattr(webbrowser, "open", _fake_browser_open)
         monkeypatch.setattr(daemon_manager_module, "_reap_stale_ephemeral_guard_daemons", lambda **_: None)
         monkeypatch.setattr(
             daemon_manager_module,
@@ -137,7 +143,7 @@ class TestNoDashboardApprovalURLWake:
         url = daemon_manager_module.ensure_guard_daemon(guard_home)
 
         assert url is not None
-        assert len(browser_opens) == 0, "No browser should have been opened by ensure_guard_daemon"
+        assert len(browser_opens) == 0, "ensure_guard_daemon must not open a browser on its own"
 
     def test_daemon_wake_survives_stale_state_file(self, tmp_path, monkeypatch) -> None:
         """When the state file references a dead process, the daemon must be retired
@@ -150,9 +156,9 @@ class TestNoDashboardApprovalURLWake:
         stale_state = {
             "pid": 99999,
             "port": 4000,
-            "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
-            "source_root": daemon_manager_module._current_guard_daemon_source_root(),
-            "runtime_fingerprint": daemon_manager_module._current_guard_daemon_runtime_fingerprint(),
+            "compatibility_version": "0.0.0-stale",
+            "source_root": "/tmp/old-install/guard",
+            "runtime_fingerprint": "stale-fingerprint",
         }
         url_iter = iter([None, None, f"http://127.0.0.1:{port}"])
         monkeypatch.setattr(daemon_manager_module, "_load_state", lambda _gh: stale_state)
@@ -161,7 +167,12 @@ class TestNoDashboardApprovalURLWake:
             "load_guard_daemon_url",
             lambda _gh: next(url_iter, f"http://127.0.0.1:{port}"),
         )
-        monkeypatch.setattr(daemon_manager_module, "_retire_guard_daemon_process", lambda _state: None)
+        retire_calls: list[dict] = []
+        monkeypatch.setattr(
+            daemon_manager_module,
+            "_retire_guard_daemon_process",
+            lambda state: retire_calls.append(state),
+        )
         monkeypatch.setattr(daemon_manager_module, "_guard_daemon_start_in_progress", lambda _gh: False)
         monkeypatch.setattr(daemon_manager_module.time, "sleep", lambda _: None)
         monkeypatch.setattr(daemon_manager_module.subprocess, "Popen", _make_start_mock(guard_home, port))
@@ -174,3 +185,4 @@ class TestNoDashboardApprovalURLWake:
         url = daemon_manager_module.ensure_guard_daemon(guard_home)
 
         assert url == f"http://127.0.0.1:{port}"
+        assert len(retire_calls) >= 1, "_retire_guard_daemon_process must be called to recover stale daemon state"

--- a/tests/test_guard_redaction.py
+++ b/tests/test_guard_redaction.py
@@ -1,0 +1,159 @@
+"""L315: Tests for Guard daemon log redaction helpers.
+
+Verifies that sensitive values are removed before Guard prints or syncs them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from codex_plugin_scanner.guard.redaction import redact_sensitive_text, redact_text
+
+
+class TestRedactText:
+    """Core redaction patterns that must fire before logging or syncing."""
+
+    def test_bearer_token_is_redacted(self) -> None:
+        result = redact_text("Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.payload.sig")
+        assert "eyJhbGciOiJSUzI1NiJ9" not in result.text
+        assert result.count >= 1
+        assert "bearer-token" in result.classifiers
+
+    def test_openai_sk_token_is_redacted(self) -> None:
+        result = redact_text("OPENAI_API_KEY=sk-abcdefgh12345678")
+        assert "sk-abcdefgh12345678" not in result.text
+        assert result.count >= 1
+        assert "openai-token" in result.classifiers
+
+    def test_github_token_is_redacted(self) -> None:
+        result = redact_text("Cloning with token ghp_abcdef1234567890abcdef1234567890")
+        assert "ghp_abcdef1234567890abcdef1234567890" not in result.text
+        assert "github-token" in result.classifiers
+
+    def test_aws_access_key_is_redacted(self) -> None:
+        result = redact_text("AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE")
+        assert "AKIAIOSFODNN7EXAMPLE" not in result.text
+        assert "aws-access-key" in result.classifiers
+
+    def test_npm_auth_token_is_redacted(self) -> None:
+        result = redact_text("_authToken=npm_my_secret_token_12345678")
+        assert "npm_my_secret_token_12345678" not in result.text
+        assert "npm-token" in result.classifiers
+
+    def test_private_key_block_is_redacted(self) -> None:
+        pem = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA\n-----END RSA PRIVATE KEY-----"
+        result = redact_text(pem)
+        assert "MIIEpAIBAAKCAQEA" not in result.text
+        assert "private-key" in result.classifiers
+
+    def test_secret_env_var_is_redacted(self) -> None:
+        result = redact_text("MY_APP_SECRET=supersecretvalue123")
+        assert "supersecretvalue123" not in result.text
+        assert "secret-env" in result.classifiers
+
+    def test_token_env_var_is_redacted(self) -> None:
+        result = redact_text("AUTH_TOKEN=hunter2")
+        assert "hunter2" not in result.text
+        assert "secret-env" in result.classifiers
+
+    def test_password_env_var_is_redacted(self) -> None:
+        result = redact_text("DB_PASSWORD=correcthorsebatterystaple")
+        assert "correcthorsebatterystaple" not in result.text
+        assert "secret-env" in result.classifiers
+
+    def test_database_connection_string_is_redacted(self) -> None:
+        result = redact_text("postgresql://user:hunter2@db.example.com:5432/prod")
+        assert "hunter2" not in result.text
+        assert "connection-string" in result.classifiers
+
+    def test_redis_url_is_redacted(self) -> None:
+        result = redact_text("redis://default:secretpassword@cache.example.com:6379/0")
+        assert "secretpassword" not in result.text
+        assert "connection-string" in result.classifiers
+
+    def test_connection_env_url_is_redacted(self) -> None:
+        result = redact_text("DATABASE_URL=postgres://user:pw@host/db")
+        assert "postgres://user:pw@host/db" not in result.text
+        assert "connection-env" in result.classifiers
+
+    def test_clean_text_returns_zero_count(self) -> None:
+        result = redact_text("Running build step: pnpm install")
+        assert result.count == 0
+        assert result.text == "Running build step: pnpm install"
+        assert result.classifiers == ()
+
+    def test_result_preserves_sha256_of_original(self) -> None:
+        import hashlib
+
+        original = "MY_TOKEN=abcdef"
+        result = redact_text(original)
+        expected_sha = hashlib.sha256(original.encode("utf-8")).hexdigest()
+        assert result.original_sha256 == expected_sha
+
+    def test_result_is_frozen(self) -> None:
+        result = redact_text("clean text")
+        with pytest.raises((AttributeError, TypeError)):
+            result.count = 99  # type: ignore[misc]
+
+    def test_multiple_secrets_in_one_string(self) -> None:
+        text = "sk-abcdefgh12345678 and ghp_abcdef1234567890abcdef1234567890"
+        result = redact_text(text)
+        assert "sk-abcdefgh12345678" not in result.text
+        assert "ghp_abcdef1234567890abcdef1234567890" not in result.text
+        assert result.count >= 2
+
+    def test_to_dict_excludes_redacted_text(self) -> None:
+        result = redact_text("MY_SECRET=hunter2")
+        d = result.to_dict()
+        assert "text" not in d
+        assert "count" in d
+        assert "classifiers" in d
+        assert "original_sha256" in d
+
+    def test_classifier_deduplication(self) -> None:
+        """Two tokens of the same type produce one classifier entry, not two."""
+        text = "sk-aaaaaaa11111111 sk-bbbbbbb22222222"
+        result = redact_text(text)
+        assert result.classifiers.count("openai-token") == 1
+
+    def test_false_positive_curl_header_not_redacted(self) -> None:
+        """Routine health-check Accept header must not be stripped."""
+        result = redact_text("curl -H 'Accept: application/json' http://localhost:4000/health")
+        assert "application/json" in result.text
+        assert result.count == 0
+
+
+class TestRedactSensitiveText:
+    """Quick inline redaction for log lines that do not need full metadata."""
+
+    def test_sk_token_is_redacted(self) -> None:
+        result = redact_sensitive_text("key=sk-abcdef1234567890")
+        assert "sk-abcdef1234567890" not in result
+
+    def test_api_key_assignment_is_redacted(self) -> None:
+        result = redact_sensitive_text("api_key: my_secret_value_here")
+        assert "my_secret_value_here" not in result
+
+    def test_clean_text_unchanged(self) -> None:
+        text = "Daemon started on port 4001"
+        assert redact_sensitive_text(text) == text
+
+
+class TestRedactTextApprovalWakeScenarios:
+    """L314/L315 combined: redaction must apply to approval-request log lines.
+
+    These scenarios simulate what Guard logs when an approval URL is accessed
+    without the browser dashboard open.  The auth token embedded in the URL
+    fragment must never appear in plain text in any log output.
+    """
+
+    def test_approval_url_with_token_fragment_is_redacted(self) -> None:
+        url_log = "Approval URL opened: http://localhost:4001/#guard-token=ghp_faketoken123456789012"
+        result = redact_text(url_log)
+        assert "ghp_faketoken123456789012" not in result.text
+
+    def test_approval_url_without_token_is_not_altered(self) -> None:
+        url_log = "Approval URL: http://localhost:4001/approvals/req-abc"
+        result = redact_text(url_log)
+        assert "http://localhost:4001/approvals/req-abc" in result.text
+        assert result.count == 0


### PR DESCRIPTION
Adds focused tests for two daemon reliability scenarios:

**Daemon wake (L314):** Verifies that `ensure_guard_daemon` correctly starts the daemon and returns an approval URL in headless / no-browser environments. Tests cover: clean start, idempotent return when already running, URL structure invariants, no-browser assertion, and stale-state recovery.

**Log redaction (L315):** Verifies that `redact_text` and `redact_sensitive_text` strip secrets before Guard prints or syncs any log line. Patterns covered: Bearer tokens, OpenAI sk- tokens, GitHub tokens, AWS access keys, npm auth tokens, PEM private keys, secret/token/password env vars, database connection strings, Redis URLs, and connection env URLs. Includes false-positive check for routine curl Accept headers and approval URLs without embedded tokens.

29 tests total.