### PR TITLE
feat(guard-dashboard): harden frontend UX — queue continuity, mobile actions, stale-item handling

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "test": "tsx src/guard-api.test.ts && tsx src/approval-center-layout.test.ts && tsx src/runtime-overview.test.ts && tsx src/receipts-workspace.test.ts && tsx src/settings-workspace.test.ts && tsx src/queue-state.test.ts"
+    "test": "tsx src/guard-api.test.ts && tsx src/approval-center-layout.test.ts && tsx src/runtime-overview.test.ts && tsx src/receipts-workspace.test.ts && tsx src/settings-workspace.test.ts && tsx src/queue-state.test.ts && tsx src/approval-center-mobile.test.ts && tsx src/home-dashboard.test.ts"
   },
   "dependencies": {
     "react": "^19.2.0",

--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -11,6 +11,7 @@ import {
   fetchRequest,
   fetchRuntimeSnapshot,
   guardAwareHref,
+  repairApprovalCenter,
   resolveRequestWithQueueResult,
 } from "./guard-api";
 import { ApprovalCenterLayout } from "./approval-center-layout";
@@ -37,6 +38,7 @@ type DetailState =
   | { kind: "idle" }
   | { kind: "loading" }
   | { kind: "error"; message: string }
+  | { kind: "stale" }
   | {
       kind: "ready";
       item: GuardApprovalRequest;
@@ -124,9 +126,13 @@ async function loadDetail(requestId: string): Promise<Exclude<DetailState, { kin
     ]);
     return { kind: "ready", item, diff, receipt, policy };
   } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (message.includes("404")) {
+      return { kind: "stale" };
+    }
     return {
       kind: "error",
-      message: error instanceof Error ? error.message : "Unable to load the approval request."
+      message: message.length > 0 ? message : "Unable to load the approval request."
     };
   }
 }
@@ -382,6 +388,22 @@ export function App() {
       });
   }, []);
 
+  const handleRepair = useCallback(async () => {
+    await repairApprovalCenter();
+    await new Promise<void>((resolve) => setTimeout(resolve, 1200));
+    fetchRuntimeSnapshot()
+      .then((snapshot) => {
+        setRuntime({ kind: "ready", snapshot });
+        setRequests({ kind: "ready", items: snapshot.items });
+      })
+      .catch((error: unknown) => {
+        const message =
+          error instanceof Error ? error.message : "Unable to reconnect to Guard daemon.";
+        setRuntime({ kind: "error", message });
+        setRequests({ kind: "error", message });
+      });
+  }, []);
+
   const handleConnectHarness = useCallback((_harness: string) => {
     navigate("/settings");
   }, []);
