### PR TITLE
feat(guard): add offline connect recovery docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ pipx run hol-guard run codex --dry-run
 pipx run hol-guard run codex
 pipx run hol-guard approvals
 pipx run hol-guard receipts
+pipx run hol-guard status
+pipx run hol-guard connect
+pipx run hol-guard connect status
+pipx run hol-guard connect repair
+pipx run hol-guard sync
+pipx run hol-guard explain install-connect
 ```
 
 What you get from Guard:

--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -66,9 +66,18 @@ Use it when you want to protect a harness before local MCP servers, skills, hook
 
    ```bash
    hol-guard connect
+   hol-guard connect status
+   hol-guard connect repair
+   hol-guard sync
    ```
 
-9. Inspect or rotate the local installation identity that cloud sync uses:
+9. Share the generated install/connect command guide when someone needs the exact local-first flow:
+
+   ```bash
+   hol-guard explain install-connect
+   ```
+
+10. Inspect or rotate the local installation identity that cloud sync uses:
 
    ```bash
    hol-guard device show
@@ -81,6 +90,7 @@ Use it when you want to protect a harness before local MCP servers, skills, hook
 | Situation | Command | What it answers |
 | :--- | :--- | :--- |
 | I need the current protection posture | `hol-guard status` | What is Guard watching, is sync connected, and what is the next action? |
+| I need install/connect docs | `hol-guard explain install-connect` | Which local-first setup and optional cloud commands should I share? |
 | I need setup or runtime troubleshooting | `hol-guard doctor <harness>` | Why is this harness or Guard runtime not behaving correctly? |
 | A launch was blocked or changed | `hol-guard diff <harness>` | What changed since the last recorded snapshot? |
 | I need to resolve a queued block | `hol-guard approvals` | Which requests are waiting, and how do I approve or deny them? |
@@ -98,7 +108,7 @@ Use it when you want to protect a harness before local MCP servers, skills, hook
 | I approved a prompt and want proof | `hol-guard receipts` | `hol-guard explain <artifact-id>` for the latest receipt and diff context |
 | I need audit or handoff evidence | `hol-guard inventory` | `hol-guard abom --format json` for machine-readable export |
 | I need to understand recent activity | `hol-guard events` | Use `--name <event>` to filter a noisy local timeline |
-| Cloud sync or pairing looks wrong | `hol-guard status` | `hol-guard connect` or `hol-guard sync --json` depending on the status output |
+| Cloud sync or pairing looks wrong | `hol-guard connect status` | `hol-guard connect repair`, `hol-guard connect`, or `hol-guard sync --json` depending on the status output |
 
 ## Evidence-first decisions
 
