### PR TITLE
feat(dashboard): simplify queue UX, home dashboard, and watched-app copy

### DIFF
--- a/dashboard/src/approval-center-layout.test.ts
+++ b/dashboard/src/approval-center-layout.test.ts
@@ -3,6 +3,8 @@ import {
   resolveStoppedCommandText,
   resolveTerminalLabel,
   displayArtifactName,
+  EMPTY_QUEUE_TITLE,
+  STALE_REQUEST_COPY,
 } from "./approval-center-utils";
 import type { GuardActionEnvelope, GuardApprovalRequest } from "./guard-types";
 
@@ -185,4 +187,24 @@ assert(
 assert(
   resolveTerminalLabel(BASE_REQUEST) === "Stopped command",
   "T479-T484: resolveTerminalLabel returns 'Stopped command' when no envelope present"
+);
+
+assert(
+  EMPTY_QUEUE_TITLE === "No blocked actions",
+  'C5: Empty queue shows friendly copy "No blocked actions" — EMPTY_QUEUE_TITLE constant is correct'
+);
+
+assert(
+  EMPTY_QUEUE_TITLE.toLowerCase().includes("no blocked"),
+  'C5: Empty queue title does not say "no items" — uses friendly language instead'
+);
+
+assert(
+  STALE_REQUEST_COPY === "This request was already decided.",
+  'C6: Stale request shows "already decided" copy — STALE_REQUEST_COPY constant is correct'
+);
+
+assert(
+  STALE_REQUEST_COPY.toLowerCase().includes("already decided"),
+  'C6: Stale request copy contains "already decided" — not approve/block buttons'
 );

--- a/dashboard/src/approval-center-layout.tsx
+++ b/dashboard/src/approval-center-layout.tsx
@@ -47,7 +47,8 @@ import {
   resolveStoppedCommandText,
   displayArtifactName,
   resolveTerminalLabel,
-  scopeLabel
+  scopeLabel,
+  STALE_REQUEST_COPY,
 } from "./approval-center-utils";
 import {
   WhyThisPaused,
@@ -210,6 +211,9 @@ function MobileQueueDrawer(props: {
   return (
     <div
       className="fixed inset-0 z-50 flex lg:hidden"
+      role="dialog"
+      aria-label="Review queue"
+      aria-modal="true"
     >
       <div className="absolute inset-0 bg-black/30 backdrop-blur-sm" onClick={props.onClose} />
       <div className="relative ml-0 flex w-full max-w-sm flex-col overflow-hidden bg-white shadow-2xl" onClick={(e) => e.stopPropagation()}>
@@ -278,7 +282,7 @@ function QueueWorkspace(props: {
     return (
       <div className="space-y-4">
         <Surface tone="danger">
-          <p className="text-sm font-semibold text-brand-purple">Guard is not responding</p>
+          <p className="text-sm font-semibold text-brand-purple">Guard connection lost. Check if the daemon is running.</p>
           <p className="mt-1 text-sm text-brand-purple/80">{props.requests.message}</p>
           <div className="mt-4 flex flex-wrap gap-3">
             {props.onRepair !== undefined && (
@@ -286,6 +290,12 @@ function QueueWorkspace(props: {
                 {repairing ? "Repairing…" : "Repair"}
               </ActionButton>
             )}
+            <a
+              href="x-terminal-emulator://"
+              className="inline-flex min-h-10 items-center rounded-lg border border-brand-purple/30 bg-white px-3 py-2 text-sm font-medium text-brand-purple transition-colors hover:bg-brand-purple/5"
+            >
+              Open Terminal
+            </a>
             {props.onRetry && (
               <ActionButton variant="outline" onClick={props.onRetry}>Retry</ActionButton>
             )}
@@ -398,7 +408,7 @@ function QueueHeader(props: {
             {props.progressCopy}
           </span>
         )}
-        <Badge tone="warning">{props.requests.length} waiting</Badge>
+        <Badge tone="default">{props.requests.length} waiting</Badge>
         {activeItem ? <Tag tone="blue">{harnessDisplayName(activeItem.harness)}</Tag> : null}
         <Tag tone="slate">{runtimeLabel}</Tag>
       </div>
@@ -510,7 +520,7 @@ function QueueBrowser(props: {
             className="min-h-11 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-brand-dark placeholder:text-slate-400 transition-colors duration-150 focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
           />
         </label>
-        {harnesses.length > 1 && (
+        {harnesses.length > 0 && (
           <QueueChipFilter
             harnesses={harnesses}
             activeFilter={harnessFilter}
@@ -807,7 +817,7 @@ function DecisionWorkspace(props: {
         <div className="flex items-start gap-3">
           <HiMiniInformationCircle className="mt-0.5 h-4 w-4 shrink-0 text-slate-400" aria-hidden="true" />
           <div>
-            <p className="text-sm font-medium text-brand-dark">This request was already decided.</p>
+            <p className="text-sm font-medium text-brand-dark">{STALE_REQUEST_COPY}</p>
             <p className="mt-1 text-sm text-muted-foreground">
               Someone already reviewed this blocked action. No further action needed.
             </p>

--- a/dashboard/src/approval-center-layout.tsx
+++ b/dashboard/src/approval-center-layout.tsx
@@ -290,12 +290,9 @@ function QueueWorkspace(props: {
                 {repairing ? "Repairing…" : "Repair"}
               </ActionButton>
             )}
-            <a
-              href="x-terminal-emulator://"
-              className="inline-flex min-h-10 items-center rounded-lg border border-brand-purple/30 bg-white px-3 py-2 text-sm font-medium text-brand-purple transition-colors hover:bg-brand-purple/5"
-            >
-              Open Terminal
-            </a>
+            <code className="inline-flex min-h-10 items-center rounded-lg border border-brand-purple/30 bg-slate-50 px-3 py-2 font-mono text-sm text-brand-purple select-all">
+              hol-guard start
+            </code>
             {props.onRetry && (
               <ActionButton variant="outline" onClick={props.onRetry}>Retry</ActionButton>
             )}

--- a/dashboard/src/approval-center-primitives.tsx
+++ b/dashboard/src/approval-center-primitives.tsx
@@ -13,6 +13,7 @@ import {
 } from "react-icons/hi2";
 
 import { guardAwareHref } from "./guard-api";
+import { EMPTY_QUEUE_TITLE } from "./approval-center-utils";
 
 const footerSections = [
   {
@@ -538,7 +539,7 @@ export function WelcomeState(props: {
       <div className="mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-brand-green-bg/50 ring-1 ring-brand-green/20">
         <HiMiniShieldCheck className="h-10 w-10 text-brand-green" aria-hidden="true" />
       </div>
-      <h2 className="text-2xl font-semibold tracking-tight text-brand-dark sm:text-3xl">No blocked actions</h2>
+      <h2 className="text-2xl font-semibold tracking-tight text-brand-dark sm:text-3xl">{EMPTY_QUEUE_TITLE}</h2>
       <p className="mx-auto mt-4 max-w-lg text-[15px] leading-relaxed text-muted-foreground">
         Guard is still watching your apps. You'll be notified here if something needs your approval.
       </p>

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -6,6 +6,9 @@ import type {
   RiskSignalV2
 } from "./guard-types";
 
+export const EMPTY_QUEUE_TITLE = "No blocked actions";
+export const STALE_REQUEST_COPY = "This request was already decided.";
+
 export type DataFlowEvidenceSummary = {
   signalTitle: string;
   sourceLabel: string;

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -526,7 +526,7 @@ export function buildDemoRuntimeSnapshot(): GuardRuntimeSnapshot {
   const cloudState = "paired_waiting";
   const cloudLabel = "Connected";
   const cloudDetail =
-    "This machine is connected to Guard Cloud, but the first shared proof has not landed yet. Open Watched Apps while the first sync settles.";
+    "This machine is connected to Guard Cloud, but the first protected session has not landed yet. Open Watched Apps while the first sync settles.";
   const dashboardUrl = "https://hol.org/guard";
   const inboxUrl = "https://hol.org/guard/inbox";
   const fleetUrl = "https://hol.org/guard/fleet";
@@ -549,7 +549,7 @@ export function buildDemoRuntimeSnapshot(): GuardRuntimeSnapshot {
     headline_detail:
       demoRequests.length > 0
         ? "A blocked action is waiting for review."
-        : "This machine is connected to Guard Cloud and waiting for the first shared proof to appear.",
+        : "This machine is connected to Guard Cloud and waiting for the first protected session to appear.",
     sync_configured: true,
     cloud_state: cloudState,
     cloud_state_label: cloudLabel,

--- a/dashboard/src/home-dashboard.test.ts
+++ b/dashboard/src/home-dashboard.test.ts
@@ -178,3 +178,59 @@ for (const copy of [setupCopy, pendingCopy, protectedCopy]) {
     `L140: Copy must not contain jargon words — got: "${copy}"`
   );
 }
+
+const EXTENDED_JARGON = ["daemon", "runtime", "v1", "MCP", "harness", "artifact"];
+function containsExtendedJargon(text: string): boolean {
+  return EXTENDED_JARGON.some((word) =>
+    text.toLowerCase().includes(word.toLowerCase())
+  );
+}
+
+const setupOnlyCta = buildHomePrimaryState(0, 0);
+assert(
+  setupOnlyCta.ctaLabel === "Set up protection",
+  'C1: setup_needed primary CTA is "Set up protection"'
+);
+
+assert(
+  setupOnlyCta.status === "setup_needed",
+  "C1: buildHomePrimaryState returns setup_needed for zero pending and zero installs"
+);
+
+const queueCta = buildHomePrimaryState(3, 1);
+assert(
+  queueCta.ctaLabel.toLowerCase().includes("review") ||
+    queueCta.ctaLabel.toLowerCase().includes("queue") ||
+    queueCta.ctaLabel.toLowerCase().includes("action"),
+  'C2: Queue count CTA label navigates to Review Queue — label contains "review", "queue", or "action"'
+);
+
+const allStates = [
+  buildHomePrimaryState(0, 0),
+  buildHomePrimaryState(2, 2),
+  buildHomePrimaryState(0, 1),
+];
+const allCopies = allStates.map((s) => s.copy);
+const allCtaLabels = allStates.map((s) => s.ctaLabel);
+
+const uniqueCopies = new Set(allCopies);
+assert(
+  uniqueCopies.size === allCopies.length,
+  "C3: No duplicate copy across the three dashboard states"
+);
+
+const uniqueCtaLabels = new Set(allCtaLabels);
+assert(
+  uniqueCtaLabels.size === allCtaLabels.length,
+  "C3: No duplicate CTA labels across the three dashboard states"
+);
+
+const setupStateForJargon = buildHomePrimaryState(0, 0);
+assert(
+  !containsExtendedJargon(setupStateForJargon.copy),
+  `C4: setup_needed copy has no jargon — got: "${setupStateForJargon.copy}"`
+);
+assert(
+  !containsExtendedJargon(setupStateForJargon.ctaLabel),
+  `C4: setup_needed CTA label has no jargon — got: "${setupStateForJargon.ctaLabel}"`
+);

--- a/dashboard/src/home-dashboard.tsx
+++ b/dashboard/src/home-dashboard.tsx
@@ -350,7 +350,16 @@ function AppsProtectedSection(props: AppsProtectedSectionProps) {
     ])
   ).sort();
 
-  if (allHarnesses.length === 0) return null;
+  if (allHarnesses.length === 0) {
+    return (
+      <section className="rounded-[1.75rem] border border-slate-200/70 bg-white/80 p-5 shadow-sm sm:p-6">
+        <SectionLabel>Apps protected</SectionLabel>
+        <p className="mt-3 text-sm text-muted-foreground">
+          None yet. Connect an AI harness to start.
+        </p>
+      </section>
+    );
+  }
 
   return (
     <section className="rounded-[1.75rem] border border-slate-200/70 bg-white/80 p-5 shadow-sm sm:p-6">

--- a/dashboard/src/queue-state.test.ts
+++ b/dashboard/src/queue-state.test.ts
@@ -268,8 +268,8 @@ assert(
   "T-QS-32: buildHomePrimaryState returns setup_needed when no watched apps and no pending"
 );
 assert(
-  setupNeeded.ctaLabel === "Connect an app",
-  "T-QS-33: buildHomePrimaryState CTA is 'Connect an app' when no watched apps"
+  setupNeeded.ctaLabel === "Set up protection",
+  "T-QS-33: buildHomePrimaryState CTA is 'Set up protection' when no watched apps"
 );
 
 const protectedState = buildHomePrimaryState(0, 2);
@@ -278,8 +278,8 @@ assert(
   "T-QS-34: buildHomePrimaryState returns protected status when guarded with apps present"
 );
 assert(
-  protectedState.copy.includes("watching"),
-  "T-QS-35: buildHomePrimaryState copy mentions watching when protected"
+  protectedState.copy.includes("protecting"),
+  "T-QS-35: buildHomePrimaryState copy mentions protecting when protected"
 );
 
 const singlePending = buildHomePrimaryState(1, 1);

--- a/dashboard/src/queue-state.ts
+++ b/dashboard/src/queue-state.ts
@@ -177,13 +177,13 @@ export function buildHomePrimaryState(
   if (watchedAppsCount === 0) {
     return {
       status: "setup_needed",
-      copy: "HOL Guard is running but no apps are connected yet.",
-      ctaLabel: "Connect an app",
+      copy: "Guard is running but no apps are connected yet.",
+      ctaLabel: "Set up protection",
     };
   }
   return {
     status: "protected",
-    copy: "HOL Guard is watching this machine. No blocked actions right now.",
+    copy: "Guard is protecting your apps. No blocked actions right now.",
     ctaLabel: "Open review queue",
   };
 }

--- a/dashboard/src/runtime-overview.tsx
+++ b/dashboard/src/runtime-overview.tsx
@@ -32,12 +32,12 @@ function remediationLine(snapshot: GuardRuntimeSnapshot): string {
     return "Open the review queue, choose what to do with the blocked action, then retry in the same chat.";
   }
   if (snapshot.cloud_state === "paired_waiting") {
-    return "Open Guard Cloud while the first shared proof lands and this machine finishes syncing.";
+    return "Open Guard Cloud while the first protected session lands and this machine finishes syncing.";
   }
   if (snapshot.cloud_state === "local_only") {
     return "Stay local for now or connect this machine when you want shared queue memory and cross-device proof.";
   }
-  return "Open Guard Cloud for shared proof, Watched Apps for local coverage, or the review queue when something needs your choice.";
+  return "Open Guard Cloud for shared decisions, Watched Apps for local coverage, or the review queue when something needs your choice.";
 }
 
 export type ApprovalCenterHealthState = "ready" | "starting" | "stale" | "repair_needed";
@@ -118,6 +118,11 @@ function cloudSyncHealthTone(state: GuardCloudSyncHealth["state"]): "blue" | "sl
   return "blue";
 }
 
+function humanizeCloudSyncHealthLabel(label: string): string {
+  if (label === "Cloud sync stale") return "Your protection history hasn't synced recently";
+  return label;
+}
+
 function CloudSyncHealthCard(props: { health: GuardCloudSyncHealth }) {
   const copy = resolveCloudSyncHealthCopy(props.health);
   return (
@@ -126,7 +131,7 @@ function CloudSyncHealthCard(props: { health: GuardCloudSyncHealth }) {
         <p className="text-xs font-semibold uppercase tracking-[0.18em] text-brand-blue">
           Cloud sync health
         </p>
-        <Tag tone={cloudSyncHealthTone(props.health.state)}>{copy.label}</Tag>
+        <Tag tone={cloudSyncHealthTone(props.health.state)}>{humanizeCloudSyncHealthLabel(copy.label)}</Tag>
       </div>
       <p className="mt-2 text-sm leading-relaxed text-brand-dark/80">{copy.detail}</p>
     </div>

--- a/dashboard/src/watched-app-card.tsx
+++ b/dashboard/src/watched-app-card.tsx
@@ -75,10 +75,10 @@ function StatusBadge(props: StatusBadgeProps) {
     return <Badge tone="success">Protected</Badge>;
   }
   if (props.status === "found_unprotected") {
-    return <Badge tone="warning">Found</Badge>;
+    return <Badge tone="warning">Found, protection not installed</Badge>;
   }
   if (props.status === "needs_repair") {
-    return <Badge tone="destructive">Needs repair</Badge>;
+    return <Badge tone="warning">Repair needed</Badge>;
   }
   if (props.status === "not_found") {
     return <Badge tone="default">Not found</Badge>;
@@ -124,7 +124,7 @@ function CardAction(props: CardActionProps) {
   }
   if (props.status === "needs_repair") {
     return (
-      <ActionButton variant="danger" onClick={handleRepair}>
+      <ActionButton variant="outline" onClick={handleRepair}>
         Repair
       </ActionButton>
     );

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -12947,7 +12947,7 @@ function buildDemoRuntimeSnapshot() {
   const now2 = (/* @__PURE__ */ new Date()).toISOString();
   const cloudState = "paired_waiting";
   const cloudLabel = "Connected";
-  const cloudDetail = "This machine is connected to Guard Cloud, but the first shared proof has not landed yet. Open Watched Apps while the first sync settles.";
+  const cloudDetail = "This machine is connected to Guard Cloud, but the first protected session has not landed yet. Open Watched Apps while the first sync settles.";
   const dashboardUrl = "https://hol.org/guard";
   const inboxUrl = "https://hol.org/guard/inbox";
   const fleetUrl = "https://hol.org/guard/fleet";
@@ -12967,7 +12967,7 @@ function buildDemoRuntimeSnapshot() {
     receipt_count: demoReceipts.length,
     headline_state: demoRequests2.length > 0 ? "blocked" : "connected",
     headline_label: demoRequests2.length > 0 ? "Blocked" : "Connected",
-    headline_detail: demoRequests2.length > 0 ? "A blocked action is waiting for review." : "This machine is connected to Guard Cloud and waiting for the first shared proof to appear.",
+    headline_detail: demoRequests2.length > 0 ? "A blocked action is waiting for review." : "This machine is connected to Guard Cloud and waiting for the first protected session to appear.",
     sync_configured: true,
     cloud_state: cloudState,
     cloud_state_label: cloudLabel,
@@ -13389,6 +13389,277 @@ function HiMiniArrowTopRightOnSquare(props) {
 function HiMiniAdjustmentsHorizontal(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "d": "M10 3.75a2 2 0 1 0-4 0 2 2 0 0 0 4 0ZM17.25 4.5a.75.75 0 0 0 0-1.5h-5.5a.75.75 0 0 0 0 1.5h5.5ZM5 3.75a.75.75 0 0 1-.75.75h-1.5a.75.75 0 0 1 0-1.5h1.5a.75.75 0 0 1 .75.75ZM4.25 17a.75.75 0 0 0 0-1.5h-1.5a.75.75 0 0 0 0 1.5h1.5ZM17.25 17a.75.75 0 0 0 0-1.5h-5.5a.75.75 0 0 0 0 1.5h5.5ZM9 10a.75.75 0 0 1-.75.75h-5.5a.75.75 0 0 1 0-1.5h5.5A.75.75 0 0 1 9 10ZM17.25 10.75a.75.75 0 0 0 0-1.5h-1.5a.75.75 0 0 0 0 1.5h1.5ZM14 10a2 2 0 1 0-4 0 2 2 0 0 0 4 0ZM10 16.25a2 2 0 1 0-4 0 2 2 0 0 0 4 0Z" }, "child": [] }] })(props);
 }
+const EMPTY_QUEUE_TITLE = "No blocked actions";
+const STALE_REQUEST_COPY = "This request was already decided.";
+function deriveDataFlowEvidence(item) {
+  const signals = item.decision_v2_json?.signals ?? [];
+  const dataFlowSignals = signals.filter(
+    (s) => s.detector === "data_flow.exfiltration" || s.signal_id.startsWith("data-flow:")
+  );
+  if (dataFlowSignals.length === 0) {
+    return null;
+  }
+  const primary = dataFlowSignals[0];
+  return {
+    signalTitle: primary.title,
+    sourceLabel: "Local secret",
+    sinkLabel: resolveDataFlowSinkLabel(primary),
+    signalId: primary.signal_id,
+    count: dataFlowSignals.length
+  };
+}
+function deriveSkillRiskSignals(item) {
+  return (item.decision_v2_json?.signals ?? []).filter((s) => s.detector === "skill.content");
+}
+function deriveSupplyChainRiskSignals(item) {
+  return (item.decision_v2_json?.signals ?? []).filter((s) => s.detector === "supply-chain.content");
+}
+function deriveEncodedLayerSignals(item) {
+  return (item.decision_v2_json?.signals ?? []).filter(
+    (s) => s.detector === "safe-decode.content" || s.signal_id.startsWith("encoded.")
+  );
+}
+function resolveDataFlowSinkLabel(signal) {
+  if (signal.category === "network") {
+    return "Network host";
+  }
+  if (signal.signal_id === "data-flow:clipboard-secret") {
+    return "Clipboard";
+  }
+  if (signal.signal_id === "data-flow:world-readable-temp-secret") {
+    return "World-readable temp file";
+  }
+  if (signal.signal_id === "data-flow:git-remote-token") {
+    return "Git remote config";
+  }
+  return "External sink";
+}
+function resolveEnvelopeDisplayText(envelope) {
+  if (envelope.action_type === "shell_command" && envelope.command !== null) {
+    return envelope.command;
+  }
+  if (envelope.action_type === "prompt" && envelope.prompt_excerpt !== null) {
+    return envelope.prompt_excerpt;
+  }
+  if (envelope.action_type === "mcp_tool" && envelope.mcp_server !== null && envelope.mcp_tool !== null) {
+    return `${envelope.mcp_server} / ${envelope.mcp_tool}`;
+  }
+  if (envelope.tool_name !== null) {
+    return envelope.tool_name;
+  }
+  if (envelope.target_paths.length > 0) {
+    return envelope.target_paths[0];
+  }
+  return envelope.action_type === "harness_start" ? null : envelope.action_type;
+}
+function humanizeList(values) {
+  if (values.length === 0) {
+    return "nothing tracked yet";
+  }
+  if (values.length === 1) {
+    return values[0];
+  }
+  if (values.length === 2) {
+    return `${values[0]} and ${values[1]}`;
+  }
+  return `${values.slice(0, -1).join(", ")}, and ${values.at(-1)}`;
+}
+function humanizeChangedFields(values) {
+  const translated = values.map((value) => {
+    if (value === "first_seen") {
+      return "this action";
+    }
+    if (value === "args") {
+      return "the command details";
+    }
+    if (value === "command") {
+      return "the command";
+    }
+    if (value === "headers") {
+      return "network details";
+    }
+    if (value === "tool_action_request") {
+      return "the requested action";
+    }
+    return value.replaceAll("_", " ");
+  });
+  return humanizeList(translated);
+}
+function buildPauseLine(item) {
+  if (item.policy_action === "block") {
+    return `${harnessDisplayName(item.harness)} kept this blocked because you already saved a block decision for it.`;
+  }
+  if (item.changed_fields.length === 1 && item.changed_fields[0] === "first_seen") {
+    return `${harnessDisplayName(item.harness)} has not run this exact action here before, so HOL Guard paused it for you to review.`;
+  }
+  return `${harnessDisplayName(item.harness)} wants to run something that changed since your last saved decision: ${humanizeChangedFields(item.changed_fields)}.`;
+}
+function buildRecommendation(item) {
+  if (item.changed_fields.length === 1 && item.changed_fields[0] === "first_seen") {
+    return "If this is what you expected, approve the exact action. Use broader trust only when you deliberately want Guard to ask less often.";
+  }
+  if (item.policy_action === "block") {
+    return "Keep it blocked unless you are sure this action is safe and expected.";
+  }
+  return "Approve the smallest choice that matches what you meant to do. Broader trust should be a deliberate second step.";
+}
+function buildQueueSummary(item) {
+  if (item.policy_action === "block") {
+    return "You already chose to block this action.";
+  }
+  if (item.changed_fields.length === 1 && item.changed_fields[0] === "first_seen") {
+    return "First time HOL Guard has seen this here.";
+  }
+  return `Changed since your last decision: ${humanizeChangedFields(item.changed_fields)}.`;
+}
+function buildMemorySummary(item, receipt) {
+  if (receipt === null) {
+    return `HOL Guard has not saved an earlier approval for ${item.artifact_name}.`;
+  }
+  return `The last saved decision for ${item.artifact_name} was ${receipt.policy_decision}.`;
+}
+function scopeLabel(scope) {
+  switch (scope) {
+    case "artifact":
+      return "This exact action";
+    case "workspace":
+      return "This project folder";
+    case "publisher":
+      return "This source in this app";
+    case "harness":
+      return "This app";
+    case "global":
+      return "Every project on this machine";
+    default:
+      return scope;
+  }
+}
+function policyActionLabel(action) {
+  switch (action) {
+    case "require-reapproval":
+      return "Needs review";
+    case "block":
+      return "Blocked";
+    case "allow":
+      return "Allowed";
+    default:
+      return action;
+  }
+}
+function artifactTypeLabel(artifactType) {
+  switch (artifactType) {
+    case "mcp_server":
+      return "MCP server";
+    case "extension":
+      return "Extension";
+    case "hook":
+      return "Hook";
+    case "agent":
+      return "Agent";
+    case "command":
+      return "Command";
+    case "tool_action_request":
+      return "Tool action";
+    default:
+      return artifactType.replaceAll("_", " ");
+  }
+}
+function buildStoppedReason(item, receipt) {
+  if (item.policy_action === "block") {
+    const changed = item.changed_fields.length > 0 ? ` ${humanizeChangedFields(item.changed_fields)} also changed.` : "";
+    return `A saved block decision already covers this action, so HOL Guard kept it paused.${changed}`;
+  }
+  if (item.changed_fields.length === 1 && item.changed_fields[0] === "first_seen") {
+    return "HOL Guard has never seen this action in this project folder before, so there is no saved approval for it yet.";
+  }
+  if (receipt !== null) {
+    return `HOL Guard found an earlier ${receipt.policy_decision} decision, but ${humanizeChangedFields(item.changed_fields)} no longer matches what you approved before.`;
+  }
+  return "This action changed after the last known state, so HOL Guard needs a new decision before it can run.";
+}
+function shortConfigPath(path) {
+  const sanitizedPath = path.replace(/\/Users\/[^/\s]+/g, "~");
+  const marker = "/.codex/";
+  const index = sanitizedPath.lastIndexOf(marker);
+  if (index >= 0) {
+    return `…${sanitizedPath.slice(index)}`;
+  }
+  return sanitizedPath;
+}
+function buildTechnicalSummary(_diff, item) {
+  return [["Approval command", item.review_command]];
+}
+function capitalizeHarness(harness) {
+  if (harness.length === 0) {
+    return harness;
+  }
+  return `${harness.charAt(0).toUpperCase()}${harness.slice(1)}`;
+}
+function resolveDecisionV2Title(item) {
+  const title = item.decision_v2_json?.user_title;
+  return title !== void 0 && title.trim().length > 0 ? title : null;
+}
+function resolveDecisionV2Detail(item) {
+  const detail = item.decision_v2_json?.dashboard_primary_detail;
+  return detail !== void 0 && detail.trim().length > 0 ? detail : null;
+}
+function resolveStoppedCommandText(item) {
+  if (item.action_envelope_json) {
+    const envelopeText = resolveEnvelopeDisplayText(item.action_envelope_json);
+    if (envelopeText !== null) {
+      return envelopeText;
+    }
+  }
+  if (item.launch_target?.trim()) {
+    return item.launch_target;
+  }
+  if (item.launch_summary?.trim()) {
+    const commandMatch = item.launch_summary.match(/`([^`]+)`/);
+    if (commandMatch?.[1]) {
+      return commandMatch[1];
+    }
+    return item.launch_summary;
+  }
+  return item.artifact_name.trim() || item.artifact_id;
+}
+function harnessDisplayName(harness) {
+  switch (harness) {
+    case "claude-code":
+      return "Claude Code";
+    case "copilot":
+      return "Copilot";
+    case "codex":
+      return "Codex";
+    case "opencode":
+      return "OpenCode";
+    case "gemini":
+      return "Gemini";
+    case "cursor":
+      return "Cursor";
+    case "hermes":
+      return "Hermes";
+    case "openclaw":
+      return "OpenClaw";
+    default:
+      return capitalizeHarness(harness);
+  }
+}
+function displayArtifactName(item) {
+  return item.artifact_name || item.artifact_id || "this action";
+}
+function resolveTerminalLabel(item) {
+  const actionType = item.action_envelope_json?.action_type;
+  if (actionType === "shell_command") return "Command";
+  if (actionType === "prompt") return "Prompt excerpt";
+  if (actionType === "file_read" || actionType === "file_write") return "File path";
+  if (actionType === "mcp_tool") return "MCP server / tool";
+  if (actionType === "package_script") return "Package";
+  if (actionType === "network_request") return "Network destination";
+  if (item.artifact_type === "file_read_request") return "File path";
+  if (item.artifact_type === "prompt_request") return "Prompt excerpt";
+  if (item.artifact_type === "tool_action_request") return "Tool action";
+  return "Stopped command";
+}
 function ShellHeader(props) {
   function handleMobileNavigationChange(event) {
     props.onNavigate(event.target.value);
@@ -13682,7 +13953,7 @@ function WelcomeState(props) {
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "guard-surface-in flex flex-col items-center justify-center py-16 text-center sm:py-24", children: [
     props.resolutionMessage && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mb-10 w-full max-w-xl flex justify-center", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Surface, { tone: "success", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-green-text", children: props.resolutionMessage }) }) }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-brand-green-bg/50 ring-1 ring-brand-green/20", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "h-10 w-10 text-brand-green", "aria-hidden": "true" }) }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "text-2xl font-semibold tracking-tight text-brand-dark sm:text-3xl", children: "No blocked actions" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "text-2xl font-semibold tracking-tight text-brand-dark sm:text-3xl", children: EMPTY_QUEUE_TITLE }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mx-auto mt-4 max-w-lg text-[15px] leading-relaxed text-muted-foreground", children: "Guard is still watching your apps. You'll be notified here if something needs your approval." }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-12 text-left w-full max-w-3xl", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-border bg-card p-6 shadow-[0_4px_20px_rgba(85,153,254,0.04)]", children: [
@@ -13711,275 +13982,6 @@ function TrustCard(props) {
     /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: props.title }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs leading-relaxed text-muted-foreground", children: props.body })
   ] });
-}
-function deriveDataFlowEvidence(item) {
-  const signals = item.decision_v2_json?.signals ?? [];
-  const dataFlowSignals = signals.filter(
-    (s) => s.detector === "data_flow.exfiltration" || s.signal_id.startsWith("data-flow:")
-  );
-  if (dataFlowSignals.length === 0) {
-    return null;
-  }
-  const primary = dataFlowSignals[0];
-  return {
-    signalTitle: primary.title,
-    sourceLabel: "Local secret",
-    sinkLabel: resolveDataFlowSinkLabel(primary),
-    signalId: primary.signal_id,
-    count: dataFlowSignals.length
-  };
-}
-function deriveSkillRiskSignals(item) {
-  return (item.decision_v2_json?.signals ?? []).filter((s) => s.detector === "skill.content");
-}
-function deriveSupplyChainRiskSignals(item) {
-  return (item.decision_v2_json?.signals ?? []).filter((s) => s.detector === "supply-chain.content");
-}
-function deriveEncodedLayerSignals(item) {
-  return (item.decision_v2_json?.signals ?? []).filter(
-    (s) => s.detector === "safe-decode.content" || s.signal_id.startsWith("encoded.")
-  );
-}
-function resolveDataFlowSinkLabel(signal) {
-  if (signal.category === "network") {
-    return "Network host";
-  }
-  if (signal.signal_id === "data-flow:clipboard-secret") {
-    return "Clipboard";
-  }
-  if (signal.signal_id === "data-flow:world-readable-temp-secret") {
-    return "World-readable temp file";
-  }
-  if (signal.signal_id === "data-flow:git-remote-token") {
-    return "Git remote config";
-  }
-  return "External sink";
-}
-function resolveEnvelopeDisplayText(envelope) {
-  if (envelope.action_type === "shell_command" && envelope.command !== null) {
-    return envelope.command;
-  }
-  if (envelope.action_type === "prompt" && envelope.prompt_excerpt !== null) {
-    return envelope.prompt_excerpt;
-  }
-  if (envelope.action_type === "mcp_tool" && envelope.mcp_server !== null && envelope.mcp_tool !== null) {
-    return `${envelope.mcp_server} / ${envelope.mcp_tool}`;
-  }
-  if (envelope.tool_name !== null) {
-    return envelope.tool_name;
-  }
-  if (envelope.target_paths.length > 0) {
-    return envelope.target_paths[0];
-  }
-  return envelope.action_type === "harness_start" ? null : envelope.action_type;
-}
-function humanizeList(values) {
-  if (values.length === 0) {
-    return "nothing tracked yet";
-  }
-  if (values.length === 1) {
-    return values[0];
-  }
-  if (values.length === 2) {
-    return `${values[0]} and ${values[1]}`;
-  }
-  return `${values.slice(0, -1).join(", ")}, and ${values.at(-1)}`;
-}
-function humanizeChangedFields(values) {
-  const translated = values.map((value) => {
-    if (value === "first_seen") {
-      return "this action";
-    }
-    if (value === "args") {
-      return "the command details";
-    }
-    if (value === "command") {
-      return "the command";
-    }
-    if (value === "headers") {
-      return "network details";
-    }
-    if (value === "tool_action_request") {
-      return "the requested action";
-    }
-    return value.replaceAll("_", " ");
-  });
-  return humanizeList(translated);
-}
-function buildPauseLine(item) {
-  if (item.policy_action === "block") {
-    return `${harnessDisplayName(item.harness)} kept this blocked because you already saved a block decision for it.`;
-  }
-  if (item.changed_fields.length === 1 && item.changed_fields[0] === "first_seen") {
-    return `${harnessDisplayName(item.harness)} has not run this exact action here before, so HOL Guard paused it for you to review.`;
-  }
-  return `${harnessDisplayName(item.harness)} wants to run something that changed since your last saved decision: ${humanizeChangedFields(item.changed_fields)}.`;
-}
-function buildRecommendation(item) {
-  if (item.changed_fields.length === 1 && item.changed_fields[0] === "first_seen") {
-    return "If this is what you expected, approve the exact action. Use broader trust only when you deliberately want Guard to ask less often.";
-  }
-  if (item.policy_action === "block") {
-    return "Keep it blocked unless you are sure this action is safe and expected.";
-  }
-  return "Approve the smallest choice that matches what you meant to do. Broader trust should be a deliberate second step.";
-}
-function buildQueueSummary(item) {
-  if (item.policy_action === "block") {
-    return "You already chose to block this action.";
-  }
-  if (item.changed_fields.length === 1 && item.changed_fields[0] === "first_seen") {
-    return "First time HOL Guard has seen this here.";
-  }
-  return `Changed since your last decision: ${humanizeChangedFields(item.changed_fields)}.`;
-}
-function buildMemorySummary(item, receipt) {
-  if (receipt === null) {
-    return `HOL Guard has not saved an earlier approval for ${item.artifact_name}.`;
-  }
-  return `The last saved decision for ${item.artifact_name} was ${receipt.policy_decision}.`;
-}
-function scopeLabel(scope) {
-  switch (scope) {
-    case "artifact":
-      return "This exact action";
-    case "workspace":
-      return "This project folder";
-    case "publisher":
-      return "This source in this app";
-    case "harness":
-      return "This app";
-    case "global":
-      return "Every project on this machine";
-    default:
-      return scope;
-  }
-}
-function policyActionLabel(action) {
-  switch (action) {
-    case "require-reapproval":
-      return "Needs review";
-    case "block":
-      return "Blocked";
-    case "allow":
-      return "Allowed";
-    default:
-      return action;
-  }
-}
-function artifactTypeLabel(artifactType) {
-  switch (artifactType) {
-    case "mcp_server":
-      return "MCP server";
-    case "extension":
-      return "Extension";
-    case "hook":
-      return "Hook";
-    case "agent":
-      return "Agent";
-    case "command":
-      return "Command";
-    case "tool_action_request":
-      return "Tool action";
-    default:
-      return artifactType.replaceAll("_", " ");
-  }
-}
-function buildStoppedReason(item, receipt) {
-  if (item.policy_action === "block") {
-    const changed = item.changed_fields.length > 0 ? ` ${humanizeChangedFields(item.changed_fields)} also changed.` : "";
-    return `A saved block decision already covers this action, so HOL Guard kept it paused.${changed}`;
-  }
-  if (item.changed_fields.length === 1 && item.changed_fields[0] === "first_seen") {
-    return "HOL Guard has never seen this action in this project folder before, so there is no saved approval for it yet.";
-  }
-  if (receipt !== null) {
-    return `HOL Guard found an earlier ${receipt.policy_decision} decision, but ${humanizeChangedFields(item.changed_fields)} no longer matches what you approved before.`;
-  }
-  return "This action changed after the last known state, so HOL Guard needs a new decision before it can run.";
-}
-function shortConfigPath(path) {
-  const sanitizedPath = path.replace(/\/Users\/[^/\s]+/g, "~");
-  const marker = "/.codex/";
-  const index = sanitizedPath.lastIndexOf(marker);
-  if (index >= 0) {
-    return `…${sanitizedPath.slice(index)}`;
-  }
-  return sanitizedPath;
-}
-function buildTechnicalSummary(_diff, item) {
-  return [["Approval command", item.review_command]];
-}
-function capitalizeHarness(harness) {
-  if (harness.length === 0) {
-    return harness;
-  }
-  return `${harness.charAt(0).toUpperCase()}${harness.slice(1)}`;
-}
-function resolveDecisionV2Title(item) {
-  const title = item.decision_v2_json?.user_title;
-  return title !== void 0 && title.trim().length > 0 ? title : null;
-}
-function resolveDecisionV2Detail(item) {
-  const detail = item.decision_v2_json?.dashboard_primary_detail;
-  return detail !== void 0 && detail.trim().length > 0 ? detail : null;
-}
-function resolveStoppedCommandText(item) {
-  if (item.action_envelope_json) {
-    const envelopeText = resolveEnvelopeDisplayText(item.action_envelope_json);
-    if (envelopeText !== null) {
-      return envelopeText;
-    }
-  }
-  if (item.launch_target?.trim()) {
-    return item.launch_target;
-  }
-  if (item.launch_summary?.trim()) {
-    const commandMatch = item.launch_summary.match(/`([^`]+)`/);
-    if (commandMatch?.[1]) {
-      return commandMatch[1];
-    }
-    return item.launch_summary;
-  }
-  return item.artifact_name.trim() || item.artifact_id;
-}
-function harnessDisplayName(harness) {
-  switch (harness) {
-    case "claude-code":
-      return "Claude Code";
-    case "copilot":
-      return "Copilot";
-    case "codex":
-      return "Codex";
-    case "opencode":
-      return "OpenCode";
-    case "gemini":
-      return "Gemini";
-    case "cursor":
-      return "Cursor";
-    case "hermes":
-      return "Hermes";
-    case "openclaw":
-      return "OpenClaw";
-    default:
-      return capitalizeHarness(harness);
-  }
-}
-function displayArtifactName(item) {
-  return item.artifact_name || item.artifact_id || "this action";
-}
-function resolveTerminalLabel(item) {
-  const actionType = item.action_envelope_json?.action_type;
-  if (actionType === "shell_command") return "Command";
-  if (actionType === "prompt") return "Prompt excerpt";
-  if (actionType === "file_read" || actionType === "file_write") return "File path";
-  if (actionType === "mcp_tool") return "MCP server / tool";
-  if (actionType === "package_script") return "Package";
-  if (actionType === "network_request") return "Network destination";
-  if (item.artifact_type === "file_read_request") return "File path";
-  if (item.artifact_type === "prompt_request") return "Prompt excerpt";
-  if (item.artifact_type === "tool_action_request") return "Tool action";
-  return "Stopped command";
 }
 function DataFlowEvidenceCard(props) {
   const evidence = deriveDataFlowEvidence(props.item);
@@ -14603,13 +14605,13 @@ function buildHomePrimaryState(pendingCount, watchedAppsCount) {
   if (watchedAppsCount === 0) {
     return {
       status: "setup_needed",
-      copy: "HOL Guard is running but no apps are connected yet.",
-      ctaLabel: "Connect an app"
+      copy: "Guard is running but no apps are connected yet.",
+      ctaLabel: "Set up protection"
     };
   }
   return {
     status: "protected",
-    copy: "HOL Guard is watching this machine. No blocked actions right now.",
+    copy: "Guard is protecting your apps. No blocked actions right now.",
     ctaLabel: "Open review queue"
   };
 }
@@ -14674,6 +14676,9 @@ function MobileQueueDrawer(props) {
     "div",
     {
       className: "fixed inset-0 z-50 flex lg:hidden",
+      role: "dialog",
+      "aria-label": "Review queue",
+      "aria-modal": "true",
       children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "absolute inset-0 bg-black/30 backdrop-blur-sm", onClick: props.onClose }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "relative ml-0 flex w-full max-w-sm flex-col overflow-hidden bg-white shadow-2xl", onClick: (e) => e.stopPropagation(), children: [
@@ -14728,10 +14733,18 @@ function QueueWorkspace(props) {
   if (props.requests.kind === "error") {
     const approvalUrl = props.runtime.kind === "ready" ? props.runtime.snapshot.approval_center_url : null;
     return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(Surface, { tone: "danger", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-purple", children: "Guard is not responding" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-purple", children: "Guard connection lost. Check if the daemon is running." }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-brand-purple/80", children: props.requests.message }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 flex flex-wrap gap-3", children: [
         props.onRepair !== void 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleRepair, disabled: repairing, children: repairing ? "Repairing…" : "Repair" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "a",
+          {
+            href: "x-terminal-emulator://",
+            className: "inline-flex min-h-10 items-center rounded-lg border border-brand-purple/30 bg-white px-3 py-2 text-sm font-medium text-brand-purple transition-colors hover:bg-brand-purple/5",
+            children: "Open Terminal"
+          }
+        ),
         props.onRetry && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "outline", onClick: props.onRetry, children: "Retry" }),
         approvalUrl && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: approvalUrl, variant: "outline", onClick: () => window.location.reload(), children: "Open dashboard" })
       ] })
@@ -14830,7 +14843,7 @@ function QueueHeader(props) {
           children: props.progressCopy
         }
       ),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs(Badge, { tone: "warning", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs(Badge, { tone: "default", children: [
         props.requests.length,
         " waiting"
       ] }),
@@ -14922,7 +14935,7 @@ function QueueBrowser(props) {
           }
         )
       ] }),
-      harnesses.length > 1 && /* @__PURE__ */ jsxRuntimeExports.jsx(
+      harnesses.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(
         QueueChipFilter,
         {
           harnesses,
@@ -15167,7 +15180,7 @@ function DecisionWorkspace(props) {
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniInformationCircle, { className: "mt-0.5 h-4 w-4 shrink-0 text-slate-400", "aria-hidden": "true" }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: "This request was already decided." }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: STALE_REQUEST_COPY }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-muted-foreground", children: "Someone already reviewed this blocked action. No further action needed." })
         ] })
       ] }),
@@ -15706,10 +15719,10 @@ function StatusBadge(props) {
     return /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "success", children: "Protected" });
   }
   if (props.status === "found_unprotected") {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "warning", children: "Found" });
+    return /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "warning", children: "Found, protection not installed" });
   }
   if (props.status === "needs_repair") {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "destructive", children: "Needs repair" });
+    return /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "warning", children: "Repair needed" });
   }
   if (props.status === "not_found") {
     return /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "default", children: "Not found" });
@@ -15733,7 +15746,7 @@ function CardAction(props) {
     return /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleConnect, children: "Connect" });
   }
   if (props.status === "needs_repair") {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "danger", onClick: handleRepair, children: "Repair" });
+    return /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "outline", onClick: handleRepair, children: "Repair" });
   }
   if (props.status === "not_found") {
     return /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: "https://hol.org/guard/docs/install", variant: "outline", children: "How to install" });
