### PR TITLE
feat(guard): add agent inventory snapshots

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -13,6 +13,7 @@ import re
 import sys
 from pathlib import Path
 
+from ..inventory_contract import GuardAgentInventorySnapshot, inventory_snapshot_from_detection
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
 from .base import HarnessAdapter, HarnessContext, _command_available, _json_payload, _run_command_probe
@@ -244,6 +245,14 @@ class HermesHarnessAdapter(HarnessAdapter):
             command_available=_command_available(self.executable),
             artifacts=tuple(artifacts),
             config_paths=tuple(found_paths),
+        )
+
+    def inventory_snapshot(self, context: HarnessContext, *, generated_at: str) -> GuardAgentInventorySnapshot:
+        return inventory_snapshot_from_detection(
+            self.detect(context),
+            generated_at=generated_at,
+            home_dir=context.home_dir,
+            workspace_dir=context.workspace_dir,
         )
 
     # ------------------------------------------------------------------

--- a/src/codex_plugin_scanner/guard/adapters/openclaw.py
+++ b/src/codex_plugin_scanner/guard/adapters/openclaw.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from ..inventory_contract import GuardAgentInventorySnapshot, inventory_snapshot_from_detection
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
 from .base import (
@@ -62,6 +63,14 @@ class OpenClawHarnessAdapter(HarnessAdapter):
             command_available=_command_available(self.executable),
             config_paths=tuple(found_paths),
             artifacts=tuple(artifacts),
+        )
+
+    def inventory_snapshot(self, context: HarnessContext, *, generated_at: str) -> GuardAgentInventorySnapshot:
+        return inventory_snapshot_from_detection(
+            self.detect(context),
+            generated_at=generated_at,
+            home_dir=context.home_dir,
+            workspace_dir=context.workspace_dir,
         )
 
     def install(self, context: HarnessContext) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -465,13 +465,16 @@ def _redact_known_path(value: str, home_dir: Path, workspace_dir: Path | None) -
 
 
 def _redact_command_value(value: str, home_dir: Path, workspace_dir: Path | None) -> str:
