### PR TITLE
fix(guard): improve approval recovery flow

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/approval_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/approval_commands.py
@@ -155,14 +155,18 @@ def _auto_open_first_pending_request(*, store: GuardStore, workspace: Path | Non
     if request is None:
         return {"opened": False, "reason": "no-pending-request"}
     approval_url = str(request.get("approval_url") or "")
-    approval_center_url = approval_url or load_guard_daemon_url(store.guard_home)
+    approval_center_url = _repaired_approval_url(approval_url, store.guard_home) or load_guard_daemon_url(
+        store.guard_home
+    )
     if approval_center_url is None:
         return {"opened": False, "reason": "missing-approval-url"}
-    request_id = str(request.get("request_id") or approval_center_url)
+    request_id = str(request.get("request_id") or "")
+    if not request_id:
+        return {"opened": False, "reason": "missing-request-id"}
     config = load_guard_config(store.guard_home, workspace)
-    approval_surface_policy = (
-        "never-auto-open" if config.approval_surface_policy == "native-only" else config.approval_surface_policy
-    )
+    approval_surface_policy = config.approval_surface_policy
+    if approval_surface_policy == "native-only":
+        approval_surface_policy = "never-auto-open"
     result = GuardSurfaceRuntime(store).ensure_surface(
         surface="approval-center",
         approval_center_url=approval_center_url,

--- a/src/codex_plugin_scanner/guard/cli/approval_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/approval_commands.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import argparse
 import urllib.parse
+import webbrowser
 from datetime import datetime, timezone
 from pathlib import Path
 
 from ..approvals import apply_approval_resolution, build_runtime_snapshot
+from ..config import load_guard_config
 from ..daemon import load_guard_daemon_url
+from ..runtime.surface_server import GuardSurfaceRuntime
 from ..store import GuardStore
 
 _HARNESS_RETRY_COPY: dict[str, str] = {
@@ -96,11 +99,13 @@ def run_approval_command(
 ) -> dict[str, object]:
     command = getattr(args, "approvals_command", None)
     if command is None:
-        return build_runtime_snapshot(
+        payload = build_runtime_snapshot(
             store=store,
             approval_center_url=load_guard_daemon_url(store.guard_home),
             now=_now(),
         )
+        payload["auto_open"] = _auto_open_first_pending_request(store=store, workspace=workspace)
+        return payload
     if command == "clear-history":
         harness = getattr(args, "harness", None)
         clear_all = bool(getattr(args, "all", False))
@@ -143,6 +148,30 @@ def run_approval_command(
         now=_now(),
     )
     return {"resolved": True, "item": item}
+
+
+def _auto_open_first_pending_request(*, store: GuardStore, workspace: Path | None) -> dict[str, object]:
+    request = store.get_next_pending_request()
+    if request is None:
+        return {"opened": False, "reason": "no-pending-request"}
+    approval_url = str(request.get("approval_url") or "")
+    approval_center_url = approval_url or load_guard_daemon_url(store.guard_home)
+    if approval_center_url is None:
+        return {"opened": False, "reason": "missing-approval-url"}
+    request_id = str(request.get("request_id") or approval_center_url)
+    config = load_guard_config(store.guard_home, workspace)
+    approval_surface_policy = (
+        "never-auto-open" if config.approval_surface_policy == "native-only" else config.approval_surface_policy
+    )
+    result = GuardSurfaceRuntime(store).ensure_surface(
+        surface="approval-center",
+        approval_center_url=approval_center_url,
+        approval_surface_policy=approval_surface_policy,
+        open_key=f"approval-request:{request_id}",
+        opener=webbrowser.open,
+    )
+    result["request_id"] = request_id
+    return result
 
 
 def run_approval_open_command(

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -215,6 +215,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                             "code": "request_unknown",
                             "title": "This request is no longer waiting.",
                             "body": "The request was either already resolved or expired. You can close this tab.",
+                            "queue_url": self._local_queue_url(),
                         },
                     },
                     status=404,
@@ -460,6 +461,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                         "code": "request_unknown",
                         "title": "This request is no longer waiting.",
                         "body": "The request was either already resolved or expired. You can close this tab.",
+                        "queue_url": self._local_queue_url(),
                     },
                 },
                 status=404,
@@ -477,6 +479,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                             "If the action is blocked and you believe it should be allowed, "
                             "you can re-submit from your AI assistant."
                         ),
+                        "queue_url": self._local_queue_url(),
                     },
                 },
                 status=409,
@@ -494,11 +497,18 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             _now(),
         )
         harness = str(updated.get("harness", ""))
