### PR TITLE
fix(security): resolve litellm and sed redos alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ pip install "hol-guard[cisco]"
 pip install "plugin-scanner[cisco]"
 ```
 
-`cisco-ai-mcp-scanner` stays in the optional `cisco` extra because it is Python 3.11+ only and adds a heavier YARA-backed install surface than the lean baseline should require. Cisco currently pins `litellm==1.83.0` in both scanner projects as its verified safe release after the PyPI compromise, so this repository keeps that Cisco-validated pin for full coverage.
+`cisco-ai-mcp-scanner` stays in the optional `cisco` extra because it is Python 3.11+ only and adds a heavier YARA-backed install surface than the lean baseline should require. Cisco currently supports the patched `litellm==1.83.10` release across the scanner install surface, so this repository keeps that Cisco-compatible pin for full coverage.
 
 On Guard surfaces, the Cisco extra adds optional offline evidence to `hol-guard scan`, `hol-guard preflight`, and `hol-guard explain <path>`. Use `--cisco-mode {auto,on,off}` to control that consumer-mode evidence path for local artifact scans. `hol-guard run` and Guard runtime prompt/file-read protection remain native Guard behavior in this pass.
 

--- a/docker-requirements.txt
+++ b/docker-requirements.txt
@@ -967,9 +967,9 @@ linkify-it-py==2.1.0 \
     --hash=sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e \
     --hash=sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b
     # via markdown-it-py
-litellm==1.83.0 \
-    --hash=sha256:860bebc76c4bb27b4cf90b4a77acd66dba25aced37e3db98750de8a1766bfb7a \
-    --hash=sha256:88c536d339248f3987571493015784671ba3f193a328e1ea6780dbebaa2094a8
+litellm==1.83.10 \
+    --hash=sha256:55203a7b5551efec8f2fccde29ee045ba057e768591e0b6b9fe1d12f00685ff8 \
+    --hash=sha256:d54eaa98f93a1eb02decf593dbb525fa1ddd4cf03686c1d5c7bb69c2a9ba2a41
     # via
     #   --override (workspace)
     #   cisco-ai-mcp-scanner

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ override-dependencies = [
     "cisco-ai-skill-scanner==2.0.9",
     "importlib-metadata==9.0.0",
     "jsonschema==4.26.0",
-    "litellm==1.83.0",
+    "litellm==1.83.10",
     "openai==2.36.0",
     "python-dotenv==1.2.2",
     "python-multipart==0.0.28",

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -132,6 +132,7 @@ from ..runtime.secret_sensitivity import (
     classify_secret_content,
     classify_secret_path,
 )
+from ..runtime.sed_scripts import sed_script_is_bounded_print
 from ..runtime.signals import RiskSignalV2
 from ..runtime.surface_server import GuardSurfaceRuntime
 from ..store import GuardStore
@@ -5178,7 +5179,6 @@ _CODEX_BENIGN_SECRET_FIXTURE_ASSIGNMENT_PATTERN = re.compile(
     \s*"""
 )
 _CODEX_SENSITIVE_SEARCH_BASENAMES = SOURCE_INSPECTION_SENSITIVE_PARTS | frozenset({"id_rsa"})
-_CODEX_SED_PRINT_SCRIPT_PATTERN = re.compile(r"^\s*(?:\$|\d+)?(?:\s*,\s*(?:\$|\d+))?p\s*$")
 _CODEX_GIT_DIFF_VALUE_OPTIONS = frozenset(
     {
         "--diff-filter",
@@ -5645,7 +5645,7 @@ def _codex_sed_targets_are_read_only_source_like(args: list[str], *, cwd: Path |
     return (
         bool(parsed.targets)
         and parsed.saw_print_suppression
-        and all(_CODEX_SED_PRINT_SCRIPT_PATTERN.fullmatch(script.strip()) for script in parsed.scripts)
+        and all(sed_script_is_bounded_print(script) for script in parsed.scripts)
         and all(_codex_search_target_is_source_like(target, cwd=cwd) for target in parsed.targets)
     )
 
@@ -5657,7 +5657,7 @@ def _codex_sed_args_are_bounded_filter(args: list[str]) -> bool:
     return (
         not parsed.targets
         and parsed.saw_print_suppression
-        and all(_CODEX_SED_PRINT_SCRIPT_PATTERN.fullmatch(script.strip()) for script in parsed.scripts)
+        and all(sed_script_is_bounded_print(script) for script in parsed.scripts)
     )
 
 

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -25,6 +25,7 @@ from .false_positive_rules import (
 )
 from .secret_sensitivity import SecretPathMatch as SensitivePathMatch
 from .secret_sensitivity import classify_secret_path
+from .sed_scripts import sed_script_is_bounded_print
 
 _FILE_READ_TOOL_NAMES = frozenset(
     {
@@ -3143,7 +3144,7 @@ def _read_only_lookup_sed_args_are_safe(args: list[str], *, require_target: bool
 
 
 def _read_only_lookup_sed_script_is_print_only(script: str) -> bool:
-    return bool(re.fullmatch(r"\s*(?:\$|\d+)?(?:\s*,\s*(?:\$|\d+))?p\s*", script))
+    return sed_script_is_bounded_print(script)
 
 
 def _read_only_lookup_head_tail_args_are_safe(args: list[str], *, require_target: bool) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/sed_scripts.py
+++ b/src/codex_plugin_scanner/guard/runtime/sed_scripts.py
@@ -1,0 +1,24 @@
+"""Safe sed script classifiers used by Guard runtime checks."""
+
+from __future__ import annotations
+
+
+def sed_script_is_bounded_print(script: str) -> bool:
+    stripped = script.strip()
+    if not stripped.endswith("p"):
+        return False
+
+    body = stripped[:-1].strip()
+    if not body:
+        return True
+    parts = body.split(",")
+    if len(parts) > 2:
+        return False
+    return all(sed_address_is_bounded(part) for part in parts)
+
+
+def sed_address_is_bounded(value: str) -> bool:
+    address = value.strip()
+    if address == "$":
+        return True
+    return address.isdecimal() and 1 <= len(address) <= 6

--- a/tests/test_cisco_install_surfaces.py
+++ b/tests/test_cisco_install_surfaces.py
@@ -30,7 +30,7 @@ def test_pyproject_keeps_cisco_mcp_scanner_optional() -> None:
     assert "cisco-ai-skill-scanner==2.0.9" in override_entries
     assert "importlib-metadata==9.0.0" in override_entries
     assert "jsonschema==4.26.0" in override_entries
-    assert "litellm==1.83.0" in override_entries
+    assert "litellm==1.83.10" in override_entries
     assert "openai==2.36.0" in override_entries
     assert "python-dotenv==1.2.2" in override_entries
     assert "python-multipart==0.0.28" in override_entries
@@ -61,7 +61,7 @@ def test_readme_distinguishes_baseline_and_full_cisco_installs() -> None:
     assert 'pip install "hol-guard[cisco]"' in readme
     assert 'pip install "plugin-scanner[cisco]"' in readme
     assert "Python 3.11+" in readme
-    assert "verified safe release after the PyPI compromise" in readme
+    assert "patched `litellm==1.83.10` release" in readme
     assert "deferred" in readme
     assert "cisco-ai-a2a-scanner" in readme
     assert "cisco-aibom" in readme
@@ -87,7 +87,7 @@ def test_repo_controlled_surfaces_prefer_cisco_extra_where_supported() -> None:
     assert "aiohttp==3.13.5" in docker_requirements
     assert "cisco-ai-mcp-scanner==" in docker_requirements
     assert "importlib-metadata==9.0.0" in docker_requirements
-    assert "litellm==1.83.0" in docker_requirements
+    assert "litellm==1.83.10" in docker_requirements
     assert "python-dotenv==1.2.2" in docker_requirements
     assert "python-multipart==0.0.28" in docker_requirements
     assert "tokenizers==0.23.1" in docker_requirements

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13444,6 +13444,21 @@ def test_codex_read_only_source_inspection_allows_safe_sed_chains(tmp_path: Path
     assert artifact is None
 
 
+def test_codex_read_only_source_inspection_rejects_unbounded_sed_ranges(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "safe.ts"
+    _write_text(source_file, "export const safe = true;\n")
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        "sed -n '9999999p' src/safe.ts",
+        cwd=workspace_dir,
+    )
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        f"sed -n '{'9' * 10000}p' src/safe.ts",
+        cwd=workspace_dir,
+    )
+
+
 def test_codex_read_only_source_inspection_rejects_sed_chain_with_secret_file(tmp_path: Path) -> None:
     workspace_dir = tmp_path / "workspace"
     route_file = workspace_dir / "src" / "api" / "routes" / "skill-registry.ts"

--- a/uv.lock
+++ b/uv.lock
@@ -19,7 +19,7 @@ overrides = [
     { name = "click", specifier = "==8.3.3" },
     { name = "importlib-metadata", specifier = "==9.0.0" },
     { name = "jsonschema", specifier = "==4.26.0" },
-    { name = "litellm", specifier = "==1.83.0" },
+    { name = "litellm", specifier = "==1.83.10" },
     { name = "openai", specifier = "==2.36.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "python-multipart", specifier = "==0.0.28" },
@@ -1488,7 +1488,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.83.0"
+version = "1.83.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1504,9 +1504,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/92/6ce9737554994ca8e536e5f4f6a87cc7c4774b656c9eb9add071caf7d54b/litellm-1.83.0.tar.gz", hash = "sha256:860bebc76c4bb27b4cf90b4a77acd66dba25aced37e3db98750de8a1766bfb7a", size = 17333062, upload-time = "2026-03-31T05:08:25.331Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/16/fc51935e406887079f0d7c20427b9a15b9fc1d558e68b4e7072331b70db4/litellm-1.83.10.tar.gz", hash = "sha256:d54eaa98f93a1eb02decf593dbb525fa1ddd4cf03686c1d5c7bb69c2a9ba2a41", size = 14726546, upload-time = "2026-04-19T02:36:28.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/2c/a670cc050fcd6f45c6199eb99e259c73aea92edba8d5c2fc1b3686d36217/litellm-1.83.0-py3-none-any.whl", hash = "sha256:88c536d339248f3987571493015784671ba3f193a328e1ea6780dbebaa2094a8", size = 15610306, upload-time = "2026-03-31T05:08:21.987Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/58/8dd69d5b1ab11f206a9c9f21b6fd191bcdd4fb3ed90b8efbf3a1291fd47c/litellm-1.83.10-py3-none-any.whl", hash = "sha256:55203a7b5551efec8f2fccde29ee045ba057e768591e0b6b9fe1d12f00685ff8", size = 16334780, upload-time = "2026-04-19T02:36:25.274Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- bump LiteLLM override/locks to 1.83.10 to address Dependabot and code scanning dependency alerts
- replace sed print-script regex checks with bounded parsers to avoid polynomial ReDoS
- add regression coverage for oversized sed ranges

## Verification
- uv lock --check
- uv run ruff check src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/runtime/secret_file_requests.py tests/test_guard_runtime.py
- uv run pytest tests/test_guard_runtime.py -k "sed_ranges or read_only_source_inspection_allows_safe_sed_chains" --tb=short
- uv run pytest tests/test_guard_runtime.py -k "codex_read_only_source_inspection or codex_source_inspection" --tb=short