### PR TITLE
fix(guard): persist scoped approval choices

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "test": "tsx src/guard-api.test.ts && tsx src/approval-center-layout.test.ts && tsx src/runtime-overview.test.ts && tsx src/receipts-workspace.test.ts && tsx src/settings-workspace.test.ts && tsx src/queue-state.test.ts && tsx src/approval-center-mobile.test.ts && tsx src/home-dashboard.test.ts"
+    "test": "tsx src/guard-api.test.ts && tsx src/approval-scopes.test.ts && tsx src/approval-center-layout.test.ts && tsx src/runtime-overview.test.ts && tsx src/receipts-workspace.test.ts && tsx src/settings-workspace.test.ts && tsx src/queue-state.test.ts && tsx src/approval-center-mobile.test.ts && tsx src/home-dashboard.test.ts"
   },
   "dependencies": {
     "react": "^19.2.0",

--- a/dashboard/src/approval-center-layout.tsx
+++ b/dashboard/src/approval-center-layout.tsx
@@ -69,6 +69,11 @@ import {
   bulkApprovePrimaryIds,
   type QueueSortDirection,
 } from "./queue-state";
+import {
+  buildDecisionPayload,
+  filterScopeChoicesForRequest,
+  normalizeDecisionScope,
+} from "./approval-scopes";
 import type {
   GuardApprovalRequest,
   GuardArtifactDiff,
@@ -744,7 +749,7 @@ function DecisionWorkspace(props: {
           bannerTimerRef.current = null;
         }
       }
-      setScope(props.detail.item.recommended_scope);
+      setScope(normalizeDecisionScope(props.detail.item, props.detail.item.recommended_scope));
       setErrorMessage(null);
       setSubmitting(null);
     }
@@ -759,21 +764,19 @@ function DecisionWorkspace(props: {
   }, []);
 
   const readyItem = props.detail.kind === "ready" ? props.detail.item : null;
-  const readyRequestId = readyItem?.request_id ?? "";
-  const readyWorkspace = readyItem?.workspace ?? undefined;
 
   const handleResolve = useCallback(
     async (action: "allow" | "block") => {
+      if (readyItem === null) return;
       setSubmitting(action);
       setErrorMessage(null);
       try {
-        await props.onResolve({
-          requestId: readyRequestId,
+        await props.onResolve(buildDecisionPayload({
+          item: readyItem,
           action,
           scope,
           reason,
-          workspace: scope === "workspace" ? readyWorkspace : undefined,
-        });
+        }));
         setResolvedState("decided");
         setResolvedBanner(action);
         bannerTimerRef.current = setTimeout(() => {
@@ -784,7 +787,7 @@ function DecisionWorkspace(props: {
         setSubmitting(null);
       }
     },
-    [props.onResolve, readyRequestId, readyWorkspace, reason, scope]
+    [props.onResolve, readyItem, reason, scope]
   );
 
   const handleRequestResolve = useCallback(
@@ -890,8 +893,9 @@ function DecisionWorkspace(props: {
     return <EmptyState title="Select an item" body="Choose a blocked item from the list to review the evidence and make a decision." tone="teach" />;
   }
   const { item, diff, receipt, policy } = props.detail;
-  const commonScopeOpts = scopeOptions.filter((option) => commonScopeValues.has(option.value));
-  const broadScopeOpts = scopeOptions.filter((option) => !commonScopeValues.has(option.value));
+  const availableScopeOptions = filterScopeChoicesForRequest(item, scopeOptions);
+  const commonScopeOpts = availableScopeOptions.filter((option) => commonScopeValues.has(option.value));
+  const broadScopeOpts = availableScopeOptions.filter((option) => !commonScopeValues.has(option.value));
   const isAlreadyDecided = item.resolution_action !== null;
   const decidedLabel =
     item.resolution_action === "allow" ? "allow" : item.resolution_action === "block" ? "block" : item.resolution_action ?? "decided";

--- a/dashboard/src/approval-scopes.test.ts
+++ b/dashboard/src/approval-scopes.test.ts
@@ -1,0 +1,81 @@
+import {
+  buildDecisionPayload,
+  scopeChoicesForRequest,
+} from "./approval-scopes";
+import type { GuardApprovalRequest } from "./guard-types";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const BASE_REQUEST: GuardApprovalRequest = {
+  request_id: "request-scope-test",
+  harness: "codex",
+  artifact_id: "codex:project:bash",
+  artifact_name: "bash",
+  artifact_type: "command",
+  artifact_hash: "sha256-scope",
+  publisher: "codex-local",
+  policy_action: "require-reapproval",
+  recommended_scope: "artifact",
+  changed_fields: ["first_seen"],
+  source_scope: "project",
+  config_path: "./config.toml",
+  workspace: "/workspace/project",
+  launch_target: "git status",
+  transport: "stdio",
+  review_command: "hol-guard approvals approve request-scope-test",
+  approval_url: "http://127.0.0.1:4781/approvals/request-scope-test",
+  status: "pending",
+  resolution_action: null,
+  resolution_scope: null,
+  reason: null,
+  created_at: "2026-04-11T12:00:00Z",
+  resolved_at: null,
+  action_envelope_json: null,
+  decision_v2_json: null,
+};
+
+const workspacePayload = buildDecisionPayload({
+  item: BASE_REQUEST,
+  action: "allow",
+  scope: "workspace",
+  reason: "approved in review",
+});
+
+assert(
+  workspacePayload.workspace === "/workspace/project",
+  "T-AS-01: workspace scope sends the request workspace to the daemon"
+);
+
+for (const scope of ["artifact", "publisher", "harness", "global"] as const) {
+  const payload = buildDecisionPayload({
+    item: BASE_REQUEST,
+    action: "allow",
+    scope,
+    reason: "approved in review",
+  });
+  assert(payload.workspace === undefined, `T-AS-02: ${scope} scope does not send a workspace`);
+}
+
+const fullScopeValues = scopeChoicesForRequest(BASE_REQUEST).map((choice) => choice.value);
+assert(
+  ["artifact", "workspace", "publisher", "harness", "global"].every((scope) => fullScopeValues.includes(scope)),
+  "T-AS-03: requests with workspace and publisher expose all approval scope kinds"
+);
+
+const requestWithoutWorkspaceOrPublisher: GuardApprovalRequest = {
+  ...BASE_REQUEST,
+  request_id: "request-no-broad-source",
+  publisher: null,
+  workspace: null,
+};
+const limitedScopeValues = scopeChoicesForRequest(requestWithoutWorkspaceOrPublisher).map((choice) => choice.value);
+
+assert(limitedScopeValues.includes("artifact"), "T-AS-04: artifact scope is always available");
+assert(limitedScopeValues.includes("harness"), "T-AS-04: harness scope is available without source metadata");
+assert(limitedScopeValues.includes("global"), "T-AS-04: global scope is available without source metadata");
+assert(!limitedScopeValues.includes("workspace"), "T-AS-04: workspace scope is hidden when the request has no workspace");
+assert(!limitedScopeValues.includes("publisher"), "T-AS-04: publisher scope is hidden when the request has no publisher");

--- a/dashboard/src/approval-scopes.ts
+++ b/dashboard/src/approval-scopes.ts
@@ -1,0 +1,92 @@
+import type { DecisionScope, GuardApprovalRequest } from "./guard-types";
+
+export type ApprovalScopeChoice = {
+  value: DecisionScope;
+  label: string;
+  description: string;
+};
+
+export const DEFAULT_SCOPE_CHOICES: ApprovalScopeChoice[] = [
+  {
+    value: "artifact",
+    label: "Just this time",
+    description: "Allow only this exact action. Guard will ask again for anything different.",
+  },
+  {
+    value: "workspace",
+    label: "This project",
+    description: "Allow this action in the current workspace only.",
+  },
+  {
+    value: "publisher",
+    label: "This source",
+    description: "Allow actions from the same source or publisher.",
+  },
+  {
+    value: "harness",
+    label: "This app",
+    description: "Allow similar actions from this AI app everywhere.",
+  },
+  {
+    value: "global",
+    label: "Everywhere",
+    description: "Allow this action across all your projects. Use with care.",
+  },
+];
+
+export function requestSupportsScope(item: GuardApprovalRequest, scope: DecisionScope): boolean {
+  if (scope === "workspace") {
+    return typeof item.workspace === "string" && item.workspace.trim().length > 0;
+  }
+  if (scope === "publisher") {
+    return typeof item.publisher === "string" && item.publisher.trim().length > 0;
+  }
+  return true;
+}
+
+export function filterScopeChoicesForRequest<T extends { value: DecisionScope }>(
+  item: GuardApprovalRequest,
+  choices: readonly T[],
+): T[] {
+  return choices.filter((choice) => requestSupportsScope(item, choice.value));
+}
+
+export function scopeChoicesForRequest(item: GuardApprovalRequest): ApprovalScopeChoice[] {
+  return filterScopeChoicesForRequest(item, DEFAULT_SCOPE_CHOICES);
+}
+
+export function normalizeDecisionScope(item: GuardApprovalRequest, scope: DecisionScope): DecisionScope {
+  if (requestSupportsScope(item, scope)) {
+    return scope;
+  }
+  if (requestSupportsScope(item, item.recommended_scope)) {
+    return item.recommended_scope;
+  }
+  return "artifact";
+}
+
+export function buildDecisionPayload(input: {
+  item: GuardApprovalRequest;
+  action: "allow" | "block";
+  scope: DecisionScope;
+  reason: string;
+}): {
+  requestId: string;
+  action: "allow" | "block";
+  scope: DecisionScope;
+  workspace?: string;
+  reason: string;
+} {
+  const normalizedScope = normalizeDecisionScope(input.item, input.scope);
+  const workspace =
+    normalizedScope === "workspace" && typeof input.item.workspace === "string"
+      ? input.item.workspace
+      : undefined;
+  return {
+    requestId: input.item.request_id,
+    action: input.action,
+    scope: normalizedScope,
+    workspace,
+    reason: input.reason,
+  };
+}

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -649,7 +649,7 @@ function ReviewDecisionCard(props: {
         setPendingAction(null);
       }
     },
-    [item?.request_id, scope, props.onResolve]
+    [item, scope, props.onResolve]
   );
 
   const handleRequestResolve = useCallback(

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -52,6 +52,11 @@ import {
 } from "./risk-signal-cards";
 import { DataFlowEvidenceCard } from "./data-flow-evidence-card";
 import { ScannerEvidenceSection } from "./scanner-evidence-badge";
+import {
+  buildDecisionPayload,
+  filterScopeChoicesForRequest,
+  normalizeDecisionScope,
+} from "./approval-scopes";
 import type {
   GuardApprovalRequest,
   GuardArtifactDiff,
@@ -90,6 +95,7 @@ type ReviewWorkspaceProps = {
     requestId: string;
     action: "allow" | "block";
     scope: DecisionScope;
+    workspace?: string;
     reason: string;
   }) => Promise<void> | void;
   onGoHome: () => void;
@@ -563,10 +569,14 @@ function ReviewDecisionCard(props: {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const allowButtonRef = useRef<HTMLButtonElement>(null);
+  const availableScopeChoices = useMemo(
+    () => (item ? filterScopeChoicesForRequest(item, scopeChoices) : scopeChoices),
+    [item]
+  );
 
   useEffect(() => {
     if (item) {
-      setScope(item.recommended_scope);
+      setScope(normalizeDecisionScope(item, item.recommended_scope));
       setResolved(null);
       setSubmitting(null);
       setConfirmScope(null);
@@ -608,14 +618,14 @@ function ReviewDecisionCard(props: {
         handleRequestResolve("block");
       }
       const scopeIndex = parseInt(event.key, 10);
-      if (scopeIndex >= 1 && scopeIndex <= 5) {
+      if (scopeIndex >= 1 && scopeIndex <= availableScopeChoices.length) {
         event.preventDefault();
-        setScope(scopeChoices[scopeIndex - 1].value);
+        setScope(availableScopeChoices[scopeIndex - 1].value);
       }
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [submitting, confirmScope, scope, item?.request_id]);
+  }, [submitting, confirmScope, scope, item?.request_id, availableScopeChoices]);
 
   const handleResolve = useCallback(
     async (action: "allow" | "block") => {
@@ -623,12 +633,12 @@ function ReviewDecisionCard(props: {
       setSubmitting(action);
       setErrorMessage(null);
       try {
-        await props.onResolve({
-          requestId: item.request_id,
+        await props.onResolve(buildDecisionPayload({
+          item,
           action,
           scope,
           reason: action === "allow" ? "approved in review" : "blocked in review",
-        });
+        }));
         setResolved(action);
         timerRef.current = setTimeout(() => setResolved(null), 2000);
       } catch (err) {
@@ -712,7 +722,7 @@ function ReviewDecisionCard(props: {
             <HiMiniExclamationTriangle className="mt-0.5 h-5 w-5 shrink-0 text-brand-attention" aria-hidden="true" />
             <div>
               <h3 className="text-sm font-semibold text-brand-dark">
-                {pendingAction === "allow" ? "Allow" : "Block"} for {scopeChoices.find((s) => s.value === confirmScope)?.label}?
+                {pendingAction === "allow" ? "Allow" : "Block"} for {availableScopeChoices.find((s) => s.value === confirmScope)?.label}?
               </h3>
               <p className="mt-1 text-sm text-muted-foreground">
                 This choice will apply {confirmScope === "global" ? "across all your projects" : "broadly"}. Are you sure?
@@ -805,7 +815,7 @@ function ReviewDecisionCard(props: {
         <div className="mt-6 space-y-2">
           <SectionLabel>How long should this choice last?</SectionLabel>
           <div className="grid gap-2 sm:grid-cols-2" role="radiogroup" aria-label="Scope selection">
-            {scopeChoices.map((choice) => (
+            {availableScopeChoices.map((choice) => (
               <button
                 key={choice.value}
                 onClick={() => setScope(choice.value)}

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -15175,15 +15175,16 @@ function computeInsights(receipts, onFilterHarness, onFilterDay) {
       return d >= prevWeekStart && d < weekAgo;
     });
     const prevBlockedCount = prevWeekReceipts.filter((r) => r.policy_decision === "block").length;
-    const prevBlockRate = prevWeekReceipts.length > 0 ? Math.round(prevBlockedCount / prevWeekReceipts.length * 100) : 0;
-    const change = blockRate - prevBlockRate;
-    const value = change === 0 ? `${blockRate}% (flat)` : `${blockRate}% (${change > 0 ? "+" : ""}${change}%)`;
+    const hasPrevWeekData = prevWeekReceipts.length > 0;
+    const prevBlockRate = hasPrevWeekData ? Math.round(prevBlockedCount / prevWeekReceipts.length * 100) : 0;
+    const change = hasPrevWeekData ? blockRate - prevBlockRate : 0;
+    const value = !hasPrevWeekData ? `${blockRate}%` : change === 0 ? `${blockRate}% (flat)` : `${blockRate}% (${change > 0 ? "+" : ""}${change}%)`;
     insights.push({
       id: "block-rate",
-      icon: change > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiOutlineArrowTrendingUp, { className: "h-4 w-4" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiOutlineArrowTrendingDown, { className: "h-4 w-4" }),
+      icon: change < 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiOutlineArrowTrendingDown, { className: "h-4 w-4" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiOutlineArrowTrendingUp, { className: "h-4 w-4" }),
       label: "Block rate this week",
       value,
-      tone: change > 0 ? "attention" : "green"
+      tone: !hasPrevWeekData ? "blue" : change > 0 ? "attention" : "green"
     });
   }
   const secretReads = monthReceipts.filter((r) => {
@@ -15829,7 +15830,6 @@ function HistoryCharts({ receipts }) {
 }
 function getPeriodDates(period) {
   const end = /* @__PURE__ */ new Date();
-  end.setHours(0, 0, 0, 0);
   const start = new Date(end);
   switch (period) {
     case "7d":
@@ -16532,6 +16532,38 @@ function ScannerEvidenceSection(props) {
     /* @__PURE__ */ jsxRuntimeExports.jsx("ul", { className: "mt-3 space-y-3", children: scannerSignals.map((signal) => /* @__PURE__ */ jsxRuntimeExports.jsx(ScannerSignalRow, { signal }, signal.signal_id)) })
   ] });
 }
+function requestSupportsScope(item, scope) {
+  if (scope === "workspace") {
+    return typeof item.workspace === "string" && item.workspace.trim().length > 0;
+  }
+  if (scope === "publisher") {
+    return typeof item.publisher === "string" && item.publisher.trim().length > 0;
+  }
+  return true;
+}
+function filterScopeChoicesForRequest(item, choices) {
+  return choices.filter((choice) => requestSupportsScope(item, choice.value));
+}
+function normalizeDecisionScope(item, scope) {
+  if (requestSupportsScope(item, scope)) {
+    return scope;
+  }
+  if (requestSupportsScope(item, item.recommended_scope)) {
+    return item.recommended_scope;
+  }
+  return "artifact";
+}
+function buildDecisionPayload(input) {
+  const normalizedScope = normalizeDecisionScope(input.item, input.scope);
+  const workspace = normalizedScope === "workspace" && typeof input.item.workspace === "string" ? input.item.workspace : void 0;
+  return {
+    requestId: input.item.request_id,
+    action: input.action,
+    scope: normalizedScope,
+    workspace,
+    reason: input.reason
+  };
+}
 const QUEUE_CATEGORIES = [
   {
     id: "credential_output",
@@ -17206,11 +17238,20 @@ function ReviewWorkspace(props) {
   const [searchTerm, setSearchTerm] = reactExports.useState("");
   const [categoryFilter, setCategoryFilter] = reactExports.useState("all");
   const [sortDirection, setSortDirection] = reactExports.useState("newest");
+  const [semanticFilter, setSemanticFilter] = reactExports.useState("all");
   const filteredRequests = reactExports.useMemo(() => {
-    const byCategory = filterQueueByCategory(requests, categoryFilter);
-    const searched = searchQueue(byCategory, searchTerm);
+    let items = requests;
+    if (semanticFilter !== "all") {
+      const group = SEMANTIC_GROUPS.find((g) => g.id === semanticFilter);
+      if (group && group.matches.length > 0) {
+        items = items.filter((item) => group.matches.includes(resolveQueueCategory(item).id));
+      }
+    } else if (categoryFilter !== "all") {
+      items = filterQueueByCategory(items, categoryFilter);
+    }
+    const searched = searchQueue(items, searchTerm);
     return sortQueue(searched, sortDirection);
-  }, [categoryFilter, requests, searchTerm, sortDirection]);
+  }, [categoryFilter, requests, searchTerm, sortDirection, semanticFilter]);
   const categoryOptions = reactExports.useMemo(() => queueCategoriesForItems(requests), [requests]);
   const activeRequest = activeRequestId !== null ? requests.find((r) => r.request_id === activeRequestId) ?? null : null;
   reactExports.useEffect(() => {
@@ -17266,9 +17307,11 @@ function ReviewWorkspace(props) {
           categoryFilter,
           searchTerm,
           sortDirection,
+          semanticFilter,
           onCategoryFilterChange: setCategoryFilter,
           onSearchTermChange: setSearchTerm,
           onSortDirectionChange: setSortDirection,
+          onSemanticFilterChange: setSemanticFilter,
           onOpenRequest: props.onOpenRequest,
           ref: queueRef
         }
@@ -17326,13 +17369,14 @@ const ReviewQueueList = reactExports.forwardRef(({
   categoryFilter,
   searchTerm,
   sortDirection,
+  semanticFilter,
   onCategoryFilterChange,
   onSearchTermChange,
   onSortDirectionChange,
+  onSemanticFilterChange,
   onOpenRequest
 }, ref) => {
   const [showFilters, setShowFilters] = reactExports.useState(false);
-  const [semanticFilter, setSemanticFilter] = reactExports.useState("all");
   const handleSearchChange = reactExports.useCallback((event) => {
     onSearchTermChange(event.target.value);
   }, [onSearchTermChange]);
@@ -17342,17 +17386,7 @@ const ReviewQueueList = reactExports.forwardRef(({
   const handleSortChange = reactExports.useCallback((event) => {
     onSortDirectionChange(event.target.value);
   }, [onSortDirectionChange]);
-  reactExports.useEffect(() => {
-    if (semanticFilter === "all") {
-      onCategoryFilterChange("all");
-    } else {
-      const group = SEMANTIC_GROUPS.find((g) => g.id === semanticFilter);
-      if (group && group.matches.length > 0) {
-        onCategoryFilterChange(group.matches[0]);
-      }
-    }
-  }, [semanticFilter, onCategoryFilterChange]);
-  const activeSemanticGroup = categoryFilter === "all" ? "all" : resolveSemanticGroup(categoryFilter);
+  const activeSemanticGroup = semanticFilter;
   const visibleGroups = reactExports.useMemo(() => {
     const available = /* @__PURE__ */ new Set();
     for (const item of requests) {
@@ -17360,7 +17394,7 @@ const ReviewQueueList = reactExports.forwardRef(({
     }
     return SEMANTIC_GROUPS.filter((g) => g.id === "all" || available.has(g.id));
   }, [requests]);
-  const isFiltered = searchTerm || categoryFilter !== "all" || sortDirection !== "newest";
+  const isFiltered = searchTerm || semanticFilter !== "all" || categoryFilter !== "all" || sortDirection !== "newest";
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("aside", { className: "space-y-3", ref, children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between gap-3", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Queue" }),
@@ -17399,7 +17433,7 @@ const ReviewQueueList = reactExports.forwardRef(({
         /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex flex-wrap gap-1", children: visibleGroups.map((group) => /* @__PURE__ */ jsxRuntimeExports.jsx(
           "button",
           {
-            onClick: () => setSemanticFilter(group.id),
+            onClick: () => onSemanticFilterChange(group.id),
             className: `rounded-full px-2.5 py-1 text-[11px] font-medium transition-all ${activeSemanticGroup === group.id ? "bg-brand-blue text-white" : "border border-slate-200 bg-white text-brand-dark hover:bg-slate-50"}`,
             children: group.label
           },
@@ -17428,7 +17462,7 @@ const ReviewQueueList = reactExports.forwardRef(({
               onSearchTermChange("");
               onCategoryFilterChange("all");
               onSortDirectionChange("newest");
-              setSemanticFilter("all");
+              onSemanticFilterChange("all");
             },
             className: "text-xs font-medium text-brand-blue hover:text-brand-dark transition-colors",
             children: "Clear all filters"
@@ -17583,9 +17617,13 @@ function ReviewDecisionCard(props) {
   const [errorMessage, setErrorMessage] = reactExports.useState(null);
   const timerRef = reactExports.useRef(null);
   const allowButtonRef = reactExports.useRef(null);
+  const availableScopeChoices = reactExports.useMemo(
+    () => item ? filterScopeChoicesForRequest(item, scopeChoices) : scopeChoices,
+    [item]
+  );
   reactExports.useEffect(() => {
     if (item) {
-      setScope(item.recommended_scope);
+      setScope(normalizeDecisionScope(item, item.recommended_scope));
       setResolved(null);
       setSubmitting(null);
       setConfirmScope(null);
@@ -17623,26 +17661,26 @@ function ReviewDecisionCard(props) {
         handleRequestResolve("block");
       }
       const scopeIndex = parseInt(event.key, 10);
-      if (scopeIndex >= 1 && scopeIndex <= 5) {
+      if (scopeIndex >= 1 && scopeIndex <= availableScopeChoices.length) {
         event.preventDefault();
-        setScope(scopeChoices[scopeIndex - 1].value);
+        setScope(availableScopeChoices[scopeIndex - 1].value);
       }
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [submitting, confirmScope, scope, item?.request_id]);
+  }, [submitting, confirmScope, scope, item?.request_id, availableScopeChoices]);
   const handleResolve = reactExports.useCallback(
     async (action) => {
       if (!item) return;
       setSubmitting(action);
       setErrorMessage(null);
       try {
-        await props.onResolve({
-          requestId: item.request_id,
+        await props.onResolve(buildDecisionPayload({
+          item,
           action,
           scope,
           reason: action === "allow" ? "approved in review" : "blocked in review"
-        });
+        }));
         setResolved(action);
         timerRef.current = setTimeout(() => setResolved(null), 2e3);
       } catch (err) {
@@ -17716,7 +17754,7 @@ function ReviewDecisionCard(props) {
         /* @__PURE__ */ jsxRuntimeExports.jsxs("h3", { className: "text-sm font-semibold text-brand-dark", children: [
           pendingAction === "allow" ? "Allow" : "Block",
           " for ",
-          scopeChoices.find((s) => s.value === confirmScope)?.label,
+          availableScopeChoices.find((s) => s.value === confirmScope)?.label,
           "?"
         ] }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-1 text-sm text-muted-foreground", children: [
@@ -17783,7 +17821,7 @@ function ReviewDecisionCard(props) {
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-6 space-y-2", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "How long should this choice last?" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "grid gap-2 sm:grid-cols-2", role: "radiogroup", "aria-label": "Scope selection", children: scopeChoices.map((choice) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "grid gap-2 sm:grid-cols-2", role: "radiogroup", "aria-label": "Scope selection", children: availableScopeChoices.map((choice) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
           "button",
           {
             onClick: () => setScope(choice.value),
@@ -18639,7 +18677,7 @@ function DecisionWorkspace(props) {
           bannerTimerRef.current = null;
         }
       }
-      setScope(props.detail.item.recommended_scope);
+      setScope(normalizeDecisionScope(props.detail.item, props.detail.item.recommended_scope));
       setErrorMessage(null);
       setSubmitting(null);
     }
@@ -18652,20 +18690,18 @@ function DecisionWorkspace(props) {
     };
   }, []);
   const readyItem = props.detail.kind === "ready" ? props.detail.item : null;
-  const readyRequestId = readyItem?.request_id ?? "";
-  const readyWorkspace = readyItem?.workspace ?? void 0;
   const handleResolve = reactExports.useCallback(
     async (action) => {
+      if (readyItem === null) return;
       setSubmitting(action);
       setErrorMessage(null);
       try {
-        await props.onResolve({
-          requestId: readyRequestId,
+        await props.onResolve(buildDecisionPayload({
+          item: readyItem,
           action,
           scope,
-          reason,
-          workspace: scope === "workspace" ? readyWorkspace : void 0
-        });
+          reason
+        }));
         setResolvedState("decided");
         setResolvedBanner(action);
         bannerTimerRef.current = setTimeout(() => {
@@ -18676,7 +18712,7 @@ function DecisionWorkspace(props) {
         setSubmitting(null);
       }
     },
-    [props.onResolve, readyRequestId, readyWorkspace, reason, scope]
+    [props.onResolve, readyItem, reason, scope]
   );
   const handleRequestResolve = reactExports.useCallback(
     (action) => {
@@ -18763,8 +18799,9 @@ function DecisionWorkspace(props) {
     return /* @__PURE__ */ jsxRuntimeExports.jsx(EmptyState, { title: "Select an item", body: "Choose a blocked item from the list to review the evidence and make a decision.", tone: "teach" });
   }
   const { item, diff, receipt, policy } = props.detail;
-  const commonScopeOpts = scopeOptions.filter((option) => commonScopeValues.has(option.value));
-  const broadScopeOpts = scopeOptions.filter((option) => !commonScopeValues.has(option.value));
+  const availableScopeOptions = filterScopeChoicesForRequest(item, scopeOptions);
+  const commonScopeOpts = availableScopeOptions.filter((option) => commonScopeValues.has(option.value));
+  const broadScopeOpts = availableScopeOptions.filter((option) => !commonScopeValues.has(option.value));
   const isAlreadyDecided = item.resolution_action !== null;
   const decidedLabel = item.resolution_action === "allow" ? "allow" : item.resolution_action === "block" ? "block" : item.resolution_action ?? "decided";
   const allowLabel = scope === "artifact" ? "Approve once" : "Approve and remember";

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -17691,7 +17691,7 @@ function ReviewDecisionCard(props) {
         setPendingAction(null);
       }
     },
-    [item?.request_id, scope, props.onResolve]
+    [item, scope, props.onResolve]
   );
   const handleRequestResolve = reactExports.useCallback(
     (action) => {

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -1470,6 +1470,55 @@ class TestGuardApprovals:
         assert status == 400
         assert "requires --workspace" in payload["error"]
 
+    @pytest.mark.parametrize("action", ["approve", "block"])
+    @pytest.mark.parametrize("scope", ["artifact", "workspace", "publisher", "harness", "global"])
+    def test_guard_daemon_resolution_route_accepts_all_scope_kinds(self, tmp_path, action, scope):
+        store = GuardStore(tmp_path / "guard-home")
+        workspace = tmp_path / "workspace"
+        request_id = f"req-{action}-{scope}"
+        store.add_approval_request(
+            GuardApprovalRequest(
+                request_id=request_id,
+                harness="codex",
+                artifact_id=f"codex:project:{scope}",
+                artifact_name=f"{scope} action",
+                artifact_hash=f"hash-{action}-{scope}",
+                publisher="codex-local",
+                policy_action="require-reapproval",
+                recommended_scope="artifact",
+                changed_fields=("args",),
+                source_scope="project",
+                config_path=str(workspace / ".codex" / "config.toml"),
+                workspace=str(workspace),
+                review_command=f"hol-guard approvals {action} {request_id}",
+                approval_url="http://127.0.0.1/pending",
+            ),
+            "2026-04-11T00:00:00+00:00",
+        )
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            request_payload = {"scope": scope, "reason": "real daemon route scope coverage"}
+            if scope == "workspace":
+                request_payload["workspace"] = str(workspace)
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/requests/{request_id}/{action}",
+                data=json.dumps(request_payload).encode("utf-8"),
+                headers=_guard_json_headers(daemon._server.auth_token),
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=5) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+                status = response.status
+        finally:
+            daemon.stop()
+
+        assert status == 200
+        assert payload["resolved"] is True
+        assert payload["resolved_request"]["resolution_action"] == ("allow" if action == "approve" else "block")
+        assert payload["resolved_request"]["resolution_scope"] == scope
+
     def test_guard_daemon_approve_route_requires_auth_token(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
         store.add_approval_request(


### PR DESCRIPTION
## Summary
- send workspace metadata for workspace-scoped approval/block decisions from both inbox review surfaces
- hide workspace/source scope choices when the request lacks the metadata the daemon requires
- add shared frontend scope payload helper and real daemon coverage for approve/block across artifact, workspace, publisher, harness, and global scopes

## Verification
- pnpm exec tsx src/approval-scopes.test.ts && pnpm test && pnpm build
- python3 -m pytest tests/test_guard_approvals.py tests/test_guard_queue_contract.py tests/test_guard_queue_api_contract.py
- python3 -m pytest tests/test_guard_policy_dedup.py tests/test_guard_daemon_repair_perf.py -k 'approved'
- git diff --check