### PR TITLE
fix(guard): allow constants source searches

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/false_positive_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/false_positive_rules.py
@@ -22,7 +22,20 @@ _SOURCE_SEARCH_TOOLS = frozenset(
 
 _READ_ONLY_INLINE_TOOLS = frozenset({"jq", "yq", "awk", "sed"})
 SOURCE_INSPECTION_PARTS = frozenset(
-    {"__tests__", "app", "dashboard", "docs", "lib", "packages", "scripts", "src", "test", "tests", "workers"}
+    {
+        "__tests__",
+        "app",
+        "constants",
+        "dashboard",
+        "docs",
+        "lib",
+        "packages",
+        "scripts",
+        "src",
+        "test",
+        "tests",
+        "workers",
+    }
 )
 SOURCE_INSPECTION_EXTENSIONS = frozenset(
     {

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -641,6 +641,57 @@ clearer UX and an implementation plan with technical references.
         assert output["recorded"] is True
         assert "approval_requests" not in output
 
+    def test_codex_post_tool_use_allows_read_only_constants_source_search_with_fixture_output(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        event = {
+            "event": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": (
+                    'rg -n "guardLead|GOOGLE_ADS_CONVERSION|Dbd2|AW-175|send_to|conversion" '
+                    "__tests__ src constants scripts/guard-tracking -g '*.ts' -g '*.tsx'"
+                )
+            },
+            "tool_response": {
+                "stdout": (
+                    "__tests__/ayet-adapter.test.ts:118:"
+                    "'https://example.test/offers?apiKey=static-key&conversion_type%5B%5D=cpe'\n"
+                    "constants/analytics.ts:3:"
+                    "export const DEFAULT_GUARD_GOOGLE_ADS_CONVERSION_ID = 'AW-17512816237';\n"
+                    "src/lib/analytics-client.ts:1322:"
+                    "send_to: `${GOOGLE_ADS_CONVERSION_ID}/${config.label}`,\n"
+                ),
+            },
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["recorded"] is True
+        assert "approval_requests" not in output
+
     def test_codex_post_tool_use_allows_read_only_source_view_with_secret_like_output(
         self,
         monkeypatch,


### PR DESCRIPTION
## Summary
- Treat `constants/` as a normal source-inspection directory for read-only searches.
- Add regression coverage for the exact `rg` search shape that was blocked from the request page.

## Verification
- Focused pytest allow/block regression group: `6 passed in 1.45s`
- Exact command classifier check: `readonly True`, targets `('__tests__', 'src', 'constants', 'scripts/guard-tracking')`
- `python3 -m ruff check src/codex_plugin_scanner/guard/runtime/false_positive_rules.py tests/test_guard_runtime.py`
- `python3 -m py_compile src/codex_plugin_scanner/guard/runtime/false_positive_rules.py tests/test_guard_runtime.py`
- `git diff --check`
