### PR TITLE
fix(codex): use current hooks feature flag

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -306,20 +306,22 @@ def codex_native_hook_state(context: HarnessContext) -> dict[str, object]:
     managed_hook_installed = (
         pre_tool_hook_installed and permission_hook_installed and prompt_hook_installed and post_tool_hook_installed
     )
+    hooks_feature_enabled = isinstance(features, dict) and features.get("hooks") is True
+    legacy_codex_hooks_enabled = isinstance(features, dict) and features.get("codex_hooks") is True
     return {
         "config_path": str(config_path),
         "config_present": config_path.is_file(),
         "hooks_path": str(hooks_path),
         "hooks_present": hooks_path.is_file(),
-        "codex_hooks_enabled": isinstance(features, dict) and features.get("codex_hooks") is True,
+        "hooks_enabled": hooks_feature_enabled,
+        "codex_hooks_enabled": hooks_feature_enabled,
+        "legacy_codex_hooks_enabled": legacy_codex_hooks_enabled,
         "managed_pre_tool_hook_installed": pre_tool_hook_installed,
         "managed_permission_request_hook_installed": permission_hook_installed,
         "managed_prompt_hook_installed": prompt_hook_installed,
         "managed_post_tool_hook_installed": post_tool_hook_installed,
         "managed_hook_installed": managed_hook_installed,
-        "protection_active": isinstance(features, dict)
-        and features.get("codex_hooks") is True
-        and managed_hook_installed,
+        "protection_active": hooks_feature_enabled and managed_hook_installed,
     }
 
 
@@ -473,7 +475,8 @@ class CodexHarnessAdapter(HarnessAdapter):
         features = payload.get("features")
         if not isinstance(features, dict):
             features = {}
-        features["codex_hooks"] = True
+        features.pop("codex_hooks", None)
+        features["hooks"] = True
         payload["features"] = features
         existing_workspace_server_names = {
             name for name, value in mcp_servers.items() if isinstance(name, str) and isinstance(value, dict)

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -306,8 +306,9 @@ def codex_native_hook_state(context: HarnessContext) -> dict[str, object]:
     managed_hook_installed = (
         pre_tool_hook_installed and permission_hook_installed and prompt_hook_installed and post_tool_hook_installed
     )
-    hooks_feature_enabled = isinstance(features, dict) and features.get("hooks") is True
-    legacy_codex_hooks_enabled = isinstance(features, dict) and features.get("codex_hooks") is True
+    features_is_table = isinstance(features, dict)
+    hooks_feature_enabled = features_is_table and features.get("hooks") is True
+    legacy_codex_hooks_enabled = features_is_table and features.get("codex_hooks") is True
     return {
         "config_path": str(config_path),
         "config_present": config_path.is_file(),

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -3853,7 +3853,8 @@ args = ["-lc", "echo hi"]
         assert output["status"] == "current"
         assert output["managed_install"]["harness"] == "codex"
         assert output["managed_install"]["active"] is True
-        assert "codex_hooks = true" in config_text
+        assert "hooks = true" in config_text
+        assert "codex_hooks" not in config_text
         assert hooks_payload["hooks"]["PreToolUse"]
 
     def test_guard_update_repairs_missing_codex_config_for_managed_install(self, tmp_path, monkeypatch, capsys):
@@ -3889,7 +3890,8 @@ args = ["-lc", "echo hi"]
         assert output["status"] == "current"
         assert output["managed_install"]["harness"] == "codex"
         assert output["managed_install"]["active"] is True
-        assert "codex_hooks = true" in config_text
+        assert "hooks = true" in config_text
+        assert "codex_hooks" not in config_text
         assert hooks_payload["hooks"]["PreToolUse"]
 
     def test_guard_update_repairs_workspace_codex_install_in_recorded_workspace(self, tmp_path, monkeypatch, capsys):
@@ -3925,7 +3927,8 @@ args = ["-lc", "echo hi"]
         assert rc == 0
         assert output["status"] == "current"
         assert output["managed_install"]["workspace"] == str(workspace_dir)
-        assert "codex_hooks = true" in config_text
+        assert "hooks = true" in config_text
+        assert "codex_hooks" not in config_text
         assert hooks_payload["hooks"]["PreToolUse"]
         assert (home_dir / ".codex" / "config.toml").exists() is False
 

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -37,6 +37,9 @@ args = ["-m", "http.server", "9000"]
         """
 approval_policy = "never"
 
+[features]
+codex_hooks = true
+
 [mcp_servers.workspace_skill]
 command = "node"
 args = ["workspace-skill.js"]
@@ -80,7 +83,8 @@ def test_guard_install_codex_rewrites_workspace_config_with_proxy_entries(tmp_pa
     assert "guard" in config_text
     assert "codex-mcp-proxy" in config_text
     assert 'approval_policy = "never"' in config_text
-    assert "codex_hooks = true" in config_text
+    assert "hooks = true" in config_text
+    assert "codex_hooks" not in config_text
     assert 'API_BASE = "https://hol.org"' in config_text
     assert 'FEATURE_FLAG = "1"' in config_text
     assert hooks_payload["hooks"]["PreToolUse"][0]["matcher"] == "Bash"

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -220,7 +220,7 @@ def test_codex_doctor_marks_partial_native_hook_install_as_broken(tmp_path: Path
     config_path = context.workspace_dir / ".codex" / "config.toml"
     hooks_path = context.workspace_dir / ".codex" / "hooks.json"
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_path.write_text("[features]\ncodex_hooks = true\n", encoding="utf-8")
+    config_path.write_text("[features]\nhooks = true\n", encoding="utf-8")
     hooks_path.write_text(
         json.dumps(
             {


### PR DESCRIPTION
## Summary
- switch Codex native hook config to [features].hooks
- remove deprecated codex_hooks during install/update repair
- keep legacy status visibility while treating only the new flag as active

## Verification
- pytest tests/test_guard_codex_install.py tests/test_guard_phase03_remainder.py -k 'codex'
- pytest tests/test_guard_cli.py -k 'guard_update_repairs_codex or guard_update_repairs_missing_codex_config or guard_update_repairs_workspace_codex_install or guard_doctor_warns_when_codex'
- ruff check src/codex_plugin_scanner/guard/adapters/codex.py tests/test_guard_codex_install.py tests/test_guard_phase03_remainder.py tests/test_guard_cli.py
- git diff --check