### PR TITLE
feat(guard): track harness usage events

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -76,6 +76,7 @@ from ..daemon.manager import (
     load_guard_daemon_auth_token,
     load_guard_daemon_url,
 )
+from ..harness_usage import record_harness_usage_events
 from ..incident import build_incident_context
 from ..mcp_tool_calls import (
     allow_tool_call,
@@ -1651,6 +1652,12 @@ def run_guard_command(
             payload=payload,
             home_dir=context.home_dir,
             workspace=runtime_workspace,
+        )
+        record_harness_usage_events(
+            store=store,
+            action=action_envelope,
+            raw_payload=payload,
+            occurred_at=_now(),
         )
         copilot_hook_stage = _copilot_hook_stage(payload) if args.harness == "copilot" else None
         copilot_runtime_tool_call = (

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1800,8 +1800,20 @@ def run_guard_command(
                     remember=False,
                 )
                 if _should_emit_copilot_hook_response(args):
+                    _record_harness_usage_for_hook(
+                        store=store,
+                        action_envelope=action_envelope,
+                        payload=payload,
+                        policy_action=policy_action,
+                    )
                     _emit_copilot_permission_request_response(behavior="allow", output_stream=output_stream)
                     return 0
+                _record_harness_usage_for_hook(
+                    store=store,
+                    action_envelope=action_envelope,
+                    payload=payload,
+                    policy_action=policy_action,
+                )
                 _emit("hook", response_payload, getattr(args, "json", False))
                 return 0
             block_tool_call(
@@ -1865,6 +1877,12 @@ def run_guard_command(
                 approval_center_url=approval_center_url,
                 queued=queued,
                 managed_install=managed_install,
+            )
+            _record_harness_usage_for_hook(
+                store=store,
+                action_envelope=action_envelope,
+                payload=payload,
+                policy_action=policy_action,
             )
             if _should_emit_copilot_hook_response(args):
                 review_context = _native_approval_center_context(response_payload, harness=args.harness)

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1653,12 +1653,6 @@ def run_guard_command(
             home_dir=context.home_dir,
             workspace=runtime_workspace,
         )
-        record_harness_usage_events(
-            store=store,
-            action=action_envelope,
-            raw_payload=payload,
-            occurred_at=_now(),
-        )
         copilot_hook_stage = _copilot_hook_stage(payload) if args.harness == "copilot" else None
         copilot_runtime_tool_call = (
             _copilot_runtime_tool_call(
@@ -1700,6 +1694,12 @@ def run_guard_command(
                     remember=False,
                 )
                 if _should_emit_copilot_hook_response(args):
+                    _record_harness_usage_for_hook(
+                        store=store,
+                        action_envelope=action_envelope,
+                        payload=payload,
+                        policy_action=policy_action,
+                    )
                     _emit_copilot_hook_response(policy_action="allow", reason="", output_stream=output_stream)
                     return 0
             else:
@@ -1714,6 +1714,12 @@ def run_guard_command(
                         risk_categories=decision.risk_categories,
                     )
                 if _should_emit_copilot_hook_response(args):
+                    _record_harness_usage_for_hook(
+                        store=store,
+                        action_envelope=action_envelope,
+                        payload=payload,
+                        policy_action=policy_action,
+                    )
                     _emit_copilot_hook_response(
                         policy_action=policy_action,
                         reason=_copilot_hook_reason(decision.summary, runtime_artifact.name),
@@ -2007,6 +2013,12 @@ def run_guard_command(
                         approval_source="inline",
                     )
                     store.add_receipt(receipt)
+                _record_harness_usage_for_hook(
+                    store=store,
+                    action_envelope=action_envelope,
+                    payload=payload,
+                    policy_action="allow",
+                )
                 return 0
             changed_capabilities = [runtime_artifact.artifact_type]
             data_flow_signals = _runtime_action_data_flow_signals(action_envelope, workspace=runtime_workspace)
@@ -2430,6 +2442,12 @@ def run_guard_command(
                 approval_source=("inline" if _optional_string(payload.get("user_override")) is not None else "policy"),
             )
             store.add_receipt(receipt)
+        _record_harness_usage_for_hook(
+            store=store,
+            action_envelope=action_envelope,
+            payload=payload,
+            policy_action=policy_action,
+        )
         if _should_emit_copilot_hook_response(args):
             _emit_copilot_hook_response(
                 policy_action=policy_action,
@@ -2488,6 +2506,24 @@ def run_guard_command(
         return 1 if policy_action in {"block", "require-reapproval"} else 0
 
     return 1
+
+
+def _record_harness_usage_for_hook(
+    *,
+    store: GuardStore,
+    action_envelope: GuardActionEnvelope | None,
+    payload: Mapping[str, object],
+    policy_action: str | None,
+) -> None:
+    usage_payload = dict(payload)
+    if isinstance(policy_action, str) and policy_action:
+        usage_payload["policy_action"] = policy_action
+    record_harness_usage_events(
+        store=store,
+        action=action_envelope,
+        raw_payload=usage_payload,
+        occurred_at=_now(),
+    )
 
 
 def _emit(command: str, payload: dict[str, object], as_json: bool) -> None:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2138,6 +2138,12 @@ def run_guard_command(
                         artifact_hash=runtime_artifact_hash,
                     )
                 if _should_emit_copilot_hook_response(args):
+                    _record_harness_usage_for_hook(
+                        store=store,
+                        action_envelope=action_envelope,
+                        payload=payload,
+                        policy_action=policy_action,
+                    )
                     _emit_copilot_hook_response(
                         policy_action=policy_action,
                         reason=_copilot_hook_reason(
@@ -2173,6 +2179,12 @@ def run_guard_command(
                         system_message=system_message,
                         additional_context=additional_context,
                         output_stream=output_stream,
+                    )
+                    _record_harness_usage_for_hook(
+                        store=store,
+                        action_envelope=action_envelope,
+                        payload=payload,
+                        policy_action=policy_action,
                     )
                     return 0
                 if not _prompt_requires_hard_block(runtime_artifact):
@@ -2261,6 +2273,12 @@ def run_guard_command(
                         managed_install=managed_install,
                     )
             if _should_emit_copilot_hook_response(args):
+                _record_harness_usage_for_hook(
+                    store=store,
+                    action_envelope=action_envelope,
+                    payload=payload,
+                    policy_action=policy_action,
+                )
                 _emit_copilot_hook_response(
                     policy_action=policy_action,
                     reason=_copilot_hook_reason(
@@ -2289,6 +2307,12 @@ def run_guard_command(
                         reason="",
                         output_stream=output_stream,
                     )
+                _record_harness_usage_for_hook(
+                    store=store,
+                    action_envelope=action_envelope,
+                    payload=payload,
+                    policy_action="allow",
+                )
                 return 0
             if codex_browser_decision == "block":
                 policy_action = "block"
@@ -2299,6 +2323,12 @@ def run_guard_command(
                         _runtime_artifact_native_reason(runtime_artifact, response_payload),
                         _native_approval_center_context(response_payload, harness=args.harness),
                     )
+                )
+                _record_harness_usage_for_hook(
+                    store=store,
+                    action_envelope=action_envelope,
+                    payload=payload,
+                    policy_action=policy_action,
                 )
                 return 2
             raw_runtime_reason = _runtime_artifact_native_reason(runtime_artifact, response_payload)
@@ -2343,8 +2373,20 @@ def run_guard_command(
                     system_message=system_message,
                     output_stream=output_stream,
                 )
+                _record_harness_usage_for_hook(
+                    store=store,
+                    action_envelope=action_envelope,
+                    payload=payload,
+                    policy_action=policy_action,
+                )
                 return 0
             _emit("hook", response_payload, getattr(args, "json", False))
+            _record_harness_usage_for_hook(
+                store=store,
+                action_envelope=action_envelope,
+                payload=payload,
+                policy_action=policy_action,
+            )
             return 1 if policy_action in {"block", "require-reapproval"} else 0
         artifact_id = _coalesce_string(
             getattr(args, "artifact_id", None),

--- a/src/codex_plugin_scanner/guard/edge_events.py
+++ b/src/codex_plugin_scanner/guard/edge_events.py
@@ -6,7 +6,7 @@ import hashlib
 from typing import cast
 
 from .models import GuardReceipt
-from .schemas.guard_event_v1 import GuardEventType, GuardEventV1
+from .schemas.guard_event_v1 import HARNESS_USAGE_EVENT_TYPES, GuardEventType, GuardEventV1
 
 
 def build_receipt_event(
@@ -165,7 +165,7 @@ def build_harness_usage_event(
     device_id: str | None = None,
     workspace_id: str | None = None,
 ) -> GuardEventV1:
-    if event_type not in {"harness.mcp.used", "harness.skill.activated"}:
+    if event_type not in HARNESS_USAGE_EVENT_TYPES:
         raise ValueError("Harness usage event type must be harness.mcp.used or harness.skill.activated")
     return _build_edge_event(
         event_type=event_type,

--- a/src/codex_plugin_scanner/guard/edge_events.py
+++ b/src/codex_plugin_scanner/guard/edge_events.py
@@ -156,6 +156,27 @@ def build_notification_delivery_event(
     )
 
 
+def build_harness_usage_event(
+    *,
+    event_type: GuardEventType,
+    subject_id: str,
+    occurred_at: str,
+    payload: dict[str, object],
+    device_id: str | None = None,
+    workspace_id: str | None = None,
+) -> GuardEventV1:
+    if event_type not in {"harness.mcp.used", "harness.skill.activated"}:
+        raise ValueError("Harness usage event type must be harness.mcp.used or harness.skill.activated")
+    return _build_edge_event(
+        event_type=event_type,
+        subject_id=subject_id,
+        occurred_at=occurred_at,
+        payload=payload,
+        device_id=device_id,
+        workspace_id=workspace_id,
+    )
+
+
 def _build_edge_event(
     *,
     event_type: GuardEventType,

--- a/src/codex_plugin_scanner/guard/harness_usage.py
+++ b/src/codex_plugin_scanner/guard/harness_usage.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import re
+import sqlite3
 from collections.abc import Mapping
 from contextlib import suppress
 from pathlib import PurePosixPath, PureWindowsPath
@@ -16,22 +17,24 @@ if TYPE_CHECKING:
     from .store import GuardStore
 
 UsageStatus = Literal["observed", "allowed", "blocked", "failed", "unknown"]
+HarnessUsageEventKind = Literal["harness.mcp.used", "harness.skill.activated"]
+HarnessUsageEventTuple = tuple[HarnessUsageEventKind, str, dict[str, object]]
 
-_SKILL_KEYS = frozenset(
+_SKILL_ACTIVATION_KEYS = frozenset(
     {
-        "skill",
-        "skillname",
-        "skillid",
-        "skilltitle",
         "activeskill",
+        "activeskillid",
+        "activeskillname",
+        "activeskillpath",
         "activatedskill",
+        "activatedskillid",
+        "activatedskillname",
         "skillpath",
-        "skilluri",
-        "skillurl",
     }
 )
 _REQUEST_ID_KEYS = ("request_id", "requestId", "tool_call_id", "toolCallId", "call_id", "callId")
 _SESSION_ID_KEYS = ("session_id", "sessionId", "conversation_id", "conversationId", "thread_id", "threadId")
+_MAX_SKILL_SEARCH_DEPTH = 6
 
 
 def record_harness_usage_events(
@@ -48,7 +51,7 @@ def record_harness_usage_events(
     events = _usage_events(action=action, raw_payload=raw_payload, occurred_at=occurred_at)
     if not events:
         return 0
-    with suppress(Exception):
+    try:
         device_id = store.get_or_create_installation_id()
         workspace_id = store.get_cloud_workspace_id()
         for event_type, subject_id, payload in events:
@@ -63,6 +66,13 @@ def record_harness_usage_events(
                 )
             )
         return len(events)
+    except (OSError, RuntimeError, ValueError, sqlite3.Error) as error:
+        with suppress(OSError, RuntimeError, ValueError, sqlite3.Error):
+            store.add_event(
+                "harness_usage_event_failed",
+                {"error_type": type(error).__name__},
+                occurred_at,
+            )
     return 0
 
 
@@ -71,8 +81,8 @@ def _usage_events(
     action: GuardActionEnvelope,
     raw_payload: Mapping[str, object],
     occurred_at: str,
-) -> list[tuple[Literal["harness.mcp.used", "harness.skill.activated"], str, dict[str, object]]]:
-    events: list[tuple[Literal["harness.mcp.used", "harness.skill.activated"], str, dict[str, object]]] = []
+) -> list[HarnessUsageEventTuple]:
+    events: list[HarnessUsageEventTuple] = []
     request_id = _string_from_keys(raw_payload, _REQUEST_ID_KEYS)
     session_id = _string_from_keys(raw_payload, _SESSION_ID_KEYS)
     base_payload = {
@@ -162,16 +172,26 @@ def _skill_details(payload: Mapping[str, object]) -> dict[str, object] | None:
     return details or None
 
 
-def _find_skill_value(payload: Mapping[str, object]) -> tuple[str, object] | None:
+def _find_skill_value(payload: object, *, depth: int = 0) -> tuple[str, object] | None:
+    if depth > _MAX_SKILL_SEARCH_DEPTH:
+        return None
+    if isinstance(payload, list):
+        for item in payload:
+            nested = _find_skill_value(item, depth=depth + 1)
+            if nested is not None:
+                return nested
+        return None
+    if not isinstance(payload, Mapping):
+        return None
     for key, value in payload.items():
         if not isinstance(key, str):
             continue
-        if _normalized_key(key) in _SKILL_KEYS and isinstance(value, (str, Mapping)):
+        if _normalized_key(key) in _SKILL_ACTIVATION_KEYS and isinstance(value, (str, Mapping)):
             if isinstance(value, str) and not value.strip():
                 continue
             return key, value
-        if isinstance(value, Mapping):
-            nested = _find_skill_value(value)
+        if isinstance(value, (Mapping, list)):
+            nested = _find_skill_value(value, depth=depth + 1)
             if nested is not None:
                 return nested
     return None
@@ -208,7 +228,7 @@ def _path_hash(value: str | None) -> str | None:
 
 
 def _looks_like_path(value: str) -> bool:
-    return value.startswith(("~", "/", "file:")) or "\\" in value
+    return value.startswith(("~", "/", "file:")) or "/" in value or "\\" in value
 
 
 def _normalized_key(value: str) -> str:

--- a/src/codex_plugin_scanner/guard/harness_usage.py
+++ b/src/codex_plugin_scanner/guard/harness_usage.py
@@ -127,6 +127,8 @@ def _usage_events(
 
 
 def _usage_status(action: GuardActionEnvelope, raw_payload: Mapping[str, object]) -> UsageStatus:
+    if action.event_name == "PostToolUseFailure":
+        return "failed"
     explicit = _string_from_keys(
         raw_payload,
         ("policy_action", "policyAction", "permission_decision", "permissionDecision"),
@@ -135,8 +137,6 @@ def _usage_status(action: GuardActionEnvelope, raw_payload: Mapping[str, object]
         return "blocked"
     if explicit in {"allow", "approve", "approved", "warn"}:
         return "allowed"
-    if action.event_name == "PostToolUseFailure":
-        return "failed"
     if action.event_name == "PostToolUse":
         return "allowed"
     if action.event_name == "PreToolUse":

--- a/src/codex_plugin_scanner/guard/harness_usage.py
+++ b/src/codex_plugin_scanner/guard/harness_usage.py
@@ -131,7 +131,7 @@ def _usage_status(action: GuardActionEnvelope, raw_payload: Mapping[str, object]
         raw_payload,
         ("policy_action", "policyAction", "permission_decision", "permissionDecision"),
     )
-    if explicit in {"block", "deny", "sandbox-required"}:
+    if explicit in {"block", "deny", "sandbox-required", "require-reapproval"}:
         return "blocked"
     if explicit in {"allow", "approve", "approved", "warn"}:
         return "allowed"

--- a/src/codex_plugin_scanner/guard/harness_usage.py
+++ b/src/codex_plugin_scanner/guard/harness_usage.py
@@ -32,6 +32,7 @@ _SKILL_ACTIVATION_KEYS = frozenset(
         "skillpath",
     }
 )
+_SKILL_PATH_KEYS = frozenset({"activeskillpath", "skillpath"})
 _REQUEST_ID_KEYS = ("request_id", "requestId", "tool_call_id", "toolCallId", "call_id", "callId")
 _SESSION_ID_KEYS = ("session_id", "sessionId", "conversation_id", "conversationId", "thread_id", "threadId")
 _MAX_SKILL_SEARCH_DEPTH = 6
@@ -149,17 +150,20 @@ def _skill_details(payload: Mapping[str, object]) -> dict[str, object] | None:
     if found is None:
         return None
     key, value = found
+    normalized_key = _normalized_key(key)
     if isinstance(value, Mapping):
         name = _safe_label(_string_from_keys(value, ("name", "title", "slug", "id")))
         identifier = _safe_label(_string_from_keys(value, ("id", "skill_id", "skillId", "slug")))
         source = _safe_label(_string_from_keys(value, ("source", "provider", "runtime")))
         path_hash = _path_hash(_string_from_keys(value, ("path", "skill_path", "skillPath", "uri", "url")))
+        if identifier is None and name is None and path_hash is not None:
+            identifier = f"path:{path_hash[:16]}"
     else:
-        label = _safe_label(str(value))
+        path_hash = _path_hash(str(value)) if normalized_key in _SKILL_PATH_KEYS else None
+        label = None if path_hash is not None else _safe_label(str(value))
         name = label
-        identifier = None if _normalized_key(key) in {"skillpath", "skilluri", "skillurl"} else label
+        identifier = f"path:{path_hash[:16]}" if path_hash is not None else label
         source = None
-        path_hash = _path_hash(str(value)) if _normalized_key(key) in {"skillpath", "skilluri", "skillurl"} else None
     details: dict[str, object] = {}
     if name is not None:
         details["skillName"] = name

--- a/src/codex_plugin_scanner/guard/harness_usage.py
+++ b/src/codex_plugin_scanner/guard/harness_usage.py
@@ -33,6 +33,17 @@ _SKILL_ACTIVATION_KEYS = frozenset(
     }
 )
 _SKILL_PATH_KEYS = frozenset({"activeskillpath", "activatedskillpath"})
+_TOOL_ARGUMENT_CONTAINER_KEYS = frozenset(
+    {
+        "args",
+        "arguments",
+        "input",
+        "parameters",
+        "toolarguments",
+        "toolcalls",
+        "toolinput",
+    }
+)
 _REQUEST_ID_KEYS = ("request_id", "requestId", "tool_call_id", "toolCallId", "call_id", "callId")
 _SESSION_ID_KEYS = ("session_id", "sessionId", "conversation_id", "conversationId", "thread_id", "threadId")
 _MAX_SKILL_SEARCH_DEPTH = 6
@@ -195,6 +206,8 @@ def _find_skill_value(payload: object, *, depth: int = 0) -> tuple[str, object] 
                 continue
             return key, value
         if isinstance(value, (Mapping, list)):
+            if _normalized_key(key) in _TOOL_ARGUMENT_CONTAINER_KEYS:
+                continue
             nested = _find_skill_value(value, depth=depth + 1)
             if nested is not None:
                 return nested

--- a/src/codex_plugin_scanner/guard/harness_usage.py
+++ b/src/codex_plugin_scanner/guard/harness_usage.py
@@ -29,10 +29,10 @@ _SKILL_ACTIVATION_KEYS = frozenset(
         "activatedskill",
         "activatedskillid",
         "activatedskillname",
-        "skillpath",
+        "activatedskillpath",
     }
 )
-_SKILL_PATH_KEYS = frozenset({"activeskillpath", "skillpath"})
+_SKILL_PATH_KEYS = frozenset({"activeskillpath", "activatedskillpath"})
 _REQUEST_ID_KEYS = ("request_id", "requestId", "tool_call_id", "toolCallId", "call_id", "callId")
 _SESSION_ID_KEYS = ("session_id", "sessionId", "conversation_id", "conversationId", "thread_id", "threadId")
 _MAX_SKILL_SEARCH_DEPTH = 6

--- a/src/codex_plugin_scanner/guard/harness_usage.py
+++ b/src/codex_plugin_scanner/guard/harness_usage.py
@@ -1,0 +1,220 @@
+"""Privacy-safe usage events for harness skills and MCP tools."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Mapping
+from contextlib import suppress
+from pathlib import PurePosixPath, PureWindowsPath
+from typing import TYPE_CHECKING, Literal
+
+from .edge_events import build_harness_usage_event
+from .runtime.actions import GuardActionEnvelope
+
+if TYPE_CHECKING:
+    from .store import GuardStore
+
+UsageStatus = Literal["observed", "allowed", "blocked", "failed", "unknown"]
+
+_SKILL_KEYS = frozenset(
+    {
+        "skill",
+        "skillname",
+        "skillid",
+        "skilltitle",
+        "activeskill",
+        "activatedskill",
+        "skillpath",
+        "skilluri",
+        "skillurl",
+    }
+)
+_REQUEST_ID_KEYS = ("request_id", "requestId", "tool_call_id", "toolCallId", "call_id", "callId")
+_SESSION_ID_KEYS = ("session_id", "sessionId", "conversation_id", "conversationId", "thread_id", "threadId")
+
+
+def record_harness_usage_events(
+    *,
+    store: GuardStore,
+    action: GuardActionEnvelope | None,
+    raw_payload: Mapping[str, object],
+    occurred_at: str,
+) -> int:
+    """Queue cloud usage events without leaking prompt, args, output, or local paths."""
+
+    if action is None:
+        return 0
+    events = _usage_events(action=action, raw_payload=raw_payload, occurred_at=occurred_at)
+    if not events:
+        return 0
+    with suppress(Exception):
+        device_id = store.get_or_create_installation_id()
+        workspace_id = store.get_cloud_workspace_id()
+        for event_type, subject_id, payload in events:
+            store.add_guard_event_v1(
+                build_harness_usage_event(
+                    event_type=event_type,
+                    subject_id=subject_id,
+                    occurred_at=occurred_at,
+                    payload=payload,
+                    device_id=device_id,
+                    workspace_id=workspace_id,
+                )
+            )
+        return len(events)
+    return 0
+
+
+def _usage_events(
+    *,
+    action: GuardActionEnvelope,
+    raw_payload: Mapping[str, object],
+    occurred_at: str,
+) -> list[tuple[Literal["harness.mcp.used", "harness.skill.activated"], str, dict[str, object]]]:
+    events: list[tuple[Literal["harness.mcp.used", "harness.skill.activated"], str, dict[str, object]]] = []
+    request_id = _string_from_keys(raw_payload, _REQUEST_ID_KEYS)
+    session_id = _string_from_keys(raw_payload, _SESSION_ID_KEYS)
+    base_payload = {
+        "harness": action.harness,
+        "eventName": action.event_name,
+        "actionType": action.action_type,
+        "workspaceHash": action.workspace_hash,
+        "requestId": request_id,
+        "sessionId": session_id,
+        "status": _usage_status(action, raw_payload),
+    }
+    if action.action_type == "mcp_tool" and action.mcp_server is not None:
+        subject_id = _subject_id(
+            "mcp",
+            action.harness,
+            action.event_name,
+            action.mcp_server,
+            action.mcp_tool or "unknown",
+            request_id or action.action_id,
+            occurred_at,
+        )
+        payload = {
+            **base_payload,
+            "mcpServer": action.mcp_server,
+            "mcpTool": action.mcp_tool,
+            "toolName": action.tool_name,
+        }
+        events.append(("harness.mcp.used", subject_id, _compact_payload(payload)))
+    skill = _skill_details(raw_payload)
+    if skill is not None:
+        subject_id = _subject_id(
+            "skill",
+            action.harness,
+            action.event_name,
+            skill.get("skillId") or skill.get("skillName") or "unknown",
+            request_id or action.action_id,
+            occurred_at,
+        )
+        payload = {**base_payload, **skill}
+        events.append(("harness.skill.activated", subject_id, _compact_payload(payload)))
+    return events
+
+
+def _usage_status(action: GuardActionEnvelope, raw_payload: Mapping[str, object]) -> UsageStatus:
+    explicit = _string_from_keys(
+        raw_payload,
+        ("policy_action", "policyAction", "permission_decision", "permissionDecision"),
+    )
+    if explicit in {"block", "deny", "sandbox-required"}:
+        return "blocked"
+    if explicit in {"allow", "approve", "approved", "warn"}:
+        return "allowed"
+    if action.event_name == "PostToolUseFailure":
+        return "failed"
+    if action.event_name == "PostToolUse":
+        return "allowed"
+    if action.event_name == "PreToolUse":
+        return "observed"
+    return "unknown"
+
+
+def _skill_details(payload: Mapping[str, object]) -> dict[str, object] | None:
+    found = _find_skill_value(payload)
+    if found is None:
+        return None
+    key, value = found
+    if isinstance(value, Mapping):
+        name = _safe_label(_string_from_keys(value, ("name", "title", "slug", "id")))
+        identifier = _safe_label(_string_from_keys(value, ("id", "skill_id", "skillId", "slug")))
+        source = _safe_label(_string_from_keys(value, ("source", "provider", "runtime")))
+        path_hash = _path_hash(_string_from_keys(value, ("path", "skill_path", "skillPath", "uri", "url")))
+    else:
+        label = _safe_label(str(value))
+        name = label
+        identifier = None if _normalized_key(key) in {"skillpath", "skilluri", "skillurl"} else label
+        source = None
+        path_hash = _path_hash(str(value)) if _normalized_key(key) in {"skillpath", "skilluri", "skillurl"} else None
+    details: dict[str, object] = {}
+    if name is not None:
+        details["skillName"] = name
+    if identifier is not None:
+        details["skillId"] = identifier
+    if source is not None:
+        details["skillSource"] = source
+    if path_hash is not None:
+        details["skillPathHash"] = path_hash
+    return details or None
+
+
+def _find_skill_value(payload: Mapping[str, object]) -> tuple[str, object] | None:
+    for key, value in payload.items():
+        if not isinstance(key, str):
+            continue
+        if _normalized_key(key) in _SKILL_KEYS and isinstance(value, (str, Mapping)):
+            if isinstance(value, str) and not value.strip():
+                continue
+            return key, value
+        if isinstance(value, Mapping):
+            nested = _find_skill_value(value)
+            if nested is not None:
+                return nested
+    return None
+
+
+def _string_from_keys(payload: Mapping[str, object], keys: tuple[str, ...]) -> str | None:
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _compact_payload(payload: Mapping[str, object]) -> dict[str, object]:
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def _safe_label(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    if _looks_like_path(stripped):
+        label = PureWindowsPath(stripped).name if "\\" in stripped else PurePosixPath(stripped).name
+        stripped = label or "skill"
+    return stripped[:120]
+
+
+def _path_hash(value: str | None) -> str | None:
+    if value is None or not _looks_like_path(value):
+        return None
+    return hashlib.sha256(value.strip().encode("utf-8")).hexdigest()
+
+
+def _looks_like_path(value: str) -> bool:
+    return value.startswith(("~", "/", "file:")) or "\\" in value
+
+
+def _normalized_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", value.lower())
+
+
+def _subject_id(*parts: str) -> str:
+    clean_parts = [part for part in parts if part]
+    return hashlib.sha256(":".join(clean_parts).encode("utf-8")).hexdigest()

--- a/src/codex_plugin_scanner/guard/schemas/guard_event_v1.py
+++ b/src/codex_plugin_scanner/guard/schemas/guard_event_v1.py
@@ -18,6 +18,9 @@ GuardEventType = Literal[
     "harness.mcp.used",
     "harness.skill.activated",
 ]
+HARNESS_USAGE_EVENT_TYPES: frozenset[str] = frozenset(
+    {"harness.mcp.used", "harness.skill.activated"}
+)
 _GUARD_EVENT_TYPES: frozenset[str] = frozenset(
     {
         "receipt.created",
@@ -28,8 +31,7 @@ _GUARD_EVENT_TYPES: frozenset[str] = frozenset(
         "access_graph.snapshot",
         "agent.handshake",
         "notification.delivery",
-        "harness.mcp.used",
-        "harness.skill.activated",
+        *HARNESS_USAGE_EVENT_TYPES,
     }
 )
 _GUARD_EVENT_SOURCES: frozenset[str] = frozenset({"edge", "approval-center", "policy", "protect-api"})

--- a/src/codex_plugin_scanner/guard/schemas/guard_event_v1.py
+++ b/src/codex_plugin_scanner/guard/schemas/guard_event_v1.py
@@ -18,9 +18,7 @@ GuardEventType = Literal[
     "harness.mcp.used",
     "harness.skill.activated",
 ]
-HARNESS_USAGE_EVENT_TYPES: frozenset[str] = frozenset(
-    {"harness.mcp.used", "harness.skill.activated"}
-)
+HARNESS_USAGE_EVENT_TYPES: frozenset[str] = frozenset({"harness.mcp.used", "harness.skill.activated"})
 _GUARD_EVENT_TYPES: frozenset[str] = frozenset(
     {
         "receipt.created",

--- a/src/codex_plugin_scanner/guard/schemas/guard_event_v1.py
+++ b/src/codex_plugin_scanner/guard/schemas/guard_event_v1.py
@@ -15,6 +15,8 @@ GuardEventType = Literal[
     "access_graph.snapshot",
     "agent.handshake",
     "notification.delivery",
+    "harness.mcp.used",
+    "harness.skill.activated",
 ]
 _GUARD_EVENT_TYPES: frozenset[str] = frozenset(
     {
@@ -26,6 +28,8 @@ _GUARD_EVENT_TYPES: frozenset[str] = frozenset(
         "access_graph.snapshot",
         "agent.handshake",
         "notification.delivery",
+        "harness.mcp.used",
+        "harness.skill.activated",
     }
 )
 _GUARD_EVENT_SOURCES: frozenset[str] = frozenset({"edge", "approval-center", "policy", "protect-api"})

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -3116,6 +3116,36 @@ clearer UX and an implementation plan with technical references.
         assert usage_payload["eventName"] == "PreToolUse"
         assert usage_payload["status"] == "blocked"
 
+    def test_guard_hook_records_failed_mcp_usage_even_with_allow_policy(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+
+        rc, _output = _run_guard_hook(
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+            harness="codex",
+            event={
+                "hook_event_name": "PostToolUseFailure",
+                "tool_name": "mcp__danger_lab__dangerous_delete",
+                "tool_input": {"target": "fixture.txt"},
+                "tool_call_id": "call-789",
+                "policy_action": "allow",
+            },
+            capsys=capsys,
+            monkeypatch=monkeypatch,
+            as_json=True,
+        )
+
+        events = GuardStore(Path(home_dir)).list_guard_events_v1(uploaded=False)
+        usage_events = [event for event in events if event["event_type"] == "harness.mcp.used"]
+        payload = usage_events[0]["payload"]
+        usage_payload = payload["payload"]
+
+        assert rc == 0
+        assert usage_payload["eventName"] == "PostToolUseFailure"
+        assert usage_payload["status"] == "failed"
+
     def test_guard_hook_records_skill_activation_event(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -3185,6 +3185,35 @@ clearer UX and an implementation plan with technical references.
         assert "skillPathHash" in usage_payload
         assert str(workspace_dir) not in json.dumps(usage_payload)
 
+    def test_guard_hook_hashes_active_skill_path_activation(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+
+        rc, _output = _run_guard_hook(
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+            harness="codex",
+            event={
+                "hook_event_name": "UserPromptSubmit",
+                "prompt": "Use a project skill.",
+                "active_skill_path": ".codex/skills/project-review/SKILL.md",
+            },
+            capsys=capsys,
+            monkeypatch=monkeypatch,
+            as_json=True,
+        )
+
+        events = GuardStore(Path(home_dir)).list_guard_events_v1(uploaded=False)
+        usage_events = [event for event in events if event["event_type"] == "harness.skill.activated"]
+        payload = usage_events[0]["payload"]
+        usage_payload = payload["payload"]
+
+        assert rc == 0
+        assert str(usage_payload["skillId"]).startswith("path:")
+        assert "skillPathHash" in usage_payload
+        assert "SKILL.md" not in json.dumps(usage_payload)
+
     def test_guard_hook_blocks_require_reapproval(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -3050,6 +3050,81 @@ clearer UX and an implementation plan with technical references.
         assert receipts[0]["artifact_id"] == "claude-code:workspace-tools"
         assert receipts[0]["user_override"] is None
 
+    def test_guard_hook_records_mcp_usage_event(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+
+        rc, _output = _run_guard_hook(
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+            harness="codex",
+            event={
+                "hook_event_name": "PostToolUse",
+                "tool_name": "mcp__danger_lab__dangerous_delete",
+                "tool_input": {"target": "fixture.txt"},
+                "tool_call_id": "call-123",
+                "session_id": "session-123",
+                "policy_action": "allow",
+            },
+            capsys=capsys,
+            monkeypatch=monkeypatch,
+            as_json=True,
+        )
+
+        events = GuardStore(Path(home_dir)).list_guard_events_v1(uploaded=False)
+        usage_events = [event for event in events if event["event_type"] == "harness.mcp.used"]
+        payload = usage_events[0]["payload"]
+        usage_payload = payload["payload"]
+
+        assert rc == 0
+        assert usage_payload["harness"] == "codex"
+        assert usage_payload["eventName"] == "PostToolUse"
+        assert usage_payload["mcpServer"] == "danger_lab"
+        assert usage_payload["mcpTool"] == "dangerous_delete"
+        assert usage_payload["status"] == "allowed"
+        assert usage_payload["requestId"] == "call-123"
+        assert "target" not in json.dumps(usage_payload)
+
+    def test_guard_hook_records_skill_activation_event(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+
+        rc, _output = _run_guard_hook(
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+            harness="claude-code",
+            event={
+                "hook_event_name": "UserPromptSubmit",
+                "prompt": "Use the project skill.",
+                "activated_skill": {
+                    "id": "project-review",
+                    "name": "Project Review",
+                    "source": "workspace",
+                    "path": str(workspace_dir / ".claude" / "skills" / "project-review" / "SKILL.md"),
+                },
+                "session_id": "session-456",
+            },
+            capsys=capsys,
+            monkeypatch=monkeypatch,
+            as_json=True,
+        )
+
+        events = GuardStore(Path(home_dir)).list_guard_events_v1(uploaded=False)
+        usage_events = [event for event in events if event["event_type"] == "harness.skill.activated"]
+        payload = usage_events[0]["payload"]
+        usage_payload = payload["payload"]
+
+        assert rc == 0
+        assert usage_payload["harness"] == "claude-code"
+        assert usage_payload["eventName"] == "UserPromptSubmit"
+        assert usage_payload["skillName"] == "Project Review"
+        assert usage_payload["skillId"] == "project-review"
+        assert usage_payload["skillSource"] == "workspace"
+        assert "skillPathHash" in usage_payload
+        assert str(workspace_dir) not in json.dumps(usage_payload)
+
     def test_guard_hook_blocks_require_reapproval(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -3214,6 +3214,34 @@ clearer UX and an implementation plan with technical references.
         assert "skillPathHash" in usage_payload
         assert "SKILL.md" not in json.dumps(usage_payload)
 
+    def test_guard_hook_ignores_tool_argument_skill_path(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+
+        rc, _output = _run_guard_hook(
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+            harness="codex",
+            event={
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {
+                    "command": "node build-skill-index.js",
+                    "skill_path": ".codex/skills/project-review/SKILL.md",
+                },
+            },
+            capsys=capsys,
+            monkeypatch=monkeypatch,
+            as_json=True,
+        )
+
+        events = GuardStore(Path(home_dir)).list_guard_events_v1(uploaded=False)
+        usage_events = [event for event in events if event["event_type"] == "harness.skill.activated"]
+
+        assert rc == 0
+        assert usage_events == []
+
     def test_guard_hook_blocks_require_reapproval(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -3228,7 +3228,7 @@ clearer UX and an implementation plan with technical references.
                 "tool_name": "Bash",
                 "tool_input": {
                     "command": "node build-skill-index.js",
-                    "skill_path": ".codex/skills/project-review/SKILL.md",
+                    "active_skill_path": ".codex/skills/project-review/SKILL.md",
                 },
             },
             capsys=capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -6393,6 +6393,10 @@ def test_guard_hook_emits_copilot_permission_request_allow_for_safe_mcp_tool(
 
     assert rc == 0
     assert output == {"behavior": "allow"}
+    events = GuardStore(home_dir).list_guard_events_v1(uploaded=False)
+    usage_events = [event for event in events if event["event_type"] == "harness.mcp.used"]
+    assert len(usage_events) == 1
+    assert usage_events[0]["payload"]["payload"]["status"] == "allowed"
 
 
 def test_guard_hook_emits_copilot_permission_request_allow_for_hook_event_name_variant(
@@ -6466,6 +6470,10 @@ def test_guard_hook_emits_copilot_permission_request_deny_for_risky_mcp_tool(
     assert "HOL Guard blocked" in output["message"]
     assert "danger_lab:dangerous_delete" in output["message"]
     assert "http://127.0.0.1:4455/approvals/" in output["message"]
+    events = GuardStore(home_dir).list_guard_events_v1(uploaded=False)
+    usage_events = [event for event in events if event["event_type"] == "harness.mcp.used"]
+    assert len(usage_events) == 1
+    assert usage_events[0]["payload"]["payload"]["status"] == "blocked"
 
 
 def test_guard_hook_emits_copilot_permission_request_deny_from_tool_calls_payload(

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -3086,6 +3086,36 @@ clearer UX and an implementation plan with technical references.
         assert usage_payload["requestId"] == "call-123"
         assert "target" not in json.dumps(usage_payload)
 
+    def test_guard_hook_records_blocked_mcp_usage_after_policy_decision(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+
+        rc, _output = _run_guard_hook(
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+            harness="codex",
+            event={
+                "hook_event_name": "PreToolUse",
+                "tool_name": "mcp__danger_lab__dangerous_delete",
+                "tool_input": {"target": "fixture.txt"},
+                "tool_call_id": "call-456",
+                "policy_action": "require-reapproval",
+            },
+            capsys=capsys,
+            monkeypatch=monkeypatch,
+            as_json=True,
+        )
+
+        events = GuardStore(Path(home_dir)).list_guard_events_v1(uploaded=False)
+        usage_events = [event for event in events if event["event_type"] == "harness.mcp.used"]
+        payload = usage_events[0]["payload"]
+        usage_payload = payload["payload"]
+
+        assert rc == 1
+        assert usage_payload["eventName"] == "PreToolUse"
+        assert usage_payload["status"] == "blocked"
+
     def test_guard_hook_records_skill_activation_event(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"


### PR DESCRIPTION
## Summary\n- add GuardEventV1 usage types for MCP tool use and skill activation\n- queue privacy-safe local usage events from harness hook payloads\n- cover MCP and skill usage queueing with regression tests\n\n## Verification\n- pytest tests/test_guard_runtime.py -k 'records_mcp_usage_event or records_skill_activation_event'\n- ruff check src/codex_plugin_scanner/guard/harness_usage.py src/codex_plugin_scanner/guard/edge_events.py src/codex_plugin_scanner/guard/schemas/guard_event_v1.py src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_runtime.py