### PR TITLE
fix(guard): redact local paths in status output

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/product.py
+++ b/src/codex_plugin_scanner/guard/cli/product.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from pathlib import Path
 from urllib.parse import urlparse
 
 from ..adapters import get_adapter
@@ -11,6 +12,7 @@ from ..config import GuardConfig
 from ..consumer import detect_all, evaluate_detection
 from ..daemon import load_guard_daemon_url
 from ..models import HarnessDetection
+from ..redaction import redact_local_path
 from ..store import GuardStore
 
 HARNESS_PRIORITY = ("codex", "claude-code", "copilot", "hermes", "cursor", "antigravity", "gemini", "opencode")
@@ -74,7 +76,7 @@ def _build_guard_product_payload(
     include_steps: bool,
 ) -> dict[str, object]:
     detections = detect_all(context)
-    harnesses = [_summarize_harness(detection, store, config) for detection in detections]
+    harnesses = [_summarize_harness(detection, store, config, context.home_dir) for detection in detections]
     recommended = _recommended_harness(harnesses)
     receipt_count = store.count_receipts()
     managed_harnesses = sum(1 for item in harnesses if item["managed"] is True)
@@ -82,8 +84,8 @@ def _build_guard_product_payload(
     approval_center_url = load_guard_daemon_url(context.guard_home)
     payload: dict[str, object] = {
         "generated_at": _now(),
-        "guard_home": str(context.guard_home),
-        "workspace": str(context.workspace_dir) if context.workspace_dir is not None else None,
+        "guard_home": _redacted_path(context.guard_home, context.home_dir),
+        "workspace": _redacted_path(context.workspace_dir, context.home_dir),
         "sync_configured": store.get_sync_credentials() is not None,
         "receipt_count": receipt_count,
         "pending_approvals": store.count_approval_requests(),
@@ -104,6 +106,7 @@ def _summarize_harness(
     detection: HarnessDetection,
     store: GuardStore,
     config: GuardConfig,
+    home_dir: Path,
 ) -> dict[str, object]:
     evaluation = evaluate_detection(detection, store, config, default_action="allow", persist=False)
     managed_install = store.get_managed_install(detection.harness)
@@ -124,8 +127,8 @@ def _summarize_harness(
         "review_count": review_count,
         "warning_count": len(detection.warnings),
         "managed": managed,
-        "shim_path": str(shim_path) if isinstance(shim_path, str) else None,
-        "config_paths": list(detection.config_paths),
+        "shim_path": _redacted_path(shim_path, home_dir) if isinstance(shim_path, str) else None,
+        "config_paths": [_redacted_path(config_path, home_dir) for config_path in detection.config_paths],
         "next_action": next_action,
         "install_command": f"{GUARD_COMMAND} install {detection.harness}",
         "run_command": f"{GUARD_COMMAND} run {detection.harness} --dry-run",
@@ -133,6 +136,12 @@ def _summarize_harness(
         "receipts_command": f"{GUARD_COMMAND} receipts",
         "approval_flow": approval_flow,
     }
+
+
+def _redacted_path(path: str | Path | None, home_dir: Path) -> str | None:
+    if path is None:
+        return None
+    return redact_local_path(str(path), home_dir=home_dir)
 
 
 def _recommended_harness(harnesses: list[dict[str, object]]) -> dict[str, object] | None:

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -11,7 +11,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from ..redaction import redact_text
+from ..redaction import redact_local_path, redact_text
 
 try:
     from rich import box
@@ -92,7 +92,7 @@ def _redact_payload(value: object, *, key: str | None = None) -> object:
         redacted = value
         for pattern, replacement in _SENSITIVE_STRING_PATTERNS:
             redacted = pattern.sub(replacement, redacted)
-        return redacted
+        return redact_local_path(redacted)
     return value
 
 

--- a/src/codex_plugin_scanner/guard/redaction.py
+++ b/src/codex_plugin_scanner/guard/redaction.py
@@ -119,9 +119,18 @@ def redact_local_path(value: str, *, home_dir: Path | None = None) -> str:
     redacted_value = value
     if home_dir is not None:
         redacted_value = _replace_home_prefix(redacted_value, str(home_dir))
-    redacted_value = _replace_home_prefix(redacted_value, str(Path.home()))
-    redacted_value = _POSIX_USER_PATH_PATTERN.sub(_replace_posix_user_path, redacted_value)
-    return _WINDOWS_USER_PATH_PATTERN.sub(_replace_windows_user_path, redacted_value)
+    current_home = _current_home_path()
+    if current_home is not None:
+        redacted_value = _replace_home_prefix(redacted_value, str(current_home))
+    redacted_value = _POSIX_USER_PATH_PATTERN.sub(_replace_user_path, redacted_value)
+    return _WINDOWS_USER_PATH_PATTERN.sub(_replace_user_path, redacted_value)
+
+
+def _current_home_path() -> Path | None:
+    try:
+        return Path.home()
+    except RuntimeError:
+        return None
 
 
 def _replace_home_prefix(value: str, home_value: str) -> str:
@@ -136,11 +145,6 @@ def _replace_home_prefix(value: str, home_value: str) -> str:
     return value
 
 
-def _replace_posix_user_path(match: re.Match[str]) -> str:
-    rest = match.group("rest")
-    return f"{match.group('prefix')}~{rest}"
-
-
-def _replace_windows_user_path(match: re.Match[str]) -> str:
+def _replace_user_path(match: re.Match[str]) -> str:
     rest = match.group("rest")
     return f"{match.group('prefix')}~{rest}"

--- a/src/codex_plugin_scanner/guard/redaction.py
+++ b/src/codex_plugin_scanner/guard/redaction.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import re
 from dataclasses import dataclass
+from pathlib import Path
 
 
 @dataclass(frozen=True, slots=True)
@@ -81,6 +82,13 @@ _REDACTION_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...] = (
 )
 
 _SENSITIVE_TEXT_PATTERN = re.compile(r"(?i)(sk-[a-z0-9_-]+|(?:token|secret|api[_-]?key)(?:\s*[:=]\s*|\s+)[^\s,;]+)")
+_POSIX_USER_PATH_PATTERN = re.compile(
+    r"(?P<prefix>^|[\s\"'=({\[])(?P<root>/(?:Users|home)/[^/\s\"'`,;:)}\]]+)(?P<rest>(?:/[^\s\"'`,;:)}\]]*)?)"
+)
+_WINDOWS_USER_PATH_PATTERN = re.compile(
+    r"(?P<prefix>^|[\s\"'=({\[])(?P<root>[A-Za-z]:[\\/]+Users[\\/]+[^\\/\s\"'`,;:)}\]]+)"
+    r"(?P<rest>(?:[\\/][^\s\"'`,;:)}\]]*)?)"
+)
 
 
 def redact_text(value: str) -> RedactedText:
@@ -105,3 +113,34 @@ def redact_text(value: str) -> RedactedText:
 
 def redact_sensitive_text(value: str) -> str:
     return _SENSITIVE_TEXT_PATTERN.sub("[redacted]", value)
+
+
+def redact_local_path(value: str, *, home_dir: Path | None = None) -> str:
+    redacted_value = value
+    if home_dir is not None:
+        redacted_value = _replace_home_prefix(redacted_value, str(home_dir))
+    redacted_value = _replace_home_prefix(redacted_value, str(Path.home()))
+    redacted_value = _POSIX_USER_PATH_PATTERN.sub(_replace_posix_user_path, redacted_value)
+    return _WINDOWS_USER_PATH_PATTERN.sub(_replace_windows_user_path, redacted_value)
+
+
+def _replace_home_prefix(value: str, home_value: str) -> str:
+    home_prefix = home_value.rstrip("/\\")
+    if not home_prefix or home_prefix in {"/", "\\"}:
+        return value
+    if value == home_prefix:
+        return "~"
+    separators = ("/", "\\")
+    if value.startswith(home_prefix) and len(value) > len(home_prefix) and value[len(home_prefix)] in separators:
+        return f"~{value[len(home_prefix) :]}"
+    return value
+
+
+def _replace_posix_user_path(match: re.Match[str]) -> str:
+    rest = match.group("rest")
+    return f"{match.group('prefix')}~{rest}"
+
+
+def _replace_windows_user_path(match: re.Match[str]) -> str:
+    rest = match.group("rest")
+    return f"{match.group('prefix')}~{rest}"

--- a/tests/test_guard_redaction.py
+++ b/tests/test_guard_redaction.py
@@ -5,9 +5,18 @@ Verifies that sensitive values are removed before Guard prints or syncs them.
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 
-from codex_plugin_scanner.guard.redaction import redact_sensitive_text, redact_text
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.cli import product
+from codex_plugin_scanner.guard.cli.render import emit_guard_payload
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.models import HarnessDetection
+from codex_plugin_scanner.guard.redaction import redact_local_path, redact_sensitive_text, redact_text
+from codex_plugin_scanner.guard.store import GuardStore
 
 
 class TestRedactText:
@@ -121,6 +130,56 @@ class TestRedactText:
         result = redact_text("curl -H 'Accept: application/json' http://localhost:4000/health")
         assert "application/json" in result.text
         assert result.count == 0
+
+
+class TestLocalPathRedaction:
+    def test_redact_local_path_replaces_home_prefix(self) -> None:
+        assert redact_local_path("/Users/alice/.hol-guard/config.toml", home_dir=Path("/Users/alice")) == (
+            "~/.hol-guard/config.toml"
+        )
+
+    def test_status_payload_omits_raw_username_and_home_paths(self, tmp_path: Path, monkeypatch) -> None:
+        user_home = Path("/Users/alice")
+        guard_home = user_home / ".hol-guard"
+        workspace = user_home / "project"
+        context = HarnessContext(home_dir=user_home, workspace_dir=workspace, guard_home=guard_home)
+        store = GuardStore(tmp_path / "guard-home")
+        config = GuardConfig(guard_home=guard_home, workspace=workspace)
+        detection = HarnessDetection(
+            harness="codex",
+            installed=True,
+            command_available=True,
+            config_paths=(str(user_home / ".codex" / "config.toml"),),
+            artifacts=(),
+        )
+        monkeypatch.setattr(product, "detect_all", lambda _context: [detection])
+
+        payload = product.build_guard_status_payload(context, store, config)
+        text = json.dumps(payload)
+
+        assert "alice" not in text
+        assert "/Users/" not in text
+        assert payload["guard_home"] == "~/.hol-guard"
+        assert payload["workspace"] == "~/project"
+        assert payload["harnesses"][0]["config_paths"] == ["~/.codex/config.toml"]
+
+    def test_settings_json_output_omits_raw_username_and_home_paths(self, capsys) -> None:
+        emit_guard_payload(
+            "settings",
+            {
+                "generated_at": "2026-01-01T00:00:00Z",
+                "guard_home": "/Users/alice/.hol-guard",
+                "config_path": "/Users/alice/.hol-guard/config.toml",
+                "settings": {"mode": "prompt", "security_level": "balanced"},
+            },
+            True,
+        )
+        output = capsys.readouterr().out
+
+        assert "alice" not in output
+        assert "/Users/" not in output
+        assert '"guard_home": "~/.hol-guard"' in output
+        assert '"config_path": "~/.hol-guard/config.toml"' in output
 
 
 class TestRedactSensitiveText:

--- a/tests/test_guard_redaction.py
+++ b/tests/test_guard_redaction.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+from codex_plugin_scanner.guard import redaction
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.cli import product
 from codex_plugin_scanner.guard.cli.render import emit_guard_payload
@@ -137,6 +138,11 @@ class TestLocalPathRedaction:
         assert redact_local_path("/Users/alice/.hol-guard/config.toml", home_dir=Path("/Users/alice")) == (
             "~/.hol-guard/config.toml"
         )
+
+    def test_redact_local_path_survives_unresolved_current_home(self, monkeypatch) -> None:
+        monkeypatch.setattr(redaction, "_current_home_path", lambda: None)
+
+        assert redact_local_path("/Users/alice/.hol-guard/config.toml") == "~/.hol-guard/config.toml"
 
     def test_status_payload_omits_raw_username_and_home_paths(self, tmp_path: Path, monkeypatch) -> None:
         user_home = Path("/Users/alice")


### PR DESCRIPTION
## Summary
- redact local user-home paths in Guard product status payloads
- sanitize CLI JSON string payloads for POSIX and Windows user-home paths
- add regression tests for status/settings JSON redaction

## Tests
- uv run pytest tests/test_guard_redaction.py -q
- uv run pytest tests/test_guard_redaction.py tests/test_guard_phase03_remainder.py -q
- uv run ruff check src/codex_plugin_scanner/guard/redaction.py src/codex_plugin_scanner/guard/cli/product.py src/codex_plugin_scanner/guard/cli/render.py tests/test_guard_redaction.py
- uv run ruff format --check src/codex_plugin_scanner/guard/redaction.py src/codex_plugin_scanner/guard/cli/product.py src/codex_plugin_scanner/guard/cli/render.py tests/test_guard_redaction.py
- uv build --wheel
- hol-guard status --json privacy scan for current username and /Users/