### PR TITLE
fix(capabilities): handle Python 3.11+ ValueError from urlsplit on bracketed regex patterns

### DIFF
--- a/src/codex_plugin_scanner/guard/capabilities.py
+++ b/src/codex_plugin_scanner/guard/capabilities.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from pathlib import PurePath
-from urllib.parse import urlsplit
+from urllib.parse import SplitResult, urlsplit
 
 from .models import GuardArtifact
 from .types import CapabilityDelta, CapabilitySet, TransportKind
@@ -286,22 +286,22 @@ def _combined_text(artifact: GuardArtifact) -> str:
     return " ".join(value for value in values if value)
 
 
+def _safe_urlsplit(value: str) -> SplitResult | None:
+    try:
+        return urlsplit(value)
+    except ValueError:
+        return None
+
+
 def _extract_network_hosts(text: str, url: str | None) -> set[str]:
     hosts: set[str] = set()
+    candidates: list[str] = list(_URL_PATTERN.findall(text))
     if url:
-        try:
-            parsed = urlsplit(url)
-            if parsed.hostname:
-                hosts.add(parsed.hostname.lower())
-        except ValueError:
-            pass
-    for candidate in _URL_PATTERN.findall(text):
-        try:
-            parsed = urlsplit(candidate)
-            if parsed.hostname:
-                hosts.add(parsed.hostname.lower())
-        except ValueError:
-            pass
+        candidates.append(url)
+    for candidate in candidates:
+        parsed = _safe_urlsplit(candidate)
+        if parsed is not None and parsed.hostname:
+            hosts.add(parsed.hostname.lower())
     for candidate in _HOST_PATTERN.findall(text):
         if candidate.count(".") < 1:
             continue
@@ -315,20 +315,13 @@ def _extract_network_hosts(text: str, url: str | None) -> set[str]:
 
 def _extract_network_schemes(text: str, url: str | None) -> set[str]:
     schemes: set[str] = set()
+    candidates: list[str] = list(_URL_PATTERN.findall(text))
     if url:
-        try:
-            parsed = urlsplit(url)
-            if parsed.scheme:
-                schemes.add(parsed.scheme.lower())
-        except ValueError:
-            pass
-    for candidate in _URL_PATTERN.findall(text):
-        try:
-            parsed = urlsplit(candidate)
-            if parsed.scheme:
-                schemes.add(parsed.scheme.lower())
-        except ValueError:
-            pass
+        candidates.append(url)
+    for candidate in candidates:
+        parsed = _safe_urlsplit(candidate)
+        if parsed is not None and parsed.scheme:
+            schemes.add(parsed.scheme.lower())
     if "ssh " in text.lower() or "scp " in text.lower():
         schemes.add("ssh")
     return schemes

--- a/src/codex_plugin_scanner/guard/capabilities.py
+++ b/src/codex_plugin_scanner/guard/capabilities.py
@@ -289,13 +289,19 @@ def _combined_text(artifact: GuardArtifact) -> str:
 def _extract_network_hosts(text: str, url: str | None) -> set[str]:
     hosts: set[str] = set()
     if url:
-        parsed = urlsplit(url)
-        if parsed.hostname:
-            hosts.add(parsed.hostname.lower())
+        try:
+            parsed = urlsplit(url)
+            if parsed.hostname:
+                hosts.add(parsed.hostname.lower())
+        except ValueError:
+            pass
     for candidate in _URL_PATTERN.findall(text):
-        parsed = urlsplit(candidate)
-        if parsed.hostname:
-            hosts.add(parsed.hostname.lower())
+        try:
+            parsed = urlsplit(candidate)
+            if parsed.hostname:
+                hosts.add(parsed.hostname.lower())
+        except ValueError:
+            pass
     for candidate in _HOST_PATTERN.findall(text):
         if candidate.count(".") < 1:
             continue
@@ -310,13 +316,19 @@ def _extract_network_hosts(text: str, url: str | None) -> set[str]:
 def _extract_network_schemes(text: str, url: str | None) -> set[str]:
     schemes: set[str] = set()
     if url:
