### PR TITLE
fix(guard): include approval links in block outputs

### DIFF
--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -262,8 +262,8 @@ def approval_center_hint(
     flow = approval_prompt_flow(harness, managed_install=managed_install)
     count = len(queued)
     risk_summary = _queue_risk_summary(queued)
-    first_approval_url = _first_approval_url(queued)
-    review_url = first_approval_url or approval_center_url
+    approval_url = first_approval_url(queued)
+    review_url = approval_url or approval_center_url
     return (
         f"Guard queued {count} approval request{'s' if count != 1 else ''} for {harness}. "
         f"{flow['summary']} "
@@ -273,7 +273,7 @@ def approval_center_hint(
     )
 
 
-def _first_approval_url(queued: list[dict[str, object]]) -> str | None:
+def first_approval_url(queued: list[dict[str, object]]) -> str | None:
     for item in queued:
         approval_url = item.get("approval_url")
         if isinstance(approval_url, str) and approval_url.strip():

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import threading
 import time
 import uuid
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -273,8 +273,10 @@ def approval_center_hint(
     )
 
 
-def first_approval_url(queued: list[dict[str, object]]) -> str | None:
+def first_approval_url(queued: Sequence[object]) -> str | None:
     for item in queued:
+        if not isinstance(item, Mapping):
+            continue
         approval_url = item.get("approval_url")
         if isinstance(approval_url, str) and approval_url.strip():
             return approval_url.strip()

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -262,13 +262,23 @@ def approval_center_hint(
     flow = approval_prompt_flow(harness, managed_install=managed_install)
     count = len(queued)
     risk_summary = _queue_risk_summary(queued)
+    first_approval_url = _first_approval_url(queued)
+    review_url = first_approval_url or approval_center_url
     return (
         f"Guard queued {count} approval request{'s' if count != 1 else ''} for {harness}. "
         f"{flow['summary']} "
-        f"Review them in the Guard approval center at {approval_center_url}. "
+        f"Review them in the Guard approval center at {review_url}. "
         f"{risk_summary} "
         f"{flow['fallback_hint']}"
     )
+
+
+def _first_approval_url(queued: list[dict[str, object]]) -> str | None:
+    for item in queued:
+        approval_url = item.get("approval_url")
+        if isinstance(approval_url, str) and approval_url.strip():
+            return approval_url.strip()
+    return None
 
 
 def build_runtime_snapshot(

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -33,6 +33,7 @@ from ..approvals import (
     approval_center_hint,
     approval_delivery_payload,
     approval_prompt_flow,
+    first_approval_url,
     queue_blocked_approvals,
     wait_for_approval_requests,
 )
@@ -3363,16 +3364,8 @@ def _native_approval_center_context(response_payload: dict[str, object], *, harn
     if not isinstance(approval_center_url, str) or not approval_center_url.strip():
         return None
     queued = response_payload.get("approval_requests")
-    first_approval_url: str | None = None
-    if isinstance(queued, list):
-        for item in queued:
-            if not isinstance(item, dict):
-                continue
-            approval_url = item.get("approval_url")
-            if isinstance(approval_url, str) and approval_url.strip():
-                first_approval_url = approval_url.strip()
-                break
-    review_url = first_approval_url or approval_center_url.strip()
+    review_url = first_approval_url(queued) if isinstance(queued, list) else None
+    review_url = review_url or approval_center_url.strip()
     harness_label = {
         "claude-code": "Claude Code",
         "codex": "Codex",

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1796,11 +1796,12 @@ def run_guard_command(
                 managed_install=managed_install,
             )
             if _should_emit_copilot_hook_response(args):
+                review_context = _native_approval_center_context(response_payload, harness=args.harness)
                 _emit_copilot_permission_request_response(
                     behavior="deny",
-                    message=(
-                        f"HOL Guard blocked {artifact_name}. {decision.summary} "
-                        f"Approve the exact call in Guard, then retry."
+                    message=_copilot_hook_reason(
+                        f"HOL Guard blocked {artifact_name}. {decision.summary}",
+                        review_context,
                     ),
                     interrupt=True,
                     output_stream=output_stream,

--- a/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
+++ b/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from typing import Any, TextIO
 
 from ..adapters.base import HarnessContext
-from ..approvals import queue_blocked_approvals
+from ..approvals import first_approval_url, queue_blocked_approvals
 from ..config import GuardConfig
 from ..daemon import ensure_guard_daemon
 from ..mcp_tool_calls import (
@@ -580,7 +580,7 @@ class RuntimeMcpGuardProxy:
             risk_categories=tool_call_risk_categories(artifact, params.get("arguments")),
         )
         request_id = str(queued[0]["request_id"]) if queued else "unknown"
-        review_url = _first_approval_url(queued) or approval_center_url
+        review_url = first_approval_url(queued) or approval_center_url
         response_data = {
             "approvalCenterUrl": approval_center_url,
             "approvalRequests": queued,
@@ -699,14 +699,6 @@ class ElicitationMcpGuardProxy(RuntimeMcpGuardProxy):
                 },
             },
         }
-
-
-def _first_approval_url(queued: list[dict[str, object]]) -> str | None:
-    for item in queued:
-        approval_url = item.get("approval_url")
-        if isinstance(approval_url, str) and approval_url.strip():
-            return approval_url.strip()
-    return None
 
 
 class CodexMcpGuardProxy(ElicitationMcpGuardProxy):

--- a/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
+++ b/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
@@ -580,18 +580,28 @@ class RuntimeMcpGuardProxy:
             risk_categories=tool_call_risk_categories(artifact, params.get("arguments")),
         )
         request_id = str(queued[0]["request_id"]) if queued else "unknown"
+        review_url = _first_approval_url(queued) or approval_center_url
+        response_data = {
+            "approvalCenterUrl": approval_center_url,
+            "approvalRequests": queued,
+            "reviewUrl": review_url,
+        }
         return _blocked_tool_response(
             message_id,
             tool_name,
             (
                 f"HOL Guard stopped tool call {tool_name} from {self.server_name}. "
-                f"Approve request {request_id} at {approval_center_url}, then retry the same action."
+                f"Approve request {request_id} at {review_url}, then retry the same action."
             ),
+            response_data,
         ), {
             "method": "tools/call",
             "tool_name": tool_name,
             "decision": "queue-approval",
             "redacted_params": _redact_json(params),
+            "approval_center_url": approval_center_url,
+            "approval_requests": queued,
+            "review_url": review_url,
         }
 
     def _capture_tools_catalog(
@@ -689,6 +699,14 @@ class ElicitationMcpGuardProxy(RuntimeMcpGuardProxy):
                 },
             },
         }
+
+
+def _first_approval_url(queued: list[dict[str, object]]) -> str | None:
+    for item in queued:
+        approval_url = item.get("approval_url")
+        if isinstance(approval_url, str) and approval_url.strip():
+            return approval_url.strip()
+    return None
 
 
 class CodexMcpGuardProxy(ElicitationMcpGuardProxy):

--- a/src/codex_plugin_scanner/guard/proxy/stdio.py
+++ b/src/codex_plugin_scanner/guard/proxy/stdio.py
@@ -291,8 +291,9 @@ class StdioGuardProxy:
                         )
                         event["approval_center_url"] = self.approval_center_url
                         event["approval_delivery"] = approval_delivery_payload(approval_flow)
+                        review_url = _first_approval_url(event["approval_requests"]) or self.approval_center_url
                         event["review_hint"] = (
-                            f"{approval_flow['summary']} Open {self.approval_center_url} to review the blocked request."
+                            f"{approval_flow['summary']} Open {review_url} to review the blocked request."
                         )
                         blocked_message = f"{blocked_message} {event['review_hint']}"
                         response_data = {
@@ -300,6 +301,7 @@ class StdioGuardProxy:
                             "approvalRequests": event["approval_requests"],
                             "approvalDelivery": event["approval_delivery"],
                             "reviewHint": event["review_hint"],
+                            "reviewUrl": review_url,
                         }
                     response = _blocked_tool_response(
                         message.get("id"),
@@ -361,3 +363,11 @@ def _is_request(message: dict[str, Any]) -> bool:
 
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _first_approval_url(queued: list[dict[str, object]]) -> str | None:
+    for item in queued:
+        approval_url = item.get("approval_url")
+        if isinstance(approval_url, str) and approval_url.strip():
+            return approval_url.strip()
+    return None

--- a/src/codex_plugin_scanner/guard/proxy/stdio.py
+++ b/src/codex_plugin_scanner/guard/proxy/stdio.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
-from ..approvals import approval_delivery_payload, approval_prompt_flow, queue_blocked_approvals
+from ..approvals import approval_delivery_payload, approval_prompt_flow, first_approval_url, queue_blocked_approvals
 from ..consumer import artifact_hash
 from ..models import HarnessDetection
 from ..receipts import build_receipt
@@ -291,7 +291,7 @@ class StdioGuardProxy:
                         )
                         event["approval_center_url"] = self.approval_center_url
                         event["approval_delivery"] = approval_delivery_payload(approval_flow)
-                        review_url = _first_approval_url(event["approval_requests"]) or self.approval_center_url
+                        review_url = first_approval_url(event["approval_requests"]) or self.approval_center_url
                         event["review_hint"] = (
                             f"{approval_flow['summary']} Open {review_url} to review the blocked request."
                         )
@@ -364,10 +364,3 @@ def _is_request(message: dict[str, Any]) -> bool:
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
-
-def _first_approval_url(queued: list[dict[str, object]]) -> str | None:
-    for item in queued:
-        approval_url = item.get("approval_url")
-        if isinstance(approval_url, str) and approval_url.strip():
-            return approval_url.strip()
-    return None

--- a/src/codex_plugin_scanner/guard/proxy/stdio.py
+++ b/src/codex_plugin_scanner/guard/proxy/stdio.py
@@ -363,4 +363,3 @@ def _is_request(message: dict[str, Any]) -> bool:
 
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
-

--- a/tests/test_guard_approval_copy_commands.py
+++ b/tests/test_guard_approval_copy_commands.py
@@ -9,7 +9,7 @@ import pytest
 
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
-from codex_plugin_scanner.guard.approvals import approval_center_hint
+from codex_plugin_scanner.guard.approvals import approval_center_hint, first_approval_url
 from codex_plugin_scanner.guard.models import GuardApprovalRequest
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -53,9 +53,7 @@ class TestHarnessBlockMessageCopyRule:
     """T732: harness block messages must never tell users to run 'hol-guard dashboard' as primary path."""
 
     @pytest.mark.parametrize("harness", _KNOWN_HARNESSES)
-    def test_approval_center_hint_does_not_require_manual_dashboard_launch(
-        self, tmp_path: Path, harness: str
-    ) -> None:
+    def test_approval_center_hint_does_not_require_manual_dashboard_launch(self, tmp_path: Path, harness: str) -> None:
         """T732: approval_center_hint must not instruct users to run 'hol-guard dashboard'."""
         context = HarnessContext(
             home_dir=tmp_path,
@@ -96,6 +94,16 @@ class TestBlockMessageNoDashboardLaunchRequired:
             assert "hol-guard dashboard" not in hint, (
                 f"CLI block message for '{harness}' must not say 'hol-guard dashboard'. Got: {hint!r}"
             )
+
+
+def test_first_approval_url_ignores_malformed_queue_items() -> None:
+    queued = [
+        "not-a-request",
+        {"approval_url": "  "},
+        {"approval_url": "http://127.0.0.1:5474/approvals/req-ok"},
+    ]
+
+    assert first_approval_url(queued) == "http://127.0.0.1:5474/approvals/req-ok"
 
 
 class TestApprovalsOpenCommand:

--- a/tests/test_guard_copilot_proxy.py
+++ b/tests/test_guard_copilot_proxy.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.proxy import CopilotMcpGuardProxy
+from codex_plugin_scanner.guard.proxy import runtime_mcp as runtime_mcp_module
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -117,3 +118,54 @@ def test_copilot_guard_proxy_prompts_inline_when_client_supports_elicitation(tmp
     assert responses[2]["id"] == 2
     assert responses[2]["result"]["content"][0]["text"] == "dangerous_delete"
     assert json.loads(marker_path.read_text(encoding="utf-8"))["name"] == "dangerous_delete"
+
+
+def test_copilot_guard_proxy_queue_block_includes_request_url(tmp_path, monkeypatch):
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    config = GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir)
+    marker_path = tmp_path / "dangerous-call.json"
+    monkeypatch.setattr(runtime_mcp_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    proxy = CopilotMcpGuardProxy(
+        server_name="danger_lab",
+        command=_child_command(marker_path),
+        context=context,
+        store=store,
+        config=config,
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".vscode" / "mcp.json"),
+    )
+    input_stream = StringIO(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "initialize",
+                        "params": {"capabilities": {}},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "method": "tools/call",
+                        "params": {"name": "dangerous_delete", "arguments": {"target": ".env"}},
+                    }
+                ),
+            ]
+        )
+        + "\n"
+    )
+    output_stream = StringIO()
+
+    exit_code = proxy.serve(stdin=input_stream, stdout=output_stream)
+    responses = [json.loads(line) for line in output_stream.getvalue().splitlines()]
+    error = responses[1]["error"]
+    approval_requests = error["data"]["approvalRequests"]
+
+    assert exit_code == 0
+    assert error["data"]["approvalCenterUrl"] == "http://127.0.0.1:4455"
+    assert approval_requests[0]["approval_url"].startswith("http://127.0.0.1:4455/approvals/")
+    assert approval_requests[0]["approval_url"] in error["message"]

