### PR TITLE
fix(dashboard): compact review command controls

### DIFF
--- a/dashboard/src/approval-center-layout.tsx
+++ b/dashboard/src/approval-center-layout.tsx
@@ -1463,6 +1463,9 @@ function BlockedActionCard(props: { item: GuardApprovalRequest }) {
   const decisionDetail = resolveDecisionV2Detail(props.item);
   const [showCommand, setShowCommand] = useState(true);
   const [shareState, setShareState] = useState<"idle" | "copied" | "failed">("idle");
+  useEffect(() => {
+    setShowCommand(true);
+  }, [props.item.request_id]);
   const isBlocked = props.item.policy_action === "block";
   const bannerBg = isBlocked
     ? "bg-gradient-to-r from-brand-purple/90 to-brand-purple/75"

--- a/dashboard/src/approval-center-layout.tsx
+++ b/dashboard/src/approval-center-layout.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { useState, useEffect, useCallback, useMemo, useRef, type ChangeEvent } from "react";
 import {
+  HiMiniChevronDown,
+  HiMiniChevronUp,
   HiMiniClipboard,
   HiMiniClipboardDocumentCheck,
   HiMiniExclamationTriangle,
@@ -1396,6 +1398,27 @@ function DecisionSteps(props: { activeStep: number }) {
   );
 }
 
+function CommandHeaderButton(props: {
+  label: string;
+  icon: ReactNode;
+  onClick: () => void;
+  ariaLabel: string;
+  expanded?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={props.onClick}
+      aria-label={props.ariaLabel}
+      aria-expanded={props.expanded}
+      className="inline-flex h-7 shrink-0 items-center gap-1 rounded-lg border border-white/15 bg-white/[0.08] px-2 font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-white/70 transition-colors hover:border-white/25 hover:bg-white/15 hover:text-white focus-visible:outline-white/50"
+    >
+      {props.icon}
+      <span className="hidden sm:inline">{props.label}</span>
+    </button>
+  );
+}
+
 function CopyCommandButton(props: { command: string }) {
   const [copied, setCopied] = useState(false);
 
@@ -1408,19 +1431,18 @@ function CopyCommandButton(props: { command: string }) {
   }, [props.command]);
 
   return (
-    <button
-      type="button"
+    <CommandHeaderButton
+      label={copied ? "Copied" : "Copy"}
+      ariaLabel="Copy command to clipboard"
       onClick={handleCopy}
-      aria-label="Copy command to clipboard"
-      className="inline-flex items-center gap-1.5 rounded-full border border-white/20 bg-white/10 px-2.5 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-white/70 transition-colors hover:bg-white/20 hover:text-white"
-    >
-      {copied ? (
-        <HiMiniClipboardDocumentCheck className="h-3.5 w-3.5" aria-hidden="true" />
-      ) : (
-        <HiMiniClipboard className="h-3.5 w-3.5" aria-hidden="true" />
-      )}
-      {copied ? "Copied" : "Copy"}
-    </button>
+      icon={
+        copied ? (
+          <HiMiniClipboardDocumentCheck className="h-3.5 w-3.5" aria-hidden="true" />
+        ) : (
+          <HiMiniClipboard className="h-3.5 w-3.5" aria-hidden="true" />
+        )
+      }
+    />
   );
 }
 
