### PR TITLE
fix(guard): allow GraphQL review queries

### DIFF
--- a/dashboard/src/approval-center-layout.tsx
+++ b/dashboard/src/approval-center-layout.tsx
@@ -77,6 +77,7 @@ import type {
   GuardRuntimeSnapshot,
   DecisionScope
 } from "./guard-types";
+import { guardAwareHref } from "./guard-api";
 
 type RequestState =
   | { kind: "loading" }
@@ -1295,6 +1296,7 @@ function resolveMcpInputSummary(payload: Record<string, unknown>): string | null
 function BlockedActionCard(props: { item: GuardApprovalRequest }) {
   const launchText = actionLaunchText(props.item);
   const decisionDetail = resolveDecisionV2Detail(props.item);
+  const [shareState, setShareState] = useState<"idle" | "copied" | "failed">("idle");
   const isBlocked = props.item.policy_action === "block";
   const bannerBg = isBlocked
     ? "bg-gradient-to-r from-brand-purple/90 to-brand-purple/75"
@@ -1310,6 +1312,19 @@ function BlockedActionCard(props: { item: GuardApprovalRequest }) {
     isMcpTool && envelope !== null
       ? resolveMcpInputSummary(envelope.raw_payload_redacted)
       : null;
+  const approvalUrl = props.item.approval_url ? guardAwareHref(props.item.approval_url) : null;
+
+  const handleCopyApprovalUrl = useCallback(async () => {
+    if (approvalUrl === null) return;
+    try {
+      await navigator.clipboard.writeText(approvalUrl);
+      setShareState("copied");
+      window.setTimeout(() => setShareState("idle"), 1800);
+    } catch {
+      setShareState("failed");
+      window.setTimeout(() => setShareState("idle"), 2400);
+    }
+  }, [approvalUrl]);
 
   return (
     <div className="overflow-hidden rounded-[1.65rem] border border-brand-blue/15 bg-white/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.85)]">
@@ -1318,16 +1333,27 @@ function BlockedActionCard(props: { item: GuardApprovalRequest }) {
         <span className="font-mono text-[11px] font-semibold uppercase tracking-[0.2em] text-white">
           {bannerLabel}
         </span>
-        {props.item.approval_url ? (
-          <a
-            href={props.item.approval_url}
-            target="_blank"
-            rel="noreferrer"
-            className="ml-auto inline-flex items-center gap-1 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-white/80 transition-colors hover:text-white"
-          >
-            Approval link
-            <HiMiniArrowTopRightOnSquare className="h-3 w-3" aria-hidden="true" />
-          </a>
+        {approvalUrl ? (
+          <div className="ml-auto flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleCopyApprovalUrl}
+              className="inline-flex items-center gap-1 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-white/80 transition-colors hover:text-white"
+              aria-label="Copy local review link"
+            >
+              <HiMiniClipboard className="h-3 w-3" aria-hidden="true" />
+              {shareState === "copied" ? "Copied" : shareState === "failed" ? "Copy failed" : "Copy link"}
+            </button>
+            <a
+              href={approvalUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-white/80 transition-colors hover:text-white"
+            >
+              Open
+              <HiMiniArrowTopRightOnSquare className="h-3 w-3" aria-hidden="true" />
+            </a>
+          </div>
         ) : null}
       </div>
       <div className="p-4">

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -163,12 +163,12 @@ export function guardAwareHref(href: string): string {
   }
 
   const url = new URL(href, window.location.origin);
-  if (url.origin !== window.location.origin) {
+  const daemonOrigin = readGuardDaemonOrigin();
+  if (url.origin !== window.location.origin && url.origin !== daemonOrigin) {
     return href;
   }
 
   const fragmentPairs = [[GUARD_TOKEN_PARAM, guardToken]];
-  const daemonOrigin = readGuardDaemonOrigin();
   if (daemonOrigin) {
     fragmentPairs.push([GUARD_DAEMON_PARAM, daemonOrigin]);
   }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -12728,11 +12728,11 @@ function guardAwareHref(href) {
     return href;
   }
   const url = new URL(href, window.location.origin);
-  if (url.origin !== window.location.origin) {
+  const daemonOrigin = readGuardDaemonOrigin();
+  if (url.origin !== window.location.origin && url.origin !== daemonOrigin) {
     return href;
   }
   const fragmentPairs = [[GUARD_TOKEN_PARAM, guardToken]];
-  const daemonOrigin = readGuardDaemonOrigin();
   if (daemonOrigin) {
     fragmentPairs.push([GUARD_DAEMON_PARAM, daemonOrigin]);
   }
@@ -15561,6 +15561,7 @@ function resolveMcpInputSummary(payload) {
 function BlockedActionCard(props) {
   const launchText = actionLaunchText(props.item);
   const decisionDetail = resolveDecisionV2Detail(props.item);
+  const [shareState, setShareState] = reactExports.useState("idle");
   const isBlocked = props.item.policy_action === "block";
   const bannerBg = isBlocked ? "bg-gradient-to-r from-brand-purple/90 to-brand-purple/75" : "bg-gradient-to-r from-brand-blue/85 to-brand-dark/80";
   const bannerLabel = isBlocked ? "Blocked" : "Paused for review";
@@ -15571,23 +15572,50 @@ function BlockedActionCard(props) {
   const mcpServer = isMcpTool ? envelope?.mcp_server ?? null : null;
   const mcpTool = isMcpTool ? envelope?.mcp_tool ?? null : null;
   const mcpInputSummary = isMcpTool && envelope !== null ? resolveMcpInputSummary(envelope.raw_payload_redacted) : null;
+  const approvalUrl = props.item.approval_url ? guardAwareHref(props.item.approval_url) : null;
+  const handleCopyApprovalUrl = reactExports.useCallback(async () => {
+    if (approvalUrl === null) return;
+    try {
+      await navigator.clipboard.writeText(approvalUrl);
+      setShareState("copied");
+      window.setTimeout(() => setShareState("idle"), 1800);
+    } catch {
+      setShareState("failed");
+      window.setTimeout(() => setShareState("idle"), 2400);
+    }
+  }, [approvalUrl]);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "overflow-hidden rounded-[1.65rem] border border-brand-blue/15 bg-white/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.85)]", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `flex items-center gap-2 px-4 py-2.5 ${bannerBg}`, children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(BannerIcon, { className: "h-3.5 w-3.5 shrink-0 text-white", "aria-hidden": "true" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-mono text-[11px] font-semibold uppercase tracking-[0.2em] text-white", children: bannerLabel }),
-      props.item.approval_url ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
-        "a",
-        {
-          href: props.item.approval_url,
-          target: "_blank",
-          rel: "noreferrer",
-          className: "ml-auto inline-flex items-center gap-1 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-white/80 transition-colors hover:text-white",
-          children: [
-            "Approval link",
-            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowTopRightOnSquare, { className: "h-3 w-3", "aria-hidden": "true" })
-          ]
-        }
-      ) : null
+      approvalUrl ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "ml-auto flex items-center gap-2", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "button",
+          {
+            type: "button",
+            onClick: handleCopyApprovalUrl,
+            className: "inline-flex items-center gap-1 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-white/80 transition-colors hover:text-white",
+            "aria-label": "Copy local review link",
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniClipboard, { className: "h-3 w-3", "aria-hidden": "true" }),
+              shareState === "copied" ? "Copied" : shareState === "failed" ? "Copy failed" : "Copy link"
+            ]
+          }
+        ),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "a",
+          {
+            href: approvalUrl,
+            target: "_blank",
+            rel: "noreferrer",
+            className: "inline-flex items-center gap-1 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-white/80 transition-colors hover:text-white",
+            children: [
+              "Open",
+              /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowTopRightOnSquare, { className: "h-3 w-3", "aria-hidden": "true" })
+            ]
+          }
+        )
+      ] }) : null
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "p-4", children: [
       isMcpTool && mcpServer !== null && mcpTool !== null && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mb-3 space-y-2 rounded-xl border border-brand-blue/20 bg-brand-blue/[0.04] px-3 py-2", children: [

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -2692,8 +2692,6 @@ def _looks_like_safe_graphql_query_file_workflow(command_text: str) -> bool:
     rest = match.group("rest").strip()
     if not rest.startswith("gh api graphql "):
         return False
-    if _path_text_looks_sensitive(rest):
-        return False
     if re.search(r"(?:;|&|\|\||\||>|<|\n)", rest):
         return False
     rest_without_allowed_query_refs = rest
@@ -2744,6 +2742,8 @@ def _looks_like_temporary_pr_threads_query_path(path_text: str) -> bool:
     if basename != "pr-threads-query.graphql":
         return False
     if not normalized.startswith("/"):
+        return False
+    if os.path.exists(normalized):
         return False
     lowered = os.path.realpath(normalized).replace("\\", "/").lower()
     return lowered.startswith(

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -2628,6 +2628,8 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
     normalized = command_text.strip()
     if not normalized:
         return False
+    if _looks_like_safe_graphql_query_file_workflow(normalized):
+        return False
     parts = _split_shell_parts(normalized)
     if not parts:
         return False
@@ -2662,6 +2664,61 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
     return any(
         command_name == "sed" and any(part == "-i" or part.startswith("-i") for part in parts[1:])
         for command_name in command_names
+    )
+
+
+_SAFE_GRAPHQL_QUERY_FILE_WORKFLOW_PATTERN = re.compile(
+    r"\A\s*cat\s*>\s*(?P<path>'[^']+'|\"[^\"]+\"|[^\s]+)\s*<<['\"]?(?P<label>[A-Za-z_][A-Za-z0-9_]*)['\"]?"
+    r"\s*\n(?P<body>.*?)\n(?P=label)\s*(?:\n|&&|;)\s*(?P<rest>.+)\Z",
+    re.DOTALL,
+)
+
+
+def _looks_like_safe_graphql_query_file_workflow(command_text: str) -> bool:
+    match = _SAFE_GRAPHQL_QUERY_FILE_WORKFLOW_PATTERN.match(command_text)
+    if match is None:
+        return False
+    target_path = _strip_shell_quotes(match.group("path").strip())
+    if not target_path.endswith(".graphql") or _path_text_looks_sensitive(target_path):
+        return False
+    body = match.group("body").strip()
+    if not re.search(r"\bquery\b", body) or re.search(r"\bmutation\b|\bsubscription\b", body):
+        return False
+    rest = match.group("rest").strip()
+    if not rest.startswith("gh api graphql "):
+        return False
+    if re.search(r"(?:^|[;&|])\s*(?:rm|mv|cp|chmod|chown|curl|wget|python|python3|node|bash|sh|zsh)\b", rest):
+        return False
+    query_file_refs = {
+        f"$(cat {target_path})",
+        f'$(cat "{target_path}")',
+        f"$(cat '{target_path}')",
+    }
+    return any(ref in rest for ref in query_file_refs) and re.search(r"(?:^|\s)-f\s+query=", rest) is not None
+
+
+def _strip_shell_quotes(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def _path_text_looks_sensitive(path_text: str) -> bool:
+    lowered = path_text.lower()
+    return any(
+        marker in lowered
+        for marker in (
+            "/.aws/",
+            "/.docker/",
+            "/.kube/",
+            "/.ssh/",
+            ".env",
+            ".git-credentials",
+            ".netrc",
+            ".npmrc",
+            ".pypirc",
+            "id_rsa",
+        )
     )
 
 

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -2679,7 +2679,11 @@ def _looks_like_safe_graphql_query_file_workflow(command_text: str) -> bool:
     if match is None:
         return False
     target_path = _strip_shell_quotes(match.group("path").strip())
-    if not target_path.endswith(".graphql") or _path_text_looks_sensitive(target_path):
+    if (
+        not target_path.endswith(".graphql")
+        or _path_text_looks_sensitive(target_path)
+        or _contains_shell_expansion(target_path)
+    ):
         return False
     body = match.group("body").strip()
     if not re.search(r"\bquery\b", body) or re.search(r"\bmutation\b|\bsubscription\b", body):
@@ -2717,6 +2721,10 @@ def _strip_shell_quotes(value: str) -> str:
     if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
         return value[1:-1]
     return value
+
+
+def _contains_shell_expansion(value: str) -> bool:
+    return "$(" in value or "`" in value or "${" in value
 
 
 def _path_text_looks_sensitive(path_text: str) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -2737,7 +2737,7 @@ def _looks_like_temporary_pr_threads_query_path(path_text: str) -> bool:
         return False
     if not normalized.startswith("/"):
         return False
-    lowered = normalized.lower()
+    lowered = os.path.realpath(normalized).replace("\\", "/").lower()
     return lowered.startswith(
         (
             "/tmp/",

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -2711,7 +2711,13 @@ def _strip_shell_quotes(value: str) -> str:
 
 
 def _contains_shell_expansion(value: str) -> bool:
-    return "$(" in value or "`" in value or "${" in value or re.search(r"\$[A-Za-z_][A-Za-z0-9_]*", value) is not None
+    return (
+        "$(" in value
+        or "`" in value
+        or "${" in value
+        or re.search(r"\$[A-Za-z_][A-Za-z0-9_]*", value) is not None
+        or re.search(r"[*?\[\]{}]", value) is not None
+    )
 
 
 def _graphql_query_file_substitution_refs(target_path: str) -> set[str]:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -2687,14 +2687,30 @@ def _looks_like_safe_graphql_query_file_workflow(command_text: str) -> bool:
     rest = match.group("rest").strip()
     if not rest.startswith("gh api graphql "):
         return False
-    if re.search(r"(?:^|[;&|])\s*(?:rm|mv|cp|chmod|chown|curl|wget|python|python3|node|bash|sh|zsh)\b", rest):
+    if _path_text_looks_sensitive(rest):
         return False
     query_file_refs = {
         f"$(cat {target_path})",
         f'$(cat "{target_path}")',
         f"$(cat '{target_path}')",
     }
-    return any(ref in rest for ref in query_file_refs) and re.search(r"(?:^|\s)-f\s+query=", rest) is not None
+    query_file_field_refs = {
+        f"query=@{target_path}",
+        f'query=@"{target_path}"',
+        f"query=@'{target_path}'",
+    }
+    if re.search(r"(?:;|&&|\|\||\||>|<|\n)", rest):
+        return False
+    rest_without_allowed_query_refs = rest
+    for ref in query_file_refs:
+        rest_without_allowed_query_refs = rest_without_allowed_query_refs.replace(ref, "")
+    if "$(" in rest_without_allowed_query_refs or "`" in rest_without_allowed_query_refs:
+        return False
+    has_query_file_read = any(ref in rest for ref in query_file_refs)
+    has_query_file_field = any(ref in rest for ref in query_file_field_refs)
+    return (has_query_file_read or has_query_file_field) and re.search(
+        r"(?:^|\s)(?:-f|--field)\s*query=", rest
+    ) is not None
 
 
 def _strip_shell_quotes(value: str) -> str:
@@ -2708,10 +2724,10 @@ def _path_text_looks_sensitive(path_text: str) -> bool:
     return any(
         marker in lowered
         for marker in (
-            "/.aws/",
-            "/.docker/",
-            "/.kube/",
-            "/.ssh/",
+            ".aws/",
+            ".docker/",
+            ".kube/",
+            ".ssh/",
             ".env",
             ".git-credentials",
             ".netrc",

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -2683,6 +2683,7 @@ def _looks_like_safe_graphql_query_file_workflow(command_text: str) -> bool:
         not target_path.endswith(".graphql")
         or _path_text_looks_sensitive(target_path)
         or _contains_shell_expansion(target_path)
+        or not _looks_like_temporary_pr_threads_query_path(target_path)
     ):
         return False
     body = match.group("body").strip()
@@ -2725,6 +2726,23 @@ def _strip_shell_quotes(value: str) -> str:
 
 def _contains_shell_expansion(value: str) -> bool:
     return "$(" in value or "`" in value or "${" in value
+
+
+def _looks_like_temporary_pr_threads_query_path(path_text: str) -> bool:
+    normalized = path_text.replace("\\", "/")
+    basename = os.path.basename(normalized)
+    if basename != "pr-threads-query.graphql":
+        return False
+    lowered = normalized.lower()
+    return any(
+        marker in lowered
+        for marker in (
+            "/tmp/",
+            "/var/folders/",
+            "/.copilot/session-state/",
+            "/.cache/",
+        )
+    )
 
 
 def _path_text_looks_sensitive(path_text: str) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -2703,7 +2703,7 @@ def _looks_like_safe_graphql_query_file_workflow(command_text: str) -> bool:
         f'query=@"{target_path}"',
         f"query=@'{target_path}'",
     }
-    if re.search(r"(?:;|&&|\|\||\||>|<|\n)", rest):
+    if re.search(r"(?:;|&|\|\||\||>|<|\n)", rest):
         return False
     rest_without_allowed_query_refs = rest
     for ref in query_file_refs:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -2715,6 +2715,8 @@ def _contains_shell_expansion(value: str) -> bool:
         "$(" in value
         or "`" in value
         or "${" in value
+        or "$'" in value
+        or '$"' in value
         or re.search(r"\$[A-Za-z_][A-Za-z0-9_]*", value) is not None
         or re.search(r"[*?\[\]{}]", value) is not None
     )

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -2729,7 +2729,7 @@ def _contains_shell_expansion(value: str) -> bool:
 
 
 def _looks_like_temporary_pr_threads_query_path(path_text: str) -> bool:
-    normalized = path_text.replace("\\", "/")
+    normalized = os.path.normpath(path_text.replace("\\", "/")).replace("\\", "/")
     basename = os.path.basename(normalized)
     if basename != "pr-threads-query.graphql":
         return False

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -2694,28 +2694,14 @@ def _looks_like_safe_graphql_query_file_workflow(command_text: str) -> bool:
         return False
     if _path_text_looks_sensitive(rest):
         return False
-    query_file_refs = {
-        f"$(cat {target_path})",
-        f'$(cat "{target_path}")',
-        f"$(cat '{target_path}')",
-    }
-    query_file_field_refs = {
-        f"query=@{target_path}",
-        f'query=@"{target_path}"',
-        f"query=@'{target_path}'",
-    }
     if re.search(r"(?:;|&|\|\||\||>|<|\n)", rest):
         return False
     rest_without_allowed_query_refs = rest
-    for ref in query_file_refs:
+    for ref in _graphql_query_file_substitution_refs(target_path):
         rest_without_allowed_query_refs = rest_without_allowed_query_refs.replace(ref, "")
     if "$(" in rest_without_allowed_query_refs or "`" in rest_without_allowed_query_refs:
         return False
-    has_query_file_read = any(ref in rest for ref in query_file_refs)
-    has_query_file_field = any(ref in rest for ref in query_file_field_refs)
-    return (has_query_file_read or has_query_file_field) and re.search(
-        r"(?:^|\s)(?:-f|--field)\s*query=", rest
-    ) is not None
+    return _rest_has_exact_graphql_query_file_arg(rest, target_path)
 
 
 def _strip_shell_quotes(value: str) -> str:
@@ -2728,6 +2714,22 @@ def _contains_shell_expansion(value: str) -> bool:
     return "$(" in value or "`" in value or "${" in value or re.search(r"\$[A-Za-z_][A-Za-z0-9_]*", value) is not None
 
 
+def _graphql_query_file_substitution_refs(target_path: str) -> set[str]:
+    return {
+        f"$(cat {target_path})",
+        f'$(cat "{target_path}")',
+        f"$(cat '{target_path}')",
+    }
+
+
+def _rest_has_exact_graphql_query_file_arg(rest: str, target_path: str) -> bool:
+    escaped_path = re.escape(target_path)
+    path_value = rf"(?:(?:\"|'){escaped_path}(?:\"|')|{escaped_path})"
+    substitution_pattern = rf"(?:^|\s)(?:-f|--field)\s+query=(?:\"|')?\$\(cat {path_value}\)(?:\"|')?(?:\s|$)"
+    field_pattern = rf"(?:^|\s)(?:-f|--field)\s+query=@{path_value}(?:\s|$)"
+    return re.search(substitution_pattern, rest) is not None or re.search(field_pattern, rest) is not None
+
+
 def _looks_like_temporary_pr_threads_query_path(path_text: str) -> bool:
     normalized = os.path.normpath(path_text.replace("\\", "/")).replace("\\", "/")
     basename = os.path.basename(normalized)
@@ -2736,17 +2738,14 @@ def _looks_like_temporary_pr_threads_query_path(path_text: str) -> bool:
     if not normalized.startswith("/"):
         return False
     lowered = normalized.lower()
-    return (
-        lowered.startswith(
-            (
-                "/tmp/",
-                "/var/tmp/",
-                "/private/tmp/",
-                "/var/folders/",
-                "/private/var/folders/",
-            )
+    return lowered.startswith(
+        (
+            "/tmp/",
+            "/var/tmp/",
+            "/private/tmp/",
+            "/var/folders/",
+            "/private/var/folders/",
         )
-        or "/.copilot/session-state/" in lowered
     )
 
 

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -2725,7 +2725,7 @@ def _strip_shell_quotes(value: str) -> str:
 
 
 def _contains_shell_expansion(value: str) -> bool:
-    return "$(" in value or "`" in value or "${" in value
+    return "$(" in value or "`" in value or "${" in value or re.search(r"\$[A-Za-z_][A-Za-z0-9_]*", value) is not None
 
 
 def _looks_like_temporary_pr_threads_query_path(path_text: str) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -2668,7 +2668,7 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
 
 
 _SAFE_GRAPHQL_QUERY_FILE_WORKFLOW_PATTERN = re.compile(
-    r"\A\s*cat\s*>\s*(?P<path>'[^']+'|\"[^\"]+\"|[^\s]+)\s*<<['\"]?(?P<label>[A-Za-z_][A-Za-z0-9_]*)['\"]?"
+    r"\A\s*cat\s*>\s*(?P<path>'[^']+'|\"[^\"]+\"|[^\s]+)\s*<<(?P<quote>['\"])(?P<label>[A-Za-z_][A-Za-z0-9_]*)(?P=quote)"
     r"\s*\n(?P<body>.*?)\n(?P=label)\s*(?:\n|&&|;)\s*(?P<rest>.+)\Z",
     re.DOTALL,
 )

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -2733,15 +2733,20 @@ def _looks_like_temporary_pr_threads_query_path(path_text: str) -> bool:
     basename = os.path.basename(normalized)
     if basename != "pr-threads-query.graphql":
         return False
+    if not normalized.startswith("/"):
+        return False
     lowered = normalized.lower()
-    return any(
-        marker in lowered
-        for marker in (
-            "/tmp/",
-            "/var/folders/",
-            "/.copilot/session-state/",
-            "/.cache/",
+    return (
+        lowered.startswith(
+            (
+                "/tmp/",
+                "/var/tmp/",
+                "/private/tmp/",
+                "/var/folders/",
+                "/private/var/folders/",
+            )
         )
+        or "/.copilot/session-state/" in lowered
     )
 
 

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1329,6 +1329,23 @@ def test_tool_action_request_classifier_rejects_graphql_workflow_with_background
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_rejects_graphql_workflow_with_repo_target():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                "cat > /work/repo/schema.graphql <<'EOF'\n"
+                "query($owner:String!){ repository(owner:$owner){ name } }\n"
+                "EOF\n"
+                'gh api graphql -F owner=hashgraph-online -f query="$(cat /work/repo/schema.graphql)"'
+            )
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_allows_graphql_at_file_workflow(tmp_path):
     query_path = tmp_path / "pr-threads-query.graphql"
     request = extract_sensitive_tool_action_request(

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1257,6 +1257,60 @@ def test_tool_action_request_classifier_rejects_graphql_mutation_file_workflow(t
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_rejects_graphql_workflow_with_extra_substitution(tmp_path):
+    query_path = tmp_path / "pr-threads-query.graphql"
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                f"cat > {query_path} <<'EOF'\n"
+                "query($owner:String!){ repository(owner:$owner){ name } }\n"
+                "EOF\n"
+                "gh api graphql "
+                f'-F owner="$(rm -rf /tmp/x)" -f query="$(cat {query_path})"'
+            )
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_rejects_graphql_workflow_with_sensitive_redirect(tmp_path):
+    query_path = tmp_path / "pr-threads-query.graphql"
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                f"cat > {query_path} <<'EOF'\n"
+                "query($owner:String!){ repository(owner:$owner){ name } }\n"
+                "EOF\n"
+                f'gh api graphql -F owner=hashgraph-online -f query="$(cat {query_path})" > ~/.ssh/authorized_keys'
+            )
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_allows_graphql_at_file_workflow(tmp_path):
+    query_path = tmp_path / "pr-threads-query.graphql"
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                f"cat > {query_path} <<'EOF'\n"
+                "query($owner:String!){ repository(owner:$owner){ name } }\n"
+                "EOF\n"
+                f"gh api graphql -F owner=hashgraph-online --field query=@{query_path}"
+            )
+        },
+    )
+
+    assert request is None
+
+
 def test_tool_action_request_classifier_detects_python_heredoc_file_write():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1476,6 +1476,23 @@ def test_tool_action_request_classifier_rejects_graphql_workflow_with_symlink_ta
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_rejects_graphql_workflow_with_glob_target():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                "cat > /tmp/*/pr-threads-query.graphql <<'EOF'\n"
+                "query($owner:String!){ repository(owner:$owner){ name } }\n"
+                "EOF\n"
+                'gh api graphql -F owner=hashgraph-online -f query="$(cat /tmp/*/pr-threads-query.graphql)"'
+            )
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_allows_graphql_at_file_workflow(tmp_path):
     query_path = tmp_path / "pr-threads-query.graphql"
     request = extract_sensitive_tool_action_request(

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1382,6 +1382,24 @@ def test_tool_action_request_classifier_rejects_graphql_workflow_with_repo_cache
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_rejects_graphql_workflow_with_temp_traversal_target():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                "cat > /tmp/../../workspace/repo/pr-threads-query.graphql <<'EOF'\n"
+                "query($owner:String!){ repository(owner:$owner){ name } }\n"
+                "EOF\n"
+                "gh api graphql -F owner=hashgraph-online "
+                '-f query="$(cat /tmp/../../workspace/repo/pr-threads-query.graphql)"'
+            )
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_allows_graphql_at_file_workflow(tmp_path):
     query_path = tmp_path / "pr-threads-query.graphql"
     request = extract_sensitive_tool_action_request(

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1476,6 +1476,25 @@ def test_tool_action_request_classifier_rejects_graphql_workflow_with_symlink_ta
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_rejects_graphql_workflow_with_existing_target(tmp_path):
+    query_path = tmp_path / "pr-threads-query.graphql"
+    query_path.write_text("existing", encoding="utf-8")
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                f"cat > {query_path} <<'EOF'\n"
+                "query($owner:String!){ repository(owner:$owner){ name } }\n"
+                "EOF\n"
+                f'gh api graphql -F owner=hashgraph-online -f query="$(cat {query_path})"'
+            )
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_rejects_graphql_workflow_with_glob_target():
     request = extract_sensitive_tool_action_request(
         "bash",
@@ -1509,6 +1528,23 @@ def test_tool_action_request_classifier_rejects_graphql_workflow_with_ansi_c_quo
 
     assert request is not None
     assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_allows_graphql_query_for_env_named_repo(tmp_path):
+    query_path = tmp_path / "pr-threads-query.graphql"
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                f"cat > {query_path} <<'EOF'\n"
+                "query($owner:String!,$name:String!){ repository(owner:$owner,name:$name){ name } }\n"
+                "EOF\n"
+                f'gh api graphql -F owner=hashgraph-online -F name=my.env.repo -f query="$(cat {query_path})"'
+            )
+        },
+    )
+
+    assert request is None
 
 
 def test_tool_action_request_classifier_allows_graphql_at_file_workflow(tmp_path):

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1365,6 +1365,23 @@ def test_tool_action_request_classifier_rejects_graphql_workflow_with_unquoted_h
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_rejects_graphql_workflow_with_repo_cache_target():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                "cat > ./.cache/pr-threads-query.graphql <<'EOF'\n"
+                "query($owner:String!){ repository(owner:$owner){ name } }\n"
+                "EOF\n"
+                'gh api graphql -F owner=hashgraph-online -f query="$(cat ./.cache/pr-threads-query.graphql)"'
+            )
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_allows_graphql_at_file_workflow(tmp_path):
     query_path = tmp_path / "pr-threads-query.graphql"
     request = extract_sensitive_tool_action_request(

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1493,6 +1493,24 @@ def test_tool_action_request_classifier_rejects_graphql_workflow_with_glob_targe
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_rejects_graphql_workflow_with_ansi_c_quoted_target():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                "cat > /tmp/$'..'/../workspace/repo/pr-threads-query.graphql <<'EOF'\n"
+                "query($owner:String!){ repository(owner:$owner){ name } }\n"
+                "EOF\n"
+                'gh api graphql -F owner=hashgraph-online -f query="$(cat /tmp/$'
+                "'..'/../workspace/repo/pr-threads-query.graphql)\""
+            )
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_allows_graphql_at_file_workflow(tmp_path):
     query_path = tmp_path / "pr-threads-query.graphql"
     request = extract_sensitive_tool_action_request(

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1311,6 +1311,24 @@ def test_tool_action_request_classifier_rejects_graphql_workflow_with_target_sub
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_rejects_graphql_workflow_with_background_chain(tmp_path):
+    query_path = tmp_path / "pr-threads-query.graphql"
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                f"cat > {query_path} <<'EOF'\n"
+                "query($owner:String!){ repository(owner:$owner){ name } }\n"
+                "EOF\n"
+                f'gh api graphql -F owner=hashgraph-online -f query="$(cat {query_path})" & rm -rf /tmp/x'
+            )
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_allows_graphql_at_file_workflow(tmp_path):
     query_path = tmp_path / "pr-threads-query.graphql"
     request = extract_sensitive_tool_action_request(

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1217,6 +1217,46 @@ def test_tool_action_request_classifier_detects_redirection_to_quoted_space_targ
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_allows_graphql_query_file_workflow(tmp_path):
+    query_path = tmp_path / "pr-threads-query.graphql"
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                f"cat > {query_path} <<'EOF'\n"
+                "query($owner:String!,$name:String!,$number:Int!){\n"
+                "  repository(owner:$owner,name:$name){\n"
+                "    pullRequest(number:$number){ reviewDecision mergeStateStatus }\n"
+                "  }\n"
+                "}\n"
+                "EOF\n"
+                "gh api graphql -F owner=hashgraph-online -F name=points-portal -F number=542 "
+                f'-f query="$(cat {query_path})"'
+            )
+        },
+    )
+
+    assert request is None
+
+
+def test_tool_action_request_classifier_rejects_graphql_mutation_file_workflow(tmp_path):
+    query_path = tmp_path / "pr-threads-query.graphql"
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                f"cat > {query_path} <<'EOF'\n"
+                "mutation($id:ID!){ deleteIssue(input:{issueId:$id}) { clientMutationId } }\n"
+                "EOF\n"
+                f'gh api graphql -F id=I_kw -f query="$(cat {query_path})"'
+            )
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_detects_python_heredoc_file_write():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1417,6 +1417,42 @@ def test_tool_action_request_classifier_rejects_graphql_workflow_with_target_var
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_rejects_graphql_workflow_with_different_query_file(tmp_path):
+    query_path = tmp_path / "pr-threads-query.graphql"
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                f"cat > {query_path} <<'EOF'\n"
+                "query($owner:String!){ repository(owner:$owner){ name } }\n"
+                "EOF\n"
+                f"gh api graphql -F owner=hashgraph-online --field query=@{query_path}.mut"
+            )
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_rejects_graphql_workflow_with_repo_copilot_target():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                "cat > /workspace/repo/.copilot/session-state/pr-threads-query.graphql <<'EOF'\n"
+                "query($owner:String!){ repository(owner:$owner){ name } }\n"
+                "EOF\n"
+                "gh api graphql -F owner=hashgraph-online "
+                '-f query="$(cat /workspace/repo/.copilot/session-state/pr-threads-query.graphql)"'
+            )
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_allows_graphql_at_file_workflow(tmp_path):
     query_path = tmp_path / "pr-threads-query.graphql"
     request = extract_sensitive_tool_action_request(

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1294,6 +1294,23 @@ def test_tool_action_request_classifier_rejects_graphql_workflow_with_sensitive_
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_rejects_graphql_workflow_with_target_substitution():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                "cat > $(rm${IFS}-rf${IFS}/tmp/x).graphql <<'EOF'\n"
+                "query($owner:String!){ repository(owner:$owner){ name } }\n"
+                "EOF\n"
+                'gh api graphql -F owner=hashgraph-online -f query="$(cat $(rm${IFS}-rf${IFS}/tmp/x).graphql)"'
+            )
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_allows_graphql_at_file_workflow(tmp_path):
     query_path = tmp_path / "pr-threads-query.graphql"
     request = extract_sensitive_tool_action_request(

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1453,6 +1453,29 @@ def test_tool_action_request_classifier_rejects_graphql_workflow_with_repo_copil
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_rejects_graphql_workflow_with_symlink_target(tmp_path):
+    link_path = tmp_path / "link"
+    try:
+        link_path.symlink_to(Path.cwd(), target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks are not supported in this environment")
+    query_path = link_path / "pr-threads-query.graphql"
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                f"cat > {query_path} <<'EOF'\n"
+                "query($owner:String!){ repository(owner:$owner){ name } }\n"
+                "EOF\n"
+                f'gh api graphql -F owner=hashgraph-online -f query="$(cat {query_path})"'
+            )
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_allows_graphql_at_file_workflow(tmp_path):
     query_path = tmp_path / "pr-threads-query.graphql"
     request = extract_sensitive_tool_action_request(

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1346,6 +1346,25 @@ def test_tool_action_request_classifier_rejects_graphql_workflow_with_repo_targe
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_rejects_graphql_workflow_with_unquoted_heredoc(tmp_path):
+    query_path = tmp_path / "pr-threads-query.graphql"
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                f"cat > {query_path} <<EOF\n"
+                "query($owner:String!){ repository(owner:$owner){ name } }\n"
+                "$(rm -rf /tmp/x)\n"
+                "EOF\n"
+                f'gh api graphql -F owner=hashgraph-online -f query="$(cat {query_path})"'
+            )
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_allows_graphql_at_file_workflow(tmp_path):
     query_path = tmp_path / "pr-threads-query.graphql"
     request = extract_sensitive_tool_action_request(

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1400,6 +1400,23 @@ def test_tool_action_request_classifier_rejects_graphql_workflow_with_temp_trave
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_rejects_graphql_workflow_with_target_variable():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                "cat > /tmp/$MAL/pr-threads-query.graphql <<'EOF'\n"
+                "query($owner:String!){ repository(owner:$owner){ name } }\n"
+                "EOF\n"
+                'gh api graphql -F owner=hashgraph-online -f query="$(cat /tmp/$MAL/pr-threads-query.graphql)"'
+            )
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_allows_graphql_at_file_workflow(tmp_path):
     query_path = tmp_path / "pr-threads-query.graphql"
     request = extract_sensitive_tool_action_request(


### PR DESCRIPTION
## Summary
- allow safe GraphQL query heredoc workflows used by PR review loops without classifying them as destructive shell commands
- keep GraphQL mutations/subscriptions and sensitive output paths blocked
- add copy/open share links for individual Guard Local approval items

## Verification
- ruff check src/codex_plugin_scanner/guard/runtime/secret_file_requests.py tests/test_guard_risk.py
- ruff format --check src/codex_plugin_scanner/guard/runtime/secret_file_requests.py tests/test_guard_risk.py
- PYTHONPATH=src pytest tests/test_guard_risk.py -k 'graphql_query_file_workflow or graphql_mutation_file_workflow or redirection_to_quoted_space_target' -q
- pnpm --dir dashboard test
- pnpm --dir dashboard run build