### PR TITLE
feat(guard): manage harnesses from dashboard

### DIFF
--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -360,8 +360,13 @@ export function App() {
     }
     if (inventoryResult.status === "fulfilled") {
       setInventory({ kind: "ready", items: inventoryResult.value });
+    } else {
+      setInventory({
+        kind: "error",
+        message: inventoryResult.reason instanceof Error ? inventoryResult.reason.message : "Unable to load watched app inventory.",
+      });
     }
-  }, [setRuntime, setRequests, setReceipts, setPolicies]);
+  }, [setRuntime, setRequests, setReceipts, setPolicies, setInventory]);
 
   const handleClearPolicies = useCallback(async (scope: { harness?: string; all?: boolean }) => {
     setClearConfirm(scope);

--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -332,10 +332,11 @@ export function App() {
   }, []);
 
   const refreshStateAfterAction = useCallback(async () => {
-    const [snapshotResult, receiptsResult, policiesResult] = await Promise.allSettled([
+    const [snapshotResult, receiptsResult, policiesResult, inventoryResult] = await Promise.allSettled([
       fetchRuntimeSnapshot(),
       fetchReceipts(),
       fetchPolicies(),
+      fetchInventory(),
     ]);
     if (snapshotResult.status === "fulfilled") {
       setRuntime({ kind: "ready", snapshot: snapshotResult.value });
@@ -356,6 +357,9 @@ export function App() {
         kind: "error",
         message: policiesResult.reason instanceof Error ? policiesResult.reason.message : "Unable to load remembered decisions.",
       });
+    }
+    if (inventoryResult.status === "fulfilled") {
+      setInventory({ kind: "ready", items: inventoryResult.value });
     }
   }, [setRuntime, setRequests, setReceipts, setPolicies]);
 
@@ -477,16 +481,16 @@ export function App() {
       });
   }, []);
 
