### PR TITLE
fix(guard): make mac approval notifications visible

### DIFF
--- a/src/codex_plugin_scanner/guard/desktop_notifications.py
+++ b/src/codex_plugin_scanner/guard/desktop_notifications.py
@@ -8,6 +8,7 @@ import platform
 import shutil
 import subprocess
 import threading
+import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -128,7 +129,10 @@ def _send_macos_notification(
                 "-open",
                 notification.approval_url,
                 "-group",
-                f"hol-guard-{notification.request_id}",
+                f"hol-guard-{notification.request_id}-{uuid.uuid4().hex}",
+                "-sound",
+                "default",
+                "-ignoreDnD",
             ],
             check=False,
             timeout=3,
@@ -141,7 +145,7 @@ def _send_macos_notification(
             (
                 f'display notification "{_escape_osascript(_macos_fallback_message(notification))}" '
                 f'with title "{_escape_osascript(notification.title)}" '
-                'subtitle "Action needs approval"'
+                'subtitle "Action needs approval" sound name "default"'
             ),
         ],
         check=False,

--- a/tests/test_guard_desktop_notifications.py
+++ b/tests/test_guard_desktop_notifications.py
@@ -46,6 +46,10 @@ def test_macos_notification_uses_terminal_notifier_when_available() -> None:
     assert sent is True
     assert calls[0][:2] == ["/usr/local/bin/terminal-notifier", "-title"]
     assert "-open" in calls[0]
+    assert "-sound" in calls[0]
+    assert "default" in calls[0]
+    assert "-ignoreDnD" in calls[0]
+    assert any(str(item).startswith("hol-guard-req-native-") for item in calls[0])
     assert "http://127.0.0.1:5474/approvals/req-native" in calls[0]
 
 
@@ -67,6 +71,7 @@ def test_macos_notification_falls_back_to_osascript() -> None:
     assert calls[0][0] == "osascript"
     assert "display notification" in calls[0][2]
     assert "HOL Guard needs approval" in calls[0][2]
+    assert 'sound name "default"' in calls[0][2]
     assert "http://127.0.0.1:5474/approvals/req-native" in calls[0][2]
 
 


### PR DESCRIPTION
## Summary\n- make macOS terminal-notifier approval alerts use unique delivery groups\n- add default sound and ignoreDnD for approval notifications\n- cover macOS notifier arguments in regression tests\n\n## Verification\n- ruff check src/codex_plugin_scanner/guard/desktop_notifications.py tests/test_guard_desktop_notifications.py\n- uv run --no-sync pytest tests/test_guard_desktop_notifications.py -q\n- local forced preview returned notification_sent=True and terminal-notifier listed the delivered preview