### PR TITLE
fix(guard): tune opaque decode signals

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/detectors.py
+++ b/src/codex_plugin_scanner/guard/runtime/detectors.py
@@ -53,8 +53,10 @@ DETECTOR_CATEGORY_TAGS: tuple[RiskSignalCategory, ...] = (
 DetectorRunStatus = Literal["ok", "disabled", "filtered", "timeout", "error"]
 _SLOW_DETECTOR_THRESHOLD_MS: int = 100
 _SENSITIVE_DECODE_CONTEXT_PATTERN = re.compile(
-    r"\.env|\.npmrc|id_(?:rsa|ed25519|ecdsa|dsa)|api[_-]?key|private[_-]?key|"
-    r"\.pem|\.key|aws[_-](?:access[_-]?key|secret[_-]?access[_-]?key|session[_-]?token|credentials?)|"
+    r"\.env(?:\.[A-Za-z0-9_-]+)?(?![A-Za-z0-9_-])|\.npmrc(?![A-Za-z0-9_-])|"
+    r"id_(?:rsa|ed25519|ecdsa|dsa)(?![A-Za-z0-9])|api[_-]?key(?![A-Za-z0-9])|"
+    r"private[_-]?key(?![A-Za-z0-9])|\.pem(?![A-Za-z0-9_-])|\.key(?![A-Za-z0-9_-])|"
+    r"aws[_-](?:access[_-]?key|secret[_-]?access[_-]?key|session[_-]?token|credentials?)(?![A-Za-z0-9])|"
     r"(?<![A-Za-z0-9])(?:credentials?|secrets?|tokens?|passwords?)(?![A-Za-z0-9])",
     re.IGNORECASE,
 )

--- a/src/codex_plugin_scanner/guard/runtime/detectors.py
+++ b/src/codex_plugin_scanner/guard/runtime/detectors.py
@@ -242,13 +242,13 @@ class SafeDecodeDetector:
         )
         for content in content_candidates:
             result = decode_layers(content)
-            signals = _safe_decode_signals(result, self.detector_id)
+            signals = _safe_decode_signals(result, self.detector_id, source_text=content)
             if signals:
                 return signals
         return ()
 
 
-def _safe_decode_signals(result: DecodeResult, detector_id: str) -> tuple[RiskSignalV2, ...]:
+def _safe_decode_signals(result: DecodeResult, detector_id: str, *, source_text: str) -> tuple[RiskSignalV2, ...]:
     if not result.layers:
         return ()
     signals: list[RiskSignalV2] = []
@@ -283,6 +283,31 @@ def _safe_decode_signals(result: DecodeResult, detector_id: str) -> tuple[RiskSi
             )
         )
     elif result.layers:
+        if _looks_like_opaque_decoded_payload(result.final_text):
+            if _has_sensitive_decode_context(source_text):
+                signals.append(
+                    RiskSignalV2(
+                        signal_id="encoded.opaque-sensitive",
+                        category="encoded",
+                        severity=severity_label_from_score(6),
+                        confidence=confidence_label_from_score(0.70),
+                        detector=detector_id,
+                        title="Opaque encoded payload near sensitive context",
+                        plain_reason=(
+                            "Guard decoded an opaque or encrypted-looking payload in a command that also references "
+                            "local secret material."
+                        ),
+                        technical_detail=f"Detector: {SAFE_DECODE_DETECTOR_VERSION}; "
+                        f"Layers: {[layer.encoding for layer in result.layers]}",
+                        evidence_ref=None,
+                        redaction_level="summary",
+                        false_positive_hint=(
+                            "Encrypted test fixtures are usually safe when no secret file or token is in scope."
+                        ),
+                        advisory_id=None,
+                    )
+                )
+            return tuple(signals)
         signals.append(
             RiskSignalV2(
                 signal_id="encoded.obfuscated-content",
@@ -304,6 +329,34 @@ def _safe_decode_signals(result: DecodeResult, detector_id: str) -> tuple[RiskSi
             )
         )
     return tuple(signals)
+
+
+def _looks_like_opaque_decoded_payload(text: str) -> bool:
+    if len(text) < 32:
+        return False
+    replacement_ratio = text.count("\ufffd") / max(len(text), 1)
+    if replacement_ratio >= 0.10:
+        return True
+    printable_count = sum(1 for char in text if char.isprintable() or char.isspace())
+    return printable_count / max(len(text), 1) < 0.75
+
+
+def _has_sensitive_decode_context(text: str) -> bool:
+    lowered = text.lower()
+    sensitive_tokens = (
+        ".env",
+        ".npmrc",
+        "id_rsa",
+        "id_ed25519",
+        "credential",
+        "secret",
+        "token",
+        "api_key",
+        "apikey",
+        "private_key",
+        "password",
+    )
+    return any(token in lowered for token in sensitive_tokens)
 
 
 class FalsePositiveSuppressorDetector:

--- a/src/codex_plugin_scanner/guard/runtime/detectors.py
+++ b/src/codex_plugin_scanner/guard/runtime/detectors.py
@@ -52,6 +52,11 @@ DETECTOR_CATEGORY_TAGS: tuple[RiskSignalCategory, ...] = (
 )
 DetectorRunStatus = Literal["ok", "disabled", "filtered", "timeout", "error"]
 _SLOW_DETECTOR_THRESHOLD_MS: int = 100
+_SENSITIVE_DECODE_CONTEXT_PATTERN = re.compile(
+    r"\.env|\.npmrc|id_(?:rsa|ed25519|ecdsa|dsa)|credential|secret|token|api[_-]?key|"
+    r"private[_-]?key|password|\.pem|\.key|aws[_-]",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -230,6 +235,7 @@ class SafeDecodeDetector:
 
     detector_id = "safe-decode.content"
     categories: tuple[RiskSignalCategory, ...] = (
+        "encoded",
         "execution",
         "network",
         "secret",
@@ -342,21 +348,7 @@ def _looks_like_opaque_decoded_payload(text: str) -> bool:
 
 
 def _has_sensitive_decode_context(text: str) -> bool:
-    lowered = text.lower()
-    sensitive_tokens = (
-        ".env",
-        ".npmrc",
-        "id_rsa",
-        "id_ed25519",
-        "credential",
-        "secret",
-        "token",
-        "api_key",
-        "apikey",
-        "private_key",
-        "password",
-    )
-    return any(token in lowered for token in sensitive_tokens)
+    return _SENSITIVE_DECODE_CONTEXT_PATTERN.search(text) is not None
 
 
 class FalsePositiveSuppressorDetector:

--- a/src/codex_plugin_scanner/guard/runtime/detectors.py
+++ b/src/codex_plugin_scanner/guard/runtime/detectors.py
@@ -53,8 +53,8 @@ DETECTOR_CATEGORY_TAGS: tuple[RiskSignalCategory, ...] = (
 DetectorRunStatus = Literal["ok", "disabled", "filtered", "timeout", "error"]
 _SLOW_DETECTOR_THRESHOLD_MS: int = 100
 _SENSITIVE_DECODE_CONTEXT_PATTERN = re.compile(
-    r"\.env|\.npmrc|id_(?:rsa|ed25519|ecdsa|dsa)|credential|secret|token|api[_-]?key|"
-    r"private[_-]?key|password|\.pem|\.key|aws[_-]",
+    r"\.env|\.npmrc|id_(?:rsa|ed25519|ecdsa|dsa)|api[_-]?key|private[_-]?key|"
+    r"\.pem|\.key|aws[_-]|(?<![A-Za-z0-9])(?:credentials?|secrets?|tokens?|passwords?)(?![A-Za-z0-9])",
     re.IGNORECASE,
 )
 

--- a/src/codex_plugin_scanner/guard/runtime/detectors.py
+++ b/src/codex_plugin_scanner/guard/runtime/detectors.py
@@ -54,7 +54,8 @@ DetectorRunStatus = Literal["ok", "disabled", "filtered", "timeout", "error"]
 _SLOW_DETECTOR_THRESHOLD_MS: int = 100
 _SENSITIVE_DECODE_CONTEXT_PATTERN = re.compile(
     r"\.env|\.npmrc|id_(?:rsa|ed25519|ecdsa|dsa)|api[_-]?key|private[_-]?key|"
-    r"\.pem|\.key|aws[_-]|(?<![A-Za-z0-9])(?:credentials?|secrets?|tokens?|passwords?)(?![A-Za-z0-9])",
+    r"\.pem|\.key|aws[_-](?:access[_-]?key|secret[_-]?access[_-]?key|session[_-]?token|credentials?)|"
+    r"(?<![A-Za-z0-9])(?:credentials?|secrets?|tokens?|passwords?)(?![A-Za-z0-9])",
     re.IGNORECASE,
 )
 

--- a/src/codex_plugin_scanner/guard/runtime/detectors.py
+++ b/src/codex_plugin_scanner/guard/runtime/detectors.py
@@ -54,7 +54,7 @@ DetectorRunStatus = Literal["ok", "disabled", "filtered", "timeout", "error"]
 _SLOW_DETECTOR_THRESHOLD_MS: int = 100
 _SENSITIVE_DECODE_CONTEXT_PATTERN = re.compile(
     r"\.env(?:\.[A-Za-z0-9_-]+)?(?![A-Za-z0-9_-])|\.npmrc(?![A-Za-z0-9_-])|"
-    r"id_(?:rsa|ed25519|ecdsa|dsa)(?![A-Za-z0-9])|api[_-]?key(?![A-Za-z0-9])|"
+    r"id_(?:rsa|ed25519|ecdsa|dsa)(?![A-Za-z0-9]|\.pub\b)|api[_-]?key(?![A-Za-z0-9])|"
     r"private[_-]?key(?![A-Za-z0-9])|\.pem(?![A-Za-z0-9_-])|\.key(?![A-Za-z0-9_-])|"
     r"aws[_-](?:access[_-]?key|secret[_-]?access[_-]?key|session[_-]?token|credentials?)(?![A-Za-z0-9])|"
     r"(?<![A-Za-z0-9])(?:credentials?|secrets?|tokens?|passwords?)(?![A-Za-z0-9])",

--- a/tests/test_guard_runtime_detectors.py
+++ b/tests/test_guard_runtime_detectors.py
@@ -926,6 +926,39 @@ def test_safe_decode_detector_does_not_match_sensitive_word_fragments(tmp_path: 
     assert signals == ()
 
 
+def test_safe_decode_detector_does_not_match_benign_aws_tooling(tmp_path: Path) -> None:
+    import base64
+
+    from codex_plugin_scanner.guard.runtime.detectors import SafeDecodeDetector
+
+    opaque = base64.b64encode(bytes(range(32)) * 4).decode()
+    action = GuardActionEnvelope(
+        schema_version=1,
+        action_id="test-safe-decode-aws-sdk-fixture",
+        harness="codex",
+        event_name="PreToolUse",
+        action_type="prompt",
+        workspace="~/workspace",
+        workspace_hash="workspace-hash",
+        tool_name=None,
+        command=None,
+        prompt_excerpt="Decode fixture prose",
+        prompt_text=f"Use this aws-sdk and aws-cli binary fixture: {opaque}",
+        target_paths=(),
+        network_hosts=(),
+        mcp_server=None,
+        mcp_tool=None,
+        package_manager=None,
+        package_name=None,
+        script_name=None,
+        raw_payload_redacted={},
+    )
+
+    signals = SafeDecodeDetector().detect(action, _context(tmp_path))
+
+    assert signals == ()
+
+
 def test_safe_decode_detector_returns_empty_for_plain_text(tmp_path: Path) -> None:
     from codex_plugin_scanner.guard.runtime.detectors import SafeDecodeDetector
 

--- a/tests/test_guard_runtime_detectors.py
+++ b/tests/test_guard_runtime_detectors.py
@@ -992,6 +992,39 @@ def test_safe_decode_detector_does_not_match_benign_secret_like_identifiers(tmp_
     assert signals == ()
 
 
+def test_safe_decode_detector_does_not_match_ssh_public_key_paths(tmp_path: Path) -> None:
+    import base64
+
+    from codex_plugin_scanner.guard.runtime.detectors import SafeDecodeDetector
+
+    opaque = base64.b64encode(bytes(range(32)) * 4).decode()
+    action = GuardActionEnvelope(
+        schema_version=1,
+        action_id="test-safe-decode-ssh-public-key",
+        harness="codex",
+        event_name="PreToolUse",
+        action_type="shell_command",
+        workspace="~/workspace",
+        workspace_hash="workspace-hash",
+        tool_name="bash",
+        command=f"ssh-copy-id -i ~/.ssh/id_ed25519.pub user@example.com; printf '{opaque}'",
+        prompt_excerpt=None,
+        prompt_text=None,
+        target_paths=(),
+        network_hosts=(),
+        mcp_server=None,
+        mcp_tool=None,
+        package_manager=None,
+        package_name=None,
+        script_name=None,
+        raw_payload_redacted={},
+    )
+
+    signals = SafeDecodeDetector().detect(action, _context(tmp_path))
+
+    assert signals == ()
+
+
 def test_safe_decode_detector_returns_empty_for_plain_text(tmp_path: Path) -> None:
     from codex_plugin_scanner.guard.runtime.detectors import SafeDecodeDetector
 

--- a/tests/test_guard_runtime_detectors.py
+++ b/tests/test_guard_runtime_detectors.py
@@ -790,6 +790,72 @@ def test_safe_decode_detector_inspects_shell_command_payloads(tmp_path: Path) ->
     assert any("safe-decode.v2" in (s.technical_detail or "") for s in signals)
 
 
+def test_safe_decode_detector_flags_opaque_payload_near_secret_context(tmp_path: Path) -> None:
+    import base64
+
+    from codex_plugin_scanner.guard.runtime.detectors import SafeDecodeDetector
+
+    opaque = base64.b64encode(bytes(range(32)) * 4).decode()
+    action = GuardActionEnvelope(
+        schema_version=1,
+        action_id="test-safe-decode-opaque-secret",
+        harness="codex",
+        event_name="PreToolUse",
+        action_type="shell_command",
+        workspace="~/workspace",
+        workspace_hash="workspace-hash",
+        tool_name="bash",
+        command=f"SECRET=$(cat .env); openssl enc -d -base64 <<< '{opaque}'",
+        prompt_excerpt=None,
+        prompt_text=None,
+        target_paths=(),
+        network_hosts=(),
+        mcp_server=None,
+        mcp_tool=None,
+        package_manager=None,
+        package_name=None,
+        script_name=None,
+        raw_payload_redacted={},
+    )
+
+    signals = SafeDecodeDetector().detect(action, _context(tmp_path))
+
+    assert any(s.signal_id == "encoded.opaque-sensitive" for s in signals)
+
+
+def test_safe_decode_detector_ignores_benign_binary_payload(tmp_path: Path) -> None:
+    import base64
+
+    from codex_plugin_scanner.guard.runtime.detectors import SafeDecodeDetector
+
+    opaque = base64.b64encode(bytes(range(32)) * 4).decode()
+    action = GuardActionEnvelope(
+        schema_version=1,
+        action_id="test-safe-decode-benign-binary",
+        harness="codex",
+        event_name="PreToolUse",
+        action_type="prompt",
+        workspace="~/workspace",
+        workspace_hash="workspace-hash",
+        tool_name=None,
+        command=None,
+        prompt_excerpt="Decode sample fixture",
+        prompt_text=f"Use this image fixture: {opaque}",
+        target_paths=(),
+        network_hosts=(),
+        mcp_server=None,
+        mcp_tool=None,
+        package_manager=None,
+        package_name=None,
+        script_name=None,
+        raw_payload_redacted={},
+    )
+
+    signals = SafeDecodeDetector().detect(action, _context(tmp_path))
+
+    assert signals == ()
+
+
 def test_safe_decode_detector_returns_empty_for_plain_text(tmp_path: Path) -> None:
     from codex_plugin_scanner.guard.runtime.detectors import SafeDecodeDetector
 

--- a/tests/test_guard_runtime_detectors.py
+++ b/tests/test_guard_runtime_detectors.py
@@ -893,6 +893,39 @@ def test_safe_decode_detector_ignores_benign_binary_payload(tmp_path: Path) -> N
     assert signals == ()
 
 
+def test_safe_decode_detector_does_not_match_sensitive_word_fragments(tmp_path: Path) -> None:
+    import base64
+
+    from codex_plugin_scanner.guard.runtime.detectors import SafeDecodeDetector
+
+    opaque = base64.b64encode(bytes(range(32)) * 4).decode()
+    action = GuardActionEnvelope(
+        schema_version=1,
+        action_id="test-safe-decode-sensitive-fragment",
+        harness="codex",
+        event_name="PreToolUse",
+        action_type="prompt",
+        workspace="~/workspace",
+        workspace_hash="workspace-hash",
+        tool_name=None,
+        command=None,
+        prompt_excerpt="Decode fixture prose",
+        prompt_text=f"Use tokenized secretary-note fixture bytes: {opaque}",
+        target_paths=(),
+        network_hosts=(),
+        mcp_server=None,
+        mcp_tool=None,
+        package_manager=None,
+        package_name=None,
+        script_name=None,
+        raw_payload_redacted={},
+    )
+
+    signals = SafeDecodeDetector().detect(action, _context(tmp_path))
+
+    assert signals == ()
+
+
 def test_safe_decode_detector_returns_empty_for_plain_text(tmp_path: Path) -> None:
     from codex_plugin_scanner.guard.runtime.detectors import SafeDecodeDetector
 

--- a/tests/test_guard_runtime_detectors.py
+++ b/tests/test_guard_runtime_detectors.py
@@ -959,6 +959,39 @@ def test_safe_decode_detector_does_not_match_benign_aws_tooling(tmp_path: Path) 
     assert signals == ()
 
 
+def test_safe_decode_detector_does_not_match_benign_secret_like_identifiers(tmp_path: Path) -> None:
+    import base64
+
+    from codex_plugin_scanner.guard.runtime.detectors import SafeDecodeDetector
+
+    opaque = base64.b64encode(bytes(range(32)) * 4).decode()
+    action = GuardActionEnvelope(
+        schema_version=1,
+        action_id="test-safe-decode-benign-secret-like-identifiers",
+        harness="codex",
+        event_name="PreToolUse",
+        action_type="prompt",
+        workspace="~/workspace",
+        workspace_hash="workspace-hash",
+        tool_name=None,
+        command=None,
+        prompt_excerpt="Decode fixture prose",
+        prompt_text=f"Document .envoy .keycloak and api-keyboard binary fixture bytes: {opaque}",
+        target_paths=(),
+        network_hosts=(),
+        mcp_server=None,
+        mcp_tool=None,
+        package_manager=None,
+        package_name=None,
+        script_name=None,
+        raw_payload_redacted={},
+    )
+
+    signals = SafeDecodeDetector().detect(action, _context(tmp_path))
+
+    assert signals == ()
+
+
 def test_safe_decode_detector_returns_empty_for_plain_text(tmp_path: Path) -> None:
     from codex_plugin_scanner.guard.runtime.detectors import SafeDecodeDetector
 

--- a/tests/test_guard_runtime_detectors.py
+++ b/tests/test_guard_runtime_detectors.py
@@ -823,6 +823,43 @@ def test_safe_decode_detector_flags_opaque_payload_near_secret_context(tmp_path:
     assert any(s.signal_id == "encoded.opaque-sensitive" for s in signals)
 
 
+def test_safe_decode_detector_runs_with_encoded_category_filter(tmp_path: Path) -> None:
+    import base64
+
+    from codex_plugin_scanner.guard.runtime.detectors import SafeDecodeDetector
+
+    opaque = base64.b64encode(bytes(range(32)) * 4).decode()
+    action = GuardActionEnvelope(
+        schema_version=1,
+        action_id="test-safe-decode-opaque-filtered",
+        harness="codex",
+        event_name="PreToolUse",
+        action_type="shell_command",
+        workspace="~/workspace",
+        workspace_hash="workspace-hash",
+        tool_name="bash",
+        command=f"ssh-add ~/.ssh/id_ecdsa; openssl enc -d -base64 <<< '{opaque}'",
+        prompt_excerpt=None,
+        prompt_text=None,
+        target_paths=(),
+        network_hosts=(),
+        mcp_server=None,
+        mcp_tool=None,
+        package_manager=None,
+        package_name=None,
+        script_name=None,
+        raw_payload_redacted={},
+    )
+
+    result = DetectorRegistry((SafeDecodeDetector(),), clock=StepClock([0.0, 0.001])).run(
+        action,
+        _context(tmp_path),
+        enabled_categories=("encoded",),
+    )
+
+    assert any(s.signal_id == "encoded.opaque-sensitive" for s in result.signals)
+
+
 def test_safe_decode_detector_ignores_benign_binary_payload(tmp_path: Path) -> None:
     import base64
 


### PR DESCRIPTION
## Summary
- flag opaque encoded payloads only when local secret context is present
- suppress benign binary fixture noise
- add regression coverage for sensitive opaque payloads and binary false positives

## Verification
- ruff check src/codex_plugin_scanner/guard/runtime/detectors.py tests/test_guard_runtime_detectors.py src/codex_plugin_scanner/guard/runtime/safe_decode.py tests/test_guard_safe_decode.py tests/test_guard_data_flow.py
- PYTHONPATH=src pytest -q tests/test_guard_runtime_detectors.py tests/test_guard_safe_decode.py tests/test_guard_data_flow.py tests/test_guard_docs.py tests/test_guard_receipt_p5_fields.py tests/test_guard_daemon_perf.py
- cd dashboard && pnpm exec tsx src/risk-signal-cards.test.ts && pnpm test && pnpm build