### PR TITLE
fix(guard): allow Guard Cloud connect preflight

### DIFF
--- a/docs/guard/release-checklist.md
+++ b/docs/guard/release-checklist.md
@@ -1,0 +1,8 @@
+# Guard Release Checklist
+
+Before each Guard harness release:
+
+- Run the automated CI suite for the release branch.
+- Update smoke evidence from `tests/fixtures/smoke-evidence-template.json` with current manual results.
+- Confirm browser-assisted Guard Cloud connect flows still open the hosted pairing page and can reach the local daemon.
+- Attach smoke evidence to the release notes or pull request before publishing.

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1562,6 +1562,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
     def _is_hosted_dashboard_api_path(path: str, path_parts: list[str]) -> bool:
         if path in {
             "/v1/capabilities",
+            "/v1/connect/complete",
             "/v1/inventory",
             "/v1/connect/state",
             "/v1/daemon/repair",

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -86,6 +86,33 @@ def test_guard_daemon_exposes_canonical_connect_state_endpoint(tmp_path) -> None
     assert state_payload["state"]["milestone"] == "waiting_for_browser"
 
 
+def test_guard_daemon_allows_hosted_connect_complete_preflight(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+
+    try:
+        preflight_request = urllib.request.Request(
+            f"http://127.0.0.1:{daemon.port}/v1/connect/complete",
+            headers={
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Private-Network": "true",
+                "Origin": "https://hol.org",
+            },
+            method="OPTIONS",
+        )
+        with urllib.request.urlopen(preflight_request, timeout=5) as response:
+            status = response.status
+            allow_origin = response.headers.get("Access-Control-Allow-Origin")
+            allow_private_network = response.headers.get("Access-Control-Allow-Private-Network")
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert allow_origin == "https://hol.org"
+    assert allow_private_network == "true"
+
+
 def test_guard_connect_preserves_pairing_when_first_sync_fails(
     tmp_path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- allow hosted Guard Cloud to preflight the local daemon `/v1/connect/complete` endpoint
- add regression coverage for Private Network Access CORS headers on the pairing completion route
- add the Guard release checklist required by smoke-evidence CI

## Verification
- `python3 -m pytest tests/test_guard_connect_flow.py -q`
- Production browser E2E: opened `https://hol.org/guard/connect` in Playwright against a patched local daemon; route polled `/v1/connect/state` with 200 responses and rendered `Guard is waiting for the machine.`
- Production browser E2E: from `https://hol.org` page origin, POSTed `/v1/connect/complete` to the patched local daemon and received HTTP 200 with `completed: true`.
- Direct release checklist invariant: `docs/guard/release-checklist.md` exists and references smoke evidence.
