### PR TITLE
fix(guard): allow bounded multi-range sed reads

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/sed_scripts.py
+++ b/src/codex_plugin_scanner/guard/runtime/sed_scripts.py
@@ -5,10 +5,18 @@ from __future__ import annotations
 
 def sed_script_is_bounded_print(script: str) -> bool:
     stripped = script.strip()
-    if not stripped.endswith("p"):
+    if not stripped:
         return False
 
-    body = stripped[:-1].strip()
+    commands = [part.strip() for part in stripped.split(";")]
+    return bool(commands) and all(sed_print_command_is_bounded(command) for command in commands)
+
+
+def sed_print_command_is_bounded(command: str) -> bool:
+    if not command.endswith("p"):
+        return False
+
+    body = command[:-1].strip()
     if not body:
         return True
     parts = body.split(",")

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -603,6 +603,15 @@ def test_tool_action_request_classifier_skips_absolute_source_line_lookup():
     assert request is None
 
 
+def test_tool_action_request_classifier_skips_multi_range_source_line_lookup():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "sed -n '206,224p;1728,1744p' __tests__/analytics-client.test.ts"},
+    )
+
+    assert request is None
+
+
 @pytest.mark.parametrize("command", ["ls", "ls .", "rg TODO"])
 def test_tool_action_request_classifier_skips_common_read_only_lookups_without_targets(command):
     request = extract_sensitive_tool_action_request("bash", {"command": command})

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -717,6 +717,48 @@ clearer UX and an implementation plan with technical references.
         assert output["recorded"] is True
         assert "approval_requests" not in output
 
+    def test_codex_post_tool_use_allows_multi_range_test_source_view_with_secret_like_output(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        source_file = workspace_dir / "__tests__" / "analytics-client.test.ts"
+        _write_text(
+            source_file,
+            "const analyticsApiKey = 'HOL_GUARD_FAKE_CREDENTIAL=fixture-only';\n",
+        )
+        event = {
+            "event": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "sed -n '206,224p;1728,1744p' __tests__/analytics-client.test.ts"},
+            "tool_response": {"stdout": "const analyticsApiKey = 'HOL_GUARD_FAKE_CREDENTIAL=fixture-only';\n"},
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["recorded"] is True
+        assert "approval_requests" not in output
+
     def test_codex_post_tool_use_blocks_absolute_source_view_outside_workspace_with_secret_like_output(
         self,
         monkeypatch,


### PR DESCRIPTION
## Summary
- allow semicolon-separated bounded sed print ranges as read-only source inspection
- keep in-place/mutating sed blocked
- add Codex PostToolUse regression for test-file source reads with credential-looking fixture text

## Verification
- uv run pytest tests/test_guard_risk.py::test_tool_action_request_classifier_skips_multi_range_source_line_lookup tests/test_guard_runtime.py::TestGuardRuntime::test_codex_post_tool_use_allows_multi_range_test_source_view_with_secret_like_output -q
- uv run ruff check src/codex_plugin_scanner/guard/runtime/sed_scripts.py tests/test_guard_risk.py tests/test_guard_runtime.py
- uv run pytest tests/test_guard_runtime.py tests/test_guard_risk.py -q
- uv build
- git diff --check