### PR TITLE
chore(release): force refreshed PyPI publish

### DIFF
--- a/docs/guard/release-notes.md
+++ b/docs/guard/release-notes.md
@@ -7,6 +7,12 @@ Update this file for every release that touches a Guard integration path.
 
 ## Unreleased
 
+### Publishing
+
+- **Force refreshed PyPI release** — Trigger the next automated publish so both
+  `hol-guard` and `plugin-scanner` advance beyond `2.0.250` after the successful
+  republish verification.
+
 ### Legacy code cleanup
 
 - **Removed unused CSS classes** — `guard-delay-1`, `guard-delay-2`, `guard-delay-3`, and


### PR DESCRIPTION
## Summary
- add a release-note marker to force a fresh main publish
- expected next publish version: 2.0.251 for both hol-guard and plugin-scanner
- no workflow/package split changes

## Verification
- git diff --check
- verified current PyPI versions before PR: hol-guard 2.0.250, plugin-scanner 2.0.250