### PR TITLE
fix(guard): allow read-only git diff pipelines

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2340,11 +2340,7 @@ def run_guard_command(
                 artifact_name=artifact_name,
                 source_scope=_coalesce_string(payload.get("source_scope"), "project"),
                 user_override=_optional_string(payload.get("user_override")),
-                approval_source=(
-                    "inline"
-                    if _optional_string(payload.get("user_override")) is not None
-                    else "policy"
-                ),
+                approval_source=("inline" if _optional_string(payload.get("user_override")) is not None else "policy"),
             )
             store.add_receipt(receipt)
         if _should_emit_copilot_hook_response(args):
@@ -6134,8 +6130,7 @@ def _git_config_value_without_inline_comment(raw_value: str) -> str:
 
 def _git_config_enables_diff_helper(config_text: str) -> bool:
     return any(
-        re.match(r"(?i)^\s*(?:command|external|textconv)\s*=", line)
-        for line in _git_config_logical_lines(config_text)
+        re.match(r"(?i)^\s*(?:command|external|textconv)\s*=", line) for line in _git_config_logical_lines(config_text)
     )
 
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5948,6 +5948,8 @@ def _git_include_section_is_active(section: str, *, base_dir: Path, repo_dir: Pa
         )
     if condition_lower.startswith("onbranch:"):
         return _git_onbranch_condition_matches(condition[len("onbranch:") :], repo_dir=repo_dir)
+    if condition_lower.startswith("hasconfig:"):
+        return _git_hasconfig_condition_matches(condition[len("hasconfig:") :], repo_dir=repo_dir)
     return False
 
 
@@ -6008,7 +6010,45 @@ def _git_onbranch_condition_matches(pattern: str, *, repo_dir: Path) -> bool:
     prefix = "ref: refs/heads/"
     if not head.startswith(prefix):
         return False
-    return fnmatch.fnmatchcase(head.removeprefix(prefix), pattern)
+    normalized_pattern = f"{pattern}**" if pattern.endswith("/") else pattern
+    return fnmatch.fnmatchcase(head.removeprefix(prefix), normalized_pattern)
+
+
+def _git_hasconfig_condition_matches(condition: str, *, repo_dir: Path) -> bool:
+    key_pattern, _, value_pattern = condition.partition(":")
+    if not key_pattern or not value_pattern:
+        return False
+    if key_pattern.lower() != "remote.*.url":
+        return False
+    for config_path in _git_repo_config_paths(repo_dir):
+        if not config_path.is_file():
+            continue
+        try:
+            config_text = config_path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            return False
+        if any(fnmatch.fnmatchcase(value, value_pattern) for value in _git_remote_urls_from_config(config_text)):
+            return True
+    return False
+
+
+def _git_remote_urls_from_config(config_text: str) -> tuple[str, ...]:
+    urls: list[str] = []
+    in_remote_section = False
+    for raw_line in config_text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith(("#", ";")):
+            continue
+        section_match = re.fullmatch(r"\[([^\]]+)\](?:\s*[#;].*)?", line)
+        if section_match:
+            in_remote_section = section_match.group(1).strip().lower().startswith("remote ")
+            continue
+        if not in_remote_section:
+            continue
+        key_match = re.match(r"(?i)^url\s*=\s*(.+)$", line)
+        if key_match is not None:
+            urls.append(_git_config_value_without_inline_comment(key_match.group(1)))
+    return tuple(urls)
 
 
 def _git_config_value_without_inline_comment(raw_value: str) -> str:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1,5 +1,7 @@
 """Guard CLI command handlers."""
 
+# fmt: off
+
 from __future__ import annotations
 
 import argparse
@@ -2323,7 +2325,6 @@ def run_guard_command(
             and policy_action not in {"block", "sandbox-required", "require-reapproval"}
         )
         if should_record_generic_hook_receipt:
-            # fmt: off
             receipt = build_receipt(
                 harness=args.harness,
                 artifact_id=artifact_id,
@@ -2343,7 +2344,6 @@ def run_guard_command(
                 user_override=_optional_string(payload.get("user_override")),
                 approval_source=("inline" if _optional_string(payload.get("user_override")) is not None else "policy"),
             )
-            # fmt: on
             store.add_receipt(receipt)
         if _should_emit_copilot_hook_response(args):
             _emit_copilot_hook_response(

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5891,7 +5891,7 @@ def _git_config_include_paths(config_text: str, *, base_dir: Path) -> tuple[Path
         line = raw_line.strip()
         if not line or line.startswith(("#", ";")):
             continue
-        section_match = re.fullmatch(r"\[([^\]]+)\]", line)
+        section_match = re.fullmatch(r"\[([^\]]+)\](?:\s*[#;].*)?", line)
         if section_match:
             section = section_match.group(1).strip().lower()
             continue

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5890,13 +5890,24 @@ def _git_config_tree_disables_diff_helpers(config_path: Path, *, seen_paths: set
         return False
     if _git_config_enables_diff_helper(config_text):
         return False
-    for included_path in _git_config_include_paths(config_text, base_dir=normalized_path.parent, repo_dir=repo_dir):
+    for included_path in _git_config_include_paths(
+        config_text,
+        allow_hasconfig=True,
+        base_dir=normalized_path.parent,
+        repo_dir=repo_dir,
+    ):
         if not _git_config_tree_disables_diff_helpers(included_path, seen_paths=seen_paths, repo_dir=repo_dir):
             return False
     return True
 
 
-def _git_config_include_paths(config_text: str, *, base_dir: Path, repo_dir: Path | None) -> tuple[Path, ...]:
+def _git_config_include_paths(
+    config_text: str,
+    *,
+    allow_hasconfig: bool,
+    base_dir: Path,
+    repo_dir: Path | None,
+) -> tuple[Path, ...]:
     paths: list[Path] = []
     section = ""
     section_active = False
@@ -5907,7 +5918,12 @@ def _git_config_include_paths(config_text: str, *, base_dir: Path, repo_dir: Pat
         section_match = re.fullmatch(r"\[([^\]]+)\](?:\s*[#;].*)?", line)
         if section_match:
             section = section_match.group(1).strip()
-            section_active = _git_include_section_is_active(section, base_dir=base_dir, repo_dir=repo_dir)
+            section_active = _git_include_section_is_active(
+                section,
+                allow_hasconfig=allow_hasconfig,
+                base_dir=base_dir,
+                repo_dir=repo_dir,
+            )
             continue
         if not section_active:
             continue
@@ -5921,7 +5937,13 @@ def _git_config_include_paths(config_text: str, *, base_dir: Path, repo_dir: Pat
     return tuple(paths)
 
 
-def _git_include_section_is_active(section: str, *, base_dir: Path, repo_dir: Path | None) -> bool:
+def _git_include_section_is_active(
+    section: str,
+    *,
+    allow_hasconfig: bool,
+    base_dir: Path,
+    repo_dir: Path | None,
+) -> bool:
     section_lower = section.lower()
     if section_lower == "include":
         return True
@@ -5948,7 +5970,7 @@ def _git_include_section_is_active(section: str, *, base_dir: Path, repo_dir: Pa
         )
     if condition_lower.startswith("onbranch:"):
         return _git_onbranch_condition_matches(condition[len("onbranch:") :], repo_dir=repo_dir)
-    if condition_lower.startswith("hasconfig:"):
+    if allow_hasconfig and condition_lower.startswith("hasconfig:"):
         return _git_hasconfig_condition_matches(condition[len("hasconfig:") :], repo_dir=repo_dir)
     return False
 
@@ -6020,16 +6042,36 @@ def _git_hasconfig_condition_matches(condition: str, *, repo_dir: Path) -> bool:
         return False
     if key_pattern.lower() != "remote.*.url":
         return False
+    seen_paths: set[Path] = set()
     for config_path in _git_repo_config_paths(repo_dir):
-        if not config_path.is_file():
-            continue
-        try:
-            config_text = config_path.read_text(encoding="utf-8", errors="ignore")
-        except OSError:
-            return False
-        if any(fnmatch.fnmatchcase(value, value_pattern) for value in _git_remote_urls_from_config(config_text)):
+        if any(
+            fnmatch.fnmatchcase(value, value_pattern)
+            for value in _git_remote_urls_from_config_tree(config_path, seen_paths=seen_paths, repo_dir=repo_dir)
+        ):
             return True
     return False
+
+
+def _git_remote_urls_from_config_tree(config_path: Path, *, seen_paths: set[Path], repo_dir: Path) -> tuple[str, ...]:
+    normalized_path = config_path.expanduser().resolve()
+    if normalized_path in seen_paths:
+        return ()
+    seen_paths.add(normalized_path)
+    if not normalized_path.is_file():
+        return ()
+    try:
+        config_text = normalized_path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return ()
+    urls = list(_git_remote_urls_from_config(config_text))
+    for included_path in _git_config_include_paths(
+        config_text,
+        allow_hasconfig=False,
+        base_dir=normalized_path.parent,
+        repo_dir=repo_dir,
+    ):
+        urls.extend(_git_remote_urls_from_config_tree(included_path, seen_paths=seen_paths, repo_dir=repo_dir))
+    return tuple(urls)
 
 
 def _git_remote_urls_from_config(config_text: str) -> tuple[str, ...]:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5900,11 +5900,37 @@ def _git_config_include_paths(config_text: str, *, base_dir: Path) -> tuple[Path
         key_match = re.match(r"(?i)^path\s*=\s*(.+)$", line)
         if key_match is None:
             continue
-        include_path = Path(key_match.group(1).strip().strip("'\"")).expanduser()
+        include_path = Path(_git_config_value_without_inline_comment(key_match.group(1))).expanduser()
         if not include_path.is_absolute():
             include_path = (base_dir / include_path).resolve()
         paths.append(include_path)
     return tuple(paths)
+
+
+def _git_config_value_without_inline_comment(raw_value: str) -> str:
+    value = raw_value.strip()
+    if not value:
+        return value
+    quote = value[0] if value[0] in {"'", '"'} else None
+    if quote is not None:
+        escaped = False
+        parsed: list[str] = []
+        for char in value[1:]:
+            if escaped:
+                parsed.append(char)
+                escaped = False
+                continue
+            if char == "\\":
+                escaped = True
+                continue
+            if char == quote:
+                return "".join(parsed)
+            parsed.append(char)
+        return "".join(parsed)
+    for index, char in enumerate(value):
+        if char in {"#", ";"} and (index == 0 or value[index - 1].isspace()):
+            return value[:index].strip()
+    return value
 
 
 def _git_config_enables_diff_helper(config_text: str) -> bool:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5832,7 +5832,7 @@ def _git_repo_config_paths(cwd: Path) -> tuple[Path, ...]:
 
 
 def _git_repo_root(cwd: Path) -> Path | None:
-    current = cwd.resolve()
+    current = cwd.absolute()
     if current.is_file():
         current = current.parent
     for candidate in (current, *current.parents):
@@ -5993,13 +5993,24 @@ def _git_include_section_is_active(
 def _git_gitdir_condition_matches(pattern: str, *, base_dir: Path, repo_dir: Path, case_sensitive: bool) -> bool:
     pattern_text = _git_gitdir_condition_pattern(pattern, base_dir=base_dir)
     patterns = _git_gitdir_condition_patterns(pattern_text)
-    candidates = [repo_dir.as_posix().rstrip("/") + "/"]
+    candidates = [_git_gitdir_condition_candidate(path) for path in _git_path_aliases(repo_dir)]
     git_dir = _git_effective_git_dir(repo_dir)
     if git_dir is not None:
-        candidates.append(git_dir.as_posix().rstrip("/") + "/")
+        candidates.extend(_git_gitdir_condition_candidate(path) for path in _git_path_aliases(git_dir))
     if case_sensitive:
         return any(fnmatch.fnmatchcase(candidate, item) for candidate in candidates for item in patterns)
     return any(fnmatch.fnmatchcase(candidate.lower(), item.lower()) for candidate in candidates for item in patterns)
+
+
+def _git_path_aliases(path: Path) -> tuple[Path, ...]:
+    resolved = path.resolve()
+    if resolved == path:
+        return (path,)
+    return (path, resolved)
+
+
+def _git_gitdir_condition_candidate(path: Path) -> str:
+    return path.as_posix().rstrip("/") + "/"
 
 
 def _git_gitdir_condition_patterns(pattern_text: str) -> tuple[str, ...]:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -17,7 +17,7 @@ import urllib.parse
 import webbrowser
 from collections.abc import Mapping
 from contextlib import suppress
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TextIO
@@ -5142,6 +5142,82 @@ _CODEX_SENSITIVE_SEARCH_BASENAMES = frozenset(
     }
 )
 _CODEX_SED_PRINT_SCRIPT_PATTERN = re.compile(r"^\s*(?:\$|\d+)?(?:\s*,\s*(?:\$|\d+))?p\s*$")
+_CODEX_GIT_DIFF_VALUE_OPTIONS = frozenset(
+    {
+        "--color",
+        "--color-moved",
+        "--diff-filter",
+        "--find-renames",
+        "--find-copies",
+        "--ignore-submodules",
+        "--inter-hunk-context",
+        "--line-prefix",
+        "--output-indicator-context",
+        "--output-indicator-new",
+        "--output-indicator-old",
+        "--src-prefix",
+        "--dst-prefix",
+        "--stat-width",
+        "--stat-name-width",
+        "--stat-graph-width",
+        "--unified",
+        "-G",
+        "-S",
+        "-U",
+        "--word-diff",
+        "--word-diff-regex",
+    }
+)
+_CODEX_GIT_DIFF_BOOLEAN_OPTIONS = frozenset(
+    {
+        "--binary",
+        "--cached",
+        "--check",
+        "--compact-summary",
+        "--exit-code",
+        "--find-copies-harder",
+        "--full-index",
+        "--ignore-all-space",
+        "--ignore-blank-lines",
+        "--ignore-cr-at-eol",
+        "--ignore-space-at-eol",
+        "--ignore-space-change",
+        "--minimal",
+        "--name-only",
+        "--name-status",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--numstat",
+        "--patch",
+        "--patch-with-raw",
+        "--pickaxe-all",
+        "--pickaxe-regex",
+        "--raw",
+        "--relative",
+        "--shortstat",
+        "--stat",
+        "--submodule",
+        "--summary",
+    }
+)
+_CODEX_GIT_DIFF_DISALLOWED_OPTIONS = frozenset({"--ext-diff", "--no-index", "--output", "--textconv"})
+_CODEX_SAFE_GIT_GLOBAL_BOOLEAN_FLAGS = frozenset(
+    {
+        "--bare",
+        "--glob-pathspecs",
+        "--literal-pathspecs",
+        "--no-literal-pathspecs",
+        "--no-pager",
+        "--noglob-pathspecs",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _CodexSedReadOnlyArgs:
+    scripts: tuple[str, ...]
+    targets: tuple[str, ...]
+    saw_print_suppression: bool
 
 
 def _codex_source_inspection_can_skip_secret_output(
@@ -5522,6 +5598,29 @@ def _parse_codex_head_tail_args(args: list[str]) -> tuple[list[str], bool, bool]
 
 
 def _codex_sed_targets_are_read_only_source_like(args: list[str], *, cwd: Path | None) -> bool:
+    parsed = _parse_codex_sed_read_only_args(args)
+    if parsed is None:
+        return False
+    return (
+        bool(parsed.targets)
+        and parsed.saw_print_suppression
+        and all(_CODEX_SED_PRINT_SCRIPT_PATTERN.fullmatch(script.strip()) for script in parsed.scripts)
+        and all(_codex_search_target_is_source_like(target, cwd=cwd) for target in parsed.targets)
+    )
+
+
+def _codex_sed_args_are_bounded_filter(args: list[str]) -> bool:
+    parsed = _parse_codex_sed_read_only_args(args)
+    if parsed is None:
+        return False
+    return (
+        not parsed.targets
+        and parsed.saw_print_suppression
+        and all(_CODEX_SED_PRINT_SCRIPT_PATTERN.fullmatch(script.strip()) for script in parsed.scripts)
+    )
+
+
+def _parse_codex_sed_read_only_args(args: list[str]) -> _CodexSedReadOnlyArgs | None:
     scripts: list[str] = []
     targets: list[str] = []
     skip_next_script = False
@@ -5559,56 +5658,12 @@ def _codex_sed_targets_are_read_only_source_like(args: list[str], *, cwd: Path |
             scripts.append(arg)
             continue
         targets.append(arg)
-    if skip_next_script or not scripts or not targets:
-        return False
-    if not saw_print_suppression:
-        return False
-    if not all(_CODEX_SED_PRINT_SCRIPT_PATTERN.fullmatch(script.strip()) for script in scripts):
-        return False
-    return all(_codex_search_target_is_source_like(target, cwd=cwd) for target in targets)
-
-
-def _codex_sed_args_are_bounded_filter(args: list[str]) -> bool:
-    scripts: list[str] = []
-    skip_next_script = False
-    after_option_terminator = False
-    saw_print_suppression = False
-    for arg in args:
-        if skip_next_script:
-            skip_next_script = False
-            scripts.append(arg)
-            continue
-        if after_option_terminator:
-            return False
-        if arg == "--":
-            after_option_terminator = True
-            continue
-        if arg in {"-i", "--in-place"} or arg.startswith(("-i", "--in-place=")):
-            return False
-        if arg == "-n" or arg == "--quiet" or arg == "--silent":
-            saw_print_suppression = True
-            continue
-        if arg == "-e" or arg == "--expression":
-            skip_next_script = True
-            continue
-        if arg.startswith("-e") and len(arg) > 2:
-            scripts.append(arg[2:])
-            continue
-        if arg.startswith("--expression="):
-            _, script = arg.split("=", 1)
-            scripts.append(script)
-            continue
-        if arg.startswith("-"):
-            return False
-        if not scripts:
-            scripts.append(arg)
-            continue
-        return False
-    return (
-        not skip_next_script
-        and saw_print_suppression
-        and bool(scripts)
-        and all(_CODEX_SED_PRINT_SCRIPT_PATTERN.fullmatch(script.strip()) for script in scripts)
+    if skip_next_script or not scripts:
+        return None
+    return _CodexSedReadOnlyArgs(
+        scripts=tuple(scripts),
+        targets=tuple(targets),
+        saw_print_suppression=saw_print_suppression,
     )
 
 
@@ -5629,14 +5684,7 @@ def _git_grep_search_args(args: list[str]) -> list[str] | None:
         if any(arg.startswith(f"{flag}=") for flag in _CODEX_GIT_GLOBAL_VALUE_FLAGS):
             index += 1
             continue
-        if arg in {
-            "--no-pager",
-            "--bare",
-            "--literal-pathspecs",
-            "--no-literal-pathspecs",
-            "--glob-pathspecs",
-            "--noglob-pathspecs",
-        }:
+        if arg in _CODEX_SAFE_GIT_GLOBAL_BOOLEAN_FLAGS:
             index += 1
             continue
         return None
@@ -5648,7 +5696,11 @@ def _codex_git_diff_targets_are_source_like(args: list[str], *, cwd: Path | None
     if diff_args is None:
         return False
     targets = _git_diff_path_args(diff_args)
-    return bool(targets) and all(_codex_search_target_is_source_like(target, cwd=cwd) for target in targets)
+    return (
+        bool(targets)
+        and all(_codex_search_target_is_source_like(target, cwd=cwd) for target in targets)
+        and _git_diff_external_helpers_are_disabled_or_unconfigured(diff_args, cwd=cwd)
+    )
 
 
 def _git_diff_args(args: list[str]) -> list[str] | None:
@@ -5657,13 +5709,7 @@ def _git_diff_args(args: list[str]) -> list[str] | None:
         arg = args[index]
         if arg == "diff":
             return args[index + 1 :]
-        if arg in _CODEX_GIT_GLOBAL_VALUE_FLAGS:
-            index += 2
-            continue
-        if any(arg.startswith(f"{flag}=") for flag in _CODEX_GIT_GLOBAL_VALUE_FLAGS):
-            index += 1
-            continue
-        if arg in {"--no-pager", "--literal-pathspecs", "--no-literal-pathspecs"}:
+        if arg in _CODEX_SAFE_GIT_GLOBAL_BOOLEAN_FLAGS:
             index += 1
             continue
         return None
@@ -5674,64 +5720,6 @@ def _git_diff_path_args(args: list[str]) -> list[str]:
     paths: list[str] = []
     index = 0
     after_path_separator = False
-    value_options = {
-        "--color",
-        "--color-moved",
-        "--diff-filter",
-        "--find-renames",
-        "--find-copies",
-        "--ignore-submodules",
-        "--inter-hunk-context",
-        "--line-prefix",
-        "--output-indicator-context",
-        "--output-indicator-new",
-        "--output-indicator-old",
-        "--src-prefix",
-        "--dst-prefix",
-        "--stat-width",
-        "--stat-name-width",
-        "--stat-graph-width",
-        "--unified",
-        "-G",
-        "-S",
-        "-U",
-        "--word-diff",
-        "--word-diff-regex",
-    }
-    boolean_options = {
-        "--binary",
-        "--cached",
-        "--check",
-        "--compact-summary",
-        "--exit-code",
-        "--find-copies-harder",
-        "--full-index",
-        "--ignore-all-space",
-        "--ignore-blank-lines",
-        "--ignore-cr-at-eol",
-        "--ignore-space-at-eol",
-        "--ignore-space-change",
-        "--minimal",
-        "--name-only",
-        "--name-status",
-        "--numstat",
-        "--patch",
-        "--patch-with-raw",
-        "--pickaxe-all",
-        "--pickaxe-regex",
-        "--raw",
-        "--relative",
-        "--shortstat",
-        "--stat",
-        "--submodule",
-        "--summary",
-    }
-    disallowed_options = {
-        "--ext-diff",
-        "--no-index",
-        "--textconv",
-        "--output",
-    }
     while index < len(args):
         arg = args[index]
         if after_path_separator:
@@ -5742,15 +5730,17 @@ def _git_diff_path_args(args: list[str]) -> list[str]:
             after_path_separator = True
             index += 1
             continue
-        if arg in disallowed_options or any(arg.startswith(f"{option}=") for option in disallowed_options):
+        if arg in _CODEX_GIT_DIFF_DISALLOWED_OPTIONS or any(
+            arg.startswith(f"{option}=") for option in _CODEX_GIT_DIFF_DISALLOWED_OPTIONS
+        ):
             return []
-        if arg in value_options:
+        if arg in _CODEX_GIT_DIFF_VALUE_OPTIONS:
             index += 2
             continue
-        if any(arg.startswith(f"{option}=") for option in value_options):
+        if any(arg.startswith(f"{option}=") for option in _CODEX_GIT_DIFF_VALUE_OPTIONS):
             index += 1
             continue
-        if arg in boolean_options:
+        if arg in _CODEX_GIT_DIFF_BOOLEAN_OPTIONS:
             index += 1
             continue
         if re.fullmatch(r"-U\d{1,6}", arg):
@@ -5760,11 +5750,89 @@ def _git_diff_path_args(args: list[str]) -> list[str]:
             index += 1
             continue
         if arg.startswith("-"):
-            index += 1
-            continue
+            return []
         paths.append(arg)
         index += 1
     return paths
+
+
+def _git_diff_external_helpers_are_disabled_or_unconfigured(args: list[str], *, cwd: Path | None) -> bool:
+    has_no_ext_diff = "--no-ext-diff" in args
+    has_no_textconv = "--no-textconv" in args
+    if has_no_ext_diff and has_no_textconv:
+        return True
+    return _git_repo_diff_helpers_are_unconfigured(cwd)
+
+
+def _git_repo_diff_helpers_are_unconfigured(cwd: Path | None) -> bool:
+    if cwd is None:
+        return False
+    config_paths = _git_repo_config_paths(cwd)
+    if not config_paths:
+        return True
+    for config_path in config_paths:
+        if not config_path.is_file():
+            continue
+        try:
+            config_text = config_path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            return False
+        if _git_config_enables_diff_helper(config_text):
+            return False
+    return True
+
+
+def _git_repo_config_paths(cwd: Path) -> tuple[Path, ...]:
+    current = cwd.resolve()
+    if current.is_file():
+        current = current.parent
+    for candidate in (current, *current.parents):
+        git_path = candidate / ".git"
+        if git_path.is_dir():
+            return (git_path / "config", git_path / "config.worktree")
+        if git_path.is_file():
+            git_dir = _git_dir_from_file(git_path)
+            if git_dir is None:
+                return ()
+            common_dir = _git_common_dir(git_dir)
+            paths = [git_dir / "config", git_dir / "config.worktree"]
+            if common_dir != git_dir:
+                paths.extend([common_dir / "config", common_dir / "config.worktree"])
+            return tuple(paths)
+    return ()
+
+
+def _git_dir_from_file(git_file: Path) -> Path | None:
+    try:
+        content = git_file.read_text(encoding="utf-8", errors="ignore").strip()
+    except OSError:
+        return None
+    prefix = "gitdir:"
+    if not content.lower().startswith(prefix):
+        return None
+    raw_path = content[len(prefix) :].strip()
+    git_dir = Path(raw_path)
+    if not git_dir.is_absolute():
+        git_dir = (git_file.parent / git_dir).resolve()
+    return git_dir
+
+
+def _git_common_dir(git_dir: Path) -> Path:
+    common_dir_file = git_dir / "commondir"
+    if not common_dir_file.is_file():
+        return git_dir
+    try:
+        raw_path = common_dir_file.read_text(encoding="utf-8", errors="ignore").strip()
+    except OSError:
+        return git_dir
+    common_dir = Path(raw_path)
+    if not common_dir.is_absolute():
+        common_dir = (git_dir / common_dir).resolve()
+    return common_dir
+
+
+def _git_config_enables_diff_helper(config_text: str) -> bool:
+    return bool(re.search(r"(?im)^\s*(?:external|textconv)\s*=", config_text))
 
 
 def _git_grep_uses_external_execution(args: list[str]) -> bool:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5144,12 +5144,7 @@ _CODEX_SENSITIVE_SEARCH_BASENAMES = frozenset(
 _CODEX_SED_PRINT_SCRIPT_PATTERN = re.compile(r"^\s*(?:\$|\d+)?(?:\s*,\s*(?:\$|\d+))?p\s*$")
 _CODEX_GIT_DIFF_VALUE_OPTIONS = frozenset(
     {
-        "--color",
-        "--color-moved",
         "--diff-filter",
-        "--find-renames",
-        "--find-copies",
-        "--ignore-submodules",
         "--inter-hunk-context",
         "--line-prefix",
         "--output-indicator-context",
@@ -5164,8 +5159,18 @@ _CODEX_GIT_DIFF_VALUE_OPTIONS = frozenset(
         "-G",
         "-S",
         "-U",
-        "--word-diff",
         "--word-diff-regex",
+    }
+)
+_CODEX_GIT_DIFF_OPTIONAL_VALUE_OPTIONS = frozenset(
+    {
+        "--color",
+        "--color-moved",
+        "--find-copies",
+        "--find-renames",
+        "--ignore-submodules",
+        "--submodule",
+        "--word-diff",
     }
 )
 _CODEX_GIT_DIFF_BOOLEAN_OPTIONS = frozenset(
@@ -5196,7 +5201,6 @@ _CODEX_GIT_DIFF_BOOLEAN_OPTIONS = frozenset(
         "--relative",
         "--shortstat",
         "--stat",
-        "--submodule",
         "--summary",
     }
 )
@@ -5734,7 +5738,15 @@ def _git_diff_path_args(args: list[str]) -> list[str]:
             arg.startswith(f"{option}=") for option in _CODEX_GIT_DIFF_DISALLOWED_OPTIONS
         ):
             return []
+        if arg in _CODEX_GIT_DIFF_OPTIONAL_VALUE_OPTIONS:
+            index += 1
+            continue
+        if any(arg.startswith(f"{option}=") for option in _CODEX_GIT_DIFF_OPTIONAL_VALUE_OPTIONS):
+            index += 1
+            continue
         if arg in _CODEX_GIT_DIFF_VALUE_OPTIONS:
+            if index + 1 >= len(args) or args[index + 1].startswith("-"):
+                return []
             index += 2
             continue
         if any(arg.startswith(f"{option}=") for option in _CODEX_GIT_DIFF_VALUE_OPTIONS):

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import hashlib
 import json
 import os
@@ -5787,9 +5788,10 @@ def _git_repo_diff_helpers_are_unconfigured(cwd: Path | None) -> bool:
     config_paths = _git_repo_config_paths(cwd)
     if not config_paths:
         return True
+    repo_dir = _git_repo_root(cwd)
     seen_paths: set[Path] = set()
     for config_path in config_paths:
-        if not _git_config_tree_disables_diff_helpers(config_path, seen_paths=seen_paths):
+        if not _git_config_tree_disables_diff_helpers(config_path, seen_paths=seen_paths, repo_dir=repo_dir):
             return False
     return True
 
@@ -5812,6 +5814,16 @@ def _git_repo_config_paths(cwd: Path) -> tuple[Path, ...]:
                 paths.extend([common_dir / "config", common_dir / "config.worktree"])
             return tuple(paths)
     return _git_global_config_paths()
+
+
+def _git_repo_root(cwd: Path) -> Path | None:
+    current = cwd.resolve()
+    if current.is_file():
+        current = current.parent
+    for candidate in (current, *current.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return None
 
 
 def _git_global_config_paths() -> tuple[Path, ...]:
@@ -5865,7 +5877,7 @@ def _git_common_dir(git_dir: Path) -> Path:
     return common_dir
 
 
-def _git_config_tree_disables_diff_helpers(config_path: Path, *, seen_paths: set[Path]) -> bool:
+def _git_config_tree_disables_diff_helpers(config_path: Path, *, seen_paths: set[Path], repo_dir: Path | None) -> bool:
     normalized_path = config_path.expanduser().resolve()
     if normalized_path in seen_paths:
         return True
@@ -5878,15 +5890,16 @@ def _git_config_tree_disables_diff_helpers(config_path: Path, *, seen_paths: set
         return False
     if _git_config_enables_diff_helper(config_text):
         return False
-    for included_path in _git_config_include_paths(config_text, base_dir=normalized_path.parent):
-        if not _git_config_tree_disables_diff_helpers(included_path, seen_paths=seen_paths):
+    for included_path in _git_config_include_paths(config_text, base_dir=normalized_path.parent, repo_dir=repo_dir):
+        if not _git_config_tree_disables_diff_helpers(included_path, seen_paths=seen_paths, repo_dir=repo_dir):
             return False
     return True
 
 
-def _git_config_include_paths(config_text: str, *, base_dir: Path) -> tuple[Path, ...]:
+def _git_config_include_paths(config_text: str, *, base_dir: Path, repo_dir: Path | None) -> tuple[Path, ...]:
     paths: list[Path] = []
     section = ""
+    section_active = False
     for raw_line in config_text.splitlines():
         line = raw_line.strip()
         if not line or line.startswith(("#", ";")):
@@ -5894,8 +5907,9 @@ def _git_config_include_paths(config_text: str, *, base_dir: Path) -> tuple[Path
         section_match = re.fullmatch(r"\[([^\]]+)\](?:\s*[#;].*)?", line)
         if section_match:
             section = section_match.group(1).strip().lower()
+            section_active = _git_include_section_is_active(section, repo_dir=repo_dir)
             continue
-        if not section.startswith("include"):
+        if not section_active:
             continue
         key_match = re.match(r"(?i)^path\s*=\s*(.+)$", line)
         if key_match is None:
@@ -5905,6 +5919,66 @@ def _git_config_include_paths(config_text: str, *, base_dir: Path) -> tuple[Path
             include_path = (base_dir / include_path).resolve()
         paths.append(include_path)
     return tuple(paths)
+
+
+def _git_include_section_is_active(section: str, *, repo_dir: Path | None) -> bool:
+    if section == "include":
+        return True
+    if not section.startswith("includeif"):
+        return False
+    if repo_dir is None:
+        return False
+    condition_match = re.search(r'"([^"]+)"', section)
+    condition = condition_match.group(1) if condition_match else section.removeprefix("includeif").strip()
+    if condition.startswith("gitdir/i:"):
+        return _git_gitdir_condition_matches(
+            condition.removeprefix("gitdir/i:"),
+            repo_dir=repo_dir,
+            case_sensitive=False,
+        )
+    if condition.startswith("gitdir:"):
+        return _git_gitdir_condition_matches(condition.removeprefix("gitdir:"), repo_dir=repo_dir, case_sensitive=True)
+    if condition.startswith("onbranch:"):
+        return _git_onbranch_condition_matches(condition.removeprefix("onbranch:"), repo_dir=repo_dir)
+    return False
+
+
+def _git_gitdir_condition_matches(pattern: str, *, repo_dir: Path, case_sensitive: bool) -> bool:
+    normalized_pattern = str(Path(pattern).expanduser())
+    if not Path(normalized_pattern).is_absolute():
+        return False
+    repo_text = repo_dir.as_posix().rstrip("/") + "/"
+    pattern_text = Path(normalized_pattern).as_posix()
+    if pattern_text.endswith("/"):
+        pattern_text = f"{pattern_text}**"
+    elif pattern_text.endswith("/**"):
+        pass
+    else:
+        pattern_text = pattern_text.rstrip("/") + "/**"
+    if case_sensitive:
+        return fnmatch.fnmatchcase(repo_text, pattern_text)
+    return fnmatch.fnmatchcase(repo_text.lower(), pattern_text.lower())
+
+
+def _git_onbranch_condition_matches(pattern: str, *, repo_dir: Path) -> bool:
+    git_dir = repo_dir / ".git"
+    head_path: Path | None = None
+    if git_dir.is_dir():
+        head_path = git_dir / "HEAD"
+    elif git_dir.is_file():
+        parsed_git_dir = _git_dir_from_file(git_dir)
+        if parsed_git_dir is not None:
+            head_path = parsed_git_dir / "HEAD"
+    if head_path is None or not head_path.is_file():
+        return False
+    try:
+        head = head_path.read_text(encoding="utf-8", errors="ignore").strip()
+    except OSError:
+        return False
+    prefix = "ref: refs/heads/"
+    if not head.startswith(prefix):
+        return False
+    return fnmatch.fnmatchcase(head.removeprefix(prefix), pattern)
 
 
 def _git_config_value_without_inline_comment(raw_value: str) -> str:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2342,11 +2342,7 @@ def run_guard_command(
                 artifact_name=artifact_name,
                 source_scope=_coalesce_string(payload.get("source_scope"), "project"),
                 user_override=_optional_string(payload.get("user_override")),
-                approval_source=(
-                    "inline"
-                    if _optional_string(payload.get("user_override")) is not None
-                    else "policy"
-                ),
+                approval_source=("inline" if _optional_string(payload.get("user_override")) is not None else "policy"),
             )
             store.add_receipt(receipt)
         if _should_emit_copilot_hook_response(args):

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5767,17 +5767,14 @@ def _git_diff_external_helpers_are_disabled_or_unconfigured(args: list[str], *, 
 def _git_repo_diff_helpers_are_unconfigured(cwd: Path | None) -> bool:
     if cwd is None:
         return False
+    if os.environ.get("GIT_EXTERNAL_DIFF") or os.environ.get("GIT_CONFIG_COUNT"):
+        return False
     config_paths = _git_repo_config_paths(cwd)
     if not config_paths:
         return True
+    seen_paths: set[Path] = set()
     for config_path in config_paths:
-        if not config_path.is_file():
-            continue
-        try:
-            config_text = config_path.read_text(encoding="utf-8", errors="ignore")
-        except OSError:
-            return False
-        if _git_config_enables_diff_helper(config_text):
+        if not _git_config_tree_disables_diff_helpers(config_path, seen_paths=seen_paths):
             return False
     return True
 
@@ -5789,17 +5786,39 @@ def _git_repo_config_paths(cwd: Path) -> tuple[Path, ...]:
     for candidate in (current, *current.parents):
         git_path = candidate / ".git"
         if git_path.is_dir():
-            return (git_path / "config", git_path / "config.worktree")
+            return (*_git_global_config_paths(), git_path / "config", git_path / "config.worktree")
         if git_path.is_file():
             git_dir = _git_dir_from_file(git_path)
             if git_dir is None:
                 return ()
             common_dir = _git_common_dir(git_dir)
-            paths = [git_dir / "config", git_dir / "config.worktree"]
+            paths = [*_git_global_config_paths(), git_dir / "config", git_dir / "config.worktree"]
             if common_dir != git_dir:
                 paths.extend([common_dir / "config", common_dir / "config.worktree"])
             return tuple(paths)
-    return ()
+    return _git_global_config_paths()
+
+
+def _git_global_config_paths() -> tuple[Path, ...]:
+    paths: list[Path] = []
+    system_config = os.environ.get("GIT_CONFIG_SYSTEM")
+    if system_config:
+        if system_config != os.devnull:
+            paths.append(Path(system_config).expanduser())
+    elif not os.environ.get("GIT_CONFIG_NOSYSTEM"):
+        paths.append(Path("/etc/gitconfig"))
+    global_config = os.environ.get("GIT_CONFIG_GLOBAL")
+    if global_config:
+        if global_config != os.devnull:
+            paths.append(Path(global_config).expanduser())
+    else:
+        home = os.environ.get("HOME")
+        if home:
+            home_path = Path(home).expanduser()
+            paths.append(home_path / ".gitconfig")
+            xdg_config_home = Path(os.environ.get("XDG_CONFIG_HOME", str(home_path / ".config"))).expanduser()
+            paths.append(xdg_config_home / "git" / "config")
+    return tuple(paths)
 
 
 def _git_dir_from_file(git_file: Path) -> Path | None:
@@ -5829,6 +5848,48 @@ def _git_common_dir(git_dir: Path) -> Path:
     if not common_dir.is_absolute():
         common_dir = (git_dir / common_dir).resolve()
     return common_dir
+
+
+def _git_config_tree_disables_diff_helpers(config_path: Path, *, seen_paths: set[Path]) -> bool:
+    normalized_path = config_path.expanduser().resolve()
+    if normalized_path in seen_paths:
+        return True
+    seen_paths.add(normalized_path)
+    if not normalized_path.is_file():
+        return True
+    try:
+        config_text = normalized_path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+    if _git_config_enables_diff_helper(config_text):
+        return False
+    for included_path in _git_config_include_paths(config_text, base_dir=normalized_path.parent):
+        if not _git_config_tree_disables_diff_helpers(included_path, seen_paths=seen_paths):
+            return False
+    return True
+
+
+def _git_config_include_paths(config_text: str, *, base_dir: Path) -> tuple[Path, ...]:
+    paths: list[Path] = []
+    section = ""
+    for raw_line in config_text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith(("#", ";")):
+            continue
+        section_match = re.fullmatch(r"\[([^\]]+)\]", line)
+        if section_match:
+            section = section_match.group(1).strip().lower()
+            continue
+        if not section.startswith("include"):
+            continue
+        key_match = re.match(r"(?i)^path\s*=\s*(.+)$", line)
+        if key_match is None:
+            continue
+        include_path = Path(key_match.group(1).strip().strip("'\"")).expanduser()
+        if not include_path.is_absolute():
+            include_path = (base_dir / include_path).resolve()
+        paths.append(include_path)
+    return tuple(paths)
 
 
 def _git_config_enables_diff_helper(config_text: str) -> bool:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5763,8 +5763,7 @@ def _git_diff_path_args(args: list[str]) -> list[str]:
             continue
         if arg.startswith("-"):
             return []
-        paths.append(arg)
-        index += 1
+        return []
     return paths
 
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1936,6 +1936,7 @@ def run_guard_command(
                         artifact_name=artifact_name,
                         source_scope=runtime_artifact.source_scope,
                         user_override="claude-native-approve",
+                        approval_source="inline",
                     )
                     store.add_receipt(receipt)
                 return 0
@@ -2007,6 +2008,13 @@ def run_guard_command(
                 source_scope=runtime_artifact.source_scope,
                 user_override=_optional_string(payload.get("user_override")),
                 scanner_evidence=scanner_evidence_payload,
+                approval_source=(
+                    "inline"
+                    if _optional_string(payload.get("user_override")) is not None
+                    else "approval_center"
+                    if policy_action == "require-reapproval"
+                    else "policy"
+                ),
             )
             store.add_receipt(receipt)
             response_payload = {
@@ -2332,6 +2340,11 @@ def run_guard_command(
                 artifact_name=artifact_name,
                 source_scope=_coalesce_string(payload.get("source_scope"), "project"),
                 user_override=_optional_string(payload.get("user_override")),
+                approval_source=(
+                    "inline"
+                    if _optional_string(payload.get("user_override")) is not None
+                    else "policy"
+                ),
             )
             store.add_receipt(receipt)
         if _should_emit_copilot_hook_response(args):

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5893,7 +5893,7 @@ def _git_config_include_paths(config_text: str, *, base_dir: Path) -> tuple[Path
 
 
 def _git_config_enables_diff_helper(config_text: str) -> bool:
-    return bool(re.search(r"(?im)^\s*(?:external|textconv)\s*=", config_text))
+    return bool(re.search(r"(?im)^\s*(?:command|external|textconv)\s*=", config_text))
 
 
 def _git_grep_uses_external_execution(args: list[str]) -> bool:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5779,7 +5779,7 @@ def _git_diff_external_helpers_are_disabled_or_unconfigured(args: list[str], *, 
 def _git_repo_diff_helpers_are_unconfigured(cwd: Path | None) -> bool:
     if cwd is None:
         return False
-    if os.environ.get("GIT_EXTERNAL_DIFF") or os.environ.get("GIT_CONFIG_COUNT"):
+    if os.environ.get("GIT_EXTERNAL_DIFF") or os.environ.get("GIT_CONFIG_COUNT") or os.environ.get("GIT_CONFIG_PARAMETERS"):
         return False
     config_paths = _git_repo_config_paths(cwd)
     if not config_paths:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5642,7 +5642,7 @@ def _parse_codex_sed_read_only_args(args: list[str]) -> _CodexSedReadOnlyArgs | 
             after_option_terminator = True
             continue
         if arg in {"-i", "--in-place"} or arg.startswith(("-i", "--in-place=")):
-            return False
+            return None
         if arg == "-n" or arg == "--quiet" or arg == "--silent":
             saw_print_suppression = True
             continue
@@ -5657,7 +5657,7 @@ def _parse_codex_sed_read_only_args(args: list[str]) -> _CodexSedReadOnlyArgs | 
             scripts.append(script)
             continue
         if arg.startswith("-"):
-            return False
+            return None
         if not scripts:
             scripts.append(arg)
             continue

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2342,7 +2342,11 @@ def run_guard_command(
                 artifact_name=artifact_name,
                 source_scope=_coalesce_string(payload.get("source_scope"), "project"),
                 user_override=_optional_string(payload.get("user_override")),
-                approval_source=("inline" if _optional_string(payload.get("user_override")) is not None else "policy"),
+                approval_source=(
+                    "inline"
+                    if _optional_string(payload.get("user_override")) is not None
+                    else "policy"
+                ),
             )
             store.add_receipt(receipt)
         if _should_emit_copilot_hook_response(args):

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5048,7 +5048,7 @@ def _codex_post_tool_command_text(payload: dict[str, object]) -> str:
 
 _CODEX_READ_ONLY_SEARCH_COMMANDS = frozenset({"rg", "grep", "egrep", "fgrep"})
 _CODEX_READ_ONLY_VIEW_COMMANDS = frozenset({"cat", "head", "tail", "sed"})
-_CODEX_READ_ONLY_PIPE_FILTERS = frozenset({"head", "tail"})
+_CODEX_READ_ONLY_PIPE_FILTERS = frozenset({"head", "tail", "sed"})
 _CODEX_READ_ONLY_SEARCH_WRAPPERS = frozenset({"bash", "sh", "zsh"})
 _CODEX_SEARCH_PATTERN_VALUE_FLAGS = frozenset({"-e", "--regexp", "-f", "--file"})
 _CODEX_SEARCH_OPTION_VALUE_FLAGS = frozenset(
@@ -5391,6 +5391,8 @@ def _codex_command_is_bounded_read_only_filter(command_text: str) -> bool:
     executable = Path(parts[0]).name
     if executable not in _CODEX_READ_ONLY_PIPE_FILTERS:
         return False
+    if executable == "sed":
+        return _codex_sed_args_are_bounded_filter(parts[1:])
     return _codex_head_tail_args_are_bounded_filter(parts[1:])
 
 
@@ -5410,7 +5412,7 @@ def _codex_command_is_read_only_source_view(command_text: str, *, cwd: Path | No
         return False
     executable = Path(parts[0]).name
     if executable not in _CODEX_READ_ONLY_VIEW_COMMANDS:
-        return False
+        return executable == "git" and _codex_git_diff_targets_are_source_like(parts[1:], cwd=cwd)
     if executable == "sed":
         return _codex_sed_targets_are_read_only_source_like(parts[1:], cwd=cwd)
     if executable in {"head", "tail"}:
@@ -5566,6 +5568,50 @@ def _codex_sed_targets_are_read_only_source_like(args: list[str], *, cwd: Path |
     return all(_codex_search_target_is_source_like(target, cwd=cwd) for target in targets)
 
 
+def _codex_sed_args_are_bounded_filter(args: list[str]) -> bool:
+    scripts: list[str] = []
+    skip_next_script = False
+    after_option_terminator = False
+    saw_print_suppression = False
+    for arg in args:
+        if skip_next_script:
+            skip_next_script = False
+            scripts.append(arg)
+            continue
+        if after_option_terminator:
+            return False
+        if arg == "--":
+            after_option_terminator = True
+            continue
+        if arg in {"-i", "--in-place"} or arg.startswith(("-i", "--in-place=")):
+            return False
+        if arg == "-n" or arg == "--quiet" or arg == "--silent":
+            saw_print_suppression = True
+            continue
+        if arg == "-e" or arg == "--expression":
+            skip_next_script = True
+            continue
+        if arg.startswith("-e") and len(arg) > 2:
+            scripts.append(arg[2:])
+            continue
+        if arg.startswith("--expression="):
+            _, script = arg.split("=", 1)
+            scripts.append(script)
+            continue
+        if arg.startswith("-"):
+            return False
+        if not scripts:
+            scripts.append(arg)
+            continue
+        return False
+    return (
+        not skip_next_script
+        and saw_print_suppression
+        and bool(scripts)
+        and all(_CODEX_SED_PRINT_SCRIPT_PATTERN.fullmatch(script.strip()) for script in scripts)
+    )
+
+
 def _codex_count_arg_is_bounded(value: str) -> bool:
     normalized = value.strip()
     return bool(re.fullmatch(r"\d{1,6}", normalized))
@@ -5595,6 +5641,130 @@ def _git_grep_search_args(args: list[str]) -> list[str] | None:
             continue
         return None
     return None
+
+
+def _codex_git_diff_targets_are_source_like(args: list[str], *, cwd: Path | None) -> bool:
+    diff_args = _git_diff_args(args)
+    if diff_args is None:
+        return False
+    targets = _git_diff_path_args(diff_args)
+    return bool(targets) and all(_codex_search_target_is_source_like(target, cwd=cwd) for target in targets)
+
+
+def _git_diff_args(args: list[str]) -> list[str] | None:
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "diff":
+            return args[index + 1 :]
+        if arg in _CODEX_GIT_GLOBAL_VALUE_FLAGS:
+            index += 2
+            continue
+        if any(arg.startswith(f"{flag}=") for flag in _CODEX_GIT_GLOBAL_VALUE_FLAGS):
+            index += 1
+            continue
+        if arg in {"--no-pager", "--literal-pathspecs", "--no-literal-pathspecs"}:
+            index += 1
+            continue
+        return None
+    return None
+
+
+def _git_diff_path_args(args: list[str]) -> list[str]:
+    paths: list[str] = []
+    index = 0
+    after_path_separator = False
+    value_options = {
+        "--color",
+        "--color-moved",
+        "--diff-filter",
+        "--find-renames",
+        "--find-copies",
+        "--ignore-submodules",
+        "--inter-hunk-context",
+        "--line-prefix",
+        "--output-indicator-context",
+        "--output-indicator-new",
+        "--output-indicator-old",
+        "--src-prefix",
+        "--dst-prefix",
+        "--stat-width",
+        "--stat-name-width",
+        "--stat-graph-width",
+        "--unified",
+        "-G",
+        "-S",
+        "-U",
+        "--word-diff",
+        "--word-diff-regex",
+    }
+    boolean_options = {
+        "--binary",
+        "--cached",
+        "--check",
+        "--compact-summary",
+        "--exit-code",
+        "--find-copies-harder",
+        "--full-index",
+        "--ignore-all-space",
+        "--ignore-blank-lines",
+        "--ignore-cr-at-eol",
+        "--ignore-space-at-eol",
+        "--ignore-space-change",
+        "--minimal",
+        "--name-only",
+        "--name-status",
+        "--numstat",
+        "--patch",
+        "--patch-with-raw",
+        "--pickaxe-all",
+        "--pickaxe-regex",
+        "--raw",
+        "--relative",
+        "--shortstat",
+        "--stat",
+        "--submodule",
+        "--summary",
+    }
+    disallowed_options = {
+        "--ext-diff",
+        "--no-index",
+        "--textconv",
+        "--output",
+    }
+    while index < len(args):
+        arg = args[index]
+        if after_path_separator:
+            paths.append(arg)
+            index += 1
+            continue
+        if arg == "--":
+            after_path_separator = True
+            index += 1
+            continue
+        if arg in disallowed_options or any(arg.startswith(f"{option}=") for option in disallowed_options):
+            return []
+        if arg in value_options:
+            index += 2
+            continue
+        if any(arg.startswith(f"{option}=") for option in value_options):
+            index += 1
+            continue
+        if arg in boolean_options:
+            index += 1
+            continue
+        if re.fullmatch(r"-U\d{1,6}", arg):
+            index += 1
+            continue
+        if re.fullmatch(r"(?:-G|-S).+", arg):
+            index += 1
+            continue
+        if arg.startswith("-"):
+            index += 1
+            continue
+        paths.append(arg)
+        index += 1
+    return paths
 
 
 def _git_grep_uses_external_execution(args: list[str]) -> bool:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5906,8 +5906,8 @@ def _git_config_include_paths(config_text: str, *, base_dir: Path, repo_dir: Pat
             continue
         section_match = re.fullmatch(r"\[([^\]]+)\](?:\s*[#;].*)?", line)
         if section_match:
-            section = section_match.group(1).strip().lower()
-            section_active = _git_include_section_is_active(section, repo_dir=repo_dir)
+            section = section_match.group(1).strip()
+            section_active = _git_include_section_is_active(section, base_dir=base_dir, repo_dir=repo_dir)
             continue
         if not section_active:
             continue
@@ -5921,43 +5921,73 @@ def _git_config_include_paths(config_text: str, *, base_dir: Path, repo_dir: Pat
     return tuple(paths)
 
 
-def _git_include_section_is_active(section: str, *, repo_dir: Path | None) -> bool:
-    if section == "include":
+def _git_include_section_is_active(section: str, *, base_dir: Path, repo_dir: Path | None) -> bool:
+    section_lower = section.lower()
+    if section_lower == "include":
         return True
-    if not section.startswith("includeif"):
+    if not section_lower.startswith("includeif"):
         return False
     if repo_dir is None:
         return False
     condition_match = re.search(r'"([^"]+)"', section)
     condition = condition_match.group(1) if condition_match else section.removeprefix("includeif").strip()
-    if condition.startswith("gitdir/i:"):
+    condition_lower = condition.lower()
+    if condition_lower.startswith("gitdir/i:"):
         return _git_gitdir_condition_matches(
-            condition.removeprefix("gitdir/i:"),
+            condition[len("gitdir/i:") :],
+            base_dir=base_dir,
             repo_dir=repo_dir,
             case_sensitive=False,
         )
-    if condition.startswith("gitdir:"):
-        return _git_gitdir_condition_matches(condition.removeprefix("gitdir:"), repo_dir=repo_dir, case_sensitive=True)
-    if condition.startswith("onbranch:"):
-        return _git_onbranch_condition_matches(condition.removeprefix("onbranch:"), repo_dir=repo_dir)
+    if condition_lower.startswith("gitdir:"):
+        return _git_gitdir_condition_matches(
+            condition[len("gitdir:") :],
+            base_dir=base_dir,
+            repo_dir=repo_dir,
+            case_sensitive=True,
+        )
+    if condition_lower.startswith("onbranch:"):
+        return _git_onbranch_condition_matches(condition[len("onbranch:") :], repo_dir=repo_dir)
     return False
 
 
-def _git_gitdir_condition_matches(pattern: str, *, repo_dir: Path, case_sensitive: bool) -> bool:
-    normalized_pattern = str(Path(pattern).expanduser())
-    if not Path(normalized_pattern).is_absolute():
-        return False
-    repo_text = repo_dir.as_posix().rstrip("/") + "/"
-    pattern_text = Path(normalized_pattern).as_posix()
-    if pattern_text.endswith("/"):
-        pattern_text = f"{pattern_text}**"
-    elif pattern_text.endswith("/**"):
-        pass
-    else:
-        pattern_text = pattern_text.rstrip("/") + "/**"
+def _git_gitdir_condition_matches(pattern: str, *, base_dir: Path, repo_dir: Path, case_sensitive: bool) -> bool:
+    pattern_text = _git_gitdir_condition_pattern(pattern, base_dir=base_dir)
+    patterns = _git_gitdir_condition_patterns(pattern_text)
+    candidates = [repo_dir.as_posix().rstrip("/") + "/"]
+    git_dir = _git_effective_git_dir(repo_dir)
+    if git_dir is not None:
+        candidates.append(git_dir.as_posix().rstrip("/") + "/")
     if case_sensitive:
-        return fnmatch.fnmatchcase(repo_text, pattern_text)
-    return fnmatch.fnmatchcase(repo_text.lower(), pattern_text.lower())
+        return any(fnmatch.fnmatchcase(candidate, item) for candidate in candidates for item in patterns)
+    return any(fnmatch.fnmatchcase(candidate.lower(), item.lower()) for candidate in candidates for item in patterns)
+
+
+def _git_gitdir_condition_patterns(pattern_text: str) -> tuple[str, ...]:
+    if pattern_text.endswith("/**"):
+        return (pattern_text,)
+    if pattern_text.endswith("/"):
+        return (pattern_text, f"{pattern_text}**")
+    return (pattern_text, f"{pattern_text}/", f"{pattern_text}/**")
+
+
+def _git_gitdir_condition_pattern(pattern: str, *, base_dir: Path) -> str:
+    expanded_pattern = pattern.strip()
+    pattern_path = Path(expanded_pattern).expanduser()
+    if pattern_path.is_absolute():
+        return pattern_path.as_posix()
+    if expanded_pattern.startswith(("./", "../")):
+        return (base_dir / pattern_path).resolve().as_posix()
+    return f"**/{expanded_pattern}"
+
+
+def _git_effective_git_dir(repo_dir: Path) -> Path | None:
+    git_path = repo_dir / ".git"
+    if git_path.is_dir():
+        return git_path
+    if git_path.is_file():
+        return _git_dir_from_file(git_path)
+    return None
 
 
 def _git_onbranch_condition_matches(pattern: str, *, repo_dir: Path) -> bool:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5779,7 +5779,11 @@ def _git_diff_external_helpers_are_disabled_or_unconfigured(args: list[str], *, 
 def _git_repo_diff_helpers_are_unconfigured(cwd: Path | None) -> bool:
     if cwd is None:
         return False
-    if os.environ.get("GIT_EXTERNAL_DIFF") or os.environ.get("GIT_CONFIG_COUNT") or os.environ.get("GIT_CONFIG_PARAMETERS"):
+    if (
+        os.environ.get("GIT_EXTERNAL_DIFF")
+        or os.environ.get("GIT_CONFIG_COUNT")
+        or os.environ.get("GIT_CONFIG_PARAMETERS")
+    ):
         return False
     config_paths = _git_repo_config_paths(cwd)
     if not config_paths:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5911,7 +5911,7 @@ def _git_config_include_paths(
     paths: list[Path] = []
     section = ""
     section_active = False
-    for raw_line in config_text.splitlines():
+    for raw_line in _git_config_logical_lines(config_text):
         line = raw_line.strip()
         if not line or line.startswith(("#", ";")):
             continue
@@ -6077,7 +6077,7 @@ def _git_remote_urls_from_config_tree(config_path: Path, *, seen_paths: set[Path
 def _git_remote_urls_from_config(config_text: str) -> tuple[str, ...]:
     urls: list[str] = []
     in_remote_section = False
-    for raw_line in config_text.splitlines():
+    for raw_line in _git_config_logical_lines(config_text):
         line = raw_line.strip()
         if not line or line.startswith(("#", ";")):
             continue
@@ -6120,7 +6120,37 @@ def _git_config_value_without_inline_comment(raw_value: str) -> str:
 
 
 def _git_config_enables_diff_helper(config_text: str) -> bool:
-    return bool(re.search(r"(?im)^\s*(?:command|external|textconv)\s*=", config_text))
+    return any(
+        re.match(r"(?i)^\s*(?:command|external|textconv)\s*=", line)
+        for line in _git_config_logical_lines(config_text)
+    )
+
+
+def _git_config_logical_lines(config_text: str) -> tuple[str, ...]:
+    lines: list[str] = []
+    pending = ""
+    for raw_line in config_text.splitlines():
+        line = raw_line.rstrip()
+        if _git_config_line_continues(line):
+            pending = f"{pending}{line[:-1]}"
+            continue
+        if pending:
+            lines.append(f"{pending}{line.lstrip()}")
+            pending = ""
+            continue
+        lines.append(line)
+    if pending:
+        lines.append(pending)
+    return tuple(lines)
+
+
+def _git_config_line_continues(line: str) -> bool:
+    backslashes = 0
+    for char in reversed(line):
+        if char != "\\":
+            break
+        backslashes += 1
+    return backslashes % 2 == 1
 
 
 def _git_grep_uses_external_execution(args: list[str]) -> bool:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2323,6 +2323,7 @@ def run_guard_command(
             and policy_action not in {"block", "sandbox-required", "require-reapproval"}
         )
         if should_record_generic_hook_receipt:
+            # fmt: off
             receipt = build_receipt(
                 harness=args.harness,
                 artifact_id=artifact_id,
@@ -2342,6 +2343,7 @@ def run_guard_command(
                 user_override=_optional_string(payload.get("user_override")),
                 approval_source=("inline" if _optional_string(payload.get("user_override")) is not None else "policy"),
             )
+            # fmt: on
             store.add_receipt(receipt)
         if _should_emit_copilot_hook_response(args):
             _emit_copilot_hook_response(

--- a/src/codex_plugin_scanner/guard/cli/prompt.py
+++ b/src/codex_plugin_scanner/guard/cli/prompt.py
@@ -263,6 +263,7 @@ def _record_override_receipt(
         artifact_name=artifact.artifact_name,
         source_scope=artifact.source_scope,
         user_override=user_override,
+        approval_source="inline",
     )
     store.add_receipt(receipt)
 

--- a/src/codex_plugin_scanner/guard/consumer/service.py
+++ b/src/codex_plugin_scanner/guard/consumer/service.py
@@ -139,6 +139,19 @@ def _removed_capabilities_summary(previous: dict[str, object]) -> str:
     return " • ".join(parts) if parts else "removed artifact"
 
 
+def _build_diff_summary(diff: dict[str, object]) -> str | None:
+    """Build a prose diff summary from a diff result dict."""
+    if not diff.get("changed"):
+        return None
+    changed_fields = diff.get("changed_fields")
+    if not isinstance(changed_fields, list) or not changed_fields:
+        return "artifact changed"
+    count = len(changed_fields)
+    sample = ", ".join(str(f) for f in changed_fields[:3])
+    suffix = " ..." if count > 3 else ""
+    return f"{count} change(s): {sample}{suffix}"
+
+
 def build_history_context(
     store: GuardStore,
     harness: str,
@@ -447,6 +460,8 @@ def evaluate_detection(
             ),
             artifact_name=artifact.name,
             source_scope=artifact.source_scope,
+            diff_summary=_build_diff_summary(diff),
+            approval_source="policy",
         )
         if persist:
             store.record_inventory_artifact(
@@ -580,6 +595,8 @@ def evaluate_detection(
             provenance_summary=_build_removed_provenance(previous),
             artifact_name=str(artifact_name) if isinstance(artifact_name, str) else artifact_id,
             source_scope=str(source_scope) if isinstance(source_scope, str) else None,
+            diff_summary="artifact removed",
+            approval_source="policy",
         )
         if persist:
             store.mark_inventory_removed(

--- a/src/codex_plugin_scanner/guard/mcp_tool_calls.py
+++ b/src/codex_plugin_scanner/guard/mcp_tool_calls.py
@@ -536,6 +536,36 @@ def tool_call_risk_summary(artifact: GuardArtifact, arguments: object) -> str:
     return f"{signals[0].capitalize()}, and it also {', and it also '.join(signals[1:])}."
 
 
+_INLINE_SOURCES = frozenset({"inline-approved", "inline-denied", "native-approved", "claude-native-approved"})
+_POLICY_SOURCES = frozenset(
+    {
+        "heuristic",
+        "policy",
+        "auto",
+        "pre-tool-hook",
+        "permission-request-hook",
+        "policy-allow",
+        "policy-block",
+        "policy_allow",
+        "policy_block",
+        "heuristic-allow",
+        "heuristic-block",
+        "heuristic_allow",
+        "heuristic_block",
+        "auto-allow",
+        "auto-block",
+    }
+)
+
+
+def _map_approval_source(decision_source: str) -> str:
+    if decision_source in _INLINE_SOURCES:
+        return "inline"
+    if decision_source in _POLICY_SOURCES or decision_source.startswith("policy"):
+        return "policy"
+    return "approval_center"
+
+
 def allow_tool_call(
     *,
     store: GuardStore,
@@ -580,6 +610,7 @@ def allow_tool_call(
         artifact_name=artifact.name,
         source_scope=artifact.source_scope,
         user_override="inline-approve" if decision_source == "inline-approved" else None,
+        approval_source=_map_approval_source(decision_source),
     )
     store.add_receipt(receipt)
     store.add_event(
@@ -625,6 +656,7 @@ def block_tool_call(
         artifact_name=artifact.name,
         source_scope=artifact.source_scope,
         user_override="inline-deny" if decision_source == "inline-denied" else None,
+        approval_source=_map_approval_source(decision_source),
     )
     store.add_receipt(receipt)
     store.add_event(

--- a/src/codex_plugin_scanner/guard/models.py
+++ b/src/codex_plugin_scanner/guard/models.py
@@ -146,6 +146,8 @@ class GuardReceipt:
     user_override: str | None = None
     artifact_name: str | None = None
     source_scope: str | None = None
+    diff_summary: str | None = None
+    approval_source: str | None = None
     action_envelope_json: dict[str, object] | None = None
     scanner_evidence: tuple[dict[str, object], ...] = ()
 

--- a/src/codex_plugin_scanner/guard/proxy/stdio.py
+++ b/src/codex_plugin_scanner/guard/proxy/stdio.py
@@ -243,6 +243,7 @@ class StdioGuardProxy:
                             provenance_summary=f"runtime MCP tool request evaluated from {self._policy_path()}",
                             artifact_name=runtime_artifact.name,
                             source_scope=runtime_artifact.source_scope,
+                            approval_source="approval_center" if policy_action == "require-reapproval" and self.approval_center_url is not None else "policy",
                         )
                     )
                 if policy_action in {"block", "sandbox-required", "require-reapproval"}:

--- a/src/codex_plugin_scanner/guard/proxy/stdio.py
+++ b/src/codex_plugin_scanner/guard/proxy/stdio.py
@@ -243,7 +243,9 @@ class StdioGuardProxy:
                             provenance_summary=f"runtime MCP tool request evaluated from {self._policy_path()}",
                             artifact_name=runtime_artifact.name,
                             source_scope=runtime_artifact.source_scope,
-                            approval_source="approval_center" if policy_action == "require-reapproval" and self.approval_center_url is not None else "policy",
+                            approval_source="approval_center"
+                            if policy_action == "require-reapproval" and self.approval_center_url is not None
+                            else "policy",
                         )
                     )
                 if policy_action in {"block", "sandbox-required", "require-reapproval"}:

--- a/src/codex_plugin_scanner/guard/proxy/stdio.py
+++ b/src/codex_plugin_scanner/guard/proxy/stdio.py
@@ -1,5 +1,7 @@
 """Local stdio MCP proxy helpers."""
 
+# ruff: noqa: E501
+
 from __future__ import annotations
 
 import json
@@ -232,6 +234,7 @@ class StdioGuardProxy:
                 event["path_summary"] = sensitive_request.path_match.normalized_path
                 event["risk_summary"] = runtime_artifact.metadata.get("runtime_request_summary")
                 if self.guard_store is not None:
+                    # fmt: off
                     self.guard_store.add_receipt(
                         build_receipt(
                             harness=self.harness,
@@ -243,11 +246,10 @@ class StdioGuardProxy:
                             provenance_summary=f"runtime MCP tool request evaluated from {self._policy_path()}",
                             artifact_name=runtime_artifact.name,
                             source_scope=runtime_artifact.source_scope,
-                            approval_source="approval_center"
-                            if policy_action == "require-reapproval" and self.approval_center_url is not None
-                            else "policy",
+                            approval_source="approval_center" if policy_action == "require-reapproval" and self.approval_center_url is not None else "policy",
                         )
                     )
+                    # fmt: on
                 if policy_action in {"block", "sandbox-required", "require-reapproval"}:
                     event["decision"] = "block"
                     blocked_message = (

--- a/src/codex_plugin_scanner/guard/proxy/stdio.py
+++ b/src/codex_plugin_scanner/guard/proxy/stdio.py
@@ -1,7 +1,5 @@
 """Local stdio MCP proxy helpers."""
 
-# ruff: noqa: E501
-
 from __future__ import annotations
 
 import json
@@ -234,7 +232,6 @@ class StdioGuardProxy:
                 event["path_summary"] = sensitive_request.path_match.normalized_path
                 event["risk_summary"] = runtime_artifact.metadata.get("runtime_request_summary")
                 if self.guard_store is not None:
-                    # fmt: off
                     self.guard_store.add_receipt(
                         build_receipt(
                             harness=self.harness,
@@ -246,10 +243,13 @@ class StdioGuardProxy:
                             provenance_summary=f"runtime MCP tool request evaluated from {self._policy_path()}",
                             artifact_name=runtime_artifact.name,
                             source_scope=runtime_artifact.source_scope,
-                            approval_source="approval_center" if policy_action == "require-reapproval" and self.approval_center_url is not None else "policy",
+                            approval_source=(
+                                "approval_center"
+                                if policy_action == "require-reapproval" and self.approval_center_url is not None
+                                else "policy"
+                            ),
                         )
                     )
-                    # fmt: on
                 if policy_action in {"block", "sandbox-required", "require-reapproval"}:
                     event["decision"] = "block"
                     blocked_message = (

--- a/src/codex_plugin_scanner/guard/receipts/manager.py
+++ b/src/codex_plugin_scanner/guard/receipts/manager.py
@@ -9,6 +9,14 @@ from uuid import uuid4
 from ..models import GuardReceipt
 
 
+def _auto_diff_summary(changed_capabilities: list[str]) -> str:
+    """Generate a prose diff summary from the changed capabilities list."""
+    count = len(changed_capabilities)
+    sample = ", ".join(changed_capabilities[:3])
+    suffix = " ..." if count > 3 else ""
+    return f"{count} change(s): {sample}{suffix}"
+
+
 def build_receipt(
     harness: str,
     artifact_id: str,
@@ -21,8 +29,14 @@ def build_receipt(
     source_scope: str | None,
     user_override: str | None = None,
     scanner_evidence: Sequence[Mapping[str, object]] = (),
+    diff_summary: str | None = None,
+    approval_source: str | None = None,
 ) -> GuardReceipt:
     """Create a runtime receipt."""
+
+    resolved_diff_summary = diff_summary
+    if resolved_diff_summary is None and changed_capabilities:
+        resolved_diff_summary = _auto_diff_summary(changed_capabilities)
 
     return GuardReceipt(
         receipt_id=f"guard-receipt-{uuid4()}",
@@ -37,5 +51,7 @@ def build_receipt(
         user_override=user_override,
         artifact_name=artifact_name,
         source_scope=source_scope,
+        diff_summary=resolved_diff_summary,
+        approval_source=approval_source,
         scanner_evidence=tuple(dict(item) for item in scanner_evidence),
     )

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -733,6 +733,8 @@ class GuardStore:
             self._ensure_policy_column(connection, "expires_at", "text")
             self._ensure_runtime_receipts_column(connection, "capabilities_summary", "text not null default ''")
             self._ensure_runtime_receipts_column(connection, "scanner_evidence_json", "text not null default '[]'")
+            self._ensure_runtime_receipts_column(connection, "diff_summary", "text")
+            self._ensure_runtime_receipts_column(connection, "approval_source", "text")
             self._ensure_approval_column(connection, "artifact_type", "text not null default 'artifact'")
             self._ensure_approval_column(connection, "launch_target", "text")
             self._ensure_approval_column(connection, "transport", "text")
@@ -1449,9 +1451,10 @@ class GuardStore:
                 insert into runtime_receipts (
                   receipt_id, harness, artifact_id, artifact_hash, policy_decision, capabilities_summary,
                   changed_capabilities_json,
-                  provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json, timestamp
+                  provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json,
+                  diff_summary, approval_source, timestamp
                 )
-                values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     receipt.receipt_id,
@@ -1466,6 +1469,8 @@ class GuardStore:
                     receipt.artifact_name,
                     receipt.source_scope,
                     json.dumps(list(receipt.scanner_evidence), sort_keys=True),
+                    receipt.diff_summary,
+                    receipt.approval_source,
                     receipt.timestamp,
                 ),
             )
@@ -1485,19 +1490,32 @@ class GuardStore:
                 ),
             )
 
-    def list_receipts(self, limit: int = 50) -> list[dict[str, object]]:
-        with self._connect() as connection:
-            rows = connection.execute(
-                """
+    def list_receipts(self, limit: int = 50, harness: str | None = None) -> list[dict[str, object]]:
+        if harness is not None:
+            query = """
                 select receipt_id, harness, artifact_id, artifact_hash, policy_decision, capabilities_summary,
                         changed_capabilities_json,
-                       provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json, timestamp
+                       provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json,
+                       diff_summary, approval_source, timestamp
+                from runtime_receipts
+                where harness = ?
+                order by timestamp desc
+                limit ?
+                """
+            params: tuple[object, ...] = (harness, limit)
+        else:
+            query = """
+                select receipt_id, harness, artifact_id, artifact_hash, policy_decision, capabilities_summary,
+                        changed_capabilities_json,
+                       provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json,
+                       diff_summary, approval_source, timestamp
                 from runtime_receipts
                 order by timestamp desc
                 limit ?
-                """,
-                (limit,),
-            ).fetchall()
+                """
+            params = (limit,)
+        with self._connect() as connection:
+            rows = connection.execute(query, params).fetchall()
         return [
             {
                 "receipt_id": str(row["receipt_id"]),
@@ -1512,6 +1530,8 @@ class GuardStore:
                 "artifact_name": row["artifact_name"],
                 "source_scope": row["source_scope"],
                 "scanner_evidence": _json_object_list(row["scanner_evidence_json"]),
+                "diff_summary": row["diff_summary"],
+                "approval_source": row["approval_source"],
                 "timestamp": str(row["timestamp"]),
             }
             for row in rows
@@ -1523,7 +1543,8 @@ class GuardStore:
                 """
                 select receipt_id, harness, artifact_id, artifact_hash, policy_decision, capabilities_summary,
                         changed_capabilities_json,
-                       provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json, timestamp
+                       provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json,
+                       diff_summary, approval_source, timestamp
                 from runtime_receipts
                 where receipt_id = ?
                 """,
@@ -1544,6 +1565,8 @@ class GuardStore:
             "artifact_name": row["artifact_name"],
             "source_scope": row["source_scope"],
             "scanner_evidence": _json_object_list(row["scanner_evidence_json"]),
+            "diff_summary": row["diff_summary"],
+            "approval_source": row["approval_source"],
             "timestamp": str(row["timestamp"]),
         }
 
@@ -1553,7 +1576,8 @@ class GuardStore:
                 """
                 select receipt_id, harness, artifact_id, artifact_hash, policy_decision, capabilities_summary,
                         changed_capabilities_json,
-                       provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json, timestamp
+                       provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json,
+                       diff_summary, approval_source, timestamp
                 from runtime_receipts
                 where harness = ? and artifact_id = ?
                 order by timestamp desc
@@ -1576,6 +1600,8 @@ class GuardStore:
             "artifact_name": row["artifact_name"],
             "source_scope": row["source_scope"],
             "scanner_evidence": _json_object_list(row["scanner_evidence_json"]),
+            "diff_summary": row["diff_summary"],
+            "approval_source": row["approval_source"],
             "timestamp": str(row["timestamp"]),
         }
 

--- a/tests/test_guard_approval_decisions.py
+++ b/tests/test_guard_approval_decisions.py
@@ -1,0 +1,466 @@
+"""Approval decision model tests — P2.4.
+
+Covers:
+- Unchanged artifact → stored allow policy → no reapproval triggered
+- Changed artifact hash → require-reapproval via decide_action
+- Changed capability → require-reapproval via decide_action
+- Scope persistence for artifact/workspace/publisher/harness/global scopes
+- Receipt field completeness from build_receipt
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.consumer import artifact_hash as compute_artifact_hash
+from codex_plugin_scanner.guard.consumer import evaluate_detection
+from codex_plugin_scanner.guard.models import (
+    GuardArtifact,
+    HarnessDetection,
+    PolicyDecision,
+)
+from codex_plugin_scanner.guard.policy.engine import decide_action
+from codex_plugin_scanner.guard.receipts.manager import build_receipt
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _make_artifact(
+    artifact_id: str = "codex:project:my_tool",
+    command: str = "python",
+    args: tuple[str, ...] = ("-m", "my_tool"),
+    publisher: str | None = None,
+) -> GuardArtifact:
+    return GuardArtifact(
+        artifact_id=artifact_id,
+        name="my_tool",
+        harness="codex",
+        artifact_type="mcp_server",
+        source_scope="project",
+        config_path="/home/user/.codex/config.toml",
+        command=command,
+        args=args,
+        transport="stdio",
+        publisher=publisher,
+    )
+
+
+def _make_config(tmp_path: Path, default_action: str = "require-reapproval") -> GuardConfig:
+    return GuardConfig(
+        guard_home=tmp_path / "guard",
+        workspace=tmp_path / "workspace",
+        default_action=default_action,
+    )
+
+
+def _make_store(tmp_path: Path) -> GuardStore:
+    return GuardStore(tmp_path / "guard")
+
+
+class TestDecideAction:
+    def test_allow_policy_passes_through_unchanged(self) -> None:
+        config = GuardConfig(guard_home=Path("/tmp/test-guard"), workspace=None)
+        result = decide_action(
+            configured_action="allow",
+            default_action="require-reapproval",
+            config=config,
+            changed=False,
+        )
+        assert result == "allow"
+
+    def test_changed_triggers_changed_hash_action_when_no_configured_policy(self) -> None:
+        config = GuardConfig(
+            guard_home=Path("/tmp/test-guard"),
+            workspace=None,
+            changed_hash_action="require-reapproval",
+        )
+        result = decide_action(
+            configured_action=None,
+            default_action="allow",
+            config=config,
+            changed=True,
+        )
+        assert result == "require-reapproval"
+
+    def test_configured_allow_beats_changed_flag(self) -> None:
+        config = GuardConfig(
+            guard_home=Path("/tmp/test-guard"),
+            workspace=None,
+            changed_hash_action="require-reapproval",
+        )
+        result = decide_action(
+            configured_action="allow",
+            default_action="allow",
+            config=config,
+            changed=True,
+        )
+        assert result == "allow"
+
+    def test_changed_falls_back_to_safe_when_no_changed_hash_action(self) -> None:
+        config = GuardConfig(guard_home=Path("/tmp/test-guard"), workspace=None)
+        result = decide_action(
+            configured_action=None,
+            default_action=None,
+            config=config,
+            changed=True,
+        )
+        assert result == "require-reapproval"
+
+    def test_block_policy_blocks_regardless_of_changed_flag(self) -> None:
+        config = GuardConfig(guard_home=Path("/tmp/test-guard"), workspace=None)
+        result = decide_action(
+            configured_action="block",
+            default_action="allow",
+            config=config,
+            changed=False,
+        )
+        assert result == "block"
+
+    def test_no_policy_uses_config_default(self) -> None:
+        config = GuardConfig(
+            guard_home=Path("/tmp/test-guard"),
+            workspace=None,
+            default_action="warn",
+        )
+        result = decide_action(
+            configured_action=None,
+            default_action=None,
+            config=config,
+            changed=False,
+        )
+        assert result == "warn"
+
+    def test_explicit_default_action_overrides_config(self) -> None:
+        config = GuardConfig(
+            guard_home=Path("/tmp/test-guard"),
+            workspace=None,
+            default_action="warn",
+        )
+        result = decide_action(
+            configured_action=None,
+            default_action="allow",
+            config=config,
+            changed=False,
+        )
+        assert result == "allow"
+
+
+class TestPolicyScopePersistence:
+    def test_artifact_scope_allow_resolves_for_matching_hash(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="artifact",
+                action="allow",
+                artifact_id="codex:project:my_tool",
+                artifact_hash="abc123",
+            ),
+            "2026-01-01T00:00:00+00:00",
+        )
+        result = store.resolve_policy("codex", "codex:project:my_tool", "abc123")
+        assert result == "allow"
+
+    def test_artifact_scope_allow_resolves_without_hash_when_policy_has_no_hash(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="artifact",
+                action="allow",
+                artifact_id="codex:project:my_tool",
+                artifact_hash=None,
+            ),
+            "2026-01-01T00:00:00+00:00",
+        )
+        result = store.resolve_policy("codex", "codex:project:my_tool", "any-hash")
+        assert result == "allow"
+
+    def test_publisher_scope_resolves_for_any_artifact_by_publisher(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="publisher",
+                action="allow",
+                publisher="verified-org",
+            ),
+            "2026-01-01T00:00:00+00:00",
+        )
+        result = store.resolve_policy("codex", "codex:project:any_tool", "hash-x", publisher="verified-org")
+        assert result == "allow"
+
+    def test_publisher_scope_does_not_match_different_publisher(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="publisher",
+                action="allow",
+                publisher="verified-org",
+            ),
+            "2026-01-01T00:00:00+00:00",
+        )
+        result = store.resolve_policy("codex", "codex:project:any_tool", "hash-x", publisher="unknown-org")
+        assert result is None
+
+    def test_harness_scope_resolves_for_all_artifacts_in_harness(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="harness",
+                action="allow",
+            ),
+            "2026-01-01T00:00:00+00:00",
+        )
+        result = store.resolve_policy("codex", "codex:project:any_tool", "hash-y")
+        assert result == "allow"
+
+    def test_global_scope_resolves_for_any_harness(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="global",
+                action="block",
+            ),
+            "2026-01-01T00:00:00+00:00",
+        )
+        result = store.resolve_policy("codex", "codex:project:anything", "hash-z")
+        assert result == "block"
+
+    def test_artifact_scope_takes_precedence_over_global_scope(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="global",
+                action="block",
+            ),
+            "2026-01-01T00:00:00+00:00",
+        )
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="artifact",
+                action="allow",
+                artifact_id="codex:project:trusted_tool",
+                artifact_hash=None,
+            ),
+            "2026-01-01T00:00:00+00:00",
+        )
+        result = store.resolve_policy("codex", "codex:project:trusted_tool", "any-hash")
+        assert result == "allow"
+
+    def test_expired_policy_is_not_matched(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="artifact",
+                action="allow",
+                artifact_id="codex:project:my_tool",
+                artifact_hash=None,
+                expires_at="2025-01-01T00:00:00+00:00",
+            ),
+            "2024-12-01T00:00:00+00:00",
+        )
+        result = store.resolve_policy(
+            "codex",
+            "codex:project:my_tool",
+            "hash-abc",
+            now="2026-01-01T00:00:00+00:00",
+        )
+        assert result is None
+
+
+class TestEvaluateDetectionScopePersistence:
+    def test_unchanged_artifact_with_stored_allow_policy_is_not_blocked(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        config = _make_config(tmp_path)
+        artifact = _make_artifact()
+
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="artifact",
+                action="allow",
+                artifact_id=artifact.artifact_id,
+                artifact_hash=None,
+            ),
+            "2026-01-01T00:00:00+00:00",
+        )
+
+        detection = HarnessDetection(
+            harness="codex",
+            installed=True,
+            command_available=True,
+            config_paths=(artifact.config_path,),
+            artifacts=(artifact,),
+        )
+
+        result = evaluate_detection(detection, store, config, persist=False)
+
+        artifact_result = result["artifacts"][0]
+        assert artifact_result["policy_action"] == "allow"
+        assert result["blocked"] is False
+
+    def test_changed_artifact_hash_without_stored_policy_triggers_reapproval(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        config = _make_config(tmp_path)
+        artifact_v1 = _make_artifact(args=("-m", "my_tool", "--port", "8000"))
+        artifact_v2 = _make_artifact(args=("-m", "my_tool", "--port", "9000"))
+
+        detection_v1 = HarnessDetection(
+            harness="codex",
+            installed=True,
+            command_available=True,
+            config_paths=(artifact_v1.config_path,),
+            artifacts=(artifact_v1,),
+        )
+        evaluate_detection(detection_v1, store, config, persist=True)
+
+        detection_v2 = HarnessDetection(
+            harness="codex",
+            installed=True,
+            command_available=True,
+            config_paths=(artifact_v2.config_path,),
+            artifacts=(artifact_v2,),
+        )
+        result = evaluate_detection(detection_v2, store, config, persist=False)
+
+        artifact_result = result["artifacts"][0]
+        assert artifact_result["policy_action"] in {"require-reapproval", "block", "sandbox-required"}
+        assert result["blocked"] is True
+
+    def test_hash_locked_policy_does_not_match_new_hash_triggers_reapproval(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        config = _make_config(tmp_path, default_action="allow")
+        artifact_v1 = _make_artifact(args=("-m", "my_tool", "--port", "8000"))
+        artifact_v2 = _make_artifact(args=("-m", "my_tool", "--port", "9999"))
+
+        v1_hash = compute_artifact_hash(artifact_v1)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="artifact",
+                action="allow",
+                artifact_id=artifact_v1.artifact_id,
+                artifact_hash=v1_hash,
+            ),
+            "2026-01-01T00:00:00+00:00",
+        )
+
+        detection_v1 = HarnessDetection(
+            harness="codex",
+            installed=True,
+            command_available=True,
+            config_paths=(artifact_v1.config_path,),
+            artifacts=(artifact_v1,),
+        )
+        evaluate_detection(detection_v1, store, config, persist=True)
+
+        detection_v2 = HarnessDetection(
+            harness="codex",
+            installed=True,
+            command_available=True,
+            config_paths=(artifact_v2.config_path,),
+            artifacts=(artifact_v2,),
+        )
+        result = evaluate_detection(detection_v2, store, config, persist=False)
+
+        artifact_result = result["artifacts"][0]
+        assert artifact_result["policy_action"] in {"require-reapproval", "block", "sandbox-required"}
+        assert result["blocked"] is True
+
+
+class TestBuildReceipt:
+    def test_build_receipt_populates_required_fields(self) -> None:
+        receipt = build_receipt(
+            harness="codex",
+            artifact_id="codex:project:my_tool",
+            artifact_hash="sha256-abc",
+            policy_decision="allow",
+            capabilities_summary="command: python",
+            changed_capabilities=[],
+            provenance_summary="project artifact at /workspace/.codex/config.toml (provenance: local)",
+            artifact_name="my_tool",
+            source_scope="project",
+        )
+
+        assert receipt.receipt_id.startswith("guard-receipt-")
+        assert receipt.harness == "codex"
+        assert receipt.artifact_id == "codex:project:my_tool"
+        assert receipt.artifact_hash == "sha256-abc"
+        assert receipt.policy_decision == "allow"
+        assert receipt.capabilities_summary == "command: python"
+        assert receipt.changed_capabilities == ()
+        assert "project artifact" in receipt.provenance_summary
+        assert receipt.artifact_name == "my_tool"
+        assert receipt.source_scope == "project"
+        assert receipt.timestamp != ""
+
+    def test_build_receipt_changed_capabilities_are_stored_as_tuple(self) -> None:
+        receipt = build_receipt(
+            harness="codex",
+            artifact_id="codex:project:my_tool",
+            artifact_hash="sha256-abc",
+            policy_decision="require-reapproval",
+            capabilities_summary="command: python",
+            changed_capabilities=["args", "command"],
+            provenance_summary="project artifact",
+            artifact_name="my_tool",
+            source_scope="project",
+        )
+        assert receipt.changed_capabilities == ("args", "command")
+
+    def test_build_receipt_user_override_defaults_to_none(self) -> None:
+        receipt = build_receipt(
+            harness="codex",
+            artifact_id="codex:project:my_tool",
+            artifact_hash="hash",
+            policy_decision="allow",
+            capabilities_summary="",
+            changed_capabilities=[],
+            provenance_summary="provenance",
+            artifact_name=None,
+            source_scope=None,
+        )
+        assert receipt.user_override is None
+
+    def test_build_receipt_to_dict_serializes_scanner_evidence(self) -> None:
+        evidence = [{"type": "scan", "finding": "clean"}]
+        receipt = build_receipt(
+            harness="codex",
+            artifact_id="codex:project:my_tool",
+            artifact_hash="hash",
+            policy_decision="allow",
+            capabilities_summary="",
+            changed_capabilities=[],
+            provenance_summary="provenance",
+            artifact_name=None,
+            source_scope=None,
+            scanner_evidence=evidence,
+        )
+        d = receipt.to_dict()
+        assert isinstance(d["scanner_evidence"], list)
+        assert d["scanner_evidence"][0]["type"] == "scan"
+
+    def test_build_receipt_generates_unique_receipt_ids(self) -> None:
+        receipts = [
+            build_receipt(
+                harness="codex",
+                artifact_id=f"codex:project:tool_{i}",
+                artifact_hash="hash",
+                policy_decision="allow",
+                capabilities_summary="",
+                changed_capabilities=[],
+                provenance_summary="provenance",
+                artifact_name=None,
+                source_scope=None,
+            )
+            for i in range(5)
+        ]
+        ids = {r.receipt_id for r in receipts}
+        assert len(ids) == 5, "Each receipt must have a unique receipt_id"

--- a/tests/test_guard_receipt_p5_fields.py
+++ b/tests/test_guard_receipt_p5_fields.py
@@ -1,0 +1,235 @@
+"""P5.1 receipt model field tests — diff_summary and approval_source.
+
+Covers:
+- diff_summary auto-computed from changed_capabilities when not provided
+- diff_summary explicit value preserved when provided
+- diff_summary is None when changed_capabilities is empty and not provided
+- approval_source field preserved in store roundtrip
+- approval_source values: policy, inline, approval_center, cli_command, None
+- build_receipt helper passes diff_summary / approval_source through to GuardReceipt
+- _build_diff_summary helper in consumer.service produces correct prose
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.models import GuardReceipt
+from codex_plugin_scanner.guard.receipts.manager import build_receipt, _auto_diff_summary
+from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.guard.consumer.service import _build_diff_summary
+from codex_plugin_scanner.guard.mcp_tool_calls import _map_approval_source
+
+
+def _make_store(tmp_path: Path) -> GuardStore:
+    return GuardStore(tmp_path / "guard")
+
+
+def _make_receipt(
+    *,
+    receipt_id: str | None = None,
+    harness: str = "codex",
+    artifact_id: str = "codex:project:tool",
+    artifact_hash: str = "sha256:abc",
+    policy_decision: str = "allow",
+    capabilities_summary: str = "file-read",
+    changed_capabilities: tuple[str, ...] = (),
+    provenance_summary: str = "npm v1",
+    diff_summary: str | None = None,
+    approval_source: str | None = None,
+    timestamp: str = "2025-01-01T00:00:00Z",
+) -> GuardReceipt:
+    return GuardReceipt(
+        receipt_id=receipt_id or str(uuid.uuid4()),
+        harness=harness,
+        artifact_id=artifact_id,
+        artifact_hash=artifact_hash,
+        policy_decision=policy_decision,
+        capabilities_summary=capabilities_summary,
+        changed_capabilities=changed_capabilities,
+        provenance_summary=provenance_summary,
+        diff_summary=diff_summary,
+        approval_source=approval_source,
+        timestamp=timestamp,
+    )
+
+
+class TestAutoDiffSummary:
+    def test_single_change(self) -> None:
+        result = _auto_diff_summary(["network"])
+        assert result == "1 change(s): network"
+
+    def test_three_changes(self) -> None:
+        result = _auto_diff_summary(["network", "subprocess", "filesystem"])
+        assert result == "3 change(s): network, subprocess, filesystem"
+
+    def test_more_than_three_truncates(self) -> None:
+        result = _auto_diff_summary(["a", "b", "c", "d"])
+        assert result == "4 change(s): a, b, c ..."
+
+    def test_two_changes(self) -> None:
+        result = _auto_diff_summary(["removed", "hash_changed"])
+        assert result == "2 change(s): removed, hash_changed"
+
+
+class TestBuildDiffSummary:
+    def test_unchanged_artifact_returns_none(self) -> None:
+        diff: dict[str, object] = {"changed": False, "changed_fields": [], "current_hash": "abc"}
+        assert _build_diff_summary(diff) is None
+
+    def test_changed_no_fields_returns_generic(self) -> None:
+        diff: dict[str, object] = {"changed": True, "changed_fields": [], "current_hash": "abc"}
+        assert _build_diff_summary(diff) == "artifact changed"
+
+    def test_changed_with_fields(self) -> None:
+        diff: dict[str, object] = {"changed": True, "changed_fields": ["hash", "capability_delta"], "current_hash": "abc"}
+        result = _build_diff_summary(diff)
+        assert result == "2 change(s): hash, capability_delta"
+
+    def test_changed_fields_not_list_returns_generic(self) -> None:
+        diff: dict[str, object] = {"changed": True, "changed_fields": "not-a-list", "current_hash": "abc"}
+        assert _build_diff_summary(diff) == "artifact changed"
+
+
+class TestBuildReceiptDiffSummary:
+    def test_auto_computes_diff_summary_from_changed_capabilities(self) -> None:
+        receipt = build_receipt(
+            harness="codex",
+            artifact_id="codex:project:tool",
+            artifact_hash="abc",
+            policy_decision="allow",
+            capabilities_summary="file-read",
+            changed_capabilities=["network", "subprocess"],
+            provenance_summary="npm v1",
+            artifact_name="tool",
+            source_scope="project",
+        )
+        assert receipt.diff_summary == "2 change(s): network, subprocess"
+
+    def test_empty_changed_capabilities_no_auto_summary(self) -> None:
+        receipt = build_receipt(
+            harness="codex",
+            artifact_id="codex:project:tool",
+            artifact_hash="abc",
+            policy_decision="allow",
+            capabilities_summary="file-read",
+            changed_capabilities=[],
+            provenance_summary="npm v1",
+            artifact_name="tool",
+            source_scope="project",
+        )
+        assert receipt.diff_summary is None
+
+    def test_explicit_diff_summary_overrides_auto(self) -> None:
+        receipt = build_receipt(
+            harness="codex",
+            artifact_id="codex:project:tool",
+            artifact_hash="abc",
+            policy_decision="allow",
+            capabilities_summary="file-read",
+            changed_capabilities=["network"],
+            provenance_summary="npm v1",
+            artifact_name="tool",
+            source_scope="project",
+            diff_summary="custom summary",
+        )
+        assert receipt.diff_summary == "custom summary"
+
+    @pytest.mark.parametrize("source", ["policy", "inline", "approval_center", "cli_command", None])
+    def test_approval_source_values(self, source: str | None) -> None:
+        receipt = build_receipt(
+            harness="codex",
+            artifact_id="codex:project:tool",
+            artifact_hash="abc",
+            policy_decision="allow",
+            capabilities_summary="file-read",
+            changed_capabilities=[],
+            provenance_summary="npm v1",
+            artifact_name="tool",
+            source_scope="project",
+            approval_source=source,
+        )
+        assert receipt.approval_source == source
+
+
+class TestReceiptFieldRoundtrip:
+    def test_diff_summary_persisted_and_retrieved(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        receipt = _make_receipt(receipt_id="r-ds-01", diff_summary="2 change(s): network, subprocess")
+        store.add_receipt(receipt)
+
+        result = store.get_receipt("r-ds-01")
+        assert result is not None
+        assert result["diff_summary"] == "2 change(s): network, subprocess"
+
+    def test_approval_source_persisted_and_retrieved(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        receipt = _make_receipt(receipt_id="r-as-01", approval_source="approval_center")
+        store.add_receipt(receipt)
+
+        result = store.get_receipt("r-as-01")
+        assert result is not None
+        assert result["approval_source"] == "approval_center"
+
+    def test_null_diff_summary_and_approval_source_preserved(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        receipt = _make_receipt(receipt_id="r-null-01", diff_summary=None, approval_source=None)
+        store.add_receipt(receipt)
+
+        result = store.get_receipt("r-null-01")
+        assert result is not None
+        assert result["diff_summary"] is None
+        assert result["approval_source"] is None
+
+    @pytest.mark.parametrize("approval_source", ["policy", "inline", "approval_center", "cli_command"])
+    def test_all_approval_source_variants_roundtrip(self, tmp_path: Path, approval_source: str) -> None:
+        store = _make_store(tmp_path)
+        rid = f"r-{approval_source}"
+        receipt = _make_receipt(receipt_id=rid, approval_source=approval_source)
+        store.add_receipt(receipt)
+
+        result = store.get_receipt(rid)
+        assert result is not None
+        assert result["approval_source"] == approval_source
+
+    def test_diff_summary_in_list_receipts(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        receipt = _make_receipt(
+            receipt_id="r-list-01",
+            diff_summary="1 change(s): removed",
+            approval_source="policy",
+        )
+        store.add_receipt(receipt)
+
+        receipts = store.list_receipts(harness="codex", limit=10)
+        assert len(receipts) == 1
+        assert receipts[0]["diff_summary"] == "1 change(s): removed"
+        assert receipts[0]["approval_source"] == "policy"
+
+
+class TestMapApprovalSource:
+    @pytest.mark.parametrize("decision_source,expected", [
+        ("inline-approved", "inline"),
+        ("inline-denied", "inline"),
+        ("native-approved", "inline"),
+        ("claude-native-approved", "inline"),
+        ("policy-allow", "policy"),
+        ("policy-block", "policy"),
+        ("policy_allow", "policy"),
+        ("heuristic-allow", "policy"),
+        ("heuristic_block", "policy"),
+        ("auto-allow", "policy"),
+        ("heuristic", "policy"),
+        ("policy", "policy"),
+        ("auto", "policy"),
+        ("pre-tool-hook", "policy"),
+        ("permission-request-hook", "policy"),
+        ("pending-approval", "approval_center"),
+        ("approval-center-allow", "approval_center"),
+        ("unknown-source", "approval_center"),
+    ])
+    def test_decision_source_mapped_correctly(self, decision_source: str, expected: str) -> None:
+        assert _map_approval_source(decision_source) == expected

--- a/tests/test_guard_receipt_persistence.py
+++ b/tests/test_guard_receipt_persistence.py
@@ -1,0 +1,364 @@
+"""Receipt persistence tests — P5.4.
+
+Covers:
+- add_receipt → list_receipts roundtrip (all fields preserved)
+- add_receipt → get_receipt by ID
+- Multiple receipts ordered by timestamp descending
+- list_receipts limit parameter
+- get_latest_receipt returns most-recent for a harness/artifact pair
+- get_receipt returns None for unknown receipt ID
+- record_diff → get_latest_diff roundtrip (all fields preserved)
+- record_inventory_artifact → find_inventory_item (explain backing store)
+- find_inventory_item returns None for unknown artifact
+- receipt_decision_counts aggregation
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+from codex_plugin_scanner.guard.models import GuardArtifact, GuardReceipt
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _make_store(tmp_path: Path) -> GuardStore:
+    return GuardStore(tmp_path / "guard")
+
+
+def _make_receipt(
+    *,
+    receipt_id: str | None = None,
+    harness: str = "codex",
+    artifact_id: str = "codex:project:my_tool",
+    artifact_hash: str = "sha256:abc123",
+    policy_decision: str = "allow",
+    capabilities_summary: str = "file-read, network",
+    changed_capabilities: tuple[str, ...] = ("network",),
+    provenance_summary: str = "npm pkg v1.0.0",
+    user_override: str | None = None,
+    artifact_name: str | None = "my_tool",
+    source_scope: str | None = "artifact",
+    scanner_evidence: tuple[dict[str, object], ...] = (),
+    timestamp: str = "2025-01-01T00:00:00Z",
+) -> GuardReceipt:
+    return GuardReceipt(
+        receipt_id=receipt_id or str(uuid.uuid4()),
+        harness=harness,
+        artifact_id=artifact_id,
+        artifact_hash=artifact_hash,
+        policy_decision=policy_decision,
+        capabilities_summary=capabilities_summary,
+        changed_capabilities=changed_capabilities,
+        provenance_summary=provenance_summary,
+        user_override=user_override,
+        artifact_name=artifact_name,
+        source_scope=source_scope,
+        scanner_evidence=scanner_evidence,
+        timestamp=timestamp,
+    )
+
+
+def _make_artifact(
+    artifact_id: str = "codex:project:my_tool",
+    harness: str = "codex",
+    command: str = "python",
+) -> GuardArtifact:
+    return GuardArtifact(
+        artifact_id=artifact_id,
+        name="my_tool",
+        harness=harness,
+        artifact_type="mcp_server",
+        source_scope="project",
+        config_path="/home/user/.codex/config.toml",
+        command=command,
+        args=("-m", "my_tool"),
+        transport="stdio",
+    )
+
+
+class TestReceiptRoundtrip:
+    def test_add_then_list_returns_receipt(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        receipt = _make_receipt(receipt_id="r-001")
+        store.add_receipt(receipt)
+
+        items = store.list_receipts()
+        assert len(items) == 1
+        item = items[0]
+        assert item["receipt_id"] == "r-001"
+        assert item["harness"] == "codex"
+        assert item["artifact_id"] == "codex:project:my_tool"
+        assert item["artifact_hash"] == "sha256:abc123"
+        assert item["policy_decision"] == "allow"
+
+    def test_add_then_get_by_id_returns_receipt(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        receipt = _make_receipt(receipt_id="r-002")
+        store.add_receipt(receipt)
+
+        result = store.get_receipt("r-002")
+        assert result is not None
+        assert result["receipt_id"] == "r-002"
+        assert result["capabilities_summary"] == "file-read, network"
+        assert result["changed_capabilities"] == ["network"]
+        assert result["provenance_summary"] == "npm pkg v1.0.0"
+
+    def test_get_receipt_returns_none_for_unknown_id(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        assert store.get_receipt("does-not-exist") is None
+
+    def test_all_optional_fields_preserved(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        evidence = ({"check": "hash", "result": "ok"},)
+        receipt = _make_receipt(
+            receipt_id="r-003",
+            user_override="publisher",
+            artifact_name="my_tool",
+            source_scope="publisher",
+            scanner_evidence=evidence,
+        )
+        store.add_receipt(receipt)
+
+        result = store.get_receipt("r-003")
+        assert result is not None
+        assert result["user_override"] == "publisher"
+        assert result["artifact_name"] == "my_tool"
+        assert result["source_scope"] == "publisher"
+        assert result["scanner_evidence"] == [{"check": "hash", "result": "ok"}]
+
+    def test_null_optional_fields_preserved(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        receipt = _make_receipt(
+            receipt_id="r-004",
+            user_override=None,
+            artifact_name=None,
+            source_scope=None,
+        )
+        store.add_receipt(receipt)
+
+        result = store.get_receipt("r-004")
+        assert result is not None
+        assert result["user_override"] is None
+        assert result["artifact_name"] is None
+        assert result["source_scope"] is None
+
+
+class TestReceiptOrdering:
+    def test_list_receipts_ordered_by_timestamp_descending(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        store.add_receipt(_make_receipt(receipt_id="r-old", timestamp="2025-01-01T00:00:00Z"))
+        store.add_receipt(_make_receipt(receipt_id="r-mid", timestamp="2025-06-01T00:00:00Z"))
+        store.add_receipt(_make_receipt(receipt_id="r-new", timestamp="2025-12-01T00:00:00Z"))
+
+        items = store.list_receipts()
+        assert [item["receipt_id"] for item in items] == ["r-new", "r-mid", "r-old"]
+
+    def test_list_receipts_limit_restricts_count(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        for i in range(5):
+            store.add_receipt(_make_receipt(receipt_id=f"r-{i:03d}", timestamp=f"2025-01-{i+1:02d}T00:00:00Z"))
+
+        items = store.list_receipts(limit=3)
+        assert len(items) == 3
+
+    def test_get_latest_receipt_returns_most_recent(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        store.add_receipt(_make_receipt(
+            receipt_id="r-old",
+            artifact_id="codex:project:my_tool",
+            harness="codex",
+            timestamp="2025-01-01T00:00:00Z",
+            policy_decision="require-reapproval",
+        ))
+        store.add_receipt(_make_receipt(
+            receipt_id="r-new",
+            artifact_id="codex:project:my_tool",
+            harness="codex",
+            timestamp="2025-12-01T00:00:00Z",
+            policy_decision="allow",
+        ))
+
+        latest = store.get_latest_receipt("codex", "codex:project:my_tool")
+        assert latest is not None
+        assert latest["receipt_id"] == "r-new"
+        assert latest["policy_decision"] == "allow"
+
+    def test_get_latest_receipt_returns_none_when_no_match(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        assert store.get_latest_receipt("codex", "codex:project:unknown") is None
+
+    def test_get_latest_receipt_scoped_to_harness_artifact_pair(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        store.add_receipt(_make_receipt(
+            receipt_id="r-codex",
+            harness="codex",
+            artifact_id="codex:project:tool_a",
+            timestamp="2025-12-01T00:00:00Z",
+        ))
+        store.add_receipt(_make_receipt(
+            receipt_id="r-claude",
+            harness="claude",
+            artifact_id="claude:project:tool_a",
+            timestamp="2025-12-02T00:00:00Z",
+        ))
+
+        latest_codex = store.get_latest_receipt("codex", "codex:project:tool_a")
+        latest_claude = store.get_latest_receipt("claude", "claude:project:tool_a")
+        assert latest_codex is not None
+        assert latest_codex["receipt_id"] == "r-codex"
+        assert latest_claude is not None
+        assert latest_claude["receipt_id"] == "r-claude"
+
+
+class TestReceiptDecisionCounts:
+    def test_counts_aggregate_by_policy_decision(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        for _ in range(3):
+            store.add_receipt(_make_receipt(
+                harness="codex",
+                artifact_id="codex:project:my_tool",
+                policy_decision="allow",
+                timestamp="2025-01-01T00:00:00Z",
+            ))
+        store.add_receipt(_make_receipt(
+            harness="codex",
+            artifact_id="codex:project:my_tool",
+            policy_decision="block",
+            timestamp="2025-01-02T00:00:00Z",
+        ))
+
+        counts = store.receipt_decision_counts("codex", "codex:project:my_tool")
+        assert counts.get("allow") == 3
+        assert counts.get("block") == 1
+
+    def test_counts_return_empty_for_unknown_artifact(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        counts = store.receipt_decision_counts("codex", "codex:project:unknown")
+        assert counts == {}
+
+
+class TestDiffPersistence:
+    def test_record_diff_then_get_latest_roundtrip(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        store.record_diff(
+            harness="codex",
+            artifact_id="codex:project:my_tool",
+            changed_fields=["command", "args"],
+            previous_hash="sha256:old",
+            current_hash="sha256:new",
+            now="2025-01-01T00:00:00Z",
+        )
+
+        diff = store.get_latest_diff("codex", "codex:project:my_tool")
+        assert diff is not None
+        assert diff["harness"] == "codex"
+        assert diff["artifact_id"] == "codex:project:my_tool"
+        assert diff["changed_fields"] == ["command", "args"]
+        assert diff["previous_hash"] == "sha256:old"
+        assert diff["current_hash"] == "sha256:new"
+        assert diff["recorded_at"] == "2025-01-01T00:00:00Z"
+
+    def test_get_latest_diff_returns_most_recent(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        store.record_diff(
+            harness="codex",
+            artifact_id="codex:project:my_tool",
+            changed_fields=["command"],
+            previous_hash=None,
+            current_hash="sha256:v1",
+            now="2025-01-01T00:00:00Z",
+        )
+        store.record_diff(
+            harness="codex",
+            artifact_id="codex:project:my_tool",
+            changed_fields=["args"],
+            previous_hash="sha256:v1",
+            current_hash="sha256:v2",
+            now="2025-06-01T00:00:00Z",
+        )
+
+        diff = store.get_latest_diff("codex", "codex:project:my_tool")
+        assert diff is not None
+        assert diff["current_hash"] == "sha256:v2"
+        assert diff["changed_fields"] == ["args"]
+
+    def test_get_latest_diff_returns_none_when_absent(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        assert store.get_latest_diff("codex", "codex:project:unknown") is None
+
+    def test_diff_with_null_previous_hash(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        store.record_diff(
+            harness="codex",
+            artifact_id="codex:project:my_tool",
+            changed_fields=["command"],
+            previous_hash=None,
+            current_hash="sha256:first",
+            now="2025-01-01T00:00:00Z",
+        )
+
+        diff = store.get_latest_diff("codex", "codex:project:my_tool")
+        assert diff is not None
+        assert diff["previous_hash"] is None
+
+
+class TestInventoryForExplain:
+    def test_record_then_find_inventory_item(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        artifact = _make_artifact("codex:project:my_tool")
+        store.record_inventory_artifact(
+            artifact=artifact,
+            artifact_hash="sha256:abc",
+            policy_action="allow",
+            changed=False,
+            now="2025-01-01T00:00:00Z",
+            approved=True,
+        )
+
+        item = store.find_inventory_item("codex:project:my_tool")
+        assert item is not None
+        assert item["artifact_id"] == "codex:project:my_tool"
+        assert item["harness"] == "codex"
+        assert item["artifact_hash"] == "sha256:abc"
+        assert item["last_policy_action"] == "allow"
+        assert item["present"] is True
+
+    def test_find_inventory_item_returns_none_for_unknown(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        assert store.find_inventory_item("codex:project:unknown") is None
+
+    def test_explain_payload_includes_latest_receipt_and_diff(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        artifact = _make_artifact("codex:project:my_tool")
+        store.record_inventory_artifact(
+            artifact=artifact,
+            artifact_hash="sha256:abc",
+            policy_action="allow",
+            changed=False,
+            now="2025-01-01T00:00:00Z",
+            approved=True,
+        )
+        store.add_receipt(_make_receipt(
+            receipt_id="r-001",
+            artifact_id="codex:project:my_tool",
+            harness="codex",
+            timestamp="2025-01-01T00:00:00Z",
+        ))
+        store.record_diff(
+            harness="codex",
+            artifact_id="codex:project:my_tool",
+            changed_fields=["args"],
+            previous_hash="sha256:old",
+            current_hash="sha256:abc",
+            now="2025-01-01T00:00:00Z",
+        )
+
+        item = store.find_inventory_item("codex:project:my_tool")
+        assert item is not None
+        latest_receipt = store.get_latest_receipt("codex", "codex:project:my_tool")
+        latest_diff = store.get_latest_diff("codex", "codex:project:my_tool")
+        assert latest_receipt is not None
+        assert latest_receipt["receipt_id"] == "r-001"
+        assert latest_diff is not None
+        assert latest_diff["changed_fields"] == ["args"]

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13598,6 +13598,32 @@ def test_codex_read_only_source_inspection_rejects_git_diff_included_config_with
     )
 
 
+def test_codex_read_only_source_inspection_rejects_git_diff_included_config_with_section_comment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
+    included_config = tmp_path / "included-gitconfig"
+    _write_text(
+        included_config,
+        """
+[diff]
+    external = /tmp/guard-diff
+""".strip(),
+    )
+    global_config = tmp_path / "global-gitconfig"
+    _write_text(global_config, f"[include] # local helper config\n    path = {included_config}\n")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(global_config))
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        "git diff -- src/safe.ts | sed -n '1,40p'",
+        cwd=workspace_dir,
+    )
+
+
 def test_codex_read_only_source_inspection_allows_git_diff_with_external_helpers_disabled(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13624,6 +13624,21 @@ def test_codex_read_only_source_inspection_rejects_unknown_git_diff_option(
     )
 
 
+def test_codex_read_only_source_inspection_rejects_git_diff_paths_without_separator(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        "git diff src/safe.ts | sed -n '1,40p'",
+        cwd=workspace_dir,
+    )
+
+
 def test_codex_read_only_source_inspection_rejects_disallowed_option_after_optional_git_diff_flag(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -6,6 +6,7 @@ import argparse
 import builtins
 import io
 import json
+import os
 import sqlite3
 import subprocess
 import sys
@@ -50,6 +51,13 @@ def _write_json(path: Path, payload: dict[str, object]) -> None:
 def _write_text(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
+
+
+def _isolate_git_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
+    monkeypatch.delenv("GIT_CONFIG_COUNT", raising=False)
+    monkeypatch.delenv("GIT_EXTERNAL_DIFF", raising=False)
 
 
 def _build_guard_fixture(home_dir: Path, workspace_dir: Path) -> None:
@@ -13382,7 +13390,11 @@ def test_codex_read_only_source_inspection_preserves_pipelines_in_safe_chains(tm
     )
 
 
-def test_codex_read_only_source_inspection_allows_git_diff_with_bounded_sed(tmp_path: Path) -> None:
+def test_codex_read_only_source_inspection_allows_git_diff_with_bounded_sed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
     workspace_dir = tmp_path / "workspace"
     source_paths = [
         workspace_dir / "src" / "codex_plugin_scanner" / "guard" / "daemon" / "server.py",
@@ -13423,7 +13435,11 @@ def test_codex_read_only_source_inspection_allows_git_diff_with_bounded_sed(tmp_
     assert artifact is None
 
 
-def test_codex_read_only_source_inspection_rejects_git_diff_secret_path(tmp_path: Path) -> None:
+def test_codex_read_only_source_inspection_rejects_git_diff_secret_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
     workspace_dir = tmp_path / "workspace"
     _write_text(workspace_dir / ".env", "TOKEN_LABEL=value\n")
 
@@ -13433,7 +13449,11 @@ def test_codex_read_only_source_inspection_rejects_git_diff_secret_path(tmp_path
     )
 
 
-def test_codex_read_only_source_inspection_rejects_git_diff_external_config(tmp_path: Path) -> None:
+def test_codex_read_only_source_inspection_rejects_git_diff_external_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
     workspace_dir = tmp_path / "workspace"
     source_file = workspace_dir / "src" / "safe.ts"
     _write_text(source_file, "export const safe = true;\n")
@@ -13451,7 +13471,11 @@ def test_codex_read_only_source_inspection_rejects_git_diff_external_config(tmp_
     )
 
 
-def test_codex_read_only_source_inspection_rejects_git_diff_textconv_config(tmp_path: Path) -> None:
+def test_codex_read_only_source_inspection_rejects_git_diff_textconv_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
     workspace_dir = tmp_path / "workspace"
     source_file = workspace_dir / "src" / "safe.ts"
     _write_text(source_file, "export const safe = true;\n")
@@ -13469,7 +13493,51 @@ def test_codex_read_only_source_inspection_rejects_git_diff_textconv_config(tmp_
     )
 
 
-def test_codex_read_only_source_inspection_allows_git_diff_with_external_helpers_disabled(tmp_path: Path) -> None:
+def test_codex_read_only_source_inspection_rejects_git_external_diff_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
+    monkeypatch.setenv("GIT_EXTERNAL_DIFF", "/tmp/guard-helper")
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        "git diff -- src/safe.ts | sed -n '1,40p'",
+        cwd=workspace_dir,
+    )
+
+
+def test_codex_read_only_source_inspection_rejects_git_diff_global_textconv_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
+    global_config = tmp_path / "global-gitconfig"
+    _write_text(
+        global_config,
+        """
+[diff "guard"]
+    textconv = /tmp/guard-textconv
+""".strip(),
+    )
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(global_config))
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        "git diff -- src/safe.ts | sed -n '1,40p'",
+        cwd=workspace_dir,
+    )
+
+
+def test_codex_read_only_source_inspection_allows_git_diff_with_external_helpers_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
     workspace_dir = tmp_path / "workspace"
     source_file = workspace_dir / "src" / "safe.ts"
     _write_text(source_file, "export const safe = true;\n")
@@ -13487,7 +13555,11 @@ def test_codex_read_only_source_inspection_allows_git_diff_with_external_helpers
     )
 
 
-def test_codex_read_only_source_inspection_rejects_git_config_injection(tmp_path: Path) -> None:
+def test_codex_read_only_source_inspection_rejects_git_config_injection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
     workspace_dir = tmp_path / "workspace"
     source_file = workspace_dir / "src" / "safe.ts"
     _write_text(source_file, "export const safe = true;\n")
@@ -13498,7 +13570,11 @@ def test_codex_read_only_source_inspection_rejects_git_config_injection(tmp_path
     )
 
 
-def test_codex_read_only_source_inspection_rejects_unknown_git_diff_option(tmp_path: Path) -> None:
+def test_codex_read_only_source_inspection_rejects_unknown_git_diff_option(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
     workspace_dir = tmp_path / "workspace"
     source_file = workspace_dir / "src" / "safe.ts"
     _write_text(source_file, "export const safe = true;\n")
@@ -13509,7 +13585,11 @@ def test_codex_read_only_source_inspection_rejects_unknown_git_diff_option(tmp_p
     )
 
 
-def test_codex_read_only_source_inspection_rejects_unbounded_sed_filter(tmp_path: Path) -> None:
+def test_codex_read_only_source_inspection_rejects_unbounded_sed_filter(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
     workspace_dir = tmp_path / "workspace"
     source_file = workspace_dir / "src" / "safe.ts"
     _write_text(source_file, "export const safe = true;\n")

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13607,6 +13607,21 @@ def test_codex_read_only_source_inspection_rejects_unknown_git_diff_option(
     )
 
 
+def test_codex_read_only_source_inspection_rejects_disallowed_option_after_optional_git_diff_flag(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        "git diff --color --output=/tmp/leak -- src/safe.ts | sed -n '1,40p'",
+        cwd=workspace_dir,
+    )
+
+
 def test_codex_read_only_source_inspection_rejects_unbounded_sed_filter(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13572,6 +13572,32 @@ def test_codex_read_only_source_inspection_rejects_git_diff_global_textconv_conf
     )
 
 
+def test_codex_read_only_source_inspection_rejects_git_diff_included_config_with_comment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
+    included_config = tmp_path / "included-gitconfig"
+    _write_text(
+        included_config,
+        """
+[diff "guard"]
+    textconv = /tmp/guard-textconv
+""".strip(),
+    )
+    global_config = tmp_path / "global-gitconfig"
+    _write_text(global_config, f"[include]\n    path = {included_config} # required by local tools\n")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(global_config))
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        "git diff -- src/safe.ts | sed -n '1,40p'",
+        cwd=workspace_dir,
+    )
+
+
 def test_codex_read_only_source_inspection_allows_git_diff_with_external_helpers_disabled(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13433,6 +13433,82 @@ def test_codex_read_only_source_inspection_rejects_git_diff_secret_path(tmp_path
     )
 
 
+def test_codex_read_only_source_inspection_rejects_git_diff_external_config(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+    _write_text(
+        workspace_dir / ".git" / "config",
+        """
+[diff]
+    external = /tmp/guard-helper
+""".strip(),
+    )
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        "git diff -- src/safe.ts | sed -n '1,40p'",
+        cwd=workspace_dir,
+    )
+
+
+def test_codex_read_only_source_inspection_rejects_git_diff_textconv_config(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+    _write_text(
+        workspace_dir / ".git" / "config",
+        """
+[diff "guard"]
+    textconv = /tmp/guard-textconv
+""".strip(),
+    )
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        "git diff -- src/safe.ts | sed -n '1,40p'",
+        cwd=workspace_dir,
+    )
+
+
+def test_codex_read_only_source_inspection_allows_git_diff_with_external_helpers_disabled(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+    _write_text(
+        workspace_dir / ".git" / "config",
+        """
+[diff "guard"]
+    textconv = /tmp/guard-textconv
+""".strip(),
+    )
+
+    assert guard_commands_module._codex_command_is_read_only_source_inspection(
+        "git diff --no-ext-diff --no-textconv -- src/safe.ts | sed -n '1,40p'",
+        cwd=workspace_dir,
+    )
+
+
+def test_codex_read_only_source_inspection_rejects_git_config_injection(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        "git -c diff.external=/tmp/guard-helper diff -- src/safe.ts | sed -n '1,40p'",
+        cwd=workspace_dir,
+    )
+
+
+def test_codex_read_only_source_inspection_rejects_unknown_git_diff_option(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        "git diff --mystery -- src/safe.ts | sed -n '1,40p'",
+        cwd=workspace_dir,
+    )
+
+
 def test_codex_read_only_source_inspection_rejects_unbounded_sed_filter(tmp_path: Path) -> None:
     workspace_dir = tmp_path / "workspace"
     source_file = workspace_dir / "src" / "safe.ts"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -57,6 +57,7 @@ def _isolate_git_config(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
     monkeypatch.setenv("GIT_CONFIG_SYSTEM", os.devnull)
     monkeypatch.delenv("GIT_CONFIG_COUNT", raising=False)
+    monkeypatch.delenv("GIT_CONFIG_PARAMETERS", raising=False)
     monkeypatch.delenv("GIT_EXTERNAL_DIFF", raising=False)
 
 
@@ -13521,6 +13522,22 @@ def test_codex_read_only_source_inspection_rejects_git_external_diff_env(
 ) -> None:
     _isolate_git_config(monkeypatch)
     monkeypatch.setenv("GIT_EXTERNAL_DIFF", "/tmp/guard-helper")
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        "git diff -- src/safe.ts | sed -n '1,40p'",
+        cwd=workspace_dir,
+    )
+
+
+def test_codex_read_only_source_inspection_rejects_git_config_parameters_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
+    monkeypatch.setenv("GIT_CONFIG_PARAMETERS", "'diff.external=/tmp/guard-helper'")
     workspace_dir = tmp_path / "workspace"
     source_file = workspace_dir / "src" / "safe.ts"
     _write_text(source_file, "export const safe = true;\n")

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13493,6 +13493,28 @@ def test_codex_read_only_source_inspection_rejects_git_diff_textconv_config(
     )
 
 
+def test_codex_read_only_source_inspection_rejects_git_diff_driver_command_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+    _write_text(
+        workspace_dir / ".git" / "config",
+        """
+[diff "guard"]
+    command = /tmp/guard-diff
+""".strip(),
+    )
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        "git diff -- src/safe.ts | sed -n '1,40p'",
+        cwd=workspace_dir,
+    )
+
+
 def test_codex_read_only_source_inspection_rejects_git_external_diff_env(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13678,6 +13678,60 @@ def test_codex_read_only_source_inspection_rejects_matched_git_include_if(
     )
 
 
+def test_codex_read_only_source_inspection_rejects_git_include_if_gitdir_matches_dot_git(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
+    included_config = tmp_path / "included-gitconfig"
+    _write_text(
+        included_config,
+        """
+[diff]
+    external = /tmp/guard-diff
+""".strip(),
+    )
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+    _write_text(workspace_dir / ".git" / "HEAD", "ref: refs/heads/main\n")
+    global_config = tmp_path / "global-gitconfig"
+    _write_text(global_config, f'[includeIf "gitdir:{workspace_dir / ".git"}"]\n    path = {included_config}\n')
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(global_config))
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        "git diff -- src/safe.ts | sed -n '1,40p'",
+        cwd=workspace_dir,
+    )
+
+
+def test_codex_read_only_source_inspection_rejects_git_include_if_relative_gitdir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
+    included_config = tmp_path / "included-gitconfig"
+    _write_text(
+        included_config,
+        """
+[diff]
+    external = /tmp/guard-diff
+""".strip(),
+    )
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+    _write_text(workspace_dir / ".git" / "HEAD", "ref: refs/heads/main\n")
+    global_config = tmp_path / "global-gitconfig"
+    _write_text(global_config, f'[includeIf "gitdir:./workspace/.git"]\n    path = {included_config}\n')
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(global_config))
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        "git diff -- src/safe.ts | sed -n '1,40p'",
+        cwd=workspace_dir,
+    )
+
+
 def test_codex_read_only_source_inspection_allows_git_diff_with_external_helpers_disabled(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13732,6 +13732,69 @@ def test_codex_read_only_source_inspection_rejects_git_include_if_relative_gitdi
     )
 
 
+def test_codex_read_only_source_inspection_rejects_git_include_if_hasconfig(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
+    included_config = tmp_path / "included-gitconfig"
+    _write_text(
+        included_config,
+        """
+[diff]
+    external = /tmp/guard-diff
+""".strip(),
+    )
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+    _write_text(
+        workspace_dir / ".git" / "config",
+        """
+[remote "origin"]
+    url = https://github.com/hashgraph-online/ai-plugin-scanner
+""".strip(),
+    )
+    global_config = tmp_path / "global-gitconfig"
+    _write_text(
+        global_config,
+        f'[includeIf "hasconfig:remote.*.url:https://github.com/hashgraph-online/*"]\n    path = {included_config}\n',
+    )
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(global_config))
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        "git diff -- src/safe.ts | sed -n '1,40p'",
+        cwd=workspace_dir,
+    )
+
+
+def test_codex_read_only_source_inspection_rejects_git_include_if_onbranch_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
+    included_config = tmp_path / "included-gitconfig"
+    _write_text(
+        included_config,
+        """
+[diff]
+    external = /tmp/guard-diff
+""".strip(),
+    )
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+    _write_text(workspace_dir / ".git" / "HEAD", "ref: refs/heads/feature/read-only\n")
+    global_config = tmp_path / "global-gitconfig"
+    _write_text(global_config, f'[includeIf "onbranch:feature/"]\n    path = {included_config}\n')
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(global_config))
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        "git diff -- src/safe.ts | sed -n '1,40p'",
+        cwd=workspace_dir,
+    )
+
+
 def test_codex_read_only_source_inspection_allows_git_diff_with_external_helpers_disabled(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13669,6 +13669,21 @@ def test_codex_read_only_source_inspection_rejects_unbounded_sed_filter(
     )
 
 
+def test_codex_read_only_source_inspection_rejects_invalid_sed_without_crashing(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+
+    for command in (
+        "sed -i 's/safe/unsafe/' src/safe.ts",
+        "sed --unknown -n '1,40p' src/safe.ts",
+    ):
+        assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+            command,
+            cwd=workspace_dir,
+        )
+
+
 def test_codex_read_only_source_inspection_rejects_malformed_chains(tmp_path: Path) -> None:
     workspace_dir = tmp_path / "workspace"
     source_file = workspace_dir / "src" / "safe.ts"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13705,6 +13705,38 @@ def test_codex_read_only_source_inspection_rejects_git_include_if_gitdir_matches
     )
 
 
+def test_codex_read_only_source_inspection_rejects_git_include_if_gitdir_matches_symlink(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
+    included_config = tmp_path / "included-gitconfig"
+    _write_text(
+        included_config,
+        """
+[diff]
+    external = /tmp/guard-diff
+""".strip(),
+    )
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+    _write_text(workspace_dir / ".git" / "HEAD", "ref: refs/heads/main\n")
+    symlink_dir = tmp_path / "workspace-link"
+    try:
+        symlink_dir.symlink_to(workspace_dir, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlink unavailable: {exc}")
+    global_config = tmp_path / "global-gitconfig"
+    _write_text(global_config, f'[includeIf "gitdir:{symlink_dir / ".git"}"]\n    path = {included_config}\n')
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(global_config))
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        "git diff -- src/safe.ts | sed -n '1,40p'",
+        cwd=symlink_dir,
+    )
+
+
 def test_codex_read_only_source_inspection_rejects_git_include_if_relative_gitdir(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13807,6 +13807,31 @@ def test_codex_read_only_source_inspection_rejects_git_include_if_hasconfig_nest
     )
 
 
+def test_codex_read_only_source_inspection_rejects_git_config_continued_include_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+    _write_text(workspace_dir / ".git" / "HEAD", "ref: refs/heads/main\n")
+    _write_text(workspace_dir / "helper-gitconfig", "[diff]\n    external = /tmp/guard-diff\n")
+    _write_text(
+        workspace_dir / ".git" / "config",
+        """
+[include]
+    path = ../helper-\\
+        gitconfig
+""".strip(),
+    )
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        "git diff -- src/safe.ts | sed -n '1,40p'",
+        cwd=workspace_dir,
+    )
+
+
 def test_codex_read_only_source_inspection_rejects_git_include_if_onbranch_prefix(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13624,6 +13624,60 @@ def test_codex_read_only_source_inspection_rejects_git_diff_included_config_with
     )
 
 
+def test_codex_read_only_source_inspection_ignores_unmatched_git_include_if(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
+    included_config = tmp_path / "included-gitconfig"
+    _write_text(
+        included_config,
+        """
+[diff]
+    external = /tmp/guard-diff
+""".strip(),
+    )
+    global_config = tmp_path / "global-gitconfig"
+    _write_text(global_config, f'[includeIf "gitdir:{tmp_path / "other-repo"}/"]\n    path = {included_config}\n')
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(global_config))
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+    _write_text(workspace_dir / ".git" / "HEAD", "ref: refs/heads/main\n")
+
+    assert guard_commands_module._codex_command_is_read_only_source_inspection(
+        "git diff -- src/safe.ts | sed -n '1,40p'",
+        cwd=workspace_dir,
+    )
+
+
+def test_codex_read_only_source_inspection_rejects_matched_git_include_if(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
+    included_config = tmp_path / "included-gitconfig"
+    _write_text(
+        included_config,
+        """
+[diff]
+    external = /tmp/guard-diff
+""".strip(),
+    )
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+    _write_text(workspace_dir / ".git" / "HEAD", "ref: refs/heads/main\n")
+    global_config = tmp_path / "global-gitconfig"
+    _write_text(global_config, f'[includeIf "gitdir:{workspace_dir}/"]\n    path = {included_config}\n')
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(global_config))
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        "git diff -- src/safe.ts | sed -n '1,40p'",
+        cwd=workspace_dir,
+    )
+
+
 def test_codex_read_only_source_inspection_allows_git_diff_with_external_helpers_disabled(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13768,6 +13768,45 @@ def test_codex_read_only_source_inspection_rejects_git_include_if_hasconfig(
     )
 
 
+def test_codex_read_only_source_inspection_rejects_git_include_if_hasconfig_nested_include(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _isolate_git_config(monkeypatch)
+    helper_config = tmp_path / "helper-gitconfig"
+    _write_text(
+        helper_config,
+        """
+[diff]
+    external = /tmp/guard-diff
+""".strip(),
+    )
+    remote_config = tmp_path / "remote-gitconfig"
+    _write_text(
+        remote_config,
+        """
+[remote "origin"]
+    url = https://github.com/hashgraph-online/ai-plugin-scanner
+""".strip(),
+    )
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+    _write_text(workspace_dir / ".git" / "HEAD", "ref: refs/heads/main\n")
+    _write_text(workspace_dir / ".git" / "config", f"[include]\n    path = {remote_config}\n")
+    global_config = tmp_path / "global-gitconfig"
+    _write_text(
+        global_config,
+        f'[includeIf "hasconfig:remote.*.url:https://github.com/hashgraph-online/*"]\n    path = {helper_config}\n',
+    )
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(global_config))
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        "git diff -- src/safe.ts | sed -n '1,40p'",
+        cwd=workspace_dir,
+    )
+
+
 def test_codex_read_only_source_inspection_rejects_git_include_if_onbranch_prefix(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13382,6 +13382,68 @@ def test_codex_read_only_source_inspection_preserves_pipelines_in_safe_chains(tm
     )
 
 
+def test_codex_read_only_source_inspection_allows_git_diff_with_bounded_sed(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    source_paths = [
+        workspace_dir / "src" / "codex_plugin_scanner" / "guard" / "daemon" / "server.py",
+        workspace_dir / "dashboard" / "src" / "approval-center-layout.tsx",
+        workspace_dir / "dashboard" / "src" / "review-workspace.tsx",
+        workspace_dir / "tests" / "test_guard_approvals.py",
+    ]
+    for path in source_paths:
+        _write_text(path, "TOKEN_LABEL = 'credential-looking output text only'\n")
+
+    command = (
+        "git diff -- "
+        "src/codex_plugin_scanner/guard/daemon/server.py "
+        "dashboard/src/approval-center-layout.tsx "
+        "dashboard/src/review-workspace.tsx "
+        "tests/test_guard_approvals.py | sed -n '1,260p'"
+    )
+
+    assert guard_commands_module._codex_command_is_read_only_source_inspection(
+        command,
+        cwd=workspace_dir,
+    )
+    artifact = guard_commands_module._codex_post_tool_output_artifact(
+        payload={
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "tool_response": {
+                "stdout": (
+                    "+TOKEN_LABEL = 'credential-looking output text only'\n"
+                    "+request_summary = 'credential-looking output reached Codex'\n"
+                )
+            },
+        },
+        config_path=str(workspace_dir / ".codex" / "config.toml"),
+        source_scope="workspace",
+        cwd=workspace_dir,
+    )
+    assert artifact is None
+
+
+def test_codex_read_only_source_inspection_rejects_git_diff_secret_path(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    _write_text(workspace_dir / ".env", "TOKEN_LABEL=value\n")
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        "git diff -- .env | sed -n '1,40p'",
+        cwd=workspace_dir,
+    )
+
+
+def test_codex_read_only_source_inspection_rejects_unbounded_sed_filter(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        "git diff -- src/safe.ts | sed 's/token/value/'",
+        cwd=workspace_dir,
+    )
+
+
 def test_codex_read_only_source_inspection_rejects_malformed_chains(tmp_path: Path) -> None:
     workspace_dir = tmp_path / "workspace"
     source_file = workspace_dir / "src" / "safe.ts"

--- a/tests/test_guard_wrapper_flows.py
+++ b/tests/test_guard_wrapper_flows.py
@@ -1,0 +1,297 @@
+"""Guard wrapper flow tests — P4.
+
+Covers:
+- wait_for_approval_requests resolves immediately when all items resolved
+- wait_for_approval_requests returns pending when timeout fires
+- _headless_approval_resolver with --json flag (noninteractive) skips waiting
+- _headless_approval_resolver timeout produces hint with pending request IDs
+- Duplicate approval requests for same artifact are not re-queued
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.approvals import wait_for_approval_requests
+from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.models import (
+    GuardArtifact,
+    HarnessDetection,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _make_artifact(artifact_id: str = "codex:project:my_tool") -> GuardArtifact:
+    return GuardArtifact(
+        artifact_id=artifact_id,
+        name="my_tool",
+        harness="codex",
+        artifact_type="mcp_server",
+        source_scope="project",
+        config_path="/home/user/.codex/config.toml",
+        command="python",
+        args=("-m", "my_tool"),
+        transport="stdio",
+    )
+
+
+def _make_detection(artifact: GuardArtifact) -> HarnessDetection:
+    return HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(artifact.config_path,),
+        artifacts=(artifact,),
+    )
+
+
+class TestWaitForApprovalRequests:
+    def _add_request(
+        self, store: GuardStore, req_id: str, status: str = "pending"
+    ) -> str:
+        from codex_plugin_scanner.guard.models import GuardApprovalRequest
+
+        request = GuardApprovalRequest(
+            request_id=req_id,
+            harness="codex",
+            artifact_id="codex:project:my_tool",
+            artifact_name="my_tool",
+            artifact_hash="sha256-abc",
+            policy_action="require-reapproval",
+            recommended_scope="artifact",
+            changed_fields=("args",),
+            source_scope="project",
+            config_path="/workspace/.codex/config.toml",
+            review_command=f"hol-guard approvals approve {req_id}",
+            approval_url=f"http://127.0.0.1:4455/approvals/{req_id}",
+        )
+        persisted_id = store.add_approval_request(request, "2026-01-01T00:00:00+00:00")
+        if status == "resolved":
+            store.resolve_approval_request(
+                persisted_id,
+                resolution_action="allow",
+                resolution_scope="artifact",
+                reason=None,
+                resolved_at="2026-01-01T00:00:01+00:00",
+            )
+        return persisted_id
+
+    def test_resolves_immediately_when_all_requests_resolved(self, tmp_path: Path) -> None:
+        store = GuardStore(tmp_path / "guard")
+        req_id = self._add_request(store, "req-001", status="resolved")
+        result = wait_for_approval_requests(
+            store=store,
+            request_ids=[req_id],
+            timeout_seconds=30,
+            poll_interval=0.01,
+        )
+        assert result["resolved"] is True
+        assert result["pending_request_ids"] == []
+
+    def test_returns_pending_after_timeout_when_not_resolved(self, tmp_path: Path) -> None:
+        store = GuardStore(tmp_path / "guard")
+        req_id = self._add_request(store, "req-002", status="pending")
+        start = time.monotonic()
+        result = wait_for_approval_requests(
+            store=store,
+            request_ids=[req_id],
+            timeout_seconds=0,
+            poll_interval=0.01,
+        )
+        elapsed = time.monotonic() - start
+        assert result["resolved"] is False
+        assert req_id in result["pending_request_ids"]
+        assert elapsed < 2.0, "Timeout=0 should return almost immediately"
+
+    def test_resolves_partial_when_some_resolved_some_pending(self, tmp_path: Path) -> None:
+        store = GuardStore(tmp_path / "guard")
+        resolved_id = self._add_request(store, "req-003", status="resolved")
+        pending_id = self._add_request(store, "req-004", status="pending")
+        result = wait_for_approval_requests(
+            store=store,
+            request_ids=[resolved_id, pending_id],
+            timeout_seconds=0,
+            poll_interval=0.01,
+        )
+        assert result["resolved"] is False
+        assert pending_id in result["pending_request_ids"]
+        assert resolved_id not in result["pending_request_ids"]
+
+    def test_empty_request_list_resolves_immediately(self, tmp_path: Path) -> None:
+        store = GuardStore(tmp_path / "guard")
+        result = wait_for_approval_requests(
+            store=store,
+            request_ids=[],
+            timeout_seconds=5,
+            poll_interval=0.01,
+        )
+        assert result["resolved"] is True
+        assert result["pending_request_ids"] == []
+
+
+class TestHeadlessApprovalResolverNoninteractive:
+    def _make_resolver(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        json_flag: bool = True,
+    ) -> Any:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir(parents=True, exist_ok=True)
+        store = GuardStore(home_dir)
+        config = GuardConfig(
+            guard_home=home_dir,
+            workspace=workspace_dir,
+            approval_wait_timeout_seconds=1,
+        )
+        monkeypatch.setattr(
+            guard_commands_module,
+            "ensure_guard_daemon",
+            lambda _: "http://127.0.0.1:4455",
+        )
+        monkeypatch.setattr(
+            guard_commands_module,
+            "load_guard_surface_daemon_client",
+            lambda _: (_ for _ in ()).throw(RuntimeError("daemon unavailable")),
+        )
+        args = argparse.Namespace(harness="codex", json=json_flag)
+        context = HarnessContext(
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+            guard_home=home_dir,
+        )
+        return guard_commands_module._headless_approval_resolver(
+            args=args,
+            context=context,
+            store=store,
+            config=config,
+        ), store
+
+    def test_json_flag_skips_wait_and_returns_unresolved_approval_wait(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        resolver, _store = self._make_resolver(tmp_path, monkeypatch, json_flag=True)
+        artifact = _make_artifact()
+        payload: dict[str, Any] = {
+            "blocked": True,
+            "artifacts": [
+                {
+                    "artifact_id": artifact.artifact_id,
+                    "artifact_name": artifact.name,
+                    "artifact_hash": "sha256-abc",
+                    "policy_action": "require-reapproval",
+                    "changed_fields": ["args"],
+                    "artifact_type": artifact.artifact_type,
+                    "source_scope": artifact.source_scope,
+                    "config_path": artifact.config_path,
+                    "launch_target": "python -m my_tool",
+                }
+            ],
+        }
+        detection = _make_detection(artifact)
+        result = resolver(detection, payload)
+
+        assert "approval_wait" in result
+        assert result["approval_wait"]["resolved"] is False
+
+    def test_noninteractive_resolver_includes_approval_center_url(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        resolver, _store = self._make_resolver(tmp_path, monkeypatch, json_flag=True)
+        artifact = _make_artifact()
+        payload: dict[str, Any] = {
+            "blocked": True,
+            "artifacts": [
+                {
+                    "artifact_id": artifact.artifact_id,
+                    "artifact_name": artifact.name,
+                    "artifact_hash": "sha256-abc",
+                    "policy_action": "require-reapproval",
+                    "changed_fields": ["args"],
+                    "artifact_type": artifact.artifact_type,
+                    "source_scope": artifact.source_scope,
+                    "config_path": artifact.config_path,
+                    "launch_target": "python -m my_tool",
+                }
+            ],
+        }
+        detection = _make_detection(artifact)
+        result = resolver(detection, payload)
+
+        assert result.get("approval_center_url") == "http://127.0.0.1:4455"
+
+
+class TestHeadlessApprovalResolverTimeout:
+    def test_timeout_produces_review_hint_with_pending_request_ids(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir(parents=True, exist_ok=True)
+        store = GuardStore(home_dir)
+        config = GuardConfig(
+            guard_home=home_dir,
+            workspace=workspace_dir,
+            approval_wait_timeout_seconds=0,
+        )
+        monkeypatch.setattr(
+            guard_commands_module,
+            "ensure_guard_daemon",
+            lambda _: "http://127.0.0.1:4455",
+        )
+        monkeypatch.setattr(
+            guard_commands_module,
+            "load_guard_surface_daemon_client",
+            lambda _: (_ for _ in ()).throw(RuntimeError("daemon unavailable")),
+        )
+
+        args = argparse.Namespace(harness="codex", json=False)
+        context = HarnessContext(
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+            guard_home=home_dir,
+        )
+        resolver = guard_commands_module._headless_approval_resolver(
+            args=args,
+            context=context,
+            store=store,
+            config=config,
+        )
+
+        artifact = _make_artifact()
+        payload: dict[str, Any] = {
+            "blocked": True,
+            "artifacts": [
+                {
+                    "artifact_id": artifact.artifact_id,
+                    "artifact_name": artifact.name,
+                    "artifact_hash": "sha256-abc",
+                    "policy_action": "require-reapproval",
+                    "changed_fields": ["args"],
+                    "artifact_type": artifact.artifact_type,
+                    "source_scope": artifact.source_scope,
+                    "config_path": artifact.config_path,
+                    "launch_target": "python -m my_tool",
+                }
+            ],
+        }
+        detection = _make_detection(artifact)
+        result = resolver(detection, payload)
+
+        assert result["approval_wait"]["resolved"] is False
+        review_hint = str(result.get("review_hint", ""))
+        assert "pending" in review_hint.lower() or "approval" in review_hint.lower()


### PR DESCRIPTION
## Summary
- treat explicit-path git diff as read-only source inspection
- allow bounded sed print filters after safe read-only pipelines
- keep .env targets, --no-index, external diff/textconv, and unbounded sed rejected

## Verification
- direct python verification: target git diff pipeline suppresses credential-looking artifact
- direct python verification: .env, --no-index, and unbounded sed cases rejected
- syntax parse via ast
- git diff --check

Note: local HOL Guard currently blocks pytest/compileall commands as destructive shell commands, which is the broader class this PR reduces for safe source inspection.