### PR TITLE
feat(dashboard): history analytics — insights, calendar, top actions, export

### DIFF
--- a/dashboard/src/history-analytics.tsx
+++ b/dashboard/src/history-analytics.tsx
@@ -1,0 +1,516 @@
+import { useCallback, useMemo, useState } from "react";
+import {
+  HiMiniChevronLeft,
+  HiMiniChevronRight,
+  HiOutlineArrowTrendingDown,
+  HiOutlineArrowTrendingUp,
+  HiOutlineFire,
+  HiOutlineShieldCheck,
+  HiOutlineNoSymbol,
+  HiMiniChevronDown,
+  HiMiniChevronUp,
+} from "react-icons/hi2";
+
+import type { GuardReceipt } from "./guard-types";
+import { harnessDisplayName } from "./approval-center-utils";
+
+// ──────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────
+
+type TimePeriod = "7d" | "30d" | "90d" | "all";
+
+interface InsightCard {
+  id: string;
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  tone: "blue" | "green" | "purple" | "attention";
+  action?: { label: string; href: string };
+}
+
+// ──────────────────────────────────────────
+// Insights
+// ──────────────────────────────────────────
+
+export function HistoryInsights({
+  receipts,
+  onFilterHarness,
+  onFilterDay,
+}: {
+  receipts: GuardReceipt[];
+  onFilterHarness?: (harness: string) => void;
+  onFilterDay?: (date: string) => void;
+}) {
+  const insights = useMemo(() => {
+    return computeInsights(receipts);
+  }, [receipts]);
+
+  if (insights.length === 0) return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-brand-dark">Insights</h3>
+      </div>
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        {insights.map((insight) => (
+          <InsightCardComponent
+            key={insight.id}
+            insight={insight}
+            onFilterHarness={onFilterHarness}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function InsightCardComponent({
+  insight,
+  onFilterHarness,
+}: {
+  insight: InsightCard;
+  onFilterHarness?: (harness: string) => void;
+}) {
+  const toneClasses = {
+    blue: "bg-blue-50/60 border-blue-200/40 text-blue-700",
+    green: "bg-emerald-50/60 border-emerald-200/40 text-emerald-700",
+    purple: "bg-purple-50/60 border-purple-200/40 text-purple-700",
+    attention: "bg-amber-50/60 border-amber-200/40 text-amber-700",
+  };
+
+  const handleClick = useCallback(() => {
+    if (insight.action && insight.action.href.startsWith("/apps/")) {
+      const harness = insight.action.href.slice("/apps/".length);
+      onFilterHarness?.(harness);
+    }
+  }, [insight.action, onFilterHarness]);
+
+  return (
+    <div
+      className={`rounded-xl border p-3 transition-colors hover:bg-opacity-80 ${toneClasses[insight.tone]}`}
+    >
+      <div className="flex items-start gap-2.5">
+        <div className="mt-0.5 shrink-0 opacity-70">{insight.icon}</div>
+        <div className="min-w-0 flex-1">
+          <p className="text-xs opacity-80">{insight.label}</p>
+          <p className="mt-0.5 text-sm font-semibold">{insight.value}</p>
+          {insight.action && (
+            <button
+              onClick={handleClick}
+              className="mt-1 text-xs underline opacity-70 transition-opacity hover:opacity-100"
+            >
+              {insight.action.label}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function computeInsights(receipts: GuardReceipt[]): InsightCard[] {
+  const now = new Date();
+  const weekAgo = new Date(now);
+  weekAgo.setDate(weekAgo.getDate() - 7);
+  const monthAgo = new Date(now);
+  monthAgo.setDate(monthAgo.getDate() - 30);
+
+  const weekReceipts = receipts.filter((r) => new Date(r.timestamp) >= weekAgo);
+  const monthReceipts = receipts.filter((r) => new Date(r.timestamp) >= monthAgo);
+
+  const insights: InsightCard[] = [];
+
+  // Most blocked action this week
+  const blockedWeek = weekReceipts.filter((r) => r.policy_decision === "block");
+  if (blockedWeek.length > 0) {
+    const topBlocked = aggregateByAction(blockedWeek)[0];
+    if (topBlocked) {
+      insights.push({
+        id: "top-blocked-week",
+        icon: <HiOutlineNoSymbol className="h-4 w-4" />,
+        label: "Most blocked this week",
+        value: topBlocked.name,
+        tone: "attention",
+      });
+    }
+  }
+
+  // App with most activity
+  const appActivity = new Map<string, number>();
+  for (const r of weekReceipts) {
+    appActivity.set(r.harness, (appActivity.get(r.harness) ?? 0) + 1);
+  }
+  const topApp = Array.from(appActivity.entries()).sort((a, b) => b[1] - a[1])[0];
+  if (topApp) {
+    insights.push({
+      id: "top-app-week",
+      icon: <HiOutlineFire className="h-4 w-4" />,
+      label: "Most active app",
+      value: harnessDisplayName(topApp[0]),
+      tone: "purple",
+      action: { label: "View", href: `/apps/${topApp[0]}` },
+    });
+  }
+
+  // Block rate
+  if (weekReceipts.length >= 5) {
+    const blockRate = Math.round((blockedWeek.length / weekReceipts.length) * 100);
+    const prevWeekReceipts = receipts.filter((r) => {
+      const d = new Date(r.timestamp);
+      return d >= new Date(weekAgo.getTime() - 7 * 24 * 60 * 60 * 1000) && d < weekAgo;
+    });
+    const prevBlockRate = prevWeekReceipts.length > 0
+      ? Math.round((prevWeekReceipts.filter((r) => r.policy_decision === "block").length / prevWeekReceipts.length) * 100)
+      : blockRate;
+    const change = blockRate - prevBlockRate;
+    const value = change === 0
+      ? `${blockRate}% (flat)`
+      : `${blockRate}% (${change > 0 ? "+" : ""}${change}%)`;
+    insights.push({
+      id: "block-rate",
+      icon: change > 0 ? <HiOutlineArrowTrendingUp className="h-4 w-4" /> : <HiOutlineArrowTrendingDown className="h-4 w-4" />,
+      label: "Block rate this week",
+      value,
+      tone: change > 0 ? "attention" : "green",
+    });
+  }
+
+  // Secret reads stopped
+  const secretReads = monthReceipts.filter((r) =>
+    (r.artifact_name ?? "").match(/\.(env|secrets?|key|token|password|credential)/i) !== null ||
+    (r.capabilities_summary ?? "").toLowerCase().includes("secret")
+  );
+  if (secretReads.length > 0) {
+    insights.push({
+      id: "secret-reads",
+      icon: <HiOutlineShieldCheck className="h-4 w-4" />,
+      label: "Secret reads stopped this month",
+      value: String(secretReads.length),
+      tone: "blue",
+    });
+  }
+
+  // New app detected
+  const harnessFirstSeen = new Map<string, Date>();
+  for (const r of receipts) {
+    const d = new Date(r.timestamp);
+    const existing = harnessFirstSeen.get(r.harness);
+    if (!existing || d < existing) {
+      harnessFirstSeen.set(r.harness, d);
+    }
+  }
+  for (const [harness, firstSeen] of harnessFirstSeen.entries()) {
+    if (firstSeen >= weekAgo) {
+      insights.push({
+        id: `new-app-${harness}`,
+        icon: <HiOutlineFire className="h-4 w-4" />,
+        label: "New app detected",
+        value: harnessDisplayName(harness),
+        tone: "purple",
+        action: { label: "Set up", href: `/apps/${harness}` },
+      });
+    }
+  }
+
+  return insights.slice(0, 3);
+}
+
+// ──────────────────────────────────────────
+// Activity Calendar
+// ──────────────────────────────────────────
+
+export function ActivityCalendar({
+  receipts,
+  onSelectDay,
+}: {
+  receipts: GuardReceipt[];
+  onSelectDay?: (date: string) => void;
+}) {
+  const [monthOffset, setMonthOffset] = useState(0);
+
+  const { year, month, days } = useMemo(() => {
+    const now = new Date();
+    const target = new Date(now.getFullYear(), now.getMonth() + monthOffset, 1);
+    const y = target.getFullYear();
+    const m = target.getMonth();
+    const firstDay = new Date(y, m, 1);
+    const lastDay = new Date(y, m + 1, 0);
+    const startOffset = firstDay.getDay(); // 0 = Sunday
+    const totalDays = lastDay.getDate();
+    return { year: y, month: m, days: totalDays, startOffset };
+  }, [monthOffset]);
+
+  const activityByDay = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const r of receipts) {
+      const d = new Date(r.timestamp);
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+      map.set(key, (map.get(key) ?? 0) + 1);
+    }
+    return map;
+  }, [receipts]);
+
+  const handlePrevMonth = useCallback(() => setMonthOffset((o) => o - 1), []);
+  const handleNextMonth = useCallback(() => setMonthOffset((o) => o + 1), []);
+  const handleToday = useCallback(() => setMonthOffset(0), []);
+
+  const monthName = new Date(year, month).toLocaleDateString(undefined, { month: "long", year: "numeric" });
+  const weekDays = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+
+  const today = new Date();
+  const todayKey = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-brand-dark">Activity</h3>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={handlePrevMonth}
+            className="rounded-md p-1 text-slate-400 transition-colors hover:bg-slate-100 hover:text-brand-dark"
+            aria-label="Previous month"
+          >
+            <HiMiniChevronLeft className="h-4 w-4" aria-hidden="true" />
+          </button>
+          <span className="min-w-[120px] text-center text-xs font-medium text-brand-dark">{monthName}</span>
+          <button
+            onClick={handleNextMonth}
+            className="rounded-md p-1 text-slate-400 transition-colors hover:bg-slate-100 hover:text-brand-dark"
+            aria-label="Next month"
+          >
+            <HiMiniChevronRight className="h-4 w-4" aria-hidden="true" />
+          </button>
+          {monthOffset !== 0 && (
+            <button
+              onClick={handleToday}
+              className="ml-1 rounded-md px-2 py-0.5 text-xs font-medium text-brand-blue hover:bg-blue-50"
+            >
+              Today
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-7 gap-1">
+        {weekDays.map((d) => (
+          <div key={d} className="text-center text-[10px] font-medium text-slate-400">
+            {d}
+          </div>
+        ))}
+        {Array.from({ length: 35 }, (_, i) => {
+          const dayIndex = i - startOffset + 1;
+          if (dayIndex < 1 || dayIndex > days) {
+            return <div key={i} className="aspect-square" />;
+          }
+          const dateKey = `${year}-${String(month + 1).padStart(2, "0")}-${String(dayIndex).padStart(2, "0")}`;
+          const count = activityByDay.get(dateKey) ?? 0;
+          const isToday = dateKey === todayKey;
+          const intensity = count === 0 ? 0 : count <= 2 ? 1 : count <= 5 ? 2 : 3;
+          const intensityClasses = [
+            "bg-white text-slate-300 hover:bg-slate-50",
+            "bg-blue-100 text-blue-700 hover:bg-blue-200",
+            "bg-blue-300 text-white hover:bg-blue-400",
+            "bg-blue-500 text-white hover:bg-blue-600",
+          ];
+          return (
+            <button
+              key={i}
+              onClick={() => count > 0 && onSelectDay?.(dateKey)}
+              disabled={count === 0}
+              className={`aspect-square rounded-md text-[10px] font-medium transition-colors ${intensityClasses[intensity]} ${isToday ? "ring-2 ring-brand-blue ring-offset-1" : ""} ${count === 0 ? "cursor-default" : "cursor-pointer"}`}
+              aria-label={`${dateKey}: ${count} actions`}
+            >
+              {dayIndex}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center gap-3 text-[10px] text-slate-400">
+        <span>No activity</span>
+        <span className="h-2.5 w-2.5 rounded-sm bg-blue-100" />
+        <span>Light</span>
+        <span className="h-2.5 w-2.5 rounded-sm bg-blue-300" />
+        <span>Medium</span>
+        <span className="h-2.5 w-2.5 rounded-sm bg-blue-500" />
+        <span>Heavy</span>
+      </div>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────
+// Top Actions
+// ──────────────────────────────────────────
+
+export function TopActions({
+  receipts,
+  onFilterAction,
+}: {
+  receipts: GuardReceipt[];
+  onFilterAction?: (name: string) => void;
+}) {
+  const [period, setPeriod] = useState<TimePeriod>("7d");
+  const [expanded, setExpanded] = useState(false);
+
+  const periodReceipts = useMemo(() => {
+    if (period === "all") return receipts;
+    const days = period === "7d" ? 7 : period === "30d" ? 30 : 90;
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - days);
+    return receipts.filter((r) => new Date(r.timestamp) >= cutoff);
+  }, [receipts, period]);
+
+  const aggregated = useMemo(() => aggregateByAction(periodReceipts), [periodReceipts]);
+  const topTotal = aggregated.slice(0, 10);
+  const topBlocked = aggregated.filter((a) => a.blocked > 0).slice(0, 10);
+  const topAllowed = aggregated.filter((a) => a.allowed > 0).slice(0, 10);
+
+  const toggleExpanded = useCallback(() => setExpanded((p) => !p), []);
+
+  if (aggregated.length === 0) return null;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-brand-dark">Top actions</h3>
+        <div className="flex items-center gap-1">
+          {(["7d", "30d", "90d", "all"] as TimePeriod[]).map((p) => (
+            <button
+              key={p}
+              onClick={() => setPeriod(p)}
+              className={`rounded-md px-2 py-0.5 text-[11px] font-medium transition-colors ${
+                period === p
+                  ? "bg-brand-blue text-white"
+                  : "text-slate-500 hover:bg-slate-100"
+              }`}
+            >
+              {p === "7d" ? "7 days" : p === "30d" ? "30 days" : p === "90d" ? "90 days" : "All time"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {!expanded ? (
+        <TopActionsList actions={topTotal} onFilterAction={onFilterAction} />
+      ) : (
+        <div className="space-y-4">
+          <TopActionsSection title="Most frequent" actions={topTotal} onFilterAction={onFilterAction} />
+          <TopActionsSection title="Most blocked" actions={topBlocked} onFilterAction={onFilterAction} />
+          <TopActionsSection title="Most allowed" actions={topAllowed} onFilterAction={onFilterAction} />
+        </div>
+      )}
+
+      <button
+        onClick={toggleExpanded}
+        className="flex items-center gap-1 text-xs font-medium text-brand-blue transition-colors hover:text-brand-dark"
+      >
+        {expanded ? (
+          <>
+            <HiMiniChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
+            Show less
+          </>
+        ) : (
+          <>
+            <HiMiniChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+            Show top blocked and allowed
+          </>
+        )}
+      </button>
+    </div>
+  );
+}
+
+function TopActionsSection({
+  title,
+  actions,
+  onFilterAction,
+}: {
+  title: string;
+  actions: ActionAggregate[];
+  onFilterAction?: (name: string) => void;
+}) {
+  if (actions.length === 0) return null;
+  return (
+    <div className="space-y-1.5">
+      <h4 className="text-xs font-medium text-slate-500">{title}</h4>
+      <TopActionsList actions={actions} onFilterAction={onFilterAction} />
+    </div>
+  );
+}
+
+function TopActionsList({
+  actions,
+  onFilterAction,
+}: {
+  actions: ActionAggregate[];
+  onFilterAction?: (name: string) => void;
+}) {
+  const maxTotal = actions[0]?.total ?? 1;
+
+  return (
+    <div className="space-y-1">
+      {actions.map((action) => {
+        const allowPct = action.total > 0 ? (action.allowed / action.total) * 100 : 0;
+        const blockPct = action.total > 0 ? (action.blocked / action.total) * 100 : 0;
+        return (
+          <button
+            key={action.name}
+            onClick={() => onFilterAction?.(action.name)}
+            className="group flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-slate-50"
+          >
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center justify-between">
+                <span className="truncate text-xs font-medium text-brand-dark">{action.name}</span>
+                <span className="shrink-0 text-[10px] text-slate-400">{action.total}</span>
+              </div>
+              <div className="mt-1 flex h-1.5 w-full overflow-hidden rounded-full bg-slate-100">
+                <div
+                  className="bg-emerald-400 transition-all"
+                  style={{ width: `${allowPct}%` }}
+                />
+                <div
+                  className="bg-brand-attention transition-all"
+                  style={{ width: `${blockPct}%` }}
+                />
+              </div>
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+interface ActionAggregate {
+  name: string;
+  total: number;
+  allowed: number;
+  blocked: number;
+  lastSeen: string;
+}
+
+function aggregateByAction(receipts: GuardReceipt[]): ActionAggregate[] {
+  const map = new Map<string, ActionAggregate>();
+  for (const r of receipts) {
+    const name = r.artifact_name ?? r.artifact_id;
+    const existing = map.get(name);
+    if (existing) {
+      existing.total += 1;
+      if (r.policy_decision === "allow") existing.allowed += 1;
+      if (r.policy_decision === "block") existing.blocked += 1;
+      if (r.timestamp > existing.lastSeen) existing.lastSeen = r.timestamp;
+    } else {
+      map.set(name, {
+        name,
+        total: 1,
+        allowed: r.policy_decision === "allow" ? 1 : 0,
+        blocked: r.policy_decision === "block" ? 1 : 0,
+        lastSeen: r.timestamp,
+      });
+    }
+  }
+  return Array.from(map.values()).sort((a, b) => b.total - a.total);
+}

--- a/dashboard/src/history-export.ts
+++ b/dashboard/src/history-export.ts
@@ -1,0 +1,87 @@
+import type { GuardReceipt } from "./guard-types";
+import { harnessDisplayName } from "./approval-center-utils";
+
+export interface ExportFilters {
+  search?: string;
+  time?: string;
+  decision?: string;
+  harness?: string;
+}
+
+export function exportReceiptsAsCsv(
+  receipts: GuardReceipt[],
+  filters?: ExportFilters
+): { blob: Blob; filename: string } {
+  const headers = [
+    "timestamp",
+    "harness",
+    "artifact_id",
+    "artifact_name",
+    "policy_decision",
+    "artifact_hash",
+    "capabilities_summary",
+    "provenance_summary",
+    "source_scope",
+  ];
+
+  const rows = receipts.map((r) => [
+    r.timestamp,
+    r.harness,
+    r.artifact_id,
+    r.artifact_name ?? "",
+    r.policy_decision,
+    r.artifact_hash,
+    r.capabilities_summary ?? "",
+    r.provenance_summary ?? "",
+    r.source_scope ?? "",
+  ]);
+
+  const csv = [headers.join(","), ...rows.map((row) => row.map(escapeCsvCell).join(","))].join("\n");
+
+  const fromDate = receipts.length > 0 ? formatDateIso(new Date(receipts[receipts.length - 1].timestamp)) : "all";
+  const toDate = receipts.length > 0 ? formatDateIso(new Date(receipts[0].timestamp)) : "all";
+  const filename = `guard-history-${fromDate}-to-${toDate}.csv`;
+
+  return { blob: new Blob([csv], { type: "text/csv;charset=utf-8;" }), filename };
+}
+
+export function exportReceiptsAsJson(
+  receipts: GuardReceipt[],
+  filters?: ExportFilters
+): { blob: Blob; filename: string } {
+  const payload = {
+    exported_at: new Date().toISOString(),
+    filter_summary: filters ?? {},
+    total_rows: receipts.length,
+    items: receipts,
+  };
+
+  const fromDate = receipts.length > 0 ? formatDateIso(new Date(receipts[receipts.length - 1].timestamp)) : "all";
+  const toDate = receipts.length > 0 ? formatDateIso(new Date(receipts[0].timestamp)) : "all";
+  const filename = `guard-history-${fromDate}-to-${toDate}.json`;
+
+  return { blob: new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" }), filename };
+}
+
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+function escapeCsvCell(value: string): string {
+  const needsQuotes = /[",\n\r]/.test(value);
+  if (needsQuotes) {
+    return `"${value.replaceAll("\"", "\"\"")}"`;
+  }
+  return value;
+}
+
+function formatDateIso(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+}

--- a/dashboard/src/receipts-workspace.tsx
+++ b/dashboard/src/receipts-workspace.tsx
@@ -1,27 +1,32 @@
-import { useCallback, useEffect, useMemo, useState, type ChangeEvent } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   HiMiniChevronDown,
   HiMiniChevronUp,
+  HiOutlineCalendarDays,
+  HiOutlineListBullet,
+  HiOutlineArrowDownTray,
 } from "react-icons/hi2";
 
 import {
   Badge,
   EmptyState,
   SectionLabel,
-  Tag,
   GuardHero,
 } from "./approval-center-primitives";
 import { harnessDisplayName, formatRelativeTime } from "./approval-center-utils";
 import type { GuardReceipt } from "./guard-types";
 import { guardAwareHref } from "./guard-api";
+import { HistoryInsights, ActivityCalendar, TopActions } from "./history-analytics";
+import { exportReceiptsAsCsv, exportReceiptsAsJson, downloadBlob } from "./history-export";
 
 type ReceiptsState =
   | { kind: "loading" }
   | { kind: "error"; message: string }
   | { kind: "ready"; items: GuardReceipt[] };
 
-type TimeFilter = "all" | "today" | "yesterday" | "week";
+type TimeFilter = "all" | "today" | "yesterday" | "week" | "last7d" | "last30d";
 type DecisionFilter = "all" | "allow" | "block";
+type ViewMode = "list" | "calendar";
 
 export function ReceiptsWorkspace(props: { receipts: ReceiptsState }) {
   if (props.receipts.kind === "loading") {
@@ -42,26 +47,59 @@ export function ReceiptsWorkspace(props: { receipts: ReceiptsState }) {
   return <ReadyReceiptsWorkspace receiptItems={props.receipts.items} />;
 }
 
-function readUrlParams(): { search: string; time: TimeFilter; decision: DecisionFilter; harness: string } {
+const TIME_FILTER_VALUES: TimeFilter[] = ["all", "today", "yesterday", "week", "last7d", "last30d"];
+const DECISION_FILTER_VALUES: DecisionFilter[] = ["all", "allow", "block"];
+
+function readUrlParams(): {
+  search: string;
+  time: TimeFilter;
+  decision: DecisionFilter;
+  harness: string;
+  view: ViewMode;
+  day: string;
+} {
   const params = new URLSearchParams(window.location.search);
   const time = params.get("time") as TimeFilter;
   const decision = params.get("decision") as DecisionFilter;
+  const view = params.get("view") as ViewMode;
   return {
     search: params.get("search") ?? "",
-    time: ["all", "today", "yesterday", "week"].includes(time) ? time : "all",
-    decision: ["all", "allow", "block"].includes(decision) ? decision : "all",
+    time: TIME_FILTER_VALUES.includes(time) ? time : "all",
+    decision: DECISION_FILTER_VALUES.includes(decision) ? decision : "all",
     harness: params.get("harness") ?? "all",
+    view: view === "calendar" ? "calendar" : "list",
+    day: params.get("day") ?? "",
   };
 }
 
-function writeUrlParams(params: { search: string; time: TimeFilter; decision: DecisionFilter; harness: string }) {
+function writeUrlParams(params: {
+  search: string;
+  time: TimeFilter;
+  decision: DecisionFilter;
+  harness: string;
+  view: ViewMode;
+  day: string;
+}) {
   const url = new URL(window.location.href);
   url.search = "";
   if (params.search) url.searchParams.set("search", params.search);
   if (params.time !== "all") url.searchParams.set("time", params.time);
   if (params.decision !== "all") url.searchParams.set("decision", params.decision);
   if (params.harness !== "all") url.searchParams.set("harness", params.harness);
+  if (params.view !== "list") url.searchParams.set("view", params.view);
+  if (params.day) url.searchParams.set("day", params.day);
   window.history.replaceState({}, "", url.toString());
+}
+
+function timeFilterLabel(filter: TimeFilter): string {
+  switch (filter) {
+    case "today": return "Today";
+    case "yesterday": return "Yesterday";
+    case "week": return "This week";
+    case "last7d": return "Last 7 days";
+    case "last30d": return "Last 30 days";
+    default: return "All time";
+  }
 }
 
 function ReadyReceiptsWorkspace(props: { receiptItems: GuardReceipt[] }) {
@@ -69,6 +107,8 @@ function ReadyReceiptsWorkspace(props: { receiptItems: GuardReceipt[] }) {
   const [search, setSearch] = useState(initial.search);
   const [timeFilter, setTimeFilter] = useState<TimeFilter>(initial.time);
   const [decisionFilter, setDecisionFilter] = useState<DecisionFilter>(initial.decision);
+  const [viewMode, setViewMode] = useState<ViewMode>(initial.view);
+  const [dayFilter, setDayFilter] = useState<string>(initial.day);
 
   const harnesses = useMemo(
     () => Array.from(new Set(props.receiptItems.map((r) => r.harness))).sort(),
@@ -85,8 +125,8 @@ function ReadyReceiptsWorkspace(props: { receiptItems: GuardReceipt[] }) {
   }, [harnesses, harnessFilter]);
 
   useEffect(() => {
-    writeUrlParams({ search, time: timeFilter, decision: decisionFilter, harness: harnessFilter });
-  }, [search, timeFilter, decisionFilter, harnessFilter]);
+    writeUrlParams({ search, time: timeFilter, decision: decisionFilter, harness: harnessFilter, view: viewMode, day: dayFilter });
+  }, [search, timeFilter, decisionFilter, harnessFilter, viewMode, dayFilter]);
 
   const filtered = useMemo(() => {
     let items = props.receiptItems;
@@ -103,12 +143,27 @@ function ReadyReceiptsWorkspace(props: { receiptItems: GuardReceipt[] }) {
       startOfYesterday.setDate(startOfYesterday.getDate() - 1);
       const startOfWeek = new Date(startOfToday);
       startOfWeek.setDate(startOfWeek.getDate() - startOfWeek.getDay());
+      const startOfLast7d = new Date(startOfToday);
+      startOfLast7d.setDate(startOfLast7d.getDate() - 7);
+      const startOfLast30d = new Date(startOfToday);
+      startOfLast30d.setDate(startOfLast30d.getDate() - 30);
       items = items.filter((r) => {
         const d = new Date(r.timestamp);
         if (timeFilter === "today") return d >= startOfToday;
         if (timeFilter === "yesterday") return d >= startOfYesterday && d < startOfToday;
         if (timeFilter === "week") return d >= startOfWeek;
+        if (timeFilter === "last7d") return d >= startOfLast7d;
+        if (timeFilter === "last30d") return d >= startOfLast30d;
         return true;
+      });
+    }
+    if (dayFilter) {
+      const dayStart = new Date(dayFilter);
+      const dayEnd = new Date(dayStart);
+      dayEnd.setDate(dayEnd.getDate() + 1);
+      items = items.filter((r) => {
+        const d = new Date(r.timestamp);
+        return d >= dayStart && d < dayEnd;
       });
     }
     if (search.trim()) {
@@ -119,7 +174,7 @@ function ReadyReceiptsWorkspace(props: { receiptItems: GuardReceipt[] }) {
       );
     }
     return items.sort((a, b) => +new Date(b.timestamp) - +new Date(a.timestamp));
-  }, [props.receiptItems, decisionFilter, harnessFilter, timeFilter, search]);
+  }, [props.receiptItems, decisionFilter, harnessFilter, timeFilter, search, dayFilter]);
 
   const groups = useMemo(() => {
     const today: GuardReceipt[] = [];
@@ -143,6 +198,32 @@ function ReadyReceiptsWorkspace(props: { receiptItems: GuardReceipt[] }) {
     return { today, yesterday, thisWeek, earlier };
   }, [filtered]);
 
+  const handleFilterHarness = useCallback((harness: string) => {
+    setHarnessFilter(harness);
+    setViewMode("list");
+  }, []);
+
+  const handleFilterDay = useCallback((day: string) => {
+    setDayFilter(day);
+    setTimeFilter("all");
+    setViewMode("list");
+  }, []);
+
+  const handleFilterAction = useCallback((name: string) => {
+    setSearch(name);
+    setViewMode("list");
+  }, []);
+
+  const handleExportCsv = useCallback(() => {
+    const { blob, filename } = exportReceiptsAsCsv(filtered, { search, time: timeFilter, decision: decisionFilter, harness: harnessFilter });
+    downloadBlob(blob, filename);
+  }, [filtered, search, timeFilter, decisionFilter, harnessFilter]);
+
+  const handleExportJson = useCallback(() => {
+    const { blob, filename } = exportReceiptsAsJson(filtered, { search, time: timeFilter, decision: decisionFilter, harness: harnessFilter });
+    downloadBlob(blob, filename);
+  }, [filtered, search, timeFilter, decisionFilter, harnessFilter]);
+
   const totalCount = props.receiptItems.length;
 
   if (totalCount === 0) {
@@ -162,6 +243,12 @@ function ReadyReceiptsWorkspace(props: { receiptItems: GuardReceipt[] }) {
         headline="History"
         subheadline="What Guard decided. Filter by time, app, or decision."
         cta={<Badge tone="info">{totalCount} saved</Badge>}
+      />
+
+      <HistoryInsights
+        receipts={props.receiptItems}
+        onFilterHarness={handleFilterHarness}
+        onFilterDay={handleFilterDay}
       />
 
       <div className="space-y-3">
@@ -209,6 +296,18 @@ function ReadyReceiptsWorkspace(props: { receiptItems: GuardReceipt[] }) {
           >
             This week
           </FilterChip>
+          <FilterChip
+            active={timeFilter === "last7d"}
+            onClick={() => setTimeFilter("last7d")}
+          >
+            Last 7d
+          </FilterChip>
+          <FilterChip
+            active={timeFilter === "last30d"}
+            onClick={() => setTimeFilter("last30d")}
+          >
+            Last 30d
+          </FilterChip>
           <span className="mx-1 h-4 w-px bg-slate-200" />
           <select
             value={harnessFilter}
@@ -220,6 +319,30 @@ function ReadyReceiptsWorkspace(props: { receiptItems: GuardReceipt[] }) {
               <option key={h} value={h}>{harnessDisplayName(h)}</option>
             ))}
           </select>
+          <span className="mx-1 h-4 w-px bg-slate-200" />
+          <ViewToggleButton active={viewMode === "list"} onClick={() => setViewMode("list")} ariaLabel="List view">
+            <HiOutlineListBullet className="h-3.5 w-3.5" aria-hidden="true" />
+          </ViewToggleButton>
+          <ViewToggleButton active={viewMode === "calendar"} onClick={() => setViewMode("calendar")} ariaLabel="Calendar view">
+            <HiOutlineCalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
+          </ViewToggleButton>
+          <span className="mx-1 h-4 w-px bg-slate-200" />
+          <button
+            onClick={handleExportCsv}
+            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-slate-500 transition-colors hover:bg-slate-100 hover:text-brand-dark"
+            title="Export as CSV"
+          >
+            <HiOutlineArrowDownTray className="h-3.5 w-3.5" aria-hidden="true" />
+            CSV
+          </button>
+          <button
+            onClick={handleExportJson}
+            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-slate-500 transition-colors hover:bg-slate-100 hover:text-brand-dark"
+            title="Export as JSON"
+          >
+            <HiOutlineArrowDownTray className="h-3.5 w-3.5" aria-hidden="true" />
+            JSON
+          </button>
         </div>
         <input
           value={search}
@@ -230,7 +353,7 @@ function ReadyReceiptsWorkspace(props: { receiptItems: GuardReceipt[] }) {
       </div>
 
       {/* Active filter chips */}
-      {(search || decisionFilter !== "all" || timeFilter !== "all" || harnessFilter !== "all") && (
+      {(search || decisionFilter !== "all" || timeFilter !== "all" || harnessFilter !== "all" || dayFilter) && (
         <div className="flex flex-wrap items-center gap-2">
           {search && (
             <ActiveFilterChip onClick={() => setSearch("")}>
@@ -244,12 +367,17 @@ function ReadyReceiptsWorkspace(props: { receiptItems: GuardReceipt[] }) {
           )}
           {timeFilter !== "all" && (
             <ActiveFilterChip onClick={() => setTimeFilter("all")}>
-              {timeFilter === "today" ? "Today" : timeFilter === "yesterday" ? "Yesterday" : "This week"}
+              {timeFilterLabel(timeFilter)}
             </ActiveFilterChip>
           )}
           {harnessFilter !== "all" && (
             <ActiveFilterChip onClick={() => setHarnessFilter("all")}>
               {harnessDisplayName(harnessFilter)}
+            </ActiveFilterChip>
+          )}
+          {dayFilter && (
+            <ActiveFilterChip onClick={() => setDayFilter("")}>
+              {dayFilter}
             </ActiveFilterChip>
           )}
           <button
@@ -258,6 +386,7 @@ function ReadyReceiptsWorkspace(props: { receiptItems: GuardReceipt[] }) {
               setDecisionFilter("all");
               setTimeFilter("all");
               setHarnessFilter("all");
+              setDayFilter("");
             }}
             className="ml-1 text-xs font-medium text-brand-blue hover:text-brand-dark transition-colors"
           >
@@ -266,7 +395,12 @@ function ReadyReceiptsWorkspace(props: { receiptItems: GuardReceipt[] }) {
         </div>
       )}
 
-      {filtered.length === 0 ? (
+      {viewMode === "calendar" ? (
+        <ActivityCalendar
+          receipts={filtered}
+          onSelectDay={handleFilterDay}
+        />
+      ) : filtered.length === 0 ? (
         <EmptyState
           title="No matching history"
           body="Try different filters or search terms."
@@ -280,7 +414,37 @@ function ReadyReceiptsWorkspace(props: { receiptItems: GuardReceipt[] }) {
           <ReceiptGroup title="Earlier" items={groups.earlier} />
         </div>
       )}
+
+      {viewMode === "list" && (
+        <TopActions receipts={filtered} onFilterAction={handleFilterAction} />
+      )}
     </div>
+  );
+}
+
+function ViewToggleButton({
+  active,
+  onClick,
+  children,
+  ariaLabel,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+  ariaLabel: string;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      aria-label={ariaLabel}
+      className={`rounded-md p-1.5 transition-colors ${
+        active
+          ? "bg-brand-blue text-white"
+          : "text-slate-400 hover:bg-slate-100 hover:text-brand-dark"
+      }`}
+    >
+      {children}
+    </button>
   );
 }
 


### PR DESCRIPTION
## Summary
Adds Phase 5.5 analytics to the History screen, making it an exploration surface instead of a simple dump.

## Changes
- **HistoryInsights** (`history-analytics.tsx`): Computed insight cards showing:
  - Most blocked action this week
  - Most active app
  - Block rate with week-over-week trend
  - Secret reads stopped this month
  - New app detected (first seen within last 7 days)
- **ActivityCalendar** (`history-analytics.tsx`): Month grid with day-by-day activity heatmap (blue intensity), month navigation, today highlight, click-to-filter day.
- **TopActions** (`history-analytics.tsx`): Aggregated action frequency list with allow/block proportion bars. Time period selector (7d/30d/90d/All). Expandable to show top blocked and top allowed separately.
- **Export** (`history-export.ts`): CSV and JSON export of the current filtered view. Filenames include date range.
- **Enhanced filters**: Added "Last 7d", "Last 30d" time filters. Calendar day selection filters history to that specific day.
- **View toggle**: List / Calendar view modes with URL persistence (`?view=calendar`).
- **Flat design**: All new components follow the flattened card density established in previous PRs.

## Verification
- [x] Build passes (`pnpm run build`)
- [x] All 8 test suites pass
- [x] No TypeScript errors
- [x] Bundle size: ~962KB JS (~174KB gzipped), ~94KB CSS

## Related Tasks
HGD500-HGD555