### PR TITLE
test(guard): add approval decision model and wrapper flow tests (P2.4/P4.4)

### DIFF
--- a/tests/test_guard_approval_decisions.py
+++ b/tests/test_guard_approval_decisions.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.consumer import artifact_hash as compute_artifact_hash
 from codex_plugin_scanner.guard.consumer import evaluate_detection
@@ -71,7 +69,11 @@ class TestDecideAction:
         assert result == "allow"
 
     def test_changed_triggers_changed_hash_action_when_no_configured_policy(self) -> None:
-        config = GuardConfig(guard_home=Path("/tmp/test-guard"), workspace=None, changed_hash_action="require-reapproval")
+        config = GuardConfig(
+            guard_home=Path("/tmp/test-guard"),
+            workspace=None,
+            changed_hash_action="require-reapproval",
+        )
         result = decide_action(
             configured_action=None,
             default_action="allow",
@@ -81,7 +83,11 @@ class TestDecideAction:
         assert result == "require-reapproval"
 
     def test_configured_allow_beats_changed_flag(self) -> None:
-        config = GuardConfig(guard_home=Path("/tmp/test-guard"), workspace=None, changed_hash_action="require-reapproval")
+        config = GuardConfig(
+            guard_home=Path("/tmp/test-guard"),
+            workspace=None,
+            changed_hash_action="require-reapproval",
+        )
         result = decide_action(
             configured_action="allow",
             default_action="allow",
@@ -111,7 +117,11 @@ class TestDecideAction:
         assert result == "block"
 
     def test_no_policy_uses_config_default(self) -> None:
-        config = GuardConfig(guard_home=Path("/tmp/test-guard"), workspace=None, default_action="warn")
+        config = GuardConfig(
+            guard_home=Path("/tmp/test-guard"),
+            workspace=None,
+            default_action="warn",
+        )
         result = decide_action(
             configured_action=None,
             default_action=None,
@@ -121,7 +131,11 @@ class TestDecideAction:
         assert result == "warn"
 
     def test_explicit_default_action_overrides_config(self) -> None:
-        config = GuardConfig(guard_home=Path("/tmp/test-guard"), workspace=None, default_action="warn")
+        config = GuardConfig(
+            guard_home=Path("/tmp/test-guard"),
+            workspace=None,
+            default_action="warn",
+        )
         result = decide_action(
             configured_action=None,
             default_action="allow",

--- a/tests/test_guard_approval_decisions.py
+++ b/tests/test_guard_approval_decisions.py
@@ -1,0 +1,452 @@
+"""Approval decision model tests — P2.4.
+
+Covers:
+- Unchanged artifact → stored allow policy → no reapproval triggered
+- Changed artifact hash → require-reapproval via decide_action
+- Changed capability → require-reapproval via decide_action
+- Scope persistence for artifact/workspace/publisher/harness/global scopes
+- Receipt field completeness from build_receipt
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.consumer import evaluate_detection
+from codex_plugin_scanner.guard.models import (
+    GuardArtifact,
+    HarnessDetection,
+    PolicyDecision,
+)
+from codex_plugin_scanner.guard.policy.engine import decide_action
+from codex_plugin_scanner.guard.receipts.manager import build_receipt
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _make_artifact(
+    artifact_id: str = "codex:project:my_tool",
+    command: str = "python",
+    args: tuple[str, ...] = ("-m", "my_tool"),
+    publisher: str | None = None,
+) -> GuardArtifact:
+    return GuardArtifact(
+        artifact_id=artifact_id,
+        name="my_tool",
+        harness="codex",
+        artifact_type="mcp_server",
+        source_scope="project",
+        config_path="/home/user/.codex/config.toml",
+        command=command,
+        args=args,
+        transport="stdio",
+        publisher=publisher,
+    )
+
+
+def _make_config(tmp_path: Path, default_action: str = "require-reapproval") -> GuardConfig:
+    return GuardConfig(
+        guard_home=tmp_path / "guard",
+        workspace=tmp_path / "workspace",
+        default_action=default_action,
+    )
+
+
+def _make_store(tmp_path: Path) -> GuardStore:
+    return GuardStore(tmp_path / "guard")
+
+
+class TestDecideAction:
+    def test_allow_policy_passes_through_unchanged(self) -> None:
+        config = GuardConfig(guard_home=Path("/tmp/test-guard"), workspace=None)
+        result = decide_action(
+            configured_action="allow",
+            default_action="require-reapproval",
+            config=config,
+            changed=False,
+        )
+        assert result == "allow"
+
+    def test_changed_triggers_changed_hash_action_when_no_configured_policy(self) -> None:
+        config = GuardConfig(guard_home=Path("/tmp/test-guard"), workspace=None, changed_hash_action="require-reapproval")
+        result = decide_action(
+            configured_action=None,
+            default_action="allow",
+            config=config,
+            changed=True,
+        )
+        assert result == "require-reapproval"
+
+    def test_configured_allow_beats_changed_flag(self) -> None:
+        config = GuardConfig(guard_home=Path("/tmp/test-guard"), workspace=None, changed_hash_action="require-reapproval")
+        result = decide_action(
+            configured_action="allow",
+            default_action="allow",
+            config=config,
+            changed=True,
+        )
+        assert result == "allow"
+
+    def test_changed_falls_back_to_safe_when_no_changed_hash_action(self) -> None:
+        config = GuardConfig(guard_home=Path("/tmp/test-guard"), workspace=None)
+        result = decide_action(
+            configured_action=None,
+            default_action=None,
+            config=config,
+            changed=True,
+        )
+        assert result == "require-reapproval"
+
+    def test_block_policy_blocks_regardless_of_changed_flag(self) -> None:
+        config = GuardConfig(guard_home=Path("/tmp/test-guard"), workspace=None)
+        result = decide_action(
+            configured_action="block",
+            default_action="allow",
+            config=config,
+            changed=False,
+        )
+        assert result == "block"
+
+    def test_no_policy_uses_config_default(self) -> None:
+        config = GuardConfig(guard_home=Path("/tmp/test-guard"), workspace=None, default_action="warn")
+        result = decide_action(
+            configured_action=None,
+            default_action=None,
+            config=config,
+            changed=False,
+        )
+        assert result == "warn"
+
+    def test_explicit_default_action_overrides_config(self) -> None:
+        config = GuardConfig(guard_home=Path("/tmp/test-guard"), workspace=None, default_action="warn")
+        result = decide_action(
+            configured_action=None,
+            default_action="allow",
+            config=config,
+            changed=False,
+        )
+        assert result == "allow"
+
+
+class TestPolicyScopePersistence:
+    def test_artifact_scope_allow_resolves_for_matching_hash(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="artifact",
+                action="allow",
+                artifact_id="codex:project:my_tool",
+                artifact_hash="abc123",
+            ),
+            "2026-01-01T00:00:00+00:00",
+        )
+        result = store.resolve_policy("codex", "codex:project:my_tool", "abc123")
+        assert result == "allow"
+
+    def test_artifact_scope_allow_resolves_without_hash_when_policy_has_no_hash(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="artifact",
+                action="allow",
+                artifact_id="codex:project:my_tool",
+                artifact_hash=None,
+            ),
+            "2026-01-01T00:00:00+00:00",
+        )
+        result = store.resolve_policy("codex", "codex:project:my_tool", "any-hash")
+        assert result == "allow"
+
+    def test_publisher_scope_resolves_for_any_artifact_by_publisher(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="publisher",
+                action="allow",
+                publisher="verified-org",
+            ),
+            "2026-01-01T00:00:00+00:00",
+        )
+        result = store.resolve_policy("codex", "codex:project:any_tool", "hash-x", publisher="verified-org")
+        assert result == "allow"
+
+    def test_publisher_scope_does_not_match_different_publisher(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="publisher",
+                action="allow",
+                publisher="verified-org",
+            ),
+            "2026-01-01T00:00:00+00:00",
+        )
+        result = store.resolve_policy("codex", "codex:project:any_tool", "hash-x", publisher="unknown-org")
+        assert result is None
+
+    def test_harness_scope_resolves_for_all_artifacts_in_harness(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="harness",
+                action="allow",
+            ),
+            "2026-01-01T00:00:00+00:00",
+        )
+        result = store.resolve_policy("codex", "codex:project:any_tool", "hash-y")
+        assert result == "allow"
+
+    def test_global_scope_resolves_for_any_harness(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="global",
+                action="block",
+            ),
+            "2026-01-01T00:00:00+00:00",
+        )
+        result = store.resolve_policy("codex", "codex:project:anything", "hash-z")
+        assert result == "block"
+
+    def test_artifact_scope_takes_precedence_over_global_scope(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="global",
+                action="block",
+            ),
+            "2026-01-01T00:00:00+00:00",
+        )
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="artifact",
+                action="allow",
+                artifact_id="codex:project:trusted_tool",
+                artifact_hash=None,
+            ),
+            "2026-01-01T00:00:00+00:00",
+        )
+        result = store.resolve_policy("codex", "codex:project:trusted_tool", "any-hash")
+        assert result == "allow"
+
+    def test_expired_policy_is_not_matched(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="artifact",
+                action="allow",
+                artifact_id="codex:project:my_tool",
+                artifact_hash=None,
+                expires_at="2025-01-01T00:00:00+00:00",
+            ),
+            "2024-12-01T00:00:00+00:00",
+        )
+        result = store.resolve_policy(
+            "codex",
+            "codex:project:my_tool",
+            "hash-abc",
+            now="2026-01-01T00:00:00+00:00",
+        )
+        assert result is None
+
+
+class TestEvaluateDetectionScopePersistence:
+    def test_unchanged_artifact_with_stored_allow_policy_is_not_blocked(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        config = _make_config(tmp_path)
+        artifact = _make_artifact()
+
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="artifact",
+                action="allow",
+                artifact_id=artifact.artifact_id,
+                artifact_hash=None,
+            ),
+            "2026-01-01T00:00:00+00:00",
+        )
+
+        detection = HarnessDetection(
+            harness="codex",
+            installed=True,
+            command_available=True,
+            config_paths=(artifact.config_path,),
+            artifacts=(artifact,),
+        )
+
+        result = evaluate_detection(detection, store, config, persist=False)
+
+        artifact_result = result["artifacts"][0]
+        assert artifact_result["policy_action"] == "allow"
+        assert result["blocked"] is False
+
+    def test_changed_artifact_hash_without_stored_policy_triggers_reapproval(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        config = _make_config(tmp_path)
+        artifact_v1 = _make_artifact(args=("-m", "my_tool", "--port", "8000"))
+        artifact_v2 = _make_artifact(args=("-m", "my_tool", "--port", "9000"))
+
+        detection_v1 = HarnessDetection(
+            harness="codex",
+            installed=True,
+            command_available=True,
+            config_paths=(artifact_v1.config_path,),
+            artifacts=(artifact_v1,),
+        )
+        evaluate_detection(detection_v1, store, config, persist=True)
+
+        detection_v2 = HarnessDetection(
+            harness="codex",
+            installed=True,
+            command_available=True,
+            config_paths=(artifact_v2.config_path,),
+            artifacts=(artifact_v2,),
+        )
+        result = evaluate_detection(detection_v2, store, config, persist=False)
+
+        artifact_result = result["artifacts"][0]
+        assert artifact_result["policy_action"] in {"require-reapproval", "block", "sandbox-required"}
+        assert result["blocked"] is True
+
+    def test_hash_locked_policy_does_not_match_new_hash_triggers_reapproval(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        config = _make_config(tmp_path, default_action="allow")
+        artifact_v1 = _make_artifact(args=("-m", "my_tool", "--port", "8000"))
+        artifact_v2 = _make_artifact(args=("-m", "my_tool", "--port", "9999"))
+
+        from codex_plugin_scanner.guard.consumer import artifact_hash as compute_hash
+
+        v1_hash = compute_hash(artifact_v1)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="artifact",
+                action="allow",
+                artifact_id=artifact_v1.artifact_id,
+                artifact_hash=v1_hash,
+            ),
+            "2026-01-01T00:00:00+00:00",
+        )
+
+        detection_v1 = HarnessDetection(
+            harness="codex",
+            installed=True,
+            command_available=True,
+            config_paths=(artifact_v1.config_path,),
+            artifacts=(artifact_v1,),
+        )
+        evaluate_detection(detection_v1, store, config, persist=True)
+
+        detection_v2 = HarnessDetection(
+            harness="codex",
+            installed=True,
+            command_available=True,
+            config_paths=(artifact_v2.config_path,),
+            artifacts=(artifact_v2,),
+        )
+        result = evaluate_detection(detection_v2, store, config, persist=False)
+
+        artifact_result = result["artifacts"][0]
+        assert artifact_result["policy_action"] in {"require-reapproval", "block", "sandbox-required"}
+
+
+class TestBuildReceipt:
+    def test_build_receipt_populates_required_fields(self) -> None:
+        receipt = build_receipt(
+            harness="codex",
+            artifact_id="codex:project:my_tool",
+            artifact_hash="sha256-abc",
+            policy_decision="allow",
+            capabilities_summary="command: python",
+            changed_capabilities=[],
+            provenance_summary="project artifact at /workspace/.codex/config.toml (provenance: local)",
+            artifact_name="my_tool",
+            source_scope="project",
+        )
+
+        assert receipt.receipt_id.startswith("guard-receipt-")
+        assert receipt.harness == "codex"
+        assert receipt.artifact_id == "codex:project:my_tool"
+        assert receipt.artifact_hash == "sha256-abc"
+        assert receipt.policy_decision == "allow"
+        assert receipt.capabilities_summary == "command: python"
+        assert receipt.changed_capabilities == ()
+        assert "project artifact" in receipt.provenance_summary
+        assert receipt.artifact_name == "my_tool"
+        assert receipt.source_scope == "project"
+        assert receipt.timestamp != ""
+
+    def test_build_receipt_changed_capabilities_are_stored_as_tuple(self) -> None:
+        receipt = build_receipt(
+            harness="codex",
+            artifact_id="codex:project:my_tool",
+            artifact_hash="sha256-abc",
+            policy_decision="require-reapproval",
+            capabilities_summary="command: python",
+            changed_capabilities=["args", "command"],
+            provenance_summary="project artifact",
+            artifact_name="my_tool",
+            source_scope="project",
+        )
+        assert receipt.changed_capabilities == ("args", "command")
+
+    def test_build_receipt_user_override_defaults_to_none(self) -> None:
+        receipt = build_receipt(
+            harness="codex",
+            artifact_id="codex:project:my_tool",
+            artifact_hash="hash",
+            policy_decision="allow",
+            capabilities_summary="",
+            changed_capabilities=[],
+            provenance_summary="provenance",
+            artifact_name=None,
+            source_scope=None,
+        )
+        assert receipt.user_override is None
+
+    def test_build_receipt_to_dict_serializes_scanner_evidence(self) -> None:
+        evidence = [{"type": "scan", "finding": "clean"}]
+        receipt = build_receipt(
+            harness="codex",
+            artifact_id="codex:project:my_tool",
+            artifact_hash="hash",
+            policy_decision="allow",
+            capabilities_summary="",
+            changed_capabilities=[],
+            provenance_summary="provenance",
+            artifact_name=None,
+            source_scope=None,
+            scanner_evidence=evidence,
+        )
+        d = receipt.to_dict()
+        assert isinstance(d["scanner_evidence"], list)
+        assert d["scanner_evidence"][0]["type"] == "scan"
+
+    def test_build_receipt_generates_unique_receipt_ids(self) -> None:
+        receipts = [
+            build_receipt(
+                harness="codex",
+                artifact_id=f"codex:project:tool_{i}",
+                artifact_hash="hash",
+                policy_decision="allow",
+                capabilities_summary="",
+                changed_capabilities=[],
+                provenance_summary="provenance",
+                artifact_name=None,
+                source_scope=None,
+            )
+            for i in range(5)
+        ]
+        ids = {r.receipt_id for r in receipts}
+        assert len(ids) == 5, "Each receipt must have a unique receipt_id"

--- a/tests/test_guard_approval_decisions.py
+++ b/tests/test_guard_approval_decisions.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.consumer import artifact_hash as compute_artifact_hash
 from codex_plugin_scanner.guard.consumer import evaluate_detection
 from codex_plugin_scanner.guard.models import (
     GuardArtifact,
@@ -325,9 +326,7 @@ class TestEvaluateDetectionScopePersistence:
         artifact_v1 = _make_artifact(args=("-m", "my_tool", "--port", "8000"))
         artifact_v2 = _make_artifact(args=("-m", "my_tool", "--port", "9999"))
 
-        from codex_plugin_scanner.guard.consumer import artifact_hash as compute_hash
-
-        v1_hash = compute_hash(artifact_v1)
+        v1_hash = compute_artifact_hash(artifact_v1)
         store.upsert_policy(
             PolicyDecision(
                 harness="codex",
@@ -359,6 +358,7 @@ class TestEvaluateDetectionScopePersistence:
 
         artifact_result = result["artifacts"][0]
         assert artifact_result["policy_action"] in {"require-reapproval", "block", "sandbox-required"}
+        assert result["blocked"] is True
 
 
 class TestBuildReceipt:

--- a/tests/test_guard_wrapper_flows.py
+++ b/tests/test_guard_wrapper_flows.py
@@ -1,0 +1,297 @@
+"""Guard wrapper flow tests — P4.
+
+Covers:
+- wait_for_approval_requests resolves immediately when all items resolved
+- wait_for_approval_requests returns pending when timeout fires
+- _headless_approval_resolver with --json flag (noninteractive) skips waiting
+- _headless_approval_resolver timeout produces hint with pending request IDs
+- Duplicate approval requests for same artifact are not re-queued
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.approvals import wait_for_approval_requests
+from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.models import (
+    GuardArtifact,
+    HarnessDetection,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _make_artifact(artifact_id: str = "codex:project:my_tool") -> GuardArtifact:
+    return GuardArtifact(
+        artifact_id=artifact_id,
+        name="my_tool",
+        harness="codex",
+        artifact_type="mcp_server",
+        source_scope="project",
+        config_path="/home/user/.codex/config.toml",
+        command="python",
+        args=("-m", "my_tool"),
+        transport="stdio",
+    )
+
+
+def _make_detection(artifact: GuardArtifact) -> HarnessDetection:
+    return HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(artifact.config_path,),
+        artifacts=(artifact,),
+    )
+
+
+class TestWaitForApprovalRequests:
+    def _add_request(
+        self, store: GuardStore, req_id: str, status: str = "pending"
+    ) -> str:
+        from codex_plugin_scanner.guard.models import GuardApprovalRequest
+
+        request = GuardApprovalRequest(
+            request_id=req_id,
+            harness="codex",
+            artifact_id="codex:project:my_tool",
+            artifact_name="my_tool",
+            artifact_hash="sha256-abc",
+            policy_action="require-reapproval",
+            recommended_scope="artifact",
+            changed_fields=("args",),
+            source_scope="project",
+            config_path="/workspace/.codex/config.toml",
+            review_command=f"hol-guard approvals approve {req_id}",
+            approval_url=f"http://127.0.0.1:4455/approvals/{req_id}",
+        )
+        persisted_id = store.add_approval_request(request, "2026-01-01T00:00:00+00:00")
+        if status == "resolved":
+            store.resolve_approval_request(
+                persisted_id,
+                resolution_action="allow",
+                resolution_scope="artifact",
+                reason=None,
+                resolved_at="2026-01-01T00:00:01+00:00",
+            )
+        return persisted_id
+
+    def test_resolves_immediately_when_all_requests_resolved(self, tmp_path: Path) -> None:
+        store = GuardStore(tmp_path / "guard")
+        req_id = self._add_request(store, "req-001", status="resolved")
+        result = wait_for_approval_requests(
+            store=store,
+            request_ids=[req_id],
+            timeout_seconds=30,
+            poll_interval=0.01,
+        )
+        assert result["resolved"] is True
+        assert result["pending_request_ids"] == []
+
+    def test_returns_pending_after_timeout_when_not_resolved(self, tmp_path: Path) -> None:
+        store = GuardStore(tmp_path / "guard")
+        req_id = self._add_request(store, "req-002", status="pending")
+        start = time.monotonic()
+        result = wait_for_approval_requests(
+            store=store,
+            request_ids=[req_id],
+            timeout_seconds=0,
+            poll_interval=0.01,
+        )
+        elapsed = time.monotonic() - start
+        assert result["resolved"] is False
+        assert req_id in result["pending_request_ids"]
+        assert elapsed < 2.0, "Timeout=0 should return almost immediately"
+
+    def test_resolves_partial_when_some_resolved_some_pending(self, tmp_path: Path) -> None:
+        store = GuardStore(tmp_path / "guard")
+        resolved_id = self._add_request(store, "req-003", status="resolved")
+        pending_id = self._add_request(store, "req-004", status="pending")
+        result = wait_for_approval_requests(
+            store=store,
+            request_ids=[resolved_id, pending_id],
+            timeout_seconds=0,
+            poll_interval=0.01,
+        )
+        assert result["resolved"] is False
+        assert pending_id in result["pending_request_ids"]
+        assert resolved_id not in result["pending_request_ids"]
+
+    def test_empty_request_list_resolves_immediately(self, tmp_path: Path) -> None:
+        store = GuardStore(tmp_path / "guard")
+        result = wait_for_approval_requests(
+            store=store,
+            request_ids=[],
+            timeout_seconds=5,
+            poll_interval=0.01,
+        )
+        assert result["resolved"] is True
+        assert result["pending_request_ids"] == []
+
+
+class TestHeadlessApprovalResolverNoninteractive:
+    def _make_resolver(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        json_flag: bool = True,
+    ) -> Any:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir(parents=True, exist_ok=True)
+        store = GuardStore(home_dir)
+        config = GuardConfig(
+            guard_home=home_dir,
+            workspace=workspace_dir,
+            approval_wait_timeout_seconds=1,
+        )
+        monkeypatch.setattr(
+            guard_commands_module,
+            "ensure_guard_daemon",
+            lambda _: "http://127.0.0.1:4455",
+        )
+        monkeypatch.setattr(
+            guard_commands_module,
+            "load_guard_surface_daemon_client",
+            lambda _: (_ for _ in ()).throw(RuntimeError("daemon unavailable")),
+        )
+        args = argparse.Namespace(harness="codex", json=json_flag)
+        context = HarnessContext(
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+            guard_home=home_dir,
+        )
+        return guard_commands_module._headless_approval_resolver(
+            args=args,
+            context=context,
+            store=store,
+            config=config,
+        ), store
+
+    def test_json_flag_skips_wait_and_returns_unresolved_approval_wait(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        resolver, _store = self._make_resolver(tmp_path, monkeypatch, json_flag=True)
+        artifact = _make_artifact()
+        payload: dict[str, Any] = {
+            "blocked": True,
+            "artifacts": [
+                {
+                    "artifact_id": artifact.artifact_id,
+                    "artifact_name": artifact.name,
+                    "artifact_hash": "sha256-abc",
+                    "policy_action": "require-reapproval",
+                    "changed_fields": ["args"],
+                    "artifact_type": artifact.artifact_type,
+                    "source_scope": artifact.source_scope,
+                    "config_path": artifact.config_path,
+                    "launch_target": "python -m my_tool",
+                }
+            ],
+        }
+        detection = _make_detection(artifact)
+        result = resolver(detection, payload)
+
+        assert "approval_wait" in result
+        assert result["approval_wait"]["resolved"] is False
+
+    def test_noninteractive_resolver_includes_approval_center_url(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        resolver, _store = self._make_resolver(tmp_path, monkeypatch, json_flag=True)
+        artifact = _make_artifact()
+        payload: dict[str, Any] = {
+            "blocked": True,
+            "artifacts": [
+                {
+                    "artifact_id": artifact.artifact_id,
+                    "artifact_name": artifact.name,
+                    "artifact_hash": "sha256-abc",
+                    "policy_action": "require-reapproval",
+                    "changed_fields": ["args"],
+                    "artifact_type": artifact.artifact_type,
+                    "source_scope": artifact.source_scope,
+                    "config_path": artifact.config_path,
+                    "launch_target": "python -m my_tool",
+                }
+            ],
+        }
+        detection = _make_detection(artifact)
+        result = resolver(detection, payload)
+
+        assert result.get("approval_center_url") == "http://127.0.0.1:4455"
+
+
+class TestHeadlessApprovalResolverTimeout:
+    def test_timeout_produces_review_hint_with_pending_request_ids(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir(parents=True, exist_ok=True)
+        store = GuardStore(home_dir)
+        config = GuardConfig(
+            guard_home=home_dir,
+            workspace=workspace_dir,
+            approval_wait_timeout_seconds=0,
+        )
+        monkeypatch.setattr(
+            guard_commands_module,
+            "ensure_guard_daemon",
+            lambda _: "http://127.0.0.1:4455",
+        )
+        monkeypatch.setattr(
+            guard_commands_module,
+            "load_guard_surface_daemon_client",
+            lambda _: (_ for _ in ()).throw(RuntimeError("daemon unavailable")),
+        )
+
+        args = argparse.Namespace(harness="codex", json=False)
+        context = HarnessContext(
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+            guard_home=home_dir,
+        )
+        resolver = guard_commands_module._headless_approval_resolver(
+            args=args,
+            context=context,
+            store=store,
+            config=config,
+        )
+
+        artifact = _make_artifact()
+        payload: dict[str, Any] = {
+            "blocked": True,
+            "artifacts": [
+                {
+                    "artifact_id": artifact.artifact_id,
+                    "artifact_name": artifact.name,
+                    "artifact_hash": "sha256-abc",
+                    "policy_action": "require-reapproval",
+                    "changed_fields": ["args"],
+                    "artifact_type": artifact.artifact_type,
+                    "source_scope": artifact.source_scope,
+                    "config_path": artifact.config_path,
+                    "launch_target": "python -m my_tool",
+                }
+            ],
+        }
+        detection = _make_detection(artifact)
+        result = resolver(detection, payload)
+
+        assert result["approval_wait"]["resolved"] is False
+        review_hint = str(result.get("review_hint", ""))
+        assert "pending" in review_hint.lower() or "approval" in review_hint.lower()


### PR DESCRIPTION
## Summary

Adds test coverage for two previously untested areas:

### P2.4 — Approval Decision Model
- **`TestDecideAction`**: 6 unit tests for `decide_action` — configured policy wins, `changed_hash_action` fires when no policy, block persists, config default used, explicit default overrides config
- **`TestPolicyScopePersistence`**: 8 tests for `GuardStore.resolve_policy` — artifact/publisher/harness/global scope resolution, scope precedence (artifact > global), expired policy rejection
- **`TestEvaluateDetectionScopePersistence`**: 3 integration tests — unchanged artifact + allow policy → not blocked; changed hash (no policy) → require-reapproval; hash-locked policy + new hash → require-reapproval
- **`TestBuildReceipt`**: 5 tests — all required fields populated, changed_capabilities stored as tuple, user_override defaults None, scanner_evidence serializes to dict list, unique receipt IDs

### P4.4 — Wrapper / Noninteractive Flows
- **`TestWaitForApprovalRequests`**: 4 tests — resolves immediately (all resolved), returns pending after timeout=0, partial resolution tracking, empty list resolves immediately
- **`TestHeadlessApprovalResolverNoninteractive`**: 2 tests — `--json` flag skips wait and returns `{resolved: False, ...}` approval_wait; result includes `approval_center_url`
- **`TestHeadlessApprovalResolverTimeout`**: 1 test — timeout=0 fires and review_hint contains "approval"/"pending" language

**Total: 30 new tests, 3117 pass including existing suite.**