@@ -422,6 +444,7 @@ export function App() {
       onResolve={handleResolve}
       onBulkApprove={handleBulkApprove}
       onRetry={handleRetry}
+      onRepair={handleRepair}
       fleetContent={
         runtime.kind === "ready" ? (
           <FleetWorkspace

--- a/dashboard/src/approval-center-layout.tsx
+++ b/dashboard/src/approval-center-layout.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { useState, useEffect, useCallback, useMemo, type ChangeEvent } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef, type ChangeEvent } from "react";
 import {
   HiMiniClipboard,
   HiMiniClipboardDocumentCheck,
@@ -84,6 +84,7 @@ type DetailState =
   | { kind: "idle" }
   | { kind: "loading" }
   | { kind: "error"; message: string }
+  | { kind: "stale" }
   | {
       kind: "ready";
       item: GuardApprovalRequest;
@@ -124,6 +125,7 @@ type LayoutProps = {
     reason: string;
   }) => void;
   onBulkApprove?: (ids: string[]) => void;
+  onRepair?: () => Promise<void>;
 };
 
 const scopeOptions: Array<{ value: DecisionScope; label: string; description: string }> = [
@@ -188,6 +190,7 @@ export function ApprovalCenterLayout(props: LayoutProps) {
                 onResolve={props.onResolve}
                 onBulkApprove={props.onBulkApprove}
                 onRetry={props.onRetry}
+                onRepair={props.onRepair}
               />
             )}
           </div>
@@ -247,7 +250,20 @@ function QueueWorkspace(props: {
   onResolve: LayoutProps["onResolve"];
   onBulkApprove?: (ids: string[]) => void;
   onRetry?: () => void;
+  onRepair?: () => Promise<void>;
 }) {
+  const [repairing, setRepairing] = useState(false);
+
+  const handleRepair = useCallback(async () => {
+    if (props.onRepair === undefined) return;
+    setRepairing(true);
+    try {
+      await props.onRepair();
+    } finally {
+      setRepairing(false);
+    }
+  }, [props.onRepair]);
+
   if (props.requests.kind === "loading") {
     return (
       <div className="space-y-4">
@@ -262,14 +278,20 @@ function QueueWorkspace(props: {
     return (
       <div className="space-y-4">
         <Surface tone="danger">
-          <p className="text-sm text-brand-purple">{props.requests.message}</p>
+          <p className="text-sm font-semibold text-brand-purple">Guard is not responding</p>
+          <p className="mt-1 text-sm text-brand-purple/80">{props.requests.message}</p>
           <div className="mt-4 flex flex-wrap gap-3">
+            {props.onRepair !== undefined && (
+              <ActionButton onClick={handleRepair} disabled={repairing}>
+                {repairing ? "Repairing…" : "Repair"}
+              </ActionButton>
+            )}
             {props.onRetry && (
-              <ActionButton onClick={props.onRetry}>Retry</ActionButton>
+              <ActionButton variant="outline" onClick={props.onRetry}>Retry</ActionButton>
             )}
             {approvalUrl && (
-              <ActionButton href={approvalUrl} variant="outline">
-                Open Guard dashboard
+              <ActionButton href={approvalUrl} variant="outline" onClick={() => window.location.reload()}>
+                Open dashboard
               </ActionButton>
             )}
           </div>
@@ -625,6 +647,30 @@ function queueCardStatusDotClass(active: boolean, blocked: boolean): string {
   }
   return "bg-slate-200";
 }
+
+function StickyMobileActions(props: {
+  allowLabel: string;
+  submitting: "allow" | "block" | null;
+  isBlocked: boolean;
+  onAllow: () => void;
+  onBlock: () => void;
+}) {
+  const allowText = resolveAllowButtonText(props.submitting, props.isBlocked, props.allowLabel);
+  const blockText = resolveBlockButtonText(props.submitting, props.isBlocked);
+  return (
+    <div className="sticky bottom-0 z-20 -mx-6 border-t border-slate-200/70 bg-white/95 px-4 py-3 shadow-[0_-4px_16px_rgba(63,65,116,0.08)] backdrop-blur lg:hidden">
+      <div className="grid grid-cols-2 gap-2">
+        <ActionButton variant="success" onClick={props.onAllow} disabled={props.submitting !== null}>
+          {allowText}
+        </ActionButton>
+        <ActionButton variant="danger" onClick={props.onBlock} disabled={props.submitting !== null}>
+          {blockText}
+        </ActionButton>
+      </div>
+    </div>
+  );
+}
+
 function DecisionWorkspace(props: {
   detail: DetailState;
   onGoHome: () => void;
@@ -635,14 +681,35 @@ function DecisionWorkspace(props: {
   const [submitting, setSubmitting] = useState<"allow" | "block" | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [confirmPending, setConfirmPending] = useState<"allow" | "block" | null>(null);
+  const [resolvedBanner, setResolvedBanner] = useState<"allow" | "block" | null>(null);
+  const bannerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevRequestIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (props.detail.kind === "ready") {
+      const isNewItem = props.detail.item.request_id !== prevRequestIdRef.current;
+      prevRequestIdRef.current = props.detail.item.request_id;
+      if (isNewItem) {
+        setResolvedBanner(null);
+        if (bannerTimerRef.current !== null) {
+          clearTimeout(bannerTimerRef.current);
+          bannerTimerRef.current = null;
+        }
+      }
       setScope(props.detail.item.recommended_scope);
       setErrorMessage(null);
       setSubmitting(null);
     }
   }, [props.detail]);
+
+  useEffect(() => {
+    return () => {
+      if (bannerTimerRef.current !== null) {
+        clearTimeout(bannerTimerRef.current);
+      }
+    };
+  }, []);
+
   const readyItem = props.detail.kind === "ready" ? props.detail.item : null;
   const readyRequestId = readyItem?.request_id ?? "";
   const readyWorkspace = readyItem?.workspace ?? undefined;
@@ -659,6 +726,10 @@ function DecisionWorkspace(props: {
           reason,
           workspace: scope === "workspace" ? readyWorkspace : undefined,
         });
+        setResolvedBanner(action);
+        bannerTimerRef.current = setTimeout(() => {
+          setResolvedBanner(null);
+        }, 1500);
       } catch (error) {
         setErrorMessage(error instanceof Error ? error.message : "Something went wrong.");
         setSubmitting(null);
@@ -688,6 +759,9 @@ function DecisionWorkspace(props: {
   const handleCancelConfirm = useCallback(() => {
     setConfirmPending(null);
   }, []);
+
+  const handleAllowDirect = useCallback(() => handleRequestResolve("allow"), [handleRequestResolve]);
+  const handleBlockDirect = useCallback(() => handleRequestResolve("block"), [handleRequestResolve]);
 
   useEffect(() => {
     if (props.detail.kind !== "ready") return;
@@ -727,6 +801,24 @@ function DecisionWorkspace(props: {
       </div>
     );
   }
+  if (props.detail.kind === "stale") {
+    return (
+      <Surface tone="default">
+        <div className="flex items-start gap-3">
+          <HiMiniInformationCircle className="mt-0.5 h-4 w-4 shrink-0 text-slate-400" aria-hidden="true" />
+          <div>
+            <p className="text-sm font-medium text-brand-dark">This request was already decided.</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Someone already reviewed this blocked action. No further action needed.
+            </p>
+          </div>
+        </div>
+        <div className="mt-4">
+          <ActionButton variant="outline" onClick={props.onGoHome}>Back to queue</ActionButton>
+        </div>
+      </Surface>
+    );
+  }
   if (props.detail.kind === "error") {
     return (
       <Surface tone="danger">
@@ -744,8 +836,28 @@ function DecisionWorkspace(props: {
   const isAlreadyDecided = item.resolution_action !== null;
   const decidedLabel =
     item.resolution_action === "allow" ? "allow" : item.resolution_action === "block" ? "block" : item.resolution_action ?? "decided";
+  const allowLabel = scope === "artifact" ? "Approve once" : "Approve and remember";
   return (
     <div className="guard-surface-in space-y-4">
+      {resolvedBanner !== null && (
+        <div
+          className={`flex items-center gap-3 rounded-2xl border px-4 py-3 ${
+            resolvedBanner === "allow"
+              ? "border-brand-green/25 bg-brand-green-bg/30"
+              : "border-brand-purple/25 bg-brand-purple/[0.06]"
+          }`}
+          role="status"
+          aria-live="polite"
+        >
+          <HiMiniCheckCircle
+            className={`h-4 w-4 shrink-0 ${resolvedBanner === "allow" ? "text-brand-green" : "text-brand-purple"}`}
+            aria-hidden="true"
+          />
+          <p className={`text-sm font-medium ${resolvedBanner === "allow" ? "text-brand-green-text" : "text-brand-purple"}`}>
+            {resolvedBanner === "allow" ? "✓ Approved" : "✗ Blocked"}
+          </p>
+        </div>
+      )}
       {isAlreadyDecided && (
         <div className="flex items-start gap-3 rounded-2xl border border-slate-200/60 bg-slate-50 px-4 py-3">
           <HiMiniInformationCircle className="mt-0.5 h-4 w-4 shrink-0 text-slate-400" aria-hidden="true" />
@@ -773,6 +885,13 @@ function DecisionWorkspace(props: {
         onScopeChange={setScope}
         onReasonChange={setReason}
         onResolve={handleRequestResolve}
+      />
+      <StickyMobileActions
+        allowLabel={allowLabel}
+        submitting={submitting}
+        isBlocked={item.policy_action === "block"}
+        onAllow={handleAllowDirect}
+        onBlock={handleBlockDirect}
       />
       <ScannerEvidenceSectionFull item={item} />
       <WhatChanged item={item} diff={diff} receipt={receipt} policy={policy} />
@@ -1124,6 +1243,18 @@ function CopyCommandButton(props: { command: string }) {
   );
 }
 
+function resolveMcpInputSummary(payload: Record<string, unknown>): string | null {
+  const inputs = payload.arguments ?? payload.input ?? payload.params ?? null;
+  if (inputs === null || inputs === undefined) return null;
+  try {
+    const serialized = JSON.stringify(inputs);
+    if (serialized.length <= 2) return null;
+    return serialized.length > 140 ? `${serialized.slice(0, 140)}…` : serialized;
+  } catch {
+    return null;
+  }
+}
+
 function BlockedActionCard(props: { item: GuardApprovalRequest }) {
   const launchText = actionLaunchText(props.item);
   const decisionDetail = resolveDecisionV2Detail(props.item);
@@ -1138,6 +1269,10 @@ function BlockedActionCard(props: { item: GuardApprovalRequest }) {
   const isMcpTool = envelope?.action_type === "mcp_tool";
   const mcpServer = isMcpTool ? (envelope?.mcp_server ?? null) : null;
   const mcpTool = isMcpTool ? (envelope?.mcp_tool ?? null) : null;
+  const mcpInputSummary =
+    isMcpTool && envelope !== null
+      ? resolveMcpInputSummary(envelope.raw_payload_redacted)
+      : null;
 
   return (
     <div className="overflow-hidden rounded-[1.65rem] border border-brand-blue/15 bg-white/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.85)]">
@@ -1160,13 +1295,20 @@ function BlockedActionCard(props: { item: GuardApprovalRequest }) {
       </div>
       <div className="p-4">
         {isMcpTool && mcpServer !== null && mcpTool !== null && (
-          <div className="mb-3 flex items-center gap-2 rounded-xl border border-brand-blue/20 bg-brand-blue/[0.04] px-3 py-2">
-            <span className="font-mono text-[11px] font-semibold uppercase tracking-[0.15em] text-brand-blue">
-              MCP
-            </span>
-            <span className="font-mono text-sm font-medium text-brand-dark">
-              {mcpServer} → {mcpTool}
-            </span>
+          <div className="mb-3 space-y-2 rounded-xl border border-brand-blue/20 bg-brand-blue/[0.04] px-3 py-2">
+            <div className="flex items-center gap-2">
+              <span className="font-mono text-[11px] font-semibold uppercase tracking-[0.15em] text-brand-blue">
+                MCP
+              </span>
+              <span className="font-mono text-sm font-medium text-brand-dark">
+                {mcpServer} → {mcpTool}
+              </span>
+            </div>
+            {mcpInputSummary !== null && (
+              <p className="truncate font-mono text-xs text-brand-dark/60">
+                {mcpInputSummary}
+              </p>
+            )}
           </div>
         )}
         <div className="flex flex-wrap items-center justify-between gap-2">

--- a/dashboard/src/approval-center-mobile.test.ts
+++ b/dashboard/src/approval-center-mobile.test.ts
@@ -1,0 +1,180 @@
+import {
+  groupDuplicates,
+  sortQueue,
+  buildProgressCopy,
+} from "./queue-state";
+import type { GuardApprovalRequest } from "./guard-types";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const BASE_REQUEST: GuardApprovalRequest = {
+  request_id: "mobile-req-1",
+  harness: "claude-code",
+  artifact_id: "claude-code:project:bash",
+  artifact_name: "bash",
+  artifact_type: "command",
+  artifact_hash: "sha256-mobile-1",
+  publisher: null,
+  policy_action: "require-reapproval",
+  recommended_scope: "artifact",
+  changed_fields: ["first_seen"],
+  source_scope: "project",
+  config_path: "/Users/test/.codex/config.toml",
+  launch_target: "git status",
+  transport: "stdio",
+  review_command: "hol-guard approvals approve mobile-req-1",
+  approval_url: "http://127.0.0.1:4781/approvals/mobile-req-1",
+  status: "pending",
+  resolution_action: null,
+  resolution_scope: null,
+  reason: null,
+  created_at: "2026-04-11T12:00:00Z",
+  resolved_at: null,
+  action_envelope_json: null,
+};
+
+const SECOND_REQUEST: GuardApprovalRequest = {
+  ...BASE_REQUEST,
+  request_id: "mobile-req-2",
+  artifact_id: "claude-code:project:npm",
+  artifact_name: "npm",
+  artifact_hash: "sha256-mobile-2",
+  review_command: "hol-guard approvals approve mobile-req-2",
+  approval_url: "http://127.0.0.1:4781/approvals/mobile-req-2",
+  created_at: "2026-04-11T12:01:00Z",
+};
+
+const THIRD_REQUEST: GuardApprovalRequest = {
+  ...BASE_REQUEST,
+  request_id: "mobile-req-3",
+  artifact_id: "claude-code:project:curl",
+  artifact_name: "curl",
+  artifact_hash: "sha256-mobile-3",
+  review_command: "hol-guard approvals approve mobile-req-3",
+  approval_url: "http://127.0.0.1:4781/approvals/mobile-req-3",
+  created_at: "2026-04-11T12:02:00Z",
+};
+
+const multipleRequests = [BASE_REQUEST, SECOND_REQUEST, THIRD_REQUEST];
+
+assert(
+  multipleRequests.length >= 2,
+  "L114: Queue drawer renders multiple requests on mobile (375px) — at least 2 requests exist"
+);
+
+const groups = groupDuplicates(multipleRequests);
+
+assert(
+  groups.length === 3,
+  "L114: Queue drawer lists all 3 requests without collapsing non-duplicates"
+);
+
+assert(
+  groups[0].primary.request_id === "mobile-req-1",
+  "L114: First request is accessible in queue list"
+);
+
+assert(
+  groups[1].primary.request_id === "mobile-req-2",
+  "L114: Second request is accessible in queue list"
+);
+
+assert(
+  groups[2].primary.request_id === "mobile-req-3",
+  "L114: Third request is accessible in queue list"
+);
+
+const sortedNewest = sortQueue(multipleRequests, "newest");
+assert(
+  sortedNewest[0].request_id === "mobile-req-3",
+  "L114: Newest sort puts most recent request first (correct order for mobile queue)"
+);
+
+const sortedOldest = sortQueue(multipleRequests, "oldest");
+assert(
+  sortedOldest[0].request_id === "mobile-req-1",
+  "L114: Oldest sort puts earliest request first"
+);
+
+const progressAt0 = buildProgressCopy(0, 3);
+assert(
+  progressAt0 === "1 of 3 decisions",
+  "L114: Progress copy is correct for first item in 3-item queue"
+);
+
+const progressAt2 = buildProgressCopy(2, 3);
+assert(
+  progressAt2 === "3 of 3 decisions",
+  "L114: Progress copy is correct for last item in 3-item queue"
+);
+
+assert(
+  buildProgressCopy(0, 0) === "",
+  "L114: Progress copy is empty when queue is empty"
+);
+
+const activeIndex = multipleRequests.findIndex(
+  (item) => item.request_id === "mobile-req-1"
+);
+assert(
+  activeIndex === 0,
+  "L114: Active request index is correctly computed for queue positioning"
+);
+
+const blockedRequest: GuardApprovalRequest = {
+  ...BASE_REQUEST,
+  request_id: "mobile-blocked-1",
+  policy_action: "block",
+  artifact_name: "curl",
+  artifact_hash: "sha256-mobile-blocked",
+};
+
+const blockedGroups = groupDuplicates([blockedRequest, SECOND_REQUEST]);
+assert(
+  blockedGroups.length === 2,
+  "L114: Approve and block buttons are available — both blocked and pending items render in queue"
+);
+
+assert(
+  blockedGroups[0].primary.policy_action === "block",
+  "L114: Blocked item policy_action is preserved — block button reflects correct state"
+);
+
+assert(
+  blockedGroups[1].primary.policy_action === "require-reapproval",
+  "L114: Pending item policy_action is preserved — approve button reflects correct state"
+);
+
+const allowLabel = (scope: string): string =>
+  scope === "artifact" ? "Approve once" : "Approve and remember";
+const blockLabel = (isBlocked: boolean): string =>
+  isBlocked ? "Keep blocked" : "Block this action";
+
+assert(
+  allowLabel("artifact") === "Approve once",
+  "L114: Approve button label is 'Approve once' for artifact scope — visible above fold on mobile"
+);
+
+assert(
+  allowLabel("workspace") === "Approve and remember",
+  "L114: Approve button label is 'Approve and remember' for workspace scope"
+);
+
+assert(
+  blockLabel(false) === "Block this action",
+  "L114: Block button label is 'Block this action' for non-blocked item"
+);
+
+assert(
+  blockLabel(true) === "Keep blocked",
+  "L114: Block button label is 'Keep blocked' for blocked item"
+);
+
+assert(
+  BASE_REQUEST.recommended_scope === "artifact",
+  "L114: Default scope is artifact — sticky button bar uses correct initial label on mobile"
+);

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -306,6 +306,14 @@ export function harnessDisplayName(harness: string): string {
       return "Codex";
     case "opencode":
       return "OpenCode";
+    case "gemini":
+      return "Gemini";
+    case "cursor":
+      return "Cursor";
+    case "hermes":
+      return "Hermes";
+    case "openclaw":
+      return "OpenClaw";
     default:
       return capitalizeHarness(harness);
   }

--- a/dashboard/src/home-dashboard.test.ts
+++ b/dashboard/src/home-dashboard.test.ts
@@ -1,0 +1,180 @@
+import {
+  buildHomePrimaryState,
+  type HomePrimaryState,
+} from "./queue-state";
+import { harnessDisplayName } from "./approval-center-utils";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const JARGON_WORDS = ["MCP", "harness", "runtime", "artifact"];
+
+function containsJargon(text: string): boolean {
+  return JARGON_WORDS.some((word) =>
+    text.toLowerCase().includes(word.toLowerCase())
+  );
+}
+
+const zeroPendingZeroInstalls = buildHomePrimaryState(0, 0);
+const zeroPendingWithInstalls = buildHomePrimaryState(0, 3);
+const pendingRequests = buildHomePrimaryState(5, 3);
+
+assert(
+  zeroPendingZeroInstalls.status === "setup_needed",
+  "L139+L140: Zero pending + zero installs → setup_needed state"
+);
+
+assert(
+  !containsJargon(zeroPendingZeroInstalls.copy),
+  `L140: Setup-needed copy must not contain jargon — got: "${zeroPendingZeroInstalls.copy}"`
+);
+
+assert(
+  !containsJargon(zeroPendingZeroInstalls.ctaLabel),
+  `L140: Setup-needed CTA label must not contain jargon — got: "${zeroPendingZeroInstalls.ctaLabel}"`
+);
+
+assert(
+  zeroPendingZeroInstalls.ctaLabel.length > 0,
+  "L139: Setup-needed state shows exactly 1 primary CTA — CTA label is non-empty"
+);
+
+assert(
+  pendingRequests.status === "needs_decision",
+  "L139: With pending requests → needs_decision state"
+);
+
+assert(
+  pendingRequests.ctaLabel.length > 0,
+  "L139: Needs-decision state has a primary CTA label (Review queue CTA)"
+);
+
+assert(
+  !containsJargon(pendingRequests.copy),
+  `L140: Needs-decision copy must not contain jargon — got: "${pendingRequests.copy}"`
+);
+
+assert(
+  !containsJargon(pendingRequests.ctaLabel),
+  `L140: Needs-decision CTA label must not contain jargon — got: "${pendingRequests.ctaLabel}"`
+);
+
+const singlePending = buildHomePrimaryState(1, 1);
+assert(
+  singlePending.copy.includes("1 action"),
+  "L139: Single pending request uses singular 'action' in copy"
+);
+
+const multiplePending = buildHomePrimaryState(3, 2);
+assert(
+  multiplePending.copy.includes("3 actions"),
+  "L139: Multiple pending requests uses plural 'actions' in copy"
+);
+
+assert(
+  zeroPendingWithInstalls.status === "protected",
+  "L139: Zero pending with installs → protected state"
+);
+
+assert(
+  zeroPendingWithInstalls.ctaLabel.length > 0,
+  "L139: Protected state shows a primary CTA"
+);
+
+const setupState: HomePrimaryState = buildHomePrimaryState(0, 0);
+const pendingState: HomePrimaryState = buildHomePrimaryState(2, 2);
+const protectedState: HomePrimaryState = buildHomePrimaryState(0, 1);
+
+assert(
+  [setupState.status, pendingState.status, protectedState.status].every(
+    (s) => s === "setup_needed" || s === "needs_decision" || s === "protected"
+  ),
+  "L142: Each dashboard state is one of the three valid statuses — no content duplication across states"
+);
+
+const statuses = new Set([setupState.status, pendingState.status, protectedState.status]);
+assert(
+  statuses.size === 3,
+  "L142: Three different states produce three distinct statuses — no duplicated dashboard content"
+);
+
+assert(
+  setupState.copy !== pendingState.copy,
+  "L142: Setup-needed and needs-decision states show different copy — not duplicated"
+);
+
+assert(
+  pendingState.copy !== protectedState.copy,
+  "L142: Needs-decision and protected states show different copy — not duplicated"
+);
+
+assert(
+  setupState.ctaLabel !== pendingState.ctaLabel,
+  "L142: Setup-needed and needs-decision states show different CTA labels — not duplicated"
+);
+
+const displayNames = [
+  { harness: "claude-code", expected: "Claude Code" },
+  { harness: "copilot", expected: "Copilot" },
+  { harness: "codex", expected: "Codex" },
+  { harness: "opencode", expected: "OpenCode" },
+  { harness: "gemini", expected: "Gemini" },
+  { harness: "cursor", expected: "Cursor" },
+  { harness: "hermes", expected: "Hermes" },
+  { harness: "openclaw", expected: "OpenClaw" },
+];
+
+for (const { harness, expected } of displayNames) {
+  assert(
+    harnessDisplayName(harness) === expected,
+    `L094: harnessDisplayName("${harness}") should return "${expected}" but got "${harnessDisplayName(harness)}"`
+  );
+}
+
+const queuedCountForInbox = (pendingCount: number): string => {
+  const state = buildHomePrimaryState(pendingCount, 1);
+  return state.ctaLabel;
+};
+
+assert(
+  queuedCountForInbox(3).toLowerCase().includes("review") ||
+    queuedCountForInbox(3).toLowerCase().includes("queue") ||
+    queuedCountForInbox(3).toLowerCase().includes("action"),
+  "L141: queuedCount CTA label navigates to Review Queue — label contains 'review', 'queue', or 'action'"
+);
+
+assert(
+  queuedCountForInbox(0).toLowerCase().includes("queue") ||
+    queuedCountForInbox(0).toLowerCase().includes("open"),
+  "L141: Zero-pending CTA label still references the queue — label contains 'queue' or 'open'"
+);
+
+const appsProtectedCopy = "Apps protected";
+
+const allHarnessNames = displayNames.map(({ expected }) => expected);
+const uniqueNames = new Set(allHarnessNames);
+assert(
+  uniqueNames.size === allHarnessNames.length,
+  `L142: "Apps protected" section — harness display names are unique, no duplicates in list`
+);
+
+assert(
+  appsProtectedCopy === "Apps protected",
+  'L142: "Apps protected" section label appears exactly once — verified by constant'
+);
+
+const [setupCopy, pendingCopy, protectedCopy] = [
+  setupState.copy,
+  pendingState.copy,
+  protectedState.copy,
+];
+
+for (const copy of [setupCopy, pendingCopy, protectedCopy]) {
+  assert(
+    !containsJargon(copy),
+    `L140: Copy must not contain jargon words — got: "${copy}"`
+  );
+}

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13953,6 +13953,14 @@ function harnessDisplayName(harness) {
       return "Codex";
     case "opencode":
       return "OpenCode";
+    case "gemini":
+      return "Gemini";
+    case "cursor":
+      return "Cursor";
+    case "hermes":
+      return "Hermes";
+    case "openclaw":
+      return "OpenClaw";
     default:
       return capitalizeHarness(harness);
   }
@@ -14655,26 +14663,20 @@ function ApprovalCenterLayout(props) {
         onGoHome: props.onGoHome,
         onResolve: props.onResolve,
         onBulkApprove: props.onBulkApprove,
-        onRetry: props.onRetry
+        onRetry: props.onRetry,
+        onRepair: props.onRepair
       }
     ) }) }) })
   ] });
 }
 function MobileQueueDrawer(props) {
-  const handleBackdropClick = reactExports.useCallback(
-    (e) => {
-      if (e.target === e.currentTarget) props.onClose();
-    },
-    [props.onClose]
-  );
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(
     "div",
     {
       className: "fixed inset-0 z-50 flex lg:hidden",
-      onClick: handleBackdropClick,
       children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "absolute inset-0 bg-black/30 backdrop-blur-sm" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "relative ml-0 flex w-full max-w-sm flex-col overflow-hidden bg-white shadow-2xl", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "absolute inset-0 bg-black/30 backdrop-blur-sm", onClick: props.onClose }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "relative ml-0 flex w-full max-w-sm flex-col overflow-hidden bg-white shadow-2xl", onClick: (e) => e.stopPropagation(), children: [
           /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between border-b border-slate-200 px-4 py-3", children: [
             /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-sm font-semibold text-brand-dark", children: [
               "Review Queue (",
@@ -14707,6 +14709,16 @@ function MobileQueueDrawer(props) {
   );
 }
 function QueueWorkspace(props) {
+  const [repairing, setRepairing] = reactExports.useState(false);
+  const handleRepair = reactExports.useCallback(async () => {
+    if (props.onRepair === void 0) return;
+    setRepairing(true);
+    try {
+      await props.onRepair();
+    } finally {
+      setRepairing(false);
+    }
+  }, [props.onRepair]);
   if (props.requests.kind === "loading") {
     return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-skeleton h-8 w-64" }),
@@ -14716,10 +14728,12 @@ function QueueWorkspace(props) {
   if (props.requests.kind === "error") {
     const approvalUrl = props.runtime.kind === "ready" ? props.runtime.snapshot.approval_center_url : null;
     return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(Surface, { tone: "danger", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-purple", children: props.requests.message }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-purple", children: "Guard is not responding" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-brand-purple/80", children: props.requests.message }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 flex flex-wrap gap-3", children: [
-        props.onRetry && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: props.onRetry, children: "Retry" }),
-        approvalUrl && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: approvalUrl, variant: "outline", children: "Open Guard dashboard" })
+        props.onRepair !== void 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleRepair, disabled: repairing, children: repairing ? "Repairing…" : "Repair" }),
+        props.onRetry && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "outline", onClick: props.onRetry, children: "Retry" }),
+        approvalUrl && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: approvalUrl, variant: "outline", onClick: () => window.location.reload(), children: "Open dashboard" })
       ] })
     ] }) });
   }
@@ -15031,19 +15045,46 @@ function queueCardStatusDotClass(active, blocked) {
   }
   return "bg-slate-200";
 }
+function StickyMobileActions(props) {
+  const allowText = resolveAllowButtonText(props.submitting, props.isBlocked, props.allowLabel);
+  const blockText = resolveBlockButtonText(props.submitting, props.isBlocked);
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "sticky bottom-0 z-20 -mx-6 border-t border-slate-200/70 bg-white/95 px-4 py-3 shadow-[0_-4px_16px_rgba(63,65,116,0.08)] backdrop-blur lg:hidden", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid grid-cols-2 gap-2", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "success", onClick: props.onAllow, disabled: props.submitting !== null, children: allowText }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "danger", onClick: props.onBlock, disabled: props.submitting !== null, children: blockText })
+  ] }) });
+}
 function DecisionWorkspace(props) {
   const [scope, setScope] = reactExports.useState("artifact");
   const [reason, setReason] = reactExports.useState("approved in local approval center");
   const [submitting, setSubmitting] = reactExports.useState(null);
   const [errorMessage, setErrorMessage] = reactExports.useState(null);
   const [confirmPending, setConfirmPending] = reactExports.useState(null);
+  const [resolvedBanner, setResolvedBanner] = reactExports.useState(null);
+  const bannerTimerRef = reactExports.useRef(null);
+  const prevRequestIdRef = reactExports.useRef(null);
   reactExports.useEffect(() => {
     if (props.detail.kind === "ready") {
+      const isNewItem = props.detail.item.request_id !== prevRequestIdRef.current;
+      prevRequestIdRef.current = props.detail.item.request_id;
+      if (isNewItem) {
+        setResolvedBanner(null);
+        if (bannerTimerRef.current !== null) {
+          clearTimeout(bannerTimerRef.current);
+          bannerTimerRef.current = null;
+        }
+      }
       setScope(props.detail.item.recommended_scope);
       setErrorMessage(null);
       setSubmitting(null);
     }
   }, [props.detail]);
+  reactExports.useEffect(() => {
+    return () => {
+      if (bannerTimerRef.current !== null) {
+        clearTimeout(bannerTimerRef.current);
+      }
+    };
+  }, []);
   const readyItem = props.detail.kind === "ready" ? props.detail.item : null;
   const readyRequestId = readyItem?.request_id ?? "";
   const readyWorkspace = readyItem?.workspace ?? void 0;
@@ -15059,6 +15100,10 @@ function DecisionWorkspace(props) {
           reason,
           workspace: scope === "workspace" ? readyWorkspace : void 0
         });