-        updated["copy"] = _build_resolution_copy(action, harness_str or harness)
+        copy = _build_resolution_copy(action, harness_str or harness)
+        updated["copy"] = copy
+        updated["retry_hint"] = copy["body"]
         self._write_json(updated)
 
     def log_message(self, fmt: str, *args: Any) -> None:
         return
+
+    def _local_queue_url(self) -> str:
+        host = self.server.server_address[0]  # type: ignore[attr-defined]
+        port = self.server.server_address[1]  # type: ignore[attr-defined]
+        return _build_local_url(host, port, "/#/inbox")
 
     def _load_request_body(self) -> tuple[dict[str, object], str | None]:
         length = int(self.headers.get("Content-Length", "0"))

--- a/tests/test_guard_approval_copy_commands.py
+++ b/tests/test_guard_approval_copy_commands.py
@@ -10,6 +10,7 @@ import pytest
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.approvals import approval_center_hint, first_approval_url
+from codex_plugin_scanner.guard.cli import approval_commands as approval_commands_module
 from codex_plugin_scanner.guard.models import GuardApprovalRequest
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -131,6 +132,58 @@ class TestApprovalsOpenCommand:
 
         assert rc != 0
         assert "error" in output
+
+
+class TestApprovalsAutoOpenCommand:
+    def test_approvals_summary_auto_opens_first_pending_request(self, tmp_path: Path, monkeypatch, capsys) -> None:
+        home_dir = tmp_path / "guard-home"
+        store = GuardStore(home_dir)
+        store.add_approval_request(_make_request(request_id="req-auto-open"), "2026-01-01T00:00:00Z")
+        opened_urls: list[str] = []
+        monkeypatch.setattr(
+            approval_commands_module,
+            "load_guard_daemon_url",
+            lambda _guard_home: "http://127.0.0.1:5474",
+        )
+        monkeypatch.setattr(
+            approval_commands_module.webbrowser,
+            "open",
+            lambda url: opened_urls.append(url) or True,
+        )
+
+        rc = main(["guard", "approvals", "--home", str(home_dir), "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert opened_urls == ["http://127.0.0.1:5474/approvals/req-auto-open"]
+        assert output["auto_open"]["opened"] is True
+        assert output["auto_open"]["request_id"] == "req-auto-open"
+
+    def test_approvals_summary_honors_native_only_auto_open_opt_out(self, tmp_path: Path, monkeypatch, capsys) -> None:
+        home_dir = tmp_path / "guard-home"
+        home_dir.mkdir(parents=True)
+        (home_dir / "config.toml").write_text('approval_surface_policy = "native-only"\n', encoding="utf-8")
+        store = GuardStore(home_dir)
+        store.add_approval_request(_make_request(request_id="req-no-open"), "2026-01-01T00:00:00Z")
+        opened_urls: list[str] = []
+        monkeypatch.setattr(
+            approval_commands_module,
+            "load_guard_daemon_url",
+            lambda _guard_home: "http://127.0.0.1:5474",
+        )
+        monkeypatch.setattr(
+            approval_commands_module.webbrowser,
+            "open",
+            lambda url: opened_urls.append(url) or True,
+        )
+
+        rc = main(["guard", "approvals", "--home", str(home_dir), "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert opened_urls == []
+        assert output["auto_open"]["opened"] is False
+        assert output["auto_open"]["reason"] == "policy-disabled"
 
 
 class TestApprovalsRetryHintCommand:

--- a/tests/test_guard_approval_copy_commands.py
+++ b/tests/test_guard_approval_copy_commands.py
@@ -33,6 +33,7 @@ def _make_request(
     request_id: str,
     harness: str = "codex",
     status: str = "pending",
+    approval_url: str | None = None,
 ) -> GuardApprovalRequest:
     return GuardApprovalRequest(
         request_id=request_id,
@@ -46,7 +47,7 @@ def _make_request(
         source_scope="project",
         config_path="/tmp/config.toml",
         review_command=f"hol-guard approvals approve {request_id}",
-        approval_url=f"http://127.0.0.1:5474/approvals/{request_id}",
+        approval_url=approval_url or f"http://127.0.0.1:5474/approvals/{request_id}",
     )
 
 
@@ -158,6 +159,35 @@ class TestApprovalsAutoOpenCommand:
         assert opened_urls == ["http://127.0.0.1:5474/approvals/req-auto-open"]
         assert output["auto_open"]["opened"] is True
         assert output["auto_open"]["request_id"] == "req-auto-open"
+
+    def test_approvals_summary_repairs_stale_auto_open_url(self, tmp_path: Path, monkeypatch, capsys) -> None:
+        home_dir = tmp_path / "guard-home"
+        store = GuardStore(home_dir)
+        store.add_approval_request(
+            _make_request(
+                request_id="req-stale-open",
+                approval_url="http://127.0.0.1:4000/approvals/req-stale-open",
+            ),
+            "2026-01-01T00:00:00Z",
+        )
+        opened_urls: list[str] = []
+        monkeypatch.setattr(
+            approval_commands_module,
+            "load_guard_daemon_url",
+            lambda _guard_home: "http://127.0.0.1:5474",
+        )
+        monkeypatch.setattr(
+            approval_commands_module.webbrowser,
+            "open",
+            lambda url: opened_urls.append(url) or True,
+        )
+
+        rc = main(["guard", "approvals", "--home", str(home_dir), "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert opened_urls == ["http://127.0.0.1:5474/approvals/req-stale-open"]
+        assert output["auto_open"]["opened"] is True
 
     def test_approvals_summary_honors_native_only_auto_open_opt_out(self, tmp_path: Path, monkeypatch, capsys) -> None:
         home_dir = tmp_path / "guard-home"

--- a/tests/test_guard_web_recovery.py
+++ b/tests/test_guard_web_recovery.py
@@ -104,8 +104,47 @@ class TestApproveBlockRecoveryPayloads:
         recovery = payload.get("recovery")
         assert isinstance(recovery, dict), "Recovery payload must be a dict"
         assert recovery.get("code") == "request_resolved"
+        assert recovery.get("queue_url") == f"http://127.0.0.1:{daemon.port}/#/inbox"
         title = recovery.get("title", "")
         assert "already" in title.lower() or "resolved" in title.lower()
+
+    def test_approve_returns_harness_retry_hint_for_browser_resume(self, tmp_path: Path) -> None:
+        store = GuardStore(tmp_path / "guard")
+        store.add_approval_request(
+            GuardApprovalRequest(
+                request_id="req-opencode-resume",
+                harness="opencode",
+                artifact_id="opencode:project:test_tool",
+                artifact_name="test_tool",
+                artifact_hash="hash-test",
+                policy_action="block",
+                recommended_scope="artifact",
+                changed_fields=(),
+                source_scope="local",
+                config_path="/tmp/config",
+                review_command="hol-guard approvals approve req-opencode-resume",
+                approval_url="http://127.0.0.1:6174/#/approve/req-opencode-resume",
+            ),
+            "2026-01-01T00:00:00+00:00",
+        )
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/requests/req-opencode-resume/approve",
+                data=json.dumps({"scope": "artifact"}).encode("utf-8"),
+                headers=_guard_json_headers(daemon._server.auth_token),
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=5) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        finally:
+            daemon.stop()
+
+        assert payload["resolved"] is True
+        assert payload["retry_hint"] == "Return to OpenCode and retry"
+        assert payload["copy"] == {"title": "Approved. Retry in chat.", "body": "Return to OpenCode and retry"}
 
     def test_approve_with_wrong_token_returns_recovery_payload_not_bare_401(self, tmp_path: Path) -> None:
         """T697/T698: approve/block with wrong token returns structured recovery payload."""
@@ -188,3 +227,4 @@ class TestApproveBlockRecoveryPayloads:
         assert isinstance(recovery, dict), "404 GET on stale request must include recovery payload"
         assert recovery.get("code") in {"request_unknown", "not_found"}
         assert recovery.get("title") is not None
+        assert recovery.get("queue_url") == f"http://127.0.0.1:{daemon.port}/#/inbox"


### PR DESCRIPTION
## Summary
- auto-open the first pending approval when reviewing the local queue, while honoring native-only opt-out
- return harness-specific retry guidance after browser approval decisions
- include queue recovery links for stale or already-resolved approval URLs

## Validation
- uv run pytest tests/test_guard_approval_copy_commands.py tests/test_guard_web_recovery.py tests/test_guard_surface_server.py::TestGuardSurfaceServer::test_guard_daemon_block_endpoint_queues_approvals_and_applies_auto_open_once tests/test_guard_surface_server.py::TestGuardSurfaceServer::test_open_approval_center_auto_open_once_tracks_operation_key tests/test_guard_surface_server.py::TestGuardSurfaceServer::test_guard_surface_runtime_force_open_bypasses_auto_open_once tests/test_guard_surface_server.py::TestGuardSurfaceServer::test_guard_surface_runtime_force_open_overrides_disabled_policy -q
- uv run ruff check src/codex_plugin_scanner/guard/cli/approval_commands.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_approval_copy_commands.py tests/test_guard_web_recovery.py
- uv run ruff format --check src/codex_plugin_scanner/guard/cli/approval_commands.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_approval_copy_commands.py tests/test_guard_web_recovery.py
- uv build --wheel