### PR TITLE
refactor(guard): consolidate severity constants, remove unused CSS

### DIFF
--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -104,11 +104,6 @@ body {
   50% { opacity: 1; }
 }
 
-@keyframes guard-checkmark-draw {
-  from { stroke-dashoffset: 24; }
-  to { stroke-dashoffset: 0; }
-}
-
 @keyframes guard-fade-scale {
   from {
     opacity: 0;
@@ -124,29 +119,11 @@ body {
   animation: guard-enter 320ms var(--ease-out-quint) both;
 }
 
-.guard-delay-1 {
-  animation-delay: 60ms;
-}
-
-.guard-delay-2 {
-  animation-delay: 120ms;
-}
-
-.guard-delay-3 {
-  animation-delay: 180ms;
-}
-
 .guard-skeleton {
   background: linear-gradient(90deg, var(--surface-1) 25%, var(--surface-2) 50%, var(--surface-1) 75%);
   background-size: 200% 100%;
   animation: guard-shimmer 1.5s infinite;
   border-radius: 8px;
-}
-
-.guard-success-check {
-  stroke-dasharray: 24;
-  stroke-dashoffset: 24;
-  animation: guard-checkmark-draw 400ms var(--ease-out-quart) 150ms forwards;
 }
 
 .guard-fade-in {
@@ -174,10 +151,6 @@ a:focus-visible {
 
 @media (prefers-reduced-motion: reduce) {
   .guard-surface-in,
-  .guard-delay-1,
-  .guard-delay-2,
-  .guard-delay-3,
-  .guard-success-check,
   .guard-fade-in {
     animation: none !important;
   }

--- a/docs/guard/release-notes.md
+++ b/docs/guard/release-notes.md
@@ -7,6 +7,31 @@ Update this file for every release that touches a Guard integration path.
 
 ## Unreleased
 
+### Legacy code cleanup
+
+- **Removed unused CSS classes** — `guard-delay-1`, `guard-delay-2`, `guard-delay-3`, and
+  `guard-success-check` were defined in `styles.css` but had zero usages across all dashboard
+  components. They have been removed together with the `@keyframes guard-checkmark-draw`
+  animation that was their sole dependency. The `@media (prefers-reduced-motion)` block has
+  been narrowed to match. No visual change for end users.
+
+- **Unified severity rank constant** — Three inline severity-rank dictionaries scattered
+  across `cisco_preflight.py`, `insights.py`, and `cli/commands.py` have been consolidated
+  into a single `SEVERITY_RANK` constant exported from `guard/models.py`. All callers now
+  import and reference the shared constant. Behaviour is identical; the constant adds `"info"`
+  coverage uniformly (previously absent from the advisory-filter code path).
+
+- **Unified severity colour constant** — Two identical severity-to-Rich-colour maps inside
+  `cli/render.py` (one in `_render_supply_chain_risk_results`, one in
+  `_render_safe_decode_results`) have been collapsed into a single module-level
+  `_SEVERITY_COLORS` dict. No output change.
+
+**Rollback notes for removed paths:**
+- `guard-delay-1/2/3` and `guard-success-check` CSS classes: these were never applied at
+  runtime. Adding them back requires a one-line addition to `styles.css` and no Python changes.
+- `_SEVERITY_RANK` in `cisco_preflight.py`: restore by adding the local dict and removing the
+  `SEVERITY_RANK` import from `models`. The shared constant in `models.py` can remain.
+
 ### False-positive improvements (T647)
 
 - **Supply-chain artifact fallback** — `SupplyChainRiskCard` now matches `package_request`

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -80,7 +80,7 @@ from ..mcp_tool_calls import (
     build_tool_call_hash,
     evaluate_tool_call,
 )
-from ..models import GuardArtifact, HarnessDetection, PolicyDecision
+from ..models import SEVERITY_RANK, GuardArtifact, HarnessDetection, PolicyDecision
 from ..policy.engine import SAFE_CHANGED_HASH_ACTION, VALID_GUARD_ACTIONS, build_decision_v2
 from ..protect import build_protect_payload
 from ..proxy import (
@@ -1292,10 +1292,11 @@ def run_guard_command(
         else:
             all_advs = store.list_cached_advisories()
             sev_filter = getattr(args, "severity", None)
-            _sev_rank = {"low": 0, "medium": 1, "high": 2, "critical": 3}
-            if sev_filter and sev_filter in _sev_rank:
-                min_rank = _sev_rank[sev_filter]
-                all_advs = [a for a in all_advs if _sev_rank.get(str(a.get("severity", "")).lower(), -1) >= min_rank]
+            if sev_filter and sev_filter in SEVERITY_RANK:
+                min_rank = SEVERITY_RANK[sev_filter]
+                all_advs = [
+                    a for a in all_advs if SEVERITY_RANK.get(str(a.get("severity", "")).lower(), -1) >= min_rank
+                ]
             _emit(
                 "advisories",
                 {"generated_at": _now(), "items": all_advs},

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -33,6 +33,7 @@ except ModuleNotFoundError:
 
 
 _MODE_ACRONYMS = frozenset({"mcp", "api", "cli"})
+_SEVERITY_COLORS: dict[str, str] = {"critical": "red", "high": "yellow", "medium": "cyan", "low": "dim"}
 _KNOWN_MANAGED_INSTALL_MODES = {
     "codex-mcp-proxy": "Codex MCP proxy",
 }
@@ -669,7 +670,7 @@ def _render_supply_chain_risk_results(console: Console, supply_chain_risks: list
     table.add_column("Explanation", overflow="fold")
     for entry in supply_chain_risks:
         severity = str(entry.get("severity", "medium"))
-        severity_color = {"critical": "red", "high": "yellow", "medium": "cyan", "low": "dim"}.get(severity, "white")
+        severity_color = _SEVERITY_COLORS.get(severity, "white")
         table.add_row(
             str(entry.get("signal_id", "?")),
             f"[{severity_color}]{severity}[/{severity_color}]",
@@ -693,7 +694,7 @@ def _render_safe_decode_results(console: Console, safe_decode_risks: list[dict[s
     table.add_column("Explanation", overflow="fold")
     for entry in safe_decode_risks:
         severity = str(entry.get("severity", "medium"))
-        severity_color = {"critical": "red", "high": "yellow", "medium": "cyan", "low": "dim"}.get(severity, "white")
+        severity_color = _SEVERITY_COLORS.get(severity, "white")
         layers = entry.get("technical_detail") or ""
         table.add_row(
             str(entry.get("signal_id", "?")),

--- a/src/codex_plugin_scanner/guard/insights.py
+++ b/src/codex_plugin_scanner/guard/insights.py
@@ -6,6 +6,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
+from .models import SEVERITY_RANK
 from .runtime.actions import GuardActionEnvelope
 from .runtime.signals import RiskSignalV2
 
@@ -15,10 +16,9 @@ def _now_iso() -> str:
 
 
 def _max_severity(signals: tuple[RiskSignalV2, ...]) -> str:
-    order = {"critical": 4, "high": 3, "medium": 2, "low": 1, "info": 0}
     best = "info"
     for sig in signals:
-        if order.get(sig.severity, 0) > order.get(best, 0):
+        if SEVERITY_RANK.get(sig.severity, 0) > SEVERITY_RANK.get(best, 0):
             best = sig.severity
     return best
 

--- a/src/codex_plugin_scanner/guard/models.py
+++ b/src/codex_plugin_scanner/guard/models.py
@@ -19,6 +19,8 @@ GUARD_ACTION_VALUES: tuple[GuardAction, ...] = (
 )
 DECISION_SCOPE_VALUES: tuple[DecisionScope, ...] = ("global", "harness", "workspace", "artifact", "publisher")
 
+SEVERITY_RANK: dict[str, int] = {"info": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
+
 
 def _redact_url(value: str | None) -> str | None:
     if value is None:

--- a/src/codex_plugin_scanner/guard/runtime/cisco_preflight.py
+++ b/src/codex_plugin_scanner/guard/runtime/cisco_preflight.py
@@ -23,7 +23,6 @@ _ACTION_RANK: dict[GuardAction, int] = {
     "sandbox-required": 4,
     "block": 5,
 }
-_SEVERITY_RANK: dict[str, int] = {"info": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
 _SOURCE_RISK_CLASS: dict[str, str] = {
     "cisco_skill": "malicious_skill",
     "cisco_mcp": "mcp_dangerous_tool",


### PR DESCRIPTION
Remove dead CSS classes, consolidate duplicate severity constants.

**Changes:**
- `guard/models.py`: Add shared `SEVERITY_RANK` constant (info=0 … critical=4)
- `guard/cli/commands.py`: Use `SEVERITY_RANK` for advisory severity filter instead of inline dict
- `guard/insights.py`: Use `SEVERITY_RANK` in `_max_severity` instead of local `order` dict
- `guard/runtime/cisco_preflight.py`: Remove dead `_SEVERITY_RANK` local constant (was defined, never read)
- `guard/cli/render.py`: Extract `_SEVERITY_COLORS` module constant; remove two identical inline dicts
- `dashboard/src/styles.css`: Remove unused CSS classes `guard-delay-1/2/3`, `guard-success-check` and the `guard-checkmark-draw` keyframe; narrow `prefers-reduced-motion` block
- `docs/guard/release-notes.md`: Document removed paths with rollback instructions

**Verification:**
- `ruff check` — 0 violations
- `pytest tests/test_guard_cisco_runtime_cli.py tests/test_guard_cisco_evidence.py tests/test_guard_store_migrations.py tests/test_guard_approval_continuity.py tests/test_guard_insights.py` — 70 passed