### PR TITLE
feat(guard): expose local runtime proof status

### DIFF
--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -211,10 +211,54 @@ export type GuardCloudSyncHealth = {
   next_retry_after: string | null;
 };
 
+export type GuardRuntimeDevice = {
+  installation_id: string;
+  device_label: string;
+  local_registered: boolean;
+};
+
+export type GuardConnectProof = {
+  pairing_completed_at: string | null;
+  first_synced_at: string | null;
+  receipts_stored: number;
+  inventory_items: number;
+  runtime_session_id: string | null;
+  runtime_session_synced_at: string | null;
+};
+
+export type GuardLatestConnectState = {
+  request_id: string | null;
+  status: string | null;
+  milestone: string | null;
+  reason: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+  expires_at: string | null;
+  completed_at: string | null;
+  proof: GuardConnectProof;
+};
+
+export type GuardProofStatus = GuardConnectProof & {
+  state:
+    | "not_connected"
+    | "waiting"
+    | "pending"
+    | "synced"
+    | "failed"
+    | "expired"
+    | "sync_unavailable";
+  label: string;
+  detail: string;
+  request_id: string | null;
+};
+
 export type GuardRuntimeSnapshot = {
   generated_at: string;
   approval_center_url: string | null;
   runtime_state: GuardRuntimeState | null;
+  device?: GuardRuntimeDevice;
+  latest_connect_state?: GuardLatestConnectState | null;
+  proof_status?: GuardProofStatus;
   pending_count: number;
   receipt_count: number;
   headline_state: GuardHeadlineState;

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -256,9 +256,9 @@ export type GuardRuntimeSnapshot = {
   generated_at: string;
   approval_center_url: string | null;
   runtime_state: GuardRuntimeState | null;
-  device?: GuardRuntimeDevice;
-  latest_connect_state?: GuardLatestConnectState | null;
-  proof_status?: GuardProofStatus;
+  device: GuardRuntimeDevice;
+  latest_connect_state: GuardLatestConnectState | null;
+  proof_status: GuardProofStatus;
   pending_count: number;
   receipt_count: number;
   headline_state: GuardHeadlineState;

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -289,15 +289,20 @@ def build_runtime_snapshot(
     next_request_id = active_request_id if active_is_pending else first_request_id
     latest_receipts = store.list_receipts(limit=receipt_limit)
     cloud_context = _build_runtime_cloud_context(store)
+    snapshot_now = now or _now()
+    latest_connect_state = _build_latest_connect_state(store, snapshot_now)
     headline_state = _resolve_runtime_headline_state(
         pending_count=store.count_approval_requests(),
         runtime_state=store.get_runtime_state(),
         cloud_state=str(cloud_context["cloud_state"]),
     )
     return {
-        "generated_at": now or _now(),
+        "generated_at": snapshot_now,
         "approval_center_url": approval_center_url,
         "runtime_state": store.get_runtime_state(),
+        "device": _build_runtime_device_context(store),
+        "latest_connect_state": latest_connect_state,
+        "proof_status": _build_runtime_proof_status(latest_connect_state),
         "pending_count": store.count_approval_requests(),
         "queue_summary": {
             "active_request_id": active_request_id if active_is_pending else None,
@@ -509,6 +514,137 @@ def _build_runtime_cloud_context(store: GuardStore) -> dict[str, object]:
     }
 
 
+def _build_runtime_device_context(store: GuardStore) -> dict[str, object]:
+    metadata = store.get_device_metadata()
+    return {
+        "installation_id": metadata["installation_id"],
+        "device_label": metadata["device_label"],
+        "local_registered": True,
+    }
+
+
+def _build_latest_connect_state(store: GuardStore, now: str) -> dict[str, object] | None:
+    state = store.get_latest_guard_connect_state(now=now)
+    if state is None:
+        return None
+    return {
+        "request_id": _optional_string(state.get("request_id")),
+        "status": _optional_string(state.get("status")),
+        "milestone": _optional_string(state.get("milestone")),
+        "reason": _optional_string(state.get("reason")),
+        "created_at": _optional_string(state.get("created_at")),
+        "updated_at": _optional_string(state.get("updated_at")),
+        "expires_at": _optional_string(state.get("expires_at")),
+        "completed_at": _optional_string(state.get("completed_at")),
+        "proof": _connect_state_proof(state.get("proof")),
+    }
+
+
+def _connect_state_proof(value: object) -> dict[str, object]:
+    source = value if isinstance(value, Mapping) else {}
+    return {
+        "pairing_completed_at": _optional_string(source.get("pairing_completed_at")),
+        "first_synced_at": _optional_string(source.get("first_synced_at")),
+        "receipts_stored": _non_negative_int(source.get("receipts_stored")),
+        "inventory_items": _non_negative_int(source.get("inventory_items")),
+        "runtime_session_id": _optional_string(source.get("runtime_session_id")),
+        "runtime_session_synced_at": _optional_string(source.get("runtime_session_synced_at")),
+    }
+
+
+def _build_runtime_proof_status(latest_state: dict[str, object] | None) -> dict[str, object]:
+    if latest_state is None:
+        return _runtime_proof_status_payload(
+            state="not_connected",
+            label="Cloud proof not started",
+            detail="Connect Guard Cloud to sync this device proof.",
+            request_id=None,
+            proof={},
+        )
+    proof = _connect_state_proof(latest_state.get("proof"))
+    status = _runtime_proof_status_name(
+        status=_optional_string(latest_state.get("status")),
+        milestone=_optional_string(latest_state.get("milestone")),
+        proof=proof,
+    )
+    return _runtime_proof_status_payload(
+        state=status,
+        label=_runtime_proof_status_label(status),
+        detail=_runtime_proof_status_detail(status),
+        request_id=_optional_string(latest_state.get("request_id")),
+        proof=proof,
+    )
+
+
+def _runtime_proof_status_payload(
+    *,
+    state: str,
+    label: str,
+    detail: str,
+    request_id: str | None,
+    proof: Mapping[str, object],
+) -> dict[str, object]:
+    return {
+        "state": state,
+        "label": label,
+        "detail": detail,
+        "request_id": request_id,
+        "pairing_completed_at": _optional_string(proof.get("pairing_completed_at")),
+        "first_synced_at": _optional_string(proof.get("first_synced_at")),
+        "runtime_session_id": _optional_string(proof.get("runtime_session_id")),
+        "runtime_session_synced_at": _optional_string(proof.get("runtime_session_synced_at")),
+        "receipts_stored": _non_negative_int(proof.get("receipts_stored")),
+        "inventory_items": _non_negative_int(proof.get("inventory_items")),
+    }
+
+
+def _runtime_proof_status_name(
+    *,
+    status: str | None,
+    milestone: str | None,
+    proof: Mapping[str, object],
+) -> str:
+    if milestone == "first_sync_succeeded" or proof.get("first_synced_at"):
+        return "synced"
+    if milestone == "sync_not_available":
+        return "sync_unavailable"
+    if status == "retry_required" or milestone == "first_sync_failed":
+        return "failed"
+    if milestone == "first_sync_pending":
+        return "pending"
+    if milestone == "expired" or status == "expired":
+        return "expired"
+    if milestone == "waiting_for_browser" or status == "waiting":
+        return "waiting"
+    return "not_connected"
+
+
+def _runtime_proof_status_label(state: str) -> str:
+    labels = {
+        "synced": "First proof synced",
+        "sync_unavailable": "Local connected, cloud sync gated",
+        "failed": "First proof needs retry",
+        "pending": "First proof pending",
+        "expired": "Pairing expired",
+        "waiting": "Waiting for browser pairing",
+        "not_connected": "Cloud proof not started",
+    }
+    return labels.get(state, "Cloud proof not started")
+
+
+def _runtime_proof_status_detail(state: str) -> str:
+    details = {
+        "synced": "This device completed its first Guard Cloud proof sync.",
+        "sync_unavailable": "Local Guard is connected. Shared cloud sync needs a paid Guard plan.",
+        "failed": "Run hol-guard connect again to finish first proof sync.",
+        "pending": "Browser pairing finished. First proof sync has not completed yet.",
+        "expired": "The pairing link expired. Run hol-guard connect again.",
+        "waiting": "Open the pairing link to register this local Guard device.",
+        "not_connected": "Connect Guard Cloud to sync this device proof.",
+    }
+    return details.get(state, "Connect Guard Cloud to sync this device proof.")
+
+
 def _build_cloud_sync_health(store: GuardStore, sync_configured: bool, cloud_state: str) -> dict[str, object]:
     pending_events = store.count_guard_events_v1(uploaded=False)
     event_summary = store.get_sync_payload("guard_events_v1_summary") or {}
@@ -689,6 +825,23 @@ def _runtime_headline_detail(headline_state: str) -> str:
         "connected": "This machine is connected to Guard Cloud and waiting for the first shared proof to appear.",
     }
     return details.get(headline_state, "This machine is protected locally.")
+
+
+def _optional_string(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _non_negative_int(value: object) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return max(0, value)
+    if isinstance(value, str) and value.strip():
+        try:
+            return max(0, int(value.strip()))
+        except ValueError:
+            return 0
+    return 0
 
 
 def _queue_risk_summary(queued: list[dict[str, object]]) -> str:

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -553,15 +553,16 @@ def _connect_state_proof(value: object) -> dict[str, object]:
 
 
 def _build_runtime_proof_status(latest_state: dict[str, object] | None) -> dict[str, object]:
+    proof = _connect_state_proof(latest_state.get("proof") if latest_state is not None else None)
     if latest_state is None:
+        status = "not_connected"
         return _runtime_proof_status_payload(
-            state="not_connected",
-            label="Cloud proof not started",
-            detail="Connect Guard Cloud to sync this device proof.",
+            state=status,
+            label=_runtime_proof_status_label(status),
+            detail=_runtime_proof_status_detail(status),
             request_id=None,
-            proof={},
+            proof=proof,
         )
-    proof = _connect_state_proof(latest_state.get("proof"))
     status = _runtime_proof_status_name(
         status=_optional_string(latest_state.get("status")),
         milestone=_optional_string(latest_state.get("milestone")),
@@ -589,12 +590,7 @@ def _runtime_proof_status_payload(
         "label": label,
         "detail": detail,
         "request_id": request_id,
-        "pairing_completed_at": _optional_string(proof.get("pairing_completed_at")),
-        "first_synced_at": _optional_string(proof.get("first_synced_at")),
-        "runtime_session_id": _optional_string(proof.get("runtime_session_id")),
-        "runtime_session_synced_at": _optional_string(proof.get("runtime_session_synced_at")),
-        "receipts_stored": _non_negative_int(proof.get("receipts_stored")),
-        "inventory_items": _non_negative_int(proof.get("inventory_items")),
+        **proof,
     }
 
 

--- a/tests/test_guard_cloud_local_sync.py
+++ b/tests/test_guard_cloud_local_sync.py
@@ -408,6 +408,101 @@ def test_runtime_snapshot_reports_endpoint_unavailable_sync_as_degraded(tmp_path
     assert snapshot["cloud_sync_health"]["label"] == "Cloud sync degraded"
 
 
+def test_runtime_snapshot_exposes_local_device_without_cloud_pairing(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    device = store.get_device_metadata()
+
+    snapshot = build_runtime_snapshot(
+        store=store,
+        approval_center_url=None,
+        now="2026-04-24T00:00:00+00:00",
+    )
+
+    assert snapshot["device"] == {
+        "installation_id": device["installation_id"],
+        "device_label": device["device_label"],
+        "local_registered": True,
+    }
+    assert snapshot["latest_connect_state"] is None
+    assert snapshot["proof_status"] == {
+        "state": "not_connected",
+        "label": "Cloud proof not started",
+        "detail": "Connect Guard Cloud to sync this device proof.",
+        "request_id": None,
+        "pairing_completed_at": None,
+        "first_synced_at": None,
+        "runtime_session_id": None,
+        "runtime_session_synced_at": None,
+        "receipts_stored": 0,
+        "inventory_items": 0,
+    }
+
+
+def test_runtime_snapshot_exposes_latest_connect_proof_without_pairing_secrets(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    connect_request = store.create_guard_connect_request(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now="2026-04-24T00:00:00+00:00",
+    )
+    request_id = str(connect_request["request_id"])
+    store.complete_guard_connect_request(
+        request_id=request_id,
+        pairing_secret=str(connect_request["pairing_secret"]),
+        token="secret-browser-session-token",
+        now="2026-04-24T00:01:00+00:00",
+    )
+    store.record_guard_connect_result(
+        request_id=request_id,
+        status="connected",
+        milestone="first_sync_succeeded",
+        now="2026-04-24T00:02:00+00:00",
+        sync_payload={
+            "synced_at": "2026-04-24T00:02:00+00:00",
+            "receipts_stored": 3,
+            "inventory_tracked": 5,
+            "runtime_session_id": "runtime-session-1",
+            "runtime_session_synced_at": "2026-04-24T00:01:30+00:00",
+        },
+    )
+
+    snapshot = build_runtime_snapshot(
+        store=store,
+        approval_center_url=None,
+        now="2026-04-24T00:03:00+00:00",
+    )
+    latest_connect_state = snapshot["latest_connect_state"]
+    proof_status = snapshot["proof_status"]
+
+    assert isinstance(latest_connect_state, dict)
+    assert latest_connect_state["request_id"] == request_id
+    assert latest_connect_state["status"] == "connected"
+    assert latest_connect_state["milestone"] == "first_sync_succeeded"
+    assert "sync_url" not in latest_connect_state
+    assert "allowed_origin" not in latest_connect_state
+    assert "secret-browser-session-token" not in json.dumps(latest_connect_state)
+    assert latest_connect_state["proof"] == {
+        "pairing_completed_at": "2026-04-24T00:01:00+00:00",
+        "first_synced_at": "2026-04-24T00:02:00+00:00",
+        "receipts_stored": 3,
+        "inventory_items": 5,
+        "runtime_session_id": "runtime-session-1",
+        "runtime_session_synced_at": "2026-04-24T00:01:30+00:00",
+    }
+    assert proof_status == {
+        "state": "synced",
+        "label": "First proof synced",
+        "detail": "This device completed its first Guard Cloud proof sync.",
+        "request_id": request_id,
+        "pairing_completed_at": "2026-04-24T00:01:00+00:00",
+        "first_synced_at": "2026-04-24T00:02:00+00:00",
+        "runtime_session_id": "runtime-session-1",
+        "runtime_session_synced_at": "2026-04-24T00:01:30+00:00",
+        "receipts_stored": 3,
+        "inventory_items": 5,
+    }
+
+
 def test_runtime_session_sync_skips_v1_event_when_ingest_was_recently_unavailable(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- expose local device metadata in the Guard runtime snapshot
- add a sanitized latest connect state and derived proof status
- type the new runtime snapshot fields for dashboard consumers

## Verification
- uv run pytest tests/test_guard_cloud_local_sync.py tests/test_guard_surface_server.py tests/test_guard_connect_flow.py -q
- uv run ruff check src/codex_plugin_scanner/guard/approvals.py tests/test_guard_cloud_local_sync.py
- uv run ruff format --check src/codex_plugin_scanner/guard/approvals.py tests/test_guard_cloud_local_sync.py
- uv build --wheel
- cd dashboard && pnpm test
- cd dashboard && pnpm build