### PR TITLE
fix(guard): open mac notification settings

### DIFF
--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -14,7 +14,11 @@ from urllib.parse import urlparse
 from .adapters import get_adapter
 from .adapters.base import HarnessContext
 from .config import load_guard_config
-from .desktop_notifications import DesktopApprovalNotification, notify_pending_approval_once
+from .desktop_notifications import (
+    DesktopApprovalNotification,
+    ensure_desktop_notification_setup,
+    notify_pending_approval_once,
+)
 from .incident import build_incident_context
 from .models import GuardApprovalRequest, HarnessDetection, PolicyDecision
 from .risk import artifact_risk_signals, artifact_risk_summary
@@ -252,6 +256,10 @@ def _notify_pending_approval(*, store: GuardStore, request: GuardApprovalRequest
         return
     if store.approval_desktop_notified_at(request.request_id) is not None:
         return
+    ensure_desktop_notification_setup(
+        store.guard_home,
+        approval_url=request.approval_url,
+    )
     notify_pending_approval_once(
         DesktopApprovalNotification(
             request_id=request.request_id,

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -16,7 +16,7 @@ from .adapters.base import HarnessContext
 from .config import load_guard_config
 from .desktop_notifications import (
     DesktopApprovalNotification,
-    ensure_desktop_notification_setup,
+    ensure_desktop_notification_setup_async,
     notify_pending_approval_once,
 )
 from .incident import build_incident_context
@@ -256,7 +256,7 @@ def _notify_pending_approval(*, store: GuardStore, request: GuardApprovalRequest
         return
     if store.approval_desktop_notified_at(request.request_id) is not None:
         return
-    ensure_desktop_notification_setup(
+    ensure_desktop_notification_setup_async(
         store.guard_home,
         approval_url=request.approval_url,
     )

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -77,6 +77,7 @@ from ..daemon.manager import (
     load_guard_daemon_auth_token,
     load_guard_daemon_url,
 )
+from ..desktop_notifications import ensure_desktop_notification_setup
 from ..harness_usage import record_harness_usage_events
 from ..incident import build_incident_context
 from ..mcp_tool_calls import (
@@ -627,6 +628,16 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
         help="List all supported harnesses with their protection contract",
     )
     doctor_parser.add_argument("--perf", action="store_true", help="Include detector performance timings")
+    doctor_parser.add_argument(
+        "--notifications",
+        action="store_true",
+        help="Send a notification preview and open macOS notification settings when needed",
+    )
+    doctor_parser.add_argument(
+        "--force-notification-settings",
+        action="store_true",
+        help="Open macOS notification settings even if Guard already prompted before",
+    )
 
     login_parser = guard_subparsers.add_parser(
         "login",
@@ -1473,6 +1484,29 @@ def run_guard_command(
         return 0
 
     if args.guard_command == "doctor":
+        if getattr(args, "notifications", False):
+            approval_center_url = ensure_guard_daemon(guard_home)
+            result = ensure_desktop_notification_setup(
+                guard_home,
+                approval_url=f"{approval_center_url.rstrip('/')}/approvals/notification-preview",
+                force=bool(getattr(args, "force_notification_settings", False)),
+            )
+            _emit(
+                "doctor",
+                {
+                    "desktop_notifications": {
+                        "platform": result.platform,
+                        "supported": result.supported,
+                        "preview_sent": result.preview_sent,
+                        "settings_opened": result.settings_opened,
+                        "settings_url": result.settings_url,
+                        "already_prompted": result.already_prompted,
+                        "notifier_path": result.notifier_path,
+                    }
+                },
+                getattr(args, "json", False),
+            )
+            return 0
         if getattr(args, "harnesses", False):
             from ..adapters.contracts import HARNESS_CONTRACTS
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1487,8 +1487,11 @@ def run_guard_command(
         if getattr(args, "notifications", False):
             approval_url = "hol-guard://notification-preview"
             if desktop_notification_setup_supported():
-                approval_center_url = ensure_guard_daemon(guard_home)
-                approval_url = f"{approval_center_url.rstrip('/')}/approvals/notification-preview"
+                try:
+                    approval_center_url = ensure_guard_daemon(guard_home)
+                    approval_url = f"{approval_center_url.rstrip('/')}/approvals/notification-preview"
+                except Exception:
+                    approval_url = "hol-guard://notification-preview"
             result = ensure_desktop_notification_setup(
                 guard_home,
                 approval_url=approval_url,

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -77,7 +77,7 @@ from ..daemon.manager import (
     load_guard_daemon_auth_token,
     load_guard_daemon_url,
 )
-from ..desktop_notifications import ensure_desktop_notification_setup
+from ..desktop_notifications import desktop_notification_setup_supported, ensure_desktop_notification_setup
 from ..harness_usage import record_harness_usage_events
 from ..incident import build_incident_context
 from ..mcp_tool_calls import (
@@ -1485,10 +1485,13 @@ def run_guard_command(
 
     if args.guard_command == "doctor":
         if getattr(args, "notifications", False):
-            approval_center_url = ensure_guard_daemon(guard_home)
+            approval_url = "hol-guard://notification-preview"
+            if desktop_notification_setup_supported():
+                approval_center_url = ensure_guard_daemon(guard_home)
+                approval_url = f"{approval_center_url.rstrip('/')}/approvals/notification-preview"
             result = ensure_desktop_notification_setup(
                 guard_home,
-                approval_url=f"{approval_center_url.rstrip('/')}/approvals/notification-preview",
+                approval_url=approval_url,
                 force=bool(getattr(args, "force_notification_settings", False)),
             )
             _emit(

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -317,7 +317,24 @@ def _bootstrap_install_summary(bootstrap_install: object, *, fallback_harness: s
 
 
 def _render_doctor(console: Console, payload: dict[str, object]) -> None:
-    if "adapters" in payload:
+    if "desktop_notifications" in payload:
+        desktop = payload.get("desktop_notifications")
+        if not isinstance(desktop, dict):
+            desktop = {}
+        summary = Table.grid(padding=(0, 1))
+        summary.add_row("Platform", f"[bold]{desktop.get('platform', 'unknown')}[/bold]")
+        summary.add_row("Supported", _bool_label(bool(desktop.get("supported"))))
+        summary.add_row("Preview sent", _bool_label(bool(desktop.get("preview_sent"))))
+        summary.add_row("Settings opened", _bool_label(bool(desktop.get("settings_opened"))))
+        summary.add_row("Already prompted", _bool_label(bool(desktop.get("already_prompted"))))
+        notifier_path = desktop.get("notifier_path")
+        if notifier_path:
+            summary.add_row("Notifier", str(notifier_path))
+        settings_url = desktop.get("settings_url")
+        if settings_url:
+            summary.add_row("Settings URL", str(settings_url))
+        console.print(Panel(summary, title="Guard notification setup", border_style="cyan"))
+    elif "adapters" in payload:
         tables = _coerce_string_list(payload.get("tables"))
         console.print(
             Panel.fit(

--- a/src/codex_plugin_scanner/guard/desktop_notifications.py
+++ b/src/codex_plugin_scanner/guard/desktop_notifications.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import html
+import json
 import os
 import platform
 import shutil
@@ -11,6 +12,11 @@ import threading
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+MACOS_NOTIFICATION_SETTINGS_URL = "x-apple.systempreferences:com.apple.Notifications-Settings.extension"
+_NOTIFICATION_SETUP_STATE_FILE = "desktop-notifications.json"
 
 
 @dataclass(frozen=True, slots=True)
@@ -21,6 +27,19 @@ class DesktopApprovalNotification:
     title: str
     message: str
     approval_url: str
+
+
+@dataclass(frozen=True, slots=True)
+class DesktopNotificationSetupResult:
+    """Result from local OS notification permission setup."""
+
+    platform: str
+    supported: bool
+    preview_sent: bool
+    settings_opened: bool
+    settings_url: str | None
+    already_prompted: bool
+    notifier_path: str | None
 
 
 _NOTIFIED_APPROVAL_IDS: set[str] = set()
@@ -103,6 +122,74 @@ def send_desktop_approval_notification(
     return False
 
 
+def ensure_desktop_notification_setup(
+    guard_home: Path,
+    *,
+    approval_url: str,
+    force: bool = False,
+    system_name: str | None = None,
+    run: Callable[..., subprocess.CompletedProcess[object]] = subprocess.run,
+    which: Callable[[str], str | None] = shutil.which,
+) -> DesktopNotificationSetupResult:
+    """Register macOS notifier and open Notifications settings when needed."""
+
+    system = system_name or platform.system()
+    if system != "Darwin" or _desktop_notifications_disabled_by_env():
+        return DesktopNotificationSetupResult(
+            platform=system,
+            supported=False,
+            preview_sent=False,
+            settings_opened=False,
+            settings_url=None,
+            already_prompted=False,
+            notifier_path=None,
+        )
+    state_path = guard_home / _NOTIFICATION_SETUP_STATE_FILE
+    already_prompted = state_path.exists()
+    terminal_notifier = which("terminal-notifier")
+    if already_prompted and not force:
+        return DesktopNotificationSetupResult(
+            platform=system,
+            supported=True,
+            preview_sent=False,
+            settings_opened=False,
+            settings_url=MACOS_NOTIFICATION_SETTINGS_URL,
+            already_prompted=True,
+            notifier_path=terminal_notifier,
+        )
+    preview_sent = send_desktop_approval_notification(
+        DesktopApprovalNotification(
+            request_id=f"notification-setup-{uuid.uuid4().hex}",
+            title="HOL Guard notifications",
+            message="Enable alerts for approval requests from HOL Guard.",
+            approval_url=approval_url,
+        ),
+        system_name=system,
+        run=run,
+        which=which,
+    )
+    settings_opened = _open_macos_notification_settings(run=run)
+    _write_notification_setup_state(
+        state_path,
+        {
+            "opened_at": _utc_now(),
+            "settings_url": MACOS_NOTIFICATION_SETTINGS_URL,
+            "preview_sent": preview_sent,
+            "settings_opened": settings_opened,
+            "notifier_path": terminal_notifier,
+        },
+    )
+    return DesktopNotificationSetupResult(
+        platform=system,
+        supported=True,
+        preview_sent=preview_sent,
+        settings_opened=settings_opened,
+        settings_url=MACOS_NOTIFICATION_SETTINGS_URL,
+        already_prompted=already_prompted,
+        notifier_path=terminal_notifier,
+    )
+
+
 def _desktop_notifications_disabled_by_env() -> bool:
     value = os.environ.get("HOL_GUARD_DESKTOP_NOTIFICATIONS", "").strip().lower()
     return value in {"0", "false", "off", "no"}
@@ -174,6 +261,18 @@ def _send_windows_notification(
     )
 
 
+def _open_macos_notification_settings(
+    *,
+    run: Callable[..., subprocess.CompletedProcess[object]],
+) -> bool:
+    return _run_notification_command(
+        run,
+        ["open", MACOS_NOTIFICATION_SETTINGS_URL],
+        check=False,
+        timeout=3,
+    )
+
+
 def _windows_toast_script(notification: DesktopApprovalNotification) -> str:
     title = _escape_powershell_single_quoted(notification.title)
     message = _escape_powershell_single_quoted(notification.message)
@@ -210,6 +309,18 @@ def _run_notification_command(
 ) -> bool:
     result = run(command, **kwargs)
     return result.returncode == 0
+
+
+def _write_notification_setup_state(state_path: Path, payload: dict[str, object]) -> None:
+    try:
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(json.dumps(payload, sort_keys=True, indent=2), encoding="utf-8")
+    except OSError:
+        return
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
 
 
 def _escape_osascript(value: str) -> str:

--- a/src/codex_plugin_scanner/guard/desktop_notifications.py
+++ b/src/codex_plugin_scanner/guard/desktop_notifications.py
@@ -307,7 +307,10 @@ def _run_notification_command(
     command: list[str],
     **kwargs: object,
 ) -> bool:
-    result = run(command, **kwargs)
+    try:
+        result = run(command, **kwargs)
+    except (OSError, subprocess.SubprocessError):
+        return False
     return result.returncode == 0
 
 

--- a/src/codex_plugin_scanner/guard/desktop_notifications.py
+++ b/src/codex_plugin_scanner/guard/desktop_notifications.py
@@ -175,16 +175,17 @@ def ensure_desktop_notification_setup(
         which=which,
     )
     settings_opened = _open_macos_notification_settings(run=run)
-    _write_notification_setup_state(
-        state_path,
-        {
-            "opened_at": _utc_now(),
-            "settings_url": MACOS_NOTIFICATION_SETTINGS_URL,
-            "preview_sent": preview_sent,
-            "settings_opened": settings_opened,
-            "notifier_path": terminal_notifier,
-        },
-    )
+    if settings_opened:
+        _write_notification_setup_state(
+            state_path,
+            {
+                "opened_at": _utc_now(),
+                "settings_url": MACOS_NOTIFICATION_SETTINGS_URL,
+                "preview_sent": preview_sent,
+                "settings_opened": settings_opened,
+                "notifier_path": terminal_notifier,
+            },
+        )
     return DesktopNotificationSetupResult(
         platform=system,
         supported=True,

--- a/src/codex_plugin_scanner/guard/desktop_notifications.py
+++ b/src/codex_plugin_scanner/guard/desktop_notifications.py
@@ -45,6 +45,8 @@ class DesktopNotificationSetupResult:
 _NOTIFIED_APPROVAL_IDS: set[str] = set()
 _NOTIFICATION_ATTEMPTS_IN_FLIGHT: set[str] = set()
 _NOTIFIED_APPROVAL_IDS_LOCK = threading.Lock()
+_NOTIFICATION_SETUP_PATHS_IN_FLIGHT: set[Path] = set()
+_NOTIFICATION_SETUP_LOCK = threading.Lock()
 
 
 def notify_pending_approval_once(
@@ -128,6 +130,37 @@ def desktop_notification_setup_supported(system_name: str | None = None) -> bool
     return (system_name or platform.system()) == "Darwin" and not _desktop_notifications_disabled_by_env()
 
 
+def ensure_desktop_notification_setup_async(
+    guard_home: Path,
+    *,
+    approval_url: str,
+    force: bool = False,
+) -> bool:
+    """Start local notification setup without delaying approval queueing."""
+
+    if not force and not desktop_notification_setup_supported():
+        return False
+    state_path = guard_home / _NOTIFICATION_SETUP_STATE_FILE
+    if state_path.exists() and not force:
+        return False
+    key = guard_home.expanduser().resolve(strict=False)
+    with _NOTIFICATION_SETUP_LOCK:
+        if key in _NOTIFICATION_SETUP_PATHS_IN_FLIGHT:
+            return False
+        _NOTIFICATION_SETUP_PATHS_IN_FLIGHT.add(key)
+    try:
+        threading.Thread(
+            target=_ensure_desktop_notification_setup_worker,
+            args=(key, guard_home, approval_url, force),
+            name=f"hol-guard-notification-setup-{uuid.uuid4().hex}",
+        ).start()
+    except Exception:
+        with _NOTIFICATION_SETUP_LOCK:
+            _NOTIFICATION_SETUP_PATHS_IN_FLIGHT.discard(key)
+        return False
+    return True
+
+
 def ensure_desktop_notification_setup(
     guard_home: Path,
     *,
@@ -195,6 +228,25 @@ def ensure_desktop_notification_setup(
         already_prompted=already_prompted,
         notifier_path=terminal_notifier,
     )
+
+
+def _ensure_desktop_notification_setup_worker(
+    key: Path,
+    guard_home: Path,
+    approval_url: str,
+    force: bool,
+) -> None:
+    try:
+        ensure_desktop_notification_setup(
+            guard_home,
+            approval_url=approval_url,
+            force=force,
+        )
+    except Exception:
+        return
+    finally:
+        with _NOTIFICATION_SETUP_LOCK:
+            _NOTIFICATION_SETUP_PATHS_IN_FLIGHT.discard(key)
 
 
 def _desktop_notifications_disabled_by_env() -> bool:

--- a/src/codex_plugin_scanner/guard/desktop_notifications.py
+++ b/src/codex_plugin_scanner/guard/desktop_notifications.py
@@ -122,6 +122,12 @@ def send_desktop_approval_notification(
     return False
 
 
+def desktop_notification_setup_supported(system_name: str | None = None) -> bool:
+    """Return whether local notification setup can prompt the current OS."""
+
+    return (system_name or platform.system()) == "Darwin" and not _desktop_notifications_disabled_by_env()
+
+
 def ensure_desktop_notification_setup(
     guard_home: Path,
     *,
@@ -134,7 +140,7 @@ def ensure_desktop_notification_setup(
     """Register macOS notifier and open Notifications settings when needed."""
 
     system = system_name or platform.system()
-    if system != "Darwin" or _desktop_notifications_disabled_by_env():
+    if not desktop_notification_setup_supported(system):
         return DesktopNotificationSetupResult(
             platform=system,
             supported=False,

--- a/src/codex_plugin_scanner/guard/desktop_notifications.py
+++ b/src/codex_plugin_scanner/guard/desktop_notifications.py
@@ -153,6 +153,7 @@ def ensure_desktop_notification_setup_async(
             target=_ensure_desktop_notification_setup_worker,
             args=(key, guard_home, approval_url, force),
             name=f"hol-guard-notification-setup-{uuid.uuid4().hex}",
+            daemon=True,
         ).start()
     except Exception:
         with _NOTIFICATION_SETUP_LOCK:

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -66,6 +66,11 @@ args = ["workspace-skill.js"]
     )
 
 
+@pytest.fixture(autouse=True)
+def _disable_real_desktop_notification_setup(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOL_GUARD_DESKTOP_NOTIFICATIONS", "0")
+
+
 class TestGuardApprovals:
     def test_guard_store_persists_and_resolves_approval_requests(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
@@ -552,7 +557,7 @@ class TestGuardApprovals:
             notice_calls.append(notification.request_id)
             return True
 
-        monkeypatch.setattr("codex_plugin_scanner.guard.approvals.ensure_desktop_notification_setup", fake_setup)
+        monkeypatch.setattr("codex_plugin_scanner.guard.approvals.ensure_desktop_notification_setup_async", fake_setup)
         monkeypatch.setattr("codex_plugin_scanner.guard.approvals.notify_pending_approval_once", fake_notify)
         guard_home = tmp_path / "guard-home"
         store = GuardStore(guard_home)
@@ -599,6 +604,7 @@ class TestGuardApprovals:
         assert notice_calls == [queued[0]["request_id"]]
 
     def test_guard_queue_notifies_desktop_once_for_new_request(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("HOL_GUARD_DESKTOP_NOTIFICATIONS", raising=False)
         notifications: list[str] = []
 
         def fake_send(notification):
@@ -615,7 +621,7 @@ class TestGuardApprovals:
             fake_send,
         )
         monkeypatch.setattr(
-            "codex_plugin_scanner.guard.approvals.ensure_desktop_notification_setup",
+            "codex_plugin_scanner.guard.approvals.ensure_desktop_notification_setup_async",
             lambda *_args, **_kwargs: None,
         )
         monkeypatch.setattr(
@@ -683,6 +689,7 @@ class TestGuardApprovals:
         assert notifications == [first[0]["request_id"]]
 
     def test_guard_queue_retries_failed_desktop_notification_for_requeued_request(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("HOL_GUARD_DESKTOP_NOTIFICATIONS", raising=False)
         notifications: list[tuple[str, bool]] = []
         outcomes = [False, True]
 
@@ -701,7 +708,7 @@ class TestGuardApprovals:
             fake_send,
         )
         monkeypatch.setattr(
-            "codex_plugin_scanner.guard.approvals.ensure_desktop_notification_setup",
+            "codex_plugin_scanner.guard.approvals.ensure_desktop_notification_setup_async",
             lambda *_args, **_kwargs: None,
         )
         monkeypatch.setattr(

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -541,6 +541,63 @@ class TestGuardApprovals:
         assert queued[0]["risk_signals"] == ["call arguments mention sensitive local files or secrets"]
         assert queued[0]["launch_summary"] == "Launches with `dangerous_delete .env`."
 
+    def test_guard_queue_runs_desktop_notification_setup_before_request_notice(self, tmp_path, monkeypatch):
+        setup_calls: list[tuple[Path, str]] = []
+        notice_calls: list[str] = []
+
+        def fake_setup(guard_home: Path, *, approval_url: str) -> None:
+            setup_calls.append((guard_home, approval_url))
+
+        def fake_notify(notification, **_kwargs):
+            notice_calls.append(notification.request_id)
+            return True
+
+        monkeypatch.setattr("codex_plugin_scanner.guard.approvals.ensure_desktop_notification_setup", fake_setup)
+        monkeypatch.setattr("codex_plugin_scanner.guard.approvals.notify_pending_approval_once", fake_notify)
+        guard_home = tmp_path / "guard-home"
+        store = GuardStore(guard_home)
+        artifact = GuardArtifact(
+            artifact_id="codex:runtime:project:danger_lab:setup_notice",
+            name="danger_lab:setup_notice",
+            harness="codex",
+            artifact_type="tool_call",
+            source_scope="project",
+            config_path=str(tmp_path / "workspace" / ".codex" / "config.toml"),
+            command="setup_notice",
+        )
+        detection = HarnessDetection(
+            harness="codex",
+            installed=True,
+            command_available=True,
+            config_paths=(artifact.config_path,),
+            artifacts=(artifact,),
+        )
+
+        queued = queue_blocked_approvals(
+            detection=detection,
+            evaluation={
+                "artifacts": [
+                    {
+                        "artifact_id": artifact.artifact_id,
+                        "artifact_name": artifact.name,
+                        "artifact_hash": "hash-runtime",
+                        "artifact_type": artifact.artifact_type,
+                        "source_scope": artifact.source_scope,
+                        "config_path": artifact.config_path,
+                        "changed_fields": ["runtime_tool_call"],
+                        "policy_action": "require-reapproval",
+                        "launch_target": "setup_notice",
+                    }
+                ]
+            },
+            store=store,
+            approval_center_url="http://127.0.0.1:4455",
+            now="2026-04-17T00:00:00+00:00",
+        )
+
+        assert setup_calls == [(guard_home, queued[0]["approval_url"])]
+        assert notice_calls == [queued[0]["request_id"]]
+
     def test_guard_queue_notifies_desktop_once_for_new_request(self, tmp_path, monkeypatch):
         notifications: list[str] = []
 
@@ -556,6 +613,10 @@ class TestGuardApprovals:
         monkeypatch.setattr(
             "codex_plugin_scanner.guard.desktop_notifications.send_desktop_approval_notification",
             fake_send,
+        )
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.approvals.ensure_desktop_notification_setup",
+            lambda *_args, **_kwargs: None,
         )
         monkeypatch.setattr(
             "codex_plugin_scanner.guard.approvals.notify_pending_approval_once",
@@ -638,6 +699,10 @@ class TestGuardApprovals:
         monkeypatch.setattr(
             "codex_plugin_scanner.guard.desktop_notifications.send_desktop_approval_notification",
             fake_send,
+        )
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.approvals.ensure_desktop_notification_setup",
+            lambda *_args, **_kwargs: None,
         )
         monkeypatch.setattr(
             "codex_plugin_scanner.guard.approvals.notify_pending_approval_once",

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -4383,6 +4383,46 @@ args = ["-lc", "echo hi"]
             "notifier_path": "/usr/local/bin/terminal-notifier",
         }
 
+    def test_guard_doctor_notifications_human_output_uses_setup_renderer(self, tmp_path, monkeypatch, capsys):
+        home_dir = tmp_path / "home"
+        guard_home = tmp_path / "guard-home"
+
+        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:5474")
+        monkeypatch.setattr(guard_commands_module, "desktop_notification_setup_supported", lambda: True)
+        monkeypatch.setattr(
+            guard_commands_module,
+            "ensure_desktop_notification_setup",
+            lambda *_args, **_kwargs: DesktopNotificationSetupResult(
+                platform="Darwin",
+                supported=True,
+                preview_sent=True,
+                settings_opened=True,
+                settings_url="x-apple.systempreferences:com.apple.Notifications-Settings.extension",
+                already_prompted=False,
+                notifier_path="/usr/local/bin/terminal-notifier",
+            ),
+        )
+
+        rc = main(
+            [
+                "guard",
+                "doctor",
+                "--notifications",
+                "--home",
+                str(home_dir),
+                "--guard-home",
+                str(guard_home),
+            ]
+        )
+        output = capsys.readouterr().out
+
+        assert rc == 0
+        assert "Guard notification setup" in output
+        assert "Platform" in output
+        assert "Darwin" in output
+        assert "Settings opened" in output
+        assert "unknown" not in output.lower()
+
     def test_guard_doctor_notifications_skips_daemon_when_setup_unsupported(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"
         guard_home = tmp_path / "guard-home"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -4329,6 +4329,7 @@ args = ["-lc", "echo hi"]
         calls: list[tuple[Path, str, bool]] = []
 
         monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:5474")
+        monkeypatch.setattr(guard_commands_module, "desktop_notification_setup_supported", lambda: True)
 
         def fake_setup(
             guard_home_path: Path,
@@ -4381,6 +4382,53 @@ args = ["-lc", "echo hi"]
             "already_prompted": False,
             "notifier_path": "/usr/local/bin/terminal-notifier",
         }
+
+    def test_guard_doctor_notifications_skips_daemon_when_setup_unsupported(self, tmp_path, monkeypatch, capsys):
+        home_dir = tmp_path / "home"
+        guard_home = tmp_path / "guard-home"
+        calls: list[tuple[Path, str, bool]] = []
+
+        def fail_daemon(_guard_home: Path) -> str:
+            raise RuntimeError("daemon should not start")
+
+        def fake_setup(
+            guard_home_path: Path,
+            *,
+            approval_url: str,
+            force: bool = False,
+        ) -> DesktopNotificationSetupResult:
+            calls.append((guard_home_path, approval_url, force))
+            return DesktopNotificationSetupResult(
+                platform="Linux",
+                supported=False,
+                preview_sent=False,
+                settings_opened=False,
+                settings_url=None,
+                already_prompted=False,
+                notifier_path=None,
+            )
+
+        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", fail_daemon)
+        monkeypatch.setattr(guard_commands_module, "desktop_notification_setup_supported", lambda: False)
+        monkeypatch.setattr(guard_commands_module, "ensure_desktop_notification_setup", fake_setup)
+
+        rc = main(
+            [
+                "guard",
+                "doctor",
+                "--notifications",
+                "--home",
+                str(home_dir),
+                "--guard-home",
+                str(guard_home),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert calls == [(guard_home, "hol-guard://notification-preview", False)]
+        assert output["desktop_notifications"]["supported"] is False
 
     def test_guard_doctor_human_output_includes_detector_registry_line(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -30,6 +30,7 @@ from codex_plugin_scanner.guard.cli import update_commands as guard_update_comma
 from codex_plugin_scanner.guard.cli.render import emit_guard_payload
 from codex_plugin_scanner.guard.config import load_guard_config, resolve_risk_action
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
+from codex_plugin_scanner.guard.desktop_notifications import DesktopNotificationSetupResult
 from codex_plugin_scanner.guard.store import GuardStore
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -4320,6 +4321,65 @@ args = ["-lc", "echo hi"]
             "debug_trace": False,
             "timeout_ms": 75,
             "disabled_detector_ids": ["secret.local"],
+        }
+
+    def test_guard_doctor_notifications_opens_system_settings(self, tmp_path, monkeypatch, capsys):
+        home_dir = tmp_path / "home"
+        guard_home = tmp_path / "guard-home"
+        calls: list[tuple[Path, str, bool]] = []
+
+        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:5474")
+
+        def fake_setup(
+            guard_home_path: Path,
+            *,
+            approval_url: str,
+            force: bool = False,
+        ) -> DesktopNotificationSetupResult:
+            calls.append((guard_home_path, approval_url, force))
+            return DesktopNotificationSetupResult(
+                platform="Darwin",
+                supported=True,
+                preview_sent=True,
+                settings_opened=True,
+                settings_url="x-apple.systempreferences:com.apple.Notifications-Settings.extension",
+                already_prompted=False,
+                notifier_path="/usr/local/bin/terminal-notifier",
+            )
+
+        monkeypatch.setattr(guard_commands_module, "ensure_desktop_notification_setup", fake_setup)
+
+        rc = main(
+            [
+                "guard",
+                "doctor",
+                "--notifications",
+                "--force-notification-settings",
+                "--home",
+                str(home_dir),
+                "--guard-home",
+                str(guard_home),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert calls == [
+            (
+                guard_home,
+                "http://127.0.0.1:5474/approvals/notification-preview",
+                True,
+            )
+        ]
+        assert output["desktop_notifications"] == {
+            "platform": "Darwin",
+            "supported": True,
+            "preview_sent": True,
+            "settings_opened": True,
+            "settings_url": "x-apple.systempreferences:com.apple.Notifications-Settings.extension",
+            "already_prompted": False,
+            "notifier_path": "/usr/local/bin/terminal-notifier",
         }
 
     def test_guard_doctor_human_output_includes_detector_registry_line(self, tmp_path, monkeypatch, capsys):

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -4430,6 +4430,53 @@ args = ["-lc", "echo hi"]
         assert calls == [(guard_home, "hol-guard://notification-preview", False)]
         assert output["desktop_notifications"]["supported"] is False
 
+    def test_guard_doctor_notifications_falls_back_when_daemon_start_fails(self, tmp_path, monkeypatch, capsys):
+        home_dir = tmp_path / "home"
+        guard_home = tmp_path / "guard-home"
+        calls: list[tuple[Path, str, bool]] = []
+
+        def fail_daemon(_guard_home: Path) -> str:
+            raise RuntimeError("port conflict")
+
+        def fake_setup(
+            guard_home_path: Path,
+            *,
+            approval_url: str,
+            force: bool = False,
+        ) -> DesktopNotificationSetupResult:
+            calls.append((guard_home_path, approval_url, force))
+            return DesktopNotificationSetupResult(
+                platform="Darwin",
+                supported=True,
+                preview_sent=True,
+                settings_opened=True,
+                settings_url="x-apple.systempreferences:com.apple.Notifications-Settings.extension",
+                already_prompted=False,
+                notifier_path="/usr/local/bin/terminal-notifier",
+            )
+
+        monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", fail_daemon)
+        monkeypatch.setattr(guard_commands_module, "desktop_notification_setup_supported", lambda: True)
+        monkeypatch.setattr(guard_commands_module, "ensure_desktop_notification_setup", fake_setup)
+
+        rc = main(
+            [
+                "guard",
+                "doctor",
+                "--notifications",
+                "--home",
+                str(home_dir),
+                "--guard-home",
+                str(guard_home),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert calls == [(guard_home, "hol-guard://notification-preview", False)]
+        assert output["desktop_notifications"]["settings_opened"] is True
+
     def test_guard_doctor_human_output_includes_detector_registry_line(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"
         guard_home = tmp_path / "guard-home"

--- a/tests/test_guard_desktop_notifications.py
+++ b/tests/test_guard_desktop_notifications.py
@@ -213,11 +213,11 @@ def test_thread_start_failure_clears_inflight(monkeypatch) -> None:
 
 
 def test_macos_setup_async_deduplicates_inflight_work(tmp_path, monkeypatch) -> None:
-    started: list[tuple[Any, tuple[Any, ...]]] = []
+    started: list[dict[str, Any]] = []
 
     class CapturingThread:
         def __init__(self, **kwargs: Any) -> None:
-            started.append((kwargs["target"], kwargs["args"]))
+            started.append(kwargs)
 
         def start(self) -> None:
             return None
@@ -236,6 +236,9 @@ def test_macos_setup_async_deduplicates_inflight_work(tmp_path, monkeypatch) -> 
         approval_url="http://127.0.0.1:5474/approvals/preview",
     )
     assert len(started) == 1
+    assert started[0]["target"].__name__ == "_ensure_desktop_notification_setup_worker"
+    assert started[0]["args"][1] == guard_home
+    assert started[0]["daemon"] is True
     with _NOTIFICATION_SETUP_LOCK:
         _NOTIFICATION_SETUP_PATHS_IN_FLIGHT.clear()
 

--- a/tests/test_guard_desktop_notifications.py
+++ b/tests/test_guard_desktop_notifications.py
@@ -7,10 +7,13 @@ from typing import Any
 
 from codex_plugin_scanner.guard.desktop_notifications import (
     _NOTIFICATION_ATTEMPTS_IN_FLIGHT,
+    _NOTIFICATION_SETUP_LOCK,
+    _NOTIFICATION_SETUP_PATHS_IN_FLIGHT,
     _NOTIFIED_APPROVAL_IDS,
     _NOTIFIED_APPROVAL_IDS_LOCK,
     DesktopApprovalNotification,
     ensure_desktop_notification_setup,
+    ensure_desktop_notification_setup_async,
     notify_pending_approval_once,
     send_desktop_approval_notification,
 )
@@ -207,6 +210,34 @@ def test_thread_start_failure_clears_inflight(monkeypatch) -> None:
     assert notify_pending_approval_once(_notification()) is False
     with _NOTIFIED_APPROVAL_IDS_LOCK:
         assert not _NOTIFICATION_ATTEMPTS_IN_FLIGHT
+
+
+def test_macos_setup_async_deduplicates_inflight_work(tmp_path, monkeypatch) -> None:
+    started: list[tuple[Any, tuple[Any, ...]]] = []
+
+    class CapturingThread:
+        def __init__(self, **kwargs: Any) -> None:
+            started.append((kwargs["target"], kwargs["args"]))
+
+        def start(self) -> None:
+            return None
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.desktop_notifications.threading.Thread", CapturingThread)
+    monkeypatch.setattr("codex_plugin_scanner.guard.desktop_notifications.platform.system", lambda: "Darwin")
+
+    guard_home = tmp_path / "guard-home"
+
+    assert ensure_desktop_notification_setup_async(
+        guard_home,
+        approval_url="http://127.0.0.1:5474/approvals/preview",
+    )
+    assert not ensure_desktop_notification_setup_async(
+        guard_home,
+        approval_url="http://127.0.0.1:5474/approvals/preview",
+    )
+    assert len(started) == 1
+    with _NOTIFICATION_SETUP_LOCK:
+        _NOTIFICATION_SETUP_PATHS_IN_FLIGHT.clear()
 
 
 def test_macos_setup_sends_preview_opens_settings_and_records_state(tmp_path) -> None:

--- a/tests/test_guard_desktop_notifications.py
+++ b/tests/test_guard_desktop_notifications.py
@@ -165,6 +165,7 @@ def test_macos_setup_command_timeout_does_not_raise(tmp_path) -> None:
     assert result.preview_sent is False
     assert result.settings_opened is False
     assert len(calls) == 2
+    assert not (tmp_path / "guard-home" / "desktop-notifications.json").exists()
 
 
 def test_failed_notification_attempt_can_retry(monkeypatch) -> None:

--- a/tests/test_guard_desktop_notifications.py
+++ b/tests/test_guard_desktop_notifications.py
@@ -133,6 +133,40 @@ def test_notification_command_nonzero_exit_is_failure() -> None:
     assert calls[0][0] == "osascript"
 
 
+def test_notification_command_launch_failure_is_best_effort() -> None:
+    def run(_command: list[str], **_: Any) -> subprocess.CompletedProcess[object]:
+        raise FileNotFoundError("osascript")
+
+    sent = send_desktop_approval_notification(
+        _notification(),
+        system_name="Darwin",
+        run=run,
+        which=lambda _name: None,
+    )
+
+    assert sent is False
+
+
+def test_macos_setup_command_timeout_does_not_raise(tmp_path) -> None:
+    calls: list[list[str]] = []
+
+    def run(command: list[str], **_: Any) -> subprocess.CompletedProcess[object]:
+        calls.append(command)
+        raise subprocess.TimeoutExpired(command, timeout=3)
+
+    result = ensure_desktop_notification_setup(
+        tmp_path / "guard-home",
+        approval_url="http://127.0.0.1:5474/approvals/preview",
+        system_name="Darwin",
+        run=run,
+        which=lambda _name: "/usr/local/bin/terminal-notifier",
+    )
+
+    assert result.preview_sent is False
+    assert result.settings_opened is False
+    assert len(calls) == 2
+
+
 def test_failed_notification_attempt_can_retry(monkeypatch) -> None:
     with _NOTIFIED_APPROVAL_IDS_LOCK:
         _NOTIFIED_APPROVAL_IDS.clear()

--- a/tests/test_guard_desktop_notifications.py
+++ b/tests/test_guard_desktop_notifications.py
@@ -10,6 +10,7 @@ from codex_plugin_scanner.guard.desktop_notifications import (
     _NOTIFIED_APPROVAL_IDS,
     _NOTIFIED_APPROVAL_IDS_LOCK,
     DesktopApprovalNotification,
+    ensure_desktop_notification_setup,
     notify_pending_approval_once,
     send_desktop_approval_notification,
 )
@@ -171,3 +172,53 @@ def test_thread_start_failure_clears_inflight(monkeypatch) -> None:
     assert notify_pending_approval_once(_notification()) is False
     with _NOTIFIED_APPROVAL_IDS_LOCK:
         assert not _NOTIFICATION_ATTEMPTS_IN_FLIGHT
+
+
+def test_macos_setup_sends_preview_opens_settings_and_records_state(tmp_path) -> None:
+    calls: list[list[str]] = []
+
+    def run(command: list[str], **_: Any) -> subprocess.CompletedProcess[object]:
+        calls.append(command)
+        return _Completed()  # type: ignore[return-value]
+
+    result = ensure_desktop_notification_setup(
+        tmp_path / "guard-home",
+        approval_url="http://127.0.0.1:5474/approvals/preview",
+        system_name="Darwin",
+        run=run,
+        which=lambda name: "/usr/local/bin/terminal-notifier" if name == "terminal-notifier" else None,
+    )
+
+    assert result.supported is True
+    assert result.preview_sent is True
+    assert result.settings_opened is True
+    assert result.already_prompted is False
+    assert result.notifier_path == "/usr/local/bin/terminal-notifier"
+    assert calls[0][0] == "/usr/local/bin/terminal-notifier"
+    assert calls[1][:2] == ["open", "x-apple.systempreferences:com.apple.Notifications-Settings.extension"]
+    assert (tmp_path / "guard-home" / "desktop-notifications.json").exists()
+
+
+def test_macos_setup_does_not_reopen_after_prompt_marker(tmp_path) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    (guard_home / "desktop-notifications.json").write_text("{}", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def run(command: list[str], **_: Any) -> subprocess.CompletedProcess[object]:
+        calls.append(command)
+        return _Completed()  # type: ignore[return-value]
+
+    result = ensure_desktop_notification_setup(
+        guard_home,
+        approval_url="http://127.0.0.1:5474/approvals/preview",
+        system_name="Darwin",
+        run=run,
+        which=lambda _name: "/usr/local/bin/terminal-notifier",
+    )
+
+    assert result.supported is True
+    assert result.already_prompted is True
+    assert result.preview_sent is False
+    assert result.settings_opened is False
+    assert calls == []


### PR DESCRIPTION
## Summary
- register macOS notification sender with a preview before first approval notice
- open macOS Notifications settings from Guard setup so users can enable terminal-notifier banners
- add doctor flags to force notification setup again

## Verification
- ruff check src/codex_plugin_scanner/guard/desktop_notifications.py src/codex_plugin_scanner/guard/approvals.py src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_desktop_notifications.py tests/test_guard_cli.py tests/test_guard_approvals.py
- uv run --no-sync pytest tests/test_guard_desktop_notifications.py tests/test_guard_cli.py::TestGuardCli::test_guard_doctor_notifications_opens_system_settings tests/test_guard_approvals.py -q
- local forced macOS setup preview returned preview_sent=True and settings_opened=True