### PR TITLE
feat(guard): notify desktop for approvals

### DIFF
--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -149,6 +149,7 @@ Home config:
 mode = "prompt"
 default_action = "warn"
 changed_hash_action = "require-reapproval"
+desktop_notifications = true
 
 [harnesses.codex]
 default_action = "allow"
@@ -298,15 +299,16 @@ That means the user should never get a silent pass-through on a risky Codex acti
 When Guard blocks a launch, it opens a persistent approval link in the terminal rather than pausing the session. You can resolve requests without leaving your harness:
 
 1. Guard returns the approval URL in the block output and queues the request locally.
-2. Open the approval center at the URL or in your browser.
-3. Approve or deny the request from the approval center UI or the CLI:
+2. On macOS and Windows, Guard also sends a native desktop notification for the new request. Set `desktop_notifications = false` in `~/.hol-guard/config.toml` or `HOL_GUARD_DESKTOP_NOTIFICATIONS=0` to disable it.
+3. Open the approval center at the URL, from the notification, or in your browser.
+4. Approve or deny the request from the approval center UI or the CLI:
 
    ```bash
    hol-guard approvals approve <request-id>
    hol-guard approvals deny <request-id>
    ```
 
-4. After you resolve the request, Guard emits copy telling you to return to your AI assistant and retry. No page reload or session restart is needed.
+5. After you resolve the request, Guard emits copy telling you to return to your AI assistant and retry. No page reload or session restart is needed.
 
 To inspect a pending request's details or get the approval URL, pass the request-id to the `approve` command with `--dry-run`, or visit the approval center URL shown in the block message directly.
 

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -242,7 +242,10 @@ def _workspace_policy_artifact_keys(request: Mapping[str, object], scope: str) -
 
 def _notify_pending_approval(*, store: GuardStore, request: GuardApprovalRequest) -> None:
     try:
-        config = load_guard_config(store.guard_home)
+        config = load_guard_config(
+            store.guard_home,
+            Path(request.workspace) if request.workspace is not None else None,
+        )
     except Exception:
         config = None
     if config is not None and not config.desktop_notifications:

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -13,6 +13,8 @@ from urllib.parse import urlparse
 
 from .adapters import get_adapter
 from .adapters.base import HarnessContext
+from .config import load_guard_config
+from .desktop_notifications import DesktopApprovalNotification, notify_pending_approval_once
 from .incident import build_incident_context
 from .models import GuardApprovalRequest, HarnessDetection, PolicyDecision
 from .risk import artifact_risk_signals, artifact_risk_summary
@@ -108,6 +110,7 @@ def queue_blocked_approvals(
             scanner_evidence=_item_scanner_evidence(item),
         )
         persisted_request_id = store.add_approval_request(request, timestamp)
