### PR TITLE
feat(guard): add mcp tool inventory

### DIFF
--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -65,6 +65,35 @@ _SENSITIVE_KEY_RE = re.compile(
     re.IGNORECASE,
 )
 _WHITESPACE_RE = re.compile(r"\s+")
+_MCP_READ_RE = re.compile(
+    r"(?<![a-z0-9])(read|reads|reading|search|searches|list|lists)(?![a-z0-9])",
+    re.IGNORECASE,
+)
+_MCP_DELETE_RE = re.compile(
+    r"(?<![a-z0-9])(delete|deletes|remove|removes|destroy|destroys)(?![a-z0-9])",
+    re.IGNORECASE,
+)
+_MCP_WRITE_RE = re.compile(
+    r"(?<![a-z0-9])(write|writes|update|updates|create|creates|modify|modifies)(?![a-z0-9])",
+    re.IGNORECASE,
+)
+_MCP_SHELL_RE = re.compile(
+    r"(?<![a-z0-9])(shell|command|commands|execute|exec|subprocess)(?![a-z0-9])",
+    re.IGNORECASE,
+)
+_MCP_SECRET_RE = re.compile(
+    r"(?<![a-z0-9])(secret|secrets|token|tokens|password|passwords|credential|credentials|api[_\-\s]?key|apiKey)(?![a-z0-9])",
+    re.IGNORECASE,
+)
+_MCP_NETWORK_RE = re.compile(
+    r"(?<![a-z0-9])(http|url|urls|network|fetch|webhook|webhooks)(?![a-z0-9])",
+    re.IGNORECASE,
+)
+_MCP_MODEL_RE = re.compile(r"(?<![a-z0-9])(sampling|model|models|llm)(?![a-z0-9])", re.IGNORECASE)
+_MCP_PERMISSION_RE = re.compile(
+    r"(?<![a-z0-9])(permission|permissions|chmod)(?![a-z0-9])",
+    re.IGNORECASE,
+)
 _IGNORED_TREE_DIR_NAMES = {".git", ".hg", ".svn", "__pycache__", ".mypy_cache", ".ruff_cache", ".venv", "node_modules"}
 _MAX_FINGERPRINT_FILE_BYTES = 1024 * 1024
 