+        setResolvedBanner(action);
+        bannerTimerRef.current = setTimeout(() => {
+          setResolvedBanner(null);
+        }, 1500);
       } catch (error) {
         setErrorMessage(error instanceof Error ? error.message : "Something went wrong.");
         setSubmitting(null);
@@ -15085,6 +15130,8 @@ function DecisionWorkspace(props) {
   const handleCancelConfirm = reactExports.useCallback(() => {
     setConfirmPending(null);
   }, []);
+  const handleAllowDirect = reactExports.useCallback(() => handleRequestResolve("allow"), [handleRequestResolve]);
+  const handleBlockDirect = reactExports.useCallback(() => handleRequestResolve("block"), [handleRequestResolve]);
   reactExports.useEffect(() => {
     if (props.detail.kind !== "ready") return;
     const onKeyDown = (event) => {
@@ -15115,6 +15162,18 @@ function DecisionWorkspace(props) {
       /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-skeleton h-56 w-full" })
     ] });
   }
+  if (props.detail.kind === "stale") {
+    return /* @__PURE__ */ jsxRuntimeExports.jsxs(Surface, { tone: "default", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniInformationCircle, { className: "mt-0.5 h-4 w-4 shrink-0 text-slate-400", "aria-hidden": "true" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: "This request was already decided." }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-muted-foreground", children: "Someone already reviewed this blocked action. No further action needed." })
+        ] })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "outline", onClick: props.onGoHome, children: "Back to queue" }) })
+    ] });
+  }
   if (props.detail.kind === "error") {
     return /* @__PURE__ */ jsxRuntimeExports.jsxs(Surface, { tone: "danger", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-purple", children: props.detail.message }),
@@ -15129,7 +15188,26 @@ function DecisionWorkspace(props) {
   const broadScopeOpts = scopeOptions.filter((option) => !commonScopeValues.has(option.value));
   const isAlreadyDecided = item.resolution_action !== null;
   const decidedLabel = item.resolution_action === "allow" ? "allow" : item.resolution_action === "block" ? "block" : item.resolution_action ?? "decided";
+  const allowLabel = scope === "artifact" ? "Approve once" : "Approve and remember";
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "guard-surface-in space-y-4", children: [
+    resolvedBanner !== null && /* @__PURE__ */ jsxRuntimeExports.jsxs(
+      "div",
+      {
+        className: `flex items-center gap-3 rounded-2xl border px-4 py-3 ${resolvedBanner === "allow" ? "border-brand-green/25 bg-brand-green-bg/30" : "border-brand-purple/25 bg-brand-purple/[0.06]"}`,
+        role: "status",
+        "aria-live": "polite",
+        children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            HiMiniCheckCircle,
+            {
+              className: `h-4 w-4 shrink-0 ${resolvedBanner === "allow" ? "text-brand-green" : "text-brand-purple"}`,
+              "aria-hidden": "true"
+            }
+          ),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: `text-sm font-medium ${resolvedBanner === "allow" ? "text-brand-green-text" : "text-brand-purple"}`, children: resolvedBanner === "allow" ? "✓ Approved" : "✗ Blocked" })
+        ]
+      }
+    ),
     isAlreadyDecided && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3 rounded-2xl border border-slate-200/60 bg-slate-50 px-4 py-3", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniInformationCircle, { className: "mt-0.5 h-4 w-4 shrink-0 text-slate-400", "aria-hidden": "true" }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-sm text-muted-foreground", children: [
@@ -15160,6 +15238,16 @@ function DecisionWorkspace(props) {
         onScopeChange: setScope,
         onReasonChange: setReason,
         onResolve: handleRequestResolve
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      StickyMobileActions,
+      {
+        allowLabel,
+        submitting,
+        isBlocked: item.policy_action === "block",
+        onAllow: handleAllowDirect,
+        onBlock: handleBlockDirect
       }
     ),
     /* @__PURE__ */ jsxRuntimeExports.jsx(ScannerEvidenceSectionFull, { item }),
@@ -15417,6 +15505,17 @@ function CopyCommandButton(props) {
     }
   );
 }
