### PR TITLE
fix(guard): keep Codex thread resume alive

### DIFF
--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -323,11 +323,6 @@ export type PrimaryReviewAction = {
 };
 
 const DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH = 24;
-const GENERIC_DUPLICATE_CONTEXT_PATTERNS = [
-  /^(codex|claude|claudecode|copilot|opencode|gemini)?promptfor[a-z0-9]*$/,
-  /^(codex|claude|claudecode|copilot|opencode|gemini)?commandfor[a-z0-9]*$/,
-  /^(codex|claude|claudecode|copilot|opencode|gemini)?toolfor[a-z0-9]*$/,
-];
 
 export function buildPrimaryReviewAction(item: GuardApprovalRequest): PrimaryReviewAction {
   return {
@@ -397,15 +392,11 @@ function duplicatesStoppedActionText(item: GuardApprovalRequest, value: string):
   }
   if (
     candidateWithoutContext.length >= DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH &&
-    (candidateWithoutContext.includes(stoppedText) || stoppedText.includes(candidateWithoutContext))
+    stoppedText.includes(candidateWithoutContext)
   ) {
     return true;
   }
-  if (!candidateText.includes(stoppedText)) {
-    return false;
-  }
-  const remainingContext = candidateText.replace(stoppedText, "");
-  return GENERIC_DUPLICATE_CONTEXT_PATTERNS.some((pattern) => pattern.test(remainingContext));
+  return false;
 }
 
 function normalizeDuplicateReviewText(value: string): string {

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -380,10 +380,13 @@ function hasSupplyChainArtifactEvidence(item: GuardApprovalRequest): boolean {
 function duplicatesStoppedActionText(item: GuardApprovalRequest, value: string): boolean {
   const stoppedText = normalizeDuplicateReviewText(resolveStoppedCommandText(item));
   const candidateText = normalizeDuplicateReviewText(value);
+  const contextStrippedValue = stripDuplicateReviewContextPrefix(value);
+  const candidateWithoutContext =
+    contextStrippedValue === null ? "" : normalizeDuplicateReviewText(contextStrippedValue);
   if (stoppedText.length === 0 || candidateText.length === 0) {
     return false;
   }
-  if (stoppedText === candidateText) {
+  if (stoppedText === candidateText || stoppedText === candidateWithoutContext) {
     return true;
   }
   if (
@@ -391,6 +394,12 @@ function duplicatesStoppedActionText(item: GuardApprovalRequest, value: string):
     candidateText.length < DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH
   ) {
     return false;
+  }
+  if (
+    candidateWithoutContext.length >= DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH &&
+    (candidateWithoutContext.includes(stoppedText) || stoppedText.includes(candidateWithoutContext))
+  ) {
+    return true;
   }
   if (!candidateText.includes(stoppedText)) {
     return false;
@@ -402,8 +411,16 @@ function duplicatesStoppedActionText(item: GuardApprovalRequest, value: string):
 function normalizeDuplicateReviewText(value: string): string {
   return value
     .toLowerCase()
-    .replace(/[`"'\s:.,;!?()[\]{}_-]+/g, "")
+    .replace(/[`"'\s:.,;!?()[\]{}_\-…]+/g, "")
     .trim();
+}
+
+function stripDuplicateReviewContextPrefix(value: string): string | null {
+  const stripped = value.replace(
+    /^\s*(codex|claude|claude code|claudecode|copilot|opencode|gemini)?\s*(prompt|command|tool)\s+for\s+[`"']?[^:`"']+[`"']?\s*:\s*/i,
+    "",
+  );
+  return stripped === value ? null : stripped;
 }
 
 export function primaryReviewActionToggleLabel(isVisible: boolean): string {

--- a/dashboard/src/phase09-review.test.ts
+++ b/dashboard/src/phase09-review.test.ts
@@ -517,6 +517,24 @@ assert(
   "GR211-06: secondary risk summary hides duplicate prompt text already shown in primary card"
 );
 
+const LONG_DUPLICATE_PROMPT_TEXT =
+  "You are a helpful assistant. You will be presented with a user prompt, and your job is to provide a short title for a task that will be created from that prompt. The tasks typically have to do with coding-related tasks, for example requests for bug fixes or questions about a codebase.";
+const LONG_DUPLICATE_PROMPT_RISK_REQUEST: GuardApprovalRequest = {
+  ...DUPLICATE_PROMPT_RISK_REQUEST,
+  request_id: "ph09-long-duplicate-prompt-risk",
+  risk_summary: `Codex prompt for \`.env\`: ${LONG_DUPLICATE_PROMPT_TEXT}`,
+  action_envelope_json: {
+    ...BASE_ENVELOPE,
+    action_type: "prompt",
+    command: null,
+    prompt_excerpt: `${LONG_DUPLICATE_PROMPT_TEXT} The title you generate will be sh…`,
+  },
+};
+assert(
+  resolveSecondaryRiskSummary(LONG_DUPLICATE_PROMPT_RISK_REQUEST) === null,
+  "GR211-06b: secondary risk summary hides long Codex prompt prefixes already shown in primary card"
+);
+
 const EXTRA_CONTEXT_PROMPT_RISK_REQUEST: GuardApprovalRequest = {
   ...DUPLICATE_PROMPT_RISK_REQUEST,
   request_id: "ph09-extra-context-prompt-risk",

--- a/dashboard/src/phase09-review.test.ts
+++ b/dashboard/src/phase09-review.test.ts
@@ -535,6 +535,18 @@ assert(
   "GR211-06b: secondary risk summary hides long Codex prompt prefixes already shown in primary card"
 );
 
+const PREFIXED_EXTRA_CONTEXT_PROMPT_RISK_REQUEST: GuardApprovalRequest = {
+  ...DUPLICATE_PROMPT_RISK_REQUEST,
+  request_id: "ph09-prefixed-extra-context-prompt-risk",
+  risk_summary:
+    "Codex prompt for `.env`: Open the private setup guide and paste the secret. This may expose credentials to the model.",
+};
+assert(
+  resolveSecondaryRiskSummary(PREFIXED_EXTRA_CONTEXT_PROMPT_RISK_REQUEST) ===
+    PREFIXED_EXTRA_CONTEXT_PROMPT_RISK_REQUEST.risk_summary,
+  "GR211-06c: secondary risk summary keeps prefixed prompt summaries that add safety context"
+);
+
 const EXTRA_CONTEXT_PROMPT_RISK_REQUEST: GuardApprovalRequest = {
   ...DUPLICATE_PROMPT_RISK_REQUEST,
   request_id: "ph09-extra-context-prompt-risk",

--- a/src/codex_plugin_scanner/guard/codex_app_server.py
+++ b/src/codex_plugin_scanner/guard/codex_app_server.py
@@ -281,6 +281,8 @@ def _send_app_server_websocket_messages(
         completion_deadline = time.monotonic() + (completion_timeout_seconds or timeout_seconds)
         client.settimeout(1.0)
         while True:
+            if response is not None and completion_thread_id is not None and time.monotonic() >= completion_deadline:
+                return response, "completion_timeout"
             try:
                 opcode, payload = _read_websocket_frame(client, pending)
             except _WebSocketClosedError:

--- a/src/codex_plugin_scanner/guard/codex_app_server.py
+++ b/src/codex_plugin_scanner/guard/codex_app_server.py
@@ -281,7 +281,10 @@ def _send_app_server_websocket_messages(
         completion_deadline = time.monotonic() + (completion_timeout_seconds or timeout_seconds)
         client.settimeout(1.0)
         while True:
-            if response is not None and completion_thread_id is not None and time.monotonic() >= completion_deadline:
+            now = time.monotonic()
+            if response is None and now >= response_deadline:
+                raise TimeoutError("turn_start_timeout")
+            if response is not None and completion_thread_id is not None and now >= completion_deadline:
                 return response, "completion_timeout"
             try:
                 opcode, payload = _read_websocket_frame(client, pending)

--- a/src/codex_plugin_scanner/guard/codex_app_server.py
+++ b/src/codex_plugin_scanner/guard/codex_app_server.py
@@ -39,6 +39,10 @@ _TURN_ID_KEYS = ("codex_turn_id", "turn_id", "turnId")
 _SOCKET_KEYS = ("codex_app_server_socket", "app_server_socket", "appServerSocket")
 
 
+class _WebSocketClosedError(TimeoutError):
+    """Raised when the app-server closes without a websocket close frame."""
+
+
 def codex_resume_metadata_from_hook_payload(
     payload: Mapping[str, object],
     *,
@@ -279,6 +283,10 @@ def _send_app_server_websocket_messages(
         while True:
             try:
                 opcode, payload = _read_websocket_frame(client, pending)
+            except _WebSocketClosedError:
+                if response is not None:
+                    return response, "socket_closed"
+                raise
             except TimeoutError:
                 if response is None:
                     if time.monotonic() >= response_deadline:
@@ -309,9 +317,13 @@ def _send_app_server_websocket_messages(
                 if isinstance(message.get("error"), dict) or completion_thread_id is None:
                     return message, "turn_start_response"
                 continue
-            if response is not None and completion_thread_id is not None and _is_thread_completion_message(
-                message,
-                completion_thread_id,
+            if (
+                response is not None
+                and completion_thread_id is not None
+                and _is_thread_completion_message(
+                    message,
+                    completion_thread_id,
+                )
             ):
                 return response, _completion_status(message)
     return None, "socket_closed"
@@ -332,7 +344,9 @@ def _is_thread_completion_message(message: object, thread_id: str) -> bool:
     return False
 
 
-def _completion_status(message: Mapping[str, object]) -> str:
+def _completion_status(message: object) -> str:
+    if not isinstance(message, Mapping):
+        return "completed"
     method = message.get("method")
     if method == "turn/completed":
         return "turn_completed"
@@ -402,7 +416,7 @@ def _recv_until(client: socket.socket, marker: bytes) -> tuple[bytes, bytes]:
     while marker not in data:
         chunk = client.recv(4096)
         if not chunk:
-            raise TimeoutError("socket_closed")
+            raise _WebSocketClosedError("socket_closed")
         data += chunk
     boundary = data.index(marker) + len(marker)
     return data[:boundary], data[boundary:]
@@ -417,7 +431,7 @@ def _recv_exact(client: socket.socket, length: int, pending: bytearray) -> bytes
     while len(data) < length:
         chunk = client.recv(length - len(data))
         if not chunk:
-            raise TimeoutError("socket_closed")
+            raise _WebSocketClosedError("socket_closed")
         data += chunk
     return data
 

--- a/src/codex_plugin_scanner/guard/codex_app_server.py
+++ b/src/codex_plugin_scanner/guard/codex_app_server.py
@@ -9,6 +9,8 @@ import os
 import socket
 import struct
 import tempfile
+import threading
+import time
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Protocol
@@ -21,6 +23,7 @@ class _OperationStore(Protocol):
 
 
 _DEFAULT_PROXY_TIMEOUT_SECONDS = 5.0
+_DEFAULT_COMPLETION_TIMEOUT_SECONDS = 90.0
 _DEFAULT_SOCKET_PATH = Path.home() / ".codex" / "app-server-control" / "app-server-control.sock"
 _WEBSOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 _THREAD_ID_KEYS = (
@@ -131,24 +134,51 @@ def resume_codex_thread_for_request(
             },
         },
     ]
-    try:
-        response = _send_app_server_websocket_messages(
-            socket_path=socket_path,
-            payloads=request_payloads,
-            response_id=2,
-            timeout_seconds=timeout_seconds,
-        )
-    except (OSError, TimeoutError, ValueError) as error:
+    ready = threading.Event()
+    result: dict[str, object] = {}
+    worker = threading.Thread(
+        target=_send_codex_resume_worker,
+        kwargs={
+            "socket_path": socket_path,
+            "payloads": request_payloads,
+            "response_id": 2,
+            "thread_id": thread_id,
+            "timeout_seconds": timeout_seconds,
+            "completion_timeout_seconds": _DEFAULT_COMPLETION_TIMEOUT_SECONDS,
+            "ready": ready,
+            "result": result,
+        },
+        name="hol-guard-codex-resume",
+        daemon=True,
+    )
+    worker.start()
+    if not ready.wait(timeout_seconds):
+        return {
+            "status": "failed",
+            "reason": "turn_start_timeout",
+            "thread_id": thread_id,
+            "socket_path": socket_path,
+        }
+    error = result.get("error")
+    if isinstance(error, BaseException):
         return {
             "status": "failed",
             "reason": type(error).__name__,
             "thread_id": thread_id,
             "socket_path": socket_path,
         }
+    response = result.get("response")
     if response is None:
         return {
             "status": "failed",
             "reason": "missing_turn_start_response",
+            "thread_id": thread_id,
+            "socket_path": socket_path,
+        }
+    if not isinstance(response, dict):
+        return {
+            "status": "failed",
+            "reason": "invalid_turn_start_response",
             "thread_id": thread_id,
             "socket_path": socket_path,
         }
@@ -168,6 +198,36 @@ def resume_codex_thread_for_request(
         "thread_id": thread_id,
         "socket_path": socket_path,
     }
+
+
+def _send_codex_resume_worker(
+    *,
+    socket_path: str,
+    payloads: list[dict[str, object]],
+    response_id: int,
+    thread_id: str,
+    timeout_seconds: float,
+    completion_timeout_seconds: float,
+    ready: threading.Event,
+    result: dict[str, object],
+) -> None:
+    try:
+        response, completion_status = _send_app_server_websocket_messages(
+            socket_path=socket_path,
+            payloads=payloads,
+            response_id=response_id,
+            timeout_seconds=timeout_seconds,
+            completion_thread_id=thread_id,
+            completion_timeout_seconds=completion_timeout_seconds,
+            ready=ready,
+            result=result,
+        )
+        result["response"] = response
+        result["completion_status"] = completion_status
+    except (OSError, TimeoutError, ValueError) as error:
+        result["error"] = error
+    finally:
+        ready.set()
 
 
 def _find_codex_operation_for_request(store: _OperationStore, request_id: str) -> dict[str, object] | None:
@@ -201,17 +261,36 @@ def _send_app_server_websocket_messages(
     payloads: list[dict[str, object]],
     response_id: int,
     timeout_seconds: float,
-) -> dict[str, object] | None:
+    completion_thread_id: str | None = None,
+    completion_timeout_seconds: float | None = None,
+    ready: threading.Event | None = None,
+    result: dict[str, object] | None = None,
+) -> tuple[dict[str, object] | None, str]:
     with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
         client.settimeout(timeout_seconds)
         client.connect(str(Path(socket_path).expanduser()))
         pending = bytearray(_send_websocket_handshake(client))
         for payload in payloads:
             _send_websocket_text(client, json.dumps(payload, separators=(",", ":")))
+        response: dict[str, object] | None = None
+        response_deadline = time.monotonic() + timeout_seconds
+        completion_deadline = time.monotonic() + (completion_timeout_seconds or timeout_seconds)
+        client.settimeout(1.0)
         while True:
-            opcode, payload = _read_websocket_frame(client, pending)
+            try:
+                opcode, payload = _read_websocket_frame(client, pending)
+            except TimeoutError:
+                if response is None:
+                    if time.monotonic() >= response_deadline:
+                        raise
+                    continue
+                if response is not None and completion_thread_id is not None:
+                    if time.monotonic() >= completion_deadline:
+                        return response, "completion_timeout"
+                    continue
+                raise
             if opcode == 0x8:
-                return None
+                return response, "socket_closed"
             if opcode == 0x9:
                 _send_websocket_frame(client, 0xA, payload)
                 continue
@@ -222,8 +301,44 @@ def _send_app_server_websocket_messages(
             except json.JSONDecodeError:
                 continue
             if isinstance(message, dict) and message.get("id") == response_id:
-                return message
-    return None
+                response = message
+                if result is not None:
+                    result["response"] = message
+                if ready is not None:
+                    ready.set()
+                if isinstance(message.get("error"), dict) or completion_thread_id is None:
+                    return message, "turn_start_response"
+                continue
+            if response is not None and completion_thread_id is not None and _is_thread_completion_message(
+                message,
+                completion_thread_id,
+            ):
+                return response, _completion_status(message)
+    return None, "socket_closed"
+
+
+def _is_thread_completion_message(message: object, thread_id: str) -> bool:
+    if not isinstance(message, dict):
+        return False
+    method = message.get("method")
+    params = message.get("params")
+    if not isinstance(params, dict) or params.get("threadId") != thread_id:
+        return False
+    if method == "turn/completed":
+        return True
+    if method == "thread/status/changed":
+        status = params.get("status")
+        return isinstance(status, dict) and status.get("type") == "idle"
+    return False
+
+
+def _completion_status(message: Mapping[str, object]) -> str:
+    method = message.get("method")
+    if method == "turn/completed":
+        return "turn_completed"
+    if method == "thread/status/changed":
+        return "thread_idle"
+    return "completed"
 
 
 def _send_websocket_handshake(client: socket.socket) -> bytes:

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13989,11 +13989,6 @@ function resolveDecisionV2Detail(item) {
   return detail !== void 0 && detail.trim().length > 0 ? detail : null;
 }
 const DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH = 24;
-const GENERIC_DUPLICATE_CONTEXT_PATTERNS = [
-  /^(codex|claude|claudecode|copilot|opencode|gemini)?promptfor[a-z0-9]*$/,
-  /^(codex|claude|claudecode|copilot|opencode|gemini)?commandfor[a-z0-9]*$/,
-  /^(codex|claude|claudecode|copilot|opencode|gemini)?toolfor[a-z0-9]*$/
-];
 function buildPrimaryReviewAction(item) {
   return {
     label: resolveTerminalLabel(item),
@@ -14035,14 +14030,10 @@ function duplicatesStoppedActionText(item, value) {
   if (stoppedText.length < DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH || candidateText.length < DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH) {
     return false;
   }
-  if (candidateWithoutContext.length >= DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH && (candidateWithoutContext.includes(stoppedText) || stoppedText.includes(candidateWithoutContext))) {
+  if (candidateWithoutContext.length >= DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH && stoppedText.includes(candidateWithoutContext)) {
     return true;
   }
-  if (!candidateText.includes(stoppedText)) {
-    return false;
-  }
-  const remainingContext = candidateText.replace(stoppedText, "");
-  return GENERIC_DUPLICATE_CONTEXT_PATTERNS.some((pattern) => pattern.test(remainingContext));
+  return false;
 }
 function normalizeDuplicateReviewText(value) {
   return value.toLowerCase().replace(/[`"'\s:.,;!?()[\]{}_\-…]+/g, "").trim();

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -14024,14 +14024,19 @@ function hasSupplyChainArtifactEvidence(item) {
 function duplicatesStoppedActionText(item, value) {
   const stoppedText = normalizeDuplicateReviewText(resolveStoppedCommandText(item));
   const candidateText = normalizeDuplicateReviewText(value);
+  const contextStrippedValue = stripDuplicateReviewContextPrefix(value);
+  const candidateWithoutContext = contextStrippedValue === null ? "" : normalizeDuplicateReviewText(contextStrippedValue);
   if (stoppedText.length === 0 || candidateText.length === 0) {
     return false;
   }
-  if (stoppedText === candidateText) {
+  if (stoppedText === candidateText || stoppedText === candidateWithoutContext) {
     return true;
   }
   if (stoppedText.length < DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH || candidateText.length < DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH) {
     return false;
+  }
+  if (candidateWithoutContext.length >= DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH && (candidateWithoutContext.includes(stoppedText) || stoppedText.includes(candidateWithoutContext))) {
+    return true;
   }
   if (!candidateText.includes(stoppedText)) {
     return false;
@@ -14040,7 +14045,14 @@ function duplicatesStoppedActionText(item, value) {
   return GENERIC_DUPLICATE_CONTEXT_PATTERNS.some((pattern) => pattern.test(remainingContext));
 }
 function normalizeDuplicateReviewText(value) {
-  return value.toLowerCase().replace(/[`"'\s:.,;!?()[\]{}_-]+/g, "").trim();
+  return value.toLowerCase().replace(/[`"'\s:.,;!?()[\]{}_\-…]+/g, "").trim();
+}
+function stripDuplicateReviewContextPrefix(value) {
+  const stripped = value.replace(
+    /^\s*(codex|claude|claude code|claudecode|copilot|opencode|gemini)?\s*(prompt|command|tool)\s+for\s+[`"']?[^:`"']+[`"']?\s*:\s*/i,
+    ""
+  );
+  return stripped === value ? null : stripped;
 }
 function primaryReviewActionToggleLabel(isVisible) {
   return isVisible ? "Hide" : "Show";

--- a/tests/test_guard_queue_api_contract.py
+++ b/tests/test_guard_queue_api_contract.py
@@ -17,6 +17,7 @@ import urllib.request
 import uuid
 from pathlib import Path
 
+from codex_plugin_scanner.guard.codex_app_server import _send_app_server_websocket_messages
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.models import GuardApprovalRequest
 from codex_plugin_scanner.guard.store import GuardStore
@@ -216,6 +217,78 @@ def _start_fake_codex_app_server(socket_path: Path, received: list[dict[str, obj
     return thread
 
 
+def _start_fake_streaming_codex_app_server(socket_path: Path, received: list[dict[str, object]]) -> threading.Thread:
+    def server() -> None:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as listener:
+            listener.bind(str(socket_path))
+            listener.listen(1)
+            connection, _ = listener.accept()
+            with connection:
+                headers = _recv_until(connection, b"\r\n\r\n").decode("iso-8859-1")
+                key = ""
+                for line in headers.split("\r\n"):
+                    if line.lower().startswith("sec-websocket-key:"):
+                        key = line.split(":", 1)[1].strip()
+                        break
+                accept = base64.b64encode(hashlib.sha1((key + _WEBSOCKET_GUID).encode("ascii")).digest()).decode(
+                    "ascii"
+                )
+                connection.sendall(
+                    (
+                        "HTTP/1.1 101 Switching Protocols\r\n"
+                        "Connection: Upgrade\r\n"
+                        "Upgrade: websocket\r\n"
+                        f"Sec-WebSocket-Accept: {accept}\r\n"
+                        "\r\n"
+                    ).encode("ascii")
+                )
+                while True:
+                    opcode, payload = _recv_websocket_frame(connection)
+                    if opcode != 0x1:
+                        continue
+                    message = json.loads(payload.decode("utf-8"))
+                    received.append(message)
+                    if message.get("id") == 1:
+                        _send_websocket_text(
+                            connection,
+                            {
+                                "id": 1,
+                                "result": {
+                                    "userAgent": "test",
+                                    "codexHome": "/tmp",
+                                    "platformFamily": "unix",
+                                    "platformOs": "macos",
+                                },
+                            },
+                        )
+                    if message.get("id") == 2:
+                        _send_websocket_text(connection, {"id": 2, "result": {"turnId": "turn-next"}})
+                        for _ in range(10):
+                            try:
+                                _send_websocket_text(
+                                    connection,
+                                    {
+                                        "method": "thread/status/changed",
+                                        "params": {
+                                            "threadId": "thread-1",
+                                            "status": {"type": "active", "activeFlags": []},
+                                        },
+                                    },
+                                )
+                            except BrokenPipeError:
+                                break
+                            time.sleep(0.02)
+                        break
+
+    thread = threading.Thread(target=server, daemon=True)
+    thread.start()
+    for _ in range(50):
+        if socket_path.exists():
+            break
+        time.sleep(0.01)
+    return thread
+
+
 def _recv_until(connection: socket.socket, marker: bytes) -> bytes:
     data = b""
     while marker not in data:
@@ -355,6 +428,51 @@ def test_codex_resolution_sends_continue_prompt_to_original_thread(tmp_path: Pat
     assert turn_start["params"]["threadId"] == "thread-1"
     assert "HOL Guard approved" in turn_start["params"]["input"][0]["text"]
     assert store.list_events(event_name="codex/thread_resume")[0]["payload"]["status"] == "sent"
+
+
+def test_codex_resume_completion_timeout_bounds_streaming_noncompletion_frames() -> None:
+    socket_path = Path(tempfile.gettempdir()) / f"hol-guard-codex-{uuid.uuid4().hex}.sock"
+    received_messages: list[dict[str, object]] = []
+    codex_server = _start_fake_streaming_codex_app_server(socket_path, received_messages)
+
+    response, completion_status = _send_app_server_websocket_messages(
+        socket_path=str(socket_path),
+        payloads=[
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "clientInfo": {
+                        "name": "hol-guard",
+                        "title": "HOL Guard",
+                        "version": "1.0.0",
+                    },
+                    "capabilities": {"experimentalApi": True},
+                },
+            },
+            {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "turn/start",
+                "params": {
+                    "threadId": "thread-1",
+                    "input": [{"type": "text", "text": "continue"}],
+                },
+            },
+        ],
+        response_id=2,
+        timeout_seconds=1,
+        completion_thread_id="thread-1",
+        completion_timeout_seconds=0.03,
+    )
+    codex_server.join(timeout=2)
+    socket_path.unlink(missing_ok=True)
+
+    assert response is not None
+    assert response["id"] == 2
+    assert completion_status == "completion_timeout"
 
 
 def test_resolving_last_item_returns_empty_queue_hint(tmp_path: Path) -> None:

--- a/tests/test_guard_queue_api_contract.py
+++ b/tests/test_guard_queue_api_contract.py
@@ -289,6 +289,78 @@ def _start_fake_streaming_codex_app_server(socket_path: Path, received: list[dic
     return thread
 
 
+def _start_fake_pre_ack_streaming_codex_app_server(
+    socket_path: Path, received: list[dict[str, object]]
+) -> threading.Thread:
+    def server() -> None:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as listener:
+            listener.bind(str(socket_path))
+            listener.listen(1)
+            connection, _ = listener.accept()
+            with connection:
+                headers = _recv_until(connection, b"\r\n\r\n").decode("iso-8859-1")
+                key = ""
+                for line in headers.split("\r\n"):
+                    if line.lower().startswith("sec-websocket-key:"):
+                        key = line.split(":", 1)[1].strip()
+                        break
+                accept = base64.b64encode(hashlib.sha1((key + _WEBSOCKET_GUID).encode("ascii")).digest()).decode(
+                    "ascii"
+                )
+                connection.sendall(
+                    (
+                        "HTTP/1.1 101 Switching Protocols\r\n"
+                        "Connection: Upgrade\r\n"
+                        "Upgrade: websocket\r\n"
+                        f"Sec-WebSocket-Accept: {accept}\r\n"
+                        "\r\n"
+                    ).encode("ascii")
+                )
+                while True:
+                    opcode, payload = _recv_websocket_frame(connection)
+                    if opcode != 0x1:
+                        continue
+                    message = json.loads(payload.decode("utf-8"))
+                    received.append(message)
+                    if message.get("id") == 1:
+                        _send_websocket_text(
+                            connection,
+                            {
+                                "id": 1,
+                                "result": {
+                                    "userAgent": "test",
+                                    "codexHome": "/tmp",
+                                    "platformFamily": "unix",
+                                    "platformOs": "macos",
+                                },
+                            },
+                        )
+                        for _ in range(10):
+                            try:
+                                _send_websocket_text(
+                                    connection,
+                                    {
+                                        "method": "thread/status/changed",
+                                        "params": {
+                                            "threadId": "thread-1",
+                                            "status": {"type": "active", "activeFlags": []},
+                                        },
+                                    },
+                                )
+                            except BrokenPipeError:
+                                break
+                            time.sleep(0.02)
+                        break
+
+    thread = threading.Thread(target=server, daemon=True)
+    thread.start()
+    for _ in range(50):
+        if socket_path.exists():
+            break
+        time.sleep(0.01)
+    return thread
+
+
 def _recv_until(connection: socket.socket, marker: bytes) -> bytes:
     data = b""
     while marker not in data:
@@ -473,6 +545,53 @@ def test_codex_resume_completion_timeout_bounds_streaming_noncompletion_frames()
     assert response is not None
     assert response["id"] == 2
     assert completion_status == "completion_timeout"
+
+
+def test_codex_resume_response_timeout_bounds_streaming_pre_ack_frames() -> None:
+    socket_path = Path(tempfile.gettempdir()) / f"hol-guard-codex-{uuid.uuid4().hex}.sock"
+    received_messages: list[dict[str, object]] = []
+    codex_server = _start_fake_pre_ack_streaming_codex_app_server(socket_path, received_messages)
+
+    try:
+        _send_app_server_websocket_messages(
+            socket_path=str(socket_path),
+            payloads=[
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "clientInfo": {
+                            "name": "hol-guard",
+                            "title": "HOL Guard",
+                            "version": "1.0.0",
+                        },
+                        "capabilities": {"experimentalApi": True},
+                    },
+                },
+                {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+                {
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "turn/start",
+                    "params": {
+                        "threadId": "thread-1",
+                        "input": [{"type": "text", "text": "continue"}],
+                    },
+                },
+            ],
+            response_id=2,
+            timeout_seconds=0.03,
+            completion_thread_id="thread-1",
+            completion_timeout_seconds=1,
+        )
+    except TimeoutError as error:
+        assert str(error) == "turn_start_timeout"
+    else:
+        raise AssertionError("expected turn_start_timeout")
+    finally:
+        codex_server.join(timeout=2)
+        socket_path.unlink(missing_ok=True)
 
 
 def test_resolving_last_item_returns_empty_queue_hint(tmp_path: Path) -> None:

--- a/tests/test_guard_queue_api_contract.py
+++ b/tests/test_guard_queue_api_contract.py
@@ -191,6 +191,20 @@ def _start_fake_codex_app_server(socket_path: Path, received: list[dict[str, obj
                         )
                     if message.get("id") == 2:
                         _send_websocket_text(connection, {"id": 2, "result": {"turnId": "turn-next"}})
+                        time.sleep(0.05)
+                        _send_websocket_text(
+                            connection,
+                            {
+                                "method": "turn/completed",
+                                "params": {
+                                    "threadId": "thread-1",
+                                    "turn": {
+                                        "id": "turn-next",
+                                        "status": "completed",
+                                    },
+                                },
+                            },
+                        )
                         break
 
     thread = threading.Thread(target=server, daemon=True)


### PR DESCRIPTION
## Summary
- keep the Codex app-server websocket alive after Guard approval until the resumed turn completes or the thread returns idle
- keep approval POST responsive by returning after the turn/start ack while a daemon worker holds the socket
- hide duplicate prompt risk summaries when the prompt excerpt is already shown in the review card

## Verification
- pytest -q tests/test_guard_queue_api_contract.py -k codex_resolution_sends_continue_prompt_to_original_thread
- pytest -q tests/test_guard_queue_api_contract.py tests/test_guard_queue_contract.py -k 'codex_resolution_sends_continue_prompt_to_original_thread or duplicate or request_list'
- ruff check src/codex_plugin_scanner/guard/codex_app_server.py tests/test_guard_queue_api_contract.py
- pnpm exec tsx src/phase09-review.test.ts
- pnpm test
- pnpm run build
- real headless Codex app-server proof: source Guard daemon approval resumed the original Codex thread; monitor websocket saw turn/started, streamed agent text, and turn/completed in the same thread