### PR TITLE
feat(dashboard): new app discovery banner, setup guide, trend line, block breakdown

### DIFF
--- a/dashboard/src/fleet-workspace.tsx
+++ b/dashboard/src/fleet-workspace.tsx
@@ -1,10 +1,12 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import {
   HiMiniCheckCircle,
   HiMiniExclamationCircle,
   HiMiniWrenchScrewdriver,
   HiMiniXCircle,
   HiMiniChevronRight,
+  HiMiniClipboard,
+  HiMiniClipboardDocumentCheck,
 } from "react-icons/hi2";
 import {
   ActionButton,
@@ -204,6 +206,114 @@ export function FleetWorkspace(props: FleetWorkspaceProps) {
             />
           )}
         </section>
+      </div>
+
+      {activeInstalls.length === 0 && (
+        <SetupGuide
+          hasReceipts={props.runtime.latest_receipts.length > 0}
+          hasInventory={inventory.length > 0}
+        />
+      )}
+    </div>
+  );
+}
+
+function SetupGuide(props: { hasReceipts: boolean; hasInventory: boolean }) {
+  const steps = [
+    {
+      id: "install",
+      label: "Install Guard hook",
+      description: "Run `hol-guard install` in your project to set up the approval hook.",
+      command: "hol-guard install",
+      done: props.hasInventory,
+    },
+    {
+      id: "run",
+      label: "Run your AI app",
+      description: "Start Codex, Claude Code, or another supported app. Guard will intercept risky actions.",
+      done: props.hasReceipts,
+    },
+    {
+      id: "verify",
+      label: "Verify in dashboard",
+      description: "Check this dashboard to see Guard protecting your app. You will see receipts appear in History.",
+      done: props.hasReceipts && props.hasInventory,
+    },
+  ];
+
+  const completedCount = steps.filter((s) => s.done).length;
+
+  return (
+    <div className="rounded-2xl border border-brand-blue/15 bg-brand-blue/[0.03] p-5 sm:p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <SectionLabel>Setup guide</SectionLabel>
+          <p className="mt-1 text-sm text-slate-500">
+            {completedCount === steps.length
+              ? "Guard is set up and running!"
+              : `${completedCount} of ${steps.length} steps completed`}
+          </p>
+        </div>
+        {completedCount === steps.length && (
+          <HiMiniCheckCircle className="h-6 w-6 text-brand-green" aria-hidden="true" />
+        )}
+      </div>
+      <div className="mt-4 space-y-3">
+        {steps.map((step, index) => (
+          <SetupStep
+            key={step.id}
+            stepNumber={index + 1}
+            label={step.label}
+            description={step.description}
+            command={step.command}
+            done={step.done}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SetupStep(props: {
+  stepNumber: number;
+  label: string;
+  description: string;
+  command?: string;
+  done: boolean;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    if (!props.command) return;
+    void navigator.clipboard.writeText(props.command).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, [props.command]);
+
+  return (
+    <div className={`flex items-start gap-3 rounded-xl border p-3 ${props.done ? "border-brand-green/20 bg-brand-green/[0.04]" : "border-slate-200 bg-white"}`}>
+      <span className={`mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-bold ${props.done ? "bg-brand-green text-white" : "bg-slate-100 text-slate-500"}`}>
+        {props.done ? <HiMiniCheckCircle className="h-4 w-4" aria-hidden="true" /> : props.stepNumber}
+      </span>
+      <div className="min-w-0 flex-1">
+        <p className={`text-sm font-medium ${props.done ? "text-brand-green-text" : "text-brand-dark"}`}>
+          {props.label}
+        </p>
+        <p className="text-xs text-slate-500">{props.description}</p>
+        {props.command && (
+          <button
+            onClick={handleCopy}
+            className="mt-1.5 inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-slate-50 px-2 py-1 text-xs font-mono text-brand-dark transition-colors hover:bg-slate-100"
+          >
+            {copied ? (
+              <HiMiniClipboardDocumentCheck className="h-3 w-3 text-brand-green" aria-hidden="true" />
+            ) : (
+              <HiMiniClipboard className="h-3 w-3" aria-hidden="true" />
+            )}
+            {props.command}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/dashboard/src/history-charts.tsx
+++ b/dashboard/src/history-charts.tsx
@@ -191,6 +191,145 @@ export function AppActivityBars({ receipts }: { receipts: GuardReceipt[] }) {
 }
 
 // ──────────────────────────────────────────
+// Decision Trend Line
+// ──────────────────────────────────────────
+
+export function DecisionTrendLine({ receipts }: { receipts: GuardReceipt[] }) {
+  const days = useMemo(() => {
+    const map = new Map<string, { allow: number; block: number }>();
+    const now = new Date();
+    for (let i = 29; i >= 0; i--) {
+      const d = new Date(now);
+      d.setDate(d.getDate() - i);
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+      map.set(key, { allow: 0, block: 0 });
+    }
+    for (const r of receipts) {
+      const d = new Date(r.timestamp);
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+      if (map.has(key)) {
+        const existing = map.get(key)!;
+        if (r.policy_decision === "allow") existing.allow += 1;
+        if (r.policy_decision === "block") existing.block += 1;
+      }
+    }
+    return Array.from(map.entries()).map(([date, counts]) => ({ date, ...counts }));
+  }, [receipts]);
+
+  const hasData = days.some((d) => d.allow > 0 || d.block > 0);
+  if (!hasData) return null;
+
+  const width = 300;
+  const height = 60;
+  const padding = 4;
+  const chartWidth = width - padding * 2;
+  const chartHeight = height - padding * 2;
+  const totalMax = Math.max(1, ...days.map((d) => d.allow + d.block));
+
+  const allowPoints = days.map((day, i) => {
+    const x = padding + (i / (days.length - 1)) * chartWidth;
+    const y = padding + chartHeight - (day.allow / totalMax) * chartHeight;
+    return `${x},${y}`;
+  }).join(" ");
+
+  const blockPoints = days.map((day, i) => {
+    const x = padding + (i / (days.length - 1)) * chartWidth;
+    const y = padding + chartHeight - (day.block / totalMax) * chartHeight;
+    return `${x},${y}`;
+  }).join(" ");
+
+  return (
+    <div className="space-y-2">
+      <h4 className="text-xs font-semibold text-brand-dark">Decision trend (30 days)</h4>
+      <svg viewBox={`0 0 ${width} ${height}`} className="w-full" preserveAspectRatio="none">
+        <polyline
+          fill="none"
+          stroke="#10b981"
+          strokeWidth="2"
+          points={allowPoints}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <polyline
+          fill="none"
+          stroke="#f59e0b"
+          strokeWidth="2"
+          points={blockPoints}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+      <div className="flex items-center gap-3 text-[10px] text-slate-400">
+        <span className="flex items-center gap-1">
+          <span className="h-1 w-4 rounded-full bg-emerald-400" />
+          Allowed
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="h-1 w-4 rounded-full bg-amber-400" />
+          Blocked
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────
+// Block Reason Breakdown
+// ──────────────────────────────────────────
+
+export function BlockReasonBreakdown({ receipts }: { receipts: GuardReceipt[] }) {
+  const reasons = useMemo(() => {
+    const blocked = receipts.filter((r) => r.policy_decision === "block");
+    const counts = new Map<string, number>();
+    for (const r of blocked) {
+      const name = (r.artifact_name ?? "").toLowerCase();
+      const caps = (r.capabilities_summary ?? "").toLowerCase();
+      if (name.includes(".env") || name.includes("secret") || caps.includes("secret")) {
+        counts.set("Secret access", (counts.get("Secret access") ?? 0) + 1);
+      } else if (caps.includes("network") || caps.includes("exfiltrat")) {
+        counts.set("Network/Exfiltration", (counts.get("Network/Exfiltration") ?? 0) + 1);
+      } else if (caps.includes("destructive") || caps.includes("rm ") || caps.includes("delete")) {
+        counts.set("Destructive", (counts.get("Destructive") ?? 0) + 1);
+      } else if (caps.includes("encoded") || caps.includes("decode")) {
+        counts.set("Encoded payload", (counts.get("Encoded payload") ?? 0) + 1);
+      } else {
+        counts.set("Other", (counts.get("Other") ?? 0) + 1);
+      }
+    }
+    return Array.from(counts.entries())
+      .map(([label, count]) => ({ label, count }))
+      .sort((a, b) => b.count - a.count);
+  }, [receipts]);
+
+  if (reasons.length === 0) return null;
+
+  const maxCount = Math.max(1, ...reasons.map((r) => r.count));
+  const colors = ["bg-amber-500", "bg-amber-400", "bg-amber-300", "bg-amber-200", "bg-slate-300"];
+
+  return (
+    <div className="space-y-2">
+      <h4 className="text-xs font-semibold text-brand-dark">Why Guard blocked</h4>
+      <div className="space-y-2">
+        {reasons.map((reason, i) => (
+          <div key={reason.label} className="space-y-1">
+            <div className="flex items-center justify-between text-xs">
+              <span className="text-slate-600">{reason.label}</span>
+              <span className="font-medium text-brand-dark">{reason.count}</span>
+            </div>
+            <div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-100">
+              <div
+                className={`h-full rounded-full ${colors[i % colors.length]} transition-all`}
+                style={{ width: `${(reason.count / maxCount) * 100}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────
 // Charts Section
 // ──────────────────────────────────────────
 
@@ -208,6 +347,12 @@ export function HistoryCharts({ receipts }: { receipts: GuardReceipt[] }) {
       </div>
       <div className="rounded-xl border border-slate-100 bg-white p-4 shadow-sm">
         <AppActivityBars receipts={receipts} />
+      </div>
+      <div className="rounded-xl border border-slate-100 bg-white p-4 shadow-sm">
+        <DecisionTrendLine receipts={receipts} />
+      </div>
+      <div className="rounded-xl border border-slate-100 bg-white p-4 shadow-sm">
+        <BlockReasonBreakdown receipts={receipts} />
       </div>
     </div>
   );

--- a/dashboard/src/home-dashboard.tsx
+++ b/dashboard/src/home-dashboard.tsx
@@ -11,6 +11,7 @@ import {
   HiMiniSparkles,
   HiMiniExclamationTriangle,
   HiMiniXMark,
+  HiMiniBolt,
 } from "react-icons/hi2";
 import {
   ActionButton,
@@ -171,6 +172,14 @@ export function HomeWorkspace(props: {
       />
 
       <StreakMilestoneBanner streak={streak} />
+
+      <NewAppDiscoveryBanner
+        managedInstalls={managedInstalls}
+        observedHarnesses={observedHarnesses}
+        receipts={snapshot.latest_receipts}
+        policies={policyItems}
+        onOpenAppDetail={props.onOpenAppDetail}
+      />
 
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1.3fr)_minmax(0,0.9fr)]">
         <section className="space-y-6">
@@ -706,6 +715,75 @@ function StreakMilestoneBanner({ streak }: { streak: number }) {
         </button>
       </div>
     </div>
+  );
+}
+
+function NewAppDiscoveryBanner(props: {
+  managedInstalls: GuardManagedInstall[];
+  observedHarnesses: string[];
+  receipts: GuardReceipt[];
+  policies: GuardPolicyDecision[];
+  onOpenAppDetail: (harness: string) => void;
+}) {
+  const activeHarnesses = new Set(props.managedInstalls.map((i) => i.harness));
+  const discovered = props.observedHarnesses.filter((h) => !activeHarnesses.has(h));
+
+  return (
+    <>
+      {discovered.map((harness) => (
+        <NewAppBanner
+          key={harness}
+          harness={harness}
+          onOpenAppDetail={props.onOpenAppDetail}
+        />
+      ))}
+    </>
+  );
+}
+
+function NewAppBanner(props: {
+  harness: string;
+  onOpenAppDetail: (harness: string) => void;
+}) {
+  const storageKey = `guard-new-app-dismissed-${props.harness}`;
+  const [dismissed, setDismissed] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return localStorage.getItem(storageKey) === "1";
+  });
+
+  const handleDismiss = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    setDismissed(true);
+    localStorage.setItem(storageKey, "1");
+  }, [storageKey]);
+
+  if (dismissed) return null;
+
+  return (
+    <button
+      onClick={() => props.onOpenAppDetail(props.harness)}
+      className="guard-fade-in flex w-full items-center gap-3 rounded-xl border border-brand-blue/15 bg-brand-blue/[0.04] px-4 py-3 text-left transition-colors hover:bg-brand-blue/[0.08]"
+    >
+      <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-brand-blue/10">
+        <HiMiniBolt className="h-4 w-4 text-brand-blue" aria-hidden="true" />
+      </span>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium text-brand-dark">
+          Guard discovered {harnessDisplayName(props.harness)}
+        </p>
+        <p className="text-xs text-slate-500">
+          Guard saw this app but it is not set up yet. Open to connect it.
+        </p>
+      </div>
+      <span
+        onClick={handleDismiss}
+        className="shrink-0 rounded-full p-1.5 text-slate-400 transition-colors hover:bg-white/70 hover:text-brand-dark"
+        aria-label={`Dismiss ${harnessDisplayName(props.harness)} discovery`}
+        role="button"
+      >
+        <HiMiniXMark className="h-4 w-4" aria-hidden="true" />
+      </span>
+    </button>
   );
 }
 


### PR DESCRIPTION
## Summary
Adds new app discovery, setup guide, and additional history charts.

## Changes
- **NewAppDiscoveryBanner** (home): Detects observed-but-not-installed apps, shows dismissible banner per app with link to app detail. Dismiss state in localStorage.
- **SetupGuide** (fleet): 3-step wizard (install hook, run app, verify) with checkmarks and copy command button. Shows when no active installs.
- **DecisionTrendLine**: SVG line chart showing allow vs block trends over 30 days
- **BlockReasonBreakdown**: horizontal bars categorizing blocks by reason (secret access, network/exfiltration, destructive, encoded, other)

## Verification
- [x] Build passes
- [x] All 8 test suites pass
- [x] No TypeScript errors

## Related Tasks
HGD077-HGD082 HGD141-HGD145 HGD520-HGD521