### PR TITLE
fix: allow hosted dashboard local network preflight

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1620,6 +1620,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "Access-Control-Allow-Origin": origin,
             "Access-Control-Allow-Methods": allow_methods,
             "Access-Control-Allow-Headers": allow_headers,
+            "Access-Control-Allow-Private-Network": "true",
             "Vary": "Origin",
         }
 
@@ -1825,6 +1826,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "Access-Control-Allow-Origin",
             "Access-Control-Allow-Methods",
             "Access-Control-Allow-Headers",
+            "Access-Control-Allow-Private-Network",
             "Vary",
         }
         validated: dict[str, str] = {}

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -1563,6 +1563,33 @@ class TestGuardSurfaceServer:
             "token": "session-token-123",
         }
 
+    def test_guard_daemon_allows_private_network_preflight_for_hosted_dashboard(self, tmp_path) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/capabilities",
+                headers={
+                    "Access-Control-Request-Headers": "authorization,x-guard-token",
+                    "Access-Control-Request-Method": "GET",
+                    "Access-Control-Request-Private-Network": "true",
+                    "Origin": "https://hol.org",
+                },
+                method="OPTIONS",
+            )
+            with urllib.request.urlopen(request, timeout=5) as response:
+                allow_origin = response.headers.get("Access-Control-Allow-Origin")
+                allow_private_network = response.headers.get("Access-Control-Allow-Private-Network")
+                status = response.status
+        finally:
+            daemon.stop()
+
+        assert status == 200
+        assert allow_origin == "https://hol.org"
+        assert allow_private_network == "true"
+
     def test_guard_daemon_rejects_browser_connect_pairing_for_wrong_origin(self, tmp_path) -> None:
         store = GuardStore(tmp_path / "guard-home")
         daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)


### PR DESCRIPTION
## Summary\n- include Access-Control-Allow-Private-Network on hosted-dashboard CORS responses\n- allow the header through daemon response validation\n- cover Chrome private-network preflight from https://hol.org\n\n## Verification\n- pytest tests/test_guard_surface_server.py -k 'private_network_preflight or browser_connect_pairing'