--- a/tests/test_guard_opencode_proxy.py
+++ b/tests/test_guard_opencode_proxy.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.config import GuardConfig
-from codex_plugin_scanner.guard.proxy import OpenCodeMcpGuardProxy
+from codex_plugin_scanner.guard.proxy import OpenCodeMcpGuardProxy, RuntimeMcpGuardProxy
+from codex_plugin_scanner.guard.proxy import runtime_mcp as runtime_mcp_module
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -96,3 +97,40 @@ def test_opencode_guard_proxy_allows_risky_tool_after_native_permission(tmp_path
     assert store.count_approval_requests() == 0
     assert receipts[0]["policy_decision"] == "allow"
     assert "native-approved" in receipts[0]["changed_capabilities"]
+
+
+def test_runtime_guard_proxy_queue_block_includes_request_url(tmp_path, monkeypatch):
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    config = GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir)
+    marker_path = tmp_path / "dangerous-call.json"
+    monkeypatch.setattr(runtime_mcp_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    proxy = RuntimeMcpGuardProxy(
+        harness="hermes",
+        server_name="danger_lab",
+        command=_child_command(marker_path),
+        context=context,
+        store=store,
+        config=config,
+        source_scope="project",
+        config_path=str(context.workspace_dir / "hermes.json"),
+        transport="local",
+    )
+
+    result = proxy.run_session(
+        [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"capabilities": {}}},
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": "dangerous_delete", "arguments": {"target": ".env.guard-proof"}},
+            },
+        ]
+    )
+    error = result["responses"][1]["error"]
+    approval_requests = error["data"]["approvalRequests"]
+
+    assert error["data"]["approvalCenterUrl"] == "http://127.0.0.1:4455"
+    assert approval_requests[0]["approval_url"].startswith("http://127.0.0.1:4455/approvals/")
+    assert approval_requests[0]["approval_url"] in error["message"]

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -490,6 +490,7 @@ clearer UX and an implementation plan with technical references.
             return original_import(name, global_ns, local_ns, fromlist, level)
 
         monkeypatch.setattr(builtins, "__import__", _guarded_import)
