### PR TITLE
fix(guard): review layout responsive improvements

### DIFF
--- a/dashboard/src/approval-center-layout.tsx
+++ b/dashboard/src/approval-center-layout.tsx
@@ -206,8 +206,8 @@ export function ApprovalCenterLayout(props: LayoutProps) {
         />
       )}
       <div className={`flex flex-col transition-all duration-200 ${sidebarCollapsed ? "lg:pl-20" : "lg:pl-64"}`}>
-        <main id="main-content" className="flex-1 p-6 lg:p-10" tabIndex={-1}>
-          <div className="mx-auto max-w-6xl">
+        <main id="main-content" className="flex-1 p-4 sm:p-6 lg:p-8" tabIndex={-1}>
+          <div className={props.view === "inbox" ? "mx-auto max-w-none" : "mx-auto max-w-6xl"}>
             {props.view === "home" ? (
               props.homeContent
             ) : props.view === "evidence" ? (

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -235,7 +235,10 @@ export function ReviewWorkspace(props: ReviewWorkspaceProps) {
             onSearchTermChange={setSearchTerm}
             onSortDirectionChange={setSortDirection}
             onSemanticFilterChange={setSemanticFilter}
-            onOpenRequest={props.onOpenRequest}
+            onOpenRequest={(id) => {
+              props.onOpenRequest(id);
+              setMobileQueueOpen(false);
+            }}
             ref={queueRef}
           />
         </div>
@@ -1097,7 +1100,7 @@ function ActionContentCard({ item }: { item: GuardApprovalRequest }) {
             <CopyButton text={launchText} />
           </span>
         </div>
-        <pre className="max-h-[50vh] overflow-y-auto whitespace-pre-wrap break-all px-3 py-3 font-mono text-sm leading-6 text-white/90">
+        <pre className="max-h-[50vh] overflow-y-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-sm leading-6 text-white/90">
           {launchText}
         </pre>
       </div>

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -138,6 +138,15 @@ export function ReviewWorkspace(props: ReviewWorkspaceProps) {
   const [semanticFilter, setSemanticFilter] = useState<SemanticGroupId>("all");
   const [mobileQueueOpen, setMobileQueueOpen] = useState(false);
 
+  const handleOpenRequest = useCallback((id: string) => {
+    props.onOpenRequest(id);
+    setMobileQueueOpen(false);
+  }, [props.onOpenRequest]);
+
+  const handleToggleMobileQueue = useCallback(() => {
+    setMobileQueueOpen((v) => !v);
+  }, []);
+
   const filteredRequests = useMemo(() => {
     let items = requests;
     if (semanticFilter !== "all") {
@@ -212,7 +221,7 @@ export function ReviewWorkspace(props: ReviewWorkspaceProps) {
       {/* Mobile queue toggle */}
       <div className="md:hidden">
         <button
-          onClick={() => setMobileQueueOpen((v) => !v)}
+          onClick={handleToggleMobileQueue}
           className="flex w-full items-center justify-between rounded-lg border border-slate-200 bg-white px-3 py-2.5 text-sm font-medium text-brand-dark"
         >
           <span>Queue ({filteredRequests.length})</span>
@@ -235,10 +244,7 @@ export function ReviewWorkspace(props: ReviewWorkspaceProps) {
             onSearchTermChange={setSearchTerm}
             onSortDirectionChange={setSortDirection}
             onSemanticFilterChange={setSemanticFilter}
-            onOpenRequest={(id) => {
-              props.onOpenRequest(id);
-              setMobileQueueOpen(false);
-            }}
+            onOpenRequest={handleOpenRequest}
             ref={queueRef}
           />
         </div>

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -135,8 +135,8 @@ export function ReviewWorkspace(props: ReviewWorkspaceProps) {
   const [searchTerm, setSearchTerm] = useState("");
   const [categoryFilter, setCategoryFilter] = useState<QueueCategoryId | "all">("all");
   const [sortDirection, setSortDirection] = useState<QueueSortDirection>("newest");
-
   const [semanticFilter, setSemanticFilter] = useState<SemanticGroupId>("all");
+  const [mobileQueueOpen, setMobileQueueOpen] = useState(false);
 
   const filteredRequests = useMemo(() => {
     let items = requests;
@@ -209,23 +209,36 @@ export function ReviewWorkspace(props: ReviewWorkspaceProps) {
         activeHarness={activeItem.harness}
       />
 
-      <div className="grid gap-6 lg:grid-cols-[320px_1fr]">
-        <ReviewQueueList
-          requests={filteredRequests}
-          totalCount={requests.length}
-          activeRequestId={activeItem.request_id}
-          categoryOptions={categoryOptions}
-          categoryFilter={categoryFilter}
-          searchTerm={searchTerm}
-          sortDirection={sortDirection}
-          semanticFilter={semanticFilter}
-          onCategoryFilterChange={setCategoryFilter}
-          onSearchTermChange={setSearchTerm}
-          onSortDirectionChange={setSortDirection}
-          onSemanticFilterChange={setSemanticFilter}
-          onOpenRequest={props.onOpenRequest}
-          ref={queueRef}
-        />
+      {/* Mobile queue toggle */}
+      <div className="md:hidden">
+        <button
+          onClick={() => setMobileQueueOpen((v) => !v)}
+          className="flex w-full items-center justify-between rounded-lg border border-slate-200 bg-white px-3 py-2.5 text-sm font-medium text-brand-dark"
+        >
+          <span>Queue ({filteredRequests.length})</span>
+          <HiMiniChevronDown className={`h-4 w-4 transition-transform ${mobileQueueOpen ? "rotate-180" : ""}`} />
+        </button>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-[260px_1fr] lg:grid-cols-[280px_1fr] xl:grid-cols-[300px_1fr] items-start">
+        <div className={`${mobileQueueOpen ? "block" : "hidden"} md:block`}>
+          <ReviewQueueList
+            requests={filteredRequests}
+            totalCount={requests.length}
+            activeRequestId={activeItem.request_id}
+            categoryOptions={categoryOptions}
+            categoryFilter={categoryFilter}
+            searchTerm={searchTerm}
+            sortDirection={sortDirection}
+            semanticFilter={semanticFilter}
+            onCategoryFilterChange={setCategoryFilter}
+            onSearchTermChange={setSearchTerm}
+            onSortDirectionChange={setSortDirection}
+            onSemanticFilterChange={setSemanticFilter}
+            onOpenRequest={props.onOpenRequest}
+            ref={queueRef}
+          />
+        </div>
         <ReviewDecisionCard
           detail={detail}
           onResolve={props.onResolve}
@@ -1084,7 +1097,7 @@ function ActionContentCard({ item }: { item: GuardApprovalRequest }) {
             <CopyButton text={launchText} />
           </span>
         </div>
-        <pre className="overflow-x-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-sm leading-6 text-white/90">
+        <pre className="max-h-[50vh] overflow-y-auto whitespace-pre-wrap break-all px-3 py-3 font-mono text-sm leading-6 text-white/90">
           {launchText}
         </pre>
       </div>

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -17240,6 +17240,13 @@ function ReviewWorkspace(props) {
   const [sortDirection, setSortDirection] = reactExports.useState("newest");
   const [semanticFilter, setSemanticFilter] = reactExports.useState("all");
   const [mobileQueueOpen, setMobileQueueOpen] = reactExports.useState(false);
+  const handleOpenRequest = reactExports.useCallback((id) => {
+    props.onOpenRequest(id);
+    setMobileQueueOpen(false);
+  }, [props.onOpenRequest]);
+  const handleToggleMobileQueue = reactExports.useCallback(() => {
+    setMobileQueueOpen((v) => !v);
+  }, []);
   const filteredRequests = reactExports.useMemo(() => {
     let items = requests;
     if (semanticFilter !== "all") {
@@ -17300,7 +17307,7 @@ function ReviewWorkspace(props) {
     /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "md:hidden", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(
       "button",
       {
-        onClick: () => setMobileQueueOpen((v) => !v),
+        onClick: handleToggleMobileQueue,
         className: "flex w-full items-center justify-between rounded-lg border border-slate-200 bg-white px-3 py-2.5 text-sm font-medium text-brand-dark",
         children: [
           /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
@@ -17328,10 +17335,7 @@ function ReviewWorkspace(props) {
           onSearchTermChange: setSearchTerm,
           onSortDirectionChange: setSortDirection,
           onSemanticFilterChange: setSemanticFilter,
-          onOpenRequest: (id) => {
-            props.onOpenRequest(id);
-            setMobileQueueOpen(false);
-          },
+          onOpenRequest: handleOpenRequest,
           ref: queueRef
         }
       ) }),

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -17328,7 +17328,10 @@ function ReviewWorkspace(props) {
           onSearchTermChange: setSearchTerm,
           onSortDirectionChange: setSortDirection,
           onSemanticFilterChange: setSemanticFilter,
-          onOpenRequest: props.onOpenRequest,
+          onOpenRequest: (id) => {
+            props.onOpenRequest(id);
+            setMobileQueueOpen(false);
+          },
           ref: queueRef
         }
       ) }),
@@ -18034,7 +18037,7 @@ function ActionContentCard({ item }) {
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ml-2 font-mono text-[10px] uppercase tracking-[0.22em] text-white/45", children: terminalLabel }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ml-auto", children: /* @__PURE__ */ jsxRuntimeExports.jsx(CopyButton, { text: launchText }) })
       ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("pre", { className: "max-h-[50vh] overflow-y-auto whitespace-pre-wrap break-all px-3 py-3 font-mono text-sm leading-6 text-white/90", children: launchText })
+      /* @__PURE__ */ jsxRuntimeExports.jsx("pre", { className: "max-h-[50vh] overflow-y-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-sm leading-6 text-white/90", children: launchText })
     ] })
   ] });
 }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -17239,6 +17239,7 @@ function ReviewWorkspace(props) {
   const [categoryFilter, setCategoryFilter] = reactExports.useState("all");
   const [sortDirection, setSortDirection] = reactExports.useState("newest");
   const [semanticFilter, setSemanticFilter] = reactExports.useState("all");
+  const [mobileQueueOpen, setMobileQueueOpen] = reactExports.useState(false);
   const filteredRequests = reactExports.useMemo(() => {
     let items = requests;
     if (semanticFilter !== "all") {
@@ -17296,8 +17297,23 @@ function ReviewWorkspace(props) {
         activeHarness: activeItem.harness
       }
     ),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-6 lg:grid-cols-[320px_1fr]", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "md:hidden", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(
+      "button",
+      {
+        onClick: () => setMobileQueueOpen((v) => !v),
+        className: "flex w-full items-center justify-between rounded-lg border border-slate-200 bg-white px-3 py-2.5 text-sm font-medium text-brand-dark",
+        children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
+            "Queue (",
+            filteredRequests.length,
+            ")"
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronDown, { className: `h-4 w-4 transition-transform ${mobileQueueOpen ? "rotate-180" : ""}` })
+        ]
+      }
+    ) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 md:grid-cols-[260px_1fr] lg:grid-cols-[280px_1fr] xl:grid-cols-[300px_1fr] items-start", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: `${mobileQueueOpen ? "block" : "hidden"} md:block`, children: /* @__PURE__ */ jsxRuntimeExports.jsx(
         ReviewQueueList,
         {
           requests: filteredRequests,
@@ -17315,7 +17331,7 @@ function ReviewWorkspace(props) {
           onOpenRequest: props.onOpenRequest,
           ref: queueRef
         }
-      ),
+      ) }),
       /* @__PURE__ */ jsxRuntimeExports.jsx(
         ReviewDecisionCard,
         {
@@ -18018,7 +18034,7 @@ function ActionContentCard({ item }) {
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ml-2 font-mono text-[10px] uppercase tracking-[0.22em] text-white/45", children: terminalLabel }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ml-auto", children: /* @__PURE__ */ jsxRuntimeExports.jsx(CopyButton, { text: launchText }) })
       ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("pre", { className: "overflow-x-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-sm leading-6 text-white/90", children: launchText })
+      /* @__PURE__ */ jsxRuntimeExports.jsx("pre", { className: "max-h-[50vh] overflow-y-auto whitespace-pre-wrap break-all px-3 py-3 font-mono text-sm leading-6 text-white/90", children: launchText })
     ] })
   ] });
 }