@@ -1439,6 +1461,7 @@ function resolveMcpInputSummary(payload: Record<string, unknown>): string | null
 function BlockedActionCard(props: { item: GuardApprovalRequest }) {
   const launchText = actionLaunchText(props.item);
   const decisionDetail = resolveDecisionV2Detail(props.item);
+  const [showCommand, setShowCommand] = useState(true);
   const [shareState, setShareState] = useState<"idle" | "copied" | "failed">("idle");
   const isBlocked = props.item.policy_action === "block";
   const bannerBg = isBlocked
@@ -1456,6 +1479,9 @@ function BlockedActionCard(props: { item: GuardApprovalRequest }) {
       ? resolveMcpInputSummary(envelope.raw_payload_redacted)
       : null;
   const approvalUrl = props.item.approval_url ? guardAwareHref(props.item.approval_url) : null;
+  const toggleCommand = useCallback(() => {
+    setShowCommand((visible) => !visible);
+  }, []);
 
   const handleCopyApprovalUrl = useCallback(async () => {
     if (approvalUrl === null) return;
@@ -1531,21 +1557,36 @@ function BlockedActionCard(props: { item: GuardApprovalRequest }) {
             {decisionDetail}
           </p>
         ) : null}
-        <div className="mt-4 rounded-xl bg-[#090d1a] p-1 shadow-[0_14px_35px_rgba(9,13,26,0.18)]">
-          <div className="flex items-center gap-1.5 border-b border-white/10 px-3 py-2">
+        <div className="mt-4 overflow-hidden rounded-xl bg-[#090d1a] shadow-[0_14px_35px_rgba(9,13,26,0.18)]">
+          <div className="flex min-h-11 flex-wrap items-center gap-1.5 border-b border-white/10 px-3 py-2 sm:flex-nowrap">
             <span className="h-2.5 w-2.5 rounded-full bg-brand-purple" />
             <span className="h-2.5 w-2.5 rounded-full bg-brand-blue" />
             <span className="h-2.5 w-2.5 rounded-full bg-brand-green" />
-            <span className="ml-2 font-mono text-[10px] uppercase tracking-[0.22em] text-white/45">
+            <span className="ml-2 min-w-0 flex-1 truncate font-mono text-[10px] uppercase tracking-[0.2em] text-white/45">
               {resolveTerminalLabel(props.item)}
             </span>
-            <span className="ml-auto">
+            <span className="ml-auto flex shrink-0 items-center gap-1.5">
               <CopyCommandButton command={launchText} />
+              <CommandHeaderButton
+                label={showCommand ? "Hide" : "Show"}
+                ariaLabel={showCommand ? "Hide stopped command" : "Show stopped command"}
+                expanded={showCommand}
+                onClick={toggleCommand}
+                icon={
+                  showCommand ? (
+                    <HiMiniChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
+                  ) : (
+                    <HiMiniChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+                  )
+                }
+              />
             </span>
           </div>
-          <pre className="overflow-x-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-sm leading-6 text-white">
-            {launchText}
-          </pre>
+          {showCommand ? (
+            <pre className="max-h-[min(34rem,48vh)] overflow-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-[13px] leading-6 text-white sm:text-sm">
+              {launchText}
+            </pre>
+          ) : null}
         </div>
         <WhyThisPaused item={props.item} />
         {isBlocked && (

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
+import { forwardRef, useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type ReactNode } from "react";
 import {
   HiMiniCheckCircle,
   HiMiniNoSymbol,
@@ -1176,32 +1176,32 @@ function PrimaryActionCard({ item }: { item: GuardApprovalRequest }) {
         </span>
       </div>
       <div className="mt-3 overflow-hidden rounded-xl bg-[#0f172a]">
-        <div className="flex flex-wrap items-center gap-1.5 border-b border-white/10 px-3 py-2">
+        <div className="flex min-h-11 flex-wrap items-center gap-1.5 border-b border-white/10 px-3 py-2 sm:flex-nowrap">
           <span className="h-2.5 w-2.5 rounded-full bg-brand-purple" />
           <span className="h-2.5 w-2.5 rounded-full bg-brand-blue" />
           <span className="h-2.5 w-2.5 rounded-full bg-brand-green" />
-          <span className="ml-2 font-mono text-[10px] uppercase tracking-[0.22em] text-white/45">
+          <span className="ml-2 min-w-0 flex-1 truncate font-mono text-[10px] uppercase tracking-[0.2em] text-white/45">
             {action.label}
           </span>
-          <span className="ml-auto flex items-center gap-2">
+          <span className="ml-auto flex shrink-0 items-center gap-1.5">
             {isVisible && <CopyButton text={action.text} />}
-            <button
-              type="button"
+            <ReviewCommandButton
               onClick={handleToggleVisibility}
-              className="inline-flex items-center gap-1 rounded-full border border-white/20 bg-white/10 px-2 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-white/70 transition-colors hover:bg-white/20 hover:text-white"
-              aria-expanded={isVisible}
-            >
-              {isVisible ? (
-                <HiMiniChevronUp className="h-3 w-3" aria-hidden="true" />
-              ) : (
-                <HiMiniChevronDown className="h-3 w-3" aria-hidden="true" />
-              )}
-              {primaryReviewActionToggleLabel(isVisible)}
-            </button>
+              label={primaryReviewActionToggleLabel(isVisible)}
+              ariaLabel={isVisible ? "Hide stopped action" : "Show stopped action"}
+              expanded={isVisible}
+              icon={
+                isVisible ? (
+                  <HiMiniChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
+                ) : (
+                  <HiMiniChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+                )
+              }
+            />
           </span>
         </div>
         {isVisible ? (
-          <pre className="max-h-[36vh] overflow-y-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-sm leading-6 text-white/90 [scrollbar-gutter:stable]">
+          <pre className="max-h-[min(34rem,48vh)] overflow-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-[13px] leading-6 text-white/90 [scrollbar-gutter:stable] sm:text-sm">
             {action.text}
           </pre>
         ) : (
@@ -1211,6 +1211,33 @@ function PrimaryActionCard({ item }: { item: GuardApprovalRequest }) {
         )}
       </div>
     </div>
+  );
+}
+
+function ReviewCommandButton({
+  label,
+  icon,
+  onClick,
+  ariaLabel,
+  expanded,
+}: {
+  label: string;
+  icon: ReactNode;
+  onClick: () => void;
+  ariaLabel: string;
+  expanded?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={ariaLabel}
+      aria-expanded={expanded}
+      className="inline-flex h-7 shrink-0 items-center gap-1 rounded-lg border border-white/15 bg-white/[0.08] px-2 font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-white/70 transition-colors hover:border-white/25 hover:bg-white/15 hover:text-white focus-visible:outline-white/50"
+    >
+      {icon}
+      <span className="hidden sm:inline">{label}</span>
+    </button>
   );
 }
 
@@ -1224,19 +1251,18 @@ function CopyButton({ text }: { text: string }) {
   }, [text]);
 
   return (
-    <button
-      type="button"
+    <ReviewCommandButton
+      label={copied ? "Copied" : "Copy"}
+      ariaLabel="Copy to clipboard"
       onClick={handleCopy}
-      aria-label="Copy to clipboard"
-      className="inline-flex items-center gap-1 rounded-full border border-white/20 bg-white/10 px-2 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-white/70 transition-colors hover:bg-white/20 hover:text-white"
-    >
-      {copied ? (
-        <HiMiniClipboardDocumentCheck className="h-3 w-3" aria-hidden="true" />
-      ) : (
-        <HiMiniClipboard className="h-3 w-3" aria-hidden="true" />
-      )}
-      {copied ? "Copied" : "Copy"}
-    </button>
+      icon={
+        copied ? (
+          <HiMiniClipboardDocumentCheck className="h-3.5 w-3.5" aria-hidden="true" />
+        ) : (
+          <HiMiniClipboard className="h-3.5 w-3.5" aria-hidden="true" />
+        )
+      }
+    />
   );
 }
 

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -19279,31 +19279,50 @@ function PrimaryActionCard({ item }) {
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "rounded-full border border-brand-blue/15 bg-brand-blue/[0.04] px-3 py-1 font-mono text-[11px] font-semibold uppercase tracking-[0.16em] text-brand-blue", children: action.label })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3 overflow-hidden rounded-xl bg-[#0f172a]", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-1.5 border-b border-white/10 px-3 py-2", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-h-11 flex-wrap items-center gap-1.5 border-b border-white/10 px-3 py-2 sm:flex-nowrap", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2.5 w-2.5 rounded-full bg-brand-purple" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2.5 w-2.5 rounded-full bg-brand-blue" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2.5 w-2.5 rounded-full bg-brand-green" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ml-2 font-mono text-[10px] uppercase tracking-[0.22em] text-white/45", children: action.label }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "ml-auto flex items-center gap-2", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ml-2 min-w-0 flex-1 truncate font-mono text-[10px] uppercase tracking-[0.2em] text-white/45", children: action.label }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "ml-auto flex shrink-0 items-center gap-1.5", children: [
           isVisible && /* @__PURE__ */ jsxRuntimeExports.jsx(CopyButton, { text: action.text }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs(
-            "button",
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            ReviewCommandButton,
             {
-              type: "button",
               onClick: handleToggleVisibility,
-              className: "inline-flex items-center gap-1 rounded-full border border-white/20 bg-white/10 px-2 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-white/70 transition-colors hover:bg-white/20 hover:text-white",
-              "aria-expanded": isVisible,
-              children: [
-                isVisible ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronUp, { className: "h-3 w-3", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronDown, { className: "h-3 w-3", "aria-hidden": "true" }),
-                primaryReviewActionToggleLabel(isVisible)
-              ]
+              label: primaryReviewActionToggleLabel(isVisible),
+              ariaLabel: isVisible ? "Hide stopped action" : "Show stopped action",
+              expanded: isVisible,
+              icon: isVisible ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronUp, { className: "h-3.5 w-3.5", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronDown, { className: "h-3.5 w-3.5", "aria-hidden": "true" })
             }
           )
         ] })
       ] }),