+        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
 
         rc = main(
             [
@@ -547,6 +548,9 @@ clearer UX and an implementation plan with technical references.
         assert rc == 1
         assert output["artifact_type"] == "prompt_request"
         assert "read .authrc" in output["launch_summary"]
+        assert output["approval_center_url"] == "http://127.0.0.1:4455"
+        assert approval_requests[0]["approval_url"].startswith("http://127.0.0.1:4455/approvals/")
+        assert approval_requests[0]["approval_url"] in output["review_hint"]
         assert approval_requests[0]["launch_target"] == "Codex prompt for `.authrc`: read .authrc"
         assert approval_requests[0]["action_envelope_json"]["action_type"] == "prompt"
         assert approval_requests[0]["action_envelope_json"]["prompt_excerpt"] == "read .authrc"
@@ -6190,6 +6194,7 @@ def test_guard_hook_emits_copilot_permission_request_deny_for_risky_mcp_tool(
     assert output["interrupt"] is True
     assert "HOL Guard blocked" in output["message"]
     assert "danger_lab:dangerous_delete" in output["message"]
+    assert "http://127.0.0.1:4455/approvals/" in output["message"]
 
 
 def test_guard_hook_emits_copilot_permission_request_deny_from_tool_calls_payload(


### PR DESCRIPTION
## Summary\n- include request-specific local approval URLs in queued approval hints\n- surface approval URLs in Copilot permission request and MCP proxy block responses\n- add harness output tests for Codex, Copilot, OpenCode-style, and runtime MCP block paths\n\n## Verification\n- uv run pytest tests/test_guard_runtime.py::TestGuardRuntime::test_guard_hook_copilot_path_does_not_require_rich_imports tests/test_guard_runtime.py::TestGuardRuntime::test_codex_prompt_request_queue_shows_original_prompt tests/test_guard_runtime.py::test_guard_hook_emits_copilot_permission_request_deny_for_risky_mcp_tool tests/test_guard_copilot_proxy.py::test_copilot_guard_proxy_queue_block_includes_request_url tests/test_guard_opencode_proxy.py::test_runtime_guard_proxy_queue_block_includes_request_url -q\n- uv run pytest tests/test_guard_runtime.py -k 'copilot_path_does_not_require_rich_imports or codex_prompt_request_queue_shows_original_prompt or copilot_permission_request_deny_for_risky_mcp_tool' tests/test_guard_copilot_proxy.py::test_copilot_guard_proxy_queue_block_includes_request_url tests/test_guard_opencode_proxy.py::test_runtime_guard_proxy_queue_block_includes_request_url -q\n- uv run ruff check src/codex_plugin_scanner/guard/approvals.py src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/proxy/runtime_mcp.py src/codex_plugin_scanner/guard/proxy/stdio.py tests/test_guard_runtime.py tests/test_guard_copilot_proxy.py tests/test_guard_opencode_proxy.py\n- uv run ruff format --check src/codex_plugin_scanner/guard/approvals.py src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/proxy/runtime_mcp.py src/codex_plugin_scanner/guard/proxy/stdio.py tests/test_guard_runtime.py tests/test_guard_copilot_proxy.py tests/test_guard_opencode_proxy.py\n- uv build --wheel