### PR TITLE
docs(guard): document init onboarding flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pipx install hol-guard
 hol-guard init
 ```
 
-`hol-guard init` is the first-run guided setup. It opens the local dashboard, finds supported harnesses, installs Guard-managed app commands where possible, starts Guard Cloud connect when you want shared history, and runs desktop notification setup so approval prompts reach you outside the terminal.
+`hol-guard init` is the first-run guided setup. It opens the local dashboard, finds supported harnesses, installs Guard-managed app commands where possible, starts the Guard Cloud connect flow when you want shared history, and runs desktop notification setup so approval prompts reach you outside the terminal.
 
 Manual and follow-up commands:
 
@@ -66,7 +66,7 @@ See [docs/guard/get-started.md](docs/guard/get-started.md) for the full local fl
 - `hol-guard start`
   Shows the next step for the harnesses Guard found.
 - `hol-guard init`
-  Runs first-install onboarding: local dashboard, harness discovery and install, optional Guard Cloud connect, and desktop notification setup.
+  Runs first-run onboarding: local dashboard, harness discovery and install, optional Guard Cloud connect, and desktop notification setup.
 - `hol-guard bootstrap`
   Detects the best local harness, starts the approval center, and installs Guard in front of it.
 - `hol-guard hermes bootstrap`

--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@
 ## Guard Quickstart
 
 ```bash
+pipx install hol-guard
+hol-guard init
+```
+
+`hol-guard init` is the first-run guided setup. It opens the local dashboard, finds supported harnesses, installs Guard-managed app commands where possible, starts Guard Cloud connect when you want shared history, and runs desktop notification setup so approval prompts reach you outside the terminal.
+
+Manual and follow-up commands:
+
+```bash
 pipx run hol-guard bootstrap
 pipx run hol-guard hermes bootstrap
 pipx run hol-guard run codex --dry-run
@@ -56,6 +65,8 @@ See [docs/guard/get-started.md](docs/guard/get-started.md) for the full local fl
 
 - `hol-guard start`
   Shows the next step for the harnesses Guard found.
+- `hol-guard init`
+  Runs first-install onboarding: local dashboard, harness discovery and install, optional Guard Cloud connect, and desktop notification setup.
 - `hol-guard bootstrap`
   Detects the best local harness, starts the approval center, and installs Guard in front of it.
 - `hol-guard hermes bootstrap`

--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -13,9 +13,9 @@ Use it when you want to protect a harness before local MCP servers, skills, hook
    hol-guard init
    ```
 
-   This opens the local dashboard, finds supported harnesses, installs Guard-managed app commands where possible, starts the Guard Cloud connect flow when you want shared history, and runs desktop notification setup for approval prompts.
+   This opens the local dashboard, finds supported harnesses, installs Guard-managed app commands where possible, starts the Guard Cloud connect flow when you want shared history, and runs desktop notification setup so approval prompts reach you outside the terminal.
 
-2. Use the manual discovery path only when you want to inspect each step yourself:
+2. Alternatively, use the manual discovery path only when you want to inspect each step yourself:
 
    ```bash
    hol-guard bootstrap
@@ -27,7 +27,7 @@ Use it when you want to protect a harness before local MCP servers, skills, hook
    hol-guard hermes bootstrap
    ```
 
-3. If you prefer the manual path, install Guard in front of the harness you use most:
+3. Or, if you prefer the manual path, install Guard in front of the harness you use most:
 
    ```bash
    hol-guard install codex
@@ -37,7 +37,7 @@ Use it when you want to protect a harness before local MCP servers, skills, hook
 
    After upgrading later, run `hol-guard update` to update the installed `hol-guard` package in that environment.
 
-4. Run one dry pass so Guard records the current state:
+4. Once setup is complete, run one dry pass so Guard records the current state:
 
    ```bash
    hol-guard run codex --dry-run
@@ -98,7 +98,7 @@ Use it when you want to protect a harness before local MCP servers, skills, hook
 | Situation | Command | What it answers |
 | :--- | :--- | :--- |
 | I need the current protection posture | `hol-guard status` | What is Guard watching, is sync connected, and what is the next action? |
-| I need first-run setup | `hol-guard init` | Which harnesses can be installed, should Cloud connect start, and are desktop notifications ready? |
+| I need first-run setup | `hol-guard init` | Open the local dashboard, install supported harnesses, start optional Cloud connect, and check desktop notifications. |
 | I need install/connect docs | `hol-guard explain install-connect` | Which local-first setup and optional cloud commands should I share? |
 | I need setup or runtime troubleshooting | `hol-guard doctor <harness>` | Why is this harness or Guard runtime not behaving correctly? |
 | A launch was blocked or changed | `hol-guard diff <harness>` | What changed since the last recorded snapshot? |

--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -7,7 +7,15 @@ Use it when you want to protect a harness before local MCP servers, skills, hook
 
 ## The everyday flow
 
-1. See what Guard found:
+1. Start the guided first-run setup:
+
+   ```bash
+   hol-guard init
+   ```
+
+   This opens the local dashboard, finds supported harnesses, installs Guard-managed app commands where possible, starts the Guard Cloud connect flow when you want shared history, and runs desktop notification setup for approval prompts.
+
+2. Use the manual discovery path only when you want to inspect each step yourself:
 
    ```bash
    hol-guard bootstrap
@@ -19,7 +27,7 @@ Use it when you want to protect a harness before local MCP servers, skills, hook
    hol-guard hermes bootstrap
    ```
 
-2. If you prefer the manual path, install Guard in front of the harness you use most:
+3. If you prefer the manual path, install Guard in front of the harness you use most:
 
    ```bash
    hol-guard install codex
