### PR TITLE
feat(guard): add cisco inventory evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ pip install "plugin-scanner[cisco]"
 
 On Guard surfaces, the Cisco extra adds optional offline evidence to `hol-guard scan`, `hol-guard preflight`, and `hol-guard explain <path>`. Use `--cisco-mode {auto,on,off}` to control that consumer-mode evidence path for local artifact scans. `hol-guard run` and Guard runtime prompt/file-read protection remain native Guard behavior in this pass.
 
+Guard inventory snapshots can also carry Cisco MCP and skill-scanner status when a Hermes or OpenClaw inventory run explicitly enables those scanners. The Cloud evidence model records scanner source, status, redacted finding text, duration, mapped artifact ID, and risk component metadata without storing raw local paths or secrets.
+
 Guard does not add Cisco AIBOM runtime integration in this pass. If AIBOM support returns later, it should stay on evidence or export surfaces rather than Guard blocking or approval logic.
 
 ### Cisco package status

--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -13,6 +13,7 @@ import re
 import sys
 from pathlib import Path
 
+from ..inventory_cisco import run_cisco_inventory_scans
 from ..inventory_contract import GuardAgentInventorySnapshot, inventory_snapshot_from_detection
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
@@ -247,12 +248,29 @@ class HermesHarnessAdapter(HarnessAdapter):
             config_paths=tuple(found_paths),
         )
 
-    def inventory_snapshot(self, context: HarnessContext, *, generated_at: str) -> GuardAgentInventorySnapshot:
+    def inventory_snapshot(
+        self,
+        context: HarnessContext,
+        *,
+        generated_at: str,
+        cisco_mcp_scan: str = "off",
+        cisco_skill_scan: str = "off",
+        cisco_timeout_seconds: float | None = None,
+    ) -> GuardAgentInventorySnapshot:
+        detection = self.detect(context)
         return inventory_snapshot_from_detection(
-            self.detect(context),
+            detection,
             generated_at=generated_at,
             home_dir=context.home_dir,
             workspace_dir=context.workspace_dir,
+            cisco_runs=run_cisco_inventory_scans(
+                harness=self.harness,
+                context=context,
+                detection=detection,
+                mcp_mode=cisco_mcp_scan,
+                skill_mode=cisco_skill_scan,
+                timeout_seconds=cisco_timeout_seconds,
+            ),
         )
 
     # ------------------------------------------------------------------

--- a/src/codex_plugin_scanner/guard/adapters/openclaw.py
+++ b/src/codex_plugin_scanner/guard/adapters/openclaw.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from ..inventory_cisco import run_cisco_inventory_scans
 from ..inventory_contract import GuardAgentInventorySnapshot, inventory_snapshot_from_detection
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
@@ -65,12 +66,29 @@ class OpenClawHarnessAdapter(HarnessAdapter):
             artifacts=tuple(artifacts),
         )
 
-    def inventory_snapshot(self, context: HarnessContext, *, generated_at: str) -> GuardAgentInventorySnapshot:
+    def inventory_snapshot(
+        self,
+        context: HarnessContext,
+        *,
+        generated_at: str,
+        cisco_mcp_scan: str = "off",
+        cisco_skill_scan: str = "off",
+        cisco_timeout_seconds: float | None = None,
+    ) -> GuardAgentInventorySnapshot:
+        detection = self.detect(context)
         return inventory_snapshot_from_detection(
-            self.detect(context),
+            detection,
             generated_at=generated_at,
             home_dir=context.home_dir,
             workspace_dir=context.workspace_dir,
+            cisco_runs=run_cisco_inventory_scans(
+                harness=self.harness,
+                context=context,
+                detection=detection,
+                mcp_mode=cisco_mcp_scan,
+                skill_mode=cisco_skill_scan,
+                timeout_seconds=cisco_timeout_seconds,
+            ),
         )
 
     def install(self, context: HarnessContext) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/inventory_cisco.py