-  const handleConnectHarness = useCallback((_harness: string) => {
-    navigate("/settings");
+  const handleConnectHarness = useCallback((harness: string) => {
+    navigate(`/apps/${encodeURIComponent(harness)}?tab=settings`);
   }, []);
 
-  const handleTestHarness = useCallback((_harness: string) => {
-    navigate("/inbox");
+  const handleTestHarness = useCallback((harness: string) => {
+    navigate(`/apps/${encodeURIComponent(harness)}?tab=settings`);
   }, []);
 
-  const handleRepairHarness = useCallback((_harness: string) => {
-    navigate("/settings");
+  const handleRepairHarness = useCallback((harness: string) => {
+    navigate(`/apps/${encodeURIComponent(harness)}?tab=settings`);
   }, []);
 
   const appDetailContent = useMemo(() => {
@@ -504,9 +508,10 @@ export function App() {
         onGoHome={handleGoHome}
         onOpenRequest={handleOpenRequest}
         onClearAppPolicies={handleClearAppPolicies}
+        onManagedInstallChanged={refreshStateAfterAction}
       />
     );
-  }, [view, appDetailHarness, runtime, receipts, policies, inventory, requests, handleGoHome, handleOpenRequest, handleClearAppPolicies]);
+  }, [view, appDetailHarness, runtime, receipts, policies, inventory, requests, handleGoHome, handleOpenRequest, handleClearAppPolicies, refreshStateAfterAction]);
 
   return (
     <>

--- a/dashboard/src/apps/app-detail-workspace.tsx
+++ b/dashboard/src/apps/app-detail-workspace.tsx
@@ -78,6 +78,9 @@ function writeTabToUrl(tab: TabKey) {
   const url = new URL(window.location.href);
   if (tab === "overview") {
     url.searchParams.delete("tab");
+    if (url.hash === "#activity" || url.hash === "#settings" || url.hash === "#overview") {
+      url.hash = "";
+    }
   } else {
     url.searchParams.set("tab", tab);
   }
@@ -1128,6 +1131,8 @@ function HarnessSetupPanel(props: {
     const phrase =
       setupState.kind === "error" && setupState.confirmationPhrase
         ? setupState.confirmationPhrase
+        : setupState.kind === "success" && setupState.result.confirmation_phrase
+        ? setupState.result.confirmation_phrase
         : `disconnect-${props.harness}`;
     void runAction("uninstall", { dryRun: false, confirmationPhrase: phrase });
   }, [props.harness, runAction, setupState]);
@@ -1577,4 +1582,3 @@ function StatCard({
     </div>
   );
 }
-

--- a/dashboard/src/apps/app-detail-workspace.tsx
+++ b/dashboard/src/apps/app-detail-workspace.tsx
@@ -13,6 +13,10 @@ import {
   HiMiniChartBar,
   HiMiniXMark,
   HiMiniChevronDown,
+  HiMiniShieldCheck,
+  HiMiniRocketLaunch,
+  HiMiniArrowPath,
+  HiMiniTrash,
 } from "react-icons/hi2";
 import {
   ActionButton,
@@ -26,6 +30,9 @@ import {
 import {
   fetchApprovalPage,
   fetchPolicy,
+  formatHarnessCommand,
+  GuardHarnessActionError,
+  runHarnessAction,
 } from "../guard-api";
 import { harnessDisplayName, formatRelativeTime } from "../approval-center-utils";
 import { useFocusTrap } from "../use-focus-trap";
@@ -37,6 +44,9 @@ import type {
   GuardReceipt,
   GuardRuntimeSnapshot,
   GuardManagedInstall,
+  GuardHarnessAction,
+  GuardHarnessActionResult,
+  GuardHarnessSetupStep,
 } from "../guard-types";
 
 type TabKey = "overview" | "activity" | "settings";
@@ -53,9 +63,12 @@ type AppDetailWorkspaceProps = {
   onGoHome: () => void;
   onOpenRequest: (requestId: string) => void;
   onClearAppPolicies?: (harness: string) => Promise<void>;
+  onManagedInstallChanged?: () => Promise<void>;
 };
 
 function readTabFromUrl(): TabKey {
+  const queryTab = new URLSearchParams(window.location.search).get("tab");
+  if (queryTab === "overview" || queryTab === "activity" || queryTab === "settings") return queryTab;
   const hash = window.location.hash.replace("#", "");
   if (hash === "activity" || hash === "settings") return hash;
   return "overview";
@@ -63,7 +76,11 @@ function readTabFromUrl(): TabKey {
 
 function writeTabToUrl(tab: TabKey) {
   const url = new URL(window.location.href);
-  url.hash = tab;
+  if (tab === "overview") {
+    url.searchParams.delete("tab");
+  } else {
+    url.searchParams.set("tab", tab);
+  }
   window.history.replaceState({}, "", url.toString());
 }
 
@@ -315,8 +332,10 @@ export function AppDetailWorkspace(props: AppDetailWorkspaceProps) {
               <AppSettingsTab
                 harness={harness}
                 status={status}
+                install={install}
                 harnessPolicies={harnessPolicies}
                 onClearAppPolicies={props.onClearAppPolicies}
+                onManagedInstallChanged={props.onManagedInstallChanged}
                 policyError={policyError}
                 onRetry={loadTabData}
               />
@@ -863,8 +882,10 @@ function ExpandableReceiptRow({ receipt, selected, onToggle }: { receipt: GuardR
 function AppSettingsTab(props: {
   harness: string;
   status: "active" | "needs_setup" | "observed" | "unknown";
+  install: GuardManagedInstall | undefined;
   harnessPolicies: GuardPolicyDecision[];
   onClearAppPolicies?: (harness: string) => Promise<void>;
+  onManagedInstallChanged?: () => Promise<void>;
   policyError: string | null;
   onRetry: () => void;
 }) {
@@ -884,6 +905,13 @@ function AppSettingsTab(props: {
   return (
     <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.8fr)]">
       <div className="space-y-6">
+        <HarnessSetupPanel
+          harness={props.harness}
+          install={props.install}
+          status={props.status}
+          onManagedInstallChanged={props.onManagedInstallChanged}
+        />
+
         {props.policyError && (
           <div className="guard-fade-in rounded-xl border border-brand-attention/10 bg-brand-attention/[0.03] p-4 sm:p-5">
             <div className="flex items-start gap-3">
@@ -996,26 +1024,386 @@ function AppSettingsTab(props: {
         )}
       </div>
 
-      <div className="space-y-6">
-        {props.status === "needs_setup" && (
-          <div className="rounded-xl border border-brand-attention/10 bg-brand-attention/[0.03] p-4 sm:p-5">
-            <div className="flex items-start gap-3">
-              <HiMiniExclamationTriangle className="mt-0.5 h-5 w-5 shrink-0 text-brand-attention" />
-              <div>
-                <SectionLabel>Setup needed</SectionLabel>
-                <p className="mt-2 text-sm text-muted-foreground">
-                  This app is detected but not active. Run Guard with this app once to complete setup.
-                </p>
-                <div className="mt-4 rounded-xl bg-white/60 p-4">
-                  <p className="font-mono text-xs text-brand-dark">{`npx @hol/guard install ${props.harness}`}</p>
-                </div>
-              </div>
+      <HarnessCoverageAside status={props.status} install={props.install} />
+    </div>
+  );
+}
+
+type HarnessSetupState =
+  | { kind: "idle" }
+  | { kind: "loading"; action: GuardHarnessAction }
+  | { kind: "ready"; plan: GuardHarnessActionResult }
+  | { kind: "success"; action: GuardHarnessAction; result: GuardHarnessActionResult }
+  | { kind: "error"; action: GuardHarnessAction; message: string; confirmationPhrase?: string; confirmCommand?: string };
+
+function HarnessSetupPanel(props: {
+  harness: string;
+  install: GuardManagedInstall | undefined;
+  status: "active" | "needs_setup" | "observed" | "unknown";
+  onManagedInstallChanged?: () => Promise<void>;
+}) {
+  const [setupState, setSetupState] = useState<HarnessSetupState>({ kind: "idle" });
+  const [disconnectArmed, setDisconnectArmed] = useState(false);
+  const active = props.install?.active === true;
+  const displayName = harnessDisplayName(props.harness);
+
+  const refreshAfterMutation = useCallback(async () => {
+    await props.onManagedInstallChanged?.();
+  }, [props.onManagedInstallChanged]);
+
+  const loadPlan = useCallback(async () => {
+    setSetupState({ kind: "loading", action: active ? "verify" : "install" });
+    try {
+      const result = active
+        ? await runHarnessAction({ harness: props.harness, action: "verify" })
+        : await runHarnessAction({ harness: props.harness, action: "install", dryRun: true });
+      setSetupState({ kind: "ready", plan: result });
+    } catch (error) {
+      setSetupState({
+        kind: "error",
+        action: active ? "verify" : "install",
+        message: error instanceof Error ? error.message : "Unable to load setup plan.",
+      });
+    }
+  }, [active, props.harness]);
+
+  useEffect(() => {
+    void loadPlan();
+  }, [loadPlan]);
+
+  const runAction = useCallback(
+    async (action: GuardHarnessAction, options: { dryRun?: boolean; confirmationPhrase?: string } = {}) => {
+      setSetupState({ kind: "loading", action });
+      try {
+        const result = await runHarnessAction({
+          harness: props.harness,
+          action,
+          dryRun: options.dryRun,
+          confirmationPhrase: options.confirmationPhrase,
+        });
+        setDisconnectArmed(false);
+        setSetupState({ kind: "success", action, result });
+        if (action !== "verify" && options.dryRun !== true) {
+          await refreshAfterMutation();
+        }
+      } catch (error) {
+        if (error instanceof GuardHarnessActionError) {
+          setSetupState({
+            kind: "error",
+            action,
+            message: setupActionErrorMessage(error),
+            confirmationPhrase: error.payload?.confirmation_phrase,
+            confirmCommand: error.payload?.confirm_command,
+          });
+        } else {
+          setSetupState({
+            kind: "error",
+            action,
+            message: error instanceof Error ? error.message : "Harness action failed.",
+          });
+        }
+      }
+    },
+    [props.harness, refreshAfterMutation]
+  );
+
+  const handleConnect = useCallback(() => {
+    void runAction("install", { dryRun: false });
+  }, [runAction]);
+
+  const handleVerify = useCallback(() => {
+    void runAction("verify");
+  }, [runAction]);
+
+  const handleRepair = useCallback(() => {
+    void runAction("repair", { dryRun: false });
+  }, [runAction]);
+
+  const handleRequestDisconnect = useCallback(() => {
+    setDisconnectArmed(true);
+    void runAction("uninstall", { dryRun: true });
+  }, [runAction]);
+
+  const handleConfirmDisconnect = useCallback(() => {
+    const phrase =
+      setupState.kind === "error" && setupState.confirmationPhrase
+        ? setupState.confirmationPhrase
+        : `disconnect-${props.harness}`;
+    void runAction("uninstall", { dryRun: false, confirmationPhrase: phrase });
+  }, [props.harness, runAction, setupState]);
+
+  const handleCancelDisconnect = useCallback(() => {
+    setDisconnectArmed(false);
+    void loadPlan();
+  }, [loadPlan]);
+
+  const busy = setupState.kind === "loading";
+  const currentPlan =
+    setupState.kind === "ready"
+      ? setupState.plan
+      : setupState.kind === "success"
+      ? setupState.result
+      : null;
+  const steps = setupStepsFor(currentPlan, active);
+  const notes = setupNotesFor(currentPlan);
+
+  return (
+    <div className="rounded-2xl border border-brand-blue/15 bg-gradient-to-br from-brand-blue/[0.055] via-white to-brand-dark/[0.025] p-4 shadow-sm sm:p-5">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <SectionLabel>Local harness install</SectionLabel>
+          <h3 className="mt-2 text-lg font-semibold text-brand-dark">
+            {active ? `${displayName} is managed by Guard` : `Connect ${displayName} from this dashboard`}
+          </h3>
+          <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+            {active
+              ? "Run safe checks, repair managed hooks, or disconnect this app without leaving the dashboard."
+              : "Guard will install the local managed hooks through the daemon. No copied shell command required."}
+          </p>
+        </div>
+        <div className="flex shrink-0 flex-wrap gap-2">
+          {!active && (
+            <ActionButton onClick={handleConnect} disabled={busy} data-primary="true">
+              <HiMiniRocketLaunch className="h-4 w-4" aria-hidden="true" />
+              {busy && setupState.kind === "loading" && setupState.action === "install" ? "Connecting..." : "Connect app"}
+            </ActionButton>
+          )}
+          {active && (
+            <>
+              <ActionButton onClick={handleVerify} disabled={busy} variant="outline">
+                <HiMiniShieldCheck className="h-4 w-4" aria-hidden="true" />
+                Test
+              </ActionButton>
+              <ActionButton onClick={handleRepair} disabled={busy} variant="outline">
+                <HiMiniArrowPath className="h-4 w-4" aria-hidden="true" />
+                Repair
+              </ActionButton>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-5 grid gap-3 md:grid-cols-3">
+        <SetupMetric label="Install state" value={active ? "Protected" : props.status === "observed" ? "Observed" : "Not connected"} active={active} />
+        <SetupMetric label="Config source" value={props.install?.workspace ?? "Local machine"} />
+        <SetupMetric label="Last changed" value={props.install ? formatRelativeTime(props.install.updated_at) : "Not yet"} />
+      </div>
+
+      {setupState.kind === "error" && (
+        <div className="mt-4 rounded-xl border border-brand-attention/15 bg-brand-attention/[0.04] p-4">
+          <div className="flex items-start gap-3">
+            <HiMiniExclamationTriangle className="mt-0.5 h-5 w-5 shrink-0 text-brand-attention" aria-hidden="true" />
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-semibold text-brand-dark">Could not finish {setupActionLabel(setupState.action)}</p>
+              <p className="mt-1 break-words text-sm text-muted-foreground">{setupState.message}</p>
+              {setupState.confirmCommand && (
+                <code className="mt-3 block overflow-x-auto rounded-lg bg-white/80 px-3 py-2 font-mono text-xs text-brand-dark">
+                  {setupState.confirmCommand}
+                </code>
+              )}
             </div>
           </div>
+        </div>
+      )}
+
+      {setupState.kind === "success" && (
+        <div className="mt-4 rounded-xl border border-brand-green/20 bg-brand-green/[0.045] p-4">
+          <div className="flex items-start gap-3">
+            <HiMiniCheckCircle className="mt-0.5 h-5 w-5 shrink-0 text-brand-green" aria-hidden="true" />
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-brand-dark">{setupSuccessTitle(setupState.action, displayName)}</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {setupState.action === "verify"
+                  ? "Safe local check completed. No app config was changed."
+                  : "Dashboard action completed through the local Guard daemon."}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {steps.length > 0 && (
+        <div className="mt-5 space-y-2">
+          {steps.map((step) => (
+            <HarnessSetupStepRow key={step.step_id} step={step} />
+          ))}
+        </div>
+      )}
+
+      {notes.length > 0 && (
+        <div className="mt-4 rounded-xl border border-slate-200/70 bg-white/80 p-4">
+          <p className="text-xs font-semibold uppercase tracking-widest text-slate-400">What changed</p>
+          <ul className="mt-2 space-y-1.5">
+            {notes.slice(0, 4).map((note) => (
+              <li key={note} className="break-words text-xs leading-relaxed text-muted-foreground">
+                {note}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="mt-5 flex flex-wrap items-center gap-2 border-t border-slate-200/70 pt-4">
+        <button
+          onClick={() => void loadPlan()}
+          disabled={busy}
+          className="inline-flex min-h-10 items-center rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark transition-colors hover:bg-slate-50 disabled:opacity-50"
+        >
+          Refresh setup
+        </button>
+        {active && !disconnectArmed && (
+          <button
+            onClick={handleRequestDisconnect}
+            disabled={busy}
+            className="inline-flex min-h-10 items-center gap-1.5 rounded-lg border border-brand-attention/20 bg-white px-3 text-sm font-medium text-brand-attention transition-colors hover:bg-brand-attention/[0.04] disabled:opacity-50"
+          >
+            <HiMiniTrash className="h-4 w-4" aria-hidden="true" />
+            Disconnect
+          </button>
+        )}
+        {active && disconnectArmed && (
+          <>
+            <button
+              onClick={handleConfirmDisconnect}
+              disabled={busy}
+              className="inline-flex min-h-10 items-center rounded-lg bg-brand-attention px-3 text-sm font-semibold text-white transition-colors hover:bg-brand-attention/90 disabled:opacity-50"
+            >
+              {busy && setupState.kind === "loading" && setupState.action === "uninstall" ? "Disconnecting..." : "Confirm disconnect"}
+            </button>
+            <button
+              onClick={handleCancelDisconnect}
+              disabled={busy}
+              className="inline-flex min-h-10 items-center rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark transition-colors hover:bg-slate-50 disabled:opacity-50"
+            >
+              Keep connected
+            </button>
+          </>
         )}
       </div>
     </div>
   );
+}
+
+function HarnessSetupStepRow({ step }: { step: GuardHarnessSetupStep }) {
+  const commandText = formatHarnessCommand(step.command);
+  return (
+    <div className="rounded-xl border border-slate-200/70 bg-white/80 p-3">
+      <div className="flex items-start gap-3">
+        <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-brand-blue/10 text-brand-blue">
+          {step.writes_config ? <HiMiniAdjustmentsHorizontal className="h-3.5 w-3.5" aria-hidden="true" /> : <HiMiniCheckCircle className="h-3.5 w-3.5" aria-hidden="true" />}
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold text-brand-dark">{step.title}</p>
+          <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">{step.body}</p>
+          {commandText && (
+            <code className="mt-2 block overflow-x-auto rounded-lg bg-slate-50 px-3 py-2 font-mono text-xs text-brand-dark">
+              {commandText}
+            </code>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function HarnessCoverageAside(props: {
+  status: "active" | "needs_setup" | "observed" | "unknown";
+  install: GuardManagedInstall | undefined;
+}) {
+  return (
+    <div className="space-y-6">
+      <div className="rounded-xl border border-slate-100 p-4 sm:p-5">
+        <SectionLabel>Protection model</SectionLabel>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Dashboard actions call the local Guard daemon directly. CLI commands are shown only as fallback copy for terminals or automation.
+        </p>
+        <div className="mt-4 space-y-2 text-xs text-muted-foreground">
+          <p>Runs locally on this machine.</p>
+          <p>Requires the one-time Guard token in this dashboard session.</p>
+          <p>Writes only the harness-managed Guard config for this app.</p>
+        </div>
+      </div>
+      {props.install?.manifest ? (
+        <div className="rounded-xl border border-slate-100 p-4 sm:p-5">
+          <SectionLabel>Managed files</SectionLabel>
+          <ManifestPathList manifest={props.install.manifest} />
+        </div>
+      ) : props.status !== "active" ? (
+        <div className="rounded-xl border border-brand-blue/10 bg-brand-blue/[0.03] p-4 sm:p-5">
+          <SectionLabel>First run</SectionLabel>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Connect this app here first. Then launch the app normally through the Guard wrapper so risky actions pause for review.
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ManifestPathList({ manifest }: { manifest: Record<string, unknown> }) {
+  const pathEntries = Object.entries(manifest).filter(
+    ([key, value]) => key.endsWith("_path") && typeof value === "string" && value.length > 0
+  );
+  if (pathEntries.length === 0) {
+    return <p className="mt-2 text-sm text-muted-foreground">Guard has no managed file paths to show for this app yet.</p>;
+  }
+  return (
+    <dl className="mt-3 space-y-2">
+      {pathEntries.slice(0, 5).map(([key, value]) => (
+        <div key={key} className="min-w-0">
+          <dt className="text-[10px] font-semibold uppercase tracking-widest text-slate-400">{key.replace(/_/g, " ")}</dt>
+          <dd className="mt-0.5 break-all font-mono text-xs text-brand-dark">{String(value)}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function SetupMetric(props: { label: string; value: string; active?: boolean }) {
+  return (
+    <div className="min-w-0 rounded-xl border border-slate-200/70 bg-white/80 p-3">
+      <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-400">{props.label}</p>
+      <p className={`mt-1 truncate text-sm font-semibold ${props.active ? "text-brand-green" : "text-brand-dark"}`}>
+        {props.value}
+      </p>
+    </div>
+  );
+}
+
+function setupStepsFor(result: GuardHarnessActionResult | null, active: boolean): GuardHarnessSetupStep[] {
+  if (!result) return [];
+  if (Array.isArray(result.steps) && result.steps.length > 0) return result.steps;
+  if (result.verification?.steps) return result.verification.steps;
+  if (!active && result.contract?.setup_steps) return result.contract.setup_steps;
+  if (active && result.contract?.verify_steps) return result.contract.verify_steps;
+  return [];
+}
+
+function setupNotesFor(result: GuardHarnessActionResult | null): string[] {
+  const manifest = result?.managed_install?.manifest;
+  const notes = manifest?.["notes"];
+  return Array.isArray(notes) ? notes.filter((note): note is string => typeof note === "string") : [];
+}
+
+function setupActionLabel(action: GuardHarnessAction): string {
+  if (action === "install") return "connect";
+  if (action === "verify") return "test";
+  if (action === "repair") return "repair";
+  return "disconnect";
+}
+
+function setupActionErrorMessage(error: GuardHarnessActionError): string {
+  if (error.payload?.error === "confirmation_required") {
+    return "Disconnect requires confirmation so accidental clicks cannot remove local protection.";
+  }
+  return error.payload?.error ?? error.message;
+}
+
+function setupSuccessTitle(action: GuardHarnessAction, displayName: string): string {
+  if (action === "install") return `${displayName} connected`;
+  if (action === "verify") return `${displayName} test complete`;
+  if (action === "repair") return `${displayName} repaired`;
+  return `${displayName} disconnected`;
 }
 
 function ActivitySparkline({ receipts }: { receipts: GuardReceipt[] }) {
@@ -1189,5 +1577,4 @@ function StatCard({
     </div>
   );
 }
-
 

--- a/dashboard/src/guard-api.test.ts
+++ b/dashboard/src/guard-api.test.ts
@@ -2,6 +2,7 @@ import {
   buildDemoRuntimeSnapshot,
   fetchApprovalPage,
   fetchQueueSummary,
+  formatHarnessCommand,
   normalizeApprovalRequest,
   parseActionEnvelope,
   parseDecisionV2,
@@ -24,6 +25,15 @@ function assert(condition: boolean, message: string): void {
 }
 
 const snapshot = buildDemoRuntimeSnapshot();
+
+assert(
+  formatHarnessCommand(["hol-guard", "apps", "connect", "opencode"]) === "hol-guard apps connect opencode",
+  "T760: harness setup fallback command should use real hol-guard apps connect command"
+);
+assert(
+  formatHarnessCommand(["hol-guard", "apps", "connect", "claude code"]) === 'hol-guard apps connect "claude code"',
+  "T760: harness setup fallback command should quote spaced args"
+);
 
 assert(snapshot.cloud_pairing_state.state === "paired_waiting", "demo snapshot exposes paired waiting state");
 assert(snapshot.cloud_pairing_state.label === snapshot.cloud_state_label, "demo pairing label matches legacy label");

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -16,6 +16,9 @@ import type {
   GuardArtifactDiff,
   GuardDecisionV2,
   GuardInventoryItem,
+  GuardHarnessAction,
+  GuardHarnessActionErrorPayload,
+  GuardHarnessActionResult,
   GuardPolicyDecision,
   GuardQueueResolutionCopy,
   GuardQueueResolutionResult,
@@ -78,6 +81,18 @@ async function readJson<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
     throw new Error(`Request failed with ${response.status}`);
   }
   return (await response.json()) as T;
+}
+
+export class GuardHarnessActionError extends Error {
+  readonly status: number;
+  readonly payload: GuardHarnessActionErrorPayload | null;
+
+  constructor(status: number, payload: GuardHarnessActionErrorPayload | null) {
+    super(payload?.error ?? `Harness action failed with ${status}`);
+    this.name = "GuardHarnessActionError";
+    this.status = status;
+    this.payload = payload;
+  }
 }
 
 function guardParams(): URLSearchParams {
@@ -201,6 +216,10 @@ function isNonNegativeNumber(value: unknown): value is number {
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
+}
+
+function isGuardHarnessActionErrorPayload(value: unknown): value is GuardHarnessActionErrorPayload {
+  return isRecord(value) && isNonEmptyString(value["error"]);
 }
 
 function isApprovalPageStatus(value: unknown): value is GuardApprovalPageStatus {
@@ -719,6 +738,61 @@ export async function clearPolicy(input: {
       source: input.source
     })
   });
+}
+
+export function formatHarnessCommand(command: string[]): string {
+  return command
+    .map((part) => (/\s/.test(part) ? JSON.stringify(part) : part))
+    .join(" ");
+}
+
+export async function runHarnessAction(input: {
+  harness: string;
+  action: GuardHarnessAction;
+  dryRun?: boolean;
+  confirmationPhrase?: string;
+}): Promise<GuardHarnessActionResult> {
+  if (isGuardDemoMode()) {
+    return {
+      harness: input.harness,
+      action: input.action,
+      dry_run: input.action === "verify" ? false : input.dryRun ?? true,
+      safe: input.action === "verify" ? true : undefined,
+      steps: [],
+      managed_install:
+        input.action === "install" || input.action === "repair"
+          ? {
+              harness: input.harness,
+              active: true,
+              workspace: null,
+              manifest: { notes: ["Demo mode only."] },
+              updated_at: new Date().toISOString()
+            }
+          : undefined
+    };
+  }
+  const response = await fetchGuardApi(
+    `/v1/harnesses/${encodeURIComponent(input.harness)}/${input.action}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...guardAuthHeaders()
+      },
+      body: JSON.stringify({
+        dry_run: input.dryRun ?? input.action !== "verify",
+        confirmation_phrase: input.confirmationPhrase
+      })
+    }
+  );
+  const payload = (await response.json().catch(() => null)) as unknown;
+  if (!response.ok) {
+    throw new GuardHarnessActionError(
+      response.status,
+      isGuardHarnessActionErrorPayload(payload) ? payload : null
+    );
+  }
+  return payload as GuardHarnessActionResult;
 }
 
 export async function fetchDiff(

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -282,6 +282,69 @@ export type GuardManagedInstall = {
   updated_at: string;
 };
 
+export type GuardHarnessAction = "install" | "verify" | "repair" | "uninstall";
+
+export type GuardHarnessSetupStep = {
+  step_id: string;
+  title: string;
+  body: string;
+  command: string[];
+  writes_config: boolean;
+  requires_confirmation: boolean;
+};
+
+export type GuardHarnessCoverage = {
+  native_hooks: boolean;
+  browser_fallback: boolean;
+  mcp_proxy: boolean;
+  prompt_hooks: boolean;
+  blind_spots: string[];
+};
+
+export type GuardHarnessSetupContract = {
+  harness: string;
+  display_name: string;
+  install_aliases: string[];
+  setup_steps: GuardHarnessSetupStep[];
+  verify_steps: GuardHarnessSetupStep[];
+  repair_steps: GuardHarnessSetupStep[];
+  coverage: GuardHarnessCoverage;
+};
+
+export type GuardHarnessVerification = {
+  checked: boolean;
+  writes_config: boolean;
+  installed: boolean;
+  command_available: boolean;
+  config_paths: string[];
+  artifact_count: number;
+  warnings: string[];
+  steps: GuardHarnessSetupStep[];
+};
+
+export type GuardHarnessActionResult = {
+  harness: string;
+  action?: GuardHarnessAction;
+  dry_run?: boolean;
+  safe?: boolean;
+  contract?: GuardHarnessSetupContract;
+  steps?: GuardHarnessSetupStep[];
+  workspace?: string | null;
+  verification?: GuardHarnessVerification;
+  managed_install?: GuardManagedInstall;
+  managed_installs?: GuardManagedInstall[];
+  auto_detected?: boolean;
+  confirmation_phrase?: string;
+  confirm_command?: string;
+};
+
+export type GuardHarnessActionErrorPayload = {
+  error: string;
+  harness?: string;
+  confirmation_phrase?: string;
+  confirm_command?: string;
+};
+
 export type GuardInventoryItem = {
   artifact_id: string;
   harness: string;

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/app-detail-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/app-detail-workspace.js
@@ -1,14 +1,20 @@
-import { r as reactExports, J as fetchApprovalPage, K as fetchPolicy, h as harnessDisplayName, j as jsxRuntimeExports, L as HiMiniArrowLeft, i as HiMiniChevronRight, G as GuardHero, A as ActionButton, P as ProofStrip, M as HiMiniHome, n as HiMiniBolt, N as HiMiniAdjustmentsHorizontal, S as SectionLabel, d as formatRelativeTime, m as HiMiniExclamationTriangle, T as Tag, O as detectCategory, Q as CATEGORIES, B as Badge, E as EmptyState, R as HiMiniCloud, U as HiMiniChartBar, l as HiMiniChevronDown } from "../guard-dashboard.js";
+import { r as reactExports, J as fetchApprovalPage, K as fetchPolicy, h as harnessDisplayName, j as jsxRuntimeExports, L as HiMiniArrowLeft, i as HiMiniChevronRight, G as GuardHero, A as ActionButton, P as ProofStrip, M as HiMiniHome, n as HiMiniBolt, N as HiMiniAdjustmentsHorizontal, S as SectionLabel, d as formatRelativeTime, m as HiMiniExclamationTriangle, T as Tag, O as detectCategory, Q as CATEGORIES, B as Badge, E as EmptyState, R as HiMiniCloud, U as HiMiniChartBar, V as runHarnessAction, W as GuardHarnessActionError, X as HiMiniRocketLaunch, c as HiMiniShieldCheck, Y as HiMiniArrowPath, H as HiMiniCheckCircle, Z as HiMiniTrash, l as HiMiniChevronDown, _ as formatHarnessCommand } from "../guard-dashboard.js";
 import { u as useFocusTrap } from "./use-focus-trap.js";
 const tabOrder = ["overview", "activity", "settings"];
 function readTabFromUrl() {
+  const queryTab = new URLSearchParams(window.location.search).get("tab");
+  if (queryTab === "overview" || queryTab === "activity" || queryTab === "settings") return queryTab;
   const hash = window.location.hash.replace("#", "");
   if (hash === "activity" || hash === "settings") return hash;
   return "overview";
 }
 function writeTabToUrl(tab) {
   const url = new URL(window.location.href);
-  url.hash = tab;
+  if (tab === "overview") {
+    url.searchParams.delete("tab");
+  } else {
+    url.searchParams.set("tab", tab);
+  }
   window.history.replaceState({}, "", url.toString());
 }
 function AppDetailWorkspace(props) {
@@ -208,8 +214,10 @@ function AppDetailWorkspace(props) {
               {
                 harness,
                 status,
+                install,
                 harnessPolicies,
                 onClearAppPolicies: props.onClearAppPolicies,
+                onManagedInstallChanged: props.onManagedInstallChanged,
                 policyError,
                 onRetry: loadTabData
               }
@@ -658,6 +666,15 @@ function AppSettingsTab(props) {
   }, [props.onClearAppPolicies, props.harness]);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.8fr)]", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        HarnessSetupPanel,
+        {
+          harness: props.harness,
+          install: props.install,
+          status: props.status,
+          onManagedInstallChanged: props.onManagedInstallChanged
+        }
+      ),
       props.policyError && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-fade-in rounded-xl border border-brand-attention/10 bg-brand-attention/[0.03] p-4 sm:p-5", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-attention", "aria-hidden": "true" }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex-1", children: [
@@ -762,15 +779,269 @@ function AppSettingsTab(props) {
         }
       )
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-6", children: props.status === "needs_setup" && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-xl border border-brand-attention/10 bg-brand-attention/[0.03] p-4 sm:p-5", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-attention" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Setup needed" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-muted-foreground", children: "This app is detected but not active. Run Guard with this app once to complete setup." }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 rounded-xl bg-white/60 p-4", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "font-mono text-xs text-brand-dark", children: `npx @hol/guard install ${props.harness}` }) })
-      ] })
-    ] }) }) })
+    /* @__PURE__ */ jsxRuntimeExports.jsx(HarnessCoverageAside, { status: props.status, install: props.install })
   ] });
+}
+function HarnessSetupPanel(props) {
+  const [setupState, setSetupState] = reactExports.useState({ kind: "idle" });
+  const [disconnectArmed, setDisconnectArmed] = reactExports.useState(false);
+  const active = props.install?.active === true;
+  const displayName = harnessDisplayName(props.harness);
+  const refreshAfterMutation = reactExports.useCallback(async () => {
+    await props.onManagedInstallChanged?.();
+  }, [props.onManagedInstallChanged]);
+  const loadPlan = reactExports.useCallback(async () => {
+    setSetupState({ kind: "loading", action: active ? "verify" : "install" });
+    try {
+      const result = active ? await runHarnessAction({ harness: props.harness, action: "verify" }) : await runHarnessAction({ harness: props.harness, action: "install", dryRun: true });
+      setSetupState({ kind: "ready", plan: result });
+    } catch (error) {
+      setSetupState({
+        kind: "error",
+        action: active ? "verify" : "install",
+        message: error instanceof Error ? error.message : "Unable to load setup plan."
+      });
+    }
+  }, [active, props.harness]);
+  reactExports.useEffect(() => {
+    void loadPlan();
+  }, [loadPlan]);
+  const runAction = reactExports.useCallback(
+    async (action, options = {}) => {
+      setSetupState({ kind: "loading", action });
+      try {
+        const result = await runHarnessAction({
+          harness: props.harness,
+          action,
+          dryRun: options.dryRun,
+          confirmationPhrase: options.confirmationPhrase
+        });
+        setDisconnectArmed(false);
+        setSetupState({ kind: "success", action, result });
+        if (action !== "verify" && options.dryRun !== true) {
+          await refreshAfterMutation();
+        }
+      } catch (error) {
+        if (error instanceof GuardHarnessActionError) {
+          setSetupState({
+            kind: "error",
+            action,
+            message: setupActionErrorMessage(error),
+            confirmationPhrase: error.payload?.confirmation_phrase,
+            confirmCommand: error.payload?.confirm_command
+          });
+        } else {
+          setSetupState({
+            kind: "error",
+            action,
+            message: error instanceof Error ? error.message : "Harness action failed."
+          });
+        }
+      }
+    },
+    [props.harness, refreshAfterMutation]
+  );
+  const handleConnect = reactExports.useCallback(() => {
+    void runAction("install", { dryRun: false });
+  }, [runAction]);
+  const handleVerify = reactExports.useCallback(() => {
+    void runAction("verify");
+  }, [runAction]);
+  const handleRepair = reactExports.useCallback(() => {
+    void runAction("repair", { dryRun: false });
+  }, [runAction]);
+  const handleRequestDisconnect = reactExports.useCallback(() => {
+    setDisconnectArmed(true);
+    void runAction("uninstall", { dryRun: true });
+  }, [runAction]);
+  const handleConfirmDisconnect = reactExports.useCallback(() => {
+    const phrase = setupState.kind === "error" && setupState.confirmationPhrase ? setupState.confirmationPhrase : `disconnect-${props.harness}`;
+    void runAction("uninstall", { dryRun: false, confirmationPhrase: phrase });
+  }, [props.harness, runAction, setupState]);
+  const handleCancelDisconnect = reactExports.useCallback(() => {
+    setDisconnectArmed(false);
+    void loadPlan();
+  }, [loadPlan]);
+  const busy = setupState.kind === "loading";
+  const currentPlan = setupState.kind === "ready" ? setupState.plan : setupState.kind === "success" ? setupState.result : null;
+  const steps = setupStepsFor(currentPlan, active);
+  const notes = setupNotesFor(currentPlan);
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-brand-blue/15 bg-gradient-to-br from-brand-blue/[0.055] via-white to-brand-dark/[0.025] p-4 shadow-sm sm:p-5", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Local harness install" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "mt-2 text-lg font-semibold text-brand-dark", children: active ? `${displayName} is managed by Guard` : `Connect ${displayName} from this dashboard` }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 max-w-2xl text-sm text-muted-foreground", children: active ? "Run safe checks, repair managed hooks, or disconnect this app without leaving the dashboard." : "Guard will install the local managed hooks through the daemon. No copied shell command required." })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex shrink-0 flex-wrap gap-2", children: [
+        !active && /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { onClick: handleConnect, disabled: busy, "data-primary": "true", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniRocketLaunch, { className: "h-4 w-4", "aria-hidden": "true" }),
+          busy && setupState.kind === "loading" && setupState.action === "install" ? "Connecting..." : "Connect app"
+        ] }),
+        active && /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { onClick: handleVerify, disabled: busy, variant: "outline", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "h-4 w-4", "aria-hidden": "true" }),
+            "Test"
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { onClick: handleRepair, disabled: busy, variant: "outline", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "h-4 w-4", "aria-hidden": "true" }),
+            "Repair"
+          ] })
+        ] })
+      ] })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 grid gap-3 md:grid-cols-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(SetupMetric, { label: "Install state", value: active ? "Protected" : props.status === "observed" ? "Observed" : "Not connected", active }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(SetupMetric, { label: "Config source", value: props.install?.workspace ?? "Local machine" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(SetupMetric, { label: "Last changed", value: props.install ? formatRelativeTime(props.install.updated_at) : "Not yet" })
+    ] }),
+    setupState.kind === "error" && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 rounded-xl border border-brand-attention/15 bg-brand-attention/[0.04] p-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-attention", "aria-hidden": "true" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 flex-1", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-sm font-semibold text-brand-dark", children: [
+          "Could not finish ",
+          setupActionLabel(setupState.action)
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 break-words text-sm text-muted-foreground", children: setupState.message }),
+        setupState.confirmCommand && /* @__PURE__ */ jsxRuntimeExports.jsx("code", { className: "mt-3 block overflow-x-auto rounded-lg bg-white/80 px-3 py-2 font-mono text-xs text-brand-dark", children: setupState.confirmCommand })
+      ] })
+    ] }) }),
+    setupState.kind === "success" && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 rounded-xl border border-brand-green/20 bg-brand-green/[0.045] p-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-green", "aria-hidden": "true" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: setupSuccessTitle(setupState.action, displayName) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-muted-foreground", children: setupState.action === "verify" ? "Safe local check completed. No app config was changed." : "Dashboard action completed through the local Guard daemon." })
+      ] })
+    ] }) }),
+    steps.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-5 space-y-2", children: steps.map((step) => /* @__PURE__ */ jsxRuntimeExports.jsx(HarnessSetupStepRow, { step }, step.step_id)) }),
+    notes.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 rounded-xl border border-slate-200/70 bg-white/80 p-4", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-widest text-slate-400", children: "What changed" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("ul", { className: "mt-2 space-y-1.5", children: notes.slice(0, 4).map((note) => /* @__PURE__ */ jsxRuntimeExports.jsx("li", { className: "break-words text-xs leading-relaxed text-muted-foreground", children: note }, note)) })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 flex flex-wrap items-center gap-2 border-t border-slate-200/70 pt-4", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "button",
+        {
+          onClick: () => void loadPlan(),
+          disabled: busy,
+          className: "inline-flex min-h-10 items-center rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark transition-colors hover:bg-slate-50 disabled:opacity-50",
+          children: "Refresh setup"
+        }
+      ),
+      active && !disconnectArmed && /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        "button",
+        {
+          onClick: handleRequestDisconnect,
+          disabled: busy,
+          className: "inline-flex min-h-10 items-center gap-1.5 rounded-lg border border-brand-attention/20 bg-white px-3 text-sm font-medium text-brand-attention transition-colors hover:bg-brand-attention/[0.04] disabled:opacity-50",
+          children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniTrash, { className: "h-4 w-4", "aria-hidden": "true" }),
+            "Disconnect"
+          ]
+        }
+      ),
+      active && disconnectArmed && /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "button",
+          {
+            onClick: handleConfirmDisconnect,
+            disabled: busy,
+            className: "inline-flex min-h-10 items-center rounded-lg bg-brand-attention px-3 text-sm font-semibold text-white transition-colors hover:bg-brand-attention/90 disabled:opacity-50",
+            children: busy && setupState.kind === "loading" && setupState.action === "uninstall" ? "Disconnecting..." : "Confirm disconnect"
+          }
+        ),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "button",
+          {
+            onClick: handleCancelDisconnect,
+            disabled: busy,
+            className: "inline-flex min-h-10 items-center rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark transition-colors hover:bg-slate-50 disabled:opacity-50",
+            children: "Keep connected"
+          }
+        )
+      ] })
+    ] })
+  ] });
+}
+function HarnessSetupStepRow({ step }) {
+  const commandText = formatHarnessCommand(step.command);
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-xl border border-slate-200/70 bg-white/80 p-3", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-brand-blue/10 text-brand-blue", children: step.writes_config ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniAdjustmentsHorizontal, { className: "h-3.5 w-3.5", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-3.5 w-3.5", "aria-hidden": "true" }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 flex-1", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: step.title }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 text-xs leading-relaxed text-muted-foreground", children: step.body }),
+      commandText && /* @__PURE__ */ jsxRuntimeExports.jsx("code", { className: "mt-2 block overflow-x-auto rounded-lg bg-slate-50 px-3 py-2 font-mono text-xs text-brand-dark", children: commandText })
+    ] })
+  ] }) });
+}
+function HarnessCoverageAside(props) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4 sm:p-5", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Protection model" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-muted-foreground", children: "Dashboard actions call the local Guard daemon directly. CLI commands are shown only as fallback copy for terminals or automation." }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 space-y-2 text-xs text-muted-foreground", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "Runs locally on this machine." }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "Requires the one-time Guard token in this dashboard session." }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { children: "Writes only the harness-managed Guard config for this app." })
+      ] })
+    ] }),
+    props.install?.manifest ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4 sm:p-5", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Managed files" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(ManifestPathList, { manifest: props.install.manifest })
+    ] }) : props.status !== "active" ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-brand-blue/10 bg-brand-blue/[0.03] p-4 sm:p-5", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "First run" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-muted-foreground", children: "Connect this app here first. Then launch the app normally through the Guard wrapper so risky actions pause for review." })
+    ] }) : null
+  ] });
+}
+function ManifestPathList({ manifest }) {
+  const pathEntries = Object.entries(manifest).filter(
+    ([key, value]) => key.endsWith("_path") && typeof value === "string" && value.length > 0
+  );
+  if (pathEntries.length === 0) {
+    return /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-muted-foreground", children: "Guard has no managed file paths to show for this app yet." });
+  }
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("dl", { className: "mt-3 space-y-2", children: pathEntries.slice(0, 5).map(([key, value]) => /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-widest text-slate-400", children: key.replace(/_/g, " ") }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-0.5 break-all font-mono text-xs text-brand-dark", children: String(value) })
+  ] }, key)) });
+}
+function SetupMetric(props) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 rounded-xl border border-slate-200/70 bg-white/80 p-3", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[10px] font-semibold uppercase tracking-widest text-slate-400", children: props.label }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: `mt-1 truncate text-sm font-semibold ${props.active ? "text-brand-green" : "text-brand-dark"}`, children: props.value })
+  ] });
+}
+function setupStepsFor(result, active) {
+  if (!result) return [];
+  if (Array.isArray(result.steps) && result.steps.length > 0) return result.steps;
+  if (result.verification?.steps) return result.verification.steps;
+  if (!active && result.contract?.setup_steps) return result.contract.setup_steps;
+  if (active && result.contract?.verify_steps) return result.contract.verify_steps;
+  return [];
+}
+function setupNotesFor(result) {
+  const manifest = result?.managed_install?.manifest;
+  const notes = manifest?.["notes"];
+  return Array.isArray(notes) ? notes.filter((note) => typeof note === "string") : [];
+}
+function setupActionLabel(action) {
+  if (action === "install") return "connect";
+  if (action === "verify") return "test";
+  if (action === "repair") return "repair";
+  return "disconnect";
+}
+function setupActionErrorMessage(error) {
+  if (error.payload?.error === "confirmation_required") {
+    return "Disconnect requires confirmation so accidental clicks cannot remove local protection.";
+  }
+  return error.payload?.error ?? error.message;
+}
+function setupSuccessTitle(action, displayName) {
+  if (action === "install") return `${displayName} connected`;
+  if (action === "verify") return `${displayName} test complete`;
+  if (action === "repair") return `${displayName} repaired`;
+  return `${displayName} disconnected`;
 }
 function ActivitySparkline({ receipts }) {
   const days = 7;

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/app-detail-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/app-detail-workspace.js
@@ -12,6 +12,9 @@ function writeTabToUrl(tab) {
   const url = new URL(window.location.href);
   if (tab === "overview") {
     url.searchParams.delete("tab");
+    if (url.hash === "#activity" || url.hash === "#settings" || url.hash === "#overview") {
+      url.hash = "";
+    }
   } else {
     url.searchParams.set("tab", tab);
   }
@@ -855,7 +858,7 @@ function HarnessSetupPanel(props) {
     void runAction("uninstall", { dryRun: true });
   }, [runAction]);
   const handleConfirmDisconnect = reactExports.useCallback(() => {
-    const phrase = setupState.kind === "error" && setupState.confirmationPhrase ? setupState.confirmationPhrase : `disconnect-${props.harness}`;
+    const phrase = setupState.kind === "error" && setupState.confirmationPhrase ? setupState.confirmationPhrase : setupState.kind === "success" && setupState.result.confirmation_phrase ? setupState.result.confirmation_phrase : `disconnect-${props.harness}`;
     void runAction("uninstall", { dryRun: false, confirmationPhrase: phrase });
   }, [props.harness, runAction, setupState]);
   const handleCancelDisconnect = reactExports.useCallback(() => {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/help-modal.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/help-modal.js
@@ -1,4 +1,4 @@
-import { r as reactExports, j as jsxRuntimeExports, V as HiMiniCommandLine, g as HiMiniXMark, W as HiMiniQuestionMarkCircle } from "../guard-dashboard.js";
+import { r as reactExports, j as jsxRuntimeExports, $ as HiMiniCommandLine, g as HiMiniXMark, a0 as HiMiniQuestionMarkCircle } from "../guard-dashboard.js";
 import { u as useFocusTrap } from "./use-focus-trap.js";
 const shortcuts = [
   {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -12709,6 +12709,16 @@ async function readJson(input, init) {
   }
   return await response.json();
 }
+class GuardHarnessActionError extends Error {
+  status;
+  payload;
+  constructor(status, payload) {
+    super(payload?.error ?? `Harness action failed with ${status}`);
+    this.name = "GuardHarnessActionError";
+    this.status = status;
+    this.payload = payload;
+  }
+}
 function guardParams() {
   const params = new URLSearchParams(window.location.search);
   const fragment = window.location.hash.startsWith("#") ? window.location.hash.slice(1) : window.location.hash;
@@ -12814,6 +12824,9 @@ function isNonNegativeNumber(value) {
 }
 function isNonEmptyString(value) {
   return typeof value === "string" && value.trim().length > 0;
+}
+function isGuardHarnessActionErrorPayload(value) {
+  return isRecord(value) && isNonEmptyString(value["error"]);
 }
 function isApprovalPageStatus(value) {
   return value === "pending" || value === "resolved" || value === "all";
@@ -13226,6 +13239,49 @@ async function clearPolicy(input) {
     })
   });
 }
+function formatHarnessCommand(command) {
+  return command.map((part) => /\s/.test(part) ? JSON.stringify(part) : part).join(" ");
+}
+async function runHarnessAction(input) {
+  if (isGuardDemoMode()) {
+    return {
+      harness: input.harness,
+      action: input.action,
+      dry_run: input.action === "verify" ? false : input.dryRun ?? true,
+      safe: input.action === "verify" ? true : void 0,
+      steps: [],
+      managed_install: input.action === "install" || input.action === "repair" ? {
+        harness: input.harness,
+        active: true,
+        workspace: null,
+        manifest: { notes: ["Demo mode only."] },
+        updated_at: (/* @__PURE__ */ new Date()).toISOString()
+      } : void 0
+    };
+  }
+  const response = await fetchGuardApi(
+    `/v1/harnesses/${encodeURIComponent(input.harness)}/${input.action}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...guardAuthHeaders()
+      },
+      body: JSON.stringify({
+        dry_run: input.dryRun ?? input.action !== "verify",
+        confirmation_phrase: input.confirmationPhrase
+      })
+    }
+  );
+  const payload = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new GuardHarnessActionError(
+      response.status,
+      isGuardHarnessActionErrorPayload(payload) ? payload : null
+    );
+  }
+  return payload;
+}
 async function fetchDiff(artifactId, harness) {
   if (isGuardDemoMode()) {
     return getDemoDiff(artifactId, harness);
@@ -13448,6 +13504,9 @@ function HiMiniXCircle(props) {
 function HiMiniWrenchScrewdriver(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M14.5 10a4.5 4.5 0 0 0 4.284-5.882c-.105-.324-.51-.391-.752-.15L15.34 6.66a.454.454 0 0 1-.493.11 3.01 3.01 0 0 1-1.618-1.616.455.455 0 0 1 .11-.494l2.694-2.692c.24-.241.174-.647-.15-.752a4.5 4.5 0 0 0-5.873 4.575c.055.873-.128 1.808-.8 2.368l-7.23 6.024a2.724 2.724 0 1 0 3.837 3.837l6.024-7.23c.56-.672 1.495-.855 2.368-.8.096.007.193.01.291.01ZM5 16a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z", "clipRule": "evenodd" }, "child": [] }, { "tag": "path", "attr": { "d": "M14.5 11.5c.173 0 .345-.007.514-.022l3.754 3.754a2.5 2.5 0 0 1-3.536 3.536l-4.41-4.41 2.172-2.607c.052-.063.147-.138.342-.196.202-.06.469-.087.777-.067.128.008.257.012.387.012ZM6 4.586l2.33 2.33a.452.452 0 0 1-.08.09L6.8 8.214 4.586 6H3.309a.5.5 0 0 1-.447-.276l-1.7-3.402a.5.5 0 0 1 .093-.577l.49-.49a.5.5 0 0 1 .577-.094l3.402 1.7A.5.5 0 0 1 6 3.31v1.277Z" }, "child": [] }] })(props);
 }
+function HiMiniTrash(props) {
+  return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M8.75 1A2.75 2.75 0 0 0 6 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 1 0 .23 1.482l.149-.022.841 10.518A2.75 2.75 0 0 0 7.596 19h4.807a2.75 2.75 0 0 0 2.742-2.53l.841-10.52.149.023a.75.75 0 0 0 .23-1.482A41.03 41.03 0 0 0 14 4.193V3.75A2.75 2.75 0 0 0 11.25 1h-2.5ZM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4ZM8.58 7.72a.75.75 0 0 0-1.5.06l.3 7.5a.75.75 0 1 0 1.5-.06l-.3-7.5Zm4.34.06a.75.75 0 1 0-1.5-.06l-.3 7.5a.75.75 0 1 0 1.5.06l.3-7.5Z", "clipRule": "evenodd" }, "child": [] }] })(props);
+}
 function HiMiniTag(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M4.5 2A2.5 2.5 0 0 0 2 4.5v3.879a2.5 2.5 0 0 0 .732 1.767l7.5 7.5a2.5 2.5 0 0 0 3.536 0l3.878-3.878a2.5 2.5 0 0 0 0-3.536l-7.5-7.5A2.5 2.5 0 0 0 8.38 2H4.5ZM5 6a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z", "clipRule": "evenodd" }, "child": [] }] })(props);
 }
@@ -13459,6 +13518,9 @@ function HiMiniShieldCheck(props) {
 }
 function HiMiniServerStack(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "d": "M4.464 3.162A2 2 0 0 1 6.28 2h7.44a2 2 0 0 1 1.816 1.162l1.154 2.5c.067.145.115.291.145.438A3.508 3.508 0 0 0 16 6H4c-.288 0-.568.035-.835.1.03-.147.078-.293.145-.438l1.154-2.5Z" }, "child": [] }, { "tag": "path", "attr": { "fillRule": "evenodd", "d": "M2 9.5a2 2 0 0 1 2-2h12a2 2 0 1 1 0 4H4a2 2 0 0 1-2-2Zm13.24 0a.75.75 0 0 1 .75-.75H16a.75.75 0 0 1 .75.75v.01a.75.75 0 0 1-.75.75h-.01a.75.75 0 0 1-.75-.75V9.5Zm-2.25-.75a.75.75 0 0 0-.75.75v.01c0 .414.336.75.75.75H13a.75.75 0 0 0 .75-.75V9.5a.75.75 0 0 0-.75-.75h-.01ZM2 15a2 2 0 0 1 2-2h12a2 2 0 1 1 0 4H4a2 2 0 0 1-2-2Zm13.24 0a.75.75 0 0 1 .75-.75H16a.75.75 0 0 1 .75.75v.01a.75.75 0 0 1-.75.75h-.01a.75.75 0 0 1-.75-.75V15Zm-2.25-.75a.75.75 0 0 0-.75.75v.01c0 .414.336.75.75.75H13a.75.75 0 0 0 .75-.75V15a.75.75 0 0 0-.75-.75h-.01Z", "clipRule": "evenodd" }, "child": [] }] })(props);
+}
+function HiMiniRocketLaunch(props) {
+  return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M4.606 12.97a.75.75 0 0 1-.134 1.051 2.494 2.494 0 0 0-.93 2.437 2.494 2.494 0 0 0 2.437-.93.75.75 0 1 1 1.186.918 3.995 3.995 0 0 1-4.482 1.332.75.75 0 0 1-.461-.461 3.994 3.994 0 0 1 1.332-4.482.75.75 0 0 1 1.052.134Z", "clipRule": "evenodd" }, "child": [] }, { "tag": "path", "attr": { "fillRule": "evenodd", "d": "M5.752 12A13.07 13.07 0 0 0 8 14.248v4.002c0 .414.336.75.75.75a5 5 0 0 0 4.797-6.414 12.984 12.984 0 0 0 5.45-10.848.75.75 0 0 0-.735-.735 12.984 12.984 0 0 0-10.849 5.45A5 5 0 0 0 1 11.25c.001.414.337.75.751.75h4.002ZM13 9a2 2 0 1 0 0-4 2 2 0 0 0 0 4Z", "clipRule": "evenodd" }, "child": [] }] })(props);
 }
 function HiMiniQuestionMarkCircle(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0ZM8.94 6.94a.75.75 0 1 1-1.061-1.061 3 3 0 1 1 2.871 5.026v.345a.75.75 0 0 1-1.5 0v-.5c0-.72.57-1.172 1.081-1.287A1.5 1.5 0 1 0 8.94 6.94ZM10 15a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z", "clipRule": "evenodd" }, "child": [] }] })(props);
@@ -19579,10 +19641,11 @@ function App() {
     navigate(`/apps/${harness}`);
   }, []);
   const refreshStateAfterAction = reactExports.useCallback(async () => {
-    const [snapshotResult, receiptsResult, policiesResult] = await Promise.allSettled([
+    const [snapshotResult, receiptsResult, policiesResult, inventoryResult] = await Promise.allSettled([
       fetchRuntimeSnapshot(),
       fetchReceipts(),
-      fetchPolicies()
+      fetchPolicies(),
+      fetchInventory()
     ]);
     if (snapshotResult.status === "fulfilled") {
       setRuntime({ kind: "ready", snapshot: snapshotResult.value });
@@ -19603,6 +19666,9 @@ function App() {
         kind: "error",
         message: policiesResult.reason instanceof Error ? policiesResult.reason.message : "Unable to load remembered decisions."
       });
+    }
+    if (inventoryResult.status === "fulfilled") {
+      setInventory({ kind: "ready", items: inventoryResult.value });
     }
   }, [setRuntime, setRequests, setReceipts, setPolicies]);
   const handleClearPolicies = reactExports.useCallback(async (scope) => {
@@ -19700,14 +19766,14 @@ function App() {
       setRequests({ kind: "error", message });
     });
   }, []);
-  const handleConnectHarness = reactExports.useCallback((_harness) => {
-    navigate("/settings");
+  const handleConnectHarness = reactExports.useCallback((harness) => {
+    navigate(`/apps/${encodeURIComponent(harness)}?tab=settings`);
   }, []);
-  const handleTestHarness = reactExports.useCallback((_harness) => {
-    navigate("/inbox");
+  const handleTestHarness = reactExports.useCallback((harness) => {
+    navigate(`/apps/${encodeURIComponent(harness)}?tab=settings`);
   }, []);
-  const handleRepairHarness = reactExports.useCallback((_harness) => {
-    navigate("/settings");
+  const handleRepairHarness = reactExports.useCallback((harness) => {
+    navigate(`/apps/${encodeURIComponent(harness)}?tab=settings`);
   }, []);
   const appDetailContent = reactExports.useMemo(() => {
     if (view !== "app-detail" || !appDetailHarness || runtime.kind !== "ready") {
@@ -19724,10 +19790,11 @@ function App() {
         requests: requests.kind === "ready" ? requests.items : [],
         onGoHome: handleGoHome,
         onOpenRequest: handleOpenRequest,
-        onClearAppPolicies: handleClearAppPolicies
+        onClearAppPolicies: handleClearAppPolicies,
+        onManagedInstallChanged: refreshStateAfterAction
       }
     );
-  }, [view, appDetailHarness, runtime, receipts, policies, inventory, requests, handleGoHome, handleOpenRequest, handleClearAppPolicies]);
+  }, [view, appDetailHarness, runtime, receipts, policies, inventory, requests, handleGoHome, handleOpenRequest, handleClearAppPolicies, refreshStateAfterAction]);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(
       "a",
@@ -19800,6 +19867,7 @@ clientExports.createRoot(container).render(
   /* @__PURE__ */ jsxRuntimeExports.jsx(reactExports.StrictMode, { children: /* @__PURE__ */ jsxRuntimeExports.jsx(App, {}) })
 );
 export {
+  HiMiniCommandLine as $,
   ActionButton as A,
   Badge as B,
   exportDiagnostics as C,
@@ -19821,9 +19889,14 @@ export {
   SectionLabel as S,
   Tag as T,
   HiMiniChartBar as U,
-  HiMiniCommandLine as V,
-  HiMiniQuestionMarkCircle as W,
+  runHarnessAction as V,
+  GuardHarnessActionError as W,
+  HiMiniRocketLaunch as X,
+  HiMiniArrowPath as Y,
+  HiMiniTrash as Z,
+  formatHarnessCommand as _,
   HiMiniFire as a,
+  HiMiniQuestionMarkCircle as a0,
   HiMiniCalendarDays as b,
   HiMiniShieldCheck as c,
   formatRelativeTime as d,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -19669,8 +19669,13 @@ function App() {
     }
     if (inventoryResult.status === "fulfilled") {
       setInventory({ kind: "ready", items: inventoryResult.value });
+    } else {
+      setInventory({
+        kind: "error",
+        message: inventoryResult.reason instanceof Error ? inventoryResult.reason.message : "Unable to load watched app inventory."
+      });
     }
-  }, [setRuntime, setRequests, setReceipts, setPolicies]);
+  }, [setRuntime, setRequests, setReceipts, setPolicies, setInventory]);
   const handleClearPolicies = reactExports.useCallback(async (scope) => {
     setClearConfirm(scope);
   }, []);

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -2006,6 +2006,16 @@
     }
   }
 
+  .bg-brand-green\/\[0\.045\] {
+    background-color: var(--brand-green);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .bg-brand-green\/\[0\.045\] {
+      background-color: color-mix(in oklab, var(--brand-green) 4.5%, transparent);
+    }
+  }
+
   .bg-brand-purple, .bg-brand-purple\/10 {
     background-color: var(--brand-purple);
   }
@@ -2347,6 +2357,20 @@
     --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
 
+  .from-brand-blue\/\[0\.055\] {
+    --tw-gradient-from: var(--brand-blue);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .from-brand-blue\/\[0\.055\] {
+      --tw-gradient-from: color-mix(in oklab, var(--brand-blue) 5.5%, transparent);
+    }
+  }
+
+  .from-brand-blue\/\[0\.055\] {
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+
   .from-brand-purple\/90 {
     --tw-gradient-from: var(--brand-purple);
   }
@@ -2364,6 +2388,12 @@
   .from-white {
     --tw-gradient-from: var(--color-white);
     --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+
+  .via-white {
+    --tw-gradient-via: var(--color-white);
+    --tw-gradient-via-stops: var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-via) var(--tw-gradient-via-position), var(--tw-gradient-to) var(--tw-gradient-to-position);
+    --tw-gradient-stops: var(--tw-gradient-via-stops);
   }
 
   .to-blue-50\/30 {
@@ -2429,6 +2459,20 @@
   }
 
   .to-brand-dark\/\[0\.03\] {
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+
+  .to-brand-dark\/\[0\.025\] {
+    --tw-gradient-to: var(--brand-dark);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .to-brand-dark\/\[0\.025\] {
+      --tw-gradient-to: color-mix(in oklab, var(--brand-dark) 2.5%, transparent);
+    }
+  }
+
+  .to-brand-dark\/\[0\.025\] {
     --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
 
@@ -2572,6 +2616,10 @@
 
   .pt-3 {
     padding-top: calc(var(--spacing) * 3);
+  }
+
+  .pt-4 {
+    padding-top: calc(var(--spacing) * 4);
   }
 
   .pt-6 {
@@ -3315,6 +3363,16 @@
       }
     }
 
+    .hover\:bg-brand-attention\/\[0\.04\]:hover {
+      background-color: var(--brand-attention);
+    }
+
+    @supports (color: color-mix(in lab, red, red)) {
+      .hover\:bg-brand-attention\/\[0\.04\]:hover {
+        background-color: color-mix(in oklab, var(--brand-attention) 4%, transparent);
+      }
+    }
+
     .hover\:bg-brand-blue\/5:hover {
       background-color: var(--brand-blue);
     }
@@ -3712,6 +3770,14 @@
 
     .sm\:items-center {
       align-items: center;
+    }
+
+    .sm\:items-start {
+      align-items: flex-start;
+    }
+
+    .sm\:justify-between {
+      justify-content: space-between;
     }
 
     .sm\:justify-end {

--- a/tests/test_guard_harness_setup.py
+++ b/tests/test_guard_harness_setup.py
@@ -135,6 +135,43 @@ def test_daemon_install_endpoint_defaults_to_dry_run(tmp_path: Path) -> None:
     assert payload["action"] == "install"
     assert payload["contract"]["harness"] == "codex"
     assert store.get_managed_install("codex") is None
+    command = payload["steps"][0]["command"]
+    assert command == ["hol-guard", "apps", "connect", "codex"]
+
+
+def test_daemon_install_endpoint_runs_managed_install_without_cli(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/harnesses/opencode/install",
+                token=daemon._server.auth_token,
+                payload={"dry_run": False},
+            )
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert payload["dry_run"] is False
+    assert payload["action"] == "install"
+    managed = payload["managed_install"]
+    assert isinstance(managed, dict)
+    assert managed["harness"] == "opencode"
+    assert managed["active"] is True
+    assert store.get_managed_install("opencode") is not None
+    config_path = home / ".config" / "opencode" / "opencode.json"
+    assert config_path.exists()
+    assert "npx" not in json.dumps(payload)
 
 
 def test_daemon_verify_endpoint_runs_safe_local_detection(tmp_path: Path) -> None:
@@ -180,6 +217,47 @@ def test_daemon_uninstall_requires_confirmation_token(tmp_path: Path) -> None:
     assert payload["error"] == "confirmation_required"
     assert payload["confirmation_phrase"] == "disconnect-codex"
     assert payload["confirm_command"] == "hol-guard apps disconnect codex --confirm disconnect-codex"
+
+
+def test_daemon_uninstall_endpoint_runs_managed_disconnect_with_confirmation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        install_status, _install_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/harnesses/opencode/install",
+                token=daemon._server.auth_token,
+                payload={"dry_run": False},
+            )
+        )
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/harnesses/opencode/uninstall",
+                token=daemon._server.auth_token,
+                payload={"dry_run": False, "confirmation_phrase": "disconnect-opencode"},
+            )
+        )
+    finally:
+        daemon.stop()
+
+    assert install_status == 200
+    assert status == 200
+    managed = payload["managed_install"]
+    assert isinstance(managed, dict)
+    assert managed["harness"] == "opencode"
+    assert managed["active"] is False
+    stored = store.get_managed_install("opencode")
+    assert stored is not None
+    assert stored["active"] is False
 
 
 def test_apps_alias_lists_harnesses_as_plain_inventory(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Summary
- add dashboard API support for local harness install, verify, repair, and disconnect actions
- replace fake NPX setup copy with dashboard-run local Guard management and real hol-guard fallback commands
- preserve Guard token hashes while app detail tabs use ?tab= settings routing
- add daemon regression coverage for dry-run, real OpenCode install, and confirmed disconnect

## Verification
- python3 -m pytest tests/test_guard_harness_setup.py -k 'daemon_install_endpoint or daemon_uninstall'
- python3 -m pytest tests/test_guard_harness_setup.py tests/test_guard_daemon_cli.py tests/test_guard_daemon_manager.py
- python3 -m pytest tests/test_guard_product_flow.py tests/test_guard_harness_smoke.py -k 'not live'
- pnpm test (dashboard)
- pnpm run build (dashboard)
- git diff --check
- browser smoke: Vite dev app at 127.0.0.1:5478 proxied to local daemon showed /apps/opencode?tab=settings with Local harness install, Connect app, real hol-guard fallback command, no fake NPX command