### PR TITLE
fix(dashboard): paginate review queue and calm evidence tab UX

### DIFF
--- a/dashboard/src/evidence/app-tab.tsx
+++ b/dashboard/src/evidence/app-tab.tsx
@@ -61,7 +61,7 @@ function AppTabRaw({ receipts }: AppTabProps) {
 
   if (appReceipts.length === 0) {
     return (
-      <div className="rounded-2xl border border-slate-100 bg-white/60 p-8 text-center">
+      <div className="rounded-xl border border-slate-100 bg-white/60 p-6 text-center">
         <p className="text-sm text-slate-500">No activity yet.</p>
         <p className="mt-1 text-xs text-slate-400">App activity will appear here after Guard makes decisions.</p>
       </div>
@@ -75,7 +75,7 @@ function AppTabRaw({ receipts }: AppTabProps) {
     const color = harnessColor(selectedApp);
 
     return (
-      <div className="space-y-6">
+      <div className="space-y-4">
         <div className="flex items-center gap-3">
           <button
             onClick={() => setSelectedApp(null)}
@@ -93,7 +93,7 @@ function AppTabRaw({ receipts }: AppTabProps) {
           </a>
         </div>
 
-        <div className="rounded-2xl border border-slate-100 bg-white/60 p-5">
+        <div className="rounded-xl border border-slate-100 bg-white/60 p-4">
           <div className="flex items-center gap-3">
             <span
               className="inline-flex h-10 w-10 items-center justify-center rounded-full text-sm font-bold text-white"
@@ -112,16 +112,16 @@ function AppTabRaw({ receipts }: AppTabProps) {
 
         <AppSparkline items={items} />
 
-        <div className="space-y-3">
+        <div className="space-y-2">
           {items.map((receipt) => (
             <div
               key={receipt.receipt_id}
-              className="rounded-2xl border border-slate-100 bg-white p-4 shadow-sm"
+              className="rounded-xl border border-slate-100 bg-white p-3"
             >
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0 flex-1">
                   <p className="text-sm text-brand-dark">{plainEnglishDescription(receipt)}</p>
-                  <p className="mt-1 text-xs text-slate-400">{formatRelativeTime(receipt.timestamp)}</p>
+                  <p className="mt-0.5 text-xs text-slate-400">{formatRelativeTime(receipt.timestamp)}</p>
                 </div>
                 <span className={`shrink-0 text-xs font-medium ${receipt.policy_decision === "allow" ? "text-brand-green" : "text-brand-attention"}`}>
                   {receipt.policy_decision === "allow" ? "Allowed" : "Stopped"}
@@ -159,7 +159,7 @@ function AppTabRaw({ receipts }: AppTabProps) {
             onClick={() => {
               setSelectedApp(harness);
             }}
-            className="flex w-full items-center justify-between gap-3 rounded-2xl border border-slate-100 bg-white p-4 text-left shadow-sm transition-all hover:shadow-md"
+            className="flex w-full items-center justify-between gap-3 rounded-xl border border-slate-100 bg-white p-3 text-left transition-all hover:border-slate-200 hover:bg-slate-50/50"
           >
             <div className="flex items-center gap-3">
               <span
@@ -184,7 +184,7 @@ function AppTabRaw({ receipts }: AppTabProps) {
       })}
 
       {filteredApps.length === 0 && (
-        <div className="rounded-2xl border border-slate-100 bg-white/60 p-8 text-center">
+        <div className="rounded-xl border border-slate-100 bg-white/60 p-6 text-center">
           <p className="text-sm text-slate-500">No apps match your search.</p>
         </div>
       )}
@@ -213,7 +213,7 @@ function AppSparkline({ items }: { items: GuardReceipt[] }) {
   const barWidth = width / buckets.length;
 
   return (
-    <div className="rounded-2xl border border-slate-100 bg-white p-4">
+    <div className="rounded-xl border border-slate-100 bg-white p-3">
       <p className="text-xs font-medium text-slate-500">Last 7 days</p>
       <svg viewBox={`0 0 ${width} ${height}`} className="mt-2 h-10 w-full" preserveAspectRatio="none">
         {buckets.map((count, i) => {

--- a/dashboard/src/evidence/evidence-filter-bar.tsx
+++ b/dashboard/src/evidence/evidence-filter-bar.tsx
@@ -206,7 +206,7 @@ export function EvidenceFilterBar({
           value={filters.time}
           onChange={handleTimeChange}
           aria-label="Time period"
-          className="min-h-10 rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+          className="min-h-9 rounded-lg border border-slate-200 bg-white px-2.5 text-sm font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
         >
           {(Object.entries(EVIDENCE_TIME_LABELS) as [EvidenceTimeFilter, string][]).map(
             ([val, label]) => (
@@ -221,7 +221,7 @@ export function EvidenceFilterBar({
           value={filters.decision}
           onChange={handleDecisionChange}
           aria-label="Decision filter"
-          className="min-h-10 rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+          className="min-h-9 rounded-lg border border-slate-200 bg-white px-2.5 text-sm font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
         >
           {(Object.entries(EVIDENCE_DECISION_LABELS) as [EvidenceDecision, string][]).map(
             ([val, label]) => (
@@ -232,42 +232,14 @@ export function EvidenceFilterBar({
           )}
         </select>
 
-        <select
-          value={filters.harness}
-          onChange={handleHarnessChange}
-          aria-label="App filter"
-          className="min-h-10 rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
-        >
-          <option value="all">All apps</option>
-          {harnesses.map((h) => (
-            <option key={h} value={h}>
-              {harnessDisplayName(h)}
-            </option>
-          ))}
-        </select>
-
-        <select
-          value={filters.category}
-          onChange={handleCategoryChange}
-          aria-label="Category filter"
-          className="min-h-10 rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
-        >
-          {CATEGORY_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
-
         <button
           type="button"
           onClick={handleToggleMore}
           aria-expanded={showMore}
           aria-label="Toggle more filters"
-          className="inline-flex min-h-10 items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark hover:bg-slate-50 transition-colors"
+          className="inline-flex min-h-9 items-center gap-1 rounded-lg border border-slate-200 bg-white px-2.5 text-sm font-medium text-brand-dark hover:bg-slate-50 transition-colors"
         >
           <HiFunnel className="h-4 w-4" aria-hidden="true" />
-          More
           {showMore ? (
             <HiMiniChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
           ) : (
@@ -278,6 +250,33 @@ export function EvidenceFilterBar({
 
       {showMore && (
         <div className="flex flex-wrap items-center gap-2 rounded-lg border border-slate-100 bg-slate-50/80 p-3">
+          <select
+            value={filters.harness}
+            onChange={handleHarnessChange}
+            aria-label="App filter"
+            className="min-h-9 rounded-lg border border-slate-200 bg-white px-2.5 text-sm font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+          >
+            <option value="all">All apps</option>
+            {harnesses.map((h) => (
+              <option key={h} value={h}>
+                {harnessDisplayName(h)}
+              </option>
+            ))}
+          </select>
+
+          <select
+            value={filters.category}
+            onChange={handleCategoryChange}
+            aria-label="Category filter"
+            className="min-h-9 rounded-lg border border-slate-200 bg-white px-2.5 text-sm font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+          >
+            {CATEGORY_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+
           <label className="flex items-center gap-2 text-sm text-brand-dark">
             <span className="shrink-0 text-xs font-medium text-slate-500">
               Source scope:

--- a/dashboard/src/receipts-workspace.tsx
+++ b/dashboard/src/receipts-workspace.tsx
@@ -26,6 +26,7 @@ import { EvidenceInsightStrip } from "./evidence/evidence-insight-strip";
 import { EvidenceAnalyticsPanel } from "./evidence/evidence-analytics-panel";
 import { EvidenceExportDrawer } from "./evidence/evidence-export-drawer";
 import { EvidenceClearModal } from "./evidence/evidence-clear-modal";
+import { AppTab } from "./evidence/app-tab";
 
 export type ReceiptsState =
   | { kind: "loading" }
@@ -126,7 +127,7 @@ interface ViewTabBarProps {
 function ViewTabBar({ view, onViewChange }: ViewTabBarProps) {
   return (
     <div
-      className="flex gap-1 rounded-xl border border-slate-200/70 bg-white/80 p-1 shadow-sm"
+      className="flex gap-0.5 border-b border-slate-200/70"
       role="tablist"
       aria-label="Evidence views"
     >
@@ -175,14 +176,17 @@ function ViewTabButton({
       aria-controls={`tabpanel-${tabKey}`}
       id={`tab-${tabKey}`}
       onClick={handleClick}
-      className={`flex flex-1 items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-all ${
+      className={`relative flex items-center gap-1.5 px-3 py-2 text-sm font-medium transition-colors ${
         isActive
-          ? "bg-brand-blue text-white shadow-sm"
-          : "text-brand-dark hover:bg-slate-50"
+          ? "text-brand-dark"
+          : "text-slate-500 hover:text-brand-dark"
       }`}
     >
       <Icon className="h-4 w-4" aria-hidden="true" />
       <span className="hidden sm:inline">{label}</span>
+      {isActive && (
+        <span className="absolute bottom-0 left-2 right-2 h-0.5 rounded-full bg-brand-blue" />
+      )}
     </button>
   );
 }
@@ -331,7 +335,7 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }: EvidenceWorkbenchP
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
       <EvidenceHeader
         totalCount={receiptItems.length}
         lastActivityAt={metrics.lastActivityAt}
@@ -339,7 +343,7 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }: EvidenceWorkbenchP
         onClear={handleOpenClear}
       />
 
-      <EvidenceInsightStrip metrics={metrics} />
+      {metrics.total > 0 && <EvidenceInsightStrip metrics={metrics} />}
 
       <EvidenceFilterBar
         filters={filters}
@@ -402,11 +406,7 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }: EvidenceWorkbenchP
             role="tabpanel"
             aria-labelledby="tab-apps"
           >
-            <EvidenceAnalyticsPanel
-              metrics={metrics}
-              onFilterHarness={handleFilterHarness}
-              onFilterCategory={handleFilterCategory}
-            />
+            <AppTab receipts={receiptItems} />
           </div>
         )}
 

--- a/dashboard/src/receipts-workspace.tsx
+++ b/dashboard/src/receipts-workspace.tsx
@@ -406,7 +406,7 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }: EvidenceWorkbenchP
             role="tabpanel"
             aria-labelledby="tab-apps"
           >
-            <AppTab receipts={receiptItems} />
+            <AppTab receipts={filtered} />
           </div>
         )}
 

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -210,6 +210,15 @@ export function ReviewWorkspace(props: ReviewWorkspaceProps) {
     }
   }, [activeRequestId, filteredRequests, props.onOpenRequest]);
 
+  // When page changes, ensure active item is on the current page
+  useEffect(() => {
+    if (pagedRequests.length === 0) return;
+    const activeOnPage = pagedRequests.some((item) => item.request_id === activeRequestId);
+    if (!activeOnPage) {
+      props.onOpenRequest(pagedRequests[0].request_id);
+    }
+  }, [currentPage, pagedRequests, activeRequestId, props.onOpenRequest]);
+
   if (requests.length === 0) {
     return <ReviewEmptyState runtime={props.runtime} resolutionMessage={props.resolutionMessage} />;
   }

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -246,6 +246,7 @@ export function ReviewWorkspace(props: ReviewWorkspaceProps) {
         <div className={`${mobileQueueOpen ? "block" : "hidden"} md:block`}>
           <ReviewQueueList
             requests={pagedRequests}
+            allFilteredRequests={filteredRequests}
             totalCount={requests.length}
             filteredCount={filteredRequests.length}
             activeRequestId={activeItem.request_id}
@@ -322,6 +323,7 @@ function resolveSemanticGroup(categoryId: QueueCategoryId): SemanticGroupId {
 
 const ReviewQueueList = forwardRef<HTMLDivElement, {
   requests: GuardApprovalRequest[];
+  allFilteredRequests: GuardApprovalRequest[];
   totalCount: number;
   filteredCount: number;
   activeRequestId: string | null;
@@ -340,6 +342,7 @@ const ReviewQueueList = forwardRef<HTMLDivElement, {
   onOpenRequest: (requestId: string) => void;
 }>(({
   requests,
+  allFilteredRequests,
   totalCount,
   filteredCount,
   activeRequestId,
@@ -377,14 +380,14 @@ const ReviewQueueList = forwardRef<HTMLDivElement, {
 
   const activeSemanticGroup = semanticFilter;
 
-  // Only show groups that have items
+  // Only show groups that have items (derive from full filtered set, not paged)
   const visibleGroups = useMemo(() => {
     const available = new Set<SemanticGroupId>();
-    for (const item of requests) {
+    for (const item of allFilteredRequests) {
       available.add(resolveSemanticGroup(resolveQueueCategory(item).id));
     }
     return SEMANTIC_GROUPS.filter((g) => g.id === "all" || available.has(g.id));
-  }, [requests]);
+  }, [allFilteredRequests]);
 
   const isFiltered = searchTerm || semanticFilter !== "all" || categoryFilter !== "all" || sortDirection !== "newest";
   const showPagination = filteredCount > QUEUE_PAGE_SIZE;

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -129,6 +129,8 @@ const scopeChoices = [
   },
 ];
 
+const QUEUE_PAGE_SIZE = 10;
+
 export function ReviewWorkspace(props: ReviewWorkspaceProps) {
   const { requests, activeRequestId, detail } = props;
   const queueRef = useRef<HTMLDivElement>(null);
@@ -137,6 +139,7 @@ export function ReviewWorkspace(props: ReviewWorkspaceProps) {
   const [sortDirection, setSortDirection] = useState<QueueSortDirection>("newest");
   const [semanticFilter, setSemanticFilter] = useState<SemanticGroupId>("all");
   const [mobileQueueOpen, setMobileQueueOpen] = useState(false);
+  const [page, setPage] = useState(1);
 
   const handleOpenRequest = useCallback((id: string) => {
     props.onOpenRequest(id);
@@ -161,6 +164,16 @@ export function ReviewWorkspace(props: ReviewWorkspaceProps) {
     return sortQueue(searched, sortDirection);
   }, [categoryFilter, requests, searchTerm, sortDirection, semanticFilter]);
 
+  // Reset page when filters change
+  useEffect(() => {
+    setPage(1);
+  }, [searchTerm, categoryFilter, sortDirection, semanticFilter]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredRequests.length / QUEUE_PAGE_SIZE));
+  const currentPage = Math.min(page, totalPages);
+  const pageStart = (currentPage - 1) * QUEUE_PAGE_SIZE;
+  const pagedRequests = filteredRequests.slice(pageStart, pageStart + QUEUE_PAGE_SIZE);
+
   const categoryOptions = useMemo(() => queueCategoriesForItems(requests), [requests]);
 
   const activeRequest =
@@ -168,25 +181,25 @@ export function ReviewWorkspace(props: ReviewWorkspaceProps) {
       ? requests.find((r) => r.request_id === activeRequestId) ?? null
       : null;
 
-  // Keyboard navigation for queue
+  // Keyboard navigation for queue (scoped to visible page)
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
-      if (filteredRequests.length === 0) return;
-      const activeIdx = filteredRequests.findIndex((r) => r.request_id === activeRequestId);
+      if (pagedRequests.length === 0) return;
+      const activeIdx = pagedRequests.findIndex((r) => r.request_id === activeRequestId);
       if (event.key === "ArrowDown") {
         event.preventDefault();
-        const nextIdx = Math.min(activeIdx + 1, filteredRequests.length - 1);
-        if (nextIdx !== activeIdx) props.onOpenRequest(filteredRequests[nextIdx].request_id);
+        const nextIdx = Math.min(activeIdx + 1, pagedRequests.length - 1);
+        if (nextIdx !== activeIdx) props.onOpenRequest(pagedRequests[nextIdx].request_id);
       }
       if (event.key === "ArrowUp") {
         event.preventDefault();
         const prevIdx = Math.max(activeIdx - 1, 0);
-        if (prevIdx !== activeIdx) props.onOpenRequest(filteredRequests[prevIdx].request_id);
+        if (prevIdx !== activeIdx) props.onOpenRequest(pagedRequests[prevIdx].request_id);
       }
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [filteredRequests, activeRequestId, props.onOpenRequest]);
+  }, [pagedRequests, activeRequestId, props.onOpenRequest]);
 
   useEffect(() => {
     if (filteredRequests.length === 0) {
@@ -232,18 +245,22 @@ export function ReviewWorkspace(props: ReviewWorkspaceProps) {
       <div className="grid gap-4 md:grid-cols-[260px_minmax(0,1fr)] lg:grid-cols-[280px_minmax(0,1fr)] xl:grid-cols-[300px_minmax(0,1fr)] items-start">
         <div className={`${mobileQueueOpen ? "block" : "hidden"} md:block`}>
           <ReviewQueueList
-            requests={filteredRequests}
+            requests={pagedRequests}
             totalCount={requests.length}
+            filteredCount={filteredRequests.length}
             activeRequestId={activeItem.request_id}
             categoryOptions={categoryOptions}
             categoryFilter={categoryFilter}
             searchTerm={searchTerm}
             sortDirection={sortDirection}
             semanticFilter={semanticFilter}
+            page={currentPage}
+            totalPages={totalPages}
             onCategoryFilterChange={setCategoryFilter}
             onSearchTermChange={setSearchTerm}
             onSortDirectionChange={setSortDirection}
             onSemanticFilterChange={setSemanticFilter}
+            onPageChange={setPage}
             onOpenRequest={handleOpenRequest}
             ref={queueRef}
           />
@@ -306,30 +323,38 @@ function resolveSemanticGroup(categoryId: QueueCategoryId): SemanticGroupId {
 const ReviewQueueList = forwardRef<HTMLDivElement, {
   requests: GuardApprovalRequest[];
   totalCount: number;
+  filteredCount: number;
   activeRequestId: string | null;
   categoryOptions: QueueCategory[];
   categoryFilter: QueueCategoryId | "all";
   searchTerm: string;
   sortDirection: QueueSortDirection;
   semanticFilter: SemanticGroupId;
+  page: number;
+  totalPages: number;
   onCategoryFilterChange: (category: QueueCategoryId | "all") => void;
   onSearchTermChange: (term: string) => void;
   onSortDirectionChange: (direction: QueueSortDirection) => void;
   onSemanticFilterChange: (group: SemanticGroupId) => void;
+  onPageChange: (page: number) => void;
   onOpenRequest: (requestId: string) => void;
 }>(({
   requests,
   totalCount,
+  filteredCount,
   activeRequestId,
   categoryOptions,
   categoryFilter,
   searchTerm,
   sortDirection,
   semanticFilter,
+  page,
+  totalPages,
   onCategoryFilterChange,
   onSearchTermChange,
   onSortDirectionChange,
   onSemanticFilterChange,
+  onPageChange,
   onOpenRequest,
 }, ref) => {
   const [showFilters, setShowFilters] = useState(false);
@@ -343,6 +368,12 @@ const ReviewQueueList = forwardRef<HTMLDivElement, {
   const handleSortChange = useCallback((event: ChangeEvent<HTMLSelectElement>) => {
     onSortDirectionChange(event.target.value as QueueSortDirection);
   }, [onSortDirectionChange]);
+  const handlePreviousPage = useCallback(() => {
+    onPageChange(Math.max(1, page - 1));
+  }, [page, onPageChange]);
+  const handleNextPage = useCallback(() => {
+    onPageChange(Math.min(totalPages, page + 1));
+  }, [page, totalPages, onPageChange]);
 
   const activeSemanticGroup = semanticFilter;
 
@@ -356,13 +387,14 @@ const ReviewQueueList = forwardRef<HTMLDivElement, {
   }, [requests]);
 
   const isFiltered = searchTerm || semanticFilter !== "all" || categoryFilter !== "all" || sortDirection !== "newest";
+  const showPagination = filteredCount > QUEUE_PAGE_SIZE;
 
   return (
     <aside className="space-y-3" ref={ref}>
       <div className="flex items-center justify-between gap-3">
         <SectionLabel>Queue</SectionLabel>
         <span className="font-mono text-[11px] font-semibold text-muted-foreground">
-          {requests.length}/{totalCount}
+          {filteredCount}/{totalCount}
         </span>
       </div>
       <div className="space-y-2 rounded-xl border border-slate-100 bg-white p-3">
@@ -444,6 +476,34 @@ const ReviewQueueList = forwardRef<HTMLDivElement, {
           </div>
         )}
       </div>
+      {showPagination && (
+        <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+          <span>
+            {((page - 1) * QUEUE_PAGE_SIZE) + 1}-{Math.min(filteredCount, page * QUEUE_PAGE_SIZE)} of {filteredCount}
+          </span>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handlePreviousPage}
+              disabled={page <= 1}
+              className="min-h-9 rounded-lg border border-slate-200 bg-white px-3 font-semibold text-brand-dark transition-colors duration-150 hover:border-brand-blue/30 disabled:pointer-events-none disabled:opacity-40"
+            >
+              Previous
+            </button>
+            <span className="font-mono text-[11px] text-slate-400">
+              {page}/{totalPages}
+            </span>
+            <button
+              type="button"
+              onClick={handleNextPage}
+              disabled={page >= totalPages}
+              className="min-h-9 rounded-lg border border-slate-200 bg-white px-3 font-semibold text-brand-dark transition-colors duration-150 hover:border-brand-blue/30 disabled:pointer-events-none disabled:opacity-40"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
     </aside>
   );
 });


### PR DESCRIPTION
## Summary
Fixes review queue pagination for long queues (40+ items) and calms the evidence tab UX.

## Changes
- **Review queue pagination**: slices to 10 items per page, adds Previous/Next controls, resets page on filter change, keyboard nav scoped to visible page
- **Evidence tab bar**: compact underline-style tabs, removed heavy container border/shadow
- **Evidence filters**: collapsed app/category filters behind More toggle by default
- **App tab**: calmer cards (rounded-xl instead of rounded-2xl, removed heavy shadows), fixed Apps tab to render AppTab instead of AnalyticsPanel
- **Spacing**: tighter gaps between evidence sections

## Verification
- [x] Build passes
- [x] All tests pass
- [x] No new dependencies