### PR TITLE
fix(guard): tolerate stale redaction during update

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -52,6 +52,7 @@ except ImportError:
             redacted_value,
         )
 
+
 try:
     from rich import box
     from rich.console import Console

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -11,7 +11,47 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from ..redaction import redact_local_path, redact_text
+from ..redaction import redact_text
+
+try:
+    from ..redaction import redact_local_path
+except ImportError:
+
+    def redact_local_path(value: str, *, home_dir: Path | None = None) -> str:
+        """Fallback for mixed installs where render.py is newer than redaction.py."""
+
+        redacted_value = value
+        if home_dir is not None:
+            redacted_value = _replace_home_prefix_fallback(redacted_value, str(home_dir))
+        try:
+            current_home = Path.home()
+        except RuntimeError:
+            current_home = None
+        if current_home is not None:
+            redacted_value = _replace_home_prefix_fallback(redacted_value, str(current_home))
+        redacted_value = re.sub(
+            r"(?P<prefix>^|[\s\"'=({\[])(?P<root>/(?:Users|home)/[^/\s\"'`,;:)}\]]+)"
+            r"(?P<rest>(?:/[^\s\"'`,;:)}\]]*)?)",
+            lambda match: f"{match.group('prefix')}~{match.group('rest')}",
+            redacted_value,
+        )
+        return re.sub(
+            r"(?P<prefix>^|[\s\"'=({\[])(?P<root>[A-Za-z]:[\\/]+Users[\\/]+[^\\/\s\"'`,;:)}\]]+)"
+            r"(?P<rest>(?:[\\/][^\s\"'`,;:)}\]]*)?)",
+            lambda match: f"{match.group('prefix')}~{match.group('rest')}",
+            redacted_value,
+        )
+
+
+def _replace_home_prefix_fallback(value: str, home_value: str) -> str:
+    home_prefix = home_value.rstrip("/\\")
+    if not home_prefix or home_prefix in {"/", "\\"}:
+        return value
+    if value == home_prefix:
+        return "~"
+    if value.startswith(home_prefix) and len(value) > len(home_prefix) and value[len(home_prefix)] in {"/", "\\"}:
+        return f"~{value[len(home_prefix) :]}"
+    return value
 
 try:
     from rich import box

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -46,8 +46,8 @@ except ImportError:
             redacted_value,
         )
         return re.sub(
-            r"(?P<prefix>^|[\s\"'=({\[])(?P<root>[A-Za-z]:[\\/]+Users[\\/]+[^\\/\s\"'`,;:)}\]]+)"
-            r"(?P<rest>(?:[\\/][^\s\"'`,;:)}\]]*)?)",
+            r"(?P<prefix>^|[\s\"'=({\[])(?P<root>[A-Za-z]:[\\/]+Users[\\/]+[^\\/ \t\r\n\"'`,;:)}\]]+)"
+            r"(?P<rest>(?:[\\/][^\\/ \t\r\n\"'`,;:)}\]]*)?)",
             r"\g<prefix>~\g<rest>",
             redacted_value,
         )

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -17,6 +17,16 @@ try:
     from ..redaction import redact_local_path
 except ImportError:
 
+    def _replace_home_prefix_fallback(value: str, home_value: str) -> str:
+        home_prefix = home_value.rstrip("/\\")
+        if not home_prefix or home_prefix in {"/", "\\"}:
+            return value
+        if value == home_prefix:
+            return "~"
+        if value.startswith(home_prefix) and len(value) > len(home_prefix) and value[len(home_prefix)] in {"/", "\\"}:
+            return f"~{value[len(home_prefix) :]}"
+        return value
+
     def redact_local_path(value: str, *, home_dir: Path | None = None) -> str:
         """Fallback for mixed installs where render.py is newer than redaction.py."""
 