+        is_new_pending_request = persisted_request_id == request.request_id
         if persisted_request_id != request.request_id:
             request = replace(
                 request,
@@ -115,6 +118,8 @@ def queue_blocked_approvals(
                 review_command=f"{GUARD_COMMAND} approvals approve {persisted_request_id}",
                 approval_url=f"{approval_center_url.rstrip('/')}/approvals/{persisted_request_id}",
             )
+        if is_new_pending_request:
+            _notify_pending_approval(store=store, request=request)
         queued.append(request.to_dict())
     return queued
 
@@ -235,6 +240,32 @@ def _workspace_policy_artifact_keys(request: Mapping[str, object], scope: str) -
     if not isinstance(artifact_hash, str) or not artifact_hash:
         return artifact_id, None
     return artifact_id, artifact_hash
+
+
+def _notify_pending_approval(*, store: GuardStore, request: GuardApprovalRequest) -> None:
+    try:
+        config = load_guard_config(store.guard_home)
+    except Exception:
+        config = None
+    if config is not None and not config.desktop_notifications:
+        return
+    notify_pending_approval_once(
+        DesktopApprovalNotification(
+            request_id=request.request_id,
+            title="HOL Guard needs approval",
+            message=_approval_notification_message(request),
+            approval_url=request.approval_url,
+        )
+    )
+
+
+def _approval_notification_message(request: GuardApprovalRequest) -> str:
+    subject = request.risk_headline or request.trigger_summary or request.artifact_name
+    harness = request.harness.replace("-", " ").title()
+    message = f"{harness} wants approval: {subject}"
+    if len(message) <= 180:
+        return message
+    return f"{message[:177].rstrip()}..."
 
 
 def _string_or_none(value: object) -> str | None:

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -110,7 +110,6 @@ def queue_blocked_approvals(
             scanner_evidence=_item_scanner_evidence(item),
         )
         persisted_request_id = store.add_approval_request(request, timestamp)
-        is_new_pending_request = persisted_request_id == request.request_id
         if persisted_request_id != request.request_id:
             request = replace(
                 request,
@@ -118,8 +117,7 @@ def queue_blocked_approvals(
                 review_command=f"{GUARD_COMMAND} approvals approve {persisted_request_id}",
                 approval_url=f"{approval_center_url.rstrip('/')}/approvals/{persisted_request_id}",
             )
-        if is_new_pending_request:
-            _notify_pending_approval(store=store, request=request)
+        _notify_pending_approval(store=store, request=request)
         queued.append(request.to_dict())
     return queued
 

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -247,13 +247,19 @@ def _notify_pending_approval(*, store: GuardStore, request: GuardApprovalRequest
         config = None
     if config is not None and not config.desktop_notifications:
         return
+    if store.approval_desktop_notified_at(request.request_id) is not None:
+        return
     notify_pending_approval_once(
         DesktopApprovalNotification(
             request_id=request.request_id,
             title="HOL Guard needs approval",
             message=_approval_notification_message(request),
             approval_url=request.approval_url,
-        )
+        ),
+        on_success=lambda: store.mark_approval_desktop_notified(
+            request.request_id,
+            _now(),
+        ),
     )
 
 

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -162,6 +162,7 @@ EDITABLE_GUARD_SETTING_KEYS = frozenset(
         "harness_risk_actions",
         "approval_wait_timeout_seconds",
         "approval_surface_policy",
+        "desktop_notifications",
         "telemetry",
         "sync",
         "billing",
@@ -257,6 +258,7 @@ class GuardConfig:
     subprocess_action: GuardAction = "warn"
     approval_wait_timeout_seconds: int = 120
     approval_surface_policy: str = "auto-open-once"
+    desktop_notifications: bool = True
     telemetry: bool = False
     sync: bool = False
     billing: bool = False
@@ -339,6 +341,7 @@ def load_guard_config(guard_home: Path, workspace: Path | None = None) -> GuardC
         subprocess_action=str(merged.get("subprocess_action", "warn")),  # type: ignore[arg-type]
         approval_wait_timeout_seconds=int(merged.get("approval_wait_timeout_seconds", 120)),
         approval_surface_policy=str(merged.get("approval_surface_policy", "auto-open-once")),
+        desktop_notifications=_coerce_loaded_bool(merged.get("desktop_notifications", True)),
         telemetry=bool(merged.get("telemetry", False)),
         sync=bool(merged.get("sync", False)),
         billing=bool(merged.get("billing", False)),
@@ -372,6 +375,7 @@ def editable_guard_settings(config: GuardConfig) -> dict[str, object]:
         "harness_risk_actions": dict(config.harness_risk_actions or {}),
         "approval_wait_timeout_seconds": config.approval_wait_timeout_seconds,
         "approval_surface_policy": config.approval_surface_policy,
+        "desktop_notifications": config.desktop_notifications,
         "telemetry": config.telemetry,
         "sync": config.sync,
         "billing": config.billing,
@@ -433,7 +437,7 @@ def _coerce_editable_setting(key: str, value: object) -> object:
         if isinstance(value, int) and not isinstance(value, bool) and 0 <= value <= 600:
             return value
         raise ValueError("Approval wait timeout must be between 0 and 600 seconds.")
-    if key in {"telemetry", "sync", "billing"}:
+    if key in {"desktop_notifications", "telemetry", "sync", "billing"}:
         if isinstance(value, bool):
             return value
         raise ValueError(f"{key} must be true or false.")

--- a/src/codex_plugin_scanner/guard/desktop_notifications.py
+++ b/src/codex_plugin_scanner/guard/desktop_notifications.py
@@ -23,6 +23,7 @@ class DesktopApprovalNotification:
 
 
 _NOTIFIED_APPROVAL_IDS: set[str] = set()
+_NOTIFICATION_ATTEMPTS_IN_FLIGHT: set[str] = set()
 _NOTIFIED_APPROVAL_IDS_LOCK = threading.Lock()
 
 
@@ -32,13 +33,24 @@ def notify_pending_approval_once(notification: DesktopApprovalNotification) -> b
     if _desktop_notifications_disabled_by_env():
         return False
     with _NOTIFIED_APPROVAL_IDS_LOCK:
-        if notification.request_id in _NOTIFIED_APPROVAL_IDS:
+        if (
+            notification.request_id in _NOTIFIED_APPROVAL_IDS
+            or notification.request_id in _NOTIFICATION_ATTEMPTS_IN_FLIGHT
+        ):
             return False
-        _NOTIFIED_APPROVAL_IDS.add(notification.request_id)
+        _NOTIFICATION_ATTEMPTS_IN_FLIGHT.add(notification.request_id)
     try:
-        return send_desktop_approval_notification(notification)
+        sent = send_desktop_approval_notification(notification)
     except Exception:
         return False
+    finally:
+        with _NOTIFIED_APPROVAL_IDS_LOCK:
+            _NOTIFICATION_ATTEMPTS_IN_FLIGHT.discard(notification.request_id)
+    if not sent:
+        return False
+    with _NOTIFIED_APPROVAL_IDS_LOCK:
+        _NOTIFIED_APPROVAL_IDS.add(notification.request_id)
+    return True
 
 
 def send_desktop_approval_notification(

--- a/src/codex_plugin_scanner/guard/desktop_notifications.py
+++ b/src/codex_plugin_scanner/guard/desktop_notifications.py
@@ -151,7 +151,16 @@ $Template = [Windows.UI.Notifications.ToastTemplateType]::ToastText02
 $Xml = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent($Template)
 $TextNodes = $Xml.GetElementsByTagName('text')
 $TextNodes.Item(0).AppendChild($Xml.CreateTextNode($Title)) > $null
-$TextNodes.Item(1).AppendChild($Xml.CreateTextNode($Message + ' Open: ' + $Url)) > $null
+$TextNodes.Item(1).AppendChild($Xml.CreateTextNode($Message)) > $null
+$ToastNode = $Xml.GetElementsByTagName('toast').Item(0)
+$ToastNode.SetAttribute('launch', $Url)
+$Actions = $Xml.CreateElement('actions')
+$OpenAction = $Xml.CreateElement('action')
+$OpenAction.SetAttribute('content', 'Open approval')
+$OpenAction.SetAttribute('arguments', $Url)
+$OpenAction.SetAttribute('activationType', 'protocol')
+$Actions.AppendChild($OpenAction) > $null
+$ToastNode.AppendChild($Actions) > $null
 $Toast = [Windows.UI.Notifications.ToastNotification]::new($Xml)
 $Notifier = [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('HOL Guard')
 $Notifier.Show($Toast)

--- a/src/codex_plugin_scanner/guard/desktop_notifications.py
+++ b/src/codex_plugin_scanner/guard/desktop_notifications.py
@@ -1,0 +1,154 @@
+"""Best-effort desktop notifications for local Guard approvals."""
+
+from __future__ import annotations
+
+import html
+import os
+import platform
+import shutil
+import subprocess
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class DesktopApprovalNotification:
+    """Notification copy for a pending local approval request."""
+
+    request_id: str
+    title: str
+    message: str
+    approval_url: str
+
+
+_NOTIFIED_APPROVAL_IDS: set[str] = set()
+_NOTIFIED_APPROVAL_IDS_LOCK = threading.Lock()
+
+
+def notify_pending_approval_once(notification: DesktopApprovalNotification) -> bool:
+    """Send one native notification for an approval request ID."""
+
+    if _desktop_notifications_disabled_by_env():
+        return False
+    with _NOTIFIED_APPROVAL_IDS_LOCK:
+        if notification.request_id in _NOTIFIED_APPROVAL_IDS:
+            return False
+        _NOTIFIED_APPROVAL_IDS.add(notification.request_id)
+    try:
+        return send_desktop_approval_notification(notification)
+    except Exception:
+        return False
+
+
+def send_desktop_approval_notification(
+    notification: DesktopApprovalNotification,
+    *,
+    system_name: str | None = None,
+    run: Callable[..., subprocess.CompletedProcess[object]] = subprocess.run,
+    which: Callable[[str], str | None] = shutil.which,
+) -> bool:
+    """Send a native desktop notification on macOS or Windows."""
+
+    system = system_name or platform.system()
+    if system == "Darwin":
+        return _send_macos_notification(notification, run=run, which=which)
+    if system == "Windows":
+        return _send_windows_notification(notification, run=run)
+    return False
+
+
+def _desktop_notifications_disabled_by_env() -> bool:
+    value = os.environ.get("HOL_GUARD_DESKTOP_NOTIFICATIONS", "").strip().lower()
+    return value in {"0", "false", "off", "no"}
+
+
+def _send_macos_notification(
+    notification: DesktopApprovalNotification,
+    *,
+    run: Callable[..., subprocess.CompletedProcess[object]],
+    which: Callable[[str], str | None],
+) -> bool:
+    terminal_notifier = which("terminal-notifier")
+    if terminal_notifier:
+        run(
+            [
+                terminal_notifier,
+                "-title",
+                notification.title,
+                "-subtitle",
+                "Action needs approval",
+                "-message",
+                notification.message,
+                "-open",
+                notification.approval_url,
+                "-group",
+                f"hol-guard-{notification.request_id}",
+            ],
+            check=False,
+            timeout=3,
+        )
+        return True
+    run(
+        [
+            "osascript",
+            "-e",
+            (
+                f'display notification "{_escape_osascript(notification.message)}" '
+                f'with title "{_escape_osascript(notification.title)}" '
+                'subtitle "Action needs approval"'
+            ),
+        ],
+        check=False,
+        timeout=3,
+    )
+    return True
+
+
+def _send_windows_notification(
+    notification: DesktopApprovalNotification,
+    *,
+    run: Callable[..., subprocess.CompletedProcess[object]],
+) -> bool:
+    script = _windows_toast_script(notification)
+    run(
+        [
+            "powershell",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            script,
+        ],
+        check=False,
+        timeout=5,
+    )
+    return True
+
+
+def _windows_toast_script(notification: DesktopApprovalNotification) -> str:
+    title = _escape_powershell_single_quoted(notification.title)
+    message = _escape_powershell_single_quoted(notification.message)
+    url = _escape_powershell_single_quoted(notification.approval_url)
+    return f"""
+$Title = '{title}'
+$Message = '{message}'
+$Url = '{url}'
+[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] > $null
+$Template = [Windows.UI.Notifications.ToastTemplateType]::ToastText02
+$Xml = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent($Template)
+$TextNodes = $Xml.GetElementsByTagName('text')
+$TextNodes.Item(0).AppendChild($Xml.CreateTextNode($Title)) > $null
+$TextNodes.Item(1).AppendChild($Xml.CreateTextNode($Message + ' Open: ' + $Url)) > $null
+$Toast = [Windows.UI.Notifications.ToastNotification]::new($Xml)
+$Notifier = [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('HOL Guard')
+$Notifier.Show($Toast)
+""".strip()
+
+
+def _escape_osascript(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _escape_powershell_single_quoted(value: str) -> str:
+    return html.unescape(value).replace("'", "''")

--- a/src/codex_plugin_scanner/guard/desktop_notifications.py
+++ b/src/codex_plugin_scanner/guard/desktop_notifications.py
@@ -83,7 +83,8 @@ def _send_macos_notification(
 ) -> bool:
     terminal_notifier = which("terminal-notifier")
     if terminal_notifier:
-        run(
+        return _run_notification_command(
+            run,
             [
                 terminal_notifier,
                 "-title",
@@ -100,8 +101,8 @@ def _send_macos_notification(
             check=False,
             timeout=3,
         )
-        return True
-    run(
+    return _run_notification_command(
+        run,
         [
             "osascript",
             "-e",
@@ -114,7 +115,6 @@ def _send_macos_notification(
         check=False,
         timeout=3,
     )
-    return True
 
 
 def _send_windows_notification(
@@ -123,7 +123,8 @@ def _send_windows_notification(
     run: Callable[..., subprocess.CompletedProcess[object]],
 ) -> bool:
     script = _windows_toast_script(notification)
-    run(
+    return _run_notification_command(
+        run,
         [
             "powershell",
             "-NoProfile",
@@ -135,7 +136,6 @@ def _send_windows_notification(
         check=False,
         timeout=5,
     )
-    return True
 
 
 def _windows_toast_script(notification: DesktopApprovalNotification) -> str:
@@ -156,6 +156,15 @@ $Toast = [Windows.UI.Notifications.ToastNotification]::new($Xml)
 $Notifier = [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('HOL Guard')
 $Notifier.Show($Toast)
 """.strip()
+
+
+def _run_notification_command(
+    run: Callable[..., subprocess.CompletedProcess[object]],
+    command: list[str],
+    **kwargs: object,
+) -> bool:
+    result = run(command, **kwargs)
+    return result.returncode == 0
 
 
 def _escape_osascript(value: str) -> str:

--- a/src/codex_plugin_scanner/guard/desktop_notifications.py
+++ b/src/codex_plugin_scanner/guard/desktop_notifications.py
@@ -31,6 +31,7 @@ def notify_pending_approval_once(
     notification: DesktopApprovalNotification,
     *,
     asynchronous: bool = True,
+    on_success: Callable[[], None] | None = None,
 ) -> bool:
     """Send one native notification for an approval request ID.
 
@@ -51,7 +52,7 @@ def notify_pending_approval_once(
         try:
             threading.Thread(
                 target=_deliver_notification,
-                args=(notification,),
+                args=(notification, on_success),
                 name=f"hol-guard-notify-{notification.request_id}",
             ).start()
         except Exception:
@@ -59,10 +60,13 @@ def notify_pending_approval_once(
                 _NOTIFICATION_ATTEMPTS_IN_FLIGHT.discard(notification.request_id)
             return False
         return True
-    return _deliver_notification(notification)
+    return _deliver_notification(notification, on_success)
 
 
-def _deliver_notification(notification: DesktopApprovalNotification) -> bool:
+def _deliver_notification(
+    notification: DesktopApprovalNotification,
+    on_success: Callable[[], None] | None = None,
+) -> bool:
     """Deliver notification and update request ID state after real success."""
 
     try:
@@ -76,6 +80,8 @@ def _deliver_notification(notification: DesktopApprovalNotification) -> bool:
         return False
     with _NOTIFIED_APPROVAL_IDS_LOCK:
         _NOTIFIED_APPROVAL_IDS.add(notification.request_id)
+    if on_success is not None:
+        on_success()
     return True
 
 

--- a/src/codex_plugin_scanner/guard/desktop_notifications.py
+++ b/src/codex_plugin_scanner/guard/desktop_notifications.py
@@ -48,11 +48,16 @@ def notify_pending_approval_once(
             return False
         _NOTIFICATION_ATTEMPTS_IN_FLIGHT.add(notification.request_id)
     if asynchronous:
-        threading.Thread(
-            target=_deliver_notification,
-            args=(notification,),
-            name=f"hol-guard-notify-{notification.request_id}",
-        ).start()
+        try:
+            threading.Thread(
+                target=_deliver_notification,
+                args=(notification,),
+                name=f"hol-guard-notify-{notification.request_id}",
+            ).start()
+        except Exception:
+            with _NOTIFIED_APPROVAL_IDS_LOCK:
+                _NOTIFICATION_ATTEMPTS_IN_FLIGHT.discard(notification.request_id)
+            return False
         return True
     return _deliver_notification(notification)
 
@@ -128,7 +133,7 @@ def _send_macos_notification(
             "osascript",
             "-e",
             (
-                f'display notification "{_escape_osascript(notification.message)}" '
+                f'display notification "{_escape_osascript(_macos_fallback_message(notification))}" '
                 f'with title "{_escape_osascript(notification.title)}" '
                 'subtitle "Action needs approval"'
             ),
@@ -199,6 +204,10 @@ def _run_notification_command(
 
 def _escape_osascript(value: str) -> str:
     return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _macos_fallback_message(notification: DesktopApprovalNotification) -> str:
+    return f"{notification.message} Open: {notification.approval_url}"
 
 
 def _escape_powershell_single_quoted(value: str) -> str:

--- a/src/codex_plugin_scanner/guard/desktop_notifications.py
+++ b/src/codex_plugin_scanner/guard/desktop_notifications.py
@@ -52,7 +52,6 @@ def notify_pending_approval_once(
             target=_deliver_notification,
             args=(notification,),
             name=f"hol-guard-notify-{notification.request_id}",
-            daemon=True,
         ).start()
         return True
     return _deliver_notification(notification)
@@ -184,7 +183,7 @@ $OpenAction.SetAttribute('activationType', 'protocol')
 $Actions.AppendChild($OpenAction) > $null
 $ToastNode.AppendChild($Actions) > $null
 $Toast = [Windows.UI.Notifications.ToastNotification]::new($Xml)
-$Notifier = [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('HOL Guard')
+$Notifier = [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier()
 $Notifier.Show($Toast)
 """.strip()
 

--- a/src/codex_plugin_scanner/guard/desktop_notifications.py
+++ b/src/codex_plugin_scanner/guard/desktop_notifications.py
@@ -27,8 +27,16 @@ _NOTIFICATION_ATTEMPTS_IN_FLIGHT: set[str] = set()
 _NOTIFIED_APPROVAL_IDS_LOCK = threading.Lock()
 
 
-def notify_pending_approval_once(notification: DesktopApprovalNotification) -> bool:
-    """Send one native notification for an approval request ID."""
+def notify_pending_approval_once(
+    notification: DesktopApprovalNotification,
+    *,
+    asynchronous: bool = True,
+) -> bool:
+    """Send one native notification for an approval request ID.
+
+    The default path dispatches native notification work off-thread so approval
+    waiting is never delayed by OS notification APIs.
+    """
 
     if _desktop_notifications_disabled_by_env():
         return False
@@ -39,6 +47,20 @@ def notify_pending_approval_once(notification: DesktopApprovalNotification) -> b
         ):
             return False
         _NOTIFICATION_ATTEMPTS_IN_FLIGHT.add(notification.request_id)
+    if asynchronous:
+        threading.Thread(
+            target=_deliver_notification,
+            args=(notification,),
+            name=f"hol-guard-notify-{notification.request_id}",
+            daemon=True,
+        ).start()
+        return True
+    return _deliver_notification(notification)
+
+
+def _deliver_notification(notification: DesktopApprovalNotification) -> bool:
+    """Deliver notification and update request ID state after real success."""
+
     try:
         sent = send_desktop_approval_notification(notification)
     except Exception:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -764,6 +764,7 @@ class GuardStore:
             self._ensure_approval_column(connection, "last_seen_at", "text")
             self._ensure_approval_column(connection, "fallback_cli_command", "text")
             self._ensure_approval_column(connection, "scanner_evidence_json", "text not null default '[]'")
+            self._ensure_approval_column(connection, "desktop_notified_at", "text")
             if not self._schema_version_applied(connection, version=3):
                 backfill_approval_queue_columns(connection)
                 self._record_schema_version(connection, version=3)
@@ -1780,6 +1781,33 @@ class GuardStore:
     def get_approval_request(self, request_id: str) -> dict[str, object] | None:
         with self._connect() as connection:
             return load_approval_request(connection, request_id)
+
+    def approval_desktop_notified_at(self, request_id: str) -> str | None:
+        with self._connect() as connection:
+            row = connection.execute(
+                """
+                select desktop_notified_at
+                from approval_requests
+                where request_id = ?
+                """,
+                (request_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        value = row["desktop_notified_at"]
+        return str(value) if isinstance(value, str) and value else None
+
+    def mark_approval_desktop_notified(self, request_id: str, notified_at: str) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                update approval_requests
+                set desktop_notified_at = ?
+                where request_id = ?
+                  and desktop_notified_at is null
+                """,
+                (notified_at, request_id),
+            )
 
     def get_next_pending_request(self, *, exclude_ids: set[str] | None = None) -> dict[str, object] | None:
         with self._connect() as connection:

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -172,6 +172,7 @@ def approval_schema_statement() -> str:
           decision_v2_json text,
           fallback_cli_command text,
           scanner_evidence_json text not null default '[]',
+          desktop_notified_at text,
           review_command text not null,
           approval_url text not null,
           status text not null,

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -544,11 +544,19 @@ class TestGuardApprovals:
     def test_guard_queue_notifies_desktop_once_for_new_request(self, tmp_path, monkeypatch):
         notifications: list[str] = []
 
-        def fake_notify(notification):
+        def fake_send(notification):
             notifications.append(notification.request_id)
             return True
 
-        monkeypatch.setattr("codex_plugin_scanner.guard.approvals.notify_pending_approval_once", fake_notify)
+        from codex_plugin_scanner.guard import desktop_notifications
+
+        with desktop_notifications._NOTIFIED_APPROVAL_IDS_LOCK:
+            desktop_notifications._NOTIFIED_APPROVAL_IDS.clear()
+            desktop_notifications._NOTIFICATION_ATTEMPTS_IN_FLIGHT.clear()
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.desktop_notifications.send_desktop_approval_notification",
+            fake_send,
+        )
         store = GuardStore(tmp_path / "guard-home")
         artifact = GuardArtifact(
             artifact_id="codex:runtime:project:danger_lab:desktop_notice",
@@ -601,6 +609,75 @@ class TestGuardApprovals:
 
         assert first[0]["request_id"] == second[0]["request_id"]
         assert notifications == [first[0]["request_id"]]
+
+    def test_guard_queue_retries_failed_desktop_notification_for_requeued_request(self, tmp_path, monkeypatch):
+        notifications: list[tuple[str, bool]] = []
+        outcomes = [False, True]
+
+        def fake_send(notification):
+            outcome = outcomes.pop(0)
+            notifications.append((notification.request_id, outcome))
+            return outcome
+
+        from codex_plugin_scanner.guard import desktop_notifications
+
+        with desktop_notifications._NOTIFIED_APPROVAL_IDS_LOCK:
+            desktop_notifications._NOTIFIED_APPROVAL_IDS.clear()
+            desktop_notifications._NOTIFICATION_ATTEMPTS_IN_FLIGHT.clear()
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.desktop_notifications.send_desktop_approval_notification",
+            fake_send,
+        )
+        store = GuardStore(tmp_path / "guard-home")
+        artifact = GuardArtifact(
+            artifact_id="codex:runtime:project:danger_lab:retry_notice",
+            name="danger_lab:retry_notice",
+            harness="codex",
+            artifact_type="tool_call",
+            source_scope="project",
+            config_path=str(tmp_path / "workspace" / ".codex" / "config.toml"),
+            command="retry_notice",
+        )
+        detection = HarnessDetection(
+            harness="codex",
+            installed=True,
+            command_available=True,
+            config_paths=(artifact.config_path,),
+            artifacts=(artifact,),
+        )
+        evaluation = {
+            "artifacts": [
+                {
+                    "artifact_id": artifact.artifact_id,
+                    "artifact_name": artifact.name,
+                    "artifact_hash": "hash-runtime",
+                    "artifact_type": artifact.artifact_type,
+                    "source_scope": artifact.source_scope,
+                    "config_path": artifact.config_path,
+                    "changed_fields": ["runtime_tool_call"],
+                    "policy_action": "require-reapproval",
+                    "launch_target": "retry_notice",
+                }
+            ]
+        }
+
+        first = queue_blocked_approvals(
+            detection=detection,
+            evaluation=evaluation,
+            store=store,
+            approval_center_url="http://127.0.0.1:4455",
+            now="2026-04-17T00:00:00+00:00",
+        )
+        second = queue_blocked_approvals(
+            detection=detection,
+            evaluation=evaluation,
+            store=store,
+            approval_center_url="http://127.0.0.1:4455",
+            now="2026-04-17T00:01:00+00:00",
+        )
+
+        assert first[0]["request_id"] == second[0]["request_id"]
+        assert notifications == [(first[0]["request_id"], False), (first[0]["request_id"], True)]
 
     def test_guard_queue_respects_disabled_desktop_notifications(self, tmp_path, monkeypatch):
         notifications: list[str] = []

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -704,7 +704,7 @@ class TestGuardApprovals:
     def test_guard_queue_respects_disabled_desktop_notifications(self, tmp_path, monkeypatch):
         notifications: list[str] = []
 
-        def fake_notify(notification):
+        def fake_notify(notification, **_kwargs):
             notifications.append(notification.request_id)
             return True
 
@@ -744,6 +744,62 @@ class TestGuardApprovals:
                         "changed_fields": ["runtime_tool_call"],
                         "policy_action": "require-reapproval",
                         "launch_target": "no_notice",
+                    }
+                ]
+            },
+            store=store,
+            approval_center_url="http://127.0.0.1:4455",
+            now="2026-04-17T00:00:00+00:00",
+        )
+
+        assert notifications == []
+
+    def test_guard_queue_respects_workspace_disabled_desktop_notifications(self, tmp_path, monkeypatch):
+        notifications: list[str] = []
+
+        def fake_notify(notification, **_kwargs):
+            notifications.append(notification.request_id)
+            return True
+
+        monkeypatch.setattr("codex_plugin_scanner.guard.approvals.notify_pending_approval_once", fake_notify)
+        guard_home = tmp_path / "guard-home"
+        workspace = tmp_path / "workspace"
+        guard_home.mkdir()
+        workspace.mkdir()
+        (guard_home / "config.toml").write_text("desktop_notifications = true\n", encoding="utf-8")
+        (workspace / ".hol-guard.toml").write_text("desktop_notifications = false\n", encoding="utf-8")
+        store = GuardStore(guard_home)
+        artifact = GuardArtifact(
+            artifact_id="codex:runtime:project:danger_lab:workspace_no_notice",
+            name="danger_lab:workspace_no_notice",
+            harness="codex",
+            artifact_type="tool_call",
+            source_scope="project",
+            config_path=str(workspace / ".codex" / "config.toml"),
+            command="workspace_no_notice",
+        )
+        detection = HarnessDetection(
+            harness="codex",
+            installed=True,
+            command_available=True,
+            config_paths=(artifact.config_path,),
+            artifacts=(artifact,),
+        )
+
+        queue_blocked_approvals(
+            detection=detection,
+            evaluation={
+                "artifacts": [
+                    {
+                        "artifact_id": artifact.artifact_id,
+                        "artifact_name": artifact.name,
+                        "artifact_hash": "hash-runtime",
+                        "artifact_type": artifact.artifact_type,
+                        "source_scope": artifact.source_scope,
+                        "config_path": artifact.config_path,
+                        "changed_fields": ["runtime_tool_call"],
+                        "policy_action": "require-reapproval",
+                        "launch_target": "workspace_no_notice",
                     }
                 ]
             },

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -541,6 +541,120 @@ class TestGuardApprovals:
         assert queued[0]["risk_signals"] == ["call arguments mention sensitive local files or secrets"]
         assert queued[0]["launch_summary"] == "Launches with `dangerous_delete .env`."
 
+    def test_guard_queue_notifies_desktop_once_for_new_request(self, tmp_path, monkeypatch):
+        notifications: list[str] = []
+
+        def fake_notify(notification):
+            notifications.append(notification.request_id)
+            return True
+
+        monkeypatch.setattr("codex_plugin_scanner.guard.approvals.notify_pending_approval_once", fake_notify)
+        store = GuardStore(tmp_path / "guard-home")
+        artifact = GuardArtifact(
+            artifact_id="codex:runtime:project:danger_lab:desktop_notice",
+            name="danger_lab:desktop_notice",
+            harness="codex",
+            artifact_type="tool_call",
+            source_scope="project",
+            config_path=str(tmp_path / "workspace" / ".codex" / "config.toml"),
+            command="desktop_notice",
+        )
+        detection = HarnessDetection(
+            harness="codex",
+            installed=True,
+            command_available=True,
+            config_paths=(artifact.config_path,),
+            artifacts=(artifact,),
+        )
+        evaluation = {
+            "artifacts": [
+                {
+                    "artifact_id": artifact.artifact_id,
+                    "artifact_name": artifact.name,
+                    "artifact_hash": "hash-runtime",
+                    "artifact_type": artifact.artifact_type,
+                    "source_scope": artifact.source_scope,
+                    "config_path": artifact.config_path,
+                    "changed_fields": ["runtime_tool_call"],
+                    "policy_action": "require-reapproval",
+                    "launch_target": "desktop_notice",
+                    "risk_summary": "Needs approval.",
+                    "risk_signals": ["sensitive action"],
+                }
+            ]
+        }
+
+        first = queue_blocked_approvals(
+            detection=detection,
+            evaluation=evaluation,
+            store=store,
+            approval_center_url="http://127.0.0.1:4455",
+            now="2026-04-17T00:00:00+00:00",
+        )
+        second = queue_blocked_approvals(
+            detection=detection,
+            evaluation=evaluation,
+            store=store,
+            approval_center_url="http://127.0.0.1:4455",
+            now="2026-04-17T00:01:00+00:00",
+        )
+
+        assert first[0]["request_id"] == second[0]["request_id"]
+        assert notifications == [first[0]["request_id"]]
+
+    def test_guard_queue_respects_disabled_desktop_notifications(self, tmp_path, monkeypatch):
+        notifications: list[str] = []
+
+        def fake_notify(notification):
+            notifications.append(notification.request_id)
+            return True
+
+        monkeypatch.setattr("codex_plugin_scanner.guard.approvals.notify_pending_approval_once", fake_notify)
+        guard_home = tmp_path / "guard-home"
+        guard_home.mkdir()
+        (guard_home / "config.toml").write_text("desktop_notifications = false\n", encoding="utf-8")
+        store = GuardStore(guard_home)
+        artifact = GuardArtifact(
+            artifact_id="codex:runtime:project:danger_lab:no_notice",
+            name="danger_lab:no_notice",
+            harness="codex",
+            artifact_type="tool_call",
+            source_scope="project",
+            config_path=str(tmp_path / "workspace" / ".codex" / "config.toml"),
+            command="no_notice",
+        )
+        detection = HarnessDetection(
+            harness="codex",
+            installed=True,
+            command_available=True,
+            config_paths=(artifact.config_path,),
+            artifacts=(artifact,),
+        )
+
+        queue_blocked_approvals(
+            detection=detection,
+            evaluation={
+                "artifacts": [
+                    {
+                        "artifact_id": artifact.artifact_id,
+                        "artifact_name": artifact.name,
+                        "artifact_hash": "hash-runtime",
+                        "artifact_type": artifact.artifact_type,
+                        "source_scope": artifact.source_scope,
+                        "config_path": artifact.config_path,
+                        "changed_fields": ["runtime_tool_call"],
+                        "policy_action": "require-reapproval",
+                        "launch_target": "no_notice",
+                    }
+                ]
+            },
+            store=store,
+            approval_center_url="http://127.0.0.1:4455",
+            now="2026-04-17T00:00:00+00:00",
+        )
+
+        assert notifications == []
+
     def test_guard_store_keeps_request_id_when_duplicate_pending_request_is_requeued(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
         original = GuardApprovalRequest(

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -557,6 +557,13 @@ class TestGuardApprovals:
             "codex_plugin_scanner.guard.desktop_notifications.send_desktop_approval_notification",
             fake_send,
         )
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.approvals.notify_pending_approval_once",
+            lambda notification: desktop_notifications.notify_pending_approval_once(
+                notification,
+                asynchronous=False,
+            ),
+        )
         store = GuardStore(tmp_path / "guard-home")
         artifact = GuardArtifact(
             artifact_id="codex:runtime:project:danger_lab:desktop_notice",
@@ -627,6 +634,13 @@ class TestGuardApprovals:
         monkeypatch.setattr(
             "codex_plugin_scanner.guard.desktop_notifications.send_desktop_approval_notification",
             fake_send,
+        )
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.approvals.notify_pending_approval_once",
+            lambda notification: desktop_notifications.notify_pending_approval_once(
+                notification,
+                asynchronous=False,
+            ),
         )
         store = GuardStore(tmp_path / "guard-home")
         artifact = GuardArtifact(

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -559,9 +559,10 @@ class TestGuardApprovals:
         )
         monkeypatch.setattr(
             "codex_plugin_scanner.guard.approvals.notify_pending_approval_once",
-            lambda notification: desktop_notifications.notify_pending_approval_once(
+            lambda notification, **kwargs: desktop_notifications.notify_pending_approval_once(
                 notification,
                 asynchronous=False,
+                **kwargs,
             ),
         )
         store = GuardStore(tmp_path / "guard-home")
@@ -606,6 +607,9 @@ class TestGuardApprovals:
             approval_center_url="http://127.0.0.1:4455",
             now="2026-04-17T00:00:00+00:00",
         )
+        with desktop_notifications._NOTIFIED_APPROVAL_IDS_LOCK:
+            desktop_notifications._NOTIFIED_APPROVAL_IDS.clear()
+            desktop_notifications._NOTIFICATION_ATTEMPTS_IN_FLIGHT.clear()
         second = queue_blocked_approvals(
             detection=detection,
             evaluation=evaluation,
@@ -637,9 +641,10 @@ class TestGuardApprovals:
         )
         monkeypatch.setattr(
             "codex_plugin_scanner.guard.approvals.notify_pending_approval_once",
-            lambda notification: desktop_notifications.notify_pending_approval_once(
+            lambda notification, **kwargs: desktop_notifications.notify_pending_approval_once(
                 notification,
                 asynchronous=False,
+                **kwargs,
             ),
         )
         store = GuardStore(tmp_path / "guard-home")
@@ -682,6 +687,9 @@ class TestGuardApprovals:
             approval_center_url="http://127.0.0.1:4455",
             now="2026-04-17T00:00:00+00:00",
         )
+        with desktop_notifications._NOTIFIED_APPROVAL_IDS_LOCK:
+            desktop_notifications._NOTIFIED_APPROVAL_IDS.clear()
+            desktop_notifications._NOTIFICATION_ATTEMPTS_IN_FLIGHT.clear()
         second = queue_blocked_approvals(
             detection=detection,
             evaluation=evaluation,

--- a/tests/test_guard_desktop_notifications.py
+++ b/tests/test_guard_desktop_notifications.py
@@ -16,7 +16,8 @@ from codex_plugin_scanner.guard.desktop_notifications import (
 
 
 class _Completed:
-    returncode = 0
+    def __init__(self, returncode: int = 0) -> None:
+        self.returncode = returncode
 
 
 def _notification() -> DesktopApprovalNotification:
@@ -102,6 +103,24 @@ def test_unsupported_platform_is_noop() -> None:
 
     assert sent is False
     assert calls == []
+
+
+def test_notification_command_nonzero_exit_is_failure() -> None:
+    calls: list[list[str]] = []
+
+    def run(command: list[str], **_: Any) -> subprocess.CompletedProcess[object]:
+        calls.append(command)
+        return _Completed(returncode=1)  # type: ignore[return-value]
+
+    sent = send_desktop_approval_notification(
+        _notification(),
+        system_name="Darwin",
+        run=run,
+        which=lambda _name: None,
+    )
+
+    assert sent is False
+    assert calls[0][0] == "osascript"
 
 
 def test_failed_notification_attempt_can_retry(monkeypatch) -> None:

--- a/tests/test_guard_desktop_notifications.py
+++ b/tests/test_guard_desktop_notifications.py
@@ -139,6 +139,6 @@ def test_failed_notification_attempt_can_retry(monkeypatch) -> None:
         fake_send,
     )
 
-    assert notify_pending_approval_once(_notification()) is False
-    assert notify_pending_approval_once(_notification()) is True
-    assert notify_pending_approval_once(_notification()) is False
+    assert notify_pending_approval_once(_notification(), asynchronous=False) is False
+    assert notify_pending_approval_once(_notification(), asynchronous=False) is True
+    assert notify_pending_approval_once(_notification(), asynchronous=False) is False

--- a/tests/test_guard_desktop_notifications.py
+++ b/tests/test_guard_desktop_notifications.py
@@ -85,6 +85,8 @@ def test_windows_notification_uses_powershell_toast() -> None:
     assert sent is True
     assert calls[0][:4] == ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass"]
     assert "ToastNotificationManager" in calls[0][-1]
+    assert "$OpenAction.SetAttribute('activationType', 'protocol')" in calls[0][-1]
+    assert "$OpenAction.SetAttribute('arguments', $Url)" in calls[0][-1]
     assert "http://127.0.0.1:5474/approvals/req-native" in calls[0][-1]
 
 

--- a/tests/test_guard_desktop_notifications.py
+++ b/tests/test_guard_desktop_notifications.py
@@ -87,6 +87,7 @@ def test_windows_notification_uses_powershell_toast() -> None:
     assert "ToastNotificationManager" in calls[0][-1]
     assert "$OpenAction.SetAttribute('activationType', 'protocol')" in calls[0][-1]
     assert "$OpenAction.SetAttribute('arguments', $Url)" in calls[0][-1]
+    assert "CreateToastNotifier()" in calls[0][-1]
     assert "http://127.0.0.1:5474/approvals/req-native" in calls[0][-1]
 
 

--- a/tests/test_guard_desktop_notifications.py
+++ b/tests/test_guard_desktop_notifications.py
@@ -67,6 +67,7 @@ def test_macos_notification_falls_back_to_osascript() -> None:
     assert calls[0][0] == "osascript"
     assert "display notification" in calls[0][2]
     assert "HOL Guard needs approval" in calls[0][2]
+    assert "http://127.0.0.1:5474/approvals/req-native" in calls[0][2]
 
 
 def test_windows_notification_uses_powershell_toast() -> None:
@@ -143,3 +144,25 @@ def test_failed_notification_attempt_can_retry(monkeypatch) -> None:
     assert notify_pending_approval_once(_notification(), asynchronous=False) is False
     assert notify_pending_approval_once(_notification(), asynchronous=False) is True
     assert notify_pending_approval_once(_notification(), asynchronous=False) is False
+
+
+def test_thread_start_failure_clears_inflight(monkeypatch) -> None:
+    with _NOTIFIED_APPROVAL_IDS_LOCK:
+        _NOTIFIED_APPROVAL_IDS.clear()
+        _NOTIFICATION_ATTEMPTS_IN_FLIGHT.clear()
+
+    class BrokenThread:
+        def __init__(self, **_: Any) -> None:
+            pass
+
+        def start(self) -> None:
+            raise RuntimeError("thread limit")
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.desktop_notifications.threading.Thread",
+        BrokenThread,
+    )
+
+    assert notify_pending_approval_once(_notification()) is False
+    with _NOTIFIED_APPROVAL_IDS_LOCK:
+        assert not _NOTIFICATION_ATTEMPTS_IN_FLIGHT

--- a/tests/test_guard_desktop_notifications.py
+++ b/tests/test_guard_desktop_notifications.py
@@ -1,0 +1,100 @@
+"""Desktop notification tests for local Guard approvals."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+
+from codex_plugin_scanner.guard.desktop_notifications import (
+    DesktopApprovalNotification,
+    send_desktop_approval_notification,
+)
+
+
+class _Completed:
+    returncode = 0
+
+
+def _notification() -> DesktopApprovalNotification:
+    return DesktopApprovalNotification(
+        request_id="req-native",
+        title="HOL Guard needs approval",
+        message="Codex wants approval: Bash shell command",
+        approval_url="http://127.0.0.1:5474/approvals/req-native",
+    )
+
+
+def test_macos_notification_uses_terminal_notifier_when_available() -> None:
+    calls: list[list[str]] = []
+
+    def run(command: list[str], **_: Any) -> subprocess.CompletedProcess[object]:
+        calls.append(command)
+        return _Completed()  # type: ignore[return-value]
+
+    sent = send_desktop_approval_notification(
+        _notification(),
+        system_name="Darwin",
+        run=run,
+        which=lambda name: "/usr/local/bin/terminal-notifier" if name == "terminal-notifier" else None,
+    )
+
+    assert sent is True
+    assert calls[0][:2] == ["/usr/local/bin/terminal-notifier", "-title"]
+    assert "-open" in calls[0]
+    assert "http://127.0.0.1:5474/approvals/req-native" in calls[0]
+
+
+def test_macos_notification_falls_back_to_osascript() -> None:
+    calls: list[list[str]] = []
+
+    def run(command: list[str], **_: Any) -> subprocess.CompletedProcess[object]:
+        calls.append(command)
+        return _Completed()  # type: ignore[return-value]
+
+    sent = send_desktop_approval_notification(
+        _notification(),
+        system_name="Darwin",
+        run=run,
+        which=lambda _name: None,
+    )
+
+    assert sent is True
+    assert calls[0][0] == "osascript"
+    assert "display notification" in calls[0][2]
+    assert "HOL Guard needs approval" in calls[0][2]
+
+
+def test_windows_notification_uses_powershell_toast() -> None:
+    calls: list[list[str]] = []
+
+    def run(command: list[str], **_: Any) -> subprocess.CompletedProcess[object]:
+        calls.append(command)
+        return _Completed()  # type: ignore[return-value]
+
+    sent = send_desktop_approval_notification(
+        _notification(),
+        system_name="Windows",
+        run=run,
+    )
+
+    assert sent is True
+    assert calls[0][:4] == ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass"]
+    assert "ToastNotificationManager" in calls[0][-1]
+    assert "http://127.0.0.1:5474/approvals/req-native" in calls[0][-1]
+
+
+def test_unsupported_platform_is_noop() -> None:
+    calls: list[list[str]] = []
+
+    def run(command: list[str], **_: Any) -> subprocess.CompletedProcess[object]:
+        calls.append(command)
+        return _Completed()  # type: ignore[return-value]
+
+    sent = send_desktop_approval_notification(
+        _notification(),
+        system_name="Linux",
+        run=run,
+    )
+
+    assert sent is False
+    assert calls == []

--- a/tests/test_guard_desktop_notifications.py
+++ b/tests/test_guard_desktop_notifications.py
@@ -6,7 +6,11 @@ import subprocess
 from typing import Any
 
 from codex_plugin_scanner.guard.desktop_notifications import (
+    _NOTIFICATION_ATTEMPTS_IN_FLIGHT,
+    _NOTIFIED_APPROVAL_IDS,
+    _NOTIFIED_APPROVAL_IDS_LOCK,
     DesktopApprovalNotification,
+    notify_pending_approval_once,
     send_desktop_approval_notification,
 )
 
@@ -98,3 +102,22 @@ def test_unsupported_platform_is_noop() -> None:
 
     assert sent is False
     assert calls == []
+
+
+def test_failed_notification_attempt_can_retry(monkeypatch) -> None:
+    with _NOTIFIED_APPROVAL_IDS_LOCK:
+        _NOTIFIED_APPROVAL_IDS.clear()
+        _NOTIFICATION_ATTEMPTS_IN_FLIGHT.clear()
+    outcomes = [False, True]
+
+    def fake_send(_notification: DesktopApprovalNotification) -> bool:
+        return outcomes.pop(0)
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.desktop_notifications.send_desktop_approval_notification",
+        fake_send,
+    )
+
+    assert notify_pending_approval_once(_notification()) is False
+    assert notify_pending_approval_once(_notification()) is True
+    assert notify_pending_approval_once(_notification()) is False


### PR DESCRIPTION
## Summary
- Add best-effort macOS and Windows desktop notifications for newly queued local approval requests
- Deduplicate notifications per approval request and keep duplicates quiet
- Add desktop_notifications config flag plus env opt-out
- Document approval notification behavior

## Verification
- pytest tests/test_guard_desktop_notifications.py tests/test_guard_approvals.py -q
- ruff check src/codex_plugin_scanner/guard/desktop_notifications.py src/codex_plugin_scanner/guard/config.py src/codex_plugin_scanner/guard/approvals.py tests/test_guard_desktop_notifications.py tests/test_guard_approvals.py

Note: python -m build was blocked by local HOL Guard approval in this environment; focused tests and ruff passed.