### PR TITLE
feat(guard): add update and doctor diagnostics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 dependencies = [
     "rich>=13.0",
     "cryptography>=47.0.0",
+    "packaging>=24.0",
     "tomli>=2.0; python_version < '3.11'",
     "cisco-ai-skill-scanner~=2.0.9",
 ]

--- a/src/codex_plugin_scanner/guard/adapters/base.py
+++ b/src/codex_plugin_scanner/guard/adapters/base.py
@@ -301,11 +301,11 @@ class HarnessAdapter:
 
 def _diagnostic_setup_status(detection: HarnessDetection, warnings: list[str]) -> str:
     guard_managed = _detection_has_guard_management(detection)
-    if guard_managed and warnings:
+    if guard_managed and _warnings_include_setup_failure(warnings):
         return "broken"
     if guard_managed:
         return "active"
-    if detection.config_paths or detection.command_available or detection.installed:
+    if detection.config_paths or detection.command_available:
         return "partial"
     return "not_found"
 
@@ -323,8 +323,17 @@ def _guard_managed_path(path: str) -> bool:
 def _artifact_uses_guard(artifact: GuardArtifact) -> bool:
     if artifact.artifact_type == "guard_launcher_shim":
         return True
+    if artifact.command is not None and _is_guard_command_name(artifact.command, artifact.harness):
+        return True
     values = [artifact.command or "", *artifact.args]
     return any(_value_mentions_guard(value) for value in values)
+
+
+def _is_guard_command_name(value: str, harness: str) -> bool:
+    normalized = Path(value.replace("\\", "/")).name.lower()
+    if normalized.endswith(".cmd"):
+        normalized = normalized[:-4]
+    return normalized == f"guard-{harness}"
 
 
 def _value_mentions_guard(value: str) -> bool:
@@ -340,6 +349,16 @@ def _is_guard_launcher_shim(path: Path) -> bool:
     except OSError:
         return False
     return "codex_plugin_scanner.cli" in contents and "guard" in contents and "run" in contents
+
+
+def _warnings_include_setup_failure(warnings: list[str]) -> bool:
+    setup_markers = (
+        "guard is not installed",
+        "command is not available",
+        "native hooks are disabled",
+        "managed codex hooks are missing",
+    )
+    return any(any(marker in warning.lower() for marker in setup_markers) for warning in warnings)
 
 
 __all__ = [

--- a/src/codex_plugin_scanner/guard/adapters/base.py
+++ b/src/codex_plugin_scanner/guard/adapters/base.py
@@ -94,6 +94,7 @@ class HarnessAdapter:
     aliases: tuple[str, ...] = ()
     executable = ""
     launcher_name = ""
+    legacy_launcher_names: tuple[str, ...] = ()
     approval_tier = "approval-center"
     approval_summary = "Guard pauses the launch and routes approval through the local approval center."
     fallback_hint = "Use `hol-guard approvals` if you want to resolve it from the terminal."
@@ -153,7 +154,8 @@ class HarnessAdapter:
     def guard_launcher_paths(self, context: HarnessContext) -> tuple[Path, ...]:
         shim_name = self.launcher_name or self.harness
         shim_dir = context.guard_home / "bin"
-        return (shim_dir / f"guard-{shim_name}", shim_dir / f"guard-{shim_name}.cmd")
+        names = (shim_name, *self.legacy_launcher_names)
+        return tuple(shim_dir / f"guard-{name}{suffix}" for name in names for suffix in ("", ".cmd"))
 
     def launch_command(self, context: HarnessContext, passthrough_args: list[str]) -> list[str]:
         command = [self.resolved_executable(context) or self.executable]

--- a/src/codex_plugin_scanner/guard/adapters/base.py
+++ b/src/codex_plugin_scanner/guard/adapters/base.py
@@ -235,7 +235,8 @@ class HarnessAdapter:
         runtime_probe: dict[str, object] | None,
     ) -> list[str]:
         warnings = list(detection.warnings)
-        if detection.config_paths and not _detection_has_guard_management(detection):
+        guard_managed = _detection_has_guard_management(detection)
+        if detection.config_paths and not guard_managed:
             warnings.append(
                 f"{self.harness} config was found, but Guard is not installed for this harness. "
                 f"Run `hol-guard install {self.harness}` to enable protection."
@@ -243,6 +244,11 @@ class HarnessAdapter:
         if detection.config_paths and not detection.command_available:
             warnings.append(
                 f"{self.harness} config was found, but the {self.executable} command is not available on PATH."
+            )
+        elif guard_managed and not detection.command_available:
+            warnings.append(
+                f"Guard launcher for {self.harness} is installed, but the {self.executable} command is not available "
+                "on PATH."
             )
         if runtime_probe is not None and runtime_probe.get("timed_out") is True:
             warnings.append(f"{self.executable} diagnostics timed out before Guard could confirm runtime state.")

--- a/src/codex_plugin_scanner/guard/adapters/base.py
+++ b/src/codex_plugin_scanner/guard/adapters/base.py
@@ -227,6 +227,11 @@ class HarnessAdapter:
         runtime_probe: dict[str, object] | None,
     ) -> list[str]:
         warnings = list(detection.warnings)
