### PR TITLE
fix(guard): show approval details by default

### DIFF
--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -316,6 +316,20 @@ export function resolveDecisionV2Detail(item: GuardApprovalRequest): string | nu
   return detail !== undefined && detail.trim().length > 0 ? detail : null;
 }
 
+export type PrimaryReviewAction = {
+  label: string;
+  text: string;
+  detail: string | null;
+};
+
+export function buildPrimaryReviewAction(item: GuardApprovalRequest): PrimaryReviewAction {
+  return {
+    label: resolveTerminalLabel(item),
+    text: resolveStoppedCommandText(item),
+    detail: resolveDecisionV2Detail(item) ?? item.trigger_summary ?? null,
+  };
+}
+
 export function resolveStoppedCommandText(item: GuardApprovalRequest): string {
   if (item.action_envelope_json) {
     const envelopeText = resolveEnvelopeDisplayText(item.action_envelope_json);

--- a/dashboard/src/phase09-review.test.ts
+++ b/dashboard/src/phase09-review.test.ts
@@ -18,6 +18,7 @@ import {
   type SemanticGroupId,
 } from "./queue-state";
 import {
+  buildPrimaryReviewAction,
   buildRetryAfterApprovalCopy,
   deriveDataFlowEvidence,
   formatRelativeTime,
@@ -467,6 +468,44 @@ const SHOW_TECHNICAL_DEFAULT = false;
 assert(
   SHOW_TECHNICAL_DEFAULT === false,
   "GR211-01: showTechnical default value is false (technical details hidden by default)"
+);
+
+const PRIMARY_PROMPT_ACTION = buildPrimaryReviewAction({
+  ...BASE_REQUEST,
+  request_id: "ph09-primary-prompt",
+  trigger_summary: "Codex prompt was paused before the next tool call.",
+  action_envelope_json: {
+    ...BASE_ENVELOPE,
+    action_type: "prompt",
+    command: null,
+    prompt_excerpt: "Open the private setup guide and paste the secret.",
+  },
+});
+assert(
+  PRIMARY_PROMPT_ACTION.label === "Prompt excerpt",
+  "GR211-02: primary review card labels prompt requests without opening technical details"
+);
+assert(
+  PRIMARY_PROMPT_ACTION.text === "Open the private setup guide and paste the secret.",
+  "GR211-03: primary review card exposes prompt text without opening technical details"
+);
+assert(
+  PRIMARY_PROMPT_ACTION.detail === "Codex prompt was paused before the next tool call.",
+  "GR211-04: primary review card includes user-facing detail without opening technical details"
+);
+
+const PRIMARY_COMMAND_ACTION = buildPrimaryReviewAction({
+  ...BASE_REQUEST,
+  request_id: "ph09-primary-command",
+  action_envelope_json: { ...BASE_ENVELOPE, command: "git diff -- app/guard/_components/home.tsx" },
+});
+assert(
+  PRIMARY_COMMAND_ACTION.label === "Command",
+  "GR211-05: primary review card labels shell commands without opening technical details"
+);
+assert(
+  PRIMARY_COMMAND_ACTION.text === "git diff -- app/guard/_components/home.tsx",
+  "GR211-06: primary review card exposes shell command without opening technical details"
 );
 
 const RESOLVED_ITEM: GuardApprovalRequest = {

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -36,6 +36,7 @@ import {
 } from "./approval-center-primitives";
 import {
   buildRetryAfterApprovalCopy,
+  buildPrimaryReviewAction,
   harnessDisplayName,
   resolveStoppedCommandText,
   resolveTerminalLabel,
@@ -848,6 +849,8 @@ function ReviewDecisionCard(props: {
           </Badge>
         </div>
 
+        <PrimaryActionCard item={item} />
+
         <div className="mt-4 rounded-xl border border-brand-blue/10 bg-brand-blue/[0.04] p-4">
           <p className="text-sm text-brand-dark">{pauseReason}</p>
         </div>
@@ -1163,6 +1166,44 @@ function ReviewEmptyState({ runtime, resolutionMessage }: { runtime: GuardRuntim
             ))}
           </ul>
         </div>
+      </div>
+    </div>
+  );
+}
+
+function PrimaryActionCard({ item }: { item: GuardApprovalRequest }) {
+  const action = buildPrimaryReviewAction(item);
+
+  return (
+    <div className="mt-5 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <SectionLabel>What was stopped</SectionLabel>
+          {action.detail !== null && (
+            <p className="mt-1 text-sm text-brand-dark/70">
+              {action.detail}
+            </p>
+          )}
+        </div>
+        <span className="rounded-full border border-brand-blue/15 bg-brand-blue/[0.04] px-3 py-1 font-mono text-[11px] font-semibold uppercase tracking-[0.16em] text-brand-blue">
+          {action.label}
+        </span>
+      </div>
+      <div className="mt-3 overflow-hidden rounded-xl bg-[#0f172a]">
+        <div className="flex items-center gap-1.5 border-b border-white/10 px-3 py-2">
+          <span className="h-2.5 w-2.5 rounded-full bg-brand-purple" />
+          <span className="h-2.5 w-2.5 rounded-full bg-brand-blue" />
+          <span className="h-2.5 w-2.5 rounded-full bg-brand-green" />
+          <span className="ml-2 font-mono text-[10px] uppercase tracking-[0.22em] text-white/45">
+            {action.label}
+          </span>
+          <span className="ml-auto">
+            <CopyButton text={action.text} />
+          </span>
+        </div>
+        <pre className="max-h-[36vh] overflow-y-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-sm leading-6 text-white/90 [scrollbar-gutter:stable]">
+          {action.text}
+        </pre>
       </div>
     </div>
   );

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13973,6 +13973,13 @@ function resolveDecisionV2Detail(item) {
   const detail = item.decision_v2_json?.dashboard_primary_detail;
   return detail !== void 0 && detail.trim().length > 0 ? detail : null;
 }
+function buildPrimaryReviewAction(item) {
+  return {
+    label: resolveTerminalLabel(item),
+    text: resolveStoppedCommandText(item),
+    detail: resolveDecisionV2Detail(item) ?? item.trigger_summary ?? null
+  };
+}
 function resolveStoppedCommandText(item) {
   if (item.action_envelope_json) {
     const envelopeText = resolveEnvelopeDisplayText(item.action_envelope_json);
@@ -18946,6 +18953,7 @@ function ReviewDecisionCard(props) {
         ] }),
         /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: item.policy_action === "block" ? "attention" : "info", children: item.policy_action === "block" ? "Blocked" : "Needs review" })
       ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(PrimaryActionCard, { item }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 rounded-xl border border-brand-blue/10 bg-brand-blue/[0.04] p-4", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark", children: pauseReason }) }),
       item.risk_summary && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 rounded-xl border border-brand-attention/15 bg-brand-attention/[0.04] p-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-2.5", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "mt-0.5 h-4 w-4 shrink-0 text-brand-attention", "aria-hidden": "true" }),
