### PR TITLE
fix(guard): allow chained source reads

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5190,27 +5190,49 @@ def _codex_command_is_read_only_source_inspection(command_text: str, *, cwd: Pat
 
 
 def _split_codex_safe_read_only_chain(command: str) -> list[str] | None:
-    try:
-        parts = _codex_shell_split(command)
-    except ValueError:
-        return None
-    if "&&" not in parts:
-        return None
     segments: list[str] = []
-    current: list[str] = []
-    for part in parts:
-        if part == "&&":
-            if not current:
-                return None
-            segments.append(shlex.join(current))
-            current = []
+    start = 0
+    quote: str | None = None
+    escaped = False
+    found_chain = False
+    index = 0
+    while index < len(command):
+        char = command[index]
+        if escaped:
+            escaped = False
+            index += 1
             continue
-        if part in {"||", ";", "&"}:
+        if char == "\\":
+            escaped = True
+            index += 1
+            continue
+        if quote is not None:
+            if char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            index += 1
+            continue
+        if command.startswith("&&", index):
+            segment = command[start:index].strip()
+            if not segment:
+                return None
+            segments.append(segment)
+            found_chain = True
+            index += 2
+            start = index
+            continue
+        if command.startswith("||", index) or char in {";", "&"}:
             return None
-        current.append(part)
-    if not current:
+        index += 1
+    if quote is not None or escaped or not found_chain:
         return None
-    segments.append(shlex.join(current))
+    segment = command[start:].strip()
+    if not segment:
+        return None
+    segments.append(segment)
     return segments if len(segments) > 1 else None
 
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5170,6 +5170,9 @@ def _codex_command_is_read_only_source_inspection(command_text: str, *, cwd: Pat
         return False
     if _codex_command_has_unquoted_glob_metachar(command):
         return False
+    chained_segments = _split_codex_safe_read_only_chain(command)
+    if chained_segments is not None:
+        return all(_codex_command_is_read_only_source_inspection(segment, cwd=cwd) for segment in chained_segments)
     segments = _split_codex_safe_read_only_pipeline(command)
     if segments is None:
         return _codex_command_is_read_only_source_search(command, cwd=cwd) or _codex_command_is_read_only_source_view(
@@ -5184,6 +5187,31 @@ def _codex_command_is_read_only_source_inspection(command_text: str, *, cwd: Pat
     ):
         return False
     return all(_codex_command_is_bounded_read_only_filter(segment) for segment in filter_segments)
+
+
+def _split_codex_safe_read_only_chain(command: str) -> list[str] | None:
+    try:
+        parts = _codex_shell_split(command)
+    except ValueError:
+        return None
+    if "&&" not in parts:
+        return None
+    segments: list[str] = []
+    current: list[str] = []
+    for part in parts:
+        if part == "&&":
+            if not current:
+                return None
+            segments.append(shlex.join(current))
+            current = []
+            continue
+        if part in {"||", ";", "&"}:
+            return None
+        current.append(part)
+    if not current:
+        return None
+    segments.append(shlex.join(current))
+    return segments if len(segments) > 1 else None
 
 
 def _codex_command_has_unquoted_glob_metachar(command: str) -> bool:

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13287,3 +13287,41 @@ def test_codex_read_only_source_inspection_rejects_sed_chain_with_secret_file(tm
         command,
         cwd=workspace_dir,
     )
+
+
+def test_codex_read_only_source_inspection_preserves_pipelines_in_safe_chains(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    route_file = workspace_dir / "src" / "api" / "routes" / "skill-registry.ts"
+    service_file = workspace_dir / "src" / "services" / "skill-registry" / "skill-registry-service.ts"
+    _write_text(route_file, "export const safe = true;\n")
+    _write_text(service_file, "export const alsoSafe = true;\n")
+
+    command = (
+        "rg skill src/api/routes/skill-registry.ts | head -20 && "
+        "sed -n '940,1005p' src/services/skill-registry/skill-registry-service.ts"
+    )
+
+    assert guard_commands_module._codex_command_is_read_only_source_inspection(
+        command,
+        cwd=workspace_dir,
+    )
+
+
+def test_codex_read_only_source_inspection_rejects_malformed_chains(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+
+    commands = [
+        "&& sed -n '1,10p' src/safe.ts",
+        "sed -n '1,10p' src/safe.ts &&",
+        "sed -n '1,10p' src/safe.ts && && cat src/safe.ts",
+        "sed -n '1,10p' src/safe.ts || cat src/safe.ts",
+        "sed -n '1,10p' src/safe.ts; cat src/safe.ts",
+    ]
+
+    for command in commands:
+        assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+            command,
+            cwd=workspace_dir,
+        )

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13243,3 +13243,47 @@ def test_codex_read_only_source_inspection_allows_quoted_bracket_targets(tmp_pat
             command,
             cwd=workspace_dir,
         )
+
+
+def test_codex_read_only_source_inspection_allows_safe_sed_chains(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    route_file = workspace_dir / "src" / "api" / "routes" / "skill-registry.ts"
+    service_file = workspace_dir / "src" / "services" / "skill-registry" / "skill-registry-service.ts"
+    _write_text(route_file, "export const headerName = 'x-api-key';\n")
+    _write_text(service_file, "export const registryTokenField = 'tokenId';\n")
+
+    command = (
+        "sed -n '450,510p' src/api/routes/skill-registry.ts && "
+        "sed -n '940,1005p' src/services/skill-registry/skill-registry-service.ts"
+    )
+
+    assert guard_commands_module._codex_command_is_read_only_source_inspection(
+        command,
+        cwd=workspace_dir,
+    )
+    artifact = guard_commands_module._codex_post_tool_output_artifact(
+        payload={
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "tool_response": {
+                "stdout": "export const headerName = 'x-api-key';\nexport const registryTokenField = 'tokenId';\n"
+            },
+        },
+        config_path=str(workspace_dir / ".codex" / "config.toml"),
+        source_scope="workspace",
+        cwd=workspace_dir,
+    )
+    assert artifact is None
+
+
+def test_codex_read_only_source_inspection_rejects_sed_chain_with_secret_file(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    route_file = workspace_dir / "src" / "api" / "routes" / "skill-registry.ts"
+    _write_text(route_file, "export const safe = true;\n")
+
+    command = "sed -n '450,510p' src/api/routes/skill-registry.ts && cat .env"
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        command,
+        cwd=workspace_dir,
+    )


### PR DESCRIPTION
## Summary
- Treat safe && chains of read-only source inspections as source inspection, not credential exfiltration
- Preserve rejection for chains that reach sensitive files like .env
- Add regression coverage for chained sed reads over TypeScript source containing key/token identifiers

## Verification
- ruff check src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_runtime.py
- ruff format --check src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_runtime.py
- PYTHONPATH=src pytest tests/test_guard_runtime.py focused source-inspection tests -q