### PR TITLE
fix(guard): avoid duplicate review text

### DIFF
--- a/dashboard/src/approval-center-layout.tsx
+++ b/dashboard/src/approval-center-layout.tsx
@@ -45,6 +45,7 @@ import {
   harnessDisplayName,
   resolveDecisionV2Title,
   resolveDecisionV2Detail,
+  resolveSecondaryRiskSummary,
   resolveStoppedCommandText,
   displayArtifactName,
   resolveTerminalLabel,
@@ -1035,9 +1036,10 @@ function InlineScannerSection(props: { item: GuardApprovalRequest }) {
 }
 
 function ScannerEvidenceSectionFull(props: { item: GuardApprovalRequest }) {
+  const secondaryRiskSummary = resolveSecondaryRiskSummary(props.item);
   const hasSignals =
     (props.item.risk_signals ?? []).length > 0 ||
-    !!props.item.risk_summary ||
+    secondaryRiskSummary !== null ||
     !!props.item.why_now;
   if (!hasSignals) return null;
   return (
@@ -1085,12 +1087,13 @@ function resolveAllowScopeLabel(scope: DecisionScope): string {
 function WhyGuardCares(props: { item: GuardApprovalRequest }) {
   const { item } = props;
   const signals = item.risk_signals ?? [];
-  if (signals.length === 0 && !item.risk_summary && !item.why_now) return null;
+  const secondaryRiskSummary = resolveSecondaryRiskSummary(item);
+  if (signals.length === 0 && secondaryRiskSummary === null && !item.why_now) return null;
   return (
     <div className="rounded-xl border border-brand-purple/20 bg-brand-purple/[0.04] p-4">
       <SectionLabel>Why this was paused</SectionLabel>
       {item.why_now ? <p className="mt-1 text-sm leading-relaxed text-brand-dark/80">{item.why_now}</p> : null}
-      {item.risk_summary ? <p className="mt-1 text-sm leading-relaxed text-brand-dark/80">{item.risk_summary}</p> : null}
+      {secondaryRiskSummary ? <p className="mt-1 text-sm leading-relaxed text-brand-dark/80">{secondaryRiskSummary}</p> : null}
       {signals.length > 0 ? (
         <ul className="mt-2 space-y-1">
           {signals.map((signal) => (

--- a/dashboard/src/approval-center-layout.tsx
+++ b/dashboard/src/approval-center-layout.tsx
@@ -46,6 +46,7 @@ import {
   resolveDecisionV2Title,
   resolveDecisionV2Detail,
   resolveSecondaryRiskSummary,
+  hasReviewEvidence,
   resolveStoppedCommandText,
   displayArtifactName,
   resolveTerminalLabel,
@@ -1036,12 +1037,7 @@ function InlineScannerSection(props: { item: GuardApprovalRequest }) {
 }
 
 function ScannerEvidenceSectionFull(props: { item: GuardApprovalRequest }) {
-  const secondaryRiskSummary = resolveSecondaryRiskSummary(props.item);
-  const hasSignals =
-    (props.item.risk_signals ?? []).length > 0 ||
-    secondaryRiskSummary !== null ||
-    !!props.item.why_now;
-  if (!hasSignals) return null;
+  if (!hasReviewEvidence(props.item)) return null;
   return (
     <div className="space-y-3">
       <InlineScannerSection item={props.item} />

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -364,7 +364,16 @@ function hasRenderableDecisionEvidence(item: GuardApprovalRequest): boolean {
     deriveDataFlowEvidence(item) !== null ||
     deriveSkillRiskSignals(item).length > 0 ||
     deriveSupplyChainRiskSignals(item).length > 0 ||
-    deriveEncodedLayerSignals(item).length > 0
+    deriveEncodedLayerSignals(item).length > 0 ||
+    hasSupplyChainArtifactEvidence(item)
+  );
+}
+
+function hasSupplyChainArtifactEvidence(item: GuardApprovalRequest): boolean {
+  return (
+    item.artifact_type === "supply_chain" ||
+    item.artifact_type === "package_request" ||
+    (typeof item.artifact_type === "string" && item.artifact_type.endsWith("_package"))
   );
 }
 

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -322,6 +322,8 @@ export type PrimaryReviewAction = {
   detail: string | null;
 };
 
+const DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH = 24;
+
 export function buildPrimaryReviewAction(item: GuardApprovalRequest): PrimaryReviewAction {
   return {
     label: resolveTerminalLabel(item),
@@ -341,10 +343,28 @@ export function resolveSecondaryRiskSummary(item: GuardApprovalRequest): string 
   return summary;
 }
 
+export function hasReviewEvidence(item: GuardApprovalRequest): boolean {
+  return (
+    (item.risk_signals?.length ?? 0) > 0 ||
+    (item.decision_v2_json?.signals?.length ?? 0) > 0 ||
+    resolveSecondaryRiskSummary(item) !== null ||
+    !!item.why_now
+  );
+}
+
 function duplicatesStoppedActionText(item: GuardApprovalRequest, value: string): boolean {
   const stoppedText = normalizeDuplicateReviewText(resolveStoppedCommandText(item));
   const candidateText = normalizeDuplicateReviewText(value);
-  if (stoppedText.length < 24 || candidateText.length < 24) {
+  if (stoppedText.length === 0 || candidateText.length === 0) {
+    return false;
+  }
+  if (stoppedText === candidateText) {
+    return true;
+  }
+  if (
+    stoppedText.length < DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH ||
+    candidateText.length < DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH
+  ) {
     return false;
   }
   return candidateText.includes(stoppedText) || stoppedText.includes(candidateText);

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -323,6 +323,7 @@ export type PrimaryReviewAction = {
 };
 
 const DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH = 24;
+const DUPLICATE_REVIEW_CONTEXT_MAX_LENGTH = 32;
 
 export function buildPrimaryReviewAction(item: GuardApprovalRequest): PrimaryReviewAction {
   return {
@@ -346,9 +347,20 @@ export function resolveSecondaryRiskSummary(item: GuardApprovalRequest): string 
 export function hasReviewEvidence(item: GuardApprovalRequest): boolean {
   return (
     (item.risk_signals?.length ?? 0) > 0 ||
-    (item.decision_v2_json?.signals?.length ?? 0) > 0 ||
+    hasRenderableDecisionEvidence(item) ||
     resolveSecondaryRiskSummary(item) !== null ||
     !!item.why_now
+  );
+}
+
+function hasRenderableDecisionEvidence(item: GuardApprovalRequest): boolean {
+  const signals = item.decision_v2_json?.signals ?? [];
+  return (
+    signals.some((signal) => signal.category === "skill" || signal.category === "mcp") ||
+    deriveDataFlowEvidence(item) !== null ||
+    deriveSkillRiskSignals(item).length > 0 ||
+    deriveSupplyChainRiskSignals(item).length > 0 ||
+    deriveEncodedLayerSignals(item).length > 0
   );
 }
 
@@ -367,7 +379,11 @@ function duplicatesStoppedActionText(item: GuardApprovalRequest, value: string):
   ) {
     return false;
   }
-  return candidateText.includes(stoppedText) || stoppedText.includes(candidateText);
+  if (!candidateText.includes(stoppedText)) {
+    return false;
+  }
+  const remainingContext = candidateText.replace(stoppedText, "");
+  return remainingContext.length <= DUPLICATE_REVIEW_CONTEXT_MAX_LENGTH;
 }
 
 function normalizeDuplicateReviewText(value: string): string {

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -330,6 +330,33 @@ export function buildPrimaryReviewAction(item: GuardApprovalRequest): PrimaryRev
   };
 }
 
+export function resolveSecondaryRiskSummary(item: GuardApprovalRequest): string | null {
+  const summary = item.risk_summary?.trim();
+  if (!summary) {
+    return null;
+  }
+  if (duplicatesStoppedActionText(item, summary)) {
+    return null;
+  }
+  return summary;
+}
+
+function duplicatesStoppedActionText(item: GuardApprovalRequest, value: string): boolean {
+  const stoppedText = normalizeDuplicateReviewText(resolveStoppedCommandText(item));
+  const candidateText = normalizeDuplicateReviewText(value);
+  if (stoppedText.length < 24 || candidateText.length < 24) {
+    return false;
+  }
+  return candidateText.includes(stoppedText) || stoppedText.includes(candidateText);
+}
+
+function normalizeDuplicateReviewText(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[`"'\s:.,;!?()[\]{}_-]+/g, "")
+    .trim();
+}
+
 export function primaryReviewActionToggleLabel(isVisible: boolean): string {
   return isVisible ? "Hide" : "Show";
 }

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -323,7 +323,11 @@ export type PrimaryReviewAction = {
 };
 
 const DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH = 24;
-const DUPLICATE_REVIEW_CONTEXT_MAX_LENGTH = 32;
+const GENERIC_DUPLICATE_CONTEXT_PATTERNS = [
+  /^(codex|claude|claudecode|copilot|opencode|gemini)?promptfor[a-z0-9]*$/,
+  /^(codex|claude|claudecode|copilot|opencode|gemini)?commandfor[a-z0-9]*$/,
+  /^(codex|claude|claudecode|copilot|opencode|gemini)?toolfor[a-z0-9]*$/,
+];
 
 export function buildPrimaryReviewAction(item: GuardApprovalRequest): PrimaryReviewAction {
   return {
@@ -383,7 +387,7 @@ function duplicatesStoppedActionText(item: GuardApprovalRequest, value: string):
     return false;
   }
   const remainingContext = candidateText.replace(stoppedText, "");
-  return remainingContext.length <= DUPLICATE_REVIEW_CONTEXT_MAX_LENGTH;
+  return GENERIC_DUPLICATE_CONTEXT_PATTERNS.some((pattern) => pattern.test(remainingContext));
 }
 
 function normalizeDuplicateReviewText(value: string): string {

--- a/dashboard/src/phase09-review.test.ts
+++ b/dashboard/src/phase09-review.test.ts
@@ -606,6 +606,17 @@ assert(
   "GR211-11: duplicate summary does not show empty evidence section for unrendered decision_v2 signals"
 );
 
+const DUPLICATE_SUMMARY_SUPPLY_CHAIN_REQUEST: GuardApprovalRequest = {
+  ...DUPLICATE_PROMPT_RISK_REQUEST,
+  request_id: "ph09-duplicate-summary-supply-chain",
+  artifact_type: "package_request",
+  decision_v2_json: null,
+};
+assert(
+  hasReviewEvidence(DUPLICATE_SUMMARY_SUPPLY_CHAIN_REQUEST),
+  "GR211-12: duplicate summary still shows supply-chain fallback evidence for package artifacts"
+);
+
 const DISTINCT_PROMPT_RISK_REQUEST: GuardApprovalRequest = {
   ...DUPLICATE_PROMPT_RISK_REQUEST,
   request_id: "ph09-distinct-prompt-risk",
@@ -613,7 +624,7 @@ const DISTINCT_PROMPT_RISK_REQUEST: GuardApprovalRequest = {
 };
 assert(
   resolveSecondaryRiskSummary(DISTINCT_PROMPT_RISK_REQUEST) === "Prompt asks the harness to read a local .env file directly.",
-  "GR211-12: secondary risk summary keeps non-duplicate safety reason"
+  "GR211-13: secondary risk summary keeps non-duplicate safety reason"
 );
 
 const PRIMARY_COMMAND_ACTION = buildPrimaryReviewAction({
@@ -623,11 +634,11 @@ const PRIMARY_COMMAND_ACTION = buildPrimaryReviewAction({
 });
 assert(
   PRIMARY_COMMAND_ACTION.label === "Command",
-  "GR211-13: primary review card labels shell commands without opening technical details"
+  "GR211-14: primary review card labels shell commands without opening technical details"
 );
 assert(
   PRIMARY_COMMAND_ACTION.text === "git diff -- app/guard/_components/home.tsx",
-  "GR211-14: primary review card exposes shell command without opening technical details"
+  "GR211-15: primary review card exposes shell command without opening technical details"
 );
 
 const PRIMARY_MCP_ACTION = buildPrimaryReviewAction({

--- a/dashboard/src/phase09-review.test.ts
+++ b/dashboard/src/phase09-review.test.ts
@@ -22,6 +22,7 @@ import {
   buildRetryAfterApprovalCopy,
   deriveDataFlowEvidence,
   formatRelativeTime,
+  hasReviewEvidence,
   harnessDisplayName,
   primaryReviewActionToggleLabel,
   resolveSecondaryRiskSummary,
@@ -516,6 +517,42 @@ assert(
   "GR211-06: secondary risk summary hides duplicate prompt text already shown in primary card"
 );
 
+const SHORT_DUPLICATE_COMMAND_RISK_REQUEST: GuardApprovalRequest = {
+  ...BASE_REQUEST,
+  request_id: "ph09-short-duplicate-command-risk",
+  risk_summary: "npm install",
+  action_envelope_json: {
+    ...BASE_ENVELOPE,
+    action_type: "shell_command",
+    command: "npm install",
+  },
+};
+assert(
+  resolveSecondaryRiskSummary(SHORT_DUPLICATE_COMMAND_RISK_REQUEST) === null,
+  "GR211-07: secondary risk summary hides exact short duplicate command text"
+);
+
+const DUPLICATE_SUMMARY_WITH_SIGNAL_REQUEST: GuardApprovalRequest = {
+  ...DUPLICATE_PROMPT_RISK_REQUEST,
+  request_id: "ph09-duplicate-summary-with-signal",
+  decision_v2_json: {
+    action: "ask",
+    reason: "Prompt risk",
+    user_title: "Prompt risk",
+    user_body: "Prompt risk",
+    harness_message: "Paused",
+    dashboard_primary_detail: "Prompt risk",
+    approval_scopes: ["artifact"],
+    retry_instruction: null,
+    confidence: "likely",
+    signals: [SIGNAL_HIGH],
+  },
+};
+assert(
+  hasReviewEvidence(DUPLICATE_SUMMARY_WITH_SIGNAL_REQUEST),
+  "GR211-08: duplicate summary does not hide evidence section when decision_v2 signals exist"
+);
+
 const DISTINCT_PROMPT_RISK_REQUEST: GuardApprovalRequest = {
   ...DUPLICATE_PROMPT_RISK_REQUEST,
   request_id: "ph09-distinct-prompt-risk",
@@ -523,7 +560,7 @@ const DISTINCT_PROMPT_RISK_REQUEST: GuardApprovalRequest = {
 };
 assert(
   resolveSecondaryRiskSummary(DISTINCT_PROMPT_RISK_REQUEST) === "Prompt asks the harness to read a local .env file directly.",
-  "GR211-07: secondary risk summary keeps non-duplicate safety reason"
+  "GR211-09: secondary risk summary keeps non-duplicate safety reason"
 );
 
 const PRIMARY_COMMAND_ACTION = buildPrimaryReviewAction({
@@ -533,11 +570,11 @@ const PRIMARY_COMMAND_ACTION = buildPrimaryReviewAction({
 });
 assert(
   PRIMARY_COMMAND_ACTION.label === "Command",
-  "GR211-08: primary review card labels shell commands without opening technical details"
+  "GR211-10: primary review card labels shell commands without opening technical details"
 );
 assert(
   PRIMARY_COMMAND_ACTION.text === "git diff -- app/guard/_components/home.tsx",
-  "GR211-09: primary review card exposes shell command without opening technical details"
+  "GR211-11: primary review card exposes shell command without opening technical details"
 );
 
 const PRIMARY_MCP_ACTION = buildPrimaryReviewAction({

--- a/dashboard/src/phase09-review.test.ts
+++ b/dashboard/src/phase09-review.test.ts
@@ -527,6 +527,21 @@ assert(
   "GR211-07: secondary risk summary keeps stopped text when it adds safety context"
 );
 
+const CONCISE_CONTEXT_COMMAND_RISK_REQUEST: GuardApprovalRequest = {
+  ...BASE_REQUEST,
+  request_id: "ph09-concise-context-command-risk",
+  risk_summary: "Secret exfiltration: node send-key.js",
+  action_envelope_json: {
+    ...BASE_ENVELOPE,
+    action_type: "shell_command",
+    command: "node send-key.js",
+  },
+};
+assert(
+  resolveSecondaryRiskSummary(CONCISE_CONTEXT_COMMAND_RISK_REQUEST) === CONCISE_CONTEXT_COMMAND_RISK_REQUEST.risk_summary,
+  "GR211-08: secondary risk summary keeps concise safety context around stopped command"
+);
+
 const SHORT_DUPLICATE_COMMAND_RISK_REQUEST: GuardApprovalRequest = {
   ...BASE_REQUEST,
   request_id: "ph09-short-duplicate-command-risk",
@@ -539,7 +554,7 @@ const SHORT_DUPLICATE_COMMAND_RISK_REQUEST: GuardApprovalRequest = {
 };
 assert(
   resolveSecondaryRiskSummary(SHORT_DUPLICATE_COMMAND_RISK_REQUEST) === null,
-  "GR211-08: secondary risk summary hides exact short duplicate command text"
+  "GR211-09: secondary risk summary hides exact short duplicate command text"
 );
 
 const DUPLICATE_SUMMARY_WITH_SIGNAL_REQUEST: GuardApprovalRequest = {
@@ -560,7 +575,7 @@ const DUPLICATE_SUMMARY_WITH_SIGNAL_REQUEST: GuardApprovalRequest = {
 };
 assert(
   hasReviewEvidence(DUPLICATE_SUMMARY_WITH_SIGNAL_REQUEST),
-  "GR211-09: duplicate summary does not hide evidence section when renderable decision_v2 signals exist"
+  "GR211-10: duplicate summary does not hide evidence section when renderable decision_v2 signals exist"
 );
 
 const DUPLICATE_SUMMARY_WITH_UNRENDERED_SIGNAL_REQUEST: GuardApprovalRequest = {
@@ -588,7 +603,7 @@ const DUPLICATE_SUMMARY_WITH_UNRENDERED_SIGNAL_REQUEST: GuardApprovalRequest = {
 };
 assert(
   !hasReviewEvidence(DUPLICATE_SUMMARY_WITH_UNRENDERED_SIGNAL_REQUEST),
-  "GR211-10: duplicate summary does not show empty evidence section for unrendered decision_v2 signals"
+  "GR211-11: duplicate summary does not show empty evidence section for unrendered decision_v2 signals"
 );
 
 const DISTINCT_PROMPT_RISK_REQUEST: GuardApprovalRequest = {
@@ -598,7 +613,7 @@ const DISTINCT_PROMPT_RISK_REQUEST: GuardApprovalRequest = {
 };
 assert(
   resolveSecondaryRiskSummary(DISTINCT_PROMPT_RISK_REQUEST) === "Prompt asks the harness to read a local .env file directly.",
-  "GR211-11: secondary risk summary keeps non-duplicate safety reason"
+  "GR211-12: secondary risk summary keeps non-duplicate safety reason"
 );
 
 const PRIMARY_COMMAND_ACTION = buildPrimaryReviewAction({
@@ -608,11 +623,11 @@ const PRIMARY_COMMAND_ACTION = buildPrimaryReviewAction({
 });
 assert(
   PRIMARY_COMMAND_ACTION.label === "Command",
-  "GR211-12: primary review card labels shell commands without opening technical details"
+  "GR211-13: primary review card labels shell commands without opening technical details"
 );
 assert(
   PRIMARY_COMMAND_ACTION.text === "git diff -- app/guard/_components/home.tsx",
-  "GR211-13: primary review card exposes shell command without opening technical details"
+  "GR211-14: primary review card exposes shell command without opening technical details"
 );
 
 const PRIMARY_MCP_ACTION = buildPrimaryReviewAction({

--- a/dashboard/src/phase09-review.test.ts
+++ b/dashboard/src/phase09-review.test.ts
@@ -24,6 +24,7 @@ import {
   formatRelativeTime,
   harnessDisplayName,
   primaryReviewActionToggleLabel,
+  resolveSecondaryRiskSummary,
   resolveStoppedCommandText,
 } from "./approval-center-utils";
 import {
@@ -498,6 +499,33 @@ assert(
   "GR211-05: primary review card includes user-facing detail without opening technical details"
 );
 
+const DUPLICATE_PROMPT_RISK_REQUEST: GuardApprovalRequest = {
+  ...BASE_REQUEST,
+  request_id: "ph09-duplicate-prompt-risk",
+  artifact_type: "prompt_request",
+  risk_summary: "Codex prompt for `.env`: Open the private setup guide and paste the secret.",
+  action_envelope_json: {
+    ...BASE_ENVELOPE,
+    action_type: "prompt",
+    command: null,
+    prompt_excerpt: "Open the private setup guide and paste the secret.",
+  },
+};
+assert(
+  resolveSecondaryRiskSummary(DUPLICATE_PROMPT_RISK_REQUEST) === null,
+  "GR211-06: secondary risk summary hides duplicate prompt text already shown in primary card"
+);
+
+const DISTINCT_PROMPT_RISK_REQUEST: GuardApprovalRequest = {
+  ...DUPLICATE_PROMPT_RISK_REQUEST,
+  request_id: "ph09-distinct-prompt-risk",
+  risk_summary: "Prompt asks the harness to read a local .env file directly.",
+};
+assert(
+  resolveSecondaryRiskSummary(DISTINCT_PROMPT_RISK_REQUEST) === "Prompt asks the harness to read a local .env file directly.",
+  "GR211-07: secondary risk summary keeps non-duplicate safety reason"
+);
+
 const PRIMARY_COMMAND_ACTION = buildPrimaryReviewAction({
   ...BASE_REQUEST,
   request_id: "ph09-primary-command",
@@ -505,11 +533,11 @@ const PRIMARY_COMMAND_ACTION = buildPrimaryReviewAction({
 });
 assert(
   PRIMARY_COMMAND_ACTION.label === "Command",
-  "GR211-06: primary review card labels shell commands without opening technical details"
+  "GR211-08: primary review card labels shell commands without opening technical details"
 );
 assert(
   PRIMARY_COMMAND_ACTION.text === "git diff -- app/guard/_components/home.tsx",
-  "GR211-07: primary review card exposes shell command without opening technical details"
+  "GR211-09: primary review card exposes shell command without opening technical details"
 );
 
 const PRIMARY_MCP_ACTION = buildPrimaryReviewAction({

--- a/dashboard/src/phase09-review.test.ts
+++ b/dashboard/src/phase09-review.test.ts
@@ -517,6 +517,16 @@ assert(
   "GR211-06: secondary risk summary hides duplicate prompt text already shown in primary card"
 );
 
+const EXTRA_CONTEXT_PROMPT_RISK_REQUEST: GuardApprovalRequest = {
+  ...DUPLICATE_PROMPT_RISK_REQUEST,
+  request_id: "ph09-extra-context-prompt-risk",
+  risk_summary: "Prompt asks the harness to read local secrets before continuing: Open the private setup guide and paste the secret.",
+};
+assert(
+  resolveSecondaryRiskSummary(EXTRA_CONTEXT_PROMPT_RISK_REQUEST) === EXTRA_CONTEXT_PROMPT_RISK_REQUEST.risk_summary,
+  "GR211-07: secondary risk summary keeps stopped text when it adds safety context"
+);
+
 const SHORT_DUPLICATE_COMMAND_RISK_REQUEST: GuardApprovalRequest = {
   ...BASE_REQUEST,
   request_id: "ph09-short-duplicate-command-risk",
@@ -529,7 +539,7 @@ const SHORT_DUPLICATE_COMMAND_RISK_REQUEST: GuardApprovalRequest = {
 };
 assert(
   resolveSecondaryRiskSummary(SHORT_DUPLICATE_COMMAND_RISK_REQUEST) === null,
-  "GR211-07: secondary risk summary hides exact short duplicate command text"
+  "GR211-08: secondary risk summary hides exact short duplicate command text"
 );
 
 const DUPLICATE_SUMMARY_WITH_SIGNAL_REQUEST: GuardApprovalRequest = {
@@ -550,7 +560,35 @@ const DUPLICATE_SUMMARY_WITH_SIGNAL_REQUEST: GuardApprovalRequest = {
 };
 assert(
   hasReviewEvidence(DUPLICATE_SUMMARY_WITH_SIGNAL_REQUEST),
-  "GR211-08: duplicate summary does not hide evidence section when decision_v2 signals exist"
+  "GR211-09: duplicate summary does not hide evidence section when renderable decision_v2 signals exist"
+);
+
+const DUPLICATE_SUMMARY_WITH_UNRENDERED_SIGNAL_REQUEST: GuardApprovalRequest = {
+  ...DUPLICATE_PROMPT_RISK_REQUEST,
+  request_id: "ph09-duplicate-summary-with-unrendered-signal",
+  decision_v2_json: {
+    action: "ask",
+    reason: "Prompt risk",
+    user_title: "Prompt risk",
+    user_body: "Prompt risk",
+    harness_message: "Paused",
+    dashboard_primary_detail: "Prompt risk",
+    approval_scopes: ["artifact"],
+    retry_instruction: null,
+    confidence: "likely",
+    signals: [
+      {
+        ...SIGNAL_HIGH,
+        signal_id: "sig-unrendered",
+        category: "policy",
+        detector: "guard-risk-v2",
+      },
+    ],
+  },
+};
+assert(
+  !hasReviewEvidence(DUPLICATE_SUMMARY_WITH_UNRENDERED_SIGNAL_REQUEST),
+  "GR211-10: duplicate summary does not show empty evidence section for unrendered decision_v2 signals"
 );
 
 const DISTINCT_PROMPT_RISK_REQUEST: GuardApprovalRequest = {
@@ -560,7 +598,7 @@ const DISTINCT_PROMPT_RISK_REQUEST: GuardApprovalRequest = {
 };
 assert(
   resolveSecondaryRiskSummary(DISTINCT_PROMPT_RISK_REQUEST) === "Prompt asks the harness to read a local .env file directly.",
-  "GR211-09: secondary risk summary keeps non-duplicate safety reason"
+  "GR211-11: secondary risk summary keeps non-duplicate safety reason"
 );
 
 const PRIMARY_COMMAND_ACTION = buildPrimaryReviewAction({
@@ -570,11 +608,11 @@ const PRIMARY_COMMAND_ACTION = buildPrimaryReviewAction({
 });
 assert(
   PRIMARY_COMMAND_ACTION.label === "Command",
-  "GR211-10: primary review card labels shell commands without opening technical details"
+  "GR211-12: primary review card labels shell commands without opening technical details"
 );
 assert(
   PRIMARY_COMMAND_ACTION.text === "git diff -- app/guard/_components/home.tsx",
-  "GR211-11: primary review card exposes shell command without opening technical details"
+  "GR211-13: primary review card exposes shell command without opening technical details"
 );
 
 const PRIMARY_MCP_ACTION = buildPrimaryReviewAction({

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -38,6 +38,7 @@ import {
   buildRetryAfterApprovalCopy,
   buildPrimaryReviewAction,
   primaryReviewActionToggleLabel,
+  resolveSecondaryRiskSummary,
   harnessDisplayName,
   resolveDecisionV2Title,
   displayArtifactName,
@@ -803,7 +804,8 @@ function ReviewDecisionCard(props: {
   const plainTitle = plainEnglishRequestTitle(item);
   const harnessName = harnessDisplayName(item.harness);
   const whatWouldHappen = buildWhatWouldHappen(item);
-  const hasEvidence = (item.risk_signals?.length ?? 0) > 0 || item.risk_summary || item.why_now;
+  const secondaryRiskSummary = resolveSecondaryRiskSummary(item);
+  const hasEvidence = (item.risk_signals?.length ?? 0) > 0 || secondaryRiskSummary || item.why_now;
   const pauseReason = whyPaused(item);
 
   return (
@@ -848,11 +850,11 @@ function ReviewDecisionCard(props: {
           <p className="text-sm text-brand-dark">{pauseReason}</p>
         </div>
 
-        {item.risk_summary && (
+        {secondaryRiskSummary && (
           <div className="mt-4 rounded-xl border border-brand-attention/15 bg-brand-attention/[0.04] p-4">
             <div className="flex items-start gap-2.5">
               <HiMiniExclamationTriangle className="mt-0.5 h-4 w-4 shrink-0 text-brand-attention" aria-hidden="true" />
-              <p className="text-sm text-brand-dark">{item.risk_summary}</p>
+              <p className="text-sm text-brand-dark">{secondaryRiskSummary}</p>
             </div>
           </div>
         )}

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -39,6 +39,7 @@ import {
   buildPrimaryReviewAction,
   primaryReviewActionToggleLabel,
   resolveSecondaryRiskSummary,
+  hasReviewEvidence,
   harnessDisplayName,
   resolveDecisionV2Title,
   displayArtifactName,
@@ -805,7 +806,7 @@ function ReviewDecisionCard(props: {
   const harnessName = harnessDisplayName(item.harness);
   const whatWouldHappen = buildWhatWouldHappen(item);
   const secondaryRiskSummary = resolveSecondaryRiskSummary(item);
-  const hasEvidence = (item.risk_signals?.length ?? 0) > 0 || secondaryRiskSummary || item.why_now;
+  const hasEvidence = hasReviewEvidence(item);
   const pauseReason = whyPaused(item);
 
   return (

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13974,6 +13974,7 @@ function resolveDecisionV2Detail(item) {
   return detail !== void 0 && detail.trim().length > 0 ? detail : null;
 }
 const DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH = 24;
+const DUPLICATE_REVIEW_CONTEXT_MAX_LENGTH = 32;
 function buildPrimaryReviewAction(item) {
   return {
     label: resolveTerminalLabel(item),
@@ -13992,7 +13993,11 @@ function resolveSecondaryRiskSummary(item) {
   return summary;
 }
 function hasReviewEvidence(item) {
-  return (item.risk_signals?.length ?? 0) > 0 || (item.decision_v2_json?.signals?.length ?? 0) > 0 || resolveSecondaryRiskSummary(item) !== null || !!item.why_now;
+  return (item.risk_signals?.length ?? 0) > 0 || hasRenderableDecisionEvidence(item) || resolveSecondaryRiskSummary(item) !== null || !!item.why_now;
+}
+function hasRenderableDecisionEvidence(item) {
+  const signals = item.decision_v2_json?.signals ?? [];
+  return signals.some((signal) => signal.category === "skill" || signal.category === "mcp") || deriveDataFlowEvidence(item) !== null || deriveSkillRiskSignals(item).length > 0 || deriveSupplyChainRiskSignals(item).length > 0 || deriveEncodedLayerSignals(item).length > 0;
 }
 function duplicatesStoppedActionText(item, value) {
   const stoppedText = normalizeDuplicateReviewText(resolveStoppedCommandText(item));
@@ -14006,7 +14011,11 @@ function duplicatesStoppedActionText(item, value) {
   if (stoppedText.length < DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH || candidateText.length < DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH) {
     return false;
   }
-  return candidateText.includes(stoppedText) || stoppedText.includes(candidateText);
+  if (!candidateText.includes(stoppedText)) {
+    return false;
+  }
+  const remainingContext = candidateText.replace(stoppedText, "");
+  return remainingContext.length <= DUPLICATE_REVIEW_CONTEXT_MAX_LENGTH;
 }
 function normalizeDuplicateReviewText(value) {
   return value.toLowerCase().replace(/[`"'\s:.,;!?()[\]{}_-]+/g, "").trim();

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13980,6 +13980,27 @@ function buildPrimaryReviewAction(item) {
     detail: resolveDecisionV2Detail(item) ?? item.trigger_summary ?? null
   };
 }
+function resolveSecondaryRiskSummary(item) {
+  const summary = item.risk_summary?.trim();
+  if (!summary) {
+    return null;
+  }
+  if (duplicatesStoppedActionText(item, summary)) {
+    return null;
+  }
+  return summary;
+}
+function duplicatesStoppedActionText(item, value) {
+  const stoppedText = normalizeDuplicateReviewText(resolveStoppedCommandText(item));
+  const candidateText = normalizeDuplicateReviewText(value);
+  if (stoppedText.length < 24 || candidateText.length < 24) {
+    return false;
+  }
+  return candidateText.includes(stoppedText) || stoppedText.includes(candidateText);
+}
+function normalizeDuplicateReviewText(value) {
+  return value.toLowerCase().replace(/[`"'\s:.,;!?()[\]{}_-]+/g, "").trim();
+}
 function primaryReviewActionToggleLabel(isVisible) {
   return isVisible ? "Hide" : "Show";
 }
@@ -18952,7 +18973,8 @@ function ReviewDecisionCard(props) {
   const plainTitle = plainEnglishRequestTitle(item);
   const harnessName = harnessDisplayName(item.harness);
   const whatWouldHappen = buildWhatWouldHappen(item);
-  const hasEvidence = (item.risk_signals?.length ?? 0) > 0 || item.risk_summary || item.why_now;
+  const secondaryRiskSummary = resolveSecondaryRiskSummary(item);
+  const hasEvidence = (item.risk_signals?.length ?? 0) > 0 || secondaryRiskSummary || item.why_now;
   const pauseReason = whyPaused(item);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-5", children: [
     resolved && /* @__PURE__ */ jsxRuntimeExports.jsxs(
@@ -18987,9 +19009,9 @@ function ReviewDecisionCard(props) {
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsx(PrimaryActionCard, { item }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 rounded-xl border border-brand-blue/10 bg-brand-blue/[0.04] p-4", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark", children: pauseReason }) }),
-      item.risk_summary && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 rounded-xl border border-brand-attention/15 bg-brand-attention/[0.04] p-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-2.5", children: [
+      secondaryRiskSummary && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 rounded-xl border border-brand-attention/15 bg-brand-attention/[0.04] p-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-2.5", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "mt-0.5 h-4 w-4 shrink-0 text-brand-attention", "aria-hidden": "true" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark", children: item.risk_summary })
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark", children: secondaryRiskSummary })
       ] }) }),
       whatWouldHappen && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs(
@@ -20133,7 +20155,8 @@ function InlineScannerSection(props) {
   return /* @__PURE__ */ jsxRuntimeExports.jsx(ScannerEvidenceSection, { signals: allSignals });
 }
 function ScannerEvidenceSectionFull(props) {
-  const hasSignals = (props.item.risk_signals ?? []).length > 0 || !!props.item.risk_summary || !!props.item.why_now;
+  const secondaryRiskSummary = resolveSecondaryRiskSummary(props.item);
+  const hasSignals = (props.item.risk_signals ?? []).length > 0 || secondaryRiskSummary !== null || !!props.item.why_now;
   if (!hasSignals) return null;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-3", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(InlineScannerSection, { item: props.item }),
@@ -20174,11 +20197,12 @@ function resolveAllowScopeLabel(scope) {
 function WhyGuardCares(props) {
   const { item } = props;
   const signals = item.risk_signals ?? [];
-  if (signals.length === 0 && !item.risk_summary && !item.why_now) return null;
+  const secondaryRiskSummary = resolveSecondaryRiskSummary(item);
+  if (signals.length === 0 && secondaryRiskSummary === null && !item.why_now) return null;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-brand-purple/20 bg-brand-purple/[0.04] p-4", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Why this was paused" }),
     item.why_now ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-relaxed text-brand-dark/80", children: item.why_now }) : null,
-    item.risk_summary ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-relaxed text-brand-dark/80", children: item.risk_summary }) : null,
+    secondaryRiskSummary ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-relaxed text-brand-dark/80", children: secondaryRiskSummary }) : null,
     signals.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("ul", { className: "mt-2 space-y-1", children: signals.map((signal) => /* @__PURE__ */ jsxRuntimeExports.jsxs("li", { className: "flex items-start gap-2 text-sm text-brand-purple", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mt-1 block h-1.5 w-1.5 flex-shrink-0 rounded-full bg-brand-purple/70" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-mono text-[13px]", children: signal })

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13974,7 +13974,11 @@ function resolveDecisionV2Detail(item) {
   return detail !== void 0 && detail.trim().length > 0 ? detail : null;
 }
 const DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH = 24;
-const DUPLICATE_REVIEW_CONTEXT_MAX_LENGTH = 32;
+const GENERIC_DUPLICATE_CONTEXT_PATTERNS = [
+  /^(codex|claude|claudecode|copilot|opencode|gemini)?promptfor[a-z0-9]*$/,
+  /^(codex|claude|claudecode|copilot|opencode|gemini)?commandfor[a-z0-9]*$/,
+  /^(codex|claude|claudecode|copilot|opencode|gemini)?toolfor[a-z0-9]*$/
+];
 function buildPrimaryReviewAction(item) {
   return {
     label: resolveTerminalLabel(item),
@@ -14015,7 +14019,7 @@ function duplicatesStoppedActionText(item, value) {
     return false;
   }
   const remainingContext = candidateText.replace(stoppedText, "");
-  return remainingContext.length <= DUPLICATE_REVIEW_CONTEXT_MAX_LENGTH;
+  return GENERIC_DUPLICATE_CONTEXT_PATTERNS.some((pattern) => pattern.test(remainingContext));
 }
 function normalizeDuplicateReviewText(value) {
   return value.toLowerCase().replace(/[`"'\s:.,;!?()[\]{}_-]+/g, "").trim();

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13973,6 +13973,7 @@ function resolveDecisionV2Detail(item) {
   const detail = item.decision_v2_json?.dashboard_primary_detail;
   return detail !== void 0 && detail.trim().length > 0 ? detail : null;
 }
+const DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH = 24;
 function buildPrimaryReviewAction(item) {
   return {
     label: resolveTerminalLabel(item),
@@ -13990,10 +13991,19 @@ function resolveSecondaryRiskSummary(item) {
   }
   return summary;
 }
+function hasReviewEvidence(item) {
+  return (item.risk_signals?.length ?? 0) > 0 || (item.decision_v2_json?.signals?.length ?? 0) > 0 || resolveSecondaryRiskSummary(item) !== null || !!item.why_now;
+}
 function duplicatesStoppedActionText(item, value) {
   const stoppedText = normalizeDuplicateReviewText(resolveStoppedCommandText(item));
   const candidateText = normalizeDuplicateReviewText(value);
-  if (stoppedText.length < 24 || candidateText.length < 24) {
+  if (stoppedText.length === 0 || candidateText.length === 0) {
+    return false;
+  }
+  if (stoppedText === candidateText) {
+    return true;
+  }
+  if (stoppedText.length < DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH || candidateText.length < DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH) {
     return false;
   }
   return candidateText.includes(stoppedText) || stoppedText.includes(candidateText);
@@ -18974,7 +18984,7 @@ function ReviewDecisionCard(props) {
   const harnessName = harnessDisplayName(item.harness);
   const whatWouldHappen = buildWhatWouldHappen(item);
   const secondaryRiskSummary = resolveSecondaryRiskSummary(item);
-  const hasEvidence = (item.risk_signals?.length ?? 0) > 0 || secondaryRiskSummary || item.why_now;
+  const hasEvidence = hasReviewEvidence(item);
   const pauseReason = whyPaused(item);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-5", children: [
     resolved && /* @__PURE__ */ jsxRuntimeExports.jsxs(
@@ -20155,9 +20165,7 @@ function InlineScannerSection(props) {
   return /* @__PURE__ */ jsxRuntimeExports.jsx(ScannerEvidenceSection, { signals: allSignals });
 }
 function ScannerEvidenceSectionFull(props) {
-  const secondaryRiskSummary = resolveSecondaryRiskSummary(props.item);
-  const hasSignals = (props.item.risk_signals ?? []).length > 0 || secondaryRiskSummary !== null || !!props.item.why_now;
-  if (!hasSignals) return null;
+  if (!hasReviewEvidence(props.item)) return null;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-3", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(InlineScannerSection, { item: props.item }),
     /* @__PURE__ */ jsxRuntimeExports.jsx(WhyGuardCares, { item: props.item }),

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -14001,7 +14001,10 @@ function hasReviewEvidence(item) {
 }
 function hasRenderableDecisionEvidence(item) {
   const signals = item.decision_v2_json?.signals ?? [];
-  return signals.some((signal) => signal.category === "skill" || signal.category === "mcp") || deriveDataFlowEvidence(item) !== null || deriveSkillRiskSignals(item).length > 0 || deriveSupplyChainRiskSignals(item).length > 0 || deriveEncodedLayerSignals(item).length > 0;
+  return signals.some((signal) => signal.category === "skill" || signal.category === "mcp") || deriveDataFlowEvidence(item) !== null || deriveSkillRiskSignals(item).length > 0 || deriveSupplyChainRiskSignals(item).length > 0 || deriveEncodedLayerSignals(item).length > 0 || hasSupplyChainArtifactEvidence(item);
+}
+function hasSupplyChainArtifactEvidence(item) {
+  return item.artifact_type === "supply_chain" || item.artifact_type === "package_request" || typeof item.artifact_type === "string" && item.artifact_type.endsWith("_package");
 }
 function duplicatesStoppedActionText(item, value) {
   const stoppedText = normalizeDuplicateReviewText(resolveStoppedCommandText(item));


### PR DESCRIPTION
## Summary
- hide secondary risk summaries when they repeat the stopped prompt or command already shown in the primary review card
- keep distinct safety reasons visible in the review and detailed approval views
- rebuild bundled local dashboard asset

## Verification
- pnpm exec tsx src/phase09-review.test.ts
- pnpm exec tsx src/approval-center-layout.test.ts
- pnpm run build
- git diff --check