### PR TITLE
refactor(dashboard): flatten review workspace cards

### DIFF
--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -187,7 +187,7 @@ const ReviewQueueList = forwardRef<HTMLDivElement, {
       <div
         role="listbox"
         aria-label="Review queue"
-        className="max-h-[70vh] space-y-2 overflow-y-auto rounded-[1.25rem] border border-slate-200/70 bg-white/60 p-2"
+        className="max-h-[70vh] space-y-2 overflow-y-auto rounded-lg border border-slate-100 bg-white p-1.5"
       >
         {requests.map((item, index) => (
           <QueueItemRow
@@ -220,7 +220,7 @@ function QueueItemRow({ item, active, index, onClick }: {
       aria-posinset={index + 1}
       aria-setsize={/* parent will provide */ undefined}
       tabIndex={active ? 0 : -1}
-      className={`w-full rounded-xl border px-3 py-2.5 text-left transition-all ${
+      className={`w-full rounded-lg py-2.5 text-left transition-all ${
         active
           ? "border-brand-blue bg-brand-blue/[0.06]"
           : "border-transparent bg-white hover:bg-slate-50"
@@ -381,7 +381,7 @@ function ReviewDecisionCard(props: {
       {/* Success banner */}
       {resolved && (
         <div
-          className={`guard-fade-in flex items-center gap-3 rounded-2xl border px-4 py-3 transition-all ${
+          className={`guard-fade-in flex items-center gap-3 rounded-xl border px-4 py-3 transition-all ${
             resolved === "allow"
               ? "border-brand-green/25 bg-brand-green-bg/30"
               : "border-brand-attention/25 bg-brand-attention/[0.04]"
@@ -401,7 +401,7 @@ function ReviewDecisionCard(props: {
 
       {/* Confirm modal for broad scopes */}
       {confirmScope !== null && pendingAction !== null && (
-        <div className="guard-fade-in rounded-[1.75rem] border border-brand-attention/25 bg-brand-attention/[0.04] p-5 shadow-sm" role="alertdialog" aria-modal="true">
+        <div className="guard-fade-in rounded-xl border border-brand-attention/15 bg-brand-attention/[0.03] p-4" role="alertdialog" aria-modal="true">
           <div className="flex items-start gap-3">
             <HiMiniExclamationTriangle className="mt-0.5 h-5 w-5 shrink-0 text-brand-attention" aria-hidden="true" />
             <div>
@@ -425,7 +425,7 @@ function ReviewDecisionCard(props: {
       )}
 
       {/* Main decision card */}
-      <div className="rounded-[1.75rem] border border-slate-200/70 bg-white/80 p-5 shadow-sm sm:p-6">
+      <div className="rounded-xl border border-slate-100 p-4 sm:p-5">
         <div className="flex items-start justify-between gap-3">
           <div>
             <SectionLabel>Paused action</SectionLabel>
@@ -574,7 +574,7 @@ function ReviewDecisionCard(props: {
 
       {/* Evidence section */}
       {hasEvidence && (
-        <div className="rounded-[1.75rem] border border-slate-200/70 bg-white/80 p-5 shadow-sm sm:p-6">
+        <div className="rounded-xl border border-slate-100 p-4 sm:p-5">
           <button
             onClick={() => setShowEvidence(!showEvidence)}
             className="flex w-full items-center justify-between text-left focus:outline-none focus:ring-2 focus:ring-brand-blue/20 rounded-lg px-2 py-1 -ml-2"
@@ -606,7 +606,7 @@ function ReviewDecisionCard(props: {
 
       {/* Last time */}
       {detail.receipt && (
-        <div className="rounded-[1.75rem] border border-slate-200/70 bg-white/80 p-5 shadow-sm sm:p-6">
+        <div className="rounded-xl border border-slate-100 p-4 sm:p-5">
           <SectionLabel>Last time</SectionLabel>
           <p className="mt-2 text-sm text-muted-foreground">
             You previously {detail.receipt.policy_decision}d a similar action{" "}
@@ -657,7 +657,7 @@ function ReviewEmptyState({ runtime, resolutionMessage }: { runtime: GuardRuntim
       )}
 
       <div className="grid gap-6 lg:grid-cols-2">
-        <div className="rounded-[1.75rem] border border-brand-green/15 bg-brand-green/[0.04] p-5 shadow-sm sm:p-6">
+        <div className="rounded-xl border border-emerald-200/60 bg-emerald-50/30 p-4 sm:p-5">
           <div className="flex items-start gap-3">
             <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-brand-green/10">
               <HiMiniShieldCheck className="h-5 w-5 text-brand-green" aria-hidden="true" />
@@ -671,7 +671,7 @@ function ReviewEmptyState({ runtime, resolutionMessage }: { runtime: GuardRuntim
           </div>
         </div>
 
-        <div className="rounded-[1.75rem] border border-slate-200/70 bg-white/80 p-5 shadow-sm sm:p-6">
+        <div className="rounded-xl border border-slate-100 p-4 sm:p-5">
           <SectionLabel>What Guard does</SectionLabel>
           <ul className="mt-3 space-y-2">
             {[
@@ -748,7 +748,7 @@ function ActionContentCard({ item }: { item: GuardApprovalRequest }) {
       )}
 
       {/* Terminal display of actual content */}
-      <div className="overflow-hidden rounded-[1.25rem] bg-[#0f172a] shadow-lg">
+      <div className="overflow-hidden rounded-xl bg-[#0f172a]">
         <div className="flex items-center gap-1.5 border-b border-white/10 px-3 py-2">
           <span className="h-2.5 w-2.5 rounded-full bg-brand-purple" />
           <span className="h-2.5 w-2.5 rounded-full bg-brand-blue" />

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -14719,7 +14719,7 @@ const ReviewQueueList = reactExports.forwardRef(({ requests, activeRequestId, on
       {
         role: "listbox",
         "aria-label": "Review queue",
-        className: "max-h-[70vh] space-y-2 overflow-y-auto rounded-[1.25rem] border border-slate-200/70 bg-white/60 p-2",
+        className: "max-h-[70vh] space-y-2 overflow-y-auto rounded-lg border border-slate-100 bg-white p-1.5",
         children: requests.map((item, index) => /* @__PURE__ */ jsxRuntimeExports.jsx(
           QueueItemRow,
           {
@@ -14750,7 +14750,7 @@ function QueueItemRow({ item, active, index, onClick }) {
         void 0
       ),
       tabIndex: active ? 0 : -1,
-      className: `w-full rounded-xl border px-3 py-2.5 text-left transition-all ${active ? "border-brand-blue bg-brand-blue/[0.06]" : "border-transparent bg-white hover:bg-slate-50"}`,
+      className: `w-full rounded-lg py-2.5 text-left transition-all ${active ? "border-brand-blue bg-brand-blue/[0.06]" : "border-transparent bg-white hover:bg-slate-50"}`,
       children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between gap-2", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "truncate text-sm font-medium text-brand-dark", children: title }),
@@ -14885,7 +14885,7 @@ function ReviewDecisionCard(props) {
     resolved && /* @__PURE__ */ jsxRuntimeExports.jsxs(
       "div",
       {
-        className: `guard-fade-in flex items-center gap-3 rounded-2xl border px-4 py-3 transition-all ${resolved === "allow" ? "border-brand-green/25 bg-brand-green-bg/30" : "border-brand-attention/25 bg-brand-attention/[0.04]"}`,
+        className: `guard-fade-in flex items-center gap-3 rounded-xl border px-4 py-3 transition-all ${resolved === "allow" ? "border-brand-green/25 bg-brand-green-bg/30" : "border-brand-attention/25 bg-brand-attention/[0.04]"}`,
         role: "status",
         "aria-live": "polite",
         children: [
@@ -14900,7 +14900,7 @@ function ReviewDecisionCard(props) {
         ]
       }
     ),
-    confirmScope !== null && pendingAction !== null && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-fade-in rounded-[1.75rem] border border-brand-attention/25 bg-brand-attention/[0.04] p-5 shadow-sm", role: "alertdialog", "aria-modal": "true", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
+    confirmScope !== null && pendingAction !== null && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-fade-in rounded-xl border border-brand-attention/15 bg-brand-attention/[0.03] p-4", role: "alertdialog", "aria-modal": "true", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-attention", "aria-hidden": "true" }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs("h3", { className: "text-sm font-semibold text-brand-dark", children: [
@@ -14923,7 +14923,7 @@ function ReviewDecisionCard(props) {
         ] })
       ] })
     ] }) }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-[1.75rem] border border-slate-200/70 bg-white/80 p-5 shadow-sm sm:p-6", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4 sm:p-5", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start justify-between gap-3", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Paused action" }),
@@ -15048,7 +15048,7 @@ function ReviewDecisionCard(props) {
         ] })
       ] })
     ] }),
-    hasEvidence && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-[1.75rem] border border-slate-200/70 bg-white/80 p-5 shadow-sm sm:p-6", children: [
+    hasEvidence && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4 sm:p-5", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs(
         "button",
         {
@@ -15070,7 +15070,7 @@ function ReviewDecisionCard(props) {
         /* @__PURE__ */ jsxRuntimeExports.jsx(DecodedLayerCard, { item })
       ] })
     ] }),
-    detail.receipt && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-[1.75rem] border border-slate-200/70 bg-white/80 p-5 shadow-sm sm:p-6", children: [
+    detail.receipt && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4 sm:p-5", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Last time" }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-2 text-sm text-muted-foreground", children: [
         "You previously ",
@@ -15115,14 +15115,14 @@ function ReviewEmptyState({ runtime, resolutionMessage }) {
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-green-text", children: resolutionMessage })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-6 lg:grid-cols-2", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-[1.75rem] border border-brand-green/15 bg-brand-green/[0.04] p-5 shadow-sm sm:p-6", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-xl border border-emerald-200/60 bg-emerald-50/30 p-4 sm:p-5", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-brand-green/10", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "h-5 w-5 text-brand-green", "aria-hidden": "true" }) }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Protection active" }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-muted-foreground", children: "Guard is running and will pause any risky actions from your AI apps. When something needs review, it will appear here." })
         ] })
       ] }) }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-[1.75rem] border border-slate-200/70 bg-white/80 p-5 shadow-sm sm:p-6", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4 sm:p-5", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "What Guard does" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("ul", { className: "mt-3 space-y-2", children: [
           "Pauses risky file reads and writes",
@@ -15171,7 +15171,7 @@ function ActionContentCard({ item }) {
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm leading-relaxed text-brand-dark/80", children: pauseReason }),
     detailText && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm leading-relaxed text-brand-dark/80", children: detailText }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "overflow-hidden rounded-[1.25rem] bg-[#0f172a] shadow-lg", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "overflow-hidden rounded-xl bg-[#0f172a]", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-1.5 border-b border-white/10 px-3 py-2", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2.5 w-2.5 rounded-full bg-brand-purple" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2.5 w-2.5 rounded-full bg-brand-blue" }),

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -71,6 +71,8 @@
 @layer theme {
   :root, :host {
     --font-sans: "Roboto", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    --color-emerald-50: oklch(97.9% .021 166.113);
+    --color-emerald-200: oklch(90.5% .093 164.15);
     --color-emerald-500: oklch(69.6% .17 162.48);
     --color-emerald-600: oklch(59.6% .145 163.225);
     --color-blue-50: oklch(97% .014 254.604);
@@ -1472,6 +1474,16 @@
     }
   }
 
+  .border-emerald-200\/60 {
+    border-color: #a4f4cf99;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .border-emerald-200\/60 {
+      border-color: color-mix(in oklab, var(--color-emerald-200) 60%, transparent);
+    }
+  }
+
   .border-emerald-500 {
     border-color: var(--color-emerald-500);
   }
@@ -1906,6 +1918,16 @@
 
   .bg-card {
     background-color: hsl(var(--card));
+  }
+
+  .bg-emerald-50\/30 {
+    background-color: #ecfdf54d;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .bg-emerald-50\/30 {
+      background-color: color-mix(in oklab, var(--color-emerald-50) 30%, transparent);
+    }
   }
 
   .bg-gray-100 {


### PR DESCRIPTION
## Summary

- Flatten queue list wrapper: remove card background, lighter border
- Flatten queue item rows: remove border, simplify hover
- Flatten decision card, confirmation modal, success banner
- Remove shadow-sm from review surfaces
- Consistent rounded-xl everywhere

## Verification

- [x] Build passes
- [x] Tests pass