### PR TITLE
fix(guard): tighten codex connect continuity

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1123,6 +1123,39 @@ def _run_init_command(
     return 1 if init_failed else 0
 
 
+def _resolve_guard_workspace(
+    args: argparse.Namespace,
+    *,
+    guard_home: Path,
+) -> Path | None:
+    explicit_workspace = getattr(args, "workspace", None)
+    if explicit_workspace:
+        return Path(explicit_workspace).resolve()
+    if getattr(args, "guard_command", None) != "apps":
+        return None
+    if getattr(args, "apps_command", None) not in {"connect", "disconnect", "repair", "test"}:
+        return None
+    harness = str(getattr(args, "harness", "")).strip()
+    if not harness:
+        return None
+    try:
+        adapter = get_adapter(harness)
+    except ValueError:
+        return None
+    cwd = Path.cwd().resolve()
+    detection = adapter.detect(
+        HarnessContext(
+            home_dir=Path.home().resolve(),
+            workspace_dir=cwd,
+            guard_home=guard_home,
+        )
+    )
+    for config_path in detection.config_paths:
+        if Path(config_path).resolve().is_relative_to(cwd):
+            return cwd
+    return None
+
+
 def _run_apps_command(
     args: argparse.Namespace,
     context: HarnessContext,
@@ -1267,7 +1300,7 @@ def run_guard_command(
 
     home_override = getattr(args, "home", None)
     guard_home = resolve_guard_home(getattr(args, "guard_home", None) or home_override)
-    workspace = Path(args.workspace).resolve() if getattr(args, "workspace", None) else None
+    workspace = _resolve_guard_workspace(args, guard_home=guard_home)
     context = HarnessContext(
         home_dir=Path(home_override).resolve() if home_override else Path.home().resolve(),
         workspace_dir=workspace,

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -108,6 +108,81 @@ def test_guard_install_codex_rewrites_workspace_config_with_proxy_entries(tmp_pa
     assert "codex" in permission_handler["command"]
 
 
+def test_guard_apps_connect_codex_defaults_to_project_scope_when_local_codex_config_exists(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    monkeypatch.chdir(workspace_dir)
+
+    rc = main(
+        [
+            "guard",
+            "apps",
+            "connect",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--guard-home",
+            str(home_dir / ".hol-guard"),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["managed_install"]["active"] is True
+    assert output["managed_install"]["workspace"] == str(workspace_dir)
+    assert output["managed_install"]["manifest"]["managed_config_path"] == str(
+        workspace_dir / ".codex" / "config.toml"
+    )
+
+
+def test_guard_apps_connect_codex_stays_global_without_local_codex_config(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    _write_text(
+        home_dir / ".codex" / "config.toml",
+        """
+[mcp_servers.global_tools]
+command = "python3"
+args = ["-m", "http.server", "9000"]
+""".strip()
+        + "\n",
+    )
+    monkeypatch.chdir(workspace_dir)
+
+    rc = main(
+        [
+            "guard",
+            "apps",
+            "connect",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--guard-home",
+            str(home_dir / ".hol-guard"),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["managed_install"]["active"] is True
+    assert output["managed_install"]["workspace"] is None
+    assert output["managed_install"]["manifest"]["managed_config_path"] == str(
+        home_dir / ".codex" / "config.toml"
+    )
+
+
 def test_guard_uninstall_codex_restores_original_workspace_config(tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -1663,11 +1663,10 @@ class TestGuardSurfaceServer:
             with urllib.request.urlopen(request, timeout=5) as response:
                 allow_origin = response.headers.get("Access-Control-Allow-Origin")
                 allow_private_network = response.headers.get("Access-Control-Allow-Private-Network")
-                status = response.status
         finally:
             daemon.stop()
 
-        assert status == 200
+        assert response.status == 200
         assert allow_origin == "https://hol.org"
         assert allow_private_network == "true"
 


### PR DESCRIPTION
- Codex app connect now prefers project scope when a local .codex/config.toml exists and stays global otherwise.
- Hosted dashboard daemon APIs now explicitly allow /v1/harnesses for real browser continuity on /guard/home.
- Focused verification: pytest for tests/test_guard_codex_install.py tests/test_guard_surface_server.py, and ruff on the touched files.