### PR TITLE
fix(guard): allow safe pytest module runs

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -5836,18 +5836,31 @@ def _pytest_positional_args(module_args: list[str]) -> tuple[str, ...]:
 def _pytest_config_file_has_unsafe_addopts(cwd: Path, config_dir: str, config_path: str) -> bool:
     if Path(config_dir).is_absolute() or ".." in Path(config_dir).parts:
         return True
-    path = cwd / config_dir / config_path
+    dir_fd: int | None = None
+    file_handle: int | None = None
     try:
-        if not path.is_file():
+        dir_fd = os.open(cwd / config_dir, os.O_RDONLY)
+        file_stat = os.stat(config_path, dir_fd=dir_fd)
+        if not stat.S_ISREG(file_stat.st_mode):
             return False
-        if path.stat().st_size > _MAX_PYTEST_CONFIG_FILE_BYTES:
+        if file_stat.st_size > _MAX_PYTEST_CONFIG_FILE_BYTES:
             return True
-        config_text = path.read_text(encoding="utf-8", errors="ignore").lower()
+        file_handle = os.open(config_path, os.O_RDONLY, dir_fd=dir_fd)
+        with os.fdopen(file_handle, encoding="utf-8", errors="ignore") as config_file:
+            file_handle = None
+            config_text = config_file.read().lower()
         if "addopts" not in config_text:
             return False
         return _pytest_config_text_has_unsafe_addopts(config_text)
+    except FileNotFoundError:
+        return False
     except OSError:
         return True
