### PR TITLE
feat(guard): cover local setup gaps

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -38,9 +38,9 @@ def run_guard_connect_command(
     opener,
     wait_timeout_seconds: int,
 ) -> dict[str, object]:
+    normalized_connect_url, allowed_origin = resolve_connect_url(connect_url)
     ensure_guard_daemon(guard_home)
     daemon_client = _load_connect_daemon_client(guard_home)
-    normalized_connect_url, allowed_origin = resolve_connect_url(connect_url)
     connect_request = daemon_client.create_connect_request(
         sync_url=sync_url,
         allowed_origin=allowed_origin,

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -48,6 +48,12 @@ def apply_managed_install(
 
 def _managed_install_payload(managed_install: dict[str, object]) -> dict[str, object]:
     payload = dict(managed_install)
+    harness = str(payload.get("harness") or "")
+    protection_contract = contract_for(harness)
+    if protection_contract is not None:
+        payload["native_hooks"] = protection_contract.native_approval
+        payload["browser_fallback"] = protection_contract.browser_fallback
+        payload["primary_integration"] = "native_hooks" if protection_contract.native_approval else "browser_fallback"
     manifest = payload.get("manifest")
     if isinstance(manifest, dict):
         for key in ("config_path", "managed_config_path", "shim_path", "mode"):

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -130,6 +130,8 @@ def _binary_diagnostics(command: list[str], installer: str) -> dict[str, object]
         path_status = "not_on_path"
     elif installer == "pipx":
         path_status = "pipx_shim_detected"
+    elif installer == "uv":
+        path_status = "uv_tool_shim_detected"
     elif expected_script_dir is not None and _script_dir(resolved_binary) == expected_script_dir:
         path_status = "matches_installer"
     else:
@@ -214,14 +216,19 @@ def _current_version() -> str:
 
 def _installer_kind() -> str:
     prefix_path = Path(sys.prefix).resolve()
+    normalized_prefix = prefix_path.as_posix().lower()
+    if "/uv/tools/" in normalized_prefix:
+        return "uv"
     if (prefix_path / "pipx_metadata.json").exists():
         return "pipx"
-    if "/pipx/venvs/" in prefix_path.as_posix().lower():
+    if "/pipx/venvs/" in normalized_prefix:
         return "pipx"
     return "pip"
 
 
 def _update_command(installer: str) -> list[str]:
+    if installer == "uv":
+        return ["uv", "tool", "upgrade", "hol-guard"]
     if installer == "pipx":
         return ["pipx", "upgrade", "hol-guard"]
     return [sys.executable, "-m", "pip", "install", "--upgrade", "hol-guard"]

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -1,0 +1,122 @@
+"""Remaining Phase 03 Guard local install, update, and connect contracts."""
+
+from __future__ import annotations
+
+import json
+import urllib.parse
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.cli import update_commands
+from codex_plugin_scanner.guard.cli.connect_flow import build_guard_connect_browser_url, run_guard_connect_command
+from codex_plugin_scanner.guard.cli.install_commands import apply_managed_install, list_harness_setup_items
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _context(tmp_path: Path) -> HarnessContext:
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    guard_home = tmp_path / "guard-home"
+    workspace.mkdir(parents=True, exist_ok=True)
+    return HarnessContext(home_dir=home, workspace_dir=workspace, guard_home=guard_home)
+
+
+def test_update_detects_uv_tool_install_and_plans_uv_upgrade(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_commands.sys, "prefix", "/Users/test/.local/share/uv/tools/hol-guard")
+    monkeypatch.setattr(update_commands.shutil, "which", lambda name: f"/Users/test/.local/bin/{name}")
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.0")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=True)
+
+    assert exit_code == 0
+    assert payload["installer"] == "uv"
+    assert payload["command"] == ["uv", "tool", "upgrade", "hol-guard"]
+    assert payload["retry_command"] == "uv tool upgrade hol-guard"
+    assert payload["binary_diagnostics"]["path_status"] == "uv_tool_shim_detected"
+
+
+def test_install_setup_listing_detects_safe_config_without_mutating_it(tmp_path: Path) -> None:
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    config_path = context.home_dir / ".cursor" / "mcp.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_text = json.dumps({"mcpServers": {"local": {"command": "node"}}})
+    config_path.write_text(config_text, encoding="utf-8")
+    before_mtime = config_path.stat().st_mtime_ns
+
+    items = list_harness_setup_items(context, store)
+
+    cursor_item = next(item for item in items if item["harness"] == "cursor")
+    assert cursor_item["status"] == "found"
+    assert cursor_item["installed"] is False
+    assert cursor_item["config_paths"] == [str(config_path)]
+    assert config_path.read_text(encoding="utf-8") == config_text
+    assert config_path.stat().st_mtime_ns == before_mtime
+
+
+def test_install_native_contract_output_prefers_native_hooks_for_supported_harnesses(tmp_path: Path) -> None:
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+
+    payload = apply_managed_install(
+        "install",
+        "codex",
+        False,
+        context,
+        store,
+        str(context.workspace_dir),
+        "2026-05-13T00:00:00Z",
+    )
+
+    managed_install = payload["managed_install"]
+    assert managed_install["harness"] == "codex"
+    assert managed_install["active"] is True
+    assert managed_install["mode"] == "codex-mcp-proxy"
+    assert managed_install["native_hooks"] is True
+    assert managed_install["primary_integration"] == "native_hooks"
+    assert managed_install["manifest"]["mode"] == "codex-mcp-proxy"
+
+
+def test_connect_rejects_invalid_url_before_daemon_start(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon_calls: list[Path] = []
+
+    def ensure_daemon(guard_home: Path) -> str:
+        daemon_calls.append(guard_home)
+        raise AssertionError("daemon must not start for invalid connect URL")
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.cli.connect_flow.ensure_guard_daemon", ensure_daemon)
+
+    with pytest.raises(ValueError, match="absolute http"):
+        run_guard_connect_command(
+            guard_home=tmp_path / "guard-home",
+            store=store,
+            sync_url="https://hol.org/api/guard/receipts/sync",
+            connect_url="not-a-url",
+            opener=lambda url: True,
+            wait_timeout_seconds=1,
+        )
+
+    assert daemon_calls == []
+
+
+def test_connect_browser_url_keeps_pairing_secret_in_fragment_only() -> None:
+    browser_url = build_guard_connect_browser_url(
+        connect_url="https://hol.org/guard/connect?source=cli",
+        daemon_url="http://127.0.0.1:4781",
+        request_id="connect-123",
+        pairing_secret="pairing-secret",
+    )
+
+    parsed = urllib.parse.urlparse(browser_url)
+    query = urllib.parse.parse_qs(parsed.query)
+    fragment = urllib.parse.parse_qs(parsed.fragment)
+
+    assert query["source"] == ["cli"]
+    assert query["guardPairRequest"] == ["connect-123"]
+    assert query["guardDaemon"] == ["http://127.0.0.1:4781"]
+    assert "pairing-secret" not in parsed.query
+    assert fragment["guardPairSecret"] == ["pairing-secret"]


### PR DESCRIPTION
## Summary
- add uv tool update detection for hol-guard update
- expose native-hook/browser-fallback install metadata for local setup payloads
- validate connect URLs before daemon startup
- add focused Phase 03 local setup/connect regression coverage

## Validation
- uv run pytest tests/test_guard_phase03_remainder.py tests/test_guard_phase03_local_install.py tests/test_guard_connect_flow.py -q
- uv run pytest tests/test_guard_phase03_remainder.py tests/test_guard_phase03_local_install.py tests/test_guard_connect_flow.py tests/test_guard_cli.py tests/test_guard_codex_install.py tests/test_guard_render.py -q
- uv run ruff check src/codex_plugin_scanner/guard/cli/update_commands.py src/codex_plugin_scanner/guard/cli/connect_flow.py src/codex_plugin_scanner/guard/cli/install_commands.py tests/test_guard_phase03_remainder.py
- uv run ruff format --check src/codex_plugin_scanner/guard/cli/update_commands.py src/codex_plugin_scanner/guard/cli/connect_flow.py src/codex_plugin_scanner/guard/cli/install_commands.py tests/test_guard_phase03_remainder.py
- uv build --wheel