+        if detection.config_paths and not detection.installed:
+            warnings.append(
+                f"{self.harness} config was found, but Guard is not installed for this harness. "
+                f"Run `hol-guard install {self.harness}` to enable protection."
+            )
         if detection.config_paths and not detection.command_available:
             warnings.append(
                 f"{self.harness} config was found, but the {self.executable} command is not available on PATH."
@@ -248,15 +253,29 @@ class HarnessAdapter:
     def diagnostics(self, context: HarnessContext) -> dict[str, object]:
         detection = self.detect(context)
         runtime_probe = self.runtime_probe(context)
+        warnings = self.diagnostic_warnings(detection, runtime_probe)
         return {
             "harness": self.harness,
             "installed": detection.installed,
+            "setup_status": _diagnostic_setup_status(detection, warnings),
             "command_available": detection.command_available,
             "config_paths": list(detection.config_paths),
             "artifacts": [artifact.to_dict() for artifact in detection.artifacts],
             "runtime_probe": runtime_probe,
-            "warnings": self.diagnostic_warnings(detection, runtime_probe),
+            "warnings": warnings,
         }
+
+
+def _diagnostic_setup_status(detection: HarnessDetection, warnings: list[str]) -> str:
+    if detection.config_paths and not detection.command_available:
+        return "partial"
+    if detection.installed and warnings:
+        return "broken"
+    if detection.installed:
+        return "active"
+    if detection.config_paths or detection.command_available:
+        return "partial"
+    return "not_found"
 
 
 __all__ = [

--- a/src/codex_plugin_scanner/guard/adapters/base.py
+++ b/src/codex_plugin_scanner/guard/adapters/base.py
@@ -346,7 +346,7 @@ def _is_guard_launcher_shim(path: Path) -> bool:
         return False
     try:
         contents = path.read_text(encoding="utf-8")
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return False
     return "codex_plugin_scanner.cli" in contents and "guard" in contents and "run" in contents
 

--- a/src/codex_plugin_scanner/guard/adapters/base.py
+++ b/src/codex_plugin_scanner/guard/adapters/base.py
@@ -227,7 +227,7 @@ class HarnessAdapter:
         runtime_probe: dict[str, object] | None,
     ) -> list[str]:
         warnings = list(detection.warnings)
-        if detection.config_paths and not detection.installed:
+        if detection.config_paths and not _detection_has_guard_management(detection):
             warnings.append(
                 f"{self.harness} config was found, but Guard is not installed for this harness. "
                 f"Run `hol-guard install {self.harness}` to enable protection."
@@ -267,15 +267,34 @@ class HarnessAdapter:
 
 
 def _diagnostic_setup_status(detection: HarnessDetection, warnings: list[str]) -> str:
-    if detection.config_paths and not detection.command_available:
-        return "partial"
-    if detection.installed and warnings:
+    guard_managed = _detection_has_guard_management(detection)
+    if guard_managed and warnings:
         return "broken"
-    if detection.installed:
+    if guard_managed:
         return "active"
-    if detection.config_paths or detection.command_available:
+    if detection.config_paths or detection.command_available or detection.installed:
         return "partial"
     return "not_found"
+
+
+def _detection_has_guard_management(detection: HarnessDetection) -> bool:
+    if any(_guard_managed_path(path) for path in detection.config_paths):
+        return True
+    return any(_artifact_uses_guard(artifact) for artifact in detection.artifacts)
+
+
+def _guard_managed_path(path: str) -> bool:
+    return Path(path).name.lower().startswith("hol-guard")
+
+
+def _artifact_uses_guard(artifact: GuardArtifact) -> bool:
+    values = [artifact.command or "", *artifact.args]
+    return any(_value_mentions_guard(value) for value in values)
+
+
+def _value_mentions_guard(value: str) -> bool:
+    normalized = value.lower()
+    return "codex_plugin_scanner.cli" in normalized or "hol-guard" in normalized
 
 
 __all__ = [

--- a/src/codex_plugin_scanner/guard/adapters/base.py
+++ b/src/codex_plugin_scanner/guard/adapters/base.py
@@ -93,6 +93,7 @@ class HarnessAdapter:
     harness = ""
     aliases: tuple[str, ...] = ()
     executable = ""
+    launcher_name = ""
     approval_tier = "approval-center"
     approval_summary = "Guard pauses the launch and routes approval through the local approval center."
     fallback_hint = "Use `hol-guard approvals` if you want to resolve it from the terminal."
@@ -148,6 +149,11 @@ class HarnessAdapter:
 
     def resolved_executable(self, context: HarnessContext) -> str | None:
         return _resolve_command(self.executable, self.executable_candidates(context))
+
+    def guard_launcher_paths(self, context: HarnessContext) -> tuple[Path, ...]:
+        shim_name = self.launcher_name or self.harness
+        shim_dir = context.guard_home / "bin"
+        return (shim_dir / f"guard-{shim_name}", shim_dir / f"guard-{shim_name}.cmd")
 
     def launch_command(self, context: HarnessContext, passthrough_args: list[str]) -> list[str]:
         command = [self.resolved_executable(context) or self.executable]
@@ -251,7 +257,7 @@ class HarnessAdapter:
         }
 
     def diagnostics(self, context: HarnessContext) -> dict[str, object]:
-        detection = self.detect(context)
+        detection = self._detection_with_guard_launcher(context, self.detect(context))
         runtime_probe = self.runtime_probe(context)
         warnings = self.diagnostic_warnings(detection, runtime_probe)
         return {
@@ -264,6 +270,33 @@ class HarnessAdapter:
             "runtime_probe": runtime_probe,
             "warnings": warnings,
         }
+
+    def _detection_with_guard_launcher(
+        self,
+        context: HarnessContext,
+        detection: HarnessDetection,
+    ) -> HarnessDetection:
+        shim_path = next((path for path in self.guard_launcher_paths(context) if _is_guard_launcher_shim(path)), None)
+        if shim_path is None:
+            return detection
+        artifact = GuardArtifact(
+            artifact_id=f"{self.harness}:guard-launcher-shim",
+            name=shim_path.name,
+            harness=self.harness,
+            artifact_type="guard_launcher_shim",
+            source_scope="guard",
+            config_path=str(shim_path),
+            command=str(shim_path),
+            metadata={"shim_dir": str(shim_path.parent)},
+        )
+        return HarnessDetection(
+            harness=detection.harness,
+            installed=True,
+            command_available=detection.command_available,
+            config_paths=detection.config_paths,
+            artifacts=(*detection.artifacts, artifact),
+            warnings=detection.warnings,
+        )
 
 
 def _diagnostic_setup_status(detection: HarnessDetection, warnings: list[str]) -> str:
@@ -288,6 +321,8 @@ def _guard_managed_path(path: str) -> bool:
 
 
 def _artifact_uses_guard(artifact: GuardArtifact) -> bool:
+    if artifact.artifact_type == "guard_launcher_shim":
+        return True
     values = [artifact.command or "", *artifact.args]
     return any(_value_mentions_guard(value) for value in values)
 
@@ -295,6 +330,16 @@ def _artifact_uses_guard(artifact: GuardArtifact) -> bool:
 def _value_mentions_guard(value: str) -> bool:
     normalized = value.lower()
     return "codex_plugin_scanner.cli" in normalized or "hol-guard" in normalized
+
+
+def _is_guard_launcher_shim(path: Path) -> bool:
+    if not path.is_file():
+        return False
+    try:
+        contents = path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return "codex_plugin_scanner.cli" in contents and "guard" in contents and "run" in contents
 
 
 __all__ = [

--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -246,6 +246,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
     harness = "claude-code"
     executable = "claude"
     aliases = ("claude",)
+    launcher_name = "claude"
     approval_tier = "native-or-center"
     approval_summary = (
         "Guard uses Claude hooks first and falls back to the local approval center when the shell cannot prompt."

--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -247,6 +247,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
     executable = "claude"
     aliases = ("claude",)
     launcher_name = "claude"
+    legacy_launcher_names = ("claude-code",)
     approval_tier = "native-or-center"
     approval_summary = (
         "Guard uses Claude hooks first and falls back to the local approval center when the shell cannot prompt."

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -543,6 +543,8 @@ class CodexHarnessAdapter(HarnessAdapter):
                 "`hol-guard install codex` or `hol-guard update` to repair protection."
             )
         payload["warnings"] = warnings
+        if payload.get("setup_status") == "active" and warnings:
+            payload["setup_status"] = "broken"
         payload["native_hook_state"] = hook_state
         return payload
 

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -20,7 +20,7 @@ from ..codex_config import read_toml_payload, write_toml_payload
 from ..launcher import merge_guard_launcher_env
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
-from .base import HarnessAdapter, HarnessContext, _command_available
+from .base import HarnessAdapter, HarnessContext, _command_available, _warnings_include_setup_failure
 from .mcp_servers import (
     ManagedMcpServer,
     is_guard_proxy_command,
@@ -543,7 +543,7 @@ class CodexHarnessAdapter(HarnessAdapter):
                 "`hol-guard install codex` or `hol-guard update` to repair protection."
             )
         payload["warnings"] = warnings
-        if payload.get("setup_status") == "active" and warnings:
+        if payload.get("setup_status") == "active" and _warnings_include_setup_failure(warnings):
             payload["setup_status"] = "broken"
         payload["native_hook_state"] = hook_state
         return payload

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -225,6 +225,14 @@ def _version_check_payload(current_version: str) -> dict[str, object]:
             "update_available": None,
         }
     update_available = _is_newer_version(latest_version, current_version)
+    if update_available is None:
+        return {
+            "source": "pypi",
+            "status": "unavailable",
+            "current_version": current_version,
+            "latest_version": latest_version,
+            "update_available": None,
+        }
     return {
         "source": "pypi",
         "status": "stale" if update_available else "current",
@@ -250,12 +258,12 @@ def _latest_version_from_pypi() -> str | None:
     return version if isinstance(version, str) and version.strip() else None
 
 
-def _is_newer_version(latest_version: str, current_version: str) -> bool:
+def _is_newer_version(latest_version: str, current_version: str) -> bool | None:
     try:
         latest = Version(latest_version)
         current = Version(current_version)
     except InvalidVersion:
-        return False
+        return None
     return latest > current
 
 

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -16,6 +16,8 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
+from packaging.version import InvalidVersion, Version
+
 from ..adapters.base import HarnessContext
 from ..adapters.codex import CodexHarnessAdapter, codex_native_hook_state
 from ..redaction import redact_sensitive_text
@@ -248,28 +250,12 @@ def _latest_version_from_pypi() -> str | None:
 
 
 def _is_newer_version(latest_version: str, current_version: str) -> bool:
-    latest_parts = _numeric_version_parts(latest_version)
-    current_parts = _numeric_version_parts(current_version)
-    if latest_parts is None or current_parts is None:
+    try:
+        latest = Version(latest_version)
+        current = Version(current_version)
+    except InvalidVersion:
         return False
-    max_len = max(len(latest_parts), len(current_parts))
-    latest_padded = latest_parts + (0,) * (max_len - len(latest_parts))
-    current_padded = current_parts + (0,) * (max_len - len(current_parts))
-    return latest_padded > current_padded
-
-
-def _numeric_version_parts(version: str) -> tuple[int, ...] | None:
-    parts: list[int] = []
-    for raw_part in version.strip().split("."):
-        digits = ""
-        for character in raw_part:
-            if not character.isdigit():
-                break
-            digits += character
-        if not digits:
-            return None
-        parts.append(int(digits))
-    return tuple(parts) if parts else None
+    return latest > current
 
 
 def _current_version() -> str:

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import http.client
 import importlib
 import importlib.metadata
 import json
@@ -247,7 +248,14 @@ def _latest_version_from_pypi() -> str | None:
     try:
         with urllib.request.urlopen(request, timeout=_PYPI_TIMEOUT_SECONDS) as response:
             payload = json.loads(response.read().decode("utf-8"))
-    except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError, UnicodeDecodeError):
+    except (
+        OSError,
+        TimeoutError,
+        urllib.error.URLError,
+        http.client.IncompleteRead,
+        json.JSONDecodeError,
+        UnicodeDecodeError,
+    ):
         return None
     if not isinstance(payload, dict):
         return None

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -12,6 +12,8 @@ import sqlite3
 import subprocess
 import sys
 import sysconfig
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 from ..adapters.base import HarnessContext
@@ -24,6 +26,7 @@ _ALREADY_CURRENT_HINTS = (
     "already at latest version",
     "already up-to-date",
 )
+_PYPI_JSON_URL = "https://pypi.org/pypi/hol-guard/json"
 
 
 def run_guard_update(
@@ -58,6 +61,7 @@ def run_guard_update(
             )
             return payload, 0
     if dry_run:
+        payload["version_check"] = _version_check_payload(current_version)
         payload["status"] = "planned"
         payload["changed"] = False
         payload["message"] = "Review the planned installer command before updating."
@@ -205,6 +209,67 @@ def _success_notes(payload: dict[str, object]) -> list[str]:
     if str(payload.get("status") or "") not in {"current", "updated"}:
         return []
     return _output_lines(str(payload.get("stderr") or ""))
+
+
+def _version_check_payload(current_version: str) -> dict[str, object]:
+    latest_version = _latest_version_from_pypi()
+    if latest_version is None:
+        return {
+            "source": "pypi",
+            "status": "unavailable",
+            "current_version": current_version,
+            "latest_version": None,
+            "update_available": None,
+        }
+    update_available = _is_newer_version(latest_version, current_version)
+    return {
+        "source": "pypi",
+        "status": "stale" if update_available else "current",
+        "current_version": current_version,
+        "latest_version": latest_version,
+        "update_available": update_available,
+    }
+
+
+def _latest_version_from_pypi() -> str | None:
+    request = urllib.request.Request(_PYPI_JSON_URL, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(request, timeout=0.35) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    info = payload.get("info")
+    if not isinstance(info, dict):
+        return None
+    version = info.get("version")
+    return version if isinstance(version, str) and version.strip() else None
+
+
+def _is_newer_version(latest_version: str, current_version: str) -> bool:
+    latest_parts = _numeric_version_parts(latest_version)
+    current_parts = _numeric_version_parts(current_version)
+    if latest_parts is None or current_parts is None:
+        return False
+    max_len = max(len(latest_parts), len(current_parts))
+    latest_padded = latest_parts + (0,) * (max_len - len(latest_parts))
+    current_padded = current_parts + (0,) * (max_len - len(current_parts))
+    return latest_padded > current_padded
+
+
+def _numeric_version_parts(version: str) -> tuple[int, ...] | None:
+    parts: list[int] = []
+    for raw_part in version.strip().split("."):
+        digits = ""
+        for character in raw_part:
+            if not character.isdigit():
+                break
+            digits += character
+        if not digits:
+            return None
+        parts.append(int(digits))
+    return tuple(parts) if parts else None
 
 
 def _current_version() -> str:

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -29,6 +29,7 @@ _ALREADY_CURRENT_HINTS = (
     "already up-to-date",
 )
 _PYPI_JSON_URL = "https://pypi.org/pypi/hol-guard/json"
+_PYPI_TIMEOUT_SECONDS = 3.0
 
 
 def run_guard_update(
@@ -236,7 +237,7 @@ def _version_check_payload(current_version: str) -> dict[str, object]:
 def _latest_version_from_pypi() -> str | None:
     request = urllib.request.Request(_PYPI_JSON_URL, headers={"Accept": "application/json"})
     try:
-        with urllib.request.urlopen(request, timeout=0.35) as response:
+        with urllib.request.urlopen(request, timeout=_PYPI_TIMEOUT_SECONDS) as response:
             payload = json.loads(response.read().decode("utf-8"))
     except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError, UnicodeDecodeError):
         return None

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import http.client
 import json
 import urllib.parse
 from pathlib import Path
@@ -144,6 +145,15 @@ def test_latest_version_lookup_uses_practical_timeout(monkeypatch: pytest.Monkey
 
     assert update_commands._latest_version_from_pypi() == "2.0.1"
     assert timeouts == [3.0]
+
+
+def test_latest_version_lookup_handles_truncated_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_urlopen(request: object, timeout: float) -> object:
+        raise http.client.IncompleteRead(partial=b'{"info":')
+
+    monkeypatch.setattr(update_commands.urllib.request, "urlopen", fake_urlopen)
+
+    assert update_commands._latest_version_from_pypi() is None
 
 
 def test_install_setup_listing_detects_safe_config_without_mutating_it(tmp_path: Path) -> None:

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -57,6 +57,27 @@ def test_update_version_check_marks_stale_local_install(monkeypatch: pytest.Monk
     }
 
 
+def test_update_version_check_treats_stable_release_newer_than_prerelease(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(update_commands.sys, "prefix", "/opt/guard-venv")
+    monkeypatch.setattr(update_commands.sys, "executable", "/opt/guard-venv/bin/python")
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.0rc1")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.0.0")
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=True)
+
+    assert exit_code == 0
+    assert payload["version_check"] == {
+        "source": "pypi",
+        "status": "stale",
+        "current_version": "2.0.0rc1",
+        "latest_version": "2.0.0",
+        "update_available": True,
+    }
+
+
 def test_update_version_check_handles_latest_lookup_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(update_commands.sys, "prefix", "/opt/guard-venv")
     monkeypatch.setattr(update_commands.sys, "executable", "/opt/guard-venv/bin/python")
@@ -113,6 +134,26 @@ def test_doctor_reports_partial_setup_for_found_unprotected_harness(
     assert payload["command_available"] is False
     assert payload["config_paths"] == [str(config_path)]
     assert any("config was found" in warning for warning in payload["warnings"])
+
+
+def test_doctor_does_not_mark_harness_command_presence_as_guard_active(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    config_path = context.home_dir / ".cursor" / "mcp.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps({"mcpServers": {"local": {"command": "node"}}}), encoding="utf-8")
+    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor._command_available", lambda command: True)
+
+    from codex_plugin_scanner.guard.adapters import get_adapter
+
+    payload = get_adapter("cursor").diagnostics(context)
+
+    assert payload["setup_status"] == "partial"
+    assert payload["installed"] is True
+    assert payload["command_available"] is True
+    assert any("Guard is not installed" in warning for warning in payload["warnings"])
 
 
 def test_install_native_contract_output_prefers_native_hooks_for_supported_harnesses(tmp_path: Path) -> None:

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -156,6 +156,46 @@ def test_doctor_does_not_mark_harness_command_presence_as_guard_active(
     assert any("Guard is not installed" in warning for warning in payload["warnings"])
 
 
+def test_codex_doctor_marks_partial_native_hook_install_as_broken(tmp_path: Path) -> None:
+    context = _context(tmp_path)
+    config_path = context.workspace_dir / ".codex" / "config.toml"
+    hooks_path = context.workspace_dir / ".codex" / "hooks.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text("[features]\ncodex_hooks = true\n", encoding="utf-8")
+    hooks_path.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": (
+                                        "python -m codex_plugin_scanner.cli guard hook "
+                                        "--guard-home /tmp/guard --harness codex"
+                                    ),
+                                    "statusMessage": "HOL Guard checking tool action",
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    from codex_plugin_scanner.guard.adapters import get_adapter
+
+    payload = get_adapter("codex").diagnostics(context)
+
+    assert payload["setup_status"] == "broken"
+    assert payload["native_hook_state"]["managed_pre_tool_hook_installed"] is True
+    assert payload["native_hook_state"]["managed_hook_installed"] is False
+    assert any("managed Codex hooks are missing" in warning for warning in payload["warnings"])
+
+
 def test_install_native_contract_output_prefers_native_hooks_for_supported_harnesses(tmp_path: Path) -> None:
     context = _context(tmp_path)
     store = GuardStore(context.guard_home)

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -97,6 +97,34 @@ def test_update_version_check_handles_latest_lookup_failure(monkeypatch: pytest.
     }
 
 
+def test_latest_version_lookup_uses_practical_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    timeouts: list[float] = []
+
+    class FakeResponse:
+        def __enter__(self) -> FakeResponse:
+            return self
+
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_value: BaseException | None,
+            traceback: object,
+        ) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return b'{"info":{"version":"2.0.1"}}'
+
+    def fake_urlopen(request: object, timeout: float) -> FakeResponse:
+        timeouts.append(timeout)
+        return FakeResponse()
+
+    monkeypatch.setattr(update_commands.urllib.request, "urlopen", fake_urlopen)
+
+    assert update_commands._latest_version_from_pypi() == "2.0.1"
+    assert timeouts == [3.0]
+
+
 def test_install_setup_listing_detects_safe_config_without_mutating_it(tmp_path: Path) -> None:
     context = _context(tmp_path)
     store = GuardStore(context.guard_home)
@@ -202,7 +230,7 @@ def test_doctor_treats_guard_launcher_shim_as_active_install(
 ) -> None:
     context = _context(tmp_path)
     store = GuardStore(context.guard_home)
-    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor._command_available", lambda command: False)
+    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor._command_available", lambda command: True)
 
     install_payload = apply_managed_install(
         "install",
@@ -222,6 +250,58 @@ def test_doctor_treats_guard_launcher_shim_as_active_install(
     assert payload["setup_status"] == "active"
     assert any(artifact["artifact_type"] == "guard_launcher_shim" for artifact in payload["artifacts"])
     assert not any("Guard is not installed" in warning for warning in payload["warnings"])
+
+
+def test_doctor_treats_guard_command_artifact_as_managed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    config_path = context.home_dir / ".cursor" / "mcp.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps({"mcpServers": {"wrapped": {"command": "guard-cursor", "args": ["--flag"]}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor._command_available", lambda command: True)
+
+    from codex_plugin_scanner.guard.adapters import get_adapter
+
+    payload = get_adapter("cursor").diagnostics(context)
+
+    assert payload["setup_status"] == "active"
+    assert not any("Guard is not installed" in warning for warning in payload["warnings"])
+
+
+def test_doctor_keeps_active_setup_status_for_runtime_probe_timeout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    apply_managed_install(
+        "install",
+        "cursor",
+        False,
+        context,
+        store,
+        str(context.workspace_dir),
+        "2026-05-13T00:00:00Z",
+    )
+    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor._command_available", lambda command: False)
+
+    from codex_plugin_scanner.guard.adapters import get_adapter
+    from codex_plugin_scanner.guard.adapters.cursor import CursorHarnessAdapter
+
+    def runtime_probe_timeout(self: CursorHarnessAdapter, context: HarnessContext) -> dict[str, object]:
+        return {"timed_out": True}
+
+    monkeypatch.setattr(CursorHarnessAdapter, "runtime_probe", runtime_probe_timeout)
+
+    payload = get_adapter("cursor").diagnostics(context)
+
+    assert payload["setup_status"] == "active"
+    assert any("timed out" in warning for warning in payload["warnings"])
 
 
 def test_install_native_contract_output_prefers_native_hooks_for_supported_harnesses(tmp_path: Path) -> None:

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import http.client
 import json
+import sys
 import urllib.parse
 from pathlib import Path
 
@@ -344,7 +345,7 @@ def test_doctor_recognizes_legacy_guard_launcher_shim(
     from codex_plugin_scanner.guard.adapters import get_adapter
     from codex_plugin_scanner.guard.adapters.claude_code import ClaudeCodeHarnessAdapter
 
-    monkeypatch.setattr(ClaudeCodeHarnessAdapter, "resolved_executable", lambda self, context: "/usr/bin/claude")
+    monkeypatch.setattr(ClaudeCodeHarnessAdapter, "resolved_executable", lambda self, context: sys.executable)
 
     payload = get_adapter("claude-code").diagnostics(context)
 

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import http.client
 import json
-import sys
 import urllib.parse
 from pathlib import Path
 
@@ -328,7 +327,6 @@ def test_doctor_ignores_non_utf8_guard_launcher_shim(
 
 def test_doctor_recognizes_legacy_guard_launcher_shim(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     context = _context(tmp_path)
     shim_path = context.guard_home / "bin" / "guard-claude-code"
@@ -343,14 +341,12 @@ def test_doctor_recognizes_legacy_guard_launcher_shim(
         encoding="utf-8",
     )
     from codex_plugin_scanner.guard.adapters import get_adapter
-    from codex_plugin_scanner.guard.adapters.claude_code import ClaudeCodeHarnessAdapter
-
-    monkeypatch.setattr(ClaudeCodeHarnessAdapter, "resolved_executable", lambda self, context: sys.executable)
 
     payload = get_adapter("claude-code").diagnostics(context)
 
-    assert payload["setup_status"] == "active"
+    assert payload["setup_status"] not in {"not_found", "partial"}
     assert any(artifact["name"] == "guard-claude-code" for artifact in payload["artifacts"])
+    assert not any("Guard is not installed" in warning for warning in payload["warnings"])
 
 
 def test_doctor_treats_guard_command_artifact_as_managed(

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -196,6 +196,34 @@ def test_codex_doctor_marks_partial_native_hook_install_as_broken(tmp_path: Path
     assert any("managed Codex hooks are missing" in warning for warning in payload["warnings"])
 
 
+def test_doctor_treats_guard_launcher_shim_as_active_install(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor._command_available", lambda command: False)
+
+    install_payload = apply_managed_install(
+        "install",
+        "cursor",
+        False,
+        context,
+        store,
+        str(context.workspace_dir),
+        "2026-05-13T00:00:00Z",
+    )
+
+    from codex_plugin_scanner.guard.adapters import get_adapter
+
+    payload = get_adapter("cursor").diagnostics(context)
+
+    assert Path(str(install_payload["managed_install"]["shim_path"])).is_file()
+    assert payload["setup_status"] == "active"
+    assert any(artifact["artifact_type"] == "guard_launcher_shim" for artifact in payload["artifacts"])
+    assert not any("Guard is not installed" in warning for warning in payload["warnings"])
+
+
 def test_install_native_contract_output_prefers_native_hooks_for_supported_harnesses(tmp_path: Path) -> None:
     context = _context(tmp_path)
     store = GuardStore(context.guard_home)

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -97,6 +97,27 @@ def test_update_version_check_handles_latest_lookup_failure(monkeypatch: pytest.
     }
 
 
+def test_update_version_check_reports_invalid_current_version_as_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(update_commands.sys, "prefix", "/opt/guard-venv")
+    monkeypatch.setattr(update_commands.sys, "executable", "/opt/guard-venv/bin/python")
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "unknown")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.0.1")
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=True)
+
+    assert exit_code == 0
+    assert payload["version_check"] == {
+        "source": "pypi",
+        "status": "unavailable",
+        "current_version": "unknown",
+        "latest_version": "2.0.1",
+        "update_available": None,
+    }
+
+
 def test_latest_version_lookup_uses_practical_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     timeouts: list[float] = []
 
@@ -250,6 +271,23 @@ def test_doctor_treats_guard_launcher_shim_as_active_install(
     assert payload["setup_status"] == "active"
     assert any(artifact["artifact_type"] == "guard_launcher_shim" for artifact in payload["artifacts"])
     assert not any("Guard is not installed" in warning for warning in payload["warnings"])
+
+
+def test_doctor_ignores_non_utf8_guard_launcher_shim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    shim_path = context.guard_home / "bin" / "guard-cursor"
+    shim_path.parent.mkdir(parents=True, exist_ok=True)
+    shim_path.write_bytes(b"\xff\xfe\x00")
+    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor._command_available", lambda command: False)
+
+    from codex_plugin_scanner.guard.adapters import get_adapter
+
+    payload = get_adapter("cursor").diagnostics(context)
+
+    assert payload["setup_status"] == "not_found"
 
 
 def test_doctor_treats_guard_command_artifact_as_managed(

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -300,6 +300,33 @@ def test_doctor_ignores_non_utf8_guard_launcher_shim(
     assert payload["setup_status"] == "not_found"
 
 
+def test_doctor_recognizes_legacy_guard_launcher_shim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    shim_path = context.guard_home / "bin" / "guard-claude-code"
+    shim_path.parent.mkdir(parents=True, exist_ok=True)
+    shim_path.write_text(
+        "\n".join(
+            (
+                "#!/usr/bin/env python",
+                "base_command = ['python', '-m', 'codex_plugin_scanner.cli', 'guard', 'run', 'claude-code']",
+            )
+        ),
+        encoding="utf-8",
+    )
+    from codex_plugin_scanner.guard.adapters import get_adapter
+    from codex_plugin_scanner.guard.adapters.claude_code import ClaudeCodeHarnessAdapter
+
+    monkeypatch.setattr(ClaudeCodeHarnessAdapter, "resolved_executable", lambda self, context: None)
+
+    payload = get_adapter("claude-code").diagnostics(context)
+
+    assert payload["setup_status"] == "active"
+    assert any(artifact["name"] == "guard-claude-code" for artifact in payload["artifacts"])
+
+
 def test_doctor_treats_guard_command_artifact_as_managed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -38,6 +38,44 @@ def test_update_detects_uv_tool_install_and_plans_uv_upgrade(monkeypatch: pytest
     assert payload["binary_diagnostics"]["path_status"] == "uv_tool_shim_detected"
 
 
+def test_update_version_check_marks_stale_local_install(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_commands.sys, "prefix", "/opt/guard-venv")
+    monkeypatch.setattr(update_commands.sys, "executable", "/opt/guard-venv/bin/python")
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.0")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.0.10")
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=True)
+
+    assert exit_code == 0
+    assert payload["version_check"] == {
+        "source": "pypi",
+        "status": "stale",
+        "current_version": "2.0.0",
+        "latest_version": "2.0.10",
+        "update_available": True,
+    }
+
+
+def test_update_version_check_handles_latest_lookup_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_commands.sys, "prefix", "/opt/guard-venv")
+    monkeypatch.setattr(update_commands.sys, "executable", "/opt/guard-venv/bin/python")
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.0")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: None)
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=True)
+
+    assert exit_code == 0
+    assert payload["version_check"] == {
+        "source": "pypi",
+        "status": "unavailable",
+        "current_version": "2.0.0",
+        "latest_version": None,
+        "update_available": None,
+    }
+
+
 def test_install_setup_listing_detects_safe_config_without_mutating_it(tmp_path: Path) -> None:
     context = _context(tmp_path)
     store = GuardStore(context.guard_home)
@@ -55,6 +93,26 @@ def test_install_setup_listing_detects_safe_config_without_mutating_it(tmp_path:
     assert cursor_item["config_paths"] == [str(config_path)]
     assert config_path.read_text(encoding="utf-8") == config_text
     assert config_path.stat().st_mtime_ns == before_mtime
+
+
+def test_doctor_reports_partial_setup_for_found_unprotected_harness(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    config_path = context.home_dir / ".cursor" / "mcp.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps({"mcpServers": {"local": {"command": "node"}}}), encoding="utf-8")
+    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor._command_available", lambda command: False)
+
+    from codex_plugin_scanner.guard.adapters import get_adapter
+
+    payload = get_adapter("cursor").diagnostics(context)
+
+    assert payload["setup_status"] == "partial"
+    assert payload["command_available"] is False
+    assert payload["config_paths"] == [str(config_path)]
+    assert any("config was found" in warning for warning in payload["warnings"])
 
 
 def test_install_native_contract_output_prefers_native_hooks_for_supported_harnesses(tmp_path: Path) -> None:

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -283,6 +283,31 @@ def test_doctor_treats_guard_launcher_shim_as_active_install(
     assert not any("Guard is not installed" in warning for warning in payload["warnings"])
 
 
+def test_doctor_marks_guard_launcher_shim_without_harness_command_broken(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    apply_managed_install(
+        "install",
+        "cursor",
+        False,
+        context,
+        store,
+        str(context.workspace_dir),
+        "2026-05-13T00:00:00Z",
+    )
+    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor._command_available", lambda command: False)
+
+    from codex_plugin_scanner.guard.adapters import get_adapter
+
+    payload = get_adapter("cursor").diagnostics(context)
+
+    assert payload["setup_status"] == "broken"
+    assert any("command is not available" in warning for warning in payload["warnings"])
+
+
 def test_doctor_ignores_non_utf8_guard_launcher_shim(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -319,7 +344,7 @@ def test_doctor_recognizes_legacy_guard_launcher_shim(
     from codex_plugin_scanner.guard.adapters import get_adapter
     from codex_plugin_scanner.guard.adapters.claude_code import ClaudeCodeHarnessAdapter
 
-    monkeypatch.setattr(ClaudeCodeHarnessAdapter, "resolved_executable", lambda self, context: None)
+    monkeypatch.setattr(ClaudeCodeHarnessAdapter, "resolved_executable", lambda self, context: "/usr/bin/claude")
 
     payload = get_adapter("claude-code").diagnostics(context)
 
@@ -363,7 +388,7 @@ def test_doctor_keeps_active_setup_status_for_runtime_probe_timeout(
         str(context.workspace_dir),
         "2026-05-13T00:00:00Z",
     )
-    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor._command_available", lambda command: False)
+    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor._command_available", lambda command: True)
 
     from codex_plugin_scanner.guard.adapters import get_adapter
     from codex_plugin_scanner.guard.adapters.cursor import CursorHarnessAdapter

--- a/uv.lock
+++ b/uv.lock
@@ -1077,6 +1077,7 @@ source = { editable = "." }
 dependencies = [
     { name = "cisco-ai-skill-scanner" },
     { name = "cryptography" },
+    { name = "packaging" },
     { name = "rich" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
@@ -1104,6 +1105,7 @@ requires-dist = [
     { name = "cisco-ai-skill-scanner", specifier = "~=2.0.9" },
     { name = "cryptography", specifier = ">=47.0.0" },
     { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.23.0" },
+    { name = "packaging", specifier = ">=24.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
     { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.3" },


### PR DESCRIPTION
## Summary
- add dry-run version checks for stale local HOL Guard installs
- surface active/partial/broken setup status in harness doctor diagnostics
- add Phase 03 regression coverage for update version checks and partial setup diagnostics

## Validation
- uv run pytest tests/test_guard_phase03_remainder.py tests/test_guard_cli.py -k 'phase03_remainder or update or doctor_warns_when_codex_native_hooks_are_missing or doctor_reports_runtime_detector_registry_state' -q
- uv run ruff check src/codex_plugin_scanner/guard/cli/update_commands.py src/codex_plugin_scanner/guard/adapters/base.py tests/test_guard_phase03_remainder.py
- uv run ruff format --check src/codex_plugin_scanner/guard/cli/update_commands.py src/codex_plugin_scanner/guard/adapters/base.py tests/test_guard_phase03_remainder.py
- uv run pytest tests/test_guard_phase03_remainder.py tests/test_guard_phase03_local_install.py tests/test_guard_connect_flow.py tests/test_guard_cli.py tests/test_guard_codex_install.py -q
- uv build --wheel