### PR TITLE
fix(guard): treat missing prior week as flat in block-rate insight

### DIFF
--- a/dashboard/src/history-analytics.tsx
+++ b/dashboard/src/history-analytics.tsx
@@ -187,26 +187,24 @@ function computeInsights(
       return d >= prevWeekStart && d < weekAgo;
     });
     const prevBlockedCount = prevWeekReceipts.filter((r) => r.policy_decision === "block").length;
-    const hasPrevWeek = prevWeekReceipts.length > 0;
-    const prevBlockRate = hasPrevWeek
+    const hasPrevWeekData = prevWeekReceipts.length > 0;
+    const prevBlockRate = hasPrevWeekData
       ? Math.round((prevBlockedCount / prevWeekReceipts.length) * 100)
       : 0;
-    const change = hasPrevWeek ? blockRate - prevBlockRate : 0;
-    const value = !hasPrevWeek
+    const change = hasPrevWeekData ? blockRate - prevBlockRate : 0;
+    const value = !hasPrevWeekData
       ? `${blockRate}%`
       : change === 0
         ? `${blockRate}% (flat)`
         : `${blockRate}% (${change > 0 ? "+" : ""}${change}%)`;
     insights.push({
       id: "block-rate",
-      icon: !hasPrevWeek || change === 0
-        ? <HiOutlineArrowTrendingUp className="h-4 w-4" />
-        : change > 0
-          ? <HiOutlineArrowTrendingUp className="h-4 w-4" />
-          : <HiOutlineArrowTrendingDown className="h-4 w-4" />,
+      icon: change < 0
+        ? <HiOutlineArrowTrendingDown className="h-4 w-4" />
+        : <HiOutlineArrowTrendingUp className="h-4 w-4" />,
       label: "Block rate this week",
       value,
-      tone: change > 0 ? "attention" : "green",
+      tone: !hasPrevWeekData ? "blue" : change > 0 ? "attention" : "green",
     });
   }
 

--- a/dashboard/src/history-analytics.tsx
+++ b/dashboard/src/history-analytics.tsx
@@ -187,16 +187,23 @@ function computeInsights(
       return d >= prevWeekStart && d < weekAgo;
     });
     const prevBlockedCount = prevWeekReceipts.filter((r) => r.policy_decision === "block").length;
-    const prevBlockRate = prevWeekReceipts.length > 0
+    const hasPrevWeek = prevWeekReceipts.length > 0;
+    const prevBlockRate = hasPrevWeek
       ? Math.round((prevBlockedCount / prevWeekReceipts.length) * 100)
       : 0;
-    const change = blockRate - prevBlockRate;
-    const value = change === 0
-      ? `${blockRate}% (flat)`
-      : `${blockRate}% (${change > 0 ? "+" : ""}${change}%)`;
+    const change = hasPrevWeek ? blockRate - prevBlockRate : 0;
+    const value = !hasPrevWeek
+      ? `${blockRate}%`
+      : change === 0
+        ? `${blockRate}% (flat)`
+        : `${blockRate}% (${change > 0 ? "+" : ""}${change}%)`;
     insights.push({
       id: "block-rate",
-      icon: change > 0 ? <HiOutlineArrowTrendingUp className="h-4 w-4" /> : <HiOutlineArrowTrendingDown className="h-4 w-4" />,
+      icon: !hasPrevWeek || change === 0
+        ? <HiOutlineArrowTrendingUp className="h-4 w-4" />
+        : change > 0
+          ? <HiOutlineArrowTrendingUp className="h-4 w-4" />
+          : <HiOutlineArrowTrendingDown className="h-4 w-4" />,
       label: "Block rate this week",
       value,
       tone: change > 0 ? "attention" : "green",


### PR DESCRIPTION
## Summary
- When no receipts exist in the previous week window, avoid forcing `prevBlockRate` to 0 and reporting an artificial increase.
- Show the current block rate without a delta and treat change as flat.

## Context
Addresses unresolved bot review thread on PR #322.