### PR TITLE
fix(guard): simplify review action details

### DIFF
--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -330,6 +330,10 @@ export function buildPrimaryReviewAction(item: GuardApprovalRequest): PrimaryRev
   };
 }
 
+export function primaryReviewActionToggleLabel(isVisible: boolean): string {
+  return isVisible ? "Hide stopped action" : "Show stopped action";
+}
+
 export function resolveStoppedCommandText(item: GuardApprovalRequest): string {
   if (item.action_envelope_json) {
     const envelopeText = resolveEnvelopeDisplayText(item.action_envelope_json);

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -325,7 +325,7 @@ export type PrimaryReviewAction = {
 export function buildPrimaryReviewAction(item: GuardApprovalRequest): PrimaryReviewAction {
   return {
     label: resolveTerminalLabel(item),
-    text: resolveStoppedCommandText(item),
+    text: resolvePrimaryReviewText(item),
     detail: resolveDecisionV2Detail(item) ?? item.trigger_summary ?? null,
   };
 }
@@ -352,6 +352,37 @@ export function resolveStoppedCommandText(item: GuardApprovalRequest): string {
     return item.launch_summary;
   }
   return item.artifact_name.trim() || item.artifact_id;
+}
+
+function resolvePrimaryReviewText(item: GuardApprovalRequest): string {
+  const baseText = resolveStoppedCommandText(item);
+  const envelope = item.action_envelope_json;
+  if (envelope?.action_type !== "mcp_tool") {
+    return baseText;
+  }
+
+  const inputSummary = serializeMcpInput(envelope.raw_payload_redacted);
+  if (inputSummary === null) {
+    return baseText;
+  }
+  return `${baseText}\n\nInput:\n${inputSummary}`;
+}
+
+function serializeMcpInput(payload: Record<string, unknown>): string | null {
+  const input = payload.arguments ?? payload.input ?? payload.params ?? null;
+  if (input === null || input === undefined) {
+    return null;
+  }
+
+  try {
+    const serialized = typeof input === "string" ? input : JSON.stringify(input, null, 2);
+    if (serialized === undefined || serialized.trim().length === 0 || serialized === "{}") {
+      return null;
+    }
+    return serialized.length > 4000 ? `${serialized.slice(0, 4000)}...` : serialized;
+  } catch {
+    return null;
+  }
 }
 
 export function harnessDisplayName(harness: string): string {

--- a/dashboard/src/phase09-review.test.ts
+++ b/dashboard/src/phase09-review.test.ts
@@ -23,6 +23,7 @@ import {
   deriveDataFlowEvidence,
   formatRelativeTime,
   harnessDisplayName,
+  primaryReviewActionToggleLabel,
   resolveStoppedCommandText,
 } from "./approval-center-utils";
 import {
@@ -464,10 +465,13 @@ assert(
   "GR210-06: groupDuplicates exposes all collapsed duplicate IDs for expand functionality"
 );
 
-const SHOW_TECHNICAL_DEFAULT = false;
 assert(
-  SHOW_TECHNICAL_DEFAULT === false,
-  "GR211-01: showTechnical default value is false (technical details hidden by default)"
+  primaryReviewActionToggleLabel(true) === "Hide stopped action",
+  "GR211-01: primary review card can hide the stopped prompt or command"
+);
+assert(
+  primaryReviewActionToggleLabel(false) === "Show stopped action",
+  "GR211-02: primary review card can restore the stopped prompt or command"
 );
 
 const PRIMARY_PROMPT_ACTION = buildPrimaryReviewAction({
@@ -483,15 +487,15 @@ const PRIMARY_PROMPT_ACTION = buildPrimaryReviewAction({
 });
 assert(
   PRIMARY_PROMPT_ACTION.label === "Prompt excerpt",
-  "GR211-02: primary review card labels prompt requests without opening technical details"
+  "GR211-03: primary review card labels prompt requests without opening technical details"
 );
 assert(
   PRIMARY_PROMPT_ACTION.text === "Open the private setup guide and paste the secret.",
-  "GR211-03: primary review card exposes prompt text without opening technical details"
+  "GR211-04: primary review card exposes prompt text without opening technical details"
 );
 assert(
   PRIMARY_PROMPT_ACTION.detail === "Codex prompt was paused before the next tool call.",
-  "GR211-04: primary review card includes user-facing detail without opening technical details"
+  "GR211-05: primary review card includes user-facing detail without opening technical details"
 );
 
 const PRIMARY_COMMAND_ACTION = buildPrimaryReviewAction({
@@ -501,11 +505,11 @@ const PRIMARY_COMMAND_ACTION = buildPrimaryReviewAction({
 });
 assert(
   PRIMARY_COMMAND_ACTION.label === "Command",
-  "GR211-05: primary review card labels shell commands without opening technical details"
+  "GR211-06: primary review card labels shell commands without opening technical details"
 );
 assert(
   PRIMARY_COMMAND_ACTION.text === "git diff -- app/guard/_components/home.tsx",
-  "GR211-06: primary review card exposes shell command without opening technical details"
+  "GR211-07: primary review card exposes shell command without opening technical details"
 );
 
 const RESOLVED_ITEM: GuardApprovalRequest = {

--- a/dashboard/src/phase09-review.test.ts
+++ b/dashboard/src/phase09-review.test.ts
@@ -512,6 +512,31 @@ assert(
   "GR211-07: primary review card exposes shell command without opening technical details"
 );
 
+const PRIMARY_MCP_ACTION = buildPrimaryReviewAction({
+  ...BASE_REQUEST,
+  request_id: "ph09-primary-mcp",
+  action_envelope_json: {
+    ...BASE_ENVELOPE,
+    action_type: "mcp_tool",
+    command: null,
+    mcp_server: "danger_lab",
+    mcp_tool: "dangerous_delete",
+    raw_payload_redacted: {
+      arguments: {
+        target: "dangerous-marker.json",
+      },
+    },
+  },
+});
+assert(
+  PRIMARY_MCP_ACTION.text.includes("danger_lab / dangerous_delete"),
+  "GR211-08: primary review card exposes MCP server and tool without opening technical details"
+);
+assert(
+  PRIMARY_MCP_ACTION.text.includes('"target": "dangerous-marker.json"'),
+  "GR211-09: primary review card exposes redacted MCP arguments without opening technical details"
+);
+
 const RESOLVED_ITEM: GuardApprovalRequest = {
   ...BASE_REQUEST,
   request_id: "ph09-resolved",

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -37,13 +37,10 @@ import {
 import {
   buildRetryAfterApprovalCopy,
   buildPrimaryReviewAction,
+  primaryReviewActionToggleLabel,
   harnessDisplayName,
-  resolveStoppedCommandText,
-  resolveTerminalLabel,
-  resolveDecisionV2Detail,
   resolveDecisionV2Title,
   displayArtifactName,
-  buildPauseLine,
   resolveEnvelopeDisplayText,
   formatRelativeTime,
 } from "./approval-center-utils";
@@ -683,7 +680,6 @@ function ReviewDecisionCard(props: {
   const [resolved, setResolved] = useState<"allow" | "block" | null>(null);
   const [showConsequences, setShowConsequences] = useState(false);
   const [showEvidence, setShowEvidence] = useState(false);
-  const [showTechnical, setShowTechnical] = useState(false);
   const [lastAction, setLastAction] = useState<"allow" | "block" | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -781,9 +777,6 @@ function ReviewDecisionCard(props: {
   const handleBlock = useCallback(() => {
     handleRequestResolve("block");
   }, [handleRequestResolve]);
-  const handleToggleTechnical = useCallback(() => {
-    setShowTechnical((visible) => !visible);
-  }, []);
   const handleToggleConsequences = useCallback(() => {
     setShowConsequences((visible) => !visible);
   }, []);
@@ -863,23 +856,6 @@ function ReviewDecisionCard(props: {
             </div>
           </div>
         )}
-
-        <div className="mt-4">
-          <button
-            type="button"
-            onClick={handleToggleTechnical}
-            className="flex items-center gap-2 text-sm font-medium text-slate-500 hover:text-brand-dark transition-colors"
-            aria-expanded={showTechnical}
-          >
-            {showTechnical ? (
-              <HiMiniChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
-            ) : (
-              <HiMiniChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
-            )}
-            {showTechnical ? "Hide technical details" : "Show technical details"}
-          </button>
-          {showTechnical && <ActionContentCard item={item} />}
-        </div>
 
         {whatWouldHappen && (
           <div className="mt-5">
@@ -1173,6 +1149,10 @@ function ReviewEmptyState({ runtime, resolutionMessage }: { runtime: GuardRuntim
 
 function PrimaryActionCard({ item }: { item: GuardApprovalRequest }) {
   const action = buildPrimaryReviewAction(item);
+  const [isVisible, setIsVisible] = useState(true);
+  const handleToggleVisibility = useCallback(() => {
+    setIsVisible((visible) => !visible);
+  }, []);
 
   return (
     <div className="mt-5 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
@@ -1197,86 +1177,32 @@ function PrimaryActionCard({ item }: { item: GuardApprovalRequest }) {
           <span className="ml-2 font-mono text-[10px] uppercase tracking-[0.22em] text-white/45">
             {action.label}
           </span>
-          <span className="ml-auto">
-            <CopyButton text={action.text} />
+          <span className="ml-auto flex items-center gap-2">
+            {isVisible && <CopyButton text={action.text} />}
+            <button
+              type="button"
+              onClick={handleToggleVisibility}
+              className="inline-flex items-center gap-1 rounded-full border border-white/20 bg-white/10 px-2 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-white/70 transition-colors hover:bg-white/20 hover:text-white"
+              aria-expanded={isVisible}
+            >
+              {isVisible ? (
+                <HiMiniChevronUp className="h-3 w-3" aria-hidden="true" />
+              ) : (
+                <HiMiniChevronDown className="h-3 w-3" aria-hidden="true" />
+              )}
+              {primaryReviewActionToggleLabel(isVisible)}
+            </button>
           </span>
         </div>
-        <pre className="max-h-[36vh] overflow-y-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-sm leading-6 text-white/90 [scrollbar-gutter:stable]">
-          {action.text}
-        </pre>
-      </div>
-    </div>
-  );
-}
-
-function ActionContentCard({ item }: { item: GuardApprovalRequest }) {
-  const launchText = resolveStoppedCommandText(item);
-  const detailText = resolveDecisionV2Detail(item);
-  const pauseReason = buildPauseLine(item);
-  const envelope = item.action_envelope_json;
-  const isMcpTool = envelope?.action_type === "mcp_tool";
-  const mcpServer = isMcpTool ? (envelope?.mcp_server ?? null) : null;
-  const mcpTool = isMcpTool ? (envelope?.mcp_tool ?? null) : null;
-  const mcpInputSummary =
-    isMcpTool && envelope !== null && envelope.raw_payload_redacted
-      ? (() => {
-          const inputs = envelope.raw_payload_redacted.arguments ?? envelope.raw_payload_redacted.input ?? envelope.raw_payload_redacted.params ?? null;
-          if (inputs === null) return null;
-          try {
-            const serialized = JSON.stringify(inputs);
-            if (serialized.length <= 2) return null;
-            return serialized.length > 140 ? `${serialized.slice(0, 140)}...` : serialized;
-          } catch {
-            return null;
-          }
-        })()
-      : null;
-  const terminalLabel = resolveTerminalLabel(item);
-
-  return (
-    <div className="mt-5 space-y-3">
-      {isMcpTool && mcpServer !== null && mcpTool !== null && (
-        <div className="rounded-xl border border-brand-blue/20 bg-brand-blue/[0.04] px-3 py-2.5">
-          <div className="flex items-center gap-2">
-            <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.15em] text-brand-blue">
-              MCP
-            </span>
-            <span className="font-mono text-sm font-medium text-brand-dark">
-              {mcpServer} → {mcpTool}
-            </span>
+        {isVisible ? (
+          <pre className="max-h-[36vh] overflow-y-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-sm leading-6 text-white/90 [scrollbar-gutter:stable]">
+            {action.text}
+          </pre>
+        ) : (
+          <div className="px-3 py-4 text-sm text-white/65">
+            Stopped action hidden. Show it before approving if you need to re-check the exact request.
           </div>
-          {mcpInputSummary !== null && (
-            <p className="mt-1 truncate font-mono text-xs text-brand-dark/60">
-              {mcpInputSummary}
-            </p>
-          )}
-        </div>
-      )}
-
-      <p className="text-sm leading-relaxed text-brand-dark/80">
-        {pauseReason}
-      </p>
-      {detailText && (
-        <p className="text-sm leading-relaxed text-brand-dark/80">
-          {detailText}
-        </p>
-      )}
-
-      <div className="overflow-hidden rounded-xl bg-[#0f172a]">
-        <div className="flex items-center gap-1.5 border-b border-white/10 px-3 py-2">
-          <span className="h-2.5 w-2.5 rounded-full bg-brand-purple" />
-          <span className="h-2.5 w-2.5 rounded-full bg-brand-blue" />
-          <span className="h-2.5 w-2.5 rounded-full bg-brand-green" />
-          <span className="ml-2 font-mono text-[10px] uppercase tracking-[0.22em] text-white/45">
-            {terminalLabel}
-          </span>
-          <span className="ml-auto">
-            <CopyButton text={launchText} />
-          </span>
-        </div>
-        <pre className="max-h-[50vh] overflow-y-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-sm leading-6 text-white/90 [scrollbar-gutter:stable]">
-          {launchText}
-        </pre>
+        )}
       </div>
     </div>
   );

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -1150,6 +1150,9 @@ function ReviewEmptyState({ runtime, resolutionMessage }: { runtime: GuardRuntim
 function PrimaryActionCard({ item }: { item: GuardApprovalRequest }) {
   const action = buildPrimaryReviewAction(item);
   const [isVisible, setIsVisible] = useState(true);
+  useEffect(() => {
+    setIsVisible(true);
+  }, [item.request_id]);
   const handleToggleVisibility = useCallback(() => {
     setIsVisible((visible) => !visible);
   }, []);

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -19183,6 +19183,9 @@ function ReviewEmptyState({ runtime, resolutionMessage }) {
 function PrimaryActionCard({ item }) {
   const action = buildPrimaryReviewAction(item);
   const [isVisible, setIsVisible] = reactExports.useState(true);
+  reactExports.useEffect(() => {
+    setIsVisible(true);
+  }, [item.request_id]);
   const handleToggleVisibility = reactExports.useCallback(() => {
     setIsVisible((visible) => !visible);
   }, []);

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13980,6 +13980,9 @@ function buildPrimaryReviewAction(item) {
     detail: resolveDecisionV2Detail(item) ?? item.trigger_summary ?? null
   };
 }
+function primaryReviewActionToggleLabel(isVisible) {
+  return isVisible ? "Hide stopped action" : "Show stopped action";
+}
 function resolveStoppedCommandText(item) {
   if (item.action_envelope_json) {
     const envelopeText = resolveEnvelopeDisplayText(item.action_envelope_json);
@@ -18800,7 +18803,6 @@ function ReviewDecisionCard(props) {
   const [resolved, setResolved] = reactExports.useState(null);
   const [showConsequences, setShowConsequences] = reactExports.useState(false);
   const [showEvidence, setShowEvidence] = reactExports.useState(false);
-  const [showTechnical, setShowTechnical] = reactExports.useState(false);
   const [lastAction, setLastAction] = reactExports.useState(null);
   const [errorMessage, setErrorMessage] = reactExports.useState(null);
   const timerRef = reactExports.useRef(null);
@@ -18892,9 +18894,6 @@ function ReviewDecisionCard(props) {
   const handleBlock = reactExports.useCallback(() => {
     handleRequestResolve("block");
   }, [handleRequestResolve]);
-  const handleToggleTechnical = reactExports.useCallback(() => {
-    setShowTechnical((visible) => !visible);
-  }, []);
   const handleToggleConsequences = reactExports.useCallback(() => {
     setShowConsequences((visible) => !visible);
   }, []);
@@ -18959,22 +18958,6 @@ function ReviewDecisionCard(props) {
         /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "mt-0.5 h-4 w-4 shrink-0 text-brand-attention", "aria-hidden": "true" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark", children: item.risk_summary })
       ] }) }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs(
-          "button",
-          {
-            type: "button",
-            onClick: handleToggleTechnical,
-            className: "flex items-center gap-2 text-sm font-medium text-slate-500 hover:text-brand-dark transition-colors",
-            "aria-expanded": showTechnical,
-            children: [
-              showTechnical ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronUp, { className: "h-3.5 w-3.5", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronDown, { className: "h-3.5 w-3.5", "aria-hidden": "true" }),
-              showTechnical ? "Hide technical details" : "Show technical details"
-            ]
-          }
-        ),
-        showTechnical && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionContentCard, { item })
-      ] }),
       whatWouldHappen && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs(
           "button",
@@ -19199,6 +19182,10 @@ function ReviewEmptyState({ runtime, resolutionMessage }) {
 }
 function PrimaryActionCard({ item }) {
   const action = buildPrimaryReviewAction(item);
+  const [isVisible, setIsVisible] = reactExports.useState(true);
+  const handleToggleVisibility = reactExports.useCallback(() => {
+    setIsVisible((visible) => !visible);
+  }, []);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center justify-between gap-3", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
@@ -19213,55 +19200,24 @@ function PrimaryActionCard({ item }) {
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2.5 w-2.5 rounded-full bg-brand-blue" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2.5 w-2.5 rounded-full bg-brand-green" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ml-2 font-mono text-[10px] uppercase tracking-[0.22em] text-white/45", children: action.label }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ml-auto", children: /* @__PURE__ */ jsxRuntimeExports.jsx(CopyButton, { text: action.text }) })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("pre", { className: "max-h-[36vh] overflow-y-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-sm leading-6 text-white/90 [scrollbar-gutter:stable]", children: action.text })
-    ] })
-  ] });
-}
-function ActionContentCard({ item }) {
-  const launchText = resolveStoppedCommandText(item);
-  const detailText = resolveDecisionV2Detail(item);
-  const pauseReason = buildPauseLine(item);
-  const envelope = item.action_envelope_json;
-  const isMcpTool = envelope?.action_type === "mcp_tool";
-  const mcpServer = isMcpTool ? envelope?.mcp_server ?? null : null;
-  const mcpTool = isMcpTool ? envelope?.mcp_tool ?? null : null;
-  const mcpInputSummary = isMcpTool && envelope !== null && envelope.raw_payload_redacted ? (() => {
-    const inputs = envelope.raw_payload_redacted.arguments ?? envelope.raw_payload_redacted.input ?? envelope.raw_payload_redacted.params ?? null;
-    if (inputs === null) return null;
-    try {
-      const serialized = JSON.stringify(inputs);
-      if (serialized.length <= 2) return null;
-      return serialized.length > 140 ? `${serialized.slice(0, 140)}...` : serialized;
-    } catch {
-      return null;
-    }
-  })() : null;
-  const terminalLabel = resolveTerminalLabel(item);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 space-y-3", children: [
-    isMcpTool && mcpServer !== null && mcpTool !== null && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-brand-blue/20 bg-brand-blue/[0.04] px-3 py-2.5", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-mono text-[10px] font-semibold uppercase tracking-[0.15em] text-brand-blue", children: "MCP" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "font-mono text-sm font-medium text-brand-dark", children: [
-          mcpServer,
-          " → ",
-          mcpTool
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "ml-auto flex items-center gap-2", children: [
+          isVisible && /* @__PURE__ */ jsxRuntimeExports.jsx(CopyButton, { text: action.text }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs(
+            "button",
+            {
+              type: "button",
+              onClick: handleToggleVisibility,
+              className: "inline-flex items-center gap-1 rounded-full border border-white/20 bg-white/10 px-2 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-white/70 transition-colors hover:bg-white/20 hover:text-white",
+              "aria-expanded": isVisible,
+              children: [
+                isVisible ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronUp, { className: "h-3 w-3", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronDown, { className: "h-3 w-3", "aria-hidden": "true" }),
+                primaryReviewActionToggleLabel(isVisible)
+              ]
+            }
+          )
         ] })
       ] }),
-      mcpInputSummary !== null && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 truncate font-mono text-xs text-brand-dark/60", children: mcpInputSummary })
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm leading-relaxed text-brand-dark/80", children: pauseReason }),
-    detailText && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm leading-relaxed text-brand-dark/80", children: detailText }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "overflow-hidden rounded-xl bg-[#0f172a]", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-1.5 border-b border-white/10 px-3 py-2", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2.5 w-2.5 rounded-full bg-brand-purple" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2.5 w-2.5 rounded-full bg-brand-blue" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2.5 w-2.5 rounded-full bg-brand-green" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ml-2 font-mono text-[10px] uppercase tracking-[0.22em] text-white/45", children: terminalLabel }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ml-auto", children: /* @__PURE__ */ jsxRuntimeExports.jsx(CopyButton, { text: launchText }) })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("pre", { className: "max-h-[50vh] overflow-y-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-sm leading-6 text-white/90 [scrollbar-gutter:stable]", children: launchText })
+      isVisible ? /* @__PURE__ */ jsxRuntimeExports.jsx("pre", { className: "max-h-[36vh] overflow-y-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-sm leading-6 text-white/90 [scrollbar-gutter:stable]", children: action.text }) : /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "px-3 py-4 text-sm text-white/65", children: "Stopped action hidden. Show it before approving if you need to re-check the exact request." })
     ] })
   ] });
 }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13976,7 +13976,7 @@ function resolveDecisionV2Detail(item) {
 function buildPrimaryReviewAction(item) {
   return {
     label: resolveTerminalLabel(item),
-    text: resolveStoppedCommandText(item),
+    text: resolvePrimaryReviewText(item),
     detail: resolveDecisionV2Detail(item) ?? item.trigger_summary ?? null
   };
 }
@@ -14001,6 +14001,36 @@ function resolveStoppedCommandText(item) {
     return item.launch_summary;
   }
   return item.artifact_name.trim() || item.artifact_id;
+}
+function resolvePrimaryReviewText(item) {
+  const baseText = resolveStoppedCommandText(item);
+  const envelope = item.action_envelope_json;
+  if (envelope?.action_type !== "mcp_tool") {
+    return baseText;
+  }
+  const inputSummary = serializeMcpInput(envelope.raw_payload_redacted);
+  if (inputSummary === null) {
+    return baseText;
+  }
+  return `${baseText}
+
+Input:
+${inputSummary}`;
+}
+function serializeMcpInput(payload) {
+  const input = payload.arguments ?? payload.input ?? payload.params ?? null;
+  if (input === null || input === void 0) {
+    return null;
+  }
+  try {
+    const serialized = typeof input === "string" ? input : JSON.stringify(input, null, 2);
+    if (serialized === void 0 || serialized.trim().length === 0 || serialized === "{}") {
+      return null;
+    }
+    return serialized.length > 4e3 ? `${serialized.slice(0, 4e3)}...` : serialized;
+  } catch {
+    return null;
+  }
 }
 function harnessDisplayName(harness) {
   const normalized = normalizeHarnessSlug(harness);

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -905,10 +905,6 @@
     max-height: 36vh;
   }
 
-  .max-h-\[50vh\] {
-    max-height: 50vh;
-  }
-
   .min-h-8 {
     min-height: calc(var(--spacing) * 8);
   }
@@ -3246,6 +3242,16 @@
   @supports (color: color-mix(in lab, red, red)) {
     .text-white\/60 {
       color: color-mix(in oklab, var(--color-white) 60%, transparent);
+    }
+  }
+
+  .text-white\/65 {
+    color: #ffffffa6;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .text-white\/65 {
+      color: color-mix(in oklab, var(--color-white) 65%, transparent);
     }
   }
 


### PR DESCRIPTION
## Summary
- remove the redundant technical-details accordion from the Review detail pane
- add a Hide/Show stopped action control directly on the primary stopped-action card
- keep copy available while the stopped action is visible and rebuild packaged local dashboard assets

## Verification
- pnpm exec tsx src/phase09-review.test.ts
- pnpm test
- pnpm run build
- git diff --check