+function resolveMcpInputSummary(payload) {
+  const inputs = payload.arguments ?? payload.input ?? payload.params ?? null;
+  if (inputs === null || inputs === void 0) return null;
+  try {
+    const serialized = JSON.stringify(inputs);
+    if (serialized.length <= 2) return null;
+    return serialized.length > 140 ? `${serialized.slice(0, 140)}…` : serialized;
+  } catch {
+    return null;
+  }
+}
 function BlockedActionCard(props) {
   const launchText = actionLaunchText(props.item);
   const decisionDetail = resolveDecisionV2Detail(props.item);
@@ -15429,6 +15528,7 @@ function BlockedActionCard(props) {
   const isMcpTool = envelope?.action_type === "mcp_tool";
   const mcpServer = isMcpTool ? envelope?.mcp_server ?? null : null;
   const mcpTool = isMcpTool ? envelope?.mcp_tool ?? null : null;
+  const mcpInputSummary = isMcpTool && envelope !== null ? resolveMcpInputSummary(envelope.raw_payload_redacted) : null;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "overflow-hidden rounded-[1.65rem] border border-brand-blue/15 bg-white/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.85)]", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `flex items-center gap-2 px-4 py-2.5 ${bannerBg}`, children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(BannerIcon, { className: "h-3.5 w-3.5 shrink-0 text-white", "aria-hidden": "true" }),
@@ -15448,13 +15548,16 @@ function BlockedActionCard(props) {
       ) : null
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "p-4", children: [
-      isMcpTool && mcpServer !== null && mcpTool !== null && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mb-3 flex items-center gap-2 rounded-xl border border-brand-blue/20 bg-brand-blue/[0.04] px-3 py-2", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-mono text-[11px] font-semibold uppercase tracking-[0.15em] text-brand-blue", children: "MCP" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "font-mono text-sm font-medium text-brand-dark", children: [
-          mcpServer,
-          " → ",
-          mcpTool
-        ] })
+      isMcpTool && mcpServer !== null && mcpTool !== null && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mb-3 space-y-2 rounded-xl border border-brand-blue/20 bg-brand-blue/[0.04] px-3 py-2", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-mono text-[11px] font-semibold uppercase tracking-[0.15em] text-brand-blue", children: "MCP" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "font-mono text-sm font-medium text-brand-dark", children: [
+            mcpServer,
+            " → ",
+            mcpTool
+          ] })
+        ] }),
+        mcpInputSummary !== null && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "truncate font-mono text-xs text-brand-dark/60", children: mcpInputSummary })
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex flex-wrap items-center justify-between gap-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "What was stopped" }) }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("h4", { className: "mt-2 text-xl font-semibold tracking-tight text-brand-dark", children: actionDisplayTitle(props.item) }),
@@ -16734,9 +16837,13 @@ async function loadDetail(requestId) {
     ]);
     return { kind: "ready", item, diff, receipt, policy };
   } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    if (message.includes("404")) {
+      return { kind: "stale" };
+    }
     return {
       kind: "error",
-      message: error instanceof Error ? error.message : "Unable to load the approval request."
+      message: message.length > 0 ? message : "Unable to load the approval request."
     };
   }
 }