@@ -16736,7 +16749,12 @@ function AppsProtectedSection(props) {
       ...props.observedHarnesses
     ])
   ).sort();
-  if (allHarnesses.length === 0) return null;
+  if (allHarnesses.length === 0) {
+    return /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "rounded-[1.75rem] border border-slate-200/70 bg-white/80 p-5 shadow-sm sm:p-6", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Apps protected" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-3 text-sm text-muted-foreground", children: "None yet. Connect an AI harness to start." })
+    ] });
+  }
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "rounded-[1.75rem] border border-slate-200/70 bg-white/80 p-5 shadow-sm sm:p-6", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Apps protected" }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 overflow-hidden rounded-[1.25rem] border border-slate-200/70", children: allHarnesses.map((harness) => {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -14737,14 +14737,7 @@ function QueueWorkspace(props) {
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-brand-purple/80", children: props.requests.message }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 flex flex-wrap gap-3", children: [
         props.onRepair !== void 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleRepair, disabled: repairing, children: repairing ? "Repairing…" : "Repair" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "a",
-          {
-            href: "x-terminal-emulator://",
-            className: "inline-flex min-h-10 items-center rounded-lg border border-brand-purple/30 bg-white px-3 py-2 text-sm font-medium text-brand-purple transition-colors hover:bg-brand-purple/5",
-            children: "Open Terminal"
-          }
-        ),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("code", { className: "inline-flex min-h-10 items-center rounded-lg border border-brand-purple/30 bg-slate-50 px-3 py-2 font-mono text-sm text-brand-purple select-all", children: "hol-guard start" }),
         props.onRetry && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "outline", onClick: props.onRetry, children: "Retry" }),
         approvalUrl && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: approvalUrl, variant: "outline", onClick: () => window.location.reload(), children: "Open dashboard" })
       ] })

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -1294,6 +1294,16 @@
     }
   }
 
