### PR TITLE
feat(dashboard): add History keyboard shortcuts g and t

### DIFF
--- a/dashboard/src/receipts-workspace.tsx
+++ b/dashboard/src/receipts-workspace.tsx
@@ -136,6 +136,16 @@ function ReadyReceiptsWorkspace(props: { receiptItems: GuardReceipt[] }) {
   useKeyboardShortcut("e", () => {
     handleExportCsv();
   }, { preventDefault: true });
+  useKeyboardShortcut("g", () => {
+    setViewMode((prev) => (prev === "list" ? "calendar" : "list"));
+  }, { preventDefault: true });
+  useKeyboardShortcut("t", () => {
+    const cycle: TimeFilter[] = ["all", "today", "yesterday", "week", "last7d", "last30d"];
+    setTimeFilter((prev) => {
+      const idx = cycle.indexOf(prev);
+      return cycle[(idx + 1) % cycle.length];
+    });
+  }, { preventDefault: true });
 
   const filtered = useMemo(() => {
     let items = props.receiptItems;


### PR DESCRIPTION
## Summary
Implements the g and t keyboard shortcuts documented in the help modal for the History screen.

## Changes
- g: toggle between list and calendar view
- t: cycle through time filters (all → today → yesterday → week → last7d → last30d)

## Verification
- [x] Build passes
- [x] All 8 test suites pass

## Related Tasks
HGD557-HGD558