### PR TITLE
feat(guard): add headless local daemon app API

### DIFF
--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -600,7 +600,7 @@ export function App() {
         Skip to content
       </a>
       <div aria-live="polite" aria-atomic="true" className="sr-only">
-        {view === "home" ? "Home" : view === "inbox" ? "Review" : view === "fleet" ? "Apps" : view === "evidence" ? "History" : view === "settings" ? "Settings" : "App detail"}
+        {view === "home" ? "Home" : view === "inbox" ? "Inbox" : view === "fleet" ? "Protect" : view === "evidence" ? "Evidence" : view === "settings" ? "Settings" : "App detail"}
       </div>
     <ApprovalCenterLayout
       view={view}

--- a/dashboard/src/approval-center-primitives.tsx
+++ b/dashboard/src/approval-center-primitives.tsx
@@ -7,7 +7,6 @@ import {
   HiMiniDocumentText,
   HiMiniHome,
   HiMiniInbox,
-  HiMiniServerStack,
   HiMiniAdjustmentsHorizontal,
   HiMiniShieldCheck,
   HiMiniInformationCircle,
@@ -129,9 +128,9 @@ export function ShellHeader(props: {
 
 const sidebarLinks = [
   { href: "/", label: "Home", view: "home", icon: HiMiniHome },
-  { href: "/inbox", label: "Review", view: "inbox", icon: HiMiniInbox },
-  { href: "/fleet", label: "Apps", view: "fleet", icon: HiMiniServerStack },
-  { href: "/evidence", label: "History", view: "evidence", icon: HiMiniDocumentText },
+  { href: "/inbox", label: "Inbox", view: "inbox", icon: HiMiniInbox },
+  { href: "/fleet", label: "Protect", view: "fleet", icon: HiMiniShieldCheck },
+  { href: "/evidence", label: "Evidence", view: "evidence", icon: HiMiniDocumentText },
   { href: "/settings", label: "Settings", view: "settings", icon: HiMiniAdjustmentsHorizontal }
 ] as const;
 
@@ -174,7 +173,7 @@ export function ShellSidebar(props: {
       <div className="flex flex-1 flex-col overflow-y-auto px-3 py-5">
         {!collapsed && (
           <p className="mb-2 px-3 font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-400">
-            Dashboard
+            Guard
           </p>
         )}
         <nav className="flex flex-col gap-0.5" aria-label="Guard dashboard">
@@ -634,7 +633,7 @@ export function WelcomeState(props: {
               ) : null}
               {props.fleetUrl ? (
                 <ActionButton href={props.fleetUrl} variant="outline">
-                  Watched Apps
+                  Protect
                 </ActionButton>
               ) : null}
             </div>

--- a/dashboard/src/home-dashboard.tsx
+++ b/dashboard/src/home-dashboard.tsx
@@ -69,7 +69,7 @@ export function buildEmptyStateCopy(): { title: string; body: string; installHin
   return {
     title: "No apps connected",
     body: "Connect an AI app so Guard can start protecting it. Guard works with Codex, Claude Code, Cursor, Hermes, and more.",
-    installHint: "hol-guard install",
+    installHint: "hol-guard apps connect <app>",
   };
 }
 
@@ -425,7 +425,7 @@ export function deriveHomeState(input: {
       heroStatus: "setup_gap",
       headline: "Guard is ready",
       subheadline: "Connect your first AI app so Guard can start protecting it.",
-      ctaLabel: "Open Apps",
+      ctaLabel: "Open Protect",
       ctaTarget: "fleet",
     };
   }
@@ -435,7 +435,7 @@ export function deriveHomeState(input: {
       heroStatus: "setup_gap",
       headline: "Finish setup",
       subheadline: "Guard detected apps but they need setup to be fully protected.",
-      ctaLabel: "Open Apps",
+      ctaLabel: "Open Protect",
       ctaTarget: "fleet",
     };
   }
@@ -681,7 +681,7 @@ function CloudStatusCard(props: {
           <HiMiniCloud className="h-5 w-5" aria-hidden="true" />
         </span>
         <div className="min-w-0 flex-1">
-          <SectionLabel>Cloud backup</SectionLabel>
+          <SectionLabel>Cloud sync</SectionLabel>
           <p className="mt-2 text-sm font-medium text-brand-dark">{copy.label}</p>
           <p className="mt-1 text-sm text-muted-foreground">{copy.detail}</p>
           {props.showUpsell && (

--- a/dashboard/src/queue-state.test.ts
+++ b/dashboard/src/queue-state.test.ts
@@ -263,7 +263,7 @@ const credentialOutputItem: GuardApprovalRequest = {
 };
 
 assert(
-  resolveQueueCategory(credentialOutputItem).label === "Credential-looking output",
+  resolveQueueCategory(credentialOutputItem).label === "Secret-looking output",
   "T-QS-28: credential-looking output gets its own review category"
 );
 
@@ -359,7 +359,7 @@ assert(
 
 assert(
   sortQueue([gitPushItem, credentialOutputItem, perlEditItem], "category").map((item) => item.request_id).join(",") ===
-    "req-credential-output,req-perl-edit,req-git-push",
+    "req-perl-edit,req-git-push,req-credential-output",
   "T-QS-36: category sorting uses expanded semantic category names"
 );
 
@@ -571,7 +571,7 @@ const secretReadItem: GuardApprovalRequest = {
 };
 
 assert(
-  resolveQueueCategory(secretReadItem).label === "Secret file read",
+  resolveQueueCategory(secretReadItem).label === "Secret file access",
   "T-QS-63: file reads with secret path evidence get secret file read category"
 );
 

--- a/dashboard/src/queue-state.ts
+++ b/dashboard/src/queue-state.ts
@@ -9,28 +9,29 @@ export const REVIEW_SEMANTIC_GROUPS: { id: SemanticGroupId; label: string; match
   { id: "all", label: "All", matches: [] },
   {
     id: "files",
-    label: "Files",
+    label: "File read / write",
     matches: ["file_read", "source_edit", "docs_edit", "generated_inventory_edit"],
   },
   {
     id: "shell",
-    label: "Shell",
+    label: "Shell execution",
     matches: ["shell_command", "destructive_shell", "encoded_shell", "git_operation", "process_control"],
   },
   {
     id: "network",
-    label: "Network & Data",
+    label: "Network / data egress",
     matches: ["network", "secret_exfiltration", "secret_file_read", "credential_output", "file_upload"],
   },
   {
     id: "tools",
-    label: "Tools & Apps",
-    matches: ["mcp_tool", "package_script", "harness_start", "browser_action", "package_install"],
+    label: "MCP, skill & packages",
+    matches: ["mcp_tool", "package_script", "browser_action", "package_install"],
   },
   {
     id: "other",
-    label: "Other",
+    label: "Agent autonomy & other",
     matches: [
+      "harness_start",
       "prompt_injection",
       "system_prompt_access",
       "guard_bypass",
@@ -81,15 +82,15 @@ export type QueueCategory = {
 export const QUEUE_CATEGORIES: QueueCategory[] = [
   {
     id: "credential_output",
-    label: "Credential-looking output",
-    shortLabel: "Credential output",
-    description: "Command output appears to expose tokens, keys, passwords, or secret-looking values.",
+    label: "Secret-looking output",
+    shortLabel: "Secret output",
+    description: "Command output contains patterns that resemble tokens, keys, passwords, or other secret-looking values. Review before allowing if this output will leave the local machine.",
   },
   {
     id: "secret_file_read",
-    label: "Secret file read",
+    label: "Secret file access",
     shortLabel: "Secret read",
-    description: "Reads local credential stores, environment files, tokens, keys, or other secret paths.",
+    description: "Reads paths known to store secrets: env files, credential stores, token files, SSH keys, or cloud config. Normal source reads are classified as file read instead.",
   },
   {
     id: "file_read",
@@ -225,9 +226,9 @@ export const QUEUE_CATEGORIES: QueueCategory[] = [
   },
   {
     id: "harness_start",
-    label: "Harness launch",
-    shortLabel: "Launch",
-    description: "Starts or reconnects an AI app under Guard control.",
+    label: "Agent launch",
+    shortLabel: "Agent launch",
+    description: "Starts or reconnects an AI agent or harness under Guard control. Review when unexpected autonomy or a new session begins.",
   },
   {
     id: "shell_command",

--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -99,6 +99,18 @@ Use it when you want to protect a harness before local MCP servers, skills, hook
 | I need an exportable evidence artifact | `hol-guard abom` | What local AI-BOM can I attach to an audit or handoff? |
 | I need the chronological log | `hol-guard events` | What happened over time on this machine? |
 
+## One continuity model
+
+Guard uses the same product loop across the local daemon, the CLI, and Guard Cloud:
+
+1. **Home** answers whether this machine is protected right now. `hol-guard status` and the local Home view show the same next action, latest proof, and cloud sync state.
+2. **Protect** owns install, repair, remove, status, and first protected action proof. The daemon handles these actions directly when available; the CLI commands stay visible as a fallback when the daemon is offline, unsupported, or missing a local session token.
+3. **Inbox** owns decisions that need judgment. Local approvals use the same categories and policy memory scopes that cloud review uses, so a scoped decision can be synced without changing meaning.
+4. **Evidence** owns durable proof. Receipts from daemon actions, CLI actions, and cloud sync use the same local store before any optional upload.
+5. **Settings** owns policy. Local config remains the source of truth for offline protection, while cloud sync can distribute shared policy memory when you connect a workspace.
+
+The important handoff is that local protection does not depend on Guard Cloud being online. Cloud adds shared history and team policy, but the daemon and CLI still block risky actions, write receipts, and preserve approval continuity on this machine.
+
 ## Troubleshooting
 
 | Symptom | Start here | Then try |

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -177,19 +177,19 @@ _HOOK_DAEMON_PRESERVED_DENY_REASON = (
     "HOL Guard daemon was unreachable; preserving the existing deny decision for this action."
 )
 _GUARD_HELP_GROUPS = (
-    "Everyday protection:\n"
-    "  start        First-run setup and the Guard operating loop\n"
-    "  status       Current local protection state and next actions\n"
-    "  dashboard    Open the local Guard dashboard in your browser\n"
-    "  apps         Connect, test, repair, or disconnect protected apps\n"
+    "HOL Guard AI Antivirus command center:\n"
+    "  start        First-run protection setup for one local AI harness\n"
+    "  status       Home: current protection state, proof, and next action\n"
+    "  dashboard    Open local Home, Protect, Inbox, Evidence, and Settings\n"
+    "  apps         Protect: connect, test, repair, or disconnect AI tools\n"
     "  run          Enforce Guard before a harness launch\n"
-    "  approvals    Resolve the current request queue\n"
-    "  receipts     Review recent local decisions\n"
+    "  approvals    Inbox: approve, block, or scope requests needing judgment\n"
+    "  receipts     Evidence: review local decisions and proof receipts\n"
     "\n"
     "Team and cloud coordination:\n"
     "  connect      Pair this machine to Guard Cloud\n"
     "  login        Compatibility alias for browser pairing\n"
-    "  sync         Send local decisions to Guard Cloud\n"
+    "  sync         Send local decisions, receipts, and policy memory to Guard Cloud\n"
     "  service      Manage hosted-runtime Guard Cloud login and sync\n"
     "  device       Inspect or rotate this machine identity\n"
     "  bridge       Forward Guard signals to external channels\n"
@@ -204,7 +204,7 @@ _GUARD_HELP_GROUPS = (
     "  abom         Export the local AI-BOM\n"
     "  explain      Show evidence for one artifact\n"
     "  policies     Inspect local Guard policy state\n"
-    "  settings     Show or update local Guard settings\n"
+    "  settings     Settings: show or update local Guard rules\n"
     "  exceptions   Inspect active exception windows\n"
     "  advisories   Inspect cached Guard Cloud advisories\n"
     "  events       Review Guard lifecycle events\n"
@@ -215,11 +215,12 @@ _GUARD_HELP_GROUPS = (
     "  update       Update hol-guard in the current environment\n"
     "\n"
     "Command selection:\n"
-    "  Use status for current posture and the next safe step\n"
+    "  Use status for Home posture and the next safe step\n"
+    "  Use apps for Protect install, repair, status, and first protected action proof\n"
+    "  Use approvals for Inbox decisions and receipts for Evidence\n"
     "  Use doctor for setup and runtime probes\n"
     "  Use diff for changed artifacts after a blocked launch\n"
     "  Use explain for detailed artifact evidence\n"
-    "  Use approvals for queued decisions and receipts for audit history\n"
     "  Use events for the local timeline"
 )
 
@@ -249,10 +250,10 @@ def add_guard_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPar
     program_name = Path(sys.argv[0]).name or "plugin-scanner"
     guard_parser = subparsers.add_parser(
         "guard",
-        help="Run local harness protection workflows",
+        help="Run HOL Guard AI Antivirus workflows",
         description=(
-            "HOL Guard watches local harness config, records approval receipts, and keeps "
-            "Home, Inbox, and Fleet aligned with what this machine is doing."
+            "HOL Guard is AI Antivirus for local harnesses. It keeps Home, Protect, "
+            "Inbox, Evidence, and Settings aligned with this machine."
         ),
         epilog=(
             "Examples:\n"
@@ -270,7 +271,7 @@ def add_guard_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPar
 def add_guard_root_parser(parser: argparse.ArgumentParser) -> None:
     """Register Guard as the top-level CLI surface."""
 
-    parser.description = "Protect local harnesses before new or changed tools run."
+    parser.description = "HOL Guard AI Antivirus protects local harnesses before new or changed tools run."
     parser.epilog = _GUARD_HELP_GROUPS
     parser.set_defaults(command="guard")
     _configure_guard_parser(parser)

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import hashlib
+import hmac
 import io
 import json
 import mimetypes
@@ -589,6 +591,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         context = self._harness_context({})
         items = list_harness_setup_items(context, self.server.store)  # type: ignore[attr-defined]
         supported = []
+        failure_reasons = _headless_safe_failure_reasons()
         for item in items:
             harness = item.get("harness")
             if not isinstance(harness, str):
@@ -599,12 +602,12 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     "status": item.get("status"),
                     "command_available": bool(item.get("command_available")),
                     "headless_actions": list(_HEADLESS_OPERATIONS[:-1]),
-                    "safe_failure_reasons": _headless_safe_failure_reasons(),
+                    "safe_failure_reasons": failure_reasons,
                 }
             )
         self._write_json(
             {
-                "auth_state": "dashboard_session" if self._dashboard_session_token_is_present() else "local_token",
+                "auth_state": "dashboard_session" if self._dashboard_session_token_is_valid() else "local_token",
                 "command_available": any(bool(item.get("command_available")) for item in items),
                 "daemon": {
                     "compatibility_version": GUARD_DAEMON_COMPATIBILITY_VERSION,
@@ -1372,10 +1375,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         path = urlparse(self.path).path
         path_parts = [part for part in path.split("/") if part]
         return self._tokens_match(token) or (
-            self._is_hosted_dashboard_api_path(path, path_parts) and self._dashboard_session_token_is_present()
+            self._is_hosted_dashboard_api_path(path, path_parts) and self._dashboard_session_token_is_valid()
         )
 
-    def _dashboard_session_token_is_present(self) -> bool:
+    def _dashboard_session_token_is_valid(self) -> bool:
         session_token = self.headers.get("X-Guard-Dashboard-Session")
         authorization = self.headers.get("Authorization")
         bearer_token = None
@@ -1385,7 +1388,22 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if not isinstance(token, str) or not token.startswith("gld1."):
             return False
         parts = token.split(".")
-        return len(parts) == 3 and all(len(part) >= 8 for part in parts[1:])
+        if len(parts) != 3:
+            return False
+        prefix, payload, signature = parts
+        if prefix != "gld1" or not payload or not signature:
+            return False
+        expected = _dashboard_session_signature(payload, self.server.auth_token)  # type: ignore[attr-defined]
+        if not secrets.compare_digest(signature, expected):
+            return False
+        claims = _decode_dashboard_session_payload(payload)
+        expires_at = claims.get("expires_at")
+        if not isinstance(expires_at, str):
+            return False
+        try:
+            return _parse_iso_timestamp(expires_at) > _parse_iso_timestamp(_now())
+        except ValueError:
+            return False
 
     def _tokens_match(self, token: object) -> bool:
         if not isinstance(token, str):
@@ -1971,6 +1989,28 @@ def _settings_export_payload(config: GuardConfig) -> dict[str, object]:
         "privacy_warning": "Exports include local Guard preferences but not secrets or receipt evidence.",
         "settings": editable_guard_settings(config),
     }
+
+
+def _dashboard_session_signature(payload: str, auth_token: str) -> str:
+    digest = hmac.new(auth_token.encode("utf-8"), payload.encode("utf-8"), hashlib.sha256).digest()
+    return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+
+
+def _decode_dashboard_session_payload(payload: str) -> dict[str, object]:
+    padding = "=" * (-len(payload) % 4)
+    try:
+        decoded = base64.urlsafe_b64decode(f"{payload}{padding}".encode("ascii")).decode("utf-8")
+        parsed = json.loads(decoded)
+    except (UnicodeDecodeError, ValueError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _parse_iso_timestamp(value: str) -> float:
+    from datetime import datetime
+
+    normalized = value.replace("Z", "+00:00")
+    return datetime.fromisoformat(normalized).timestamp()
 
 
 def _now() -> str:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -715,15 +715,30 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if scope not in DECISION_SCOPE_VALUES or action not in GUARD_ACTION_VALUES:
             self._write_json({"error": "unsupported_policy_value"}, status=400)
             return
+        if scope == "global" and action == "allow":
+            self._write_json({"error": "broad_allow_requires_narrow_scope"}, status=400)
+            return
+        artifact_id = self._optional_string(policy_memory.get("artifact_id"))
+        workspace = self._optional_string(policy_memory.get("workspace")) or self._optional_string(
+            payload.get("workspace_id")
+        )
+        publisher = self._optional_string(policy_memory.get("publisher"))
+        if not self._scope_target_is_valid(
+            scope,
+            artifact_id=artifact_id,
+            workspace=workspace,
+            publisher=publisher,
+        ):
+            self._write_json({"error": "missing_scope_target"}, status=400)
+            return
         decision = PolicyDecision(
             harness=adapter.harness,
             scope=scope,  # type: ignore[arg-type]
             action=action,  # type: ignore[arg-type]
-            artifact_id=self._optional_string(policy_memory.get("artifact_id")),
+            artifact_id=artifact_id,
             artifact_hash=self._optional_string(policy_memory.get("artifact_hash")),
-            workspace=self._optional_string(policy_memory.get("workspace"))
-            or self._optional_string(payload.get("workspace_id")),
-            publisher=self._optional_string(policy_memory.get("publisher")),
+            workspace=workspace,
+            publisher=publisher,
             reason=self._optional_string(policy_memory.get("reason")) or "Guard Cloud policy memory sync",
             source="cloud-sync",
             expires_at=self._optional_string(policy_memory.get("expires_at")),

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -710,6 +710,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json({"error": "unknown_harness"}, status=404)
             return
         policy_memory = self._policy_memory_payload(payload.get("policy_memory"))
+        if not policy_memory:
+            self._write_json({"error": "missing_policy_memory"}, status=400)
+            return
         scope = self._optional_string(policy_memory.get("scope")) or "harness"
         action = self._optional_string(policy_memory.get("action")) or "review"
         if scope not in DECISION_SCOPE_VALUES or action not in GUARD_ACTION_VALUES:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -725,9 +725,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json({"error": "broad_allow_requires_narrow_scope"}, status=400)
             return
         artifact_id = self._optional_string(policy_memory.get("artifact_id"))
-        workspace = self._optional_string(policy_memory.get("workspace")) or self._optional_string(
-            payload.get("workspace_id")
-        )
+        workspace = self._optional_string(policy_memory.get("workspace"))
         publisher = self._optional_string(policy_memory.get("publisher"))
         if not self._scope_target_is_valid(
             scope,

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import io
 import json
 import mimetypes
 import os
+import platform
 import secrets
 import threading
 import time
@@ -40,7 +42,8 @@ from ..config import (
     reset_guard_settings,
     update_guard_settings,
 )
-from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES
+from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES, PolicyDecision
+from ..receipts.manager import build_receipt
 from ..runtime.surface_server import GuardSurfaceRuntime
 from ..store import GuardStore
 from ..store_approvals import InvalidApprovalCursorError
@@ -86,6 +89,24 @@ _DEFAULT_GUARD_DAEMON_IDLE_TIMEOUT_SECONDS = 30 * 60
 _EPHEMERAL_GUARD_DAEMON_IDLE_TIMEOUT_SECONDS = 5
 _GUARD_DAEMON_IDLE_POLL_INTERVAL_SECONDS = 0.5
 _HOSTED_GUARD_DASHBOARD_ORIGINS = frozenset({"https://hol.org", "https://www.hol.org"})
+_HEADLESS_APP_ACTIONS = {
+    "connect": ("install", "install"),
+    "repair": ("repair", "repair"),
+    "disconnect": ("remove", "uninstall"),
+    "status": ("status", "verify"),
+    "test": ("scan", "verify"),
+}
+_HEADLESS_OPERATIONS = ("install", "repair", "remove", "status", "scan", "policy_sync")
+
+
+def _headless_safe_failure_reasons() -> dict[str, str]:
+    return {
+        "offline": "Local Guard daemon is unavailable.",
+        "timeout": "Local Guard daemon did not answer before the browser timeout.",
+        "unauthorized": "Dashboard session is missing or stale.",
+        "unsupported": "Harness is not supported by this daemon.",
+        "confirmation_required": "Remove actions need the harness confirmation phrase.",
+    }
 
 
 class _GuardDaemonHandler(BaseHTTPRequestHandler):
@@ -98,7 +119,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         headers = self._cors_headers_for_request(
             allow_methods="GET, POST, DELETE, OPTIONS",
-            allow_headers="Content-Type, X-Guard-Token",
+            allow_headers="Authorization, Content-Type, X-Guard-Dashboard-Session, X-Guard-Token",
         )
         if headers is None:
             self._write_empty(status=403)
@@ -135,6 +156,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     "package_version": __version__,
                 }
             )
+            return
+        if parsed.path == "/v1/capabilities":
+            self._handle_capabilities()
             return
         if parsed.path == "/v1/sessions":
             self._write_json({"items": store.list_guard_sessions(limit=200)})
@@ -440,6 +464,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if parsed.path == "/v1/policy/clear":
             self._handle_policy_clear(payload)
             return
+        if parsed.path == "/v1/policy/sync":
+            self._handle_headless_policy_sync(payload)
+            return
         if parsed.path == "/v1/settings":
             self._handle_settings_update(payload)
             return
@@ -455,6 +482,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         if len(path_parts) == 4 and path_parts[:2] == ["v1", "harnesses"]:
             self._handle_harness_action(path_parts[2], path_parts[3], payload)
+            return
+        if len(path_parts) == 3 and path_parts[:2] == ["v1", "apps"]:
+            self._handle_headless_app_action(path_parts[2], payload)
             return
         request_id, action, matched = self._resolve_request_action(path_parts, payload)
         if not matched:
@@ -554,6 +584,222 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return (payload if isinstance(payload, dict) else {}), None
         form_payload = parse_qs(raw_body)
         return {key: values[-1] for key, values in form_payload.items() if values}, None
+
+    def _handle_capabilities(self) -> None:
+        context = self._harness_context({})
+        items = list_harness_setup_items(context, self.server.store)  # type: ignore[attr-defined]
+        supported = []
+        for item in items:
+            harness = item.get("harness")
+            if not isinstance(harness, str):
+                continue
+            supported.append(
+                {
+                    "harness": harness,
+                    "status": item.get("status"),
+                    "command_available": bool(item.get("command_available")),
+                    "headless_actions": list(_HEADLESS_OPERATIONS[:-1]),
+                    "safe_failure_reasons": _headless_safe_failure_reasons(),
+                }
+            )
+        self._write_json(
+            {
+                "auth_state": "dashboard_session" if self._dashboard_session_token_is_present() else "local_token",
+                "command_available": any(bool(item.get("command_available")) for item in items),
+                "daemon": {
+                    "compatibility_version": GUARD_DAEMON_COMPATIBILITY_VERSION,
+                    "package_version": __version__,
+                    "platform": platform.system().lower() or "unknown",
+                },
+                "headless_api": {
+                    "operations": list(_HEADLESS_OPERATIONS),
+                    "routes": {
+                        "install": "/v1/apps/connect",
+                        "repair": "/v1/apps/repair",
+                        "remove": "/v1/apps/disconnect",
+                        "status": "/v1/apps/status",
+                        "scan": "/v1/apps/test",
+                        "policy_sync": "/v1/policy/sync",
+                    },
+                },
+                "safe_failure_reasons": _headless_safe_failure_reasons(),
+                "supported_harnesses": sorted(item["harness"] for item in supported),
+                "items": supported,
+            }
+        )
+
+    def _handle_headless_app_action(self, action_path: str, payload: dict[str, object]) -> None:
+        mapping = _HEADLESS_APP_ACTIONS.get(action_path)
+        if mapping is None:
+            self._write_json({"error": "not_found"}, status=404)
+            return
+        operation, harness_action = mapping
+        harness = self._optional_string(payload.get("harness"))
+        if harness is None:
+            self._write_json({"error": "missing_harness"}, status=400)
+            return
+        try:
+            adapter = get_adapter(harness)
+        except ValueError:
+            self._write_json({"error": "unknown_harness"}, status=404)
+            return
+
+        context = self._harness_context(payload)
+        try:
+            if harness_action == "verify":
+                result = build_harness_verification(adapter.harness, context, self.server.store)  # type: ignore[attr-defined]
+            else:
+                result = self._run_headless_managed_action(adapter.harness, harness_action, payload, context)
+        except ValueError as error:
+            self._write_json({"error": str(error)}, status=400)
+            return
+
+        receipt = self._record_headless_receipt(
+            harness=adapter.harness,
+            operation=operation,
+            payload=payload,
+            result=result,
+            workspace_id=self._optional_string(payload.get("workspace_id")),
+        )
+        self._write_json(
+            {
+                "harness": adapter.harness,
+                "operation": operation,
+                "result": result,
+                "receipt": receipt,
+                "status": "completed",
+            }
+        )
+
+    def _run_headless_managed_action(
+        self,
+        harness: str,
+        action: str,
+        payload: dict[str, object],
+        context: HarnessContext,
+    ) -> dict[str, object]:
+        if action == "uninstall":
+            expected_confirmation = uninstall_confirmation_token(harness)
+            confirmation = self._optional_string(payload.get("confirmation_phrase")) or self._optional_string(
+                payload.get("confirmation_token")
+            )
+            if confirmation != expected_confirmation:
+                raise ValueError("confirmation_required")
+        install_command = "uninstall" if action == "uninstall" else "install"
+        return apply_managed_install(
+            install_command,
+            harness,
+            False,
+            context,
+            self.server.store,  # type: ignore[attr-defined]
+            self._optional_string(payload.get("workspace_id")),
+            _now(),
+        )
+
+    def _handle_headless_policy_sync(self, payload: dict[str, object]) -> None:
+        harness = self._optional_string(payload.get("harness"))
+        if harness is None:
+            self._write_json({"error": "missing_harness"}, status=400)
+            return
+        try:
+            adapter = get_adapter(harness)
+        except ValueError:
+            self._write_json({"error": "unknown_harness"}, status=404)
+            return
+        policy_memory = self._policy_memory_payload(payload.get("policy_memory"))
+        scope = self._optional_string(policy_memory.get("scope")) or "harness"
+        action = self._optional_string(policy_memory.get("action")) or "review"
+        if scope not in DECISION_SCOPE_VALUES or action not in GUARD_ACTION_VALUES:
+            self._write_json({"error": "unsupported_policy_value"}, status=400)
+            return
+        decision = PolicyDecision(
+            harness=adapter.harness,
+            scope=scope,  # type: ignore[arg-type]
+            action=action,  # type: ignore[arg-type]
+            artifact_id=self._optional_string(policy_memory.get("artifact_id")),
+            artifact_hash=self._optional_string(policy_memory.get("artifact_hash")),
+            workspace=self._optional_string(policy_memory.get("workspace"))
+            or self._optional_string(payload.get("workspace_id")),
+            publisher=self._optional_string(policy_memory.get("publisher")),
+            reason=self._optional_string(policy_memory.get("reason")) or "Guard Cloud policy memory sync",
+            source="cloud-sync",
+            expires_at=self._optional_string(policy_memory.get("expires_at")),
+        )
+        self.server.store.upsert_policy(decision, _now())  # type: ignore[attr-defined]
+        receipt = self._record_headless_receipt(
+            harness=adapter.harness,
+            operation="policy_sync",
+            payload=payload,
+            result={"decision": decision.to_dict()},
+            workspace_id=decision.workspace,
+        )
+        self._write_json(
+            {
+                "harness": adapter.harness,
+                "operation": "policy_sync",
+                "receipt": receipt,
+                "status": "completed",
+            }
+        )
+
+    @staticmethod
+    def _policy_memory_payload(value: object) -> dict[str, object]:
+        if isinstance(value, dict):
+            return dict(value)
+        if isinstance(value, str) and value.strip():
+            try:
+                parsed = json.loads(value)
+            except json.JSONDecodeError:
+                return {}
+            return parsed if isinstance(parsed, dict) else {}
+        return {}
+
+    def _record_headless_receipt(
+        self,
+        *,
+        harness: str,
+        operation: str,
+        payload: dict[str, object],
+        result: dict[str, object],
+        workspace_id: str | None,
+    ) -> dict[str, object]:
+        material = json.dumps(
+            {
+                "harness": harness,
+                "operation": operation,
+                "result_keys": sorted(result.keys()),
+                "workspace_id": workspace_id,
+            },
+            sort_keys=True,
+        )
+        artifact_hash = hashlib.sha256(material.encode("utf-8")).hexdigest()
+        changed_capabilities = [] if operation in {"status", "scan"} else [operation]
+        receipt = build_receipt(
+            harness=harness,
+            artifact_id=f"headless:{harness}:{operation}",
+            artifact_hash=artifact_hash,
+            policy_decision="allow",
+            capabilities_summary=f"Guard local daemon completed headless {operation}.",
+            changed_capabilities=changed_capabilities,
+            provenance_summary="Guard Cloud local daemon API",
+            artifact_name=f"Headless {operation}",
+            source_scope="local-daemon",
+            scanner_evidence=(
+                {
+                    "operation": operation,
+                    "workspace_id": workspace_id,
+                    "status": "completed",
+                },
+            ),
+            approval_source="guard-cloud-headless",
+        )
+        self.server.store.add_receipt(receipt)  # type: ignore[attr-defined]
+        return {
+            "id": receipt.receipt_id,
+            "operation": operation,
+            "status": "completed",
+            "timestamp": receipt.timestamp,
+        }
 
     def _handle_policy_clear(self, payload: dict[str, object]) -> None:
         harness = self._optional_string(payload.get("harness"))
@@ -1123,7 +1369,23 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
 
     def _header_token_is_valid(self) -> bool:
         token = self.headers.get("X-Guard-Token")
-        return self._tokens_match(token)
+        path = urlparse(self.path).path
+        path_parts = [part for part in path.split("/") if part]
+        return self._tokens_match(token) or (
+            self._is_hosted_dashboard_api_path(path, path_parts) and self._dashboard_session_token_is_present()
+        )
+
+    def _dashboard_session_token_is_present(self) -> bool:
+        session_token = self.headers.get("X-Guard-Dashboard-Session")
+        authorization = self.headers.get("Authorization")
+        bearer_token = None
+        if isinstance(authorization, str) and authorization.lower().startswith("bearer "):
+            bearer_token = authorization[7:].strip()
+        token = session_token if isinstance(session_token, str) and session_token.strip() else bearer_token
+        if not isinstance(token, str) or not token.startswith("gld1."):
+            return False
+        parts = token.split(".")
+        return len(parts) == 3 and all(len(part) >= 8 for part in parts[1:])
 
     def _tokens_match(self, token: object) -> bool:
         if not isinstance(token, str):
@@ -1205,6 +1467,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
     @staticmethod
     def _is_hosted_dashboard_api_path(path: str, path_parts: list[str]) -> bool:
         if path in {
+            "/v1/capabilities",
             "/v1/inventory",
             "/v1/connect/state",
             "/v1/daemon/repair",
@@ -1213,6 +1476,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/harnesses",
             "/v1/policy",
             "/v1/policy/clear",
+            "/v1/policy/sync",
             "/v1/receipts",
             "/v1/receipts/latest",
             "/v1/requests",
@@ -1240,6 +1504,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 "uninstall",
             }
         ):
+            return True
+        if len(path_parts) == 3 and path_parts[:2] == ["v1", "apps"] and path_parts[2] in _HEADLESS_APP_ACTIONS:
             return True
         return len(path_parts) == 4 and path_parts[:2] == ["v1", "artifacts"] and path_parts[3] == "diff"
 
@@ -1279,7 +1545,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         origin: str,
         *,
         allow_methods: str = "POST, OPTIONS",
-        allow_headers: str = "Content-Type, X-Guard-Token",
+        allow_headers: str = "Authorization, Content-Type, X-Guard-Dashboard-Session, X-Guard-Token",
     ) -> dict[str, str]:
         return {
             "Access-Control-Allow-Origin": origin,
@@ -1292,7 +1558,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         self,
         *,
         allow_methods: str = "POST, OPTIONS",
-        allow_headers: str = "Content-Type, X-Guard-Token",
+        allow_headers: str = "Authorization, Content-Type, X-Guard-Dashboard-Session, X-Guard-Token",
     ) -> dict[str, str] | None:
         parsed = urlparse(self.path)
         path_parts = [part for part in parsed.path.split("/") if part]
@@ -1424,11 +1690,14 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/operations/block",
             "/v1/policy/decisions",
             "/v1/policy/clear",
+            "/v1/policy/sync",
             "/v1/settings",
             "/v1/settings/import",
             "/v1/settings/reset",
             "/v1/daemon/repair",
         }:
+            return True
+        if len(path_parts) == 3 and path_parts[:2] == ["v1", "apps"] and path_parts[2] in _HEADLESS_APP_ACTIONS:
             return True
         if len(path_parts) == 4 and path_parts[:2] == ["v1", "operations"] and path_parts[3] in {"items", "status"}:
             return True

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -735,6 +735,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         ):
             self._write_json({"error": "missing_scope_target"}, status=400)
             return
+        expires_at = _normalized_iso_timestamp_string(policy_memory.get("expires_at"))
+        if policy_memory.get("expires_at") is not None and expires_at is None:
+            self._write_json({"error": "invalid_policy_expiry"}, status=400)
+            return
         decision = PolicyDecision(
             harness=adapter.harness,
             scope=scope,  # type: ignore[arg-type]
@@ -745,7 +749,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             publisher=publisher,
             reason=self._optional_string(policy_memory.get("reason")) or "Guard Cloud policy memory sync",
             source="cloud-sync",
-            expires_at=self._optional_string(policy_memory.get("expires_at")),
+            expires_at=expires_at,
         )
         self.server.store.upsert_policy(decision, _now())  # type: ignore[attr-defined]
         receipt = self._record_headless_receipt(
@@ -2037,6 +2041,20 @@ def _parse_iso_timestamp(value: str) -> float:
 
     normalized = value.replace("Z", "+00:00")
     return datetime.fromisoformat(normalized).timestamp()
+
+
+def _normalized_iso_timestamp_string(value: object) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    from datetime import datetime, timezone
+
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).isoformat()
 
 
 def _now() -> str:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -713,8 +713,11 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if not policy_memory:
             self._write_json({"error": "missing_policy_memory"}, status=400)
             return
-        scope = self._optional_string(policy_memory.get("scope")) or "harness"
-        action = self._optional_string(policy_memory.get("action")) or "review"
+        scope = self._optional_string(policy_memory.get("scope"))
+        action = self._optional_string(policy_memory.get("action"))
+        if scope is None or action is None:
+            self._write_json({"error": "missing_policy_fields"}, status=400)
+            return
         if scope not in DECISION_SCOPE_VALUES or action not in GUARD_ACTION_VALUES:
             self._write_json({"error": "unsupported_policy_value"}, status=400)
             return
@@ -1402,8 +1405,15 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         bearer_token = None
         if isinstance(authorization, str) and authorization.lower().startswith("bearer "):
             bearer_token = authorization[7:].strip()
-        token = session_token if isinstance(session_token, str) and session_token.strip() else bearer_token
-        if not isinstance(token, str) or not token.startswith("gld1."):
+        candidates = [
+            candidate
+            for candidate in (session_token, bearer_token)
+            if isinstance(candidate, str) and candidate.strip()
+        ]
+        return any(self._dashboard_session_token_matches(candidate) for candidate in candidates)
+
+    def _dashboard_session_token_matches(self, token: str) -> bool:
+        if not token.startswith("gld1."):
             return False
         parts = token.split(".")
         if len(parts) != 3:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1408,9 +1408,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if isinstance(authorization, str) and authorization.lower().startswith("bearer "):
             bearer_token = authorization[7:].strip()
         candidates = [
-            candidate
-            for candidate in (session_token, bearer_token)
-            if isinstance(candidate, str) and candidate.strip()
+            candidate for candidate in (session_token, bearer_token) if isinstance(candidate, str) and candidate.strip()
         ]
         return any(self._dashboard_session_token_matches(candidate) for candidate in candidates)
 

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/home-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/home-dashboard.js
@@ -32,7 +32,7 @@ function buildEmptyStateCopy() {
   return {
     title: "No apps connected",
     body: "Connect an AI app so Guard can start protecting it. Guard works with Codex, Claude Code, Cursor, Hermes, and more.",
-    installHint: "hol-guard install"
+    installHint: "hol-guard apps connect <app>"
   };
 }
 function buildDaemonErrorCopy() {
@@ -297,7 +297,7 @@ function deriveHomeState(input) {
       heroStatus: "setup_gap",
       headline: "Guard is ready",
       subheadline: "Connect your first AI app so Guard can start protecting it.",
-      ctaLabel: "Open Apps",
+      ctaLabel: "Open Protect",
       ctaTarget: "fleet"
     };
   }
@@ -306,7 +306,7 @@ function deriveHomeState(input) {
       heroStatus: "setup_gap",
       headline: "Finish setup",
       subheadline: "Guard detected apps but they need setup to be fully protected.",
-      ctaLabel: "Open Apps",
+      ctaLabel: "Open Protect",
       ctaTarget: "fleet"
     };
   }
@@ -502,7 +502,7 @@ function CloudStatusCard(props) {
   return /* @__PURE__ */ jsxRuntimeExports.jsx("section", { className: "rounded-2xl border border-brand-blue/15 bg-brand-blue/[0.04] p-5 shadow-sm sm:p-6", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/80 text-brand-blue", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCloud, { className: "h-5 w-5", "aria-hidden": "true" }) }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 flex-1", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Cloud backup" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Cloud sync" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm font-medium text-brand-dark", children: copy.label }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-muted-foreground", children: copy.detail }),
       props.showUpsell && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "outline", onClick: props.onOpenSettings, children: "Open sync settings" }) })

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -14170,9 +14170,9 @@ function ShellHeader(props) {
 }
 const sidebarLinks = [
   { href: "/", label: "Home", view: "home", icon: HiMiniHome },
-  { href: "/inbox", label: "Review", view: "inbox", icon: HiMiniInbox },
-  { href: "/fleet", label: "Apps", view: "fleet", icon: HiMiniServerStack },
-  { href: "/evidence", label: "History", view: "evidence", icon: HiMiniDocumentText },
+  { href: "/inbox", label: "Inbox", view: "inbox", icon: HiMiniInbox },
+  { href: "/fleet", label: "Protect", view: "fleet", icon: HiMiniShieldCheck },
+  { href: "/evidence", label: "Evidence", view: "evidence", icon: HiMiniDocumentText },
   { href: "/settings", label: "Settings", view: "settings", icon: HiMiniAdjustmentsHorizontal }
 ];
 function ShellSidebar(props) {
@@ -14205,7 +14205,7 @@ function ShellSidebar(props) {
       )
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-1 flex-col overflow-y-auto px-3 py-5", children: [
-      !collapsed && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mb-2 px-3 font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-400", children: "Dashboard" }),
+      !collapsed && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mb-2 px-3 font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-400", children: "Guard" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("nav", { className: "flex flex-col gap-0.5", "aria-label": "Guard dashboard", children: sidebarLinks.map((item) => {
         const Icon = item.icon;
         return /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -14419,7 +14419,7 @@ function WelcomeState(props) {
           /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: props.connectUrl, children: "Open pairing flow" }),
           props.dashboardUrl ? /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: props.dashboardUrl, variant: "outline", children: "Open Home" }) : null,
           props.inboxUrl ? /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: props.inboxUrl, variant: "outline", children: "Review Queue" }) : null,
-          props.fleetUrl ? /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: props.fleetUrl, variant: "outline", children: "Watched Apps" }) : null
+          props.fleetUrl ? /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: props.fleetUrl, variant: "outline", children: "Protect" }) : null
         ] }) : /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-3 rounded-lg bg-surface-1 px-5 py-3 font-mono text-sm", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-muted-foreground", children: "$" }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-brand-dark", children: "hol-guard connect" })
@@ -17579,28 +17579,29 @@ const REVIEW_SEMANTIC_GROUPS = [
   { id: "all", label: "All", matches: [] },
   {
     id: "files",
-    label: "Files",
+    label: "File read / write",
     matches: ["file_read", "source_edit", "docs_edit", "generated_inventory_edit"]
   },
   {
     id: "shell",
-    label: "Shell",
+    label: "Shell execution",
     matches: ["shell_command", "destructive_shell", "encoded_shell", "git_operation", "process_control"]
   },
   {
     id: "network",
-    label: "Network & Data",
+    label: "Network / data egress",
     matches: ["network", "secret_exfiltration", "secret_file_read", "credential_output", "file_upload"]
   },
   {
     id: "tools",
-    label: "Tools & Apps",
-    matches: ["mcp_tool", "package_script", "harness_start", "browser_action", "package_install"]
+    label: "MCP, skill & packages",
+    matches: ["mcp_tool", "package_script", "browser_action", "package_install"]
   },
   {
     id: "other",
-    label: "Other",
+    label: "Agent autonomy & other",
     matches: [
+      "harness_start",
       "prompt_injection",
       "system_prompt_access",
       "guard_bypass",
@@ -17614,15 +17615,15 @@ const REVIEW_SEMANTIC_GROUPS = [
 const QUEUE_CATEGORIES = [
   {
     id: "credential_output",
-    label: "Credential-looking output",
-    shortLabel: "Credential output",
-    description: "Command output appears to expose tokens, keys, passwords, or secret-looking values."
+    label: "Secret-looking output",
+    shortLabel: "Secret output",
+    description: "Command output contains patterns that resemble tokens, keys, passwords, or other secret-looking values. Review before allowing if this output will leave the local machine."
   },
   {
     id: "secret_file_read",
-    label: "Secret file read",
+    label: "Secret file access",
     shortLabel: "Secret read",
-    description: "Reads local credential stores, environment files, tokens, keys, or other secret paths."
+    description: "Reads paths known to store secrets: env files, credential stores, token files, SSH keys, or cloud config. Normal source reads are classified as file read instead."
   },
   {
     id: "file_read",
@@ -17758,9 +17759,9 @@ const QUEUE_CATEGORIES = [
   },
   {
     id: "harness_start",
-    label: "Harness launch",
-    shortLabel: "Launch",
-    description: "Starts or reconnects an AI app under Guard control."
+    label: "Agent launch",
+    shortLabel: "Agent launch",
+    description: "Starts or reconnects an AI agent or harness under Guard control. Review when unexpected autonomy or a new session begins."
   },
   {
     id: "shell_command",
@@ -21178,7 +21179,7 @@ function App() {
         children: "Skip to content"
       }
     ),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { "aria-live": "polite", "aria-atomic": "true", className: "sr-only", children: view === "home" ? "Home" : view === "inbox" ? "Review" : view === "fleet" ? "Apps" : view === "evidence" ? "History" : view === "settings" ? "Settings" : "App detail" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { "aria-live": "polite", "aria-atomic": "true", className: "sr-only", children: view === "home" ? "Home" : view === "inbox" ? "Inbox" : view === "fleet" ? "Protect" : view === "evidence" ? "Evidence" : view === "settings" ? "Settings" : "App detail" }),
     /* @__PURE__ */ jsxRuntimeExports.jsx(
       ApprovalCenterLayout,
       {

--- a/tests/test_cursor_adapter.py
+++ b/tests/test_cursor_adapter.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.cursor import CursorHarnessAdapter
 

--- a/tests/test_gemini_adapter.py
+++ b/tests/test_gemini_adapter.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.gemini import GeminiHarnessAdapter
 

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -1741,7 +1741,7 @@ class TestGuardApprovals:
             daemon.stop()
 
         assert status == 200
-        assert allow_headers == "Content-Type, X-Guard-Token"
+        assert allow_headers == "Authorization, Content-Type, X-Guard-Dashboard-Session, X-Guard-Token"
 
     def test_guard_daemon_allows_hosted_guard_dashboard_to_resolve_requests(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import sqlite3
 import subprocess
@@ -67,6 +68,21 @@ def _write_codex_pre_tool_payload(path: Path, workspace_dir: Path, command: str)
             }
         ),
     )
+
+
+def test_guard_help_uses_ai_antivirus_product_language() -> None:
+    parser = argparse.ArgumentParser(prog="hol-guard")
+    guard_commands_module.add_guard_root_parser(parser)
+
+    help_text = parser.format_help()
+
+    assert "AI Antivirus" in help_text
+    assert "Home" in help_text
+    assert "Protect" in help_text
+    assert "Inbox" in help_text
+    assert "Evidence" in help_text
+    assert "Settings" in help_text
+    assert "Watched Apps" not in help_text
 
 
 def test_guard_settings_show_and_update_security_level(tmp_path, capsys):

--- a/tests/test_guard_hashnet_mcp_canaries.py
+++ b/tests/test_guard_hashnet_mcp_canaries.py
@@ -13,13 +13,10 @@ Scenarios:
 
 from __future__ import annotations
 
-import pytest
-
 from codex_plugin_scanner.guard.runtime.mcp_protection import (
     build_mcp_server_identity,
     build_mcp_tool_identity,
 )
-
 
 _HASHNET_CONFIG_PATH = "~/.codex/config.toml"
 

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -33,6 +33,8 @@ def _request(
     method: str = "POST",
     payload: dict[str, object] | None = None,
     token: str | None = None,
+    authorization_token: str | None = None,
+    dashboard_session_token: str | None = None,
     origin: str = "https://hol.org",
 ) -> urllib.request.Request:
     data = json.dumps(payload or {}).encode("utf-8") if method != "GET" else None
@@ -43,6 +45,10 @@ def _request(
     if token is not None:
         headers["Authorization"] = f"Bearer {token}"
         headers["X-Guard-Dashboard-Session"] = token
+    if authorization_token is not None:
+        headers["Authorization"] = f"Bearer {authorization_token}"
+    if dashboard_session_token is not None:
+        headers["X-Guard-Dashboard-Session"] = dashboard_session_token
     return urllib.request.Request(
         f"http://127.0.0.1:{port}{path}",
         data=data,
@@ -250,6 +256,32 @@ def test_headless_policy_sync_rejects_empty_policy_memory(tmp_path: Path) -> Non
     assert store.list_policy_decisions(harness="codex") == []
 
 
+def test_headless_policy_sync_requires_explicit_scope_and_action(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/policy/sync",
+                token=token,
+                payload={
+                    "harness": "codex",
+                    "operation": "policy_sync",
+                    "policy_memory": json.dumps({"reason": "missing scope and action"}),
+                },
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 400
+    assert payload["error"] == "missing_policy_fields"
+    assert store.list_policy_decisions(harness="codex") == []
+
+
 def test_headless_api_rejects_missing_auth_and_bad_harness(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
@@ -299,6 +331,28 @@ def test_headless_api_rejects_forged_dashboard_session_token(tmp_path: Path) -> 
 
     assert status == 401
     assert payload["error"] == "unauthorized"
+
+
+def test_headless_api_uses_valid_bearer_session_when_session_header_is_bad(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/apps/status",
+                payload={"harness": "codex", "operation": "status"},
+                authorization_token=token,
+                dashboard_session_token="gld1.abcdefghijklmnop.qrstuvwxyz123456",
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert payload["receipt"]["operation"] == "status"
 
 
 def test_headless_api_does_not_read_env_files(

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -183,6 +183,48 @@ def test_headless_policy_sync_persists_policy_and_receipt(tmp_path: Path) -> Non
     assert store.list_receipts(limit=5, harness="codex")
 
 
+def test_headless_policy_sync_rejects_global_allow_and_missing_scope_targets(
+    tmp_path: Path,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        global_status, global_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/policy/sync",
+                token=token,
+                payload={
+                    "harness": "codex",
+                    "operation": "policy_sync",
+                    "policy_memory": json.dumps({"scope": "global", "action": "allow"}),
+                },
+            ),
+        )
+        workspace_status, workspace_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/policy/sync",
+                token=token,
+                payload={
+                    "harness": "codex",
+                    "operation": "policy_sync",
+                    "policy_memory": json.dumps({"scope": "workspace", "action": "review"}),
+                },
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert global_status == 400
+    assert global_payload["error"] == "broad_allow_requires_narrow_scope"
+    assert workspace_status == 400
+    assert workspace_payload["error"] == "missing_scope_target"
+    assert store.list_policy_decisions(harness="codex") == []
+
+
 def test_headless_api_rejects_missing_auth_and_bad_harness(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -1,0 +1,213 @@
+"""Headless daemon API contract for Guard Cloud app actions."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.daemon import GuardDaemonServer
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _read_json_response(request: urllib.request.Request) -> tuple[int, dict[str, object]]:
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            return response.status, json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        return error.code, json.loads(error.read().decode("utf-8"))
+
+
+def _request(
+    port: int,
+    path: str,
+    *,
+    method: str = "POST",
+    payload: dict[str, object] | None = None,
+    token: str | None = "gld1.abcdefghijklmnop.qrstuvwxyz123456",
+    origin: str = "https://hol.org",
+) -> urllib.request.Request:
+    data = json.dumps(payload or {}).encode("utf-8") if method != "GET" else None
+    headers = {
+        "Content-Type": "application/json",
+        "Origin": origin,
+    }
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+        headers["X-Guard-Dashboard-Session"] = token
+    return urllib.request.Request(
+        f"http://127.0.0.1:{port}{path}",
+        data=data,
+        headers=headers,
+        method=method,
+    )
+
+
+def test_headless_capabilities_endpoint_reports_safe_action_contract(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, payload = _read_json_response(
+            _request(daemon.port, "/v1/capabilities", method="GET"),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert payload["auth_state"] == "dashboard_session"
+    assert payload["headless_api"]["operations"] == [
+        "install",
+        "repair",
+        "remove",
+        "status",
+        "scan",
+        "policy_sync",
+    ]
+    assert "codex" in payload["supported_harnesses"]
+    assert payload["safe_failure_reasons"]["unsupported"] == "Harness is not supported by this daemon."
+
+
+def test_headless_app_operations_write_receipts_without_cli_copy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        for path, operation in (
+            ("/v1/apps/connect", "install"),
+            ("/v1/apps/repair", "repair"),
+            ("/v1/apps/status", "status"),
+            ("/v1/apps/test", "scan"),
+            ("/v1/apps/disconnect", "remove"),
+        ):
+            status, payload = _read_json_response(
+                _request(
+                    daemon.port,
+                    path,
+                    payload={
+                        "harness": "opencode",
+                        "operation": operation,
+                        "workspace_id": "workspace-1",
+                        "confirmation_phrase": "disconnect-opencode",
+                    },
+                ),
+            )
+            assert status == 200
+            assert payload["receipt"]["status"] == "completed"
+            assert payload["receipt"]["operation"] == operation
+            assert "npx" not in json.dumps(payload)
+    finally:
+        daemon.stop()
+
+    receipts = store.list_receipts(limit=20, harness="opencode")
+    receipt_operations = {receipt["artifact_name"] for receipt in receipts}
+    assert {
+        "Headless install",
+        "Headless repair",
+        "Headless status",
+        "Headless scan",
+        "Headless remove",
+    }.issubset(receipt_operations)
+
+
+def test_headless_policy_sync_persists_policy_and_receipt(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/policy/sync",
+                payload={
+                    "harness": "codex",
+                    "operation": "policy_sync",
+                    "workspace_id": "workspace-1",
+                    "policy_memory": json.dumps(
+                        {
+                            "scope": "harness",
+                            "action": "review",
+                            "reason": "Cloud policy memory",
+                        }
+                    ),
+                },
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert payload["receipt"]["operation"] == "policy_sync"
+    decisions = store.list_policy_decisions(harness="codex")
+    assert decisions[0]["scope"] == "harness"
+    assert decisions[0]["action"] == "review"
+    assert store.list_receipts(limit=5, harness="codex")
+
+
+def test_headless_api_rejects_missing_auth_and_bad_harness(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        auth_status, auth_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/apps/status",
+                payload={"harness": "codex", "operation": "status"},
+                token=None,
+            ),
+        )
+        bad_status, bad_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/apps/status",
+                payload={"harness": "not-real", "operation": "status"},
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert auth_status == 401
+    assert auth_payload["error"] == "unauthorized"
+    assert bad_status == 404
+    assert bad_payload["error"] == "unknown_harness"
+
+
+def test_headless_api_does_not_read_env_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    env_path = home / ".agents" / "skills" / "x" / ".env"
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    env_path.write_text("SECRET=value\n", encoding="utf-8")
+    monkeypatch.setattr(Path, "home", lambda: home)
+    original_read_text = Path.read_text
+
+    def guarded_read_text(path: Path, *args: object, **kwargs: object) -> str:
+        if path.name == ".env":
+            raise AssertionError("headless daemon API must not read .env files")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", guarded_read_text)
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, payload = _read_json_response(
+            _request(daemon.port, "/v1/apps/test", payload={"harness": "codex", "operation": "scan"}),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert payload["receipt"]["operation"] == "scan"

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
+import hmac
 import json
 import urllib.error
 import urllib.request
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
+from codex_plugin_scanner.guard.daemon.manager import load_guard_daemon_auth_token
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -27,7 +32,7 @@ def _request(
     *,
     method: str = "POST",
     payload: dict[str, object] | None = None,
-    token: str | None = "gld1.abcdefghijklmnop.qrstuvwxyz123456",
+    token: str | None = None,
     origin: str = "https://hol.org",
 ) -> urllib.request.Request:
     data = json.dumps(payload or {}).encode("utf-8") if method != "GET" else None
@@ -46,13 +51,34 @@ def _request(
     )
 
 
+def _dashboard_token(auth_token: str) -> str:
+    payload_json = json.dumps(
+        {
+            "version": "guard-local-daemon-session.v1",
+            "expires_at": datetime(2099, 1, 1, tzinfo=timezone.utc).isoformat(),
+        },
+        separators=(",", ":"),
+    )
+    payload = base64.urlsafe_b64encode(payload_json.encode("utf-8")).decode("ascii").rstrip("=")
+    signature = hmac.new(auth_token.encode("utf-8"), payload.encode("utf-8"), hashlib.sha256).digest()
+    encoded_signature = base64.urlsafe_b64encode(signature).decode("ascii").rstrip("=")
+    return f"gld1.{payload}.{encoded_signature}"
+
+
+def _dashboard_token_for(store: GuardStore) -> str:
+    auth_token = load_guard_daemon_auth_token(store.guard_home)
+    assert auth_token is not None
+    return _dashboard_token(auth_token)
+
+
 def test_headless_capabilities_endpoint_reports_safe_action_contract(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
     try:
+        token = _dashboard_token_for(store)
         status, payload = _read_json_response(
-            _request(daemon.port, "/v1/capabilities", method="GET"),
+            _request(daemon.port, "/v1/capabilities", method="GET", token=token),
         )
     finally:
         daemon.stop()
@@ -82,6 +108,7 @@ def test_headless_app_operations_write_receipts_without_cli_copy(
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
     try:
+        token = _dashboard_token_for(store)
         for path, operation in (
             ("/v1/apps/connect", "install"),
             ("/v1/apps/repair", "repair"),
@@ -93,6 +120,7 @@ def test_headless_app_operations_write_receipts_without_cli_copy(
                 _request(
                     daemon.port,
                     path,
+                    token=token,
                     payload={
                         "harness": "opencode",
                         "operation": operation,
@@ -124,10 +152,12 @@ def test_headless_policy_sync_persists_policy_and_receipt(tmp_path: Path) -> Non
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
     try:
+        token = _dashboard_token_for(store)
         status, payload = _read_json_response(
             _request(
                 daemon.port,
                 "/v1/policy/sync",
+                token=token,
                 payload={
                     "harness": "codex",
                     "operation": "policy_sync",
@@ -158,6 +188,7 @@ def test_headless_api_rejects_missing_auth_and_bad_harness(tmp_path: Path) -> No
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
     try:
+        token = _dashboard_token_for(store)
         auth_status, auth_payload = _read_json_response(
             _request(
                 daemon.port,
@@ -170,6 +201,7 @@ def test_headless_api_rejects_missing_auth_and_bad_harness(tmp_path: Path) -> No
             _request(
                 daemon.port,
                 "/v1/apps/status",
+                token=token,
                 payload={"harness": "not-real", "operation": "status"},
             ),
         )
@@ -180,6 +212,26 @@ def test_headless_api_rejects_missing_auth_and_bad_harness(tmp_path: Path) -> No
     assert auth_payload["error"] == "unauthorized"
     assert bad_status == 404
     assert bad_payload["error"] == "unknown_harness"
+
+
+def test_headless_api_rejects_forged_dashboard_session_token(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/apps/status",
+                payload={"harness": "codex", "operation": "status"},
+                token="gld1.abcdefghijklmnop.qrstuvwxyz123456",
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 401
+    assert payload["error"] == "unauthorized"
 
 
 def test_headless_api_does_not_read_env_files(
@@ -203,8 +255,14 @@ def test_headless_api_does_not_read_env_files(
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
     try:
+        token = _dashboard_token_for(store)
         status, payload = _read_json_response(
-            _request(daemon.port, "/v1/apps/test", payload={"harness": "codex", "operation": "scan"}),
+            _request(
+                daemon.port,
+                "/v1/apps/test",
+                token=token,
+                payload={"harness": "codex", "operation": "scan"},
+            ),
         )
     finally:
         daemon.stop()

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -221,6 +221,19 @@ def test_headless_policy_sync_rejects_global_allow_and_missing_scope_targets(
                 },
             ),
         )
+        cloud_workspace_status, cloud_workspace_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/policy/sync",
+                token=token,
+                payload={
+                    "harness": "codex",
+                    "operation": "policy_sync",
+                    "workspace_id": "cloud-workspace-id",
+                    "policy_memory": json.dumps({"scope": "workspace", "action": "review"}),
+                },
+            ),
+        )
     finally:
         daemon.stop()
 
@@ -228,6 +241,8 @@ def test_headless_policy_sync_rejects_global_allow_and_missing_scope_targets(
     assert global_payload["error"] == "broad_allow_requires_narrow_scope"
     assert workspace_status == 400
     assert workspace_payload["error"] == "missing_scope_target"
+    assert cloud_workspace_status == 400
+    assert cloud_workspace_payload["error"] == "missing_scope_target"
     assert store.list_policy_decisions(harness="codex") == []
 
 

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -225,6 +225,31 @@ def test_headless_policy_sync_rejects_global_allow_and_missing_scope_targets(
     assert store.list_policy_decisions(harness="codex") == []
 
 
+def test_headless_policy_sync_rejects_empty_policy_memory(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/policy/sync",
+                token=token,
+                payload={
+                    "harness": "codex",
+                    "operation": "policy_sync",
+                },
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 400
+    assert payload["error"] == "missing_policy_memory"
+    assert store.list_policy_decisions(harness="codex") == []
+
+
 def test_headless_api_rejects_missing_auth_and_bad_harness(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -172,6 +172,7 @@ def test_headless_policy_sync_persists_policy_and_receipt(tmp_path: Path) -> Non
                         {
                             "scope": "harness",
                             "action": "review",
+                            "expires_at": "2099-01-01T00:00:00Z",
                             "reason": "Cloud policy memory",
                         }
                     ),
@@ -186,6 +187,7 @@ def test_headless_policy_sync_persists_policy_and_receipt(tmp_path: Path) -> Non
     decisions = store.list_policy_decisions(harness="codex")
     assert decisions[0]["scope"] == "harness"
     assert decisions[0]["action"] == "review"
+    assert decisions[0]["expires_at"] == "2099-01-01T00:00:00+00:00"
     assert store.list_receipts(limit=5, harness="codex")
 
 
@@ -294,6 +296,38 @@ def test_headless_policy_sync_requires_explicit_scope_and_action(tmp_path: Path)
 
     assert status == 400
     assert payload["error"] == "missing_policy_fields"
+    assert store.list_policy_decisions(harness="codex") == []
+
+
+def test_headless_policy_sync_rejects_malformed_expiry(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/policy/sync",
+                token=token,
+                payload={
+                    "harness": "codex",
+                    "operation": "policy_sync",
+                    "policy_memory": json.dumps(
+                        {
+                            "scope": "harness",
+                            "action": "review",
+                            "expires_at": "9",
+                        }
+                    ),
+                },
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 400
+    assert payload["error"] == "invalid_policy_expiry"
     assert store.list_policy_decisions(harness="codex") == []
 
 

--- a/tests/test_guard_product_flow.py
+++ b/tests/test_guard_product_flow.py
@@ -305,13 +305,15 @@ class TestGuardProductFlow:
         output = capsys.readouterr().out
 
         assert excinfo.value.code == 0
-        assert "Everyday protection:" in output
+        assert "HOL Guard AI Antivirus command center:" in output
         assert "Team and cloud coordination:" in output
         assert "Advanced and diagnostics:" in output
-        assert "start        First-run setup and the Guard operating loop" in output
+        assert "start        First-run protection setup for one local AI harness" in output
         assert "connect      Pair this machine to Guard Cloud" in output
         assert "doctor       Run local diagnostics" in output
-        assert "Use status for current posture" in output
+        assert "Use status for Home posture" in output
+        assert "Use apps for Protect install, repair, status, and first protected action proof" in output
+        assert "Use approvals for Inbox decisions and receipts for Evidence" in output
         assert "Use doctor for setup and runtime probes" in output
         assert "Use diff for changed artifacts" in output
         assert "Use explain for detailed artifact evidence" in output

--- a/tests/test_guard_receipt_p5_fields.py
+++ b/tests/test_guard_receipt_p5_fields.py
@@ -17,11 +17,11 @@ from pathlib import Path
 
 import pytest
 
-from codex_plugin_scanner.guard.models import GuardReceipt
-from codex_plugin_scanner.guard.receipts.manager import build_receipt, _auto_diff_summary
-from codex_plugin_scanner.guard.store import GuardStore
 from codex_plugin_scanner.guard.consumer.service import _build_diff_summary
 from codex_plugin_scanner.guard.mcp_tool_calls import _map_approval_source
+from codex_plugin_scanner.guard.models import GuardReceipt
+from codex_plugin_scanner.guard.receipts.manager import _auto_diff_summary, build_receipt
+from codex_plugin_scanner.guard.store import GuardStore
 
 
 def _make_store(tmp_path: Path) -> GuardStore:
@@ -85,7 +85,11 @@ class TestBuildDiffSummary:
         assert _build_diff_summary(diff) == "artifact changed"
 
     def test_changed_with_fields(self) -> None:
-        diff: dict[str, object] = {"changed": True, "changed_fields": ["hash", "capability_delta"], "current_hash": "abc"}
+        diff: dict[str, object] = {
+            "changed": True,
+            "changed_fields": ["hash", "capability_delta"],
+            "current_hash": "abc",
+        }
         result = _build_diff_summary(diff)
         assert result == "2 change(s): hash, capability_delta"
 

--- a/tests/test_guard_registry_broker_skills_canaries.py
+++ b/tests/test_guard_registry_broker_skills_canaries.py
@@ -13,15 +13,11 @@ These tests verify that:
 
 from __future__ import annotations
 
-import pytest
-
 from codex_plugin_scanner.guard.consumer.service import (
     build_provenance_bundle,
     score_verdict,
 )
 from codex_plugin_scanner.guard.types import ProvenanceBundle
-from codex_plugin_scanner.guard.store import GuardStore
-
 
 _HOL_REGISTRY_PUBLISHER = "@hol-org/registry"
 _HOL_REGISTRY_ADVISORY_CLEAN = {
@@ -46,7 +42,7 @@ class _FakeStore:
     def __init__(self, advisories: list[dict]) -> None:
         self._advisories = advisories
 
-    def list_cached_advisories(self, *, limit: int = 200) -> list[dict]:  # noqa: D401
+    def list_cached_advisories(self, *, limit: int = 200) -> list[dict]:
         return self._advisories[:limit]
 
 
@@ -72,8 +68,6 @@ class TestRegistryBrokerSkillsAttested:
 
     def test_verdict_action_is_allow_for_clean_artifact(self) -> None:
         from codex_plugin_scanner.guard.types import (
-            GuardSignal,
-            CapabilityDelta,
             HistoryContext,
         )
 


### PR DESCRIPTION
## Summary
- add headless local daemon app endpoints for app actions, policy sync, capabilities, and receipts
- align local Guard command center labels and review taxonomy with AI Antivirus surfaces
- document local CLI, daemon, and cloud continuity

## Validation
- ruff check src tests
- pytest -q
- cd dashboard && pnpm test -- --run
- cd dashboard && pnpm build