-      isVisible ? /* @__PURE__ */ jsxRuntimeExports.jsx("pre", { className: "max-h-[36vh] overflow-y-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-sm leading-6 text-white/90 [scrollbar-gutter:stable]", children: action.text }) : /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "px-3 py-4 text-sm text-white/65", children: "Stopped action hidden. Show it before approving if you need to re-check the exact request." })
+      isVisible ? /* @__PURE__ */ jsxRuntimeExports.jsx("pre", { className: "max-h-[min(34rem,48vh)] overflow-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-[13px] leading-6 text-white/90 [scrollbar-gutter:stable] sm:text-sm", children: action.text }) : /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "px-3 py-4 text-sm text-white/65", children: "Stopped action hidden. Show it before approving if you need to re-check the exact request." })
     ] })
   ] });
+}
+function ReviewCommandButton({
+  label,
+  icon,
+  onClick,
+  ariaLabel,
+  expanded
+}) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
+    "button",
+    {
+      type: "button",
+      onClick,
+      "aria-label": ariaLabel,
+      "aria-expanded": expanded,
+      className: "inline-flex h-7 shrink-0 items-center gap-1 rounded-lg border border-white/15 bg-white/[0.08] px-2 font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-white/70 transition-colors hover:border-white/25 hover:bg-white/15 hover:text-white focus-visible:outline-white/50",
+      children: [
+        icon,
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "hidden sm:inline", children: label })
+      ]
+    }
+  );
 }
 function CopyButton({ text }) {
   const [copied, setCopied] = reactExports.useState(false);
@@ -19313,17 +19332,13 @@ function CopyButton({ text }) {
       setTimeout(() => setCopied(false), 2e3);
     });
   }, [text]);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
