### PR TITLE
fix(guard): hide token-like app slugs

### DIFF
--- a/dashboard/src/app-routing.test.ts
+++ b/dashboard/src/app-routing.test.ts
@@ -23,8 +23,22 @@ assert(normalizeHarnessSlug(" OpenCode ") === "opencode", "normalizer trims and 
 assert(normalizeHarnessSlug("*") === null, "normalizer rejects wildcard pseudo-harness");
 assert(normalizeHarnessSlug("global") === null, "normalizer rejects global pseudo-harness");
 assert(normalizeHarnessSlug("cursor-") === null, "normalizer rejects trailing separators");
+assert(
+  normalizeHarnessSlug("Ce2b7ac2ccab4fab9902347b033bf25e") === null,
+  "normalizer rejects 32-char hex token-like pseudo-harnesses"
+);
+assert(
+  normalizeHarnessSlug("d75ba142-bf53-4f27-aebc-4884278c421a") === null,
+  "normalizer rejects UUID token-like pseudo-harnesses"
+);
 assert(normalizeHarnessFilter("cursor") === "cursor", "filter normalizer keeps valid app harness");
 assert(normalizeHarnessFilter("*") === "all", "filter normalizer maps wildcard pseudo-harness to all apps");
+assert(normalizeHarnessFilter("Ce2b7ac2ccab4fab9902347b033bf25e") === "all", "filter normalizer maps token-like pseudo-harness to all apps");
 assert(isDisplayableHarness("codex"), "real app harness is displayable");
 assert(!isDisplayableHarness("*"), "wildcard pseudo-harness is not displayable");
+assert(!isDisplayableHarness("Ce2b7ac2ccab4fab9902347b033bf25e"), "token-like pseudo-harness is not displayable");
 assert(harnessDisplayName("*") === "All apps", "wildcard pseudo-harness never renders as raw star");
+assert(
+  harnessDisplayName("Ce2b7ac2ccab4fab9902347b033bf25e") === "Unknown app",
+  "token-like pseudo-harness never renders raw"
+);

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -270,11 +270,19 @@ function capitalizeHarness(harness: string): string {
 }
 
 const HARNESS_SLUG_PATTERN = /^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$/;
+const HEX_TOKEN_HARNESS_PATTERN = /^[a-f0-9]{16,64}$/;
+const UUID_HARNESS_PATTERN = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/;
 const NON_APP_HARNESS_SLUGS = new Set(["*", "all", "any", "global"]);
 
 export function normalizeHarnessSlug(harness: string | null | undefined): string | null {
   const slug = typeof harness === "string" ? harness.trim().toLowerCase() : "";
-  if (slug.length === 0 || NON_APP_HARNESS_SLUGS.has(slug) || !HARNESS_SLUG_PATTERN.test(slug)) {
+  if (
+    slug.length === 0 ||
+    NON_APP_HARNESS_SLUGS.has(slug) ||
+    HEX_TOKEN_HARNESS_PATTERN.test(slug) ||
+    UUID_HARNESS_PATTERN.test(slug) ||
+    !HARNESS_SLUG_PATTERN.test(slug)
+  ) {
     return null;
   }
   return slug;
@@ -319,7 +327,20 @@ export function resolveStoppedCommandText(item: GuardApprovalRequest): string {
 }
 
 export function harnessDisplayName(harness: string): string {
-  switch (harness) {
+  const normalized = normalizeHarnessSlug(harness);
+  if (normalized === null) {
+    switch (harness.trim().toLowerCase()) {
+      case "*":
+      case "all":
+      case "any":
+      case "global":
+        return "All apps";
+      default:
+        return "Unknown app";
+    }
+  }
+
+  switch (normalized) {
     case "*":
     case "all":
     case "any":
@@ -342,7 +363,7 @@ export function harnessDisplayName(harness: string): string {
     case "openclaw":
       return "OpenClaw";
     default:
-      return capitalizeHarness(harness);
+      return capitalizeHarness(normalized);
   }
 }
 

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -341,11 +341,6 @@ export function harnessDisplayName(harness: string): string {
   }
 
   switch (normalized) {
-    case "*":
-    case "all":
-    case "any":
-    case "global":
-      return "All apps";
     case "claude-code":
       return "Claude Code";
     case "copilot":

--- a/dashboard/src/home-dashboard.test.ts
+++ b/dashboard/src/home-dashboard.test.ts
@@ -3,6 +3,8 @@ import {
   type HomePrimaryState,
 } from "./queue-state";
 import { harnessDisplayName } from "./approval-center-utils";
+import { resolveNewAppDiscoveries } from "./home-dashboard";
+import type { GuardManagedInstall } from "./guard-types";
 
 function assert(condition: boolean, message: string): void {
   if (!condition) {
@@ -164,6 +166,28 @@ assert(
 assert(
   appsProtectedCopy === "Apps protected",
   'L142: "Apps protected" section label appears exactly once — verified by constant'
+);
+
+const managedDiscoveryInstalls: GuardManagedInstall[] = [
+  {
+    harness: "cursor",
+    active: true,
+    workspace: null,
+    manifest: {},
+    updated_at: "2026-05-12T00:00:00Z",
+  },
+];
+
+const newAppDiscoveries = resolveNewAppDiscoveries(managedDiscoveryInstalls, [
+  "cursor",
+  "opencode",
+  "Ce2b7ac2ccab4fab9902347b033bf25e",
+  "d75ba142-bf53-4f27-aebc-4884278c421a",
+]);
+
+assert(
+  newAppDiscoveries.length === 1 && newAppDiscoveries[0] === "opencode",
+  `Discovery banner should show only real unprotected apps — got: ${newAppDiscoveries.join(", ")}`
 );
 
 const [setupCopy, pendingCopy, protectedCopy] = [

--- a/dashboard/src/home-dashboard.tsx
+++ b/dashboard/src/home-dashboard.tsx
@@ -725,8 +725,7 @@ function NewAppDiscoveryBanner(props: {
   policies: GuardPolicyDecision[];
   onOpenAppDetail: (harness: string) => void;
 }) {
-  const activeHarnesses = new Set(props.managedInstalls.map((i) => i.harness));
-  const discovered = props.observedHarnesses.filter((h) => !activeHarnesses.has(h));
+  const discovered = resolveNewAppDiscoveries(props.managedInstalls, props.observedHarnesses);
 
   return (
     <>
@@ -739,6 +738,14 @@ function NewAppDiscoveryBanner(props: {
       ))}
     </>
   );
+}
+
+export function resolveNewAppDiscoveries(
+  managedInstalls: GuardManagedInstall[],
+  observedHarnesses: string[]
+): string[] {
+  const activeHarnesses = new Set(managedInstalls.filter((i) => isDisplayableHarness(i.harness)).map((i) => i.harness));
+  return observedHarnesses.filter((h) => isDisplayableHarness(h) && !activeHarnesses.has(h));
 }
 
 function NewAppBanner(props: {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/home-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/home-dashboard.js
@@ -536,8 +536,7 @@ function StreakMilestoneBanner({ streak }) {
   ] });
 }
 function NewAppDiscoveryBanner(props) {
-  const activeHarnesses = new Set(props.managedInstalls.map((i) => i.harness));
-  const discovered = props.observedHarnesses.filter((h) => !activeHarnesses.has(h));
+  const discovered = resolveNewAppDiscoveries(props.managedInstalls, props.observedHarnesses);
   return /* @__PURE__ */ jsxRuntimeExports.jsx(jsxRuntimeExports.Fragment, { children: discovered.map((harness) => /* @__PURE__ */ jsxRuntimeExports.jsx(
     NewAppBanner,
     {
@@ -546,6 +545,10 @@ function NewAppDiscoveryBanner(props) {
     },
     harness
   )) });
+}
+function resolveNewAppDiscoveries(managedInstalls, observedHarnesses) {
+  const activeHarnesses = new Set(managedInstalls.filter((i) => isDisplayableHarness(i.harness)).map((i) => i.harness));
+  return observedHarnesses.filter((h) => isDisplayableHarness(h) && !activeHarnesses.has(h));
 }
 function NewAppBanner(props) {
   const storageKey = `guard-new-app-dismissed-${props.harness}`;
@@ -621,5 +624,6 @@ function CollapsibleCard(props) {
   ] });
 }
 export {
-  HomeWorkspace
+  HomeWorkspace,
+  resolveNewAppDiscoveries
 };

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13840,10 +13840,12 @@ function capitalizeHarness(harness) {
   return `${harness.charAt(0).toUpperCase()}${harness.slice(1)}`;
 }
 const HARNESS_SLUG_PATTERN = /^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$/;
+const HEX_TOKEN_HARNESS_PATTERN = /^[a-f0-9]{16,64}$/;
+const UUID_HARNESS_PATTERN = /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/;
 const NON_APP_HARNESS_SLUGS = /* @__PURE__ */ new Set(["*", "all", "any", "global"]);
 function normalizeHarnessSlug(harness) {
   const slug = typeof harness === "string" ? harness.trim().toLowerCase() : "";
-  if (slug.length === 0 || NON_APP_HARNESS_SLUGS.has(slug) || !HARNESS_SLUG_PATTERN.test(slug)) {
+  if (slug.length === 0 || NON_APP_HARNESS_SLUGS.has(slug) || HEX_TOKEN_HARNESS_PATTERN.test(slug) || UUID_HARNESS_PATTERN.test(slug) || !HARNESS_SLUG_PATTERN.test(slug)) {
     return null;
   }
   return slug;
@@ -13879,7 +13881,19 @@ function resolveStoppedCommandText(item) {
   return item.artifact_name.trim() || item.artifact_id;
 }
 function harnessDisplayName(harness) {
-  switch (harness) {
+  const normalized = normalizeHarnessSlug(harness);
+  if (normalized === null) {
+    switch (harness.trim().toLowerCase()) {
+      case "*":
+      case "all":
+      case "any":
+      case "global":
+        return "All apps";
+      default:
+        return "Unknown app";
+    }
+  }
+  switch (normalized) {
     case "*":
     case "all":
     case "any":
@@ -13902,7 +13916,7 @@ function harnessDisplayName(harness) {
     case "openclaw":
       return "OpenClaw";
     default:
-      return capitalizeHarness(harness);
+      return capitalizeHarness(normalized);
   }
 }
 function displayArtifactName(item) {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13894,11 +13894,6 @@ function harnessDisplayName(harness) {
     }
   }
   switch (normalized) {
-    case "*":
-    case "all":
-    case "any":
-    case "global":
-      return "All apps";
     case "claude-code":
       return "Claude Code";
     case "copilot":


### PR DESCRIPTION
## Summary
- reject token/hash/UUID-looking harness IDs before they can become app routes or discovery cards
- prevent Home discovery banners from rendering invalid pseudo-app harnesses
- avoid raw token-like harness display by falling back to Unknown app

## Verification
- pnpm test
- pnpm run build
- git diff --check