### PR TITLE
fix(guard): persist scoped approval retries

### DIFF
--- a/dashboard/src/approval-center-layout.test.ts
+++ b/dashboard/src/approval-center-layout.test.ts
@@ -5,6 +5,8 @@ import {
   displayArtifactName,
   EMPTY_QUEUE_TITLE,
   STALE_REQUEST_COPY,
+  buildRecommendation,
+  scopeLabel,
 } from "./approval-center-utils";
 import type { GuardActionEnvelope, GuardApprovalRequest } from "./guard-types";
 
@@ -207,4 +209,19 @@ assert(
 assert(
   STALE_REQUEST_COPY.toLowerCase().includes("already decided"),
   'C6: Stale request copy contains "already decided" — not approve/block buttons'
+);
+
+assert(
+  scopeLabel("artifact") === "This retry only",
+  "C7: Artifact scope copy makes one-retry behavior clear"
+);
+
+assert(
+  scopeLabel("workspace") === "Same action in this project",
+  "C8: Workspace scope copy makes same-action project behavior clear"
+);
+
+assert(
+  buildRecommendation(BASE_REQUEST).includes("Project approval remembers this same action"),
+  "C9: Recommendation explains project approval does not trust new sensitive actions"
 );

--- a/dashboard/src/approval-center-layout.tsx
+++ b/dashboard/src/approval-center-layout.tsx
@@ -289,7 +289,11 @@ function QueueWorkspace(props: {
     const approvalUrl =
       props.runtime.kind === "ready" ? props.runtime.snapshot.approval_center_url : null;
     const handleOpenDaemon = () => {
-      window.open("http://localhost:7957", "_blank");
+      if (approvalUrl !== null) {
+        window.open(approvalUrl, "_blank", "noopener,noreferrer");
+      } else {
+        void handleRepair();
+      }
     };
     return (
       <div className="space-y-4">

--- a/dashboard/src/approval-center-layout.tsx
+++ b/dashboard/src/approval-center-layout.tsx
@@ -131,8 +131,16 @@ type LayoutProps = {
 };
 
 const scopeOptions: Array<{ value: DecisionScope; label: string; description: string }> = [
-  { value: "artifact", label: "This exact action", description: "Ask again if the command or tool details change." },
-  { value: "workspace", label: "This project folder", description: "Remember this choice only for this project." },
+  {
+    value: "artifact",
+    label: "This retry only",
+    description: "Remember this exact prompt, command, tool, path, or host fingerprint."
+  },
+  {
+    value: "workspace",
+    label: "Same action in this project",
+    description: "Skip the next prompt for this same action here; different sensitive actions still ask."
+  },
   { value: "publisher", label: "This source", description: "Trust future actions from the same source in this app." },
   { value: "harness", label: "This app", description: "Trust matching actions from this app." },
   { value: "global", label: "Every project", description: "Use this choice across this machine." }

--- a/dashboard/src/approval-center-layout.tsx
+++ b/dashboard/src/approval-center-layout.tsx
@@ -59,6 +59,7 @@ import {
 } from "./approval-center-review-cards";
 import {
   buildProgressCopy,
+  buildNextUpChipText,
   sortQueue,
   searchQueue,
   groupDuplicates,
@@ -279,15 +280,21 @@ function QueueWorkspace(props: {
   if (props.requests.kind === "error") {
     const approvalUrl =
       props.runtime.kind === "ready" ? props.runtime.snapshot.approval_center_url : null;
+    const handleOpenDaemon = () => {
+      window.open("http://localhost:7957", "_blank");
+    };
     return (
       <div className="space-y-4">
         <Surface tone="danger">
-          <p className="text-sm font-semibold text-brand-purple">Guard connection lost. Check if the daemon is running.</p>
+          <p className="text-sm font-semibold text-brand-purple">Guard daemon not responding — click to reconnect.</p>
           <p className="mt-1 text-sm text-brand-purple/80">{props.requests.message}</p>
           <div className="mt-4 flex flex-wrap gap-3">
+            <ActionButton onClick={handleOpenDaemon}>
+              Repair
+            </ActionButton>
             {props.onRepair !== undefined && (
-              <ActionButton onClick={handleRepair} disabled={repairing}>
-                {repairing ? "Repairing…" : "Repair"}
+              <ActionButton onClick={handleRepair} disabled={repairing} variant="outline">
+                {repairing ? "Repairing…" : "Reconnect"}
               </ActionButton>
             )}
             <code className="inline-flex min-h-10 items-center rounded-lg border border-brand-purple/30 bg-slate-50 px-3 py-2 font-mono text-sm text-brand-purple select-all">hol-guard start</code>
@@ -515,7 +522,7 @@ function QueueBrowser(props: {
             className="min-h-11 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-brand-dark placeholder:text-slate-400 transition-colors duration-150 focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
           />
         </label>
-        {harnesses.length > 0 && (
+        {harnesses.length >= 2 && (
           <QueueChipFilter
             harnesses={harnesses}
             activeFilter={harnessFilter}
@@ -589,8 +596,8 @@ function QueueCardRow(props: {
       {props.nextUpItem !== null && (
         <div className="border-t border-slate-100 bg-slate-50/60 px-4 py-2">
           <p className="truncate text-[11px] text-muted-foreground">
-            <span className="font-semibold">Next up:</span>{" "}
-            {displayArtifactName(props.nextUpItem)}
+            <span className="font-semibold">Next:</span>{" "}
+            {buildNextUpChipText(props.nextUpItem)}
           </p>
         </div>
       )}
@@ -687,6 +694,7 @@ function DecisionWorkspace(props: {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [confirmPending, setConfirmPending] = useState<"allow" | "block" | null>(null);
   const [resolvedBanner, setResolvedBanner] = useState<"allow" | "block" | null>(null);
+  const [resolvedState, setResolvedState] = useState<"idle" | "decided" | "loaded">("idle");
   const bannerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevRequestIdRef = useRef<string | null>(null);
 
@@ -696,6 +704,7 @@ function DecisionWorkspace(props: {
       prevRequestIdRef.current = props.detail.item.request_id;
       if (isNewItem) {
         setResolvedBanner(null);
+        setResolvedState("loaded");
         if (bannerTimerRef.current !== null) {
           clearTimeout(bannerTimerRef.current);
           bannerTimerRef.current = null;
@@ -731,6 +740,7 @@ function DecisionWorkspace(props: {
           reason,
           workspace: scope === "workspace" ? readyWorkspace : undefined,
         });
+        setResolvedState("decided");
         setResolvedBanner(action);
         bannerTimerRef.current = setTimeout(() => {
           setResolvedBanner(null);
@@ -800,6 +810,16 @@ function DecisionWorkspace(props: {
   if (props.detail.kind === "loading") {
     return (
       <div className="space-y-4">
+        {resolvedState === "decided" && (
+          <div
+            className="flex items-center gap-3 rounded-2xl border border-brand-green/25 bg-brand-green-bg/30 px-4 py-3"
+            role="status"
+            aria-live="polite"
+          >
+            <HiMiniCheckCircle className="h-4 w-4 shrink-0 text-brand-green" aria-hidden="true" />
+            <p className="text-sm font-medium text-brand-green-text">Decided — loading next…</p>
+          </div>
+        )}
         <div className="guard-skeleton h-8 w-48" />
         <div className="guard-skeleton h-40 w-full" />
         <div className="guard-skeleton h-56 w-full" />

--- a/dashboard/src/approval-center-primitives.tsx
+++ b/dashboard/src/approval-center-primitives.tsx
@@ -92,11 +92,13 @@ export function ShellHeader(props: {
           <button
             type="button"
             onClick={props.onOpenMobileQueue}
-            aria-label="Open queue list"
+            aria-label={`Open queue list — ${props.queuedCount} decisions waiting`}
             className="inline-flex min-h-11 shrink-0 items-center gap-1.5 rounded-full border border-white/25 bg-white/10 px-3 py-2 text-sm font-semibold text-white no-underline transition-colors duration-150 hover:bg-white/15"
           >
             <HiBars3 className="h-4 w-4" aria-hidden="true" />
-            {props.queuedCount > 99 ? "99+" : props.queuedCount}
+            {props.queuedCount > 1
+              ? `${props.queuedCount > 99 ? "99+" : props.queuedCount} decisions waiting`
+              : props.queuedCount}
           </button>
         )}
         {(!props.onOpenMobileQueue || props.view !== "inbox" || props.queuedCount === 0) && (
@@ -541,7 +543,7 @@ export function WelcomeState(props: {
       </div>
       <h2 className="text-2xl font-semibold tracking-tight text-brand-dark sm:text-3xl">{EMPTY_QUEUE_TITLE}</h2>
       <p className="mx-auto mt-4 max-w-lg text-[15px] leading-relaxed text-muted-foreground">
-        Guard is still watching your apps. You'll be notified here if something needs your approval.
+        Guard is still watching your apps.
       </p>
       
       <div className="mt-12 text-left w-full max-w-3xl">

--- a/dashboard/src/approval-center-primitives.tsx
+++ b/dashboard/src/approval-center-primitives.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent, ReactNode } from "react";
+import type { ButtonHTMLAttributes, ChangeEvent, ReactNode } from "react";
 import {
   HiMiniArrowTopRightOnSquare,
   HiMiniCloud,
@@ -296,29 +296,31 @@ export function EmptyState(props: {
   );
 }
 
-export function ActionButton(props: {
+type ActionButtonProps = {
   children: ReactNode;
   onClick?: () => void;
   href?: string;
   variant?: "primary" | "secondary" | "danger" | "outline" | "ghost" | "success";
   disabled?: boolean;
-}) {
-  const className = actionButtonClass(props.variant);
-  if (props.href) {
+} & Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children" | "className" | "onClick" | "type">;
+
+export function ActionButton({ children, href, variant, disabled, onClick, ...buttonProps }: ActionButtonProps) {
+  const className = actionButtonClass(variant);
+  if (href) {
     return (
       <a
-        href={guardAwareHref(props.href)}
-        target={props.href.startsWith("https://") ? "_blank" : undefined}
-        rel={props.href.startsWith("https://") ? "noreferrer" : undefined}
+        href={guardAwareHref(href)}
+        target={href.startsWith("https://") ? "_blank" : undefined}
+        rel={href.startsWith("https://") ? "noreferrer" : undefined}
         className={className}
       >
-        {props.children}
+        {children}
       </a>
     );
   }
   return (
-    <button type="button" className={className} onClick={props.onClick} disabled={props.disabled}>
-      {props.children}
+    <button type="button" className={className} onClick={onClick} disabled={disabled} {...buttonProps}>
+      {children}
     </button>
   );
 }

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -131,12 +131,12 @@ export function buildPauseLine(item: GuardApprovalRequest): string {
 
 export function buildRecommendation(item: GuardApprovalRequest): string {
   if (item.changed_fields.length === 1 && item.changed_fields[0] === "first_seen") {
-    return "If this is what you expected, approve the exact action. Use broader trust only when you deliberately want Guard to ask less often.";
+    return "If this is what you expected, approve this retry. Project approval remembers this same action here without trusting new sensitive actions.";
   }
   if (item.policy_action === "block") {
     return "Keep it blocked unless you are sure this action is safe and expected.";
   }
-  return "Approve the smallest choice that matches what you meant to do. Broader trust should be a deliberate second step.";
+  return "Approve the smallest choice that matches what you meant to do. Different commands, prompts, paths, hosts, or tools should ask again.";
 }
 
 export function buildQueueSummary(item: GuardApprovalRequest): string {
@@ -162,9 +162,9 @@ export function buildMemorySummary(
 export function scopeLabel(scope: string): string {
   switch (scope) {
     case "artifact":
-      return "This exact action";
+      return "This retry only";
     case "workspace":
-      return "This project folder";
+      return "Same action in this project";
     case "publisher":
       return "This source in this app";
     case "harness":

--- a/dashboard/src/home-dashboard.tsx
+++ b/dashboard/src/home-dashboard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 
 import {
   HiMiniCheckCircle,
@@ -176,8 +176,6 @@ export function HomeWorkspace(props: {
         cloudState={snapshot.cloud_state}
         connectUrl={snapshot.connect_url}
         fleetUrl={snapshot.fleet_url}
-        activeInstallsCount={activeInstalls.length}
-        latestReceiptsCount={snapshot.latest_receipts.length}
         onOpenInbox={props.onOpenInbox}
         onOpenFleet={props.onOpenFleet}
       />
@@ -239,13 +237,9 @@ function ProtectionHero(props: {
   cloudState: "local_only" | "paired_waiting" | "paired_active";
   connectUrl: string;
   fleetUrl: string;
-  activeInstallsCount: number;
-  latestReceiptsCount: number;
   onOpenInbox: () => void;
   onOpenFleet: () => void;
 }) {
-  const [testRunning, setTestRunning] = useState(false);
-
   const handlePrimaryCta = useCallback(() => {
     if (props.status === "setup_needed") {
       props.onOpenFleet();
@@ -253,15 +247,6 @@ function ProtectionHero(props: {
       props.onOpenInbox();
     }
   }, [props.status, props.onOpenInbox, props.onOpenFleet]);
-
-  const handleRunTest = useCallback(() => {
-    setTestRunning(true);
-    fetch("/v1/protect/test")
-      .catch(() => undefined)
-      .finally(() => {
-        setTestRunning(false);
-      });
-  }, []);
 
   const heroBg = heroBackgroundClass(props.status);
   const statusBadge =
@@ -275,9 +260,6 @@ function ProtectionHero(props: {
 
   const showConnectCta =
     props.cloudState === "local_only" && !props.syncConfigured;
-
-  const showTestProtection =
-    props.activeInstallsCount > 0 && props.latestReceiptsCount === 0;
 
   const showGuardCloud = props.cloudState !== "local_only";
 
@@ -299,11 +281,6 @@ function ProtectionHero(props: {
           <ActionButton onClick={handlePrimaryCta} data-primary="true" aria-label={props.ctaLabel}>
             {props.ctaLabel}
           </ActionButton>
-          {showTestProtection && (
-            <ActionButton onClick={handleRunTest} variant="secondary" disabled={testRunning}>
-              {testRunning ? "Running test…" : "Run a quick protection test"}
-            </ActionButton>
-          )}
           {showConnectCta && props.status !== "needs_decision" && (
             <ActionButton href={props.connectUrl} variant="secondary">
               Connect this machine
@@ -312,7 +289,7 @@ function ProtectionHero(props: {
         </div>
         {showGuardCloud && (
           <a
-            href="https://hol.org/guard"
+            href={props.fleetUrl}
             target="_blank"
             rel="noreferrer"
             className="inline-flex items-center gap-1 text-sm font-medium text-brand-blue transition-colors hover:text-brand-blue/70"

--- a/dashboard/src/home-dashboard.tsx
+++ b/dashboard/src/home-dashboard.tsx
@@ -1,9 +1,10 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 
 import {
   HiMiniCheckCircle,
   HiMiniExclamationCircle,
   HiMiniMinusCircle,
+  HiMiniArrowTopRightOnSquare,
 } from "react-icons/hi2";
 import {
   ActionButton,
@@ -48,6 +49,55 @@ function heroBackgroundClass(status: HomeProtectionStatus): string {
     return "bg-[radial-gradient(circle_at_top_left,rgba(85,153,254,0.12),transparent_32%),linear-gradient(135deg,#ffffff_0%,#ffffff_58%,rgba(85,153,254,0.06)_100%)]";
   }
   return "bg-[radial-gradient(circle_at_top_left,rgba(85,153,254,0.12),transparent_32%),linear-gradient(135deg,#ffffff_0%,#ffffff_58%,rgba(72,223,123,0.10)_100%)]";
+}
+
+const KNOWN_HARNESSES = [
+  "codex",
+  "claude-code",
+  "opencode",
+  "copilot",
+  "gemini",
+  "cursor",
+  "hermes",
+  "openclaw",
+] as const;
+
+type SetupSuggestionRowProps = {
+  harness: string;
+};
+
+function SetupSuggestionRow(props: SetupSuggestionRowProps) {
+  return (
+    <li className="flex items-center justify-between gap-3 border-b border-slate-200/70 px-4 py-3 last:border-b-0">
+      <p className="text-sm text-brand-dark">
+        Set up <span className="font-medium">{harnessDisplayName(props.harness)}</span> →{" "}
+        <span className="font-mono text-xs text-brand-blue">
+          hol-guard apps connect {props.harness}
+        </span>
+      </p>
+    </li>
+  );
+}
+
+type SetupSuggestionsSectionProps = {
+  configuredHarnesses: string[];
+};
+
+function SetupSuggestionsSection(props: SetupSuggestionsSectionProps) {
+  const unconfigured = KNOWN_HARNESSES.filter(
+    (h) => !props.configuredHarnesses.includes(h)
+  );
+  if (unconfigured.length === 0) return null;
+  return (
+    <section className="rounded-[1.75rem] border border-slate-200/70 bg-white/80 p-5 shadow-sm sm:p-6">
+      <SectionLabel>Connect more apps</SectionLabel>
+      <ul className="mt-3 overflow-hidden rounded-[1.25rem] border border-slate-200/70">
+        {unconfigured.slice(0, 4).map((harness) => (
+          <SetupSuggestionRow key={harness} harness={harness} />
+        ))}
+      </ul>
+    </section>
+  );
 }
 
 function ClearHarnessButton(props: {
@@ -145,6 +195,10 @@ export function HomeWorkspace(props: {
         observedHarnesses={observedHarnesses}
       />
 
+      {primaryState.status === "setup_needed" && (
+        <SetupSuggestionsSection configuredHarnesses={observedHarnesses} />
+      )}
+
       {snapshot.latest_receipts.length > 0 && (
         <RecentProtectionSection receipts={snapshot.latest_receipts} />
       )}
@@ -190,6 +244,8 @@ function ProtectionHero(props: {
   onOpenInbox: () => void;
   onOpenFleet: () => void;
 }) {
+  const [testRunning, setTestRunning] = useState(false);
+
   const handlePrimaryCta = useCallback(() => {
     if (props.status === "setup_needed") {
       props.onOpenFleet();
@@ -197,6 +253,15 @@ function ProtectionHero(props: {
       props.onOpenInbox();
     }
   }, [props.status, props.onOpenInbox, props.onOpenFleet]);
+
+  const handleRunTest = useCallback(() => {
+    setTestRunning(true);
+    fetch("/v1/protect/test")
+      .catch(() => undefined)
+      .finally(() => {
+        setTestRunning(false);
+      });
+  }, []);
 
   const heroBg = heroBackgroundClass(props.status);
   const statusBadge =
@@ -214,23 +279,29 @@ function ProtectionHero(props: {
   const showTestProtection =
     props.activeInstallsCount > 0 && props.latestReceiptsCount === 0;
 
+  const showGuardCloud = props.cloudState !== "local_only";
+
   return (
     <section
       className={`guard-surface-in relative overflow-hidden rounded-[2rem] border border-brand-blue/15 ${heroBg} p-5 shadow-[0_20px_60px_rgba(63,65,116,0.08)] sm:p-6 lg:p-7`}
+      role="region"
+      aria-label="Protection status"
     >
       <div className="pointer-events-none absolute right-10 top-8 h-24 w-24 rounded-full bg-brand-blue/20 blur-3xl" />
       <div className="relative space-y-4">
         <div className="flex flex-wrap items-center gap-2">
           <SectionLabel>Protection status</SectionLabel>
           {statusBadge}
-          {props.cloudState !== "local_only" && <Tag tone="blue">Cloud synced</Tag>}
+          {props.cloudState !== "local_only" && <Tag tone="blue">Cloud backup up to date</Tag>}
         </div>
         <h2 className="text-xl font-semibold tracking-tight text-brand-dark">{props.copy}</h2>
         <div className="flex flex-wrap gap-3">
-          <ActionButton onClick={handlePrimaryCta}>{props.ctaLabel}</ActionButton>
+          <ActionButton onClick={handlePrimaryCta} data-primary="true" aria-label={props.ctaLabel}>
+            {props.ctaLabel}
+          </ActionButton>
           {showTestProtection && (
-            <ActionButton href={props.fleetUrl} variant="secondary">
-              Test protection
+            <ActionButton onClick={handleRunTest} variant="secondary" disabled={testRunning}>
+              {testRunning ? "Running test…" : "Run a quick protection test"}
             </ActionButton>
           )}
           {showConnectCta && props.status !== "needs_decision" && (
@@ -239,6 +310,17 @@ function ProtectionHero(props: {
             </ActionButton>
           )}
         </div>
+        {showGuardCloud && (
+          <a
+            href="https://hol.org/guard"
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 text-sm font-medium text-brand-blue transition-colors hover:text-brand-blue/70"
+          >
+            Open Guard Cloud
+            <HiMiniArrowTopRightOnSquare className="h-3.5 w-3.5" aria-hidden="true" />
+          </a>
+        )}
       </div>
     </section>
   );

--- a/dashboard/src/queue-state.ts
+++ b/dashboard/src/queue-state.ts
@@ -1,3 +1,4 @@
+import { useRef, useCallback } from "react";
 import type { GuardApprovalRequest, GuardQueueResolutionResult } from "./guard-types";
 
 export type QueueSortDirection = "newest" | "oldest";
@@ -161,6 +162,29 @@ export function resolveStaleRequestRecovery(
     return activeRequestId;
   }
   return items[0]?.request_id ?? null;
+}
+
+export type IsResolvingGuard = {
+  isResolvingRef: React.RefObject<boolean>;
+  setResolving: (value: boolean) => void;
+};
+
+export function useIsResolving(): IsResolvingGuard {
+  const isResolvingRef = useRef(false);
+  const setResolving = useCallback((value: boolean) => {
+    isResolvingRef.current = value;
+  }, []);
+  return { isResolvingRef, setResolving };
+}
+
+export function buildNextUpChipText(item: GuardApprovalRequest): string {
+  const envelope = item.action_envelope_json;
+  const preview =
+    envelope?.command?.slice(0, 40) ??
+    envelope?.mcp_tool ??
+    envelope?.prompt_excerpt?.slice(0, 40) ??
+    item.artifact_type;
+  return `${item.harness} — ${preview}`;
 }
 
 export function buildHomePrimaryState(

--- a/dashboard/src/runtime-overview.tsx
+++ b/dashboard/src/runtime-overview.tsx
@@ -120,7 +120,9 @@ function cloudSyncHealthTone(state: GuardCloudSyncHealth["state"]): "blue" | "sl
 
 function humanizeCloudSyncHealthLabel(label: string): string {
   const labels: Record<string, string> = {
-    "Cloud sync stale": "Your protection history hasn't synced recently",
+    "Cloud sync stale": "Cloud backup is out of date",
+    "Cloud sync healthy": "Cloud backup up to date",
+    "First shared proof": "First cloud backup",
   };
   return labels[label] ?? label;
 }
@@ -131,7 +133,7 @@ function CloudSyncHealthCard(props: { health: GuardCloudSyncHealth }) {
     <div className="rounded-xl border border-border bg-white px-5 py-4">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <p className="text-xs font-semibold uppercase tracking-[0.18em] text-brand-blue">
-          Cloud sync health
+          Guard cloud backup
         </p>
         <Tag tone={cloudSyncHealthTone(props.health.state)}>{humanizeCloudSyncHealthLabel(copy.label)}</Tag>
       </div>

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -23,6 +23,13 @@ GUARD_DASHBOARD_URL = "https://hol.org/guard"
 GUARD_INBOX_URL = f"{GUARD_DASHBOARD_URL}/inbox"
 GUARD_FLEET_URL = f"{GUARD_DASHBOARD_URL}/fleet"
 GUARD_CONNECT_URL = f"{GUARD_DASHBOARD_URL}/connect"
+_WORKSPACE_SCOPED_RUNTIME_ARTIFACT_TYPES = frozenset(
+    {
+        "file_read_request",
+        "prompt_request",
+        "tool_action_request",
+    }
+)
 
 
 class ApprovalRequestNotFoundError(ValueError):
@@ -133,12 +140,13 @@ def apply_approval_resolution(
         raise ValueError(f"Approval request {request_id} requires --workspace for workspace scope.")
     if scope == "publisher" and not isinstance(request.get("publisher"), str):
         raise ValueError(f"Approval request {request_id} has no publisher scope to approve.")
+    workspace_artifact_id, workspace_artifact_hash = _workspace_policy_artifact_keys(request, scope)
     decision = PolicyDecision(
         harness="*" if scope == "global" else str(request["harness"]),
         scope=scope,
         action="allow" if action == "allow" else "block",
-        artifact_id=str(request["artifact_id"]) if scope == "artifact" else None,
-        artifact_hash=str(request["artifact_hash"]) if scope == "artifact" else None,
+        artifact_id=str(request["artifact_id"]) if scope == "artifact" else workspace_artifact_id,
+        artifact_hash=str(request["artifact_hash"]) if scope == "artifact" else workspace_artifact_hash,
         workspace=workspace if scope == "workspace" else None,
         publisher=str(request["publisher"]) if scope == "publisher" else None,
         reason=reason,
@@ -164,7 +172,7 @@ def apply_approval_resolution(
             resolved_scope_ids = store.resolve_matching_approval_requests(
                 harness=resolution_harness,
                 scope=scope,
-                artifact_id=str(request["artifact_id"]) if scope == "artifact" else None,
+                artifact_id=str(request["artifact_id"]) if scope == "artifact" else workspace_artifact_id,
                 workspace=workspace if scope == "workspace" else None,
                 publisher=(
                     str(request["publisher"])
@@ -184,7 +192,7 @@ def apply_approval_resolution(
         resolved_ids = store.resolve_matching_approval_requests(
             harness=resolution_harness,
             scope=scope,
-            artifact_id=str(request["artifact_id"]) if scope == "artifact" else None,
+            artifact_id=str(request["artifact_id"]) if scope == "artifact" else workspace_artifact_id,
             workspace=workspace if scope == "workspace" else None,
             publisher=(
                 str(request["publisher"])
@@ -208,6 +216,18 @@ def apply_approval_resolution(
     if updated is None:
         raise ValueError(f"Approval request disappeared: {request_id}")
     return updated
+
+
+def _workspace_policy_artifact_keys(request: Mapping[str, object], scope: str) -> tuple[str | None, str | None]:
+    if scope != "workspace" or request.get("artifact_type") not in _WORKSPACE_SCOPED_RUNTIME_ARTIFACT_TYPES:
+        return None, None
+    artifact_id = request.get("artifact_id")
+    artifact_hash = request.get("artifact_hash")
+    if not isinstance(artifact_id, str) or not artifact_id:
+        return None, None
+    if not isinstance(artifact_hash, str) or not artifact_hash:
+        return artifact_id, None
+    return artifact_id, artifact_hash
 
 
 def _refresh_queue_result(

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3399,6 +3399,13 @@ def _runtime_stored_policy_action(
         and scope in {"workspace", "publisher", "harness", "global"}
         and _runtime_artifact_risk_classes(artifact)
     ):
+        if scope == "workspace":
+            decision_artifact_id = _optional_string(decision.get("artifact_id"))
+            decision_artifact_hash = _optional_string(decision.get("artifact_hash"))
+            if decision_artifact_id == artifact_id and (
+                decision_artifact_hash is None or decision_artifact_hash == artifact_hash
+            ):
+                return action
         return None
     return action
 

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13496,12 +13496,12 @@ function buildPauseLine(item) {
 }
 function buildRecommendation(item) {
   if (item.changed_fields.length === 1 && item.changed_fields[0] === "first_seen") {
-    return "If this is what you expected, approve the exact action. Use broader trust only when you deliberately want Guard to ask less often.";
+    return "If this is what you expected, approve this retry. Project approval remembers this same action here without trusting new sensitive actions.";
   }
   if (item.policy_action === "block") {
     return "Keep it blocked unless you are sure this action is safe and expected.";
   }
-  return "Approve the smallest choice that matches what you meant to do. Broader trust should be a deliberate second step.";
+  return "Approve the smallest choice that matches what you meant to do. Different commands, prompts, paths, hosts, or tools should ask again.";
 }
 function buildQueueSummary(item) {
   if (item.policy_action === "block") {
@@ -13521,9 +13521,9 @@ function buildMemorySummary(item, receipt) {
 function scopeLabel(scope) {
   switch (scope) {
     case "artifact":
-      return "This exact action";
+      return "This retry only";
     case "workspace":
-      return "This project folder";
+      return "Same action in this project";
     case "publisher":
       return "This source in this app";
     case "harness":
@@ -14621,8 +14621,16 @@ function buildHomePrimaryState(pendingCount, watchedAppsCount) {
   };
 }
 const scopeOptions = [
-  { value: "artifact", label: "This exact action", description: "Ask again if the command or tool details change." },
-  { value: "workspace", label: "This project folder", description: "Remember this choice only for this project." },
+  {
+    value: "artifact",
+    label: "This retry only",
+    description: "Remember this exact prompt, command, tool, path, or host fingerprint."
+  },
+  {
+    value: "workspace",
+    label: "Same action in this project",
+    description: "Skip the next prompt for this same action here; different sensitive actions still ask."
+  },
   { value: "publisher", label: "This source", description: "Trust future actions from the same source in this app." },
   { value: "harness", label: "This app", description: "Trust matching actions from this app." },
   { value: "global", label: "Every project", description: "Use this choice across this machine." }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13696,11 +13696,11 @@ function ShellHeader(props) {
           {
             type: "button",
             onClick: props.onOpenMobileQueue,
-            "aria-label": "Open queue list",
+            "aria-label": `Open queue list — ${props.queuedCount} decisions waiting`,
             className: "inline-flex min-h-11 shrink-0 items-center gap-1.5 rounded-full border border-white/25 bg-white/10 px-3 py-2 text-sm font-semibold text-white no-underline transition-colors duration-150 hover:bg-white/15",
             children: [
               /* @__PURE__ */ jsxRuntimeExports.jsx(HiBars3, { className: "h-4 w-4", "aria-hidden": "true" }),
-              props.queuedCount > 99 ? "99+" : props.queuedCount
+              props.queuedCount > 1 ? `${props.queuedCount > 99 ? "99+" : props.queuedCount} decisions waiting` : props.queuedCount
             ]
           }
         ),
@@ -13954,7 +13954,7 @@ function WelcomeState(props) {
     props.resolutionMessage && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mb-10 w-full max-w-xl flex justify-center", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Surface, { tone: "success", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-green-text", children: props.resolutionMessage }) }) }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-brand-green-bg/50 ring-1 ring-brand-green/20", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "h-10 w-10 text-brand-green", "aria-hidden": "true" }) }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "text-2xl font-semibold tracking-tight text-brand-dark sm:text-3xl", children: EMPTY_QUEUE_TITLE }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mx-auto mt-4 max-w-lg text-[15px] leading-relaxed text-muted-foreground", children: "Guard is still watching your apps. You'll be notified here if something needs your approval." }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mx-auto mt-4 max-w-lg text-[15px] leading-relaxed text-muted-foreground", children: "Guard is still watching your apps." }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-12 text-left w-full max-w-3xl", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-border bg-card p-6 shadow-[0_4px_20px_rgba(85,153,254,0.04)]", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-[0.18em] text-brand-blue mb-4", children: "Sync decisions" }),
@@ -14594,6 +14594,11 @@ function searchQueue(items, term) {
     return parts.join(" ").toLowerCase().includes(normalized);
   });
 }
+function buildNextUpChipText(item) {
+  const envelope = item.action_envelope_json;
+  const preview = envelope?.command?.slice(0, 40) ?? envelope?.mcp_tool ?? envelope?.prompt_excerpt?.slice(0, 40) ?? item.artifact_type;
+  return `${item.harness} — ${preview}`;
+}
 function buildHomePrimaryState(pendingCount, watchedAppsCount) {
   if (pendingCount > 0) {
     return {
@@ -14732,11 +14737,15 @@ function QueueWorkspace(props) {
   }
   if (props.requests.kind === "error") {
     const approvalUrl = props.runtime.kind === "ready" ? props.runtime.snapshot.approval_center_url : null;
+    const handleOpenDaemon = () => {
+      window.open("http://localhost:7957", "_blank");
+    };
     return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(Surface, { tone: "danger", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-purple", children: "Guard connection lost. Check if the daemon is running." }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-purple", children: "Guard daemon not responding — click to reconnect." }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-brand-purple/80", children: props.requests.message }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 flex flex-wrap gap-3", children: [
-        props.onRepair !== void 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleRepair, disabled: repairing, children: repairing ? "Repairing…" : "Repair" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleOpenDaemon, children: "Repair" }),
+        props.onRepair !== void 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleRepair, disabled: repairing, variant: "outline", children: repairing ? "Repairing…" : "Reconnect" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("code", { className: "inline-flex min-h-10 items-center rounded-lg border border-brand-purple/30 bg-slate-50 px-3 py-2 font-mono text-sm text-brand-purple select-all", children: "hol-guard start" }),
         props.onRetry && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "outline", onClick: props.onRetry, children: "Retry" }),
         approvalUrl && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: approvalUrl, variant: "outline", onClick: () => window.location.reload(), children: "Open dashboard" })
@@ -14928,7 +14937,7 @@ function QueueBrowser(props) {
           }
         )
       ] }),
-      harnesses.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(
+      harnesses.length >= 2 && /* @__PURE__ */ jsxRuntimeExports.jsx(
         QueueChipFilter,
         {
           harnesses,
@@ -14991,9 +15000,9 @@ function QueueCardRow(props) {
       }
     ),
     props.nextUpItem !== null && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "border-t border-slate-100 bg-slate-50/60 px-4 py-2", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "truncate text-[11px] text-muted-foreground", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-semibold", children: "Next up:" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-semibold", children: "Next:" }),
       " ",
-      displayArtifactName(props.nextUpItem)
+      buildNextUpChipText(props.nextUpItem)
     ] }) })
   ] });
 }
@@ -15066,6 +15075,7 @@ function DecisionWorkspace(props) {
   const [errorMessage, setErrorMessage] = reactExports.useState(null);
   const [confirmPending, setConfirmPending] = reactExports.useState(null);
   const [resolvedBanner, setResolvedBanner] = reactExports.useState(null);
+  const [resolvedState, setResolvedState] = reactExports.useState("idle");
   const bannerTimerRef = reactExports.useRef(null);
   const prevRequestIdRef = reactExports.useRef(null);
   reactExports.useEffect(() => {
@@ -15074,6 +15084,7 @@ function DecisionWorkspace(props) {
       prevRequestIdRef.current = props.detail.item.request_id;
       if (isNewItem) {
         setResolvedBanner(null);
+        setResolvedState("loaded");
         if (bannerTimerRef.current !== null) {
           clearTimeout(bannerTimerRef.current);
           bannerTimerRef.current = null;
@@ -15106,6 +15117,7 @@ function DecisionWorkspace(props) {
           reason,
           workspace: scope === "workspace" ? readyWorkspace : void 0
         });
+        setResolvedState("decided");
         setResolvedBanner(action);
         bannerTimerRef.current = setTimeout(() => {
           setResolvedBanner(null);
@@ -15163,6 +15175,18 @@ function DecisionWorkspace(props) {
   }, [props.detail.kind, submitting, handleRequestResolve, confirmPending, handleConfirmResolve, handleCancelConfirm]);
   if (props.detail.kind === "loading") {
     return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
+      resolvedState === "decided" && /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        "div",
+        {
+          className: "flex items-center gap-3 rounded-2xl border border-brand-green/25 bg-brand-green-bg/30 px-4 py-3",
+          role: "status",
+          "aria-live": "polite",
+          children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-4 w-4 shrink-0 text-brand-green", "aria-hidden": "true" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-green-text", children: "Decided — loading next…" })
+          ]
+        }
+      ),
       /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-skeleton h-8 w-48" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-skeleton h-40 w-full" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-skeleton h-56 w-full" })
@@ -16539,6 +16563,38 @@ function heroBackgroundClass(status) {
   }
   return "bg-[radial-gradient(circle_at_top_left,rgba(85,153,254,0.12),transparent_32%),linear-gradient(135deg,#ffffff_0%,#ffffff_58%,rgba(72,223,123,0.10)_100%)]";
 }
+const KNOWN_HARNESSES = [
+  "codex",
+  "claude-code",
+  "opencode",
+  "copilot",
+  "gemini",
+  "cursor",
+  "hermes",
+  "openclaw"
+];
+function SetupSuggestionRow(props) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("li", { className: "flex items-center justify-between gap-3 border-b border-slate-200/70 px-4 py-3 last:border-b-0", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-sm text-brand-dark", children: [
+    "Set up ",
+    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-medium", children: harnessDisplayName(props.harness) }),
+    " →",
+    " ",
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "font-mono text-xs text-brand-blue", children: [
+      "hol-guard apps connect ",
+      props.harness
+    ] })
+  ] }) });
+}
+function SetupSuggestionsSection(props) {
+  const unconfigured = KNOWN_HARNESSES.filter(
+    (h) => !props.configuredHarnesses.includes(h)
+  );
+  if (unconfigured.length === 0) return null;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "rounded-[1.75rem] border border-slate-200/70 bg-white/80 p-5 shadow-sm sm:p-6", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Connect more apps" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("ul", { className: "mt-3 overflow-hidden rounded-[1.25rem] border border-slate-200/70", children: unconfigured.slice(0, 4).map((harness) => /* @__PURE__ */ jsxRuntimeExports.jsx(SetupSuggestionRow, { harness }, harness)) })
+  ] });
+}
 function ClearHarnessButton(props) {
   const handleClick = reactExports.useCallback(() => {
     void props.onClearPolicies({ harness: props.harness });
@@ -16618,6 +16674,7 @@ function HomeWorkspace(props) {
         observedHarnesses
       }
     ),
+    primaryState.status === "setup_needed" && /* @__PURE__ */ jsxRuntimeExports.jsx(SetupSuggestionsSection, { configuredHarnesses: observedHarnesses }),
     snapshot.latest_receipts.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(RecentProtectionSection, { receipts: snapshot.latest_receipts }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("section", { className: "rounded-[1.75rem] border border-brand-blue/15 bg-brand-blue/[0.04] p-5 sm:p-6", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("details", { className: "group", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("summary", { className: "flex cursor-pointer select-none items-center justify-between gap-3 text-sm font-semibold text-brand-dark [&::-webkit-details-marker]:hidden", children: [
@@ -16640,6 +16697,7 @@ function HomeWorkspace(props) {
   ] });
 }
 function ProtectionHero(props) {
+  const [testRunning, setTestRunning] = reactExports.useState(false);
   const handlePrimaryCta = reactExports.useCallback(() => {
     if (props.status === "setup_needed") {
       props.onOpenFleet();
@@ -16647,6 +16705,12 @@ function ProtectionHero(props) {
       props.onOpenInbox();
     }
   }, [props.status, props.onOpenInbox, props.onOpenFleet]);
+  const handleRunTest = reactExports.useCallback(() => {
+    setTestRunning(true);
+    fetch("/v1/protect/test").catch(() => void 0).finally(() => {
+      setTestRunning(false);
+    });
+  }, []);
   const heroBg = heroBackgroundClass(props.status);
   const statusBadge = props.status === "needs_decision" ? /* @__PURE__ */ jsxRuntimeExports.jsxs(Badge, { tone: "default", children: [
     props.queuedCount,
@@ -16654,24 +16718,40 @@ function ProtectionHero(props) {
   ] }) : props.status === "setup_needed" ? /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "default", children: "Setup needed" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "success", children: "Protected" });
   const showConnectCta = props.cloudState === "local_only" && !props.syncConfigured;
   const showTestProtection = props.activeInstallsCount > 0 && props.latestReceiptsCount === 0;
+  const showGuardCloud = props.cloudState !== "local_only";
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(
     "section",
     {
       className: `guard-surface-in relative overflow-hidden rounded-[2rem] border border-brand-blue/15 ${heroBg} p-5 shadow-[0_20px_60px_rgba(63,65,116,0.08)] sm:p-6 lg:p-7`,
+      role: "region",
+      "aria-label": "Protection status",
       children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "pointer-events-none absolute right-10 top-8 h-24 w-24 rounded-full bg-brand-blue/20 blur-3xl" }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "relative space-y-4", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Protection status" }),
             statusBadge,
-            props.cloudState !== "local_only" && /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: "blue", children: "Cloud synced" })
+            props.cloudState !== "local_only" && /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: "blue", children: "Cloud backup up to date" })
           ] }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "text-xl font-semibold tracking-tight text-brand-dark", children: props.copy }),
           /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap gap-3", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handlePrimaryCta, children: props.ctaLabel }),
-            showTestProtection && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: props.fleetUrl, variant: "secondary", children: "Test protection" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handlePrimaryCta, "data-primary": "true", "aria-label": props.ctaLabel, children: props.ctaLabel }),
+            showTestProtection && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleRunTest, variant: "secondary", disabled: testRunning, children: testRunning ? "Running test…" : "Run a quick protection test" }),
             showConnectCta && props.status !== "needs_decision" && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: props.connectUrl, variant: "secondary", children: "Connect this machine" })
-          ] })
+          ] }),
+          showGuardCloud && /* @__PURE__ */ jsxRuntimeExports.jsxs(
+            "a",
+            {
+              href: "https://hol.org/guard",
+              target: "_blank",
+              rel: "noreferrer",
+              className: "inline-flex items-center gap-1 text-sm font-medium text-brand-blue transition-colors hover:text-brand-blue/70",
+              children: [
+                "Open Guard Cloud",
+                /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowTopRightOnSquare, { className: "h-3.5 w-3.5", "aria-hidden": "true" })
+              ]
+            }
+          )
         ] })
       ]
     }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13799,21 +13799,21 @@ function EmptyState(props) {
     props.action ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4", children: props.action }) : null
   ] });
 }
-function ActionButton(props) {
-  const className = actionButtonClass(props.variant);
-  if (props.href) {
+function ActionButton({ children, href, variant, disabled, onClick, ...buttonProps }) {
+  const className = actionButtonClass(variant);
+  if (href) {
     return /* @__PURE__ */ jsxRuntimeExports.jsx(
       "a",
       {
-        href: guardAwareHref(props.href),
-        target: props.href.startsWith("https://") ? "_blank" : void 0,
-        rel: props.href.startsWith("https://") ? "noreferrer" : void 0,
+        href: guardAwareHref(href),
+        target: href.startsWith("https://") ? "_blank" : void 0,
+        rel: href.startsWith("https://") ? "noreferrer" : void 0,
         className,
-        children: props.children
+        children
       }
     );
   }
-  return /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", className, onClick: props.onClick, disabled: props.disabled, children: props.children });
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("button", { type: "button", className, onClick, disabled, ...buttonProps, children });
 }
 function ListControls(props) {
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `grid gap-2 sm:grid-cols-[minmax(0,1fr)_180px]${props.className ? ` ${props.className}` : ""}`, children: [
@@ -14746,7 +14746,11 @@ function QueueWorkspace(props) {
   if (props.requests.kind === "error") {
     const approvalUrl = props.runtime.kind === "ready" ? props.runtime.snapshot.approval_center_url : null;
     const handleOpenDaemon = () => {
-      window.open("http://localhost:7957", "_blank");
+      if (approvalUrl !== null) {
+        window.open(approvalUrl, "_blank", "noopener,noreferrer");
+      } else {
+        void handleRepair();
+      }
     };
     return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(Surface, { tone: "danger", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-purple", children: "Guard daemon not responding — click to reconnect." }),
@@ -16659,8 +16663,6 @@ function HomeWorkspace(props) {
         cloudState: snapshot.cloud_state,
         connectUrl: snapshot.connect_url,
         fleetUrl: snapshot.fleet_url,
-        activeInstallsCount: activeInstalls.length,
-        latestReceiptsCount: snapshot.latest_receipts.length,
         onOpenInbox: props.onOpenInbox,
         onOpenFleet: props.onOpenFleet
       }
@@ -16705,7 +16707,6 @@ function HomeWorkspace(props) {
   ] });
 }
 function ProtectionHero(props) {
-  const [testRunning, setTestRunning] = reactExports.useState(false);
   const handlePrimaryCta = reactExports.useCallback(() => {
     if (props.status === "setup_needed") {
       props.onOpenFleet();
@@ -16713,19 +16714,12 @@ function ProtectionHero(props) {
       props.onOpenInbox();
     }
   }, [props.status, props.onOpenInbox, props.onOpenFleet]);
-  const handleRunTest = reactExports.useCallback(() => {
-    setTestRunning(true);
-    fetch("/v1/protect/test").catch(() => void 0).finally(() => {
-      setTestRunning(false);
-    });
-  }, []);
   const heroBg = heroBackgroundClass(props.status);
   const statusBadge = props.status === "needs_decision" ? /* @__PURE__ */ jsxRuntimeExports.jsxs(Badge, { tone: "default", children: [
     props.queuedCount,
     " waiting"
   ] }) : props.status === "setup_needed" ? /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "default", children: "Setup needed" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "success", children: "Protected" });
   const showConnectCta = props.cloudState === "local_only" && !props.syncConfigured;
-  const showTestProtection = props.activeInstallsCount > 0 && props.latestReceiptsCount === 0;
   const showGuardCloud = props.cloudState !== "local_only";
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(
     "section",
@@ -16744,13 +16738,12 @@ function ProtectionHero(props) {
           /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "text-xl font-semibold tracking-tight text-brand-dark", children: props.copy }),
           /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap gap-3", children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handlePrimaryCta, "data-primary": "true", "aria-label": props.ctaLabel, children: props.ctaLabel }),
-            showTestProtection && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleRunTest, variant: "secondary", disabled: testRunning, children: testRunning ? "Running test…" : "Run a quick protection test" }),
             showConnectCta && props.status !== "needs_decision" && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: props.connectUrl, variant: "secondary", children: "Connect this machine" })
           ] }),
           showGuardCloud && /* @__PURE__ */ jsxRuntimeExports.jsxs(
             "a",
             {
-              href: "https://hol.org/guard",
+              href: props.fleetUrl,
               target: "_blank",
               rel: "noreferrer",
               className: "inline-flex items-center gap-1 text-sm font-medium text-brand-blue transition-colors hover:text-brand-blue/70",

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1388,17 +1388,37 @@ class GuardStore:
                       artifact_hash is null or (? is not null and artifact_hash = ?)
                     )
                   )
-                  or (scope = 'workspace' and workspace = ?)
+                  or (
+                    scope = 'workspace' and workspace = ? and (
+                      artifact_id is null or (
+                        artifact_id = ? and (
+                          artifact_hash is null or (? is not null and artifact_hash = ?)
+                        )
+                      )
+                    )
+                  )
                   or (scope = 'publisher' and publisher = ?)
                   or scope = 'harness'
                   or scope = 'global'
                 )
                 and (expires_at is null or expires_at > ?)
                 order by case scope when 'artifact' then 0 when 'workspace' then 1 when 'publisher' then 2
-                         when 'harness' then 3 else 4 end,
+                          when 'harness' then 3 else 4 end,
+                         case when scope = 'workspace' and artifact_id is not null then 0 else 1 end,
                          updated_at desc
                 """,
-                (harness, artifact_id, artifact_hash, artifact_hash, workspace, publisher, current_time),
+                (
+                    harness,
+                    artifact_id,
+                    artifact_hash,
+                    artifact_hash,
+                    workspace,
+                    artifact_id,
+                    artifact_hash,
+                    artifact_hash,
+                    publisher,
+                    current_time,
+                ),
             ).fetchall()
         if not rows:
             return None
@@ -1416,8 +1436,8 @@ class GuardStore:
 
     @staticmethod
     def _normalized_policy_keys(decision: PolicyDecision) -> tuple[str | None, str | None, str | None, str | None]:
-        artifact_id = decision.artifact_id if decision.scope == "artifact" else None
-        artifact_hash = decision.artifact_hash if decision.scope == "artifact" else None
+        artifact_id = decision.artifact_id if decision.scope in {"artifact", "workspace"} else None
+        artifact_hash = decision.artifact_hash if decision.scope in {"artifact", "workspace"} else None
         workspace = decision.workspace if decision.scope == "workspace" else None
         publisher = decision.publisher if decision.scope == "publisher" else None
         return artifact_id, artifact_hash, workspace, publisher
@@ -1816,6 +1836,7 @@ class GuardStore:
                 return []
             return self._resolve_workspace_matching_approval_requests(
                 harness=harness,
+                artifact_id=artifact_id,
                 workspace=workspace,
                 resolution_action=resolution_action,
                 resolution_scope=resolution_scope,
@@ -1888,6 +1909,7 @@ class GuardStore:
         self,
         *,
         harness: str,
+        artifact_id: str | None,
         workspace: str,
         resolution_action: str,
         resolution_scope: str,
@@ -1898,7 +1920,7 @@ class GuardStore:
             connection.execute("begin immediate")
             rows = connection.execute(
                 """
-                select request_id, config_path
+                select request_id, artifact_id, config_path
                 from approval_requests
                 where status = 'pending'
                   and harness = ?
@@ -1907,7 +1929,10 @@ class GuardStore:
                 (harness,),
             ).fetchall()
             matching_ids = [
-                str(row["request_id"]) for row in rows if _path_within_workspace(str(row["config_path"]), workspace)
+                str(row["request_id"])
+                for row in rows
+                if _path_within_workspace(str(row["config_path"]), workspace)
+                and (artifact_id is None or row["artifact_id"] == artifact_id)
             ]
             for chunk in _chunks(matching_ids, _SQLITE_ID_BATCH_SIZE):
                 placeholders = ", ".join("?" for _ in chunk)

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -10943,7 +10943,11 @@ def test_guard_hook_claude_native_block_does_not_queue_approval_center_request(t
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
     _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 0\n")
-    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(
+        guard_commands_module,
+        "ensure_guard_daemon",
+        lambda _guard_home: "http://127.0.0.1:4455",
+    )
     blocked_event = {
         "hook_event_name": "PreToolUse",
         "tool_name": "Bash",
@@ -11289,6 +11293,172 @@ def test_guard_hook_codex_user_prompt_submit_reuses_artifact_approval(
     payload = json.loads(output)
     assert payload["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
     assert store.list_approval_requests(limit=10) == []
+
+
+def test_guard_hook_codex_user_prompt_submit_reuses_workspace_approval_for_same_prompt(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 0\n")
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    event = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "Open ./.npmrc",
+        "source_scope": "project",
+    }
+
+    _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event=event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    store = GuardStore(home_dir)
+    pending = store.list_approval_requests(limit=10)
+    assert len(pending) == 1
+    apply_approval_resolution(
+        store=store,
+        request_id=str(pending[0]["request_id"]),
+        action="allow",
+        scope="workspace",
+        workspace=str(workspace_dir),
+        reason="approved in browser",
+    )
+
+    rc, output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event=event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+
+    assert rc == 0
+    payload = json.loads(output)
+    assert payload["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+    assert store.list_approval_requests(limit=10) == []
+
+
+def test_guard_hook_codex_user_prompt_submit_workspace_approval_stays_in_workspace(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    other_workspace_dir = tmp_path / "other-workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _build_guard_fixture(home_dir, other_workspace_dir)
+    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 0\n")
+    monkeypatch.setattr(
+        guard_commands_module,
+        "ensure_guard_daemon",
+        lambda _guard_home: "http://127.0.0.1:4455",
+    )
+    event = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "Open ./.npmrc",
+        "source_scope": "project",
+    }
+
+    _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event=event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    store = GuardStore(home_dir)
+    pending = store.list_approval_requests(limit=10)
+    apply_approval_resolution(
+        store=store,
+        request_id=str(pending[0]["request_id"]),
+        action="allow",
+        scope="workspace",
+        workspace=str(workspace_dir),
+        reason="approved in browser",
+    )
+
+    rc, output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=other_workspace_dir,
+        harness="codex",
+        event=event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+
+    assert rc == 0
+    payload = json.loads(output)
+    assert payload["decision"] == "block"
+    assert "HOL Guard" in payload["reason"]
+
+
+def test_guard_hook_codex_user_prompt_submit_workspace_approval_requires_same_prompt_action(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 0\n")
+    monkeypatch.setattr(
+        guard_commands_module,
+        "ensure_guard_daemon",
+        lambda _guard_home: "http://127.0.0.1:4455",
+    )
+    secret_event = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "Open ./.npmrc",
+        "source_scope": "project",
+    }
+    destructive_event = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "Run rm -rf ./dangerous-marker.json.",
+        "source_scope": "project",
+    }
+
+    _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event=secret_event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    store = GuardStore(home_dir)
+    pending = store.list_approval_requests(limit=10)
+    apply_approval_resolution(
+        store=store,
+        request_id=str(pending[0]["request_id"]),
+        action="allow",
+        scope="workspace",
+        workspace=str(workspace_dir),
+        reason="approved in browser",
+    )
+
+    rc, output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event=destructive_event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+
+    assert rc == 0
+    payload = json.loads(output)
+    assert payload["decision"] == "block"
+    assert "HOL Guard" in payload["reason"]
 
 
 def test_guard_hook_codex_user_prompt_submit_uses_strictest_mixed_prompt_risk(


### PR DESCRIPTION
Summary:
- persist workspace approvals for risky runtime prompts/tool actions using same artifact identity plus workspace
- keep different workspaces and materially different sensitive actions blocked
- clarify Approval Center scope copy for retry/project approvals

Validation:
- python3 -m pytest
- python3 -m ruff check src tests
- cd dashboard && pnpm test && pnpm build
- local hook/daemon proof: block -> approve via daemon HTTP workspace scope -> retry allowed; different prompt and workspace still blocked