### PR TITLE
fix(container): install locked requirements without resolving

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 
 COPY docker-requirements.txt LICENSE README.md /app/
 
-RUN python3 -m pip install --require-hashes -r /app/docker-requirements.txt
+RUN python3 -m pip install --no-deps --require-hashes -r /app/docker-requirements.txt
 
 COPY src /app/src
 

--- a/tests/test_cisco_install_surfaces.py
+++ b/tests/test_cisco_install_surfaces.py
@@ -80,7 +80,7 @@ def test_repo_controlled_surfaces_prefer_cisco_extra_where_supported() -> None:
     assert "uv sync --frozen --extra dev --extra publish --extra cisco" in publish_workflow
     assert 'uv tool install "hol-guard[cisco]==' in publish_workflow
     assert "COPY docker-requirements.txt LICENSE README.md /app/" in dockerfile
-    assert "RUN python3 -m pip install --require-hashes -r /app/docker-requirements.txt" in dockerfile
+    assert "RUN python3 -m pip install --no-deps --require-hashes -r /app/docker-requirements.txt" in dockerfile
     requirements_copy_index = dockerfile.index("COPY docker-requirements.txt LICENSE README.md /app/")
     source_copy_index = dockerfile.index("COPY src /app/src")
     assert requirements_copy_index < source_copy_index


### PR DESCRIPTION
## Summary
- install Docker's fully locked hashed requirements with pip --no-deps so pip does not re-resolve uv override pins
- keep hash enforcement for every package in docker-requirements.txt
- update packaging surface regression test

## Verification
- uv run ruff check tests/test_cisco_install_surfaces.py
- uv run pytest tests/test_cisco_install_surfaces.py --tb=short
- post-merge publish failure root cause: pip dependency re-resolution during Docker build rejected locked Cisco override pins