@@ -302,4 +312,3 @@ curl -s -X POST "http://127.0.0.1:${GUARD_PORT}/v1/daemon/repair" \
 ```
 
 After repair, restart Guard, then retry the block message URL or relaunch your harness through Guard. Pending approval requests are preserved across repairs.
-

--- a/docs/guard/local-vs-cloud.md
+++ b/docs/guard/local-vs-cloud.md
@@ -23,3 +23,12 @@ Optional cloud features:
 - shared team policy
 
 The local runtime does not require any hosted service. `hol-guard connect` is the preferred way to pair a machine with Guard Cloud later, and `hol-guard login` remains as a compatibility alias for the same browser sign-in flow. They do not unlock the core safety workflow.
+
+Use these commands when you need to check or repair optional cloud pairing without disturbing local protection:
+
+```bash
+hol-guard connect status
+hol-guard connect repair
+hol-guard sync
+hol-guard explain install-connect
+```

--- a/docs/guard/testing-matrix.md
+++ b/docs/guard/testing-matrix.md
@@ -34,6 +34,12 @@ Manual verification should include:
 - `hol-guard install codex`
 - `hol-guard run codex --dry-run --default-action allow --json`
 - `hol-guard receipts`
+- `hol-guard status`
+- `hol-guard connect`
+- `hol-guard connect status`
+- `hol-guard connect repair`
+- `hol-guard sync`
+- `hol-guard explain install-connect`
 - `hol-guard explain codex:project:<artifact-name>`
 - `hol-guard diff codex`
 - `hol-guard events`

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -139,8 +139,10 @@ from .bootstrap import DEFAULT_ALIAS_NAME, build_guard_bootstrap_payload
 from .connect_flow import (
     DEFAULT_GUARD_CONNECT_URL,
     DEFAULT_GUARD_SYNC_URL,
+    build_connect_status_payload,
     run_guard_connect_command,
 )
+from .docs import build_install_connect_docs_payload
 from .install_commands import (
     apply_managed_install,
     build_harness_setup_plan,
@@ -581,6 +583,7 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
         "connect",
         help="Open the browser, pair this runtime to HOL Guard, and send the first sync",
     )
+    connect_parser.add_argument("connect_command", nargs="?", choices=("status", "repair", "re-pair"))
     _add_guard_common_args(connect_parser)
     connect_parser.add_argument("--sync-url", default=DEFAULT_GUARD_SYNC_URL, type=_guard_http_url)
     connect_parser.add_argument("--connect-url", default=DEFAULT_GUARD_CONNECT_URL, type=_guard_http_url)
@@ -1368,7 +1371,10 @@ def run_guard_command(
         return int(payload.get("exit_code", 0))
 
     if args.guard_command == "explain":
-        payload = _build_explain_payload_with_mode(store, args.target, cisco_mode=args.cisco_mode)
+        if str(args.target).strip().lower() == "install-connect":
+            payload = build_install_connect_docs_payload()
+        else:
+            payload = _build_explain_payload_with_mode(store, args.target, cisco_mode=args.cisco_mode)
         _emit("explain", payload, getattr(args, "json", False))
         return 0
 
@@ -1450,6 +1456,16 @@ def run_guard_command(
         return 0 if bool(payload.get("connected")) else 1
 
     if args.guard_command == "connect":
+        connect_subcommand = getattr(args, "connect_command", None)
+        if connect_subcommand in {"status", "repair", "re-pair"}:
+            payload = build_connect_status_payload(
+                store=store,
+                sync_url=args.sync_url,
+                connect_url=args.connect_url,
+                action=str(connect_subcommand),
+            )
+            _emit("connect", payload, getattr(args, "json", False))
+            return 0
         try:
             payload = _run_guard_connect_flow(
                 guard_home=guard_home,

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -18,6 +18,9 @@ from ..store import GuardStore
 
 DEFAULT_GUARD_SYNC_URL = "https://hol.org/api/guard/receipts/sync"
 DEFAULT_GUARD_CONNECT_URL = "https://hol.org/guard/connect"
+CONNECT_COMMAND = "hol-guard connect"
+CONNECT_STATUS_COMMAND = "hol-guard connect status"
+CONNECT_REPAIR_COMMAND = "hol-guard connect repair"
 
 
 def _load_connect_daemon_client(guard_home: Path) -> GuardSurfaceDaemonClient:
@@ -323,6 +326,48 @@ def build_connect_payload(
             "target": connect_url,
         }
     return payload
+
+
+def build_connect_status_payload(
+    *,
+    store: GuardStore,
+    sync_url: str,
+    connect_url: str,
+    action: str = "status",
+) -> dict[str, object]:
+    latest_state = store.get_latest_guard_connect_state(now=datetime.now(timezone.utc).isoformat())
+    status = str(latest_state.get("status") or "not_paired") if latest_state is not None else "not_paired"
+    milestone = str(latest_state.get("milestone") or "not_started") if latest_state is not None else "not_started"
+    reason = latest_state.get("reason") if latest_state is not None else None
+    stored_sync_url = latest_state.get("sync_url") if latest_state is not None else None
+    payload: dict[str, object] = {
+        "status": status,
+        "milestone": milestone,
+        "reason": reason,
+        "latest_connect_state": latest_state,
+        "sync_url": stored_sync_url if isinstance(stored_sync_url, str) and stored_sync_url.strip() else sync_url,
+        "connect_url": connect_url,
+        "connect_command": CONNECT_COMMAND,
+        "recovery_command": connect_recovery_command(latest_state),
+        "connect_status_command": CONNECT_STATUS_COMMAND,
+        "connect_repair_command": CONNECT_REPAIR_COMMAND,
+    }
+    if action in {"repair", "re-pair"}:
+        payload["repair_action"] = "rerun_connect"
+        payload["repair_message"] = "Run hol-guard connect to create a fresh pairing request and first sync."
+    return payload
+
+
+def connect_recovery_command(latest_state: dict[str, object] | None) -> str:
+    if latest_state is None:
+        return CONNECT_COMMAND
+    milestone = str(latest_state.get("milestone") or "")
+    status = str(latest_state.get("status") or "")
+    if status in {"retry_required", "expired"} or milestone in {"first_sync_failed", "expired", "sync_not_available"}:
+        return CONNECT_COMMAND
+    if status == "connected" and milestone == "first_sync_succeeded":
+        return "hol-guard sync"
+    return CONNECT_COMMAND
 
 
 def _build_sync_not_available_payload(

--- a/src/codex_plugin_scanner/guard/cli/docs.py
+++ b/src/codex_plugin_scanner/guard/cli/docs.py
@@ -1,0 +1,113 @@
+"""Shared Guard install/connect documentation payloads."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class GuardDocCommand:
+    stage: str
+    command: str
+    title: str
+    detail: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "stage": self.stage,
+            "command": self.command,
+            "title": self.title,
+            "detail": self.detail,
+        }
+
+
+def install_connect_command_catalog() -> tuple[GuardDocCommand, ...]:
+    return (
+        GuardDocCommand(
+            stage="local-setup",
+            command="hol-guard bootstrap",
+            title="Bootstrap local protection",
+            detail="Detect the best local harness, start the approval center, and install Guard locally.",
+        ),
+        GuardDocCommand(
+            stage="local-setup",
+            command="hol-guard install codex",
+            title="Install a harness launcher",
+            detail="Use the harness you rely on most; Codex is the common first local target.",
+        ),
+        GuardDocCommand(
+            stage="local-baseline",
+            command="hol-guard run codex --dry-run",
+            title="Record the baseline",
+            detail="Capture current local tool state before a real launch.",
+        ),
+        GuardDocCommand(
+            stage="local-run",
+            command="hol-guard run codex",
+            title="Launch through Guard",
+            detail="Review changed tools before the harness receives control.",
+        ),
+        GuardDocCommand(
+            stage="local-approval",
+            command="hol-guard approvals",
+            title="Resolve queued approvals",
+            detail="Use this when a non-interactive shell cannot render native approval.",
+        ),
+        GuardDocCommand(
+            stage="local-audit",
+            command="hol-guard receipts",
+            title="Review local receipts",
+            detail="Inspect the local audit trail for prior allow/block decisions.",
+        ),
+        GuardDocCommand(
+            stage="local-status",
+            command="hol-guard status",
+            title="Check current posture",
+            detail="See local protection, cloud pairing state, and the next safe command.",
+        ),
+        GuardDocCommand(
+            stage="cloud-optional",
+            command="hol-guard connect",
+            title="Pair Guard Cloud later",
+            detail="Open browser pairing only when shared history or team coordination is needed.",
+        ),
+        GuardDocCommand(
+            stage="cloud-recovery",
+            command="hol-guard connect status",
+            title="Inspect pairing recovery",
+            detail="Show the latest pairing milestone and retry command without opening a browser.",
+        ),
+        GuardDocCommand(
+            stage="cloud-recovery",
+            command="hol-guard connect repair",
+            title="Start re-pair guidance",
+            detail="Print the recovery path for stale, failed, or incomplete cloud pairing.",
+        ),
+        GuardDocCommand(
+            stage="cloud-sync",
+            command="hol-guard sync",
+            title="Sync local receipts",
+            detail="Send local receipts only after credentials are configured.",
+        ),
+        GuardDocCommand(
+            stage="docs",
+            command="hol-guard explain install-connect",
+            title="Share install/connect docs",
+            detail="Generate the same install and connect command catalog from the CLI.",
+        ),
+    )
+
+
+def build_install_connect_docs_payload() -> dict[str, object]:
+    commands = [item.to_dict() for item in install_connect_command_catalog()]
+    return {
+        "target": "install-connect",
+        "category": "guard-docs",
+        "summary": "Local Guard setup works offline; Guard Cloud pairing is optional and recoverable.",
+        "commands": commands,
+        "share_commands": {
+            "terminal": "hol-guard explain install-connect",
+            "json": "hol-guard explain install-connect --json",
+            "cloud": "hol-guard connect status",
+        },
+    }

--- a/src/codex_plugin_scanner/guard/cli/product.py
+++ b/src/codex_plugin_scanner/guard/cli/product.py
@@ -14,6 +14,7 @@ from ..daemon import load_guard_daemon_url
 from ..models import HarnessDetection
 from ..redaction import redact_local_path
 from ..store import GuardStore
+from .connect_flow import CONNECT_COMMAND, CONNECT_REPAIR_COMMAND, CONNECT_STATUS_COMMAND, connect_recovery_command
 
 HARNESS_PRIORITY = ("codex", "claude-code", "copilot", "hermes", "cursor", "antigravity", "gemini", "opencode")
 GUARD_COMMAND = "hol-guard"
@@ -229,6 +230,7 @@ def _build_cloud_context(store: GuardStore) -> dict[str, object]:
     team_policy_pack = _coerce_payload_dict(store.get_sync_payload("team_policy_pack"))
     sync_summary = _coerce_payload_dict(store.get_sync_payload("sync_summary"))
     last_sync_at = _optional_string(sync_summary.get("synced_at"))
+    latest_connect_state = store.get_latest_guard_connect_state(now=_now())
     remote_payload_active = bool(advisories or alert_preferences or remote_policy or team_policy_pack)
     cloud_state = _resolve_cloud_state(
         sync_configured=credentials is not None,
@@ -244,7 +246,11 @@ def _build_cloud_context(store: GuardStore) -> dict[str, object]:
         "inbox_url": inbox_url,
         "fleet_url": fleet_url,
         "connect_url": connect_url,
-        "connect_command": f"{GUARD_COMMAND} connect",
+        "connect_command": CONNECT_COMMAND,
+        "connect_status_command": CONNECT_STATUS_COMMAND,
+        "connect_repair_command": CONNECT_REPAIR_COMMAND,
+        "connect_recovery_command": connect_recovery_command(latest_connect_state),
+        "latest_connect_state": latest_connect_state,
         "sync_command": f"{GUARD_COMMAND} sync",
         "last_sync_at": last_sync_at,
         "advisory_count": len(advisories),

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -881,6 +881,12 @@ def _render_connect(console: Console, payload: dict[str, object]) -> None:
         cloud_pairing_url = payload.get("cloud_pairing_url") or payload.get("connect_url") or "unknown"
         body.add_row("Cloud URL", str(cloud_pairing_url))
         body.add_row("Sync endpoint", str(payload.get("sync_url") or "unknown"))
+        recovery_command = payload.get("recovery_command")
+        if isinstance(recovery_command, str) and recovery_command.strip():
+            body.add_row("Recovery command", recovery_command)
+        repair_message = payload.get("repair_message")
+        if isinstance(repair_message, str) and repair_message.strip():
+            body.add_row("Repair note", repair_message)
         sync_payload = payload.get("sync")
         should_render_sync_counts = False
         if isinstance(sync_payload, dict):

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -9,6 +9,7 @@ import urllib.request
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
+from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.cli.connect_flow import (
     _start_guard_runtime_session,
     run_guard_connect_command,
@@ -167,6 +168,135 @@ def test_guard_connect_preserves_pairing_when_first_sync_fails(
     assert "guardPairSecret=" in str(payload["connect_url"])
     assert payload["sync"]["synced_at"] is None
     assert payload["proof"]["first_synced_at"] is None
+
+
+def test_guard_connect_status_reports_retry_recovery_command(tmp_path, capsys) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    sync_url = "https://guard.example.test/sync"
+    request = store.create_guard_connect_request(
+        sync_url=sync_url,
+        allowed_origin="https://hol.org",
+        now="2026-04-15T00:00:00+00:00",
+    )
+    store.complete_guard_connect_request(
+        request_id=str(request["request_id"]),
+        pairing_secret=str(request["pairing_secret"]),
+        token="session-token-123",
+        now="2026-04-15T00:00:01+00:00",
+    )
+    store.record_guard_connect_result(
+        request_id=str(request["request_id"]),
+        status="retry_required",
+        milestone="first_sync_failed",
+        now="2026-04-15T00:00:02+00:00",
+        reason="sync_unreachable",
+        sync_payload={"synced_at": None},
+    )
+
+    rc = main(["guard", "connect", "status", "--guard-home", str(guard_home), "--json"])
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["status"] == "retry_required"
+    assert output["milestone"] == "first_sync_failed"
+    assert output["reason"] == "sync_unreachable"
+    assert output["sync_url"] == sync_url
+    assert output["recovery_command"] == "hol-guard connect"
+    assert output["connect_status_command"] == "hol-guard connect status"
+
+
+def test_guard_connect_repair_prints_repair_guidance(tmp_path, capsys) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    request = store.create_guard_connect_request(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now="2026-04-15T00:00:00+00:00",
+    )
+    store.record_guard_connect_result(
+        request_id=str(request["request_id"]),
+        status="retry_required",
+        milestone="first_sync_failed",
+        now="2026-04-15T00:00:02+00:00",
+        reason="sync_unreachable",
+        sync_payload={"synced_at": None},
+    )
+
+    rc = main(["guard", "connect", "repair", "--guard-home", str(guard_home), "--json"])
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["repair_action"] == "rerun_connect"
+    assert output["repair_message"] == "Run hol-guard connect to create a fresh pairing request and first sync."
+    assert output["recovery_command"] == "hol-guard connect"
+
+
+def test_guard_connect_repair_human_output_includes_recovery_command(tmp_path, capsys) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    request = store.create_guard_connect_request(
+        sync_url="https://guard.example.test/sync",
+        allowed_origin="https://hol.org",
+        now="2026-04-15T00:00:00+00:00",
+    )
+    store.record_guard_connect_result(
+        request_id=str(request["request_id"]),
+        status="retry_required",
+        milestone="first_sync_failed",
+        now="2026-04-15T00:00:02+00:00",
+        reason="sync_unreachable",
+        sync_payload={"synced_at": None},
+    )
+
+    rc = main(["guard", "connect", "repair", "--guard-home", str(guard_home)])
+    output = capsys.readouterr().out
+
+    assert rc == 0
+    assert "Recovery command" in output
+    assert "hol-guard connect" in output
+    assert "Repair note" in output
+
+
+def test_guard_status_surfaces_latest_connect_retry_state(tmp_path, capsys) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    guard_home = tmp_path / "guard-home"
+    _build_guard_fixture(home_dir, workspace_dir)
+    store = GuardStore(guard_home)
+    request = store.create_guard_connect_request(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now="2026-04-15T00:00:00+00:00",
+    )
+    store.record_guard_connect_result(
+        request_id=str(request["request_id"]),
+        status="retry_required",
+        milestone="first_sync_failed",
+        now="2026-04-15T00:00:02+00:00",
+        reason="sync_unreachable",
+        sync_payload={"synced_at": None},
+    )
+
+    rc = main(
+        [
+            "guard",
+            "status",
+            "--home",
+            str(home_dir),
+            "--guard-home",
+            str(guard_home),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["latest_connect_state"]["status"] == "retry_required"
+    assert output["latest_connect_state"]["milestone"] == "first_sync_failed"
+    assert output["connect_recovery_command"] == "hol-guard connect"
 
 
 def test_guard_connect_preserves_local_protection_when_cloud_token_creation_fails(

--- a/tests/test_guard_docs.py
+++ b/tests/test_guard_docs.py
@@ -1,0 +1,41 @@
+"""Generated Guard install/connect docs contract tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.cli.docs import install_connect_command_catalog
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read_repo_file(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_explain_install_connect_shares_canonical_command_catalog(capsys) -> None:
+    rc = main(["guard", "explain", "install-connect", "--json"])
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["target"] == "install-connect"
+    assert output["category"] == "guard-docs"
+    assert output["commands"] == [item.to_dict() for item in install_connect_command_catalog()]
+    assert output["share_commands"]["terminal"] == "hol-guard explain install-connect"
+    assert output["share_commands"]["cloud"] == "hol-guard connect status"
+
+
+def test_static_docs_include_canonical_install_connect_commands() -> None:
+    docs_text = "\n".join(
+        [
+            _read_repo_file("README.md"),
+            _read_repo_file("docs/guard/get-started.md"),
+            _read_repo_file("docs/guard/local-vs-cloud.md"),
+            _read_repo_file("docs/guard/testing-matrix.md"),
+        ]
+    )
+
+    for item in install_connect_command_catalog():
+        assert item.command in docs_text

--- a/tests/test_guard_product_flow.py
+++ b/tests/test_guard_product_flow.py
@@ -119,6 +119,46 @@ class TestGuardProductFlow:
         assert output["next_steps"][0]["command"] == "hol-guard install codex"
         assert output["next_steps"][1]["command"] == "hol-guard run codex --dry-run"
 
+    def test_guard_bootstrap_stays_local_when_cloud_is_unreachable(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        guard_home = tmp_path / "guard-home"
+        _build_guard_fixture(home_dir, workspace_dir)
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.cli.bootstrap.ensure_guard_daemon",
+            lambda _guard_home: "http://127.0.0.1:5474",
+        )
+
+        def fail_cloud_call(*_args, **_kwargs):
+            raise AssertionError("offline bootstrap must not call Guard Cloud")
+
+        monkeypatch.setattr("codex_plugin_scanner.guard.cli.commands.sync_receipts", fail_cloud_call)
+        monkeypatch.setattr("codex_plugin_scanner.guard.cli.commands.sync_runtime_session", fail_cloud_call)
+        monkeypatch.setattr("codex_plugin_scanner.guard.cli.commands.webbrowser.open", fail_cloud_call)
+
+        rc = main(
+            [
+                "guard",
+                "bootstrap",
+                "--home",
+                str(home_dir),
+                "--guard-home",
+                str(guard_home),
+                "--workspace",
+                str(workspace_dir),
+                "--skip-install",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["sync_configured"] is False
+        assert output["cloud_state"] == "local_only"
+        assert output["approval_center_url"] == "http://127.0.0.1:5474"
+        assert output["bootstrap_install"]["reason"] == "skipped_by_flag"
+        assert GuardStore(guard_home).get_sync_credentials() is None
+
     def test_guard_start_recommends_copilot_when_it_is_the_only_detected_harness(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
@@ -253,6 +293,8 @@ class TestGuardProductFlow:
         assert output["inbox_url"] == "https://hol.org/guard/inbox"
         assert output["fleet_url"] == "https://hol.org/guard/fleet"
         assert output["connect_command"] == "hol-guard connect"
+        assert output["connect_status_command"] == "hol-guard connect status"
+        assert output["connect_recovery_command"] == "hol-guard connect"
 
     def test_guard_help_groups_commands_by_everyday_cloud_and_advanced_work(self, capsys, monkeypatch):
         monkeypatch.setattr(sys, "argv", ["hol-guard"])


### PR DESCRIPTION
## Summary
- prove Guard bootstrap stays local/offline with no cloud sync dependency
- add connect status and repair recovery surfaces plus status payload connect state
- add generated install/connect docs catalog and static docs consistency tests

## Tests
- uv run pytest tests/test_guard_product_flow.py tests/test_guard_connect_flow.py tests/test_guard_daemon_cli.py tests/test_guard_product_model_contracts.py tests/test_guard_docs.py -q
- uv run ruff check src/codex_plugin_scanner/guard/cli/docs.py src/codex_plugin_scanner/guard/cli/connect_flow.py src/codex_plugin_scanner/guard/cli/product.py src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/cli/render.py tests/test_guard_product_flow.py tests/test_guard_connect_flow.py tests/test_guard_docs.py
- uv run ruff format --check src/codex_plugin_scanner/guard/cli/docs.py src/codex_plugin_scanner/guard/cli/connect_flow.py src/codex_plugin_scanner/guard/cli/product.py src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/cli/render.py tests/test_guard_product_flow.py tests/test_guard_connect_flow.py tests/test_guard_docs.py
- uv build --wheel
- uv run hol-guard explain install-connect --json
- uv run hol-guard connect status --json
- uv run hol-guard connect repair --json
- uv run hol-guard connect repair