@@ -32,26 +42,15 @@ except ImportError:
         redacted_value = re.sub(
             r"(?P<prefix>^|[\s\"'=({\[])(?P<root>/(?:Users|home)/[^/\s\"'`,;:)}\]]+)"
             r"(?P<rest>(?:/[^\s\"'`,;:)}\]]*)?)",
-            lambda match: f"{match.group('prefix')}~{match.group('rest')}",
+            r"\g<prefix>~\g<rest>",
             redacted_value,
         )
         return re.sub(
             r"(?P<prefix>^|[\s\"'=({\[])(?P<root>[A-Za-z]:[\\/]+Users[\\/]+[^\\/\s\"'`,;:)}\]]+)"
             r"(?P<rest>(?:[\\/][^\s\"'`,;:)}\]]*)?)",
-            lambda match: f"{match.group('prefix')}~{match.group('rest')}",
+            r"\g<prefix>~\g<rest>",
             redacted_value,
         )
-
-
-def _replace_home_prefix_fallback(value: str, home_value: str) -> str:
-    home_prefix = home_value.rstrip("/\\")
-    if not home_prefix or home_prefix in {"/", "\\"}:
-        return value
-    if value == home_prefix:
-        return "~"
-    if value.startswith(home_prefix) and len(value) > len(home_prefix) and value[len(home_prefix)] in {"/", "\\"}:
-        return f"~{value[len(home_prefix) :]}"
-    return value
 
 try:
     from rich import box

--- a/tests/test_guard_render.py
+++ b/tests/test_guard_render.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import sys
+import types
 from pathlib import Path
 
 from codex_plugin_scanner.guard.cli import render
@@ -56,6 +58,34 @@ def test_guard_render_redacts_sensitive_values_before_rich_renderer(monkeypatch)
     assert isinstance(payload, dict)
     assert payload["api_key"] == "*****"
     assert payload["launch_summary"] == "api_key=***** token=*****"
+
+
+def test_guard_render_fallback_redacts_local_paths_when_redaction_module_is_stale() -> None:
+    home_dir = Path("/Users/example")
+
+    assert render.redact_local_path("/Users/example/project/file.txt", home_dir=home_dir) == "~/project/file.txt"
+    assert render.redact_local_path("/Users/other/project/file.txt", home_dir=home_dir) == "~/project/file.txt"
+
+
+def test_guard_render_import_tolerates_stale_redaction_module_without_local_path_helper(monkeypatch) -> None:
+    module_name = "codex_plugin_scanner.guard.cli.render"
+    stale_redaction = types.ModuleType("codex_plugin_scanner.guard.redaction")
+
+    def fake_redact_text(value: str) -> object:
+        return types.SimpleNamespace(text=value)
+
+    stale_redaction.redact_text = fake_redact_text  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "codex_plugin_scanner.guard.redaction", stale_redaction)
+    monkeypatch.delitem(sys.modules, module_name)
+
+    try:
+        imported = __import__(module_name, fromlist=["redact_local_path"])
+    finally:
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+    assert imported.redact_local_path("/Users/example/project/file.txt", home_dir=Path("/Users/example")) == (
+        "~/project/file.txt"
+    )
 
 
 def test_guard_json_render_redacts_after_command_specific_payload_shape(capsys) -> None:

--- a/tests/test_guard_render.py
+++ b/tests/test_guard_render.py
@@ -65,6 +65,7 @@ def test_guard_render_fallback_redacts_local_paths_when_redaction_module_is_stal
 
     assert render.redact_local_path("/Users/example/project/file.txt", home_dir=home_dir) == "~/project/file.txt"
     assert render.redact_local_path("/Users/other/project/file.txt", home_dir=home_dir) == "~/project/file.txt"
+    assert render.redact_local_path(r"C:\Users\example\project\file.txt") == r"~\project\file.txt"
 
 
 def test_guard_render_import_tolerates_stale_redaction_module_without_local_path_helper(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- tolerate mixed hol-guard installs where CLI render code is newer than the redaction module
- keep local path redaction available through a small fallback so `hol-guard update` can import and run
- add regression coverage for stale redaction modules during import

## Verification
- `pytest tests/test_guard_render.py`
- `pytest tests/test_guard_cli.py -k "guard_update_runs_pip_upgrade_in_current_environment or guard_update_uses_pipx_when_running_from_pipx"`
- `ruff check src/codex_plugin_scanner/guard/cli/render.py tests/test_guard_render.py tests/test_guard_cli.py`

Signed commit verified with `git log -1 --show-signature --pretty=fuller`. 