### PR TITLE
fix(guard): allow read-only find sed scans

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -103,6 +103,7 @@ _READ_ONLY_LOOKUP_COMMANDS = frozenset(
     {"cat", "fd", "find", "grep", "egrep", "fgrep", "head", "ls", "rg", "sed", "tail"}
 )
 _READ_ONLY_LOOKUP_FILTERS = frozenset({"grep", "egrep", "fgrep", "head", "sed", "tail"})
+_FIND_EXEC_PLACEHOLDER_TARGET = "guard-find-placeholder.py"
 _NODE_INLINE_EVAL_FLAGS = frozenset({"-e", "--eval", "-p", "--print"})
 _NODE_OPTION_FLAGS_WITH_VALUE = frozenset(
     {
@@ -3447,16 +3448,24 @@ def _find_args_use_write_or_unsafe_exec_action(args: list[str]) -> bool:
             if index + 1 >= len(args):
                 return True
             command_name = Path(args[index + 1]).name.lower()
-            if command_name not in {"echo", "printf", "true", "false", "test", "["}:
+            exec_args: list[str] = []
+            exec_index = index + 2
+            while exec_index < len(args) and args[exec_index] not in {";", r"\;", "+"}:
+                exec_args.append(args[exec_index])
+                exec_index += 1
+            is_safe_builtin = command_name in {"echo", "printf", "true", "false", "test", "["}
+            is_read_only_sed = command_name == "sed" and _find_exec_sed_args_are_read_only(exec_args)
+            if not is_safe_builtin and not is_read_only_sed:
                 return True
-            index += 2
-            while index < len(args) and args[index] not in {";", r"\;", "+"}:
-                index += 1
-            if index < len(args):
-                index += 1
+            index = exec_index + 1 if exec_index < len(args) else exec_index
             continue
         index += 1
     return False
+
+
+def _find_exec_sed_args_are_read_only(args: list[str]) -> bool:
+    normalized_args = [_FIND_EXEC_PLACEHOLDER_TARGET if arg == "{}" else arg for arg in args]
+    return _read_only_lookup_sed_args_are_safe(normalized_args, require_target=True)
 
 
 def _contains_destructive_node_inline_script(script: str) -> bool:

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -1156,6 +1156,21 @@ def test_tool_action_request_classifier_skips_find_name_delete_literal():
     assert request is None
 
 
+def test_tool_action_request_classifier_skips_find_exec_bounded_sed_read():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {
+            "command": (
+                "find ~/CascadeProjects/hashgraph-online/hol-points-portal/.git/hooks "
+                "-maxdepth 1 -type f ! -name '*.sample' -print "
+                "-exec sed -n '1,180p' {} \\; 2>/dev/null || true"
+            ),
+        },
+    )
+
+    assert request is None
+
+
 def test_tool_action_request_classifier_skips_node_script_argument_named_eval_flag():
     request = extract_sensitive_tool_action_request(
         "bash",
@@ -1425,6 +1440,16 @@ def test_tool_action_request_classifier_detects_find_exec_rm_bypass():
     request = extract_sensitive_tool_action_request(
         "bash",
         {"command": "find . -name dangerous-marker.json -exec rm {} ;"},
+    )
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
+def test_tool_action_request_classifier_detects_find_exec_sed_in_place_write():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "find . -name '*.txt' -exec sed -i 's/foo/bar/g' {} \\;"},
     )
 
     assert request is not None


### PR DESCRIPTION
## Summary
- allow `find -exec sed -n ... {} \;` when the sed script is a bounded print/read
- keep mutating `find -exec sed -i ...` and destructive `find -exec rm ...` classified as destructive
- add regression coverage for the paused Codex hook-read command

## Verification
- pytest tests/test_guard_risk.py -k "find_exec_bounded_sed_read or find_exec_sed_in_place_write or find_exec_rm_bypass or find_exec_literal_delete_string"
- pytest tests/test_guard_risk.py
- pytest tests/test_guard_runtime.py -k "find_exec"
- ruff check src/codex_plugin_scanner/guard/runtime/secret_file_requests.py tests/test_guard_risk.py