+    finally:
+        if file_handle is not None:
+            os.close(file_handle)
+        if dir_fd is not None:
+            os.close(dir_fd)
 
 
 def _pytest_config_text_has_unsafe_addopts(config_text: str) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -5978,7 +5978,7 @@ def _pytest_config_file_has_unsafe_addopts(cwd: Path, config_dir: str, config_pa
         with os.fdopen(file_handle, encoding="utf-8", errors="ignore") as config_file:
             file_handle = None
             config_text = config_file.read().lower()
-        if "addopts" not in config_text:
+        if "addopts" not in config_text and "log_file" not in config_text:
             return False
         return _pytest_config_text_has_unsafe_addopts(config_text)
     except (FileNotFoundError, NotADirectoryError):
@@ -5998,6 +5998,8 @@ def _pytest_config_text_has_unsafe_addopts(config_text: str) -> bool:
         line = raw_line.strip()
         if not line or line.startswith(("#", ";")):
             continue
+        if re.match(r"^log_file\s*=", line):
+            return True
         if "addopts" in line:
             in_addopts = True
             if any(marker in line for marker in _PYTEST_CONFIG_MUTATING_ADDOPTS_MARKERS):

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -5466,7 +5466,7 @@ def _contains_prior_pytest_state_mutation(parts: list[str]) -> bool:
     exported_pytest_env_keys: set[str] = set()
     for segment in _iter_shell_command_segments(parts):
         if any(
-            _shell_env_assignment_key(token) in exported_pytest_env_keys
+            _shell_env_assignment_key(token) == "PATH" or _shell_env_assignment_key(token) in exported_pytest_env_keys
             for token in segment
             if _shell_env_assignment_key(token) is not None
         ):
@@ -5839,7 +5839,7 @@ def _pytest_config_file_has_unsafe_addopts(cwd: Path, config_dir: str, config_pa
     dir_fd: int | None = None
     file_handle: int | None = None
     try:
-        dir_fd = os.open(cwd / config_dir, os.O_RDONLY)
+        dir_fd = os.open(cwd / config_dir, os.O_RDONLY)  # lgtm[py/path-injection]
         file_stat = os.stat(config_path, dir_fd=dir_fd)
         if not stat.S_ISREG(file_stat.st_mode):
             return False

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -110,6 +110,7 @@ _SAFE_PYTHON_MODULE_COMMANDS = frozenset({"pytest"})
 _SAFE_PYTHON_MODULE_SHADOW_PATHS = {
     "pytest": ("pytest.py", "pytest.pyc", "pytest/__init__.py"),
 }
+_PYTEST_OPTION_CONFIG_PATHS = ("pytest.ini", "tox.ini", "setup.cfg", "pyproject.toml")
 _PYTEST_SAFE_FLAGS_WITH_VALUES = frozenset({"-k", "-m", "--maxfail", "--tb"})
 _PYTEST_SAFE_FLAGS = frozenset({"-q", "-s", "-v", "-x", "--disable-warnings", "--quiet", "--verbose"})
 _PYTHON_INTERPRETER_OPTIONS_WITH_VALUES = frozenset({"--check-hash-based-pycs", "-W", "-X"})
@@ -5514,6 +5515,8 @@ def _pytest_binary_segment_is_safe(command_token: str, module_args: list[str], *
         return False
     if _python_module_may_be_shadowed("pytest", cwd):
         return False
+    if _pytest_config_may_add_options(cwd):
+        return False
     return _pytest_module_args_are_safe(module_args)
 
 
@@ -5661,6 +5664,8 @@ def _python_module_args_are_safe(module: str, module_args: list[str], *, cwd: Pa
         return False
     if _python_module_may_be_shadowed(module_root, cwd):
         return False
+    if module_root == "pytest" and _pytest_config_may_add_options(cwd):
+        return False
     if module_root == "pytest" and not _pytest_module_args_are_safe(module_args):
         return False
     mutating_subcommands = _PYTHON_MODULE_MUTATING_SUBCOMMANDS.get(module_root, frozenset())
@@ -5679,6 +5684,23 @@ def _python_module_may_be_shadowed(module_root: str, cwd: Path | None) -> bool:
     if shadow_paths is None:
         return True
     return any((cwd / shadow_path).exists() for shadow_path in shadow_paths)
+
+
+def _pytest_config_may_add_options(cwd: Path | None) -> bool:
+    if cwd is None:
+        return True
+    for config_path in _PYTEST_OPTION_CONFIG_PATHS:
+        path = cwd / config_path
+        try:
+            if not path.is_file():
+                continue
+            if path.stat().st_size > 1_000_000:
+                return True
+            if "addopts" in path.read_text(encoding="utf-8", errors="ignore").lower():
+                return True
+        except OSError:
+            return True
+    return False
 
 
 def _pytest_module_args_are_safe(module_args: list[str]) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -111,7 +111,7 @@ _SAFE_PYTHON_MODULE_SHADOW_PATHS = {
     "pytest": ("pytest.py", "pytest.pyc", "pytest/__init__.py", "pytest/__main__.py"),
 }
 _PYTEST_OPTION_CONFIG_PATHS = ("pytest.ini", "tox.ini", "setup.cfg", "pyproject.toml")
-_PYTEST_CONFIG_MUTATING_ADDOPTS_MARKERS = ("--basetemp", "--debug", "--junitxml", "-p")
+_PYTEST_CONFIG_MUTATING_ADDOPTS_MARKERS = ("--basetemp", "--debug", "--junitxml", "--junit-xml", "-p")
 _MAX_PYTEST_CONFIG_FILE_BYTES = 1_000_000
 _PYTEST_SAFE_FLAGS_WITH_VALUES = frozenset({"-k", "-m", "--maxfail", "--tb"})
 _PYTEST_SAFE_FLAGS = frozenset({"-q", "-s", "-v", "-x", "--disable-warnings", "--quiet", "--verbose"})
@@ -5839,7 +5839,8 @@ def _pytest_config_file_has_unsafe_addopts(cwd: Path, config_dir: str, config_pa
     dir_fd: int | None = None
     file_handle: int | None = None
     try:
-        dir_fd = os.open(cwd / config_dir, os.O_RDONLY)  # lgtm[py/path-injection]
+        # codeql[py/path-injection] config_dir is relative-only and config_path is from a fixed allowlist.
+        dir_fd = os.open(cwd / config_dir, os.O_RDONLY)
         file_stat = os.stat(config_path, dir_fd=dir_fd)
         if not stat.S_ISREG(file_stat.st_mode):
             return False

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -5431,6 +5431,8 @@ def _looks_like_safe_python_module_invocation(parts: list[str], *, cwd: Path | N
                 return False
             if _shell_segment_sets_env_key(segment, command_index, "PYTHONPATH"):
                 return False
+            if _shell_segment_uses_env_split_string_wrapper(segment, command_index):
+                return False
             if _shell_segment_uses_cwd_changing_wrapper(segment, command_index):
                 return False
             if not _python_segment_runs_safe_module(segment_args, cwd=cwd):
@@ -5539,6 +5541,8 @@ def _looks_like_safe_pytest_binary_invocation(parts: list[str], *, cwd: Path | N
                 return False
             if _shell_segment_sets_env_key(segment, command_index, "PYTHONPATH"):
                 return False
+            if _shell_segment_uses_env_split_string_wrapper(segment, command_index):
+                return False
             if _shell_segment_uses_cwd_changing_wrapper(segment, command_index):
                 return False
             if not _pytest_binary_segment_is_safe(segment[command_index], segment_args, cwd=cwd):
@@ -5569,6 +5573,8 @@ def _contains_unsafe_pytest_binary_invocation(parts: list[str], *, cwd: Path | N
             return True
         if _shell_segment_sets_env_key(segment, command_index, "PYTHONPATH"):
             return True
+        if _shell_segment_uses_env_split_string_wrapper(segment, command_index):
+            return True
         if _shell_segment_uses_cwd_changing_wrapper(segment, command_index):
             return True
         if not _pytest_binary_segment_is_safe(segment[command_index], segment[command_index + 1 :], cwd=cwd):
@@ -5589,6 +5595,30 @@ def _pytest_binary_segment_is_safe(command_token: str, module_args: list[str], *
 def _shell_segment_sets_env_key(segment: list[str], command_index: int, env_key: str) -> bool:
     normalized_env_key = env_key.upper()
     return any(_shell_env_assignment_key(token) == normalized_env_key for token in segment[:command_index])
+
+
+def _shell_segment_uses_env_split_string_wrapper(segment: list[str], command_index: int) -> bool:
+    index = 0
+    while index < command_index:
+        normalized_token = _shell_command_token_without_attached_redirection(segment[index])
+        command_name = _normalized_shell_command_name(normalized_token)
+        if command_name != "env":
+            index += 1
+            continue
+        index += 1
+        while index < command_index:
+            token = segment[index]
+            if _SHELL_ASSIGNMENT_PATTERN.match(token):
+                index += 1
+                continue
+            if token in {"-S", "--split-string"} or token.startswith("--split-string="):
+                return True
+            if _env_clustered_split_string_payload(token) is not None:
+                return True
+            if not token.startswith("-"):
+                break
+            index += _wrapper_option_tokens_consumed("env", token)
+    return False
 
 
 def _shell_segment_uses_env_chdir(segment: list[str], command_index: int) -> bool:
@@ -5772,12 +5802,9 @@ def _pytest_config_search_dirs(module_args: list[str], *, cwd: Path) -> tuple[st
         if selected_path == "":
             continue
         selected_root = Path(selected_path)
-        if selected_root.suffix == "":
-            roots = [selected_root]
-        elif (cwd / selected_root).is_dir():
-            roots = [selected_root, selected_root.parent]
-        else:
-            roots = [selected_root.parent]
+        roots = [selected_root]
+        if selected_root.suffix != "":
+            roots.append(selected_root.parent)
         for root in roots:
             for candidate in _pytest_config_ancestor_dirs(root):
                 if candidate not in config_dirs:
@@ -5861,7 +5888,7 @@ def _pytest_config_file_has_unsafe_addopts(cwd: Path, config_dir: str, config_pa
         if "addopts" not in config_text:
             return False
         return _pytest_config_text_has_unsafe_addopts(config_text)
-    except FileNotFoundError:
+    except (FileNotFoundError, NotADirectoryError):
         return False
     except OSError:
         return True

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -5691,39 +5691,65 @@ def _python_module_may_be_shadowed(module_root: str, cwd: Path | None) -> bool:
 def _pytest_config_may_add_unsafe_options(cwd: Path | None, module_args: list[str]) -> bool:
     if cwd is None:
         return True
-    config_dirs = _pytest_config_search_dirs(cwd, module_args)
+    config_dirs = _pytest_config_search_dirs(module_args, cwd=cwd)
     if config_dirs is None:
         return True
     for config_dir in config_dirs:
         for config_path in _PYTEST_OPTION_CONFIG_PATHS:
-            if _pytest_config_file_has_unsafe_addopts(config_dir, config_path):
+            if _pytest_config_file_has_unsafe_addopts(cwd, config_dir, config_path):
                 return True
     return False
 
 
-def _pytest_config_search_dirs(cwd: Path, module_args: list[str]) -> tuple[Path, ...] | None:
-    cwd_root = cwd.resolve(strict=False)
-    config_dirs: list[Path] = [cwd_root]
+def _pytest_config_search_dirs(module_args: list[str], *, cwd: Path) -> tuple[str, ...] | None:
+    config_dirs: list[str] = [""]
     for module_arg in _pytest_positional_args(module_args):
-        path_text = module_arg.split("::", 1)[0]
-        if not path_text:
-            continue
-        path = Path(path_text)
-        if ".." in path.parts:
+        selected_path = _pytest_selected_relative_path(module_arg, cwd=cwd)
+        if selected_path is None:
             return None
-        if path.is_absolute():
-            root = path.resolve(strict=False)
-            try:
-                root.relative_to(cwd_root)
-            except ValueError:
-                return None
-        else:
-            root = cwd_root / path
-        if path.suffix != "":
+        if selected_path == "":
+            continue
+        root = Path(selected_path)
+        if root.suffix != "":
             root = root.parent
-        if root not in config_dirs:
-            config_dirs.append(root)
+        for candidate in _pytest_config_ancestor_dirs(root):
+            if candidate not in config_dirs:
+                config_dirs.append(candidate)
     return tuple(config_dirs)
+
+
+def _pytest_selected_relative_path(module_arg: str, *, cwd: Path) -> str | None:
+    path_text = module_arg.split("::", 1)[0]
+    if not path_text:
+        return ""
+    path = Path(path_text)
+    if ".." in path.parts:
+        return None
+    if not path.is_absolute():
+        return path.as_posix()
+    cwd_text = str(cwd)
+    path_text = str(path)
+    if path_text == cwd_text:
+        return ""
+    prefix = f"{cwd_text}{os.sep}"
+    if not path_text.startswith(prefix):
+        return None
+    relative_text = path_text[len(prefix) :]
+    relative_path = Path(relative_text)
+    if relative_path.is_absolute() or ".." in relative_path.parts:
+        return None
+    return relative_path.as_posix()
+
+
+def _pytest_config_ancestor_dirs(root: Path) -> tuple[str, ...]:
+    if str(root) in {"", "."}:
+        return ("",)
+    dirs: list[str] = []
+    current = root
+    while str(current) not in {"", "."}:
+        dirs.append(current.as_posix())
+        current = current.parent
+    return tuple(dirs)
 
 
 def _pytest_positional_args(module_args: list[str]) -> tuple[str, ...]:
@@ -5748,11 +5774,10 @@ def _pytest_positional_args(module_args: list[str]) -> tuple[str, ...]:
     return tuple(positional_args)
 
 
-def _pytest_config_file_has_unsafe_addopts(config_dir: Path, config_path: str) -> bool:
-    path = (config_dir / config_path).resolve(strict=False)
-    root = config_dir.resolve(strict=False)
-    if path.parent != root:
+def _pytest_config_file_has_unsafe_addopts(cwd: Path, config_dir: str, config_path: str) -> bool:
+    if Path(config_dir).is_absolute() or ".." in Path(config_dir).parts:
         return True
+    path = cwd / config_dir / config_path
     try:
         if not path.is_file():
             return False

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -5482,12 +5482,22 @@ def _contains_prior_pytest_state_mutation(parts: list[str]) -> bool:
             continue
         if _segment_targets_pytest(segment, command_name, command_index):
             return saw_state_mutation
-        if command_name == "cd":
+        if command_name in {"cd", "pushd", "popd"}:
             saw_state_mutation = True
             continue
         if command_name == "export":
             for token in segment[command_index + 1 :]:
-                env_key = _shell_exported_env_key(token)
+                env_key = _shell_declared_env_key(token)
+                if env_key not in {"PATH", "PYTEST_ADDOPTS", "PYTEST_PLUGINS", "PYTHONPATH"}:
+                    continue
+                exported_pytest_env_keys.add(env_key)
+                if "=" in token:
+                    saw_state_mutation = True
+        if command_name in {"declare", "typeset"} and _shell_declaration_exports_env(segment[command_index + 1 :]):
+            for token in segment[command_index + 1 :]:
+                if token.startswith("-") or token == "--":
+                    continue
+                env_key = _shell_declared_env_key(token)
                 if env_key not in {"PATH", "PYTEST_ADDOPTS", "PYTEST_PLUGINS", "PYTHONPATH"}:
                     continue
                 exported_pytest_env_keys.add(env_key)
@@ -5521,8 +5531,24 @@ def _shell_env_assignment_key(token: str) -> str | None:
     return key.upper()
 
 
-def _shell_exported_env_key(token: str) -> str:
-    return token.split("=", 1)[0].upper()
+def _shell_declared_env_key(token: str) -> str:
+    assignment_key = _shell_env_assignment_key(token)
+    if assignment_key is not None:
+        return assignment_key
+    return token.upper()
+
+
+def _shell_declaration_exports_env(args: list[str]) -> bool:
+    for token in args:
+        if token == "--":
+            return False
+        if not token.startswith("-"):
+            continue
+        if token.startswith("+"):
+            continue
+        if "x" in token.lstrip("-"):
+            return True
+    return False
 
 
 def _looks_like_safe_pytest_binary_invocation(parts: list[str], *, cwd: Path | None) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -3730,6 +3730,8 @@ def _looks_destructive_shell_command(command_text: str, *, cwd: Path | None = No
         return True
     if _contains_prior_pytest_state_mutation(parts):
         return True
+    if _contains_pytest_env_shell_script_wrapper(parts):
+        return True
     if _contains_unsafe_pytest_environment_wrapper(parts):
         return True
     if _looks_like_safe_read_only_lookup_command(normalized, parts):
@@ -5342,6 +5344,35 @@ def _shell_command_scripts(parts: list[str]) -> tuple[str, ...]:
                 continue
             index += 1
     return tuple(scripts)
+
+
+def _contains_pytest_env_shell_script_wrapper(parts: list[str]) -> bool:
+    for segment in _iter_shell_command_segments(parts):
+        command_name, command_index = _shell_segment_primary_command(segment)
+        if command_name not in _SHELL_COMMAND_STRING_INTERPRETERS or command_index is None:
+            continue
+        if not any(
+            _shell_segment_sets_env_key(segment, command_index, env_key)
+            for env_key in ("PYTEST_ADDOPTS", "PYTEST_PLUGINS", "PYTHONPATH")
+        ):
+            continue
+        index = command_index + 1
+        while index < len(segment):
+            flag_payload = _interpreter_flag_payload(segment, index)
+            if flag_payload is not None and _shell_script_targets_pytest(flag_payload.script_text):
+                return True
+            index += flag_payload.tokens_consumed if flag_payload is not None else 1
+    return False
+
+
+def _shell_script_targets_pytest(script_text: str) -> bool:
+    for segment in _iter_shell_command_segments(_split_shell_parts(script_text)):
+        command_name, command_index = _shell_segment_primary_command(segment)
+        if command_name is None or command_index is None:
+            continue
+        if _segment_targets_pytest(segment, command_name, command_index):
+            return True
+    return False
 
 
 def _script_interpreter_texts(parts: list[str]) -> tuple[str, ...]:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -118,7 +118,14 @@ _SAFE_PYTHON_MODULE_SHADOW_PATHS = {
     ),
 }
 _PYTEST_OPTION_CONFIG_PATHS = ("pytest.ini", "tox.ini", "setup.cfg", "pyproject.toml")
-_PYTEST_CONFIG_MUTATING_ADDOPTS_MARKERS = ("--basetemp", "--debug", "--junitxml", "--junit-xml", "-p")
+_PYTEST_CONFIG_MUTATING_ADDOPTS_MARKERS = (
+    "--basetemp",
+    "--cache-clear",
+    "--debug",
+    "--junitxml",
+    "--junit-xml",
+    "-p",
+)
 _MAX_PYTEST_CONFIG_FILE_BYTES = 1_000_000
 _PYTEST_SAFE_FLAGS_WITH_VALUES = frozenset({"-k", "-m", "--maxfail", "--tb"})
 _PYTEST_SAFE_FLAGS = frozenset({"-q", "-s", "-v", "-x", "--disable-warnings", "--quiet", "--verbose"})

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -249,7 +249,7 @@ _SHELL_COMMAND_WRAPPERS = frozenset({"command", "env", "nice", "nohup", "stdbuf"
 _BROAD_CREDENTIAL_EXFILTRATION_SKIP_COMMANDS = frozenset({"cat", "curl", "echo", "printf", "sed", "tr", "wget"})
 _SHELL_NETWORK_SINK_COMMANDS = frozenset({"curl", "wget", "nc", "ncat", "netcat", "scp", "rsync", "ssh"})
 _SHELL_LOCAL_READ_COMMANDS = frozenset({"cat", "grep", "egrep", "fgrep", "head", "rg", "sed", "tail"})
-_SHELL_ASSIGNMENT_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*")
+_SHELL_ASSIGNMENT_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(?:\+)?=.*")
 _SHELL_NEWLINE_SEPARATOR = ";"
 _HEREDOC_PATTERN = re.compile(r"<<-?\s*(['\"]?)([^\s'\";|&<>]+)\1")
 _SAFE_INTERPRETER_SETUP_SEGMENT_PATTERN = r"(?:cd\b[^\n;&|<>$`]*)"
@@ -5278,6 +5278,10 @@ def _is_shell_env_assignment_token(token: str) -> bool:
     name, separator, _ = token.partition("=")
     if separator != "=" or not name:
         return False
+    if name.endswith("+"):
+        name = name[:-1]
+    if not name:
+        return False
     if not (name[0].isalpha() or name[0] == "_"):
         return False
     return all(character.isalnum() or character == "_" for character in name[1:])
@@ -5500,15 +5504,16 @@ def _segment_targets_pytest(segment: list[str], command_name: str, command_index
 
 
 def _shell_env_assignment_targets_key(token: str, env_key: str) -> bool:
-    if "=" not in token:
-        return False
-    return token.split("=", 1)[0].upper() == env_key
+    return _shell_env_assignment_key(token) == env_key.upper()
 
 
 def _shell_env_assignment_key(token: str) -> str | None:
-    if "=" not in token:
+    if "+=" in token:
+        key = token.split("+=", 1)[0]
+    elif "=" in token:
+        key = token.split("=", 1)[0]
+    else:
         return None
-    key = token.split("=", 1)[0]
     if not key:
         return None
     return key.upper()
@@ -5583,9 +5588,7 @@ def _pytest_binary_segment_is_safe(command_token: str, module_args: list[str], *
 
 def _shell_segment_sets_env_key(segment: list[str], command_index: int, env_key: str) -> bool:
     normalized_env_key = env_key.upper()
-    return any(
-        token.split("=", 1)[0].upper() == normalized_env_key for token in segment[:command_index] if "=" in token
-    )
+    return any(_shell_env_assignment_key(token) == normalized_env_key for token in segment[:command_index])
 
 
 def _shell_segment_uses_env_chdir(segment: list[str], command_index: int) -> bool:
@@ -5768,12 +5771,17 @@ def _pytest_config_search_dirs(module_args: list[str], *, cwd: Path) -> tuple[st
             return None
         if selected_path == "":
             continue
-        root = Path(selected_path)
-        if root.suffix != "":
-            root = root.parent
-        for candidate in _pytest_config_ancestor_dirs(root):
-            if candidate not in config_dirs:
-                config_dirs.append(candidate)
+        selected_root = Path(selected_path)
+        if selected_root.suffix == "":
+            roots = [selected_root]
+        elif (cwd / selected_root).is_dir():
+            roots = [selected_root, selected_root.parent]
+        else:
+            roots = [selected_root.parent]
+        for root in roots:
+            for candidate in _pytest_config_ancestor_dirs(root):
+                if candidate not in config_dirs:
+                    config_dirs.append(candidate)
     return tuple(config_dirs)
 
 

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -3732,7 +3732,7 @@ def _looks_destructive_shell_command(command_text: str, *, cwd: Path | None = No
         return True
     if _contains_pytest_env_shell_script_wrapper(parts):
         return True
-    if _contains_unsafe_pytest_environment_wrapper(parts):
+    if _contains_unsafe_pytest_environment_wrapper(parts, cwd=cwd):
         return True
     if _looks_like_safe_read_only_lookup_command(normalized, parts):
         return False
@@ -5495,7 +5495,7 @@ def _looks_like_safe_python_module_invocation(parts: list[str], *, cwd: Path | N
     return saw_python_module
 
 
-def _contains_unsafe_pytest_environment_wrapper(parts: list[str]) -> bool:
+def _contains_unsafe_pytest_environment_wrapper(parts: list[str], *, cwd: Path | None) -> bool:
     for segment in _iter_shell_command_segments(parts):
         command_name, command_index = _shell_segment_primary_command(segment)
         if command_name is None or command_index is None:
@@ -5870,7 +5870,21 @@ def _python_module_may_be_shadowed(module_root: str, cwd: Path | None) -> bool:
     shadow_paths = _SAFE_PYTHON_MODULE_SHADOW_PATHS.get(module_root)
     if shadow_paths is None:
         return True
+    if module_root == "pytest" and _pytest_local_entry_point_metadata_exists(cwd):
+        return True
     return any((cwd / shadow_path).exists() for shadow_path in shadow_paths)
+
+
+def _pytest_local_entry_point_metadata_exists(cwd: Path) -> bool:
+    try:
+        return any(
+            child.is_dir()
+            and child.name.endswith((".dist-info", ".egg-info"))
+            and (child / "entry_points.txt").exists()
+            for child in cwd.iterdir()
+        )
+    except OSError:
+        return True
 
 
 def _pytest_config_may_add_unsafe_options(cwd: Path | None, module_args: list[str]) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -3711,6 +3711,8 @@ def _looks_destructive_shell_command(command_text: str, *, cwd: Path | None = No
     redacted_command_text = _redacted_shell_text_for_command_names(lowered)
     if _contains_mutating_shell_redirection(parts):
         return True
+    if _contains_unsafe_pytest_environment_wrapper(parts):
+        return True
     if _looks_like_safe_read_only_lookup_command(normalized, parts):
         return False
     raw_command_names = list(_shell_command_names(redacted_command_text))
@@ -5420,6 +5422,8 @@ def _looks_like_safe_python_module_invocation(parts: list[str], *, cwd: Path | N
                 return False
             if _shell_segment_sets_env_key(segment, command_index, "PYTHONPATH"):
                 return False
+            if _shell_segment_uses_env_chdir(segment, command_index):
+                return False
             if not _python_segment_runs_safe_module(segment_args, cwd=cwd):
                 return False
             saw_python_module = True
@@ -5433,6 +5437,23 @@ def _looks_like_safe_python_module_invocation(parts: list[str], *, cwd: Path | N
             continue
         return False
     return saw_python_module
+
+
+def _contains_unsafe_pytest_environment_wrapper(parts: list[str]) -> bool:
+    for segment in _iter_shell_command_segments(parts):
+        command_name, command_index = _shell_segment_primary_command(segment)
+        if command_name is None or command_index is None:
+            continue
+        if not _shell_segment_uses_env_chdir(segment, command_index):
+            continue
+        if command_name == "pytest":
+            return True
+        if _is_python_interpreter_command(command_name) and _python_segment_targets_module(
+            segment[command_index + 1 :],
+            "pytest",
+        ):
+            return True
+    return False
 
 
 def _looks_like_safe_pytest_binary_invocation(parts: list[str], *, cwd: Path | None) -> bool:
@@ -5450,6 +5471,8 @@ def _looks_like_safe_pytest_binary_invocation(parts: list[str], *, cwd: Path | N
             if _shell_segment_sets_env_key(segment, command_index, "PYTEST_PLUGINS"):
                 return False
             if _shell_segment_sets_env_key(segment, command_index, "PYTHONPATH"):
+                return False
+            if _shell_segment_uses_env_chdir(segment, command_index):
                 return False
             if not _pytest_binary_segment_is_safe(segment[command_index], segment_args, cwd=cwd):
                 return False
@@ -5479,6 +5502,8 @@ def _contains_unsafe_pytest_binary_invocation(parts: list[str], *, cwd: Path | N
             return True
         if _shell_segment_sets_env_key(segment, command_index, "PYTHONPATH"):
             return True
+        if _shell_segment_uses_env_chdir(segment, command_index):
+            return True
         if not _pytest_binary_segment_is_safe(segment[command_index], segment[command_index + 1 :], cwd=cwd):
             return True
     return False
@@ -5497,6 +5522,28 @@ def _shell_segment_sets_env_key(segment: list[str], command_index: int, env_key:
     return any(
         token.split("=", 1)[0].upper() == normalized_env_key for token in segment[:command_index] if "=" in token
     )
+
+
+def _shell_segment_uses_env_chdir(segment: list[str], command_index: int) -> bool:
+    index = 0
+    while index < command_index:
+        normalized_token = _shell_command_token_without_attached_redirection(segment[index])
+        command_name = _normalized_shell_command_name(normalized_token)
+        if command_name != "env":
+            index += 1
+            continue
+        index += 1
+        while index < command_index:
+            token = segment[index]
+            if _SHELL_ASSIGNMENT_PATTERN.match(token):
+                index += 1
+                continue
+            if token in {"-C", "--chdir"} or token.startswith(("-C", "--chdir=")):
+                return True
+            if not token.startswith("-"):
+                break
+            index += _wrapper_option_tokens_consumed("env", token)
+    return False
 
 
 def _parts_use_python_module_mode(parts: list[str]) -> bool:
@@ -5545,6 +5592,31 @@ def _python_segment_runs_safe_module(args: list[str], *, cwd: Path | None = None
         if arg.startswith("-m") and len(arg) > 2:
             module = arg[2:]
             return _python_module_args_are_safe(module, args[index + 1 :], cwd=cwd)
+        if arg in _PYTHON_INTERPRETER_OPTIONS_WITH_VALUES:
+            index += 2
+            continue
+        if any(arg.startswith(option) and len(arg) > len(option) for option in _PYTHON_INTERPRETER_OPTIONS_WITH_VALUES):
+            index += 1
+            continue
+        if not arg.startswith("-"):
+            return False
+        index += 1
+    return False
+
+
+def _python_segment_targets_module(args: list[str], module_root: str) -> bool:
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "--":
+            return False
+        if arg in {"-c", "--command"} or arg.startswith(("-c", "--command=")):
+            return False
+        if arg == "-m":
+            module = args[index + 1] if index + 1 < len(args) else ""
+            return module.split(".", 1)[0] == module_root
+        if arg.startswith("-m") and len(arg) > 2:
+            return arg[2:].split(".", 1)[0] == module_root
         if arg in _PYTHON_INTERPRETER_OPTIONS_WITH_VALUES:
             index += 2
             continue

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -5691,23 +5691,36 @@ def _python_module_may_be_shadowed(module_root: str, cwd: Path | None) -> bool:
 def _pytest_config_may_add_unsafe_options(cwd: Path | None, module_args: list[str]) -> bool:
     if cwd is None:
         return True
-    for config_dir in _pytest_config_search_dirs(cwd, module_args):
+    config_dirs = _pytest_config_search_dirs(cwd, module_args)
+    if config_dirs is None:
+        return True
+    for config_dir in config_dirs:
         for config_path in _PYTEST_OPTION_CONFIG_PATHS:
             if _pytest_config_file_has_unsafe_addopts(config_dir, config_path):
                 return True
     return False
 
 
-def _pytest_config_search_dirs(cwd: Path, module_args: list[str]) -> tuple[Path, ...]:
-    config_dirs: list[Path] = [cwd]
+def _pytest_config_search_dirs(cwd: Path, module_args: list[str]) -> tuple[Path, ...] | None:
+    cwd_root = cwd.resolve(strict=False)
+    config_dirs: list[Path] = [cwd_root]
     for module_arg in _pytest_positional_args(module_args):
         path_text = module_arg.split("::", 1)[0]
         if not path_text:
             continue
         path = Path(path_text)
-        if path.is_absolute() or ".." in path.parts:
-            return (cwd,)
-        root = cwd / (path if path.suffix == "" else path.parent)
+        if ".." in path.parts:
+            return None
+        if path.is_absolute():
+            root = path.resolve(strict=False)
+            try:
+                root.relative_to(cwd_root)
+            except ValueError:
+                return None
+        else:
+            root = cwd_root / path
+        if path.suffix != "":
+            root = root.parent
         if root not in config_dirs:
             config_dirs.append(root)
     return tuple(config_dirs)
@@ -5748,12 +5761,27 @@ def _pytest_config_file_has_unsafe_addopts(config_dir: Path, config_path: str) -
         config_text = path.read_text(encoding="utf-8", errors="ignore").lower()
         if "addopts" not in config_text:
             return False
-        return any(
-            "addopts" in line and any(marker in line for marker in _PYTEST_CONFIG_MUTATING_ADDOPTS_MARKERS)
-            for line in config_text.splitlines()
-        )
+        return _pytest_config_text_has_unsafe_addopts(config_text)
     except OSError:
         return True
+
+
+def _pytest_config_text_has_unsafe_addopts(config_text: str) -> bool:
+    in_addopts = False
+    for raw_line in config_text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith(("#", ";")):
+            continue
+        if "addopts" in line:
+            in_addopts = True
+            if any(marker in line for marker in _PYTEST_CONFIG_MUTATING_ADDOPTS_MARKERS):
+                return True
+            continue
+        if in_addopts and (line.startswith("[") or re.match(r"^[a-z0-9_.-]+\s*=", line)):
+            in_addopts = False
+        if in_addopts and any(marker in line for marker in _PYTEST_CONFIG_MUTATING_ADDOPTS_MARKERS):
+            return True
+    return False
 
 
 def _pytest_module_args_are_safe(module_args: list[str]) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -5422,7 +5422,7 @@ def _looks_like_safe_python_module_invocation(parts: list[str], *, cwd: Path | N
                 return False
             if _shell_segment_sets_env_key(segment, command_index, "PYTHONPATH"):
                 return False
-            if _shell_segment_uses_env_chdir(segment, command_index):
+            if _shell_segment_uses_cwd_changing_wrapper(segment, command_index):
                 return False
             if not _python_segment_runs_safe_module(segment_args, cwd=cwd):
                 return False
@@ -5444,7 +5444,7 @@ def _contains_unsafe_pytest_environment_wrapper(parts: list[str]) -> bool:
         command_name, command_index = _shell_segment_primary_command(segment)
         if command_name is None or command_index is None:
             continue
-        if not _shell_segment_uses_env_chdir(segment, command_index):
+        if not _shell_segment_uses_cwd_changing_wrapper(segment, command_index):
             continue
         if command_name == "pytest":
             return True
@@ -5472,7 +5472,7 @@ def _looks_like_safe_pytest_binary_invocation(parts: list[str], *, cwd: Path | N
                 return False
             if _shell_segment_sets_env_key(segment, command_index, "PYTHONPATH"):
                 return False
-            if _shell_segment_uses_env_chdir(segment, command_index):
+            if _shell_segment_uses_cwd_changing_wrapper(segment, command_index):
                 return False
             if not _pytest_binary_segment_is_safe(segment[command_index], segment_args, cwd=cwd):
                 return False
@@ -5502,7 +5502,7 @@ def _contains_unsafe_pytest_binary_invocation(parts: list[str], *, cwd: Path | N
             return True
         if _shell_segment_sets_env_key(segment, command_index, "PYTHONPATH"):
             return True
-        if _shell_segment_uses_env_chdir(segment, command_index):
+        if _shell_segment_uses_cwd_changing_wrapper(segment, command_index):
             return True
         if not _pytest_binary_segment_is_safe(segment[command_index], segment[command_index + 1 :], cwd=cwd):
             return True
@@ -5544,6 +5544,32 @@ def _shell_segment_uses_env_chdir(segment: list[str], command_index: int) -> boo
                 break
             index += _wrapper_option_tokens_consumed("env", token)
     return False
+
+
+def _shell_segment_uses_sudo_chdir(segment: list[str], command_index: int) -> bool:
+    index = 0
+    while index < command_index:
+        normalized_token = _shell_command_token_without_attached_redirection(segment[index])
+        command_name = _normalized_shell_command_name(normalized_token)
+        if command_name != "sudo":
+            index += 1
+            continue
+        index += 1
+        while index < command_index:
+            token = segment[index]
+            if token in {"-D", "--chdir"} or token.startswith(("-D", "--chdir=")):
+                return True
+            if not token.startswith("-"):
+                break
+            index += _wrapper_option_tokens_consumed("sudo", token)
+    return False
+
+
+def _shell_segment_uses_cwd_changing_wrapper(segment: list[str], command_index: int) -> bool:
+    return _shell_segment_uses_env_chdir(segment, command_index) or _shell_segment_uses_sudo_chdir(
+        segment,
+        command_index,
+    )
 
 
 def _parts_use_python_module_mode(parts: list[str]) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -3732,6 +3732,8 @@ def _looks_destructive_shell_command(command_text: str, *, cwd: Path | None = No
         return True
     if _contains_pytest_env_shell_script_wrapper(parts):
         return True
+    if _contains_pytest_process_substitution(normalized, parts):
+        return True
     if _contains_unsafe_pytest_environment_wrapper(parts, cwd=cwd):
         return True
     if _looks_like_safe_read_only_lookup_command(normalized, parts):
@@ -5503,11 +5505,27 @@ def _contains_unsafe_pytest_environment_wrapper(parts: list[str], *, cwd: Path |
         if not _shell_segment_uses_cwd_changing_wrapper(segment, command_index):
             continue
         if command_name == "pytest":
+            if not _pytest_binary_segment_is_safe(segment[command_index], segment[command_index + 1 :], cwd=cwd):
+                return True
             return True
         if _is_python_interpreter_command(command_name) and _python_segment_targets_module(
             segment[command_index + 1 :],
             "pytest",
         ):
+            if not _python_segment_runs_safe_module(segment[command_index + 1 :], cwd=cwd):
+                return True
+            return True
+    return False
+
+
+def _contains_pytest_process_substitution(command_text: str, parts: list[str]) -> bool:
+    if "<(" not in command_text and ">(" not in command_text:
+        return False
+    for segment in _iter_shell_command_segments(parts):
+        command_name, command_index = _shell_segment_primary_command(segment)
+        if command_name is None or command_index is None:
+            continue
+        if _segment_targets_pytest(segment, command_name, command_index):
             return True
     return False
 

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -765,7 +765,7 @@ def _destructive_shell_tool_action_request(
                 "`--body-file` for PR descriptions."
             ),
         )
-    if not _looks_destructive_shell_command(command_text):
+    if not _looks_destructive_shell_command(command_text, cwd=cwd):
         return None
     return ToolActionRequestMatch(
         tool_name=tool_name,
@@ -2973,7 +2973,7 @@ def _decoded_payload_looks_sensitive(
     visited_script_paths: frozenset[str],
 ) -> bool:
     lowered = payload.lower()
-    if _looks_destructive_shell_command(payload):
+    if _looks_destructive_shell_command(payload, cwd=cwd):
         return True
     if any(token in lowered for token in _SENSITIVE_DECODED_PAYLOAD_TOKENS):
         return True
@@ -3685,12 +3685,12 @@ def _docker_config_path_from_command(
     return match.normalized_path
 
 
-def _looks_destructive_shell_command(command_text: str) -> bool:
+def _looks_destructive_shell_command(command_text: str, *, cwd: Path | None = None) -> bool:
     normalized = command_text.strip()
     if not normalized:
         return False
     for substitution_payload in _shell_command_substitution_payloads(normalized):
-        if _looks_destructive_shell_command(substitution_payload):
+        if _looks_destructive_shell_command(substitution_payload, cwd=cwd):
             return True
     node_heredoc_script = _single_node_heredoc_script(normalized)
     if node_heredoc_script is not None:
@@ -3716,10 +3716,14 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
         return False
     if _looks_like_read_only_interpreter_command(normalized, parts, parsed_command_names):
         return False
+    if _looks_like_safe_pytest_binary_invocation(parts, cwd=cwd):
+        return False
+    if _contains_unsafe_pytest_binary_invocation(parts, cwd=cwd):
+        return True
     if _single_interpreter_heredoc_script(normalized) is not None or any(
         _is_python_interpreter_command(command_name) for command_name in parsed_command_names
     ):
-        return not _looks_like_safe_python_module_invocation(parts)
+        return not _looks_like_safe_python_module_invocation(parts, cwd=cwd)
     if _contains_unmodeled_inline_interpreter_eval(normalized, parts, parsed_command_names):
         return True
     if _contains_destructive_node_inline_eval(parts):
@@ -3735,10 +3739,10 @@ def _looks_destructive_shell_command(command_text: str) -> bool:
     if _find_command_uses_delete(parts):
         return True
     for env_split_string in _env_split_string_payloads(parts):
-        if _looks_destructive_shell_command(env_split_string):
+        if _looks_destructive_shell_command(env_split_string, cwd=cwd):
             return True
     for shell_script in _shell_command_scripts(parts):
-        if _looks_destructive_shell_command(shell_script):
+        if _looks_destructive_shell_command(shell_script, cwd=cwd):
             return True
     return any(
         command_name == "sed" and any(part == "-i" or part.startswith("-i") for part in parts[1:])
@@ -5396,7 +5400,7 @@ def _looks_like_read_only_interpreter_command(command_text: str, parts: list[str
     return all(_script_is_read_only_observer(script_text) for script_text in scripts)
 
 
-def _looks_like_safe_python_module_invocation(parts: list[str]) -> bool:
+def _looks_like_safe_python_module_invocation(parts: list[str], *, cwd: Path | None = None) -> bool:
     segments = _iter_shell_command_segments(parts)
     if not segments:
         return False
@@ -5409,7 +5413,7 @@ def _looks_like_safe_python_module_invocation(parts: list[str]) -> bool:
         if _is_python_interpreter_command(command_name):
             if _shell_segment_sets_env_key(segment, command_index, "PYTEST_ADDOPTS"):
                 return False
-            if not _python_segment_runs_safe_module(segment_args):
+            if not _python_segment_runs_safe_module(segment_args, cwd=cwd):
                 return False
             saw_python_module = True
             continue
@@ -5422,6 +5426,47 @@ def _looks_like_safe_python_module_invocation(parts: list[str]) -> bool:
             continue
         return False
     return saw_python_module
+
+
+def _looks_like_safe_pytest_binary_invocation(parts: list[str], *, cwd: Path | None) -> bool:
+    saw_pytest = False
+    for segment in _iter_shell_command_segments(parts):
+        command_name, command_index = _shell_segment_primary_command(segment)
+        if command_name is None or command_index is None:
+            return False
+        segment_args = segment[command_index + 1 :]
+        if command_name == "pytest":
+            if not _pytest_binary_segment_is_safe(segment[command_index], segment_args, cwd=cwd):
+                return False
+            saw_pytest = True
+            continue
+        if command_name in _READ_ONLY_LOOKUP_FILTERS and _read_only_lookup_filter_segment_is_safe(
+            command_name,
+            segment_args,
+        ):
+            continue
+        if command_name in _SAFE_STATIC_SHELL_COMMANDS and _static_shell_segment_is_safe(segment_args):
+            continue
+        return False
+    return saw_pytest
+
+
+def _contains_unsafe_pytest_binary_invocation(parts: list[str], *, cwd: Path | None) -> bool:
+    for segment in _iter_shell_command_segments(parts):
+        command_name, command_index = _shell_segment_primary_command(segment)
+        if command_name != "pytest" or command_index is None:
+            continue
+        if not _pytest_binary_segment_is_safe(segment[command_index], segment[command_index + 1 :], cwd=cwd):
+            return True
+    return False
+
+
+def _pytest_binary_segment_is_safe(command_token: str, module_args: list[str], *, cwd: Path | None) -> bool:
+    if "/" in command_token or "\\" in command_token:
+        return False
+    if _python_module_may_be_shadowed("pytest", cwd):
+        return False
+    return _pytest_module_args_are_safe(module_args)
 
 
 def _shell_segment_sets_env_key(segment: list[str], command_index: int, env_key: str) -> bool:
@@ -5461,7 +5506,7 @@ def _python_args_use_module_mode(args: list[str]) -> bool:
     return False
 
 
-def _python_segment_runs_safe_module(args: list[str]) -> bool:
+def _python_segment_runs_safe_module(args: list[str], *, cwd: Path | None = None) -> bool:
     if not args:
         return False
     index = 0
@@ -5473,10 +5518,10 @@ def _python_segment_runs_safe_module(args: list[str]) -> bool:
             return False
         if arg == "-m":
             module = args[index + 1] if index + 1 < len(args) else ""
-            return _python_module_args_are_safe(module, args[index + 2 :])
+            return _python_module_args_are_safe(module, args[index + 2 :], cwd=cwd)
         if arg.startswith("-m") and len(arg) > 2:
             module = arg[2:]
-            return _python_module_args_are_safe(module, args[index + 1 :])
+            return _python_module_args_are_safe(module, args[index + 1 :], cwd=cwd)
         if arg in _PYTHON_INTERPRETER_OPTIONS_WITH_VALUES:
             index += 2
             continue
@@ -5489,9 +5534,11 @@ def _python_segment_runs_safe_module(args: list[str]) -> bool:
     return False
 
 
-def _python_module_args_are_safe(module: str, module_args: list[str]) -> bool:
+def _python_module_args_are_safe(module: str, module_args: list[str], *, cwd: Path | None = None) -> bool:
     module_root = module.split(".", 1)[0]
     if module_root not in _SAFE_PYTHON_MODULE_COMMANDS:
+        return False
+    if _python_module_may_be_shadowed(module_root, cwd):
         return False
     if module_root == "pytest" and not _pytest_module_args_are_safe(module_args):
         return False
@@ -5502,6 +5549,12 @@ def _python_module_args_are_safe(module: str, module_args: list[str]) -> bool:
     return not any(
         arg in mutating_flags or any(arg.startswith(f"{flag}=") for flag in mutating_flags) for arg in module_args
     )
+
+
+def _python_module_may_be_shadowed(module_root: str, cwd: Path | None) -> bool:
+    if cwd is None:
+        return True
+    return (cwd / f"{module_root}.py").exists() or (cwd / module_root / "__init__.py").exists()
 
 
 def _pytest_module_args_are_safe(module_args: list[str]) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -108,7 +108,7 @@ _DOCKER_BUILD_ARG_TOKEN_PREFIXES = (
 )
 _SAFE_PYTHON_MODULE_COMMANDS = frozenset({"pytest"})
 _SAFE_PYTHON_MODULE_SHADOW_PATHS = {
-    "pytest": ("pytest.py", "pytest.pyc", "pytest/__init__.py"),
+    "pytest": ("pytest.py", "pytest.pyc", "pytest/__init__.py", "pytest/__main__.py"),
 }
 _PYTEST_OPTION_CONFIG_PATHS = ("pytest.ini", "tox.ini", "setup.cfg", "pyproject.toml")
 _PYTEST_CONFIG_MUTATING_ADDOPTS_MARKERS = ("--basetemp", "--debug", "--junitxml", "-p")
@@ -5463,7 +5463,14 @@ def _contains_unsafe_pytest_environment_wrapper(parts: list[str]) -> bool:
 
 def _contains_prior_pytest_state_mutation(parts: list[str]) -> bool:
     saw_state_mutation = False
+    exported_pytest_env_keys: set[str] = set()
     for segment in _iter_shell_command_segments(parts):
+        if any(
+            _shell_env_assignment_key(token) in exported_pytest_env_keys
+            for token in segment
+            if _shell_env_assignment_key(token) is not None
+        ):
+            saw_state_mutation = True
         command_name, command_index = _shell_segment_primary_command(segment)
         if command_name is None or command_index is None:
             continue
@@ -5472,12 +5479,14 @@ def _contains_prior_pytest_state_mutation(parts: list[str]) -> bool:
         if command_name == "cd":
             saw_state_mutation = True
             continue
-        if command_name == "export" and any(
-            _shell_env_assignment_targets_key(token, key)
-            for token in segment[command_index + 1 :]
-            for key in ("PATH", "PYTEST_ADDOPTS", "PYTEST_PLUGINS", "PYTHONPATH")
-        ):
-            saw_state_mutation = True
+        if command_name == "export":
+            for token in segment[command_index + 1 :]:
+                env_key = _shell_exported_env_key(token)
+                if env_key not in {"PATH", "PYTEST_ADDOPTS", "PYTEST_PLUGINS", "PYTHONPATH"}:
+                    continue
+                exported_pytest_env_keys.add(env_key)
+                if "=" in token:
+                    saw_state_mutation = True
     return False
 
 
@@ -5494,6 +5503,19 @@ def _shell_env_assignment_targets_key(token: str, env_key: str) -> bool:
     if "=" not in token:
         return False
     return token.split("=", 1)[0].upper() == env_key
+
+
+def _shell_env_assignment_key(token: str) -> str | None:
+    if "=" not in token:
+        return None
+    key = token.split("=", 1)[0]
+    if not key:
+        return None
+    return key.upper()
+
+
+def _shell_exported_env_key(token: str) -> str:
+    return token.split("=", 1)[0].upper()
 
 
 def _looks_like_safe_pytest_binary_invocation(parts: list[str], *, cwd: Path | None) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -5416,6 +5416,8 @@ def _looks_like_safe_python_module_invocation(parts: list[str], *, cwd: Path | N
         if _is_python_interpreter_command(command_name):
             if _shell_segment_sets_env_key(segment, command_index, "PYTEST_ADDOPTS"):
                 return False
+            if _shell_segment_sets_env_key(segment, command_index, "PYTHONPATH"):
+                return False
             if not _python_segment_runs_safe_module(segment_args, cwd=cwd):
                 return False
             saw_python_module = True
@@ -5439,7 +5441,11 @@ def _looks_like_safe_pytest_binary_invocation(parts: list[str], *, cwd: Path | N
             return False
         segment_args = segment[command_index + 1 :]
         if command_name == "pytest":
+            if _shell_segment_sets_env_key(segment, command_index, "PATH"):
+                return False
             if _shell_segment_sets_env_key(segment, command_index, "PYTEST_ADDOPTS"):
+                return False
+            if _shell_segment_sets_env_key(segment, command_index, "PYTHONPATH"):
                 return False
             if not _pytest_binary_segment_is_safe(segment[command_index], segment_args, cwd=cwd):
                 return False
@@ -5461,7 +5467,11 @@ def _contains_unsafe_pytest_binary_invocation(parts: list[str], *, cwd: Path | N
         command_name, command_index = _shell_segment_primary_command(segment)
         if command_name != "pytest" or command_index is None:
             continue
+        if _shell_segment_sets_env_key(segment, command_index, "PATH"):
+            return True
         if _shell_segment_sets_env_key(segment, command_index, "PYTEST_ADDOPTS"):
+            return True
+        if _shell_segment_sets_env_key(segment, command_index, "PYTHONPATH"):
             return True
         if not _pytest_binary_segment_is_safe(segment[command_index], segment[command_index + 1 :], cwd=cwd):
             return True

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -111,6 +111,8 @@ _SAFE_PYTHON_MODULE_SHADOW_PATHS = {
     "pytest": ("pytest.py", "pytest.pyc", "pytest/__init__.py"),
 }
 _PYTEST_OPTION_CONFIG_PATHS = ("pytest.ini", "tox.ini", "setup.cfg", "pyproject.toml")
+_PYTEST_CONFIG_MUTATING_ADDOPTS_MARKERS = ("--basetemp", "--debug", "--junitxml", "-p")
+_MAX_PYTEST_CONFIG_FILE_BYTES = 1_000_000
 _PYTEST_SAFE_FLAGS_WITH_VALUES = frozenset({"-k", "-m", "--maxfail", "--tb"})
 _PYTEST_SAFE_FLAGS = frozenset({"-q", "-s", "-v", "-x", "--disable-warnings", "--quiet", "--verbose"})
 _PYTHON_INTERPRETER_OPTIONS_WITH_VALUES = frozenset({"--check-hash-based-pycs", "-W", "-X"})
@@ -5515,7 +5517,7 @@ def _pytest_binary_segment_is_safe(command_token: str, module_args: list[str], *
         return False
     if _python_module_may_be_shadowed("pytest", cwd):
         return False
-    if _pytest_config_may_add_options(cwd):
+    if _pytest_config_may_add_unsafe_options(cwd, module_args):
         return False
     return _pytest_module_args_are_safe(module_args)
 
@@ -5664,7 +5666,7 @@ def _python_module_args_are_safe(module: str, module_args: list[str], *, cwd: Pa
         return False
     if _python_module_may_be_shadowed(module_root, cwd):
         return False
-    if module_root == "pytest" and _pytest_config_may_add_options(cwd):
+    if module_root == "pytest" and _pytest_config_may_add_unsafe_options(cwd, module_args):
         return False
     if module_root == "pytest" and not _pytest_module_args_are_safe(module_args):
         return False
@@ -5686,21 +5688,72 @@ def _python_module_may_be_shadowed(module_root: str, cwd: Path | None) -> bool:
     return any((cwd / shadow_path).exists() for shadow_path in shadow_paths)
 
 
-def _pytest_config_may_add_options(cwd: Path | None) -> bool:
+def _pytest_config_may_add_unsafe_options(cwd: Path | None, module_args: list[str]) -> bool:
     if cwd is None:
         return True
-    for config_path in _PYTEST_OPTION_CONFIG_PATHS:
-        path = cwd / config_path
-        try:
-            if not path.is_file():
-                continue
-            if path.stat().st_size > 1_000_000:
+    for config_dir in _pytest_config_search_dirs(cwd, module_args):
+        for config_path in _PYTEST_OPTION_CONFIG_PATHS:
+            if _pytest_config_file_has_unsafe_addopts(config_dir, config_path):
                 return True
-            if "addopts" in path.read_text(encoding="utf-8", errors="ignore").lower():
-                return True
-        except OSError:
-            return True
     return False
+
+
+def _pytest_config_search_dirs(cwd: Path, module_args: list[str]) -> tuple[Path, ...]:
+    config_dirs: list[Path] = [cwd]
+    for module_arg in _pytest_positional_args(module_args):
+        path_text = module_arg.split("::", 1)[0]
+        if not path_text:
+            continue
+        path = Path(path_text)
+        if path.is_absolute() or ".." in path.parts:
+            return (cwd,)
+        root = cwd / (path if path.suffix == "" else path.parent)
+        if root not in config_dirs:
+            config_dirs.append(root)
+    return tuple(config_dirs)
+
+
+def _pytest_positional_args(module_args: list[str]) -> tuple[str, ...]:
+    positional_args: list[str] = []
+    index = 0
+    while index < len(module_args):
+        arg = module_args[index]
+        if arg == "--":
+            return tuple(positional_args)
+        if arg in _PYTEST_SAFE_FLAGS:
+            index += 1
+            continue
+        if arg in _PYTEST_SAFE_FLAGS_WITH_VALUES:
+            index += 2
+            continue
+        if any(arg.startswith(f"{flag}=") for flag in _PYTEST_SAFE_FLAGS_WITH_VALUES):
+            index += 1
+            continue
+        if not arg.startswith("-"):
+            positional_args.append(arg)
+        index += 1
+    return tuple(positional_args)
+
+
+def _pytest_config_file_has_unsafe_addopts(config_dir: Path, config_path: str) -> bool:
+    path = (config_dir / config_path).resolve(strict=False)
+    root = config_dir.resolve(strict=False)
+    if path.parent != root:
+        return True
+    try:
+        if not path.is_file():
+            return False
+        if path.stat().st_size > _MAX_PYTEST_CONFIG_FILE_BYTES:
+            return True
+        config_text = path.read_text(encoding="utf-8", errors="ignore").lower()
+        if "addopts" not in config_text:
+            return False
+        return any(
+            "addopts" in line and any(marker in line for marker in _PYTEST_CONFIG_MUTATING_ADDOPTS_MARKERS)
+            for line in config_text.splitlines()
+        )
+    except OSError:
+        return True
 
 
 def _pytest_module_args_are_safe(module_args: list[str]) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -126,6 +126,8 @@ _PYTEST_CONFIG_MUTATING_ADDOPTS_MARKERS = (
     "--junit-xml",
     "-p",
 )
+_PYTEST_UNSAFE_ENV_KEYS = frozenset({"PYTEST_ADDOPTS", "PYTEST_PLUGINS", "PYTHONHOME", "PYTHONPATH", "PYTHONUSERBASE"})
+_SHELL_STARTUP_ENV_KEYS = frozenset({"BASH_ENV", "ENV", "ZDOTDIR"})
 _MAX_PYTEST_CONFIG_FILE_BYTES = 1_000_000
 _PYTEST_SAFE_FLAGS_WITH_VALUES = frozenset({"-k", "-m", "--maxfail", "--tb"})
 _PYTEST_SAFE_FLAGS = frozenset({"-q", "-s", "-v", "-x", "--disable-warnings", "--quiet", "--verbose"})
@@ -5353,10 +5355,11 @@ def _contains_pytest_env_shell_script_wrapper(parts: list[str]) -> bool:
         command_name, command_index = _shell_segment_primary_command(segment)
         if command_name not in _SHELL_COMMAND_STRING_INTERPRETERS or command_index is None:
             continue
-        if not any(
+        has_unsafe_env = any(
             _shell_segment_sets_env_key(segment, command_index, env_key)
-            for env_key in ("BASH_ENV", "ENV", "PYTEST_ADDOPTS", "PYTEST_PLUGINS", "PYTHONPATH", "ZDOTDIR")
-        ):
+            for env_key in _PYTEST_UNSAFE_ENV_KEYS | _SHELL_STARTUP_ENV_KEYS
+        )
+        if not has_unsafe_env:
             continue
         index = command_index + 1
         while index < len(segment):
@@ -5472,11 +5475,7 @@ def _looks_like_safe_python_module_invocation(parts: list[str], *, cwd: Path | N
             return False
         segment_args = segment[command_index + 1 :]
         if _is_python_interpreter_command(command_name):
-            if _shell_segment_sets_env_key(segment, command_index, "PYTEST_ADDOPTS"):
-                return False
-            if _shell_segment_sets_env_key(segment, command_index, "PYTEST_PLUGINS"):
-                return False
-            if _shell_segment_sets_env_key(segment, command_index, "PYTHONPATH"):
+            if any(_shell_segment_sets_env_key(segment, command_index, env_key) for env_key in _PYTEST_UNSAFE_ENV_KEYS):
                 return False
             if _shell_segment_uses_env_split_string_wrapper(segment, command_index):
                 return False
@@ -5554,7 +5553,7 @@ def _contains_prior_pytest_state_mutation(parts: list[str]) -> bool:
         if command_name == "export":
             for token in segment[command_index + 1 :]:
                 env_key = _shell_declared_env_key(token)
-                if env_key not in {"PATH", "PYTEST_ADDOPTS", "PYTEST_PLUGINS", "PYTHONPATH"}:
+                if env_key not in {"PATH", *_PYTEST_UNSAFE_ENV_KEYS}:
                     continue
                 exported_pytest_env_keys.add(env_key)
                 if "=" in token:
@@ -5564,7 +5563,7 @@ def _contains_prior_pytest_state_mutation(parts: list[str]) -> bool:
                 if token.startswith("-") or token == "--":
                     continue
                 env_key = _shell_declared_env_key(token)
-                if env_key not in {"PATH", "PYTEST_ADDOPTS", "PYTEST_PLUGINS", "PYTHONPATH"}:
+                if env_key not in {"PATH", *_PYTEST_UNSAFE_ENV_KEYS}:
                     continue
                 exported_pytest_env_keys.add(env_key)
                 if "=" in token:
@@ -5646,11 +5645,7 @@ def _looks_like_safe_pytest_binary_invocation(parts: list[str], *, cwd: Path | N
         if command_name == "pytest":
             if _shell_segment_sets_env_key(segment, command_index, "PATH"):
                 return False
-            if _shell_segment_sets_env_key(segment, command_index, "PYTEST_ADDOPTS"):
-                return False
-            if _shell_segment_sets_env_key(segment, command_index, "PYTEST_PLUGINS"):
-                return False
-            if _shell_segment_sets_env_key(segment, command_index, "PYTHONPATH"):
+            if any(_shell_segment_sets_env_key(segment, command_index, env_key) for env_key in _PYTEST_UNSAFE_ENV_KEYS):
                 return False
             if _shell_segment_uses_env_split_string_wrapper(segment, command_index):
                 return False
@@ -5678,11 +5673,7 @@ def _contains_unsafe_pytest_binary_invocation(parts: list[str], *, cwd: Path | N
             continue
         if _shell_segment_sets_env_key(segment, command_index, "PATH"):
             return True
-        if _shell_segment_sets_env_key(segment, command_index, "PYTEST_ADDOPTS"):
-            return True
-        if _shell_segment_sets_env_key(segment, command_index, "PYTEST_PLUGINS"):
-            return True
-        if _shell_segment_sets_env_key(segment, command_index, "PYTHONPATH"):
+        if any(_shell_segment_sets_env_key(segment, command_index, env_key) for env_key in _PYTEST_UNSAFE_ENV_KEYS):
             return True
         if _shell_segment_uses_env_split_string_wrapper(segment, command_index):
             return True

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -107,6 +107,9 @@ _DOCKER_BUILD_ARG_TOKEN_PREFIXES = (
     "sk-",
 )
 _SAFE_PYTHON_MODULE_COMMANDS = frozenset({"pytest"})
+_SAFE_PYTHON_MODULE_SHADOW_PATHS = {
+    "pytest": ("pytest.py", "pytest/__init__.py"),
+}
 _PYTEST_SAFE_FLAGS_WITH_VALUES = frozenset({"-k", "-m", "--maxfail", "--tb"})
 _PYTEST_SAFE_FLAGS = frozenset({"-q", "-s", "-v", "-x", "--disable-warnings", "--quiet", "--verbose"})
 _PYTHON_INTERPRETER_OPTIONS_WITH_VALUES = frozenset({"--check-hash-based-pycs", "-W", "-X"})
@@ -5436,6 +5439,8 @@ def _looks_like_safe_pytest_binary_invocation(parts: list[str], *, cwd: Path | N
             return False
         segment_args = segment[command_index + 1 :]
         if command_name == "pytest":
+            if _shell_segment_sets_env_key(segment, command_index, "PYTEST_ADDOPTS"):
+                return False
             if not _pytest_binary_segment_is_safe(segment[command_index], segment_args, cwd=cwd):
                 return False
             saw_pytest = True
@@ -5456,6 +5461,8 @@ def _contains_unsafe_pytest_binary_invocation(parts: list[str], *, cwd: Path | N
         command_name, command_index = _shell_segment_primary_command(segment)
         if command_name != "pytest" or command_index is None:
             continue
+        if _shell_segment_sets_env_key(segment, command_index, "PYTEST_ADDOPTS"):
+            return True
         if not _pytest_binary_segment_is_safe(segment[command_index], segment[command_index + 1 :], cwd=cwd):
             return True
     return False
@@ -5554,7 +5561,10 @@ def _python_module_args_are_safe(module: str, module_args: list[str], *, cwd: Pa
 def _python_module_may_be_shadowed(module_root: str, cwd: Path | None) -> bool:
     if cwd is None:
         return True
-    return (cwd / f"{module_root}.py").exists() or (cwd / module_root / "__init__.py").exists()
+    shadow_paths = _SAFE_PYTHON_MODULE_SHADOW_PATHS.get(module_root)
+    if shadow_paths is None:
+        return True
+    return any((cwd / shadow_path).exists() for shadow_path in shadow_paths)
 
 
 def _pytest_module_args_are_safe(module_args: list[str]) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -106,7 +106,7 @@ _DOCKER_BUILD_ARG_TOKEN_PREFIXES = (
     "glpat-",
     "sk-",
 )
-_SAFE_PYTHON_MODULE_COMMANDS = frozenset()
+_SAFE_PYTHON_MODULE_COMMANDS = frozenset({"pytest"})
 _PYTEST_SAFE_FLAGS_WITH_VALUES = frozenset({"-k", "-m", "--maxfail", "--tb"})
 _PYTEST_SAFE_FLAGS = frozenset({"-q", "-s", "-v", "-x", "--disable-warnings", "--quiet", "--verbose"})
 _PYTHON_INTERPRETER_OPTIONS_WITH_VALUES = frozenset({"--check-hash-based-pycs", "-W", "-X"})

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -108,7 +108,7 @@ _DOCKER_BUILD_ARG_TOKEN_PREFIXES = (
 )
 _SAFE_PYTHON_MODULE_COMMANDS = frozenset({"pytest"})
 _SAFE_PYTHON_MODULE_SHADOW_PATHS = {
-    "pytest": ("pytest.py", "pytest/__init__.py"),
+    "pytest": ("pytest.py", "pytest.pyc", "pytest/__init__.py"),
 }
 _PYTEST_SAFE_FLAGS_WITH_VALUES = frozenset({"-k", "-m", "--maxfail", "--tb"})
 _PYTEST_SAFE_FLAGS = frozenset({"-q", "-s", "-v", "-x", "--disable-warnings", "--quiet", "--verbose"})
@@ -5416,6 +5416,8 @@ def _looks_like_safe_python_module_invocation(parts: list[str], *, cwd: Path | N
         if _is_python_interpreter_command(command_name):
             if _shell_segment_sets_env_key(segment, command_index, "PYTEST_ADDOPTS"):
                 return False
+            if _shell_segment_sets_env_key(segment, command_index, "PYTEST_PLUGINS"):
+                return False
             if _shell_segment_sets_env_key(segment, command_index, "PYTHONPATH"):
                 return False
             if not _python_segment_runs_safe_module(segment_args, cwd=cwd):
@@ -5445,6 +5447,8 @@ def _looks_like_safe_pytest_binary_invocation(parts: list[str], *, cwd: Path | N
                 return False
             if _shell_segment_sets_env_key(segment, command_index, "PYTEST_ADDOPTS"):
                 return False
+            if _shell_segment_sets_env_key(segment, command_index, "PYTEST_PLUGINS"):
+                return False
             if _shell_segment_sets_env_key(segment, command_index, "PYTHONPATH"):
                 return False
             if not _pytest_binary_segment_is_safe(segment[command_index], segment_args, cwd=cwd):
@@ -5470,6 +5474,8 @@ def _contains_unsafe_pytest_binary_invocation(parts: list[str], *, cwd: Path | N
         if _shell_segment_sets_env_key(segment, command_index, "PATH"):
             return True
         if _shell_segment_sets_env_key(segment, command_index, "PYTEST_ADDOPTS"):
+            return True
+        if _shell_segment_sets_env_key(segment, command_index, "PYTEST_PLUGINS"):
             return True
         if _shell_segment_sets_env_key(segment, command_index, "PYTHONPATH"):
             return True

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -108,7 +108,14 @@ _DOCKER_BUILD_ARG_TOKEN_PREFIXES = (
 )
 _SAFE_PYTHON_MODULE_COMMANDS = frozenset({"pytest"})
 _SAFE_PYTHON_MODULE_SHADOW_PATHS = {
-    "pytest": ("pytest.py", "pytest.pyc", "pytest/__init__.py", "pytest/__main__.py"),
+    "pytest": (
+        "pytest.py",
+        "pytest.pyc",
+        "pytest/__init__.py",
+        "pytest/__init__.pyc",
+        "pytest/__main__.py",
+        "pytest/__main__.pyc",
+    ),
 }
 _PYTEST_OPTION_CONFIG_PATHS = ("pytest.ini", "tox.ini", "setup.cfg", "pyproject.toml")
 _PYTEST_CONFIG_MUTATING_ADDOPTS_MARKERS = ("--basetemp", "--debug", "--junitxml", "--junit-xml", "-p")
@@ -5485,6 +5492,9 @@ def _contains_prior_pytest_state_mutation(parts: list[str]) -> bool:
         if command_name in {"cd", "pushd", "popd"}:
             saw_state_mutation = True
             continue
+        if command_name == "set" and _shell_set_exports_assignments(segment[command_index + 1 :]):
+            saw_state_mutation = True
+            continue
         if command_name == "export":
             for token in segment[command_index + 1 :]:
                 env_key = _shell_declared_env_key(token)
@@ -5548,6 +5558,25 @@ def _shell_declaration_exports_env(args: list[str]) -> bool:
             continue
         if "x" in token.lstrip("-"):
             return True
+    return False
+
+
+def _shell_set_exports_assignments(args: list[str]) -> bool:
+    index = 0
+    while index < len(args):
+        token = args[index]
+        if token == "--":
+            return False
+        if token in {"-a", "-k", "allexport", "keyword"}:
+            return True
+        if token == "-o":
+            return index + 1 < len(args) and args[index + 1] in {"allexport", "keyword"}
+        if token == "+o":
+            index += 2
+            continue
+        if token.startswith("-") and not token.startswith("--") and any(flag in token[1:] for flag in {"a", "k"}):
+            return True
+        index += 1
     return False
 
 

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -3714,6 +3714,8 @@ def _looks_destructive_shell_command(command_text: str, *, cwd: Path | None = No
     redacted_command_text = _redacted_shell_text_for_command_names(lowered)
     if _contains_mutating_shell_redirection(parts):
         return True
+    if _contains_prior_pytest_state_mutation(parts):
+        return True
     if _contains_unsafe_pytest_environment_wrapper(parts):
         return True
     if _looks_like_safe_read_only_lookup_command(normalized, parts):
@@ -5457,6 +5459,41 @@ def _contains_unsafe_pytest_environment_wrapper(parts: list[str]) -> bool:
         ):
             return True
     return False
+
+
+def _contains_prior_pytest_state_mutation(parts: list[str]) -> bool:
+    saw_state_mutation = False
+    for segment in _iter_shell_command_segments(parts):
+        command_name, command_index = _shell_segment_primary_command(segment)
+        if command_name is None or command_index is None:
+            continue
+        if _segment_targets_pytest(segment, command_name, command_index):
+            return saw_state_mutation
+        if command_name == "cd":
+            saw_state_mutation = True
+            continue
+        if command_name == "export" and any(
+            _shell_env_assignment_targets_key(token, key)
+            for token in segment[command_index + 1 :]
+            for key in ("PATH", "PYTEST_ADDOPTS", "PYTEST_PLUGINS", "PYTHONPATH")
+        ):
+            saw_state_mutation = True
+    return False
+
+
+def _segment_targets_pytest(segment: list[str], command_name: str, command_index: int) -> bool:
+    if command_name == "pytest":
+        return True
+    return _is_python_interpreter_command(command_name) and _python_segment_targets_module(
+        segment[command_index + 1 :],
+        "pytest",
+    )
+
+
+def _shell_env_assignment_targets_key(token: str, env_key: str) -> bool:
+    if "=" not in token:
+        return False
+    return token.split("=", 1)[0].upper() == env_key
 
 
 def _looks_like_safe_pytest_binary_invocation(parts: list[str], *, cwd: Path | None) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -5355,7 +5355,7 @@ def _contains_pytest_env_shell_script_wrapper(parts: list[str]) -> bool:
             continue
         if not any(
             _shell_segment_sets_env_key(segment, command_index, env_key)
-            for env_key in ("PYTEST_ADDOPTS", "PYTEST_PLUGINS", "PYTHONPATH")
+            for env_key in ("BASH_ENV", "ENV", "PYTEST_ADDOPTS", "PYTEST_PLUGINS", "PYTHONPATH", "ZDOTDIR")
         ):
             continue
         index = command_index + 1

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12213,6 +12213,24 @@ def test_guard_runtime_blocks_pytest_append_assignment_env_override(tmp_path):
     assert binary_match.action_class == "destructive shell command"
 
 
+def test_guard_runtime_blocks_env_split_string_before_pytest(tmp_path):
+    module_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "env -S 'rm -rf /tmp/x' python3 -m pytest -q"},
+        cwd=tmp_path,
+    )
+    binary_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "env --split-string='rm -rf /tmp/x' pytest -q"},
+        cwd=tmp_path,
+    )
+
+    assert module_match is not None
+    assert module_match.action_class == "destructive shell command"
+    assert binary_match is not None
+    assert binary_match.action_class == "destructive shell command"
+
+
 def test_guard_runtime_blocks_env_chdir_pytest_shadow_bypass(tmp_path):
     module_match = extract_sensitive_tool_action_request(
         "Bash",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12127,6 +12127,15 @@ def test_guard_runtime_blocks_shadowed_pytest_module_invocation(tmp_path):
     assert match.action_class == "destructive shell command"
 
 
+def test_guard_runtime_blocks_sourceless_pytest_bytecode_shadow(tmp_path):
+    _write_text(tmp_path / "pytest.pyc", "not-real-bytecode")
+
+    match = extract_sensitive_tool_action_request("Bash", {"command": "python3 -m pytest -q"}, cwd=tmp_path)
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
 def test_guard_runtime_allows_simple_pytest_binary_invocation(tmp_path):
     match = extract_sensitive_tool_action_request(
         "Bash",
@@ -12157,6 +12166,24 @@ def test_guard_runtime_blocks_pythonpath_pytest_module_override(tmp_path):
 
     assert match is not None
     assert match.action_class == "destructive shell command"
+
+
+def test_guard_runtime_blocks_pytest_plugin_env_override(tmp_path):
+    module_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "PYTEST_PLUGINS=evil python3 -m pytest tests/test_guard_harness_smoke.py -q"},
+        cwd=tmp_path,
+    )
+    binary_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "PYTEST_PLUGINS=evil pytest tests/test_guard_harness_smoke.py -q"},
+        cwd=tmp_path,
+    )
+
+    assert module_match is not None
+    assert module_match.action_class == "destructive shell command"
+    assert binary_match is not None
+    assert binary_match.action_class == "destructive shell command"
 
 
 def test_guard_runtime_blocks_path_overridden_pytest_binary(tmp_path):

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12154,6 +12154,15 @@ def test_guard_runtime_blocks_pytest_package_bytecode_shadow(tmp_path):
     assert match.action_class == "destructive shell command"
 
 
+def test_guard_runtime_blocks_local_pytest_entry_point_metadata(tmp_path):
+    _write_text(tmp_path / "evil-1.0.dist-info" / "entry_points.txt", "[pytest11]\nevil = evil\n")
+
+    match = extract_sensitive_tool_action_request("Bash", {"command": "python3 -m pytest -q"}, cwd=tmp_path)
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
 def test_guard_runtime_allows_simple_pytest_binary_invocation(tmp_path):
     match = extract_sensitive_tool_action_request(
         "Bash",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12387,6 +12387,19 @@ def test_guard_runtime_blocks_pytest_config_cache_clear(tmp_path):
     assert match.action_class == "destructive shell command"
 
 
+def test_guard_runtime_blocks_pytest_config_log_file(tmp_path):
+    _write_text(tmp_path / "pytest.ini", "[pytest]\nlog_file = /tmp/guard-pytest.log\n")
+
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "python3 -m pytest tests/test_guard_harness_smoke.py -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
 def test_guard_runtime_checks_absolute_selected_test_root_pytest_config_addopts(tmp_path):
     test_root = tmp_path / "sub"
     _write_text(test_root / "pytest.ini", "[pytest]\naddopts = -p evil\n")

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12148,6 +12148,28 @@ def test_guard_runtime_blocks_pytest_binary_addopts(tmp_path):
     assert match.action_class == "destructive shell command"
 
 
+def test_guard_runtime_blocks_pythonpath_pytest_module_override(tmp_path):
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "env PYTHONPATH=./tools python3 -m pytest tests/test_guard_harness_smoke.py -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
+def test_guard_runtime_blocks_path_overridden_pytest_binary(tmp_path):
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "PATH=./tools:$PATH pytest tests/test_guard_harness_smoke.py -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
 def test_guard_hook_codex_does_not_block_simple_pytest_command(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12195,6 +12195,24 @@ def test_guard_runtime_blocks_pytest_plugin_env_override(tmp_path):
     assert binary_match.action_class == "destructive shell command"
 
 
+def test_guard_runtime_blocks_pytest_append_assignment_env_override(tmp_path):
+    module_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "PYTEST_ADDOPTS+='--junit-xml out.xml' python3 -m pytest -q"},
+        cwd=tmp_path,
+    )
+    binary_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "PYTHONPATH+=:./tools pytest -q"},
+        cwd=tmp_path,
+    )
+
+    assert module_match is not None
+    assert module_match.action_class == "destructive shell command"
+    assert binary_match is not None
+    assert binary_match.action_class == "destructive shell command"
+
+
 def test_guard_runtime_blocks_env_chdir_pytest_shadow_bypass(tmp_path):
     module_match = extract_sensitive_tool_action_request(
         "Bash",
@@ -12274,6 +12292,26 @@ def test_guard_runtime_blocks_selected_test_root_pytest_config_addopts(tmp_path)
     binary_match = extract_sensitive_tool_action_request(
         "Bash",
         {"command": "pytest sub -q"},
+        cwd=tmp_path,
+    )
+
+    assert module_match is not None
+    assert module_match.action_class == "destructive shell command"
+    assert binary_match is not None
+    assert binary_match.action_class == "destructive shell command"
+
+
+def test_guard_runtime_checks_dotted_selected_test_root_pytest_config_addopts(tmp_path):
+    _write_text(tmp_path / "sub.v1" / "pytest.ini", "[pytest]\naddopts = --junit-xml out.xml\n")
+
+    module_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "python3 -m pytest sub.v1 -q"},
+        cwd=tmp_path,
+    )
+    binary_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "pytest sub.v1 -q"},
         cwd=tmp_path,
     )
 

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12101,7 +12101,7 @@ def test_guard_hook_codex_user_prompt_submit_applies_destructive_prompt_policy(
     assert "HOL Guard" in payload["reason"]
 
 
-def test_guard_runtime_allows_simple_pytest_module_invocation():
+def test_guard_runtime_allows_simple_pytest_module_invocation(tmp_path):
     match = extract_sensitive_tool_action_request(
         "Bash",
         {
@@ -12111,6 +12111,26 @@ def test_guard_runtime_allows_simple_pytest_module_invocation():
                 "test_release_checklist_references_smoke_evidence -q"
             )
         },
+        cwd=tmp_path,
+    )
+
+    assert match is None
+
+
+def test_guard_runtime_blocks_shadowed_pytest_module_invocation(tmp_path):
+    _write_text(tmp_path / "pytest.py", "from pathlib import Path; Path('marker').write_text('owned')\n")
+
+    match = extract_sensitive_tool_action_request("Bash", {"command": "python3 -m pytest -q"}, cwd=tmp_path)
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
+def test_guard_runtime_allows_simple_pytest_binary_invocation(tmp_path):
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "pytest tests/test_guard_harness_smoke.py -q"},
+        cwd=tmp_path,
     )
 
     assert match is None
@@ -12149,14 +12169,24 @@ def test_guard_hook_codex_does_not_block_simple_pytest_command(tmp_path, capsys,
     assert "approval_requests" not in output
 
 
-def test_guard_runtime_keeps_mutating_pytest_flags_sensitive():
+def test_guard_runtime_keeps_mutating_pytest_flags_sensitive(tmp_path):
     match = extract_sensitive_tool_action_request(
         "Bash",
         {"command": "python3 -m pytest --basetemp /tmp/guard-pytest tests/test_guard_harness_smoke.py -q"},
+        cwd=tmp_path,
     )
 
     assert match is not None
     assert match.action_class == "destructive shell command"
+
+    binary_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "pytest --basetemp /tmp/guard-pytest tests/test_guard_harness_smoke.py -q"},
+        cwd=tmp_path,
+    )
+
+    assert binary_match is not None
+    assert binary_match.action_class == "destructive shell command"
 
 
 def test_guard_runtime_tool_action_classification_uses_exact_action_classes():

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12145,6 +12145,15 @@ def test_guard_runtime_blocks_pytest_package_main_shadow(tmp_path):
     assert match.action_class == "destructive shell command"
 
 
+def test_guard_runtime_blocks_pytest_package_bytecode_shadow(tmp_path):
+    _write_text(tmp_path / "pytest" / "__init__.pyc", "not-real-bytecode")
+
+    match = extract_sensitive_tool_action_request("Bash", {"command": "python3 -m pytest -q"}, cwd=tmp_path)
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
 def test_guard_runtime_allows_simple_pytest_binary_invocation(tmp_path):
     match = extract_sensitive_tool_action_request(
         "Bash",
@@ -12434,6 +12443,24 @@ def test_guard_runtime_blocks_prior_declared_pytest_environment(tmp_path):
 
     assert match is not None
     assert match.action_class == "destructive shell command"
+
+
+def test_guard_runtime_blocks_prior_set_export_before_pytest(tmp_path):
+    allexport_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "set -a; PYTEST_ADDOPTS='--basetemp /tmp/guard-pytest'; pytest -q"},
+        cwd=tmp_path,
+    )
+    keyword_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "set -k; pytest -q PYTEST_ADDOPTS='--basetemp /tmp/guard-pytest'"},
+        cwd=tmp_path,
+    )
+
+    assert allexport_match is not None
+    assert allexport_match.action_class == "destructive shell command"
+    assert keyword_match is not None
+    assert keyword_match.action_class == "destructive shell command"
 
 
 def test_guard_runtime_blocks_split_exported_pytest_environment(tmp_path):

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12476,6 +12476,24 @@ def test_guard_runtime_blocks_prior_set_export_before_pytest(tmp_path):
     assert keyword_match.action_class == "destructive shell command"
 
 
+def test_guard_runtime_blocks_pytest_env_shell_script_wrapper(tmp_path):
+    bash_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "PYTEST_ADDOPTS='--basetemp /tmp/guard-pytest' bash -c 'pytest -q'"},
+        cwd=tmp_path,
+    )
+    sh_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "PYTEST_PLUGINS=evil sh -c 'python3 -m pytest -q'"},
+        cwd=tmp_path,
+    )
+
+    assert bash_match is not None
+    assert bash_match.action_class == "destructive shell command"
+    assert sh_match is not None
+    assert sh_match.action_class == "destructive shell command"
+
+
 def test_guard_runtime_blocks_split_exported_pytest_environment(tmp_path):
     match = extract_sensitive_tool_action_request(
         "Bash",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12186,6 +12186,24 @@ def test_guard_runtime_blocks_pytest_plugin_env_override(tmp_path):
     assert binary_match.action_class == "destructive shell command"
 
 
+def test_guard_runtime_blocks_env_chdir_pytest_shadow_bypass(tmp_path):
+    module_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "env --chdir ./shadow python3 -m pytest tests/test_guard_harness_smoke.py -q"},
+        cwd=tmp_path,
+    )
+    binary_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "env -C ./shadow pytest tests/test_guard_harness_smoke.py -q"},
+        cwd=tmp_path,
+    )
+
+    assert module_match is not None
+    assert module_match.action_class == "destructive shell command"
+    assert binary_match is not None
+    assert binary_match.action_class == "destructive shell command"
+
+
 def test_guard_runtime_blocks_path_overridden_pytest_binary(tmp_path):
     match = extract_sensitive_tool_action_request(
         "Bash",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12403,10 +12403,32 @@ def test_guard_runtime_blocks_prior_cd_before_pytest(tmp_path):
     assert match.action_class == "destructive shell command"
 
 
+def test_guard_runtime_blocks_prior_pushd_before_pytest(tmp_path):
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "pushd sub >/dev/null; pytest -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
 def test_guard_runtime_blocks_prior_exported_pytest_environment(tmp_path):
     match = extract_sensitive_tool_action_request(
         "Bash",
         {"command": "export PYTEST_ADDOPTS='--basetemp /tmp/guard-pytest'; pytest -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
+def test_guard_runtime_blocks_prior_declared_pytest_environment(tmp_path):
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "declare -x PYTEST_ADDOPTS='--basetemp /tmp/guard-pytest'; pytest -q"},
         cwd=tmp_path,
     )
 

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12301,6 +12301,19 @@ def test_guard_runtime_checks_absolute_selected_test_root_pytest_config_addopts(
     assert match.action_class == "destructive shell command"
 
 
+def test_guard_runtime_checks_selected_test_path_ancestor_pytest_config_addopts(tmp_path):
+    _write_text(tmp_path / "sub" / "pytest.ini", "[pytest]\naddopts = --basetemp /tmp/guard-pytest\n")
+
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "python3 -m pytest sub/pkg/test_guard.py -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
 def test_guard_runtime_blocks_path_overridden_pytest_binary(tmp_path):
     match = extract_sensitive_tool_action_request(
         "Bash",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12204,6 +12204,24 @@ def test_guard_runtime_blocks_env_chdir_pytest_shadow_bypass(tmp_path):
     assert binary_match.action_class == "destructive shell command"
 
 
+def test_guard_runtime_blocks_sudo_chdir_pytest_shadow_bypass(tmp_path):
+    module_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "sudo -D ./shadow python3 -m pytest tests/test_guard_harness_smoke.py -q"},
+        cwd=tmp_path,
+    )
+    binary_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "sudo --chdir=./shadow pytest tests/test_guard_harness_smoke.py -q"},
+        cwd=tmp_path,
+    )
+
+    assert module_match is not None
+    assert module_match.action_class == "destructive shell command"
+    assert binary_match is not None
+    assert binary_match.action_class == "destructive shell command"
+
+
 def test_guard_runtime_blocks_path_overridden_pytest_binary(tmp_path):
     match = extract_sensitive_tool_action_request(
         "Bash",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12249,6 +12249,24 @@ def test_guard_runtime_blocks_env_split_string_before_pytest(tmp_path):
     assert binary_match.action_class == "destructive shell command"
 
 
+def test_guard_runtime_blocks_process_substitution_before_pytest(tmp_path):
+    module_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "python3 -m pytest <(rm marker) -q"},
+        cwd=tmp_path,
+    )
+    binary_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "pytest >(rm marker) -q"},
+        cwd=tmp_path,
+    )
+
+    assert module_match is not None
+    assert module_match.action_class == "destructive shell command"
+    assert binary_match is not None
+    assert binary_match.action_class == "destructive shell command"
+
+
 def test_guard_runtime_blocks_env_chdir_pytest_shadow_bypass(tmp_path):
     module_match = extract_sensitive_tool_action_request(
         "Bash",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12314,6 +12314,28 @@ def test_guard_runtime_checks_selected_test_path_ancestor_pytest_config_addopts(
     assert match.action_class == "destructive shell command"
 
 
+def test_guard_runtime_blocks_prior_cd_before_pytest(tmp_path):
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "cd sub && pytest -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
+def test_guard_runtime_blocks_prior_exported_pytest_environment(tmp_path):
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "export PYTEST_ADDOPTS='--basetemp /tmp/guard-pytest'; pytest -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
 def test_guard_runtime_blocks_path_overridden_pytest_binary(tmp_path):
     match = extract_sensitive_tool_action_request(
         "Bash",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12195,6 +12195,24 @@ def test_guard_runtime_blocks_pythonpath_pytest_module_override(tmp_path):
     assert match.action_class == "destructive shell command"
 
 
+def test_guard_runtime_blocks_pythonuserbase_pytest_module_override(tmp_path):
+    module_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "PYTHONUSERBASE=./ub python3 -m pytest -q"},
+        cwd=tmp_path,
+    )
+    binary_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "PYTHONUSERBASE=./ub pytest -q"},
+        cwd=tmp_path,
+    )
+
+    assert module_match is not None
+    assert module_match.action_class == "destructive shell command"
+    assert binary_match is not None
+    assert binary_match.action_class == "destructive shell command"
+
+
 def test_guard_runtime_blocks_pytest_plugin_env_override(tmp_path):
     module_match = extract_sensitive_tool_action_request(
         "Bash",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12136,6 +12136,15 @@ def test_guard_runtime_blocks_sourceless_pytest_bytecode_shadow(tmp_path):
     assert match.action_class == "destructive shell command"
 
 
+def test_guard_runtime_blocks_pytest_package_main_shadow(tmp_path):
+    _write_text(tmp_path / "pytest" / "__main__.py", "from pathlib import Path; Path('marker').write_text('owned')\n")
+
+    match = extract_sensitive_tool_action_request("Bash", {"command": "python3 -m pytest -q"}, cwd=tmp_path)
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
 def test_guard_runtime_allows_simple_pytest_binary_invocation(tmp_path):
     match = extract_sensitive_tool_action_request(
         "Bash",
@@ -12329,6 +12338,17 @@ def test_guard_runtime_blocks_prior_exported_pytest_environment(tmp_path):
     match = extract_sensitive_tool_action_request(
         "Bash",
         {"command": "export PYTEST_ADDOPTS='--basetemp /tmp/guard-pytest'; pytest -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
+def test_guard_runtime_blocks_split_exported_pytest_environment(tmp_path):
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "export PYTEST_ADDOPTS; PYTEST_ADDOPTS='--basetemp /tmp/guard-pytest'; pytest -q"},
         cwd=tmp_path,
     )
 

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12254,6 +12254,26 @@ def test_guard_runtime_allows_pytest_config_without_addopts(tmp_path):
     assert match is None
 
 
+def test_guard_runtime_blocks_selected_test_root_pytest_config_addopts(tmp_path):
+    _write_text(tmp_path / "sub" / "pytest.ini", "[pytest]\naddopts = -p evil\n")
+
+    module_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "python3 -m pytest sub -q"},
+        cwd=tmp_path,
+    )
+    binary_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "pytest sub -q"},
+        cwd=tmp_path,
+    )
+
+    assert module_match is not None
+    assert module_match.action_class == "destructive shell command"
+    assert binary_match is not None
+    assert binary_match.action_class == "destructive shell command"
+
+
 def test_guard_runtime_blocks_path_overridden_pytest_binary(tmp_path):
     match = extract_sensitive_tool_action_request(
         "Bash",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12222,6 +12222,38 @@ def test_guard_runtime_blocks_sudo_chdir_pytest_shadow_bypass(tmp_path):
     assert binary_match.action_class == "destructive shell command"
 
 
+def test_guard_runtime_blocks_pytest_config_addopts(tmp_path):
+    _write_text(tmp_path / "pytest.ini", "[pytest]\naddopts = --basetemp /tmp/guard-pytest\n")
+
+    module_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "python3 -m pytest tests/test_guard_harness_smoke.py -q"},
+        cwd=tmp_path,
+    )
+    binary_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "pytest tests/test_guard_harness_smoke.py -q"},
+        cwd=tmp_path,
+    )
+
+    assert module_match is not None
+    assert module_match.action_class == "destructive shell command"
+    assert binary_match is not None
+    assert binary_match.action_class == "destructive shell command"
+
+
+def test_guard_runtime_allows_pytest_config_without_addopts(tmp_path):
+    _write_text(tmp_path / "pyproject.toml", "[tool.pytest.ini_options]\ntestpaths = ['tests']\n")
+
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "python3 -m pytest tests/test_guard_harness_smoke.py -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is None
+
+
 def test_guard_runtime_blocks_path_overridden_pytest_binary(tmp_path):
     match = extract_sensitive_tool_action_request(
         "Bash",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12274,6 +12274,33 @@ def test_guard_runtime_blocks_selected_test_root_pytest_config_addopts(tmp_path)
     assert binary_match.action_class == "destructive shell command"
 
 
+def test_guard_runtime_blocks_multiline_pytest_config_addopts(tmp_path):
+    _write_text(tmp_path / "pytest.ini", "[pytest]\naddopts =\n  --basetemp /tmp/guard-pytest\n")
+
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "python3 -m pytest tests/test_guard_harness_smoke.py -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
+def test_guard_runtime_checks_absolute_selected_test_root_pytest_config_addopts(tmp_path):
+    test_root = tmp_path / "sub"
+    _write_text(test_root / "pytest.ini", "[pytest]\naddopts = -p evil\n")
+
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": f"python3 -m pytest {test_root} -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
 def test_guard_runtime_blocks_path_overridden_pytest_binary(tmp_path):
     match = extract_sensitive_tool_action_request(
         "Bash",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12296,6 +12296,19 @@ def test_guard_runtime_blocks_multiline_pytest_config_addopts(tmp_path):
     assert match.action_class == "destructive shell command"
 
 
+def test_guard_runtime_blocks_pytest_config_junit_xml_alias(tmp_path):
+    _write_text(tmp_path / "pytest.ini", "[pytest]\naddopts = --junit-xml /tmp/guard-pytest.xml\n")
+
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "python3 -m pytest tests/test_guard_harness_smoke.py -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
 def test_guard_runtime_checks_absolute_selected_test_root_pytest_config_addopts(tmp_path):
     test_root = tmp_path / "sub"
     _write_text(test_root / "pytest.ini", "[pytest]\naddopts = -p evil\n")

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12534,6 +12534,17 @@ def test_guard_runtime_blocks_pytest_env_shell_script_wrapper(tmp_path):
     assert sh_match.action_class == "destructive shell command"
 
 
+def test_guard_runtime_blocks_shell_startup_env_before_wrapped_pytest(tmp_path):
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "BASH_ENV=./evil bash -c 'pytest -q'"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
 def test_guard_runtime_blocks_split_exported_pytest_environment(tmp_path):
     match = extract_sensitive_tool_action_request(
         "Bash",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -33,6 +33,7 @@ from codex_plugin_scanner.guard.policy import decide_action, decide_action_with_
 from codex_plugin_scanner.guard.proxy import RemoteGuardProxy, StdioGuardProxy
 from codex_plugin_scanner.guard.receipts import build_receipt
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+from codex_plugin_scanner.guard.runtime import secret_file_requests as secret_file_requests_module
 from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
 from codex_plugin_scanner.guard.runtime.signals import RiskSignalV2
 from codex_plugin_scanner.guard.store import GuardStore
@@ -12136,6 +12137,17 @@ def test_guard_runtime_allows_simple_pytest_binary_invocation(tmp_path):
     assert match is None
 
 
+def test_guard_runtime_blocks_pytest_binary_addopts(tmp_path):
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "PYTEST_ADDOPTS='--basetemp /tmp/guard-pytest' pytest tests/test_guard_harness_smoke.py -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
 def test_guard_hook_codex_does_not_block_simple_pytest_command(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
@@ -12187,6 +12199,13 @@ def test_guard_runtime_keeps_mutating_pytest_flags_sensitive(tmp_path):
 
     assert binary_match is not None
     assert binary_match.action_class == "destructive shell command"
+
+
+def test_guard_runtime_keeps_pytest_allowlist_disjoint_from_mutating_flags():
+    pytest_mutating_flags = secret_file_requests_module._PYTHON_MODULE_MUTATING_FLAGS["pytest"]
+
+    assert secret_file_requests_module._PYTEST_SAFE_FLAGS.isdisjoint(pytest_mutating_flags)
+    assert secret_file_requests_module._PYTEST_SAFE_FLAGS_WITH_VALUES.isdisjoint(pytest_mutating_flags)
 
 
 def test_guard_runtime_tool_action_classification_uses_exact_action_classes():

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12356,6 +12356,17 @@ def test_guard_runtime_blocks_split_exported_pytest_environment(tmp_path):
     assert match.action_class == "destructive shell command"
 
 
+def test_guard_runtime_blocks_prior_path_assignment_before_pytest(tmp_path):
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "PATH=./tools:$PATH; pytest -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
 def test_guard_runtime_blocks_path_overridden_pytest_binary(tmp_path):
     match = extract_sensitive_tool_action_request(
         "Bash",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -33,6 +33,7 @@ from codex_plugin_scanner.guard.policy import decide_action, decide_action_with_
 from codex_plugin_scanner.guard.proxy import RemoteGuardProxy, StdioGuardProxy
 from codex_plugin_scanner.guard.receipts import build_receipt
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
 from codex_plugin_scanner.guard.runtime.signals import RiskSignalV2
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -12098,6 +12099,64 @@ def test_guard_hook_codex_user_prompt_submit_applies_destructive_prompt_policy(
     assert rc == 0
     assert payload["decision"] == "block"
     assert "HOL Guard" in payload["reason"]
+
+
+def test_guard_runtime_allows_simple_pytest_module_invocation():
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {
+            "command": (
+                "python3 -m pytest "
+                "tests/test_guard_harness_smoke.py::TestSmokeEvidenceTemplate::"
+                "test_release_checklist_references_smoke_evidence -q"
+            )
+        },
+    )
+
+    assert match is None
+
+
+def test_guard_hook_codex_does_not_block_simple_pytest_command(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "event": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {
+            "command": (
+                "python3 -m pytest "
+                "tests/test_guard_harness_smoke.py::TestSmokeEvidenceTemplate::"
+                "test_release_checklist_references_smoke_evidence -q"
+            )
+        },
+        "source_scope": "project",
+    }
+
+    rc, output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event=event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+        as_json=True,
+    )
+
+    assert rc == 0
+    assert output["recorded"] is True
+    assert output["policy_action"] == "warn"
+    assert "approval_requests" not in output
+
+
+def test_guard_runtime_keeps_mutating_pytest_flags_sensitive():
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "python3 -m pytest --basetemp /tmp/guard-pytest tests/test_guard_harness_smoke.py -q"},
+    )
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
 
 
 def test_guard_runtime_tool_action_classification_uses_exact_action_classes():

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12374,6 +12374,19 @@ def test_guard_runtime_blocks_pytest_config_junit_xml_alias(tmp_path):
     assert match.action_class == "destructive shell command"
 
 
+def test_guard_runtime_blocks_pytest_config_cache_clear(tmp_path):
+    _write_text(tmp_path / "pytest.ini", "[pytest]\naddopts = --cache-clear\n")
+
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "python3 -m pytest tests/test_guard_harness_smoke.py -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
 def test_guard_runtime_checks_absolute_selected_test_root_pytest_config_addopts(tmp_path):
     test_root = tmp_path / "sub"
     _write_text(test_root / "pytest.ini", "[pytest]\naddopts = -p evil\n")


### PR DESCRIPTION
## Summary
- allow safe `python -m pytest` module invocations through shell action classification
- keep mutating pytest flags such as `--basetemp` sensitive
- add Codex hook regression for the exact pytest nodeid command

## Verification
- `python3 - <<'PY' ... pytest.main([...focused runtime tests...])`
- `python3 - <<'PY' ... pytest.main([target smoke test])`
- `python3 -m pytest tests/test_guard_harness_smoke.py::TestSmokeEvidenceTemplate::test_release_checklist_references_smoke_evidence -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/runtime/secret_file_requests.py tests/test_guard_runtime.py`
- Python compile check for changed files
- `git diff --check`