-    path_redacted = _redact_known_path(value, home_dir, workspace_dir)
-    if path_redacted != value:
-        return path_redacted
+    redacted = re.sub(r"https?://[^\s]+", lambda match: redact_url(match.group(0)), value)
+    redacted = re.sub(
+        r"(^|\s)(/[^\s]+)",
+        lambda match: f"{match.group(1)}{_redact_known_path(match.group(2), home_dir, workspace_dir)}",
+        redacted,
+    )
     redacted = re.sub(
         r"(?i)(authorization:\s*bearer\s+)\S+",
         r"\1redacted",
-        value,
+        redacted,
     )
     redacted = re.sub(
         r"(?i)((?:api[_-]?key|auth|password|secret|token)=)\S+",
@@ -483,8 +486,6 @@ def _redact_command_value(value: str, home_dir: Path, workspace_dir: Path | None
         r"\1redacted",
         redacted,
     )
-    if "://" in redacted:
-        return redact_url(redacted)
     return redacted
 
 

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -292,6 +292,8 @@ def redact_headers(headers: dict[str, str]) -> dict[str, str]:
 def redact_url(value: str) -> str:
     parsed = urlsplit(value)
     hostname = parsed.hostname or parsed.netloc
+    if ":" in hostname and not hostname.startswith("["):
+        hostname = f"[{hostname}]"
     netloc = hostname
     try:
         port = parsed.port
@@ -473,6 +475,11 @@ def _redact_command_value(value: str, home_dir: Path, workspace_dir: Path | None
     )
     redacted = re.sub(
         r"(?i)((?:api[_-]?key|auth|password|secret|token)=)\S+",
+        r"\1redacted",
+        redacted,
+    )
+    redacted = re.sub(
+        r"(?i)((?:--)?(?:api[_-]?key|auth|password|secret|token)\s+)\S+",
         r"\1redacted",
         redacted,
     )

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -433,7 +433,7 @@ def _sanitize_paths(value: object, home_dir: Path, workspace_dir: Path | None) -
         for key, item in value.items():
             string_key = str(key)
             if _SENSITIVE_KEY_RE.search(string_key):
-                redacted[string_key] = "present_redacted"
+                redacted[string_key] = item if isinstance(item, bool) else "present_redacted"
                 continue
             redacted[string_key] = _sanitize_paths(item, home_dir, workspace_dir)
         return redacted

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -8,7 +8,7 @@ import json
 import re
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Literal, cast
+from typing import Literal
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 InventoryItemKind = Literal[
@@ -49,6 +49,16 @@ InventorySeverity = Literal["critical", "high", "medium", "low", "info"]
 InventoryConfidence = Literal["high", "medium", "low", "unknown"]
 InventoryDriftState = Literal["new", "changed", "removed", "unchanged"]
 DockerProofStatus = Literal["passed", "failed", "skipped", "stale"]
+AgentInventoryType = Literal["hermes", "openclaw", "codex", "claude-code", "cursor", "gemini", "opencode"]
+_AGENT_INVENTORY_TYPES: tuple[AgentInventoryType, ...] = (
+    "hermes",
+    "openclaw",
+    "codex",
+    "claude-code",
+    "cursor",
+    "gemini",
+    "opencode",
+)
 
 _SENSITIVE_KEY_RE = re.compile(
     r"(auth|authorization|bearer|token|secret|password|credential|api[^a-z0-9]?key)",
@@ -153,7 +163,7 @@ class GuardAgentInventoryItem:
 class GuardAgentInventorySnapshot:
     snapshot_id: str
     agent_id: str
-    agent_type: Literal["hermes", "openclaw", "codex", "claude-code", "cursor", "gemini", "opencode"]
+    agent_type: AgentInventoryType
     generated_at: str
     runtime_version: str | None = None
     items: tuple[GuardAgentInventoryItem, ...] = ()
@@ -283,8 +293,12 @@ def redact_url(value: str) -> str:
     parsed = urlsplit(value)
     hostname = parsed.hostname or parsed.netloc
     netloc = hostname
-    if parsed.port is not None:
-        netloc = f"{netloc}:{parsed.port}"
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+    if port is not None:
+        netloc = f"{netloc}:{port}"
     redacted_pairs = [
         (key, "redacted" if _SENSITIVE_KEY_RE.search(key) else item)
         for key, item in parse_qsl(parsed.query, keep_blank_values=True)
@@ -340,9 +354,10 @@ def _item_from_artifact(
     )
 
 
-def _agent_type(value: str) -> Literal["hermes", "openclaw", "codex", "claude-code", "cursor", "gemini", "opencode"]:
-    if value in {"hermes", "openclaw", "codex", "claude-code", "cursor", "gemini", "opencode"}:
-        return cast(Literal["hermes", "openclaw", "codex", "claude-code", "cursor", "gemini", "opencode"], value)
+def _agent_type(value: str) -> AgentInventoryType:
+    for agent_type in _AGENT_INVENTORY_TYPES:
+        if value == agent_type:
+            return agent_type
     return "codex"
 
 
@@ -400,7 +415,7 @@ def _safe_artifact_metadata(
     if isinstance(config_path, str) and config_path:
         metadata["configPath"] = _redact_known_path(config_path, home_dir, workspace_dir)
     if isinstance(command, str) and command:
-        metadata["command"] = _redact_known_path(command, home_dir, workspace_dir)
+        metadata["command"] = _redact_command_value(command, home_dir, workspace_dir)
     if isinstance(url, str) and url:
         metadata["url"] = redact_url(url)
         metadata["endpointHostClass"] = classify_endpoint_host(url)
@@ -418,11 +433,11 @@ def _sanitize_paths(value: object, home_dir: Path, workspace_dir: Path | None) -
         for key, item in value.items():
             string_key = str(key)
             if _SENSITIVE_KEY_RE.search(string_key):
-                redacted[string_key] = "present_redacted" if item else "absent"
+                redacted[string_key] = "present_redacted"
                 continue
             redacted[string_key] = _sanitize_paths(item, home_dir, workspace_dir)
         return redacted
-    if isinstance(value, list | tuple):
+    if isinstance(value, (list, tuple)):
         return [_sanitize_paths(item, home_dir, workspace_dir) for item in value]
     if isinstance(value, str):
         if "://" in value:
@@ -441,16 +456,35 @@ def _redact_known_path(value: str, home_dir: Path, workspace_dir: Path | None) -
             try:
                 relative = path.resolve().relative_to(workspace_dir.resolve())
                 return f"{{workspace}}/{relative.as_posix()}"
-            except ValueError:
+            except (OSError, RuntimeError, ValueError):
                 return path.name
         return path.name
     return value
 
 
+def _redact_command_value(value: str, home_dir: Path, workspace_dir: Path | None) -> str:
+    path_redacted = _redact_known_path(value, home_dir, workspace_dir)
+    if path_redacted != value:
+        return path_redacted
+    redacted = re.sub(
+        r"(?i)(authorization:\s*bearer\s+)\S+",
+        r"\1redacted",
+        value,
+    )
+    redacted = re.sub(
+        r"(?i)((?:api[_-]?key|auth|password|secret|token)=)\S+",
+        r"\1redacted",
+        redacted,
+    )
+    if "://" in redacted:
+        return redact_url(redacted)
+    return redacted
+
+
 def _safe_json(value: object) -> object:
     if isinstance(value, dict):
         return {str(key): _safe_json(item) for key, item in value.items()}
-    if isinstance(value, list | tuple):
+    if isinstance(value, (list, tuple)):
         return [_safe_json(item) for item in value]
     if isinstance(value, Path):
         return value.name

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -200,7 +200,7 @@ def inventory_snapshot_from_detection(
         )
         for artifact in artifacts
     )
-    config_paths = tuple(str(path) for path in getattr(detection, "config_paths", ()))
+    config_paths = tuple(dict.fromkeys(str(path) for path in getattr(detection, "config_paths", ())))
     sources = tuple(
         GuardInventorySource(
             source_id=f"{harness}:config:{fingerprint_text(redact_local_path(path, home_dir=home_dir))[:12]}",
@@ -301,7 +301,7 @@ def redact_url(value: str) -> str:
         netloc = f"{netloc}:{port}"
     redacted_pairs = [
         (key, "redacted" if _SENSITIVE_KEY_RE.search(key) else item)
-        for key, item in parse_qsl(parsed.query, keep_blank_values=True)
+        for key, item in parse_qsl(parsed.query.replace(";", "&"), keep_blank_values=True)
     ]
     return urlunsplit((parsed.scheme, netloc, parsed.path, urlencode(redacted_pairs), parsed.fragment))
 

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -290,7 +290,10 @@ def redact_headers(headers: dict[str, str]) -> dict[str, str]:
 
 
 def redact_url(value: str) -> str:
-    parsed = urlsplit(value)
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return "malformed_url_redacted"
     hostname = parsed.hostname or parsed.netloc
     if ":" in hostname and not hostname.startswith("["):
         hostname = f"[{hostname}]"
@@ -465,7 +468,11 @@ def _redact_known_path(value: str, home_dir: Path, workspace_dir: Path | None) -
 
 
 def _redact_command_value(value: str, home_dir: Path, workspace_dir: Path | None) -> str:
-    redacted = re.sub(r"https?://[^\s]+", lambda match: redact_url(match.group(0)), value)
+    redacted = re.sub(
+        r"(?i)\b[a-z][a-z0-9+.-]*://[^\s]+",
+        lambda match: redact_url(match.group(0)),
+        value,
+    )
     redacted = re.sub(
         r"(^|\s)(/[^\s]+)",
         lambda match: f"{match.group(1)}{_redact_known_path(match.group(2), home_dir, workspace_dir)}",

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import ipaddress
 import json
 import re
 from dataclasses import asdict, dataclass, field
@@ -49,8 +50,13 @@ InventoryConfidence = Literal["high", "medium", "low", "unknown"]
 InventoryDriftState = Literal["new", "changed", "removed", "unchanged"]
 DockerProofStatus = Literal["passed", "failed", "skipped", "stale"]
 
-_SENSITIVE_KEY_RE = re.compile(r"(authorization|bearer|token|secret|password|credential|api[_-]?key)", re.IGNORECASE)
+_SENSITIVE_KEY_RE = re.compile(
+    r"(auth|authorization|bearer|token|secret|password|credential|api[^a-z0-9]?key)",
+    re.IGNORECASE,
+)
 _WHITESPACE_RE = re.compile(r"\s+")
+_IGNORED_TREE_DIR_NAMES = {".git", ".hg", ".svn", "__pycache__", ".mypy_cache", ".ruff_cache", ".venv", "node_modules"}
+_MAX_FINGERPRINT_FILE_BYTES = 1024 * 1024
 
 
 @dataclass(frozen=True, slots=True)
@@ -244,10 +250,16 @@ def fingerprint_path_tree(root: Path, *, home_dir: Path | None = None) -> str:
     if root.is_file():
         paths = [root]
     else:
-        paths = sorted(path for path in root.rglob("*") if path.is_file() and path.name != ".env")
+        paths = sorted(
+            path
+            for path in root.rglob("*")
+            if path.is_file()
+            and path.name != ".env"
+            and not any(part in _IGNORED_TREE_DIR_NAMES for part in path.parts)
+        )
     for path in paths:
         safe_path = redact_local_path(path, home_dir=home_dir)
-        content_hash = fingerprint_text(path.read_text(encoding="utf-8", errors="ignore"))
+        content_hash = _fingerprint_file_bytes(path)
         entries.append({"path": safe_path, "sha256": content_hash})
     return fingerprint_mapping(entries)
 
@@ -287,8 +299,11 @@ def classify_endpoint_host(value: str | None) -> Literal["none", "local_loopback
     host = (parsed.hostname or "").lower()
     if host in {"localhost", "127.0.0.1", "::1"}:
         return "local_loopback"
-    if host.startswith("10.") or host.startswith("192.168.") or host.startswith("172.16."):
-        return "local_private"
+    try:
+        if ipaddress.ip_address(host).is_private:
+            return "local_private"
+    except ValueError:
+        pass
     return "remote_public"
 
 
@@ -317,7 +332,7 @@ def _item_from_artifact(
         item_kind=item_kind,
         display_name=name,
         source_fingerprint=fingerprint_mapping({"harness": harness, "artifact_id": artifact_id}),
-        content_hash=fingerprint_mapping(semantic_text),
+        content_hash=semantic_text,
         capability_categories=_capabilities_for_artifact(artifact_type, safe_metadata),
         risk_level=_risk_level(safe_metadata),
         scanner_sources=("hol-detector",),
@@ -396,6 +411,8 @@ def _safe_artifact_metadata(
 
 
 def _sanitize_paths(value: object, home_dir: Path, workspace_dir: Path | None) -> object:
+    if isinstance(value, Path):
+        return _redact_known_path(str(value), home_dir, workspace_dir)
     if isinstance(value, dict):
         redacted: dict[str, object] = {}
         for key, item in value.items():
@@ -438,5 +455,18 @@ def _safe_json(value: object) -> object:
     if isinstance(value, Path):
         return value.name
     if isinstance(value, str):
-        return redact_url(value) if "://" in value else value
+        return value
     return value
+
+
+def _fingerprint_file_bytes(path: Path) -> str:
+    digest = hashlib.sha256()
+    remaining = _MAX_FINGERPRINT_FILE_BYTES
+    with path.open("rb") as file_handle:
+        while remaining > 0:
+            chunk = file_handle.read(min(65536, remaining))
+            if not chunk:
+                break
+            digest.update(chunk)
+            remaining -= len(chunk)
+    return digest.hexdigest()

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -1,0 +1,442 @@
+"""Structured Guard agent inventory contract and safe serializers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Literal, cast
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+InventoryItemKind = Literal[
+    "agent",
+    "skill",
+    "mcp_server",
+    "mcp_tool",
+    "plugin",
+    "channel",
+    "hook",
+    "overlay",
+    "repository",
+    "container_image",
+    "policy",
+    "secret_reference",
+    "network_endpoint",
+]
+InventoryCapability = Literal[
+    "reads_files",
+    "reads_secrets",
+    "writes_files",
+    "deletes_files",
+    "runs_shell",
+    "executes_code",
+    "network_egress",
+    "network_ingress",
+    "posts_messages",
+    "reads_messages",
+    "uses_browser",
+    "uses_clipboard",
+    "uses_model_sampling",
+    "changes_permissions",
+    "loads_remote_code",
+    "unknown",
+]
+InventoryFindingSource = Literal["cisco-mcp-scanner", "cisco-skill-scanner", "hol-detector", "docker-proof", "metadata"]
+InventorySeverity = Literal["critical", "high", "medium", "low", "info"]
+InventoryConfidence = Literal["high", "medium", "low", "unknown"]
+InventoryDriftState = Literal["new", "changed", "removed", "unchanged"]
+DockerProofStatus = Literal["passed", "failed", "skipped", "stale"]
+
+_SENSITIVE_KEY_RE = re.compile(r"(authorization|bearer|token|secret|password|credential|api[_-]?key)", re.IGNORECASE)
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+@dataclass(frozen=True, slots=True)
+class GuardAgentInventoryFinding:
+    finding_id: str
+    source: InventoryFindingSource
+    severity: InventorySeverity
+    confidence: InventoryConfidence
+    title: str
+    artifact_id: str
+    check_id: str
+    summary: str | None = None
+    evidence: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class GuardAgentInventoryDrift:
+    drift_id: str
+    item_id: str
+    state: InventoryDriftState
+    previous_hash: str | None
+    current_hash: str | None
+    changed_fields: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class GuardAgentInventoryDockerProof:
+    proof_id: str
+    agent_id: str
+    agent_type: str
+    image_reference: str
+    status: DockerProofStatus
+    captured_at: str
+    log_hash: str
+    redaction_report: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class GuardAgentIntegrationRun:
+    run_id: str
+    agent_id: str
+    agent_type: str
+    status: Literal["started", "completed", "failed"]
+    started_at: str
+    completed_at: str | None = None
+    message: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GuardHarnessSetupStep:
+    step_id: str
+    agent_type: str
+    status: Literal["not_started", "running", "completed", "failed"]
+    label: str
+    safe_command: str | None = None
+    detail: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GuardInventoryRiskComponent:
+    component_id: str
+    source: InventoryFindingSource
+    severity: InventorySeverity
+    confidence: InventoryConfidence
+    score_delta: int
+    summary: str
+
+
+@dataclass(frozen=True, slots=True)
+class GuardInventorySource:
+    source_id: str
+    source_type: Literal["config", "docker", "scanner", "runtime", "repository"]
+    status: Literal["available", "missing", "failed"]
+    captured_at: str | None = None
+    detail: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class GuardAgentInventoryItem:
+    item_id: str
+    item_kind: InventoryItemKind
+    display_name: str
+    source_fingerprint: str
+    content_hash: str
+    capability_categories: tuple[InventoryCapability, ...]
+    risk_level: InventorySeverity = "info"
+    security_score: int = 100
+    scanner_sources: tuple[InventoryFindingSource, ...] = ()
+    drift_state: InventoryDriftState = "unchanged"
+    metadata: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class GuardAgentInventorySnapshot:
+    snapshot_id: str
+    agent_id: str
+    agent_type: Literal["hermes", "openclaw", "codex", "claude-code", "cursor", "gemini", "opencode"]
+    generated_at: str
+    runtime_version: str | None = None
+    items: tuple[GuardAgentInventoryItem, ...] = ()
+    findings: tuple[GuardAgentInventoryFinding, ...] = ()
+    drift: tuple[GuardAgentInventoryDrift, ...] = ()
+    docker_proofs: tuple[GuardAgentInventoryDockerProof, ...] = ()
+    sources: tuple[GuardInventorySource, ...] = ()
+    redaction_report: dict[str, object] = field(default_factory=dict)
+
+
+def serialize_inventory_snapshot(snapshot: GuardAgentInventorySnapshot) -> dict[str, object]:
+    payload = _safe_json(asdict(snapshot))
+    if not isinstance(payload, dict):
+        raise TypeError("Inventory snapshot serialization produced invalid payload.")
+    return payload
+
+
+def inventory_snapshot_from_detection(
+    detection: object,
+    *,
+    generated_at: str,
+    home_dir: Path,
+    workspace_dir: Path | None = None,
+    runtime_version: str | None = None,
+) -> GuardAgentInventorySnapshot:
+    harness = str(getattr(detection, "harness", "unknown"))
+    artifacts = tuple(getattr(detection, "artifacts", ()))
+    items = tuple(
+        _item_from_artifact(
+            harness,
+            artifact,
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+        )
+        for artifact in artifacts
+    )
+    config_paths = tuple(str(path) for path in getattr(detection, "config_paths", ()))
+    sources = tuple(
+        GuardInventorySource(
+            source_id=f"{harness}:config:{fingerprint_text(redact_local_path(path, home_dir=home_dir))[:12]}",
+            source_type="config",
+            status="available",
+            captured_at=generated_at,
+            detail=redact_local_path(path, home_dir=home_dir),
+        )
+        for path in config_paths
+    )
+    snapshot_hash = fingerprint_mapping(
+        {
+            "agent_type": harness,
+            "generated_at": generated_at,
+            "item_ids": [item.item_id for item in items],
+        }
+    )
+    return GuardAgentInventorySnapshot(
+        snapshot_id=f"{harness}:snapshot:{snapshot_hash[:24]}",
+        agent_id=f"{harness}:local",
+        agent_type=_agent_type(harness),
+        generated_at=generated_at,
+        runtime_version=runtime_version,
+        items=items,
+        sources=sources,
+        redaction_report={
+            "rawSecretsIncluded": False,
+            "redactedFields": ("headers", "env", "url", "paths"),
+        },
+    )
+
+
+def fingerprint_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def fingerprint_mapping(value: object) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return fingerprint_text(encoded)
+
+
+def inventory_item_id(agent_type: str, item_kind: str, display_name: str, semantic_text: str) -> str:
+    normalized_text = _WHITESPACE_RE.sub(" ", semantic_text.strip())
+    digest = fingerprint_mapping(
+        {
+            "agent_type": agent_type,
+            "display_name": display_name.strip().lower(),
+            "item_kind": item_kind,
+            "semantic_text": normalized_text,
+        }
+    )
+    return f"{agent_type}:{item_kind}:{digest[:24]}"
+
+
+def fingerprint_path_tree(root: Path, *, home_dir: Path | None = None) -> str:
+    entries: list[dict[str, str]] = []
+    if root.is_file():
+        paths = [root]
+    else:
+        paths = sorted(path for path in root.rglob("*") if path.is_file() and path.name != ".env")
+    for path in paths:
+        safe_path = redact_local_path(path, home_dir=home_dir)
+        content_hash = fingerprint_text(path.read_text(encoding="utf-8", errors="ignore"))
+        entries.append({"path": safe_path, "sha256": content_hash})
+    return fingerprint_mapping(entries)
+
+
+def redact_local_path(path: str | Path, *, home_dir: Path | None = None) -> str:
+    candidate = Path(path)
+    if home_dir is None:
+        return candidate.name
+    try:
+        relative = candidate.resolve().relative_to(home_dir.resolve())
+    except ValueError:
+        return candidate.name
+    return f"{{home}}/{relative.as_posix()}"
+
+
+def redact_headers(headers: dict[str, str]) -> dict[str, str]:
+    return {key.lower(): "present_redacted" if _SENSITIVE_KEY_RE.search(key) else "present" for key in headers}
+
+
+def redact_url(value: str) -> str:
+    parsed = urlsplit(value)
+    hostname = parsed.hostname or parsed.netloc
+    netloc = hostname
+    if parsed.port is not None:
+        netloc = f"{netloc}:{parsed.port}"
+    redacted_pairs = [
+        (key, "redacted" if _SENSITIVE_KEY_RE.search(key) else item)
+        for key, item in parse_qsl(parsed.query, keep_blank_values=True)
+    ]
+    return urlunsplit((parsed.scheme, netloc, parsed.path, urlencode(redacted_pairs), parsed.fragment))
+
+
+def classify_endpoint_host(value: str | None) -> Literal["none", "local_loopback", "local_private", "remote_public"]:
+    if not value:
+        return "none"
+    parsed = urlsplit(value)
+    host = (parsed.hostname or "").lower()
+    if host in {"localhost", "127.0.0.1", "::1"}:
+        return "local_loopback"
+    if host.startswith("10.") or host.startswith("192.168.") or host.startswith("172.16."):
+        return "local_private"
+    return "remote_public"
+
+
+def _item_from_artifact(
+    harness: str,
+    artifact: object,
+    *,
+    home_dir: Path,
+    workspace_dir: Path | None,
+) -> GuardAgentInventoryItem:
+    artifact_id = str(getattr(artifact, "artifact_id", "artifact"))
+    artifact_type = str(getattr(artifact, "artifact_type", "unknown"))
+    name = str(getattr(artifact, "name", artifact_id))
+    safe_metadata = _safe_artifact_metadata(artifact, home_dir=home_dir, workspace_dir=workspace_dir)
+    item_kind = _item_kind(artifact_type)
+    semantic_text = fingerprint_mapping(
+        {
+            "artifact_id": artifact_id,
+            "artifact_type": artifact_type,
+            "name": name,
+            "metadata": safe_metadata,
+        }
+    )
+    return GuardAgentInventoryItem(
+        item_id=artifact_id,
+        item_kind=item_kind,
+        display_name=name,
+        source_fingerprint=fingerprint_mapping({"harness": harness, "artifact_id": artifact_id}),
+        content_hash=fingerprint_mapping(semantic_text),
+        capability_categories=_capabilities_for_artifact(artifact_type, safe_metadata),
+        risk_level=_risk_level(safe_metadata),
+        scanner_sources=("hol-detector",),
+        metadata=safe_metadata,
+    )
+
+
+def _agent_type(value: str) -> Literal["hermes", "openclaw", "codex", "claude-code", "cursor", "gemini", "opencode"]:
+    if value in {"hermes", "openclaw", "codex", "claude-code", "cursor", "gemini", "opencode"}:
+        return cast(Literal["hermes", "openclaw", "codex", "claude-code", "cursor", "gemini", "opencode"], value)
+    return "codex"
+
+
+def _item_kind(artifact_type: str) -> InventoryItemKind:
+    if artifact_type in {"skill", "skill_file"}:
+        return "skill"
+    if artifact_type == "mcp_server":
+        return "mcp_server"
+    if artifact_type == "channel":
+        return "channel"
+    if artifact_type in {"gateway_config", "config"}:
+        return "agent"
+    return "plugin"
+
+
+def _capabilities_for_artifact(
+    artifact_type: str,
+    metadata: dict[str, object],
+) -> tuple[InventoryCapability, ...]:
+    capabilities: set[InventoryCapability] = set()
+    if artifact_type in {"skill", "skill_file"}:
+        capabilities.add("reads_files")
+    if artifact_type == "mcp_server":
+        capabilities.add("network_egress")
+        if metadata.get("transport") == "stdio":
+            capabilities.add("runs_shell")
+    if artifact_type == "channel":
+        capabilities.update({"reads_messages", "posts_messages", "network_ingress"})
+    if bool(metadata.get("has_env_secrets")) or bool(metadata.get("has_auth_headers")):
+        capabilities.add("reads_secrets")
+    return tuple(sorted(capabilities)) if capabilities else ("unknown",)
+
+
+def _risk_level(metadata: dict[str, object]) -> InventorySeverity:
+    if metadata.get("has_auth_headers") or metadata.get("has_env_secrets"):
+        return "high"
+    if metadata.get("endpointHostClass") == "remote_public":
+        return "medium"
+    return "info"
+
+
+def _safe_artifact_metadata(
+    artifact: object,
+    *,
+    home_dir: Path,
+    workspace_dir: Path | None,
+) -> dict[str, object]:
+    artifact_type = str(getattr(artifact, "artifact_type", "unknown"))
+    raw_metadata = getattr(artifact, "metadata", {})
+    metadata = _sanitize_paths(raw_metadata if isinstance(raw_metadata, dict) else {}, home_dir, workspace_dir)
+    config_path = getattr(artifact, "config_path", None)
+    command = getattr(artifact, "command", None)
+    url = getattr(artifact, "url", None)
+    transport = getattr(artifact, "transport", None)
+    if isinstance(config_path, str) and config_path:
+        metadata["configPath"] = _redact_known_path(config_path, home_dir, workspace_dir)
+    if isinstance(command, str) and command:
+        metadata["command"] = _redact_known_path(command, home_dir, workspace_dir)
+    if isinstance(url, str) and url:
+        metadata["url"] = redact_url(url)
+        metadata["endpointHostClass"] = classify_endpoint_host(url)
+    if isinstance(transport, str) and transport:
+        metadata["transport"] = transport
+    metadata["artifactType"] = artifact_type
+    return metadata
+
+
+def _sanitize_paths(value: object, home_dir: Path, workspace_dir: Path | None) -> object:
+    if isinstance(value, dict):
+        redacted: dict[str, object] = {}
+        for key, item in value.items():
+            string_key = str(key)
+            if _SENSITIVE_KEY_RE.search(string_key):
+                redacted[string_key] = "present_redacted" if item else "absent"
+                continue
+            redacted[string_key] = _sanitize_paths(item, home_dir, workspace_dir)
+        return redacted
+    if isinstance(value, list | tuple):
+        return [_sanitize_paths(item, home_dir, workspace_dir) for item in value]
+    if isinstance(value, str):
+        if "://" in value:
+            return redact_url(value)
+        return _redact_known_path(value, home_dir, workspace_dir)
+    return value
+
+
+def _redact_known_path(value: str, home_dir: Path, workspace_dir: Path | None) -> str:
+    path = Path(value)
+    if path.is_absolute():
+        home_redacted = redact_local_path(path, home_dir=home_dir)
+        if home_redacted.startswith("{home}/"):
+            return home_redacted
+        if workspace_dir is not None:
+            try:
+                relative = path.resolve().relative_to(workspace_dir.resolve())
+                return f"{{workspace}}/{relative.as_posix()}"
+            except ValueError:
+                return path.name
+        return path.name
+    return value
+
+
+def _safe_json(value: object) -> object:
+    if isinstance(value, dict):
+        return {str(key): _safe_json(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [_safe_json(item) for item in value]
+    if isinstance(value, Path):
+        return value.name
+    if isinstance(value, str):
+        return redact_url(value) if "://" in value else value
+    return value

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -314,7 +314,10 @@ def redact_url(value: str) -> str:
 def classify_endpoint_host(value: str | None) -> Literal["none", "local_loopback", "local_private", "remote_public"]:
     if not value:
         return "none"
-    parsed = urlsplit(value)
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return "remote_public"
     host = (parsed.hostname or "").lower()
     if host in {"localhost", "127.0.0.1", "::1"}:
         return "local_loopback"

--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_plugin_scanner.guard.inventory_contract import (
+    GuardAgentInventoryFinding,
+    GuardAgentInventoryItem,
+    GuardAgentInventorySnapshot,
+    classify_endpoint_host,
+    fingerprint_mapping,
+    fingerprint_path_tree,
+    fingerprint_text,
+    inventory_item_id,
+    redact_headers,
+    redact_local_path,
+    redact_url,
+    serialize_inventory_snapshot,
+)
+
+
+def test_inventory_snapshot_serialization_redacts_raw_secrets(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "home" / "skills" / "danger"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("use token sk-testsecretvalue and Authorization: Bearer secret\n")
+
+    snapshot = GuardAgentInventorySnapshot(
+        snapshot_id="snap-hermes-1",
+        agent_id="agent-hermes",
+        agent_type="hermes",
+        generated_at="2026-05-10T00:00:00Z",
+        runtime_version="hermes-test",
+        items=(
+            GuardAgentInventoryItem(
+                item_id="skill-danger",
+                item_kind="skill",
+                display_name="Danger skill",
+                source_fingerprint=fingerprint_path_tree(skill_dir, home_dir=tmp_path / "home"),
+                content_hash=fingerprint_text((skill_dir / "SKILL.md").read_text()),
+                capability_categories=("reads_secrets", "network_egress"),
+                metadata={
+                    "headers": redact_headers({"Authorization": "Bearer secret", "X-Trace": "safe"}),
+                    "url": redact_url("https://user:pass@example.com/mcp?token=secret&mode=safe"),
+                    "path": redact_local_path(skill_dir / "SKILL.md", home_dir=tmp_path / "home"),
+                },
+            ),
+        ),
+        findings=(
+            GuardAgentInventoryFinding(
+                finding_id="finding-1",
+                source="hol-detector",
+                severity="high",
+                confidence="high",
+                title="Secret access",
+                artifact_id="skill-danger",
+                check_id="secret-access",
+            ),
+        ),
+        redaction_report={"raw_secret_values": False, "redacted_fields": ("headers.authorization", "url.token")},
+    )
+
+    payload = serialize_inventory_snapshot(snapshot)
+    encoded = json.dumps(payload, sort_keys=True)
+
+    assert "sk-testsecretvalue" not in encoded
+    assert "Bearer secret" not in encoded
+    assert "user:pass" not in encoded
+    assert str(tmp_path / "home") not in encoded
+    assert payload["items"][0]["metadata"]["headers"]["authorization"] == "present_redacted"
+    assert payload["items"][0]["metadata"]["headers"]["x-trace"] == "present"
+
+
+def test_inventory_helpers_emit_safe_endpoint_and_stable_hashes(tmp_path: Path) -> None:
+    config_a = {"b": [2, 1], "a": {"nested": True}}
+    config_b = {"a": {"nested": True}, "b": [2, 1]}
+    path_a = tmp_path / "skill-a" / "SKILL.md"
+    path_b = tmp_path / "renamed" / "SKILL.md"
+    path_a.parent.mkdir()
+    path_b.parent.mkdir()
+    path_a.write_text("name: demo\n\nRun search query\n")
+    path_b.write_text("name: demo\n\nRun search   query\n")
+
+    assert fingerprint_mapping(config_a) == fingerprint_mapping(config_b)
+    assert inventory_item_id("hermes", "skill", "demo", path_a.read_text()) == inventory_item_id(
+        "hermes",
+        "skill",
+        "demo",
+        path_b.read_text(),
+    )
+    assert classify_endpoint_host("https://user:pass@example.com/mcp?token=value") == "remote_public"
+    assert redact_url("https://user:pass@example.com/mcp?token=value&mode=safe") == "https://example.com/mcp?token=redacted&mode=safe"
+    assert redact_local_path(path_a, home_dir=tmp_path) == "{home}/skill-a/SKILL.md"

--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -88,5 +88,44 @@ def test_inventory_helpers_emit_safe_endpoint_and_stable_hashes(tmp_path: Path) 
         path_b.read_text(),
     )
     assert classify_endpoint_host("https://user:pass@example.com/mcp?token=value") == "remote_public"
+    assert classify_endpoint_host("http://172.20.4.5:8080/mcp") == "local_private"
     assert redact_url("https://user:pass@example.com/mcp?token=value&mode=safe") == "https://example.com/mcp?token=redacted&mode=safe"
+    assert redact_url("https://example.com/mcp?auth=value&mode=safe") == "https://example.com/mcp?auth=redacted&mode=safe"
     assert redact_local_path(path_a, home_dir=tmp_path) == "{home}/skill-a/SKILL.md"
+
+
+def test_fingerprint_path_tree_skips_large_ignored_and_path_objects(tmp_path: Path) -> None:
+    root = tmp_path / "workspace"
+    (root / "node_modules" / "pkg").mkdir(parents=True)
+    (root / ".git" / "objects").mkdir(parents=True)
+    (root / "safe").mkdir(parents=True)
+    (root / "safe" / "config.json").write_text('{"ok": true}\n')
+    (root / "node_modules" / "pkg" / "ignored.json").write_text('{"ignored": true}\n')
+    (root / ".git" / "objects" / "ignored").write_text("ignored\n")
+
+    fingerprint = fingerprint_path_tree(root, home_dir=tmp_path)
+    (root / "node_modules" / "pkg" / "ignored.json").write_text('{"ignored": "changed"}\n')
+    (root / ".git" / "objects" / "ignored").write_text("changed\n")
+    fingerprint_after_ignored_changes = fingerprint_path_tree(root, home_dir=tmp_path)
+    snapshot = GuardAgentInventorySnapshot(
+        snapshot_id="snap-path-object",
+        agent_id="agent",
+        agent_type="openclaw",
+        generated_at="2026-05-10T00:00:00Z",
+        items=(
+            GuardAgentInventoryItem(
+                item_id="item",
+                item_kind="repository",
+                display_name="Repo",
+                source_fingerprint=fingerprint,
+                content_hash=fingerprint_text("repo"),
+                capability_categories=("reads_files",),
+                metadata={"pathObject": root / "safe" / "config.json"},
+            ),
+        ),
+    )
+
+    encoded = json.dumps(serialize_inventory_snapshot(snapshot), sort_keys=True)
+
+    assert fingerprint_after_ignored_changes == fingerprint
+    assert str(tmp_path) not in encoded

--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -98,6 +98,7 @@ def test_inventory_helpers_emit_safe_endpoint_and_stable_hashes(tmp_path: Path) 
     )
     assert classify_endpoint_host("https://user:pass@example.com/mcp?token=value") == "remote_public"
     assert classify_endpoint_host("http://172.20.4.5:8080/mcp") == "local_private"
+    assert classify_endpoint_host("http://[not-an-ip]/mcp") == "remote_public"
     assert redact_url("https://user:pass@example.com/mcp?token=value&mode=safe") == "https://example.com/mcp?token=redacted&mode=safe"
     assert redact_url("https://example.com/mcp?auth=value&mode=safe") == "https://example.com/mcp?auth=redacted&mode=safe"
     assert redact_url("https://example.com/mcp?mode=safe;token=value") == "https://example.com/mcp?mode=safe&token=redacted"

--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -91,6 +91,7 @@ def test_inventory_helpers_emit_safe_endpoint_and_stable_hashes(tmp_path: Path) 
     assert classify_endpoint_host("http://172.20.4.5:8080/mcp") == "local_private"
     assert redact_url("https://user:pass@example.com/mcp?token=value&mode=safe") == "https://example.com/mcp?token=redacted&mode=safe"
     assert redact_url("https://example.com/mcp?auth=value&mode=safe") == "https://example.com/mcp?auth=redacted&mode=safe"
+    assert redact_url("http://localhost:${PORT}/mcp?auth=value") == "http://localhost/mcp?auth=redacted"
     assert redact_local_path(path_a, home_dir=tmp_path) == "{home}/skill-a/SKILL.md"
 
 

--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -12,11 +12,20 @@ from codex_plugin_scanner.guard.inventory_contract import (
     fingerprint_path_tree,
     fingerprint_text,
     inventory_item_id,
+    inventory_snapshot_from_detection,
     redact_headers,
     redact_local_path,
     redact_url,
     serialize_inventory_snapshot,
 )
+
+
+class _Detection:
+    harness = "hermes"
+    artifacts = ()
+
+    def __init__(self, config_paths: tuple[str, ...]) -> None:
+        self.config_paths = config_paths
 
 
 def test_inventory_snapshot_serialization_redacts_raw_secrets(tmp_path: Path) -> None:
@@ -91,6 +100,7 @@ def test_inventory_helpers_emit_safe_endpoint_and_stable_hashes(tmp_path: Path) 
     assert classify_endpoint_host("http://172.20.4.5:8080/mcp") == "local_private"
     assert redact_url("https://user:pass@example.com/mcp?token=value&mode=safe") == "https://example.com/mcp?token=redacted&mode=safe"
     assert redact_url("https://example.com/mcp?auth=value&mode=safe") == "https://example.com/mcp?auth=redacted&mode=safe"
+    assert redact_url("https://example.com/mcp?mode=safe;token=value") == "https://example.com/mcp?mode=safe&token=redacted"
     assert redact_url("http://localhost:${PORT}/mcp?auth=value") == "http://localhost/mcp?auth=redacted"
     assert redact_local_path(path_a, home_dir=tmp_path) == "{home}/skill-a/SKILL.md"
 
@@ -130,3 +140,17 @@ def test_fingerprint_path_tree_skips_large_ignored_and_path_objects(tmp_path: Pa
 
     assert fingerprint_after_ignored_changes == fingerprint
     assert str(tmp_path) not in encoded
+
+
+def test_inventory_snapshot_deduplicates_config_sources(tmp_path: Path) -> None:
+    config_path = tmp_path / ".hermes" / "config.yaml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text("mcp_servers: {}\n")
+
+    snapshot = inventory_snapshot_from_detection(
+        _Detection((str(config_path), str(config_path))),
+        generated_at="2026-05-10T00:00:00Z",
+        home_dir=tmp_path,
+    )
+
+    assert len(snapshot.sources) == 1

--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -102,6 +102,7 @@ def test_inventory_helpers_emit_safe_endpoint_and_stable_hashes(tmp_path: Path) 
     assert redact_url("https://example.com/mcp?auth=value&mode=safe") == "https://example.com/mcp?auth=redacted&mode=safe"
     assert redact_url("https://example.com/mcp?mode=safe;token=value") == "https://example.com/mcp?mode=safe&token=redacted"
     assert redact_url("http://localhost:${PORT}/mcp?auth=value") == "http://localhost/mcp?auth=redacted"
+    assert redact_url("http://[2001:db8::1]:8080/mcp?token=value") == "http://[2001:db8::1]:8080/mcp?token=redacted"
     assert redact_local_path(path_a, home_dir=tmp_path) == "{home}/skill-a/SKILL.md"
 
 

--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -103,6 +103,7 @@ def test_inventory_helpers_emit_safe_endpoint_and_stable_hashes(tmp_path: Path) 
     assert redact_url("https://example.com/mcp?mode=safe;token=value") == "https://example.com/mcp?mode=safe&token=redacted"
     assert redact_url("http://localhost:${PORT}/mcp?auth=value") == "http://localhost/mcp?auth=redacted"
     assert redact_url("http://[2001:db8::1]:8080/mcp?token=value") == "http://[2001:db8::1]:8080/mcp?token=redacted"
+    assert redact_url("http://[not-an-ip]/mcp?token=value") == "malformed_url_redacted"
     assert redact_local_path(path_a, home_dir=tmp_path) == "{home}/skill-a/SKILL.md"
 
 

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -97,7 +97,9 @@ def test_inventory_snapshot_redacts_hermes_skills_and_mcp_config(tmp_path: Path)
         (
             "mcp_servers:\n"
             "  docs:\n"
-            '    command: "/usr/bin/node --token guard_live_secret https://user:pass@example.com/mcp?auth=guard_live_secret"\n'
+            '    command: "/usr/bin/node --token guard_live_secret '
+            'HTTPS://user:pass@example.com/mcp?auth=guard_live_secret '
+            'ws://user:pass@example.com/socket"\n'
             '    url: "https://user:pass@example.com/mcp?token=guard_live_secret&mode=safe"\n'
             "    headers:\n"
             '      Authorization: "Bearer guard_live_secret"\n'

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -108,9 +108,12 @@ def test_inventory_snapshot_redacts_hermes_skills_and_mcp_config(tmp_path: Path)
     snapshot = HermesHarnessAdapter().inventory_snapshot(context, generated_at="2026-05-10T00:00:00Z")
     payload = serialize_inventory_snapshot(snapshot)
     encoded = json.dumps(payload, sort_keys=True)
+    mcp_items = [item for item in payload["items"] if item["item_kind"] == "mcp_server"]
 
     assert payload["agent_type"] == "hermes"
     assert {item["item_kind"] for item in payload["items"]} >= {"skill", "mcp_server"}
+    assert all(item["metadata"]["has_env_secrets"] is False for item in mcp_items)
+    assert all(item["metadata"]["has_auth_headers"] is True for item in mcp_items)
     assert "guard_live_secret" not in encoded
     assert "Bearer guard_live_secret" not in encoded
     assert "--token=guard_live_secret" not in encoded

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -97,7 +97,7 @@ def test_inventory_snapshot_redacts_hermes_skills_and_mcp_config(tmp_path: Path)
         (
             "mcp_servers:\n"
             "  docs:\n"
-            '    command: "node --token guard_live_secret server.js"\n'
+            '    command: "/usr/bin/node --token guard_live_secret https://user:pass@example.com/mcp?auth=guard_live_secret"\n'
             '    url: "https://user:pass@example.com/mcp?token=guard_live_secret&mode=safe"\n'
             "    headers:\n"
             '      Authorization: "Bearer guard_live_secret"\n'
@@ -117,6 +117,7 @@ def test_inventory_snapshot_redacts_hermes_skills_and_mcp_config(tmp_path: Path)
     assert "guard_live_secret" not in encoded
     assert "Bearer guard_live_secret" not in encoded
     assert "--token guard_live_secret" not in encoded
+    assert "user:pass" not in encoded
     assert str(tmp_path) not in encoded
 
 

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -97,6 +97,7 @@ def test_inventory_snapshot_redacts_hermes_skills_and_mcp_config(tmp_path: Path)
         (
             "mcp_servers:\n"
             "  docs:\n"
+            '    command: "node --token=guard_live_secret server.js"\n'
             '    url: "https://user:pass@example.com/mcp?token=guard_live_secret&mode=safe"\n'
             "    headers:\n"
             '      Authorization: "Bearer guard_live_secret"\n'
@@ -112,6 +113,7 @@ def test_inventory_snapshot_redacts_hermes_skills_and_mcp_config(tmp_path: Path)
     assert {item["item_kind"] for item in payload["items"]} >= {"skill", "mcp_server"}
     assert "guard_live_secret" not in encoded
     assert "Bearer guard_live_secret" not in encoded
+    assert "--token=guard_live_secret" not in encoded
     assert str(tmp_path) not in encoded
 
 

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -12,6 +12,7 @@ from codex_plugin_scanner.guard.adapters.hermes import (
     _extract_env_mentions,
     _looks_like_secret,
 )
+from codex_plugin_scanner.guard.inventory_contract import serialize_inventory_snapshot
 from codex_plugin_scanner.guard.risk import artifact_risk_signals
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -84,6 +85,34 @@ def test_install_generates_guard_managed_overlay_and_pretool_files(tmp_path: Pat
     assert overlay_payload["remote-docs"]["args"][-3:] == ["--server", "yaml:remote-docs", "--stdio"]
     assert manifest["servers"]["yaml:remote-docs"]["env"] == {"GITHUB_TOKEN": "ghp_test_token"}
     assert manifest["servers"]["yaml:remote-docs"]["headers"] == {"Authorization": "Bearer test-token"}
+
+
+def test_inventory_snapshot_redacts_hermes_skills_and_mcp_config(tmp_path: Path) -> None:
+    _write(
+        tmp_path / ".hermes" / "skills" / "ops" / "reviewer" / "SKILL.md",
+        "---\nname: reviewer\n---\nUse ${GITHUB_TOKEN} and call remote docs.\n",
+    )
+    _write(
+        tmp_path / ".hermes" / "config.yaml",
+        (
+            "mcp_servers:\n"
+            "  docs:\n"
+            '    url: "https://user:pass@example.com/mcp?token=guard_live_secret&mode=safe"\n'
+            "    headers:\n"
+            '      Authorization: "Bearer guard_live_secret"\n'
+        ),
+    )
+    context = _ctx(tmp_path)
+
+    snapshot = HermesHarnessAdapter().inventory_snapshot(context, generated_at="2026-05-10T00:00:00Z")
+    payload = serialize_inventory_snapshot(snapshot)
+    encoded = json.dumps(payload, sort_keys=True)
+
+    assert payload["agent_type"] == "hermes"
+    assert {item["item_kind"] for item in payload["items"]} >= {"skill", "mcp_server"}
+    assert "guard_live_secret" not in encoded
+    assert "Bearer guard_live_secret" not in encoded
+    assert str(tmp_path) not in encoded
 
 
 def test_install_includes_non_secret_cloud_identity_hints_when_configured(tmp_path: Path):

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -97,7 +97,7 @@ def test_inventory_snapshot_redacts_hermes_skills_and_mcp_config(tmp_path: Path)
         (
             "mcp_servers:\n"
             "  docs:\n"
-            '    command: "node --token=guard_live_secret server.js"\n'
+            '    command: "node --token guard_live_secret server.js"\n'
             '    url: "https://user:pass@example.com/mcp?token=guard_live_secret&mode=safe"\n'
             "    headers:\n"
             '      Authorization: "Bearer guard_live_secret"\n'
@@ -116,7 +116,7 @@ def test_inventory_snapshot_redacts_hermes_skills_and_mcp_config(tmp_path: Path)
     assert all(item["metadata"]["has_auth_headers"] is True for item in mcp_items)
     assert "guard_live_secret" not in encoded
     assert "Bearer guard_live_secret" not in encoded
-    assert "--token=guard_live_secret" not in encoded
+    assert "--token guard_live_secret" not in encoded
     assert str(tmp_path) not in encoded
 
 

--- a/tests/test_openclaw_adapter.py
+++ b/tests/test_openclaw_adapter.py
@@ -10,6 +10,7 @@ import pytest
 from codex_plugin_scanner.guard.adapters import get_adapter, list_adapters
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.openclaw import OpenClawHarnessAdapter
+from codex_plugin_scanner.guard.inventory_contract import serialize_inventory_snapshot
 from codex_plugin_scanner.guard.risk import artifact_risk_signals
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -104,6 +105,39 @@ def test_detects_openclaw_config_channels_mcp_and_skills(tmp_path: Path) -> None
     assert artifacts["openclaw:config:global"].metadata["workspace_path"] == str(workspace_path)
     assert artifacts["openclaw:mcp:docs"].transport == "http"
     assert artifacts["openclaw:mcp:local"].to_dict()["metadata"]["env"]["API_TOKEN"] == "*****"
+
+
+def test_inventory_snapshot_redacts_openclaw_channels_mcp_and_skills(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    config_path = context.home_dir / ".openclaw" / "openclaw.json"
+    skill_root = context.home_dir / ".openclaw" / "workspace" / "skills"
+    _write(
+        config_path,
+        json.dumps(
+            {
+                "channels": {"telegram": {"dmPolicy": "open", "allowFrom": ["*"]}},
+                "mcp": {
+                    "servers": {
+                        "docs": {
+                            "url": "https://user:pass@example.com/mcp?token=guard_live_secret",
+                            "headers": {"Authorization": "Bearer guard_live_secret"},
+                        }
+                    }
+                },
+            }
+        ),
+    )
+    _write(skill_root / "reviewer" / "SKILL.md", "---\nname: reviewer\n---\nRead project files.\n")
+
+    snapshot = OpenClawHarnessAdapter().inventory_snapshot(context, generated_at="2026-05-10T00:00:00Z")
+    payload = serialize_inventory_snapshot(snapshot)
+    encoded = json.dumps(payload, sort_keys=True)
+
+    assert payload["agent_type"] == "openclaw"
+    assert {item["item_kind"] for item in payload["items"]} >= {"channel", "mcp_server", "skill"}
+    assert "guard_live_secret" not in encoded
+    assert str(context.home_dir) not in encoded
+    assert str(context.workspace_dir) not in encoded
 
 
 def test_openclaw_flags_open_dm_policy_and_remote_mcp(tmp_path: Path) -> None:


### PR DESCRIPTION
Adds structured Guard agent inventory snapshots for Hermes and OpenClaw with redacted serialization, stable fingerprints, and regression coverage.\n\nVerification:\n- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -p no:cacheprovider tests/test_guard_inventory_contract.py tests/test_hermes_adapter.py::test_inventory_snapshot_redacts_hermes_skills_and_mcp_config tests/test_openclaw_adapter.py::test_inventory_snapshot_redacts_openclaw_channels_mcp_and_skills\n- python3 -m ruff check src/codex_plugin_scanner/guard/inventory_contract.py src/codex_plugin_scanner/guard/adapters/hermes.py src/codex_plugin_scanner/guard/adapters/openclaw.py tests/test_guard_inventory_contract.py tests/test_hermes_adapter.py tests/test_openclaw_adapter.py