### PR TITLE
fix(guard): add specific inbox review categories

### DIFF
--- a/dashboard/src/queue-state.test.ts
+++ b/dashboard/src/queue-state.test.ts
@@ -300,33 +300,33 @@ assert(
 );
 assert(
   needsDecision.ctaLabel === "Review blocked action",
-  "T-QS-31: buildHomePrimaryState CTA is 'Review blocked action' when pending"
+  "T-QS-36: buildHomePrimaryState CTA is 'Review blocked action' when pending"
 );
 
 const setupNeeded = buildHomePrimaryState(0, 0);
 assert(
   setupNeeded.status === "setup_needed",
-  "T-QS-32: buildHomePrimaryState returns setup_needed when no watched apps and no pending"
+  "T-QS-37: buildHomePrimaryState returns setup_needed when no watched apps and no pending"
 );
 assert(
   setupNeeded.ctaLabel === "Set up protection",
-  "T-QS-33: buildHomePrimaryState CTA is 'Set up protection' when no watched apps"
+  "T-QS-38: buildHomePrimaryState CTA is 'Set up protection' when no watched apps"
 );
 
 const protectedState = buildHomePrimaryState(0, 2);
 assert(
   protectedState.status === "protected",
-  "T-QS-34: buildHomePrimaryState returns protected status when guarded with apps present"
+  "T-QS-39: buildHomePrimaryState returns protected status when guarded with apps present"
 );
 assert(
   protectedState.copy.includes("protecting"),
-  "T-QS-35: buildHomePrimaryState copy mentions protecting when protected"
+  "T-QS-40: buildHomePrimaryState copy mentions protecting when protected"
 );
 
 const singlePending = buildHomePrimaryState(1, 1);
 assert(
   singlePending.copy.includes("1 action paused"),
-  "T-QS-36: buildHomePrimaryState uses singular 'action' when exactly one pending"
+  "T-QS-41: buildHomePrimaryState uses singular 'action' when exactly one pending"
 );
 
 const fileReadEnvelope: GuardActionEnvelope = {

--- a/dashboard/src/queue-state.test.ts
+++ b/dashboard/src/queue-state.test.ts
@@ -10,6 +10,9 @@ import {
   isReadOnlyQueueGroup,
   bulkApproveActionCount,
   bulkApprovePrimaryIds,
+  filterQueueByCategory,
+  queueCategoriesForItems,
+  resolveQueueCategory,
 } from "./queue-state";
 
 function assert(condition: boolean, message: string): void {
@@ -210,6 +213,44 @@ assert(emptyResults.length === 0, "T-QS-21: searchQueue returns empty array when
 const allResults = searchQueue([BASE_REQUEST, shellItem], "");
 assert(allResults.length === 2, "T-QS-22: searchQueue returns all items when search term is empty");
 
+const perlEditEnvelope: GuardActionEnvelope = {
+  ...shellEnvelope,
+  command: "perl -0pi -e 's/\\n\\z//' docs/guard-cloud-api-inventory.generated.md docs/guard-cloud-route-inventory.generated.md",
+};
+
+const perlEditItem: GuardApprovalRequest = {
+  ...BASE_REQUEST,
+  request_id: "req-perl-edit",
+  artifact_name: "Bash destructive shell command",
+  action_envelope_json: perlEditEnvelope,
+  risk_summary: "Requests a sensitive native tool action: destructive shell command.",
+};
+
+assert(
+  resolveQueueCategory(perlEditItem).label === "File edit command",
+  "T-QS-23: perl -0pi in-place doc edit is categorized as File edit command, not destructive shell"
+);
+
+assert(
+  filterQueueByCategory([BASE_REQUEST, perlEditItem], "file_edit").map((item) => item.request_id).join(",") === "req-perl-edit",
+  "T-QS-24: filterQueueByCategory isolates file edit review items"
+);
+
+assert(
+  searchQueue([perlEditItem], "file edit").length === 1,
+  "T-QS-25: searchQueue matches semantic review category labels"
+);
+
+assert(
+  sortQueue([shellItem, perlEditItem], "category")[0].request_id === "req-perl-edit",
+  "T-QS-26: sortQueue can group review items by category"
+);
+
+assert(
+  queueCategoriesForItems([shellItem, perlEditItem]).some((category) => category.id === "file_edit"),
+  "T-QS-27: queueCategoriesForItems exposes specific category filters present in queue"
+);
+
 const mcpEnvelope: GuardActionEnvelope = {
   ...shellEnvelope,
   action_type: "mcp_tool",
@@ -225,37 +266,37 @@ const mcpItem: GuardApprovalRequest = {
 };
 
 const mcpResults = searchQueue([BASE_REQUEST, shellItem, mcpItem], "filesystem");
-assert(mcpResults.length === 1, "T-QS-23: searchQueue matches MCP server name");
-assert(mcpResults[0].request_id === "req-mcp", "T-QS-24: searchQueue returns correct item for MCP server search");
+assert(mcpResults.length === 1, "T-QS-28: searchQueue matches MCP server name");
+assert(mcpResults[0].request_id === "req-mcp", "T-QS-29: searchQueue returns correct item for MCP server search");
 
 assert(
   resolveStaleRequestRecovery("req-1", [BASE_REQUEST, req2]) === "req-1",
-  "T-QS-25: resolveStaleRequestRecovery returns active ID when request is still in queue"
+  "T-QS-30: resolveStaleRequestRecovery returns active ID when request is still in queue"
 );
 
 assert(
   resolveStaleRequestRecovery("req-gone", [req2, req3]) === "req-2",
-  "T-QS-26: resolveStaleRequestRecovery falls back to first queue item when active request is stale"
+  "T-QS-31: resolveStaleRequestRecovery falls back to first queue item when active request is stale"
 );
 
 assert(
   resolveStaleRequestRecovery("req-gone", []) === null,
-  "T-QS-27: resolveStaleRequestRecovery returns null when queue is empty and request is stale"
+  "T-QS-32: resolveStaleRequestRecovery returns null when queue is empty and request is stale"
 );
 
 assert(
   resolveStaleRequestRecovery(null, [BASE_REQUEST]) === null,
-  "T-QS-28: resolveStaleRequestRecovery returns null when activeRequestId is null"
+  "T-QS-33: resolveStaleRequestRecovery returns null when activeRequestId is null"
 );
 
 const needsDecision = buildHomePrimaryState(3, 2);
 assert(
   needsDecision.status === "needs_decision",
-  "T-QS-29: buildHomePrimaryState returns needs_decision status when pending count is greater than zero"
+  "T-QS-34: buildHomePrimaryState returns needs_decision status when pending count is greater than zero"
 );
 assert(
   needsDecision.copy.includes("3 actions"),
-  "T-QS-30: buildHomePrimaryState includes action count in copy when pending"
+  "T-QS-35: buildHomePrimaryState includes action count in copy when pending"
 );
 assert(
   needsDecision.ctaLabel === "Review blocked action",

--- a/dashboard/src/queue-state.ts
+++ b/dashboard/src/queue-state.ts
@@ -249,7 +249,11 @@ function resolveQueueCategoryId(item: GuardApprovalRequest): QueueCategoryId {
   const decisionCategories = item.decision_v2_json?.signals.map((signal) => signal.category) ?? [];
   const text = queueCategoryText(item);
 
-  if (decisionCategories.includes("network") || textIncludesAny(text, ["network host", "outbound", "webhook", "curl ", "https://", "http://"])) {
+  if (
+    decisionCategories.includes("network") ||
+    textIncludesAny(text, ["network host", "outbound", "webhook", "https://", "http://"]) ||
+    /\bcurl\b/.test(text)
+  ) {
     if (textIncludesAny(text, ["secret", "credential", "token", "api key", "upload", "exfiltrat"])) {
       return "data_exfiltration";
     }
@@ -343,9 +347,15 @@ export function sortQueue(
   items: GuardApprovalRequest[],
   direction: QueueSortDirection
 ): GuardApprovalRequest[] {
+  const categoryLabels =
+    direction === "category"
+      ? new Map(items.map((item) => [item.request_id, resolveQueueCategory(item).label]))
+      : null;
   return [...items].sort((a, b) => {
-    if (direction === "category") {
-      const categoryDelta = resolveQueueCategory(a).label.localeCompare(resolveQueueCategory(b).label);
+    if (categoryLabels !== null) {
+      const categoryDelta = (categoryLabels.get(a.request_id) ?? "").localeCompare(
+        categoryLabels.get(b.request_id) ?? ""
+      );
       if (categoryDelta !== 0) {
         return categoryDelta;
       }
@@ -379,18 +389,25 @@ export function searchQueue(items: GuardApprovalRequest[], term: string): GuardA
   }
   return items.filter((item) => {
     const envelope = item.action_envelope_json;
+    const category = resolveQueueCategory(item);
     const parts: string[] = [
       item.artifact_name,
+      item.artifact_id,
       item.artifact_type,
       item.harness,
       item.policy_action,
+      item.risk_headline ?? "",
+      item.risk_summary ?? "",
+      item.trigger_summary ?? "",
+      item.launch_summary ?? "",
+      item.why_now ?? "",
       envelope?.command ?? "",
       envelope?.prompt_excerpt ?? "",
       envelope?.mcp_server ?? "",
       envelope?.mcp_tool ?? "",
       envelope?.package_name ?? "",
-      resolveQueueCategory(item).label,
-      resolveQueueCategory(item).shortLabel,
+      category.label,
+      category.shortLabel,
       ...(envelope?.network_hosts ?? []),
       ...(envelope?.target_paths ?? []),
     ];

--- a/dashboard/src/queue-state.ts
+++ b/dashboard/src/queue-state.ts
@@ -1,7 +1,126 @@
 import { useRef, useCallback } from "react";
 import type { GuardApprovalRequest, GuardQueueResolutionResult } from "./guard-types";
 
-export type QueueSortDirection = "newest" | "oldest";
+export type QueueSortDirection = "newest" | "oldest" | "category";
+
+export type QueueCategoryId =
+  | "secret_access"
+  | "data_exfiltration"
+  | "file_edit"
+  | "file_read"
+  | "destructive_shell"
+  | "encoded_shell"
+  | "network"
+  | "mcp_tool"
+  | "package_script"
+  | "prompt_instruction"
+  | "config_change"
+  | "browser_action"
+  | "harness_start"
+  | "shell_command"
+  | "other";
+
+export type QueueCategory = {
+  id: QueueCategoryId;
+  label: string;
+  shortLabel: string;
+  description: string;
+};
+
+export const QUEUE_CATEGORIES: QueueCategory[] = [
+  {
+    id: "secret_access",
+    label: "Secret or credential access",
+    shortLabel: "Secrets",
+    description: "Reads or exposes local credentials, tokens, keys, or secret files.",
+  },
+  {
+    id: "data_exfiltration",
+    label: "Data exfiltration path",
+    shortLabel: "Exfiltration",
+    description: "Moves local sensitive data toward a network host, upload, clipboard, or external sink.",
+  },
+  {
+    id: "file_edit",
+    label: "File edit command",
+    shortLabel: "File edit",
+    description: "Changes local files in place without matching a delete or wipe pattern.",
+  },
+  {
+    id: "file_read",
+    label: "Sensitive file read",
+    shortLabel: "File read",
+    description: "Requests local file contents, paths, or read-only filesystem access.",
+  },
+  {
+    id: "destructive_shell",
+    label: "Destructive shell command",
+    shortLabel: "Destructive",
+    description: "Deletes, overwrites, wipes, force-cleans, or otherwise risks data loss.",
+  },
+  {
+    id: "encoded_shell",
+    label: "Encoded shell execution",
+    shortLabel: "Encoded shell",
+    description: "Runs encoded, encrypted, decoded, or obfuscated shell payloads.",
+  },
+  {
+    id: "network",
+    label: "Network access",
+    shortLabel: "Network",
+    description: "Contacts hosts, downloads, calls APIs, or opens network destinations.",
+  },
+  {
+    id: "mcp_tool",
+    label: "MCP tool call",
+    shortLabel: "MCP",
+    description: "Invokes an MCP server or tool with sensitive arguments.",
+  },
+  {
+    id: "package_script",
+    label: "Package script",
+    shortLabel: "Package",
+    description: "Runs install, postinstall, build, or package-manager scripts.",
+  },
+  {
+    id: "prompt_instruction",
+    label: "Prompt instruction",
+    shortLabel: "Prompt",
+    description: "User or model prompt asks the harness to perform a sensitive action.",
+  },
+  {
+    id: "config_change",
+    label: "Configuration change",
+    shortLabel: "Config",
+    description: "Modifies Guard, harness, project, or tool configuration.",
+  },
+  {
+    id: "browser_action",
+    label: "Browser action",
+    shortLabel: "Browser",
+    description: "Uses browser automation, navigation, or form interaction.",
+  },
+  {
+    id: "harness_start",
+    label: "Harness launch",
+    shortLabel: "Launch",
+    description: "Starts or reconnects an AI app under Guard control.",
+  },
+  {
+    id: "shell_command",
+    label: "Shell command",
+    shortLabel: "Shell",
+    description: "Runs a shell command that does not fit a more specific category.",
+  },
+  {
+    id: "other",
+    label: "Other review",
+    shortLabel: "Other",
+    description: "Needs review but has no more specific category signal.",
+  },
+];
+
+const QUEUE_CATEGORY_BY_ID = new Map(QUEUE_CATEGORIES.map((category) => [category.id, category]));
 
 export type QueueGroup = {
   primary: GuardApprovalRequest;
@@ -109,21 +228,148 @@ function queueTimestamp(item: GuardApprovalRequest): number {
   return new Date(item.last_seen_at ?? item.created_at).getTime();
 }
 
+export function queueCategoryById(id: QueueCategoryId): QueueCategory {
+  return QUEUE_CATEGORY_BY_ID.get(id) ?? QUEUE_CATEGORIES[QUEUE_CATEGORIES.length - 1];
+}
+
+export function resolveQueueCategory(item: GuardApprovalRequest): QueueCategory {
+  return queueCategoryById(resolveQueueCategoryId(item));
+}
+
+export function queueCategoriesForItems(items: GuardApprovalRequest[]): QueueCategory[] {
+  const seen = new Set<QueueCategoryId>();
+  for (const item of items) {
+    seen.add(resolveQueueCategory(item).id);
+  }
+  return QUEUE_CATEGORIES.filter((category) => seen.has(category.id));
+}
+
+function resolveQueueCategoryId(item: GuardApprovalRequest): QueueCategoryId {
+  const envelope = item.action_envelope_json;
+  const decisionCategories = item.decision_v2_json?.signals.map((signal) => signal.category) ?? [];
+  const text = queueCategoryText(item);
+
+  if (decisionCategories.includes("network") || textIncludesAny(text, ["network host", "outbound", "webhook", "curl ", "https://", "http://"])) {
+    if (textIncludesAny(text, ["secret", "credential", "token", "api key", "upload", "exfiltrat"])) {
+      return "data_exfiltration";
+    }
+    return "network";
+  }
+  if (decisionCategories.includes("secret") || textIncludesAny(text, ["credential-looking", "secret", ".env", "token", "api key", "password", "private key"])) {
+    return "secret_access";
+  }
+  if (textIncludesAny(text, ["encoded or encrypted shell command", "base64", "openssl enc", "xxd -r", "decode-and-exec"])) {
+    return "encoded_shell";
+  }
+  if (envelope?.action_type === "file_read" || item.artifact_type === "file_read_request") {
+    return "file_read";
+  }
+  if (envelope?.action_type === "mcp_tool") {
+    return "mcp_tool";
+  }
+  if (envelope?.action_type === "package_script") {
+    return "package_script";
+  }
+  if (envelope?.action_type === "prompt") {
+    return "prompt_instruction";
+  }
+  if (envelope?.action_type === "config_change") {
+    return "config_change";
+  }
+  if (envelope?.action_type === "browser_action") {
+    return "browser_action";
+  }
+  if (envelope?.action_type === "harness_start") {
+    return "harness_start";
+  }
+  if (envelope?.action_type === "file_write" || commandLooksLikeFileEdit(envelope?.command ?? item.launch_target ?? "")) {
+    return "file_edit";
+  }
+  if (textIncludesAny(text, ["destructive shell command", " rm -", "rm -rf", "delete", "wipe", "force-clean", "git clean -fd", "truncate"])) {
+    return "destructive_shell";
+  }
+  if (envelope?.action_type === "shell_command" || item.artifact_type === "command" || text.includes("shell command")) {
+    return "shell_command";
+  }
+  return "other";
+}
+
+function queueCategoryText(item: GuardApprovalRequest): string {
+  const envelope = item.action_envelope_json;
+  return [
+    item.artifact_name,
+    item.artifact_type,
+    item.risk_headline ?? "",
+    item.risk_summary ?? "",
+    item.trigger_summary ?? "",
+    item.launch_summary ?? "",
+    item.why_now ?? "",
+    item.launch_target ?? "",
+    envelope?.action_type ?? "",
+    envelope?.command ?? "",
+    envelope?.tool_name ?? "",
+    envelope?.prompt_excerpt ?? "",
+    envelope?.mcp_server ?? "",
+    envelope?.mcp_tool ?? "",
+    envelope?.package_manager ?? "",
+    envelope?.package_name ?? "",
+    envelope?.script_name ?? "",
+    ...(item.risk_signals ?? []),
+    ...(envelope?.target_paths ?? []),
+    ...(envelope?.network_hosts ?? []),
+    ...(item.decision_v2_json?.signals.map((signal) => `${signal.category} ${signal.title} ${signal.plain_reason}`) ?? []),
+  ].join(" ").toLowerCase();
+}
+
+function textIncludesAny(text: string, needles: string[]): boolean {
+  return needles.some((needle) => text.includes(needle));
+}
+
+function commandLooksLikeFileEdit(command: string): boolean {
+  const normalized = command.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  return (
+    /\bperl\b[\s\S]*\s-[\w-]*i\b/.test(normalized) ||
+    /\bsed\b[\s\S]*\s-[\w-]*i\b/.test(normalized) ||
+    /\bpython(?:3)?\b[\s\S]*(?:write_text|open\([^)]*,\s*['"]w|path\.write)/.test(normalized) ||
+    /\btee\s+-a?\b/.test(normalized) ||
+    /\bapply_patch\b/.test(normalized)
+  );
+}
+
 export function sortQueue(
   items: GuardApprovalRequest[],
   direction: QueueSortDirection
 ): GuardApprovalRequest[] {
   return [...items].sort((a, b) => {
+    if (direction === "category") {
+      const categoryDelta = resolveQueueCategory(a).label.localeCompare(resolveQueueCategory(b).label);
+      if (categoryDelta !== 0) {
+        return categoryDelta;
+      }
+    }
     const dateA = queueTimestamp(a);
     const dateB = queueTimestamp(b);
-    const dateDelta = direction === "newest" ? dateB - dateA : dateA - dateB;
+    const dateDelta = direction === "oldest" ? dateA - dateB : dateB - dateA;
     if (dateDelta !== 0) {
       return dateDelta;
     }
-    return direction === "newest"
-      ? b.request_id.localeCompare(a.request_id)
-      : a.request_id.localeCompare(b.request_id);
+    return direction === "oldest"
+      ? a.request_id.localeCompare(b.request_id)
+      : b.request_id.localeCompare(a.request_id);
   });
+}
+
+export function filterQueueByCategory(
+  items: GuardApprovalRequest[],
+  categoryId: QueueCategoryId | "all"
+): GuardApprovalRequest[] {
+  if (categoryId === "all") {
+    return items;
+  }
+  return items.filter((item) => resolveQueueCategory(item).id === categoryId);
 }
 
 export function searchQueue(items: GuardApprovalRequest[], term: string): GuardApprovalRequest[] {
@@ -143,6 +389,8 @@ export function searchQueue(items: GuardApprovalRequest[], term: string): GuardA
       envelope?.mcp_server ?? "",
       envelope?.mcp_tool ?? "",
       envelope?.package_name ?? "",
+      resolveQueueCategory(item).label,
+      resolveQueueCategory(item).shortLabel,
       ...(envelope?.network_hosts ?? []),
       ...(envelope?.target_paths ?? []),
     ];

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -63,6 +63,7 @@ import {
   filterQueueByCategory,
   queueCategoriesForItems,
   resolveQueueCategory,
+  searchQueue,
   sortQueue,
   type QueueCategory,
   type QueueCategoryId,
@@ -129,11 +130,7 @@ export function ReviewWorkspace(props: ReviewWorkspaceProps) {
 
   const filteredRequests = useMemo(() => {
     const byCategory = filterQueueByCategory(requests, categoryFilter);
-    const normalized = searchTerm.trim().toLowerCase();
-    const searched =
-      normalized.length === 0
-        ? byCategory
-        : byCategory.filter((item) => reviewItemSearchText(item).includes(normalized));
+    const searched = searchQueue(byCategory, searchTerm);
     return sortQueue(searched, sortDirection);
   }, [categoryFilter, requests, searchTerm, sortDirection]);
 
@@ -400,7 +397,7 @@ function QueueItemRow({ item, active, index, onOpenRequest }: {
         </div>
         {isBlocked ? <HiMiniNoSymbol className="h-3.5 w-3.5 shrink-0 text-brand-attention" aria-hidden="true" /> : null}
       </div>
-      <p className="mt-0.5 text-[11px] text-muted-foreground">
+      <p className="mt-0.5 truncate text-[11px] text-muted-foreground">
         {harnessDisplayName(item.harness)} · {preview}
       </p>
     </button>
@@ -440,32 +437,6 @@ function iconForQueueCategory(categoryId: QueueCategoryId) {
     case "other":
       return HiMiniDocumentPlus;
   }
-}
-
-function reviewItemSearchText(item: GuardApprovalRequest): string {
-  const envelope = item.action_envelope_json;
-  const category = resolveQueueCategory(item);
-  return [
-    item.artifact_name,
-    item.artifact_id,
-    item.artifact_type,
-    item.harness,
-    item.policy_action,
-    item.risk_headline ?? "",
-    item.risk_summary ?? "",
-    item.trigger_summary ?? "",
-    item.launch_summary ?? "",
-    item.why_now ?? "",
-    category.label,
-    category.shortLabel,
-    envelope?.command ?? "",
-    envelope?.prompt_excerpt ?? "",
-    envelope?.mcp_server ?? "",
-    envelope?.mcp_tool ?? "",
-    envelope?.package_name ?? "",
-    ...(envelope?.network_hosts ?? []),
-    ...(envelope?.target_paths ?? []),
-  ].join(" ").toLowerCase();
 }
 
 function queueItemPreview(item: GuardApprovalRequest): string {

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { forwardRef, useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
 import {
   HiMiniCheckCircle,
   HiMiniNoSymbol,
@@ -6,7 +6,6 @@ import {
   HiMiniExclamationTriangle,
   HiMiniInformationCircle,
   HiMiniChevronLeft,
-  HiMiniBolt,
   HiMiniDocumentText,
   HiMiniArrowPath,
   HiMiniChevronDown,
@@ -14,6 +13,16 @@ import {
   HiMiniArrowTopRightOnSquare,
   HiMiniClipboard,
   HiMiniClipboardDocumentCheck,
+  HiMiniCodeBracket,
+  HiMiniCommandLine,
+  HiMiniCog6Tooth,
+  HiMiniCube,
+  HiMiniDocumentMagnifyingGlass,
+  HiMiniDocumentPlus,
+  HiMiniGlobeAlt,
+  HiMiniKey,
+  HiMiniPencilSquare,
+  HiMiniServerStack,
 } from "react-icons/hi2";
 import {
   ActionButton,
@@ -50,6 +59,15 @@ import type {
   GuardRuntimeSnapshot,
   DecisionScope,
 } from "./guard-types";
+import {
+  filterQueueByCategory,
+  queueCategoriesForItems,
+  resolveQueueCategory,
+  sortQueue,
+  type QueueCategory,
+  type QueueCategoryId,
+  type QueueSortDirection,
+} from "./queue-state";
 
 export type ReviewViewModel = {
   item: GuardApprovalRequest;
@@ -105,46 +123,90 @@ const scopeChoices = [
 export function ReviewWorkspace(props: ReviewWorkspaceProps) {
   const { requests, activeRequestId, detail } = props;
   const queueRef = useRef<HTMLDivElement>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [categoryFilter, setCategoryFilter] = useState<QueueCategoryId | "all">("all");
+  const [sortDirection, setSortDirection] = useState<QueueSortDirection>("newest");
+
+  const filteredRequests = useMemo(() => {
+    const byCategory = filterQueueByCategory(requests, categoryFilter);
+    const normalized = searchTerm.trim().toLowerCase();
+    const searched =
+      normalized.length === 0
+        ? byCategory
+        : byCategory.filter((item) => reviewItemSearchText(item).includes(normalized));
+    return sortQueue(searched, sortDirection);
+  }, [categoryFilter, requests, searchTerm, sortDirection]);
+
+  const categoryOptions = useMemo(() => queueCategoriesForItems(requests), [requests]);
+
+  const activeRequest =
+    activeRequestId !== null
+      ? requests.find((r) => r.request_id === activeRequestId) ?? null
+      : null;
 
   // Keyboard navigation for queue
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
-      if (requests.length === 0) return;
-      const activeIdx = requests.findIndex((r) => r.request_id === activeRequestId);
+      if (filteredRequests.length === 0) return;
+      const activeIdx = filteredRequests.findIndex((r) => r.request_id === activeRequestId);
       if (event.key === "ArrowDown") {
         event.preventDefault();
-        const nextIdx = Math.min(activeIdx + 1, requests.length - 1);
-        if (nextIdx !== activeIdx) props.onOpenRequest(requests[nextIdx].request_id);
+        const nextIdx = Math.min(activeIdx + 1, filteredRequests.length - 1);
+        if (nextIdx !== activeIdx) props.onOpenRequest(filteredRequests[nextIdx].request_id);
       }
       if (event.key === "ArrowUp") {
         event.preventDefault();
         const prevIdx = Math.max(activeIdx - 1, 0);
-        if (prevIdx !== activeIdx) props.onOpenRequest(requests[prevIdx].request_id);
+        if (prevIdx !== activeIdx) props.onOpenRequest(filteredRequests[prevIdx].request_id);
       }
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [requests, activeRequestId, props.onOpenRequest]);
+  }, [filteredRequests, activeRequestId, props.onOpenRequest]);
+
+  useEffect(() => {
+    if (filteredRequests.length === 0) {
+      return;
+    }
+    if (activeRequestId === null || !filteredRequests.some((item) => item.request_id === activeRequestId)) {
+      props.onOpenRequest(filteredRequests[0].request_id);
+    }
+  }, [activeRequestId, filteredRequests, props.onOpenRequest]);
 
   if (requests.length === 0) {
     return <ReviewEmptyState runtime={props.runtime} resolutionMessage={props.resolutionMessage} />;
   }
 
-  const activeItem = activeRequestId
-    ? requests.find((r) => r.request_id === activeRequestId) ?? requests[0]
-    : requests[0];
+  const activeItem = activeRequest ?? filteredRequests[0] ?? requests[0];
 
-  const progressIndex = requests.findIndex((r) => r.request_id === activeItem.request_id);
-  const progress = `${Math.max(0, progressIndex) + 1} of ${requests.length}`;
+  const progressIndex = filteredRequests.findIndex((r) => r.request_id === activeItem.request_id);
+  const progress =
+    filteredRequests.length > 0
+      ? `${Math.max(0, progressIndex) + 1} of ${filteredRequests.length}`
+      : `0 of ${requests.length}`;
 
   return (
     <div className="space-y-6">
-      <ReviewHeader count={requests.length} progress={progress} activeHarness={activeItem.harness} />
+      <ReviewHeader
+        count={requests.length}
+        filteredCount={filteredRequests.length}
+        progress={progress}
+        activeHarness={activeItem.harness}
+        activeCategory={resolveQueueCategory(activeItem)}
+      />
 
       <div className="grid gap-6 lg:grid-cols-[320px_1fr]">
         <ReviewQueueList
-          requests={requests}
+          requests={filteredRequests}
+          totalCount={requests.length}
           activeRequestId={activeItem.request_id}
+          categoryOptions={categoryOptions}
+          categoryFilter={categoryFilter}
+          searchTerm={searchTerm}
+          sortDirection={sortDirection}
+          onCategoryFilterChange={setCategoryFilter}
+          onSearchTermChange={setSearchTerm}
+          onSortDirectionChange={setSortDirection}
           onOpenRequest={props.onOpenRequest}
           ref={queueRef}
         />
@@ -158,7 +220,19 @@ export function ReviewWorkspace(props: ReviewWorkspaceProps) {
   );
 }
 
-function ReviewHeader({ count, progress, activeHarness }: { count: number; progress: string; activeHarness: string }) {
+function ReviewHeader({
+  count,
+  filteredCount,
+  progress,
+  activeHarness,
+  activeCategory,
+}: {
+  count: number;
+  filteredCount: number;
+  progress: string;
+  activeHarness: string;
+  activeCategory: QueueCategory;
+}) {
   return (
     <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
       <div>
@@ -170,7 +244,9 @@ function ReviewHeader({ count, progress, activeHarness }: { count: number; progr
       <div className="flex flex-wrap items-center gap-2">
         <span className="font-mono text-xs text-muted-foreground">{progress}</span>
         <Badge tone="info">{count} waiting</Badge>
+        {filteredCount !== count ? <Tag tone="slate">{filteredCount} shown</Tag> : null}
         <Tag tone="blue">{harnessDisplayName(activeHarness)}</Tag>
+        <Tag tone="slate">{activeCategory.shortLabel}</Tag>
       </div>
     </div>
   );
@@ -178,43 +254,128 @@ function ReviewHeader({ count, progress, activeHarness }: { count: number; progr
 
 const ReviewQueueList = forwardRef<HTMLDivElement, {
   requests: GuardApprovalRequest[];
+  totalCount: number;
   activeRequestId: string | null;
+  categoryOptions: QueueCategory[];
+  categoryFilter: QueueCategoryId | "all";
+  searchTerm: string;
+  sortDirection: QueueSortDirection;
+  onCategoryFilterChange: (category: QueueCategoryId | "all") => void;
+  onSearchTermChange: (term: string) => void;
+  onSortDirectionChange: (direction: QueueSortDirection) => void;
   onOpenRequest: (requestId: string) => void;
-}>(({ requests, activeRequestId, onOpenRequest }, ref) => {
+}>(({
+  requests,
+  totalCount,
+  activeRequestId,
+  categoryOptions,
+  categoryFilter,
+  searchTerm,
+  sortDirection,
+  onCategoryFilterChange,
+  onSearchTermChange,
+  onSortDirectionChange,
+  onOpenRequest,
+}, ref) => {
+  const handleSearchChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    onSearchTermChange(event.target.value);
+  }, [onSearchTermChange]);
+  const handleCategoryChange = useCallback((event: ChangeEvent<HTMLSelectElement>) => {
+    onCategoryFilterChange(event.target.value as QueueCategoryId | "all");
+  }, [onCategoryFilterChange]);
+  const handleSortChange = useCallback((event: ChangeEvent<HTMLSelectElement>) => {
+    onSortDirectionChange(event.target.value as QueueSortDirection);
+  }, [onSortDirectionChange]);
+
   return (
     <aside className="space-y-3" ref={ref}>
-      <SectionLabel>Queue</SectionLabel>
+      <div className="flex items-center justify-between gap-3">
+        <SectionLabel>Queue</SectionLabel>
+        <span className="font-mono text-[11px] font-semibold text-muted-foreground">
+          {requests.length}/{totalCount}
+        </span>
+      </div>
+      <div className="space-y-2 rounded-xl border border-slate-100 bg-white p-3">
+        <label className="block">
+          <span className="sr-only">Search review queue</span>
+          <input
+            type="search"
+            value={searchTerm}
+            onChange={handleSearchChange}
+            placeholder="Search command, category, host..."
+            className="min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-brand-dark placeholder:text-slate-400 focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+          />
+        </label>
+        <label className="block">
+          <span className="sr-only">Review category</span>
+          <select
+            value={categoryFilter}
+            onChange={handleCategoryChange}
+            className="min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+          >
+            <option value="all">All categories</option>
+            {categoryOptions.map((category) => (
+              <option key={category.id} value={category.id}>
+                {category.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block">
+          <span className="sr-only">Sort review queue</span>
+          <select
+            value={sortDirection}
+            onChange={handleSortChange}
+            className="min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+          >
+            <option value="newest">Newest first</option>
+            <option value="oldest">Oldest first</option>
+            <option value="category">Category</option>
+          </select>
+        </label>
+      </div>
       <div
         role="listbox"
         aria-label="Review queue"
         className="max-h-[70vh] space-y-2 overflow-y-auto rounded-lg border border-slate-100 bg-white p-1.5"
       >
-        {requests.map((item, index) => (
-          <QueueItemRow
-            key={item.request_id}
-            item={item}
-            active={item.request_id === activeRequestId}
-            index={index}
-            onClick={() => onOpenRequest(item.request_id)}
-          />
-        ))}
+        {requests.length > 0 ? (
+          requests.map((item, index) => (
+            <QueueItemRow
+              key={item.request_id}
+              item={item}
+              active={item.request_id === activeRequestId}
+              index={index}
+              onOpenRequest={onOpenRequest}
+            />
+          ))
+        ) : (
+          <div className="px-3 py-5">
+            <EmptyState title="No matching actions" body="Try a different category, search, or sort mode." tone="teach" />
+          </div>
+        )}
       </div>
     </aside>
   );
 });
 ReviewQueueList.displayName = "ReviewQueueList";
 
-function QueueItemRow({ item, active, index, onClick }: {
+function QueueItemRow({ item, active, index, onOpenRequest }: {
   item: GuardApprovalRequest;
   active: boolean;
   index: number;
-  onClick: () => void;
+  onOpenRequest: (requestId: string) => void;
 }) {
-  const title = item.artifact_name ?? item.artifact_id;
   const isBlocked = item.policy_action === "block";
+  const category = resolveQueueCategory(item);
+  const CategoryIcon = iconForQueueCategory(category.id);
+  const preview = queueItemPreview(item);
+  const handleClick = useCallback(() => {
+    onOpenRequest(item.request_id);
+  }, [item.request_id, onOpenRequest]);
   return (
     <button
-      onClick={onClick}
+      onClick={handleClick}
       role="option"
       aria-selected={active}
       aria-posinset={index + 1}
@@ -227,17 +388,94 @@ function QueueItemRow({ item, active, index, onClick }: {
       }`}
     >
       <div className="flex items-center justify-between gap-2">
-        <p className="truncate text-sm font-medium text-brand-dark">{title}</p>
-        {isBlocked ? (
-          <HiMiniNoSymbol className="h-3.5 w-3.5 shrink-0 text-brand-attention" aria-hidden="true" />
-        ) : (
-          <HiMiniBolt className="h-3.5 w-3.5 shrink-0 text-brand-blue" aria-hidden="true" />
-        )}
+        <div className="flex min-w-0 items-center gap-2">
+          <span
+            className={`inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ${
+              active ? "bg-brand-blue/10 text-brand-blue" : "bg-slate-50 text-slate-500"
+            }`}
+          >
+            <CategoryIcon className="h-4 w-4" aria-hidden="true" />
+          </span>
+          <p className="truncate text-sm font-medium text-brand-dark">{category.label}</p>
+        </div>
+        {isBlocked ? <HiMiniNoSymbol className="h-3.5 w-3.5 shrink-0 text-brand-attention" aria-hidden="true" /> : null}
       </div>
       <p className="mt-0.5 text-[11px] text-muted-foreground">
-        {harnessDisplayName(item.harness)}
+        {harnessDisplayName(item.harness)} · {preview}
       </p>
     </button>
+  );
+}
+
+function iconForQueueCategory(categoryId: QueueCategoryId) {
+  switch (categoryId) {
+    case "secret_access":
+      return HiMiniKey;
+    case "data_exfiltration":
+      return HiMiniArrowTopRightOnSquare;
+    case "file_edit":
+      return HiMiniPencilSquare;
+    case "file_read":
+      return HiMiniDocumentMagnifyingGlass;
+    case "destructive_shell":
+      return HiMiniNoSymbol;
+    case "encoded_shell":
+      return HiMiniCodeBracket;
+    case "network":
+      return HiMiniGlobeAlt;
+    case "mcp_tool":
+      return HiMiniServerStack;
+    case "package_script":
+      return HiMiniCube;
+    case "prompt_instruction":
+      return HiMiniInformationCircle;
+    case "config_change":
+      return HiMiniCog6Tooth;
+    case "browser_action":
+      return HiMiniArrowTopRightOnSquare;
+    case "harness_start":
+      return HiMiniShieldCheck;
+    case "shell_command":
+      return HiMiniCommandLine;
+    case "other":
+      return HiMiniDocumentPlus;
+  }
+}
+
+function reviewItemSearchText(item: GuardApprovalRequest): string {
+  const envelope = item.action_envelope_json;
+  const category = resolveQueueCategory(item);
+  return [
+    item.artifact_name,
+    item.artifact_id,
+    item.artifact_type,
+    item.harness,
+    item.policy_action,
+    item.risk_headline ?? "",
+    item.risk_summary ?? "",
+    item.trigger_summary ?? "",
+    item.launch_summary ?? "",
+    item.why_now ?? "",
+    category.label,
+    category.shortLabel,
+    envelope?.command ?? "",
+    envelope?.prompt_excerpt ?? "",
+    envelope?.mcp_server ?? "",
+    envelope?.mcp_tool ?? "",
+    envelope?.package_name ?? "",
+    ...(envelope?.network_hosts ?? []),
+    ...(envelope?.target_paths ?? []),
+  ].join(" ").toLowerCase();
+}
+
+function queueItemPreview(item: GuardApprovalRequest): string {
+  const envelope = item.action_envelope_json;
+  return (
+    envelope?.command ??
+    envelope?.mcp_tool ??
+    envelope?.prompt_excerpt ??
+    envelope?.package_name ??
+    displayArtifactName(item)
   );
 }
 
@@ -810,5 +1048,3 @@ function buildWhatWouldHappen(item: GuardApprovalRequest): string | null {
   }
   return `Without Guard, this action would run immediately. Guard paused it so you can review and decide.`;
 }
-
-

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/app-detail-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/app-detail-workspace.js
@@ -1,0 +1,895 @@
+import { r as reactExports, D as fetchApprovalPage, F as fetchPolicy, h as harnessDisplayName, j as jsxRuntimeExports, I as HiMiniArrowLeft, i as HiMiniChevronRight, G as GuardHero, A as ActionButton, P as ProofStrip, J as HiMiniHome, K as HiMiniBolt, L as HiMiniAdjustmentsHorizontal, S as SectionLabel, d as formatRelativeTime, m as HiMiniExclamationTriangle, T as Tag, B as Badge, E as EmptyState, M as HiMiniCloud, N as HiMiniChartBar, l as HiMiniChevronDown } from "../guard-dashboard.js";
+import { u as useFocusTrap } from "./use-focus-trap.js";
+const tabOrder = ["overview", "activity", "settings"];
+function readTabFromUrl() {
+  const hash = window.location.hash.replace("#", "");
+  if (hash === "activity" || hash === "settings") return hash;
+  return "overview";
+}
+function writeTabToUrl(tab) {
+  const url = new URL(window.location.href);
+  url.hash = tab;
+  window.history.replaceState({}, "", url.toString());
+}
+function AppDetailWorkspace(props) {
+  const [activeTab, setActiveTab] = reactExports.useState(readTabFromUrl);
+  const [tabDirection, setTabDirection] = reactExports.useState("right");
+  const touchStartX = reactExports.useRef(null);
+  reactExports.useEffect(() => {
+    function handleHashChange() {
+      setActiveTab(readTabFromUrl());
+    }
+    window.addEventListener("hashchange", handleHashChange);
+    return () => window.removeEventListener("hashchange", handleHashChange);
+  }, []);
+  const [harnessQueue, setHarnessQueue] = reactExports.useState({ kind: "loading" });
+  const [harnessPolicy, setHarnessPolicy] = reactExports.useState({ kind: "loading" });
+  const { harness, runtime, receipts, policies, inventory } = props;
+  const loadTabData = reactExports.useCallback(() => {
+    let cancelled = false;
+    setHarnessQueue({ kind: "loading" });
+    setHarnessPolicy({ kind: "loading" });
+    Promise.allSettled([
+      fetchApprovalPage({ harness, status: "pending" }),
+      fetchPolicy(harness)
+    ]).then(([queueResult, policyResult]) => {
+      if (cancelled) return;
+      if (queueResult.status === "fulfilled") {
+        setHarnessQueue({ kind: "ready", items: queueResult.value.items ?? [] });
+      } else {
+        setHarnessQueue({
+          kind: "error",
+          message: queueResult.reason instanceof Error ? queueResult.reason.message : "Unable to load queue."
+        });
+      }
+      if (policyResult.status === "fulfilled") {
+        setHarnessPolicy({ kind: "ready", items: policyResult.value ?? [] });
+      } else {
+        setHarnessPolicy({
+          kind: "error",
+          message: policyResult.reason instanceof Error ? policyResult.reason.message : "Unable to load policy."
+        });
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [harness]);
+  reactExports.useEffect(() => {
+    const cleanup = loadTabData();
+    return cleanup;
+  }, [loadTabData]);
+  const install = runtime.managed_installs?.find((i) => i.harness === harness);
+  const isActive = install?.active === true;
+  const isObserved = runtime.items.some((i) => i.harness === harness) || receipts.some((r) => r.harness === harness) || policies.some((p) => p.harness === harness);
+  const harnessReceipts = reactExports.useMemo(
+    () => receipts.filter((r) => r.harness === harness).sort((a, b) => +new Date(b.timestamp) - +new Date(a.timestamp)),
+    [receipts, harness]
+  );
+  const harnessInventory = reactExports.useMemo(
+    () => inventory.filter((i) => i.harness === harness && i.present),
+    [inventory, harness]
+  );
+  const harnessPolicies = reactExports.useMemo(
+    () => harnessPolicy.kind === "ready" ? harnessPolicy.items : policies.filter((p) => p.harness === harness),
+    [harnessPolicy, policies, harness]
+  );
+  const pendingItems = reactExports.useMemo(
+    () => harnessQueue.kind === "ready" ? harnessQueue.items : props.requests.filter((r) => r.harness === harness),
+    [harnessQueue, props.requests, harness]
+  );
+  const totalActions = harnessReceipts.length;
+  const blockedCount = harnessReceipts.filter((r) => r.policy_decision === "block").length;
+  const allowedCount = harnessReceipts.filter((r) => r.policy_decision === "allow").length;
+  const blockRate = totalActions > 0 ? Math.round(blockedCount / totalActions * 100) : 0;
+  const lastActivity = harnessReceipts[0]?.timestamp ?? null;
+  const isLoading = harnessQueue.kind === "loading" || harnessPolicy.kind === "loading";
+  const queueError = harnessQueue.kind === "error" ? harnessQueue.message : null;
+  const policyError = harnessPolicy.kind === "error" ? harnessPolicy.message : null;
+  const status = isActive ? "active" : install !== void 0 ? "needs_setup" : isObserved ? "observed" : "unknown";
+  const heroStatus = status === "active" ? "clear" : status === "needs_setup" ? "setup_gap" : "needs_review";
+  const heroHeadline = status === "active" ? `${harnessDisplayName(harness)} is protected` : status === "needs_setup" ? `${harnessDisplayName(harness)} needs setup` : isObserved ? `${harnessDisplayName(harness)} is observed` : `${harnessDisplayName(harness)}`;
+  const heroSub = status === "active" ? "Guard is watching this app. Review its activity and settings below." : status === "needs_setup" ? "Finish setup so Guard can protect this app." : isObserved ? "Guard has seen activity but install is not active." : "This app has not been seen yet.";
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        "button",
+        {
+          onClick: props.onGoHome,
+          className: "inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-sm font-medium text-brand-dark transition-colors hover:bg-slate-100",
+          children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowLeft, { className: "h-4 w-4", "aria-hidden": "true" }),
+            "Home"
+          ]
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronRight, { className: "h-4 w-4 text-slate-300", "aria-hidden": "true" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm text-muted-foreground", children: "Apps" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronRight, { className: "h-4 w-4 text-slate-300", "aria-hidden": "true" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: harnessDisplayName(harness) })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      GuardHero,
+      {
+        status: heroStatus,
+        headline: heroHeadline,
+        subheadline: heroSub,
+        cta: pendingItems.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          ActionButton,
+          {
+            onClick: () => setActiveTab("activity"),
+            "data-primary": "true",
+            children: [
+              "Review ",
+              pendingItems.length,
+              " pending"
+            ]
+          }
+        ) : status === "needs_setup" ? /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: () => setActiveTab("settings"), "data-primary": "true", children: "Open Settings" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: () => setActiveTab("activity"), "data-primary": "true", children: "View Activity" })
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      ProofStrip,
+      {
+        items: [
+          { label: "Pending", value: pendingItems.length, tone: pendingItems.length > 0 ? "blue" : "slate" },
+          { label: "Total actions", value: totalActions, tone: totalActions > 0 ? "purple" : "slate" },
+          { label: "Blocked", value: `${blockRate}%`, tone: blockRate > 0 ? "blue" : "slate" },
+          { label: "Status", value: isActive ? "active" : "inactive", tone: isActive ? "green" : "slate" }
+        ]
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex gap-1 rounded-xl border border-slate-200/70 bg-white/80 p-1 shadow-sm", children: [
+        { key: "overview", label: "Overview", icon: HiMiniHome },
+        { key: "activity", label: "Activity", icon: HiMiniBolt },
+        { key: "settings", label: "Settings", icon: HiMiniAdjustmentsHorizontal }
+      ].map((t) => {
+        const Icon = t.icon;
+        const isActive2 = activeTab === t.key;
+        return /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "button",
+          {
+            onClick: () => handleTabChange(t.key),
+            className: `flex flex-1 items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-all ${isActive2 ? "bg-brand-blue text-white shadow-sm" : "text-brand-dark hover:bg-slate-50"}`,
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx(Icon, { className: "h-4 w-4" }),
+              t.label
+            ]
+          },
+          t.key
+        );
+      }) }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "px-1 text-[11px] text-muted-foreground lg:hidden", children: "Swipe or tap tabs to switch views" })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs(
+      "div",
+      {
+        className: "min-h-[300px]",
+        onTouchStart: handleTouchStart,
+        onTouchEnd: handleTouchEnd,
+        children: [
+          isLoading && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-skeleton h-36 w-full" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-skeleton h-8 w-1/2" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-skeleton h-48 w-full" })
+          ] }),
+          !isLoading && /* @__PURE__ */ jsxRuntimeExports.jsxs(TabContent, { activeTab, direction: tabDirection, children: [
+            activeTab === "overview" && /* @__PURE__ */ jsxRuntimeExports.jsx(
+              AppOverviewTab,
+              {
+                harness,
+                status,
+                install,
+                totalActions,
+                allowedCount,
+                blockedCount,
+                blockRate,
+                lastActivity,
+                harnessReceipts,
+                harnessInventory,
+                pendingItems,
+                onOpenRequest: props.onOpenRequest
+              }
+            ),
+            activeTab === "activity" && /* @__PURE__ */ jsxRuntimeExports.jsx(
+              AppActivityTab,
+              {
+                harness,
+                pendingItems,
+                harnessReceipts,
+                onOpenRequest: props.onOpenRequest,
+                queueError,
+                onRetry: loadTabData
+              }
+            ),
+            activeTab === "settings" && /* @__PURE__ */ jsxRuntimeExports.jsx(
+              AppSettingsTab,
+              {
+                harness,
+                status,
+                harnessPolicies,
+                onClearAppPolicies: props.onClearAppPolicies,
+                policyError,
+                onRetry: loadTabData
+              }
+            )
+          ] })
+        ]
+      }
+    )
+  ] });
+  function handleTabChange(next) {
+    const currentIndex = tabOrder.indexOf(activeTab);
+    const nextIndex = tabOrder.indexOf(next);
+    setTabDirection(nextIndex > currentIndex ? "right" : "left");
+    setActiveTab(next);
+    writeTabToUrl(next);
+  }
+  function handleTouchStart(e) {
+    touchStartX.current = e.changedTouches[0].screenX;
+  }
+  function handleTouchEnd(e) {
+    if (touchStartX.current === null) return;
+    const endX = e.changedTouches[0].screenX;
+    const diff = touchStartX.current - endX;
+    const threshold = 50;
+    const currentIndex = tabOrder.indexOf(activeTab);
+    if (diff > threshold && currentIndex < tabOrder.length - 1) {
+      handleTabChange(tabOrder[currentIndex + 1]);
+    } else if (diff < -threshold && currentIndex > 0) {
+      handleTabChange(tabOrder[currentIndex - 1]);
+    }
+    touchStartX.current = null;
+  }
+}
+function AppStatusBadge({ status }) {
+  if (status === "active") return /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "success", children: "Active" });
+  if (status === "needs_setup") return /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "attention", children: "Needs setup" });
+  if (status === "observed") return /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "default", children: "Observed" });
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "default", children: "Unknown" });
+}
+function AppOverviewTab(props) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-6 lg:grid-cols-[minmax(0,1.3fr)_minmax(0,0.9fr)]", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "space-y-6", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4 sm:p-5", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between gap-3", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Status" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-muted-foreground", children: props.status === "active" ? "Guard is actively protecting this app." : props.status === "needs_setup" ? "Guard detected this app but it needs setup." : props.status === "observed" ? "Guard has seen activity from this app." : "This app has not been seen yet." })
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(AppStatusBadge, { status: props.status })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 grid grid-cols-2 gap-3 sm:grid-cols-4", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(StatCard, { label: "Total actions", value: props.totalActions }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(StatCard, { label: "Allowed", value: props.allowedCount, tone: "green" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(StatCard, { label: "Blocked", value: props.blockedCount, tone: props.blockedCount > 0 ? "attention" : "slate" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(StatCard, { label: "Block rate", value: `${props.blockRate}%`, tone: props.blockRate > 10 ? "attention" : "slate" })
+        ] }),
+        props.harnessReceipts.length >= 5 && /* @__PURE__ */ jsxRuntimeExports.jsx(RiskSnapshot, { receipts: props.harnessReceipts }),
+        props.lastActivity && /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-4 text-xs text-muted-foreground", children: [
+          "Last activity: ",
+          formatRelativeTime(props.lastActivity)
+        ] }),
+        props.harnessReceipts.length >= 3 && /* @__PURE__ */ jsxRuntimeExports.jsx(ActivitySparkline, { receipts: props.harnessReceipts }),
+        props.blockedCount > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(
+          CloudValueBanner,
+          {
+            icon: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "h-4 w-4 text-brand-attention" }),
+            title: "Team alerts available",
+            body: "Cloud would alert your team when Guard blocks actions like this.",
+            cta: { label: "Learn more", href: "https://hol.org/guard/pricing" }
+          }
+        )
+      ] }),
+      props.pendingItems.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-brand-blue/10 bg-brand-blue/[0.03] p-4 sm:p-5", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Pending review" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-2 text-sm text-muted-foreground", children: [
+          "These actions from ",
+          harnessDisplayName(props.harness),
+          " need your decision."
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 space-y-2", children: props.pendingItems.slice(0, 5).map((item) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "button",
+          {
+            onClick: () => props.onOpenRequest(item.request_id),
+            className: "flex w-full items-center justify-between rounded-xl border border-slate-200/70 bg-white px-4 py-3 text-left transition-shadow hover:shadow-sm",
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: item.artifact_name ?? item.artifact_id }),
+                /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-0.5 text-xs text-muted-foreground", children: [
+                  item.artifact_type,
+                  " · ",
+                  formatRelativeTime(item.created_at)
+                ] })
+              ] }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronRight, { className: "h-4 w-4 shrink-0 text-slate-300" })
+            ]
+          },
+          item.request_id
+        )) })
+      ] })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "space-y-6", children: [
+      props.harnessReceipts.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4 sm:p-5", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Recent events" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-muted-foreground", children: "What Guard decided recently." }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 space-y-3", children: props.harnessReceipts.slice(0, 5).map((receipt) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "div",
+          {
+            className: "flex items-start justify-between gap-3 rounded-xl border border-slate-200/70 bg-white px-4 py-3",
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-sm text-brand-dark", children: [
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-medium", children: receipt.policy_decision === "allow" ? "Allowed" : "Blocked" }),
+                  " ",
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-mono text-xs", children: receipt.artifact_name ?? receipt.artifact_id })
+                ] }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs text-muted-foreground", children: formatRelativeTime(receipt.timestamp) })
+              ] }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: receipt.policy_decision === "allow" ? "green" : "attention", children: receipt.policy_decision })
+            ]
+          },
+          receipt.receipt_id
+        )) })
+      ] }),
+      props.harnessInventory.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4 sm:p-5", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Discovered items" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-muted-foreground", children: "Tools and plugins Guard found in this app." }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 space-y-2", children: props.harnessInventory.slice(0, 8).map((item) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "div",
+          {
+            className: "flex items-center justify-between rounded-lg border border-slate-200/70 px-3 py-2",
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "truncate text-sm text-brand-dark", children: item.artifact_name ?? item.artifact_id }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "shrink-0 text-[11px] text-muted-foreground", children: item.artifact_type })
+            ]
+          },
+          item.artifact_id
+        )) })
+      ] })
+    ] })
+  ] });
+}
+function AppActivityTab(props) {
+  const [filter, setFilter] = reactExports.useState("all");
+  const [timeFilter, setTimeFilter] = reactExports.useState("all");
+  const [search, setSearch] = reactExports.useState("");
+  const [selectedIds, setSelectedIds] = reactExports.useState(/* @__PURE__ */ new Set());
+  reactExports.useEffect(() => {
+    function handleKeyDown(event) {
+      if (event.key === " " && document.activeElement?.tagName !== "INPUT") {
+        const focused = document.activeElement;
+        if (focused?.closest('[role="listitem"]')) {
+          const checkbox = focused.querySelector('input[type="checkbox"]');
+          if (checkbox) {
+            event.preventDefault();
+            checkbox.click();
+          }
+        }
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+  const filteredReceipts = reactExports.useMemo(() => {
+    let items = props.harnessReceipts;
+    if (filter === "allowed") items = items.filter((r) => r.policy_decision === "allow");
+    if (filter === "blocked") items = items.filter((r) => r.policy_decision === "block");
+    if (timeFilter === "today") {
+      const start = /* @__PURE__ */ new Date();
+      start.setHours(0, 0, 0, 0);
+      items = items.filter((r) => new Date(r.timestamp) >= start);
+    }
+    if (timeFilter === "week") {
+      const start = /* @__PURE__ */ new Date();
+      start.setDate(start.getDate() - 7);
+      items = items.filter((r) => new Date(r.timestamp) >= start);
+    }
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      items = items.filter(
+        (r) => (r.artifact_name ?? r.artifact_id).toLowerCase().includes(q)
+      );
+    }
+    return items;
+  }, [props.harnessReceipts, filter, timeFilter, search]);
+  const groups = reactExports.useMemo(() => {
+    const today = [];
+    const yesterday = [];
+    const thisWeek = [];
+    const earlier = [];
+    const now = /* @__PURE__ */ new Date();
+    const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const startOfYesterday = new Date(startOfToday);
+    startOfYesterday.setDate(startOfYesterday.getDate() - 1);
+    const startOfWeek = new Date(startOfToday);
+    startOfWeek.setDate(startOfWeek.getDate() - startOfWeek.getDay());
+    filteredReceipts.forEach((r) => {
+      const d = new Date(r.timestamp);
+      if (d >= startOfToday) today.push(r);
+      else if (d >= startOfYesterday) yesterday.push(r);
+      else if (d >= startOfWeek) thisWeek.push(r);
+      else earlier.push(r);
+    });
+    return { today, yesterday, thisWeek, earlier };
+  }, [filteredReceipts]);
+  const hasPending = props.pendingItems.length > 0;
+  const allReceiptIds = reactExports.useMemo(() => filteredReceipts.map((r) => r.receipt_id), [filteredReceipts]);
+  const selectedCount = selectedIds.size;
+  const toggleSelection = reactExports.useCallback((id) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+  const selectAll = reactExports.useCallback(() => {
+    setSelectedIds(new Set(allReceiptIds));
+  }, [allReceiptIds]);
+  const clearSelection = reactExports.useCallback(() => {
+    setSelectedIds(/* @__PURE__ */ new Set());
+  }, []);
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
+    props.queueError && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-fade-in rounded-xl border border-brand-attention/10 bg-brand-attention/[0.03] p-4 sm:p-5", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-attention", "aria-hidden": "true" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex-1", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: "Unable to load activity" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-muted-foreground", children: props.queueError }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "button",
+          {
+            onClick: props.onRetry,
+            className: "mt-3 inline-flex min-h-9 items-center rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark transition-colors hover:bg-slate-50",
+            children: "Retry"
+          }
+        )
+      ] })
+    ] }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4 sm:p-5", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
+        [
+          { key: "all", label: "All" },
+          { key: "pending", label: `Pending (${props.pendingItems.length})` },
+          { key: "allowed", label: "Allowed" },
+          { key: "blocked", label: "Blocked" }
+        ].map((c) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "button",
+          {
+            onClick: () => {
+              setFilter(c.key);
+              clearSelection();
+            },
+            className: `rounded-full px-3 py-1.5 text-xs font-medium transition-all ${filter === c.key ? "bg-brand-blue text-white shadow-sm" : "border border-slate-200 bg-white text-brand-dark hover:bg-slate-50"}`,
+            children: c.label
+          },
+          c.key
+        )),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "ml-auto flex gap-2", children: [
+          { key: "all", label: "All time" },
+          { key: "today", label: "Today" },
+          { key: "week", label: "This week" }
+        ].map((c) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "button",
+          {
+            onClick: () => {
+              setTimeFilter(c.key);
+              clearSelection();
+            },
+            className: `rounded-full px-3 py-1.5 text-xs font-medium transition-all ${timeFilter === c.key ? "bg-brand-dark text-white shadow-sm" : "border border-slate-200 bg-white text-brand-dark hover:bg-slate-50"}`,
+            children: c.label
+          },
+          c.key
+        )) })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "input",
+        {
+          value: search,
+          onChange: (e) => {
+            setSearch(e.target.value);
+            clearSelection();
+          },
+          placeholder: "Search by name...",
+          className: "mt-3 w-full rounded-xl border border-slate-200/70 bg-white px-4 py-2.5 text-sm text-brand-dark placeholder:text-slate-400 focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+        }
+      )
+    ] }),
+    filter !== "pending" && filteredReceipts.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "button",
+        {
+          onClick: selectedCount === allReceiptIds.length ? clearSelection : selectAll,
+          className: "rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-brand-dark transition-colors hover:bg-slate-50",
+          children: selectedCount === allReceiptIds.length ? "Deselect all" : "Select all"
+        }
+      ),
+      selectedCount > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-xs text-muted-foreground", children: [
+        selectedCount,
+        " selected"
+      ] })
+    ] }),
+    filter === "pending" && hasPending && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-3", children: props.pendingItems.map((item) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
+      "button",
+      {
+        onClick: () => props.onOpenRequest(item.request_id),
+        className: "flex w-full items-center justify-between rounded-xl border border-brand-blue/15 bg-brand-blue/[0.04] px-4 py-3 text-left transition-shadow hover:shadow-sm",
+        children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: item.artifact_name ?? item.artifact_id }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-0.5 text-xs text-muted-foreground", children: [
+              item.artifact_type,
+              " · ",
+              formatRelativeTime(item.created_at)
+            ] })
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "info", children: "Pending" })
+        ]
+      },
+      item.request_id
+    )) }),
+    filter !== "pending" && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-6", children: filteredReceipts.length === 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+      EmptyState,
+      {
+        title: "No activity yet",
+        body: filter === "all" ? "Guard hasn't recorded any decisions for this app yet. Allow or block an action and it will appear here." : `No ${filter} decisions match your filters.`,
+        tone: "teach"
+      }
+    ) : /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(ReceiptGroup, { title: "Today", items: groups.today, selectedIds, onToggle: toggleSelection }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(ReceiptGroup, { title: "Yesterday", items: groups.yesterday, selectedIds, onToggle: toggleSelection }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(ReceiptGroup, { title: "This week", items: groups.thisWeek, selectedIds, onToggle: toggleSelection }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(ReceiptGroup, { title: "Earlier", items: groups.earlier, selectedIds, onToggle: toggleSelection })
+    ] }) })
+  ] });
+}
+function ReceiptGroup({ title, items, selectedIds, onToggle }) {
+  if (items.length === 0) return null;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4 sm:p-5", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: title }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-xs text-muted-foreground", children: [
+        items.length,
+        " events"
+      ] })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 space-y-3", children: items.map((receipt) => /* @__PURE__ */ jsxRuntimeExports.jsx(ExpandableReceiptRow, { receipt, selected: selectedIds.has(receipt.receipt_id), onToggle }, receipt.receipt_id)) })
+  ] });
+}
+function ExpandableReceiptRow({ receipt, selected, onToggle }) {
+  const [expanded, setExpanded] = reactExports.useState(false);
+  const decisionLabel = receipt.policy_decision === "allow" ? "Allowed" : "Blocked";
+  const name = receipt.artifact_name ?? receipt.artifact_id;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-200/70 bg-white overflow-hidden", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex w-full items-start gap-2 px-4 py-3", children: [
+      onToggle !== void 0 && /* @__PURE__ */ jsxRuntimeExports.jsx("label", { className: "flex items-center pt-0.5", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "input",
+        {
+          type: "checkbox",
+          checked: selected ?? false,
+          onChange: () => onToggle(receipt.receipt_id),
+          className: "h-4 w-4 rounded border-slate-300 text-brand-blue focus:ring-brand-blue",
+          "aria-label": `Select ${name}`
+        }
+      ) }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        "button",
+        {
+          onClick: () => setExpanded(!expanded),
+          className: "flex flex-1 items-start justify-between gap-3 text-left transition-colors hover:bg-slate-50 rounded-lg -m-1 p-1",
+          "aria-expanded": expanded,
+          children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-sm text-brand-dark", children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-medium", children: decisionLabel }),
+                " ",
+                /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-mono text-xs", children: name })
+              ] }),
+              receipt.capabilities_summary && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs text-muted-foreground", children: receipt.capabilities_summary }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-[11px] text-muted-foreground", children: formatRelativeTime(receipt.timestamp) })
+            ] }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: receipt.policy_decision === "allow" ? "green" : "attention", children: receipt.policy_decision }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx(
+                HiMiniChevronDown,
+                {
+                  className: `h-4 w-4 text-slate-400 transition-transform ${expanded ? "rotate-180" : ""}`,
+                  "aria-hidden": "true"
+                }
+              )
+            ] })
+          ]
+        }
+      )
+    ] }),
+    expanded && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-fade-in border-t border-slate-200/70 bg-slate-50/60 px-4 py-3", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("dl", { className: "grid grid-cols-1 gap-2 text-xs", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-muted-foreground", children: "Action ID" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-0.5 font-mono text-brand-dark", children: receipt.artifact_id })
+      ] }),
+      receipt.artifact_hash && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-muted-foreground", children: "Hash" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-0.5 font-mono text-brand-dark", children: receipt.artifact_hash })
+      ] }),
+      receipt.capabilities_summary && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-muted-foreground", children: "Capabilities" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-0.5 text-brand-dark", children: receipt.capabilities_summary })
+      ] }),
+      receipt.provenance_summary && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-muted-foreground", children: "Provenance" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-0.5 text-brand-dark", children: receipt.provenance_summary })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-muted-foreground", children: "Time" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-0.5 font-mono text-brand-dark", children: new Date(receipt.timestamp).toLocaleString() })
+      ] })
+    ] }) })
+  ] });
+}
+function AppSettingsTab(props) {
+  const [showClearConfirm, setShowClearConfirm] = reactExports.useState(false);
+  const [clearing, setClearing] = reactExports.useState(false);
+  const confirmRef = reactExports.useRef(null);
+  useFocusTrap(showClearConfirm, confirmRef);
+  const handleClear = reactExports.useCallback(async () => {
+    if (!props.onClearAppPolicies) return;
+    setClearing(true);
+    await props.onClearAppPolicies(props.harness);
+    setClearing(false);
+    setShowClearConfirm(false);
+  }, [props.onClearAppPolicies, props.harness]);
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.8fr)]", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
+      props.policyError && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-fade-in rounded-xl border border-brand-attention/10 bg-brand-attention/[0.03] p-4 sm:p-5", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-attention", "aria-hidden": "true" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex-1", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: "Unable to load decisions" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-muted-foreground", children: props.policyError }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "button",
+            {
+              onClick: props.onRetry,
+              className: "mt-3 inline-flex min-h-9 items-center rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark transition-colors hover:bg-slate-50",
+              children: "Retry"
+            }
+          )
+        ] })
+      ] }) }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4 sm:p-5", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between gap-3", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Remembered decisions" }),
+          props.harnessPolicies.length > 0 && props.onClearAppPolicies && /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "button",
+            {
+              onClick: () => setShowClearConfirm(true),
+              className: "text-xs font-medium text-brand-attention hover:text-brand-dark transition-colors",
+              children: "Clear all"
+            }
+          )
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-2 text-sm text-muted-foreground", children: [
+          "Guard remembers these choices for ",
+          harnessDisplayName(props.harness),
+          ". Remove any to be asked again."
+        ] }),
+        props.harnessPolicies.length === 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+          EmptyState,
+          {
+            title: "No remembered decisions",
+            body: "Guard will remember choices here after you allow or block actions for this app.",
+            tone: "teach"
+          }
+        ) }) : /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: `mt-4 space-y-2 ${clearing ? "guard-fade-out" : ""}`, children: props.harnessPolicies.map((policy) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "div",
+          {
+            className: "flex items-center justify-between rounded-lg border border-slate-200/70 px-4 py-3 transition-all duration-200 hover:border-brand-blue/30 hover:shadow-sm",
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: policy.scope === "global" ? "Every project" : policy.scope === "harness" ? "This app" : policy.scope === "artifact" && policy.artifact_id ? policy.artifact_id : policy.scope }),
+                /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-0.5 text-xs text-muted-foreground", children: [
+                  policy.action,
+                  " · ",
+                  policy.reason || "No reason given"
+                ] })
+              ] }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: policy.action === "allow" ? "green" : policy.action === "block" ? "attention" : "blue", children: policy.action })
+            ]
+          },
+          `${policy.scope}-${policy.artifact_id ?? policy.workspace ?? "global"}`
+        )) })
+      ] }),
+      showClearConfirm && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { ref: confirmRef, className: "guard-fade-in rounded-xl border border-brand-attention/10 bg-brand-attention/[0.03] p-4 sm:p-5", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-attention", "aria-hidden": "true" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("h3", { className: "text-sm font-semibold text-brand-dark", children: [
+            "Clear all remembered decisions for ",
+            harnessDisplayName(props.harness),
+            "?"
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-1 text-sm text-muted-foreground", children: [
+            "This will remove ",
+            props.harnessPolicies.length,
+            " remembered decision",
+            props.harnessPolicies.length !== 1 ? "s" : "",
+            ". Guard will ask again next time matching actions run."
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 flex flex-wrap gap-2", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "button",
+              {
+                onClick: handleClear,
+                disabled: clearing,
+                className: "inline-flex min-h-9 items-center rounded-lg bg-brand-attention px-3 text-sm font-semibold text-white transition-colors hover:bg-brand-attention/90 disabled:opacity-50",
+                children: clearing ? "Clearing…" : "Clear decisions"
+              }
+            ),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "button",
+              {
+                onClick: () => setShowClearConfirm(false),
+                className: "inline-flex min-h-9 items-center rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark transition-colors hover:bg-slate-50",
+                children: "Keep decisions"
+              }
+            )
+          ] })
+        ] })
+      ] }) }),
+      props.harnessPolicies.length > 0 && !showClearConfirm && /* @__PURE__ */ jsxRuntimeExports.jsx(
+        CloudValueBanner,
+        {
+          icon: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCloud, { className: "h-4 w-4 text-brand-blue" }),
+          title: "Team policy sync",
+          body: "Cloud keeps your team's rules consistent across all devices.",
+          cta: { label: "Learn more", href: "https://hol.org/guard/pricing" }
+        }
+      )
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-6", children: props.status === "needs_setup" && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-xl border border-brand-attention/10 bg-brand-attention/[0.03] p-4 sm:p-5", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-attention" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Setup needed" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-muted-foreground", children: "This app is detected but not active. Run Guard with this app once to complete setup." }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 rounded-xl bg-white/60 p-4", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "font-mono text-xs text-brand-dark", children: `npx @hol/guard install ${props.harness}` }) })
+      ] })
+    ] }) }) })
+  ] });
+}
+function ActivitySparkline({ receipts }) {
+  const days = 7;
+  const data = reactExports.useMemo(() => {
+    const result = [];
+    const now = /* @__PURE__ */ new Date();
+    for (let i = days - 1; i >= 0; i--) {
+      const d = new Date(now);
+      d.setDate(d.getDate() - i);
+      d.setHours(0, 0, 0, 0);
+      const end = new Date(d);
+      end.setDate(end.getDate() + 1);
+      const dayReceipts = receipts.filter((r) => {
+        const rt = new Date(r.timestamp);
+        return rt >= d && rt < end;
+      });
+      result.push({
+        date: d.toLocaleDateString("en-US", { weekday: "short" }),
+        allowed: dayReceipts.filter((r) => r.policy_decision === "allow").length,
+        blocked: dayReceipts.filter((r) => r.policy_decision === "block").length
+      });
+    }
+    return result;
+  }, [receipts]);
+  const maxVal = Math.max(...data.map((d) => d.allowed + d.blocked), 1);
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4 sm:p-5", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Last 7 days" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChartBar, { className: "h-4 w-4 text-slate-400", "aria-hidden": "true" })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 flex items-end gap-2", children: data.map((day) => {
+      const total = day.allowed + day.blocked;
+      const height = total > 0 ? Math.max(20, total / maxVal * 100) : 4;
+      return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-1 flex-col items-center gap-1", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex w-full gap-0.5", style: { height: `${height}px` }, children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "div",
+            {
+              className: "flex-1 rounded-t bg-brand-green/60",
+              style: { height: `${day.allowed > 0 ? day.allowed / total * 100 : 0}%` },
+              title: `${day.allowed} allowed`
+            }
+          ),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "div",
+            {
+              className: "flex-1 rounded-t bg-brand-attention/60",
+              style: { height: `${day.blocked > 0 ? day.blocked / total * 100 : 0}%` },
+              title: `${day.blocked} blocked`
+            }
+          )
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-[10px] text-muted-foreground", children: day.date })
+      ] }, day.date);
+    }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-2 flex items-center gap-4", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "flex items-center gap-1.5 text-[10px] text-muted-foreground", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2 w-2 rounded-sm bg-brand-green/60" }),
+        "Allowed"
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "flex items-center gap-1.5 text-[10px] text-muted-foreground", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2 w-2 rounded-sm bg-brand-attention/60" }),
+        "Blocked"
+      ] })
+    ] })
+  ] });
+}
+function RiskSnapshot({ receipts }) {
+  const analysis = reactExports.useMemo(() => {
+    const blockedCount = receipts.filter((r) => r.policy_decision === "block").length;
+    const allowedCount = receipts.filter((r) => r.policy_decision === "allow").length;
+    return { blocked: blockedCount, allowed: allowedCount, total: receipts.length };
+  }, [receipts]);
+  if (analysis.total === 0) return null;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 rounded-xl border border-brand-blue/10 bg-brand-blue/[0.03] p-4", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Activity breakdown" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-2 space-y-1.5 text-sm text-brand-dark", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-medium", children: analysis.allowed }),
+        " ",
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-muted-foreground", children: "allowed" })
+      ] }),
+      analysis.blocked > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-medium text-brand-attention", children: analysis.blocked }),
+        " ",
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-muted-foreground", children: "blocked" })
+      ] })
+    ] })
+  ] });
+}
+function TabContent({
+  activeTab,
+  direction,
+  children
+}) {
+  const animationClass = direction === "right" ? "guard-tab-enter" : "guard-tab-enter-reverse";
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: `${animationClass}`, children }, activeTab);
+}
+function CloudValueBanner({
+  icon,
+  title,
+  body,
+  cta
+}) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-xl border border-brand-purple/10 bg-brand-purple/[0.03] p-4 sm:p-5", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-0.5 shrink-0", children: icon }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex-1", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: title }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-muted-foreground", children: body }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        "a",
+        {
+          href: cta.href,
+          target: "_blank",
+          rel: "noopener noreferrer",
+          className: "mt-3 inline-flex items-center gap-1 text-sm font-medium text-brand-blue hover:text-brand-dark transition-colors",
+          children: [
+            cta.label,
+            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronRight, { className: "h-3 w-3", "aria-hidden": "true" })
+          ]
+        }
+      )
+    ] })
+  ] }) });
+}
+function StatCard({
+  label,
+  value,
+  tone
+}) {
+  const toneClass = tone === "green" ? "text-brand-green" : tone === "attention" ? "text-brand-attention" : tone === "blue" ? "text-brand-blue" : "text-brand-dark";
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-200/70 bg-white p-3 text-center", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: `text-xl font-semibold ${toneClass}`, children: value }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground", children: label })
+  ] });
+}
+export {
+  AppDetailWorkspace
+};

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/fleet-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/fleet-workspace.js
@@ -1,0 +1,146 @@
+import { j as jsxRuntimeExports, G as GuardHero, A as ActionButton, P as ProofStrip, S as SectionLabel, h as harnessDisplayName, i as HiMiniChevronRight, E as EmptyState, H as HiMiniCheckCircle, o as HiMiniExclamationCircle, p as HiMiniWrenchScrewdriver, q as HiMiniXCircle } from "../guard-dashboard.js";
+function collectHarnesses(snapshot) {
+  const harnesses = /* @__PURE__ */ new Set();
+  for (const item of snapshot.items) harnesses.add(item.harness);
+  for (const receipt of snapshot.latest_receipts) harnesses.add(receipt.harness);
+  return Array.from(harnesses).sort((a, b) => a.localeCompare(b));
+}
+function renderReceiptContext(receipt) {
+  return `${harnessDisplayName(receipt.harness)} · ${receipt.policy_decision.replace(/-/g, " ")}`;
+}
+function resolveAppStatus(install, hasInventory, hasReceipts) {
+  if (install !== void 0) {
+    if (install.active) return "protected";
+    return "needs_repair";
+  }
+  if (!hasInventory && !hasReceipts) return "not_found";
+  return "found_unprotected";
+}
+function StatusIcon({ status }) {
+  if (status === "protected") return /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-4 w-4 text-emerald-500", "aria-hidden": "true" });
+  if (status === "found_unprotected") return /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationCircle, { className: "h-4 w-4 text-brand-attention", "aria-hidden": "true" });
+  if (status === "needs_repair") return /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniWrenchScrewdriver, { className: "h-4 w-4 text-brand-purple", "aria-hidden": "true" });
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniXCircle, { className: "h-4 w-4 text-slate-300", "aria-hidden": "true" });
+}
+function StatusBadge({ status }) {
+  if (status === "protected") return /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs font-medium text-emerald-600", children: "Protected" });
+  if (status === "found_unprotected") return /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs font-medium text-brand-attention", children: "Found, not installed" });
+  if (status === "needs_repair") return /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs font-medium text-brand-purple", children: "Repair needed" });
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs text-slate-400", children: "Not found" });
+}
+function FleetWorkspace(props) {
+  const harnesses = collectHarnesses(props.runtime);
+  const managedInstalls = props.runtime.managed_installs ?? [];
+  const activeInstalls = managedInstalls.filter((i) => i.active);
+  const inventory = props.inventory.kind === "ready" ? props.inventory.items : [];
+  const visibleHarnesses = Array.from(
+    /* @__PURE__ */ new Set([
+      ...managedInstalls.map((i) => i.harness),
+      ...harnesses,
+      ...inventory.map((i) => i.harness),
+      ...props.policies.map((p) => p.harness)
+    ])
+  ).sort((a, b) => a.localeCompare(b));
+  const runtimeState = props.runtime.runtime_state;
+  const receiptHarnesses = new Set(props.runtime.latest_receipts.map((r) => r.harness));
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-8", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      GuardHero,
+      {
+        status: activeInstalls.length > 0 ? "clear" : "setup_gap",
+        headline: activeInstalls.length > 0 ? "Your apps are covered" : "Connect an app to start",
+        subheadline: activeInstalls.length > 0 ? "Confirm that Guard is running and protecting your local AI apps." : "Guard works with Codex, Claude Code, Cursor, Hermes, OpenClaw, and more.",
+        cta: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: props.runtime.fleet_url, children: "Open Cloud Devices" }),
+        secondaryCta: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: props.runtime.dashboard_url, variant: "outline", children: "Open Home" })
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      ProofStrip,
+      {
+        items: [
+          { label: "Needs review", value: `${props.runtime.pending_count}`, tone: props.runtime.pending_count > 0 ? "blue" : "slate" },
+          { label: "History", value: `${props.runtime.receipt_count}`, tone: "purple" },
+          { label: "Watched apps", value: `${activeInstalls.length > 0 ? activeInstalls.length : visibleHarnesses.length}`, tone: activeInstalls.length > 0 ? "green" : "slate" },
+          { label: "Runtime", value: runtimeState ? "active" : "offline", tone: runtimeState ? "green" : "slate" }
+        ]
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-8 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,0.8fr)]", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mb-4", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "App coverage" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-500", children: "Which apps Guard is watching on this machine." })
+        ] }),
+        visibleHarnesses.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "divide-y divide-slate-100 border-t border-slate-100", children: visibleHarnesses.map((harness) => {
+          const install = managedInstalls.find((i) => i.harness === harness);
+          const harnessInventory = inventory.filter((i) => i.harness === harness && i.present);
+          const harnessPolicies = props.policies.filter((p) => p.harness === harness);
+          const hasReceipts = receiptHarnesses.has(harness);
+          const status = resolveAppStatus(install, harnessInventory.length > 0, hasReceipts);
+          const isClickable = props.onOpenAppDetail !== void 0;
+          return /* @__PURE__ */ jsxRuntimeExports.jsxs(
+            "div",
+            {
+              className: `flex items-center justify-between gap-3 py-3 transition-colors ${isClickable ? "cursor-pointer hover:bg-slate-50/60" : ""}`,
+              onClick: isClickable ? () => props.onOpenAppDetail?.(harness) : void 0,
+              role: isClickable ? "button" : void 0,
+              tabIndex: isClickable ? 0 : void 0,
+              onKeyDown: isClickable ? (e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  props.onOpenAppDetail?.(harness);
+                }
+              } : void 0,
+              children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 items-center gap-3", children: [
+                  /* @__PURE__ */ jsxRuntimeExports.jsx(StatusIcon, { status }),
+                  /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: harnessDisplayName(harness) }),
+                    /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-xs text-slate-400", children: [
+                      harnessInventory.length,
+                      " actions · ",
+                      harnessPolicies.length,
+                      " decisions"
+                    ] })
+                  ] })
+                ] }),
+                /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2", children: [
+                  /* @__PURE__ */ jsxRuntimeExports.jsx(StatusBadge, { status }),
+                  isClickable && /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronRight, { className: "h-4 w-4 text-slate-300", "aria-hidden": "true" })
+                ] })
+              ]
+            },
+            harness
+          );
+        }) }) : /* @__PURE__ */ jsxRuntimeExports.jsx(
+          EmptyState,
+          {
+            title: "No watched apps yet",
+            body: "Run HOL Guard once with Codex, Claude Code, Cursor, Hermes, or another supported app and this machine will show coverage here.",
+            tone: "teach"
+          }
+        ),
+        props.inventory.kind === "error" ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-3 text-xs text-slate-500", children: props.inventory.message }) : null
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mb-4", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Recent choices" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-500", children: "What Guard decided recently." })
+        ] }),
+        props.runtime.latest_receipts.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-0 divide-y divide-slate-100 border-t border-slate-100", children: props.runtime.latest_receipts.slice(0, 6).map((receipt) => /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "py-2.5", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "truncate text-sm font-medium text-brand-dark", children: receipt.artifact_name ?? receipt.artifact_id }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-400", children: renderReceiptContext(receipt) })
+        ] }, receipt.receipt_id)) }) : /* @__PURE__ */ jsxRuntimeExports.jsx(
+          EmptyState,
+          {
+            title: "No choices yet",
+            body: "Allow or block an action once and HOL Guard will start building local history for this machine."
+          }
+        )
+      ] })
+    ] })
+  ] });
+}
+export {
+  FleetWorkspace
+};

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/help-modal.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/help-modal.js
@@ -1,0 +1,118 @@
+import { r as reactExports, j as jsxRuntimeExports, O as HiMiniCommandLine, g as HiMiniXMark, Q as HiMiniQuestionMarkCircle } from "../guard-dashboard.js";
+import { u as useFocusTrap } from "./use-focus-trap.js";
+const shortcuts = [
+  {
+    title: "Review",
+    items: [
+      { keys: ["A"], description: "Allow the current action" },
+      { keys: ["B"], description: "Block the current action" },
+      { keys: ["↑", "↓"], description: "Navigate queue items" },
+      { keys: ["Enter"], description: "Open selected queue item" },
+      { keys: ["1"], description: "Select 'Just this time' scope" },
+      { keys: ["2"], description: "Select 'This project' scope" },
+      { keys: ["3"], description: "Select 'This source' scope" },
+      { keys: ["4"], description: "Select 'This app' scope" },
+      { keys: ["5"], description: "Select 'Everywhere' scope" }
+    ]
+  },
+  {
+    title: "History",
+    items: [
+      { keys: ["f"], description: "Focus search" },
+      { keys: ["e"], description: "Export current view" },
+      { keys: ["g"], description: "Toggle grouping" },
+      { keys: ["t"], description: "Toggle time range" }
+    ]
+  },
+  {
+    title: "Navigation",
+    items: [
+      { keys: ["/"], description: "Focus search input" },
+      { keys: ["?"], description: "Open this help" },
+      { keys: ["Esc"], description: "Close modal or drawer" }
+    ]
+  }
+];
+function HelpModal(props) {
+  const dialogRef = reactExports.useRef(null);
+  useFocusTrap(props.open, dialogRef);
+  reactExports.useEffect(() => {
+    if (!props.open) return;
+    function handleKeyDown(event) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        props.onClose();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [props.open, props.onClose]);
+  const handleBackdropClick = reactExports.useCallback(
+    (e) => {
+      if (e.target === e.currentTarget) props.onClose();
+    },
+    [props.onClose]
+  );
+  if (!props.open) return null;
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(
+    "div",
+    {
+      className: "guard-fade-in fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4 backdrop-blur-sm",
+      onClick: handleBackdropClick,
+      role: "dialog",
+      "aria-modal": "true",
+      "aria-label": "Keyboard shortcuts help",
+      children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { ref: dialogRef, className: "guard-fade-in w-full max-w-lg rounded-2xl border border-slate-200/70 bg-white/95 p-6 shadow-2xl", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2.5", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCommandLine, { className: "h-5 w-5 text-brand-blue", "aria-hidden": "true" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "text-lg font-semibold tracking-tight text-brand-dark", children: "Keyboard shortcuts" })
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "button",
+            {
+              type: "button",
+              onClick: props.onClose,
+              "aria-label": "Close help",
+              className: "rounded-full p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-brand-dark",
+              children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniXMark, { className: "h-5 w-5", "aria-hidden": "true" })
+            }
+          )
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-muted-foreground", children: "Use these shortcuts to review actions faster. Shortcuts work when you are not typing in a text field." }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-5 space-y-5", children: shortcuts.map((group) => /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "font-mono text-[10px] font-semibold uppercase tracking-[0.22em] text-muted-foreground", children: group.title }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-2 space-y-2", children: group.items.map((item) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
+            "div",
+            {
+              className: "flex items-center justify-between gap-3",
+              children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm text-brand-dark", children: item.description }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "flex shrink-0 gap-1", children: item.keys.map((key) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+                  "kbd",
+                  {
+                    className: "inline-flex h-7 min-w-7 items-center justify-center rounded-md border border-slate-200 bg-slate-50 px-1.5 font-mono text-[11px] font-semibold text-brand-dark shadow-sm",
+                    children: key
+                  },
+                  key
+                )) })
+              ]
+            },
+            item.description
+          )) })
+        ] }, group.title)) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-6 flex items-center gap-2 rounded-xl border border-brand-blue/15 bg-brand-blue/[0.04] px-4 py-3", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniQuestionMarkCircle, { className: "h-4 w-4 shrink-0 text-brand-blue", "aria-hidden": "true" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-xs text-muted-foreground", children: [
+            "Press ",
+            /* @__PURE__ */ jsxRuntimeExports.jsx("kbd", { className: "rounded bg-slate-100 px-1 py-0.5 font-mono text-[10px]", children: "?" }),
+            " anytime to open this help."
+          ] })
+        ] })
+      ] })
+    }
+  );
+}
+export {
+  HelpModal
+};

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/home-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/home-dashboard.js
@@ -1,0 +1,563 @@
+import { r as reactExports, j as jsxRuntimeExports, E as EmptyState, A as ActionButton, H as HiMiniCheckCircle, G as GuardHero, P as ProofStrip, f as formatNumber, a as HiMiniFire, b as HiMiniCalendarDays, c as HiMiniShieldCheck, S as SectionLabel, h as harnessDisplayName, d as formatRelativeTime, e as HiMiniSparkles, g as HiMiniXMark, B as Badge, i as HiMiniChevronRight, k as HiMiniChevronUp, l as HiMiniChevronDown, m as HiMiniExclamationTriangle, n as HiMiniMinusCircle } from "../guard-dashboard.js";
+import { u as useFocusTrap } from "./use-focus-trap.js";
+function HomeWorkspace(props) {
+  const [toastMessage, setToastMessage] = reactExports.useState(null);
+  const toastTimerRef = reactExports.useRef(null);
+  reactExports.useEffect(() => {
+    return () => {
+      if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    };
+  }, []);
+  const showToast = reactExports.useCallback((message) => {
+    setToastMessage(message);
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    toastTimerRef.current = setTimeout(() => setToastMessage(null), 3e3);
+  }, []);
+  const handleClearPolicies = reactExports.useCallback((scope) => {
+    props.onClearPolicies(scope);
+  }, [props.onClearPolicies]);
+  const snapshot = props.runtime.kind === "ready" ? props.runtime.snapshot : null;
+  const queuedCount = props.requests.kind === "ready" ? props.requests.items.length : 0;
+  const policyItems = props.policies.kind === "ready" ? props.policies.items : [];
+  const managedInstalls = snapshot?.managed_installs ?? [];
+  const activeInstalls = managedInstalls.filter((item) => item.active);
+  const observedHarnesses = snapshot ? Array.from(
+    /* @__PURE__ */ new Set([
+      ...snapshot.items.map((item) => item.harness),
+      ...snapshot.latest_receipts.map((receipt) => receipt.harness),
+      ...policyItems.map((policy) => policy.harness)
+    ])
+  ).sort() : [];
+  const clearHarnesses = activeInstalls.length > 0 ? activeInstalls.map((i) => i.harness) : observedHarnesses;
+  const watchedAppsCount = activeInstalls.length > 0 ? activeInstalls.length : observedHarnesses.length;
+  const state = reactExports.useMemo(
+    () => deriveHomeState({
+      hasActiveInstalls: activeInstalls.length > 0,
+      hasObservedHarnesses: observedHarnesses.length > 0,
+      queuedCount,
+      watchedAppsCount
+    }),
+    [activeInstalls.length, observedHarnesses.length, queuedCount, watchedAppsCount]
+  );
+  const dailyStory = reactExports.useMemo(() => snapshot ? buildDailyStory(snapshot.latest_receipts, queuedCount) : null, [snapshot, queuedCount]);
+  const streak = reactExports.useMemo(() => snapshot ? computeStreak(snapshot.latest_receipts) : 0, [snapshot]);
+  const weeklySummary = reactExports.useMemo(() => snapshot ? buildWeeklySummary(snapshot.latest_receipts) : null, [snapshot]);
+  const ctaAction = state.ctaTarget === "inbox" ? props.onOpenInbox : state.ctaTarget === "fleet" ? props.onOpenFleet : props.onOpenEvidence;
+  if (props.runtime.kind === "loading" || props.requests.kind === "loading") {
+    return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-skeleton h-36 w-full" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-skeleton h-16 w-full" })
+    ] });
+  }
+  if (props.runtime.kind === "error") {
+    return /* @__PURE__ */ jsxRuntimeExports.jsx(
+      EmptyState,
+      {
+        title: "Guard is not connected",
+        body: props.runtime.message,
+        action: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: props.onOpenInbox, children: "Open review queue" }),
+        tone: "teach"
+      }
+    );
+  }
+  if (!snapshot) return null;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
+    toastMessage && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "guard-fade-in fixed bottom-6 right-6 z-50 flex items-center gap-3 rounded-xl border border-brand-green/25 bg-brand-green-bg/90 px-4 py-3 shadow-lg backdrop-blur", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-4 w-4 shrink-0 text-brand-green", "aria-hidden": "true" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-green-text", children: toastMessage })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      GuardHero,
+      {
+        status: state.heroStatus,
+        headline: state.headline,
+        subheadline: state.subheadline,
+        cta: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: ctaAction, "data-primary": "true", children: state.ctaLabel })
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      ProofStrip,
+      {
+        items: [
+          { label: "Pending", value: formatNumber(queuedCount), tone: queuedCount > 0 ? "blue" : "slate" },
+          { label: "Apps", value: formatNumber(watchedAppsCount), tone: watchedAppsCount > 0 ? "green" : "slate" },
+          { label: "Streak", value: formatNumber(streak), tone: streak > 1 ? "purple" : "slate", icon: streak > 1 ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniFire, { className: "h-3.5 w-3.5 text-brand-purple", "aria-hidden": "true" }) : null, hint: streak > 0 ? "Consecutive days with Guard activity. Resets after 48h of inactivity." : "Guard activity streak" },
+          { label: "History", value: formatNumber(snapshot?.receipt_count ?? 0), tone: "purple" }
+        ]
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(StreakMilestoneBanner, { streak }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-6 lg:grid-cols-[minmax(0,1.3fr)_minmax(0,0.9fr)]", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "space-y-6", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          AppsAtAGlance,
+          {
+            managedInstalls,
+            observedHarnesses,
+            queuedItems: props.requests.kind === "ready" ? props.requests.items : [],
+            onOpenAppDetail: props.onOpenAppDetail
+          }
+        ),
+        weeklySummary && /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          CollapsibleCard,
+          {
+            id: "weekly-summary",
+            icon: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCalendarDays, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-purple", "aria-hidden": "true" }),
+            label: "This week",
+            defaultOpen: true,
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-muted-foreground", children: weeklySummary.body }),
+              weeklySummary.stats && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 flex flex-wrap gap-2", children: weeklySummary.stats.map((s) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
+                "span",
+                {
+                  className: "rounded-full bg-white/70 px-3 py-1 text-xs font-medium text-brand-dark",
+                  children: [
+                    s.value,
+                    " ",
+                    s.label
+                  ]
+                },
+                s.label
+              )) })
+            ]
+          }
+        ),
+        dailyStory && /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          CollapsibleCard,
+          {
+            id: "daily-brief",
+            icon: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-green", "aria-hidden": "true" }),
+            label: dailyStory.title,
+            defaultOpen: true,
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-muted-foreground", children: dailyStory.body }),
+              dailyStory.stats && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 flex flex-wrap gap-2", children: dailyStory.stats.map((s) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
+                "span",
+                {
+                  className: "rounded-full bg-white/70 px-3 py-1 text-xs font-medium text-brand-dark",
+                  children: [
+                    s.value,
+                    " ",
+                    s.label
+                  ]
+                },
+                s.label
+              )) })
+            ]
+          }
+        )
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "space-y-6", children: [
+        snapshot.latest_receipts.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(RecentProtectionSection, { receipts: snapshot.latest_receipts }),
+        policyItems.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Reset remembered decisions" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-500", children: "Clear remembered decisions when you want Guard to ask again next time. This does not remove your history." }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 flex flex-wrap gap-2", children: clearHarnesses.slice(0, 4).map((harness) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+            ClearHarnessButton,
+            {
+              harness,
+              onClearPolicies: handleClearPolicies
+            },
+            harness
+          )) })
+        ] })
+      ] })
+    ] }),
+    props.clearConfirm && /* @__PURE__ */ jsxRuntimeExports.jsx(
+      ClearConfirmDialog,
+      {
+        clearConfirm: props.clearConfirm,
+        onCancelClear: props.onCancelClear,
+        onConfirmClear: async () => {
+          const confirm = props.clearConfirm;
+          await props.onConfirmClear();
+          if (confirm?.harness) {
+            showToast(`Cleared for ${harnessDisplayName(confirm.harness)}`);
+          } else if (confirm?.all) {
+            showToast("Cleared all decisions");
+          }
+        }
+      }
+    )
+  ] });
+}
+function ClearConfirmDialog(props) {
+  const dialogRef = reactExports.useRef(null);
+  useFocusTrap(true, dialogRef);
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-fade-in fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4 backdrop-blur-sm", role: "dialog", "aria-modal": "true", "aria-label": "Confirm clear decisions", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { ref: dialogRef, className: "guard-fade-in w-full max-w-md rounded-2xl border border-brand-attention/20 bg-white p-6 shadow-2xl", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-attention", "aria-hidden": "true" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "text-lg font-semibold tracking-tight text-brand-dark", children: "Clear remembered decisions?" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-2 text-sm text-muted-foreground", children: [
+          "This will remove ",
+          props.clearConfirm.all ? "all saved approvals" : `decisions for ${props.clearConfirm.harness ?? "this app"}`,
+          ". Guard will ask again next time matching actions run."
+        ] })
+      ] })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 flex flex-col gap-2 sm:flex-row sm:justify-end", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "button",
+        {
+          type: "button",
+          onClick: props.onCancelClear,
+          className: "inline-flex min-h-11 items-center justify-center rounded-lg border border-slate-200 bg-white px-4 text-sm font-medium text-brand-dark transition-colors hover:bg-slate-50",
+          children: "Keep decisions"
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "button",
+        {
+          type: "button",
+          onClick: props.onConfirmClear,
+          className: "inline-flex min-h-11 items-center justify-center rounded-lg bg-brand-attention px-4 text-sm font-semibold text-white transition-colors hover:bg-brand-attention/90",
+          children: "Clear decisions"
+        }
+      )
+    ] })
+  ] }) });
+}
+function deriveHomeState(input) {
+  const { hasActiveInstalls, hasObservedHarnesses, queuedCount, watchedAppsCount } = input;
+  if (queuedCount > 0) {
+    return {
+      heroStatus: "needs_review",
+      headline: queuedCount === 1 ? "1 action needs review" : `${queuedCount} actions need review`,
+      subheadline: "Guard stopped something. Review and decide whether to allow or block it.",
+      ctaLabel: "Review now",
+      ctaTarget: "inbox"
+    };
+  }
+  if (!hasActiveInstalls && !hasObservedHarnesses) {
+    return {
+      heroStatus: "setup_gap",
+      headline: "Guard is ready",
+      subheadline: "Connect your first AI app so Guard can start protecting it.",
+      ctaLabel: "Open Apps",
+      ctaTarget: "fleet"
+    };
+  }
+  if (!hasActiveInstalls && hasObservedHarnesses) {
+    return {
+      heroStatus: "setup_gap",
+      headline: "Finish setup",
+      subheadline: "Guard detected apps but they need setup to be fully protected.",
+      ctaLabel: "Open Apps",
+      ctaTarget: "fleet"
+    };
+  }
+  return {
+    heroStatus: "clear",
+    headline: "All clear",
+    subheadline: `Guard is watching your AI work. ${watchedAppsCount} app${watchedAppsCount !== 1 ? "s" : ""} protected. Nothing needs you right now.`,
+    ctaLabel: "View history",
+    ctaTarget: "evidence"
+  };
+}
+function buildDailyStory(receipts, queuedCount) {
+  const today = /* @__PURE__ */ new Date();
+  today.setHours(0, 0, 0, 0);
+  const todayReceipts = receipts.filter((r) => new Date(r.timestamp) >= today);
+  const allowedToday = todayReceipts.filter((r) => r.policy_decision === "allow").length;
+  const blockedToday = todayReceipts.filter((r) => r.policy_decision === "block").length;
+  if (queuedCount > 0) {
+    return {
+      title: "Needs your attention",
+      body: `${queuedCount} action${queuedCount === 1 ? " is" : "s are"} waiting for review. Guard paused them to keep you safe.`,
+      stats: [{ label: "pending review", value: queuedCount }]
+    };
+  }
+  if (allowedToday + blockedToday > 0) {
+    return {
+      title: "Today so far",
+      body: `Guard allowed ${allowedToday} action${allowedToday !== 1 ? "s" : ""} and blocked ${blockedToday}.`,
+      stats: [
+        { label: "allowed", value: allowedToday },
+        { label: "blocked", value: blockedToday }
+      ]
+    };
+  }
+  if (receipts.length > 0) {
+    const last = receipts[0];
+    return {
+      title: "All quiet",
+      body: `No new activity today. Last decision was ${formatRelativeTime(last.timestamp)}.`
+    };
+  }
+  return null;
+}
+function computeStreak(receipts) {
+  if (receipts.length === 0) return 0;
+  const sortedByTime = [...receipts].sort((a, b) => +new Date(b.timestamp) - +new Date(a.timestamp));
+  const mostRecent = new Date(sortedByTime[0].timestamp);
+  const now = /* @__PURE__ */ new Date();
+  const diffHours = (now.getTime() - mostRecent.getTime()) / (1e3 * 60 * 60);
+  if (diffHours > 48) return 0;
+  const dates = new Set(receipts.map((r) => new Date(r.timestamp).toDateString()));
+  const sortedDates = Array.from(dates).sort((a, b) => +new Date(b) - +new Date(a));
+  let streak = 0;
+  const today = /* @__PURE__ */ new Date();
+  today.setHours(0, 0, 0, 0);
+  let checkDate = new Date(today);
+  for (const dateStr of sortedDates) {
+    const d = new Date(dateStr);
+    d.setHours(0, 0, 0, 0);
+    if (d.getTime() === checkDate.getTime()) {
+      streak++;
+      checkDate.setDate(checkDate.getDate() - 1);
+    } else if (d.getTime() < checkDate.getTime()) {
+      break;
+    }
+  }
+  return streak;
+}
+function buildWeeklySummary(receipts) {
+  const now = /* @__PURE__ */ new Date();
+  const startOfWeek = new Date(now);
+  startOfWeek.setDate(now.getDate() - now.getDay());
+  startOfWeek.setHours(0, 0, 0, 0);
+  const weekReceipts = receipts.filter((r) => new Date(r.timestamp) >= startOfWeek);
+  if (weekReceipts.length === 0) return null;
+  const allowed = weekReceipts.filter((r) => r.policy_decision === "allow").length;
+  const blocked = weekReceipts.filter((r) => r.policy_decision === "block").length;
+  const uniqueApps = new Set(weekReceipts.map((r) => r.harness)).size;
+  return {
+    body: `Guard reviewed ${weekReceipts.length} actions across ${uniqueApps} app${uniqueApps !== 1 ? "s" : ""} this week.`,
+    stats: [
+      { label: "allowed", value: allowed },
+      { label: "blocked", value: blocked },
+      { label: "apps", value: uniqueApps }
+    ]
+  };
+}
+function AppsAtAGlance(props) {
+  const pendingByHarness = reactExports.useMemo(() => {
+    const map = /* @__PURE__ */ new Map();
+    for (const item of props.queuedItems) {
+      map.set(item.harness, (map.get(item.harness) ?? 0) + 1);
+    }
+    return map;
+  }, [props.queuedItems]);
+  const sortedHarnesses = reactExports.useMemo(() => {
+    const all = Array.from(
+      /* @__PURE__ */ new Set([
+        ...props.managedInstalls.map((i) => i.harness),
+        ...props.observedHarnesses
+      ])
+    );
+    return all.sort((a, b) => {
+      const aInstall = props.managedInstalls.find((i) => i.harness === a);
+      const bInstall = props.managedInstalls.find((i) => i.harness === b);
+      const aPending = pendingByHarness.get(a) ?? 0;
+      const bPending = pendingByHarness.get(b) ?? 0;
+      const aScore = (aInstall?.active ? 3 : aInstall !== void 0 ? 2 : props.observedHarnesses.includes(a) ? 1 : 0) + (aPending > 0 ? 4 : 0);
+      const bScore = (bInstall?.active ? 3 : bInstall !== void 0 ? 2 : props.observedHarnesses.includes(b) ? 1 : 0) + (bPending > 0 ? 4 : 0);
+      return bScore - aScore;
+    });
+  }, [props.managedInstalls, props.observedHarnesses, pendingByHarness]);
+  const [focusedIndex, setFocusedIndex] = reactExports.useState(-1);
+  const listRef = reactExports.useRef(null);
+  const handleKeyDown = reactExports.useCallback(
+    (e, index) => {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        const next = Math.min(index + 1, sortedHarnesses.length - 1);
+        setFocusedIndex(next);
+        const nextBtn = listRef.current?.querySelectorAll("button[data-app-item]")[next];
+        nextBtn?.focus();
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        const prev = Math.max(index - 1, 0);
+        setFocusedIndex(prev);
+        const prevBtn = listRef.current?.querySelectorAll("button[data-app-item]")[prev];
+        prevBtn?.focus();
+      } else if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        props.onOpenAppDetail(sortedHarnesses[index]);
+      }
+    },
+    [sortedHarnesses, props.onOpenAppDetail]
+  );
+  if (sortedHarnesses.length === 0) {
+    return /* @__PURE__ */ jsxRuntimeExports.jsx(
+      EmptyState,
+      {
+        title: "No apps connected yet",
+        body: "Connect an AI app so Guard can start protecting it. Guard works with Codex, Claude Code, Cursor, Hermes, OpenClaw, and more.",
+        tone: "teach"
+      }
+    );
+  }
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mb-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Apps at a glance" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-500", children: "Guard is watching these apps on this machine." })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { ref: listRef, className: "divide-y divide-slate-100 border-t border-slate-100", role: "list", "aria-label": "Apps at a glance", children: sortedHarnesses.map((harness, index) => {
+      const install = props.managedInstalls.find((i) => i.harness === harness);
+      const isObserved = props.observedHarnesses.includes(harness);
+      const pending = pendingByHarness.get(harness) ?? 0;
+      return /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        "button",
+        {
+          "data-app-item": true,
+          onClick: () => props.onOpenAppDetail(harness),
+          onKeyDown: (e) => handleKeyDown(e, index),
+          onFocus: () => setFocusedIndex(index),
+          onBlur: () => setFocusedIndex(-1),
+          className: `flex w-full items-center justify-between gap-3 py-2.5 text-left transition-colors hover:bg-slate-50/60 ${focusedIndex === index ? "bg-brand-blue/[0.04]" : ""}`,
+          role: "listitem",
+          children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 items-center gap-2.5", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx(AppStatusIcon, { install, isObserved }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "truncate text-sm font-medium text-brand-dark", children: harnessDisplayName(harness) })
+            ] }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2", children: [
+              pending > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs(Badge, { tone: "info", children: [
+                pending,
+                " pending"
+              ] }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx(AppStatusBadge, { install, isObserved }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronRight, { className: "h-4 w-4 shrink-0 text-slate-300", "aria-hidden": "true" })
+            ] })
+          ]
+        },
+        harness
+      );
+    }) })
+  ] });
+}
+function AppStatusIcon(props) {
+  if (props.install?.active === true) {
+    return /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-4 w-4 shrink-0 text-brand-green", "aria-hidden": "true" });
+  }
+  if (props.install !== void 0 && !props.install.active) {
+    return /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniMinusCircle, { className: "h-4 w-4 shrink-0 text-brand-attention", "aria-hidden": "true" });
+  }
+  if (props.isObserved) {
+    return /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniMinusCircle, { className: "h-4 w-4 shrink-0 text-slate-400", "aria-hidden": "true" });
+  }
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniMinusCircle, { className: "h-4 w-4 shrink-0 text-slate-300", "aria-hidden": "true" });
+}
+function AppStatusBadge(props) {
+  if (props.install?.active === true) {
+    return /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "success", children: "Active" });
+  }
+  if (props.install !== void 0 && !props.install.active) {
+    return /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "attention", children: "Needs setup" });
+  }
+  if (props.isObserved) {
+    return /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "default", children: "Observed" });
+  }
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "default", children: "Unknown" });
+}
+function ClearHarnessButton(props) {
+  const handleClick = reactExports.useCallback(() => {
+    void props.onClearPolicies({ harness: props.harness });
+  }, [props.onClearPolicies, props.harness]);
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { variant: "outline", onClick: handleClick, children: [
+    "Clear ",
+    props.harness
+  ] });
+}
+function RecentReceiptRow(props) {
+  const { receipt } = props;
+  const decisionLabel = receipt.policy_decision === "allow" ? "allowed" : "blocked";
+  const name = receipt.artifact_name ?? receipt.artifact_id;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start justify-between gap-3 border-b border-slate-200/70 px-4 py-3 last:border-b-0", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "min-w-0", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-sm text-brand-dark", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-medium", children: harnessDisplayName(receipt.harness) }),
+      " ",
+      decisionLabel,
+      " ",
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-mono text-xs", children: name })
+    ] }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "shrink-0 text-[11px] text-muted-foreground", children: formatRelativeTime(receipt.timestamp) })
+  ] });
+}
+function RecentProtectionSection(props) {
+  const recent = props.receipts.slice(0, 3);
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "rounded-2xl border border-slate-200/70 bg-white/80 p-5 shadow-sm sm:p-6", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Recent protection" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-muted-foreground", children: "What Guard stopped or allowed recently." }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 overflow-hidden rounded-xl border border-slate-200/70", children: recent.map((receipt) => /* @__PURE__ */ jsxRuntimeExports.jsx(RecentReceiptRow, { receipt }, receipt.receipt_id)) })
+  ] });
+}
+const MILESTONE_STREAKS = [7, 14, 30];
+function StreakMilestoneBanner({ streak }) {
+  const milestone = MILESTONE_STREAKS.includes(streak) ? streak : null;
+  const storageKey = milestone ? `guard-streak-milestone-dismissed-${milestone}` : "";
+  const [dismissed, setDismissed] = reactExports.useState(() => {
+    if (typeof window === "undefined" || !storageKey) return true;
+    return localStorage.getItem(storageKey) === "1";
+  });
+  const handleDismiss = reactExports.useCallback(() => {
+    setDismissed(true);
+    if (storageKey) localStorage.setItem(storageKey, "1");
+  }, [storageKey]);
+  if (!milestone || dismissed) return null;
+  const messages = {
+    7: "One week of consistent protection! Guard is watching out for you every day.",
+    14: "Two weeks strong! Your security routine is paying off.",
+    30: "A full month of daily protection! You are building a great security habit."
+  };
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "guard-fade-in relative overflow-hidden rounded-2xl border border-brand-purple/20 bg-brand-purple/[0.04] p-5 shadow-sm sm:p-6", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "absolute -right-6 -top-6 h-24 w-24 rounded-full bg-brand-purple/10" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "relative flex items-start gap-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-brand-purple/10", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniSparkles, { className: "h-5 w-5 text-brand-purple", "aria-hidden": "true" }) }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex-1", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs(SectionLabel, { children: [
+          streak,
+          " day streak!"
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-muted-foreground", children: messages[milestone] })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "button",
+        {
+          onClick: handleDismiss,
+          className: "shrink-0 rounded-full p-1.5 text-muted-foreground transition-colors hover:bg-white/70 hover:text-brand-dark",
+          "aria-label": "Dismiss streak celebration",
+          children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniXMark, { className: "h-4 w-4", "aria-hidden": "true" })
+        }
+      )
+    ] })
+  ] });
+}
+function CollapsibleCard(props) {
+  const storageKey = `guard-collapsed-${props.id}`;
+  const [isOpen, setIsOpen] = reactExports.useState(() => {
+    if (typeof window === "undefined") return props.defaultOpen ?? true;
+    const saved = localStorage.getItem(storageKey);
+    return saved === null ? props.defaultOpen ?? true : saved === "1";
+  });
+  const toggle = reactExports.useCallback(() => {
+    setIsOpen((prev) => {
+      const next = !prev;
+      localStorage.setItem(storageKey, next ? "1" : "0");
+      return next;
+    });
+  }, [storageKey]);
+  const borderClass = props.id === "daily-brief" ? "border-brand-green/15 bg-brand-green/[0.04]" : "border-brand-purple/15 bg-brand-purple/[0.04]";
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `rounded-2xl border ${borderClass} p-5 shadow-sm sm:p-6`, children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs(
+      "button",
+      {
+        onClick: toggle,
+        className: "flex w-full items-center gap-3 text-left",
+        "aria-expanded": isOpen,
+        "aria-controls": `collapsible-content-${props.id}`,
+        children: [
+          props.icon,
+          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex-1", children: /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: props.label }) }),
+          isOpen ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronUp, { className: "h-4 w-4 shrink-0 text-muted-foreground", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronDown, { className: "h-4 w-4 shrink-0 text-muted-foreground", "aria-hidden": "true" })
+        ]
+      }
+    ),
+    isOpen && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: `collapsible-content-${props.id}`, className: "mt-3 guard-fade-in", children: props.children })
+  ] });
+}
+export {
+  HomeWorkspace
+};

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/settings-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/settings-workspace.js
@@ -1,0 +1,598 @@
+import { r as reactExports, s as fetchSettings, t as fetchRuntimeSnapshot, u as updateSettings, v as clearPolicy, w as clearEvidence, x as exportDiagnostics, y as repairApprovalCenter, j as jsxRuntimeExports, E as EmptyState, G as GuardHero, T as Tag, c as HiMiniShieldCheck, S as SectionLabel, z as HiMiniLockClosed, C as HiMiniCog6Tooth, H as HiMiniCheckCircle, A as ActionButton, m as HiMiniExclamationTriangle, k as HiMiniChevronUp, l as HiMiniChevronDown } from "../guard-dashboard.js";
+function resolveProtectionLevelCopy(level) {
+  if (level === "gentle") {
+    return "Monitors quietly, asks only for high-risk actions";
+  }
+  if (level === "balanced") {
+    return "Asks before secrets and destructive commands";
+  }
+  if (level === "strict") {
+    return "Asks more often, including new network";
+  }
+  if (level === "paranoid") {
+    return "Asks before nearly every action";
+  }
+  return "Custom rules active";
+}
+const resolveSecurityLevelDescription = resolveProtectionLevelCopy;
+function buildClearPolicyPayload(all) {
+  return { all };
+}
+const actionOptions = [
+  { value: "allow", label: "Allow" },
+  { value: "warn", label: "Warn" },
+  { value: "review", label: "Review" },
+  { value: "require-reapproval", label: "Ask again" },
+  { value: "sandbox-required", label: "Require sandbox" },
+  { value: "block", label: "Block" }
+];
+const surfacePolicyOptions = [
+  { value: "auto-open-once", label: "Open approval center once" },
+  { value: "approval-center", label: "Approval center only" },
+  { value: "native-only", label: "Harness prompt only" }
+];
+const securityLevels = [
+  {
+    value: "balanced",
+    label: "Balanced",
+    description: "Ask before secret access, hidden execution, exfiltration, and destructive actions.",
+    icon: HiMiniShieldCheck,
+    protects: ["Secret file access", "Credential sharing", "Destructive shell commands", "Hidden scripts"],
+    tone: "blue"
+  },
+  {
+    value: "strict",
+    label: "Strict",
+    description: "Ask more often, including new network destinations.",
+    icon: HiMiniLockClosed,
+    protects: ["Everything in Balanced", "New network destinations"],
+    tone: "purple"
+  },
+  {
+    value: "custom",
+    label: "Custom",
+    description: "Use the exact choices below for this machine and connected apps.",
+    icon: HiMiniCog6Tooth,
+    protects: [],
+    tone: "slate"
+  }
+];
+const riskControls = [
+  { key: "local_secret_read", label: "Local secrets", description: "Files such as .env, .npmrc, .netrc, SSH keys, and cloud credentials." },
+  { key: "credential_exfiltration", label: "Credential sharing", description: "Commands or scripts that appear to send keys, tokens, or credentials away." },
+  { key: "data_flow_exfiltration", label: "Secret data flow", description: "Detected source-to-sink route where a local secret is read and its value reaches a network or external sink." },
+  { key: "destructive_shell", label: "Destructive commands", description: "Shell actions that delete, overwrite, or rewrite local files." },
+  { key: "encoded_execution", label: "Hidden scripts", description: "Encoded, encrypted, or decoded-and-run command payloads." },
+  { key: "network_egress", label: "New network destinations", description: "Outbound connections Guard has not seen in this context." }
+];
+const riskProfileActions = {
+  balanced: {
+    local_secret_read: "require-reapproval",
+    credential_exfiltration: "require-reapproval",
+    data_flow_exfiltration: "require-reapproval",
+    destructive_shell: "require-reapproval",
+    encoded_execution: "require-reapproval",
+    network_egress: "warn"
+  },
+  strict: {
+    local_secret_read: "require-reapproval",
+    credential_exfiltration: "require-reapproval",
+    data_flow_exfiltration: "block",
+    destructive_shell: "require-reapproval",
+    encoded_execution: "require-reapproval",
+    network_egress: "require-reapproval"
+  },
+  custom: {
+    local_secret_read: "require-reapproval",
+    credential_exfiltration: "require-reapproval",
+    data_flow_exfiltration: "require-reapproval",
+    destructive_shell: "require-reapproval",
+    encoded_execution: "require-reapproval",
+    network_egress: "warn"
+  }
+};
+function normalizeSettingsPayload(payload) {
+  return { ...payload, settings: normalizeGuardSettings(payload.settings) };
+}
+function normalizeGuardSettings(settings) {
+  const defaults = riskProfileActions[settings.security_level];
+  const explicitOverrides = settings.risk_action_overrides ?? {};
+  const effectiveRiskActions = riskControls.reduce((actions, risk) => {
+    actions[risk.key] = settings.risk_actions?.[risk.key] ?? explicitOverrides[risk.key] ?? defaults[risk.key];
+    return actions;
+  }, {});
+  return {
+    ...settings,
+    risk_actions: effectiveRiskActions,
+    risk_action_overrides: explicitOverrides,
+    harness_risk_actions: settings.harness_risk_actions ?? {}
+  };
+}
+function buildConsequenceSummary(settings) {
+  const level = settings.security_level;
+  const mode = settings.mode;
+  if (mode === "observe") return "Guard is watching and recording what your AI apps do, but it will not pause any actions. Switch to Prompt or Enforce when you want Guard to actively protect you.";
+  if (level === "balanced") return "Guard will ask before secret access, hidden execution, and destructive commands. New network destinations get a warning. This is the recommended setting for most users.";
+  if (level === "strict") return "Guard will ask before almost every risky action, including new network destinations. Use this when working with sensitive data or untrusted AI tools.";
+  if (level === "custom") return "You have customized individual risk controls. Review the choices below to make sure they match how you want Guard to behave.";
+  return "";
+}
+function hasUnsavedChanges(saved, draft) {
+  if (saved === null || draft === null) return false;
+  return JSON.stringify(saved) !== JSON.stringify(draft);
+}
+function SettingsWorkspace() {
+  const [state, setState] = reactExports.useState({ kind: "loading" });
+  const [draft, setDraft] = reactExports.useState(null);
+  const [saving, setSaving] = reactExports.useState(false);
+  const [saveSuccess, setSaveSuccess] = reactExports.useState(false);
+  const [saveError, setSaveError] = reactExports.useState(null);
+  const [clearingApprovals, setClearingApprovals] = reactExports.useState(false);
+  const [clearingEvidence, setClearingEvidence] = reactExports.useState(false);
+  const [exporting, setExporting] = reactExports.useState(false);
+  const [repairing, setRepairing] = reactExports.useState(false);
+  const [actionMessage, setActionMessage] = reactExports.useState(null);
+  const [perfSnapshot, setPerfSnapshot] = reactExports.useState(null);
+  const [pendingMode, setPendingMode] = reactExports.useState(null);
+  const [expandedSections, setExpandedSections] = reactExports.useState({ "protection": true, "risk": false, "diagnostics": false });
+  const saveSuccessTimerRef = reactExports.useRef(null);
+  const savedSettingsRef = reactExports.useRef(null);
+  reactExports.useEffect(() => {
+    let cancelled = false;
+    fetchSettings().then((payload) => {
+      if (!cancelled) {
+        const normalizedPayload = normalizeSettingsPayload(payload);
+        setState({ kind: "ready", payload: normalizedPayload });
+        setDraft(normalizedPayload.settings);
+        savedSettingsRef.current = normalizedPayload.settings;
+      }
+    }).catch((error) => {
+      if (!cancelled) {
+        setState({ kind: "error", message: error instanceof Error ? error.message : "Unable to load Guard settings." });
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  reactExports.useEffect(() => {
+    let cancelled = false;
+    fetchRuntimeSnapshot().then((snapshot) => {
+      if (!cancelled) setPerfSnapshot(snapshot);
+    }).catch((error) => {
+      console.error("Failed to fetch runtime snapshot:", error);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  reactExports.useEffect(() => {
+    return () => {
+      if (saveSuccessTimerRef.current !== null) clearTimeout(saveSuccessTimerRef.current);
+    };
+  }, []);
+  reactExports.useEffect(() => {
+    function handleBeforeUnload(event) {
+      if (hasUnsavedChanges(savedSettingsRef.current, draft)) {
+        event.preventDefault();
+        event.returnValue = "";
+      }
+    }
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [draft]);
+  const toggleSection = reactExports.useCallback((key) => {
+    setExpandedSections((prev) => ({ ...prev, [key]: !prev[key] }));
+  }, []);
+  const handleStringChange = reactExports.useCallback(
+    (key) => (event) => {
+      setDraft((value) => value === null ? value : { ...value, [key]: event.target.value });
+      setSaveError(null);
+    },
+    []
+  );
+  const handleSecurityLevelChange = reactExports.useCallback((securityLevel) => {
+    setDraft((value) => {
+      if (value === null) return value;
+      if (securityLevel === "custom") return { ...value, security_level: securityLevel };
+      return { ...value, security_level: securityLevel, risk_actions: riskProfileActions[securityLevel], risk_action_overrides: {}, harness_risk_actions: {} };
+    });
+    setSaveError(null);
+  }, []);
+  const handleRiskActionChange = reactExports.useCallback(
+    (riskKey) => (event) => {
+      setDraft((value) => {
+        if (value === null) return value;
+        return { ...value, security_level: "custom", risk_actions: { ...value.risk_actions, [riskKey]: event.target.value }, risk_action_overrides: { ...value.risk_action_overrides, [riskKey]: event.target.value } };
+      });
+      setSaveError(null);
+    },
+    []
+  );
+  const handleCodexSecretReadChange = reactExports.useCallback((event) => {
+    setDraft((value) => {
+      if (value === null) return value;
+      return { ...value, security_level: "custom", harness_risk_actions: { ...value.harness_risk_actions, codex: { ...value.harness_risk_actions.codex ?? {}, local_secret_read: event.target.value } } };
+    });
+    setSaveError(null);
+  }, []);
+  const handleTimeoutChange = reactExports.useCallback((event) => {
+    const nextValue = Number.parseInt(event.target.value, 10);
+    setDraft((value) => value === null ? value : { ...value, approval_wait_timeout_seconds: Number.isNaN(nextValue) ? 0 : nextValue });
+    setSaveError(null);
+  }, []);
+  const handleModeChange = reactExports.useCallback((event) => {
+    const nextMode = event.target.value;
+    if (nextMode === "observe") {
+      setPendingMode(nextMode);
+      return;
+    }
+    setDraft((value) => value === null ? value : { ...value, mode: nextMode });
+    setSaveError(null);
+  }, []);
+  const confirmModeChange = reactExports.useCallback(() => {
+    if (pendingMode === null) return;
+    setDraft((value) => value === null ? value : { ...value, mode: pendingMode });
+    setPendingMode(null);
+    setSaveError(null);
+  }, [pendingMode]);
+  const cancelModeChange = reactExports.useCallback(() => {
+    setPendingMode(null);
+  }, []);
+  const handleBooleanChange = reactExports.useCallback(
+    (key) => (event) => {
+      setDraft((value) => value === null ? value : { ...value, [key]: event.target.checked });
+      setSaveError(null);
+    },
+    []
+  );
+  const handleSave = reactExports.useCallback(async () => {
+    if (draft === null) return;
+    setSaving(true);
+    setSaveError(null);
+    setSaveSuccess(false);
+    try {
+      const payload = await updateSettings({ ...draft, risk_actions: draft.security_level === "custom" ? draft.risk_actions : draft.risk_action_overrides });
+      const normalizedPayload = normalizeSettingsPayload(payload);
+      setState({ kind: "ready", payload: normalizedPayload });
+      setDraft(normalizedPayload.settings);
+      savedSettingsRef.current = normalizedPayload.settings;
+      setSaveSuccess(true);
+      if (saveSuccessTimerRef.current !== null) clearTimeout(saveSuccessTimerRef.current);
+      saveSuccessTimerRef.current = setTimeout(() => setSaveSuccess(false), 2e3);
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : "Unable to save settings.");
+    } finally {
+      setSaving(false);
+    }
+  }, [draft]);
+  const handleClearApprovals = reactExports.useCallback(async () => {
+    if (!window.confirm("Clear all saved approvals? Guard will ask again for previously approved actions.")) return;
+    setClearingApprovals(true);
+    setActionMessage(null);
+    try {
+      await clearPolicy({ all: true });
+      setActionMessage("All saved approvals cleared.");
+    } catch (error) {
+      setActionMessage(error instanceof Error ? error.message : "Unable to clear approvals.");
+    } finally {
+      setClearingApprovals(false);
+    }
+  }, []);
+  const handleClearEvidence = reactExports.useCallback(async () => {
+    if (!window.confirm("Clear the evidence log permanently? This cannot be undone.")) return;
+    setClearingEvidence(true);
+    setActionMessage(null);
+    try {
+      await clearEvidence();
+      setActionMessage("Evidence log cleared.");
+    } catch (error) {
+      setActionMessage(error instanceof Error ? error.message : "Unable to clear evidence.");
+    } finally {
+      setClearingEvidence(false);
+    }
+  }, []);
+  const handleExportDiagnostics = reactExports.useCallback(async () => {
+    setExporting(true);
+    setActionMessage(null);
+    try {
+      const blob = await exportDiagnostics();
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = `guard-diagnostics-${Date.now()}.json`;
+      anchor.click();
+      URL.revokeObjectURL(url);
+      setActionMessage("Diagnostics exported.");
+    } catch (error) {
+      setActionMessage(error instanceof Error ? error.message : "Unable to export diagnostics.");
+    } finally {
+      setExporting(false);
+    }
+  }, []);
+  const handleRepairApprovalCenter = reactExports.useCallback(async () => {
+    if (!window.confirm("Reset the approval center locator? The daemon will be reachable again after Guard restarts. Pending approvals are preserved.")) return;
+    setRepairing(true);
+    setActionMessage(null);
+    try {
+      await repairApprovalCenter();
+      setActionMessage("Approval center repaired. Restart Guard to reconnect.");
+    } catch (error) {
+      setActionMessage(error instanceof Error ? error.message : "Unable to repair approval center.");
+    } finally {
+      setRepairing(false);
+    }
+  }, []);
+  if (state.kind === "loading") {
+    return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-skeleton h-10 w-64" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-skeleton h-72 w-full" })
+    ] });
+  }
+  if (state.kind === "error" || draft === null) {
+    return /* @__PURE__ */ jsxRuntimeExports.jsx(EmptyState, { title: "Settings are unavailable", body: state.kind === "error" ? state.message : "Guard did not return editable settings.", tone: "teach" });
+  }
+  const modeHelp = draft.mode === "enforce" ? "Guard blocks risky actions until a saved decision allows them." : draft.mode === "observe" ? "Guard records what it sees without pausing actions." : "Guard asks before risky actions continue.";
+  const consequenceSummary = buildConsequenceSummary(draft);
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      GuardHero,
+      {
+        status: "clear",
+        headline: "Choose how protective Guard should be",
+        subheadline: "Start with a simple security level, then tune exact risk types when a trusted app needs more room to work.",
+        cta: /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: "blue", children: draft.mode })
+      }
+    ),
+    consequenceSummary && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-xl border border-brand-blue/10 bg-brand-blue/[0.03] p-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-blue" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "What to expect" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-500", children: consequenceSummary })
+      ] })
+    ] }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        AccordionSection,
+        {
+          title: "Protection level",
+          subtitle: `${draft.security_level === "balanced" ? "Balanced" : draft.security_level === "strict" ? "Strict" : "Custom"} · ${draft.mode}`,
+          expanded: expandedSections["protection"],
+          onToggle: () => toggleSection("protection"),
+          children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "grid gap-3 md:grid-cols-3", children: securityLevels.map((level) => {
+              const LevelIcon = level.icon;
+              const isSelected = draft.security_level === level.value;
+              const iconColorClass = level.tone === "blue" ? "text-brand-blue" : level.tone === "purple" ? "text-brand-purple" : "text-slate-500";
+              const iconBgClass = level.tone === "blue" ? "bg-brand-blue/10" : level.tone === "purple" ? "bg-brand-purple/10" : "bg-slate-100";
+              const selectedBorderClass = level.tone === "blue" ? "border-brand-blue/30 bg-brand-blue/[0.05]" : level.tone === "purple" ? "border-brand-purple/30 bg-brand-purple/[0.04]" : "border-slate-300 bg-slate-50";
+              return /* @__PURE__ */ jsxRuntimeExports.jsxs(
+                "button",
+                {
+                  type: "button",
+                  onClick: () => handleSecurityLevelChange(level.value),
+                  "aria-pressed": isSelected,
+                  className: `relative rounded-xl border p-4 text-left transition-all duration-150 hover:-translate-y-0.5 ${isSelected ? selectedBorderClass : "border-transparent bg-slate-50/80 hover:bg-white"}`,
+                  children: [
+                    isSelected && /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "absolute right-3 top-3 flex h-5 w-5 items-center justify-center rounded-full bg-[#059669]", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-3.5 w-3.5 text-white", "aria-hidden": "true" }) }),
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `inline-flex h-8 w-8 items-center justify-center rounded-lg ${iconBgClass}`, children: /* @__PURE__ */ jsxRuntimeExports.jsx(LevelIcon, { className: `h-4 w-4 ${iconColorClass}`, "aria-hidden": "true" }) }),
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mt-2 block text-sm font-semibold text-brand-dark", children: level.label }),
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mt-1 block text-xs leading-relaxed text-slate-500", children: level.description }),
+                    level.protects.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx("ul", { className: "mt-2 space-y-0.5", children: level.protects.map((item) => /* @__PURE__ */ jsxRuntimeExports.jsxs("li", { className: "flex items-center gap-1.5 text-[11px] text-slate-500", children: [
+                      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `h-1 w-1 shrink-0 rounded-full ${iconColorClass}` }),
+                      item
+                    ] }, item)) })
+                  ]
+                },
+                level.value
+              );
+            }) }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Protection mode" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-2 grid gap-2 sm:grid-cols-3", children: ["prompt", "enforce", "observe"].map((mode) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
+                "label",
+                {
+                  className: `cursor-pointer rounded-lg border p-3 transition-all ${draft.mode === mode ? "border-brand-blue/25 bg-brand-blue/[0.04]" : "border-transparent bg-slate-50/80 hover:bg-white"}`,
+                  children: [
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("input", { type: "radio", name: "mode", value: mode, checked: draft.mode === mode, onChange: handleModeChange, className: "sr-only" }),
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-semibold capitalize text-brand-dark", children: mode })
+                  ]
+                },
+                mode
+              )) }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-slate-500", children: modeHelp })
+            ] }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 sm:grid-cols-2", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("label", { htmlFor: "approval-wait", className: "block text-sm font-semibold text-brand-dark", children: "Approval wait timeout" }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Seconds to wait before returning to the harness" }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx("input", { id: "approval-wait", type: "number", min: 0, max: 600, value: draft.approval_wait_timeout_seconds, onChange: handleTimeoutChange, className: "mt-2 min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-1 focus:ring-brand-blue/20" })
+              ] }),
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2", children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx(SettingToggle, { label: "Telemetry", checked: draft.telemetry, onChange: handleBooleanChange("telemetry") }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx(SettingToggle, { label: "Cloud sync", checked: draft.sync, onChange: handleBooleanChange("sync") }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx(SettingToggle, { label: "Billing features", checked: draft.billing, onChange: handleBooleanChange("billing") })
+              ] })
+            ] })
+          ] })
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        AccordionSection,
+        {
+          title: "Risk choices",
+          subtitle: draft.security_level !== "custom" ? `Managed by ${draft.security_level}` : "Custom overrides active",
+          expanded: expandedSections["risk"],
+          onToggle: () => toggleSection("risk"),
+          children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
+            draft.security_level !== "custom" && /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-sm text-slate-500", children: [
+              "All risk behaviors are set by the ",
+              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-semibold", children: draft.security_level === "balanced" ? "Balanced" : "Strict" }),
+              " level. Select ",
+              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-semibold", children: "Custom" }),
+              " above to override individual choices."
+            ] }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: `divide-y divide-slate-100 border-t border-slate-100 ${draft.security_level !== "custom" ? "opacity-60" : ""}`, children: riskControls.map((risk) => /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-2 py-3 md:grid-cols-[minmax(0,1fr)_200px] md:items-center", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: risk.label }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: risk.description })
+              ] }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx(SettingSelect, { label: "Guard should", value: draft.risk_actions[risk.key] ?? "require-reapproval", options: actionOptions, onChange: handleRiskActionChange(risk.key), disabled: draft.security_level !== "custom" })
+            ] }, risk.key)) }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `grid gap-2 py-3 md:grid-cols-[minmax(0,1fr)_200px] md:items-center border-t border-slate-100 ${draft.security_level !== "custom" ? "opacity-60" : ""}`, children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: "Codex reading local secret files" }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Use this only for trusted projects where Codex should be allowed to open files such as .env or .npmrc." })
+              ] }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx(SettingSelect, { label: "Codex should", value: draft.harness_risk_actions.codex?.local_secret_read ?? draft.risk_actions.local_secret_read ?? "require-reapproval", options: actionOptions, onChange: handleCodexSecretReadChange, disabled: draft.security_level !== "custom" })
+            ] }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "border-t border-slate-100 pt-3", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Advanced defaults" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-2 grid gap-3 sm:grid-cols-2", children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx(SettingSelect, { label: "New action", value: draft.default_action, options: actionOptions, onChange: handleStringChange("default_action") }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx(SettingSelect, { label: "Unknown source", value: draft.unknown_publisher_action, options: actionOptions, onChange: handleStringChange("unknown_publisher_action") }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx(SettingSelect, { label: "Changed command", value: draft.changed_hash_action, options: actionOptions, onChange: handleStringChange("changed_hash_action") }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx(SettingSelect, { label: "New network domain", value: draft.new_network_domain_action, options: actionOptions, onChange: handleStringChange("new_network_domain_action") }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx(SettingSelect, { label: "Subprocess action", value: draft.subprocess_action, options: actionOptions, onChange: handleStringChange("subprocess_action") }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx(SettingSelect, { label: "Approval surface", value: draft.approval_surface_policy, options: surfacePolicyOptions, onChange: handleStringChange("approval_surface_policy") })
+              ] })
+            ] })
+          ] })
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        AccordionSection,
+        {
+          title: "Diagnostics & data",
+          subtitle: "Clear approvals, export logs, repair",
+          expanded: expandedSections["diagnostics"],
+          onToggle: () => toggleSection("diagnostics"),
+          children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
+            perfSnapshot !== null && /* @__PURE__ */ jsxRuntimeExports.jsx(DiagnosticsPerfCard, { snapshot: perfSnapshot }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 sm:grid-cols-2", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-3", children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: "Clear saved approvals" }),
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Removes all stored allow/block decisions. Guard will ask again for previously approved actions." }),
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleClearApprovals, disabled: clearingApprovals, variant: "outline", children: clearingApprovals ? "Clearing…" : "Clear approvals" }) })
+                ] }),
+                /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: "Clear evidence log" }),
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Permanently removes all recorded evidence. This cannot be undone." }),
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleClearEvidence, disabled: clearingEvidence, variant: "outline", children: clearingEvidence ? "Clearing…" : "Clear evidence" }) })
+                ] })
+              ] }),
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-3", children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: "Export diagnostics" }),
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Downloads a JSON file with local Guard evidence for debugging or support." }),
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleExportDiagnostics, disabled: exporting, variant: "secondary", children: exporting ? "Exporting…" : "Export" }) })
+                ] }),
+                /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: "Repair approval center" }),
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Resets the approval center locator when the approval link returns an API error." }),
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleRepairApprovalCenter, disabled: repairing, variant: "secondary", children: repairing ? "Repairing…" : "Repair" }) })
+                ] })
+              ] })
+            ] }),
+            actionMessage ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-600", children: actionMessage }) : null
+          ] })
+        }
+      )
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "sticky bottom-4 rounded-xl border border-slate-200 bg-white/95 p-4 shadow-lg backdrop-blur", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center justify-between gap-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleSave, disabled: saving || saveSuccess, children: saveSuccess ? /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "flex items-center gap-2", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-4 w-4", "aria-hidden": "true" }),
+          "Saved"
+        ] }) : saving ? "Saving…" : "Save settings" }),
+        hasUnsavedChanges(savedSettingsRef.current, draft) && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "ml-3 inline-flex items-center gap-1.5 text-xs font-medium text-brand-attention", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-1.5 w-1.5 rounded-full bg-brand-attention" }),
+          "Unsaved changes"
+        ] })
+      ] }),
+      saveSuccess ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-emerald-600", children: "Settings saved" }) : saveError ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-purple", children: saveError }) : /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Use this for local tuning. Team policy from Guard Cloud may still override some decisions." })
+    ] }) }),
+    pendingMode === "observe" && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-fade-in fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4 backdrop-blur-sm", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "w-full max-w-sm rounded-2xl border border-brand-attention/15 bg-white p-6 shadow-xl", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-brand-attention/10", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "h-5 w-5 text-brand-attention", "aria-hidden": "true" }) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "text-base font-semibold text-brand-dark", children: "Switch to Observe mode?" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-slate-500", children: "In Observe mode, Guard records what your AI apps do but does not pause any actions. This reduces your protection. Only use this when debugging or in trusted environments." })
+        ] })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-6 flex flex-wrap gap-2", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("button", { onClick: confirmModeChange, className: "inline-flex min-h-11 items-center rounded-lg bg-brand-attention px-4 text-sm font-semibold text-white transition-colors hover:bg-brand-attention/90", children: "Switch to Observe" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("button", { onClick: cancelModeChange, className: "inline-flex min-h-11 items-center rounded-lg border border-slate-200 bg-white px-4 text-sm font-medium text-brand-dark transition-colors hover:bg-slate-50", children: "Keep current mode" })
+      ] })
+    ] }) })
+  ] });
+}
+function AccordionSection(props) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 overflow-hidden", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs(
+      "button",
+      {
+        onClick: props.onToggle,
+        className: "flex w-full items-center justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-slate-50/60",
+        "aria-expanded": props.expanded,
+        children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: props.title }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-400", children: props.subtitle })
+          ] }),
+          props.expanded ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronUp, { className: "h-4 w-4 text-slate-400", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronDown, { className: "h-4 w-4 text-slate-400", "aria-hidden": "true" })
+        ]
+      }
+    ),
+    props.expanded && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "border-t border-slate-100 px-4 py-4", children: props.children })
+  ] });
+}
+function DiagnosticsPerfCard(props) {
+  const threadCount = props.snapshot.thread_count;
+  const daemonPort = props.snapshot.runtime_state?.daemon_port ?? null;
+  const startedAt = props.snapshot.runtime_state?.started_at ?? null;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-lg bg-slate-50/80 px-3 py-2", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold text-brand-dark", children: "Runtime" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-slate-500", children: [
+      threadCount !== void 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
+        threadCount,
+        " threads"
+      ] }),
+      daemonPort !== null && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
+        "Port ",
+        daemonPort
+      ] }),
+      startedAt !== null && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
+        "Started ",
+        new Date(startedAt).toLocaleTimeString()
+      ] })
+    ] })
+  ] });
+}
+function SettingSelect(props) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs font-medium text-slate-500", children: props.label }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "select",
+      {
+        value: props.value,
+        onChange: props.onChange,
+        disabled: props.disabled,
+        className: "mt-1 min-h-9 w-full rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-1 focus:ring-brand-blue/20 disabled:cursor-not-allowed disabled:opacity-60",
+        children: props.options.map((option) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: option.value, children: option.label }, option.value))
+      }
+    )
+  ] });
+}
+function SettingToggle(props) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "flex min-h-10 cursor-pointer items-center justify-between gap-3 rounded-lg border border-slate-100 bg-slate-50/60 px-3 py-2 transition-colors hover:bg-slate-100/60", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm text-brand-dark", children: props.label }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("input", { type: "checkbox", checked: props.checked, onChange: props.onChange, className: "h-4 w-4 accent-brand-blue" })
+  ] });
+}
+export {
+  SettingsWorkspace,
+  buildClearPolicyPayload,
+  resolveSecurityLevelDescription
+};

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/use-focus-trap.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/use-focus-trap.js
@@ -1,0 +1,58 @@
+import { r as reactExports } from "../guard-dashboard.js";
+function getFocusableElements(container) {
+  const selector = [
+    "button:not([disabled])",
+    "a[href]",
+    "input:not([disabled])",
+    "select:not([disabled])",
+    "textarea:not([disabled])",
+    '[tabindex]:not([tabindex="-1"])',
+    "[contenteditable]"
+  ].join(",");
+  return Array.from(container.querySelectorAll(selector)).filter(
+    (el) => el instanceof HTMLElement && el.offsetParent !== null
+  );
+}
+function useFocusTrap(active, containerRef) {
+  const previouslyFocusedRef = reactExports.useRef(null);
+  reactExports.useEffect(() => {
+    if (!active) return;
+    const container = containerRef.current;
+    if (!container) return;
+    previouslyFocusedRef.current = document.activeElement;
+    const focusable = getFocusableElements(container);
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (first) {
+      first.focus();
+    }
+    function handleKeyDown(event) {
+      if (event.key !== "Tab") return;
+      if (focusable.length === 0) {
+        event.preventDefault();
+        return;
+      }
+      if (event.shiftKey) {
+        if (document.activeElement === first) {
+          event.preventDefault();
+          last?.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          event.preventDefault();
+          first?.focus();
+        }
+      }
+    }
+    container.addEventListener("keydown", handleKeyDown);
+    return () => {
+      container.removeEventListener("keydown", handleKeyDown);
+      if (previouslyFocusedRef.current && previouslyFocusedRef.current.isConnected) {
+        previouslyFocusedRef.current.focus();
+      }
+    };
+  }, [active, containerRef]);
+}
+export {
+  useFocusTrap as u
+};

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -15711,7 +15711,7 @@ function resolveQueueCategoryId(item) {
   const envelope = item.action_envelope_json;
   const decisionCategories = item.decision_v2_json?.signals.map((signal) => signal.category) ?? [];
   const text = queueCategoryText(item);
-  if (decisionCategories.includes("network") || textIncludesAny(text, ["network host", "outbound", "webhook", "curl ", "https://", "http://"])) {
+  if (decisionCategories.includes("network") || textIncludesAny(text, ["network host", "outbound", "webhook", "https://", "http://"]) || /\bcurl\b/.test(text)) {
     if (textIncludesAny(text, ["secret", "credential", "token", "api key", "upload", "exfiltrat"])) {
       return "data_exfiltration";
     }
@@ -15792,9 +15792,12 @@ function commandLooksLikeFileEdit(command) {
   return /\bperl\b[\s\S]*\s-[\w-]*i\b/.test(normalized) || /\bsed\b[\s\S]*\s-[\w-]*i\b/.test(normalized) || /\bpython(?:3)?\b[\s\S]*(?:write_text|open\([^)]*,\s*['"]w|path\.write)/.test(normalized) || /\btee\s+-a?\b/.test(normalized) || /\bapply_patch\b/.test(normalized);
 }
 function sortQueue(items, direction) {
+  const categoryLabels = direction === "category" ? new Map(items.map((item) => [item.request_id, resolveQueueCategory(item).label])) : null;
   return [...items].sort((a, b) => {
-    if (direction === "category") {
-      const categoryDelta = resolveQueueCategory(a).label.localeCompare(resolveQueueCategory(b).label);
+    if (categoryLabels !== null) {
+      const categoryDelta = (categoryLabels.get(a.request_id) ?? "").localeCompare(
+        categoryLabels.get(b.request_id) ?? ""
+      );
       if (categoryDelta !== 0) {
         return categoryDelta;
       }
@@ -15821,18 +15824,25 @@ function searchQueue(items, term) {
   }
   return items.filter((item) => {
     const envelope = item.action_envelope_json;
+    const category = resolveQueueCategory(item);
     const parts = [
       item.artifact_name,
+      item.artifact_id,
       item.artifact_type,
       item.harness,
       item.policy_action,
+      item.risk_headline ?? "",
+      item.risk_summary ?? "",
+      item.trigger_summary ?? "",
+      item.launch_summary ?? "",
+      item.why_now ?? "",
       envelope?.command ?? "",
       envelope?.prompt_excerpt ?? "",
       envelope?.mcp_server ?? "",
       envelope?.mcp_tool ?? "",
       envelope?.package_name ?? "",
-      resolveQueueCategory(item).label,
-      resolveQueueCategory(item).shortLabel,
+      category.label,
+      category.shortLabel,
       ...envelope?.network_hosts ?? [],
       ...envelope?.target_paths ?? []
     ];
@@ -15879,8 +15889,7 @@ function ReviewWorkspace(props) {
   const [sortDirection, setSortDirection] = reactExports.useState("newest");
   const filteredRequests = reactExports.useMemo(() => {
     const byCategory = filterQueueByCategory(requests, categoryFilter);
-    const normalized = searchTerm.trim().toLowerCase();
-    const searched = normalized.length === 0 ? byCategory : byCategory.filter((item) => reviewItemSearchText(item).includes(normalized));
+    const searched = searchQueue(byCategory, searchTerm);
     return sortQueue(searched, sortDirection);
   }, [categoryFilter, requests, searchTerm, sortDirection]);
   const categoryOptions = reactExports.useMemo(() => queueCategoriesForItems(requests), [requests]);
@@ -16117,7 +16126,7 @@ function QueueItemRow({ item, active, index, onOpenRequest }) {
           ] }),
           isBlocked ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniNoSymbol, { className: "h-3.5 w-3.5 shrink-0 text-brand-attention", "aria-hidden": "true" }) : null
         ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-0.5 text-[11px] text-muted-foreground", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-0.5 truncate text-[11px] text-muted-foreground", children: [
           harnessDisplayName(item.harness),
           " · ",
           preview
@@ -16159,31 +16168,6 @@ function iconForQueueCategory(categoryId) {
     case "other":
       return HiMiniDocumentPlus;
   }
-}
-function reviewItemSearchText(item) {
-  const envelope = item.action_envelope_json;
-  const category = resolveQueueCategory(item);
-  return [
-    item.artifact_name,
-    item.artifact_id,
-    item.artifact_type,
-    item.harness,
-    item.policy_action,
-    item.risk_headline ?? "",
-    item.risk_summary ?? "",
-    item.trigger_summary ?? "",
-    item.launch_summary ?? "",
-    item.why_now ?? "",
-    category.label,
-    category.shortLabel,
-    envelope?.command ?? "",
-    envelope?.prompt_excerpt ?? "",
-    envelope?.mcp_server ?? "",
-    envelope?.mcp_tool ?? "",
-    envelope?.package_name ?? "",
-    ...envelope?.network_hosts ?? [],
-    ...envelope?.target_paths ?? []
-  ].join(" ").toLowerCase();
 }
 function queueItemPreview(item) {
   const envelope = item.action_envelope_json;

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -1,3 +1,4 @@
+const __vite__mapDeps=(i,m=__vite__mapDeps,d=(m.f||(m.f=["assets/chunks/home-dashboard.js","assets/chunks/use-focus-trap.js","assets/chunks/app-detail-workspace.js","assets/chunks/help-modal.js"])))=>i.map(i=>d[i]);
 (function polyfill() {
   const relList = document.createElement("link").relList;
   if (relList && relList.supports && relList.supports("modulepreload")) return;
@@ -11250,7 +11251,7 @@ function requireReactDomClient_production() {
     r: requestFormReset,
     D: prefetchDNS,
     C: preconnect,
-    L: preload,
+    L: preload2,
     m: preloadModule,
     X: preinitScript,
     S: preinitStyle,
@@ -11282,7 +11283,7 @@ function requireReactDomClient_production() {
     previousDispatcher.C(href, crossOrigin);
     preconnectAs("preconnect", href, crossOrigin);
   }
-  function preload(href, as, options2) {
+  function preload2(href, as, options2) {
     previousDispatcher.L(href, as, options2);
     var ownerDocument = globalDocument;
     if (ownerDocument && href && as) {
@@ -12482,6 +12483,60 @@ function requireClient() {
   return client.exports;
 }
 var clientExports = requireClient();
+const scriptRel = "modulepreload";
+const assetsURL = function(dep) {
+  return "/" + dep;
+};
+const seen = {};
+const __vitePreload = function preload(baseModule, deps, importerUrl) {
+  let promise = Promise.resolve();
+  if (deps && deps.length > 0) {
+    let allSettled = function(promises$2) {
+      return Promise.all(promises$2.map((p) => Promise.resolve(p).then((value$1) => ({
+        status: "fulfilled",
+        value: value$1
+      }), (reason) => ({
+        status: "rejected",
+        reason
+      }))));
+    };
+    document.getElementsByTagName("link");
+    const cspNonceMeta = document.querySelector("meta[property=csp-nonce]");
+    const cspNonce = cspNonceMeta?.nonce || cspNonceMeta?.getAttribute("nonce");
+    promise = allSettled(deps.map((dep) => {
+      dep = assetsURL(dep);
+      if (dep in seen) return;
+      seen[dep] = true;
+      const isCss = dep.endsWith(".css");
+      const cssSelector = isCss ? '[rel="stylesheet"]' : "";
+      if (document.querySelector(`link[href="${dep}"]${cssSelector}`)) return;
+      const link = document.createElement("link");
+      link.rel = isCss ? "stylesheet" : scriptRel;
+      if (!isCss) link.as = "script";
+      link.crossOrigin = "";
+      link.href = dep;
+      if (cspNonce) link.setAttribute("nonce", cspNonce);
+      document.head.appendChild(link);
+      if (isCss) return new Promise((res, rej) => {
+        link.addEventListener("load", res);
+        link.addEventListener("error", () => rej(/* @__PURE__ */ new Error(`Unable to preload CSS for ${dep}`)));
+      });
+    }));
+  }
+  function handlePreloadError(err$2) {
+    const e$1 = new Event("vite:preloadError", { cancelable: true });
+    e$1.payload = err$2;
+    window.dispatchEvent(e$1);
+    if (!e$1.defaultPrevented) throw err$2;
+  }
+  return promise.then((res) => {
+    for (const item of res || []) {
+      if (item.status !== "rejected") continue;
+      handlePreloadError(item.reason);
+    }
+    return baseModule().catch(handlePreloadError);
+  });
+};
 const GUARD_ACTION_TYPES = [
   "prompt",
   "shell_command",
@@ -13363,6 +13418,30 @@ function IconBase(props) {
 function HiBars3(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 24 24", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M3 6.75A.75.75 0 0 1 3.75 6h16.5a.75.75 0 0 1 0 1.5H3.75A.75.75 0 0 1 3 6.75ZM3 12a.75.75 0 0 1 .75-.75h16.5a.75.75 0 0 1 0 1.5H3.75A.75.75 0 0 1 3 12Zm0 5.25a.75.75 0 0 1 .75-.75h16.5a.75.75 0 0 1 0 1.5H3.75a.75.75 0 0 1-.75-.75Z", "clipRule": "evenodd" }, "child": [] }] })(props);
 }
+function HiOutlineShieldCheck(props) {
+  return GenIcon({ "attr": { "fill": "none", "viewBox": "0 0 24 24", "strokeWidth": "1.5", "stroke": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "strokeLinecap": "round", "strokeLinejoin": "round", "d": "M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z" }, "child": [] }] })(props);
+}
+function HiOutlineNoSymbol(props) {
+  return GenIcon({ "attr": { "fill": "none", "viewBox": "0 0 24 24", "strokeWidth": "1.5", "stroke": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "strokeLinecap": "round", "strokeLinejoin": "round", "d": "M18.364 18.364A9 9 0 0 0 5.636 5.636m12.728 12.728A9 9 0 0 1 5.636 5.636m12.728 12.728L5.636 5.636" }, "child": [] }] })(props);
+}
+function HiOutlineListBullet(props) {
+  return GenIcon({ "attr": { "fill": "none", "viewBox": "0 0 24 24", "strokeWidth": "1.5", "stroke": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "strokeLinecap": "round", "strokeLinejoin": "round", "d": "M8.25 6.75h12M8.25 12h12m-12 5.25h12M3.75 6.75h.007v.008H3.75V6.75Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0ZM3.75 12h.007v.008H3.75V12Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm-.375 5.25h.007v.008H3.75v-.008Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" }, "child": [] }] })(props);
+}
+function HiOutlineFire(props) {
+  return GenIcon({ "attr": { "fill": "none", "viewBox": "0 0 24 24", "strokeWidth": "1.5", "stroke": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "strokeLinecap": "round", "strokeLinejoin": "round", "d": "M15.362 5.214A8.252 8.252 0 0 1 12 21 8.25 8.25 0 0 1 6.038 7.047 8.287 8.287 0 0 0 9 9.601a8.983 8.983 0 0 1 3.361-6.867 8.21 8.21 0 0 0 3 2.48Z" }, "child": [] }, { "tag": "path", "attr": { "strokeLinecap": "round", "strokeLinejoin": "round", "d": "M12 18a3.75 3.75 0 0 0 .495-7.468 5.99 5.99 0 0 0-1.925 3.547 5.975 5.975 0 0 1-2.133-1.001A3.75 3.75 0 0 0 12 18Z" }, "child": [] }] })(props);
+}
+function HiOutlineCalendarDays(props) {
+  return GenIcon({ "attr": { "fill": "none", "viewBox": "0 0 24 24", "strokeWidth": "1.5", "stroke": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "strokeLinecap": "round", "strokeLinejoin": "round", "d": "M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5m-9-6h.008v.008H12v-.008ZM12 15h.008v.008H12V15Zm0 2.25h.008v.008H12v-.008ZM9.75 15h.008v.008H9.75V15Zm0 2.25h.008v.008H9.75v-.008ZM7.5 15h.008v.008H7.5V15Zm0 2.25h.008v.008H7.5v-.008Zm6.75-4.5h.008v.008h-.008v-.008Zm0 2.25h.008v.008h-.008V15Zm0 2.25h.008v.008h-.008v-.008Zm2.25-4.5h.008v.008H16.5v-.008Zm0 2.25h.008v.008H16.5V15Z" }, "child": [] }] })(props);
+}
+function HiOutlineArrowTrendingUp(props) {
+  return GenIcon({ "attr": { "fill": "none", "viewBox": "0 0 24 24", "strokeWidth": "1.5", "stroke": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "strokeLinecap": "round", "strokeLinejoin": "round", "d": "M2.25 18 9 11.25l4.306 4.306a11.95 11.95 0 0 1 5.814-5.518l2.74-1.22m0 0-5.94-2.281m5.94 2.28-2.28 5.941" }, "child": [] }] })(props);
+}
+function HiOutlineArrowTrendingDown(props) {
+  return GenIcon({ "attr": { "fill": "none", "viewBox": "0 0 24 24", "strokeWidth": "1.5", "stroke": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "strokeLinecap": "round", "strokeLinejoin": "round", "d": "M2.25 6 9 12.75l4.286-4.286a11.948 11.948 0 0 1 4.306 6.43l.776 2.898m0 0 3.182-5.511m-3.182 5.51-5.511-3.181" }, "child": [] }] })(props);
+}
+function HiOutlineArrowDownTray(props) {
+  return GenIcon({ "attr": { "fill": "none", "viewBox": "0 0 24 24", "strokeWidth": "1.5", "stroke": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "strokeLinecap": "round", "strokeLinejoin": "round", "d": "M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" }, "child": [] }] })(props);
+}
 function HiMiniXMark(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "d": "M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" }, "child": [] }] })(props);
 }
@@ -13384,6 +13463,9 @@ function HiMiniServerStack(props) {
 function HiMiniQuestionMarkCircle(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0ZM8.94 6.94a.75.75 0 1 1-1.061-1.061 3 3 0 1 1 2.871 5.026v.345a.75.75 0 0 1-1.5 0v-.5c0-.72.57-1.172 1.081-1.287A1.5 1.5 0 1 0 8.94 6.94ZM10 15a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z", "clipRule": "evenodd" }, "child": [] }] })(props);
 }
+function HiMiniPencilSquare(props) {
+  return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "d": "m5.433 13.917 1.262-3.155A4 4 0 0 1 7.58 9.42l6.92-6.918a2.121 2.121 0 0 1 3 3l-6.92 6.918c-.383.383-.84.685-1.343.886l-3.154 1.262a.5.5 0 0 1-.65-.65Z" }, "child": [] }, { "tag": "path", "attr": { "d": "M3.5 5.75c0-.69.56-1.25 1.25-1.25H10A.75.75 0 0 0 10 3H4.75A2.75 2.75 0 0 0 2 5.75v9.5A2.75 2.75 0 0 0 4.75 18h9.5A2.75 2.75 0 0 0 17 15.25V10a.75.75 0 0 0-1.5 0v5.25c0 .69-.56 1.25-1.25 1.25h-9.5c-.69 0-1.25-.56-1.25-1.25v-9.5Z" }, "child": [] }] })(props);
+}
 function HiMiniNoSymbol(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "m5.965 4.904 9.131 9.131a6.5 6.5 0 0 0-9.131-9.131Zm8.07 10.192L4.904 5.965a6.5 6.5 0 0 0 9.131 9.131ZM4.343 4.343a8 8 0 1 1 11.314 11.314A8 8 0 0 1 4.343 4.343Z", "clipRule": "evenodd" }, "child": [] }] })(props);
 }
@@ -13393,6 +13475,9 @@ function HiMiniMinusCircle(props) {
 function HiMiniLockClosed(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M10 1a4.5 4.5 0 0 0-4.5 4.5V9H5a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-6a2 2 0 0 0-2-2h-.5V5.5A4.5 4.5 0 0 0 10 1Zm3 8V5.5a3 3 0 1 0-6 0V9h6Z", "clipRule": "evenodd" }, "child": [] }] })(props);
 }
+function HiMiniKey(props) {
+  return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M8 7a5 5 0 1 1 3.61 4.804l-1.903 1.903A1 1 0 0 1 9 14H8v1a1 1 0 0 1-1 1H6v1a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-2a1 1 0 0 1 .293-.707L8.196 8.39A5.002 5.002 0 0 1 8 7Zm5-3a.75.75 0 0 0 0 1.5A1.5 1.5 0 0 1 14.5 7 .75.75 0 0 0 16 7a3 3 0 0 0-3-3Z", "clipRule": "evenodd" }, "child": [] }] })(props);
+}
 function HiMiniInformationCircle(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z", "clipRule": "evenodd" }, "child": [] }] })(props);
 }
@@ -13401,6 +13486,9 @@ function HiMiniInbox(props) {
 }
 function HiMiniHome(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M9.293 2.293a1 1 0 0 1 1.414 0l7 7A1 1 0 0 1 17 11h-1v6a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-3a1 1 0 0 0-1-1H9a1 1 0 0 0-1 1v3a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-6H3a1 1 0 0 1-.707-1.707l7-7Z", "clipRule": "evenodd" }, "child": [] }] })(props);
+}
+function HiMiniGlobeAlt(props) {
+  return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "d": "M16.555 5.412a8.028 8.028 0 0 0-3.503-2.81 14.899 14.899 0 0 1 1.663 4.472 8.547 8.547 0 0 0 1.84-1.662ZM13.326 7.825a13.43 13.43 0 0 0-2.413-5.773 8.087 8.087 0 0 0-1.826 0 13.43 13.43 0 0 0-2.413 5.773A8.473 8.473 0 0 0 10 8.5c1.18 0 2.304-.24 3.326-.675ZM6.514 9.376A9.98 9.98 0 0 0 10 10c1.226 0 2.4-.22 3.486-.624a13.54 13.54 0 0 1-.351 3.759A13.54 13.54 0 0 1 10 13.5c-1.079 0-2.128-.127-3.134-.366a13.538 13.538 0 0 1-.352-3.758ZM5.285 7.074a14.9 14.9 0 0 1 1.663-4.471 8.028 8.028 0 0 0-3.503 2.81c.529.638 1.149 1.199 1.84 1.66ZM17.334 6.798a7.973 7.973 0 0 1 .614 4.115 13.47 13.47 0 0 1-3.178 1.72 15.093 15.093 0 0 0 .174-3.939 10.043 10.043 0 0 0 2.39-1.896ZM2.666 6.798a10.042 10.042 0 0 0 2.39 1.896 15.196 15.196 0 0 0 .174 3.94 13.472 13.472 0 0 1-3.178-1.72 7.973 7.973 0 0 1 .615-4.115ZM10 15c.898 0 1.778-.079 2.633-.23a13.473 13.473 0 0 1-1.72 3.178 8.099 8.099 0 0 1-1.826 0 13.47 13.47 0 0 1-1.72-3.178c.855.151 1.735.23 2.633.23ZM14.357 14.357a14.912 14.912 0 0 1-1.305 3.04 8.027 8.027 0 0 0 4.345-4.345c-.953.542-1.971.981-3.04 1.305ZM6.948 17.397a8.027 8.027 0 0 1-4.345-4.345c.953.542 1.971.981 3.04 1.305a14.912 14.912 0 0 0 1.305 3.04Z" }, "child": [] }] })(props);
 }
 function HiMiniFire(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M13.5 4.938a7 7 0 1 1-9.006 1.737c.202-.257.59-.218.793.039.278.352.594.672.943.954.332.269.786-.049.773-.476a5.977 5.977 0 0 1 .572-2.759 6.026 6.026 0 0 1 2.486-2.665c.247-.14.55-.016.677.238A6.967 6.967 0 0 0 13.5 4.938ZM14 12a4 4 0 0 1-4 4c-1.913 0-3.52-1.398-3.91-3.182-.093-.429.44-.643.814-.413a4.043 4.043 0 0 0 1.601.564c.303.038.531-.24.51-.544a5.975 5.975 0 0 1 1.315-4.192.447.447 0 0 1 .431-.16A4.001 4.001 0 0 1 14 12Z", "clipRule": "evenodd" }, "child": [] }] })(props);
@@ -13414,11 +13502,23 @@ function HiMiniExclamationCircle(props) {
 function HiMiniDocumentText(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M4.5 2A1.5 1.5 0 0 0 3 3.5v13A1.5 1.5 0 0 0 4.5 18h11a1.5 1.5 0 0 0 1.5-1.5V7.621a1.5 1.5 0 0 0-.44-1.06l-4.12-4.122A1.5 1.5 0 0 0 11.378 2H4.5Zm2.25 8.5a.75.75 0 0 0 0 1.5h6.5a.75.75 0 0 0 0-1.5h-6.5Zm0 3a.75.75 0 0 0 0 1.5h6.5a.75.75 0 0 0 0-1.5h-6.5Z", "clipRule": "evenodd" }, "child": [] }] })(props);
 }
+function HiMiniDocumentPlus(props) {
+  return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M4.5 2A1.5 1.5 0 0 0 3 3.5v13A1.5 1.5 0 0 0 4.5 18h11a1.5 1.5 0 0 0 1.5-1.5V7.621a1.5 1.5 0 0 0-.44-1.06l-4.12-4.122A1.5 1.5 0 0 0 11.378 2H4.5ZM10 8a.75.75 0 0 1 .75.75v1.5h1.5a.75.75 0 0 1 0 1.5h-1.5v1.5a.75.75 0 0 1-1.5 0v-1.5h-1.5a.75.75 0 0 1 0-1.5h1.5v-1.5A.75.75 0 0 1 10 8Z", "clipRule": "evenodd" }, "child": [] }] })(props);
+}
+function HiMiniDocumentMagnifyingGlass(props) {
+  return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "d": "M8 10a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0Z" }, "child": [] }, { "tag": "path", "attr": { "fillRule": "evenodd", "d": "M4.5 2A1.5 1.5 0 0 0 3 3.5v13A1.5 1.5 0 0 0 4.5 18h11a1.5 1.5 0 0 0 1.5-1.5V7.621a1.5 1.5 0 0 0-.44-1.06l-4.12-4.122A1.5 1.5 0 0 0 11.378 2H4.5Zm5 5a3 3 0 1 0 1.524 5.585l1.196 1.195a.75.75 0 1 0 1.06-1.06l-1.195-1.196A3 3 0 0 0 9.5 7Z", "clipRule": "evenodd" }, "child": [] }] })(props);
+}
+function HiMiniCube(props) {
+  return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "d": "M10.362 1.093a.75.75 0 0 0-.724 0L2.523 5.018 10 9.143l7.477-4.125-7.115-3.925ZM18 6.443l-7.25 4v8.25l6.862-3.786A.75.75 0 0 0 18 14.25V6.443ZM9.25 18.693v-8.25l-7.25-4v7.807a.75.75 0 0 0 .388.657l6.862 3.786Z" }, "child": [] }] })(props);
+}
 function HiMiniCommandLine(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M3.25 3A2.25 2.25 0 0 0 1 5.25v9.5A2.25 2.25 0 0 0 3.25 17h13.5A2.25 2.25 0 0 0 19 14.75v-9.5A2.25 2.25 0 0 0 16.75 3H3.25Zm.943 8.752a.75.75 0 0 1 .055-1.06L6.128 9l-1.88-1.693a.75.75 0 1 1 1.004-1.114l2.5 2.25a.75.75 0 0 1 0 1.114l-2.5 2.25a.75.75 0 0 1-1.06-.055ZM9.75 10.25a.75.75 0 0 0 0 1.5h2.5a.75.75 0 0 0 0-1.5h-2.5Z", "clipRule": "evenodd" }, "child": [] }] })(props);
 }
 function HiMiniCog6Tooth(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M7.84 1.804A1 1 0 0 1 8.82 1h2.36a1 1 0 0 1 .98.804l.331 1.652a6.993 6.993 0 0 1 1.929 1.115l1.598-.54a1 1 0 0 1 1.186.447l1.18 2.044a1 1 0 0 1-.205 1.251l-1.267 1.113a7.047 7.047 0 0 1 0 2.228l1.267 1.113a1 1 0 0 1 .206 1.25l-1.18 2.045a1 1 0 0 1-1.187.447l-1.598-.54a6.993 6.993 0 0 1-1.929 1.115l-.33 1.652a1 1 0 0 1-.98.804H8.82a1 1 0 0 1-.98-.804l-.331-1.652a6.993 6.993 0 0 1-1.929-1.115l-1.598.54a1 1 0 0 1-1.186-.447l-1.18-2.044a1 1 0 0 1 .205-1.251l1.267-1.114a7.05 7.05 0 0 1 0-2.227L1.821 7.773a1 1 0 0 1-.206-1.25l1.18-2.045a1 1 0 0 1 1.187-.447l1.598.54A6.992 6.992 0 0 1 7.51 3.456l.33-1.652ZM10 13a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z", "clipRule": "evenodd" }, "child": [] }] })(props);
+}
+function HiMiniCodeBracket(props) {
+  return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M6.28 5.22a.75.75 0 0 1 0 1.06L2.56 10l3.72 3.72a.75.75 0 0 1-1.06 1.06L.97 10.53a.75.75 0 0 1 0-1.06l4.25-4.25a.75.75 0 0 1 1.06 0Zm7.44 0a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L17.44 10l-3.72-3.72a.75.75 0 0 1 0-1.06ZM11.377 2.011a.75.75 0 0 1 .612.867l-2.5 14.5a.75.75 0 0 1-1.478-.255l2.5-14.5a.75.75 0 0 1 .866-.612Z", "clipRule": "evenodd" }, "child": [] }] })(props);
 }
 function HiMiniCloud(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "d": "M1 12.5A4.5 4.5 0 0 0 5.5 17H15a4 4 0 0 0 1.866-7.539 3.504 3.504 0 0 0-4.504-4.272A4.5 4.5 0 0 0 4.06 8.235 4.502 4.502 0 0 0 1 12.5Z" }, "child": [] }] })(props);
@@ -13432,10 +13532,10 @@ function HiMiniClipboardDocumentCheck(props) {
 function HiMiniChevronUp(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M9.47 6.47a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 1 1-1.06 1.06L10 8.06l-3.72 3.72a.75.75 0 0 1-1.06-1.06l4.25-4.25Z", "clipRule": "evenodd" }, "child": [] }] })(props);
 }
-function HiMiniChevronRight(props) {
+function HiMiniChevronRight$1(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M8.22 5.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L11.94 10 8.22 6.28a.75.75 0 0 1 0-1.06Z", "clipRule": "evenodd" }, "child": [] }] })(props);
 }
-function HiMiniChevronLeft(props) {
+function HiMiniChevronLeft$1(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M11.78 5.22a.75.75 0 0 1 0 1.06L8.06 10l3.72 3.72a.75.75 0 1 1-1.06 1.06l-4.25-4.25a.75.75 0 0 1 0-1.06l4.25-4.25a.75.75 0 0 1 1.06 0Z", "clipRule": "evenodd" }, "child": [] }] })(props);
 }
 function HiMiniChevronDown(props) {
@@ -13726,6 +13826,11 @@ function harnessDisplayName(harness) {
 function displayArtifactName(item) {
   return item.artifact_name || item.artifact_id || "this action";
 }
+function formatNumber(n) {
+  if (n >= 1e6) return `${(n / 1e6).toFixed(1).replace(/\.0$/, "")}M`;
+  if (n >= 1e3) return `${(n / 1e3).toFixed(1).replace(/\.0$/, "")}K`;
+  return String(n);
+}
 function formatRelativeTime(timestamp) {
   try {
     const date = new Date(timestamp);
@@ -13826,13 +13931,36 @@ const sidebarLinks = [
   { href: "/settings", label: "Settings", view: "settings", icon: HiMiniAdjustmentsHorizontal }
 ];
 function ShellSidebar(props) {
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("aside", { className: "fixed inset-y-0 left-0 z-40 hidden w-64 flex-col border-r border-slate-200 bg-[#f8fafc] lg:flex", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex min-h-[72px] shrink-0 items-center border-b border-brand-blue/20 bg-gradient-to-r from-brand-blue to-brand-dark px-6", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("a", { href: guardAwareHref("/"), className: "flex items-center gap-2.5 text-white no-underline transition-opacity hover:opacity-85", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("img", { src: "/brand/Logo_Icon_Dark.png", alt: "HOL", className: "h-10 w-10 shrink-0 rounded-none bg-transparent object-contain" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-mono text-base font-semibold tracking-tight text-white", children: "HOL Guard" })
-    ] }) }),
+  const collapsed = props.collapsed ?? false;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("aside", { className: `fixed inset-y-0 left-0 z-40 hidden flex-col border-r border-slate-200 bg-[#f8fafc] transition-all duration-200 lg:flex ${collapsed ? "w-20" : "w-64"}`, children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-h-[72px] shrink-0 items-center border-b border-brand-blue/20 bg-gradient-to-r from-brand-blue to-brand-dark px-6", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("a", { href: guardAwareHref("/"), className: "flex items-center gap-2.5 text-white no-underline transition-opacity hover:opacity-85", title: "HOL Guard", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("img", { src: "/brand/Logo_Icon_Dark.png", alt: "HOL", className: "h-10 w-10 shrink-0 rounded-none bg-transparent object-contain" }),
+        !collapsed && /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-mono text-base font-semibold tracking-tight text-white", children: "HOL Guard" })
+      ] }),
+      !collapsed && /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "button",
+        {
+          onClick: props.onToggleCollapse,
+          className: "ml-auto rounded-md p-1 text-white/60 transition-colors hover:bg-white/10 hover:text-white",
+          "aria-label": "Collapse sidebar",
+          title: "Collapse sidebar",
+          children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronLeft, { className: "h-4 w-4", "aria-hidden": "true" })
+        }
+      ),
+      collapsed && /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "button",
+        {
+          onClick: props.onToggleCollapse,
+          className: "absolute -right-3 top-6 rounded-full border border-slate-200 bg-white p-1 text-slate-400 shadow-sm transition-colors hover:text-brand-dark",
+          "aria-label": "Expand sidebar",
+          title: "Expand sidebar",
+          children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronRight, { className: "h-3.5 w-3.5", "aria-hidden": "true" })
+        }
+      )
+    ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-1 flex-col overflow-y-auto px-3 py-5", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mb-2 px-3 font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-400", children: "Dashboard" }),
+      !collapsed && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mb-2 px-3 font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-400", children: "Dashboard" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("nav", { className: "flex flex-col gap-0.5", "aria-label": "Guard dashboard", children: sidebarLinks.map((item) => {
         const Icon = item.icon;
         return /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -13842,17 +13970,18 @@ function ShellSidebar(props) {
             active: props.view === item.view || props.view === "app-detail" && item.view === "fleet",
             icon: /* @__PURE__ */ jsxRuntimeExports.jsx(Icon, { className: "h-4 w-4" }),
             badgeCount: item.view === "inbox" ? props.queuedCount : 0,
+            collapsed,
             children: item.label
           },
           item.href
         );
       }) }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-6 space-y-2", children: [
+      !collapsed && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-6 space-y-2", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "px-3 font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-400", children: "Quick Actions" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx(SidebarAction, { href: "/", icon: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCommandLine, { className: "h-4 w-4", "aria-hidden": "true" }), children: "Local dashboard" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx(SidebarAction, { href: "https://hol.org/guard", external: true, icon: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCloud, { className: "h-4 w-4", "aria-hidden": "true" }), children: "Open Guard Cloud" })
       ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-auto pt-6", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mx-2 overflow-hidden rounded-xl border border-brand-blue/25 bg-gradient-to-br from-brand-blue/[0.05] to-brand-dark/[0.03]", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2 px-3 pb-2.5 pt-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-auto pt-6", children: !collapsed ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mx-2 overflow-hidden rounded-xl border border-brand-blue/25 bg-gradient-to-br from-brand-blue/[0.05] to-brand-dark/[0.03]", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2 px-3 pb-2.5 pt-3", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between gap-2", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-1.5", children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "h-3.5 w-3.5 text-brand-blue" }),
@@ -13862,7 +13991,7 @@ function ShellSidebar(props) {
         ] }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] leading-relaxed text-brand-dark/70", children: props.queuedCount > 0 ? `${props.queuedCount} local ${props.queuedCount === 1 ? "action needs" : "actions need"} a Guard decision.` : "No local approvals are waiting." }),
         props.activeHarness ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "inline-flex rounded-full bg-white/70 px-2 py-1 font-mono text-[10px] font-semibold text-slate-500", children: props.activeHarness }) : null
-      ] }) }) })
+      ] }) }) : /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex justify-center", children: /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `inline-flex h-5 min-w-5 items-center justify-center rounded-full text-[10px] font-bold ${props.queuedCount > 0 ? "bg-brand-blue/15 text-brand-blue" : "bg-slate-200 text-slate-400"}`, children: props.queuedCount > 0 ? props.queuedCount > 99 ? "99+" : props.queuedCount : "0" }) }) })
     ] })
   ] });
 }
@@ -13963,32 +14092,36 @@ function PaginationControls(props) {
   ] });
 }
 function SidebarLink(props) {
+  const collapsed = props.collapsed ?? false;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(
     "a",
     {
       href: guardAwareHref(props.href),
       "aria-current": props.active ? "page" : void 0,
-      className: `flex min-h-10 items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium no-underline transition-colors duration-150 ${props.active ? "bg-brand-blue/[0.05] font-semibold text-brand-dark" : "text-slate-600 hover:bg-slate-200/50 hover:text-slate-900"}`,
+      title: collapsed ? String(props.children) : void 0,
+      className: `flex min-h-10 items-center rounded-lg no-underline transition-colors duration-150 ${collapsed ? "justify-center px-2 py-2" : "gap-2.5 px-3 py-2 text-sm font-medium"} ${props.active ? "bg-brand-blue/[0.05] font-semibold text-brand-dark" : "text-slate-600 hover:bg-slate-200/50 hover:text-slate-900"}`,
       children: [
         props.icon ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `shrink-0 ${props.active ? "text-brand-blue" : "text-slate-400"}`, children: props.icon }) : null,
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "flex-1 truncate", children: props.children }),
-        props.badgeCount && props.badgeCount > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ml-auto inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-brand-blue/15 px-1.5 text-[10px] font-bold text-brand-blue", children: props.badgeCount > 99 ? "99+" : props.badgeCount }) : null
+        !collapsed && /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "flex-1 truncate", children: props.children }),
+        !collapsed && props.badgeCount && props.badgeCount > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ml-auto inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-brand-blue/15 px-1.5 text-[10px] font-bold text-brand-blue", children: props.badgeCount > 99 ? "99+" : props.badgeCount }) : null
       ]
     }
   );
 }
 function SidebarAction(props) {
+  const collapsed = props.collapsed ?? false;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(
     "a",
     {
       href: props.external ? props.href : guardAwareHref(props.href),
       target: props.external ? "_blank" : void 0,
       rel: props.external ? "noreferrer" : void 0,
-      className: "flex min-h-10 items-center gap-2.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 no-underline transition-colors duration-150 hover:border-brand-blue/30 hover:text-brand-dark",
+      title: collapsed ? String(props.children) : void 0,
+      className: `flex min-h-10 items-center rounded-lg border border-slate-200 bg-white no-underline transition-colors duration-150 hover:border-brand-blue/30 hover:text-brand-dark ${collapsed ? "justify-center px-2 py-2" : "gap-2.5 px-3 py-2 text-sm font-medium text-slate-700"}`,
       children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "shrink-0 text-slate-400", children: props.icon }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "flex-1 truncate", children: props.children }),
-        props.external ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowTopRightOnSquare, { className: "h-3.5 w-3.5 shrink-0 text-slate-300" }) : null
+        !collapsed && /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "flex-1 truncate", children: props.children }),
+        !collapsed && props.external ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowTopRightOnSquare, { className: "h-3.5 w-3.5 shrink-0 text-slate-300" }) : null
       ]
     }
   );
@@ -14212,6 +14345,621 @@ function DecodedLayerCard(props) {
     }
   );
 }
+function HistoryInsights({
+  receipts,
+  onFilterHarness,
+  onFilterDay
+}) {
+  const insights = reactExports.useMemo(() => {
+    return computeInsights(receipts);
+  }, [receipts]);
+  if (insights.length === 0) return null;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-3", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex items-center justify-between", children: /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "text-sm font-semibold text-brand-dark", children: "Insights" }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3", children: insights.map((insight) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+      InsightCardComponent,
+      {
+        insight,
+        onFilterHarness
+      },
+      insight.id
+    )) })
+  ] });
+}
+function InsightCardComponent({
+  insight,
+  onFilterHarness
+}) {
+  const toneClasses = {
+    blue: "bg-blue-50/60 border-blue-200/40 text-blue-700",
+    green: "bg-emerald-50/60 border-emerald-200/40 text-emerald-700",
+    purple: "bg-purple-50/60 border-purple-200/40 text-purple-700",
+    attention: "bg-amber-50/60 border-amber-200/40 text-amber-700"
+  };
+  const handleClick = reactExports.useCallback(() => {
+    if (insight.action && insight.action.href.startsWith("/apps/")) {
+      const harness = insight.action.href.slice("/apps/".length);
+      onFilterHarness?.(harness);
+    }
+  }, [insight.action, onFilterHarness]);
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(
+    "div",
+    {
+      className: `rounded-xl border p-3 transition-colors hover:bg-opacity-80 ${toneClasses[insight.tone]}`,
+      children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-2.5", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-0.5 shrink-0 opacity-70", children: insight.icon }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 flex-1", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs opacity-80", children: insight.label }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 text-sm font-semibold", children: insight.value }),
+          insight.action && /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "button",
+            {
+              onClick: handleClick,
+              className: "mt-1 text-xs underline opacity-70 transition-opacity hover:opacity-100",
+              children: insight.action.label
+            }
+          )
+        ] })
+      ] })
+    }
+  );
+}
+function computeInsights(receipts) {
+  const now2 = /* @__PURE__ */ new Date();
+  const weekAgo = new Date(now2);
+  weekAgo.setDate(weekAgo.getDate() - 7);
+  const monthAgo = new Date(now2);
+  monthAgo.setDate(monthAgo.getDate() - 30);
+  const weekReceipts = receipts.filter((r) => new Date(r.timestamp) >= weekAgo);
+  const monthReceipts = receipts.filter((r) => new Date(r.timestamp) >= monthAgo);
+  const insights = [];
+  const blockedWeek = weekReceipts.filter((r) => r.policy_decision === "block");
+  if (blockedWeek.length > 0) {
+    const topBlocked = aggregateByAction(blockedWeek)[0];
+    if (topBlocked) {
+      insights.push({
+        id: "top-blocked-week",
+        icon: /* @__PURE__ */ jsxRuntimeExports.jsx(HiOutlineNoSymbol, { className: "h-4 w-4" }),
+        label: "Most blocked this week",
+        value: topBlocked.name,
+        tone: "attention"
+      });
+    }
+  }
+  const appActivity = /* @__PURE__ */ new Map();
+  for (const r of weekReceipts) {
+    appActivity.set(r.harness, (appActivity.get(r.harness) ?? 0) + 1);
+  }
+  const topApp = Array.from(appActivity.entries()).sort((a, b) => b[1] - a[1])[0];
+  if (topApp) {
+    insights.push({
+      id: "top-app-week",
+      icon: /* @__PURE__ */ jsxRuntimeExports.jsx(HiOutlineFire, { className: "h-4 w-4" }),
+      label: "Most active app",
+      value: harnessDisplayName(topApp[0]),
+      tone: "purple",
+      action: { label: "View", href: `/apps/${topApp[0]}` }
+    });
+  }
+  if (weekReceipts.length >= 5) {
+    const blockRate = Math.round(blockedWeek.length / weekReceipts.length * 100);
+    const prevWeekReceipts = receipts.filter((r) => {
+      const d = new Date(r.timestamp);
+      return d >= new Date(weekAgo.getTime() - 7 * 24 * 60 * 60 * 1e3) && d < weekAgo;
+    });
+    const prevBlockRate = prevWeekReceipts.length > 0 ? Math.round(prevWeekReceipts.filter((r) => r.policy_decision === "block").length / prevWeekReceipts.length * 100) : blockRate;
+    const change = blockRate - prevBlockRate;
+    const value = change === 0 ? `${blockRate}% (flat)` : `${blockRate}% (${change > 0 ? "+" : ""}${change}%)`;
+    insights.push({
+      id: "block-rate",
+      icon: change > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiOutlineArrowTrendingUp, { className: "h-4 w-4" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiOutlineArrowTrendingDown, { className: "h-4 w-4" }),
+      label: "Block rate this week",
+      value,
+      tone: change > 0 ? "attention" : "green"
+    });
+  }
+  const secretReads = monthReceipts.filter(
+    (r) => (r.artifact_name ?? "").match(/\.(env|secrets?|key|token|password|credential)/i) !== null || (r.capabilities_summary ?? "").toLowerCase().includes("secret")
+  );
+  if (secretReads.length > 0) {
+    insights.push({
+      id: "secret-reads",
+      icon: /* @__PURE__ */ jsxRuntimeExports.jsx(HiOutlineShieldCheck, { className: "h-4 w-4" }),
+      label: "Secret reads stopped this month",
+      value: String(secretReads.length),
+      tone: "blue"
+    });
+  }
+  const harnessFirstSeen = /* @__PURE__ */ new Map();
+  for (const r of receipts) {
+    const d = new Date(r.timestamp);
+    const existing = harnessFirstSeen.get(r.harness);
+    if (!existing || d < existing) {
+      harnessFirstSeen.set(r.harness, d);
+    }
+  }
+  for (const [harness, firstSeen] of harnessFirstSeen.entries()) {
+    if (firstSeen >= weekAgo) {
+      insights.push({
+        id: `new-app-${harness}`,
+        icon: /* @__PURE__ */ jsxRuntimeExports.jsx(HiOutlineFire, { className: "h-4 w-4" }),
+        label: "New app detected",
+        value: harnessDisplayName(harness),
+        tone: "purple",
+        action: { label: "Set up", href: `/apps/${harness}` }
+      });
+    }
+  }
+  return insights.slice(0, 3);
+}
+function ActivityCalendar({
+  receipts,
+  onSelectDay
+}) {
+  const [monthOffset, setMonthOffset] = reactExports.useState(0);
+  const { year, month, days } = reactExports.useMemo(() => {
+    const now2 = /* @__PURE__ */ new Date();
+    const target = new Date(now2.getFullYear(), now2.getMonth() + monthOffset, 1);
+    const y = target.getFullYear();
+    const m = target.getMonth();
+    const firstDay = new Date(y, m, 1);
+    const lastDay = new Date(y, m + 1, 0);
+    const startOffset2 = firstDay.getDay();
+    const totalDays = lastDay.getDate();
+    return { year: y, month: m, days: totalDays, startOffset: startOffset2 };
+  }, [monthOffset]);
+  const activityByDay = reactExports.useMemo(() => {
+    const map = /* @__PURE__ */ new Map();
+    for (const r of receipts) {
+      const d = new Date(r.timestamp);
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+      map.set(key, (map.get(key) ?? 0) + 1);
+    }
+    return map;
+  }, [receipts]);
+  const handlePrevMonth = reactExports.useCallback(() => setMonthOffset((o) => o - 1), []);
+  const handleNextMonth = reactExports.useCallback(() => setMonthOffset((o) => o + 1), []);
+  const handleToday = reactExports.useCallback(() => setMonthOffset(0), []);
+  const monthName = new Date(year, month).toLocaleDateString(void 0, { month: "long", year: "numeric" });
+  const weekDays = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+  const today = /* @__PURE__ */ new Date();
+  const todayKey = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-3", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "text-sm font-semibold text-brand-dark", children: "Activity" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-1", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "button",
+          {
+            onClick: handlePrevMonth,
+            className: "rounded-md p-1 text-slate-400 transition-colors hover:bg-slate-100 hover:text-brand-dark",
+            "aria-label": "Previous month",
+            children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronLeft$1, { className: "h-4 w-4", "aria-hidden": "true" })
+          }
+        ),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "min-w-[120px] text-center text-xs font-medium text-brand-dark", children: monthName }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "button",
+          {
+            onClick: handleNextMonth,
+            className: "rounded-md p-1 text-slate-400 transition-colors hover:bg-slate-100 hover:text-brand-dark",
+            "aria-label": "Next month",
+            children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronRight$1, { className: "h-4 w-4", "aria-hidden": "true" })
+          }
+        ),
+        monthOffset !== 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "button",
+          {
+            onClick: handleToday,
+            className: "ml-1 rounded-md px-2 py-0.5 text-xs font-medium text-brand-blue hover:bg-blue-50",
+            children: "Today"
+          }
+        )
+      ] })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid grid-cols-7 gap-1", children: [
+      weekDays.map((d) => /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "text-center text-[10px] font-medium text-slate-400", children: d }, d)),
+      Array.from({ length: 35 }, (_, i) => {
+        const dayIndex = i - startOffset + 1;
+        if (dayIndex < 1 || dayIndex > days) {
+          return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "aspect-square" }, i);
+        }
+        const dateKey = `${year}-${String(month + 1).padStart(2, "0")}-${String(dayIndex).padStart(2, "0")}`;
+        const count = activityByDay.get(dateKey) ?? 0;
+        const isToday = dateKey === todayKey;
+        const intensity = count === 0 ? 0 : count <= 2 ? 1 : count <= 5 ? 2 : 3;
+        const intensityClasses = [
+          "bg-white text-slate-300 hover:bg-slate-50",
+          "bg-blue-100 text-blue-700 hover:bg-blue-200",
+          "bg-blue-300 text-white hover:bg-blue-400",
+          "bg-blue-500 text-white hover:bg-blue-600"
+        ];
+        return /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "button",
+          {
+            onClick: () => count > 0 && onSelectDay?.(dateKey),
+            disabled: count === 0,
+            className: `aspect-square rounded-md text-[10px] font-medium transition-colors ${intensityClasses[intensity]} ${isToday ? "ring-2 ring-brand-blue ring-offset-1" : ""} ${count === 0 ? "cursor-default" : "cursor-pointer"}`,
+            "aria-label": `${dateKey}: ${count} actions`,
+            children: dayIndex
+          },
+          i
+        );
+      })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-3 text-[10px] text-slate-400", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "No activity" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2.5 w-2.5 rounded-sm bg-blue-100" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Light" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2.5 w-2.5 rounded-sm bg-blue-300" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Medium" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2.5 w-2.5 rounded-sm bg-blue-500" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Heavy" })
+    ] })
+  ] });
+}
+function TopActions({
+  receipts,
+  onFilterAction
+}) {
+  const [period, setPeriod] = reactExports.useState("7d");
+  const [expanded, setExpanded] = reactExports.useState(false);
+  const periodReceipts = reactExports.useMemo(() => {
+    if (period === "all") return receipts;
+    const days = period === "7d" ? 7 : period === "30d" ? 30 : 90;
+    const cutoff = /* @__PURE__ */ new Date();
+    cutoff.setDate(cutoff.getDate() - days);
+    return receipts.filter((r) => new Date(r.timestamp) >= cutoff);
+  }, [receipts, period]);
+  const aggregated = reactExports.useMemo(() => aggregateByAction(periodReceipts), [periodReceipts]);
+  const topTotal = aggregated.slice(0, 10);
+  const topBlocked = aggregated.filter((a) => a.blocked > 0).slice(0, 10);
+  const topAllowed = aggregated.filter((a) => a.allowed > 0).slice(0, 10);
+  const toggleExpanded = reactExports.useCallback(() => setExpanded((p) => !p), []);
+  if (aggregated.length === 0) return null;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-3", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "text-sm font-semibold text-brand-dark", children: "Top actions" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex items-center gap-1", children: ["7d", "30d", "90d", "all"].map((p) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "button",
+        {
+          onClick: () => setPeriod(p),
+          className: `rounded-md px-2 py-0.5 text-[11px] font-medium transition-colors ${period === p ? "bg-brand-blue text-white" : "text-slate-500 hover:bg-slate-100"}`,
+          children: p === "7d" ? "7 days" : p === "30d" ? "30 days" : p === "90d" ? "90 days" : "All time"
+        },
+        p
+      )) })
+    ] }),
+    !expanded ? /* @__PURE__ */ jsxRuntimeExports.jsx(TopActionsList, { actions: topTotal, onFilterAction }) : /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(TopActionsSection, { title: "Most frequent", actions: topTotal, onFilterAction }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(TopActionsSection, { title: "Most blocked", actions: topBlocked, onFilterAction }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(TopActionsSection, { title: "Most allowed", actions: topAllowed, onFilterAction })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "button",
+      {
+        onClick: toggleExpanded,
+        className: "flex items-center gap-1 text-xs font-medium text-brand-blue transition-colors hover:text-brand-dark",
+        children: expanded ? /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronUp, { className: "h-3.5 w-3.5", "aria-hidden": "true" }),
+          "Show less"
+        ] }) : /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronDown, { className: "h-3.5 w-3.5", "aria-hidden": "true" }),
+          "Show top blocked and allowed"
+        ] })
+      }
+    )
+  ] });
+}
+function TopActionsSection({
+  title,
+  actions,
+  onFilterAction
+}) {
+  if (actions.length === 0) return null;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-1.5", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("h4", { className: "text-xs font-medium text-slate-500", children: title }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(TopActionsList, { actions, onFilterAction })
+  ] });
+}
+function TopActionsList({
+  actions,
+  onFilterAction
+}) {
+  actions[0]?.total ?? 1;
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-1", children: actions.map((action) => {
+    const allowPct = action.total > 0 ? action.allowed / action.total * 100 : 0;
+    const blockPct = action.total > 0 ? action.blocked / action.total * 100 : 0;
+    return /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "button",
+      {
+        onClick: () => onFilterAction?.(action.name),
+        className: "group flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-slate-50",
+        children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 flex-1", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "truncate text-xs font-medium text-brand-dark", children: action.name }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "shrink-0 text-[10px] text-slate-400", children: action.total })
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-1 flex h-1.5 w-full overflow-hidden rounded-full bg-slate-100", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "div",
+              {
+                className: "bg-emerald-400 transition-all",
+                style: { width: `${allowPct}%` }
+              }
+            ),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "div",
+              {
+                className: "bg-brand-attention transition-all",
+                style: { width: `${blockPct}%` }
+              }
+            )
+          ] })
+        ] })
+      },
+      action.name
+    );
+  }) });
+}
+function aggregateByAction(receipts) {
+  const map = /* @__PURE__ */ new Map();
+  for (const r of receipts) {
+    const name = r.artifact_name ?? r.artifact_id;
+    const existing = map.get(name);
+    if (existing) {
+      existing.total += 1;
+      if (r.policy_decision === "allow") existing.allowed += 1;
+      if (r.policy_decision === "block") existing.blocked += 1;
+      if (r.timestamp > existing.lastSeen) existing.lastSeen = r.timestamp;
+    } else {
+      map.set(name, {
+        name,
+        total: 1,
+        allowed: r.policy_decision === "allow" ? 1 : 0,
+        blocked: r.policy_decision === "block" ? 1 : 0,
+        lastSeen: r.timestamp
+      });
+    }
+  }
+  return Array.from(map.values()).sort((a, b) => b.total - a.total);
+}
+function exportReceiptsAsCsv(receipts, filters) {
+  const headers = [
+    "timestamp",
+    "harness",
+    "artifact_id",
+    "artifact_name",
+    "policy_decision",
+    "artifact_hash",
+    "capabilities_summary",
+    "provenance_summary",
+    "source_scope"
+  ];
+  const rows = receipts.map((r) => [
+    r.timestamp,
+    r.harness,
+    r.artifact_id,
+    r.artifact_name ?? "",
+    r.policy_decision,
+    r.artifact_hash,
+    r.capabilities_summary ?? "",
+    r.provenance_summary ?? "",
+    r.source_scope ?? ""
+  ]);
+  const csv = [headers.join(","), ...rows.map((row) => row.map(escapeCsvCell).join(","))].join("\n");
+  const fromDate = receipts.length > 0 ? formatDateIso(new Date(receipts[receipts.length - 1].timestamp)) : "all";
+  const toDate = receipts.length > 0 ? formatDateIso(new Date(receipts[0].timestamp)) : "all";
+  const filename = `guard-history-${fromDate}-to-${toDate}.csv`;
+  return { blob: new Blob([csv], { type: "text/csv;charset=utf-8;" }), filename };
+}
+function exportReceiptsAsJson(receipts, filters) {
+  const payload = {
+    exported_at: (/* @__PURE__ */ new Date()).toISOString(),
+    filter_summary: filters ?? {},
+    total_rows: receipts.length,
+    items: receipts
+  };
+  const fromDate = receipts.length > 0 ? formatDateIso(new Date(receipts[receipts.length - 1].timestamp)) : "all";
+  const toDate = receipts.length > 0 ? formatDateIso(new Date(receipts[0].timestamp)) : "all";
+  const filename = `guard-history-${fromDate}-to-${toDate}.json`;
+  return { blob: new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" }), filename };
+}
+function downloadBlob(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+function escapeCsvCell(value) {
+  const needsQuotes = /[",\n\r]/.test(value);
+  if (needsQuotes) {
+    return `"${value.replaceAll('"', '""')}"`;
+  }
+  return value;
+}
+function formatDateIso(date) {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+}
+function useKeyboardShortcut(key, callback, options = {}) {
+  const callbackRef = reactExports.useRef(callback);
+  callbackRef.current = callback;
+  reactExports.useEffect(() => {
+    function handleKeyDown(event) {
+      const target = event.target;
+      if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable) {
+        return;
+      }
+      if (event.key !== key) return;
+      if (options.preventDefault) {
+        event.preventDefault();
+      }
+      callbackRef.current(event);
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [key, options.preventDefault]);
+}
+function DecisionPieChart({ receipts }) {
+  const { allow, block, total } = reactExports.useMemo(() => {
+    const allow2 = receipts.filter((r) => r.policy_decision === "allow").length;
+    const block2 = receipts.filter((r) => r.policy_decision === "block").length;
+    return { allow: allow2, block: block2, total: receipts.length };
+  }, [receipts]);
+  if (total === 0) return null;
+  const allowPct = Math.round(allow / total * 100);
+  const blockPct = Math.round(block / total * 100);
+  const radius = 40;
+  const circumference = 2 * Math.PI * radius;
+  const allowDash = allow / total * circumference;
+  const blockDash = block / total * circumference;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("h4", { className: "text-xs font-semibold text-brand-dark", children: "Decisions" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-4", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("svg", { viewBox: "0 0 100 100", className: "h-20 w-20 -rotate-90", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("circle", { cx: "50", cy: "50", r: radius, fill: "none", stroke: "#e2e8f0", strokeWidth: "12" }),
+        allow > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "circle",
+          {
+            cx: "50",
+            cy: "50",
+            r: radius,
+            fill: "none",
+            stroke: "#10b981",
+            strokeWidth: "12",
+            strokeDasharray: `${allowDash} ${circumference - allowDash}`,
+            strokeLinecap: "round"
+          }
+        ),
+        block > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "circle",
+          {
+            cx: "50",
+            cy: "50",
+            r: radius,
+            fill: "none",
+            stroke: "#f59e0b",
+            strokeWidth: "12",
+            strokeDasharray: `${blockDash} ${circumference - blockDash}`,
+            strokeDashoffset: -allowDash,
+            strokeLinecap: "round"
+          }
+        )
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-1", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-1.5 text-xs", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2.5 w-2.5 rounded-full bg-emerald-500" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-slate-500", children: "Allowed" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "ml-auto font-medium text-brand-dark", children: [
+            allowPct,
+            "%"
+          ] })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-1.5 text-xs", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2.5 w-2.5 rounded-full bg-amber-500" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-slate-500", children: "Blocked" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "ml-auto font-medium text-brand-dark", children: [
+            blockPct,
+            "%"
+          ] })
+        ] })
+      ] })
+    ] })
+  ] });
+}
+function ActivityBarChart({ receipts }) {
+  const days = reactExports.useMemo(() => {
+    const map = /* @__PURE__ */ new Map();
+    const now2 = /* @__PURE__ */ new Date();
+    for (let i = 29; i >= 0; i--) {
+      const d = new Date(now2);
+      d.setDate(d.getDate() - i);
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+      map.set(key, { allow: 0, block: 0 });
+    }
+    for (const r of receipts) {
+      const d = new Date(r.timestamp);
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+      if (map.has(key)) {
+        const existing = map.get(key);
+        if (r.policy_decision === "allow") existing.allow += 1;
+        if (r.policy_decision === "block") existing.block += 1;
+      }
+    }
+    return Array.from(map.entries()).map(([date, counts]) => ({ date, ...counts }));
+  }, [receipts]);
+  const maxTotal = Math.max(1, ...days.map((d) => d.allow + d.block));
+  if (days.every((d) => d.allow === 0 && d.block === 0)) return null;
+  const formatDayLabel = (date) => {
+    const d = new Date(date);
+    return `${d.getMonth() + 1}/${d.getDate()}`;
+  };
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("h4", { className: "text-xs font-semibold text-brand-dark", children: "Activity (last 30 days)" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex h-32 items-end gap-0.5", children: days.map((day) => {
+      const total = day.allow + day.block;
+      const heightPct = total > 0 ? total / maxTotal * 100 : 0;
+      const allowPctOfTotal = total > 0 ? day.allow / total * 100 : 0;
+      return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "group relative flex flex-1 flex-col justify-end", title: `${formatDayLabel(day.date)}: ${total} actions`, children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex w-full flex-col-reverse overflow-hidden rounded-t-sm", style: { height: `${heightPct}%` }, children: [
+          day.allow > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "bg-emerald-400 transition-all", style: { height: `${allowPctOfTotal}%`, minHeight: day.allow > 0 ? 1 : 0 } }),
+          day.block > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "bg-amber-400 transition-all", style: { height: `${100 - allowPctOfTotal}%`, minHeight: day.block > 0 ? 1 : 0 } })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mt-0.5 text-center text-[8px] text-slate-300 opacity-0 transition-opacity group-hover:opacity-100", children: formatDayLabel(day.date) })
+      ] }, day.date);
+    }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-3 text-[10px] text-slate-400", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "flex items-center gap-1", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2 w-2 rounded-sm bg-emerald-400" }),
+        "Allowed"
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "flex items-center gap-1", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2 w-2 rounded-sm bg-amber-400" }),
+        "Blocked"
+      ] })
+    ] })
+  ] });
+}
+function AppActivityBars({ receipts }) {
+  const apps = reactExports.useMemo(() => {
+    const map = /* @__PURE__ */ new Map();
+    for (const r of receipts) {
+      map.set(r.harness, (map.get(r.harness) ?? 0) + 1);
+    }
+    return Array.from(map.entries()).map(([harness, count]) => ({ harness, count })).sort((a, b) => b.count - a.count).slice(0, 5);
+  }, [receipts]);
+  const maxCount = Math.max(1, ...apps.map((a) => a.count));
+  if (apps.length === 0) return null;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("h4", { className: "text-xs font-semibold text-brand-dark", children: "Top apps" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-2", children: apps.map((app) => /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-1", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between text-xs", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-slate-600", children: harnessDisplayName(app.harness) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-medium text-brand-dark", children: app.count })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "h-1.5 w-full overflow-hidden rounded-full bg-slate-100", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "div",
+        {
+          className: "h-full rounded-full bg-brand-blue transition-all",
+          style: { width: `${app.count / maxCount * 100}%` }
+        }
+      ) })
+    ] }, app.harness)) })
+  ] });
+}
+function HistoryCharts({ receipts }) {
+  const hasData = receipts.length > 0;
+  if (!hasData) return null;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 sm:grid-cols-2 lg:grid-cols-3", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-xl border border-slate-100 bg-white p-4 shadow-sm", children: /* @__PURE__ */ jsxRuntimeExports.jsx(DecisionPieChart, { receipts }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-xl border border-slate-100 bg-white p-4 shadow-sm", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActivityBarChart, { receipts }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-xl border border-slate-100 bg-white p-4 shadow-sm", children: /* @__PURE__ */ jsxRuntimeExports.jsx(AppActivityBars, { receipts }) })
+  ] });
+}
 function ReceiptsWorkspace(props) {
   if (props.receipts.kind === "loading") {
     return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
@@ -14224,15 +14972,20 @@ function ReceiptsWorkspace(props) {
   }
   return /* @__PURE__ */ jsxRuntimeExports.jsx(ReadyReceiptsWorkspace, { receiptItems: props.receipts.items });
 }
+const TIME_FILTER_VALUES = ["all", "today", "yesterday", "week", "last7d", "last30d"];
+const DECISION_FILTER_VALUES = ["all", "allow", "block"];
 function readUrlParams() {
   const params = new URLSearchParams(window.location.search);
   const time = params.get("time");
   const decision = params.get("decision");
+  const view = params.get("view");
   return {
     search: params.get("search") ?? "",
-    time: ["all", "today", "yesterday", "week"].includes(time) ? time : "all",
-    decision: ["all", "allow", "block"].includes(decision) ? decision : "all",
-    harness: params.get("harness") ?? "all"
+    time: TIME_FILTER_VALUES.includes(time) ? time : "all",
+    decision: DECISION_FILTER_VALUES.includes(decision) ? decision : "all",
+    harness: params.get("harness") ?? "all",
+    view: view === "calendar" ? "calendar" : "list",
+    day: params.get("day") ?? ""
   };
 }
 function writeUrlParams(params) {
@@ -14242,13 +14995,33 @@ function writeUrlParams(params) {
   if (params.time !== "all") url.searchParams.set("time", params.time);
   if (params.decision !== "all") url.searchParams.set("decision", params.decision);
   if (params.harness !== "all") url.searchParams.set("harness", params.harness);
+  if (params.view !== "list") url.searchParams.set("view", params.view);
+  if (params.day) url.searchParams.set("day", params.day);
   window.history.replaceState({}, "", url.toString());
+}
+function timeFilterLabel(filter) {
+  switch (filter) {
+    case "today":
+      return "Today";
+    case "yesterday":
+      return "Yesterday";
+    case "week":
+      return "This week";
+    case "last7d":
+      return "Last 7 days";
+    case "last30d":
+      return "Last 30 days";
+    default:
+      return "All time";
+  }
 }
 function ReadyReceiptsWorkspace(props) {
   const initial = reactExports.useMemo(() => readUrlParams(), []);
   const [search, setSearch] = reactExports.useState(initial.search);
   const [timeFilter, setTimeFilter] = reactExports.useState(initial.time);
   const [decisionFilter, setDecisionFilter] = reactExports.useState(initial.decision);
+  const [viewMode, setViewMode] = reactExports.useState(initial.view);
+  const [dayFilter, setDayFilter] = reactExports.useState(initial.day);
   const harnesses = reactExports.useMemo(
     () => Array.from(new Set(props.receiptItems.map((r) => r.harness))).sort(),
     [props.receiptItems]
@@ -14262,8 +15035,25 @@ function ReadyReceiptsWorkspace(props) {
     }
   }, [harnesses, harnessFilter]);
   reactExports.useEffect(() => {
-    writeUrlParams({ search, time: timeFilter, decision: decisionFilter, harness: harnessFilter });
-  }, [search, timeFilter, decisionFilter, harnessFilter]);
+    writeUrlParams({ search, time: timeFilter, decision: decisionFilter, harness: harnessFilter, view: viewMode, day: dayFilter });
+  }, [search, timeFilter, decisionFilter, harnessFilter, viewMode, dayFilter]);
+  const searchRef = reactExports.useRef(null);
+  useKeyboardShortcut("f", () => {
+    searchRef.current?.focus();
+  }, { preventDefault: true });
+  useKeyboardShortcut("e", () => {
+    handleExportCsv();
+  }, { preventDefault: true });
+  useKeyboardShortcut("g", () => {
+    setViewMode((prev) => prev === "list" ? "calendar" : "list");
+  }, { preventDefault: true });
+  useKeyboardShortcut("t", () => {
+    const cycle = ["all", "today", "yesterday", "week", "last7d", "last30d"];
+    setTimeFilter((prev) => {
+      const idx = cycle.indexOf(prev);
+      return cycle[(idx + 1) % cycle.length];
+    });
+  }, { preventDefault: true });
   const filtered = reactExports.useMemo(() => {
     let items = props.receiptItems;
     if (decisionFilter !== "all") {
@@ -14279,12 +15069,27 @@ function ReadyReceiptsWorkspace(props) {
       startOfYesterday.setDate(startOfYesterday.getDate() - 1);
       const startOfWeek = new Date(startOfToday);
       startOfWeek.setDate(startOfWeek.getDate() - startOfWeek.getDay());
+      const startOfLast7d = new Date(startOfToday);
+      startOfLast7d.setDate(startOfLast7d.getDate() - 7);
+      const startOfLast30d = new Date(startOfToday);
+      startOfLast30d.setDate(startOfLast30d.getDate() - 30);
       items = items.filter((r) => {
         const d = new Date(r.timestamp);
         if (timeFilter === "today") return d >= startOfToday;
         if (timeFilter === "yesterday") return d >= startOfYesterday && d < startOfToday;
         if (timeFilter === "week") return d >= startOfWeek;
+        if (timeFilter === "last7d") return d >= startOfLast7d;
+        if (timeFilter === "last30d") return d >= startOfLast30d;
         return true;
+      });
+    }
+    if (dayFilter) {
+      const dayStart = new Date(dayFilter);
+      const dayEnd = new Date(dayStart);
+      dayEnd.setDate(dayEnd.getDate() + 1);
+      items = items.filter((r) => {
+        const d = new Date(r.timestamp);
+        return d >= dayStart && d < dayEnd;
       });
     }
     if (search.trim()) {
@@ -14294,7 +15099,7 @@ function ReadyReceiptsWorkspace(props) {
       );
     }
     return items.sort((a, b) => +new Date(b.timestamp) - +new Date(a.timestamp));
-  }, [props.receiptItems, decisionFilter, harnessFilter, timeFilter, search]);
+  }, [props.receiptItems, decisionFilter, harnessFilter, timeFilter, search, dayFilter]);
   const groups = reactExports.useMemo(() => {
     const today = [];
     const yesterday = [];
@@ -14315,6 +15120,27 @@ function ReadyReceiptsWorkspace(props) {
     });
     return { today, yesterday, thisWeek, earlier };
   }, [filtered]);
+  const handleFilterHarness = reactExports.useCallback((harness) => {
+    setHarnessFilter(harness);
+    setViewMode("list");
+  }, []);
+  const handleFilterDay = reactExports.useCallback((day) => {
+    setDayFilter(day);
+    setTimeFilter("all");
+    setViewMode("list");
+  }, []);
+  const handleFilterAction = reactExports.useCallback((name) => {
+    setSearch(name);
+    setViewMode("list");
+  }, []);
+  const handleExportCsv = reactExports.useCallback(() => {
+    const { blob, filename } = exportReceiptsAsCsv(filtered);
+    downloadBlob(blob, filename);
+  }, [filtered, search, timeFilter, decisionFilter, harnessFilter]);
+  const handleExportJson = reactExports.useCallback(() => {
+    const { blob, filename } = exportReceiptsAsJson(filtered, { search, time: timeFilter, decision: decisionFilter, harness: harnessFilter });
+    downloadBlob(blob, filename);
+  }, [filtered, search, timeFilter, decisionFilter, harnessFilter]);
   const totalCount = props.receiptItems.length;
   if (totalCount === 0) {
     return /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -14339,6 +15165,15 @@ function ReadyReceiptsWorkspace(props) {
         ] })
       }
     ),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      HistoryInsights,
+      {
+        receipts: props.receiptItems,
+        onFilterHarness: handleFilterHarness,
+        onFilterDay: handleFilterDay
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(HistoryCharts, { receipts: filtered }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-3", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-1.5", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -14398,6 +15233,22 @@ function ReadyReceiptsWorkspace(props) {
             children: "This week"
           }
         ),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          FilterChip,
+          {
+            active: timeFilter === "last7d",
+            onClick: () => setTimeFilter("last7d"),
+            children: "Last 7d"
+          }
+        ),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          FilterChip,
+          {
+            active: timeFilter === "last30d",
+            onClick: () => setTimeFilter("last30d"),
+            children: "Last 30d"
+          }
+        ),
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mx-1 h-4 w-px bg-slate-200" }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs(
           "select",
@@ -14410,11 +15261,40 @@ function ReadyReceiptsWorkspace(props) {
               harnesses.map((h) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: h, children: harnessDisplayName(h) }, h))
             ]
           }
+        ),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mx-1 h-4 w-px bg-slate-200" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(ViewToggleButton, { active: viewMode === "list", onClick: () => setViewMode("list"), ariaLabel: "List view", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiOutlineListBullet, { className: "h-3.5 w-3.5", "aria-hidden": "true" }) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(ViewToggleButton, { active: viewMode === "calendar", onClick: () => setViewMode("calendar"), ariaLabel: "Calendar view", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiOutlineCalendarDays, { className: "h-3.5 w-3.5", "aria-hidden": "true" }) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mx-1 h-4 w-px bg-slate-200" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "button",
+          {
+            onClick: handleExportCsv,
+            className: "inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-slate-500 transition-colors hover:bg-slate-100 hover:text-brand-dark",
+            title: "Export as CSV",
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx(HiOutlineArrowDownTray, { className: "h-3.5 w-3.5", "aria-hidden": "true" }),
+              "CSV"
+            ]
+          }
+        ),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "button",
+          {
+            onClick: handleExportJson,
+            className: "inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-slate-500 transition-colors hover:bg-slate-100 hover:text-brand-dark",
+            title: "Export as JSON",
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx(HiOutlineArrowDownTray, { className: "h-3.5 w-3.5", "aria-hidden": "true" }),
+              "JSON"
+            ]
+          }
         )
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsx(
         "input",
         {
+          ref: searchRef,
           value: search,
           onChange: (e) => setSearch(e.target.value),
           placeholder: "Search by name or app...",
@@ -14422,14 +15302,15 @@ function ReadyReceiptsWorkspace(props) {
         }
       )
     ] }),
-    (search || decisionFilter !== "all" || timeFilter !== "all" || harnessFilter !== "all") && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
+    (search || decisionFilter !== "all" || timeFilter !== "all" || harnessFilter !== "all" || dayFilter) && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
       search && /* @__PURE__ */ jsxRuntimeExports.jsxs(ActiveFilterChip, { onClick: () => setSearch(""), children: [
         "Search: ",
         search
       ] }),
       decisionFilter !== "all" && /* @__PURE__ */ jsxRuntimeExports.jsx(ActiveFilterChip, { onClick: () => setDecisionFilter("all"), children: decisionFilter === "allow" ? "Allowed" : "Blocked" }),
-      timeFilter !== "all" && /* @__PURE__ */ jsxRuntimeExports.jsx(ActiveFilterChip, { onClick: () => setTimeFilter("all"), children: timeFilter === "today" ? "Today" : timeFilter === "yesterday" ? "Yesterday" : "This week" }),
+      timeFilter !== "all" && /* @__PURE__ */ jsxRuntimeExports.jsx(ActiveFilterChip, { onClick: () => setTimeFilter("all"), children: timeFilterLabel(timeFilter) }),
       harnessFilter !== "all" && /* @__PURE__ */ jsxRuntimeExports.jsx(ActiveFilterChip, { onClick: () => setHarnessFilter("all"), children: harnessDisplayName(harnessFilter) }),
+      dayFilter && /* @__PURE__ */ jsxRuntimeExports.jsx(ActiveFilterChip, { onClick: () => setDayFilter(""), children: dayFilter }),
       /* @__PURE__ */ jsxRuntimeExports.jsx(
         "button",
         {
@@ -14438,13 +15319,20 @@ function ReadyReceiptsWorkspace(props) {
             setDecisionFilter("all");
             setTimeFilter("all");
             setHarnessFilter("all");
+            setDayFilter("");
           },
           className: "ml-1 text-xs font-medium text-brand-blue hover:text-brand-dark transition-colors",
           children: "Clear all"
         }
       )
     ] }),
-    filtered.length === 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+    viewMode === "calendar" ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+      ActivityCalendar,
+      {
+        receipts: filtered,
+        onSelectDay: handleFilterDay
+      }
+    ) : filtered.length === 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(
       EmptyState,
       {
         title: "No matching history",
@@ -14452,12 +15340,29 @@ function ReadyReceiptsWorkspace(props) {
         tone: "teach"
       }
     ) : /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(ReceiptGroup$1, { title: "Today", items: groups.today }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(ReceiptGroup$1, { title: "Yesterday", items: groups.yesterday }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(ReceiptGroup$1, { title: "This week", items: groups.thisWeek }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(ReceiptGroup$1, { title: "Earlier", items: groups.earlier })
-    ] })
+      /* @__PURE__ */ jsxRuntimeExports.jsx(ReceiptGroup, { title: "Today", items: groups.today }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(ReceiptGroup, { title: "Yesterday", items: groups.yesterday }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(ReceiptGroup, { title: "This week", items: groups.thisWeek }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(ReceiptGroup, { title: "Earlier", items: groups.earlier })
+    ] }),
+    viewMode === "list" && /* @__PURE__ */ jsxRuntimeExports.jsx(TopActions, { receipts: filtered, onFilterAction: handleFilterAction })
   ] });
+}
+function ViewToggleButton({
+  active,
+  onClick,
+  children,
+  ariaLabel
+}) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(
+    "button",
+    {
+      onClick,
+      "aria-label": ariaLabel,
+      className: `rounded-md p-1.5 transition-colors ${active ? "bg-brand-blue text-white" : "text-slate-400 hover:bg-slate-100 hover:text-brand-dark"}`,
+      children
+    }
+  );
 }
 function FilterChip({
   active,
@@ -14492,7 +15397,7 @@ function ActiveFilterChip({
 function getGroupCollapsedKey(title) {
   return `guard-history-group-${title.toLowerCase().replace(/\s+/g, "-")}`;
 }
-function ReceiptGroup$1({ title, items }) {
+function ReceiptGroup({ title, items }) {
   const storageKey = getGroupCollapsedKey(title);
   const [collapsed, setCollapsed] = reactExports.useState(() => {
     try {
@@ -14618,6 +15523,327 @@ function ScannerEvidenceSection(props) {
     /* @__PURE__ */ jsxRuntimeExports.jsx("ul", { className: "mt-3 space-y-3", children: scannerSignals.map((signal) => /* @__PURE__ */ jsxRuntimeExports.jsx(ScannerSignalRow, { signal }, signal.signal_id)) })
   ] });
 }
+const QUEUE_CATEGORIES = [
+  {
+    id: "secret_access",
+    label: "Secret or credential access",
+    shortLabel: "Secrets",
+    description: "Reads or exposes local credentials, tokens, keys, or secret files."
+  },
+  {
+    id: "data_exfiltration",
+    label: "Data exfiltration path",
+    shortLabel: "Exfiltration",
+    description: "Moves local sensitive data toward a network host, upload, clipboard, or external sink."
+  },
+  {
+    id: "file_edit",
+    label: "File edit command",
+    shortLabel: "File edit",
+    description: "Changes local files in place without matching a delete or wipe pattern."
+  },
+  {
+    id: "file_read",
+    label: "Sensitive file read",
+    shortLabel: "File read",
+    description: "Requests local file contents, paths, or read-only filesystem access."
+  },
+  {
+    id: "destructive_shell",
+    label: "Destructive shell command",
+    shortLabel: "Destructive",
+    description: "Deletes, overwrites, wipes, force-cleans, or otherwise risks data loss."
+  },
+  {
+    id: "encoded_shell",
+    label: "Encoded shell execution",
+    shortLabel: "Encoded shell",
+    description: "Runs encoded, encrypted, decoded, or obfuscated shell payloads."
+  },
+  {
+    id: "network",
+    label: "Network access",
+    shortLabel: "Network",
+    description: "Contacts hosts, downloads, calls APIs, or opens network destinations."
+  },
+  {
+    id: "mcp_tool",
+    label: "MCP tool call",
+    shortLabel: "MCP",
+    description: "Invokes an MCP server or tool with sensitive arguments."
+  },
+  {
+    id: "package_script",
+    label: "Package script",
+    shortLabel: "Package",
+    description: "Runs install, postinstall, build, or package-manager scripts."
+  },
+  {
+    id: "prompt_instruction",
+    label: "Prompt instruction",
+    shortLabel: "Prompt",
+    description: "User or model prompt asks the harness to perform a sensitive action."
+  },
+  {
+    id: "config_change",
+    label: "Configuration change",
+    shortLabel: "Config",
+    description: "Modifies Guard, harness, project, or tool configuration."
+  },
+  {
+    id: "browser_action",
+    label: "Browser action",
+    shortLabel: "Browser",
+    description: "Uses browser automation, navigation, or form interaction."
+  },
+  {
+    id: "harness_start",
+    label: "Harness launch",
+    shortLabel: "Launch",
+    description: "Starts or reconnects an AI app under Guard control."
+  },
+  {
+    id: "shell_command",
+    label: "Shell command",
+    shortLabel: "Shell",
+    description: "Runs a shell command that does not fit a more specific category."
+  },
+  {
+    id: "other",
+    label: "Other review",
+    shortLabel: "Other",
+    description: "Needs review but has no more specific category signal."
+  }
+];
+const QUEUE_CATEGORY_BY_ID = new Map(QUEUE_CATEGORIES.map((category) => [category.id, category]));
+function isReadOnlyQueueGroup(group) {
+  return group.primary.policy_action !== "block" && (group.primary.action_envelope_json?.action_type === "file_read" || group.primary.artifact_type === "file_read_request");
+}
+function bulkApproveActionCount(groups) {
+  return groups.reduce((sum, g) => sum + 1 + g.duplicateCount, 0);
+}
+function bulkApprovePrimaryIds(groups) {
+  return groups.map((g) => g.primary.request_id);
+}
+function buildProgressCopy(activeIndex, total) {
+  if (total === 0) {
+    return "";
+  }
+  return `${activeIndex + 1} of ${total} decisions`;
+}
+function selectNextAfterResolution(result, currentItems) {
+  if (result.next_selectable_request_id !== null) {
+    return result.next_selectable_request_id;
+  }
+  const remaining = result.remaining_pending_summaries;
+  if (remaining.length > 0) {
+    return remaining[0].request_id;
+  }
+  const resolvedIds = new Set(result.resolved_duplicate_ids);
+  if (result.resolved_scope_ids !== void 0) {
+    for (const id of result.resolved_scope_ids) {
+      resolvedIds.add(id);
+    }
+  }
+  if (result.resolved_request !== null) {
+    resolvedIds.add(result.resolved_request.request_id);
+  }
+  if (result.item !== null) {
+    resolvedIds.add(result.item.request_id);
+  }
+  const next = currentItems.find((item) => !resolvedIds.has(item.request_id));
+  return next?.request_id ?? null;
+}
+function groupDuplicates(items) {
+  const seen2 = /* @__PURE__ */ new Set();
+  const groups = [];
+  const groupedItems = /* @__PURE__ */ new Map();
+  for (const item of items) {
+    const groupId = item.queue_group_id ?? null;
+    if (groupId === null) {
+      continue;
+    }
+    const peers = groupedItems.get(groupId) ?? [];
+    peers.push(item);
+    groupedItems.set(groupId, peers);
+  }
+  for (const item of items) {
+    if (seen2.has(item.request_id)) {
+      continue;
+    }
+    seen2.add(item.request_id);
+    const groupId = item.queue_group_id ?? null;
+    if (groupId !== null) {
+      const peers = (groupedItems.get(groupId) ?? []).filter(
+        (peer) => peer.request_id !== item.request_id && !seen2.has(peer.request_id)
+      );
+      for (const peer of peers) {
+        seen2.add(peer.request_id);
+      }
+      groups.push({
+        primary: item,
+        duplicateCount: peers.length,
+        duplicateIds: peers.map((p) => p.request_id)
+      });
+    } else {
+      groups.push({ primary: item, duplicateCount: 0, duplicateIds: [] });
+    }
+  }
+  return groups;
+}
+function queueTimestamp(item) {
+  return new Date(item.last_seen_at ?? item.created_at).getTime();
+}
+function queueCategoryById(id) {
+  return QUEUE_CATEGORY_BY_ID.get(id) ?? QUEUE_CATEGORIES[QUEUE_CATEGORIES.length - 1];
+}
+function resolveQueueCategory(item) {
+  return queueCategoryById(resolveQueueCategoryId(item));
+}
+function queueCategoriesForItems(items) {
+  const seen2 = /* @__PURE__ */ new Set();
+  for (const item of items) {
+    seen2.add(resolveQueueCategory(item).id);
+  }
+  return QUEUE_CATEGORIES.filter((category) => seen2.has(category.id));
+}
+function resolveQueueCategoryId(item) {
+  const envelope = item.action_envelope_json;
+  const decisionCategories = item.decision_v2_json?.signals.map((signal) => signal.category) ?? [];
+  const text = queueCategoryText(item);
+  if (decisionCategories.includes("network") || textIncludesAny(text, ["network host", "outbound", "webhook", "curl ", "https://", "http://"])) {
+    if (textIncludesAny(text, ["secret", "credential", "token", "api key", "upload", "exfiltrat"])) {
+      return "data_exfiltration";
+    }
+    return "network";
+  }
+  if (decisionCategories.includes("secret") || textIncludesAny(text, ["credential-looking", "secret", ".env", "token", "api key", "password", "private key"])) {
+    return "secret_access";
+  }
+  if (textIncludesAny(text, ["encoded or encrypted shell command", "base64", "openssl enc", "xxd -r", "decode-and-exec"])) {
+    return "encoded_shell";
+  }
+  if (envelope?.action_type === "file_read" || item.artifact_type === "file_read_request") {
+    return "file_read";
+  }
+  if (envelope?.action_type === "mcp_tool") {
+    return "mcp_tool";
+  }
+  if (envelope?.action_type === "package_script") {
+    return "package_script";
+  }
+  if (envelope?.action_type === "prompt") {
+    return "prompt_instruction";
+  }
+  if (envelope?.action_type === "config_change") {
+    return "config_change";
+  }
+  if (envelope?.action_type === "browser_action") {
+    return "browser_action";
+  }
+  if (envelope?.action_type === "harness_start") {
+    return "harness_start";
+  }
+  if (envelope?.action_type === "file_write" || commandLooksLikeFileEdit(envelope?.command ?? item.launch_target ?? "")) {
+    return "file_edit";
+  }
+  if (textIncludesAny(text, ["destructive shell command", " rm -", "rm -rf", "delete", "wipe", "force-clean", "git clean -fd", "truncate"])) {
+    return "destructive_shell";
+  }
+  if (envelope?.action_type === "shell_command" || item.artifact_type === "command" || text.includes("shell command")) {
+    return "shell_command";
+  }
+  return "other";
+}
+function queueCategoryText(item) {
+  const envelope = item.action_envelope_json;
+  return [
+    item.artifact_name,
+    item.artifact_type,
+    item.risk_headline ?? "",
+    item.risk_summary ?? "",
+    item.trigger_summary ?? "",
+    item.launch_summary ?? "",
+    item.why_now ?? "",
+    item.launch_target ?? "",
+    envelope?.action_type ?? "",
+    envelope?.command ?? "",
+    envelope?.tool_name ?? "",
+    envelope?.prompt_excerpt ?? "",
+    envelope?.mcp_server ?? "",
+    envelope?.mcp_tool ?? "",
+    envelope?.package_manager ?? "",
+    envelope?.package_name ?? "",
+    envelope?.script_name ?? "",
+    ...item.risk_signals ?? [],
+    ...envelope?.target_paths ?? [],
+    ...envelope?.network_hosts ?? [],
+    ...item.decision_v2_json?.signals.map((signal) => `${signal.category} ${signal.title} ${signal.plain_reason}`) ?? []
+  ].join(" ").toLowerCase();
+}
+function textIncludesAny(text, needles) {
+  return needles.some((needle) => text.includes(needle));
+}
+function commandLooksLikeFileEdit(command) {
+  const normalized = command.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  return /\bperl\b[\s\S]*\s-[\w-]*i\b/.test(normalized) || /\bsed\b[\s\S]*\s-[\w-]*i\b/.test(normalized) || /\bpython(?:3)?\b[\s\S]*(?:write_text|open\([^)]*,\s*['"]w|path\.write)/.test(normalized) || /\btee\s+-a?\b/.test(normalized) || /\bapply_patch\b/.test(normalized);
+}
+function sortQueue(items, direction) {
+  return [...items].sort((a, b) => {
+    if (direction === "category") {
+      const categoryDelta = resolveQueueCategory(a).label.localeCompare(resolveQueueCategory(b).label);
+      if (categoryDelta !== 0) {
+        return categoryDelta;
+      }
+    }
+    const dateA = queueTimestamp(a);
+    const dateB = queueTimestamp(b);
+    const dateDelta = direction === "oldest" ? dateA - dateB : dateB - dateA;
+    if (dateDelta !== 0) {
+      return dateDelta;
+    }
+    return direction === "oldest" ? a.request_id.localeCompare(b.request_id) : b.request_id.localeCompare(a.request_id);
+  });
+}
+function filterQueueByCategory(items, categoryId) {
+  if (categoryId === "all") {
+    return items;
+  }
+  return items.filter((item) => resolveQueueCategory(item).id === categoryId);
+}
+function searchQueue(items, term) {
+  const normalized = term.trim().toLowerCase();
+  if (normalized.length === 0) {
+    return items;
+  }
+  return items.filter((item) => {
+    const envelope = item.action_envelope_json;
+    const parts = [
+      item.artifact_name,
+      item.artifact_type,
+      item.harness,
+      item.policy_action,
+      envelope?.command ?? "",
+      envelope?.prompt_excerpt ?? "",
+      envelope?.mcp_server ?? "",
+      envelope?.mcp_tool ?? "",
+      envelope?.package_name ?? "",
+      resolveQueueCategory(item).label,
+      resolveQueueCategory(item).shortLabel,
+      ...envelope?.network_hosts ?? [],
+      ...envelope?.target_paths ?? []
+    ];
+    return parts.join(" ").toLowerCase().includes(normalized);
+  });
+}
+function buildNextUpChipText(item) {
+  const envelope = item.action_envelope_json;
+  const preview = envelope?.command?.slice(0, 40) ?? envelope?.mcp_tool ?? envelope?.prompt_excerpt?.slice(0, 40) ?? item.artifact_type;
+  return `${item.harness} — ${preview}`;
+}
 const scopeChoices = [
   {
     value: "artifact",
@@ -14648,38 +15874,74 @@ const scopeChoices = [
 function ReviewWorkspace(props) {
   const { requests, activeRequestId, detail } = props;
   const queueRef = reactExports.useRef(null);
+  const [searchTerm, setSearchTerm] = reactExports.useState("");
+  const [categoryFilter, setCategoryFilter] = reactExports.useState("all");
+  const [sortDirection, setSortDirection] = reactExports.useState("newest");
+  const filteredRequests = reactExports.useMemo(() => {
+    const byCategory = filterQueueByCategory(requests, categoryFilter);
+    const normalized = searchTerm.trim().toLowerCase();
+    const searched = normalized.length === 0 ? byCategory : byCategory.filter((item) => reviewItemSearchText(item).includes(normalized));
+    return sortQueue(searched, sortDirection);
+  }, [categoryFilter, requests, searchTerm, sortDirection]);
+  const categoryOptions = reactExports.useMemo(() => queueCategoriesForItems(requests), [requests]);
+  const activeRequest = activeRequestId !== null ? requests.find((r) => r.request_id === activeRequestId) ?? null : null;
   reactExports.useEffect(() => {
     function handleKeyDown(event) {
-      if (requests.length === 0) return;
-      const activeIdx = requests.findIndex((r) => r.request_id === activeRequestId);
+      if (filteredRequests.length === 0) return;
+      const activeIdx = filteredRequests.findIndex((r) => r.request_id === activeRequestId);
       if (event.key === "ArrowDown") {
         event.preventDefault();
-        const nextIdx = Math.min(activeIdx + 1, requests.length - 1);
-        if (nextIdx !== activeIdx) props.onOpenRequest(requests[nextIdx].request_id);
+        const nextIdx = Math.min(activeIdx + 1, filteredRequests.length - 1);
+        if (nextIdx !== activeIdx) props.onOpenRequest(filteredRequests[nextIdx].request_id);
       }
       if (event.key === "ArrowUp") {
         event.preventDefault();
         const prevIdx = Math.max(activeIdx - 1, 0);
-        if (prevIdx !== activeIdx) props.onOpenRequest(requests[prevIdx].request_id);
+        if (prevIdx !== activeIdx) props.onOpenRequest(filteredRequests[prevIdx].request_id);
       }
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [requests, activeRequestId, props.onOpenRequest]);
+  }, [filteredRequests, activeRequestId, props.onOpenRequest]);
+  reactExports.useEffect(() => {
+    if (filteredRequests.length === 0) {
+      return;
+    }
+    if (activeRequestId === null || !filteredRequests.some((item) => item.request_id === activeRequestId)) {
+      props.onOpenRequest(filteredRequests[0].request_id);
+    }
+  }, [activeRequestId, filteredRequests, props.onOpenRequest]);
   if (requests.length === 0) {
     return /* @__PURE__ */ jsxRuntimeExports.jsx(ReviewEmptyState, { runtime: props.runtime, resolutionMessage: props.resolutionMessage });
   }
-  const activeItem = activeRequestId ? requests.find((r) => r.request_id === activeRequestId) ?? requests[0] : requests[0];
-  const progressIndex = requests.findIndex((r) => r.request_id === activeItem.request_id);
-  const progress = `${Math.max(0, progressIndex) + 1} of ${requests.length}`;
+  const activeItem = activeRequest ?? filteredRequests[0] ?? requests[0];
+  const progressIndex = filteredRequests.findIndex((r) => r.request_id === activeItem.request_id);
+  const progress = filteredRequests.length > 0 ? `${Math.max(0, progressIndex) + 1} of ${filteredRequests.length}` : `0 of ${requests.length}`;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx(ReviewHeader, { count: requests.length, progress, activeHarness: activeItem.harness }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      ReviewHeader,
+      {
+        count: requests.length,
+        filteredCount: filteredRequests.length,
+        progress,
+        activeHarness: activeItem.harness,
+        activeCategory: resolveQueueCategory(activeItem)
+      }
+    ),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-6 lg:grid-cols-[320px_1fr]", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(
         ReviewQueueList,
         {
-          requests,
+          requests: filteredRequests,
+          totalCount: requests.length,
           activeRequestId: activeItem.request_id,
+          categoryOptions,
+          categoryFilter,
+          searchTerm,
+          sortDirection,
+          onCategoryFilterChange: setCategoryFilter,
+          onSearchTermChange: setSearchTerm,
+          onSortDirectionChange: setSortDirection,
           onOpenRequest: props.onOpenRequest,
           ref: queueRef
         }
@@ -14695,7 +15957,13 @@ function ReviewWorkspace(props) {
     ] })
   ] });
 }
-function ReviewHeader({ count, progress, activeHarness }) {
+function ReviewHeader({
+  count,
+  filteredCount,
+  progress,
+  activeHarness,
+  activeCategory
+}) {
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("h1", { className: "text-2xl font-semibold tracking-[-0.02em] text-brand-dark", children: "Review" }),
@@ -14707,41 +15975,125 @@ function ReviewHeader({ count, progress, activeHarness }) {
         count,
         " waiting"
       ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: "blue", children: harnessDisplayName(activeHarness) })
+      filteredCount !== count ? /* @__PURE__ */ jsxRuntimeExports.jsxs(Tag, { tone: "slate", children: [
+        filteredCount,
+        " shown"
+      ] }) : null,
+      /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: "blue", children: harnessDisplayName(activeHarness) }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: "slate", children: activeCategory.shortLabel })
     ] })
   ] });
 }
-const ReviewQueueList = reactExports.forwardRef(({ requests, activeRequestId, onOpenRequest }, ref) => {
+const ReviewQueueList = reactExports.forwardRef(({
+  requests,
+  totalCount,
+  activeRequestId,
+  categoryOptions,
+  categoryFilter,
+  searchTerm,
+  sortDirection,
+  onCategoryFilterChange,
+  onSearchTermChange,
+  onSortDirectionChange,
+  onOpenRequest
+}, ref) => {
+  const handleSearchChange = reactExports.useCallback((event) => {
+    onSearchTermChange(event.target.value);
+  }, [onSearchTermChange]);
+  const handleCategoryChange = reactExports.useCallback((event) => {
+    onCategoryFilterChange(event.target.value);
+  }, [onCategoryFilterChange]);
+  const handleSortChange = reactExports.useCallback((event) => {
+    onSortDirectionChange(event.target.value);
+  }, [onSortDirectionChange]);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("aside", { className: "space-y-3", ref, children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Queue" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between gap-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Queue" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "font-mono text-[11px] font-semibold text-muted-foreground", children: [
+        requests.length,
+        "/",
+        totalCount
+      ] })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2 rounded-xl border border-slate-100 bg-white p-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "sr-only", children: "Search review queue" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "input",
+          {
+            type: "search",
+            value: searchTerm,
+            onChange: handleSearchChange,
+            placeholder: "Search command, category, host...",
+            className: "min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-brand-dark placeholder:text-slate-400 focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+          }
+        )
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "sr-only", children: "Review category" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "select",
+          {
+            value: categoryFilter,
+            onChange: handleCategoryChange,
+            className: "min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20",
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "all", children: "All categories" }),
+              categoryOptions.map((category) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: category.id, children: category.label }, category.id))
+            ]
+          }
+        )
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "sr-only", children: "Sort review queue" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "select",
+          {
+            value: sortDirection,
+            onChange: handleSortChange,
+            className: "min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20",
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "newest", children: "Newest first" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "oldest", children: "Oldest first" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "category", children: "Category" })
+            ]
+          }
+        )
+      ] })
+    ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsx(
       "div",
       {
         role: "listbox",
         "aria-label": "Review queue",
         className: "max-h-[70vh] space-y-2 overflow-y-auto rounded-lg border border-slate-100 bg-white p-1.5",
-        children: requests.map((item, index) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+        children: requests.length > 0 ? requests.map((item, index) => /* @__PURE__ */ jsxRuntimeExports.jsx(
           QueueItemRow,
           {
             item,
             active: item.request_id === activeRequestId,
             index,
-            onClick: () => onOpenRequest(item.request_id)
+            onOpenRequest
           },
           item.request_id
-        ))
+        )) : /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "px-3 py-5", children: /* @__PURE__ */ jsxRuntimeExports.jsx(EmptyState, { title: "No matching actions", body: "Try a different category, search, or sort mode.", tone: "teach" }) })
       }
     )
   ] });
 });
 ReviewQueueList.displayName = "ReviewQueueList";
-function QueueItemRow({ item, active, index, onClick }) {
-  const title = item.artifact_name ?? item.artifact_id;
+function QueueItemRow({ item, active, index, onOpenRequest }) {
   const isBlocked = item.policy_action === "block";
+  const category = resolveQueueCategory(item);
+  const CategoryIcon = iconForQueueCategory(category.id);
+  const preview = queueItemPreview(item);
+  const handleClick = reactExports.useCallback(() => {
+    onOpenRequest(item.request_id);
+  }, [item.request_id, onOpenRequest]);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(
     "button",
     {
-      onClick,
+      onClick: handleClick,
       role: "option",
       "aria-selected": active,
       "aria-posinset": index + 1,
@@ -14753,13 +16105,89 @@ function QueueItemRow({ item, active, index, onClick }) {
       className: `w-full rounded-lg py-2.5 text-left transition-all ${active ? "border-brand-blue bg-brand-blue/[0.06]" : "border-transparent bg-white hover:bg-slate-50"}`,
       children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between gap-2", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "truncate text-sm font-medium text-brand-dark", children: title }),
-          isBlocked ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniNoSymbol, { className: "h-3.5 w-3.5 shrink-0 text-brand-attention", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniBolt, { className: "h-3.5 w-3.5 shrink-0 text-brand-blue", "aria-hidden": "true" })
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 items-center gap-2", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "span",
+              {
+                className: `inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ${active ? "bg-brand-blue/10 text-brand-blue" : "bg-slate-50 text-slate-500"}`,
+                children: /* @__PURE__ */ jsxRuntimeExports.jsx(CategoryIcon, { className: "h-4 w-4", "aria-hidden": "true" })
+              }
+            ),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "truncate text-sm font-medium text-brand-dark", children: category.label })
+          ] }),
+          isBlocked ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniNoSymbol, { className: "h-3.5 w-3.5 shrink-0 text-brand-attention", "aria-hidden": "true" }) : null
         ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 text-[11px] text-muted-foreground", children: harnessDisplayName(item.harness) })
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-0.5 text-[11px] text-muted-foreground", children: [
+          harnessDisplayName(item.harness),
+          " · ",
+          preview
+        ] })
       ]
     }
   );
+}
+function iconForQueueCategory(categoryId) {
+  switch (categoryId) {
+    case "secret_access":
+      return HiMiniKey;
+    case "data_exfiltration":
+      return HiMiniArrowTopRightOnSquare;
+    case "file_edit":
+      return HiMiniPencilSquare;
+    case "file_read":
+      return HiMiniDocumentMagnifyingGlass;
+    case "destructive_shell":
+      return HiMiniNoSymbol;
+    case "encoded_shell":
+      return HiMiniCodeBracket;
+    case "network":
+      return HiMiniGlobeAlt;
+    case "mcp_tool":
+      return HiMiniServerStack;
+    case "package_script":
+      return HiMiniCube;
+    case "prompt_instruction":
+      return HiMiniInformationCircle;
+    case "config_change":
+      return HiMiniCog6Tooth;
+    case "browser_action":
+      return HiMiniArrowTopRightOnSquare;
+    case "harness_start":
+      return HiMiniShieldCheck;
+    case "shell_command":
+      return HiMiniCommandLine;
+    case "other":
+      return HiMiniDocumentPlus;
+  }
+}
+function reviewItemSearchText(item) {
+  const envelope = item.action_envelope_json;
+  const category = resolveQueueCategory(item);
+  return [
+    item.artifact_name,
+    item.artifact_id,
+    item.artifact_type,
+    item.harness,
+    item.policy_action,
+    item.risk_headline ?? "",
+    item.risk_summary ?? "",
+    item.trigger_summary ?? "",
+    item.launch_summary ?? "",
+    item.why_now ?? "",
+    category.label,
+    category.shortLabel,
+    envelope?.command ?? "",
+    envelope?.prompt_excerpt ?? "",
+    envelope?.mcp_server ?? "",
+    envelope?.mcp_tool ?? "",
+    envelope?.package_name ?? "",
+    ...envelope?.network_hosts ?? [],
+    ...envelope?.target_paths ?? []
+  ].join(" ").toLowerCase();
+}
+function queueItemPreview(item) {
+  const envelope = item.action_envelope_json;
+  return envelope?.command ?? envelope?.mcp_tool ?? envelope?.prompt_excerpt ?? envelope?.package_name ?? displayArtifactName(item);
 }
 function ReviewDecisionCard(props) {
   const detail = props.detail;
@@ -15346,123 +16774,6 @@ function ConfirmModal(props) {
     }
   );
 }
-function isReadOnlyQueueGroup(group) {
-  return group.primary.policy_action !== "block" && (group.primary.action_envelope_json?.action_type === "file_read" || group.primary.artifact_type === "file_read_request");
-}
-function bulkApproveActionCount(groups) {
-  return groups.reduce((sum, g) => sum + 1 + g.duplicateCount, 0);
-}
-function bulkApprovePrimaryIds(groups) {
-  return groups.map((g) => g.primary.request_id);
-}
-function buildProgressCopy(activeIndex, total) {
-  if (total === 0) {
-    return "";
-  }
-  return `${activeIndex + 1} of ${total} decisions`;
-}
-function selectNextAfterResolution(result, currentItems) {
-  if (result.next_selectable_request_id !== null) {
-    return result.next_selectable_request_id;
-  }
-  const remaining = result.remaining_pending_summaries;
-  if (remaining.length > 0) {
-    return remaining[0].request_id;
-  }
-  const resolvedIds = new Set(result.resolved_duplicate_ids);
-  if (result.resolved_scope_ids !== void 0) {
-    for (const id of result.resolved_scope_ids) {
-      resolvedIds.add(id);
-    }
-  }
-  if (result.resolved_request !== null) {
-    resolvedIds.add(result.resolved_request.request_id);
-  }
-  if (result.item !== null) {
-    resolvedIds.add(result.item.request_id);
-  }
-  const next = currentItems.find((item) => !resolvedIds.has(item.request_id));
-  return next?.request_id ?? null;
-}
-function groupDuplicates(items) {
-  const seen = /* @__PURE__ */ new Set();
-  const groups = [];
-  const groupedItems = /* @__PURE__ */ new Map();
-  for (const item of items) {
-    const groupId = item.queue_group_id ?? null;
-    if (groupId === null) {
-      continue;
-    }
-    const peers = groupedItems.get(groupId) ?? [];
-    peers.push(item);
-    groupedItems.set(groupId, peers);
-  }
-  for (const item of items) {
-    if (seen.has(item.request_id)) {
-      continue;
-    }
-    seen.add(item.request_id);
-    const groupId = item.queue_group_id ?? null;
-    if (groupId !== null) {
-      const peers = (groupedItems.get(groupId) ?? []).filter(
-        (peer) => peer.request_id !== item.request_id && !seen.has(peer.request_id)
-      );
-      for (const peer of peers) {
-        seen.add(peer.request_id);
-      }
-      groups.push({
-        primary: item,
-        duplicateCount: peers.length,
-        duplicateIds: peers.map((p) => p.request_id)
-      });
-    } else {
-      groups.push({ primary: item, duplicateCount: 0, duplicateIds: [] });
-    }
-  }
-  return groups;
-}
-function queueTimestamp(item) {
-  return new Date(item.last_seen_at ?? item.created_at).getTime();
-}
-function sortQueue(items, direction) {
-  return [...items].sort((a, b) => {
-    const dateA = queueTimestamp(a);
-    const dateB = queueTimestamp(b);
-    const dateDelta = direction === "newest" ? dateB - dateA : dateA - dateB;
-    if (dateDelta !== 0) {
-      return dateDelta;
-    }
-    return direction === "newest" ? b.request_id.localeCompare(a.request_id) : a.request_id.localeCompare(b.request_id);
-  });
-}
-function searchQueue(items, term) {
-  const normalized = term.trim().toLowerCase();
-  if (normalized.length === 0) {
-    return items;
-  }
-  return items.filter((item) => {
-    const envelope = item.action_envelope_json;
-    const parts = [
-      item.artifact_name,
-      item.artifact_type,
-      item.harness,
-      item.policy_action,
-      envelope?.command ?? "",
-      envelope?.prompt_excerpt ?? "",
-      envelope?.mcp_server ?? "",
-      envelope?.mcp_tool ?? "",
-      envelope?.package_name ?? "",
-      ...envelope?.network_hosts ?? [],
-      ...envelope?.target_paths ?? []
-    ];
-    return parts.join(" ").toLowerCase().includes(normalized);
-  });
-}
-function buildNextUpChipText(item) {
-  const envelope = item.action_envelope_json;
-  const preview = envelope?.command?.slice(0, 40) ?? envelope?.mcp_tool ?? envelope?.prompt_excerpt?.slice(0, 40) ?? item.artifact_type;
-  return `${item.harness} — ${preview}`;
-}
 const scopeOptions = [
   {
     value: "artifact",
@@ -15483,10 +16794,27 @@ const broadScopeValues = /* @__PURE__ */ new Set(["publisher", "harness", "globa
 const queuePageSize = 8;
 function ApprovalCenterLayout(props) {
   const [mobileQueueOpen, setMobileQueueOpen] = reactExports.useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = reactExports.useState(() => {
+    try {
+      return localStorage.getItem("guard-sidebar-collapsed") === "true";
+    } catch {
+      return false;
+    }
+  });
   const queuedItems = props.requests.kind === "ready" ? props.requests.items : [];
   const activeHarness = props.detail.kind === "ready" ? props.detail.item.harness : queuedItems[0]?.harness ?? null;
   const handleOpenMobileQueue = reactExports.useCallback(() => setMobileQueueOpen(true), []);
   const handleCloseMobileQueue = reactExports.useCallback(() => setMobileQueueOpen(false), []);
+  const handleToggleSidebar = reactExports.useCallback(() => {
+    setSidebarCollapsed((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem("guard-sidebar-collapsed", String(next));
+      } catch {
+      }
+      return next;
+    });
+  }, []);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-h-screen bg-white text-brand-dark", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(
       ShellHeader,
@@ -15498,7 +16826,7 @@ function ApprovalCenterLayout(props) {
         onOpenMobileQueue: handleOpenMobileQueue
       }
     ),
-    /* @__PURE__ */ jsxRuntimeExports.jsx(ShellSidebar, { queuedCount: queuedItems.length, activeHarness, view: props.view }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(ShellSidebar, { queuedCount: queuedItems.length, activeHarness, view: props.view, collapsed: sidebarCollapsed, onToggleCollapse: handleToggleSidebar }),
     mobileQueueOpen && props.view === "inbox" && props.requests.kind === "ready" && /* @__PURE__ */ jsxRuntimeExports.jsx(
       MobileQueueDrawer,
       {
@@ -15509,7 +16837,7 @@ function ApprovalCenterLayout(props) {
         onBulkApprove: props.onBulkApprove
       }
     ),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex flex-col lg:pl-64", children: /* @__PURE__ */ jsxRuntimeExports.jsx("main", { className: "flex-1 p-6 lg:p-10", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mx-auto max-w-6xl", children: props.view === "home" ? props.homeContent : props.view === "evidence" ? /* @__PURE__ */ jsxRuntimeExports.jsx(ReceiptsWorkspace, { receipts: props.receipts }) : props.view === "fleet" ? props.fleetContent : props.view === "app-detail" ? props.appDetailContent : props.view === "settings" ? props.settingsContent : props.view === "inbox" ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: `flex flex-col transition-all duration-200 ${sidebarCollapsed ? "lg:pl-20" : "lg:pl-64"}`, children: /* @__PURE__ */ jsxRuntimeExports.jsx("main", { className: "flex-1 p-6 lg:p-10", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mx-auto max-w-6xl", children: props.view === "home" ? props.homeContent : props.view === "evidence" ? /* @__PURE__ */ jsxRuntimeExports.jsx(ReceiptsWorkspace, { receipts: props.receipts }) : props.view === "fleet" ? props.fleetContent : props.view === "app-detail" ? props.appDetailContent : props.view === "settings" ? props.settingsContent : props.view === "inbox" ? /* @__PURE__ */ jsxRuntimeExports.jsx(
       ReviewWorkspace,
       {
         requests: props.requests.kind === "ready" ? props.requests.items : [],
@@ -15684,7 +17012,7 @@ function QueueWorkspace(props) {
           onClick: props.onGoHome,
           className: "mb-3 flex items-center gap-1 text-sm font-medium text-brand-blue transition-colors hover:text-brand-blue/70 lg:hidden",
           children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronLeft, { className: "h-4 w-4", "aria-hidden": "true" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronLeft$1, { className: "h-4 w-4", "aria-hidden": "true" }),
             "Back to queue"
           ]
         }
@@ -15833,7 +17161,7 @@ function QueueBrowser(props) {
         )
       ] })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "divide-y divide-slate-200/70 overflow-hidden rounded-[1.5rem] border border-slate-200/70 bg-white/75 shadow-sm", children: visibleGroups.length > 0 ? visibleGroups.map((group) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "divide-y divide-slate-200/70 overflow-hidden rounded-2xl border border-slate-200/70 bg-white/75 shadow-sm", children: visibleGroups.length > 0 ? visibleGroups.map((group) => /* @__PURE__ */ jsxRuntimeExports.jsx(
       QueueCardRow,
       {
         group,
@@ -16245,7 +17573,7 @@ function RuleBuilder(props) {
   const handleReasonChange = reactExports.useCallback((e) => {
     props.onReasonChange(e.target.value);
   }, [props.onReasonChange]);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "guard-surface-in relative overflow-hidden rounded-[2rem] border border-brand-blue/15 bg-[radial-gradient(circle_at_top_left,rgba(85,153,254,0.12),transparent_32%),linear-gradient(135deg,#ffffff_0%,#ffffff_58%,rgba(85,153,254,0.08)_100%)] p-5 shadow-[0_20px_60px_rgba(63,65,116,0.08)] sm:p-6 lg:p-7", children: [
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "guard-surface-in relative overflow-hidden rounded-2xl border border-brand-blue/15 bg-[radial-gradient(circle_at_top_left,rgba(85,153,254,0.12),transparent_32%),linear-gradient(135deg,#ffffff_0%,#ffffff_58%,rgba(85,153,254,0.08)_100%)] p-5 shadow-[0_20px_60px_rgba(63,65,116,0.08)] sm:p-6 lg:p-7", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "pointer-events-none absolute right-8 top-8 h-24 w-24 rounded-full bg-brand-green/20 blur-3xl" }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "relative", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
@@ -16294,7 +17622,7 @@ function RuleBuilder(props) {
           )) }),
           /* @__PURE__ */ jsxRuntimeExports.jsxs("details", { children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx("summary", { className: "cursor-pointer select-none py-1 font-mono text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground transition-colors hover:text-brand-dark/70 [&::-webkit-details-marker]:hidden", children: "› Broader approval scopes" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-2 rounded-[1rem] border border-brand-blue/20 bg-brand-blue/[0.04] p-2", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-2 rounded-xl border border-brand-blue/20 bg-brand-blue/[0.04] p-2", children: [
               /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mb-2 px-1 text-[11px] font-medium text-brand-blue", children: "Broader scopes apply across more sessions. Use only when the narrower options are not enough." }),
               /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "grid gap-2 sm:grid-cols-3 xl:grid-cols-1", children: props.broadScopeOptions.map((option) => /* @__PURE__ */ jsxRuntimeExports.jsx(
                 ScopeOptionRow,
@@ -16330,7 +17658,7 @@ function RuleBuilder(props) {
 function DecisionActionPanel(props) {
   const allowText = resolveAllowButtonText(props.submitting, props.isBlocked, props.allowLabel);
   const blockText = resolveBlockButtonText(props.submitting, props.isBlocked);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-[1.65rem] border border-white/80 bg-white/80 p-4 shadow-[0_16px_40px_rgba(63,65,116,0.10)] backdrop-blur", children: [
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-white/80 bg-white/80 p-4 shadow-[0_16px_40px_rgba(63,65,116,0.10)] backdrop-blur", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Decision" }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-6 text-brand-dark/70", children: props.previewText }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3 grid gap-1.5", children: [
@@ -16444,7 +17772,7 @@ function BlockedActionCard(props) {
       window.setTimeout(() => setShareState("idle"), 2400);
     }
   }, [approvalUrl]);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "overflow-hidden rounded-[1.65rem] border border-brand-blue/15 bg-white/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.85)]", children: [
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "overflow-hidden rounded-2xl border border-brand-blue/15 bg-white/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.85)]", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `flex items-center gap-2 px-4 py-2.5 ${bannerBg}`, children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(BannerIcon, { className: "h-3.5 w-3.5 shrink-0 text-white", "aria-hidden": "true" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-mono text-[11px] font-semibold uppercase tracking-[0.2em] text-white", children: bannerLabel }),
@@ -16498,7 +17826,7 @@ function BlockedActionCard(props) {
         "."
       ] }),
       decisionDetail !== null ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-6 text-brand-dark/80", children: decisionDetail }) : null,
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 rounded-[1.25rem] bg-[#090d1a] p-1 shadow-[0_14px_35px_rgba(9,13,26,0.18)]", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 rounded-xl bg-[#090d1a] p-1 shadow-[0_14px_35px_rgba(9,13,26,0.18)]", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-1.5 border-b border-white/10 px-3 py-2", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2.5 w-2.5 rounded-full bg-brand-purple" }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2.5 w-2.5 rounded-full bg-brand-blue" }),
@@ -16509,7 +17837,7 @@ function BlockedActionCard(props) {
         /* @__PURE__ */ jsxRuntimeExports.jsx("pre", { className: "overflow-x-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-sm leading-6 text-white", children: launchText })
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsx(WhyThisPaused, { item: props.item }),
-      isBlocked && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 rounded-[1rem] border border-brand-purple/20 bg-brand-purple/[0.05] px-3 py-2.5", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-sm leading-6 text-brand-purple", children: [
+      isBlocked && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 rounded-xl border border-brand-purple/20 bg-brand-purple/[0.05] px-3 py-2.5", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-sm leading-6 text-brand-purple", children: [
         "HOL Guard blocked this based on a saved decision. If this is a false positive, choose ",
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-semibold", children: "Allow" }),
         " below and pick how broadly to remember the override."
@@ -16568,7 +17896,7 @@ function ScopeOption(props) {
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(
     "label",
     {
-      className: `flex cursor-pointer items-start gap-3 rounded-[1.15rem] border p-3 transition-all duration-150 ${props.checked ? "border-brand-blue/30 bg-white shadow-sm" : "border-transparent bg-white/55 hover:border-brand-dark/15 hover:bg-white"}`,
+      className: `flex cursor-pointer items-start gap-3 rounded-xl border p-3 transition-all duration-150 ${props.checked ? "border-brand-blue/30 bg-white shadow-sm" : "border-transparent bg-white/55 hover:border-brand-dark/15 hover:bg-white"}`,
       children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx(
           "input",
@@ -16608,2327 +17936,6 @@ function simplifyRiskHeadline(headline, harness) {
   }
   return headline;
 }
-function collectHarnesses(snapshot) {
-  const harnesses = /* @__PURE__ */ new Set();
-  for (const item of snapshot.items) harnesses.add(item.harness);
-  for (const receipt of snapshot.latest_receipts) harnesses.add(receipt.harness);
-  return Array.from(harnesses).sort((a, b) => a.localeCompare(b));
-}
-function renderReceiptContext(receipt) {
-  return `${harnessDisplayName(receipt.harness)} · ${receipt.policy_decision.replace(/-/g, " ")}`;
-}
-function resolveAppStatus(install, hasInventory, hasReceipts) {
-  if (install !== void 0) {
-    if (install.active) return "protected";
-    return "needs_repair";
-  }
-  if (!hasInventory && !hasReceipts) return "not_found";
-  return "found_unprotected";
-}
-function StatusIcon({ status }) {
-  if (status === "protected") return /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-4 w-4 text-emerald-500", "aria-hidden": "true" });
-  if (status === "found_unprotected") return /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationCircle, { className: "h-4 w-4 text-brand-attention", "aria-hidden": "true" });
-  if (status === "needs_repair") return /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniWrenchScrewdriver, { className: "h-4 w-4 text-brand-purple", "aria-hidden": "true" });
-  return /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniXCircle, { className: "h-4 w-4 text-slate-300", "aria-hidden": "true" });
-}
-function StatusBadge({ status }) {
-  if (status === "protected") return /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs font-medium text-emerald-600", children: "Protected" });
-  if (status === "found_unprotected") return /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs font-medium text-brand-attention", children: "Found, not installed" });
-  if (status === "needs_repair") return /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs font-medium text-brand-purple", children: "Repair needed" });
-  return /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs text-slate-400", children: "Not found" });
-}
-function FleetWorkspace(props) {
-  const harnesses = collectHarnesses(props.runtime);
-  const managedInstalls = props.runtime.managed_installs ?? [];
-  const activeInstalls = managedInstalls.filter((i) => i.active);
-  const inventory = props.inventory.kind === "ready" ? props.inventory.items : [];
-  const visibleHarnesses = Array.from(
-    /* @__PURE__ */ new Set([
-      ...managedInstalls.map((i) => i.harness),
-      ...harnesses,
-      ...inventory.map((i) => i.harness),
-      ...props.policies.map((p) => p.harness)
-    ])
-  ).sort((a, b) => a.localeCompare(b));
-  const runtimeState = props.runtime.runtime_state;
-  const receiptHarnesses = new Set(props.runtime.latest_receipts.map((r) => r.harness));
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-8", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx(
-      GuardHero,
-      {
-        status: activeInstalls.length > 0 ? "clear" : "setup_gap",
-        headline: activeInstalls.length > 0 ? "Your apps are covered" : "Connect an app to start",
-        subheadline: activeInstalls.length > 0 ? "Confirm that Guard is running and protecting your local AI apps." : "Guard works with Codex, Claude Code, Cursor, Hermes, OpenClaw, and more.",
-        cta: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: props.runtime.fleet_url, children: "Open Cloud Devices" }),
-        secondaryCta: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: props.runtime.dashboard_url, variant: "outline", children: "Open Home" })
-      }
-    ),
-    /* @__PURE__ */ jsxRuntimeExports.jsx(
-      ProofStrip,
-      {
-        items: [
-          { label: "Needs review", value: `${props.runtime.pending_count}`, tone: props.runtime.pending_count > 0 ? "blue" : "slate" },
-          { label: "History", value: `${props.runtime.receipt_count}`, tone: "purple" },
-          { label: "Watched apps", value: `${activeInstalls.length > 0 ? activeInstalls.length : visibleHarnesses.length}`, tone: activeInstalls.length > 0 ? "green" : "slate" },
-          { label: "Runtime", value: runtimeState ? "active" : "offline", tone: runtimeState ? "green" : "slate" }
-        ]
-      }
-    ),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-8 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,0.8fr)]", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mb-4", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "App coverage" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-500", children: "Which apps Guard is watching on this machine." })
-        ] }),
-        visibleHarnesses.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "divide-y divide-slate-100 border-t border-slate-100", children: visibleHarnesses.map((harness) => {
-          const install = managedInstalls.find((i) => i.harness === harness);
-          const harnessInventory = inventory.filter((i) => i.harness === harness && i.present);
-          const harnessPolicies = props.policies.filter((p) => p.harness === harness);
-          const hasReceipts = receiptHarnesses.has(harness);
-          const status = resolveAppStatus(install, harnessInventory.length > 0, hasReceipts);
-          const isClickable = props.onOpenAppDetail !== void 0;
-          return /* @__PURE__ */ jsxRuntimeExports.jsxs(
-            "div",
-            {
-              className: `flex items-center justify-between gap-3 py-3 transition-colors ${isClickable ? "cursor-pointer hover:bg-slate-50/60" : ""}`,
-              onClick: isClickable ? () => props.onOpenAppDetail?.(harness) : void 0,
-              role: isClickable ? "button" : void 0,
-              tabIndex: isClickable ? 0 : void 0,
-              onKeyDown: isClickable ? (e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  props.onOpenAppDetail?.(harness);
-                }
-              } : void 0,
-              children: [
-                /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 items-center gap-3", children: [
-                  /* @__PURE__ */ jsxRuntimeExports.jsx(StatusIcon, { status }),
-                  /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
-                    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: harnessDisplayName(harness) }),
-                    /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-xs text-slate-400", children: [
-                      harnessInventory.length,
-                      " actions · ",
-                      harnessPolicies.length,
-                      " decisions"
-                    ] })
-                  ] })
-                ] }),
-                /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2", children: [
-                  /* @__PURE__ */ jsxRuntimeExports.jsx(StatusBadge, { status }),
-                  isClickable && /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronRight, { className: "h-4 w-4 text-slate-300", "aria-hidden": "true" })
-                ] })
-              ]
-            },
-            harness
-          );
-        }) }) : /* @__PURE__ */ jsxRuntimeExports.jsx(
-          EmptyState,
-          {
-            title: "No watched apps yet",
-            body: "Run HOL Guard once with Codex, Claude Code, Cursor, Hermes, or another supported app and this machine will show coverage here.",
-            tone: "teach"
-          }
-        ),
-        props.inventory.kind === "error" ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-3 text-xs text-slate-500", children: props.inventory.message }) : null
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mb-4", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Recent choices" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-500", children: "What Guard decided recently." })
-        ] }),
-        props.runtime.latest_receipts.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-0 divide-y divide-slate-100 border-t border-slate-100", children: props.runtime.latest_receipts.slice(0, 6).map((receipt) => /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "py-2.5", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "truncate text-sm font-medium text-brand-dark", children: receipt.artifact_name ?? receipt.artifact_id }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-400", children: renderReceiptContext(receipt) })
-        ] }, receipt.receipt_id)) }) : /* @__PURE__ */ jsxRuntimeExports.jsx(
-          EmptyState,
-          {
-            title: "No choices yet",
-            body: "Allow or block an action once and HOL Guard will start building local history for this machine."
-          }
-        )
-      ] })
-    ] })
-  ] });
-}
-const actionOptions = [
-  { value: "allow", label: "Allow" },
-  { value: "warn", label: "Warn" },
-  { value: "review", label: "Review" },
-  { value: "require-reapproval", label: "Ask again" },
-  { value: "sandbox-required", label: "Require sandbox" },
-  { value: "block", label: "Block" }
-];
-const surfacePolicyOptions = [
-  { value: "auto-open-once", label: "Open approval center once" },
-  { value: "approval-center", label: "Approval center only" },
-  { value: "native-only", label: "Harness prompt only" }
-];
-const securityLevels = [
-  {
-    value: "balanced",
-    label: "Balanced",
-    description: "Ask before secret access, hidden execution, exfiltration, and destructive actions.",
-    icon: HiMiniShieldCheck,
-    protects: ["Secret file access", "Credential sharing", "Destructive shell commands", "Hidden scripts"],
-    tone: "blue"
-  },
-  {
-    value: "strict",
-    label: "Strict",
-    description: "Ask more often, including new network destinations.",
-    icon: HiMiniLockClosed,
-    protects: ["Everything in Balanced", "New network destinations"],
-    tone: "purple"
-  },
-  {
-    value: "custom",
-    label: "Custom",
-    description: "Use the exact choices below for this machine and connected apps.",
-    icon: HiMiniCog6Tooth,
-    protects: [],
-    tone: "slate"
-  }
-];
-const riskControls = [
-  { key: "local_secret_read", label: "Local secrets", description: "Files such as .env, .npmrc, .netrc, SSH keys, and cloud credentials." },
-  { key: "credential_exfiltration", label: "Credential sharing", description: "Commands or scripts that appear to send keys, tokens, or credentials away." },
-  { key: "data_flow_exfiltration", label: "Secret data flow", description: "Detected source-to-sink route where a local secret is read and its value reaches a network or external sink." },
-  { key: "destructive_shell", label: "Destructive commands", description: "Shell actions that delete, overwrite, or rewrite local files." },
-  { key: "encoded_execution", label: "Hidden scripts", description: "Encoded, encrypted, or decoded-and-run command payloads." },
-  { key: "network_egress", label: "New network destinations", description: "Outbound connections Guard has not seen in this context." }
-];
-const riskProfileActions = {
-  balanced: {
-    local_secret_read: "require-reapproval",
-    credential_exfiltration: "require-reapproval",
-    data_flow_exfiltration: "require-reapproval",
-    destructive_shell: "require-reapproval",
-    encoded_execution: "require-reapproval",
-    network_egress: "warn"
-  },
-  strict: {
-    local_secret_read: "require-reapproval",
-    credential_exfiltration: "require-reapproval",
-    data_flow_exfiltration: "block",
-    destructive_shell: "require-reapproval",
-    encoded_execution: "require-reapproval",
-    network_egress: "require-reapproval"
-  },
-  custom: {
-    local_secret_read: "require-reapproval",
-    credential_exfiltration: "require-reapproval",
-    data_flow_exfiltration: "require-reapproval",
-    destructive_shell: "require-reapproval",
-    encoded_execution: "require-reapproval",
-    network_egress: "warn"
-  }
-};
-function normalizeSettingsPayload(payload) {
-  return { ...payload, settings: normalizeGuardSettings(payload.settings) };
-}
-function normalizeGuardSettings(settings) {
-  const defaults = riskProfileActions[settings.security_level];
-  const explicitOverrides = settings.risk_action_overrides ?? {};
-  const effectiveRiskActions = riskControls.reduce((actions, risk) => {
-    actions[risk.key] = settings.risk_actions?.[risk.key] ?? explicitOverrides[risk.key] ?? defaults[risk.key];
-    return actions;
-  }, {});
-  return {
-    ...settings,
-    risk_actions: effectiveRiskActions,
-    risk_action_overrides: explicitOverrides,
-    harness_risk_actions: settings.harness_risk_actions ?? {}
-  };
-}
-function buildConsequenceSummary(settings) {
-  const level = settings.security_level;
-  const mode = settings.mode;
-  if (mode === "observe") return "Guard is watching and recording what your AI apps do, but it will not pause any actions. Switch to Prompt or Enforce when you want Guard to actively protect you.";
-  if (level === "balanced") return "Guard will ask before secret access, hidden execution, and destructive commands. New network destinations get a warning. This is the recommended setting for most users.";
-  if (level === "strict") return "Guard will ask before almost every risky action, including new network destinations. Use this when working with sensitive data or untrusted AI tools.";
-  if (level === "custom") return "You have customized individual risk controls. Review the choices below to make sure they match how you want Guard to behave.";
-  return "";
-}
-function hasUnsavedChanges(saved, draft) {
-  if (saved === null || draft === null) return false;
-  return JSON.stringify(saved) !== JSON.stringify(draft);
-}
-function SettingsWorkspace() {
-  const [state, setState] = reactExports.useState({ kind: "loading" });
-  const [draft, setDraft] = reactExports.useState(null);
-  const [saving, setSaving] = reactExports.useState(false);
-  const [saveSuccess, setSaveSuccess] = reactExports.useState(false);
-  const [saveError, setSaveError] = reactExports.useState(null);
-  const [clearingApprovals, setClearingApprovals] = reactExports.useState(false);
-  const [clearingEvidence, setClearingEvidence] = reactExports.useState(false);
-  const [exporting, setExporting] = reactExports.useState(false);
-  const [repairing, setRepairing] = reactExports.useState(false);
-  const [actionMessage, setActionMessage] = reactExports.useState(null);
-  const [perfSnapshot, setPerfSnapshot] = reactExports.useState(null);
-  const [pendingMode, setPendingMode] = reactExports.useState(null);
-  const [expandedSections, setExpandedSections] = reactExports.useState({ "protection": true, "risk": false, "diagnostics": false });
-  const saveSuccessTimerRef = reactExports.useRef(null);
-  const savedSettingsRef = reactExports.useRef(null);
-  reactExports.useEffect(() => {
-    let cancelled = false;
-    fetchSettings().then((payload) => {
-      if (!cancelled) {
-        const normalizedPayload = normalizeSettingsPayload(payload);
-        setState({ kind: "ready", payload: normalizedPayload });
-        setDraft(normalizedPayload.settings);
-        savedSettingsRef.current = normalizedPayload.settings;
-      }
-    }).catch((error) => {
-      if (!cancelled) {
-        setState({ kind: "error", message: error instanceof Error ? error.message : "Unable to load Guard settings." });
-      }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-  reactExports.useEffect(() => {
-    let cancelled = false;
-    fetchRuntimeSnapshot().then((snapshot) => {
-      if (!cancelled) setPerfSnapshot(snapshot);
-    }).catch((error) => {
-      console.error("Failed to fetch runtime snapshot:", error);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-  reactExports.useEffect(() => {
-    return () => {
-      if (saveSuccessTimerRef.current !== null) clearTimeout(saveSuccessTimerRef.current);
-    };
-  }, []);
-  reactExports.useEffect(() => {
-    function handleBeforeUnload(event) {
-      if (hasUnsavedChanges(savedSettingsRef.current, draft)) {
-        event.preventDefault();
-        event.returnValue = "";
-      }
-    }
-    window.addEventListener("beforeunload", handleBeforeUnload);
-    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
-  }, [draft]);
-  const toggleSection = reactExports.useCallback((key) => {
-    setExpandedSections((prev) => ({ ...prev, [key]: !prev[key] }));
-  }, []);
-  const handleStringChange = reactExports.useCallback(
-    (key) => (event) => {
-      setDraft((value) => value === null ? value : { ...value, [key]: event.target.value });
-      setSaveError(null);
-    },
-    []
-  );
-  const handleSecurityLevelChange = reactExports.useCallback((securityLevel) => {
-    setDraft((value) => {
-      if (value === null) return value;
-      if (securityLevel === "custom") return { ...value, security_level: securityLevel };
-      return { ...value, security_level: securityLevel, risk_actions: riskProfileActions[securityLevel], risk_action_overrides: {}, harness_risk_actions: {} };
-    });
-    setSaveError(null);
-  }, []);
-  const handleRiskActionChange = reactExports.useCallback(
-    (riskKey) => (event) => {
-      setDraft((value) => {
-        if (value === null) return value;
-        return { ...value, security_level: "custom", risk_actions: { ...value.risk_actions, [riskKey]: event.target.value }, risk_action_overrides: { ...value.risk_action_overrides, [riskKey]: event.target.value } };
-      });
-      setSaveError(null);
-    },
-    []
-  );
-  const handleCodexSecretReadChange = reactExports.useCallback((event) => {
-    setDraft((value) => {
-      if (value === null) return value;
-      return { ...value, security_level: "custom", harness_risk_actions: { ...value.harness_risk_actions, codex: { ...value.harness_risk_actions.codex ?? {}, local_secret_read: event.target.value } } };
-    });
-    setSaveError(null);
-  }, []);
-  const handleTimeoutChange = reactExports.useCallback((event) => {
-    const nextValue = Number.parseInt(event.target.value, 10);
-    setDraft((value) => value === null ? value : { ...value, approval_wait_timeout_seconds: Number.isNaN(nextValue) ? 0 : nextValue });
-    setSaveError(null);
-  }, []);
-  const handleModeChange = reactExports.useCallback((event) => {
-    const nextMode = event.target.value;
-    if (nextMode === "observe") {
-      setPendingMode(nextMode);
-      return;
-    }
-    setDraft((value) => value === null ? value : { ...value, mode: nextMode });
-    setSaveError(null);
-  }, []);
-  const confirmModeChange = reactExports.useCallback(() => {
-    if (pendingMode === null) return;
-    setDraft((value) => value === null ? value : { ...value, mode: pendingMode });
-    setPendingMode(null);
-    setSaveError(null);
-  }, [pendingMode]);
-  const cancelModeChange = reactExports.useCallback(() => {
-    setPendingMode(null);
-  }, []);
-  const handleBooleanChange = reactExports.useCallback(
-    (key) => (event) => {
-      setDraft((value) => value === null ? value : { ...value, [key]: event.target.checked });
-      setSaveError(null);
-    },
-    []
-  );
-  const handleSave = reactExports.useCallback(async () => {
-    if (draft === null) return;
-    setSaving(true);
-    setSaveError(null);
-    setSaveSuccess(false);
-    try {
-      const payload = await updateSettings({ ...draft, risk_actions: draft.security_level === "custom" ? draft.risk_actions : draft.risk_action_overrides });
-      const normalizedPayload = normalizeSettingsPayload(payload);
-      setState({ kind: "ready", payload: normalizedPayload });
-      setDraft(normalizedPayload.settings);
-      savedSettingsRef.current = normalizedPayload.settings;
-      setSaveSuccess(true);
-      if (saveSuccessTimerRef.current !== null) clearTimeout(saveSuccessTimerRef.current);
-      saveSuccessTimerRef.current = setTimeout(() => setSaveSuccess(false), 2e3);
-    } catch (error) {
-      setSaveError(error instanceof Error ? error.message : "Unable to save settings.");
-    } finally {
-      setSaving(false);
-    }
-  }, [draft]);
-  const handleClearApprovals = reactExports.useCallback(async () => {
-    if (!window.confirm("Clear all saved approvals? Guard will ask again for previously approved actions.")) return;
-    setClearingApprovals(true);
-    setActionMessage(null);
-    try {
-      await clearPolicy({ all: true });
-      setActionMessage("All saved approvals cleared.");
-    } catch (error) {
-      setActionMessage(error instanceof Error ? error.message : "Unable to clear approvals.");
-    } finally {
-      setClearingApprovals(false);
-    }
-  }, []);
-  const handleClearEvidence = reactExports.useCallback(async () => {
-    if (!window.confirm("Clear the evidence log permanently? This cannot be undone.")) return;
-    setClearingEvidence(true);
-    setActionMessage(null);
-    try {
-      await clearEvidence();
-      setActionMessage("Evidence log cleared.");
-    } catch (error) {
-      setActionMessage(error instanceof Error ? error.message : "Unable to clear evidence.");
-    } finally {
-      setClearingEvidence(false);
-    }
-  }, []);
-  const handleExportDiagnostics = reactExports.useCallback(async () => {
-    setExporting(true);
-    setActionMessage(null);
-    try {
-      const blob = await exportDiagnostics();
-      const url = URL.createObjectURL(blob);
-      const anchor = document.createElement("a");
-      anchor.href = url;
-      anchor.download = `guard-diagnostics-${Date.now()}.json`;
-      anchor.click();
-      URL.revokeObjectURL(url);
-      setActionMessage("Diagnostics exported.");
-    } catch (error) {
-      setActionMessage(error instanceof Error ? error.message : "Unable to export diagnostics.");
-    } finally {
-      setExporting(false);
-    }
-  }, []);
-  const handleRepairApprovalCenter = reactExports.useCallback(async () => {
-    if (!window.confirm("Reset the approval center locator? The daemon will be reachable again after Guard restarts. Pending approvals are preserved.")) return;
-    setRepairing(true);
-    setActionMessage(null);
-    try {
-      await repairApprovalCenter();
-      setActionMessage("Approval center repaired. Restart Guard to reconnect.");
-    } catch (error) {
-      setActionMessage(error instanceof Error ? error.message : "Unable to repair approval center.");
-    } finally {
-      setRepairing(false);
-    }
-  }, []);
-  if (state.kind === "loading") {
-    return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-skeleton h-10 w-64" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-skeleton h-72 w-full" })
-    ] });
-  }
-  if (state.kind === "error" || draft === null) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx(EmptyState, { title: "Settings are unavailable", body: state.kind === "error" ? state.message : "Guard did not return editable settings.", tone: "teach" });
-  }
-  const modeHelp = draft.mode === "enforce" ? "Guard blocks risky actions until a saved decision allows them." : draft.mode === "observe" ? "Guard records what it sees without pausing actions." : "Guard asks before risky actions continue.";
-  const consequenceSummary = buildConsequenceSummary(draft);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx(
-      GuardHero,
-      {
-        status: "clear",
-        headline: "Choose how protective Guard should be",
-        subheadline: "Start with a simple security level, then tune exact risk types when a trusted app needs more room to work.",
-        cta: /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: "blue", children: draft.mode })
-      }
-    ),
-    consequenceSummary && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-xl border border-brand-blue/10 bg-brand-blue/[0.03] p-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-blue" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "What to expect" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-500", children: consequenceSummary })
-      ] })
-    ] }) }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
-        AccordionSection,
-        {
-          title: "Protection level",
-          subtitle: `${draft.security_level === "balanced" ? "Balanced" : draft.security_level === "strict" ? "Strict" : "Custom"} · ${draft.mode}`,
-          expanded: expandedSections["protection"],
-          onToggle: () => toggleSection("protection"),
-          children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "grid gap-3 md:grid-cols-3", children: securityLevels.map((level) => {
-              const LevelIcon = level.icon;
-              const isSelected = draft.security_level === level.value;
-              const iconColorClass = level.tone === "blue" ? "text-brand-blue" : level.tone === "purple" ? "text-brand-purple" : "text-slate-500";
-              const iconBgClass = level.tone === "blue" ? "bg-brand-blue/10" : level.tone === "purple" ? "bg-brand-purple/10" : "bg-slate-100";
-              const selectedBorderClass = level.tone === "blue" ? "border-brand-blue/30 bg-brand-blue/[0.05]" : level.tone === "purple" ? "border-brand-purple/30 bg-brand-purple/[0.04]" : "border-slate-300 bg-slate-50";
-              return /* @__PURE__ */ jsxRuntimeExports.jsxs(
-                "button",
-                {
-                  type: "button",
-                  onClick: () => handleSecurityLevelChange(level.value),
-                  "aria-pressed": isSelected,
-                  className: `relative rounded-xl border p-4 text-left transition-all duration-150 hover:-translate-y-0.5 ${isSelected ? selectedBorderClass : "border-transparent bg-slate-50/80 hover:bg-white"}`,
-                  children: [
-                    isSelected && /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "absolute right-3 top-3 flex h-5 w-5 items-center justify-center rounded-full bg-[#059669]", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-3.5 w-3.5 text-white", "aria-hidden": "true" }) }),
-                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `inline-flex h-8 w-8 items-center justify-center rounded-lg ${iconBgClass}`, children: /* @__PURE__ */ jsxRuntimeExports.jsx(LevelIcon, { className: `h-4 w-4 ${iconColorClass}`, "aria-hidden": "true" }) }),
-                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mt-2 block text-sm font-semibold text-brand-dark", children: level.label }),
-                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mt-1 block text-xs leading-relaxed text-slate-500", children: level.description }),
-                    level.protects.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx("ul", { className: "mt-2 space-y-0.5", children: level.protects.map((item) => /* @__PURE__ */ jsxRuntimeExports.jsxs("li", { className: "flex items-center gap-1.5 text-[11px] text-slate-500", children: [
-                      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `h-1 w-1 shrink-0 rounded-full ${iconColorClass}` }),
-                      item
-                    ] }, item)) })
-                  ]
-                },
-                level.value
-              );
-            }) }),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Protection mode" }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-2 grid gap-2 sm:grid-cols-3", children: ["prompt", "enforce", "observe"].map((mode) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
-                "label",
-                {
-                  className: `cursor-pointer rounded-lg border p-3 transition-all ${draft.mode === mode ? "border-brand-blue/25 bg-brand-blue/[0.04]" : "border-transparent bg-slate-50/80 hover:bg-white"}`,
-                  children: [
-                    /* @__PURE__ */ jsxRuntimeExports.jsx("input", { type: "radio", name: "mode", value: mode, checked: draft.mode === mode, onChange: handleModeChange, className: "sr-only" }),
-                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-semibold capitalize text-brand-dark", children: mode })
-                  ]
-                },
-                mode
-              )) }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-slate-500", children: modeHelp })
-            ] }),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 sm:grid-cols-2", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-                /* @__PURE__ */ jsxRuntimeExports.jsx("label", { htmlFor: "approval-wait", className: "block text-sm font-semibold text-brand-dark", children: "Approval wait timeout" }),
-                /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Seconds to wait before returning to the harness" }),
-                /* @__PURE__ */ jsxRuntimeExports.jsx("input", { id: "approval-wait", type: "number", min: 0, max: 600, value: draft.approval_wait_timeout_seconds, onChange: handleTimeoutChange, className: "mt-2 min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-1 focus:ring-brand-blue/20" })
-              ] }),
-              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2", children: [
-                /* @__PURE__ */ jsxRuntimeExports.jsx(SettingToggle, { label: "Telemetry", checked: draft.telemetry, onChange: handleBooleanChange("telemetry") }),
-                /* @__PURE__ */ jsxRuntimeExports.jsx(SettingToggle, { label: "Cloud sync", checked: draft.sync, onChange: handleBooleanChange("sync") }),
-                /* @__PURE__ */ jsxRuntimeExports.jsx(SettingToggle, { label: "Billing features", checked: draft.billing, onChange: handleBooleanChange("billing") })
-              ] })
-            ] })
-          ] })
-        }
-      ),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
-        AccordionSection,
-        {
-          title: "Risk choices",
-          subtitle: draft.security_level !== "custom" ? `Managed by ${draft.security_level}` : "Custom overrides active",
-          expanded: expandedSections["risk"],
-          onToggle: () => toggleSection("risk"),
-          children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
-            draft.security_level !== "custom" && /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-sm text-slate-500", children: [
-              "All risk behaviors are set by the ",
-              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-semibold", children: draft.security_level === "balanced" ? "Balanced" : "Strict" }),
-              " level. Select ",
-              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-semibold", children: "Custom" }),
-              " above to override individual choices."
-            ] }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: `divide-y divide-slate-100 border-t border-slate-100 ${draft.security_level !== "custom" ? "opacity-60" : ""}`, children: riskControls.map((risk) => /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-2 py-3 md:grid-cols-[minmax(0,1fr)_200px] md:items-center", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-                /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: risk.label }),
-                /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: risk.description })
-              ] }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx(SettingSelect, { label: "Guard should", value: draft.risk_actions[risk.key] ?? "require-reapproval", options: actionOptions, onChange: handleRiskActionChange(risk.key), disabled: draft.security_level !== "custom" })
-            ] }, risk.key)) }),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `grid gap-2 py-3 md:grid-cols-[minmax(0,1fr)_200px] md:items-center border-t border-slate-100 ${draft.security_level !== "custom" ? "opacity-60" : ""}`, children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-                /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: "Codex reading local secret files" }),
-                /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Use this only for trusted projects where Codex should be allowed to open files such as .env or .npmrc." })
-              ] }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx(SettingSelect, { label: "Codex should", value: draft.harness_risk_actions.codex?.local_secret_read ?? draft.risk_actions.local_secret_read ?? "require-reapproval", options: actionOptions, onChange: handleCodexSecretReadChange, disabled: draft.security_level !== "custom" })
-            ] }),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "border-t border-slate-100 pt-3", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Advanced defaults" }),
-              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-2 grid gap-3 sm:grid-cols-2", children: [
-                /* @__PURE__ */ jsxRuntimeExports.jsx(SettingSelect, { label: "New action", value: draft.default_action, options: actionOptions, onChange: handleStringChange("default_action") }),
-                /* @__PURE__ */ jsxRuntimeExports.jsx(SettingSelect, { label: "Unknown source", value: draft.unknown_publisher_action, options: actionOptions, onChange: handleStringChange("unknown_publisher_action") }),
-                /* @__PURE__ */ jsxRuntimeExports.jsx(SettingSelect, { label: "Changed command", value: draft.changed_hash_action, options: actionOptions, onChange: handleStringChange("changed_hash_action") }),
-                /* @__PURE__ */ jsxRuntimeExports.jsx(SettingSelect, { label: "New network domain", value: draft.new_network_domain_action, options: actionOptions, onChange: handleStringChange("new_network_domain_action") }),
-                /* @__PURE__ */ jsxRuntimeExports.jsx(SettingSelect, { label: "Subprocess action", value: draft.subprocess_action, options: actionOptions, onChange: handleStringChange("subprocess_action") }),
-                /* @__PURE__ */ jsxRuntimeExports.jsx(SettingSelect, { label: "Approval surface", value: draft.approval_surface_policy, options: surfacePolicyOptions, onChange: handleStringChange("approval_surface_policy") })
-              ] })
-            ] })
-          ] })
-        }
-      ),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
-        AccordionSection,
-        {
-          title: "Diagnostics & data",
-          subtitle: "Clear approvals, export logs, repair",
-          expanded: expandedSections["diagnostics"],
-          onToggle: () => toggleSection("diagnostics"),
-          children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
-            perfSnapshot !== null && /* @__PURE__ */ jsxRuntimeExports.jsx(DiagnosticsPerfCard, { snapshot: perfSnapshot }),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 sm:grid-cols-2", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-3", children: [
-                /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-                  /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: "Clear saved approvals" }),
-                  /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Removes all stored allow/block decisions. Guard will ask again for previously approved actions." }),
-                  /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleClearApprovals, disabled: clearingApprovals, variant: "outline", children: clearingApprovals ? "Clearing…" : "Clear approvals" }) })
-                ] }),
-                /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-                  /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: "Clear evidence log" }),
-                  /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Permanently removes all recorded evidence. This cannot be undone." }),
-                  /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleClearEvidence, disabled: clearingEvidence, variant: "outline", children: clearingEvidence ? "Clearing…" : "Clear evidence" }) })
-                ] })
-              ] }),
-              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-3", children: [
-                /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-                  /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: "Export diagnostics" }),
-                  /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Downloads a JSON file with local Guard evidence for debugging or support." }),
-                  /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleExportDiagnostics, disabled: exporting, variant: "secondary", children: exporting ? "Exporting…" : "Export" }) })
-                ] }),
-                /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-                  /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: "Repair approval center" }),
-                  /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Resets the approval center locator when the approval link returns an API error." }),
-                  /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleRepairApprovalCenter, disabled: repairing, variant: "secondary", children: repairing ? "Repairing…" : "Repair" }) })
-                ] })
-              ] })
-            ] }),
-            actionMessage ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-600", children: actionMessage }) : null
-          ] })
-        }
-      )
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "sticky bottom-4 rounded-xl border border-slate-200 bg-white/95 p-4 shadow-lg backdrop-blur", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center justify-between gap-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleSave, disabled: saving || saveSuccess, children: saveSuccess ? /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "flex items-center gap-2", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-4 w-4", "aria-hidden": "true" }),
-          "Saved"
-        ] }) : saving ? "Saving…" : "Save settings" }),
-        hasUnsavedChanges(savedSettingsRef.current, draft) && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "ml-3 inline-flex items-center gap-1.5 text-xs font-medium text-brand-attention", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-1.5 w-1.5 rounded-full bg-brand-attention" }),
-          "Unsaved changes"
-        ] })
-      ] }),
-      saveSuccess ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-emerald-600", children: "Settings saved" }) : saveError ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-purple", children: saveError }) : /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Use this for local tuning. Team policy from Guard Cloud may still override some decisions." })
-    ] }) }),
-    pendingMode === "observe" && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-fade-in fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4 backdrop-blur-sm", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "w-full max-w-sm rounded-2xl border border-brand-attention/15 bg-white p-6 shadow-xl", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-brand-attention/10", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "h-5 w-5 text-brand-attention", "aria-hidden": "true" }) }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "text-base font-semibold text-brand-dark", children: "Switch to Observe mode?" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-slate-500", children: "In Observe mode, Guard records what your AI apps do but does not pause any actions. This reduces your protection. Only use this when debugging or in trusted environments." })
-        ] })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-6 flex flex-wrap gap-2", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("button", { onClick: confirmModeChange, className: "inline-flex min-h-11 items-center rounded-lg bg-brand-attention px-4 text-sm font-semibold text-white transition-colors hover:bg-brand-attention/90", children: "Switch to Observe" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("button", { onClick: cancelModeChange, className: "inline-flex min-h-11 items-center rounded-lg border border-slate-200 bg-white px-4 text-sm font-medium text-brand-dark transition-colors hover:bg-slate-50", children: "Keep current mode" })
-      ] })
-    ] }) })
-  ] });
-}
-function AccordionSection(props) {
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 overflow-hidden", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "button",
-      {
-        onClick: props.onToggle,
-        className: "flex w-full items-center justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-slate-50/60",
-        "aria-expanded": props.expanded,
-        children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: props.title }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-400", children: props.subtitle })
-          ] }),
-          props.expanded ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronUp, { className: "h-4 w-4 text-slate-400", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronDown, { className: "h-4 w-4 text-slate-400", "aria-hidden": "true" })
-        ]
-      }
-    ),
-    props.expanded && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "border-t border-slate-100 px-4 py-4", children: props.children })
-  ] });
-}
-function DiagnosticsPerfCard(props) {
-  const threadCount = props.snapshot.thread_count;
-  const daemonPort = props.snapshot.runtime_state?.daemon_port ?? null;
-  const startedAt = props.snapshot.runtime_state?.started_at ?? null;
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-lg bg-slate-50/80 px-3 py-2", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold text-brand-dark", children: "Runtime" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-slate-500", children: [
-      threadCount !== void 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
-        threadCount,
-        " threads"
-      ] }),
-      daemonPort !== null && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
-        "Port ",
-        daemonPort
-      ] }),
-      startedAt !== null && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
-        "Started ",
-        new Date(startedAt).toLocaleTimeString()
-      ] })
-    ] })
-  ] });
-}
-function SettingSelect(props) {
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs font-medium text-slate-500", children: props.label }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx(
-      "select",
-      {
-        value: props.value,
-        onChange: props.onChange,
-        disabled: props.disabled,
-        className: "mt-1 min-h-9 w-full rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-1 focus:ring-brand-blue/20 disabled:cursor-not-allowed disabled:opacity-60",
-        children: props.options.map((option) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: option.value, children: option.label }, option.value))
-      }
-    )
-  ] });
-}
-function SettingToggle(props) {
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "flex min-h-10 cursor-pointer items-center justify-between gap-3 rounded-lg border border-slate-100 bg-slate-50/60 px-3 py-2 transition-colors hover:bg-slate-100/60", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm text-brand-dark", children: props.label }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("input", { type: "checkbox", checked: props.checked, onChange: props.onChange, className: "h-4 w-4 accent-brand-blue" })
-  ] });
-}
-function getFocusableElements(container2) {
-  const selector = [
-    "button:not([disabled])",
-    "a[href]",
-    "input:not([disabled])",
-    "select:not([disabled])",
-    "textarea:not([disabled])",
-    '[tabindex]:not([tabindex="-1"])',
-    "[contenteditable]"
-  ].join(",");
-  return Array.from(container2.querySelectorAll(selector)).filter(
-    (el) => el instanceof HTMLElement && el.offsetParent !== null
-  );
-}
-function useFocusTrap(active, containerRef) {
-  const previouslyFocusedRef = reactExports.useRef(null);
-  reactExports.useEffect(() => {
-    if (!active) return;
-    const container2 = containerRef.current;
-    if (!container2) return;
-    previouslyFocusedRef.current = document.activeElement;
-    const focusable = getFocusableElements(container2);
-    const first = focusable[0];
-    const last = focusable[focusable.length - 1];
-    if (first) {
-      first.focus();
-    }
-    function handleKeyDown(event) {
-      if (event.key !== "Tab") return;
-      if (focusable.length === 0) {
-        event.preventDefault();
-        return;
-      }
-      if (event.shiftKey) {
-        if (document.activeElement === first) {
-          event.preventDefault();
-          last?.focus();
-        }
-      } else {
-        if (document.activeElement === last) {
-          event.preventDefault();
-          first?.focus();
-        }
-      }
-    }
-    container2.addEventListener("keydown", handleKeyDown);
-    return () => {
-      container2.removeEventListener("keydown", handleKeyDown);
-      if (previouslyFocusedRef.current && previouslyFocusedRef.current.isConnected) {
-        previouslyFocusedRef.current.focus();
-      }
-    };
-  }, [active, containerRef]);
-}
-function HomeWorkspace(props) {
-  const [toastMessage, setToastMessage] = reactExports.useState(null);
-  const toastTimerRef = reactExports.useRef(null);
-  reactExports.useEffect(() => {
-    return () => {
-      if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
-    };
-  }, []);
-  const showToast = reactExports.useCallback((message) => {
-    setToastMessage(message);
-    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
-    toastTimerRef.current = setTimeout(() => setToastMessage(null), 3e3);
-  }, []);
-  const handleClearPolicies = reactExports.useCallback((scope) => {
-    props.onClearPolicies(scope);
-  }, [props.onClearPolicies]);
-  const snapshot = props.runtime.kind === "ready" ? props.runtime.snapshot : null;
-  const queuedCount = props.requests.kind === "ready" ? props.requests.items.length : 0;
-  const policyItems = props.policies.kind === "ready" ? props.policies.items : [];
-  const managedInstalls = snapshot?.managed_installs ?? [];
-  const activeInstalls = managedInstalls.filter((item) => item.active);
-  const observedHarnesses = snapshot ? Array.from(
-    /* @__PURE__ */ new Set([
-      ...snapshot.items.map((item) => item.harness),
-      ...snapshot.latest_receipts.map((receipt) => receipt.harness),
-      ...policyItems.map((policy) => policy.harness)
-    ])
-  ).sort() : [];
-  const clearHarnesses = activeInstalls.length > 0 ? activeInstalls.map((i) => i.harness) : observedHarnesses;
-  const watchedAppsCount = activeInstalls.length > 0 ? activeInstalls.length : observedHarnesses.length;
-  const state = reactExports.useMemo(
-    () => deriveHomeState({
-      hasActiveInstalls: activeInstalls.length > 0,
-      hasObservedHarnesses: observedHarnesses.length > 0,
-      queuedCount,
-      watchedAppsCount
-    }),
-    [activeInstalls.length, observedHarnesses.length, queuedCount, watchedAppsCount]
-  );
-  const dailyStory = reactExports.useMemo(() => snapshot ? buildDailyStory(snapshot.latest_receipts, queuedCount) : null, [snapshot, queuedCount]);
-  const streak = reactExports.useMemo(() => snapshot ? computeStreak(snapshot.latest_receipts) : 0, [snapshot]);
-  const weeklySummary = reactExports.useMemo(() => snapshot ? buildWeeklySummary(snapshot.latest_receipts) : null, [snapshot]);
-  const ctaAction = state.ctaTarget === "inbox" ? props.onOpenInbox : state.ctaTarget === "fleet" ? props.onOpenFleet : props.onOpenEvidence;
-  if (props.runtime.kind === "loading" || props.requests.kind === "loading") {
-    return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-skeleton h-36 w-full" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-skeleton h-16 w-full" })
-    ] });
-  }
-  if (props.runtime.kind === "error") {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx(
-      EmptyState,
-      {
-        title: "Guard is not connected",
-        body: props.runtime.message,
-        action: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: props.onOpenInbox, children: "Open review queue" }),
-        tone: "teach"
-      }
-    );
-  }
-  if (!snapshot) return null;
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
-    toastMessage && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "guard-fade-in fixed bottom-6 right-6 z-50 flex items-center gap-3 rounded-[1.25rem] border border-brand-green/25 bg-brand-green-bg/90 px-4 py-3 shadow-lg backdrop-blur", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-4 w-4 shrink-0 text-brand-green", "aria-hidden": "true" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-green-text", children: toastMessage })
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx(
-      GuardHero,
-      {
-        status: state.heroStatus,
-        headline: state.headline,
-        subheadline: state.subheadline,
-        cta: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: ctaAction, "data-primary": "true", children: state.ctaLabel })
-      }
-    ),
-    /* @__PURE__ */ jsxRuntimeExports.jsx(
-      ProofStrip,
-      {
-        items: [
-          { label: "Pending", value: queuedCount, tone: queuedCount > 0 ? "blue" : "slate" },
-          { label: "Apps", value: watchedAppsCount, tone: watchedAppsCount > 0 ? "green" : "slate" },
-          { label: "Streak", value: streak, tone: streak > 1 ? "purple" : "slate", icon: streak > 1 ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniFire, { className: "h-3.5 w-3.5 text-brand-purple", "aria-hidden": "true" }) : null, hint: streak > 0 ? "Consecutive days with Guard activity. Resets after 48h of inactivity." : "Guard activity streak" },
-          { label: "History", value: snapshot?.receipt_count ?? 0, tone: "purple" }
-        ]
-      }
-    ),
-    /* @__PURE__ */ jsxRuntimeExports.jsx(StreakMilestoneBanner, { streak }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-6 lg:grid-cols-[minmax(0,1.3fr)_minmax(0,0.9fr)]", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "space-y-6", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          AppsAtAGlance,
-          {
-            managedInstalls,
-            observedHarnesses,
-            queuedItems: props.requests.kind === "ready" ? props.requests.items : [],
-            onOpenAppDetail: props.onOpenAppDetail
-          }
-        ),
-        weeklySummary && /* @__PURE__ */ jsxRuntimeExports.jsxs(
-          CollapsibleCard,
-          {
-            id: "weekly-summary",
-            icon: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCalendarDays, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-purple", "aria-hidden": "true" }),
-            label: "This week",
-            defaultOpen: true,
-            children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-muted-foreground", children: weeklySummary.body }),
-              weeklySummary.stats && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 flex flex-wrap gap-2", children: weeklySummary.stats.map((s) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
-                "span",
-                {
-                  className: "rounded-full bg-white/70 px-3 py-1 text-xs font-medium text-brand-dark",
-                  children: [
-                    s.value,
-                    " ",
-                    s.label
-                  ]
-                },
-                s.label
-              )) })
-            ]
-          }
-        ),
-        dailyStory && /* @__PURE__ */ jsxRuntimeExports.jsxs(
-          CollapsibleCard,
-          {
-            id: "daily-brief",
-            icon: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-green", "aria-hidden": "true" }),
-            label: dailyStory.title,
-            defaultOpen: true,
-            children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-muted-foreground", children: dailyStory.body }),
-              dailyStory.stats && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 flex flex-wrap gap-2", children: dailyStory.stats.map((s) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
-                "span",
-                {
-                  className: "rounded-full bg-white/70 px-3 py-1 text-xs font-medium text-brand-dark",
-                  children: [
-                    s.value,
-                    " ",
-                    s.label
-                  ]
-                },
-                s.label
-              )) })
-            ]
-          }
-        )
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "space-y-6", children: [
-        snapshot.latest_receipts.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(RecentProtectionSection, { receipts: snapshot.latest_receipts }),
-        policyItems.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Reset remembered decisions" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-500", children: "Clear remembered decisions when you want Guard to ask again next time. This does not remove your history." }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 flex flex-wrap gap-2", children: clearHarnesses.slice(0, 4).map((harness) => /* @__PURE__ */ jsxRuntimeExports.jsx(
-            ClearHarnessButton,
-            {
-              harness,
-              onClearPolicies: handleClearPolicies
-            },
-            harness
-          )) })
-        ] })
-      ] })
-    ] }),
-    props.clearConfirm && /* @__PURE__ */ jsxRuntimeExports.jsx(
-      ClearConfirmDialog,
-      {
-        clearConfirm: props.clearConfirm,
-        onCancelClear: props.onCancelClear,
-        onConfirmClear: async () => {
-          const confirm = props.clearConfirm;
-          await props.onConfirmClear();
-          if (confirm?.harness) {
-            showToast(`Cleared for ${harnessDisplayName(confirm.harness)}`);
-          } else if (confirm?.all) {
-            showToast("Cleared all decisions");
-          }
-        }
-      }
-    )
-  ] });
-}
-function ClearConfirmDialog(props) {
-  const dialogRef = reactExports.useRef(null);
-  useFocusTrap(true, dialogRef);
-  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-fade-in fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4 backdrop-blur-sm", role: "dialog", "aria-modal": "true", "aria-label": "Confirm clear decisions", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { ref: dialogRef, className: "guard-fade-in w-full max-w-md rounded-[1.75rem] border border-brand-attention/20 bg-white p-6 shadow-2xl", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-attention", "aria-hidden": "true" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "text-lg font-semibold tracking-tight text-brand-dark", children: "Clear remembered decisions?" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-2 text-sm text-muted-foreground", children: [
-          "This will remove ",
-          props.clearConfirm.all ? "all saved approvals" : `decisions for ${props.clearConfirm.harness ?? "this app"}`,
-          ". Guard will ask again next time matching actions run."
-        ] })
-      ] })
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 flex flex-col gap-2 sm:flex-row sm:justify-end", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "button",
-        {
-          type: "button",
-          onClick: props.onCancelClear,
-          className: "inline-flex min-h-11 items-center justify-center rounded-lg border border-slate-200 bg-white px-4 text-sm font-medium text-brand-dark transition-colors hover:bg-slate-50",
-          children: "Keep decisions"
-        }
-      ),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "button",
-        {
-          type: "button",
-          onClick: props.onConfirmClear,
-          className: "inline-flex min-h-11 items-center justify-center rounded-lg bg-brand-attention px-4 text-sm font-semibold text-white transition-colors hover:bg-brand-attention/90",
-          children: "Clear decisions"
-        }
-      )
-    ] })
-  ] }) });
-}
-function deriveHomeState(input) {
-  const { hasActiveInstalls, hasObservedHarnesses, queuedCount, watchedAppsCount } = input;
-  if (queuedCount > 0) {
-    return {
-      heroStatus: "needs_review",
-      headline: queuedCount === 1 ? "1 action needs review" : `${queuedCount} actions need review`,
-      subheadline: "Guard stopped something. Review and decide whether to allow or block it.",
-      ctaLabel: "Review now",
-      ctaTarget: "inbox"
-    };
-  }
-  if (!hasActiveInstalls && !hasObservedHarnesses) {
-    return {
-      heroStatus: "setup_gap",
-      headline: "Guard is ready",
-      subheadline: "Connect your first AI app so Guard can start protecting it.",
-      ctaLabel: "Open Apps",
-      ctaTarget: "fleet"
-    };
-  }
-  if (!hasActiveInstalls && hasObservedHarnesses) {
-    return {
-      heroStatus: "setup_gap",
-      headline: "Finish setup",
-      subheadline: "Guard detected apps but they need setup to be fully protected.",
-      ctaLabel: "Open Apps",
-      ctaTarget: "fleet"
-    };
-  }
-  return {
-    heroStatus: "clear",
-    headline: "All clear",
-    subheadline: `Guard is watching your AI work. ${watchedAppsCount} app${watchedAppsCount !== 1 ? "s" : ""} protected. Nothing needs you right now.`,
-    ctaLabel: "View history",
-    ctaTarget: "evidence"
-  };
-}
-function buildDailyStory(receipts, queuedCount) {
-  const today = /* @__PURE__ */ new Date();
-  today.setHours(0, 0, 0, 0);
-  const todayReceipts = receipts.filter((r) => new Date(r.timestamp) >= today);
-  const allowedToday = todayReceipts.filter((r) => r.policy_decision === "allow").length;
-  const blockedToday = todayReceipts.filter((r) => r.policy_decision === "block").length;
-  if (queuedCount > 0) {
-    return {
-      title: "Needs your attention",
-      body: `${queuedCount} action${queuedCount === 1 ? " is" : "s are"} waiting for review. Guard paused them to keep you safe.`,
-      stats: [{ label: "pending review", value: queuedCount }]
-    };
-  }
-  if (allowedToday + blockedToday > 0) {
-    return {
-      title: "Today so far",
-      body: `Guard allowed ${allowedToday} action${allowedToday !== 1 ? "s" : ""} and blocked ${blockedToday}.`,
-      stats: [
-        { label: "allowed", value: allowedToday },
-        { label: "blocked", value: blockedToday }
-      ]
-    };
-  }
-  if (receipts.length > 0) {
-    const last = receipts[0];
-    return {
-      title: "All quiet",
-      body: `No new activity today. Last decision was ${formatRelativeTime(last.timestamp)}.`
-    };
-  }
-  return null;
-}
-function computeStreak(receipts) {
-  if (receipts.length === 0) return 0;
-  const sortedByTime = [...receipts].sort((a, b) => +new Date(b.timestamp) - +new Date(a.timestamp));
-  const mostRecent = new Date(sortedByTime[0].timestamp);
-  const now2 = /* @__PURE__ */ new Date();
-  const diffHours = (now2.getTime() - mostRecent.getTime()) / (1e3 * 60 * 60);
-  if (diffHours > 48) return 0;
-  const dates = new Set(receipts.map((r) => new Date(r.timestamp).toDateString()));
-  const sortedDates = Array.from(dates).sort((a, b) => +new Date(b) - +new Date(a));
-  let streak = 0;
-  const today = /* @__PURE__ */ new Date();
-  today.setHours(0, 0, 0, 0);
-  let checkDate = new Date(today);
-  for (const dateStr of sortedDates) {
-    const d = new Date(dateStr);
-    d.setHours(0, 0, 0, 0);
-    if (d.getTime() === checkDate.getTime()) {
-      streak++;
-      checkDate.setDate(checkDate.getDate() - 1);
-    } else if (d.getTime() < checkDate.getTime()) {
-      break;
-    }
-  }
-  return streak;
-}
-function buildWeeklySummary(receipts) {
-  const now2 = /* @__PURE__ */ new Date();
-  const startOfWeek = new Date(now2);
-  startOfWeek.setDate(now2.getDate() - now2.getDay());
-  startOfWeek.setHours(0, 0, 0, 0);
-  const weekReceipts = receipts.filter((r) => new Date(r.timestamp) >= startOfWeek);
-  if (weekReceipts.length === 0) return null;
-  const allowed = weekReceipts.filter((r) => r.policy_decision === "allow").length;
-  const blocked = weekReceipts.filter((r) => r.policy_decision === "block").length;
-  const uniqueApps = new Set(weekReceipts.map((r) => r.harness)).size;
-  return {
-    body: `Guard reviewed ${weekReceipts.length} actions across ${uniqueApps} app${uniqueApps !== 1 ? "s" : ""} this week.`,
-    stats: [
-      { label: "allowed", value: allowed },
-      { label: "blocked", value: blocked },
-      { label: "apps", value: uniqueApps }
-    ]
-  };
-}
-function AppsAtAGlance(props) {
-  const pendingByHarness = reactExports.useMemo(() => {
-    const map = /* @__PURE__ */ new Map();
-    for (const item of props.queuedItems) {
-      map.set(item.harness, (map.get(item.harness) ?? 0) + 1);
-    }
-    return map;
-  }, [props.queuedItems]);
-  const sortedHarnesses = reactExports.useMemo(() => {
-    const all = Array.from(
-      /* @__PURE__ */ new Set([
-        ...props.managedInstalls.map((i) => i.harness),
-        ...props.observedHarnesses
-      ])
-    );
-    return all.sort((a, b) => {
-      const aInstall = props.managedInstalls.find((i) => i.harness === a);
-      const bInstall = props.managedInstalls.find((i) => i.harness === b);
-      const aPending = pendingByHarness.get(a) ?? 0;
-      const bPending = pendingByHarness.get(b) ?? 0;
-      const aScore = (aInstall?.active ? 3 : aInstall !== void 0 ? 2 : props.observedHarnesses.includes(a) ? 1 : 0) + (aPending > 0 ? 4 : 0);
-      const bScore = (bInstall?.active ? 3 : bInstall !== void 0 ? 2 : props.observedHarnesses.includes(b) ? 1 : 0) + (bPending > 0 ? 4 : 0);
-      return bScore - aScore;
-    });
-  }, [props.managedInstalls, props.observedHarnesses, pendingByHarness]);
-  const [focusedIndex, setFocusedIndex] = reactExports.useState(-1);
-  const listRef = reactExports.useRef(null);
-  const handleKeyDown = reactExports.useCallback(
-    (e, index) => {
-      if (e.key === "ArrowDown") {
-        e.preventDefault();
-        const next = Math.min(index + 1, sortedHarnesses.length - 1);
-        setFocusedIndex(next);
-        const nextBtn = listRef.current?.querySelectorAll("button[data-app-item]")[next];
-        nextBtn?.focus();
-      } else if (e.key === "ArrowUp") {
-        e.preventDefault();
-        const prev = Math.max(index - 1, 0);
-        setFocusedIndex(prev);
-        const prevBtn = listRef.current?.querySelectorAll("button[data-app-item]")[prev];
-        prevBtn?.focus();
-      } else if (e.key === "Enter" || e.key === " ") {
-        e.preventDefault();
-        props.onOpenAppDetail(sortedHarnesses[index]);
-      }
-    },
-    [sortedHarnesses, props.onOpenAppDetail]
-  );
-  if (sortedHarnesses.length === 0) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx(
-      EmptyState,
-      {
-        title: "No apps connected yet",
-        body: "Connect an AI app so Guard can start protecting it. Guard works with Codex, Claude Code, Cursor, Hermes, OpenClaw, and more.",
-        tone: "teach"
-      }
-    );
-  }
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mb-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Apps at a glance" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-500", children: "Guard is watching these apps on this machine." })
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { ref: listRef, className: "divide-y divide-slate-100 border-t border-slate-100", role: "list", "aria-label": "Apps at a glance", children: sortedHarnesses.map((harness, index) => {
-      const install = props.managedInstalls.find((i) => i.harness === harness);
-      const isObserved = props.observedHarnesses.includes(harness);
-      const pending = pendingByHarness.get(harness) ?? 0;
-      return /* @__PURE__ */ jsxRuntimeExports.jsxs(
-        "button",
-        {
-          "data-app-item": true,
-          onClick: () => props.onOpenAppDetail(harness),
-          onKeyDown: (e) => handleKeyDown(e, index),
-          onFocus: () => setFocusedIndex(index),
-          onBlur: () => setFocusedIndex(-1),
-          className: `flex w-full items-center justify-between gap-3 py-2.5 text-left transition-colors hover:bg-slate-50/60 ${focusedIndex === index ? "bg-brand-blue/[0.04]" : ""}`,
-          role: "listitem",
-          children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 items-center gap-2.5", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx(AppStatusIcon, { install, isObserved }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "truncate text-sm font-medium text-brand-dark", children: harnessDisplayName(harness) })
-            ] }),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2", children: [
-              pending > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs(Badge, { tone: "info", children: [
-                pending,
-                " pending"
-              ] }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx(AppStatusBadge$1, { install, isObserved }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronRight, { className: "h-4 w-4 shrink-0 text-slate-300", "aria-hidden": "true" })
-            ] })
-          ]
-        },
-        harness
-      );
-    }) })
-  ] });
-}
-function AppStatusIcon(props) {
-  if (props.install?.active === true) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-4 w-4 shrink-0 text-brand-green", "aria-hidden": "true" });
-  }
-  if (props.install !== void 0 && !props.install.active) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniMinusCircle, { className: "h-4 w-4 shrink-0 text-brand-attention", "aria-hidden": "true" });
-  }
-  if (props.isObserved) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniMinusCircle, { className: "h-4 w-4 shrink-0 text-slate-400", "aria-hidden": "true" });
-  }
-  return /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniMinusCircle, { className: "h-4 w-4 shrink-0 text-slate-300", "aria-hidden": "true" });
-}
-function AppStatusBadge$1(props) {
-  if (props.install?.active === true) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "success", children: "Active" });
-  }
-  if (props.install !== void 0 && !props.install.active) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "attention", children: "Needs setup" });
-  }
-  if (props.isObserved) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "default", children: "Observed" });
-  }
-  return /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "default", children: "Unknown" });
-}
-function ClearHarnessButton(props) {
-  const handleClick = reactExports.useCallback(() => {
-    void props.onClearPolicies({ harness: props.harness });
-  }, [props.onClearPolicies, props.harness]);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { variant: "outline", onClick: handleClick, children: [
-    "Clear ",
-    props.harness
-  ] });
-}
-function RecentReceiptRow(props) {
-  const { receipt } = props;
-  const decisionLabel = receipt.policy_decision === "allow" ? "allowed" : "blocked";
-  const name = receipt.artifact_name ?? receipt.artifact_id;
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start justify-between gap-3 border-b border-slate-200/70 px-4 py-3 last:border-b-0", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "min-w-0", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-sm text-brand-dark", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-medium", children: harnessDisplayName(receipt.harness) }),
-      " ",
-      decisionLabel,
-      " ",
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-mono text-xs", children: name })
-    ] }) }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "shrink-0 text-[11px] text-muted-foreground", children: formatRelativeTime(receipt.timestamp) })
-  ] });
-}
-function RecentProtectionSection(props) {
-  const recent = props.receipts.slice(0, 3);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "rounded-[1.75rem] border border-slate-200/70 bg-white/80 p-5 shadow-sm sm:p-6", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Recent protection" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-muted-foreground", children: "What Guard stopped or allowed recently." }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 overflow-hidden rounded-[1.25rem] border border-slate-200/70", children: recent.map((receipt) => /* @__PURE__ */ jsxRuntimeExports.jsx(RecentReceiptRow, { receipt }, receipt.receipt_id)) })
-  ] });
-}
-const MILESTONE_STREAKS = [7, 14, 30];
-function StreakMilestoneBanner({ streak }) {
-  const milestone = MILESTONE_STREAKS.includes(streak) ? streak : null;
-  const storageKey = milestone ? `guard-streak-milestone-dismissed-${milestone}` : "";
-  const [dismissed, setDismissed] = reactExports.useState(() => {
-    if (typeof window === "undefined" || !storageKey) return true;
-    return localStorage.getItem(storageKey) === "1";
-  });
-  const handleDismiss = reactExports.useCallback(() => {
-    setDismissed(true);
-    if (storageKey) localStorage.setItem(storageKey, "1");
-  }, [storageKey]);
-  if (!milestone || dismissed) return null;
-  const messages = {
-    7: "One week of consistent protection! Guard is watching out for you every day.",
-    14: "Two weeks strong! Your security routine is paying off.",
-    30: "A full month of daily protection! You are building a great security habit."
-  };
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "guard-fade-in relative overflow-hidden rounded-[1.75rem] border border-brand-purple/20 bg-brand-purple/[0.04] p-5 shadow-sm sm:p-6", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "absolute -right-6 -top-6 h-24 w-24 rounded-full bg-brand-purple/10" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "relative flex items-start gap-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-brand-purple/10", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniSparkles, { className: "h-5 w-5 text-brand-purple", "aria-hidden": "true" }) }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex-1", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs(SectionLabel, { children: [
-          streak,
-          " day streak!"
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-muted-foreground", children: messages[milestone] })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "button",
-        {
-          onClick: handleDismiss,
-          className: "shrink-0 rounded-full p-1.5 text-muted-foreground transition-colors hover:bg-white/70 hover:text-brand-dark",
-          "aria-label": "Dismiss streak celebration",
-          children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniXMark, { className: "h-4 w-4", "aria-hidden": "true" })
-        }
-      )
-    ] })
-  ] });
-}
-function CollapsibleCard(props) {
-  const storageKey = `guard-collapsed-${props.id}`;
-  const [isOpen, setIsOpen] = reactExports.useState(() => {
-    if (typeof window === "undefined") return props.defaultOpen ?? true;
-    const saved = localStorage.getItem(storageKey);
-    return saved === null ? props.defaultOpen ?? true : saved === "1";
-  });
-  const toggle = reactExports.useCallback(() => {
-    setIsOpen((prev) => {
-      const next = !prev;
-      localStorage.setItem(storageKey, next ? "1" : "0");
-      return next;
-    });
-  }, [storageKey]);
-  const borderClass = props.id === "daily-brief" ? "border-brand-green/15 bg-brand-green/[0.04]" : "border-brand-purple/15 bg-brand-purple/[0.04]";
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `rounded-[1.75rem] border ${borderClass} p-5 shadow-sm sm:p-6`, children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "button",
-      {
-        onClick: toggle,
-        className: "flex w-full items-center gap-3 text-left",
-        "aria-expanded": isOpen,
-        "aria-controls": `collapsible-content-${props.id}`,
-        children: [
-          props.icon,
-          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex-1", children: /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: props.label }) }),
-          isOpen ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronUp, { className: "h-4 w-4 shrink-0 text-muted-foreground", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronDown, { className: "h-4 w-4 shrink-0 text-muted-foreground", "aria-hidden": "true" })
-        ]
-      }
-    ),
-    isOpen && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: `collapsible-content-${props.id}`, className: "mt-3 guard-fade-in", children: props.children })
-  ] });
-}
-const tabOrder = ["overview", "activity", "settings"];
-function readTabFromUrl() {
-  const hash = window.location.hash.replace("#", "");
-  if (hash === "activity" || hash === "settings") return hash;
-  return "overview";
-}
-function writeTabToUrl(tab) {
-  const url = new URL(window.location.href);
-  url.hash = tab;
-  window.history.replaceState({}, "", url.toString());
-}
-function AppDetailWorkspace(props) {
-  const [activeTab, setActiveTab] = reactExports.useState(readTabFromUrl);
-  const [tabDirection, setTabDirection] = reactExports.useState("right");
-  const touchStartX = reactExports.useRef(null);
-  reactExports.useEffect(() => {
-    function handleHashChange() {
-      setActiveTab(readTabFromUrl());
-    }
-    window.addEventListener("hashchange", handleHashChange);
-    return () => window.removeEventListener("hashchange", handleHashChange);
-  }, []);
-  const [harnessQueue, setHarnessQueue] = reactExports.useState({ kind: "loading" });
-  const [harnessPolicy, setHarnessPolicy] = reactExports.useState({ kind: "loading" });
-  const { harness, runtime, receipts, policies, inventory } = props;
-  const loadTabData = reactExports.useCallback(() => {
-    let cancelled = false;
-    setHarnessQueue({ kind: "loading" });
-    setHarnessPolicy({ kind: "loading" });
-    Promise.allSettled([
-      fetchApprovalPage({ harness, status: "pending" }),
-      fetchPolicy(harness)
-    ]).then(([queueResult, policyResult]) => {
-      if (cancelled) return;
-      if (queueResult.status === "fulfilled") {
-        setHarnessQueue({ kind: "ready", items: queueResult.value.items ?? [] });
-      } else {
-        setHarnessQueue({
-          kind: "error",
-          message: queueResult.reason instanceof Error ? queueResult.reason.message : "Unable to load queue."
-        });
-      }
-      if (policyResult.status === "fulfilled") {
-        setHarnessPolicy({ kind: "ready", items: policyResult.value ?? [] });
-      } else {
-        setHarnessPolicy({
-          kind: "error",
-          message: policyResult.reason instanceof Error ? policyResult.reason.message : "Unable to load policy."
-        });
-      }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [harness]);
-  reactExports.useEffect(() => {
-    const cleanup = loadTabData();
-    return cleanup;
-  }, [loadTabData]);
-  const install = runtime.managed_installs?.find((i) => i.harness === harness);
-  const isActive = install?.active === true;
-  const isObserved = runtime.items.some((i) => i.harness === harness) || receipts.some((r) => r.harness === harness) || policies.some((p) => p.harness === harness);
-  const harnessReceipts = reactExports.useMemo(
-    () => receipts.filter((r) => r.harness === harness).sort((a, b) => +new Date(b.timestamp) - +new Date(a.timestamp)),
-    [receipts, harness]
-  );
-  const harnessInventory = reactExports.useMemo(
-    () => inventory.filter((i) => i.harness === harness && i.present),
-    [inventory, harness]
-  );
-  const harnessPolicies = reactExports.useMemo(
-    () => harnessPolicy.kind === "ready" ? harnessPolicy.items : policies.filter((p) => p.harness === harness),
-    [harnessPolicy, policies, harness]
-  );
-  const pendingItems = reactExports.useMemo(
-    () => harnessQueue.kind === "ready" ? harnessQueue.items : props.requests.filter((r) => r.harness === harness),
-    [harnessQueue, props.requests, harness]
-  );
-  const totalActions = harnessReceipts.length;
-  const blockedCount = harnessReceipts.filter((r) => r.policy_decision === "block").length;
-  const allowedCount = harnessReceipts.filter((r) => r.policy_decision === "allow").length;
-  const blockRate = totalActions > 0 ? Math.round(blockedCount / totalActions * 100) : 0;
-  const lastActivity = harnessReceipts[0]?.timestamp ?? null;
-  const isLoading = harnessQueue.kind === "loading" || harnessPolicy.kind === "loading";
-  const queueError = harnessQueue.kind === "error" ? harnessQueue.message : null;
-  const policyError = harnessPolicy.kind === "error" ? harnessPolicy.message : null;
-  const status = isActive ? "active" : install !== void 0 ? "needs_setup" : isObserved ? "observed" : "unknown";
-  const heroStatus = status === "active" ? "clear" : status === "needs_setup" ? "setup_gap" : "needs_review";
-  const heroHeadline = status === "active" ? `${harnessDisplayName(harness)} is protected` : status === "needs_setup" ? `${harnessDisplayName(harness)} needs setup` : isObserved ? `${harnessDisplayName(harness)} is observed` : `${harnessDisplayName(harness)}`;
-  const heroSub = status === "active" ? "Guard is watching this app. Review its activity and settings below." : status === "needs_setup" ? "Finish setup so Guard can protect this app." : isObserved ? "Guard has seen activity but install is not active." : "This app has not been seen yet.";
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs(
-        "button",
-        {
-          onClick: props.onGoHome,
-          className: "inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-sm font-medium text-brand-dark transition-colors hover:bg-slate-100",
-          children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowLeft, { className: "h-4 w-4", "aria-hidden": "true" }),
-            "Home"
-          ]
-        }
-      ),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronRight, { className: "h-4 w-4 text-slate-300", "aria-hidden": "true" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm text-muted-foreground", children: "Apps" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronRight, { className: "h-4 w-4 text-slate-300", "aria-hidden": "true" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: harnessDisplayName(harness) })
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx(
-      GuardHero,
-      {
-        status: heroStatus,
-        headline: heroHeadline,
-        subheadline: heroSub,
-        cta: pendingItems.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
-          ActionButton,
-          {
-            onClick: () => setActiveTab("activity"),
-            "data-primary": "true",
-            children: [
-              "Review ",
-              pendingItems.length,
-              " pending"
-            ]
-          }
-        ) : status === "needs_setup" ? /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: () => setActiveTab("settings"), "data-primary": "true", children: "Open Settings" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: () => setActiveTab("activity"), "data-primary": "true", children: "View Activity" })
-      }
-    ),
-    /* @__PURE__ */ jsxRuntimeExports.jsx(
-      ProofStrip,
-      {
-        items: [
-          { label: "Pending", value: pendingItems.length, tone: pendingItems.length > 0 ? "blue" : "slate" },
-          { label: "Total actions", value: totalActions, tone: totalActions > 0 ? "purple" : "slate" },
-          { label: "Blocked", value: `${blockRate}%`, tone: blockRate > 0 ? "blue" : "slate" },
-          { label: "Status", value: isActive ? "active" : "inactive", tone: isActive ? "green" : "slate" }
-        ]
-      }
-    ),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex gap-1 rounded-xl border border-slate-200/70 bg-white/80 p-1 shadow-sm", children: [
-        { key: "overview", label: "Overview", icon: HiMiniHome },
-        { key: "activity", label: "Activity", icon: HiMiniBolt },
-        { key: "settings", label: "Settings", icon: HiMiniAdjustmentsHorizontal }
-      ].map((t) => {
-        const Icon = t.icon;
-        const isActive2 = activeTab === t.key;
-        return /* @__PURE__ */ jsxRuntimeExports.jsxs(
-          "button",
-          {
-            onClick: () => handleTabChange(t.key),
-            className: `flex flex-1 items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-all ${isActive2 ? "bg-brand-blue text-white shadow-sm" : "text-brand-dark hover:bg-slate-50"}`,
-            children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx(Icon, { className: "h-4 w-4" }),
-              t.label
-            ]
-          },
-          t.key
-        );
-      }) }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "px-1 text-[11px] text-muted-foreground lg:hidden", children: "Swipe or tap tabs to switch views" })
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "div",
-      {
-        className: "min-h-[300px]",
-        onTouchStart: handleTouchStart,
-        onTouchEnd: handleTouchEnd,
-        children: [
-          isLoading && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-skeleton h-36 w-full" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-skeleton h-8 w-1/2" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-skeleton h-48 w-full" })
-          ] }),
-          !isLoading && /* @__PURE__ */ jsxRuntimeExports.jsxs(TabContent, { activeTab, direction: tabDirection, children: [
-            activeTab === "overview" && /* @__PURE__ */ jsxRuntimeExports.jsx(
-              AppOverviewTab,
-              {
-                harness,
-                status,
-                install,
-                totalActions,
-                allowedCount,
-                blockedCount,
-                blockRate,
-                lastActivity,
-                harnessReceipts,
-                harnessInventory,
-                pendingItems,
-                onOpenRequest: props.onOpenRequest
-              }
-            ),
-            activeTab === "activity" && /* @__PURE__ */ jsxRuntimeExports.jsx(
-              AppActivityTab,
-              {
-                harness,
-                pendingItems,
-                harnessReceipts,
-                onOpenRequest: props.onOpenRequest,
-                queueError,
-                onRetry: loadTabData
-              }
-            ),
-            activeTab === "settings" && /* @__PURE__ */ jsxRuntimeExports.jsx(
-              AppSettingsTab,
-              {
-                harness,
-                status,
-                harnessPolicies,
-                onClearAppPolicies: props.onClearAppPolicies,
-                policyError,
-                onRetry: loadTabData
-              }
-            )
-          ] })
-        ]
-      }
-    )
-  ] });
-  function handleTabChange(next) {
-    const currentIndex = tabOrder.indexOf(activeTab);
-    const nextIndex = tabOrder.indexOf(next);
-    setTabDirection(nextIndex > currentIndex ? "right" : "left");
-    setActiveTab(next);
-    writeTabToUrl(next);
-  }
-  function handleTouchStart(e) {
-    touchStartX.current = e.changedTouches[0].screenX;
-  }
-  function handleTouchEnd(e) {
-    if (touchStartX.current === null) return;
-    const endX = e.changedTouches[0].screenX;
-    const diff = touchStartX.current - endX;
-    const threshold = 50;
-    const currentIndex = tabOrder.indexOf(activeTab);
-    if (diff > threshold && currentIndex < tabOrder.length - 1) {
-      handleTabChange(tabOrder[currentIndex + 1]);
-    } else if (diff < -threshold && currentIndex > 0) {
-      handleTabChange(tabOrder[currentIndex - 1]);
-    }
-    touchStartX.current = null;
-  }
-}
-function AppStatusBadge({ status }) {
-  if (status === "active") return /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "success", children: "Active" });
-  if (status === "needs_setup") return /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "attention", children: "Needs setup" });
-  if (status === "observed") return /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "default", children: "Observed" });
-  return /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "default", children: "Unknown" });
-}
-function AppOverviewTab(props) {
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-6 lg:grid-cols-[minmax(0,1.3fr)_minmax(0,0.9fr)]", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "space-y-6", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4 sm:p-5", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between gap-3", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Status" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-muted-foreground", children: props.status === "active" ? "Guard is actively protecting this app." : props.status === "needs_setup" ? "Guard detected this app but it needs setup." : props.status === "observed" ? "Guard has seen activity from this app." : "This app has not been seen yet." })
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(AppStatusBadge, { status: props.status })
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 grid grid-cols-2 gap-3 sm:grid-cols-4", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(StatCard, { label: "Total actions", value: props.totalActions }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(StatCard, { label: "Allowed", value: props.allowedCount, tone: "green" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(StatCard, { label: "Blocked", value: props.blockedCount, tone: props.blockedCount > 0 ? "attention" : "slate" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(StatCard, { label: "Block rate", value: `${props.blockRate}%`, tone: props.blockRate > 10 ? "attention" : "slate" })
-        ] }),
-        props.harnessReceipts.length >= 5 && /* @__PURE__ */ jsxRuntimeExports.jsx(RiskSnapshot, { receipts: props.harnessReceipts }),
-        props.lastActivity && /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-4 text-xs text-muted-foreground", children: [
-          "Last activity: ",
-          formatRelativeTime(props.lastActivity)
-        ] }),
-        props.harnessReceipts.length >= 3 && /* @__PURE__ */ jsxRuntimeExports.jsx(ActivitySparkline, { receipts: props.harnessReceipts }),
-        props.blockedCount > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(
-          CloudValueBanner,
-          {
-            icon: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "h-4 w-4 text-brand-attention" }),
-            title: "Team alerts available",
-            body: "Cloud would alert your team when Guard blocks actions like this.",
-            cta: { label: "Learn more", href: "https://hol.org/guard/pricing" }
-          }
-        )
-      ] }),
-      props.pendingItems.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-brand-blue/10 bg-brand-blue/[0.03] p-4 sm:p-5", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Pending review" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-2 text-sm text-muted-foreground", children: [
-          "These actions from ",
-          harnessDisplayName(props.harness),
-          " need your decision."
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 space-y-2", children: props.pendingItems.slice(0, 5).map((item) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
-          "button",
-          {
-            onClick: () => props.onOpenRequest(item.request_id),
-            className: "flex w-full items-center justify-between rounded-xl border border-slate-200/70 bg-white px-4 py-3 text-left transition-shadow hover:shadow-sm",
-            children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
-                /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: item.artifact_name ?? item.artifact_id }),
-                /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-0.5 text-xs text-muted-foreground", children: [
-                  item.artifact_type,
-                  " · ",
-                  formatRelativeTime(item.created_at)
-                ] })
-              ] }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronRight, { className: "h-4 w-4 shrink-0 text-slate-300" })
-            ]
-          },
-          item.request_id
-        )) })
-      ] })
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "space-y-6", children: [
-      props.harnessReceipts.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4 sm:p-5", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Recent events" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-muted-foreground", children: "What Guard decided recently." }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 space-y-3", children: props.harnessReceipts.slice(0, 5).map((receipt) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
-          "div",
-          {
-            className: "flex items-start justify-between gap-3 rounded-xl border border-slate-200/70 bg-white px-4 py-3",
-            children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
-                /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-sm text-brand-dark", children: [
-                  /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-medium", children: receipt.policy_decision === "allow" ? "Allowed" : "Blocked" }),
-                  " ",
-                  /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-mono text-xs", children: receipt.artifact_name ?? receipt.artifact_id })
-                ] }),
-                /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs text-muted-foreground", children: formatRelativeTime(receipt.timestamp) })
-              ] }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: receipt.policy_decision === "allow" ? "green" : "attention", children: receipt.policy_decision })
-            ]
-          },
-          receipt.receipt_id
-        )) })
-      ] }),
-      props.harnessInventory.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4 sm:p-5", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Discovered items" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-muted-foreground", children: "Tools and plugins Guard found in this app." }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 space-y-2", children: props.harnessInventory.slice(0, 8).map((item) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
-          "div",
-          {
-            className: "flex items-center justify-between rounded-lg border border-slate-200/70 px-3 py-2",
-            children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "truncate text-sm text-brand-dark", children: item.artifact_name ?? item.artifact_id }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "shrink-0 text-[11px] text-muted-foreground", children: item.artifact_type })
-            ]
-          },
-          item.artifact_id
-        )) })
-      ] })
-    ] })
-  ] });
-}
-function AppActivityTab(props) {
-  const [filter, setFilter] = reactExports.useState("all");
-  const [timeFilter, setTimeFilter] = reactExports.useState("all");
-  const [search, setSearch] = reactExports.useState("");
-  const [selectedIds, setSelectedIds] = reactExports.useState(/* @__PURE__ */ new Set());
-  reactExports.useEffect(() => {
-    function handleKeyDown(event) {
-      if (event.key === " " && document.activeElement?.tagName !== "INPUT") {
-        const focused = document.activeElement;
-        if (focused?.closest('[role="listitem"]')) {
-          const checkbox = focused.querySelector('input[type="checkbox"]');
-          if (checkbox) {
-            event.preventDefault();
-            checkbox.click();
-          }
-        }
-      }
-    }
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, []);
-  const filteredReceipts = reactExports.useMemo(() => {
-    let items = props.harnessReceipts;
-    if (filter === "allowed") items = items.filter((r) => r.policy_decision === "allow");
-    if (filter === "blocked") items = items.filter((r) => r.policy_decision === "block");
-    if (timeFilter === "today") {
-      const start = /* @__PURE__ */ new Date();
-      start.setHours(0, 0, 0, 0);
-      items = items.filter((r) => new Date(r.timestamp) >= start);
-    }
-    if (timeFilter === "week") {
-      const start = /* @__PURE__ */ new Date();
-      start.setDate(start.getDate() - 7);
-      items = items.filter((r) => new Date(r.timestamp) >= start);
-    }
-    if (search.trim()) {
-      const q = search.toLowerCase();
-      items = items.filter(
-        (r) => (r.artifact_name ?? r.artifact_id).toLowerCase().includes(q)
-      );
-    }
-    return items;
-  }, [props.harnessReceipts, filter, timeFilter, search]);
-  const groups = reactExports.useMemo(() => {
-    const today = [];
-    const yesterday = [];
-    const thisWeek = [];
-    const earlier = [];
-    const now2 = /* @__PURE__ */ new Date();
-    const startOfToday = new Date(now2.getFullYear(), now2.getMonth(), now2.getDate());
-    const startOfYesterday = new Date(startOfToday);
-    startOfYesterday.setDate(startOfYesterday.getDate() - 1);
-    const startOfWeek = new Date(startOfToday);
-    startOfWeek.setDate(startOfWeek.getDate() - startOfWeek.getDay());
-    filteredReceipts.forEach((r) => {
-      const d = new Date(r.timestamp);
-      if (d >= startOfToday) today.push(r);
-      else if (d >= startOfYesterday) yesterday.push(r);
-      else if (d >= startOfWeek) thisWeek.push(r);
-      else earlier.push(r);
-    });
-    return { today, yesterday, thisWeek, earlier };
-  }, [filteredReceipts]);
-  const hasPending = props.pendingItems.length > 0;
-  const allReceiptIds = reactExports.useMemo(() => filteredReceipts.map((r) => r.receipt_id), [filteredReceipts]);
-  const selectedCount = selectedIds.size;
-  const toggleSelection = reactExports.useCallback((id) => {
-    setSelectedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  }, []);
-  const selectAll = reactExports.useCallback(() => {
-    setSelectedIds(new Set(allReceiptIds));
-  }, [allReceiptIds]);
-  const clearSelection = reactExports.useCallback(() => {
-    setSelectedIds(/* @__PURE__ */ new Set());
-  }, []);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
-    props.queueError && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-fade-in rounded-xl border border-brand-attention/10 bg-brand-attention/[0.03] p-4 sm:p-5", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-attention", "aria-hidden": "true" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex-1", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: "Unable to load activity" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-muted-foreground", children: props.queueError }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "button",
-          {
-            onClick: props.onRetry,
-            className: "mt-3 inline-flex min-h-9 items-center rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark transition-colors hover:bg-slate-50",
-            children: "Retry"
-          }
-        )
-      ] })
-    ] }) }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4 sm:p-5", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
-        [
-          { key: "all", label: "All" },
-          { key: "pending", label: `Pending (${props.pendingItems.length})` },
-          { key: "allowed", label: "Allowed" },
-          { key: "blocked", label: "Blocked" }
-        ].map((c) => /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "button",
-          {
-            onClick: () => {
-              setFilter(c.key);
-              clearSelection();
-            },
-            className: `rounded-full px-3 py-1.5 text-xs font-medium transition-all ${filter === c.key ? "bg-brand-blue text-white shadow-sm" : "border border-slate-200 bg-white text-brand-dark hover:bg-slate-50"}`,
-            children: c.label
-          },
-          c.key
-        )),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "ml-auto flex gap-2", children: [
-          { key: "all", label: "All time" },
-          { key: "today", label: "Today" },
-          { key: "week", label: "This week" }
-        ].map((c) => /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "button",
-          {
-            onClick: () => {
-              setTimeFilter(c.key);
-              clearSelection();
-            },
-            className: `rounded-full px-3 py-1.5 text-xs font-medium transition-all ${timeFilter === c.key ? "bg-brand-dark text-white shadow-sm" : "border border-slate-200 bg-white text-brand-dark hover:bg-slate-50"}`,
-            children: c.label
-          },
-          c.key
-        )) })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "input",
-        {
-          value: search,
-          onChange: (e) => {
-            setSearch(e.target.value);
-            clearSelection();
-          },
-          placeholder: "Search by name...",
-          className: "mt-3 w-full rounded-xl border border-slate-200/70 bg-white px-4 py-2.5 text-sm text-brand-dark placeholder:text-slate-400 focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
-        }
-      )
-    ] }),
-    filter !== "pending" && filteredReceipts.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "button",
-        {
-          onClick: selectedCount === allReceiptIds.length ? clearSelection : selectAll,
-          className: "rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-brand-dark transition-colors hover:bg-slate-50",
-          children: selectedCount === allReceiptIds.length ? "Deselect all" : "Select all"
-        }
-      ),
-      selectedCount > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-xs text-muted-foreground", children: [
-        selectedCount,
-        " selected"
-      ] })
-    ] }),
-    filter === "pending" && hasPending && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-3", children: props.pendingItems.map((item) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "button",
-      {
-        onClick: () => props.onOpenRequest(item.request_id),
-        className: "flex w-full items-center justify-between rounded-xl border border-brand-blue/15 bg-brand-blue/[0.04] px-4 py-3 text-left transition-shadow hover:shadow-sm",
-        children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: item.artifact_name ?? item.artifact_id }),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-0.5 text-xs text-muted-foreground", children: [
-              item.artifact_type,
-              " · ",
-              formatRelativeTime(item.created_at)
-            ] })
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "info", children: "Pending" })
-        ]
-      },
-      item.request_id
-    )) }),
-    filter !== "pending" && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-6", children: filteredReceipts.length === 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(
-      EmptyState,
-      {
-        title: "No activity yet",
-        body: filter === "all" ? "Guard hasn't recorded any decisions for this app yet. Allow or block an action and it will appear here." : `No ${filter} decisions match your filters.`,
-        tone: "teach"
-      }
-    ) : /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(ReceiptGroup, { title: "Today", items: groups.today, selectedIds, onToggle: toggleSelection }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(ReceiptGroup, { title: "Yesterday", items: groups.yesterday, selectedIds, onToggle: toggleSelection }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(ReceiptGroup, { title: "This week", items: groups.thisWeek, selectedIds, onToggle: toggleSelection }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(ReceiptGroup, { title: "Earlier", items: groups.earlier, selectedIds, onToggle: toggleSelection })
-    ] }) })
-  ] });
-}
-function ReceiptGroup({ title, items, selectedIds, onToggle }) {
-  if (items.length === 0) return null;
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4 sm:p-5", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: title }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-xs text-muted-foreground", children: [
-        items.length,
-        " events"
-      ] })
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 space-y-3", children: items.map((receipt) => /* @__PURE__ */ jsxRuntimeExports.jsx(ExpandableReceiptRow, { receipt, selected: selectedIds.has(receipt.receipt_id), onToggle }, receipt.receipt_id)) })
-  ] });
-}
-function ExpandableReceiptRow({ receipt, selected, onToggle }) {
-  const [expanded, setExpanded] = reactExports.useState(false);
-  const decisionLabel = receipt.policy_decision === "allow" ? "Allowed" : "Blocked";
-  const name = receipt.artifact_name ?? receipt.artifact_id;
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-200/70 bg-white overflow-hidden", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex w-full items-start gap-2 px-4 py-3", children: [
-      onToggle !== void 0 && /* @__PURE__ */ jsxRuntimeExports.jsx("label", { className: "flex items-center pt-0.5", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "input",
-        {
-          type: "checkbox",
-          checked: selected ?? false,
-          onChange: () => onToggle(receipt.receipt_id),
-          className: "h-4 w-4 rounded border-slate-300 text-brand-blue focus:ring-brand-blue",
-          "aria-label": `Select ${name}`
-        }
-      ) }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs(
-        "button",
-        {
-          onClick: () => setExpanded(!expanded),
-          className: "flex flex-1 items-start justify-between gap-3 text-left transition-colors hover:bg-slate-50 rounded-lg -m-1 p-1",
-          "aria-expanded": expanded,
-          children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-sm text-brand-dark", children: [
-                /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-medium", children: decisionLabel }),
-                " ",
-                /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-mono text-xs", children: name })
-              ] }),
-              receipt.capabilities_summary && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs text-muted-foreground", children: receipt.capabilities_summary }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-[11px] text-muted-foreground", children: formatRelativeTime(receipt.timestamp) })
-            ] }),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: receipt.policy_decision === "allow" ? "green" : "attention", children: receipt.policy_decision }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx(
-                HiMiniChevronDown,
-                {
-                  className: `h-4 w-4 text-slate-400 transition-transform ${expanded ? "rotate-180" : ""}`,
-                  "aria-hidden": "true"
-                }
-              )
-            ] })
-          ]
-        }
-      )
-    ] }),
-    expanded && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-fade-in border-t border-slate-200/70 bg-slate-50/60 px-4 py-3", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("dl", { className: "grid grid-cols-1 gap-2 text-xs", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-muted-foreground", children: "Action ID" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-0.5 font-mono text-brand-dark", children: receipt.artifact_id })
-      ] }),
-      receipt.artifact_hash && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-muted-foreground", children: "Hash" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-0.5 font-mono text-brand-dark", children: receipt.artifact_hash })
-      ] }),
-      receipt.capabilities_summary && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-muted-foreground", children: "Capabilities" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-0.5 text-brand-dark", children: receipt.capabilities_summary })
-      ] }),
-      receipt.provenance_summary && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-muted-foreground", children: "Provenance" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-0.5 text-brand-dark", children: receipt.provenance_summary })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-muted-foreground", children: "Time" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-0.5 font-mono text-brand-dark", children: new Date(receipt.timestamp).toLocaleString() })
-      ] })
-    ] }) })
-  ] });
-}
-function AppSettingsTab(props) {
-  const [showClearConfirm, setShowClearConfirm] = reactExports.useState(false);
-  const [clearing, setClearing] = reactExports.useState(false);
-  const confirmRef = reactExports.useRef(null);
-  useFocusTrap(showClearConfirm, confirmRef);
-  const handleClear = reactExports.useCallback(async () => {
-    if (!props.onClearAppPolicies) return;
-    setClearing(true);
-    await props.onClearAppPolicies(props.harness);
-    setClearing(false);
-    setShowClearConfirm(false);
-  }, [props.onClearAppPolicies, props.harness]);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.8fr)]", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
-      props.policyError && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-fade-in rounded-xl border border-brand-attention/10 bg-brand-attention/[0.03] p-4 sm:p-5", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-attention", "aria-hidden": "true" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex-1", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: "Unable to load decisions" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-muted-foreground", children: props.policyError }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "button",
-            {
-              onClick: props.onRetry,
-              className: "mt-3 inline-flex min-h-9 items-center rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark transition-colors hover:bg-slate-50",
-              children: "Retry"
-            }
-          )
-        ] })
-      ] }) }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4 sm:p-5", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between gap-3", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Remembered decisions" }),
-          props.harnessPolicies.length > 0 && props.onClearAppPolicies && /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "button",
-            {
-              onClick: () => setShowClearConfirm(true),
-              className: "text-xs font-medium text-brand-attention hover:text-brand-dark transition-colors",
-              children: "Clear all"
-            }
-          )
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-2 text-sm text-muted-foreground", children: [
-          "Guard remembers these choices for ",
-          harnessDisplayName(props.harness),
-          ". Remove any to be asked again."
-        ] }),
-        props.harnessPolicies.length === 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
-          EmptyState,
-          {
-            title: "No remembered decisions",
-            body: "Guard will remember choices here after you allow or block actions for this app.",
-            tone: "teach"
-          }
-        ) }) : /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: `mt-4 space-y-2 ${clearing ? "guard-fade-out" : ""}`, children: props.harnessPolicies.map((policy) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
-          "div",
-          {
-            className: "flex items-center justify-between rounded-lg border border-slate-200/70 px-4 py-3 transition-all duration-200 hover:border-brand-blue/30 hover:shadow-sm",
-            children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
-                /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: policy.scope === "global" ? "Every project" : policy.scope === "harness" ? "This app" : policy.scope === "artifact" && policy.artifact_id ? policy.artifact_id : policy.scope }),
-                /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-0.5 text-xs text-muted-foreground", children: [
-                  policy.action,
-                  " · ",
-                  policy.reason || "No reason given"
-                ] })
-              ] }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: policy.action === "allow" ? "green" : policy.action === "block" ? "attention" : "blue", children: policy.action })
-            ]
-          },
-          `${policy.scope}-${policy.artifact_id ?? policy.workspace ?? "global"}`
-        )) })
-      ] }),
-      showClearConfirm && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { ref: confirmRef, className: "guard-fade-in rounded-xl border border-brand-attention/10 bg-brand-attention/[0.03] p-4 sm:p-5", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-attention", "aria-hidden": "true" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("h3", { className: "text-sm font-semibold text-brand-dark", children: [
-            "Clear all remembered decisions for ",
-            harnessDisplayName(props.harness),
-            "?"
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-1 text-sm text-muted-foreground", children: [
-            "This will remove ",
-            props.harnessPolicies.length,
-            " remembered decision",
-            props.harnessPolicies.length !== 1 ? "s" : "",
-            ". Guard will ask again next time matching actions run."
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 flex flex-wrap gap-2", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx(
-              "button",
-              {
-                onClick: handleClear,
-                disabled: clearing,
-                className: "inline-flex min-h-9 items-center rounded-lg bg-brand-attention px-3 text-sm font-semibold text-white transition-colors hover:bg-brand-attention/90 disabled:opacity-50",
-                children: clearing ? "Clearing…" : "Clear decisions"
-              }
-            ),
-            /* @__PURE__ */ jsxRuntimeExports.jsx(
-              "button",
-              {
-                onClick: () => setShowClearConfirm(false),
-                className: "inline-flex min-h-9 items-center rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark transition-colors hover:bg-slate-50",
-                children: "Keep decisions"
-              }
-            )
-          ] })
-        ] })
-      ] }) }),
-      props.harnessPolicies.length > 0 && !showClearConfirm && /* @__PURE__ */ jsxRuntimeExports.jsx(
-        CloudValueBanner,
-        {
-          icon: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCloud, { className: "h-4 w-4 text-brand-blue" }),
-          title: "Team policy sync",
-          body: "Cloud keeps your team's rules consistent across all devices.",
-          cta: { label: "Learn more", href: "https://hol.org/guard/pricing" }
-        }
-      )
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-6", children: props.status === "needs_setup" && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-xl border border-brand-attention/10 bg-brand-attention/[0.03] p-4 sm:p-5", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-attention" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Setup needed" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-muted-foreground", children: "This app is detected but not active. Run Guard with this app once to complete setup." }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 rounded-xl bg-white/60 p-4", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "font-mono text-xs text-brand-dark", children: `npx @hol/guard install ${props.harness}` }) })
-      ] })
-    ] }) }) })
-  ] });
-}
-function ActivitySparkline({ receipts }) {
-  const days = 7;
-  const data = reactExports.useMemo(() => {
-    const result = [];
-    const now2 = /* @__PURE__ */ new Date();
-    for (let i = days - 1; i >= 0; i--) {
-      const d = new Date(now2);
-      d.setDate(d.getDate() - i);
-      d.setHours(0, 0, 0, 0);
-      const end = new Date(d);
-      end.setDate(end.getDate() + 1);
-      const dayReceipts = receipts.filter((r) => {
-        const rt = new Date(r.timestamp);
-        return rt >= d && rt < end;
-      });
-      result.push({
-        date: d.toLocaleDateString("en-US", { weekday: "short" }),
-        allowed: dayReceipts.filter((r) => r.policy_decision === "allow").length,
-        blocked: dayReceipts.filter((r) => r.policy_decision === "block").length
-      });
-    }
-    return result;
-  }, [receipts]);
-  const maxVal = Math.max(...data.map((d) => d.allowed + d.blocked), 1);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4 sm:p-5", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Last 7 days" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChartBar, { className: "h-4 w-4 text-slate-400", "aria-hidden": "true" })
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 flex items-end gap-2", children: data.map((day) => {
-      const total = day.allowed + day.blocked;
-      const height = total > 0 ? Math.max(20, total / maxVal * 100) : 4;
-      return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-1 flex-col items-center gap-1", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex w-full gap-0.5", style: { height: `${height}px` }, children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "div",
-            {
-              className: "flex-1 rounded-t bg-brand-green/60",
-              style: { height: `${day.allowed > 0 ? day.allowed / total * 100 : 0}%` },
-              title: `${day.allowed} allowed`
-            }
-          ),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "div",
-            {
-              className: "flex-1 rounded-t bg-brand-attention/60",
-              style: { height: `${day.blocked > 0 ? day.blocked / total * 100 : 0}%` },
-              title: `${day.blocked} blocked`
-            }
-          )
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-[10px] text-muted-foreground", children: day.date })
-      ] }, day.date);
-    }) }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-2 flex items-center gap-4", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "flex items-center gap-1.5 text-[10px] text-muted-foreground", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2 w-2 rounded-sm bg-brand-green/60" }),
-        "Allowed"
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "flex items-center gap-1.5 text-[10px] text-muted-foreground", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2 w-2 rounded-sm bg-brand-attention/60" }),
-        "Blocked"
-      ] })
-    ] })
-  ] });
-}
-function RiskSnapshot({ receipts }) {
-  const analysis = reactExports.useMemo(() => {
-    const blockedCount = receipts.filter((r) => r.policy_decision === "block").length;
-    const allowedCount = receipts.filter((r) => r.policy_decision === "allow").length;
-    return { blocked: blockedCount, allowed: allowedCount, total: receipts.length };
-  }, [receipts]);
-  if (analysis.total === 0) return null;
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 rounded-xl border border-brand-blue/10 bg-brand-blue/[0.03] p-4", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Activity breakdown" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-2 space-y-1.5 text-sm text-brand-dark", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-medium", children: analysis.allowed }),
-        " ",
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-muted-foreground", children: "allowed" })
-      ] }),
-      analysis.blocked > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-medium text-brand-attention", children: analysis.blocked }),
-        " ",
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-muted-foreground", children: "blocked" })
-      ] })
-    ] })
-  ] });
-}
-function TabContent({
-  activeTab,
-  direction,
-  children
-}) {
-  const animationClass = direction === "right" ? "guard-tab-enter" : "guard-tab-enter-reverse";
-  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: `${animationClass}`, children }, activeTab);
-}
-function CloudValueBanner({
-  icon,
-  title,
-  body,
-  cta
-}) {
-  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-xl border border-brand-purple/10 bg-brand-purple/[0.03] p-4 sm:p-5", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-0.5 shrink-0", children: icon }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex-1", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: title }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-muted-foreground", children: body }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs(
-        "a",
-        {
-          href: cta.href,
-          target: "_blank",
-          rel: "noopener noreferrer",
-          className: "mt-3 inline-flex items-center gap-1 text-sm font-medium text-brand-blue hover:text-brand-dark transition-colors",
-          children: [
-            cta.label,
-            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronRight, { className: "h-3 w-3", "aria-hidden": "true" })
-          ]
-        }
-      )
-    ] })
-  ] }) });
-}
-function StatCard({
-  label,
-  value,
-  tone
-}) {
-  const toneClass = tone === "green" ? "text-brand-green" : tone === "attention" ? "text-brand-attention" : tone === "blue" ? "text-brand-blue" : "text-brand-dark";
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-200/70 bg-white p-3 text-center", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: `text-xl font-semibold ${toneClass}`, children: value }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground", children: label })
-  ] });
-}
-const shortcuts = [
-  {
-    title: "Review",
-    items: [
-      { keys: ["A"], description: "Allow the current action" },
-      { keys: ["B"], description: "Block the current action" },
-      { keys: ["↑", "↓"], description: "Navigate queue items" },
-      { keys: ["Enter"], description: "Open selected queue item" },
-      { keys: ["1"], description: "Select 'Just this time' scope" },
-      { keys: ["2"], description: "Select 'This project' scope" },
-      { keys: ["3"], description: "Select 'This source' scope" },
-      { keys: ["4"], description: "Select 'This app' scope" },
-      { keys: ["5"], description: "Select 'Everywhere' scope" }
-    ]
-  },
-  {
-    title: "Navigation",
-    items: [
-      { keys: ["/"], description: "Focus search input" },
-      { keys: ["?"], description: "Open this help" },
-      { keys: ["Esc"], description: "Close modal or drawer" }
-    ]
-  }
-];
-function HelpModal(props) {
-  const dialogRef = reactExports.useRef(null);
-  useFocusTrap(props.open, dialogRef);
-  reactExports.useEffect(() => {
-    if (!props.open) return;
-    function handleKeyDown(event) {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        props.onClose();
-      }
-    }
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [props.open, props.onClose]);
-  const handleBackdropClick = reactExports.useCallback(
-    (e) => {
-      if (e.target === e.currentTarget) props.onClose();
-    },
-    [props.onClose]
-  );
-  if (!props.open) return null;
-  return /* @__PURE__ */ jsxRuntimeExports.jsx(
-    "div",
-    {
-      className: "guard-fade-in fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4 backdrop-blur-sm",
-      onClick: handleBackdropClick,
-      role: "dialog",
-      "aria-modal": "true",
-      "aria-label": "Keyboard shortcuts help",
-      children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { ref: dialogRef, className: "guard-fade-in w-full max-w-lg rounded-[1.75rem] border border-slate-200/70 bg-white/95 p-6 shadow-2xl", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2.5", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCommandLine, { className: "h-5 w-5 text-brand-blue", "aria-hidden": "true" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "text-lg font-semibold tracking-tight text-brand-dark", children: "Keyboard shortcuts" })
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "button",
-            {
-              type: "button",
-              onClick: props.onClose,
-              "aria-label": "Close help",
-              className: "rounded-full p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-brand-dark",
-              children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniXMark, { className: "h-5 w-5", "aria-hidden": "true" })
-            }
-          )
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-muted-foreground", children: "Use these shortcuts to review actions faster. Shortcuts work when you are not typing in a text field." }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-5 space-y-5", children: shortcuts.map((group) => /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "font-mono text-[10px] font-semibold uppercase tracking-[0.22em] text-muted-foreground", children: group.title }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-2 space-y-2", children: group.items.map((item) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
-            "div",
-            {
-              className: "flex items-center justify-between gap-3",
-              children: [
-                /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm text-brand-dark", children: item.description }),
-                /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "flex shrink-0 gap-1", children: item.keys.map((key) => /* @__PURE__ */ jsxRuntimeExports.jsx(
-                  "kbd",
-                  {
-                    className: "inline-flex h-7 min-w-7 items-center justify-center rounded-md border border-slate-200 bg-slate-50 px-1.5 font-mono text-[11px] font-semibold text-brand-dark shadow-sm",
-                    children: key
-                  },
-                  key
-                )) })
-              ]
-            },
-            item.description
-          )) })
-        ] }, group.title)) }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-6 flex items-center gap-2 rounded-xl border border-brand-blue/15 bg-brand-blue/[0.04] px-4 py-3", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniQuestionMarkCircle, { className: "h-4 w-4 shrink-0 text-brand-blue", "aria-hidden": "true" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-xs text-muted-foreground", children: [
-            "Press ",
-            /* @__PURE__ */ jsxRuntimeExports.jsx("kbd", { className: "rounded bg-slate-100 px-1 py-0.5 font-mono text-[10px]", children: "?" }),
-            " anytime to open this help."
-          ] })
-        ] })
-      ] })
-    }
-  );
-}
 class ErrorBoundary extends reactExports.Component {
   constructor(props) {
     super(props);
@@ -18965,6 +17972,14 @@ class ErrorBoundary extends reactExports.Component {
     }
     return this.props.children;
   }
+}
+const HomeWorkspace = reactExports.lazy(() => __vitePreload(() => import("./chunks/home-dashboard.js"), true ? __vite__mapDeps([0,1]) : void 0));
+const FleetWorkspace = reactExports.lazy(() => __vitePreload(() => import("./chunks/fleet-workspace.js"), true ? [] : void 0));
+const SettingsWorkspace = reactExports.lazy(() => __vitePreload(() => import("./chunks/settings-workspace.js"), true ? [] : void 0));
+const AppDetailWorkspace = reactExports.lazy(() => __vitePreload(() => import("./chunks/app-detail-workspace.js"), true ? __vite__mapDeps([2,1]) : void 0));
+const HelpModal = reactExports.lazy(() => __vitePreload(() => import("./chunks/help-modal.js"), true ? __vite__mapDeps([3,1]) : void 0));
+function LazyFallback() {
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex min-h-[200px] items-center justify-center", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-skeleton h-8 w-48" }) });
 }
 function usePathname() {
   const [pathname, setPathname] = reactExports.useState(window.location.pathname);
@@ -19345,7 +18360,7 @@ function App() {
         inventory: inventory.kind === "ready" ? inventory.items : [],
         activeRequestId,
         resolutionMessage,
-        homeContent: /* @__PURE__ */ jsxRuntimeExports.jsx(
+        homeContent: /* @__PURE__ */ jsxRuntimeExports.jsx(reactExports.Suspense, { fallback: /* @__PURE__ */ jsxRuntimeExports.jsx(LazyFallback, {}), children: /* @__PURE__ */ jsxRuntimeExports.jsx(
           HomeWorkspace,
           {
             requests,
@@ -19361,7 +18376,7 @@ function App() {
             onConfirmClear: handleConfirmClear,
             onCancelClear: handleCancelClear
           }
-        ),
+        ) }),
         onGoHome: handleGoHome,
         onNavigate: navigate,
         onOpenRequest: handleOpenRequest,
@@ -19369,7 +18384,7 @@ function App() {
         onBulkApprove: handleBulkApprove,
         onRetry: handleRetry,
         onRepair: handleRepair,
-        fleetContent: runtime.kind === "ready" ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+        fleetContent: runtime.kind === "ready" ? /* @__PURE__ */ jsxRuntimeExports.jsx(reactExports.Suspense, { fallback: /* @__PURE__ */ jsxRuntimeExports.jsx(LazyFallback, {}), children: /* @__PURE__ */ jsxRuntimeExports.jsx(
           FleetWorkspace,
           {
             runtime: runtime.snapshot,
@@ -19380,12 +18395,12 @@ function App() {
             onRepairHarness: handleRepairHarness,
             onOpenAppDetail: handleOpenAppDetail
           }
-        ) : null,
-        appDetailContent: /* @__PURE__ */ jsxRuntimeExports.jsx(ErrorBoundary, { onReset: handleGoHome, children: appDetailContent }),
-        settingsContent: /* @__PURE__ */ jsxRuntimeExports.jsx(SettingsWorkspace, {})
+        ) }) : null,
+        appDetailContent: /* @__PURE__ */ jsxRuntimeExports.jsx(ErrorBoundary, { onReset: handleGoHome, children: /* @__PURE__ */ jsxRuntimeExports.jsx(reactExports.Suspense, { fallback: /* @__PURE__ */ jsxRuntimeExports.jsx(LazyFallback, {}), children: appDetailContent }) }),
+        settingsContent: /* @__PURE__ */ jsxRuntimeExports.jsx(reactExports.Suspense, { fallback: /* @__PURE__ */ jsxRuntimeExports.jsx(LazyFallback, {}), children: /* @__PURE__ */ jsxRuntimeExports.jsx(SettingsWorkspace, {}) })
       }
     ),
-    helpOpen && /* @__PURE__ */ jsxRuntimeExports.jsx(HelpModal, { open: helpOpen, onClose: () => setHelpOpen(false) })
+    helpOpen && /* @__PURE__ */ jsxRuntimeExports.jsx(reactExports.Suspense, { fallback: null, children: /* @__PURE__ */ jsxRuntimeExports.jsx(HelpModal, { open: helpOpen, onClose: () => setHelpOpen(false) }) })
   ] });
 }
 const container = document.getElementById("guard-dashboard-root");
@@ -19395,3 +18410,50 @@ if (container === null) {
 clientExports.createRoot(container).render(
   /* @__PURE__ */ jsxRuntimeExports.jsx(reactExports.StrictMode, { children: /* @__PURE__ */ jsxRuntimeExports.jsx(App, {}) })
 );
+export {
+  ActionButton as A,
+  Badge as B,
+  HiMiniCog6Tooth as C,
+  fetchApprovalPage as D,
+  EmptyState as E,
+  fetchPolicy as F,
+  GuardHero as G,
+  HiMiniCheckCircle as H,
+  HiMiniArrowLeft as I,
+  HiMiniHome as J,
+  HiMiniBolt as K,
+  HiMiniAdjustmentsHorizontal as L,
+  HiMiniCloud as M,
+  HiMiniChartBar as N,
+  HiMiniCommandLine as O,
+  ProofStrip as P,
+  HiMiniQuestionMarkCircle as Q,
+  SectionLabel as S,
+  Tag as T,
+  HiMiniFire as a,
+  HiMiniCalendarDays as b,
+  HiMiniShieldCheck as c,
+  formatRelativeTime as d,
+  HiMiniSparkles as e,
+  formatNumber as f,
+  HiMiniXMark as g,
+  harnessDisplayName as h,
+  HiMiniChevronRight$1 as i,
+  jsxRuntimeExports as j,
+  HiMiniChevronUp as k,
+  HiMiniChevronDown as l,
+  HiMiniExclamationTriangle as m,
+  HiMiniMinusCircle as n,
+  HiMiniExclamationCircle as o,
+  HiMiniWrenchScrewdriver as p,
+  HiMiniXCircle as q,
+  reactExports as r,
+  fetchSettings as s,
+  fetchRuntimeSnapshot as t,
+  updateSettings as u,
+  clearPolicy as v,
+  clearEvidence as w,
+  exportDiagnostics as x,
+  repairApprovalCenter as y,
+  HiMiniLockClosed as z
+};

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -71,17 +71,31 @@
 @layer theme {
   :root, :host {
     --font-sans: "Roboto", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    --color-amber-50: oklch(98.7% .022 95.277);
+    --color-amber-200: oklch(92.4% .12 95.746);
+    --color-amber-400: oklch(82.8% .189 84.429);
+    --color-amber-500: oklch(76.9% .188 70.08);
+    --color-amber-700: oklch(55.5% .163 48.998);
     --color-emerald-50: oklch(97.9% .021 166.113);
     --color-emerald-200: oklch(90.5% .093 164.15);
+    --color-emerald-400: oklch(76.5% .177 163.223);
     --color-emerald-500: oklch(69.6% .17 162.48);
     --color-emerald-600: oklch(59.6% .145 163.225);
+    --color-emerald-700: oklch(50.8% .118 165.612);
     --color-blue-50: oklch(97% .014 254.604);
+    --color-blue-100: oklch(93.2% .032 255.585);
     --color-blue-200: oklch(88.2% .059 254.128);
+    --color-blue-300: oklch(80.9% .105 251.813);
+    --color-blue-400: oklch(70.7% .165 254.624);
     --color-blue-500: oklch(62.3% .214 259.815);
+    --color-blue-600: oklch(54.6% .245 262.881);
     --color-blue-700: oklch(48.8% .243 264.376);
     --color-indigo-100: oklch(93% .034 272.788);
     --color-indigo-200: oklch(87% .065 274.039);
     --color-indigo-300: oklch(78.5% .115 274.713);
+    --color-purple-50: oklch(97.7% .014 308.299);
+    --color-purple-200: oklch(90.2% .063 306.703);
+    --color-purple-700: oklch(49.6% .265 301.924);
     --color-slate-50: oklch(98.4% .003 247.858);
     --color-slate-100: oklch(96.8% .007 247.896);
     --color-slate-200: oklch(92.9% .013 255.508);
@@ -463,8 +477,16 @@
     top: calc(var(--spacing) * 4);
   }
 
+  .top-6 {
+    top: calc(var(--spacing) * 6);
+  }
+
   .top-8 {
     top: calc(var(--spacing) * 8);
+  }
+
+  .-right-3 {
+    right: calc(var(--spacing) * -3);
   }
 
   .-right-6 {
@@ -704,6 +726,10 @@
     display: inline-flex;
   }
 
+  .aspect-square {
+    aspect-ratio: 1;
+  }
+
   .h-1 {
     height: calc(var(--spacing) * 1);
   }
@@ -800,6 +826,10 @@
     height: auto;
   }
 
+  .h-full {
+    height: 100%;
+  }
+
   .max-h-\[70vh\] {
     max-height: 70vh;
   }
@@ -822,6 +852,10 @@
 
   .min-h-\[72px\] {
     min-height: 72px;
+  }
+
+  .min-h-\[200px\] {
+    min-height: 200px;
   }
 
   .min-h-\[300px\] {
@@ -960,6 +994,10 @@
     min-width: calc(var(--spacing) * 7);
   }
 
+  .min-w-\[120px\] {
+    min-width: 120px;
+  }
+
   .flex-1 {
     flex: 1;
   }
@@ -968,12 +1006,20 @@
     flex-shrink: 0;
   }
 
+  .-rotate-90 {
+    rotate: -90deg;
+  }
+
   .rotate-180 {
     rotate: 180deg;
   }
 
   .animate-spin {
     animation: var(--animate-spin);
+  }
+
+  .cursor-default {
+    cursor: default;
   }
 
   .cursor-pointer {
@@ -992,8 +1038,16 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  .grid-cols-7 {
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+  }
+
   .flex-col {
     flex-direction: column;
+  }
+
+  .flex-col-reverse {
+    flex-direction: column-reverse;
   }
 
   .flex-wrap {
@@ -1018,6 +1072,10 @@
 
   .justify-center {
     justify-content: center;
+  }
+
+  .justify-end {
+    justify-content: flex-end;
   }
 
   .gap-0 {
@@ -1188,34 +1246,6 @@
     border-radius: var(--radius-2xl);
   }
 
-  .rounded-\[1\.5rem\] {
-    border-radius: 1.5rem;
-  }
-
-  .rounded-\[1\.15rem\] {
-    border-radius: 1.15rem;
-  }
-
-  .rounded-\[1\.25rem\] {
-    border-radius: 1.25rem;
-  }
-
-  .rounded-\[1\.65rem\] {
-    border-radius: 1.65rem;
-  }
-
-  .rounded-\[1\.75rem\] {
-    border-radius: 1.75rem;
-  }
-
-  .rounded-\[1rem\] {
-    border-radius: 1rem;
-  }
-
-  .rounded-\[2rem\] {
-    border-radius: 2rem;
-  }
-
   .rounded-full {
     border-radius: 3.40282e38px;
   }
@@ -1243,6 +1273,11 @@
   .rounded-t {
     border-top-left-radius: .25rem;
     border-top-right-radius: .25rem;
+  }
+
+  .rounded-t-sm {
+    border-top-left-radius: var(--radius-sm);
+    border-top-right-radius: var(--radius-sm);
   }
 
   .border {
@@ -1287,6 +1322,26 @@
   @supports (color: color-mix(in lab, red, red)) {
     .border-accent\/20 {
       border-color: color-mix(in oklab, hsl(var(--accent)) 20%, transparent);
+    }
+  }
+
+  .border-amber-200\/40 {
+    border-color: #fee68566;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .border-amber-200\/40 {
+      border-color: color-mix(in oklab, var(--color-amber-200) 40%, transparent);
+    }
+  }
+
+  .border-blue-200\/40 {
+    border-color: #bedbff66;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .border-blue-200\/40 {
+      border-color: color-mix(in oklab, var(--color-blue-200) 40%, transparent);
     }
   }
 
@@ -1474,6 +1529,16 @@
     }
   }
 
+  .border-emerald-200\/40 {
+    border-color: #a4f4cf66;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .border-emerald-200\/40 {
+      border-color: color-mix(in oklab, var(--color-emerald-200) 40%, transparent);
+    }
+  }
+
   .border-emerald-200\/60 {
     border-color: #a4f4cf99;
   }
@@ -1499,6 +1564,16 @@
   @supports (color: color-mix(in lab, red, red)) {
     .border-indigo-200\/20 {
       border-color: color-mix(in oklab, var(--color-indigo-200) 20%, transparent);
+    }
+  }
+
+  .border-purple-200\/40 {
+    border-color: #e9d5ff66;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .border-purple-200\/40 {
+      border-color: color-mix(in oklab, var(--color-purple-200) 40%, transparent);
     }
   }
 
@@ -1604,6 +1679,24 @@
     }
   }
 
+  .bg-amber-50\/60 {
+    background-color: #fffbeb99;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .bg-amber-50\/60 {
+      background-color: color-mix(in oklab, var(--color-amber-50) 60%, transparent);
+    }
+  }
+
+  .bg-amber-400 {
+    background-color: var(--color-amber-400);
+  }
+
+  .bg-amber-500 {
+    background-color: var(--color-amber-500);
+  }
+
   .bg-black\/30 {
     background-color: #0000004d;
   }
@@ -1612,6 +1705,28 @@
     .bg-black\/30 {
       background-color: color-mix(in oklab, var(--color-black) 30%, transparent);
     }
+  }
+
+  .bg-blue-50\/60 {
+    background-color: #eff6ff99;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .bg-blue-50\/60 {
+      background-color: color-mix(in oklab, var(--color-blue-50) 60%, transparent);
+    }
+  }
+
+  .bg-blue-100 {
+    background-color: var(--color-blue-100);
+  }
+
+  .bg-blue-300 {
+    background-color: var(--color-blue-300);
+  }
+
+  .bg-blue-500 {
+    background-color: var(--color-blue-500);
   }
 
   .bg-blue-500\/10 {
@@ -1930,8 +2045,36 @@
     }
   }
 
+  .bg-emerald-50\/60 {
+    background-color: #ecfdf599;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .bg-emerald-50\/60 {
+      background-color: color-mix(in oklab, var(--color-emerald-50) 60%, transparent);
+    }
+  }
+
+  .bg-emerald-400 {
+    background-color: var(--color-emerald-400);
+  }
+
+  .bg-emerald-500 {
+    background-color: var(--color-emerald-500);
+  }
+
   .bg-gray-100 {
     background-color: var(--color-gray-100);
+  }
+
+  .bg-purple-50\/60 {
+    background-color: #faf5ff99;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .bg-purple-50\/60 {
+      background-color: color-mix(in oklab, var(--color-purple-50) 60%, transparent);
+    }
   }
 
   .bg-slate-50 {
@@ -2438,6 +2581,10 @@
     line-height: var(--tw-leading, var(--text-xs--line-height));
   }
 
+  .text-\[8px\] {
+    font-size: 8px;
+  }
+
   .text-\[9px\] {
     font-size: 9px;
   }
@@ -2553,6 +2700,10 @@
     color: hsl(var(--accent));
   }
 
+  .text-amber-700 {
+    color: var(--color-amber-700);
+  }
+
   .text-blue-200 {
     color: var(--color-blue-200);
   }
@@ -2651,6 +2802,10 @@
     color: var(--color-emerald-600);
   }
 
+  .text-emerald-700 {
+    color: var(--color-emerald-700);
+  }
+
   .text-gray-500 {
     color: var(--color-gray-500);
   }
@@ -2673,6 +2828,10 @@
 
   .text-muted-foreground {
     color: hsl(var(--muted-foreground));
+  }
+
+  .text-purple-700 {
+    color: var(--color-purple-700);
   }
 
   .text-slate-300 {
@@ -2710,6 +2869,16 @@
   @supports (color: color-mix(in lab, red, red)) {
     .text-white\/45 {
       color: color-mix(in oklab, var(--color-white) 45%, transparent);
+    }
+  }
+
+  .text-white\/60 {
+    color: #fff9;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .text-white\/60 {
+      color: color-mix(in oklab, var(--color-white) 60%, transparent);
     }
   }
 
@@ -2755,12 +2924,28 @@
     text-decoration-line: none;
   }
 
+  .underline {
+    text-decoration-line: underline;
+  }
+
   .accent-brand-blue {
     accent-color: var(--brand-blue);
   }
 
+  .opacity-0 {
+    opacity: 0;
+  }
+
   .opacity-60 {
     opacity: .6;
+  }
+
+  .opacity-70 {
+    opacity: .7;
+  }
+
+  .opacity-80 {
+    opacity: .8;
   }
 
   .shadow-2xl {
@@ -2823,6 +3008,11 @@
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
 
+  .ring-2 {
+    --tw-ring-shadow: var(--tw-ring-inset, ) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+
   .shadow-brand-blue\/10 {
     --tw-shadow-color: var(--brand-blue);
   }
@@ -2853,6 +3043,10 @@
     }
   }
 
+  .ring-brand-blue {
+    --tw-ring-color: var(--brand-blue);
+  }
+
   .ring-brand-green\/20 {
     --tw-ring-color: var(--brand-green);
   }
@@ -2861,6 +3055,11 @@
     .ring-brand-green\/20 {
       --tw-ring-color: color-mix(in oklab, var(--brand-green) 20%, transparent);
     }
+  }
+
+  .ring-offset-1 {
+    --tw-ring-offset-width: 1px;
+    --tw-ring-offset-shadow: var(--tw-ring-inset, ) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
   }
 
   .ring-offset-background {
@@ -2966,6 +3165,10 @@
     .group-hover\:text-slate-500:is(:where(.group):hover *) {
       color: var(--color-slate-500);
     }
+
+    .group-hover\:opacity-100:is(:where(.group):hover *) {
+      opacity: 1;
+    }
   }
 
   .placeholder\:text-muted-foreground::placeholder {
@@ -3013,6 +3216,22 @@
 
     .hover\:bg-\[\#047857\]:hover {
       background-color: #047857;
+    }
+
+    .hover\:bg-blue-50:hover {
+      background-color: var(--color-blue-50);
+    }
+
+    .hover\:bg-blue-200:hover {
+      background-color: var(--color-blue-200);
+    }
+
+    .hover\:bg-blue-400:hover {
+      background-color: var(--color-blue-400);
+    }
+
+    .hover\:bg-blue-600:hover {
+      background-color: var(--color-blue-600);
     }
 
     .hover\:bg-brand-attention\/90:hover {
@@ -3131,6 +3350,16 @@
       background-color: var(--color-white);
     }
 
+    .hover\:bg-white\/10:hover {
+      background-color: #ffffff1a;
+    }
+
+    @supports (color: color-mix(in lab, red, red)) {
+      .hover\:bg-white\/10:hover {
+        background-color: color-mix(in oklab, var(--color-white) 10%, transparent);
+      }
+    }
+
     .hover\:bg-white\/15:hover {
       background-color: #ffffff26;
     }
@@ -3199,6 +3428,10 @@
 
     .hover\:opacity-85:hover {
       opacity: .85;
+    }
+
+    .hover\:opacity-100:hover {
+      opacity: 1;
     }
 
     .hover\:shadow-md:hover {
@@ -3454,6 +3687,10 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
+    .lg\:grid-cols-3 {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
     .lg\:grid-cols-4 {
       grid-template-columns: repeat(4, minmax(0, 1fr));
     }
@@ -3508,6 +3745,10 @@
 
     .lg\:py-12 {
       padding-block: calc(var(--spacing) * 12);
+    }
+
+    .lg\:pl-20 {
+      padding-left: calc(var(--spacing) * 20);
     }
 
     .lg\:pl-64 {
@@ -3626,16 +3867,6 @@ body {
   }
 }
 
-@keyframes guard-pulse-dot {
-  0%, 100% {
-    opacity: .4;
-  }
-
-  50% {
-    opacity: 1;
-  }
-}
-
 @keyframes guard-fade-scale {
   from {
     opacity: 0;
@@ -3733,26 +3964,12 @@ input:focus-visible, button:focus-visible, a:focus-visible {
   }
 }
 
-@keyframes guard-pulse {
-  0%, 100% {
-    box-shadow: 0 0 #5599fe33;
-  }
-
-  50% {
-    box-shadow: 0 0 0 6px #5599fe00;
-  }
-}
-
 .guard-fade-out {
   animation: guard-fade-out .25s var(--ease-out-quart) both;
 }
 
-.guard-pulse {
-  animation: 2s ease-in-out infinite guard-pulse;
-}
-
 @media (prefers-reduced-motion: reduce) {
-  .guard-surface-in, .guard-fade-in, .guard-fade-out, .guard-tab-enter, .guard-tab-enter-reverse, .guard-pulse, .guard-skeleton {
+  .guard-surface-in, .guard-fade-in, .guard-fade-out, .guard-tab-enter, .guard-tab-enter-reverse, .guard-skeleton {
     animation: none !important;
   }
 


### PR DESCRIPTION
## Summary
- add semantic review categories for local approval center inbox items
- show category-specific labels and icons, with search/filter/sort by category
- classify in-place file edits like perl -0pi as File edit command instead of destructive shell in the UI
- rebuild packaged dashboard static assets

## Verification
- pnpm test (dashboard)
- pnpm build (dashboard)
- python3 -m pytest tests/test_guard_risk.py tests/test_guard_queue_api_contract.py
- local smoke: http://127.0.0.1:5480/inbox returned 200