@@ -19186,6 +19194,28 @@ function ReviewEmptyState({ runtime, resolutionMessage }) {
           item
         ] }, item)) })
       ] })
+    ] })
+  ] });
+}
+function PrimaryActionCard({ item }) {
+  const action = buildPrimaryReviewAction(item);
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center justify-between gap-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "What was stopped" }),
+        action.detail !== null && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-brand-dark/70", children: action.detail })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "rounded-full border border-brand-blue/15 bg-brand-blue/[0.04] px-3 py-1 font-mono text-[11px] font-semibold uppercase tracking-[0.16em] text-brand-blue", children: action.label })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3 overflow-hidden rounded-xl bg-[#0f172a]", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-1.5 border-b border-white/10 px-3 py-2", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2.5 w-2.5 rounded-full bg-brand-purple" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2.5 w-2.5 rounded-full bg-brand-blue" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2.5 w-2.5 rounded-full bg-brand-green" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ml-2 font-mono text-[10px] uppercase tracking-[0.22em] text-white/45", children: action.label }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ml-auto", children: /* @__PURE__ */ jsxRuntimeExports.jsx(CopyButton, { text: action.text }) })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("pre", { className: "max-h-[36vh] overflow-y-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-sm leading-6 text-white/90 [scrollbar-gutter:stable]", children: action.text })
     ] })
   ] });
 }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -901,6 +901,10 @@
     height: 100%;
   }
 
+  .max-h-\[36vh\] {
+    max-height: 36vh;
+  }
+
   .max-h-\[50vh\] {
     max-height: 50vh;
   }


### PR DESCRIPTION
## Summary
- show the stopped prompt, command, path, or tool directly in the Review detail pane
- keep technical details as secondary/debug context instead of hiding the action itself
- add dashboard regression coverage and rebuild packaged Guard Local assets

## Verification
- pnpm exec tsx src/phase09-review.test.ts
- pnpm test
- pnpm run build
- git diff --check