### PR TITLE
fix(guard): handle Python 3.11+ ValueError from urlsplit in risk and advisory_model

### DIFF
--- a/src/codex_plugin_scanner/guard/advisory_model.py
+++ b/src/codex_plugin_scanner/guard/advisory_model.py
@@ -137,7 +137,10 @@ def _endpoint_indicator_matches(values: object, source_url: str | None) -> bool:
 def _normalized_url_indicator(value: str | None) -> str:
     if value is None:
         return ""
-    parsed = urlsplit(value)
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return normalize_identity_value(value)
     if not parsed.scheme or not parsed.netloc:
         return normalize_identity_value(value)
     path = parsed.path.rstrip("/")

--- a/src/codex_plugin_scanner/guard/risk.py
+++ b/src/codex_plugin_scanner/guard/risk.py
@@ -286,7 +286,10 @@ def extract_network_hosts(text: str) -> set[str]:
 
     hosts: set[str] = set()
     for value in _URL_PATTERN.findall(text):
-        parsed = urlsplit(value)
+        try:
+            parsed = urlsplit(value)
+        except ValueError:
+            continue
         if parsed.hostname:
             hosts.add(parsed.hostname.lower())
     for match in _HOST_PATTERN.finditer(text):

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -28,7 +28,9 @@ from codex_plugin_scanner.guard.risk import (
     detect_encoded_command,
     detect_guard_bypass,
     detect_staged_download,
+    extract_network_hosts,
 )
+from codex_plugin_scanner.guard.advisory_model import _normalized_url_indicator
 from codex_plugin_scanner.guard.runtime.actions import normalize_codex_hook_payload
 from codex_plugin_scanner.guard.runtime.secret_file_requests import (
     _path_text_is_within_root_text,
@@ -3004,3 +3006,14 @@ def test_risk_helpers_detect_encoded_download_and_bypass_patterns():
     assert encoded_signals
     assert staged_signals
     assert bypass_signals
+
+
+def test_extract_network_hosts_tolerates_bracketed_regex_in_url():
+    regex_pattern = r"https://[^:]*:\([^@]*\)@.*|\1|"
+    hosts = extract_network_hosts(f"credential strip using {regex_pattern}")
+    assert isinstance(hosts, set)
+
+
+def test_normalized_url_indicator_tolerates_bracketed_regex():
+    result = _normalized_url_indicator(r"https://[^:]*:\([^@]*\)@.*|\1|")
+    assert isinstance(result, str)

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -3011,9 +3011,10 @@ def test_risk_helpers_detect_encoded_download_and_bypass_patterns():
 def test_extract_network_hosts_tolerates_bracketed_regex_in_url():
     regex_pattern = r"https://[^:]*:\([^@]*\)@.*|\1|"
     hosts = extract_network_hosts(f"credential strip using {regex_pattern}")
-    assert isinstance(hosts, set)
+    assert hosts == set()
 
 
 def test_normalized_url_indicator_tolerates_bracketed_regex():
-    result = _normalized_url_indicator(r"https://[^:]*:\([^@]*\)@.*|\1|")
-    assert isinstance(result, str)
+    raw = r"https://[^:]*:\([^@]*\)@.*|\1|"
+    result = _normalized_url_indicator(raw)
+    assert result == raw


### PR DESCRIPTION
## Summary

Python 3.11+ added strict bracketed-netloc validation to `urlsplit`, raising `ValueError` when the netloc contains characters that are not valid IPv6 addresses. This affects harnesses (e.g. Hermes) that store regex patterns in artifact command fields—patterns like `https://[^:]*:\([^@]*\)@.*|\1|` are matched by `_URL_PATTERN` and passed to `urlsplit`, causing a crash.

PR #335 fixed `capabilities.py`. This PR addresses two additional unprotected call sites:

- **`risk.py:extract_network_hosts`** — adds `try/except ValueError: continue` around `urlsplit` in the URL candidate loop
- **`advisory_model.py:_normalized_url_indicator`** — adds `try/except ValueError` around `urlsplit` with graceful fallback to identity normalization

## Testing

Two regression tests added to `test_guard_risk.py` covering both fixed paths.