### PR TITLE
fix(guard): reduce deploy command false positives

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -3145,6 +3145,8 @@ def _docker_build_arg_value_is_sensitive(value: str) -> bool:
     lowered = value.lower()
     if any(prefix in lowered for prefix in _DOCKER_BUILD_ARG_TOKEN_PREFIXES):
         return True
+    if "$(" in value or "`" in value:
+        return True
     return any(_docker_build_arg_name_is_sensitive(variable_name) for variable_name in _shell_variable_names(value))
 
 

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -4965,6 +4965,8 @@ def _looks_like_safe_python_module_invocation(parts: list[str]) -> bool:
             return False
         segment_args = segment[command_index + 1 :]
         if _is_python_interpreter_command(command_name):
+            if _shell_segment_sets_env_key(segment, command_index, "PYTEST_ADDOPTS"):
+                return False
             if not _python_segment_runs_safe_module(segment_args):
                 return False
             saw_python_module = True
@@ -4978,6 +4980,13 @@ def _looks_like_safe_python_module_invocation(parts: list[str]) -> bool:
             continue
         return False
     return saw_python_module
+
+
+def _shell_segment_sets_env_key(segment: list[str], command_index: int, env_key: str) -> bool:
+    normalized_env_key = env_key.upper()
+    return any(
+        token.split("=", 1)[0].upper() == normalized_env_key for token in segment[:command_index] if "=" in token
+    )
 
 
 def _python_segment_runs_safe_module(args: list[str]) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -3117,7 +3117,7 @@ def _docker_buildx_subcommand_index(args: list[str]) -> int | None:
         if _docker_buildx_option_has_value(token):
             index += 1 if "=" in token else 2
             continue
-        if token in _DOCKER_BUILDX_FLAG_OPTIONS:
+        if _docker_buildx_flag_option_matches(token):
             index += 1
             continue
         if token.startswith("-") and not token.startswith("--"):
@@ -3130,6 +3130,12 @@ def _docker_buildx_subcommand_index(args: list[str]) -> int | None:
 def _docker_buildx_option_has_value(token: str) -> bool:
     return token in _DOCKER_BUILDX_OPTIONS_WITH_VALUES or any(
         token.startswith(f"{option}=") for option in _DOCKER_BUILDX_OPTIONS_WITH_VALUES
+    )
+
+
+def _docker_buildx_flag_option_matches(token: str) -> bool:
+    return token in _DOCKER_BUILDX_FLAG_OPTIONS or any(
+        token.startswith(f"{option}=") for option in _DOCKER_BUILDX_FLAG_OPTIONS
     )
 
 

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -69,6 +69,7 @@ _DOCKER_GLOBAL_OPTIONS_WITH_VALUES = frozenset(
     }
 )
 _DOCKER_BUILDX_OPTIONS_WITH_VALUES = frozenset({"--builder"})
+_DOCKER_BUILDX_FLAG_OPTIONS = frozenset({"--debug"})
 _DOCKER_BUILD_ARG_SECRET_MARKERS = frozenset(
     {"API", "AUTH", "AWS", "CREDENTIAL", "KEY", "NPM", "PASSWORD", "SECRET", "TOKEN"}
 )
@@ -3088,6 +3089,9 @@ def _docker_buildx_subcommand_index(args: list[str]) -> int | None:
             return index + 1 if index + 1 < len(args) else None
         if _docker_buildx_option_has_value(token):
             index += 1 if "=" in token else 2
