### PR TITLE
feat(guard): resume Codex thread after approval

### DIFF
--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -474,7 +474,11 @@ export function App() {
         setResolutionMessage(null);
         navigate(`/requests/${nextId}`);
       } else {
-        setResolutionMessage(result.resolution_summary || "Decision saved. Return to your chat and retry the command.");
+        const fallbackMessage =
+          result.codex_resume?.status === "sent"
+            ? "Decision saved. HOL Guard sent Codex a continue prompt in the original thread."
+            : "Decision saved. Return to your chat and retry the command.";
+        setResolutionMessage(result.resolution_summary || fallbackMessage);
         navigate("/inbox");
       }
       await refreshStateAfterAction();

--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -474,11 +474,7 @@ export function App() {
         setResolutionMessage(null);
         navigate(`/requests/${nextId}`);
       } else {
-        const fallbackMessage =
-          result.codex_resume?.status === "sent"
-            ? "Decision saved. HOL Guard sent Codex a continue prompt in the original thread."
-            : "Decision saved. Return to your chat and retry the command.";
-        setResolutionMessage(result.resolution_summary || fallbackMessage);
+        setResolutionMessage(result.resolution_summary || "Decision saved. Return to your chat and retry the command.");
         navigate("/inbox");
       }
       await refreshStateAfterAction();

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -20,6 +20,7 @@ import type {
   GuardHarnessActionErrorPayload,
   GuardHarnessActionResult,
   GuardPolicyDecision,
+  GuardCodexResumeResult,
   GuardQueueResolutionCopy,
   GuardQueueResolutionResult,
   GuardQueueSummary,
@@ -68,7 +69,13 @@ type RuntimeSnapshotPayload = Omit<GuardRuntimeSnapshot, "items"> & {
 
 type QueueResolutionPayload = Omit<
   GuardQueueResolutionResult,
-  "item" | "resolved_request" | "remaining_pending_summaries" | "resolved_duplicate_ids" | "resolved_scope_ids" | "copy"
+  | "item"
+  | "resolved_request"
+  | "remaining_pending_summaries"
+  | "resolved_duplicate_ids"
+  | "resolved_scope_ids"
+  | "copy"
+  | "codex_resume"
 > & {
   item?: RawGuardApprovalRequest | null;
   resolved_request?: RawGuardApprovalRequest | null;
@@ -76,6 +83,7 @@ type QueueResolutionPayload = Omit<
   resolved_duplicate_ids?: unknown;
   resolved_scope_ids?: unknown;
   copy?: unknown;
+  codex_resume?: unknown;
 };
 
 async function readJson<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
@@ -506,6 +514,23 @@ function normalizeQueueCopy(raw: unknown): GuardQueueResolutionCopy | null {
   return { title, body };
 }
 
+function normalizeCodexResume(raw: unknown): GuardCodexResumeResult | null {
+  if (!isRecord(raw)) {
+    return null;
+  }
+  const status = raw["status"];
+  const reason = raw["reason"];
+  const threadId = raw["thread_id"];
+  if (
+    (status !== "sent" && status !== "skipped" && status !== "failed") ||
+    typeof reason !== "string" ||
+    typeof threadId !== "string"
+  ) {
+    return null;
+  }
+  return { status, reason, thread_id: threadId };
+}
+
 function normalizeQueueResolution(payload: QueueResolutionPayload): GuardQueueResolutionResult {
   return {
     resolved: payload.resolved === true,
@@ -520,7 +545,8 @@ function normalizeQueueResolution(payload: QueueResolutionPayload): GuardQueueRe
     resolved_scope_ids: isStringArray(payload.resolved_scope_ids) ? payload.resolved_scope_ids : undefined,
     resolution_summary: typeof payload.resolution_summary === "string" ? payload.resolution_summary : "",
     retry_hint: isStringOrNull(payload.retry_hint) ? payload.retry_hint : null,
-    copy: normalizeQueueCopy(payload.copy)
+    copy: normalizeQueueCopy(payload.copy),
+    codex_resume: normalizeCodexResume(payload.codex_resume)
   };
 }
 
@@ -993,7 +1019,8 @@ export async function resolveRequestWithQueueResult(input: {
       resolved_duplicate_ids: [],
       resolution_summary: "Decision saved.",
       retry_hint: null,
-      copy: null
+      copy: null,
+      codex_resume: null
     };
   }
   const actionPath = input.action === "allow" ? "approve" : "block";

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -521,11 +521,8 @@ function normalizeCodexResume(raw: unknown): GuardCodexResumeResult | null {
   const status = raw["status"];
   const reason = raw["reason"];
   const threadId = raw["thread_id"];
-  if (
-    (status !== "sent" && status !== "skipped" && status !== "failed") ||
-    typeof reason !== "string" ||
-    typeof threadId !== "string"
-  ) {
+  const isKnownStatus = status === "sent" || status === "skipped" || status === "failed";
+  if (!isKnownStatus || typeof reason !== "string" || typeof threadId !== "string") {
     return null;
   }
   return { status, reason, thread_id: threadId };

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -168,6 +168,12 @@ export type GuardQueueResolutionCopy = {
   body: string;
 };
 
+export type GuardCodexResumeResult = {
+  status: "sent" | "skipped" | "failed";
+  reason: string;
+  thread_id: string;
+};
+
 export type GuardQueueResolutionResult = {
   resolved: boolean;
   item: GuardApprovalRequest | null;
@@ -180,6 +186,7 @@ export type GuardQueueResolutionResult = {
   resolution_summary: string;
   retry_hint: string | null;
   copy: GuardQueueResolutionCopy | null;
+  codex_resume?: GuardCodexResumeResult | null;
 };
 
 export type GuardRuntimeState = {

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -44,6 +44,7 @@ from ..bridge import (
     TelegramBackend,
     WebhookBackend,
 )
+from ..codex_app_server import codex_resume_metadata_from_hook_payload
 from ..config import (
     DEFAULT_SECURITY_LEVEL,
     VALID_RISK_ACTION_KEYS,
@@ -1854,6 +1855,7 @@ def run_guard_command(
                     metadata={
                         "tool_name": str(payload.get("tool_name", "")),
                         "hook_name": "permissionRequest",
+                        **codex_resume_metadata_from_hook_payload(payload),
                     },
                     detection=runtime_detection.to_dict(),
                     evaluation=evaluation_payload,
@@ -2256,6 +2258,7 @@ def run_guard_command(
                             metadata={
                                 "tool_name": str(payload.get("tool_name", "")),
                                 "event": str(payload.get("event", "")),
+                                **codex_resume_metadata_from_hook_payload(payload),
                             },
                             detection=runtime_detection.to_dict(),
                             evaluation=evaluation_payload,

--- a/src/codex_plugin_scanner/guard/codex_app_server.py
+++ b/src/codex_plugin_scanner/guard/codex_app_server.py
@@ -103,6 +103,7 @@ def resume_codex_thread_for_request(
     prompt = _continuation_prompt(action)
     request_payloads = [
         {
+            "jsonrpc": "2.0",
             "id": 1,
             "method": "initialize",
             "params": {
@@ -121,8 +122,9 @@ def resume_codex_thread_for_request(
                 },
             },
         },
-        {"method": "initialized", "params": {}},
+        {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
         {
+            "jsonrpc": "2.0",
             "id": 2,
             "method": "turn/start",
             "params": {

--- a/src/codex_plugin_scanner/guard/codex_app_server.py
+++ b/src/codex_plugin_scanner/guard/codex_app_server.py
@@ -17,6 +17,8 @@ from typing import Protocol
 class _OperationStore(Protocol):
     def list_guard_operations(self, session_id: str | None = None, limit: int = 100) -> list[dict[str, object]]: ...
 
+    def get_guard_operation_for_approval_request(self, request_id: str) -> dict[str, object] | None: ...
+
 
 _DEFAULT_PROXY_TIMEOUT_SECONDS = 5.0
 _DEFAULT_SOCKET_PATH = Path.home() / ".codex" / "app-server-control" / "app-server-control.sock"
@@ -169,7 +171,10 @@ def resume_codex_thread_for_request(
 
 
 def _find_codex_operation_for_request(store: _OperationStore, request_id: str) -> dict[str, object] | None:
-    for operation in store.list_guard_operations(limit=200):
+    operation = store.get_guard_operation_for_approval_request(request_id)
+    if operation is not None and str(operation.get("harness")) == "codex":
+        return operation
+    for operation in store.list_guard_operations(limit=1000):
         if str(operation.get("harness")) != "codex":
             continue
         request_ids = operation.get("approval_request_ids")
@@ -200,11 +205,11 @@ def _send_app_server_websocket_messages(
     with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
         client.settimeout(timeout_seconds)
         client.connect(str(Path(socket_path).expanduser()))
-        _send_websocket_handshake(client)
+        pending = bytearray(_send_websocket_handshake(client))
         for payload in payloads:
             _send_websocket_text(client, json.dumps(payload, separators=(",", ":")))
         while True:
-            opcode, payload = _read_websocket_frame(client)
+            opcode, payload = _read_websocket_frame(client, pending)
             if opcode == 0x8:
                 return None
             if opcode == 0x9:
@@ -221,7 +226,7 @@ def _send_app_server_websocket_messages(
     return None
 
 
-def _send_websocket_handshake(client: socket.socket) -> None:
+def _send_websocket_handshake(client: socket.socket) -> bytes:
     key = base64.b64encode(os.urandom(16)).decode("ascii")
     request = (
         "GET / HTTP/1.1\r\n"
@@ -233,7 +238,7 @@ def _send_websocket_handshake(client: socket.socket) -> None:
         "\r\n"
     )
     client.sendall(request.encode("ascii"))
-    response = _recv_until(client, b"\r\n\r\n")
+    response, leftover = _recv_until(client, b"\r\n\r\n")
     header_text = response.decode("iso-8859-1", errors="replace")
     if not header_text.startswith("HTTP/1.1 101"):
         raise ValueError("websocket_upgrade_failed")
@@ -241,6 +246,7 @@ def _send_websocket_handshake(client: socket.socket) -> None:
     headers = _parse_http_headers(header_text)
     if headers.get("sec-websocket-accept") != expected_accept:
         raise ValueError("websocket_accept_mismatch")
+    return leftover
 
 
 def _send_websocket_text(client: socket.socket, text: str) -> None:
@@ -260,34 +266,39 @@ def _send_websocket_frame(client: socket.socket, opcode: int, payload: bytes) ->
     client.sendall(header + mask + masked)
 
 
-def _read_websocket_frame(client: socket.socket) -> tuple[int, bytes]:
-    header = _recv_exact(client, 2)
+def _read_websocket_frame(client: socket.socket, pending: bytearray) -> tuple[int, bytes]:
+    header = _recv_exact(client, 2, pending)
     first, second = header
     opcode = first & 0x0F
     length = second & 0x7F
     if length == 126:
-        length = struct.unpack("!H", _recv_exact(client, 2))[0]
+        length = struct.unpack("!H", _recv_exact(client, 2, pending))[0]
     elif length == 127:
-        length = struct.unpack("!Q", _recv_exact(client, 8))[0]
-    mask = _recv_exact(client, 4) if second & 0x80 else None
-    payload = _recv_exact(client, length) if length else b""
+        length = struct.unpack("!Q", _recv_exact(client, 8, pending))[0]
+    mask = _recv_exact(client, 4, pending) if second & 0x80 else None
+    payload = _recv_exact(client, length, pending) if length else b""
     if mask is not None:
         payload = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
     return opcode, payload
 
 
-def _recv_until(client: socket.socket, marker: bytes) -> bytes:
+def _recv_until(client: socket.socket, marker: bytes) -> tuple[bytes, bytes]:
     data = b""
     while marker not in data:
         chunk = client.recv(4096)
         if not chunk:
             raise TimeoutError("socket_closed")
         data += chunk
-    return data
+    boundary = data.index(marker) + len(marker)
+    return data[:boundary], data[boundary:]
 
 
-def _recv_exact(client: socket.socket, length: int) -> bytes:
+def _recv_exact(client: socket.socket, length: int, pending: bytearray) -> bytes:
     data = b""
+    if pending:
+        take = min(length, len(pending))
+        data += bytes(pending[:take])
+        del pending[:take]
     while len(data) < length:
         chunk = client.recv(length - len(data))
         if not chunk:

--- a/src/codex_plugin_scanner/guard/codex_app_server.py
+++ b/src/codex_plugin_scanner/guard/codex_app_server.py
@@ -1,0 +1,269 @@
+"""Codex app-server continuation helpers for Guard approval resolution."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Protocol
+
+
+class _OperationStore(Protocol):
+    def list_guard_operations(self, session_id: str | None = None, limit: int = 100) -> list[dict[str, object]]: ...
+
+
+_DEFAULT_PROXY_TIMEOUT_SECONDS = 5.0
+_DEFAULT_SOCKET_PATH = Path.home() / ".codex" / "app-server-control" / "app-server-control.sock"
+_APP_BUNDLE_CODEX = Path("/Applications/Codex.app/Contents/Resources/codex")
+_THREAD_ID_KEYS = (
+    "codex_thread_id",
+    "thread_id",
+    "threadId",
+    "conversation_id",
+    "conversationId",
+    "session_id",
+    "sessionId",
+)
+_TURN_ID_KEYS = ("codex_turn_id", "turn_id", "turnId")
+_SOCKET_KEYS = ("codex_app_server_socket", "app_server_socket", "appServerSocket")
+
+
+def codex_resume_metadata_from_hook_payload(
+    payload: Mapping[str, object],
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    """Extract local-only Codex app-server continuation metadata from a hook payload."""
+
+    env = environ or os.environ
+    thread_id = _first_string(payload, _THREAD_ID_KEYS)
+    if thread_id is None:
+        return {}
+    metadata: dict[str, object] = {
+        "codex_thread_id": thread_id,
+    }
+    turn_id = _first_string(payload, _TURN_ID_KEYS)
+    if turn_id is not None:
+        metadata["codex_turn_id"] = turn_id
+    socket_path = _first_string(payload, _SOCKET_KEYS) or _first_string_from_env(
+        env,
+        ("CODEX_APP_SERVER_SOCKET", "CODEX_APP_SERVER_CONTROL_SOCKET"),
+    )
+    if socket_path is not None:
+        metadata["codex_app_server_socket"] = socket_path
+    return metadata
+
+
+def resume_codex_thread_for_request(
+    *,
+    store: _OperationStore,
+    request_id: str,
+    action: str,
+    proxy_command: list[str] | None = None,
+    environ: Mapping[str, str] | None = None,
+    timeout_seconds: float = _DEFAULT_PROXY_TIMEOUT_SECONDS,
+) -> dict[str, object] | None:
+    """Send a guarded continuation prompt to the Codex thread that queued a request."""
+
+    operation = _find_codex_operation_for_request(store, request_id)
+    if operation is None:
+        return None
+    metadata = operation.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    thread_id = _first_string(metadata, ("codex_thread_id", "thread_id", "threadId", "session_id", "sessionId"))
+    if thread_id is None:
+        return None
+    socket_path = _first_string(metadata, _SOCKET_KEYS) or str(_DEFAULT_SOCKET_PATH)
+    if not _is_safe_local_socket_path(socket_path):
+        return {
+            "status": "skipped",
+            "reason": "unsafe_socket_path",
+            "thread_id": thread_id,
+        }
+    if not Path(socket_path).expanduser().exists():
+        return {
+            "status": "skipped",
+            "reason": "socket_not_available",
+            "thread_id": thread_id,
+            "socket_path": socket_path,
+        }
+    command = proxy_command or _default_proxy_command(socket_path, environ=environ)
+    if command is None:
+        return {
+            "status": "skipped",
+            "reason": "codex_command_not_found",
+            "thread_id": thread_id,
+            "socket_path": socket_path,
+        }
+    prompt = _continuation_prompt(action)
+    request_payloads = [
+        {
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "clientInfo": {
+                    "name": "hol-guard",
+                    "title": "HOL Guard",
+                    "version": "1.0.0",
+                },
+                "capabilities": {
+                    "experimentalApi": True,
+                    "optOutNotificationMethods": [
+                        "thread/status/changed",
+                        "turn/started",
+                        "turn/completed",
+                    ],
+                },
+            },
+        },
+        {"method": "initialized", "params": {}},
+        {
+            "id": 2,
+            "method": "turn/start",
+            "params": {
+                "threadId": thread_id,
+                "input": [{"type": "text", "text": prompt}],
+                "responsesapiClientMetadata": {
+                    "hol_guard_request_id": request_id,
+                    "hol_guard_resolution": "allow" if action == "allow" else "block",
+                },
+            },
+        },
+    ]
+    input_bytes = "".join(json.dumps(payload, separators=(",", ":")) + "\n" for payload in request_payloads).encode(
+        "utf-8"
+    )
+    try:
+        completed = subprocess.run(
+            command,
+            input=input_bytes,
+            capture_output=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        return {
+            "status": "failed",
+            "reason": type(error).__name__,
+            "thread_id": thread_id,
+            "socket_path": socket_path,
+        }
+    response = _parse_jsonrpc_response(completed.stdout.decode("utf-8", errors="replace"))
+    if completed.returncode != 0:
+        return {
+            "status": "failed",
+            "reason": "proxy_failed",
+            "thread_id": thread_id,
+            "socket_path": socket_path,
+            "returncode": completed.returncode,
+        }
+    if response is None:
+        return {
+            "status": "failed",
+            "reason": "missing_turn_start_response",
+            "thread_id": thread_id,
+            "socket_path": socket_path,
+        }
+    if isinstance(response.get("error"), dict):
+        error = response["error"]
+        message = error.get("message") if isinstance(error, dict) else None
+        return {
+            "status": "failed",
+            "reason": "turn_start_error",
+            "message": str(message) if isinstance(message, str) else "Codex app-server rejected the continuation.",
+            "thread_id": thread_id,
+            "socket_path": socket_path,
+        }
+    return {
+        "status": "sent",
+        "reason": "turn_start_sent",
+        "thread_id": thread_id,
+        "socket_path": socket_path,
+    }
+
+
+def _find_codex_operation_for_request(store: _OperationStore, request_id: str) -> dict[str, object] | None:
+    for operation in store.list_guard_operations(limit=200):
+        if str(operation.get("harness")) != "codex":
+            continue
+        request_ids = operation.get("approval_request_ids")
+        if isinstance(request_ids, list) and request_id in {str(item) for item in request_ids}:
+            return operation
+    return None
+
+
+def _default_proxy_command(socket_path: str, *, environ: Mapping[str, str] | None) -> list[str] | None:
+    env = environ or os.environ
+    configured = env.get("HOL_GUARD_CODEX_COMMAND")
+    if configured:
+        command_path = configured
+    else:
+        command_path = shutil.which("codex") or (str(_APP_BUNDLE_CODEX) if _APP_BUNDLE_CODEX.exists() else "")
+    if not command_path:
+        return None
+    return [command_path, "app-server", "proxy", "--sock", socket_path]
+
+
+def _continuation_prompt(action: str) -> str:
+    if action == "allow":
+        return (
+            "HOL Guard approved the paused action. Continue from where you stopped, retry the same "
+            "blocked action once, and do not repeat work that already succeeded."
+        )
+    return (
+        "HOL Guard kept the paused action blocked. Continue from where you stopped with a safe "
+        "alternative and do not retry the blocked action."
+    )
+
+
+def _parse_jsonrpc_response(stdout: str) -> dict[str, object] | None:
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict) and payload.get("id") == 2:
+            return payload
+    return None
+
+
+def _is_safe_local_socket_path(socket_path: str) -> bool:
+    path = Path(socket_path).expanduser()
+    try:
+        resolved = path.resolve(strict=False)
+    except OSError:
+        return False
+    home = Path.home().resolve()
+    tmp = Path("/tmp").resolve()
+    var_tmp = Path("/var/tmp").resolve()
+    system_tmp = Path(tempfile.gettempdir()).resolve()
+    return resolved.is_absolute() and (
+        resolved.is_relative_to(home)
+        or resolved.is_relative_to(tmp)
+        or resolved.is_relative_to(var_tmp)
+        or resolved.is_relative_to(system_tmp)
+    )
+
+
+def _first_string(payload: Mapping[str, object], keys: tuple[str, ...]) -> str | None:
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _first_string_from_env(env: Mapping[str, str], keys: tuple[str, ...]) -> str | None:
+    for key in keys:
+        value = env.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None

--- a/src/codex_plugin_scanner/guard/codex_app_server.py
+++ b/src/codex_plugin_scanner/guard/codex_app_server.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import json
 import os
-import shutil
-import subprocess
+import socket
+import struct
 import tempfile
 from collections.abc import Mapping
 from pathlib import Path
@@ -18,7 +20,7 @@ class _OperationStore(Protocol):
 
 _DEFAULT_PROXY_TIMEOUT_SECONDS = 5.0
 _DEFAULT_SOCKET_PATH = Path.home() / ".codex" / "app-server-control" / "app-server-control.sock"
-_APP_BUNDLE_CODEX = Path("/Applications/Codex.app/Contents/Resources/codex")
+_WEBSOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 _THREAD_ID_KEYS = (
     "codex_thread_id",
     "thread_id",
@@ -63,8 +65,6 @@ def resume_codex_thread_for_request(
     store: _OperationStore,
     request_id: str,
     action: str,
-    proxy_command: list[str] | None = None,
-    environ: Mapping[str, str] | None = None,
     timeout_seconds: float = _DEFAULT_PROXY_TIMEOUT_SECONDS,
 ) -> dict[str, object] | None:
     """Send a guarded continuation prompt to the Codex thread that queued a request."""
@@ -89,14 +89,6 @@ def resume_codex_thread_for_request(
         return {
             "status": "skipped",
             "reason": "socket_not_available",
-            "thread_id": thread_id,
-            "socket_path": socket_path,
-        }
-    command = proxy_command or _default_proxy_command(socket_path, environ=environ)
-    if command is None:
-        return {
-            "status": "skipped",
-            "reason": "codex_command_not_found",
             "thread_id": thread_id,
             "socket_path": socket_path,
         }
@@ -137,32 +129,19 @@ def resume_codex_thread_for_request(
             },
         },
     ]
-    input_bytes = "".join(json.dumps(payload, separators=(",", ":")) + "\n" for payload in request_payloads).encode(
-        "utf-8"
-    )
     try:
-        completed = subprocess.run(
-            command,
-            input=input_bytes,
-            capture_output=True,
-            timeout=timeout_seconds,
-            check=False,
+        response = _send_app_server_websocket_messages(
+            socket_path=socket_path,
+            payloads=request_payloads,
+            response_id=2,
+            timeout_seconds=timeout_seconds,
         )
-    except (OSError, subprocess.TimeoutExpired) as error:
+    except (OSError, TimeoutError, ValueError) as error:
         return {
             "status": "failed",
             "reason": type(error).__name__,
             "thread_id": thread_id,
             "socket_path": socket_path,
-        }
-    response = _parse_jsonrpc_response(completed.stdout.decode("utf-8", errors="replace"))
-    if completed.returncode != 0:
-        return {
-            "status": "failed",
-            "reason": "proxy_failed",
-            "thread_id": thread_id,
-            "socket_path": socket_path,
-            "returncode": completed.returncode,
         }
     if response is None:
         return {
@@ -199,18 +178,6 @@ def _find_codex_operation_for_request(store: _OperationStore, request_id: str) -
     return None
 
 
-def _default_proxy_command(socket_path: str, *, environ: Mapping[str, str] | None) -> list[str] | None:
-    env = environ or os.environ
-    configured = env.get("HOL_GUARD_CODEX_COMMAND")
-    if configured:
-        command_path = configured
-    else:
-        command_path = shutil.which("codex") or (str(_APP_BUNDLE_CODEX) if _APP_BUNDLE_CODEX.exists() else "")
-    if not command_path:
-        return None
-    return [command_path, "app-server", "proxy", "--sock", socket_path]
-
-
 def _continuation_prompt(action: str) -> str:
     if action == "allow":
         return (
@@ -223,18 +190,120 @@ def _continuation_prompt(action: str) -> str:
     )
 
 
-def _parse_jsonrpc_response(stdout: str) -> dict[str, object] | None:
-    for line in stdout.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            payload = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if isinstance(payload, dict) and payload.get("id") == 2:
-            return payload
+def _send_app_server_websocket_messages(
+    *,
+    socket_path: str,
+    payloads: list[dict[str, object]],
+    response_id: int,
+    timeout_seconds: float,
+) -> dict[str, object] | None:
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+        client.settimeout(timeout_seconds)
+        client.connect(str(Path(socket_path).expanduser()))
+        _send_websocket_handshake(client)
+        for payload in payloads:
+            _send_websocket_text(client, json.dumps(payload, separators=(",", ":")))
+        while True:
+            opcode, payload = _read_websocket_frame(client)
+            if opcode == 0x8:
+                return None
+            if opcode == 0x9:
+                _send_websocket_frame(client, 0xA, payload)
+                continue
+            if opcode != 0x1:
+                continue
+            try:
+                message = json.loads(payload.decode("utf-8"))
+            except json.JSONDecodeError:
+                continue
+            if isinstance(message, dict) and message.get("id") == response_id:
+                return message
     return None
+
+
+def _send_websocket_handshake(client: socket.socket) -> None:
+    key = base64.b64encode(os.urandom(16)).decode("ascii")
+    request = (
+        "GET / HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        f"Sec-WebSocket-Key: {key}\r\n"
+        "Sec-WebSocket-Version: 13\r\n"
+        "\r\n"
+    )
+    client.sendall(request.encode("ascii"))
+    response = _recv_until(client, b"\r\n\r\n")
+    header_text = response.decode("iso-8859-1", errors="replace")
+    if not header_text.startswith("HTTP/1.1 101"):
+        raise ValueError("websocket_upgrade_failed")
+    expected_accept = base64.b64encode(hashlib.sha1((key + _WEBSOCKET_GUID).encode("ascii")).digest()).decode("ascii")
+    headers = _parse_http_headers(header_text)
+    if headers.get("sec-websocket-accept") != expected_accept:
+        raise ValueError("websocket_accept_mismatch")
+
+
+def _send_websocket_text(client: socket.socket, text: str) -> None:
+    _send_websocket_frame(client, 0x1, text.encode("utf-8"))
+
+
+def _send_websocket_frame(client: socket.socket, opcode: int, payload: bytes) -> None:
+    mask = os.urandom(4)
+    length = len(payload)
+    if length < 126:
+        header = bytes([0x80 | opcode, 0x80 | length])
+    elif length < 65_536:
+        header = bytes([0x80 | opcode, 0x80 | 126]) + struct.pack("!H", length)
+    else:
+        header = bytes([0x80 | opcode, 0x80 | 127]) + struct.pack("!Q", length)
+    masked = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+    client.sendall(header + mask + masked)
+
+
+def _read_websocket_frame(client: socket.socket) -> tuple[int, bytes]:
+    header = _recv_exact(client, 2)
+    first, second = header
+    opcode = first & 0x0F
+    length = second & 0x7F
+    if length == 126:
+        length = struct.unpack("!H", _recv_exact(client, 2))[0]
+    elif length == 127:
+        length = struct.unpack("!Q", _recv_exact(client, 8))[0]
+    mask = _recv_exact(client, 4) if second & 0x80 else None
+    payload = _recv_exact(client, length) if length else b""
+    if mask is not None:
+        payload = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+    return opcode, payload
+
+
+def _recv_until(client: socket.socket, marker: bytes) -> bytes:
+    data = b""
+    while marker not in data:
+        chunk = client.recv(4096)
+        if not chunk:
+            raise TimeoutError("socket_closed")
+        data += chunk
+    return data
+
+
+def _recv_exact(client: socket.socket, length: int) -> bytes:
+    data = b""
+    while len(data) < length:
+        chunk = client.recv(length - len(data))
+        if not chunk:
+            raise TimeoutError("socket_closed")
+        data += chunk
+    return data
+
+
+def _parse_http_headers(header_text: str) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    for line in header_text.split("\r\n")[1:]:
+        if ":" not in line:
+            continue
+        name, value = line.split(":", 1)
+        headers[name.strip().lower()] = value.strip()
+    return headers
 
 
 def _is_safe_local_socket_path(socket_path: str) -> bool:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -37,6 +37,7 @@ from ..cli.install_commands import (
     list_harness_setup_items,
     uninstall_confirmation_token,
 )
+from ..codex_app_server import resume_codex_thread_for_request
 from ..config import (
     GuardConfig,
     editable_guard_settings,
@@ -557,6 +558,28 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         )
         harness = str(updated.get("harness", ""))
         copy = _build_resolution_copy(action, harness_str or harness)
+        codex_resume = None
+        if action in {"allow", "block"}:
+            codex_resume = resume_codex_thread_for_request(
+                store=self.server.store,  # type: ignore[attr-defined]
+                request_id=request_id,
+                action=action,
+            )
+        if codex_resume is not None:
+            updated["codex_resume"] = codex_resume
+            self.server.store.add_event(  # type: ignore[attr-defined]
+                "codex/thread_resume",
+                {"request_id": request_id, "action": action, **codex_resume},
+                _now(),
+            )
+            if codex_resume.get("status") == "sent":
+                updated["resolution_summary"] = (
+                    "Decision saved. HOL Guard sent Codex a continue prompt in the original thread."
+                )
+                copy = {
+                    "title": "Decision saved. Codex is continuing.",
+                    "body": "HOL Guard sent a continue prompt to the original Codex thread.",
+                }
         updated["copy"] = copy
         updated["retry_hint"] = copy["body"]
         self._write_json(updated)

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13048,6 +13048,18 @@ function normalizeQueueCopy(raw) {
   }
   return { title, body };
 }
+function normalizeCodexResume(raw) {
+  if (!isRecord(raw)) {
+    return null;
+  }
+  const status = raw["status"];
+  const reason = raw["reason"];
+  const threadId = raw["thread_id"];
+  if (status !== "sent" && status !== "skipped" && status !== "failed" || typeof reason !== "string" || typeof threadId !== "string") {
+    return null;
+  }
+  return { status, reason, thread_id: threadId };
+}
 function normalizeQueueResolution(payload) {
   return {
     resolved: payload.resolved === true,
@@ -13060,7 +13072,8 @@ function normalizeQueueResolution(payload) {
     resolved_scope_ids: isStringArray(payload.resolved_scope_ids) ? payload.resolved_scope_ids : void 0,
     resolution_summary: typeof payload.resolution_summary === "string" ? payload.resolution_summary : "",
     retry_hint: isStringOrNull(payload.retry_hint) ? payload.retry_hint : null,
-    copy: normalizeQueueCopy(payload.copy)
+    copy: normalizeQueueCopy(payload.copy),
+    codex_resume: normalizeCodexResume(payload.codex_resume)
   };
 }
 function queueSearchParams(input) {
@@ -13407,7 +13420,8 @@ async function resolveRequestWithQueueResult(input) {
       resolved_duplicate_ids: [],
       resolution_summary: "Decision saved.",
       retry_hint: null,
-      copy: null
+      copy: null,
+      codex_resume: null
     };
   }
   const actionPath = input.action === "allow" ? "approve" : "block";
@@ -21169,7 +21183,8 @@ function App() {
         setResolutionMessage(null);
         navigate(`/requests/${nextId}`);
       } else {
-        setResolutionMessage(result.resolution_summary || "Decision saved. Return to your chat and retry the command.");
+        const fallbackMessage = result.codex_resume?.status === "sent" ? "Decision saved. HOL Guard sent Codex a continue prompt in the original thread." : "Decision saved. Return to your chat and retry the command.";
+        setResolutionMessage(result.resolution_summary || fallbackMessage);
         navigate("/inbox");
       }
       await refreshStateAfterAction();

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13055,7 +13055,8 @@ function normalizeCodexResume(raw) {
   const status = raw["status"];
   const reason = raw["reason"];
   const threadId = raw["thread_id"];
-  if (status !== "sent" && status !== "skipped" && status !== "failed" || typeof reason !== "string" || typeof threadId !== "string") {
+  const isKnownStatus = status === "sent" || status === "skipped" || status === "failed";
+  if (!isKnownStatus || typeof reason !== "string" || typeof threadId !== "string") {
     return null;
   }
   return { status, reason, thread_id: threadId };
@@ -21183,8 +21184,7 @@ function App() {
         setResolutionMessage(null);
         navigate(`/requests/${nextId}`);
       } else {
-        const fallbackMessage = result.codex_resume?.status === "sent" ? "Decision saved. HOL Guard sent Codex a continue prompt in the original thread." : "Decision saved. Return to your chat and retry the command.";
-        setResolutionMessage(result.resolution_summary || fallbackMessage);
+        setResolutionMessage(result.resolution_summary || "Decision saved. Return to your chat and retry the command.");
         navigate("/inbox");
       }
       await refreshStateAfterAction();

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -3044,6 +3044,36 @@ class GuardStore:
             for row in rows
         ]
 
+    def get_guard_operation_for_approval_request(self, request_id: str) -> dict[str, object] | None:
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                select operation_id, session_id, harness, operation_type, status, approval_request_ids_json,
+                       resume_token, metadata_json, created_at, updated_at
+                from guard_operations
+                where approval_request_ids_json like ?
+                order by updated_at desc, operation_id desc
+                """,
+                (f"%{request_id}%",),
+            ).fetchall()
+        for row in rows:
+            approval_request_ids = json.loads(str(row["approval_request_ids_json"]))
+            if request_id not in {str(item) for item in approval_request_ids}:
+                continue
+            return {
+                "operation_id": str(row["operation_id"]),
+                "session_id": str(row["session_id"]),
+                "harness": str(row["harness"]),
+                "operation_type": str(row["operation_type"]),
+                "status": str(row["status"]),
+                "approval_request_ids": approval_request_ids,
+                "resume_token": str(row["resume_token"]) if row["resume_token"] is not None else None,
+                "metadata": json.loads(str(row["metadata_json"])),
+                "created_at": str(row["created_at"]),
+                "updated_at": str(row["updated_at"]),
+            }
+        return None
+
     def add_guard_operation_item(
         self,
         *,

--- a/tests/test_guard_queue_api_contract.py
+++ b/tests/test_guard_queue_api_contract.py
@@ -2,16 +2,26 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import json
+import socket
 import sqlite3
+import struct
+import tempfile
+import threading
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
+import uuid
 from pathlib import Path
 
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.models import GuardApprovalRequest
 from codex_plugin_scanner.guard.store import GuardStore
+
+_WEBSOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
 
 def _request(
@@ -135,6 +145,103 @@ def _post_error(port: int, token: str, path: str, payload: dict[str, object]) ->
     raise AssertionError("expected HTTPError")
 
 
+def _start_fake_codex_app_server(socket_path: Path, received: list[dict[str, object]]) -> threading.Thread:
+    def server() -> None:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as listener:
+            listener.bind(str(socket_path))
+            listener.listen(1)
+            connection, _ = listener.accept()
+            with connection:
+                headers = _recv_until(connection, b"\r\n\r\n").decode("iso-8859-1")
+                key = ""
+                for line in headers.split("\r\n"):
+                    if line.lower().startswith("sec-websocket-key:"):
+                        key = line.split(":", 1)[1].strip()
+                        break
+                accept = base64.b64encode(hashlib.sha1((key + _WEBSOCKET_GUID).encode("ascii")).digest()).decode(
+                    "ascii"
+                )
+                connection.sendall(
+                    (
+                        "HTTP/1.1 101 Switching Protocols\r\n"
+                        "Connection: Upgrade\r\n"
+                        "Upgrade: websocket\r\n"
+                        f"Sec-WebSocket-Accept: {accept}\r\n"
+                        "\r\n"
+                    ).encode("ascii")
+                )
+                while True:
+                    opcode, payload = _recv_websocket_frame(connection)
+                    if opcode != 0x1:
+                        continue
+                    message = json.loads(payload.decode("utf-8"))
+                    received.append(message)
+                    if message.get("id") == 1:
+                        _send_websocket_text(
+                            connection,
+                            {
+                                "id": 1,
+                                "result": {
+                                    "userAgent": "test",
+                                    "codexHome": "/tmp",
+                                    "platformFamily": "unix",
+                                    "platformOs": "macos",
+                                },
+                            },
+                        )
+                    if message.get("id") == 2:
+                        _send_websocket_text(connection, {"id": 2, "result": {"turnId": "turn-next"}})
+                        break
+
+    thread = threading.Thread(target=server, daemon=True)
+    thread.start()
+    for _ in range(50):
+        if socket_path.exists():
+            break
+        time.sleep(0.01)
+    return thread
+
+
+def _recv_until(connection: socket.socket, marker: bytes) -> bytes:
+    data = b""
+    while marker not in data:
+        data += connection.recv(4096)
+    return data
+
+
+def _recv_exact(connection: socket.socket, length: int) -> bytes:
+    data = b""
+    while len(data) < length:
+        data += connection.recv(length - len(data))
+    return data
+
+
+def _recv_websocket_frame(connection: socket.socket) -> tuple[int, bytes]:
+    first, second = _recv_exact(connection, 2)
+    length = second & 0x7F
+    if length == 126:
+        length = struct.unpack("!H", _recv_exact(connection, 2))[0]
+    elif length == 127:
+        length = struct.unpack("!Q", _recv_exact(connection, 8))[0]
+    mask = _recv_exact(connection, 4) if second & 0x80 else None
+    payload = _recv_exact(connection, length) if length else b""
+    if mask is not None:
+        payload = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+    return first & 0x0F, payload
+
+
+def _send_websocket_text(connection: socket.socket, payload: dict[str, object]) -> None:
+    data = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    length = len(data)
+    if length < 126:
+        header = bytes([0x81, length])
+    elif length < 65_536:
+        header = bytes([0x81, 126]) + struct.pack("!H", length)
+    else:
+        header = bytes([0x81, 127]) + struct.pack("!Q", length)
+    connection.sendall(header + data)
+
+
 def test_resolving_active_item_with_two_remaining_returns_next_hint(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     _populate(
@@ -165,37 +272,12 @@ def test_resolving_active_item_with_two_remaining_returns_next_hint(tmp_path: Pa
     assert store.get_approval_request("req-active")["resolution_action"] == "allow"
 
 
-def test_codex_resolution_sends_continue_prompt_to_original_thread(tmp_path: Path, monkeypatch) -> None:
+def test_codex_resolution_sends_continue_prompt_to_original_thread(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    _populate(store, [_request("req-active")])
-    socket_path = tmp_path / "codex.sock"
-    socket_path.write_text("", encoding="utf-8")
-    proxy_input = tmp_path / "proxy-input.jsonl"
-    proxy_script = tmp_path / "codex-proxy.py"
-    proxy_script.write_text(
-        """
-#!/usr/bin/env python3
-import json
-import pathlib
-import sys
-
-raw = sys.stdin.read()
-pathlib.Path(sys.argv[-1]).with_name("proxy-input.jsonl").write_text(raw, encoding="utf-8")
-print(json.dumps({
-    "id": 1,
-    "result": {
-        "userAgent": "test",
-        "codexHome": "/tmp",
-        "platformFamily": "unix",
-        "platformOs": "macos",
-    },
-}))
-print(json.dumps({"id": 2, "result": {"turnId": "turn-next"}}))
-""".lstrip(),
-        encoding="utf-8",
-    )
-    proxy_script.chmod(0o755)
-    monkeypatch.setenv("HOL_GUARD_CODEX_COMMAND", str(proxy_script))
+    _populate(store, [_request("req-active", command="echo guard resume")])
+    socket_path = Path(tempfile.gettempdir()) / f"hol-guard-codex-{uuid.uuid4().hex}.sock"
+    received_messages: list[dict[str, object]] = []
+    codex_server = _start_fake_codex_app_server(socket_path, received_messages)
     session = store.upsert_guard_session(
         session_id="guard-session-1",
         harness="codex",
@@ -235,9 +317,10 @@ print(json.dumps({"id": 2, "result": {"turnId": "turn-next"}}))
         )
     finally:
         daemon.stop()
+        codex_server.join(timeout=2)
+        socket_path.unlink(missing_ok=True)
 
-    sent_lines = [json.loads(line) for line in proxy_input.read_text(encoding="utf-8").splitlines() if line.strip()]
-    turn_start = sent_lines[-1]
+    turn_start = received_messages[-1]
     assert payload["codex_resume"]["status"] == "sent"
     assert payload["resolution_summary"] == (
         "Decision saved. HOL Guard sent Codex a continue prompt in the original thread."

--- a/tests/test_guard_queue_api_contract.py
+++ b/tests/test_guard_queue_api_contract.py
@@ -165,6 +165,89 @@ def test_resolving_active_item_with_two_remaining_returns_next_hint(tmp_path: Pa
     assert store.get_approval_request("req-active")["resolution_action"] == "allow"
 
 
+def test_codex_resolution_sends_continue_prompt_to_original_thread(tmp_path: Path, monkeypatch) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _populate(store, [_request("req-active")])
+    socket_path = tmp_path / "codex.sock"
+    socket_path.write_text("", encoding="utf-8")
+    proxy_input = tmp_path / "proxy-input.jsonl"
+    proxy_script = tmp_path / "codex-proxy.py"
+    proxy_script.write_text(
+        """
+#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+raw = sys.stdin.read()
+pathlib.Path(sys.argv[-1]).with_name("proxy-input.jsonl").write_text(raw, encoding="utf-8")
+print(json.dumps({
+    "id": 1,
+    "result": {
+        "userAgent": "test",
+        "codexHome": "/tmp",
+        "platformFamily": "unix",
+        "platformOs": "macos",
+    },
+}))
+print(json.dumps({"id": 2, "result": {"turnId": "turn-next"}}))
+""".lstrip(),
+        encoding="utf-8",
+    )
+    proxy_script.chmod(0o755)
+    monkeypatch.setenv("HOL_GUARD_CODEX_COMMAND", str(proxy_script))
+    session = store.upsert_guard_session(
+        session_id="guard-session-1",
+        harness="codex",
+        surface="harness-adapter",
+        status="waiting_on_approval",
+        client_name="codex-hook",
+        client_title="Codex hook",
+        client_version="1.0.0",
+        workspace=str(tmp_path),
+        capabilities=["approval-resolution"],
+        now="2026-05-08T10:00:00+00:00",
+    )
+    store.upsert_guard_operation(
+        operation_id="operation-1",
+        session_id=str(session["session_id"]),
+        harness="codex",
+        operation_type="tool_call",
+        status="waiting_on_approval",
+        approval_request_ids=["req-active"],
+        resume_token="resume-token",
+        metadata={
+            "codex_thread_id": "thread-1",
+            "codex_turn_id": "turn-1",
+            "codex_app_server_socket": str(socket_path),
+        },
+        now="2026-05-08T10:00:00+00:00",
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+
+    try:
+        payload = _post_json(
+            daemon.port,
+            daemon._server.auth_token,
+            "/v1/requests/req-active/approve",
+            {"scope": "artifact", "reason": "reviewed"},
+        )
+    finally:
+        daemon.stop()
+
+    sent_lines = [json.loads(line) for line in proxy_input.read_text(encoding="utf-8").splitlines() if line.strip()]
+    turn_start = sent_lines[-1]
+    assert payload["codex_resume"]["status"] == "sent"
+    assert payload["resolution_summary"] == (
+        "Decision saved. HOL Guard sent Codex a continue prompt in the original thread."
+    )
+    assert turn_start["method"] == "turn/start"
+    assert turn_start["params"]["threadId"] == "thread-1"
+    assert "HOL Guard approved" in turn_start["params"]["input"][0]["text"]
+    assert store.list_events(event_name="codex/thread_resume")[0]["payload"]["status"] == "sent"
+
+
 def test_resolving_last_item_returns_empty_queue_hint(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     _populate(store, [_request("req-only")])

--- a/tests/test_guard_queue_api_contract.py
+++ b/tests/test_guard_queue_api_contract.py
@@ -305,6 +305,18 @@ def test_codex_resolution_sends_continue_prompt_to_original_thread(tmp_path: Pat
         },
         now="2026-05-08T10:00:00+00:00",
     )
+    for index in range(225):
+        store.upsert_guard_operation(
+            operation_id=f"noise-operation-{index:03d}",
+            session_id=str(session["session_id"]),
+            harness="codex",
+            operation_type="tool_call",
+            status="resolved",
+            approval_request_ids=[f"noise-request-{index:03d}"],
+            resume_token=None,
+            metadata={"codex_thread_id": f"noise-thread-{index:03d}"},
+            now=f"2026-05-08T10:01:{index % 60:02d}+00:00",
+        )
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
 


### PR DESCRIPTION
## Summary
- capture Codex thread/socket metadata from Guard hook payloads when queueing blocked operations
- send a Codex app-server continuation prompt after dashboard approval or block decisions resolve
- surface continuation status through the local dashboard API and UI response copy

## Verification
- ruff check src/codex_plugin_scanner/guard/codex_app_server.py src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_queue_api_contract.py
- pytest tests/test_guard_queue_api_contract.py -k 'codex_resolution_sends_continue_prompt or resolving_active_item_with_two_remaining'
- pytest tests/test_guard_runtime.py -k 'codex_browser_approval_decision_updates_daemon_operation_status or guard_hook_codex_pretooluse_browser_approval_resumes_original_tool'
- pnpm exec tsx src/guard-api.test.ts
- pnpm exec tsx src/approval-center-layout.test.ts
- pnpm exec tsx src/phase09-review.test.ts
- pnpm run build