### PR TITLE
fix: harden guard app-connect daemon responses

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -117,6 +117,140 @@ def _headless_safe_failure_reasons() -> dict[str, str]:
     }
 
 
+def _headless_detection_status_to_app_status(value: object) -> str:
+    if value == "protected":
+        return "protected"
+    if value == "found":
+        return "observed"
+    if value == "not_found":
+        return "inactive"
+    return "unknown"
+
+
+def _headless_error_payload(
+    *,
+    code: str,
+    message: str,
+    retryable: bool,
+    detail: str | None = None,
+) -> dict[str, object]:
+    error_payload: dict[str, object] = {
+        "code": code,
+        "message": message,
+        "retryable": retryable,
+    }
+    if detail:
+        error_payload["detail"] = detail
+    payload: dict[str, object] = {
+        "status": "failed",
+        "error": error_payload,
+    }
+    return payload
+
+
+def _headless_action_error_payload(
+    *,
+    operation: str,
+    error_code: str,
+) -> tuple[int, dict[str, object]]:
+    if error_code == "missing_harness":
+        return 400, _headless_error_payload(
+            code="missing_harness",
+            message="Choose an app before retrying.",
+            retryable=False,
+        )
+    if error_code == "unknown_harness":
+        return 404, _headless_error_payload(
+            code="unknown_harness",
+            message="This app is not supported by local Guard.",
+            retryable=False,
+        )
+    if error_code == "confirmation_required":
+        return 409, _headless_error_payload(
+            code="confirmation_required",
+            message="Disconnect needs the local confirmation phrase before Guard removes protection.",
+            retryable=False,
+        )
+    if error_code == "unsupported_operation":
+        return 400, _headless_error_payload(
+            code="unsupported_operation",
+            message="This daemon cannot run the requested app action.",
+            retryable=False,
+        )
+    operation_code = "proof_failed" if operation == "scan" else f"{operation}_failed"
+    operation_label = "proof test" if operation == "scan" else operation
+    return 400, _headless_error_payload(
+        code=operation_code,
+        message=f"Guard could not finish the {operation_label}.",
+        retryable=True,
+        detail=error_code,
+    )
+
+
+def _headless_app_status_from_result(*, operation: str, result: dict[str, object]) -> str:
+    if operation in {"install", "repair"}:
+        managed_install = result.get("managed_install")
+        if isinstance(managed_install, dict) and bool(managed_install.get("active")):
+            return "protected"
+        return "unknown"
+    verification = result.get("verification")
+    if isinstance(verification, dict):
+        if bool(verification.get("installed")):
+            return "protected"
+        if bool(verification.get("command_available")) or bool(verification.get("config_paths")):
+            return "observed"
+        return "inactive"
+    return "unknown"
+
+
+def _headless_action_state_payload(
+    *,
+    harness: str,
+    operation: str,
+    result: dict[str, object],
+    receipt: dict[str, object],
+) -> dict[str, object]:
+    app_status = _headless_app_status_from_result(operation=operation, result=result)
+    if operation == "install":
+        outcome = "app_connected"
+        message = f"{harness} is connected through local Guard."
+        proof_status = "pending"
+    elif operation == "repair":
+        outcome = "app_repaired"
+        message = f"{harness} protection was refreshed."
+        proof_status = "pending"
+    elif operation == "remove":
+        outcome = "app_disconnected"
+        message = f"{harness} protection was removed."
+        proof_status = "not_applicable"
+    elif operation == "scan":
+        proof_passed = app_status == "protected"
+        outcome = "proof_passed" if proof_passed else "proof_failed"
+        message = (
+            f"{harness} proof completed and Guard sees local protection."
+            if proof_passed
+            else f"{harness} proof completed, but Guard does not see active local protection yet."
+        )
+        proof_status = "passed" if proof_passed else "failed"
+    else:
+        outcome = "status_checked"
+        message = f"{harness} status checked."
+        proof_status = "not_applicable"
+    return {
+        "app_status": app_status,
+        "message": message,
+        "outcome": outcome,
+        "proof_status": proof_status,
+        "receipt_summary": {
+            "id": receipt.get("id"),
+            "operation": receipt.get("operation"),
+            "status": receipt.get("status"),
+            "timestamp": receipt.get("timestamp"),
+        },
+        "retryable": operation in {"install", "repair", "scan"},
+    }
+
+
 class _GuardDaemonHandler(BaseHTTPRequestHandler):
     _MAX_BODY_BYTES = 1_000_000
 
