### PR TITLE
fix(guard): keep queue after scoped approvals

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -449,7 +449,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 workspace=self._optional_string(payload.get("workspace")),
                 reason=self._optional_string(payload.get("reason")),
                 return_queue_result=True,
-                resolve_scope_matches=True,
+                resolve_scope_matches=False,
             )
         except ApprovalRequestNotFoundError:
             self._write_json(

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -1472,7 +1472,7 @@ class TestGuardApprovals:
 
     @pytest.mark.parametrize("action", ["approve", "block"])
     @pytest.mark.parametrize("scope", ["artifact", "workspace", "publisher", "harness", "global"])
-    def test_guard_daemon_resolution_route_accepts_all_scope_kinds(self, tmp_path, action, scope):
+    def test_guard_daemon_resolution_route_accepts_all_scope_kinds_without_clearing_queue(self, tmp_path, action, scope):
         store = GuardStore(tmp_path / "guard-home")
         workspace = tmp_path / "workspace"
         request_id = f"req-{action}-{scope}"
@@ -1494,6 +1494,25 @@ class TestGuardApprovals:
                 approval_url="http://127.0.0.1/pending",
             ),
             "2026-04-11T00:00:00+00:00",
+        )
+        store.add_approval_request(
+            GuardApprovalRequest(
+                request_id=f"{request_id}-other",
+                harness="codex",
+                artifact_id=f"codex:project:{scope}-other",
+                artifact_name=f"{scope} other action",
+                artifact_hash=f"hash-{action}-{scope}-other",
+                publisher="codex-local",
+                policy_action="require-reapproval",
+                recommended_scope="artifact",
+                changed_fields=("args",),
+                source_scope="project",
+                config_path=str(workspace / ".codex" / "config.toml"),
+                workspace=str(workspace),
+                review_command=f"hol-guard approvals {action} {request_id}-other",
+                approval_url="http://127.0.0.1/pending-other",
+            ),
+            "2026-04-11T00:01:00+00:00",
         )
         daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
         daemon.start()
@@ -1518,6 +1537,9 @@ class TestGuardApprovals:
         assert payload["resolved"] is True
         assert payload["resolved_request"]["resolution_action"] == ("allow" if action == "approve" else "block")
         assert payload["resolved_request"]["resolution_scope"] == scope
+        assert payload["remaining_pending_count"] == 1
+        assert payload["next_selectable_request_id"] == f"{request_id}-other"
+        assert store.get_approval_request(f"{request_id}-other")["status"] == "pending"
 
     def test_guard_daemon_approve_route_requires_auth_token(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")

--- a/tests/test_guard_queue_api_contract.py
+++ b/tests/test_guard_queue_api_contract.py
@@ -20,6 +20,7 @@ def _request(
     harness: str = "codex",
     command: str = "cat ~/.npmrc",
     artifact_id: str | None = None,
+    publisher: str | None = None,
     prompt_excerpt: str | None = None,
     mcp_server: str | None = None,
     mcp_tool: str | None = None,
@@ -41,6 +42,7 @@ def _request(
         artifact_id=artifact_id or f"{harness}:project:{request_id}",
         artifact_name=request_id,
         artifact_hash=f"hash-{request_id}",
+        publisher=publisher,
         policy_action="require-reapproval",
         recommended_scope="artifact",
         changed_fields=("args",),
@@ -195,7 +197,7 @@ def test_resolving_duplicate_group_reports_collapsed_ids(tmp_path: Path) -> None
     assert payload["next_selectable_request_id"] == "req-unrelated"
 
 
-def test_broad_scope_resolution_refreshes_queue_envelope(tmp_path: Path) -> None:
+def test_broad_scope_resolution_keeps_other_reviews_pending(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     _populate(store, [_request("req-active"), _request("req-covered", command="cat ~/.pypirc")])
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
@@ -211,12 +213,16 @@ def test_broad_scope_resolution_refreshes_queue_envelope(tmp_path: Path) -> None
     finally:
         daemon.stop()
 
-    assert payload["remaining_pending_count"] == 0
-    assert payload["next_selectable_request_id"] is None
-    assert payload["resolved_scope_ids"] == ["req-covered"]
+    assert payload["remaining_pending_count"] == 1
+    assert payload["next_selectable_request_id"] == "req-covered"
+    assert payload.get("resolved_scope_ids") in (None, [])
+    assert store.get_approval_request("req-covered")["status"] == "pending"
+    decisions = store.list_policy_decisions("codex")
+    assert len(decisions) == 1
+    assert decisions[0]["scope"] == "harness"
 
 
-def test_artifact_scope_resolution_refreshes_queue_envelope(tmp_path: Path) -> None:
+def test_artifact_scope_resolution_keeps_same_artifact_review_pending(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     shared_artifact = "codex:project:shared-tool"
     _populate(
@@ -240,9 +246,10 @@ def test_artifact_scope_resolution_refreshes_queue_envelope(tmp_path: Path) -> N
     finally:
         daemon.stop()
 
-    assert payload["remaining_pending_count"] == 1
+    assert payload["remaining_pending_count"] == 2
     assert payload["next_selectable_request_id"] == "req-unrelated"
-    assert payload["resolved_scope_ids"] == ["req-covered"]
+    assert payload.get("resolved_scope_ids") in (None, [])
+    assert store.get_approval_request("req-covered")["status"] == "pending"
 
 
 def test_resolving_stale_item_returns_recovery_payload(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- stop local daemon approval API from retroactively resolving every pending review matched by a broad approval scope
- keep the selected broad policy persisted for future retries while only resolving the reviewed queue item
- update real daemon API tests so artifact/workspace/publisher/harness/global approve/block choices leave other pending reviews in the queue

## Verification
- python3 -m pytest tests/test_guard_queue_api_contract.py -k 'broad_scope_resolution_keeps_other_reviews_pending or artifact_scope_resolution_keeps_same_artifact_review_pending'
- python3 -m pytest tests/test_guard_queue_api_contract.py -k 'broad_scope_resolution_keeps_other_reviews_pending or artifact_scope_resolution_keeps_same_artifact_review_pending' && python3 -m pytest tests/test_guard_approvals.py -k 'resolution_route_accepts_all_scope_kinds_without_clearing_queue'
- python3 -m pytest tests/test_guard_approvals.py tests/test_guard_queue_contract.py tests/test_guard_queue_api_contract.py tests/test_guard_policy_dedup.py
- git diff --check