@@ -387,8 +416,8 @@ def _mcp_tool_items_from_artifact(
             continue
         display_name = _string_value(raw_tool.get("title")) or name
         description = _string_value(raw_tool.get("description")) or ""
-        input_schema = raw_tool.get("inputSchema") or raw_tool.get("input_schema")
-        output_schema = raw_tool.get("outputSchema") or raw_tool.get("output_schema")
+        input_schema = _first_present_value(raw_tool, "inputSchema", "input_schema")
+        output_schema = _first_present_value(raw_tool, "outputSchema", "output_schema")
         annotations = raw_tool.get("annotations")
         safe_annotations = annotations if isinstance(annotations, dict) else {}
         metadata = {
@@ -434,6 +463,13 @@ def _string_value(value: object) -> str | None:
     return value if isinstance(value, str) else None
 
 
+def _first_present_value(mapping: dict[str, object], *keys: str) -> object | None:
+    for key in keys:
+        if key in mapping:
+            return mapping[key]
+    return None
+
+
 def _capabilities_for_mcp_tool(
     name: str,
     description: str,
@@ -442,21 +478,21 @@ def _capabilities_for_mcp_tool(
 ) -> tuple[InventoryCapability, ...]:
     text = f"{name} {description} {json.dumps(input_schema, sort_keys=True, default=str)}".lower()
     capabilities: set[InventoryCapability] = set()
-    if annotations.get("readOnlyHint") is True or "read" in text or "search" in text or "list" in text:
+    if annotations.get("readOnlyHint") is True or _MCP_READ_RE.search(text):
         capabilities.add("reads_files")
-    if annotations.get("destructiveHint") is True or any(term in text for term in ("delete", "remove", "destroy")):
+    if annotations.get("destructiveHint") is True or _MCP_DELETE_RE.search(text):
         capabilities.update({"writes_files", "deletes_files"})
-    if annotations.get("writeHint") is True or any(term in text for term in ("write", "update", "create", "modify")):
+    if annotations.get("writeHint") is True or _MCP_WRITE_RE.search(text):
         capabilities.add("writes_files")
-    if any(term in text for term in ("shell", "command", "execute", "exec", "subprocess")):
+    if _MCP_SHELL_RE.search(text):
         capabilities.add("runs_shell")
-    if any(term in text for term in ("secret", "token", "password", "credential", "api key")):
+    if _MCP_SECRET_RE.search(text):
         capabilities.add("reads_secrets")
-    if any(term in text for term in ("http", "url", "network", "fetch", "webhook")):
+    if _MCP_NETWORK_RE.search(text):
         capabilities.add("network_egress")
-    if any(term in text for term in ("sampling", "model", "llm")):
+    if _MCP_MODEL_RE.search(text):
         capabilities.add("uses_model_sampling")
-    if "permission" in text or "chmod" in text:
+    if _MCP_PERMISSION_RE.search(text):
         capabilities.add("changes_permissions")
     return tuple(sorted(capabilities)) if capabilities else ("unknown",)
 

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -403,8 +403,8 @@ def _mcp_tool_items_from_artifact(
     raw_metadata = getattr(artifact, "metadata", {})
     if not isinstance(raw_metadata, dict):
         return ()
-    raw_tools = raw_metadata.get("tools") or raw_metadata.get("tool_schemas") or raw_metadata.get("toolSchemas")
-    if not isinstance(raw_tools, list):
+    raw_tools = _mcp_tool_definitions(raw_metadata)
+    if not raw_tools:
         return ()
 
     items: list[GuardAgentInventoryItem] = []
@@ -470,13 +470,47 @@ def _first_present_value(mapping: dict[str, object], *keys: str) -> object | Non
     return None
 
 
+def _mcp_tool_definitions(metadata: dict[str, object]) -> tuple[dict[str, object], ...]:
+    tools: list[dict[str, object]] = []
+    seen_names: set[str] = set()
+    for key in ("tools", "tool_schemas", "toolSchemas"):
+        raw_tools = metadata.get(key)
+        if not isinstance(raw_tools, list):
+            continue
+        for raw_tool in raw_tools:
+            if not isinstance(raw_tool, dict):
+                continue
+            name = raw_tool.get("name")
+            if not isinstance(name, str) or not name.strip() or name in seen_names:
+                continue
+            tools.append(raw_tool)
+            seen_names.add(name)
+    return tuple(tools)
+
+
+def _mcp_schema_signal_text(value: object) -> str:
+    if isinstance(value, dict):
+        parts: list[str] = []
+        for key, item in value.items():
+            if key in {"$schema", "$id"}:
+                continue
+            parts.append(key)
+            parts.append(_mcp_schema_signal_text(item))
+        return " ".join(part for part in parts if part)
+    if isinstance(value, list):
+        return " ".join(_mcp_schema_signal_text(item) for item in value)
+    if isinstance(value, str):
+        return value
+    return ""
+
+
 def _capabilities_for_mcp_tool(
     name: str,
     description: str,
     input_schema: object,
     annotations: dict[str, object],
 ) -> tuple[InventoryCapability, ...]:
-    text = f"{name} {description} {json.dumps(input_schema, sort_keys=True, default=str)}".lower()
+    text = f"{name} {description} {_mcp_schema_signal_text(input_schema)}".lower()
     capabilities: set[InventoryCapability] = set()
     if annotations.get("readOnlyHint") is True or _MCP_READ_RE.search(text):
         capabilities.add("reads_files")

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -191,15 +191,16 @@ def inventory_snapshot_from_detection(
 ) -> GuardAgentInventorySnapshot:
     harness = str(getattr(detection, "harness", "unknown"))
     artifacts = tuple(getattr(detection, "artifacts", ()))
-    items = tuple(
-        _item_from_artifact(
+    items: list[GuardAgentInventoryItem] = []
+    for artifact in artifacts:
+        item = _item_from_artifact(
             harness,
             artifact,
             home_dir=home_dir,
             workspace_dir=workspace_dir,
         )
-        for artifact in artifacts
-    )
+        items.append(item)
+        items.extend(_mcp_tool_items_from_artifact(harness, artifact, item))
     config_paths = tuple(dict.fromkeys(str(path) for path in getattr(detection, "config_paths", ())))
     sources = tuple(
         GuardInventorySource(
@@ -224,7 +225,7 @@ def inventory_snapshot_from_detection(
         agent_type=_agent_type(harness),
         generated_at=generated_at,
         runtime_version=runtime_version,
-        items=items,
+        items=tuple(items),
         sources=sources,
         redaction_report={
             "rawSecretsIncluded": False,
@@ -360,6 +361,115 @@ def _item_from_artifact(
         scanner_sources=("hol-detector",),
         metadata=safe_metadata,
     )
+
+
+def _mcp_tool_items_from_artifact(
+    harness: str,
+    artifact: object,
+    server_item: GuardAgentInventoryItem,
+) -> tuple[GuardAgentInventoryItem, ...]:
+    artifact_type = str(getattr(artifact, "artifact_type", "unknown"))
+    if artifact_type != "mcp_server":
+        return ()
+    raw_metadata = getattr(artifact, "metadata", {})
+    if not isinstance(raw_metadata, dict):
+        return ()
+    raw_tools = raw_metadata.get("tools") or raw_metadata.get("tool_schemas") or raw_metadata.get("toolSchemas")
+    if not isinstance(raw_tools, list):
+        return ()
+
+    items: list[GuardAgentInventoryItem] = []
+    for raw_tool in raw_tools:
+        if not isinstance(raw_tool, dict):
+            continue
+        name = raw_tool.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        display_name = _string_value(raw_tool.get("title")) or name
+        description = _string_value(raw_tool.get("description")) or ""
+        input_schema = raw_tool.get("inputSchema") or raw_tool.get("input_schema")
+        output_schema = raw_tool.get("outputSchema") or raw_tool.get("output_schema")
+        annotations = raw_tool.get("annotations")
+        safe_annotations = annotations if isinstance(annotations, dict) else {}
+        metadata = {
+            "serverItemId": server_item.item_id,
+            "toolName": name,
+            "title": display_name,
+            "descriptionHash": fingerprint_text(description),
+            "inputSchemaHash": fingerprint_mapping(input_schema) if input_schema is not None else None,
+            "outputSchemaHash": fingerprint_mapping(output_schema) if output_schema is not None else None,
+            "annotations": safe_annotations,
+            "schemaPresent": input_schema is not None or output_schema is not None,
+        }
+        capabilities = _capabilities_for_mcp_tool(name, description, input_schema, safe_annotations)
+        semantic_hash = fingerprint_mapping(
+            {
+                "server": server_item.item_id,
+                "name": name,
+                "description": description,
+                "inputSchema": input_schema,
+                "outputSchema": output_schema,
+                "annotations": safe_annotations,
+            }
+        )
+        items.append(
+            GuardAgentInventoryItem(
+                item_id=f"{server_item.item_id}:tool:{name}",
+                item_kind="mcp_tool",
+                display_name=display_name,
+                source_fingerprint=fingerprint_mapping(
+                    {"harness": harness, "server": server_item.item_id, "tool": name}
+                ),
+                content_hash=semantic_hash,
+                capability_categories=capabilities,
+                risk_level=_risk_level_for_capabilities(capabilities),
+                scanner_sources=("hol-detector",),
+                metadata=metadata,
+            )
+        )
+    return tuple(items)
+
+
+def _string_value(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _capabilities_for_mcp_tool(
+    name: str,
+    description: str,
+    input_schema: object,
+    annotations: dict[str, object],
+) -> tuple[InventoryCapability, ...]:
+    text = f"{name} {description} {json.dumps(input_schema, sort_keys=True, default=str)}".lower()
+    capabilities: set[InventoryCapability] = set()
+    if annotations.get("readOnlyHint") is True or "read" in text or "search" in text or "list" in text:
+        capabilities.add("reads_files")
+    if annotations.get("destructiveHint") is True or any(term in text for term in ("delete", "remove", "destroy")):
+        capabilities.update({"writes_files", "deletes_files"})
+    if annotations.get("writeHint") is True or any(term in text for term in ("write", "update", "create", "modify")):
+        capabilities.add("writes_files")
+    if any(term in text for term in ("shell", "command", "execute", "exec", "subprocess")):
+        capabilities.add("runs_shell")
+    if any(term in text for term in ("secret", "token", "password", "credential", "api key")):
+        capabilities.add("reads_secrets")
+    if any(term in text for term in ("http", "url", "network", "fetch", "webhook")):
+        capabilities.add("network_egress")
+    if any(term in text for term in ("sampling", "model", "llm")):
+        capabilities.add("uses_model_sampling")
+    if "permission" in text or "chmod" in text:
+        capabilities.add("changes_permissions")
+    return tuple(sorted(capabilities)) if capabilities else ("unknown",)
+
+
+def _risk_level_for_capabilities(capabilities: tuple[InventoryCapability, ...]) -> InventorySeverity:
+    if any(capability in capabilities for capability in ("deletes_files", "reads_secrets", "runs_shell")):
+        return "high"
+    if any(
+        capability in capabilities
+        for capability in ("writes_files", "network_egress", "uses_model_sampling", "changes_permissions")
+    ):
+        return "medium"
+    return "info"
 
 
 def _agent_type(value: str) -> AgentInventoryType:

--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -18,6 +18,7 @@ from codex_plugin_scanner.guard.inventory_contract import (
     redact_url,
     serialize_inventory_snapshot,
 )
+from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
 
 
 class _Detection:
@@ -157,3 +158,84 @@ def test_inventory_snapshot_deduplicates_config_sources(tmp_path: Path) -> None:
     )
 
     assert len(snapshot.sources) == 1
+
+
+def test_inventory_snapshot_extracts_mcp_tool_items(tmp_path: Path) -> None:
+    detection = HarnessDetection(
+        harness="hermes",
+        installed=True,
+        command_available=False,
+        config_paths=(),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="hermes:mcp:json:tools",
+                name="tools",
+                harness="hermes",
+                artifact_type="mcp_server",
+                source_scope="global",
+                config_path=str(tmp_path / ".hermes" / "mcp_servers.json"),
+                metadata={
+                    "tools": [
+                        {
+                            "name": "search_docs",
+                            "title": "Search docs",
+                            "description": "Read-only search over project documentation.",
+                            "inputSchema": {"type": "object", "properties": {"query": {"type": "string"}}},
+                            "outputSchema": {"type": "object"},
+                            "annotations": {"readOnlyHint": True, "destructiveHint": False},
+                        },
+                        {
+                            "name": "delete_file",
+                            "description": "Delete a file from disk.",
+                            "inputSchema": {"type": "object", "properties": {"path": {"type": "string"}}},
+                            "annotations": {"destructiveHint": True},
+                        },
+                    ]
+                },
+            ),
+        ),
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-05-10T00:00:00Z",
+        home_dir=tmp_path,
+    )
+    items = {item.item_id: item for item in snapshot.items}
+
+    assert "hermes:mcp:json:tools:tool:search_docs" in items
+    assert "hermes:mcp:json:tools:tool:delete_file" in items
+    assert items["hermes:mcp:json:tools:tool:search_docs"].capability_categories == ("reads_files",)
+    assert "writes_files" in items["hermes:mcp:json:tools:tool:delete_file"].capability_categories
+    assert items["hermes:mcp:json:tools:tool:delete_file"].risk_level == "high"
+
+
+def test_inventory_snapshot_handles_missing_mcp_tool_schema_and_scale(tmp_path: Path) -> None:
+    tools = [{"name": f"tool_{index}", "description": "No schema available."} for index in range(500)]
+    detection = HarnessDetection(
+        harness="openclaw",
+        installed=True,
+        command_available=False,
+        config_paths=(),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="openclaw:mcp:bulk",
+                name="bulk",
+                harness="openclaw",
+                artifact_type="mcp_server",
+                source_scope="global",
+                config_path=str(tmp_path / ".openclaw" / "openclaw.json"),
+                metadata={"tools": tools},
+            ),
+        ),
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-05-10T00:00:00Z",
+        home_dir=tmp_path,
+    )
+    tool_items = [item for item in snapshot.items if item.item_kind == "mcp_tool"]
+
+    assert len(tool_items) == 500
+    assert all(item.capability_categories == ("unknown",) for item in tool_items)

--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -318,3 +318,91 @@ def test_inventory_snapshot_mcp_capabilities_avoid_substring_false_positives(tmp
 
     assert tool_items["thread_listener"].capability_categories == ("unknown",)
     assert tool_items["credential_probe"].capability_categories == ("reads_secrets",)
+
+
+def test_inventory_snapshot_mcp_capabilities_ignore_schema_boilerplate(tmp_path: Path) -> None:
+    detection = HarnessDetection(
+        harness="hermes",
+        installed=True,
+        command_available=False,
+        config_paths=(),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="hermes:mcp:schema-boilerplate",
+                name="schema-boilerplate",
+                harness="hermes",
+                artifact_type="mcp_server",
+                source_scope="global",
+                config_path=str(tmp_path / ".hermes" / "mcp_servers.json"),
+                metadata={
+                    "tools": [
+                        {
+                            "name": "local_formatter",
+                            "inputSchema": {
+                                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                                "type": "object",
+                                "properties": {"format": {"type": "string"}},
+                            },
+                        },
+                        {
+                            "name": "remote_probe",
+                            "inputSchema": {
+                                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                                "type": "object",
+                                "properties": {"url": {"type": "string"}},
+                            },
+                        },
+                    ]
+                },
+            ),
+        ),
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-05-10T00:00:00Z",
+        home_dir=tmp_path,
+    )
+    tool_items = {item.display_name: item for item in snapshot.items if item.item_kind == "mcp_tool"}
+
+    assert tool_items["local_formatter"].capability_categories == ("unknown",)
+    assert tool_items["remote_probe"].capability_categories == ("network_egress",)
+
+
+def test_inventory_snapshot_mcp_tool_fallback_skips_non_schema_tool_allowlist(tmp_path: Path) -> None:
+    detection = HarnessDetection(
+        harness="hermes",
+        installed=True,
+        command_available=False,
+        config_paths=(),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="hermes:mcp:tool-schema-fallback",
+                name="tool-schema-fallback",
+                harness="hermes",
+                artifact_type="mcp_server",
+                source_scope="global",
+                config_path=str(tmp_path / ".hermes" / "mcp_servers.json"),
+                metadata={
+                    "tools": ["*"],
+                    "tool_schemas": [
+                        {
+                            "name": "search_repo",
+                            "description": "Search local project files.",
+                        }
+                    ],
+                },
+            ),
+        ),
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-05-10T00:00:00Z",
+        home_dir=tmp_path,
+    )
+    tool_items = [item for item in snapshot.items if item.item_kind == "mcp_tool"]
+
+    assert len(tool_items) == 1
+    assert tool_items[0].display_name == "search_repo"
+    assert tool_items[0].capability_categories == ("reads_files",)

--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -239,3 +239,82 @@ def test_inventory_snapshot_handles_missing_mcp_tool_schema_and_scale(tmp_path: 
 
     assert len(tool_items) == 500
     assert all(item.capability_categories == ("unknown",) for item in tool_items)
+
+
+def test_inventory_snapshot_preserves_empty_mcp_tool_schemas(tmp_path: Path) -> None:
+    detection = HarnessDetection(
+        harness="hermes",
+        installed=True,
+        command_available=False,
+        config_paths=(),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="hermes:mcp:empty-schema",
+                name="empty-schema",
+                harness="hermes",
+                artifact_type="mcp_server",
+                source_scope="global",
+                config_path=str(tmp_path / ".hermes" / "mcp_servers.json"),
+                metadata={"tools": [{"name": "ping", "inputSchema": {}, "output_schema": {}}]},
+            ),
+        ),
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-05-10T00:00:00Z",
+        home_dir=tmp_path,
+    )
+    tool = next(item for item in snapshot.items if item.item_kind == "mcp_tool")
+
+    assert tool.metadata["schemaPresent"] is True
+    assert tool.metadata["inputSchemaHash"] == fingerprint_mapping({})
+    assert tool.metadata["outputSchemaHash"] == fingerprint_mapping({})
+
+
+def test_inventory_snapshot_mcp_capabilities_avoid_substring_false_positives(tmp_path: Path) -> None:
+    detection = HarnessDetection(
+        harness="hermes",
+        installed=True,
+        command_available=False,
+        config_paths=(),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="hermes:mcp:false-positive",
+                name="false-positive",
+                harness="hermes",
+                artifact_type="mcp_server",
+                source_scope="global",
+                config_path=str(tmp_path / ".hermes" / "mcp_servers.json"),
+                metadata={
+                    "tools": [
+                        {
+                            "name": "thread_listener",
+                            "description": "Returns execution_id for listened events.",
+                            "inputSchema": {"type": "object", "properties": {"execution_id": {"type": "string"}}},
+                        },
+                        {
+                            "name": "credential_probe",
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {
+                                    "api_key": {"type": "string"},
+                                    "apiKey": {"type": "string"},
+                                },
+                            },
+                        },
+                    ]
+                },
+            ),
+        ),
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-05-10T00:00:00Z",
+        home_dir=tmp_path,
+    )
+    tool_items = {item.display_name: item for item in snapshot.items if item.item_kind == "mcp_tool"}
+
+    assert tool_items["thread_listener"].capability_categories == ("unknown",)
+    assert tool_items["credential_probe"].capability_categories == ("reads_secrets",)


### PR DESCRIPTION
Adds MCP tool-level inventory extraction from server metadata, including schema hashing, capability classification, risk levels, scale coverage, and regression tests.\n\nVerification:\n- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -p no:cacheprovider tests/test_guard_inventory_contract.py\n- python3 -m ruff check src/codex_plugin_scanner/guard/inventory_contract.py tests/test_guard_inventory_contract.py