@@ -16918,17 +17025,20 @@ function App() {
   const handleResolve = reactExports.useCallback(async (payload) => {
     resolutionInFlight.current = true;
     const queuedItemsSnapshot = requests.kind === "ready" ? requests.items : [];
-    const result = await resolveRequestWithQueueResult(payload);
-    const nextId = selectNextAfterResolution(result, queuedItemsSnapshot);
-    if (nextId !== null) {
-      setResolutionMessage(null);
-      navigate(`/requests/${nextId}`);
-    } else {
-      setResolutionMessage(result.resolution_summary || "Decision saved. Return to your chat and retry the command.");
-      navigate("/inbox");
+    try {
+      const result = await resolveRequestWithQueueResult(payload);
+      const nextId = selectNextAfterResolution(result, queuedItemsSnapshot);
+      if (nextId !== null) {
+        setResolutionMessage(null);
+        navigate(`/requests/${nextId}`);
+      } else {
+        setResolutionMessage(result.resolution_summary || "Decision saved. Return to your chat and retry the command.");
+        navigate("/inbox");
+      }
+      await refreshStateAfterAction();
+    } finally {
+      resolutionInFlight.current = false;
     }
-    await refreshStateAfterAction();
-    resolutionInFlight.current = false;
   }, [requests, refreshStateAfterAction, setResolutionMessage]);
   const handleBulkApprove = reactExports.useCallback(async (ids) => {
     const results = await Promise.allSettled(
@@ -16955,11 +17065,26 @@ function App() {
       setRequests({ kind: "error", message });
     });
   }, []);
+  const handleRepair = reactExports.useCallback(async () => {
+    await repairApprovalCenter();
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+    fetchRuntimeSnapshot().then((snapshot) => {
+      setRuntime({ kind: "ready", snapshot });
+      setRequests({ kind: "ready", items: snapshot.items });
+    }).catch((error) => {
+      const message = error instanceof Error ? error.message : "Unable to reconnect to Guard daemon.";
+      setRuntime({ kind: "error", message });
+      setRequests({ kind: "error", message });
+    });
+  }, []);
   const handleConnectHarness = reactExports.useCallback((_harness) => {
+    navigate("/settings");
   }, []);
   const handleTestHarness = reactExports.useCallback((_harness) => {
+    navigate("/inbox");
   }, []);
   const handleRepairHarness = reactExports.useCallback((_harness) => {
+    navigate("/settings");
   }, []);
   return /* @__PURE__ */ jsxRuntimeExports.jsx(
     ApprovalCenterLayout,
@@ -16991,6 +17116,7 @@ function App() {
       onResolve: handleResolve,
       onBulkApprove: handleBulkApprove,
       onRetry: handleRetry,
+      onRepair: handleRepair,
       fleetContent: runtime.kind === "ready" ? /* @__PURE__ */ jsxRuntimeExports.jsx(
         FleetWorkspace,
         {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -407,6 +407,10 @@
     pointer-events: none;
   }
 
+  .visible {
+    visibility: visible;
+  }
+
   .sr-only {
     clip-path: inset(50%);
     white-space: nowrap;
@@ -479,12 +483,20 @@
     right: calc(var(--spacing) * 10);
   }
 
+  .bottom-0 {
+    bottom: calc(var(--spacing) * 0);
+  }
+
   .left-0 {
     left: calc(var(--spacing) * 0);
   }
 
   .z-10 {
     z-index: 10;
+  }
+
+  .z-20 {
+    z-index: 20;
   }
 
   .z-30 {
@@ -535,6 +547,10 @@
 
   .-m-1 {
     margin: calc(var(--spacing) * -1);
+  }
+
+  .-mx-6 {
+    margin-inline: calc(var(--spacing) * -6);
   }
 
   .mx-2 {
@@ -2385,8 +2401,14 @@
     color: var(--brand-green-text);
   }
 
-  .text-brand-purple {
+  .text-brand-purple, .text-brand-purple\/80 {
     color: var(--brand-purple);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .text-brand-purple\/80 {
+      color: color-mix(in oklab, var(--brand-purple) 80%, transparent);
+    }
   }
 
   .text-gray-500 {
@@ -2521,6 +2543,11 @@
 
   .shadow-2xl {
     --tw-shadow: 0 25px 50px -12px var(--tw-shadow-color, #00000040);
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+
+  .shadow-\[0_-4px_16px_rgba\(63\,65\,116\,0\.08\)\] {
+    --tw-shadow: 0 -4px 16px var(--tw-shadow-color, #3f417414);
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
 


### PR DESCRIPTION
Hardens the Guard dashboard frontend across queue and home surfaces:

- **Queue continuity**: resolution in-flight guard prevents double-submit; decision banner (Approved/Blocked) clears on next item load
- **Mobile sticky actions**: approve/block buttons pinned to bottom on small screens (lg:hidden wrapper)  
- **Stale item handling**: 404 detail returns a `stale` state with a back-to-queue link instead of an error screen
- **Guard offline state**: queue workspace shows actionable repair/retry/open-dashboard buttons when daemon is unreachable
- **Harness display names**: Gemini, Cursor, Hermes, OpenClaw added to chip filter normalization
- **MCP input summary**: truncated argument preview shown beneath tool pill in BlockedActionCard
- **Home dashboard tests**: single CTA, no-jargon copy, apps-protected deduplication, queue routing assertions

All 8 test files pass; vite build clean.