@@ -18234,7 +18250,7 @@ function ApprovalCenterLayout(props) {
         onBulkApprove: props.onBulkApprove
       }
     ),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: `flex flex-col transition-all duration-200 ${sidebarCollapsed ? "lg:pl-20" : "lg:pl-64"}`, children: /* @__PURE__ */ jsxRuntimeExports.jsx("main", { id: "main-content", className: "flex-1 p-6 lg:p-10", tabIndex: -1, children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mx-auto max-w-6xl", children: props.view === "home" ? props.homeContent : props.view === "evidence" ? /* @__PURE__ */ jsxRuntimeExports.jsx(ReceiptsWorkspace, { receipts: props.receipts }) : props.view === "fleet" ? props.fleetContent : props.view === "app-detail" ? props.appDetailContent : props.view === "settings" ? props.settingsContent : props.view === "inbox" ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: `flex flex-col transition-all duration-200 ${sidebarCollapsed ? "lg:pl-20" : "lg:pl-64"}`, children: /* @__PURE__ */ jsxRuntimeExports.jsx("main", { id: "main-content", className: "flex-1 p-4 sm:p-6 lg:p-8", tabIndex: -1, children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: props.view === "inbox" ? "mx-auto max-w-none" : "mx-auto max-w-6xl", children: props.view === "home" ? props.homeContent : props.view === "evidence" ? /* @__PURE__ */ jsxRuntimeExports.jsx(ReceiptsWorkspace, { receipts: props.receipts }) : props.view === "fleet" ? props.fleetContent : props.view === "app-detail" ? props.appDetailContent : props.view === "settings" ? props.settingsContent : props.view === "inbox" ? /* @__PURE__ */ jsxRuntimeExports.jsx(
       ReviewWorkspace,
       {
         requests: props.requests.kind === "ready" ? props.requests.items : [],

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -843,6 +843,10 @@
     height: 100%;
   }
 
+  .max-h-\[50vh\] {
+    max-height: 50vh;
+  }
+
   .max-h-\[70vh\] {
     max-height: 70vh;
   }
@@ -993,6 +997,10 @@
 
   .max-w-md {
     max-width: var(--container-md);
+  }
+
+  .max-w-none {
+    max-width: none;
   }
 
   .max-w-sm {
@@ -3767,8 +3775,16 @@
   }
 
   @media (min-width: 48rem) {
+    .md\:block {
+      display: block;
+    }
+
     .md\:flex {
       display: flex;
+    }
+
+    .md\:hidden {
+      display: none;
     }
 
     .md\:grid-cols-2 {
@@ -3777,6 +3793,10 @@
 
     .md\:grid-cols-3 {
       grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .md\:grid-cols-\[260px_1fr\] {
+      grid-template-columns: 260px 1fr;
     }
 
     .md\:grid-cols-\[minmax\(0\,1fr\)_200px\] {
@@ -3817,12 +3837,12 @@
       grid-template-columns: repeat(4, minmax(0, 1fr));
     }
 
-    .lg\:grid-cols-\[300px_1fr\] {
-      grid-template-columns: 300px 1fr;
+    .lg\:grid-cols-\[280px_1fr\] {
+      grid-template-columns: 280px 1fr;
     }
 
-    .lg\:grid-cols-\[320px_1fr\] {
-      grid-template-columns: 320px 1fr;
+    .lg\:grid-cols-\[300px_1fr\] {
+      grid-template-columns: 300px 1fr;
     }
 
     .lg\:grid-cols-\[minmax\(0\,1\.3fr\)_minmax\(0\,0\.9fr\)\] {
@@ -3857,8 +3877,8 @@
       padding: calc(var(--spacing) * 7);
     }
 
-    .lg\:p-10 {
-      padding: calc(var(--spacing) * 10);
+    .lg\:p-8 {
+      padding: calc(var(--spacing) * 8);
     }
 
     .lg\:px-8 {
@@ -3889,6 +3909,10 @@
 
     .xl\:grid-cols-1 {
       grid-template-columns: repeat(1, minmax(0, 1fr));
+    }
+
+    .xl\:grid-cols-\[300px_1fr\] {
+      grid-template-columns: 300px 1fr;
     }
 
     .xl\:grid-cols-\[minmax\(0\,1\.08fr\)_minmax\(340px\,0\.92fr\)\] {


### PR DESCRIPTION
## Summary
- Long prompts/commands now wrap properly instead of being truncated
- Inbox view uses full width instead of being constrained to max-w-6xl
- Mobile: queue list is collapsible, layout adapts at md breakpoint
- Reduced grid gap and sidebar width for better space usage

## Fixes
1. Terminal `<pre>`: removed `overflow-x-auto`, added `break-all` and `max-h-[50vh]` with vertical scroll
2. Layout: removed `max-w-6xl` constraint on inbox view, reduced main padding on small screens
3. Mobile: added queue toggle button, grid collapses at `md` instead of `lg`, narrower sidebar columns