+++ b/src/codex_plugin_scanner/guard/inventory_cisco.py
@@ -1,0 +1,165 @@
+"""Cisco scanner bridge for Guard inventory snapshots."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from ..integrations.cisco_mcp_scanner import run_cisco_mcp_scan
+from ..integrations.cisco_skill_scanner import run_cisco_skill_scan
+from ..models import Finding
+from .adapters.base import HarnessContext
+
+CiscoInventorySource = Literal["cisco-mcp-scanner", "cisco-skill-scanner"]
+
+
+@dataclass(frozen=True, slots=True)
+class CiscoInventoryRun:
+    source: CiscoInventorySource
+    status: str
+    message: str
+    findings: tuple[Finding, ...]
+    duration_ms: int
+    metadata: dict[str, object]
+
+
+def run_cisco_inventory_scans(
+    *,
+    harness: str,
+    context: HarnessContext,
+    detection: object,
+    mcp_mode: str = "off",
+    skill_mode: str = "off",
+    timeout_seconds: float | None = None,
+) -> tuple[CiscoInventoryRun, ...]:
+    runs: list[CiscoInventoryRun] = []
+    if mcp_mode != "off":
+        runs.append(_run_mcp_inventory_scan(context=context, mode=mcp_mode, timeout_seconds=timeout_seconds))
+    if skill_mode != "off":
+        runs.append(
+            _run_skill_inventory_scan(
+                harness=harness,
+                context=context,
+                detection=detection,
+                mode=skill_mode,
+                timeout_seconds=timeout_seconds,
+            )
+        )
+    return tuple(runs)
+
+
+def _run_mcp_inventory_scan(
+    *,
+    context: HarnessContext,
+    mode: str,
+    timeout_seconds: float | None,
+) -> CiscoInventoryRun:
+    root = _mcp_scan_root(context)
+    if root is None:
+        return CiscoInventoryRun(
+            source="cisco-mcp-scanner",
+            status="skipped",
+            message="No .mcp.json found; Cisco MCP inventory scan skipped.",
+            findings=(),
+            duration_ms=0,
+            metadata={"target": "missing", "targetsScanned": 0, "mode": mode},
+        )
+    started = time.perf_counter()
+    summary = run_cisco_mcp_scan(root, mode=mode, timeout_seconds=timeout_seconds)
+    duration_ms = int((time.perf_counter() - started) * 1000)
+    return CiscoInventoryRun(
+        source="cisco-mcp-scanner",
+        status=str(summary.status.value),
+        message=summary.message,
+        findings=summary.findings,
+        duration_ms=duration_ms,
+        metadata={
+            "target": root.name,
+            "targetsScanned": summary.targets_scanned,
+            "totalFindings": summary.total_findings,
+            "findingsBySeverity": summary.findings_by_severity,
+            "analyzersUsed": summary.analyzers_used,
+            "scanMode": summary.scan_mode,
+            "mode": mode,
+        },
+    )
+
+
+def _run_skill_inventory_scan(
+    *,
+    harness: str,
+    context: HarnessContext,
+    detection: object,
+    mode: str,
+    timeout_seconds: float | None,
+) -> CiscoInventoryRun:
+    root = _skill_scan_root(harness=harness, context=context, detection=detection)
+    if root is None:
+        return CiscoInventoryRun(
+            source="cisco-skill-scanner",
+            status="skipped",
+            message="No skill directory found; Cisco skill inventory scan skipped.",
+            findings=(),
+            duration_ms=0,
+            metadata={"target": "missing", "skillsScanned": 0, "mode": mode},
+        )
+    started = time.perf_counter()
+    summary = run_cisco_skill_scan(root, mode=mode, timeout_seconds=timeout_seconds)
+    duration_ms = int((time.perf_counter() - started) * 1000)
+    return CiscoInventoryRun(
+        source="cisco-skill-scanner",
+        status=str(summary.status.value),
+        message=summary.message,
+        findings=summary.findings,
+        duration_ms=duration_ms,
+        metadata={
+            "target": root.name,
+            "skillsScanned": summary.skills_scanned,
+            "skillsSkipped": summary.skills_skipped,
+            "totalFindings": summary.total_findings,
+            "findingsBySeverity": summary.findings_by_severity,
+            "analyzersUsed": summary.analyzers_used,
+            "policyName": summary.policy_name,
+            "mode": mode,
+        },
+    )
+
+
+def _mcp_scan_root(context: HarnessContext) -> Path | None:
+    candidates = []
+    if context.workspace_dir is not None:
+        candidates.append(context.workspace_dir)
+    candidates.append(context.home_dir)
+    for candidate in candidates:
+        if (candidate / ".mcp.json").is_file():
+            return candidate
+    return None
+
+
+def _skill_scan_root(*, harness: str, context: HarnessContext, detection: object) -> Path | None:
+    if harness == "hermes":
+        hermes_skills = context.home_dir / ".hermes" / "skills"
+        if hermes_skills.is_dir():
+            return hermes_skills
+    artifacts = tuple(getattr(detection, "artifacts", ()))
+    for artifact in artifacts:
+        artifact_type = str(getattr(artifact, "artifact_type", ""))
+        if artifact_type not in {"skill", "skill_file"}:
+            continue
+        config_path = getattr(artifact, "config_path", None)
+        if not isinstance(config_path, str):
+            continue
+        skill_path = Path(config_path)
+        root = _nearest_skills_root(skill_path)
+        if root is not None and root.is_dir():
+            return root
+    return None
+
+
+def _nearest_skills_root(path: Path) -> Path | None:
+    for parent in path.parents:
+        if parent.name == "skills":
+            return parent
+    return None

--- a/src/codex_plugin_scanner/guard/inventory_cisco.py
+++ b/src/codex_plugin_scanner/guard/inventory_cisco.py
@@ -148,11 +148,21 @@ def _skill_scan_root(*, harness: str, context: HarnessContext, detection: object
         artifact_type = str(getattr(artifact, "artifact_type", ""))
         if artifact_type not in {"skill", "skill_file"}:
             continue
+        metadata = getattr(artifact, "metadata", {})
+        if isinstance(metadata, dict):
+            skill_root = metadata.get("skill_root")
+            if isinstance(skill_root, str):
+                root = Path(skill_root)
+                if root.is_dir():
+                    return root
         config_path = getattr(artifact, "config_path", None)
         if not isinstance(config_path, str):
             continue
         skill_path = Path(config_path)
         root = _nearest_skills_root(skill_path)
+        if root is not None and root.is_dir():
+            return root
+        root = _nearest_skill_dir(skill_path)
         if root is not None and root.is_dir():
             return root
     return None
@@ -161,5 +171,14 @@ def _skill_scan_root(*, harness: str, context: HarnessContext, detection: object
 def _nearest_skills_root(path: Path) -> Path | None:
     for parent in path.parents:
         if parent.name == "skills":
+            return parent
+    return None
+
+
+def _nearest_skill_dir(path: Path) -> Path | None:
+    if path.name == "SKILL.md":
+        return path.parent
+    for parent in path.parents:
+        if (parent / "SKILL.md").is_file():
             return parent
     return None

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -64,9 +64,7 @@ _SENSITIVE_KEY_RE = re.compile(
     r"(auth|authorization|bearer|token|secret|password|credential|api[^a-z0-9]?key)",
     re.IGNORECASE,
 )
-_SENSITIVE_VALUE_RE = re.compile(
-    r"(?i)(gh[pousr]_[a-z0-9_]+|sk-[a-z0-9_-]+|guard_live_[a-z0-9_-]+|bearer\s+\S+)"
-)
+_SENSITIVE_VALUE_RE = re.compile(r"(?i)(gh[pousr]_[a-z0-9_]+|sk-[a-z0-9_-]+|guard_live_[a-z0-9_-]+|bearer\s+\S+)")
 _WHITESPACE_RE = re.compile(r"\s+")
 _MCP_READ_RE = re.compile(
     r"(?<![a-z0-9])(read|reads|reading|search|searches|list|lists)(?![a-z0-9])",
@@ -575,7 +573,7 @@ def _cisco_inventory_findings(
             workspace_dir=workspace_dir,
         )
         duration_ms = getattr(run, "duration_ms", None)
-        for raw_finding in tuple(getattr(run, "findings", ())):
+        for raw_finding in tuple(getattr(run, "findings", ()) or ()):
             rule_id = str(getattr(raw_finding, "rule_id", "cisco-finding") or "cisco-finding")
             title = _safe_finding_text(
                 str(getattr(raw_finding, "title", "Cisco scanner finding") or "Cisco scanner finding"),

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -64,6 +64,9 @@ _SENSITIVE_KEY_RE = re.compile(
     r"(auth|authorization|bearer|token|secret|password|credential|api[^a-z0-9]?key)",
     re.IGNORECASE,
 )
+_SENSITIVE_VALUE_RE = re.compile(
+    r"(?i)(gh[pousr]_[a-z0-9_]+|sk-[a-z0-9_-]+|guard_live_[a-z0-9_-]+|bearer\s+\S+)"
+)
 _WHITESPACE_RE = re.compile(r"\s+")
 _MCP_READ_RE = re.compile(
     r"(?<![a-z0-9])(read|reads|reading|search|searches|list|lists)(?![a-z0-9])",
@@ -217,6 +220,7 @@ def inventory_snapshot_from_detection(
     home_dir: Path,
     workspace_dir: Path | None = None,
     runtime_version: str | None = None,
+    cisco_runs: tuple[object, ...] = (),
 ) -> GuardAgentInventorySnapshot:
     harness = str(getattr(detection, "harness", "unknown"))
     artifacts = tuple(getattr(detection, "artifacts", ()))
@@ -231,7 +235,7 @@ def inventory_snapshot_from_detection(
         items.append(item)
         items.extend(_mcp_tool_items_from_artifact(harness, artifact, item))
     config_paths = tuple(dict.fromkeys(str(path) for path in getattr(detection, "config_paths", ())))
-    sources = tuple(
+    config_sources = tuple(
         GuardInventorySource(
             source_id=f"{harness}:config:{fingerprint_text(redact_local_path(path, home_dir=home_dir))[:12]}",
             source_type="config",
@@ -241,11 +245,19 @@ def inventory_snapshot_from_detection(
         )
         for path in config_paths
     )
+    cisco_findings = _cisco_inventory_findings(
+        cisco_runs,
+        items=tuple(items),
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+    )
+    sources = (*config_sources, *_cisco_inventory_sources(cisco_runs))
     snapshot_hash = fingerprint_mapping(
         {
             "agent_type": harness,
             "generated_at": generated_at,
             "item_ids": [item.item_id for item in items],
+            "finding_ids": [finding.finding_id for finding in cisco_findings],
         }
     )
     return GuardAgentInventorySnapshot(
@@ -255,10 +267,11 @@ def inventory_snapshot_from_detection(
         generated_at=generated_at,
         runtime_version=runtime_version,
         items=tuple(items),
+        findings=cisco_findings,
         sources=sources,
         redaction_report={
             "rawSecretsIncluded": False,
-            "redactedFields": ("headers", "env", "url", "paths"),
+            "redactedFields": ("headers", "env", "url", "paths", "ciscoFindingText"),
         },
     )
 
@@ -540,6 +553,162 @@ def _risk_level_for_capabilities(capabilities: tuple[InventoryCapability, ...]) 
     ):
         return "medium"
     return "info"
+
+
+def _cisco_inventory_findings(
+    cisco_runs: tuple[object, ...],
+    *,
+    items: tuple[GuardAgentInventoryItem, ...],
+    home_dir: Path,
+    workspace_dir: Path | None,
+) -> tuple[GuardAgentInventoryFinding, ...]:
+    findings: list[GuardAgentInventoryFinding] = []
+    seen: set[str] = set()
+    for run in cisco_runs:
+        source = _cisco_source(run)
+        if source is None:
+            continue
+        run_status = str(getattr(run, "status", "unknown"))
+        run_message = _safe_finding_text(
+            str(getattr(run, "message", "")),
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+        )
+        duration_ms = getattr(run, "duration_ms", None)
+        for raw_finding in tuple(getattr(run, "findings", ())):
+            rule_id = str(getattr(raw_finding, "rule_id", "cisco-finding") or "cisco-finding")
+            title = _safe_finding_text(
+                str(getattr(raw_finding, "title", "Cisco scanner finding") or "Cisco scanner finding"),
+                home_dir=home_dir,
+                workspace_dir=workspace_dir,
+            )
+            file_path = getattr(raw_finding, "file_path", None)
+            safe_path = (
+                _redact_known_path(str(file_path), home_dir, workspace_dir)
+                if isinstance(file_path, str) and file_path
+                else None
+            )
+            line_number = getattr(raw_finding, "line_number", None)
+            finding_hash = fingerprint_mapping(
+                {
+                    "source": source,
+                    "rule_id": rule_id,
+                    "title": title,
+                    "path": safe_path,
+                    "line": line_number if isinstance(line_number, int) else None,
+                }
+            )
+            finding_id = f"{source}:{rule_id}:{finding_hash[:16]}"
+            if finding_id in seen:
+                continue
+            seen.add(finding_id)
+            severity = _inventory_severity(getattr(raw_finding, "severity", "info"))
+            findings.append(
+                GuardAgentInventoryFinding(
+                    finding_id=finding_id,
+                    source=source,
+                    severity=severity,
+                    confidence="high" if run_status == "enabled" else "unknown",
+                    title=title,
+                    artifact_id=_artifact_id_for_cisco_finding(safe_path, items),
+                    check_id=rule_id,
+                    summary=_safe_finding_text(
+                        str(getattr(raw_finding, "description", "") or ""),
+                        home_dir=home_dir,
+                        workspace_dir=workspace_dir,
+                    ),
+                    evidence={
+                        "scannerStatus": run_status,
+                        "scannerMessage": run_message,
+                        "filePath": safe_path,
+                        "lineNumber": line_number if isinstance(line_number, int) else None,
+                        "durationMs": duration_ms if isinstance(duration_ms, int) else None,
+                        "riskComponent": {
+                            "source": source,
+                            "severity": severity,
+                            "confidence": "high" if run_status == "enabled" else "unknown",
+                            "scoreDelta": _score_delta_for_severity(severity),
+                        },
+                    },
+                )
+            )
+    return tuple(findings)
+
+
+def _cisco_inventory_sources(cisco_runs: tuple[object, ...]) -> tuple[GuardInventorySource, ...]:
+    sources: list[GuardInventorySource] = []
+    for run in cisco_runs:
+        source = _cisco_source(run)
+        if source is None:
+            continue
+        status = str(getattr(run, "status", "unknown"))
+        detail = _safe_source_detail(run)
+        sources.append(
+            GuardInventorySource(
+                source_id=f"{source}:{fingerprint_mapping({'status': status, 'detail': detail})[:12]}",
+                source_type="scanner",
+                status=_source_status_for_cisco_status(status),
+                detail=detail,
+            )
+        )
+    return tuple(sources)
+
+
+def _cisco_source(run: object) -> InventoryFindingSource | None:
+    source = str(getattr(run, "source", ""))
+    if source in {"cisco-mcp-scanner", "cisco-skill-scanner"}:
+        return source
+    return None
+
+
+def _inventory_severity(value: object) -> InventorySeverity:
+    severity_value = str(getattr(value, "value", value)).strip().lower()
+    if severity_value in {"critical", "high", "medium", "low", "info"}:
+        return severity_value
+    return "info"
+
+
+def _score_delta_for_severity(severity: InventorySeverity) -> int:
+    return {"critical": -40, "high": -25, "medium": -12, "low": -5, "info": 0}[severity]
+
+
+def _artifact_id_for_cisco_finding(
+    safe_path: str | None,
+    items: tuple[GuardAgentInventoryItem, ...],
+) -> str:
+    if safe_path is None:
+        return "unknown"
+    for item in items:
+        config_path = item.metadata.get("configPath")
+        if isinstance(config_path, str) and (config_path == safe_path or config_path.endswith(safe_path)):
+            return item.item_id
+    return "unknown"
+
+
+def _source_status_for_cisco_status(status: str) -> Literal["available", "missing", "failed"]:
+    if status == "enabled":
+        return "available"
+    if status in {"failed", "timed_out"}:
+        return "failed"
+    return "missing"
+
+
+def _safe_source_detail(run: object) -> str:
+    status = str(getattr(run, "status", "unknown"))
+    metadata = getattr(run, "metadata", {})
+    finding_count = None
+    if isinstance(metadata, dict):
+        candidate = metadata.get("totalFindings")
+        if isinstance(candidate, int):
+            finding_count = candidate
+    suffix = f", findings={finding_count}" if finding_count is not None else ""
+    return f"status={status}{suffix}"
+
+
+def _safe_finding_text(value: str, *, home_dir: Path, workspace_dir: Path | None) -> str:
+    redacted = _SENSITIVE_VALUE_RE.sub("redacted", value)
+    redacted = _redact_command_value(redacted, home_dir, workspace_dir)
+    return redacted[:500]
 
 
 def _agent_type(value: str) -> AgentInventoryType:

--- a/tests/test_guard_inventory_cisco.py
+++ b/tests/test_guard_inventory_cisco.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.inventory_cisco import run_cisco_inventory_scans
+from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
+from codex_plugin_scanner.integrations.cisco_skill_scanner import CiscoIntegrationStatus
+from codex_plugin_scanner.models import Finding, Severity
+
+
+@dataclass(frozen=True, slots=True)
+class _McpSummary:
+    status: CiscoIntegrationStatus
+    message: str
+    findings: tuple[Finding, ...]
+    targets_scanned: int
+    analyzers_used: tuple[str, ...]
+    total_findings: int
+    findings_by_severity: dict[str, int]
+    scan_mode: str = "static"
+
+
+@dataclass(frozen=True, slots=True)
+class _SkillSummary:
+    status: CiscoIntegrationStatus
+    message: str
+    findings: tuple[Finding, ...]
+    skills_scanned: int
+    skills_skipped: tuple[str, ...]
+    analyzers_used: tuple[str, ...]
+    policy_name: str
+    total_findings: int
+    findings_by_severity: dict[str, int]
+
+
+def _ctx(tmp_path: Path) -> HarnessContext:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    guard_home = tmp_path / "guard-home"
+    home_dir.mkdir(parents=True)
+    workspace_dir.mkdir(parents=True)
+    guard_home.mkdir(parents=True)
+    return HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=guard_home)
+
+
+def test_cisco_inventory_scans_report_missing_targets_without_running_dependencies(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    detection = HarnessDetection(
+        harness="hermes",
+        installed=True,
+        command_available=False,
+        config_paths=(),
+        artifacts=(),
+    )
+
+    runs = run_cisco_inventory_scans(
+        harness="hermes",
+        context=context,
+        detection=detection,
+        mcp_mode="auto",
+        skill_mode="auto",
+    )
+
+    assert [run.source for run in runs] == ["cisco-mcp-scanner", "cisco-skill-scanner"]
+    assert all(run.status == "skipped" for run in runs)
+    assert all(run.duration_ms == 0 for run in runs)
+
+
+def test_cisco_inventory_scans_run_mcp_and_skill_scanners_with_required_mode(tmp_path: Path, monkeypatch) -> None:
+    context = _ctx(tmp_path)
+    (context.workspace_dir / ".mcp.json").write_text('{"mcpServers": {}}\n')
+    skill_path = context.home_dir / ".hermes" / "skills" / "ops" / "reviewer" / "SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text("---\nname: reviewer\n---\nReview local files.\n")
+    detection = HarnessDetection(
+        harness="hermes",
+        installed=True,
+        command_available=False,
+        config_paths=(str(skill_path),),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="hermes:skill:ops:reviewer",
+                name="reviewer",
+                harness="hermes",
+                artifact_type="skill",
+                source_scope="global",
+                config_path=str(skill_path),
+            ),
+        ),
+    )
+    calls: list[tuple[str, Path, str, float | None]] = []
+
+    def fake_mcp_scan(plugin_dir: Path, mode: str, timeout_seconds: float | None = None) -> _McpSummary:
+        calls.append(("mcp", plugin_dir, mode, timeout_seconds))
+        return _McpSummary(
+            status=CiscoIntegrationStatus.ENABLED,
+            message="MCP scanner completed.",
+            findings=(),
+            targets_scanned=1,
+            analyzers_used=("yara",),
+            total_findings=0,
+            findings_by_severity={severity.value: 0 for severity in Severity},
+        )
+
+    def fake_skill_scan(skills_dir: Path, mode: str, timeout_seconds: float | None = None) -> _SkillSummary:
+        calls.append(("skill", skills_dir, mode, timeout_seconds))
+        return _SkillSummary(
+            status=CiscoIntegrationStatus.ENABLED,
+            message="Skill scanner completed.",
+            findings=(),
+            skills_scanned=1,
+            skills_skipped=(),
+            analyzers_used=("prompt-injection",),
+            policy_name="balanced",
+            total_findings=0,
+            findings_by_severity={severity.value: 0 for severity in Severity},
+        )
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.inventory_cisco.run_cisco_mcp_scan", fake_mcp_scan)
+    monkeypatch.setattr("codex_plugin_scanner.guard.inventory_cisco.run_cisco_skill_scan", fake_skill_scan)
+
+    runs = run_cisco_inventory_scans(
+        harness="hermes",
+        context=context,
+        detection=detection,
+        mcp_mode="on",
+        skill_mode="on",
+        timeout_seconds=3.5,
+    )
+
+    assert [call[0] for call in calls] == ["mcp", "skill"]
+    assert calls[0][1] == context.workspace_dir
+    assert calls[1][1] == context.home_dir / ".hermes" / "skills"
+    assert all(call[2] == "on" and call[3] == 3.5 for call in calls)
+    assert all(run.status == "enabled" for run in runs)
+
+
+def test_cisco_inventory_scans_preserve_timeout_status(tmp_path: Path, monkeypatch) -> None:
+    context = _ctx(tmp_path)
+    (context.workspace_dir / ".mcp.json").write_text('{"mcpServers": {}}\n')
+    detection = HarnessDetection(
+        harness="openclaw",
+        installed=True,
+        command_available=False,
+        config_paths=(),
+        artifacts=(),
+    )
+
+    def fake_mcp_scan(plugin_dir: Path, mode: str, timeout_seconds: float | None = None) -> object:
+        del plugin_dir, mode, timeout_seconds
+        return SimpleNamespace(
+            status=CiscoIntegrationStatus.TIMED_OUT,
+            message="Cisco MCP scanner timed out.",
+            findings=(),
+            targets_scanned=0,
+            analyzers_used=(),
+            total_findings=0,
+            findings_by_severity={severity.value: 0 for severity in Severity},
+            scan_mode="static",
+        )
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.inventory_cisco.run_cisco_mcp_scan", fake_mcp_scan)
+
+    runs = run_cisco_inventory_scans(
+        harness="openclaw",
+        context=context,
+        detection=detection,
+        mcp_mode="on",
+    )
+
+    assert runs[0].source == "cisco-mcp-scanner"
+    assert runs[0].status == "timed_out"
+    assert runs[0].metadata["targetsScanned"] == 0

--- a/tests/test_guard_inventory_cisco.py
+++ b/tests/test_guard_inventory_cisco.py
@@ -174,3 +174,55 @@ def test_cisco_inventory_scans_preserve_timeout_status(tmp_path: Path, monkeypat
     assert runs[0].source == "cisco-mcp-scanner"
     assert runs[0].status == "timed_out"
     assert runs[0].metadata["targetsScanned"] == 0
+
+
+def test_cisco_inventory_scans_use_detected_nonstandard_skill_roots(tmp_path: Path, monkeypatch) -> None:
+    context = _ctx(tmp_path)
+    extra_root = context.home_dir / "shared-openclaw-skills"
+    skill_path = extra_root / "reviewer" / "SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text("---\nname: reviewer\n---\nReview local files.\n")
+    detection = HarnessDetection(
+        harness="openclaw",
+        installed=True,
+        command_available=False,
+        config_paths=(str(skill_path),),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="openclaw:skill:extra:reviewer",
+                name="reviewer",
+                harness="openclaw",
+                artifact_type="skill",
+                source_scope="global",
+                config_path=str(skill_path),
+                metadata={"skill_root": str(extra_root)},
+            ),
+        ),
+    )
+    calls: list[Path] = []
+
+    def fake_skill_scan(skills_dir: Path, mode: str, timeout_seconds: float | None = None) -> _SkillSummary:
+        del mode, timeout_seconds
+        calls.append(skills_dir)
+        return _SkillSummary(
+            status=CiscoIntegrationStatus.ENABLED,
+            message="Skill scanner completed.",
+            findings=(),
+            skills_scanned=1,
+            skills_skipped=(),
+            analyzers_used=("prompt-injection",),
+            policy_name="balanced",
+            total_findings=0,
+            findings_by_severity={severity.value: 0 for severity in Severity},
+        )
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.inventory_cisco.run_cisco_skill_scan", fake_skill_scan)
+
+    run_cisco_inventory_scans(
+        harness="openclaw",
+        context=context,
+        detection=detection,
+        skill_mode="on",
+    )
+
+    assert calls == [extra_root]

--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from codex_plugin_scanner.guard.inventory_cisco import CiscoInventoryRun
 from codex_plugin_scanner.guard.inventory_contract import (
     GuardAgentInventoryFinding,
     GuardAgentInventoryItem,
@@ -19,6 +20,7 @@ from codex_plugin_scanner.guard.inventory_contract import (
     serialize_inventory_snapshot,
 )
 from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
+from codex_plugin_scanner.models import Finding, Severity
 
 
 class _Detection:
@@ -406,3 +408,64 @@ def test_inventory_snapshot_mcp_tool_fallback_skips_non_schema_tool_allowlist(tm
     assert len(tool_items) == 1
     assert tool_items[0].display_name == "search_repo"
     assert tool_items[0].capability_categories == ("reads_files",)
+
+
+def test_inventory_snapshot_maps_cisco_findings_to_redacted_inventory_evidence(tmp_path: Path) -> None:
+    skill_path = tmp_path / ".hermes" / "skills" / "ops" / "reviewer" / "SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text("---\nname: reviewer\n---\nUse safe local review.\n")
+    detection = HarnessDetection(
+        harness="hermes",
+        installed=True,
+        command_available=False,
+        config_paths=(str(skill_path),),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="hermes:skill:ops:reviewer",
+                name="reviewer",
+                harness="hermes",
+                artifact_type="skill",
+                source_scope="global",
+                config_path=str(skill_path),
+                metadata={"content_hash": "abc123"},
+            ),
+        ),
+    )
+    finding = Finding(
+        rule_id="CISCO-SKILL-PROMPT-INJECTION",
+        severity=Severity.HIGH,
+        category="skill-security",
+        title="Prompt injection guard_live_secret",
+        description=f"Unsafe instruction in {skill_path} with token=guard_live_secret",
+        file_path=str(skill_path),
+        line_number=7,
+        source="cisco-skill-scanner",
+    )
+    cisco_run = CiscoInventoryRun(
+        source="cisco-skill-scanner",
+        status="enabled",
+        message="Cisco skill scanner found guard_live_secret",
+        findings=(finding, finding),
+        duration_ms=42,
+        metadata={"totalFindings": 2},
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-05-10T00:00:00Z",
+        home_dir=tmp_path,
+        cisco_runs=(cisco_run,),
+    )
+    payload = serialize_inventory_snapshot(snapshot)
+    encoded = json.dumps(payload, sort_keys=True)
+
+    assert len(payload["findings"]) == 1
+    assert payload["findings"][0]["source"] == "cisco-skill-scanner"
+    assert payload["findings"][0]["severity"] == "high"
+    assert payload["findings"][0]["confidence"] == "high"
+    assert payload["findings"][0]["artifact_id"] == "hermes:skill:ops:reviewer"
+    assert payload["findings"][0]["evidence"]["durationMs"] == 42
+    assert payload["findings"][0]["evidence"]["riskComponent"]["scoreDelta"] == -25
+    assert payload["sources"][-1]["source_type"] == "scanner"
+    assert "guard_live_secret" not in encoded
+    assert str(tmp_path) not in encoded

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -12,9 +12,11 @@ from codex_plugin_scanner.guard.adapters.hermes import (
     _extract_env_mentions,
     _looks_like_secret,
 )
+from codex_plugin_scanner.guard.inventory_cisco import CiscoInventoryRun
 from codex_plugin_scanner.guard.inventory_contract import serialize_inventory_snapshot
 from codex_plugin_scanner.guard.risk import artifact_risk_signals
 from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.models import Finding, Severity
 
 FIXTURES = Path(__file__).parent / "fixtures" / "hermes-plugin-evil"
 
@@ -121,6 +123,50 @@ def test_inventory_snapshot_redacts_hermes_skills_and_mcp_config(tmp_path: Path)
     assert "--token guard_live_secret" not in encoded
     assert "user:pass" not in encoded
     assert str(tmp_path) not in encoded
+
+
+def test_inventory_snapshot_can_include_cisco_hermes_inventory_runs(tmp_path: Path, monkeypatch) -> None:
+    _write(
+        tmp_path / ".hermes" / "skills" / "ops" / "reviewer" / "SKILL.md",
+        "---\nname: reviewer\n---\nReview local files.\n",
+    )
+    context = _ctx(tmp_path)
+    calls: list[dict[str, object]] = []
+
+    def fake_cisco_runs(**kwargs):
+        calls.append(kwargs)
+        return (
+            CiscoInventoryRun(
+                source="cisco-skill-scanner",
+                status="enabled",
+                message="Cisco skill scanner completed.",
+                findings=(
+                    Finding(
+                        rule_id="CISCO-SKILL-001",
+                        severity=Severity.MEDIUM,
+                        category="skill-security",
+                        title="Review instruction risk",
+                        description="Prompt injection pattern.",
+                        file_path=str(tmp_path / ".hermes" / "skills" / "ops" / "reviewer" / "SKILL.md"),
+                        source="cisco-skill-scanner",
+                    ),
+                ),
+                duration_ms=12,
+                metadata={"totalFindings": 1},
+            ),
+        )
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.hermes.run_cisco_inventory_scans", fake_cisco_runs)
+
+    snapshot = HermesHarnessAdapter().inventory_snapshot(
+        context,
+        generated_at="2026-05-10T00:00:00Z",
+        cisco_skill_scan="on",
+    )
+
+    assert calls[0]["harness"] == "hermes"
+    assert calls[0]["skill_mode"] == "on"
+    assert snapshot.findings[0].source == "cisco-skill-scanner"
 
 
 def test_install_includes_non_secret_cloud_identity_hints_when_configured(tmp_path: Path):

--- a/tests/test_openclaw_adapter.py
+++ b/tests/test_openclaw_adapter.py
@@ -10,9 +10,11 @@ import pytest
 from codex_plugin_scanner.guard.adapters import get_adapter, list_adapters
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.openclaw import OpenClawHarnessAdapter
+from codex_plugin_scanner.guard.inventory_cisco import CiscoInventoryRun
 from codex_plugin_scanner.guard.inventory_contract import serialize_inventory_snapshot
 from codex_plugin_scanner.guard.risk import artifact_risk_signals
 from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.models import Finding, Severity
 
 
 def _ctx(tmp_path: Path) -> HarnessContext:
@@ -138,6 +140,50 @@ def test_inventory_snapshot_redacts_openclaw_channels_mcp_and_skills(tmp_path: P
     assert "guard_live_secret" not in encoded
     assert str(context.home_dir) not in encoded
     assert str(context.workspace_dir) not in encoded
+
+
+def test_inventory_snapshot_can_include_cisco_openclaw_inventory_runs(tmp_path: Path, monkeypatch) -> None:
+    context = _ctx(tmp_path)
+    config_path = context.home_dir / ".openclaw" / "openclaw.json"
+    skill_path = context.home_dir / ".openclaw" / "workspace" / "skills" / "reviewer" / "SKILL.md"
+    _write(config_path, json.dumps({"skills": {"load": {}}}))
+    _write(skill_path, "---\nname: reviewer\n---\nReview local files.\n")
+    calls: list[dict[str, object]] = []
+
+    def fake_cisco_runs(**kwargs):
+        calls.append(kwargs)
+        return (
+            CiscoInventoryRun(
+                source="cisco-skill-scanner",
+                status="enabled",
+                message="Cisco skill scanner completed.",
+                findings=(
+                    Finding(
+                        rule_id="CISCO-SKILL-001",
+                        severity=Severity.LOW,
+                        category="skill-security",
+                        title="Review instruction risk",
+                        description="Prompt injection pattern.",
+                        file_path=str(skill_path),
+                        source="cisco-skill-scanner",
+                    ),
+                ),
+                duration_ms=9,
+                metadata={"totalFindings": 1},
+            ),
+        )
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.openclaw.run_cisco_inventory_scans", fake_cisco_runs)
+
+    snapshot = OpenClawHarnessAdapter().inventory_snapshot(
+        context,
+        generated_at="2026-05-10T00:00:00Z",
+        cisco_skill_scan="on",
+    )
+
+    assert calls[0]["harness"] == "openclaw"
+    assert calls[0]["skill_mode"] == "on"
+    assert snapshot.findings[0].source == "cisco-skill-scanner"
 
 
 def test_openclaw_flags_open_dm_policy_and_remote_mcp(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary\n- add optional Cisco MCP and skill scanner evidence to Guard inventory snapshots\n- normalize Cisco findings into redacted inventory findings with scanner source, status, duration, mapped artifact IDs, and risk component metadata\n- add regression coverage for Hermes/OpenClaw inventory generation, missing scanner targets, timeouts, dedupe, and redaction\n\n## Verification\n- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -p no:cacheprovider tests/test_guard_inventory_contract.py tests/test_guard_inventory_cisco.py tests/test_hermes_adapter.py tests/test_openclaw_adapter.py tests/test_guard_cisco_evidence.py tests/test_guard_cisco_runtime_cli.py tests/test_cisco_install_surfaces.py\n- python3 -m ruff check src/codex_plugin_scanner/guard/inventory_contract.py src/codex_plugin_scanner/guard/inventory_cisco.py src/codex_plugin_scanner/guard/adapters/hermes.py src/codex_plugin_scanner/guard/adapters/openclaw.py tests/test_guard_inventory_contract.py tests/test_guard_inventory_cisco.py tests/test_hermes_adapter.py tests/test_openclaw_adapter.py