### PR TITLE
fix(guard): hide duplicate prompt summaries

### DIFF
--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -420,10 +420,18 @@ function duplicatesStoppedActionText(item: GuardApprovalRequest, value: string):
 
 function extractDuplicateReviewRemainder(candidateText: string, stoppedText: string): string {
   const candidate = candidateText.trim();
-  const stopped = stoppedText.trim();
-  return candidate.toLowerCase().startsWith(stopped.toLowerCase())
-    ? candidate.slice(stopped.length).trim()
-    : "";
+  const stopped = normalizeDuplicateReviewText(stoppedText);
+  if (stopped.length === 0) {
+    return "";
+  }
+  let normalizedPrefix = "";
+  for (let index = 0; index < candidate.length; index += 1) {
+    normalizedPrefix += normalizeDuplicateReviewText(candidate[index]);
+    if (normalizedPrefix.length >= stopped.length) {
+      return normalizedPrefix.startsWith(stopped) ? candidate.slice(index + 1).trim() : "";
+    }
+  }
+  return "";
 }
 
 function hasDuplicateReviewSafetyContextRemainder(remainder: string): boolean {

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -324,8 +324,14 @@ export type PrimaryReviewAction = {
 
 const DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH = 24;
 const DUPLICATE_REVIEW_PREFIX_MIN_LENGTH = 80;
-const DUPLICATE_REVIEW_SAFETY_CONTEXT_PATTERN =
-  /(credential|secret|token|password|key|expose|exfiltrat|leak|sensitive|danger|risk|malicious|destructive|network|delete|remove|root|host|thirdparty|external|admin|privilege|permission|unauthorized|remote|upload|send|sends|write|execute|shell|process)/;
+const DUPLICATE_REVIEW_SAFETY_CONTEXT_PATTERNS = [
+  /\b(api[-\s]?key|credential|secret|token|password|sensitive|malicious|destructive|unauthorized)\b/i,
+  /\b(expose|exposes|exposed|leak|leaks|leaked|exfiltrate|exfiltrates|exfiltration)\b/i,
+  /\b(may|could|can|would|will)\s+(expose|leak|send|upload|exfiltrate|delete|remove|modify|overwrite|execute|run)\b/i,
+  /\bruns?\s+as\s+(root|admin|administrator)\b/i,
+  /\bsends?\s+(data|contents|files?|credentials?|secrets?|tokens?)\s+to\b/i,
+  /\b(third[-\s]?party|remote|external)\s+host\b/i,
+];
 
 export function buildPrimaryReviewAction(item: GuardApprovalRequest): PrimaryReviewAction {
   return {
@@ -376,11 +382,14 @@ function hasSupplyChainArtifactEvidence(item: GuardApprovalRequest): boolean {
 }
 
 function duplicatesStoppedActionText(item: GuardApprovalRequest, value: string): boolean {
-  const stoppedText = normalizeDuplicateReviewText(resolveStoppedCommandText(item));
+  const stoppedActionText = resolveStoppedCommandText(item);
+  const stoppedText = normalizeDuplicateReviewText(stoppedActionText);
   const candidateText = normalizeDuplicateReviewText(value);
   const contextStrippedValue = stripDuplicateReviewContextPrefix(value);
   const candidateWithoutContext =
     contextStrippedValue === null ? "" : normalizeDuplicateReviewText(contextStrippedValue);
+  const candidateRemainder =
+    contextStrippedValue === null ? "" : extractDuplicateReviewRemainder(contextStrippedValue, stoppedActionText);
   if (stoppedText.length === 0 || candidateText.length === 0) {
     return false;
   }
@@ -402,16 +411,23 @@ function duplicatesStoppedActionText(item: GuardApprovalRequest, value: string):
   if (
     stoppedText.length >= DUPLICATE_REVIEW_PREFIX_MIN_LENGTH &&
     candidateWithoutContext.startsWith(stoppedText) &&
-    !hasDuplicateReviewSafetyContextRemainder(candidateWithoutContext, stoppedText)
+    !hasDuplicateReviewSafetyContextRemainder(candidateRemainder)
   ) {
     return true;
   }
   return false;
 }
 
-function hasDuplicateReviewSafetyContextRemainder(candidateText: string, stoppedText: string): boolean {
-  const remainder = candidateText.slice(stoppedText.length);
-  return DUPLICATE_REVIEW_SAFETY_CONTEXT_PATTERN.test(remainder);
+function extractDuplicateReviewRemainder(candidateText: string, stoppedText: string): string {
+  const candidate = candidateText.trim();
+  const stopped = stoppedText.trim();
+  return candidate.toLowerCase().startsWith(stopped.toLowerCase())
+    ? candidate.slice(stopped.length).trim()
+    : "";
+}
+
+function hasDuplicateReviewSafetyContextRemainder(remainder: string): boolean {
+  return DUPLICATE_REVIEW_SAFETY_CONTEXT_PATTERNS.some((pattern) => pattern.test(remainder));
 }
 
 function normalizeDuplicateReviewText(value: string): string {

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -383,6 +383,8 @@ function hasSupplyChainArtifactEvidence(item: GuardApprovalRequest): boolean {
 
 function duplicatesStoppedActionText(item: GuardApprovalRequest, value: string): boolean {
   const stoppedActionText = resolveStoppedCommandText(item);
+  const canUseLongPromptPrefix =
+    item.action_envelope_json?.action_type === "prompt" || item.artifact_type === "prompt_request";
   const stoppedText = normalizeDuplicateReviewText(stoppedActionText);
   const candidateText = normalizeDuplicateReviewText(value);
   const contextStrippedValue = stripDuplicateReviewContextPrefix(value);
@@ -409,6 +411,7 @@ function duplicatesStoppedActionText(item: GuardApprovalRequest, value: string):
     return true;
   }
   if (
+    canUseLongPromptPrefix &&
     stoppedText.length >= DUPLICATE_REVIEW_PREFIX_MIN_LENGTH &&
     candidateWithoutContext.startsWith(stoppedText) &&
     !hasDuplicateReviewSafetyContextRemainder(candidateRemainder)

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -323,6 +323,7 @@ export type PrimaryReviewAction = {
 };
 
 const DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH = 24;
+const DUPLICATE_REVIEW_PREFIX_MIN_LENGTH = 80;
 
 export function buildPrimaryReviewAction(item: GuardApprovalRequest): PrimaryReviewAction {
   return {
@@ -393,6 +394,12 @@ function duplicatesStoppedActionText(item: GuardApprovalRequest, value: string):
   if (
     candidateWithoutContext.length >= DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH &&
     stoppedText.includes(candidateWithoutContext)
+  ) {
+    return true;
+  }
+  if (
+    stoppedText.length >= DUPLICATE_REVIEW_PREFIX_MIN_LENGTH &&
+    candidateWithoutContext.startsWith(stoppedText)
   ) {
     return true;
   }

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -325,7 +325,7 @@ export type PrimaryReviewAction = {
 const DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH = 24;
 const DUPLICATE_REVIEW_PREFIX_MIN_LENGTH = 80;
 const DUPLICATE_REVIEW_SAFETY_CONTEXT_PATTERNS = [
-  /\b(api[-\s]?key|credential|secret|token|password|sensitive|malicious|destructive|unauthorized)\b/i,
+  /\b(api[-_\s]?keys?|credentials?|secrets?|tokens?|passwords?|sensitive|malicious|destructive|unauthorized)\b/i,
   /\b(expose|exposes|exposed|leak|leaks|leaked|exfiltrate|exfiltrates|exfiltration)\b/i,
   /\b(may|could|can|would|will)\s+(expose|leak|send|upload|exfiltrate|delete|remove|modify|overwrite|execute|run)\b/i,
   /\bruns?\s+as\s+(root|admin|administrator)\b/i,

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -324,6 +324,8 @@ export type PrimaryReviewAction = {
 
 const DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH = 24;
 const DUPLICATE_REVIEW_PREFIX_MIN_LENGTH = 80;
+const DUPLICATE_REVIEW_SAFETY_CONTEXT_PATTERN =
+  /(credential|secret|token|password|key|expose|exfiltrat|leak|sensitive|danger|risk|malicious|destructive|network|delete|remove)/;
 
 export function buildPrimaryReviewAction(item: GuardApprovalRequest): PrimaryReviewAction {
   return {
@@ -399,11 +401,17 @@ function duplicatesStoppedActionText(item: GuardApprovalRequest, value: string):
   }
   if (
     stoppedText.length >= DUPLICATE_REVIEW_PREFIX_MIN_LENGTH &&
-    candidateWithoutContext.startsWith(stoppedText)
+    candidateWithoutContext.startsWith(stoppedText) &&
+    !hasDuplicateReviewSafetyContextRemainder(candidateWithoutContext, stoppedText)
   ) {
     return true;
   }
   return false;
+}
+
+function hasDuplicateReviewSafetyContextRemainder(candidateText: string, stoppedText: string): boolean {
+  const remainder = candidateText.slice(stoppedText.length);
+  return DUPLICATE_REVIEW_SAFETY_CONTEXT_PATTERN.test(remainder);
 }
 
 function normalizeDuplicateReviewText(value: string): string {

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -325,7 +325,7 @@ export type PrimaryReviewAction = {
 const DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH = 24;
 const DUPLICATE_REVIEW_PREFIX_MIN_LENGTH = 80;
 const DUPLICATE_REVIEW_SAFETY_CONTEXT_PATTERN =
-  /(credential|secret|token|password|key|expose|exfiltrat|leak|sensitive|danger|risk|malicious|destructive|network|delete|remove)/;
+  /(credential|secret|token|password|key|expose|exfiltrat|leak|sensitive|danger|risk|malicious|destructive|network|delete|remove|root|host|thirdparty|external|admin|privilege|permission|unauthorized|remote|upload|send|sends|write|execute|shell|process)/;
 
 export function buildPrimaryReviewAction(item: GuardApprovalRequest): PrimaryReviewAction {
   return {

--- a/dashboard/src/phase09-review.test.ts
+++ b/dashboard/src/phase09-review.test.ts
@@ -605,6 +605,17 @@ assert(
   "GR211-06h: secondary risk summary keeps safety context after normalized prefix extraction"
 );
 
+const PROMPT_WITH_SECRET_VARIANT_CONTEXT_REQUEST: GuardApprovalRequest = {
+  ...LONGER_DUPLICATE_PROMPT_RISK_REQUEST,
+  request_id: "ph09-prompt-with-secret-variant-context",
+  risk_summary: `Codex prompt for \`.npmrc\`: ${TRUNCATED_PRIMARY_PROMPT_TEXT} contains API_KEY credentials.`,
+};
+assert(
+  resolveSecondaryRiskSummary(PROMPT_WITH_SECRET_VARIANT_CONTEXT_REQUEST) ===
+    PROMPT_WITH_SECRET_VARIANT_CONTEXT_REQUEST.risk_summary,
+  "GR211-06i: secondary risk summary keeps plural and env-style secret context"
+);
+
 const PREFIXED_EXTRA_CONTEXT_PROMPT_RISK_REQUEST: GuardApprovalRequest = {
   ...DUPLICATE_PROMPT_RISK_REQUEST,
   request_id: "ph09-prefixed-extra-context-prompt-risk",

--- a/dashboard/src/phase09-review.test.ts
+++ b/dashboard/src/phase09-review.test.ts
@@ -668,6 +668,24 @@ assert(
   "GR211-09: secondary risk summary hides exact short duplicate command text"
 );
 
+const LONG_COMMAND_WITH_CONTEXT_TEXT =
+  "node scripts/sync-dashboard-data.js --workspace /Users/test/project --target review-workspace --format json --include-local-cache";
+const LONG_COMMAND_WITH_CONTEXT_REQUEST: GuardApprovalRequest = {
+  ...BASE_REQUEST,
+  request_id: "ph09-long-command-with-context",
+  risk_summary: `Codex command for \`shell\`: ${LONG_COMMAND_WITH_CONTEXT_TEXT} dry run mode disabled.`,
+  action_envelope_json: {
+    ...BASE_ENVELOPE,
+    action_type: "shell_command",
+    command: LONG_COMMAND_WITH_CONTEXT_TEXT,
+  },
+};
+assert(
+  resolveSecondaryRiskSummary(LONG_COMMAND_WITH_CONTEXT_REQUEST) ===
+    LONG_COMMAND_WITH_CONTEXT_REQUEST.risk_summary,
+  "GR211-09b: secondary risk summary keeps long shell command context"
+);
+
 const DUPLICATE_SUMMARY_WITH_SIGNAL_REQUEST: GuardApprovalRequest = {
   ...DUPLICATE_PROMPT_RISK_REQUEST,
   request_id: "ph09-duplicate-summary-with-signal",

--- a/dashboard/src/phase09-review.test.ts
+++ b/dashboard/src/phase09-review.test.ts
@@ -575,6 +575,16 @@ assert(
   "GR211-06f: secondary risk summary keeps longer prompt prefixes when the suffix adds non-keyword risk context"
 );
 
+const LONGER_PROMPT_WITH_BENIGN_WRITE_CONTINUATION_REQUEST: GuardApprovalRequest = {
+  ...LONGER_DUPLICATE_PROMPT_RISK_REQUEST,
+  request_id: "ph09-longer-prompt-with-benign-write-continuation",
+  risk_summary: `Codex prompt for \`.npmrc\`: ${TRUNCATED_PRIMARY_PROMPT_TEXT} write tests for the updated dashboard flow.`,
+};
+assert(
+  resolveSecondaryRiskSummary(LONGER_PROMPT_WITH_BENIGN_WRITE_CONTINUATION_REQUEST) === null,
+  "GR211-06g: secondary risk summary hides normal prompt continuation text that contains broad non-risk verbs"
+);
+
 const PREFIXED_EXTRA_CONTEXT_PROMPT_RISK_REQUEST: GuardApprovalRequest = {
   ...DUPLICATE_PROMPT_RISK_REQUEST,
   request_id: "ph09-prefixed-extra-context-prompt-risk",

--- a/dashboard/src/phase09-review.test.ts
+++ b/dashboard/src/phase09-review.test.ts
@@ -564,6 +564,17 @@ assert(
   "GR211-06e: secondary risk summary keeps longer prompt prefixes when the suffix adds safety context"
 );
 
+const LONGER_PROMPT_WITH_NON_KEYWORD_CONTEXT_REQUEST: GuardApprovalRequest = {
+  ...LONGER_DUPLICATE_PROMPT_RISK_REQUEST,
+  request_id: "ph09-longer-prompt-with-non-keyword-context",
+  risk_summary: `Codex prompt for \`.npmrc\`: ${TRUNCATED_PRIMARY_PROMPT_TEXT} runs as root and sends data to a third-party host.`,
+};
+assert(
+  resolveSecondaryRiskSummary(LONGER_PROMPT_WITH_NON_KEYWORD_CONTEXT_REQUEST) ===
+    LONGER_PROMPT_WITH_NON_KEYWORD_CONTEXT_REQUEST.risk_summary,
+  "GR211-06f: secondary risk summary keeps longer prompt prefixes when the suffix adds non-keyword risk context"
+);
+
 const PREFIXED_EXTRA_CONTEXT_PROMPT_RISK_REQUEST: GuardApprovalRequest = {
   ...DUPLICATE_PROMPT_RISK_REQUEST,
   request_id: "ph09-prefixed-extra-context-prompt-risk",

--- a/dashboard/src/phase09-review.test.ts
+++ b/dashboard/src/phase09-review.test.ts
@@ -535,6 +535,24 @@ assert(
   "GR211-06b: secondary risk summary hides long Codex prompt prefixes already shown in primary card"
 );
 
+const TRUNCATED_PRIMARY_PROMPT_TEXT =
+  "# Overview Generate 0 to 3 hyperpersonalized suggestions for what this user can do with Codex in this local project: /Users/test/project Get an understanding of the user's intent and goals by deeply viewing";
+const LONGER_DUPLICATE_PROMPT_RISK_REQUEST: GuardApprovalRequest = {
+  ...DUPLICATE_PROMPT_RISK_REQUEST,
+  request_id: "ph09-longer-duplicate-prompt-risk",
+  risk_summary: `Codex prompt for \`.npmrc\`: ${TRUNCATED_PRIMARY_PROMPT_TEXT} their connected apps. Suggest actionable tasks that they would actually act on/click.`,
+  action_envelope_json: {
+    ...BASE_ENVELOPE,
+    action_type: "prompt",
+    command: null,
+    prompt_excerpt: TRUNCATED_PRIMARY_PROMPT_TEXT,
+  },
+};
+assert(
+  resolveSecondaryRiskSummary(LONGER_DUPLICATE_PROMPT_RISK_REQUEST) === null,
+  "GR211-06d: secondary risk summary hides longer prompt prefixes when primary card already shows the prompt excerpt"
+);
+
 const PREFIXED_EXTRA_CONTEXT_PROMPT_RISK_REQUEST: GuardApprovalRequest = {
   ...DUPLICATE_PROMPT_RISK_REQUEST,
   request_id: "ph09-prefixed-extra-context-prompt-risk",

--- a/dashboard/src/phase09-review.test.ts
+++ b/dashboard/src/phase09-review.test.ts
@@ -585,6 +585,26 @@ assert(
   "GR211-06g: secondary risk summary hides normal prompt continuation text that contains broad non-risk verbs"
 );
 
+const REFLOWED_PRIMARY_PROMPT_TEXT =
+  "# Overview\nGenerate 0 to 3 hyperpersonalized suggestions for what this user can do with Codex in this local project: /Users/test/project. Get an understanding of the user's intent and goals by deeply viewing";
+const REFLOWED_PROMPT_WITH_SAFETY_CONTEXT_REQUEST: GuardApprovalRequest = {
+  ...LONGER_DUPLICATE_PROMPT_RISK_REQUEST,
+  request_id: "ph09-reflowed-prompt-with-safety-context",
+  risk_summary:
+    "Codex prompt for `.npmrc`: # Overview Generate 0 to 3 hyperpersonalized suggestions for what this user can do with Codex in this local project /Users/test/project Get an understanding of the user's intent and goals by deeply viewing. This may expose npm registry credentials to the model.",
+  action_envelope_json: {
+    ...BASE_ENVELOPE,
+    action_type: "prompt",
+    command: null,
+    prompt_excerpt: REFLOWED_PRIMARY_PROMPT_TEXT,
+  },
+};
+assert(
+  resolveSecondaryRiskSummary(REFLOWED_PROMPT_WITH_SAFETY_CONTEXT_REQUEST) ===
+    REFLOWED_PROMPT_WITH_SAFETY_CONTEXT_REQUEST.risk_summary,
+  "GR211-06h: secondary risk summary keeps safety context after normalized prefix extraction"
+);
+
 const PREFIXED_EXTRA_CONTEXT_PROMPT_RISK_REQUEST: GuardApprovalRequest = {
   ...DUPLICATE_PROMPT_RISK_REQUEST,
   request_id: "ph09-prefixed-extra-context-prompt-risk",

--- a/dashboard/src/phase09-review.test.ts
+++ b/dashboard/src/phase09-review.test.ts
@@ -553,6 +553,17 @@ assert(
   "GR211-06d: secondary risk summary hides longer prompt prefixes when primary card already shows the prompt excerpt"
 );
 
+const LONGER_PROMPT_WITH_SAFETY_CONTEXT_REQUEST: GuardApprovalRequest = {
+  ...LONGER_DUPLICATE_PROMPT_RISK_REQUEST,
+  request_id: "ph09-longer-prompt-with-safety-context",
+  risk_summary: `Codex prompt for \`.npmrc\`: ${TRUNCATED_PRIMARY_PROMPT_TEXT} This may expose npm registry credentials to the model.`,
+};
+assert(
+  resolveSecondaryRiskSummary(LONGER_PROMPT_WITH_SAFETY_CONTEXT_REQUEST) ===
+    LONGER_PROMPT_WITH_SAFETY_CONTEXT_REQUEST.risk_summary,
+  "GR211-06e: secondary risk summary keeps longer prompt prefixes when the suffix adds safety context"
+);
+
 const PREFIXED_EXTRA_CONTEXT_PROMPT_RISK_REQUEST: GuardApprovalRequest = {
   ...DUPLICATE_PROMPT_RISK_REQUEST,
   request_id: "ph09-prefixed-extra-context-prompt-risk",

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -14051,8 +14051,18 @@ function duplicatesStoppedActionText(item, value) {
 }
 function extractDuplicateReviewRemainder(candidateText, stoppedText) {
   const candidate = candidateText.trim();
-  const stopped = stoppedText.trim();
-  return candidate.toLowerCase().startsWith(stopped.toLowerCase()) ? candidate.slice(stopped.length).trim() : "";
+  const stopped = normalizeDuplicateReviewText(stoppedText);
+  if (stopped.length === 0) {
+    return "";
+  }
+  let normalizedPrefix = "";
+  for (let index = 0; index < candidate.length; index += 1) {
+    normalizedPrefix += normalizeDuplicateReviewText(candidate[index]);
+    if (normalizedPrefix.length >= stopped.length) {
+      return normalizedPrefix.startsWith(stopped) ? candidate.slice(index + 1).trim() : "";
+    }
+  }
+  return "";
 }
 function hasDuplicateReviewSafetyContextRemainder(remainder) {
   return DUPLICATE_REVIEW_SAFETY_CONTEXT_PATTERNS.some((pattern) => pattern.test(remainder));

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13991,7 +13991,7 @@ function resolveDecisionV2Detail(item) {
 const DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH = 24;
 const DUPLICATE_REVIEW_PREFIX_MIN_LENGTH = 80;
 const DUPLICATE_REVIEW_SAFETY_CONTEXT_PATTERNS = [
-  /\b(api[-\s]?key|credential|secret|token|password|sensitive|malicious|destructive|unauthorized)\b/i,
+  /\b(api[-_\s]?keys?|credentials?|secrets?|tokens?|passwords?|sensitive|malicious|destructive|unauthorized)\b/i,
   /\b(expose|exposes|exposed|leak|leaks|leaked|exfiltrate|exfiltrates|exfiltration)\b/i,
   /\b(may|could|can|would|will)\s+(expose|leak|send|upload|exfiltrate|delete|remove|modify|overwrite|execute|run)\b/i,
   /\bruns?\s+as\s+(root|admin|administrator)\b/i,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13990,7 +13990,14 @@ function resolveDecisionV2Detail(item) {
 }
 const DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH = 24;
 const DUPLICATE_REVIEW_PREFIX_MIN_LENGTH = 80;
-const DUPLICATE_REVIEW_SAFETY_CONTEXT_PATTERN = /(credential|secret|token|password|key|expose|exfiltrat|leak|sensitive|danger|risk|malicious|destructive|network|delete|remove|root|host|thirdparty|external|admin|privilege|permission|unauthorized|remote|upload|send|sends|write|execute|shell|process)/;
+const DUPLICATE_REVIEW_SAFETY_CONTEXT_PATTERNS = [
+  /\b(api[-\s]?key|credential|secret|token|password|sensitive|malicious|destructive|unauthorized)\b/i,
+  /\b(expose|exposes|exposed|leak|leaks|leaked|exfiltrate|exfiltrates|exfiltration)\b/i,
+  /\b(may|could|can|would|will)\s+(expose|leak|send|upload|exfiltrate|delete|remove|modify|overwrite|execute|run)\b/i,
+  /\bruns?\s+as\s+(root|admin|administrator)\b/i,
+  /\bsends?\s+(data|contents|files?|credentials?|secrets?|tokens?)\s+to\b/i,
+  /\b(third[-\s]?party|remote|external)\s+host\b/i
+];
 function buildPrimaryReviewAction(item) {
   return {
     label: resolveTerminalLabel(item),
@@ -14019,10 +14026,12 @@ function hasSupplyChainArtifactEvidence(item) {
   return item.artifact_type === "supply_chain" || item.artifact_type === "package_request" || typeof item.artifact_type === "string" && item.artifact_type.endsWith("_package");
 }
 function duplicatesStoppedActionText(item, value) {
-  const stoppedText = normalizeDuplicateReviewText(resolveStoppedCommandText(item));
+  const stoppedActionText = resolveStoppedCommandText(item);
+  const stoppedText = normalizeDuplicateReviewText(stoppedActionText);
   const candidateText = normalizeDuplicateReviewText(value);
   const contextStrippedValue = stripDuplicateReviewContextPrefix(value);
   const candidateWithoutContext = contextStrippedValue === null ? "" : normalizeDuplicateReviewText(contextStrippedValue);
+  const candidateRemainder = contextStrippedValue === null ? "" : extractDuplicateReviewRemainder(contextStrippedValue, stoppedActionText);
   if (stoppedText.length === 0 || candidateText.length === 0) {
     return false;
   }
@@ -14035,14 +14044,18 @@ function duplicatesStoppedActionText(item, value) {
   if (candidateWithoutContext.length >= DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH && stoppedText.includes(candidateWithoutContext)) {
     return true;
   }
-  if (stoppedText.length >= DUPLICATE_REVIEW_PREFIX_MIN_LENGTH && candidateWithoutContext.startsWith(stoppedText) && !hasDuplicateReviewSafetyContextRemainder(candidateWithoutContext, stoppedText)) {
+  if (stoppedText.length >= DUPLICATE_REVIEW_PREFIX_MIN_LENGTH && candidateWithoutContext.startsWith(stoppedText) && !hasDuplicateReviewSafetyContextRemainder(candidateRemainder)) {
     return true;
   }
   return false;
 }
-function hasDuplicateReviewSafetyContextRemainder(candidateText, stoppedText) {
-  const remainder = candidateText.slice(stoppedText.length);
-  return DUPLICATE_REVIEW_SAFETY_CONTEXT_PATTERN.test(remainder);
+function extractDuplicateReviewRemainder(candidateText, stoppedText) {
+  const candidate = candidateText.trim();
+  const stopped = stoppedText.trim();
+  return candidate.toLowerCase().startsWith(stopped.toLowerCase()) ? candidate.slice(stopped.length).trim() : "";
+}
+function hasDuplicateReviewSafetyContextRemainder(remainder) {
+  return DUPLICATE_REVIEW_SAFETY_CONTEXT_PATTERNS.some((pattern) => pattern.test(remainder));
 }
 function normalizeDuplicateReviewText(value) {
   return value.toLowerCase().replace(/[`"'\s:.,;!?()[\]{}_\-…]+/g, "").trim();

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13989,6 +13989,7 @@ function resolveDecisionV2Detail(item) {
   return detail !== void 0 && detail.trim().length > 0 ? detail : null;
 }
 const DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH = 24;
+const DUPLICATE_REVIEW_PREFIX_MIN_LENGTH = 80;
 function buildPrimaryReviewAction(item) {
   return {
     label: resolveTerminalLabel(item),
@@ -14031,6 +14032,9 @@ function duplicatesStoppedActionText(item, value) {
     return false;
   }
   if (candidateWithoutContext.length >= DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH && stoppedText.includes(candidateWithoutContext)) {
+    return true;
+  }
+  if (stoppedText.length >= DUPLICATE_REVIEW_PREFIX_MIN_LENGTH && candidateWithoutContext.startsWith(stoppedText)) {
     return true;
   }
   return false;

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13990,7 +13990,7 @@ function resolveDecisionV2Detail(item) {
 }
 const DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH = 24;
 const DUPLICATE_REVIEW_PREFIX_MIN_LENGTH = 80;
-const DUPLICATE_REVIEW_SAFETY_CONTEXT_PATTERN = /(credential|secret|token|password|key|expose|exfiltrat|leak|sensitive|danger|risk|malicious|destructive|network|delete|remove)/;
+const DUPLICATE_REVIEW_SAFETY_CONTEXT_PATTERN = /(credential|secret|token|password|key|expose|exfiltrat|leak|sensitive|danger|risk|malicious|destructive|network|delete|remove|root|host|thirdparty|external|admin|privilege|permission|unauthorized|remote|upload|send|sends|write|execute|shell|process)/;
 function buildPrimaryReviewAction(item) {
   return {
     label: resolveTerminalLabel(item),

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -14027,6 +14027,7 @@ function hasSupplyChainArtifactEvidence(item) {
 }
 function duplicatesStoppedActionText(item, value) {
   const stoppedActionText = resolveStoppedCommandText(item);
+  const canUseLongPromptPrefix = item.action_envelope_json?.action_type === "prompt" || item.artifact_type === "prompt_request";
   const stoppedText = normalizeDuplicateReviewText(stoppedActionText);
   const candidateText = normalizeDuplicateReviewText(value);
   const contextStrippedValue = stripDuplicateReviewContextPrefix(value);
@@ -14044,7 +14045,7 @@ function duplicatesStoppedActionText(item, value) {
   if (candidateWithoutContext.length >= DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH && stoppedText.includes(candidateWithoutContext)) {
     return true;
   }
-  if (stoppedText.length >= DUPLICATE_REVIEW_PREFIX_MIN_LENGTH && candidateWithoutContext.startsWith(stoppedText) && !hasDuplicateReviewSafetyContextRemainder(candidateRemainder)) {
+  if (canUseLongPromptPrefix && stoppedText.length >= DUPLICATE_REVIEW_PREFIX_MIN_LENGTH && candidateWithoutContext.startsWith(stoppedText) && !hasDuplicateReviewSafetyContextRemainder(candidateRemainder)) {
     return true;
   }
   return false;

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13990,6 +13990,7 @@ function resolveDecisionV2Detail(item) {
 }
 const DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH = 24;
 const DUPLICATE_REVIEW_PREFIX_MIN_LENGTH = 80;
+const DUPLICATE_REVIEW_SAFETY_CONTEXT_PATTERN = /(credential|secret|token|password|key|expose|exfiltrat|leak|sensitive|danger|risk|malicious|destructive|network|delete|remove)/;
 function buildPrimaryReviewAction(item) {
   return {
     label: resolveTerminalLabel(item),
@@ -14034,10 +14035,14 @@ function duplicatesStoppedActionText(item, value) {
   if (candidateWithoutContext.length >= DUPLICATE_REVIEW_SUBSTRING_MIN_LENGTH && stoppedText.includes(candidateWithoutContext)) {
     return true;
   }
-  if (stoppedText.length >= DUPLICATE_REVIEW_PREFIX_MIN_LENGTH && candidateWithoutContext.startsWith(stoppedText)) {
+  if (stoppedText.length >= DUPLICATE_REVIEW_PREFIX_MIN_LENGTH && candidateWithoutContext.startsWith(stoppedText) && !hasDuplicateReviewSafetyContextRemainder(candidateWithoutContext, stoppedText)) {
     return true;
   }
   return false;
+}
+function hasDuplicateReviewSafetyContextRemainder(candidateText, stoppedText) {
+  const remainder = candidateText.slice(stoppedText.length);
+  return DUPLICATE_REVIEW_SAFETY_CONTEXT_PATTERN.test(remainder);
 }
 function normalizeDuplicateReviewText(value) {
   return value.toLowerCase().replace(/[`"'\s:.,;!?()[\]{}_\-…]+/g, "").trim();


### PR DESCRIPTION
## Summary
- suppress secondary risk warnings when they only repeat a longer prompt already shown in the primary review card
- keep short prompt summaries that add safety context visible
- rebuild the bundled local dashboard asset

## Verification
- pnpm --dir dashboard exec tsx src/phase09-review.test.ts
- pnpm --dir dashboard test
- pnpm --dir dashboard build
- git diff --check