-    "button",
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(
+    ReviewCommandButton,
     {
-      type: "button",
+      label: copied ? "Copied" : "Copy",
+      ariaLabel: "Copy to clipboard",
       onClick: handleCopy,
-      "aria-label": "Copy to clipboard",
-      className: "inline-flex items-center gap-1 rounded-full border border-white/20 bg-white/10 px-2 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-white/70 transition-colors hover:bg-white/20 hover:text-white",
-      children: [
-        copied ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniClipboardDocumentCheck, { className: "h-3 w-3", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniClipboard, { className: "h-3 w-3", "aria-hidden": "true" }),
-        copied ? "Copied" : "Copy"
-      ]
+      icon: copied ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniClipboardDocumentCheck, { className: "h-3.5 w-3.5", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniClipboard, { className: "h-3.5 w-3.5", "aria-hidden": "true" })
     }
   );
 }
@@ -20422,6 +20437,22 @@ function copyApprovalUrlLabel(shareState) {
   }
   return "Copy link";
 }
+function CommandHeaderButton(props) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
+    "button",
+    {
+      type: "button",
+      onClick: props.onClick,
+      "aria-label": props.ariaLabel,
+      "aria-expanded": props.expanded,
+      className: "inline-flex h-7 shrink-0 items-center gap-1 rounded-lg border border-white/15 bg-white/[0.08] px-2 font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-white/70 transition-colors hover:border-white/25 hover:bg-white/15 hover:text-white focus-visible:outline-white/50",
+      children: [
+        props.icon,
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "hidden sm:inline", children: props.label })
+      ]
+    }
+  );
+}
 function CopyCommandButton(props) {
   const [copied, setCopied] = reactExports.useState(false);
   const handleCopy = reactExports.useCallback(() => {
@@ -20431,17 +20462,13 @@ function CopyCommandButton(props) {
       return timer;
     });
   }, [props.command]);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
-    "button",
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(
+    CommandHeaderButton,
     {
-      type: "button",
+      label: copied ? "Copied" : "Copy",
+      ariaLabel: "Copy command to clipboard",
       onClick: handleCopy,
-      "aria-label": "Copy command to clipboard",
-      className: "inline-flex items-center gap-1.5 rounded-full border border-white/20 bg-white/10 px-2.5 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-white/70 transition-colors hover:bg-white/20 hover:text-white",
-      children: [
-        copied ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniClipboardDocumentCheck, { className: "h-3.5 w-3.5", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniClipboard, { className: "h-3.5 w-3.5", "aria-hidden": "true" }),
-        copied ? "Copied" : "Copy"
-      ]
+      icon: copied ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniClipboardDocumentCheck, { className: "h-3.5 w-3.5", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniClipboard, { className: "h-3.5 w-3.5", "aria-hidden": "true" })
     }
   );
 }