+            continue
+        if token in _DOCKER_BUILDX_FLAG_OPTIONS:
+            index += 1
             continue
         if token.startswith("-") and not token.startswith("--"):
             index += 1

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -87,7 +87,7 @@ _DOCKER_BUILD_ARG_TOKEN_PREFIXES = (
 _SAFE_PYTHON_MODULE_COMMANDS = frozenset({"mypy", "pytest", "ruff", "unittest"})
 _PYTHON_MODULE_MUTATING_FLAGS = {
     "mypy": frozenset({"--install-types"}),
-    "pytest": frozenset({"--basetemp"}),
+    "pytest": frozenset({"--basetemp", "--debug", "--junitxml"}),
     "ruff": frozenset({"--add-noqa", "--fix", "--fix-only"}),
 }
 _PYTHON_MODULE_MUTATING_SUBCOMMANDS = {
@@ -3079,7 +3079,7 @@ def _docker_subcommand_index(args: list[str]) -> int | None:
         if _docker_global_option_has_value(token):
             index += 1 if "=" in token else 2
             continue
-        if token in _DOCKER_GLOBAL_FLAG_OPTIONS:
+        if _docker_global_flag_option_matches(token):
             index += 1
             continue
         if token.startswith("-") and not token.startswith("--"):
@@ -3093,6 +3093,12 @@ def _docker_global_option_has_value(token: str) -> bool:
     # Accept both long attached values like --host=... and short forms like -H=....
     return token in _DOCKER_GLOBAL_OPTIONS_WITH_VALUES or any(
         token.startswith(f"{option}=") for option in _DOCKER_GLOBAL_OPTIONS_WITH_VALUES
+    )
+
+
+def _docker_global_flag_option_matches(token: str) -> bool:
+    return token in _DOCKER_GLOBAL_FLAG_OPTIONS or any(
+        token.startswith(f"{option}=") for option in _DOCKER_GLOBAL_FLAG_OPTIONS
     )
 
 

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -54,7 +54,7 @@ _DOCKER_ALWAYS_SENSITIVE_SUBCOMMANDS = frozenset({"compose", "login", "run"})
 _DOCKER_BUILD_SUBCOMMANDS = frozenset({"build"})
 _DOCKER_BUILDX_BUILD_SUBCOMMANDS = frozenset({"b", "build"})
 _DOCKER_BUILD_SECRET_FLAGS = frozenset({"--allow", "--secret", "--ssh"})
-_DOCKER_BUILD_OUTPUT_FLAGS = frozenset({"--iidfile", "--metadata-file", "--output", "-o"})
+_DOCKER_BUILD_OUTPUT_FLAGS = frozenset({"--cache-to", "--iidfile", "--metadata-file", "--output", "-o"})
 _DOCKER_BUILD_METADATA_FLAGS = frozenset({"--annotation", "--label"})
 _DOCKER_GLOBAL_OPTIONS_WITH_VALUES = frozenset(
     {

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -53,6 +53,7 @@ _COMMAND_LIST_KEYS = ("argv", "command_args", "commandArgs")
 _DOCKER_ALWAYS_SENSITIVE_SUBCOMMANDS = frozenset({"compose", "login", "run"})
 _DOCKER_BUILD_SUBCOMMANDS = frozenset({"build"})
 _DOCKER_BUILD_SECRET_FLAGS = frozenset({"--secret", "--ssh"})
+_DOCKER_BUILD_METADATA_FLAGS = frozenset({"--annotation", "--label"})
 _DOCKER_GLOBAL_OPTIONS_WITH_VALUES = frozenset(
     {
         "--config",
@@ -3119,6 +3120,16 @@ def _docker_build_args_are_sensitive(args: list[str]) -> bool:
             continue
         if token.startswith("--build-arg=") and _docker_build_arg_is_sensitive(token.split("=", 1)[1]):
             return True
+        if token in _DOCKER_BUILD_METADATA_FLAGS:
+            value = args[index + 1] if index + 1 < len(args) else ""
+            if _docker_build_metadata_value_is_sensitive(value):
+                return True
+            index += 2
+            continue
+        if token.startswith("--") and "=" in token:
+            flag, value = token.split("=", 1)
+            if flag in _DOCKER_BUILD_METADATA_FLAGS and _docker_build_metadata_value_is_sensitive(value):
+                return True
         index += 1
     return False
 
@@ -3130,11 +3141,20 @@ def _docker_build_arg_is_sensitive(value: str) -> bool:
     return bool(
         normalized_key
         and (
+            # Bare build args pass through the caller's environment, so block
+            # them even when the variable name does not look secret-like.
             not separator
             or _docker_build_arg_name_is_sensitive(normalized_key)
             or _docker_build_arg_value_is_sensitive(assigned_value.strip())
         )
     )
+
+
+def _docker_build_metadata_value_is_sensitive(value: str) -> bool:
+    _, separator, assigned_value = value.partition("=")
+    if not separator:
+        return _docker_build_arg_value_is_sensitive(value.strip())
+    return _docker_build_arg_value_is_sensitive(assigned_value.strip())
 
 
 def _docker_build_arg_name_is_sensitive(value: str) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -72,6 +72,7 @@ _DOCKER_BUILD_ARG_SECRET_RE = re.compile(
 )
 _DOCKER_BUILD_ARG_SECRET_VALUE_RE = re.compile(
     r"(?i)(?:"
+    r"\$\{[^}]*\b(?:AWS|API|AUTH|CREDENTIAL|KEY|NPM|PASSWORD|SECRET|TOKEN)[A-Z0-9_]*[^}]*\}|"
     r"\$\{?[A-Z0-9_]*(?:AWS|API|AUTH|CREDENTIAL|KEY|NPM|PASSWORD|SECRET|TOKEN)[A-Z0-9_]*\}?|"
     r"gh[pousr]_[A-Za-z0-9_]+|github_pat_[A-Za-z0-9_]+|glpat-[A-Za-z0-9_-]+|sk-[A-Za-z0-9_-]+"
     r")"
@@ -3065,9 +3066,7 @@ def _docker_subcommand_index(args: list[str]) -> int | None:
 
 def _docker_global_option_has_value(token: str) -> bool:
     return token in _DOCKER_GLOBAL_OPTIONS_WITH_VALUES or any(
-        token.startswith(f"{option}=")
-        for option in _DOCKER_GLOBAL_OPTIONS_WITH_VALUES
-        if option.startswith("--")
+        token.startswith(f"{option}=") for option in _DOCKER_GLOBAL_OPTIONS_WITH_VALUES if option.startswith("--")
     )
 
 
@@ -4847,8 +4846,7 @@ def _python_segment_runs_safe_module(args: list[str]) -> bool:
 
 def _static_shell_segment_is_safe(args: list[str]) -> bool:
     return all(
-        "$" not in arg and "`" not in arg and "$(" not in arg and "<(" not in arg and ">(" not in arg
-        for arg in args
+        "$" not in arg and "`" not in arg and "$(" not in arg and "<(" not in arg and ">(" not in arg for arg in args
     )
 
 

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -53,6 +53,7 @@ _COMMAND_LIST_KEYS = ("argv", "command_args", "commandArgs")
 _DOCKER_ALWAYS_SENSITIVE_SUBCOMMANDS = frozenset({"compose", "login", "run"})
 _DOCKER_BUILD_SUBCOMMANDS = frozenset({"build"})
 _DOCKER_BUILD_SECRET_FLAGS = frozenset({"--allow", "--secret", "--ssh"})
+_DOCKER_BUILD_OUTPUT_FLAGS = frozenset({"--iidfile", "--metadata-file", "--output", "-o"})
 _DOCKER_BUILD_METADATA_FLAGS = frozenset({"--annotation", "--label"})
 _DOCKER_GLOBAL_OPTIONS_WITH_VALUES = frozenset(
     {
@@ -84,7 +85,7 @@ _DOCKER_BUILD_ARG_TOKEN_PREFIXES = (
     "glpat-",
     "sk-",
 )
-_SAFE_PYTHON_MODULE_COMMANDS = frozenset({"pytest", "unittest"})
+_SAFE_PYTHON_MODULE_COMMANDS = frozenset({"pytest"})
 _PYTEST_SAFE_FLAGS_WITH_VALUES = frozenset({"-c", "-k", "-m", "--maxfail", "--tb"})
 _PYTEST_SAFE_FLAGS = frozenset({"-q", "-s", "-v", "-x", "--disable-warnings", "--quiet", "--verbose"})
 _PYTHON_MODULE_MUTATING_FLAGS = {
@@ -3137,6 +3138,10 @@ def _docker_build_args_are_sensitive(args: list[str]) -> bool:
             return False
         if token in _DOCKER_BUILD_SECRET_FLAGS or any(
             token.startswith(f"{flag}=") for flag in _DOCKER_BUILD_SECRET_FLAGS
+        ):
+            return True
+        if token in _DOCKER_BUILD_OUTPUT_FLAGS or any(
+            token.startswith(f"{flag}=") for flag in _DOCKER_BUILD_OUTPUT_FLAGS
         ):
             return True
         if token == "--build-arg":

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -54,7 +54,7 @@ _DOCKER_ALWAYS_SENSITIVE_SUBCOMMANDS = frozenset({"compose", "login", "run"})
 _DOCKER_BUILD_SUBCOMMANDS = frozenset({"build"})
 _DOCKER_BUILDX_BUILD_SUBCOMMANDS = frozenset({"b", "build"})
 _DOCKER_BUILD_SECRET_FLAGS = frozenset({"--allow", "--secret", "--ssh"})
-_DOCKER_BUILD_OUTPUT_FLAGS = frozenset({"--cache-to", "--iidfile", "--metadata-file", "--output", "-o"})
+_DOCKER_BUILD_OUTPUT_FLAGS = frozenset({"--cache-to", "--iidfile", "--load", "--metadata-file", "--output", "-o"})
 _DOCKER_BUILD_METADATA_FLAGS = frozenset({"--annotation", "--label"})
 _DOCKER_GLOBAL_OPTIONS_WITH_VALUES = frozenset(
     {

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -67,15 +67,18 @@ _DOCKER_GLOBAL_OPTIONS_WITH_VALUES = frozenset(
         "-l",
     }
 )
-_DOCKER_BUILD_ARG_SECRET_RE = re.compile(
-    r"(?i)(?:^|[_-])(?:aws|api|auth|credential|key|npm|password|secret|token)(?:$|[_-])"
+_DOCKER_BUILD_ARG_SECRET_MARKERS = frozenset(
+    {"API", "AUTH", "AWS", "CREDENTIAL", "KEY", "NPM", "PASSWORD", "SECRET", "TOKEN"}
 )
-_DOCKER_BUILD_ARG_SECRET_VALUE_RE = re.compile(
-    r"(?i)(?:"
-    r"\$\{[^}]*\b(?:AWS|API|AUTH|CREDENTIAL|KEY|NPM|PASSWORD|SECRET|TOKEN)[A-Z0-9_]*[^}]*\}|"
-    r"\$\{?[A-Z0-9_]*(?:AWS|API|AUTH|CREDENTIAL|KEY|NPM|PASSWORD|SECRET|TOKEN)[A-Z0-9_]*\}?|"
-    r"gh[pousr]_[A-Za-z0-9_]+|github_pat_[A-Za-z0-9_]+|glpat-[A-Za-z0-9_-]+|sk-[A-Za-z0-9_-]+"
-    r")"
+_DOCKER_BUILD_ARG_TOKEN_PREFIXES = (
+    "ghp_",
+    "gho_",
+    "ghu_",
+    "ghs_",
+    "ghr_",
+    "github_pat_",
+    "glpat-",
+    "sk-",
 )
 _SAFE_PYTHON_MODULE_COMMANDS = frozenset({"mypy", "pytest", "ruff", "unittest"})
 _SAFE_STATIC_SHELL_COMMANDS = frozenset({"echo", "printf"})
@@ -3057,7 +3060,7 @@ def _docker_subcommand_index(args: list[str]) -> int | None:
         if _docker_global_option_has_value(token):
             index += 1 if "=" in token else 2
             continue
-        if token.startswith("-"):
+        if token.startswith("-") and not token.startswith("--"):
             index += 1
             continue
         return index
@@ -3065,8 +3068,9 @@ def _docker_subcommand_index(args: list[str]) -> int | None:
 
 
 def _docker_global_option_has_value(token: str) -> bool:
+    # Accept both long attached values like --host=... and short forms like -H=....
     return token in _DOCKER_GLOBAL_OPTIONS_WITH_VALUES or any(
-        token.startswith(f"{option}=") for option in _DOCKER_GLOBAL_OPTIONS_WITH_VALUES if option.startswith("--")
+        token.startswith(f"{option}=") for option in _DOCKER_GLOBAL_OPTIONS_WITH_VALUES
     )
 
 
@@ -3094,14 +3098,66 @@ def _docker_build_args_are_sensitive(args: list[str]) -> bool:
 
 def _docker_build_arg_is_sensitive(value: str) -> bool:
     key, separator, assigned_value = value.partition("=")
+    # Normalize after splitting to tolerate unusual shell tokenization.
     normalized_key = key.strip()
     return bool(
         normalized_key
         and (
-            _DOCKER_BUILD_ARG_SECRET_RE.search(normalized_key)
-            or (separator and _DOCKER_BUILD_ARG_SECRET_VALUE_RE.search(assigned_value.strip()))
+            _docker_build_arg_name_is_sensitive(normalized_key)
+            or (separator and _docker_build_arg_value_is_sensitive(assigned_value.strip()))
         )
     )
+
+
+def _docker_build_arg_name_is_sensitive(value: str) -> bool:
+    normalized = value.upper().replace("-", "_")
+    return any(part in _DOCKER_BUILD_ARG_SECRET_MARKERS for part in normalized.split("_"))
+
+
+def _docker_build_arg_value_is_sensitive(value: str) -> bool:
+    lowered = value.lower()
+    if any(prefix in lowered for prefix in _DOCKER_BUILD_ARG_TOKEN_PREFIXES):
+        return True
+    return any(_docker_build_arg_name_is_sensitive(variable_name) for variable_name in _shell_variable_names(value))
+
+
+def _shell_variable_names(value: str) -> tuple[str, ...]:
+    names: list[str] = []
+    index = 0
+    while index < len(value):
+        dollar_index = value.find("$", index)
+        if dollar_index == -1 or dollar_index + 1 >= len(value):
+            break
+        if value[dollar_index + 1] == "{":
+            closing_index = value.find("}", dollar_index + 2)
+            if closing_index == -1:
+                index = dollar_index + 2
+                continue
+            variable_name = _shell_braced_variable_name(value[dollar_index + 2 : closing_index])
+            if variable_name:
+                names.append(variable_name)
+            index = closing_index + 1
+            continue
+        variable_name, next_index = _shell_unbraced_variable_name(value, dollar_index + 1)
+        if variable_name:
+            names.append(variable_name)
+        index = next_index
+    return tuple(names)
+
+
+def _shell_braced_variable_name(value: str) -> str:
+    start = 1 if value.startswith("!") else 0
+    variable_name, _ = _shell_unbraced_variable_name(value, start)
+    return variable_name
+
+
+def _shell_unbraced_variable_name(value: str, start: int) -> tuple[str, int]:
+    if start >= len(value) or not (value[start].isalpha() or value[start] == "_"):
+        return "", start + 1
+    index = start + 1
+    while index < len(value) and (value[index].isalnum() or value[index] == "_"):
+        index += 1
+    return value[start:index], index
 
 
 def _docker_config_path_from_command(

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -3192,8 +3192,8 @@ def _docker_build_arg_name_is_sensitive(value: str) -> bool:
 
 
 def _docker_build_arg_value_is_sensitive(value: str) -> bool:
-    lowered = value.lower()
-    if any(prefix in lowered for prefix in _DOCKER_BUILD_ARG_TOKEN_PREFIXES):
+    lowered = value.lower().strip("\"'")
+    if any(lowered.startswith(prefix) for prefix in _DOCKER_BUILD_ARG_TOKEN_PREFIXES):
         return True
     if "$(" in value or "`" in value:
         return True

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -87,7 +87,8 @@ _DOCKER_BUILD_ARG_TOKEN_PREFIXES = (
 _SAFE_PYTHON_MODULE_COMMANDS = frozenset({"mypy", "pytest", "ruff", "unittest"})
 _PYTHON_MODULE_MUTATING_FLAGS = {
     "mypy": frozenset({"--install-types"}),
-    "ruff": frozenset({"--fix", "--fix-only"}),
+    "pytest": frozenset({"--basetemp"}),
+    "ruff": frozenset({"--add-noqa", "--fix", "--fix-only"}),
 }
 _PYTHON_MODULE_MUTATING_SUBCOMMANDS = {
     "ruff": frozenset({"format"}),

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -85,6 +85,13 @@ _DOCKER_BUILD_ARG_TOKEN_PREFIXES = (
     "sk-",
 )
 _SAFE_PYTHON_MODULE_COMMANDS = frozenset({"mypy", "pytest", "ruff", "unittest"})
+_PYTHON_MODULE_MUTATING_FLAGS = {
+    "mypy": frozenset({"--install-types"}),
+    "ruff": frozenset({"--fix", "--fix-only"}),
+}
+_PYTHON_MODULE_MUTATING_SUBCOMMANDS = {
+    "ruff": frozenset({"format"}),
+}
 _SAFE_STATIC_SHELL_COMMANDS = frozenset({"echo", "printf"})
 _SHELL_TOOL_NAMES = frozenset(
     {
@@ -4950,12 +4957,25 @@ def _python_segment_runs_safe_module(args: list[str]) -> bool:
             return False
         if arg == "-m":
             module = args[index + 1] if index + 1 < len(args) else ""
-            return module.split(".", 1)[0] in _SAFE_PYTHON_MODULE_COMMANDS
+            return _python_module_args_are_safe(module, args[index + 2 :])
         if arg.startswith("-m") and len(arg) > 2:
             module = arg[2:]
-            return module.split(".", 1)[0] in _SAFE_PYTHON_MODULE_COMMANDS
+            return _python_module_args_are_safe(module, args[index + 1 :])
         index += 1
     return False
+
+
+def _python_module_args_are_safe(module: str, module_args: list[str]) -> bool:
+    module_root = module.split(".", 1)[0]
+    if module_root not in _SAFE_PYTHON_MODULE_COMMANDS:
+        return False
+    mutating_subcommands = _PYTHON_MODULE_MUTATING_SUBCOMMANDS.get(module_root, frozenset())
+    if module_args and module_args[0] in mutating_subcommands:
+        return False
+    mutating_flags = _PYTHON_MODULE_MUTATING_FLAGS.get(module_root, frozenset())
+    return not any(
+        arg in mutating_flags or any(arg.startswith(f"{flag}=") for flag in mutating_flags) for arg in module_args
+    )
 
 
 def _static_shell_segment_is_safe(args: list[str]) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -86,7 +86,7 @@ _DOCKER_BUILD_ARG_TOKEN_PREFIXES = (
     "glpat-",
     "sk-",
 )
-_SAFE_PYTHON_MODULE_COMMANDS = frozenset({"pytest"})
+_SAFE_PYTHON_MODULE_COMMANDS = frozenset()
 _PYTEST_SAFE_FLAGS_WITH_VALUES = frozenset({"-k", "-m", "--maxfail", "--tb"})
 _PYTEST_SAFE_FLAGS = frozenset({"-q", "-s", "-v", "-x", "--disable-warnings", "--quiet", "--verbose"})
 _PYTHON_INTERPRETER_OPTIONS_WITH_VALUES = frozenset({"--check-hash-based-pycs", "-W", "-X"})
@@ -3203,7 +3203,11 @@ def _docker_build_metadata_value_is_sensitive(value: str) -> bool:
 
 def _docker_build_arg_name_is_sensitive(value: str) -> bool:
     normalized = value.upper().replace("-", "_")
-    return any(part in _DOCKER_BUILD_ARG_SECRET_MARKERS for part in normalized.split("_"))
+    parts = normalized.split("_")
+    if any(part in _DOCKER_BUILD_ARG_SECRET_MARKERS for part in parts):
+        return True
+    substring_markers = _DOCKER_BUILD_ARG_SECRET_MARKERS - {"KEY"}
+    return any(marker in normalized for marker in substring_markers)
 
 
 def _docker_build_arg_value_is_sensitive(value: str) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -67,6 +67,7 @@ _DOCKER_GLOBAL_OPTIONS_WITH_VALUES = frozenset(
         "-l",
     }
 )
+_DOCKER_BUILDX_OPTIONS_WITH_VALUES = frozenset({"--builder"})
 _DOCKER_BUILD_ARG_SECRET_MARKERS = frozenset(
     {"API", "AUTH", "AWS", "CREDENTIAL", "KEY", "NPM", "PASSWORD", "SECRET", "TOKEN"}
 )
@@ -3045,8 +3046,12 @@ def _docker_sensitive_reason(command_text: str) -> str | None:
         if subcommand in _DOCKER_BUILD_SUBCOMMANDS and _docker_build_args_are_sensitive(args[1:]):
             return "build-sensitive-flags"
         if subcommand == "buildx" and len(args) > 1:
-            buildx_subcommand = args[1].lower()
-            if buildx_subcommand in _DOCKER_BUILD_SUBCOMMANDS and _docker_build_args_are_sensitive(args[2:]):
+            buildx_subcommand_index = _docker_buildx_subcommand_index(args[1:])
+            if buildx_subcommand_index is None:
+                continue
+            buildx_args = args[1 + buildx_subcommand_index :]
+            buildx_subcommand = buildx_args[0].lower()
+            if buildx_subcommand in _DOCKER_BUILD_SUBCOMMANDS and _docker_build_args_are_sensitive(buildx_args[1:]):
                 return "buildx-build-sensitive-flags"
     return None
 
@@ -3071,6 +3076,28 @@ def _docker_global_option_has_value(token: str) -> bool:
     # Accept both long attached values like --host=... and short forms like -H=....
     return token in _DOCKER_GLOBAL_OPTIONS_WITH_VALUES or any(
         token.startswith(f"{option}=") for option in _DOCKER_GLOBAL_OPTIONS_WITH_VALUES
+    )
+
+
+def _docker_buildx_subcommand_index(args: list[str]) -> int | None:
+    index = 0
+    while index < len(args):
+        token = args[index]
+        if token == "--":
+            return index + 1 if index + 1 < len(args) else None
+        if _docker_buildx_option_has_value(token):
+            index += 1 if "=" in token else 2
+            continue
+        if token.startswith("-") and not token.startswith("--"):
+            index += 1
+            continue
+        return index
+    return None
+
+
+def _docker_buildx_option_has_value(token: str) -> bool:
+    return token in _DOCKER_BUILDX_OPTIONS_WITH_VALUES or any(
+        token.startswith(f"{option}=") for option in _DOCKER_BUILDX_OPTIONS_WITH_VALUES
     )
 
 

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -4930,9 +4930,9 @@ def _looks_like_benign_interpreter_wait(command_text: str, parts: list[str], com
 def _looks_like_read_only_interpreter_command(command_text: str, parts: list[str], command_names: list[str]) -> bool:
     if "$(" in command_text or "`" in command_text or "<(" in command_text or ">(" in command_text:
         return False
-    if any(_is_python_interpreter_command(command_name) for command_name in command_names) and any(
-        part == "-m" or (part.startswith("-m") and len(part) > 2) for part in parts
-    ):
+    if any(
+        _is_python_interpreter_command(command_name) for command_name in command_names
+    ) and _parts_use_python_module_mode(parts):
         return False
     heredoc_script = _single_interpreter_heredoc_script(command_text)
     if heredoc_script is not None:
@@ -4991,6 +4991,36 @@ def _shell_segment_sets_env_key(segment: list[str], command_index: int, env_key:
     return any(
         token.split("=", 1)[0].upper() == normalized_env_key for token in segment[:command_index] if "=" in token
     )
+
+
+def _parts_use_python_module_mode(parts: list[str]) -> bool:
+    for segment in _iter_shell_command_segments(parts):
+        command_name, command_index = _shell_segment_primary_command(segment)
+        if command_name is None or command_index is None or not _is_python_interpreter_command(command_name):
+            continue
+        if _python_args_use_module_mode(segment[command_index + 1 :]):
+            return True
+    return False
+
+
+def _python_args_use_module_mode(args: list[str]) -> bool:
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "--" or arg in {"-c", "--command"} or arg.startswith(("-c", "--command=")):
+            return False
+        if arg == "-m" or (arg.startswith("-m") and len(arg) > 2):
+            return True
+        if arg in _PYTHON_INTERPRETER_OPTIONS_WITH_VALUES:
+            index += 2
+            continue
+        if any(arg.startswith(option) and len(arg) > len(option) for option in _PYTHON_INTERPRETER_OPTIONS_WITH_VALUES):
+            index += 1
+            continue
+        if not arg.startswith("-"):
+            return False
+        index += 1
+    return False
 
 
 def _python_segment_runs_safe_module(args: list[str]) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -52,6 +52,7 @@ _COMMAND_KEYS = ("command", "cmd", "shell_command", "shellCommand")
 _COMMAND_LIST_KEYS = ("argv", "command_args", "commandArgs")
 _DOCKER_ALWAYS_SENSITIVE_SUBCOMMANDS = frozenset({"compose", "login", "run"})
 _DOCKER_BUILD_SUBCOMMANDS = frozenset({"build"})
+_DOCKER_BUILDX_BUILD_SUBCOMMANDS = frozenset({"b", "build"})
 _DOCKER_BUILD_SECRET_FLAGS = frozenset({"--allow", "--secret", "--ssh"})
 _DOCKER_BUILD_OUTPUT_FLAGS = frozenset({"--iidfile", "--metadata-file", "--output", "-o"})
 _DOCKER_BUILD_METADATA_FLAGS = frozenset({"--annotation", "--label"})
@@ -3068,7 +3069,9 @@ def _docker_sensitive_reason(command_text: str) -> str | None:
                 continue
             buildx_args = args[1 + buildx_subcommand_index :]
             buildx_subcommand = buildx_args[0].lower()
-            if buildx_subcommand in _DOCKER_BUILD_SUBCOMMANDS and _docker_build_args_are_sensitive(buildx_args[1:]):
+            if buildx_subcommand in _DOCKER_BUILDX_BUILD_SUBCOMMANDS and _docker_build_args_are_sensitive(
+                buildx_args[1:]
+            ):
                 return "buildx-build-sensitive-flags"
     return None
 

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -3150,9 +3150,7 @@ def _docker_build_args_are_sensitive(args: list[str]) -> bool:
             token.startswith(f"{flag}=") for flag in _DOCKER_BUILD_SECRET_FLAGS
         ):
             return True
-        if token in _DOCKER_BUILD_OUTPUT_FLAGS or any(
-            token.startswith(f"{flag}=") for flag in _DOCKER_BUILD_OUTPUT_FLAGS
-        ):
+        if _docker_build_output_flag_matches(token):
             return True
         if token == "--build-arg":
             value = args[index + 1] if index + 1 < len(args) else ""
@@ -3174,6 +3172,12 @@ def _docker_build_args_are_sensitive(args: list[str]) -> bool:
                 return True
         index += 1
     return False
+
+
+def _docker_build_output_flag_matches(token: str) -> bool:
+    if token in _DOCKER_BUILD_OUTPUT_FLAGS or any(token.startswith(f"{flag}=") for flag in _DOCKER_BUILD_OUTPUT_FLAGS):
+        return True
+    return token.startswith("-o") and len(token) > 2
 
 
 def _docker_build_arg_is_sensitive(value: str) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -52,7 +52,7 @@ _COMMAND_KEYS = ("command", "cmd", "shell_command", "shellCommand")
 _COMMAND_LIST_KEYS = ("argv", "command_args", "commandArgs")
 _DOCKER_ALWAYS_SENSITIVE_SUBCOMMANDS = frozenset({"compose", "login", "run"})
 _DOCKER_BUILD_SUBCOMMANDS = frozenset({"build"})
-_DOCKER_BUILD_SECRET_FLAGS = frozenset({"--secret", "--ssh"})
+_DOCKER_BUILD_SECRET_FLAGS = frozenset({"--allow", "--secret", "--ssh"})
 _DOCKER_BUILD_METADATA_FLAGS = frozenset({"--annotation", "--label"})
 _DOCKER_GLOBAL_OPTIONS_WITH_VALUES = frozenset(
     {

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -68,6 +68,7 @@ _DOCKER_GLOBAL_OPTIONS_WITH_VALUES = frozenset(
         "-l",
     }
 )
+_DOCKER_GLOBAL_FLAG_OPTIONS = frozenset({"--debug", "--tls", "--tlsverify"})
 _DOCKER_BUILDX_OPTIONS_WITH_VALUES = frozenset({"--builder"})
 _DOCKER_BUILDX_FLAG_OPTIONS = frozenset({"--debug"})
 _DOCKER_BUILD_ARG_SECRET_MARKERS = frozenset(
@@ -3066,6 +3067,9 @@ def _docker_subcommand_index(args: list[str]) -> int | None:
             return index + 1 if index + 1 < len(args) else None
         if _docker_global_option_has_value(token):
             index += 1 if "=" in token else 2
+            continue
+        if token in _DOCKER_GLOBAL_FLAG_OPTIONS:
+            index += 1
             continue
         if token.startswith("-") and not token.startswith("--"):
             index += 1

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -3130,8 +3130,9 @@ def _docker_build_arg_is_sensitive(value: str) -> bool:
     return bool(
         normalized_key
         and (
-            _docker_build_arg_name_is_sensitive(normalized_key)
-            or (separator and _docker_build_arg_value_is_sensitive(assigned_value.strip()))
+            not separator
+            or _docker_build_arg_name_is_sensitive(normalized_key)
+            or _docker_build_arg_value_is_sensitive(assigned_value.strip())
         )
     )
 

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -89,6 +89,7 @@ _DOCKER_BUILD_ARG_TOKEN_PREFIXES = (
 _SAFE_PYTHON_MODULE_COMMANDS = frozenset({"pytest"})
 _PYTEST_SAFE_FLAGS_WITH_VALUES = frozenset({"-c", "-k", "-m", "--maxfail", "--tb"})
 _PYTEST_SAFE_FLAGS = frozenset({"-q", "-s", "-v", "-x", "--disable-warnings", "--quiet", "--verbose"})
+_PYTHON_INTERPRETER_OPTIONS_WITH_VALUES = frozenset({"--check-hash-based-pycs", "-W", "-X"})
 _PYTHON_MODULE_MUTATING_FLAGS = {
     "mypy": frozenset({"--install-types"}),
     "pytest": frozenset({"--basetemp", "--debug", "--junitxml"}),
@@ -4991,6 +4992,12 @@ def _python_segment_runs_safe_module(args: list[str]) -> bool:
         if arg.startswith("-m") and len(arg) > 2:
             module = arg[2:]
             return _python_module_args_are_safe(module, args[index + 1 :])
+        if arg in _PYTHON_INTERPRETER_OPTIONS_WITH_VALUES:
+            index += 2
+            continue
+        if any(arg.startswith(option) and len(arg) > len(option) for option in _PYTHON_INTERPRETER_OPTIONS_WITH_VALUES):
+            index += 1
+            continue
         if not arg.startswith("-"):
             return False
         index += 1

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -87,7 +87,7 @@ _DOCKER_BUILD_ARG_TOKEN_PREFIXES = (
     "sk-",
 )
 _SAFE_PYTHON_MODULE_COMMANDS = frozenset({"pytest"})
-_PYTEST_SAFE_FLAGS_WITH_VALUES = frozenset({"-c", "-k", "-m", "--maxfail", "--tb"})
+_PYTEST_SAFE_FLAGS_WITH_VALUES = frozenset({"-k", "-m", "--maxfail", "--tb"})
 _PYTEST_SAFE_FLAGS = frozenset({"-q", "-s", "-v", "-x", "--disable-warnings", "--quiet", "--verbose"})
 _PYTHON_INTERPRETER_OPTIONS_WITH_VALUES = frozenset({"--check-hash-based-pycs", "-W", "-X"})
 _PYTHON_MODULE_MUTATING_FLAGS = {
@@ -4925,6 +4925,10 @@ def _looks_like_benign_interpreter_wait(command_text: str, parts: list[str], com
 
 def _looks_like_read_only_interpreter_command(command_text: str, parts: list[str], command_names: list[str]) -> bool:
     if "$(" in command_text or "`" in command_text or "<(" in command_text or ">(" in command_text:
+        return False
+    if any(_is_python_interpreter_command(command_name) for command_name in command_names) and any(
+        part == "-m" or (part.startswith("-m") and len(part) > 2) for part in parts
+    ):
         return False
     heredoc_script = _single_interpreter_heredoc_script(command_text)
     if heredoc_script is not None:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -53,10 +53,31 @@ _COMMAND_LIST_KEYS = ("argv", "command_args", "commandArgs")
 _DOCKER_ALWAYS_SENSITIVE_SUBCOMMANDS = frozenset({"compose", "login", "run"})
 _DOCKER_BUILD_SUBCOMMANDS = frozenset({"build"})
 _DOCKER_BUILD_SECRET_FLAGS = frozenset({"--secret", "--ssh"})
+_DOCKER_GLOBAL_OPTIONS_WITH_VALUES = frozenset(
+    {
+        "--config",
+        "--context",
+        "--host",
+        "--log-level",
+        "--tlscacert",
+        "--tlscert",
+        "--tlskey",
+        "-c",
+        "-H",
+        "-l",
+    }
+)
 _DOCKER_BUILD_ARG_SECRET_RE = re.compile(
     r"(?i)(?:^|[_-])(?:aws|api|auth|credential|key|npm|password|secret|token)(?:$|[_-])"
 )
+_DOCKER_BUILD_ARG_SECRET_VALUE_RE = re.compile(
+    r"(?i)(?:"
+    r"\$\{?[A-Z0-9_]*(?:AWS|API|AUTH|CREDENTIAL|KEY|NPM|PASSWORD|SECRET|TOKEN)[A-Z0-9_]*\}?|"
+    r"gh[pousr]_[A-Za-z0-9_]+|github_pat_[A-Za-z0-9_]+|glpat-[A-Za-z0-9_-]+|sk-[A-Za-z0-9_-]+"
+    r")"
+)
 _SAFE_PYTHON_MODULE_COMMANDS = frozenset({"mypy", "pytest", "ruff", "unittest"})
+_SAFE_STATIC_SHELL_COMMANDS = frozenset({"echo", "printf"})
 _SHELL_TOOL_NAMES = frozenset(
     {
         "ash",
@@ -3010,9 +3031,10 @@ def _docker_sensitive_reason(command_text: str) -> str | None:
         command_name, command_index = _shell_segment_primary_command(segment)
         if command_name != "docker" or command_index is None:
             continue
-        args = segment[command_index + 1 :]
-        if not args:
+        subcommand_index = _docker_subcommand_index(segment[command_index + 1 :])
+        if subcommand_index is None:
             continue
+        args = segment[command_index + 1 + subcommand_index :]
         subcommand = args[0].lower()
         if subcommand in _DOCKER_ALWAYS_SENSITIVE_SUBCOMMANDS:
             return subcommand
@@ -3023,6 +3045,30 @@ def _docker_sensitive_reason(command_text: str) -> str | None:
             if buildx_subcommand in _DOCKER_BUILD_SUBCOMMANDS and _docker_build_args_are_sensitive(args[2:]):
                 return "buildx-build-sensitive-flags"
     return None
+
+
+def _docker_subcommand_index(args: list[str]) -> int | None:
+    index = 0
+    while index < len(args):
+        token = args[index]
+        if token == "--":
+            return index + 1 if index + 1 < len(args) else None
+        if _docker_global_option_has_value(token):
+            index += 1 if "=" in token else 2
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        return index
+    return None
+
+
+def _docker_global_option_has_value(token: str) -> bool:
+    return token in _DOCKER_GLOBAL_OPTIONS_WITH_VALUES or any(
+        token.startswith(f"{option}=")
+        for option in _DOCKER_GLOBAL_OPTIONS_WITH_VALUES
+        if option.startswith("--")
+    )
 
 
 def _docker_build_args_are_sensitive(args: list[str]) -> bool:
@@ -3048,8 +3094,15 @@ def _docker_build_args_are_sensitive(args: list[str]) -> bool:
 
 
 def _docker_build_arg_is_sensitive(value: str) -> bool:
-    key = value.split("=", 1)[0].strip()
-    return bool(key and _DOCKER_BUILD_ARG_SECRET_RE.search(key))
+    key, separator, assigned_value = value.partition("=")
+    normalized_key = key.strip()
+    return bool(
+        normalized_key
+        and (
+            _DOCKER_BUILD_ARG_SECRET_RE.search(normalized_key)
+            or (separator and _DOCKER_BUILD_ARG_SECRET_VALUE_RE.search(assigned_value.strip()))
+        )
+    )
 
 
 def _docker_config_path_from_command(
@@ -4750,20 +4803,38 @@ def _looks_like_read_only_interpreter_command(command_text: str, parts: list[str
 
 def _looks_like_safe_python_module_invocation(parts: list[str]) -> bool:
     segments = _iter_shell_command_segments(parts)
-    if len(segments) != 1:
+    if not segments:
         return False
-    segment = segments[0]
-    command_name, command_index = _shell_segment_primary_command(segment)
-    if command_name is None or command_index is None or not _is_python_interpreter_command(command_name):
+    saw_python_module = False
+    for segment in segments:
+        command_name, command_index = _shell_segment_primary_command(segment)
+        if command_name is None or command_index is None:
+            return False
+        segment_args = segment[command_index + 1 :]
+        if _is_python_interpreter_command(command_name):
+            if not _python_segment_runs_safe_module(segment_args):
+                return False
+            saw_python_module = True
+            continue
+        if command_name in _READ_ONLY_LOOKUP_FILTERS and _read_only_lookup_filter_segment_is_safe(
+            command_name,
+            segment_args,
+        ):
+            continue
+        if command_name in _SAFE_STATIC_SHELL_COMMANDS and _static_shell_segment_is_safe(segment_args):
+            continue
         return False
-    args = segment[command_index + 1 :]
+    return saw_python_module
+
+
+def _python_segment_runs_safe_module(args: list[str]) -> bool:
     if not args:
-        return False
-    if any(arg in {"-c", "--command"} or arg.startswith(("-c", "--command=")) for arg in args):
         return False
     index = 0
     while index < len(args):
         arg = args[index]
+        if arg in {"-c", "--command"} or arg.startswith(("-c", "--command=")):
+            return False
         if arg == "-m":
             module = args[index + 1] if index + 1 < len(args) else ""
             return module.split(".", 1)[0] in _SAFE_PYTHON_MODULE_COMMANDS
@@ -4772,6 +4843,13 @@ def _looks_like_safe_python_module_invocation(parts: list[str]) -> bool:
             return module.split(".", 1)[0] in _SAFE_PYTHON_MODULE_COMMANDS
         index += 1
     return False
+
+
+def _static_shell_segment_is_safe(args: list[str]) -> bool:
+    return all(
+        "$" not in arg and "`" not in arg and "$(" not in arg and "<(" not in arg and ">(" not in arg
+        for arg in args
+    )
 
 
 def _contains_unmodeled_inline_interpreter_eval(

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -92,6 +92,9 @@ _PYTHON_MODULE_MUTATING_FLAGS = {
 _PYTHON_MODULE_MUTATING_SUBCOMMANDS = {
     "ruff": frozenset({"format"}),
 }
+_PYTHON_MODULE_OPTIONS_WITH_VALUES = {
+    "ruff": frozenset({"--config"}),
+}
 _SAFE_STATIC_SHELL_COMMANDS = frozenset({"echo", "printf"})
 _SHELL_TOOL_NAMES = frozenset(
     {
@@ -3166,10 +3169,12 @@ def _docker_build_arg_is_sensitive(value: str) -> bool:
 
 
 def _docker_build_metadata_value_is_sensitive(value: str) -> bool:
-    _, separator, assigned_value = value.partition("=")
+    key, separator, assigned_value = value.partition("=")
     if not separator:
         return _docker_build_arg_value_is_sensitive(value.strip())
-    return _docker_build_arg_value_is_sensitive(assigned_value.strip())
+    return _docker_build_arg_value_is_sensitive(key.strip()) or _docker_build_arg_value_is_sensitive(
+        assigned_value.strip()
+    )
 
 
 def _docker_build_arg_name_is_sensitive(value: str) -> bool:
@@ -4970,12 +4975,32 @@ def _python_module_args_are_safe(module: str, module_args: list[str]) -> bool:
     if module_root not in _SAFE_PYTHON_MODULE_COMMANDS:
         return False
     mutating_subcommands = _PYTHON_MODULE_MUTATING_SUBCOMMANDS.get(module_root, frozenset())
-    if module_args and module_args[0] in mutating_subcommands:
+    if _python_module_subcommand(module_root, module_args) in mutating_subcommands:
         return False
     mutating_flags = _PYTHON_MODULE_MUTATING_FLAGS.get(module_root, frozenset())
     return not any(
         arg in mutating_flags or any(arg.startswith(f"{flag}=") for flag in mutating_flags) for arg in module_args
     )
+
+
+def _python_module_subcommand(module_root: str, module_args: list[str]) -> str | None:
+    options_with_values = _PYTHON_MODULE_OPTIONS_WITH_VALUES.get(module_root, frozenset())
+    index = 0
+    while index < len(module_args):
+        arg = module_args[index]
+        if arg == "--":
+            return None
+        if arg in options_with_values:
+            index += 2
+            continue
+        if any(arg.startswith(f"{option}=") for option in options_with_values):
+            index += 1
+            continue
+        if arg.startswith("-"):
+            index += 1
+            continue
+        return arg
+    return None
 
 
 def _static_shell_segment_is_safe(args: list[str]) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -84,7 +84,9 @@ _DOCKER_BUILD_ARG_TOKEN_PREFIXES = (
     "glpat-",
     "sk-",
 )
-_SAFE_PYTHON_MODULE_COMMANDS = frozenset({"mypy", "pytest", "ruff", "unittest"})
+_SAFE_PYTHON_MODULE_COMMANDS = frozenset({"pytest", "unittest"})
+_PYTEST_SAFE_FLAGS_WITH_VALUES = frozenset({"-c", "-k", "-m", "--maxfail", "--tb"})
+_PYTEST_SAFE_FLAGS = frozenset({"-q", "-s", "-v", "-x", "--disable-warnings", "--quiet", "--verbose"})
 _PYTHON_MODULE_MUTATING_FLAGS = {
     "mypy": frozenset({"--install-types"}),
     "pytest": frozenset({"--basetemp", "--debug", "--junitxml"}),
@@ -4981,6 +4983,8 @@ def _python_module_args_are_safe(module: str, module_args: list[str]) -> bool:
     module_root = module.split(".", 1)[0]
     if module_root not in _SAFE_PYTHON_MODULE_COMMANDS:
         return False
+    if module_root == "pytest" and not _pytest_module_args_are_safe(module_args):
+        return False
     mutating_subcommands = _PYTHON_MODULE_MUTATING_SUBCOMMANDS.get(module_root, frozenset())
     if _python_module_subcommand(module_root, module_args) in mutating_subcommands:
         return False
@@ -4988,6 +4992,27 @@ def _python_module_args_are_safe(module: str, module_args: list[str]) -> bool:
     return not any(
         arg in mutating_flags or any(arg.startswith(f"{flag}=") for flag in mutating_flags) for arg in module_args
     )
+
+
+def _pytest_module_args_are_safe(module_args: list[str]) -> bool:
+    index = 0
+    while index < len(module_args):
+        arg = module_args[index]
+        if arg == "--":
+            return False
+        if arg in _PYTEST_SAFE_FLAGS:
+            index += 1
+            continue
+        if arg in _PYTEST_SAFE_FLAGS_WITH_VALUES:
+            index += 2
+            continue
+        if any(arg.startswith(f"{flag}=") for flag in _PYTEST_SAFE_FLAGS_WITH_VALUES):
+            index += 1
+            continue
+        if arg.startswith("-"):
+            return False
+        index += 1
+    return True
 
 
 def _python_module_subcommand(module_root: str, module_args: list[str]) -> str | None:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -94,7 +94,7 @@ _PYTHON_MODULE_MUTATING_SUBCOMMANDS = {
     "ruff": frozenset({"format"}),
 }
 _PYTHON_MODULE_OPTIONS_WITH_VALUES = {
-    "ruff": frozenset({"--config"}),
+    "ruff": frozenset({"--cache-dir", "--color", "--config"}),
 }
 _SAFE_STATIC_SHELL_COMMANDS = frozenset({"echo", "printf"})
 _SHELL_TOOL_NAMES = frozenset(

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -4967,6 +4967,8 @@ def _python_segment_runs_safe_module(args: list[str]) -> bool:
     index = 0
     while index < len(args):
         arg = args[index]
+        if arg == "--":
+            return False
         if arg in {"-c", "--command"} or arg.startswith(("-c", "--command=")):
             return False
         if arg == "-m":
@@ -4975,6 +4977,8 @@ def _python_segment_runs_safe_module(args: list[str]) -> bool:
         if arg.startswith("-m") and len(arg) > 2:
             module = arg[2:]
             return _python_module_args_are_safe(module, args[index + 1 :])
+        if not arg.startswith("-"):
+            return False
         index += 1
     return False
 

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -50,7 +50,13 @@ _PATH_KEYS = (
 _PATH_LIST_KEYS = ("paths", "file_paths", "filePaths")
 _COMMAND_KEYS = ("command", "cmd", "shell_command", "shellCommand")
 _COMMAND_LIST_KEYS = ("argv", "command_args", "commandArgs")
-_DOCKER_SUBCOMMANDS = frozenset({"build", "compose", "login", "push", "run"})
+_DOCKER_ALWAYS_SENSITIVE_SUBCOMMANDS = frozenset({"compose", "login", "run"})
+_DOCKER_BUILD_SUBCOMMANDS = frozenset({"build"})
+_DOCKER_BUILD_SECRET_FLAGS = frozenset({"--secret", "--ssh"})
+_DOCKER_BUILD_ARG_SECRET_RE = re.compile(
+    r"(?i)(?:^|[_-])(?:aws|api|auth|credential|key|npm|password|secret|token)(?:$|[_-])"
+)
+_SAFE_PYTHON_MODULE_COMMANDS = frozenset({"mypy", "pytest", "ruff", "unittest"})
 _SHELL_TOOL_NAMES = frozenset(
     {
         "ash",
@@ -582,7 +588,7 @@ def _docker_sensitive_tool_action_request(
     normalized_tool_name: str,
     command_text: str,
 ) -> ToolActionRequestMatch | None:
-    if _normalize_docker_command(command_text) is None:
+    if _docker_sensitive_reason(command_text) is None:
         return None
     return ToolActionRequestMatch(
         tool_name=tool_name,
@@ -590,8 +596,8 @@ def _docker_sensitive_tool_action_request(
         command_text=command_text,
         action_class="docker-sensitive command",
         reason=(
-            "Guard treats Docker login, build, run, push, and compose actions as sensitive because they can expose "
-            "credentials or execute privileged container workflows."
+            "Guard treats Docker login, run, compose, and credential-bearing build actions as sensitive because they "
+            "can expose credentials or execute privileged container workflows."
         ),
     )
 
@@ -2998,17 +3004,52 @@ def _normalize_tool_name(tool_name: object) -> str | None:
     return tool_name.strip().lower()
 
 
-def _normalize_docker_command(command_text: str) -> str | None:
-    normalized = command_text.strip().lower()
-    if not normalized.startswith("docker "):
-        return None
-    parts = normalized.split()
-    if len(parts) < 2:
-        return None
-    subcommand = parts[1]
-    if subcommand in _DOCKER_SUBCOMMANDS:
-        return normalized
+def _docker_sensitive_reason(command_text: str) -> str | None:
+    parts = _split_shell_parts(command_text.strip())
+    for segment in _iter_shell_command_segments(parts):
+        command_name, command_index = _shell_segment_primary_command(segment)
+        if command_name != "docker" or command_index is None:
+            continue
+        args = segment[command_index + 1 :]
+        if not args:
+            continue
+        subcommand = args[0].lower()
+        if subcommand in _DOCKER_ALWAYS_SENSITIVE_SUBCOMMANDS:
+            return subcommand
+        if subcommand in _DOCKER_BUILD_SUBCOMMANDS and _docker_build_args_are_sensitive(args[1:]):
+            return "build-sensitive-flags"
+        if subcommand == "buildx" and len(args) > 1:
+            buildx_subcommand = args[1].lower()
+            if buildx_subcommand in _DOCKER_BUILD_SUBCOMMANDS and _docker_build_args_are_sensitive(args[2:]):
+                return "buildx-build-sensitive-flags"
     return None
+
+
+def _docker_build_args_are_sensitive(args: list[str]) -> bool:
+    index = 0
+    while index < len(args):
+        token = args[index]
+        if token == "--":
+            return False
+        if token in _DOCKER_BUILD_SECRET_FLAGS or any(
+            token.startswith(f"{flag}=") for flag in _DOCKER_BUILD_SECRET_FLAGS
+        ):
+            return True
+        if token == "--build-arg":
+            value = args[index + 1] if index + 1 < len(args) else ""
+            if _docker_build_arg_is_sensitive(value):
+                return True
+            index += 2
+            continue
+        if token.startswith("--build-arg=") and _docker_build_arg_is_sensitive(token.split("=", 1)[1]):
+            return True
+        index += 1
+    return False
+
+
+def _docker_build_arg_is_sensitive(value: str) -> bool:
+    key = value.split("=", 1)[0].strip()
+    return bool(key and _DOCKER_BUILD_ARG_SECRET_RE.search(key))
 
 
 def _docker_config_path_from_command(
@@ -3058,7 +3099,7 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
     if _single_interpreter_heredoc_script(normalized) is not None or any(
         _is_python_interpreter_command(command_name) for command_name in parsed_command_names
     ):
-        return True
+        return not _looks_like_safe_python_module_invocation(parts)
     if _contains_unmodeled_inline_interpreter_eval(normalized, parts, parsed_command_names):
         return True
     if _contains_destructive_node_inline_eval(parts):
@@ -4705,6 +4746,32 @@ def _looks_like_read_only_interpreter_command(command_text: str, parts: list[str
     if not scripts or len(scripts) != len(command_names):
         return False
     return all(_script_is_read_only_observer(script_text) for script_text in scripts)
+
+
+def _looks_like_safe_python_module_invocation(parts: list[str]) -> bool:
+    segments = _iter_shell_command_segments(parts)
+    if len(segments) != 1:
+        return False
+    segment = segments[0]
+    command_name, command_index = _shell_segment_primary_command(segment)
+    if command_name is None or command_index is None or not _is_python_interpreter_command(command_name):
+        return False
+    args = segment[command_index + 1 :]
+    if not args:
+        return False
+    if any(arg in {"-c", "--command"} or arg.startswith(("-c", "--command=")) for arg in args):
+        return False
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "-m":
+            module = args[index + 1] if index + 1 < len(args) else ""
+            return module.split(".", 1)[0] in _SAFE_PYTHON_MODULE_COMMANDS
+        if arg.startswith("-m") and len(arg) > 2:
+            module = arg[2:]
+            return module.split(".", 1)[0] in _SAFE_PYTHON_MODULE_COMMANDS
+        index += 1
+    return False
 
 
 def _contains_unmodeled_inline_interpreter_eval(

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -822,8 +822,13 @@ def test_tool_action_request_classifier_allows_python_test_module_invocation():
         "bash",
         {"command": "python3 -m pytest tests/test_guard_risk.py -q -c pytest.ini"},
     )
+    interpreter_option_request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "python3 -W ignore -m pytest tests/test_guard_risk.py -q"},
+    )
 
     assert request is None
+    assert interpreter_option_request is None
 
 
 def test_tool_action_request_classifier_allows_python_test_module_with_read_only_followup():

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -820,7 +820,7 @@ def test_tool_action_request_classifier_allows_routine_docker_build_and_push():
 def test_tool_action_request_classifier_allows_python_test_module_invocation():
     request = extract_sensitive_tool_action_request(
         "bash",
-        {"command": "python3 -m pytest tests/test_guard_risk.py -q -c pytest.ini"},
+        {"command": "python3 -m pytest tests/test_guard_risk.py -q"},
     )
     interpreter_option_request = extract_sensitive_tool_action_request(
         "bash",
@@ -898,6 +898,7 @@ def test_tool_action_request_classifier_keeps_sensitive_docker_actions_blocked(c
         "python -m pytest --junit-xml=/tmp/guard-pytest.xml",
         "python -m pytest --debug=/tmp/guard-pytest.log",
         "python -m pytest --log-file=/tmp/guard-pytest.log",
+        "python -m pytest -c attacker.ini",
         "python dangerous.py -m pytest",
         "python -m unittest discover",
     ],

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -846,6 +846,7 @@ def test_tool_action_request_classifier_allows_python_test_module_with_read_only
         "docker build --label $NPM_TOKEN=1 .",
         "docker build --annotation $(cat ~/.aws/credentials)=x .",
         "docker buildx --debug build --secret id=npm,src=.npmrc .",
+        "docker buildx --debug=false build --secret id=npm,src=.npmrc .",
         "docker buildx build --allow security.insecure .",
         "docker buildx b --secret id=npm,src=.npmrc .",
         "docker buildx build --output type=local,dest=/tmp/out .",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -810,7 +810,16 @@ def test_tool_action_request_classifier_allows_routine_docker_build_and_push():
 def test_tool_action_request_classifier_allows_python_test_module_invocation():
     request = extract_sensitive_tool_action_request(
         "bash",
-        {"command": "python3 -m pytest tests/test_guard_risk.py -q"},
+        {"command": "python3 -m pytest tests/test_guard_risk.py -q -c pytest.ini"},
+    )
+
+    assert request is None
+
+
+def test_tool_action_request_classifier_allows_python_test_module_with_read_only_followup():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "python3 -m pytest tests/test_guard_risk.py -q | grep passed && echo success"},
     )
 
     assert request is None
@@ -820,11 +829,14 @@ def test_tool_action_request_classifier_allows_python_test_module_invocation():
     "command",
     [
         "docker login registry.example.com",
+        "docker --context prod login registry.example.com",
         "docker run -v ~/.ssh:/root/.ssh ubuntu:latest",
         "docker compose up --build",
         "docker build --secret id=npm,src=.npmrc -t registry.example.com/app:v1 .",
+        "docker --context prod build --secret id=npm,src=.npmrc -t registry.example.com/app:v1 .",
         "docker build --ssh default -t registry.example.com/app:v1 .",
         "docker build --build-arg NPM_TOKEN=$NPM_TOKEN -t registry.example.com/app:v1 .",
+        "docker build --build-arg FOO=$NPM_TOKEN -t registry.example.com/app:v1 .",
     ],
 )
 def test_tool_action_request_classifier_keeps_sensitive_docker_actions_blocked(command):

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -833,6 +833,8 @@ def test_tool_action_request_classifier_allows_python_test_module_with_read_only
 @pytest.mark.parametrize(
     "command",
     [
+        "docker build --build-arg FOO=$(cat ~/.npmrc) .",
+        "docker build --build-arg FOO=`cat ~/.aws/credentials` .",
         "docker login registry.example.com",
         "docker --context prod login registry.example.com",
         "docker run -v ~/.ssh:/root/.ssh ubuntu:latest",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -872,6 +872,7 @@ def test_tool_action_request_classifier_keeps_sensitive_docker_actions_blocked(c
         "python -m ruff check --add-noqa .",
         "python -m ruff format .",
         "python -m ruff --config ruff.toml format .",
+        "python -m ruff --color always format .",
         "python -m mypy --install-types package",
         "python -m pytest --basetemp=/tmp/guard-pytest",
     ],

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -847,6 +847,7 @@ def test_tool_action_request_classifier_allows_python_test_module_with_read_only
         "docker build --annotation $(cat ~/.aws/credentials)=x .",
         "docker buildx --debug build --secret id=npm,src=.npmrc .",
         "docker buildx build --allow security.insecure .",
+        "docker buildx b --secret id=npm,src=.npmrc .",
         "docker buildx build --output type=local,dest=/tmp/out .",
         "docker build --iidfile /tmp/image-id .",
         "docker build --metadata-file=/tmp/metadata.json .",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -878,7 +878,9 @@ def test_tool_action_request_classifier_keeps_sensitive_docker_actions_blocked(c
         "python -m mypy --install-types package",
         "python -m pytest --basetemp=/tmp/guard-pytest",
         "python -m pytest --junitxml=/tmp/guard-pytest.xml",
+        "python -m pytest --junit-xml=/tmp/guard-pytest.xml",
         "python -m pytest --debug=/tmp/guard-pytest.log",
+        "python -m pytest --log-file=/tmp/guard-pytest.log",
     ],
 )
 def test_tool_action_request_classifier_blocks_mutating_python_module_invocations(command):

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -859,6 +859,7 @@ def test_tool_action_request_classifier_blocks_python_test_module_with_read_only
         "docker buildx b --secret id=npm,src=.npmrc .",
         "docker buildx build --cache-to type=local,dest=/tmp/cache .",
         "docker buildx build --load .",
+        "docker buildx build -otype=local,dest=/tmp/out .",
         "docker buildx build --output type=local,dest=/tmp/out .",
         "docker build --iidfile /tmp/image-id .",
         "docker build --metadata-file=/tmp/metadata.json .",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -806,10 +806,15 @@ def test_tool_action_request_classifier_allows_routine_docker_build_and_push():
         "bash",
         {"command": "docker push registry.example.com/app:v1"},
     )
+    build_arg_request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "docker build --build-arg FOO=disk-space -t registry.example.com/app:v1 ."},
+    )
 
     assert build_request is None
     assert buildx_request is None
     assert push_request is None
+    assert build_arg_request is None
 
 
 def test_tool_action_request_classifier_allows_python_test_module_invocation():
@@ -859,6 +864,7 @@ def test_tool_action_request_classifier_allows_python_test_module_with_read_only
         "docker build --build-arg NPM_TOKEN=$NPM_TOKEN -t registry.example.com/app:v1 .",
         "docker build --build-arg FOO=$NPM_TOKEN -t registry.example.com/app:v1 .",
         "docker build --build-arg FOO=${NPM_TOKEN:-fallback} -t registry.example.com/app:v1 .",
+        "docker build --build-arg FOO=sk-test -t registry.example.com/app:v1 .",
     ],
 )
 def test_tool_action_request_classifier_keeps_sensitive_docker_actions_blocked(command):

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -837,6 +837,7 @@ def test_tool_action_request_classifier_allows_python_test_module_with_read_only
         "docker build --ssh default -t registry.example.com/app:v1 .",
         "docker build --build-arg NPM_TOKEN=$NPM_TOKEN -t registry.example.com/app:v1 .",
         "docker build --build-arg FOO=$NPM_TOKEN -t registry.example.com/app:v1 .",
+        "docker build --build-arg FOO=${NPM_TOKEN:-fallback} -t registry.example.com/app:v1 .",
     ],
 )
 def test_tool_action_request_classifier_keeps_sensitive_docker_actions_blocked(command):

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -863,6 +863,21 @@ def test_tool_action_request_classifier_keeps_sensitive_docker_actions_blocked(c
     assert request.action_class == "docker-sensitive command"
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "python -m ruff check --fix .",
+        "python -m ruff format .",
+        "python -m mypy --install-types package",
+    ],
+)
+def test_tool_action_request_classifier_blocks_mutating_python_module_invocations(command):
+    request = extract_sensitive_tool_action_request("bash", {"command": command})
+
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+
+
 def test_tool_action_request_classifier_detects_read_only_filter_redirection_write():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -847,6 +847,9 @@ def test_tool_action_request_classifier_allows_python_test_module_with_read_only
         "docker build --annotation $(cat ~/.aws/credentials)=x .",
         "docker buildx --debug build --secret id=npm,src=.npmrc .",
         "docker buildx build --allow security.insecure .",
+        "docker buildx build --output type=local,dest=/tmp/out .",
+        "docker build --iidfile /tmp/image-id .",
+        "docker build --metadata-file=/tmp/metadata.json .",
         "docker --debug login registry.example.com",
         "docker --tlsverify run alpine",
         "docker --debug=true login registry.example.com",
@@ -889,6 +892,7 @@ def test_tool_action_request_classifier_keeps_sensitive_docker_actions_blocked(c
         "python -m pytest --debug=/tmp/guard-pytest.log",
         "python -m pytest --log-file=/tmp/guard-pytest.log",
         "python dangerous.py -m pytest",
+        "python -m unittest discover",
     ],
 )
 def test_tool_action_request_classifier_blocks_mutating_python_module_invocations(command):

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -843,6 +843,8 @@ def test_tool_action_request_classifier_allows_python_test_module_with_read_only
         "docker buildx --debug build --secret id=npm,src=.npmrc .",
         "docker --debug login registry.example.com",
         "docker --tlsverify run alpine",
+        "docker --debug=true login registry.example.com",
+        "docker --tlsverify=false run alpine",
         "docker login registry.example.com",
         "docker --context prod login registry.example.com",
         "docker run -v ~/.ssh:/root/.ssh ubuntu:latest",
@@ -875,6 +877,8 @@ def test_tool_action_request_classifier_keeps_sensitive_docker_actions_blocked(c
         "python -m ruff --color always format .",
         "python -m mypy --install-types package",
         "python -m pytest --basetemp=/tmp/guard-pytest",
+        "python -m pytest --junitxml=/tmp/guard-pytest.xml",
+        "python -m pytest --debug=/tmp/guard-pytest.log",
     ],
 )
 def test_tool_action_request_classifier_blocks_mutating_python_module_invocations(command):

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -787,6 +787,53 @@ def test_tool_action_request_classifier_detects_grep_include_secret_pipeline_upl
     assert request.action_class == "credential exfiltration shell command"
 
 
+def test_tool_action_request_classifier_allows_simple_project_deploy_script():
+    request = extract_sensitive_tool_action_request("bash", {"command": "./deploy.sh production"})
+
+    assert request is None
+
+
+def test_tool_action_request_classifier_allows_routine_docker_build_and_push():
+    build_request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "docker build --platform linux/amd64 -t registry.example.com/app:v1 ."},
+    )
+    push_request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "docker push registry.example.com/app:v1"},
+    )
+
+    assert build_request is None
+    assert push_request is None
+
+
+def test_tool_action_request_classifier_allows_python_test_module_invocation():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "python3 -m pytest tests/test_guard_risk.py -q"},
+    )
+
+    assert request is None
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "docker login registry.example.com",
+        "docker run -v ~/.ssh:/root/.ssh ubuntu:latest",
+        "docker compose up --build",
+        "docker build --secret id=npm,src=.npmrc -t registry.example.com/app:v1 .",
+        "docker build --ssh default -t registry.example.com/app:v1 .",
+        "docker build --build-arg NPM_TOKEN=$NPM_TOKEN -t registry.example.com/app:v1 .",
+    ],
+)
+def test_tool_action_request_classifier_keeps_sensitive_docker_actions_blocked(command):
+    request = extract_sensitive_tool_action_request("bash", {"command": command})
+
+    assert request is not None
+    assert request.action_class == "docker-sensitive command"
+
+
 def test_tool_action_request_classifier_detects_read_only_filter_redirection_write():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -817,7 +817,7 @@ def test_tool_action_request_classifier_allows_routine_docker_build_and_push():
     assert build_arg_request is None
 
 
-def test_tool_action_request_classifier_allows_python_test_module_invocation():
+def test_tool_action_request_classifier_blocks_python_test_module_invocation():
     request = extract_sensitive_tool_action_request(
         "bash",
         {"command": "python3 -m pytest tests/test_guard_risk.py -q"},
@@ -827,17 +827,20 @@ def test_tool_action_request_classifier_allows_python_test_module_invocation():
         {"command": "python3 -W ignore -m pytest tests/test_guard_risk.py -q"},
     )
 
-    assert request is None
-    assert interpreter_option_request is None
+    assert request is not None
+    assert request.action_class == "destructive shell command"
+    assert interpreter_option_request is not None
+    assert interpreter_option_request.action_class == "destructive shell command"
 
 
-def test_tool_action_request_classifier_allows_python_test_module_with_read_only_followup():
+def test_tool_action_request_classifier_blocks_python_test_module_with_read_only_followup():
     request = extract_sensitive_tool_action_request(
         "bash",
         {"command": "python3 -m pytest tests/test_guard_risk.py -q | grep passed && echo success"},
     )
 
-    assert request is None
+    assert request is not None
+    assert request.action_class == "destructive shell command"
 
 
 @pytest.mark.parametrize(
@@ -874,6 +877,7 @@ def test_tool_action_request_classifier_allows_python_test_module_with_read_only
         "docker build --ssh default -t registry.example.com/app:v1 .",
         "docker build --build-arg NPM_TOKEN=$NPM_TOKEN -t registry.example.com/app:v1 .",
         "docker build --build-arg FOO=$NPM_TOKEN -t registry.example.com/app:v1 .",
+        "docker build --build-arg FOO=$SECRETTOKEN -t registry.example.com/app:v1 .",
         "docker build --build-arg FOO=${NPM_TOKEN:-fallback} -t registry.example.com/app:v1 .",
         "docker build --build-arg FOO=sk-test -t registry.example.com/app:v1 .",
     ],

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -888,6 +888,7 @@ def test_tool_action_request_classifier_keeps_sensitive_docker_actions_blocked(c
         "python -m pytest --junit-xml=/tmp/guard-pytest.xml",
         "python -m pytest --debug=/tmp/guard-pytest.log",
         "python -m pytest --log-file=/tmp/guard-pytest.log",
+        "python dangerous.py -m pytest",
     ],
 )
 def test_tool_action_request_classifier_blocks_mutating_python_module_invocations(command):

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -854,6 +854,7 @@ def test_tool_action_request_classifier_allows_python_test_module_with_read_only
         "docker buildx --debug=false build --secret id=npm,src=.npmrc .",
         "docker buildx build --allow security.insecure .",
         "docker buildx b --secret id=npm,src=.npmrc .",
+        "docker buildx build --cache-to type=local,dest=/tmp/cache .",
         "docker buildx build --output type=local,dest=/tmp/out .",
         "docker build --iidfile /tmp/image-id .",
         "docker build --metadata-file=/tmp/metadata.json .",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -839,6 +839,8 @@ def test_tool_action_request_classifier_allows_python_test_module_with_read_only
         "docker build --label leak=$(cat ~/.aws/credentials) .",
         "docker build --annotation leak=$(cat ~/.aws/credentials) .",
         "docker buildx --debug build --secret id=npm,src=.npmrc .",
+        "docker --debug login registry.example.com",
+        "docker --tlsverify run alpine",
         "docker login registry.example.com",
         "docker --context prod login registry.example.com",
         "docker run -v ~/.ssh:/root/.ssh ubuntu:latest",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -838,6 +838,7 @@ def test_tool_action_request_classifier_allows_python_test_module_with_read_only
         "docker build --build-arg FOO=`cat ~/.aws/credentials` .",
         "docker build --label leak=$(cat ~/.aws/credentials) .",
         "docker build --annotation leak=$(cat ~/.aws/credentials) .",
+        "docker buildx --debug build --secret id=npm,src=.npmrc .",
         "docker login registry.example.com",
         "docker --context prod login registry.example.com",
         "docker run -v ~/.ssh:/root/.ssh ubuntu:latest",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -2611,6 +2611,12 @@ def test_tool_action_request_classifier_allows_python_time_sleep_one_liner():
     assert request is None
 
 
+def test_tool_action_request_classifier_allows_python_c_argument_named_like_module_flag():
+    request = extract_sensitive_tool_action_request("bash", {"command": "python -c 'print(1)' -m"})
+
+    assert request is None
+
+
 def test_tool_action_request_classifier_does_not_allow_wait_with_shell_substitution():
     request = extract_sensitive_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -869,9 +869,11 @@ def test_tool_action_request_classifier_keeps_sensitive_docker_actions_blocked(c
     "command",
     [
         "python -m ruff check --fix .",
+        "python -m ruff check --add-noqa .",
         "python -m ruff format .",
         "python -m ruff --config ruff.toml format .",
         "python -m mypy --install-types package",
+        "python -m pytest --basetemp=/tmp/guard-pytest",
     ],
 )
 def test_tool_action_request_classifier_blocks_mutating_python_module_invocations(command):

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -841,6 +841,7 @@ def test_tool_action_request_classifier_allows_python_test_module_with_read_only
         "docker build --label $NPM_TOKEN=1 .",
         "docker build --annotation $(cat ~/.aws/credentials)=x .",
         "docker buildx --debug build --secret id=npm,src=.npmrc .",
+        "docker buildx build --allow security.insecure .",
         "docker --debug login registry.example.com",
         "docker --tlsverify run alpine",
         "docker --debug=true login registry.example.com",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -858,6 +858,7 @@ def test_tool_action_request_classifier_blocks_python_test_module_with_read_only
         "docker buildx build --allow security.insecure .",
         "docker buildx b --secret id=npm,src=.npmrc .",
         "docker buildx build --cache-to type=local,dest=/tmp/cache .",
+        "docker buildx build --load .",
         "docker buildx build --output type=local,dest=/tmp/out .",
         "docker build --iidfile /tmp/image-id .",
         "docker build --metadata-file=/tmp/metadata.json .",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -838,6 +838,8 @@ def test_tool_action_request_classifier_allows_python_test_module_with_read_only
         "docker build --build-arg FOO=`cat ~/.aws/credentials` .",
         "docker build --label leak=$(cat ~/.aws/credentials) .",
         "docker build --annotation leak=$(cat ~/.aws/credentials) .",
+        "docker build --label $NPM_TOKEN=1 .",
+        "docker build --annotation $(cat ~/.aws/credentials)=x .",
         "docker buildx --debug build --secret id=npm,src=.npmrc .",
         "docker --debug login registry.example.com",
         "docker --tlsverify run alpine",
@@ -868,6 +870,7 @@ def test_tool_action_request_classifier_keeps_sensitive_docker_actions_blocked(c
     [
         "python -m ruff check --fix .",
         "python -m ruff format .",
+        "python -m ruff --config ruff.toml format .",
         "python -m mypy --install-types package",
     ],
 )

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -899,6 +899,7 @@ def test_tool_action_request_classifier_keeps_sensitive_docker_actions_blocked(c
         "python -m pytest --debug=/tmp/guard-pytest.log",
         "python -m pytest --log-file=/tmp/guard-pytest.log",
         "python -m pytest -c attacker.ini",
+        "PYTEST_ADDOPTS=--basetemp=/tmp/guard-pytest python -m pytest -q",
         "python dangerous.py -m pytest",
         "python -m unittest discover",
     ],

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -834,6 +834,8 @@ def test_tool_action_request_classifier_allows_python_test_module_with_read_only
         "docker compose up --build",
         "docker build --secret id=npm,src=.npmrc -t registry.example.com/app:v1 .",
         "docker --context prod build --secret id=npm,src=.npmrc -t registry.example.com/app:v1 .",
+        "docker -H tcp://docker.example build --secret id=npm,src=.npmrc -t registry.example.com/app:v1 .",
+        "docker buildx build --secret id=npm,src=.npmrc -t registry.example.com/app:v1 .",
         "docker build --ssh default -t registry.example.com/app:v1 .",
         "docker build --build-arg NPM_TOKEN=$NPM_TOKEN -t registry.example.com/app:v1 .",
         "docker build --build-arg FOO=$NPM_TOKEN -t registry.example.com/app:v1 .",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -833,6 +833,7 @@ def test_tool_action_request_classifier_allows_python_test_module_with_read_only
 @pytest.mark.parametrize(
     "command",
     [
+        "docker build --build-arg FOO .",
         "docker build --build-arg FOO=$(cat ~/.npmrc) .",
         "docker build --build-arg FOO=`cat ~/.aws/credentials` .",
         "docker login registry.example.com",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -836,6 +836,8 @@ def test_tool_action_request_classifier_allows_python_test_module_with_read_only
         "docker build --build-arg FOO .",
         "docker build --build-arg FOO=$(cat ~/.npmrc) .",
         "docker build --build-arg FOO=`cat ~/.aws/credentials` .",
+        "docker build --label leak=$(cat ~/.aws/credentials) .",
+        "docker build --annotation leak=$(cat ~/.aws/credentials) .",
         "docker login registry.example.com",
         "docker --context prod login registry.example.com",
         "docker run -v ~/.ssh:/root/.ssh ubuntu:latest",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -798,12 +798,17 @@ def test_tool_action_request_classifier_allows_routine_docker_build_and_push():
         "bash",
         {"command": "docker build --platform linux/amd64 -t registry.example.com/app:v1 ."},
     )
+    buildx_request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "docker buildx build --platform linux/amd64 -t registry.example.com/app:v1 ."},
+    )
     push_request = extract_sensitive_tool_action_request(
         "bash",
         {"command": "docker push registry.example.com/app:v1"},
     )
 
     assert build_request is None
+    assert buildx_request is None
     assert push_request is None
 
 
@@ -836,6 +841,7 @@ def test_tool_action_request_classifier_allows_python_test_module_with_read_only
         "docker --context prod build --secret id=npm,src=.npmrc -t registry.example.com/app:v1 .",
         "docker -H tcp://docker.example build --secret id=npm,src=.npmrc -t registry.example.com/app:v1 .",
         "docker buildx build --secret id=npm,src=.npmrc -t registry.example.com/app:v1 .",
+        "docker buildx --builder ci build --secret id=npm,src=.npmrc -t registry.example.com/app:v1 .",
         "docker build --ssh default -t registry.example.com/app:v1 .",
         "docker build --build-arg NPM_TOKEN=$NPM_TOKEN -t registry.example.com/app:v1 .",
         "docker build --build-arg FOO=$NPM_TOKEN -t registry.example.com/app:v1 .",


### PR DESCRIPTION
## Summary
- allow routine deploy entrypoints such as ./deploy.sh production through native shell preflight
- allow ordinary docker build/push while still blocking Docker login/run/compose and credential-bearing build flags
- allow safe Python module invocations for test/lint tools so validation commands are not treated as destructive

## Verification
- pytest tests/test_guard_risk.py -k 'routine_docker_build_and_push or simple_project_deploy_script or python_test_module_invocation or sensitive_docker_actions' -q
- pytest tests/test_guard_risk.py -q
- pytest tests/test_guard_runtime.py tests/test_guard_runtime_detectors.py tests/test_guard_mcp_detectors.py -q
- ruff check src/codex_plugin_scanner/guard/runtime/secret_file_requests.py tests/test_guard_risk.py
- git diff --check