### PR TITLE
feat(guard): harden local install flows

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/approval_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/approval_commands.py
@@ -191,7 +191,11 @@ def _repaired_approval_url(approval_url: str, guard_home: Path) -> str:
         return approval_url
     parsed_approval = urllib.parse.urlparse(approval_url)
     parsed_daemon = urllib.parse.urlparse(daemon_url)
-    if parsed_approval.scheme not in {"http", "https"} or parsed_approval.hostname not in {"127.0.0.1", "localhost"}:
+    if parsed_approval.scheme not in {"http", "https"} or parsed_approval.hostname not in {
+        "127.0.0.1",
+        "::1",
+        "localhost",
+    }:
         return approval_url
     return urllib.parse.urlunparse(
         (

--- a/src/codex_plugin_scanner/guard/cli/approval_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/approval_commands.py
@@ -189,8 +189,11 @@ def _repaired_approval_url(approval_url: str, guard_home: Path) -> str:
     daemon_url = load_guard_daemon_url(guard_home)
     if daemon_url is None:
         return approval_url
-    parsed_approval = urllib.parse.urlparse(approval_url)
-    parsed_daemon = urllib.parse.urlparse(daemon_url)
+    try:
+        parsed_approval = urllib.parse.urlparse(approval_url)
+        parsed_daemon = urllib.parse.urlparse(daemon_url)
+    except ValueError:
+        return approval_url
     if parsed_approval.scheme not in {"http", "https"} or parsed_approval.hostname not in {
         "127.0.0.1",
         "::1",

--- a/src/codex_plugin_scanner/guard/cli/approval_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/approval_commands.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import urllib.parse
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -153,7 +154,13 @@ def run_approval_open_command(
     item = store.get_approval_request(request_id)
     if item is None:
         return {"error": "not_found", "request_id": request_id}, 1
-    return {"request_id": request_id, "approval_url": str(item.get("approval_url", ""))}, 0
+    approval_url = str(item.get("approval_url", ""))
+    repaired_url = _repaired_approval_url(approval_url, store.guard_home)
+    return {
+        "request_id": request_id,
+        "approval_url": repaired_url,
+        "repaired": repaired_url != approval_url,
+    }, 0
 
 
 def run_approval_retry_hint_command(
@@ -176,3 +183,23 @@ def run_approval_retry_hint_command(
 
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _repaired_approval_url(approval_url: str, guard_home: Path) -> str:
+    daemon_url = load_guard_daemon_url(guard_home)
+    if daemon_url is None:
+        return approval_url
+    parsed_approval = urllib.parse.urlparse(approval_url)
+    parsed_daemon = urllib.parse.urlparse(daemon_url)
+    if parsed_approval.scheme not in {"http", "https"} or parsed_approval.hostname not in {"127.0.0.1", "localhost"}:
+        return approval_url
+    return urllib.parse.urlunparse(
+        (
+            parsed_daemon.scheme,
+            parsed_daemon.netloc,
+            parsed_approval.path,
+            parsed_approval.params,
+            parsed_approval.query,
+            parsed_approval.fragment,
+        )
+    )

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -109,29 +109,31 @@ def run_guard_connect_command(
         plan_msg = str(plan_error).strip() or "Cloud sync requires a paid Guard plan."
         pending_sync_payload = dict(runtime_sync_summary)
         pending_sync_payload["synced_at"] = None
-        pending_state = _record_connect_result(
+        return _build_sync_not_available_payload(
             daemon_client=daemon_client,
             store=store,
             request_id=str(connect_request["request_id"]),
-            status="retry_required",
-            milestone="first_sync_failed",
             reason=plan_msg,
             sync=pending_sync_payload,
-        )
-        return build_connect_payload(
-            state=pending_state,
             browser_opened=browser_opened,
             connect_url=browser_url,
             sync_url=sync_url,
-            connected=False,
-            sync=pending_sync_payload,
-            sync_available=False,
-            sync_message=plan_msg,
         )
     except (RuntimeError, OSError, urllib.error.URLError, json.JSONDecodeError) as error:
         sync_message = str(error)
         pending_sync_payload = dict(runtime_sync_summary)
         pending_sync_payload["synced_at"] = None
+        if _is_paid_plan_sync_error(sync_message):
+            return _build_sync_not_available_payload(
+                daemon_client=daemon_client,
+                store=store,
+                request_id=str(connect_request["request_id"]),
+                reason=sync_message,
+                sync=pending_sync_payload,
+                browser_opened=browser_opened,
+                connect_url=browser_url,
+                sync_url=sync_url,
+            )
         pending_state = _record_connect_result(
             daemon_client=daemon_client,
             store=store,
@@ -314,7 +316,46 @@ def build_connect_payload(
         payload["sync"] = sync
     if sync_message is not None and sync_message.strip():
         payload["sync_message"] = sync_message
+    if not browser_opened:
+        payload["next_action"] = {
+            "label": "Copy pairing URL",
+            "reason": "Browser did not open automatically.",
+            "target": connect_url,
+        }
     return payload
+
+
+def _build_sync_not_available_payload(
+    *,
+    daemon_client: GuardSurfaceDaemonClient,
+    store: GuardStore,
+    request_id: str,
+    reason: str,
+    sync: dict[str, object],
+    browser_opened: bool,
+    connect_url: str,
+    sync_url: str,
+) -> dict[str, object]:
+    message = "Local Guard is connected. Shared cloud sync needs a paid Guard plan."
+    pending_state = _record_connect_result(
+        daemon_client=daemon_client,
+        store=store,
+        request_id=request_id,
+        status="connected",
+        milestone="sync_not_available",
+        reason=message,
+        sync={**sync, "sync_not_available_reason": reason},
+    )
+    return build_connect_payload(
+        state=pending_state,
+        browser_opened=browser_opened,
+        connect_url=connect_url,
+        sync_url=sync_url,
+        connected=True,
+        sync={**sync, "sync_not_available_reason": reason},
+        sync_available=False,
+        sync_message=message,
+    )
 
 
 def _record_connect_result(

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -32,7 +32,7 @@ def apply_managed_install(
         store.set_managed_install(canonical_harness, active, workspace, manifest, now)
         managed_install = store.get_managed_install(canonical_harness)
         if managed_install is not None:
-            managed_installs.append(managed_install)
+            managed_installs.append(_managed_install_payload(managed_install))
     payload: dict[str, object] = {
         "managed_installs": managed_installs,
         "auto_detected": requested_harness is None or install_all,
@@ -43,6 +43,17 @@ def apply_managed_install(
         skill_scan = scan_workspace_skills(context.workspace_dir, store, now)
         if skill_scan:
             payload["skill_scan"] = skill_scan
+    return payload
+
+
+def _managed_install_payload(managed_install: dict[str, object]) -> dict[str, object]:
+    payload = dict(managed_install)
+    manifest = payload.get("manifest")
+    if isinstance(manifest, dict):
+        for key in ("config_path", "managed_config_path", "shim_path", "mode"):
+            value = manifest.get(key)
+            if value is not None:
+                payload[key] = value
     return payload
 
 

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib
 import importlib.metadata
 import json
+import shlex
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -12,6 +14,7 @@ from pathlib import Path
 
 from ..adapters.base import HarnessContext
 from ..adapters.codex import CodexHarnessAdapter, codex_native_hook_state
+from ..redaction import redact_sensitive_text
 from ..store import GuardStore
 from .install_commands import apply_managed_install
 
@@ -36,6 +39,8 @@ def run_guard_update(
         "current_version": current_version,
         "installer": installer,
         "command": command,
+        "retry_command": _shell_command(command),
+        "binary_diagnostics": _binary_diagnostics(command),
         "dry_run": dry_run,
     }
     direct_url = _direct_url_payload()
@@ -65,7 +70,8 @@ def run_guard_update(
     except OSError as error:
         payload["status"] = "failed"
         payload["changed"] = False
-        payload["error"] = str(error)
+        payload["error"] = redact_sensitive_text(str(error))
+        payload["message"] = "HOL Guard update failed before the installer started."
         return payload, 1
     payload["stdout"] = _normalize_output_text(result.stdout)
     payload["stderr"] = _normalize_output_text(result.stderr)
@@ -104,7 +110,28 @@ def run_guard_update(
 
 
 def _normalize_output_text(value: str) -> str:
-    return value.strip()
+    return redact_sensitive_text(value.strip())
+
+
+def _shell_command(command: list[str]) -> str:
+    return shlex.join(command)
+
+
+def _binary_diagnostics(command: list[str]) -> dict[str, object]:
+    resolved_binary = shutil.which("hol-guard")
+    installer_binary = command[0] if command else ""
+    path_status = "unknown"
+    if resolved_binary is None:
+        path_status = "not_on_path"
+    elif Path(resolved_binary).resolve() == Path(installer_binary).resolve():
+        path_status = "matches_installer"
+    else:
+        path_status = "path_mismatch"
+    return {
+        "resolved_hol_guard": resolved_binary,
+        "installer_binary": installer_binary,
+        "path_status": path_status,
+    }
 
 
 def _output_lines(value: str) -> list[str]:

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import importlib.metadata
 import json
+import os
 import shlex
 import shutil
 import sqlite3
@@ -114,6 +115,8 @@ def _normalize_output_text(value: str) -> str:
 
 
 def _shell_command(command: list[str]) -> str:
+    if os.name == "nt":
+        return subprocess.list2cmdline(command)
     return shlex.join(command)
 
 

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -129,7 +129,7 @@ def _binary_diagnostics(command: list[str], installer: str) -> dict[str, object]
         path_status = "not_on_path"
     elif installer == "pipx":
         path_status = "pipx_shim_detected"
-    elif expected_script_dir is not None and Path(resolved_binary).resolve().parent == expected_script_dir:
+    elif expected_script_dir is not None and _script_dir(resolved_binary) == expected_script_dir:
         path_status = "matches_installer"
     else:
         path_status = "path_mismatch"
@@ -144,7 +144,11 @@ def _binary_diagnostics(command: list[str], installer: str) -> dict[str, object]
 def _expected_script_dir(installer_binary: str, installer: str) -> Path | None:
     if installer != "pip" or not installer_binary:
         return None
-    return Path(installer_binary).resolve().parent
+    return _script_dir(installer_binary)
+
+
+def _script_dir(path: str) -> Path:
+    return Path(path).expanduser().parent
 
 
 def _output_lines(value: str) -> list[str]:

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -11,6 +11,7 @@ import shutil
 import sqlite3
 import subprocess
 import sys
+import sysconfig
 from pathlib import Path
 
 from ..adapters.base import HarnessContext
@@ -144,11 +145,21 @@ def _binary_diagnostics(command: list[str], installer: str) -> dict[str, object]
 def _expected_script_dir(installer_binary: str, installer: str) -> Path | None:
     if installer != "pip" or not installer_binary:
         return None
+    scripts_dir = sysconfig.get_path("scripts")
+    if scripts_dir:
+        return _directory_path(scripts_dir)
     return _script_dir(installer_binary)
 
 
 def _script_dir(path: str) -> Path:
-    return Path(path).expanduser().parent
+    return _directory_path(Path(path).expanduser().parent)
+
+
+def _directory_path(path: str | Path) -> Path:
+    directory = Path(path).expanduser()
+    if not directory.is_absolute():
+        directory = Path.cwd() / directory
+    return directory.resolve(strict=False)
 
 
 def _output_lines(value: str) -> list[str]:

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -41,7 +41,7 @@ def run_guard_update(
         "installer": installer,
         "command": command,
         "retry_command": _shell_command(command),
-        "binary_diagnostics": _binary_diagnostics(command),
+        "binary_diagnostics": _binary_diagnostics(command, installer),
         "dry_run": dry_run,
     }
     direct_url = _direct_url_payload()
@@ -120,21 +120,31 @@ def _shell_command(command: list[str]) -> str:
     return shlex.join(command)
 
 
-def _binary_diagnostics(command: list[str]) -> dict[str, object]:
+def _binary_diagnostics(command: list[str], installer: str) -> dict[str, object]:
     resolved_binary = shutil.which("hol-guard")
     installer_binary = command[0] if command else ""
+    expected_script_dir = _expected_script_dir(installer_binary, installer)
     path_status = "unknown"
     if resolved_binary is None:
         path_status = "not_on_path"
-    elif Path(resolved_binary).resolve() == Path(installer_binary).resolve():
+    elif installer == "pipx":
+        path_status = "pipx_shim_detected"
+    elif expected_script_dir is not None and Path(resolved_binary).resolve().parent == expected_script_dir:
         path_status = "matches_installer"
     else:
         path_status = "path_mismatch"
     return {
         "resolved_hol_guard": resolved_binary,
         "installer_binary": installer_binary,
+        "expected_script_dir": str(expected_script_dir) if expected_script_dir is not None else None,
         "path_status": path_status,
     }
+
+
+def _expected_script_dir(installer_binary: str, installer: str) -> Path | None:
+    if installer != "pip" or not installer_binary:
+        return None
+    return Path(installer_binary).resolve().parent
 
 
 def _output_lines(value: str) -> list[str]:

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6699,12 +6699,14 @@ url = http://127.0.0.1:8787/guard-canary
                 "receiptsStored": 1,
             }
 
-        assert connect_rc == 1
-        assert connect_output["connected"] is False
-        assert connect_output["status"] == "retry_required"
-        assert connect_output["milestone"] == "first_sync_failed"
-        assert connect_output["reason"] == "Guard sync requires a Pro or Team plan."
-        assert connect_output["sync_message"] == "Guard sync requires a Pro or Team plan."
+        assert connect_rc == 0
+        assert connect_output["connected"] is True
+        assert connect_output["sync_available"] is False
+        assert connect_output["status"] == "connected"
+        assert connect_output["milestone"] == "sync_not_available"
+        assert connect_output["reason"] == "Local Guard is connected. Shared cloud sync needs a paid Guard plan."
+        assert connect_output["sync_message"] == "Local Guard is connected. Shared cloud sync needs a paid Guard plan."
+        assert connect_output["sync"]["sync_not_available_reason"] == "Guard sync requires a Pro or Team plan."
 
     def test_guard_dashboard_opens_local_approval_center(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
@@ -7308,10 +7310,12 @@ url = http://127.0.0.1:8787/guard-canary
             wait_timeout_seconds=1,
         )
 
-        assert payload["connected"] is False
-        assert payload["status"] == "retry_required"
-        assert payload["milestone"] == "first_sync_failed"
-        assert payload["sync_message"] == "Guard Cloud sync requires a paid Guard plan"
+        assert payload["connected"] is True
+        assert payload["sync_available"] is False
+        assert payload["status"] == "connected"
+        assert payload["milestone"] == "sync_not_available"
+        assert payload["sync_message"] == "Local Guard is connected. Shared cloud sync needs a paid Guard plan."
+        assert payload["sync"]["sync_not_available_reason"] == "Guard Cloud sync requires a paid Guard plan"
 
     def test_guard_connect_reports_guard_plan_required_without_failing_pairing(self, tmp_path, monkeypatch):
         store = GuardStore(tmp_path / "guard-home")
@@ -7391,10 +7395,12 @@ url = http://127.0.0.1:8787/guard-canary
             wait_timeout_seconds=1,
         )
 
-        assert payload["connected"] is False
-        assert payload["status"] == "retry_required"
-        assert payload["milestone"] == "first_sync_failed"
-        assert payload["sync_message"] == "Guard plan required"
+        assert payload["connected"] is True
+        assert payload["sync_available"] is False
+        assert payload["status"] == "connected"
+        assert payload["milestone"] == "sync_not_available"
+        assert payload["sync_message"] == "Local Guard is connected. Shared cloud sync needs a paid Guard plan."
+        assert payload["sync"]["sync_not_available_reason"] == "Guard plan required"
 
     def test_guard_sync_persists_advisories_from_endpoint(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -297,11 +297,13 @@ def test_guard_connect_prefers_paid_plan_sync_note_over_runtime_sync_timeout(
     finally:
         daemon.stop()
 
-    assert payload["connected"] is False
-    assert payload["status"] == "retry_required"
-    assert payload["milestone"] == "first_sync_failed"
-    assert payload["reason"] == "Guard Cloud sync requires a paid Guard plan"
-    assert payload["sync_message"] == "Guard Cloud sync requires a paid Guard plan"
+    assert payload["connected"] is True
+    assert payload["sync_available"] is False
+    assert payload["status"] == "connected"
+    assert payload["milestone"] == "sync_not_available"
+    assert payload["reason"] == "Local Guard is connected. Shared cloud sync needs a paid Guard plan."
+    assert payload["sync_message"] == "Local Guard is connected. Shared cloud sync needs a paid Guard plan."
+    assert payload["sync"]["sync_not_available_reason"] == "Guard Cloud sync requires a paid Guard plan"
 
 
 def test_guard_connect_preserves_http_402_payment_required_sync_note(
@@ -373,11 +375,13 @@ def test_guard_connect_preserves_http_402_payment_required_sync_note(
     finally:
         daemon.stop()
 
-    assert payload["connected"] is False
-    assert payload["status"] == "retry_required"
-    assert payload["milestone"] == "first_sync_failed"
-    assert payload["reason"] == "HTTP Error 402: Payment Required"
-    assert payload["sync_message"] == "HTTP Error 402: Payment Required"
+    assert payload["connected"] is True
+    assert payload["sync_available"] is False
+    assert payload["status"] == "connected"
+    assert payload["milestone"] == "sync_not_available"
+    assert payload["reason"] == "Local Guard is connected. Shared cloud sync needs a paid Guard plan."
+    assert payload["sync_message"] == "Local Guard is connected. Shared cloud sync needs a paid Guard plan."
+    assert payload["sync"]["sync_not_available_reason"] == "HTTP Error 402: Payment Required"
 
 
 def test_guard_connect_keeps_pairing_when_runtime_sync_fails(

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -73,7 +73,7 @@ def test_install_aliases_resolve_to_native_contracts() -> None:
         assert adapter.harness == canonical
         assert alias in contract.install_aliases
         assert contract.coverage.browser_fallback is True
-        assert contract.coverage.native_hooks == contract.coverage.native_hooks
+        assert contract.coverage.native_hooks == (canonical in {"claude-code", "codex", "copilot"})
 
 
 def test_managed_install_is_idempotent_and_uninstall_tracks_guard_owned_state(tmp_path: Path) -> None:
@@ -208,4 +208,33 @@ def test_approval_open_repairs_stale_local_url(tmp_path: Path, monkeypatch: pyte
 
     assert exit_code == 0
     assert payload["approval_url"] == "http://127.0.0.1:4781/approvals/request-1"
+    assert payload["repaired"] is True
+
+
+def test_approval_open_repairs_ipv6_local_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    request = GuardApprovalRequest(
+        request_id="request-ipv6",
+        harness="codex",
+        artifact_id="artifact-1",
+        artifact_name="Tool",
+        artifact_hash="hash",
+        policy_action="block",
+        recommended_scope="artifact",
+        changed_fields=(),
+        source_scope="local",
+        config_path="config.toml",
+        review_command="hol-guard approvals approve request-ipv6",
+        approval_url="http://[::1]:4000/approvals/request-ipv6",
+    )
+    store.add_approval_request(request, "2026-05-12T00:00:00Z")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.approval_commands.load_guard_daemon_url",
+        lambda guard_home: "http://127.0.0.1:4781",
+    )
+
+    payload, exit_code = run_approval_open_command(argparse.Namespace(request_id="request-ipv6"), store=store)
+
+    assert exit_code == 0
+    assert payload["approval_url"] == "http://127.0.0.1:4781/approvals/request-ipv6"
     assert payload["repaired"] is True

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -56,6 +56,41 @@ def test_update_failure_redacts_output_and_returns_retry_command(monkeypatch: py
     assert payload["binary_diagnostics"]["path_status"] == "path_mismatch"
 
 
+def test_update_binary_diagnostics_accepts_same_environment_script(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.0")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pip")
+    monkeypatch.setattr(update_commands.sys, "executable", "/opt/guard/bin/python")
+    monkeypatch.setattr(
+        update_commands.shutil,
+        "which",
+        lambda name: "/opt/guard/bin/hol-guard" if name == "hol-guard" else None,
+    )
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=True)
+
+    assert exit_code == 0
+    assert payload["binary_diagnostics"]["path_status"] == "matches_installer"
+    assert payload["binary_diagnostics"]["expected_script_dir"] == "/opt/guard/bin"
+
+
+def test_update_binary_diagnostics_treats_pipx_shim_as_healthy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.0")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+    monkeypatch.setattr(
+        update_commands.shutil,
+        "which",
+        lambda name: "/Users/test/.local/bin/hol-guard" if name == "hol-guard" else None,
+    )
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=True)
+
+    assert exit_code == 0
+    assert payload["binary_diagnostics"]["path_status"] == "pipx_shim_detected"
+    assert payload["binary_diagnostics"]["expected_script_dir"] is None
+
+
 def test_install_aliases_resolve_to_native_contracts() -> None:
     aliases = {
         "claude": "claude-code",

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -315,3 +315,32 @@ def test_approval_open_repairs_ipv6_local_url(tmp_path: Path, monkeypatch: pytes
     assert exit_code == 0
     assert payload["approval_url"] == "http://127.0.0.1:4781/approvals/request-ipv6"
     assert payload["repaired"] is True
+
+
+def test_approval_open_preserves_malformed_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    request = GuardApprovalRequest(
+        request_id="request-bad-url",
+        harness="codex",
+        artifact_id="artifact-1",
+        artifact_name="Tool",
+        artifact_hash="hash",
+        policy_action="block",
+        recommended_scope="artifact",
+        changed_fields=(),
+        source_scope="local",
+        config_path="config.toml",
+        review_command="hol-guard approvals approve request-bad-url",
+        approval_url="http://[::1:4000/approvals/request-bad-url",
+    )
+    store.add_approval_request(request, "2026-05-12T00:00:00Z")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.approval_commands.load_guard_daemon_url",
+        lambda guard_home: "http://127.0.0.1:4781",
+    )
+
+    payload, exit_code = run_approval_open_command(argparse.Namespace(request_id="request-bad-url"), store=store)
+
+    assert exit_code == 0
+    assert payload["approval_url"] == "http://[::1:4000/approvals/request-bad-url"
+    assert payload["repaired"] is False

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -74,6 +74,26 @@ def test_update_binary_diagnostics_accepts_same_environment_script(monkeypatch: 
     assert payload["binary_diagnostics"]["expected_script_dir"] == "/opt/guard/bin"
 
 
+def test_update_binary_diagnostics_keeps_venv_script_dir_without_resolving_python(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.0")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pip")
+    monkeypatch.setattr(update_commands.sys, "executable", "/workspace/.venv/bin/python")
+    monkeypatch.setattr(
+        update_commands.shutil,
+        "which",
+        lambda name: "/workspace/.venv/bin/hol-guard" if name == "hol-guard" else None,
+    )
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=True)
+
+    assert exit_code == 0
+    assert payload["binary_diagnostics"]["path_status"] == "matches_installer"
+    assert payload["binary_diagnostics"]["expected_script_dir"] == "/workspace/.venv/bin"
+
+
 def test_update_binary_diagnostics_treats_pipx_shim_as_healthy(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.0")
     monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -1,0 +1,211 @@
+"""Phase 03 Guard local install, update, connect, and approval flow contracts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters import get_adapter
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.cli import update_commands
+from codex_plugin_scanner.guard.cli.approval_commands import run_approval_open_command
+from codex_plugin_scanner.guard.cli.connect_flow import run_guard_connect_command
+from codex_plugin_scanner.guard.cli.install_commands import apply_managed_install
+from codex_plugin_scanner.guard.models import GuardApprovalRequest
+from codex_plugin_scanner.guard.runtime import GuardSyncNotAvailableError
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _context(tmp_path: Path) -> HarnessContext:
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    guard_home = tmp_path / "guard-home"
+    workspace.mkdir(parents=True, exist_ok=True)
+    return HarnessContext(home_dir=home, workspace_dir=workspace, guard_home=guard_home)
+
+
+def test_update_failure_redacts_output_and_returns_retry_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.0")
+    monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda: "2.0.0")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pip")
+    monkeypatch.setattr(update_commands.sys, "executable", "/opt/guard/bin/python")
+    monkeypatch.setattr(
+        update_commands.shutil,
+        "which",
+        lambda name: "/usr/local/bin/hol-guard" if name == "hol-guard" else None,
+    )
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert command == ["/opt/guard/bin/python", "-m", "pip", "install", "--upgrade", "hol-guard"]
+        return subprocess.CompletedProcess(command, 1, "", "AUTH_TOKEN=hunter2\nnetwork unreachable")
+
+    monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False)
+
+    assert exit_code == 1
+    assert payload["status"] == "failed"
+    assert payload["retry_command"] == "/opt/guard/bin/python -m pip install --upgrade hol-guard"
+    assert "network unreachable" in str(payload["stderr"])
+    assert "hunter2" not in json.dumps(payload)
+    assert payload["binary_diagnostics"]["path_status"] == "path_mismatch"
+
+
+def test_install_aliases_resolve_to_native_contracts() -> None:
+    aliases = {
+        "claude": "claude-code",
+        "claude-code": "claude-code",
+        "codex": "codex",
+        "opencode": "opencode",
+        "copilot": "copilot",
+        "cursor": "cursor",
+        "gemini": "gemini",
+    }
+
+    for alias, canonical in aliases.items():
+        adapter = get_adapter(alias)
+        contract = adapter.setup_contract()
+        assert adapter.harness == canonical
+        assert alias in contract.install_aliases
+        assert contract.coverage.browser_fallback is True
+        assert contract.coverage.native_hooks == contract.coverage.native_hooks
+
+
+def test_managed_install_is_idempotent_and_uninstall_tracks_guard_owned_state(tmp_path: Path) -> None:
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+
+    first = apply_managed_install(
+        "install", "opencode", False, context, store, str(context.workspace_dir), "2026-05-12T00:00:00Z"
+    )
+    second = apply_managed_install(
+        "install", "opencode", False, context, store, str(context.workspace_dir), "2026-05-12T00:00:01Z"
+    )
+    removed = apply_managed_install(
+        "uninstall",
+        "opencode",
+        False,
+        context,
+        store,
+        str(context.workspace_dir),
+        "2026-05-12T00:00:02Z",
+    )
+
+    assert first["managed_install"]["harness"] == "opencode"
+    assert second["managed_install"]["config_path"] == first["managed_install"]["config_path"]
+    assert removed["managed_install"]["active"] is False
+    assert store.get_managed_install("opencode")["active"] is False
+
+
+def test_connect_free_plan_error_keeps_local_pairing_successful(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+
+    class DaemonClient:
+        daemon_url = "http://127.0.0.1:4781"
+
+        def create_connect_request(self, *, sync_url: str, allowed_origin: str) -> dict[str, object]:
+            return {
+                "request_id": "connect-free-plan",
+                "pairing_secret": "pairing-secret",
+                "expires_at": "2026-05-12T00:05:00Z",
+            }
+
+        def report_connect_result(
+            self,
+            *,
+            request_id: str,
+            status: str,
+            milestone: str,
+            reason: str | None = None,
+            sync: dict[str, object] | None = None,
+        ) -> dict[str, object]:
+            return {
+                "request_id": request_id,
+                "status": status,
+                "milestone": milestone,
+                "reason": reason,
+                "completed_at": "2026-05-12T00:00:10Z",
+                "expires_at": "2026-05-12T00:05:00Z",
+                "proof": sync or {},
+            }
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.cli.connect_flow.ensure_guard_daemon", lambda guard_home: "ok")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.connect_flow.load_guard_surface_daemon_client",
+        lambda guard_home: DaemonClient(),
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.connect_flow.wait_for_connect_transition",
+        lambda **kwargs: {
+            "request_id": "connect-free-plan",
+            "status": "connected",
+            "milestone": "first_sync_pending",
+            "completed_at": "2026-05-12T00:00:10Z",
+            "proof": {},
+        },
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.connect_flow.sync_runtime_session",
+        lambda current_store, *, session: {
+            "runtime_session_id": "guard-session-1",
+            "runtime_session_synced_at": "2026-05-12T00:00:11Z",
+            "runtime_sessions_visible": 1,
+        },
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.connect_flow.sync_receipts",
+        lambda current_store: (_ for _ in ()).throw(GuardSyncNotAvailableError("HTTP Error 403: plan required")),
+    )
+
+    payload = run_guard_connect_command(
+        guard_home=tmp_path / "guard-home",
+        store=store,
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        connect_url="https://hol.org/guard/connect",
+        opener=lambda url: False,
+        wait_timeout_seconds=1,
+    )
+
+    assert payload["connected"] is True
+    assert payload["sync_available"] is False
+    assert payload["status"] == "connected"
+    assert payload["milestone"] == "sync_not_available"
+    assert payload["sync_message"] == "Local Guard is connected. Shared cloud sync needs a paid Guard plan."
+    assert payload["next_action"]["label"] == "Copy pairing URL"
+
+
+def test_approval_open_repairs_stale_local_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    request = GuardApprovalRequest(
+        request_id="request-1",
+        harness="codex",
+        artifact_id="artifact-1",
+        artifact_name="Tool",
+        artifact_hash="hash",
+        policy_action="block",
+        recommended_scope="artifact",
+        changed_fields=(),
+        source_scope="local",
+        config_path="config.toml",
+        review_command="hol-guard approvals approve request-1",
+        approval_url="http://127.0.0.1:4000/approvals/request-1",
+    )
+    store.add_approval_request(request, "2026-05-12T00:00:00Z")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.approval_commands.load_guard_daemon_url",
+        lambda guard_home: "http://127.0.0.1:4781",
+    )
+
+    payload, exit_code = run_approval_open_command(argparse.Namespace(request_id="request-1"), store=store)
+
+    assert exit_code == 0
+    assert payload["approval_url"] == "http://127.0.0.1:4781/approvals/request-1"
+    assert payload["repaired"] is True

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -34,6 +34,7 @@ def test_update_failure_redacts_output_and_returns_retry_command(monkeypatch: py
     monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
     monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pip")
     monkeypatch.setattr(update_commands.sys, "executable", "/opt/guard/bin/python")
+    monkeypatch.setattr(update_commands.sysconfig, "get_path", lambda name: "/opt/guard/bin")
     monkeypatch.setattr(
         update_commands.shutil,
         "which",
@@ -61,6 +62,7 @@ def test_update_binary_diagnostics_accepts_same_environment_script(monkeypatch: 
     monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
     monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pip")
     monkeypatch.setattr(update_commands.sys, "executable", "/opt/guard/bin/python")
+    monkeypatch.setattr(update_commands.sysconfig, "get_path", lambda name: "/opt/guard/bin")
     monkeypatch.setattr(
         update_commands.shutil,
         "which",
@@ -81,6 +83,7 @@ def test_update_binary_diagnostics_keeps_venv_script_dir_without_resolving_pytho
     monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
     monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pip")
     monkeypatch.setattr(update_commands.sys, "executable", "/workspace/.venv/bin/python")
+    monkeypatch.setattr(update_commands.sysconfig, "get_path", lambda name: "/workspace/.venv/bin")
     monkeypatch.setattr(
         update_commands.shutil,
         "which",
@@ -92,6 +95,25 @@ def test_update_binary_diagnostics_keeps_venv_script_dir_without_resolving_pytho
     assert exit_code == 0
     assert payload["binary_diagnostics"]["path_status"] == "matches_installer"
     assert payload["binary_diagnostics"]["expected_script_dir"] == "/workspace/.venv/bin"
+
+
+def test_update_binary_diagnostics_uses_python_scripts_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.0")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pip")
+    monkeypatch.setattr(update_commands.sys, "executable", "/opt/python/bin/python")
+    monkeypatch.setattr(update_commands.sysconfig, "get_path", lambda name: "/opt/python/scripts")
+    monkeypatch.setattr(
+        update_commands.shutil,
+        "which",
+        lambda name: "/opt/python/scripts/hol-guard" if name == "hol-guard" else None,
+    )
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=True)
+
+    assert exit_code == 0
+    assert payload["binary_diagnostics"]["path_status"] == "matches_installer"
+    assert payload["binary_diagnostics"]["expected_script_dir"] == "/opt/python/scripts"
 
 
 def test_update_binary_diagnostics_treats_pipx_shim_as_healthy(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- harden update failure payloads with redacted output, retry commands, and binary diagnostics
- treat paid-plan cloud sync limits as local pairing success with clear upgrade guidance
- repair stale local approval URLs and expose flattened managed-install paths for app workflows
- add Phase 03 local install/connect regression coverage

## Verification
- uv run pytest tests/test_guard_phase03_local_install.py tests/test_guard_connect_flow.py tests/test_guard_harness_setup.py tests/test_guard_daemon_wake.py tests/test_guard_daemon_cli.py tests/test_guard_redaction.py -q
- uv run pytest tests/test_guard_cli.py tests/test_guard_codex_install.py tests/test_guard_phase03_local_install.py tests/test_guard_connect_flow.py -q
- uv run pytest tests/test_guard_*.py -q
- uv run ruff check src/codex_plugin_scanner/guard/cli/update_commands.py src/codex_plugin_scanner/guard/cli/install_commands.py src/codex_plugin_scanner/guard/cli/connect_flow.py src/codex_plugin_scanner/guard/cli/approval_commands.py tests/test_guard_phase03_local_install.py tests/test_guard_connect_flow.py tests/test_guard_cli.py
- uv run ruff format --check src/codex_plugin_scanner/guard/cli/update_commands.py src/codex_plugin_scanner/guard/cli/install_commands.py src/codex_plugin_scanner/guard/cli/connect_flow.py src/codex_plugin_scanner/guard/cli/approval_commands.py tests/test_guard_phase03_local_install.py tests/test_guard_connect_flow.py tests/test_guard_cli.py
- uv build --wheel