@@ -20459,6 +20486,7 @@ function resolveMcpInputSummary(payload) {
 function BlockedActionCard(props) {
   const launchText = actionLaunchText(props.item);
   const decisionDetail = resolveDecisionV2Detail(props.item);
+  const [showCommand, setShowCommand] = reactExports.useState(true);
   const [shareState, setShareState] = reactExports.useState("idle");
   const isBlocked = props.item.policy_action === "block";
   const bannerBg = isBlocked ? "bg-gradient-to-r from-brand-purple/90 to-brand-purple/75" : "bg-gradient-to-r from-brand-blue/85 to-brand-dark/80";
@@ -20471,6 +20499,9 @@ function BlockedActionCard(props) {
   const mcpTool = isMcpTool ? envelope?.mcp_tool ?? null : null;
   const mcpInputSummary = isMcpTool && envelope !== null ? resolveMcpInputSummary(envelope.raw_payload_redacted) : null;
   const approvalUrl = props.item.approval_url ? guardAwareHref(props.item.approval_url) : null;
+  const toggleCommand = reactExports.useCallback(() => {
+    setShowCommand((visible) => !visible);
+  }, []);
   const handleCopyApprovalUrl = reactExports.useCallback(async () => {
     if (approvalUrl === null) return;
     try {
@@ -20536,15 +20567,27 @@ function BlockedActionCard(props) {
         "."
       ] }),
       decisionDetail !== null ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-6 text-brand-dark/80", children: decisionDetail }) : null,
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 rounded-xl bg-[#090d1a] p-1 shadow-[0_14px_35px_rgba(9,13,26,0.18)]", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-1.5 border-b border-white/10 px-3 py-2", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 overflow-hidden rounded-xl bg-[#090d1a] shadow-[0_14px_35px_rgba(9,13,26,0.18)]", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-h-11 flex-wrap items-center gap-1.5 border-b border-white/10 px-3 py-2 sm:flex-nowrap", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2.5 w-2.5 rounded-full bg-brand-purple" }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2.5 w-2.5 rounded-full bg-brand-blue" }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "h-2.5 w-2.5 rounded-full bg-brand-green" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ml-2 font-mono text-[10px] uppercase tracking-[0.22em] text-white/45", children: resolveTerminalLabel(props.item) }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ml-auto", children: /* @__PURE__ */ jsxRuntimeExports.jsx(CopyCommandButton, { command: launchText }) })
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ml-2 min-w-0 flex-1 truncate font-mono text-[10px] uppercase tracking-[0.2em] text-white/45", children: resolveTerminalLabel(props.item) }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "ml-auto flex shrink-0 items-center gap-1.5", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(CopyCommandButton, { command: launchText }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              CommandHeaderButton,
+              {
+                label: showCommand ? "Hide" : "Show",
+                ariaLabel: showCommand ? "Hide stopped command" : "Show stopped command",
+                expanded: showCommand,
+                onClick: toggleCommand,
+                icon: showCommand ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronUp, { className: "h-3.5 w-3.5", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronDown, { className: "h-3.5 w-3.5", "aria-hidden": "true" })
+              }
+            )
+          ] })
         ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("pre", { className: "overflow-x-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-sm leading-6 text-white", children: launchText })
+        showCommand ? /* @__PURE__ */ jsxRuntimeExports.jsx("pre", { className: "max-h-[min(34rem,48vh)] overflow-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-[13px] leading-6 text-white sm:text-sm", children: launchText }) : null
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsx(WhyThisPaused, { item: props.item }),
       isBlocked && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 rounded-xl border border-brand-purple/20 bg-brand-purple/[0.05] px-3 py-2.5", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-sm leading-6 text-brand-purple", children: [

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -20488,6 +20488,9 @@ function BlockedActionCard(props) {
   const decisionDetail = resolveDecisionV2Detail(props.item);
   const [showCommand, setShowCommand] = reactExports.useState(true);
   const [shareState, setShareState] = reactExports.useState("idle");
+  reactExports.useEffect(() => {
+    setShowCommand(true);
+  }, [props.item.request_id]);
   const isBlocked = props.item.policy_action === "block";
   const bannerBg = isBlocked ? "bg-gradient-to-r from-brand-purple/90 to-brand-purple/75" : "bg-gradient-to-r from-brand-blue/85 to-brand-dark/80";
   const bannerLabel = isBlocked ? "Blocked" : "Paused for review";

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -901,8 +901,8 @@
     height: 100%;
   }
 
-  .max-h-\[36vh\] {
-    max-height: 36vh;
+  .max-h-\[min\(34rem\,48vh\)\] {
+    max-height: min(34rem, 48vh);
   }
 
   .min-h-8 {
@@ -1355,6 +1355,10 @@
     overflow: hidden;
   }
 
+  .overflow-auto {
+    overflow: auto;
+  }
+
   .overflow-hidden {
     overflow: hidden;
   }
@@ -1769,13 +1773,13 @@
     }
   }
 
-  .border-white\/20 {
-    border-color: #fff3;
+  .border-white\/15 {
+    border-color: #ffffff26;
   }
 
   @supports (color: color-mix(in lab, red, red)) {
-    .border-white\/20 {
-      border-color: color-mix(in oklab, var(--color-white) 20%, transparent);
+    .border-white\/15 {
+      border-color: color-mix(in oklab, var(--color-white) 15%, transparent);
     }
   }
 
@@ -2461,6 +2465,16 @@
     }
   }
 
+  .bg-white\/\[0\.08\] {
+    background-color: #ffffff14;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .bg-white\/\[0\.08\] {
+      background-color: color-mix(in oklab, var(--color-white) 8%, transparent);
+    }
+  }
+
   .bg-gradient-to-b {
     --tw-gradient-position: to bottom in oklab;
     background-image: linear-gradient(var(--tw-gradient-stops));
@@ -2993,6 +3007,11 @@
   .tracking-\[0\.2em\] {
     --tw-tracking: .2em;
     letter-spacing: .2em;
+  }
+
+  .tracking-\[0\.12em\] {
+    --tw-tracking: .12em;
+    letter-spacing: .12em;
   }
 
   .tracking-\[0\.15em\] {
@@ -3612,6 +3631,16 @@
       border-color: var(--color-slate-300);
     }
 
+    .hover\:border-white\/25:hover {
+      border-color: #ffffff40;
+    }
+
+    @supports (color: color-mix(in lab, red, red)) {
+      .hover\:border-white\/25:hover {
+        border-color: color-mix(in oklab, var(--color-white) 25%, transparent);
+      }
+    }
+
     .hover\:bg-\[\#047857\]:hover {
       background-color: #047857;
     }
@@ -3785,16 +3814,6 @@
     @supports (color: color-mix(in lab, red, red)) {
       .hover\:bg-white\/15:hover {
         background-color: color-mix(in oklab, var(--color-white) 15%, transparent);
-      }
-    }
-
-    .hover\:bg-white\/20:hover {
-      background-color: #fff3;
-    }
-
-    @supports (color: color-mix(in lab, red, red)) {
-      .hover\:bg-white\/20:hover {
-        background-color: color-mix(in oklab, var(--color-white) 20%, transparent);
       }
     }
 
@@ -4035,6 +4054,16 @@
     --tw-ring-offset-shadow: var(--tw-ring-inset, ) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
   }
 