@@ -629,8 +763,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 continue
             supported.append(
                 {
+                    "display_name": item.get("display_name"),
                     "harness": harness,
-                    "status": item.get("status"),
+                    "status": _headless_detection_status_to_app_status(item.get("status")),
                     "command_available": bool(item.get("command_available")),
                     "headless_actions": list(_HEADLESS_OPERATIONS[:-1]),
                     "safe_failure_reasons": failure_reasons,
@@ -665,17 +800,29 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
     def _handle_headless_app_action(self, action_path: str, payload: dict[str, object]) -> None:
         mapping = _HEADLESS_APP_ACTIONS.get(action_path)
         if mapping is None:
-            self._write_json({"error": "not_found"}, status=404)
+            status, payload = _headless_action_error_payload(
+                operation=action_path,
+                error_code="unsupported_operation",
+            )
+            self._write_json(payload, status=status)
             return
         operation, harness_action = mapping
         harness = self._optional_string(payload.get("harness"))
         if harness is None:
-            self._write_json({"error": "missing_harness"}, status=400)
+            status, error_payload = _headless_action_error_payload(
+                operation=operation,
+                error_code="missing_harness",
+            )
+            self._write_json(error_payload, status=status)
             return
         try:
             adapter = get_adapter(harness)
         except ValueError:
-            self._write_json({"error": "unknown_harness"}, status=404)
+            status, error_payload = _headless_action_error_payload(
+                operation=operation,
+                error_code="unknown_harness",
+            )
+            self._write_json(error_payload, status=status)
             return
 
         context = self._harness_context(payload)
@@ -685,7 +832,11 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             else:
                 result = self._run_headless_managed_action(adapter.harness, harness_action, payload, context)
         except ValueError as error:
-            self._write_json({"error": str(error)}, status=400)
+            status, error_payload = _headless_action_error_payload(
+                operation=operation,
+                error_code=str(error),
+            )
+            self._write_json(error_payload, status=status)
             return
 
         receipt = self._record_headless_receipt(
@@ -701,6 +852,12 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 "operation": operation,
                 "result": result,
                 "receipt": receipt,
+                "state": _headless_action_state_payload(
+                    harness=adapter.harness,
+                    operation=operation,
+                    result=result,
+                    receipt=receipt,
+                ),
                 "status": "completed",
             }
         )

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -118,13 +118,12 @@ def _headless_safe_failure_reasons() -> dict[str, str]:
 
 
 def _headless_detection_status_to_app_status(value: object) -> str:
-    if value == "protected":
-        return "protected"
-    if value == "found":
-        return "observed"
-    if value == "not_found":
-        return "inactive"
-    return "unknown"
+    status_map = {
+        "protected": "protected",
+        "found": "observed",
+        "not_found": "inactive",
+    }
+    return status_map.get(str(value), "unknown")
 
 
 def _headless_error_payload(
@@ -153,29 +152,35 @@ def _headless_action_error_payload(
     operation: str,
     error_code: str,
 ) -> tuple[int, dict[str, object]]:
-    if error_code == "missing_harness":
-        return 400, _headless_error_payload(
-            code="missing_harness",
-            message="Choose an app before retrying.",
-            retryable=False,
-        )
-    if error_code == "unknown_harness":
-        return 404, _headless_error_payload(
-            code="unknown_harness",
-            message="This app is not supported by local Guard.",
-            retryable=False,
-        )
-    if error_code == "confirmation_required":
-        return 409, _headless_error_payload(
-            code="confirmation_required",
-            message="Disconnect needs the local confirmation phrase before Guard removes protection.",
-            retryable=False,
-        )
-    if error_code == "unsupported_operation":
-        return 400, _headless_error_payload(
-            code="unsupported_operation",
-            message="This daemon cannot run the requested app action.",
-            retryable=False,
+    error_details = {
+        "missing_harness": (
+            400,
+            "Choose an app before retrying.",
+            False,
+        ),
+        "unknown_harness": (
+            404,
+            "This app is not supported by local Guard.",
+            False,
+        ),
+        "confirmation_required": (
+            409,
+            "Disconnect needs the local confirmation phrase before Guard removes protection.",
+            False,
+        ),
+        "unsupported_operation": (
+            400,
+            "This daemon cannot run the requested app action.",
+            False,
+        ),
+    }
+    known_error = error_details.get(error_code)
+    if known_error is not None:
+        status, message, retryable = known_error
+        return status, _headless_error_payload(
+            code=error_code,
+            message=message,
+            retryable=retryable,
         )
     operation_code = "proof_failed" if operation == "scan" else f"{operation}_failed"
     operation_label = "proof test" if operation == "scan" else operation
@@ -183,7 +188,6 @@ def _headless_action_error_payload(
         code=operation_code,
         message=f"Guard could not finish the {operation_label}.",
         retryable=True,
-        detail=error_code,
     )
 
 
@@ -192,6 +196,11 @@ def _headless_app_status_from_result(*, operation: str, result: dict[str, object
         managed_install = result.get("managed_install")
         if isinstance(managed_install, dict) and bool(managed_install.get("active")):
             return "protected"
+        return "unknown"
+    if operation == "remove":
+        managed_install = result.get("managed_install")
+        if isinstance(managed_install, dict) and managed_install.get("active") is False:
+            return "inactive"
         return "unknown"
     verification = result.get("verification")
     if isinstance(verification, dict):
@@ -800,11 +809,11 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
     def _handle_headless_app_action(self, action_path: str, payload: dict[str, object]) -> None:
         mapping = _HEADLESS_APP_ACTIONS.get(action_path)
         if mapping is None:
-            status, payload = _headless_action_error_payload(
+            status, error_payload = _headless_action_error_payload(
                 operation=action_path,
                 error_code="unsupported_operation",
             )
-            self._write_json(payload, status=status)
+            self._write_json(error_payload, status=status)
             return
         operation, harness_action = mapping
         harness = self._optional_string(payload.get("harness"))

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import pytest
 
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
+from codex_plugin_scanner.guard.daemon.server import _headless_action_error_payload
 from codex_plugin_scanner.guard.daemon.manager import load_guard_daemon_auth_token
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -148,6 +149,9 @@ def test_headless_app_operations_write_receipts_without_cli_copy(
             if operation == "install":
                 assert payload["state"]["outcome"] == "app_connected"
                 assert payload["state"]["app_status"] == "protected"
+            if operation == "remove":
+                assert payload["state"]["outcome"] == "app_disconnected"
+                assert payload["state"]["app_status"] == "inactive"
             if operation == "scan":
                 assert payload["state"]["outcome"] == "proof_passed"
                 assert payload["state"]["proof_status"] == "passed"
@@ -478,3 +482,20 @@ def test_headless_api_rejects_missing_harness_with_structured_error(tmp_path: Pa
     assert payload["status"] == "failed"
     assert payload["error"]["code"] == "missing_harness"
     assert payload["error"]["retryable"] is False
+
+
+def test_headless_generic_action_error_omits_unstructured_detail() -> None:
+    status, payload = _headless_action_error_payload(
+        operation="repair",
+        error_code="unexpected daemon blowup",
+    )
+
+    assert status == 400
+    assert payload == {
+        "status": "failed",
+        "error": {
+            "code": "repair_failed",
+            "message": "Guard could not finish the repair.",
+            "retryable": True,
+        },
+    }

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -101,6 +101,10 @@ def test_headless_capabilities_endpoint_reports_safe_action_contract(tmp_path: P
     ]
     assert "codex" in payload["supported_harnesses"]
     assert payload["safe_failure_reasons"]["unsupported"] == "Harness is not supported by this daemon."
+    codex_item = next(item for item in payload["items"] if item["harness"] == "codex")
+    assert codex_item["display_name"] == "Codex"
+    assert codex_item["headless_actions"] == ["install", "repair", "remove", "status", "scan"]
+    assert codex_item["status"] in {"inactive", "observed", "protected"}
 
 
 def test_headless_app_operations_write_receipts_without_cli_copy(
@@ -138,7 +142,15 @@ def test_headless_app_operations_write_receipts_without_cli_copy(
             assert status == 200
             assert payload["receipt"]["status"] == "completed"
             assert payload["receipt"]["operation"] == operation
+            assert payload["state"]["receipt_summary"]["id"] == payload["receipt"]["id"]
+            assert payload["state"]["receipt_summary"]["operation"] == operation
             assert "npx" not in json.dumps(payload)
+            if operation == "install":
+                assert payload["state"]["outcome"] == "app_connected"
+                assert payload["state"]["app_status"] == "protected"
+            if operation == "scan":
+                assert payload["state"]["outcome"] == "proof_passed"
+                assert payload["state"]["proof_status"] == "passed"
     finally:
         daemon.stop()
 
@@ -359,7 +371,9 @@ def test_headless_api_rejects_missing_auth_and_bad_harness(tmp_path: Path) -> No
     assert auth_status == 401
     assert auth_payload["error"] == "unauthorized"
     assert bad_status == 404
-    assert bad_payload["error"] == "unknown_harness"
+    assert bad_payload["status"] == "failed"
+    assert bad_payload["error"]["code"] == "unknown_harness"
+    assert bad_payload["error"]["retryable"] is False
 
 
 def test_headless_api_rejects_forged_dashboard_session_token(tmp_path: Path) -> None:
@@ -439,3 +453,28 @@ def test_headless_api_does_not_read_env_files(
 
     assert status == 200
     assert payload["receipt"]["operation"] == "scan"
+    assert payload["state"]["outcome"] == "proof_failed"
+    assert payload["state"]["proof_status"] == "failed"
+
+
+def test_headless_api_rejects_missing_harness_with_structured_error(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/apps/connect",
+                token=token,
+                payload={"operation": "install"},
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 400
+    assert payload["status"] == "failed"
+    assert payload["error"]["code"] == "missing_harness"
+    assert payload["error"]["retryable"] is False


### PR DESCRIPTION
## Summary
- normalize headless app-connect capability and action responses for Guard Cloud consumers
- return structured action state and error payloads so retries and proof results are stable
- extend daemon API regression coverage for the new contract

## Verification
- pytest tests/test_guard_headless_daemon_api.py tests/test_guard_harness_setup.py tests/test_guard_codex_install.py -q
