### PR TITLE
refactor(dashboard): shared components, home metrics, flat surfaces

### DIFF
--- a/dashboard/src/approval-center-primitives.tsx
+++ b/dashboard/src/approval-center-primitives.tsx
@@ -16,6 +16,8 @@ import {
   HiMiniCheckCircle,
   HiMiniArrowRight,
   HiMiniExclamationTriangle,
+  HiMiniChevronDown,
+  HiMiniChevronUp,
 } from "react-icons/hi2";
 
 import { guardAwareHref } from "./guard-api";
@@ -695,23 +697,19 @@ export function GuardHero(props: {
 }
 
 export function ProofStrip(props: {
-  items: Array<{ label: string; value: string | number; tone?: "blue" | "green" | "purple" | "slate"; icon?: ReactNode; pulse?: boolean; hint?: string }>;
+  items: Array<{ label: string; value: string | number; tone?: "blue" | "green" | "purple" | "slate"; icon?: ReactNode; hint?: string }>;
 }) {
   return (
-    <div className="grid gap-4 sm:grid-cols-3">
-      {props.items.map((item) => (
-        <div
-          key={item.label}
-          className={`flex items-baseline gap-2 ${item.pulse ? "guard-pulse" : ""}`}
-          title={item.hint}
-        >
-          <p className="text-2xl font-semibold tracking-tight text-brand-dark">{item.value}</p>
-          <div className="flex items-center gap-1">
-            <p className="text-xs text-muted-foreground">{item.label}</p>
-            {item.icon}
+    <div className="grid gap-x-8 gap-y-4 sm:grid-cols-2 lg:grid-cols-4">
+      {props.items.map((item) => {
+        const toneColor = item.tone === "blue" ? "text-brand-blue" : item.tone === "green" ? "text-emerald-600" : item.tone === "purple" ? "text-brand-purple" : "text-brand-dark";
+        return (
+          <div key={item.label} className="flex flex-col" title={item.hint}>
+            <p className="text-[11px] font-semibold uppercase tracking-wider text-slate-400">{item.label}</p>
+            <p className={`text-2xl font-semibold tracking-tight ${toneColor}`}>{item.value}</p>
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }
@@ -740,6 +738,146 @@ export function NextActionCard(props: {
       <SectionLabel>{props.title}</SectionLabel>
       <p className="mt-2 text-sm leading-relaxed text-brand-dark/70">{props.body}</p>
       <div className="mt-4">{props.cta}</div>
+    </div>
+  );
+}
+
+export function SegmentedControl<T extends string>(props: {
+  options: Array<{ value: T; label: string }>;
+  value: T;
+  onChange: (value: T) => void;
+}) {
+  return (
+    <div className="inline-flex rounded-lg border border-slate-200 bg-slate-50 p-0.5">
+      {props.options.map((opt) => (
+        <button
+          key={opt.value}
+          type="button"
+          onClick={() => props.onChange(opt.value)}
+          className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+            props.value === opt.value
+              ? "bg-white text-brand-dark shadow-sm"
+              : "text-slate-500 hover:text-brand-dark"
+          }`}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function ListRow(props: {
+  children: ReactNode;
+  accent?: "green" | "attention" | "blue" | "none";
+  onClick?: () => void;
+  href?: string;
+}) {
+  const accentClass =
+    props.accent === "green"
+      ? "border-l-2 border-emerald-500 pl-3"
+      : props.accent === "attention"
+      ? "border-l-2 border-brand-attention pl-3"
+      : props.accent === "blue"
+      ? "border-l-2 border-brand-blue pl-3"
+      : "pl-3.5";
+  const clickable = props.onClick !== undefined || props.href !== undefined;
+  const content = (
+    <div
+      className={`flex items-center gap-3 border-b border-slate-100 py-2.5 transition-colors hover:bg-slate-50/60 ${accentClass} ${
+        clickable ? "cursor-pointer" : ""
+      }`}
+      onClick={props.onClick}
+      role={clickable ? "button" : undefined}
+      tabIndex={clickable ? 0 : undefined}
+      onKeyDown={
+        clickable
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                props.onClick?.();
+              }
+            }
+          : undefined
+      }
+    >
+      {props.children}
+    </div>
+  );
+  if (props.href) {
+    return (
+      <a href={guardAwareHref(props.href)} className="block no-underline">
+        {content}
+      </a>
+    );
+  }
+  return content;
+}
+
+export function TabBar<T extends string>(props: {
+  tabs: Array<{ value: T; label: string }>;
+  active: T;
+  onChange: (value: T) => void;
+}) {
+  return (
+    <div className="flex gap-1 rounded-lg border border-slate-200 bg-slate-50 p-0.5">
+      {props.tabs.map((tab) => (
+        <button
+          key={tab.value}
+          type="button"
+          onClick={() => props.onChange(tab.value)}
+          className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+            props.active === tab.value
+              ? "bg-white text-brand-dark shadow-sm"
+              : "text-slate-500 hover:text-brand-dark"
+          }`}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function AccordionSection(props: {
+  title: string;
+  subtitle?: string;
+  expanded: boolean;
+  onToggle: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <div className="rounded-xl border border-slate-100 overflow-hidden">
+      <button
+        onClick={props.onToggle}
+        className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-slate-50/60"
+        aria-expanded={props.expanded}
+      >
+        <div>
+          <p className="text-sm font-semibold text-brand-dark">{props.title}</p>
+          {props.subtitle ? <p className="text-xs text-slate-400">{props.subtitle}</p> : null}
+        </div>
+        {props.expanded ? (
+          <HiMiniChevronUp className="h-4 w-4 text-slate-400" aria-hidden="true" />
+        ) : (
+          <HiMiniChevronDown className="h-4 w-4 text-slate-400" aria-hidden="true" />
+        )}
+      </button>
+      {props.expanded && (
+        <div className="border-t border-slate-100 px-4 py-4">
+          {props.children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function StickyActionBar(props: {
+  children: ReactNode;
+}) {
+  return (
+    <div className="sticky bottom-4 z-30 rounded-xl border border-slate-200 bg-white/95 p-4 shadow-lg backdrop-blur">
+      {props.children}
     </div>
   );
 }

--- a/dashboard/src/home-dashboard.tsx
+++ b/dashboard/src/home-dashboard.tsx
@@ -163,9 +163,10 @@ export function HomeWorkspace(props: {
 
       <ProofStrip
         items={[
-          { label: "Needs your choice", value: queuedCount, tone: queuedCount > 0 ? "blue" : "slate", pulse: queuedCount > 0 },
-          { label: "Apps watched", value: watchedAppsCount, tone: watchedAppsCount > 0 ? "green" : "slate" },
-          { label: "Day streak", value: streak, tone: streak > 1 ? "purple" : "slate", icon: streak > 1 ? <HiMiniFire className="h-3.5 w-3.5 text-brand-purple" aria-hidden="true" /> : null, hint: streak > 0 ? "Consecutive days with Guard activity. Resets after 48h of inactivity." : "Guard activity streak" },
+          { label: "Pending", value: queuedCount, tone: queuedCount > 0 ? "blue" : "slate" },
+          { label: "Apps", value: watchedAppsCount, tone: watchedAppsCount > 0 ? "green" : "slate" },
+          { label: "Streak", value: streak, tone: streak > 1 ? "purple" : "slate", icon: streak > 1 ? <HiMiniFire className="h-3.5 w-3.5 text-brand-purple" aria-hidden="true" /> : null, hint: streak > 0 ? "Consecutive days with Guard activity. Resets after 48h of inactivity." : "Guard activity streak" },
+          { label: "History", value: snapshot?.receipt_count ?? 0, tone: "purple" },
         ]}
       />
 
@@ -233,12 +234,12 @@ export function HomeWorkspace(props: {
           )}
 
           {policyItems.length > 0 && (
-            <div className="rounded-[1.75rem] border border-slate-200/70 bg-white/80 p-5 shadow-sm sm:p-6">
+            <div className="rounded-xl border border-slate-100 p-4">
               <SectionLabel>Reset remembered decisions</SectionLabel>
-              <p className="mt-2 text-sm text-muted-foreground">
+              <p className="mt-1 text-sm text-slate-500">
                 Clear remembered decisions when you want Guard to ask again next time. This does not remove your history.
               </p>
-              <div className="mt-4 flex flex-wrap gap-2">
+              <div className="mt-3 flex flex-wrap gap-2">
                 {clearHarnesses.slice(0, 4).map((harness: string) => (
                   <ClearHarnessButton
                     key={harness}
@@ -526,12 +527,14 @@ function AppsAtAGlance(props: {
   }
 
   return (
-    <div className="rounded-[1.75rem] border border-slate-200/70 bg-white/80 p-5 shadow-sm sm:p-6">
-      <SectionLabel>Apps at a glance</SectionLabel>
-      <p className="mt-2 text-sm text-muted-foreground">
-        Guard is watching these apps on this machine.
-      </p>
-      <div ref={listRef} className="mt-4 space-y-2" role="list" aria-label="Apps at a glance">
+    <div>
+      <div className="mb-3">
+        <SectionLabel>Apps at a glance</SectionLabel>
+        <p className="mt-1 text-sm text-slate-500">
+          Guard is watching these apps on this machine.
+        </p>
+      </div>
+      <div ref={listRef} className="divide-y divide-slate-100 border-t border-slate-100" role="list" aria-label="Apps at a glance">
         {sortedHarnesses.map((harness, index) => {
           const install = props.managedInstalls.find((i) => i.harness === harness);
           const isObserved = props.observedHarnesses.includes(harness);
@@ -544,10 +547,10 @@ function AppsAtAGlance(props: {
               onKeyDown={(e) => handleKeyDown(e, index)}
               onFocus={() => setFocusedIndex(index)}
               onBlur={() => setFocusedIndex(-1)}
-              className={`flex w-full items-center justify-between gap-3 rounded-xl border px-4 py-3 text-left transition-all duration-150 hover:bg-slate-50 hover:shadow-sm active:scale-[0.99] ${
+              className={`flex w-full items-center justify-between gap-3 py-2.5 text-left transition-colors hover:bg-slate-50/60 ${
                 focusedIndex === index
-                  ? "border-brand-blue/50 bg-brand-blue/[0.04] ring-1 ring-brand-blue/20"
-                  : "border-slate-200/70"
+                  ? "bg-brand-blue/[0.04]"
+                  : ""
               }`}
               role="listitem"
             >

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -14095,21 +14095,13 @@ function GuardHero(props) {
   );
 }
 function ProofStrip(props) {
-  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "grid gap-4 sm:grid-cols-3", children: props.items.map((item) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
-    "div",
-    {
-      className: `flex items-baseline gap-2 ${item.pulse ? "guard-pulse" : ""}`,
-      title: item.hint,
-      children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-2xl font-semibold tracking-tight text-brand-dark", children: item.value }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-1", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-muted-foreground", children: item.label }),
-          item.icon
-        ] })
-      ]
-    },
-    item.label
-  )) });
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "grid gap-x-8 gap-y-4 sm:grid-cols-2 lg:grid-cols-4", children: props.items.map((item) => {
+    const toneColor = item.tone === "blue" ? "text-brand-blue" : item.tone === "green" ? "text-emerald-600" : item.tone === "purple" ? "text-brand-purple" : "text-brand-dark";
+    return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col", title: item.hint, children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] font-semibold uppercase tracking-wider text-slate-400", children: item.label }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: `text-2xl font-semibold tracking-tight ${toneColor}`, children: item.value })
+    ] }, item.label);
+  }) });
 }
 function DataFlowEvidenceCard(props) {
   const evidence = deriveDataFlowEvidence(props.item);
@@ -17464,9 +17456,10 @@ function HomeWorkspace(props) {
       ProofStrip,
       {
         items: [
-          { label: "Needs your choice", value: queuedCount, tone: queuedCount > 0 ? "blue" : "slate", pulse: queuedCount > 0 },
-          { label: "Apps watched", value: watchedAppsCount, tone: watchedAppsCount > 0 ? "green" : "slate" },
-          { label: "Day streak", value: streak, tone: streak > 1 ? "purple" : "slate", icon: streak > 1 ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniFire, { className: "h-3.5 w-3.5 text-brand-purple", "aria-hidden": "true" }) : null, hint: streak > 0 ? "Consecutive days with Guard activity. Resets after 48h of inactivity." : "Guard activity streak" }
+          { label: "Pending", value: queuedCount, tone: queuedCount > 0 ? "blue" : "slate" },
+          { label: "Apps", value: watchedAppsCount, tone: watchedAppsCount > 0 ? "green" : "slate" },
+          { label: "Streak", value: streak, tone: streak > 1 ? "purple" : "slate", icon: streak > 1 ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniFire, { className: "h-3.5 w-3.5 text-brand-purple", "aria-hidden": "true" }) : null, hint: streak > 0 ? "Consecutive days with Guard activity. Resets after 48h of inactivity." : "Guard activity streak" },
+          { label: "History", value: snapshot?.receipt_count ?? 0, tone: "purple" }
         ]
       }
     ),
@@ -17533,10 +17526,10 @@ function HomeWorkspace(props) {
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "space-y-6", children: [
         snapshot.latest_receipts.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(RecentProtectionSection, { receipts: snapshot.latest_receipts }),
-        policyItems.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-[1.75rem] border border-slate-200/70 bg-white/80 p-5 shadow-sm sm:p-6", children: [
+        policyItems.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Reset remembered decisions" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-muted-foreground", children: "Clear remembered decisions when you want Guard to ask again next time. This does not remove your history." }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 flex flex-wrap gap-2", children: clearHarnesses.slice(0, 4).map((harness) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-500", children: "Clear remembered decisions when you want Guard to ask again next time. This does not remove your history." }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 flex flex-wrap gap-2", children: clearHarnesses.slice(0, 4).map((harness) => /* @__PURE__ */ jsxRuntimeExports.jsx(
             ClearHarnessButton,
             {
               harness,
@@ -17773,10 +17766,12 @@ function AppsAtAGlance(props) {
       }
     );
   }
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-[1.75rem] border border-slate-200/70 bg-white/80 p-5 shadow-sm sm:p-6", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Apps at a glance" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-muted-foreground", children: "Guard is watching these apps on this machine." }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { ref: listRef, className: "mt-4 space-y-2", role: "list", "aria-label": "Apps at a glance", children: sortedHarnesses.map((harness, index) => {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mb-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Apps at a glance" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-500", children: "Guard is watching these apps on this machine." })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { ref: listRef, className: "divide-y divide-slate-100 border-t border-slate-100", role: "list", "aria-label": "Apps at a glance", children: sortedHarnesses.map((harness, index) => {
       const install = props.managedInstalls.find((i) => i.harness === harness);
       const isObserved = props.observedHarnesses.includes(harness);
       const pending = pendingByHarness.get(harness) ?? 0;
@@ -17788,7 +17783,7 @@ function AppsAtAGlance(props) {
           onKeyDown: (e) => handleKeyDown(e, index),
           onFocus: () => setFocusedIndex(index),
           onBlur: () => setFocusedIndex(-1),
-          className: `flex w-full items-center justify-between gap-3 rounded-xl border px-4 py-3 text-left transition-all duration-150 hover:bg-slate-50 hover:shadow-sm active:scale-[0.99] ${focusedIndex === index ? "border-brand-blue/50 bg-brand-blue/[0.04] ring-1 ring-brand-blue/20" : "border-slate-200/70"}`,
+          className: `flex w-full items-center justify-between gap-3 py-2.5 text-left transition-colors hover:bg-slate-50/60 ${focusedIndex === index ? "bg-brand-blue/[0.04]" : ""}`,
           role: "listitem",
           children: [
             /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 items-center gap-2.5", children: [

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -998,10 +998,6 @@
     flex-wrap: wrap;
   }
 
-  .items-baseline {
-    align-items: baseline;
-  }
-
   .items-center {
     align-items: center;
   }
@@ -1130,8 +1126,16 @@
     column-gap: calc(var(--spacing) * 4);
   }
 
+  .gap-x-8 {
+    column-gap: calc(var(--spacing) * 8);
+  }
+
   .gap-y-1 {
     row-gap: calc(var(--spacing) * 1);
+  }
+
+  .gap-y-4 {
+    row-gap: calc(var(--spacing) * 4);
   }
 
   :where(.divide-y > :not(:last-child)) {
@@ -1298,7 +1302,7 @@
     border-color: hsl(var(--border));
   }
 
-  .border-brand-attention\/10 {
+  .border-brand-attention, .border-brand-attention\/10 {
     border-color: var(--brand-attention);
   }
 
@@ -1388,16 +1392,6 @@
     }
   }
 
-  .border-brand-blue\/50 {
-    border-color: var(--brand-blue);
-  }
-
-  @supports (color: color-mix(in lab, red, red)) {
-    .border-brand-blue\/50 {
-      border-color: color-mix(in oklab, var(--brand-blue) 50%, transparent);
-    }
-  }
-
   .border-brand-green\/15 {
     border-color: var(--brand-green);
   }
@@ -1476,6 +1470,10 @@
     .border-brand-purple\/30 {
       border-color: color-mix(in oklab, var(--brand-purple) 30%, transparent);
     }
+  }
+
+  .border-emerald-500 {
+    border-color: var(--color-emerald-500);
   }
 
   .border-gray-200 {
@@ -2224,6 +2222,10 @@
     object-fit: contain;
   }
 
+  .p-0\.5 {
+    padding: calc(var(--spacing) * .5);
+  }
+
   .p-1 {
     padding: calc(var(--spacing) * 1);
   }
@@ -2358,6 +2360,14 @@
 
   .pb-4 {
     padding-bottom: calc(var(--spacing) * 4);
+  }
+
+  .pl-3 {
+    padding-left: calc(var(--spacing) * 3);
+  }
+
+  .pl-3\.5 {
+    padding-left: calc(var(--spacing) * 3.5);
   }
 
   .pl-4 {
@@ -2818,16 +2828,6 @@
   @supports (color: color-mix(in lab, red, red)) {
     .shadow-emerald-500\/15 {
       --tw-shadow-color: color-mix(in oklab, color-mix(in oklab, var(--color-emerald-500) 15%, transparent) var(--tw-shadow-alpha), transparent);
-    }
-  }
-
-  .ring-brand-blue\/20 {
-    --tw-ring-color: var(--brand-blue);
-  }
-
-  @supports (color: color-mix(in lab, red, red)) {
-    .ring-brand-blue\/20 {
-      --tw-ring-color: color-mix(in oklab, var(--brand-blue) 20%, transparent);
     }
   }
 
@@ -3298,10 +3298,6 @@
 
   .active\:scale-\[0\.98\]:active {
     scale: .98;
-  }
-
-  .active\:scale-\[0\.99\]:active {
-    scale: .99;
   }
 
   .disabled\:pointer-events-none:disabled {


### PR DESCRIPTION
## Summary

- Add shared components: SegmentedControl, ListRow, TabBar, AccordionSection, StickyActionBar
- Fix Home ProofStrip labels: Pending / Apps / Streak / History (noun phrases)
- Flatten AppsAtAGlance card wrapper → divider-based list
- Flatten Reset remembered decisions card
- Remove pulse animation from metrics

## Verification

- [x] Build passes
- [x] Tests pass
- [x] TypeScript 0 errors