+  .focus-visible\:outline-white\/50:focus-visible {
+    outline-color: #ffffff80;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .focus-visible\:outline-white\/50:focus-visible {
+      outline-color: color-mix(in oklab, var(--color-white) 50%, transparent);
+    }
+  }
+
   .focus-visible\:outline-none:focus-visible {
     --tw-outline-style: none;
     outline-style: none;
@@ -4101,6 +4130,10 @@
 
     .sm\:flex-row {
       flex-direction: row;
+    }
+
+    .sm\:flex-nowrap {
+      flex-wrap: nowrap;
     }
 
     .sm\:items-center {
@@ -4176,6 +4209,11 @@
     .sm\:text-3xl {
       font-size: var(--text-3xl);
       line-height: var(--tw-leading, var(--text-3xl--line-height));
+    }
+
+    .sm\:text-sm {
+      font-size: var(--text-sm);
+      line-height: var(--tw-leading, var(--text-sm--line-height));
     }
   }
 


### PR DESCRIPTION
## Summary
- Compact the Copy and Hide controls in the review command/evidence card
- Hide action labels on narrow screens while preserving accessible labels
- Add the same compact command controls to the fallback approval layout and rebuild packaged static assets

## Verification
- pnpm --dir dashboard build
- pnpm --dir dashboard test
- git diff --check
- Browser proof with mocked pending review at http://127.0.0.1:4175/inbox?guard-token=test-token: desktop Copy 85x28, Hide 79x28; mobile controls 32x28; Hide collapses command body