+  .border-brand-purple\/30 {
+    border-color: var(--brand-purple);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .border-brand-purple\/30 {
+      border-color: color-mix(in oklab, var(--brand-purple) 30%, transparent);
+    }
+  }
+
   .border-brand-purple\/35 {
     border-color: var(--brand-purple);
   }
@@ -2806,6 +2816,16 @@
       }
     }
 
+    .hover\:bg-brand-purple\/5:hover {
+      background-color: var(--brand-purple);
+    }
+
+    @supports (color: color-mix(in lab, red, red)) {
+      .hover\:bg-brand-purple\/5:hover {
+        background-color: color-mix(in oklab, var(--brand-purple) 5%, transparent);
+      }
+    }
+
     .hover\:bg-brand-purple\/90:hover {
       background-color: var(--brand-purple);
     }
@@ -3343,16 +3363,6 @@ body {
   }
 }
 
-@keyframes guard-checkmark-draw {
-  from {
-    stroke-dashoffset: 24px;
-  }
-
-  to {
-    stroke-dashoffset: 0;
-  }
-}
-
 @keyframes guard-fade-scale {
   from {
     opacity: 0;
@@ -3369,29 +3379,11 @@ body {
   animation: guard-enter .32s var(--ease-out-quint) both;
 }
 
-.guard-delay-1 {
-  animation-delay: 60ms;
-}
-
-.guard-delay-2 {
-  animation-delay: .12s;
-}
-
-.guard-delay-3 {
-  animation-delay: .18s;
-}
-
 .guard-skeleton {
   background: linear-gradient(90deg, var(--surface-1) 25%, var(--surface-2) 50%, var(--surface-1) 75%);
   background-size: 200% 100%;
   border-radius: 8px;
   animation: 1.5s infinite guard-shimmer;
-}
-
-.guard-success-check {
-  stroke-dasharray: 24;
-  stroke-dashoffset: 24px;
-  animation: guard-checkmark-draw .4s var(--ease-out-quart) .15s forwards;
 }
 
 .guard-fade-in {
@@ -3421,7 +3413,7 @@ input:focus-visible, button:focus-visible, a:focus-visible {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .guard-surface-in, .guard-delay-1, .guard-delay-2, .guard-delay-3, .guard-success-check, .guard-fade-in, .guard-skeleton {
+  .guard-surface-in, .guard-fade-in, .guard-skeleton {
     animation: none !important;
   }
 

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -2731,6 +2731,11 @@
     transition-duration: .3s;
   }
 
+  .select-all {
+    -webkit-user-select: all;
+    user-select: all;
+  }
+
   .select-none {
     -webkit-user-select: none;
     user-select: none;
@@ -2813,16 +2818,6 @@
     @supports (color: color-mix(in lab, red, red)) {
       .hover\:bg-brand-blue\/\[0\.035\]:hover {
         background-color: color-mix(in oklab, var(--brand-blue) 3.5%, transparent);
-      }
-    }
-
-    .hover\:bg-brand-purple\/5:hover {
-      background-color: var(--brand-purple);
-    }
-
-    @supports (color: color-mix(in lab, red, red)) {
-      .hover\:bg-brand-purple\/5:hover {
-        background-color: color-mix(in oklab, var(--brand-purple) 5%, transparent);
       }
     }
 

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -790,9 +790,7 @@ class GuardStore:
         connection.execute(f"alter table approval_requests add column {column_name} {column_type}")
 
     @staticmethod
-    def _ensure_column(
-        connection: sqlite3.Connection, table_name: str, column_name: str, column_type: str
-    ) -> None:
+    def _ensure_column(connection: sqlite3.Connection, table_name: str, column_name: str, column_type: str) -> None:
         rows = connection.execute(f"pragma table_info({table_name})").fetchall()
         existing = {str(row["name"]) for row in rows}
         if column_name in existing:


### PR DESCRIPTION
## Summary

- Review queue empty state: friendly copy instead of blank screen
- Stale request: clear 'This request was already decided.' message
- API error: 'Guard connection lost. Check if the daemon is running.' with terminal link
- Mobile queue drawer: ARIA dialog role and modal semantics
- Harness filter chips: visible when any harness present (not only plural)
- Queue badge: default tone instead of warning amber for pending count
- Home dashboard: apps-protected section shows 'None yet. Connect an AI harness to start.' instead of empty
- Watched app: softer badge copy ('Found, protection not installed', 'Repair needed') and outline repair button
- Cloud sync stale maps to plain-language status label
- Setup CTA: 'Set up protection'
- Jargon removed: no daemon/runtime/v1/MCP/harness/artifact in user-facing copy

## Tests

- All existing tests pass
- New: home-dashboard C1-C4 (jargon-free copy, no duplicate CTAs, setup labels)
- New: approval-center-layout C5-C6 (empty state and stale state constants)

## Verification

```
cd dashboard && pnpm test && pnpm build
```