-        parsed = urlsplit(url)
-        if parsed.scheme:
-            schemes.add(parsed.scheme.lower())
+        try:
+            parsed = urlsplit(url)
+            if parsed.scheme:
+                schemes.add(parsed.scheme.lower())
+        except ValueError:
+            pass
     for candidate in _URL_PATTERN.findall(text):
-        parsed = urlsplit(candidate)
-        if parsed.scheme:
-            schemes.add(parsed.scheme.lower())
+        try:
+            parsed = urlsplit(candidate)
+            if parsed.scheme:
+                schemes.add(parsed.scheme.lower())
+        except ValueError:
+            pass
     if "ssh " in text.lower() or "scp " in text.lower():
         schemes.add("ssh")
     return schemes

--- a/src/codex_plugin_scanner/guard/models.py
+++ b/src/codex_plugin_scanner/guard/models.py
@@ -25,7 +25,10 @@ SEVERITY_RANK: dict[str, int] = {"info": 0, "low": 1, "medium": 2, "high": 3, "c
 def _redact_url(value: str | None) -> str | None:
     if value is None:
         return None
-    parsed = urlsplit(value)
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return value
     if not parsed.query:
         return value
     redacted_pairs = []

--- a/tests/test_guard_capabilities.py
+++ b/tests/test_guard_capabilities.py
@@ -92,3 +92,42 @@ def test_normalize_artifact_capabilities_ignores_common_local_file_suffixes_as_h
     capabilities = normalize_artifact_capabilities(artifact)
 
     assert capabilities.network_hosts == ()
+
+
+def test_normalize_artifact_capabilities_tolerates_bracketed_regex_in_command():
+    artifact = GuardArtifact(
+        artifact_id="hermes:project:regex-tool",
+        name="regex-tool",
+        harness="hermes",
+        artifact_type="allowed_tool",
+        source_scope="project",
+        config_path="/home/user/.hermes/config.json",
+        command=".*|\\1|",
+        args=(),
+        transport="stdio",
+    )
+
+    capabilities = normalize_artifact_capabilities(artifact)
+
+    assert capabilities.network_hosts == ()
+    assert capabilities.network_schemes == ()
+
+
+def test_normalize_artifact_capabilities_tolerates_bracketed_regex_in_url():
+    artifact = GuardArtifact(
+        artifact_id="hermes:project:regex-url-tool",
+        name="regex-url-tool",
+        harness="hermes",
+        artifact_type="allowed_tool",
+        source_scope="project",
+        config_path="/home/user/.hermes/config.json",
+        command="echo",
+        args=(),
+        transport="stdio",
+        url="[.*|\\1|]",
+    )
+
+    capabilities = normalize_artifact_capabilities(artifact)
+
+    assert capabilities.network_hosts == ()
+    assert capabilities.network_schemes == ()

--- a/tests/test_guard_capabilities.py
+++ b/tests/test_guard_capabilities.py
@@ -124,7 +124,7 @@ def test_normalize_artifact_capabilities_tolerates_bracketed_regex_in_url():
         command="echo",
         args=(),
         transport="stdio",
-        url="[.*|\\1|]",
+        url="http://[.*|\\1|]",
     )
 
     capabilities = normalize_artifact_capabilities(artifact)


### PR DESCRIPTION
## Summary

Python 3.11 tightened `urllib.parse.urlsplit` to validate bracketed hosts, calling `ipaddress.ip_address` internally for `[...]` sequences. When artifact commands or URLs contain regex patterns like `.*|\1|` or `[.*|\1|]` (e.g. Hermes `allowed_tool` entries), this causes `urlsplit` to raise `ValueError`, which bubbles through `_extract_network_hosts` / `_extract_network_schemes` → `normalize_artifact_capabilities` → `_summarize_harness` and crashes `hol-guard status` / `hol-guard run`.

## Fix

Wrap all `urlsplit()` calls in `_extract_network_hosts` and `_extract_network_schemes` with `try/except ValueError` so malformed candidates are silently skipped rather than propagating.

## Tests

Two new regression tests in `test_guard_capabilities.py`:
- `test_normalize_artifact_capabilities_tolerates_bracketed_regex_in_command`
- `test_normalize_artifact_capabilities_tolerates_bracketed_regex_in_url`