@@ -29,25 +37,25 @@ Use it when you want to protect a harness before local MCP servers, skills, hook
 
    After upgrading later, run `hol-guard update` to update the installed `hol-guard` package in that environment.
 
-3. Run one dry pass so Guard records the current state:
+4. Run one dry pass so Guard records the current state:
 
    ```bash
    hol-guard run codex --dry-run
    ```
 
-4. Launch through Guard after that. Guard will stop and ask if a tool is new or changed:
+5. Launch through Guard after that. Guard will stop and ask if a tool is new or changed:
 
    ```bash
    hol-guard run codex
    ```
 
-5. If the shell is interactive, approve inline. If the shell cannot prompt, Guard queues the change in the local approval center instead of ending the session with a dead stop:
+6. If the shell is interactive, approve inline. If the shell cannot prompt, Guard queues the change in the local approval center instead of ending the session with a dead stop:
 
    ```bash
    hol-guard approvals
    ```
 
-6. Review or resolve changes from the terminal when you want a text-only path:
+7. Review or resolve changes from the terminal when you want a text-only path:
 
    ```bash
    hol-guard approvals approve <request-id>
@@ -55,14 +63,14 @@ Use it when you want to protect a harness before local MCP servers, skills, hook
    hol-guard diff codex
    ```
 
-7. Check receipts and current status:
+8. Check receipts and current status:
 
    ```bash
    hol-guard receipts
    hol-guard status
    ```
 
-8. Connect cloud sync later only if you want shared history:
+9. Connect cloud sync later only if you want shared history:
 
    ```bash
    hol-guard connect
@@ -71,13 +79,13 @@ Use it when you want to protect a harness before local MCP servers, skills, hook
    hol-guard sync
    ```
 
-9. Share the generated install/connect command guide when someone needs the exact local-first flow:
+10. Share the generated install/connect command guide when someone needs the exact local-first flow:
 
    ```bash
    hol-guard explain install-connect
    ```
 
-10. Inspect or rotate the local installation identity that cloud sync uses:
+11. Inspect or rotate the local installation identity that cloud sync uses:
 
    ```bash
    hol-guard device show
@@ -90,6 +98,7 @@ Use it when you want to protect a harness before local MCP servers, skills, hook
 | Situation | Command | What it answers |
 | :--- | :--- | :--- |
 | I need the current protection posture | `hol-guard status` | What is Guard watching, is sync connected, and what is the next action? |
+| I need first-run setup | `hol-guard init` | Which harnesses can be installed, should Cloud connect start, and are desktop notifications ready? |
 | I need install/connect docs | `hol-guard explain install-connect` | Which local-first setup and optional cloud commands should I share? |
 | I need setup or runtime troubleshooting | `hol-guard doctor <harness>` | Why is this harness or Guard runtime not behaving correctly? |
 | A launch was blocked or changed | `hol-guard diff <harness>` | What changed since the last recorded snapshot? |

--- a/tests/test_guard_docs.py
+++ b/tests/test_guard_docs.py
@@ -42,16 +42,25 @@ def test_static_docs_include_canonical_install_connect_commands() -> None:
 
 
 def test_static_docs_make_init_the_first_run_path() -> None:
-    docs_text = "\n".join(
-        [
-            _read_repo_file("README.md"),
-            _read_repo_file("docs/guard/get-started.md"),
-        ]
-    )
+    readme_text = _read_repo_file("README.md")
+    get_started_text = _read_repo_file("docs/guard/get-started.md")
 
-    assert "hol-guard init" in docs_text
-    assert "first-run" in docs_text.lower() or "first-install" in docs_text.lower()
-    assert "desktop notification" in docs_text.lower()
+    readme_quickstart = readme_text.split("## Guard Quickstart", 1)[1].split(
+        "Manual and follow-up commands:",
+        1,
+    )[0]
+    everyday_flow = get_started_text.split("## The everyday flow", 1)[1].split(
+        "## Which command should I use?",
+        1,
+    )[0]
+    first_step = everyday_flow.split("2. Alternatively", 1)[0]
+
+    assert "hol-guard init" in readme_quickstart
+    assert "hol-guard init" in first_step
+    assert "hol-guard bootstrap" not in first_step
+    assert "first-run" in readme_text.lower()
+    assert "first-run" in get_started_text.lower()
+    assert "desktop notification" in get_started_text.lower()
 
 
 def test_static_docs_explain_safe_decode_sandbox_guarantee() -> None:

--- a/tests/test_guard_docs.py
+++ b/tests/test_guard_docs.py
@@ -41,6 +41,19 @@ def test_static_docs_include_canonical_install_connect_commands() -> None:
         assert item.command in docs_text
 
 
+def test_static_docs_make_init_the_first_run_path() -> None:
+    docs_text = "\n".join(
+        [
+            _read_repo_file("README.md"),
+            _read_repo_file("docs/guard/get-started.md"),
+        ]
+    )
+
+    assert "hol-guard init" in docs_text
+    assert "first-run" in docs_text.lower() or "first-install" in docs_text.lower()
+    assert "desktop notification" in docs_text.lower()
+
+
 def test_static_docs_explain_safe_decode_sandbox_guarantee() -> None:
     docs_text = "\n".join(
         [


### PR DESCRIPTION
## Summary
- make hol-guard init the primary first-run setup path in README
- explain that init opens the local dashboard, discovers/install harnesses, starts optional Cloud connect, and initializes desktop notifications
- add docs regression coverage for the init first-run path

## Verification
- python3 -m pytest tests/test_guard_docs.py -q
- git diff --check