### PR TITLE
fix(guard): allow bounded fd skill reads

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -117,6 +117,8 @@ from ..runtime.false_positive_rules import (
     SOURCE_INSPECTION_EXTENSIONS,
     SOURCE_INSPECTION_PARTS,
     SOURCE_INSPECTION_SENSITIVE_PARTS,
+    fd_exec_token_is_plain_sed,
+    split_fd_args_and_exec,
     target_is_known_skill_doc_path,
 )
 from ..runtime.runner import (
@@ -7129,7 +7131,7 @@ def _codex_fd_targets_are_source_like(args: list[str], *, cwd: Path | None) -> b
 
 
 def _codex_fd_targets(args: list[str]) -> tuple[str, ...]:
-    parsed = _codex_split_fd_args_and_exec(args)
+    parsed = split_fd_args_and_exec(args)
     fd_args = parsed[0] if parsed is not None else args
     positional: list[str] = []
     search_paths: list[str] = []
@@ -7165,28 +7167,19 @@ def _codex_fd_targets(args: list[str]) -> tuple[str, ...]:
 
 
 def _codex_fd_exec_is_bounded_read_only(args: list[str]) -> bool:
-    parsed = _codex_split_fd_args_and_exec(args)
+    parsed = split_fd_args_and_exec(args)
     if parsed is None:
         return not any(
             arg in {"-x", "-X", "--exec", "--exec-batch"} or arg.startswith(("--exec=", "--exec-batch="))
             for arg in args
         )
     _fd_args, exec_parts = parsed
-    if not exec_parts or Path(exec_parts[0]).name != "sed" or "/" in exec_parts[0] or "\\" in exec_parts[0]:
+    if not exec_parts or not fd_exec_token_is_plain_sed(exec_parts[0]):
         return False
     if exec_parts.count("{}") != 1:
         return False
     sed_args = [arg for arg in exec_parts[1:] if arg != "{}"]
     return _codex_sed_args_are_bounded_filter(sed_args)
-
-
-def _codex_split_fd_args_and_exec(args: list[str]) -> tuple[list[str], list[str]] | None:
-    for index, arg in enumerate(args):
-        if arg in {"-X", "--exec-batch"} or arg.startswith(("--exec=", "--exec-batch=")):
-            return None
-        if arg in {"-x", "--exec"}:
-            return args[:index], args[index + 1 :]
-    return None
 
 
 def _codex_search_targets(args: list[str], *, executable: str) -> tuple[str, ...]:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5872,7 +5872,7 @@ def _codex_post_tool_command_text(payload: dict[str, object]) -> str:
     return ""
 
 
-_CODEX_READ_ONLY_SEARCH_COMMANDS = frozenset({"rg", "grep", "egrep", "fgrep"})
+_CODEX_READ_ONLY_SEARCH_COMMANDS = frozenset({"fd", "rg", "grep", "egrep", "fgrep"})
 _CODEX_READ_ONLY_VIEW_COMMANDS = frozenset({"cat", "head", "tail", "sed"})
 _CODEX_READ_ONLY_PIPE_FILTERS = frozenset({"head", "tail", "sed"})
 _CODEX_READ_ONLY_SEARCH_WRAPPERS = frozenset({"bash", "sh", "zsh"})
@@ -6082,6 +6082,8 @@ def _codex_source_inspection_target_tokens(parts: list[str]) -> tuple[str, ...]:
             return tuple(targets) if valid and not skip_next else ()
         return tuple(_codex_cat_targets(args))
     if executable in _CODEX_READ_ONLY_SEARCH_COMMANDS:
+        if executable == "fd":
+            return _codex_fd_targets(args)
         return _codex_search_targets(args, executable=executable)
     if executable == "git":
         git_grep_args = _git_grep_search_args(args)
@@ -6190,22 +6192,32 @@ def _split_codex_safe_read_only_chain(command: str) -> list[str] | None:
 def _codex_command_has_unquoted_glob_metachar(command: str) -> bool:
     quote: str | None = None
     escaped = False
-    for char in command:
+    index = 0
+    while index < len(command):
+        char = command[index]
         if escaped:
             escaped = False
+            index += 1
             continue
         if char == "\\":
             escaped = True
+            index += 1
             continue
         if quote is not None:
             if char == quote:
                 quote = None
+            index += 1
             continue
         if char in {"'", '"'}:
             quote = char
+            index += 1
+            continue
+        if command.startswith("{}", index):
+            index += 2
             continue
         if char in {"*", "?", "[", "]", "{", "}"}:
             return True
+        index += 1
     return False
 
 
@@ -6378,6 +6390,10 @@ def _codex_command_is_read_only_source_search(command_text: str, *, cwd: Path | 
         return False
     executable = Path(parts[0]).name
     if executable in _CODEX_READ_ONLY_SEARCH_COMMANDS:
+        if executable == "fd":
+            return _codex_fd_targets_are_source_like(parts[1:], cwd=cwd) and _codex_fd_exec_is_bounded_read_only(
+                parts[1:]
+            )
         if executable == "rg" and "--no-config" not in parts and os.environ.get("RIPGREP_CONFIG_PATH"):
             return False
         return _codex_search_targets_are_source_like(parts[1:], cwd=cwd, executable=executable)
@@ -7081,6 +7097,74 @@ def _codex_search_targets_are_source_like(args: list[str], *, cwd: Path | None, 
     return bool(targets) and all(_codex_search_target_is_source_like(target, cwd=cwd) for target in targets)
 
 
+def _codex_fd_targets_are_source_like(args: list[str], *, cwd: Path | None) -> bool:
+    targets = _codex_fd_targets(args)
+    if not targets:
+        return False
+    return all(_codex_search_target_is_source_like(target, cwd=cwd) for target in targets)
+
+
+def _codex_fd_targets(args: list[str]) -> tuple[str, ...]:
+    parsed = _codex_split_fd_args_and_exec(args)
+    fd_args = parsed[0] if parsed is not None else args
+    positional: list[str] = []
+    skip_next = False
+    option_value_flags = {
+        "-d",
+        "--max-depth",
+        "-E",
+        "--exclude",
+        "-e",
+        "--extension",
+        "-t",
+        "--type",
+        "--changed-before",
+        "--changed-within",
+        "-j",
+        "--threads",
+    }
+    for arg in fd_args:
+        if skip_next:
+            skip_next = False
+            continue
+        if arg in option_value_flags:
+            skip_next = True
+            continue
+        if any(arg.startswith(f"{flag}=") for flag in option_value_flags if flag.startswith("--")):
+            continue
+        if arg.startswith("-"):
+            continue
+        positional.append(arg)
+    if len(positional) >= 2:
+        return tuple(positional[1:])
+    return ()
+
+
+def _codex_fd_exec_is_bounded_read_only(args: list[str]) -> bool:
+    parsed = _codex_split_fd_args_and_exec(args)
+    if parsed is None:
+        return not any(
+            arg in {"-x", "-X", "--exec", "--exec-batch"} or arg.startswith(("--exec=", "--exec-batch="))
+            for arg in args
+        )
+    _fd_args, exec_parts = parsed
+    if not exec_parts or Path(exec_parts[0]).name != "sed" or "/" in exec_parts[0] or "\\" in exec_parts[0]:
+        return False
+    if exec_parts.count("{}") != 1:
+        return False
+    sed_args = [arg for arg in exec_parts[1:] if arg != "{}"]
+    return _codex_sed_args_are_bounded_filter(sed_args)
+
+
+def _codex_split_fd_args_and_exec(args: list[str]) -> tuple[list[str], list[str]] | None:
+    for index, arg in enumerate(args):
+        if arg in {"-X", "--exec-batch"} or arg.startswith(("--exec=", "--exec-batch=")):
+            return None
+        if arg in {"-x", "--exec"}:
+            return args[:index], args[index + 1 :]
+    return None
+
+
 def _codex_search_targets(args: list[str], *, executable: str) -> tuple[str, ...]:
     positional: list[str] = []
     skip_next = False
@@ -7146,6 +7230,8 @@ def _codex_search_target_is_source_like(target: str, *, cwd: Path | None) -> boo
     stripped = target.strip().strip("'\"")
     if not stripped:
         return False
+    if _codex_search_target_is_known_skill_doc_path(stripped):
+        return True
     if stripped.startswith("~"):
         return False
     if any(char in stripped for char in ("*", "?", "{", "}")):
@@ -7194,6 +7280,25 @@ def _codex_search_target_is_source_like(target: str, *, cwd: Path | None) -> boo
     if Path(stripped).name.lower() in _CODEX_BENIGN_SOURCE_DOTFILES:
         return True
     return Path(stripped).suffix.lower() in _CODEX_SOURCE_SEARCH_EXTENSIONS
+
+
+def _codex_search_target_is_known_skill_doc_path(target: str) -> bool:
+    if any(marker in target for marker in ("$", "`", "<", ">", "|", ";", "&")):
+        return False
+    expanded = Path(os.path.expanduser(target)).resolve(strict=False)
+    home = Path.home().resolve(strict=False)
+    allowed_roots = (
+        home / ".codex" / "superpowers" / "skills",
+        home / ".codex" / "skills",
+        home / ".agents" / "skills",
+    )
+    for root in allowed_roots:
+        try:
+            expanded.relative_to(root.resolve(strict=False))
+        except ValueError:
+            continue
+        return True
+    return False
 
 
 def _codex_absolute_search_target_is_source_like(target_path: Path) -> bool:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -7159,6 +7159,7 @@ def _codex_fd_exec_is_bounded_read_only(args: list[str]) -> bool:
         return not any(
             arg in {"-x", "-X", "--exec", "--exec-batch"}
             or arg.startswith(("-x", "-X", "--exec=", "--exec-batch="))
+            or (arg.startswith("-") and not arg.startswith("--") and ("x" in arg[1:] or "X" in arg[1:]))
             for arg in args
         )
     _fd_args, exec_parts = parsed

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -7116,7 +7116,8 @@ def _codex_fd_exec_is_bounded_read_only(args: list[str]) -> bool:
     parsed = split_fd_args_and_exec(args)
     if parsed is None:
         return not any(
-            arg in {"-x", "-X", "--exec", "--exec-batch"} or arg.startswith(("--exec=", "--exec-batch="))
+            arg in {"-x", "-X", "--exec", "--exec-batch"}
+            or arg.startswith(("-x", "-X", "--exec=", "--exec-batch="))
             for arg in args
         )
     _fd_args, exec_parts = parsed

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -117,6 +117,7 @@ from ..runtime.false_positive_rules import (
     SOURCE_INSPECTION_EXTENSIONS,
     SOURCE_INSPECTION_PARTS,
     SOURCE_INSPECTION_SENSITIVE_PARTS,
+    target_is_known_skill_doc_path,
 )
 from ..runtime.runner import (
     GuardSyncNotConfiguredError,
@@ -5899,6 +5900,30 @@ _CODEX_SEARCH_UNSAFE_SHORT_FLAGS_BY_EXECUTABLE = {
     "grep": frozenset({"R"}),
     "rg": frozenset({"L"}),
 }
+_CODEX_FD_OPTION_VALUE_FLAGS = frozenset(
+    {
+        "-d",
+        "--max-depth",
+        "-E",
+        "--exclude",
+        "-e",
+        "--extension",
+        "-t",
+        "--type",
+        "-S",
+        "--size",
+        "-o",
+        "--owner",
+        "--changed-before",
+        "--changed-within",
+        "--changed-after",
+        "-j",
+        "--threads",
+        "--base-directory",
+        "--path-separator",
+        "--search-path",
+    }
+)
 _CODEX_GIT_GLOBAL_VALUE_FLAGS = frozenset(
     {"-c", "--config-env", "--exec-path", "--git-dir", "--work-tree", "--namespace"}
 )
@@ -7109,28 +7134,14 @@ def _codex_fd_targets(args: list[str]) -> tuple[str, ...]:
     fd_args = parsed[0] if parsed is not None else args
     positional: list[str] = []
     skip_next = False
-    option_value_flags = {
-        "-d",
-        "--max-depth",
-        "-E",
-        "--exclude",
-        "-e",
-        "--extension",
-        "-t",
-        "--type",
-        "--changed-before",
-        "--changed-within",
-        "-j",
-        "--threads",
-    }
     for arg in fd_args:
         if skip_next:
             skip_next = False
             continue
-        if arg in option_value_flags:
+        if arg in _CODEX_FD_OPTION_VALUE_FLAGS:
             skip_next = True
             continue
-        if any(arg.startswith(f"{flag}=") for flag in option_value_flags if flag.startswith("--")):
+        if any(arg.startswith(f"{flag}=") for flag in _CODEX_FD_OPTION_VALUE_FLAGS if flag.startswith("--")):
             continue
         if arg.startswith("-"):
             continue
@@ -7230,7 +7241,7 @@ def _codex_search_target_is_source_like(target: str, *, cwd: Path | None) -> boo
     stripped = target.strip().strip("'\"")
     if not stripped:
         return False
-    if _codex_search_target_is_known_skill_doc_path(stripped):
+    if target_is_known_skill_doc_path(stripped):
         return True
     if stripped.startswith("~"):
         return False
@@ -7280,25 +7291,6 @@ def _codex_search_target_is_source_like(target: str, *, cwd: Path | None) -> boo
     if Path(stripped).name.lower() in _CODEX_BENIGN_SOURCE_DOTFILES:
         return True
     return Path(stripped).suffix.lower() in _CODEX_SOURCE_SEARCH_EXTENSIONS
-
-
-def _codex_search_target_is_known_skill_doc_path(target: str) -> bool:
-    if any(marker in target for marker in ("$", "`", "<", ">", "|", ";", "&")):
-        return False
-    expanded = Path(os.path.expanduser(target)).resolve(strict=False)
-    home = Path.home().resolve(strict=False)
-    allowed_roots = (
-        home / ".codex" / "superpowers" / "skills",
-        home / ".codex" / "skills",
-        home / ".agents" / "skills",
-    )
-    for root in allowed_roots:
-        try:
-            expanded.relative_to(root.resolve(strict=False))
-        except ValueError:
-            continue
-        return True
-    return False
 
 
 def _codex_absolute_search_target_is_source_like(target_path: Path) -> bool:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5270,10 +5270,11 @@ def _hook_runtime_artifact(
             config_path=str(_runtime_policy_path(harness, home_dir, workspace)),
             source_scope=_coalesce_string(payload.get("source_scope"), "project"),
             cwd=workspace,
+            home_dir=home_dir,
         )
         if output_artifact is not None:
             return output_artifact
-        if _codex_post_tool_command_is_read_only_source_inspection(payload=payload, cwd=workspace):
+        if _codex_post_tool_command_is_read_only_source_inspection(payload=payload, cwd=workspace, home_dir=home_dir):
             return None
     if event_name == "UserPromptSubmit":
         prompt_text = payload.get("prompt")
@@ -5410,6 +5411,7 @@ def _codex_post_tool_output_artifact(
     config_path: str,
     source_scope: str,
     cwd: Path | None,
+    home_dir: Path | None,
 ) -> GuardArtifact | None:
     response_text = _collect_codex_tool_response_text(payload.get("tool_response"))
     tool_name = _coalesce_string(payload.get("tool_name"), "Bash")
@@ -5430,6 +5432,7 @@ def _codex_post_tool_output_artifact(
         response_text=response_text,
         content_matches=content_matches,
         cwd=cwd,
+        home_dir=home_dir,
     ):
         return None
     fingerprint = hashlib.sha256(
@@ -5639,9 +5642,9 @@ def _codex_pipeline_segment_may_read_local_content(segment: str, *, index: int, 
             parts,
             cwd=cwd,
         )
-    return _codex_command_is_read_only_source_search(segment, cwd=cwd) or _codex_command_is_read_only_source_view(
-        segment, cwd=cwd
-    )
+    return _codex_command_is_read_only_source_search(
+        segment, cwd=cwd, home_dir=None
+    ) or _codex_command_is_read_only_source_view(segment, cwd=cwd, home_dir=None)
 
 
 def _codex_command_parts_may_read_local_content(parts: list[str], *, cwd: Path | None) -> bool:
@@ -5677,9 +5680,9 @@ def _codex_command_sequence_is_read_only_source_inspection(parts: list[str], *, 
     if not command_parts:
         return False
     segment = shlex.join(command_parts)
-    return _codex_command_is_read_only_source_search(segment, cwd=cwd) or _codex_command_is_read_only_source_view(
-        segment, cwd=cwd
-    )
+    return _codex_command_is_read_only_source_search(
+        segment, cwd=cwd, home_dir=None
+    ) or _codex_command_is_read_only_source_view(segment, cwd=cwd, home_dir=None)
 
 
 def _codex_command_sequence_starts_with_local_reader(parts: list[str], *, cwd: Path | None) -> bool:
@@ -5852,9 +5855,9 @@ def _codex_command_part_is_local_reader(parts: list[str], index: int, *, cwd: Pa
         return True
     if parts[index - 1] == "|":
         segment = shlex.join(parts[index:])
-        return _codex_command_is_read_only_source_search(segment, cwd=cwd) or _codex_command_is_read_only_source_view(
-            segment, cwd=cwd
-        )
+        return _codex_command_is_read_only_source_search(
+            segment, cwd=cwd, home_dir=None
+        ) or _codex_command_is_read_only_source_view(segment, cwd=cwd, home_dir=None)
     return parts[index - 1] in {"&&", "||", ";", "&", "|&"}
 
 
@@ -5862,9 +5865,14 @@ def _codex_post_tool_command_is_read_only_source_inspection(
     *,
     payload: dict[str, object],
     cwd: Path | None,
+    home_dir: Path | None,
 ) -> bool:
     command_text = _codex_post_tool_command_text(payload)
-    return bool(command_text) and _codex_command_is_read_only_source_inspection(command_text, cwd=cwd)
+    return bool(command_text) and _codex_command_is_read_only_source_inspection(
+        command_text,
+        cwd=cwd,
+        home_dir=home_dir,
+    )
 
 
 def _codex_post_tool_command_text(payload: dict[str, object]) -> str:
@@ -6010,8 +6018,9 @@ def _codex_source_inspection_can_skip_secret_output(
     response_text: str,
     content_matches: tuple[SecretContentMatch, ...],
     cwd: Path | None,
+    home_dir: Path | None,
 ) -> bool:
-    if not _codex_command_is_read_only_source_inspection(command_text, cwd=cwd):
+    if not _codex_command_is_read_only_source_inspection(command_text, cwd=cwd, home_dir=home_dir):
         return False
     if _codex_command_references_sensitive_local_source(command_text, cwd=cwd):
         return False
@@ -6121,7 +6130,12 @@ def _codex_cat_targets(args: list[str]) -> list[str]:
     return targets
 
 
-def _codex_command_is_read_only_source_inspection(command_text: str, *, cwd: Path | None) -> bool:
+def _codex_command_is_read_only_source_inspection(
+    command_text: str,
+    *,
+    cwd: Path | None,
+    home_dir: Path | None,
+) -> bool:
     command = command_text.strip()
     if not command:
         return False
@@ -6129,18 +6143,23 @@ def _codex_command_is_read_only_source_inspection(command_text: str, *, cwd: Pat
         return False
     chained_segments = _split_codex_safe_read_only_chain(command)
     if chained_segments is not None:
-        return all(_codex_command_is_read_only_source_inspection(segment, cwd=cwd) for segment in chained_segments)
+        return all(
+            _codex_command_is_read_only_source_inspection(segment, cwd=cwd, home_dir=home_dir)
+            for segment in chained_segments
+        )
     segments = _split_codex_safe_read_only_pipeline(command)
     if segments is None:
-        return _codex_command_is_read_only_source_search(command, cwd=cwd) or _codex_command_is_read_only_source_view(
-            command, cwd=cwd
-        )
+        return _codex_command_is_read_only_source_search(
+            command,
+            cwd=cwd,
+            home_dir=home_dir,
+        ) or _codex_command_is_read_only_source_view(command, cwd=cwd, home_dir=home_dir)
     if not segments:
         return False
     first_segment, *filter_segments = segments
     if not (
-        _codex_command_is_read_only_source_search(first_segment, cwd=cwd)
-        or _codex_command_is_read_only_source_view(first_segment, cwd=cwd)
+        _codex_command_is_read_only_source_search(first_segment, cwd=cwd, home_dir=home_dir)
+        or _codex_command_is_read_only_source_view(first_segment, cwd=cwd, home_dir=home_dir)
     ):
         return False
     return all(_codex_command_is_bounded_read_only_filter(segment) for segment in filter_segments)
@@ -6354,7 +6373,7 @@ def _codex_command_is_bounded_read_only_filter(command_text: str) -> bool:
     return _codex_head_tail_args_are_bounded_filter(parts[1:])
 
 
-def _codex_command_is_read_only_source_view(command_text: str, *, cwd: Path | None) -> bool:
+def _codex_command_is_read_only_source_view(command_text: str, *, cwd: Path | None, home_dir: Path | None) -> bool:
     command = command_text.strip()
     if not command:
         return False
@@ -6370,15 +6389,15 @@ def _codex_command_is_read_only_source_view(command_text: str, *, cwd: Path | No
         return False
     executable = Path(parts[0]).name
     if executable not in _CODEX_READ_ONLY_VIEW_COMMANDS:
-        return executable == "git" and _codex_git_diff_targets_are_source_like(parts[1:], cwd=cwd)
+        return executable == "git" and _codex_git_diff_targets_are_source_like(parts[1:], cwd=cwd, home_dir=home_dir)
     if executable == "sed":
-        return _codex_sed_targets_are_read_only_source_like(parts[1:], cwd=cwd)
+        return _codex_sed_targets_are_read_only_source_like(parts[1:], cwd=cwd, home_dir=home_dir)
     if executable in {"head", "tail"}:
-        return _codex_head_tail_targets_are_source_like(parts[1:], cwd=cwd)
-    return _codex_cat_targets_are_source_like(parts[1:], cwd=cwd)
+        return _codex_head_tail_targets_are_source_like(parts[1:], cwd=cwd, home_dir=home_dir)
+    return _codex_cat_targets_are_source_like(parts[1:], cwd=cwd, home_dir=home_dir)
 
 
-def _codex_command_is_read_only_source_search(command_text: str, *, cwd: Path | None) -> bool:
+def _codex_command_is_read_only_source_search(command_text: str, *, cwd: Path | None, home_dir: Path | None) -> bool:
     command = command_text.strip()
     if not command:
         return False
@@ -6395,20 +6414,22 @@ def _codex_command_is_read_only_source_search(command_text: str, *, cwd: Path | 
     executable = Path(parts[0]).name
     if executable in _CODEX_READ_ONLY_SEARCH_COMMANDS:
         if executable == "fd":
-            return _codex_fd_targets_are_source_like(parts[1:], cwd=cwd) and _codex_fd_exec_is_bounded_read_only(
-                parts[1:]
-            )
+            return _codex_fd_targets_are_source_like(
+                parts[1:],
+                cwd=cwd,
+                home_dir=home_dir,
+            ) and _codex_fd_exec_is_bounded_read_only(parts[1:])
         if executable == "rg" and "--no-config" not in parts and os.environ.get("RIPGREP_CONFIG_PATH"):
             return False
-        return _codex_search_targets_are_source_like(parts[1:], cwd=cwd, executable=executable)
+        return _codex_search_targets_are_source_like(parts[1:], cwd=cwd, home_dir=home_dir, executable=executable)
     git_grep_args = _git_grep_search_args(parts[1:]) if executable == "git" else None
     if git_grep_args is not None:
         if _git_grep_uses_external_execution(git_grep_args):
             return False
-        return _codex_search_targets_are_source_like(git_grep_args, cwd=cwd, executable=executable)
+        return _codex_search_targets_are_source_like(git_grep_args, cwd=cwd, home_dir=home_dir, executable=executable)
     script_index = _shell_wrapper_script_index(parts) if executable in _CODEX_READ_ONLY_SEARCH_WRAPPERS else None
     if script_index is not None and script_index < len(parts):
-        return _codex_command_is_read_only_source_search(parts[script_index], cwd=cwd)
+        return _codex_command_is_read_only_source_search(parts[script_index], cwd=cwd, home_dir=home_dir)
     return False
 
 
@@ -6416,7 +6437,7 @@ def _codex_command_uses_untrusted_search_binary(executable_token: str) -> bool:
     return executable_token.startswith(".") or "/" in executable_token or "\\" in executable_token
 
 
-def _codex_cat_targets_are_source_like(args: list[str], *, cwd: Path | None) -> bool:
+def _codex_cat_targets_are_source_like(args: list[str], *, cwd: Path | None, home_dir: Path | None) -> bool:
     targets: list[str] = []
     after_option_terminator = False
     for arg in args:
@@ -6431,7 +6452,9 @@ def _codex_cat_targets_are_source_like(args: list[str], *, cwd: Path | None) -> 
         if arg.startswith("-"):
             continue
         targets.append(arg)
-    return bool(targets) and all(_codex_search_target_is_source_like(target, cwd=cwd) for target in targets)
+    return bool(targets) and all(
+        _codex_search_target_is_source_like(target, cwd=cwd, home_dir=home_dir) for target in targets
+    )
 
 
 def _codex_head_tail_args_are_bounded_filter(args: list[str]) -> bool:
@@ -6439,13 +6462,13 @@ def _codex_head_tail_args_are_bounded_filter(args: list[str]) -> bool:
     return valid and not skip_next and not targets
 
 
-def _codex_head_tail_targets_are_source_like(args: list[str], *, cwd: Path | None) -> bool:
+def _codex_head_tail_targets_are_source_like(args: list[str], *, cwd: Path | None, home_dir: Path | None) -> bool:
     targets, valid, skip_next = _parse_codex_head_tail_args(args)
     return (
         valid
         and not skip_next
         and bool(targets)
-        and all(_codex_search_target_is_source_like(target, cwd=cwd) for target in targets)
+        and all(_codex_search_target_is_source_like(target, cwd=cwd, home_dir=home_dir) for target in targets)
     )
 
 
@@ -6483,7 +6506,7 @@ def _parse_codex_head_tail_args(args: list[str]) -> tuple[list[str], bool, bool]
     return targets, True, skip_next
 
 
-def _codex_sed_targets_are_read_only_source_like(args: list[str], *, cwd: Path | None) -> bool:
+def _codex_sed_targets_are_read_only_source_like(args: list[str], *, cwd: Path | None, home_dir: Path | None) -> bool:
     parsed = _parse_codex_sed_read_only_args(args)
     if parsed is None:
         return False
@@ -6491,7 +6514,7 @@ def _codex_sed_targets_are_read_only_source_like(args: list[str], *, cwd: Path |
         bool(parsed.targets)
         and parsed.saw_print_suppression
         and all(sed_script_is_bounded_print(script) for script in parsed.scripts)
-        and all(_codex_search_target_is_source_like(target, cwd=cwd) for target in parsed.targets)
+        and all(_codex_search_target_is_source_like(target, cwd=cwd, home_dir=home_dir) for target in parsed.targets)
     )
 
 
@@ -6577,14 +6600,14 @@ def _git_grep_search_args(args: list[str]) -> list[str] | None:
     return None
 
 
-def _codex_git_diff_targets_are_source_like(args: list[str], *, cwd: Path | None) -> bool:
+def _codex_git_diff_targets_are_source_like(args: list[str], *, cwd: Path | None, home_dir: Path | None) -> bool:
     diff_args = _git_diff_args(args)
     if diff_args is None:
         return False
     targets = _git_diff_path_args(diff_args)
     return (
         bool(targets)
-        and all(_codex_search_target_is_source_like(target, cwd=cwd) for target in targets)
+        and all(_codex_search_target_is_source_like(target, cwd=cwd, home_dir=home_dir) for target in targets)
         and _git_diff_external_helpers_are_disabled_or_unconfigured(diff_args, cwd=cwd)
     )
 
@@ -7094,18 +7117,26 @@ def _codex_command_has_unquoted_shell_control(command: str) -> bool:
     return False
 
 
-def _codex_search_targets_are_source_like(args: list[str], *, cwd: Path | None, executable: str) -> bool:
+def _codex_search_targets_are_source_like(
+    args: list[str],
+    *,
+    cwd: Path | None,
+    home_dir: Path | None,
+    executable: str,
+) -> bool:
     targets = _codex_search_targets(args, executable=executable)
     if not targets:
         return False
-    return bool(targets) and all(_codex_search_target_is_source_like(target, cwd=cwd) for target in targets)
+    return bool(targets) and all(
+        _codex_search_target_is_source_like(target, cwd=cwd, home_dir=home_dir) for target in targets
+    )
 
 
-def _codex_fd_targets_are_source_like(args: list[str], *, cwd: Path | None) -> bool:
+def _codex_fd_targets_are_source_like(args: list[str], *, cwd: Path | None, home_dir: Path | None) -> bool:
     targets = _codex_fd_targets(args)
     if not targets:
         return False
-    return all(_codex_search_target_is_source_like(target, cwd=cwd) for target in targets)
+    return all(_codex_search_target_is_source_like(target, cwd=cwd, home_dir=home_dir) for target in targets)
 
 
 def _codex_fd_targets(args: list[str]) -> tuple[str, ...]:
@@ -7190,11 +7221,11 @@ def _codex_search_arg_is_unsafe(arg: str, *, executable: str, option_value_flags
     return False
 
 
-def _codex_search_target_is_source_like(target: str, *, cwd: Path | None) -> bool:
+def _codex_search_target_is_source_like(target: str, *, cwd: Path | None, home_dir: Path | None) -> bool:
     stripped = target.strip().strip("'\"")
     if not stripped:
         return False
-    if target_is_known_skill_doc_path(stripped):
+    if target_is_known_skill_doc_path(stripped, home_dir=home_dir):
         return True
     if stripped.startswith("~"):
         return False

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5411,7 +5411,7 @@ def _codex_post_tool_output_artifact(
     config_path: str,
     source_scope: str,
     cwd: Path | None,
-    home_dir: Path | None,
+    home_dir: Path | None = None,
 ) -> GuardArtifact | None:
     response_text = _collect_codex_tool_response_text(payload.get("tool_response"))
     tool_name = _coalesce_string(payload.get("tool_name"), "Bash")
@@ -6018,7 +6018,7 @@ def _codex_source_inspection_can_skip_secret_output(
     response_text: str,
     content_matches: tuple[SecretContentMatch, ...],
     cwd: Path | None,
-    home_dir: Path | None,
+    home_dir: Path | None = None,
 ) -> bool:
     if not _codex_command_is_read_only_source_inspection(command_text, cwd=cwd, home_dir=home_dir):
         return False
@@ -6134,7 +6134,7 @@ def _codex_command_is_read_only_source_inspection(
     command_text: str,
     *,
     cwd: Path | None,
-    home_dir: Path | None,
+    home_dir: Path | None = None,
 ) -> bool:
     command = command_text.strip()
     if not command:
@@ -6373,7 +6373,12 @@ def _codex_command_is_bounded_read_only_filter(command_text: str) -> bool:
     return _codex_head_tail_args_are_bounded_filter(parts[1:])
 
 
-def _codex_command_is_read_only_source_view(command_text: str, *, cwd: Path | None, home_dir: Path | None) -> bool:
+def _codex_command_is_read_only_source_view(
+    command_text: str,
+    *,
+    cwd: Path | None,
+    home_dir: Path | None = None,
+) -> bool:
     command = command_text.strip()
     if not command:
         return False
@@ -6397,7 +6402,12 @@ def _codex_command_is_read_only_source_view(command_text: str, *, cwd: Path | No
     return _codex_cat_targets_are_source_like(parts[1:], cwd=cwd, home_dir=home_dir)
 
 
-def _codex_command_is_read_only_source_search(command_text: str, *, cwd: Path | None, home_dir: Path | None) -> bool:
+def _codex_command_is_read_only_source_search(
+    command_text: str,
+    *,
+    cwd: Path | None,
+    home_dir: Path | None = None,
+) -> bool:
     command = command_text.strip()
     if not command:
         return False

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -118,6 +118,7 @@ from ..runtime.false_positive_rules import (
     SOURCE_INSPECTION_PARTS,
     SOURCE_INSPECTION_SENSITIVE_PARTS,
     fd_exec_token_is_plain_sed,
+    fd_search_targets,
     split_fd_args_and_exec,
     target_is_known_skill_doc_path,
 )
@@ -5902,29 +5903,6 @@ _CODEX_SEARCH_UNSAFE_SHORT_FLAGS_BY_EXECUTABLE = {
     "grep": frozenset({"R"}),
     "rg": frozenset({"L"}),
 }
-_CODEX_FD_OPTION_VALUE_FLAGS = frozenset(
-    {
-        "-d",
-        "--max-depth",
-        "-E",
-        "--exclude",
-        "-e",
-        "--extension",
-        "-t",
-        "--type",
-        "-S",
-        "--size",
-        "-o",
-        "--owner",
-        "--changed-before",
-        "--changed-within",
-        "--changed-after",
-        "-j",
-        "--threads",
-        "--base-directory",
-        "--path-separator",
-    }
-)
 _CODEX_GIT_GLOBAL_VALUE_FLAGS = frozenset(
     {"-c", "--config-env", "--exec-path", "--git-dir", "--work-tree", "--namespace"}
 )
@@ -7131,39 +7109,7 @@ def _codex_fd_targets_are_source_like(args: list[str], *, cwd: Path | None) -> b
 
 
 def _codex_fd_targets(args: list[str]) -> tuple[str, ...]:
-    parsed = split_fd_args_and_exec(args)
-    fd_args = parsed[0] if parsed is not None else args
-    positional: list[str] = []
-    search_paths: list[str] = []
-    skip_next = False
-    for index, arg in enumerate(fd_args):
-        if skip_next:
-            skip_next = False
-            continue
-        if arg == "--base-directory" or arg.startswith("--base-directory="):
-            return ("__guard_unsafe_fd_base_directory__",)
-        if arg == "--search-path":
-            if index + 1 >= len(fd_args):
-                return ("__guard_missing_fd_search_path__",)
-            search_paths.append(fd_args[index + 1])
-            skip_next = True
-            continue
-        if arg.startswith("--search-path="):
-            search_paths.append(arg.split("=", 1)[1])
-            continue
-        if arg in _CODEX_FD_OPTION_VALUE_FLAGS:
-            skip_next = True
-            continue
-        if any(arg.startswith(f"{flag}=") for flag in _CODEX_FD_OPTION_VALUE_FLAGS if flag.startswith("--")):
-            continue
-        if arg.startswith("-"):
-            continue
-        positional.append(arg)
-    if search_paths:
-        return tuple(search_paths)
-    if len(positional) >= 2:
-        return tuple(positional[1:])
-    return ()
+    return fd_search_targets(args) or ("__guard_unsafe_fd_args__",)
 
 
 def _codex_fd_exec_is_bounded_read_only(args: list[str]) -> bool:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -117,6 +117,7 @@ from ..runtime.false_positive_rules import (
     SOURCE_INSPECTION_EXTENSIONS,
     SOURCE_INSPECTION_PARTS,
     SOURCE_INSPECTION_SENSITIVE_PARTS,
+    fd_arg_requests_exec,
     fd_exec_token_is_plain_sed,
     fd_search_targets,
     split_fd_args_and_exec,
@@ -7156,12 +7157,7 @@ def _codex_fd_targets(args: list[str]) -> tuple[str, ...]:
 def _codex_fd_exec_is_bounded_read_only(args: list[str]) -> bool:
     parsed = split_fd_args_and_exec(args)
     if parsed is None:
-        return not any(
-            arg in {"-x", "-X", "--exec", "--exec-batch"}
-            or arg.startswith(("-x", "-X", "--exec=", "--exec-batch="))
-            or (arg.startswith("-") and not arg.startswith("--") and ("x" in arg[1:] or "X" in arg[1:]))
-            for arg in args
-        )
+        return not any(fd_arg_requests_exec(arg) for arg in args)
     _fd_args, exec_parts = parsed
     if not exec_parts or not fd_exec_token_is_plain_sed(exec_parts[0]):
         return False

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5921,7 +5921,6 @@ _CODEX_FD_OPTION_VALUE_FLAGS = frozenset(
         "--threads",
         "--base-directory",
         "--path-separator",
-        "--search-path",
     }
 )
 _CODEX_GIT_GLOBAL_VALUE_FLAGS = frozenset(
@@ -7133,10 +7132,22 @@ def _codex_fd_targets(args: list[str]) -> tuple[str, ...]:
     parsed = _codex_split_fd_args_and_exec(args)
     fd_args = parsed[0] if parsed is not None else args
     positional: list[str] = []
+    search_paths: list[str] = []
     skip_next = False
-    for arg in fd_args:
+    for index, arg in enumerate(fd_args):
         if skip_next:
             skip_next = False
+            continue
+        if arg == "--base-directory" or arg.startswith("--base-directory="):
+            return ("__guard_unsafe_fd_base_directory__",)
+        if arg == "--search-path":
+            if index + 1 >= len(fd_args):
+                return ("__guard_missing_fd_search_path__",)
+            search_paths.append(fd_args[index + 1])
+            skip_next = True
+            continue
+        if arg.startswith("--search-path="):
+            search_paths.append(arg.split("=", 1)[1])
             continue
         if arg in _CODEX_FD_OPTION_VALUE_FLAGS:
             skip_next = True
@@ -7146,6 +7157,8 @@ def _codex_fd_targets(args: list[str]) -> tuple[str, ...]:
         if arg.startswith("-"):
             continue
         positional.append(arg)
+    if search_paths:
+        return tuple(search_paths)
     if len(positional) >= 2:
         return tuple(positional[1:])
     return ()

--- a/src/codex_plugin_scanner/guard/runtime/false_positive_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/false_positive_rules.py
@@ -102,6 +102,7 @@ def target_is_known_skill_doc_path(target: str, *, home_dir: Path | None = None)
             return True
     return False
 
+
 _FIND_MUTATING_FLAGS = re.compile(
     r"(?:^|[\s])-(?:delete|exec\s+rm|exec\s+unlink|exec\s+shred|execdir\s+rm)\b"
     r"|(?:^|[\s])-exec\s+\S+[^\r\n;&|]{0,100}\{.*\}\s*(?:\\;|;|\+)",

--- a/src/codex_plugin_scanner/guard/runtime/false_positive_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/false_positive_rules.py
@@ -115,7 +115,10 @@ def target_is_known_skill_doc_path(target: str, *, home_dir: Path | None = None)
     """Return true for known local skill-doc roots without resolving user path text."""
     if any(marker in target for marker in ("$", "`", "<", ">", "|", ";", "&")):
         return False
-    expanded = os.path.expanduser(target)
+    if target == "~" or target.startswith("~/"):
+        expanded = f"{home_dir or Path.home()}{target[1:]}"
+    else:
+        expanded = os.path.expanduser(target)
     normalized = os.path.normpath(expanded).replace("\\", "/")
     home = os.path.normpath(str(home_dir or Path.home())).replace("\\", "/")
     for suffix in KNOWN_SKILL_DOC_ROOT_SUFFIXES:

--- a/src/codex_plugin_scanner/guard/runtime/false_positive_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/false_positive_rules.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import os
 import re
 import shlex
 from collections.abc import Sequence
 from dataclasses import dataclass
+from pathlib import Path
 
 _SOURCE_SEARCH_TOOLS = frozenset(
     {
@@ -67,6 +69,11 @@ SOURCE_INSPECTION_SENSITIVE_PARTS = frozenset(
     {".aws", ".docker", ".env", ".git-credentials", ".kube", ".netrc", ".npmrc", ".pypirc", ".ssh", "credentials"}
 )
 SOURCE_INSPECTION_BENIGN_DOTFILES = frozenset({".nvmrc"})
+KNOWN_SKILL_DOC_ROOT_SUFFIXES = (
+    ".codex/superpowers/skills",
+    ".codex/skills",
+    ".agents/skills",
+)
 
 _SECRET_FILE_NAMES = re.compile(
     r"(?<![A-Za-z0-9_.-])"
@@ -80,6 +87,20 @@ _PIPE_TO_EXFIL = re.compile(
     r"[|;]\s*(?:curl|wget|nc|ncat|netcat|scp|rsync|aws\s+s3|gsutil|gcloud)\b",
     re.IGNORECASE,
 )
+
+
+def target_is_known_skill_doc_path(target: str, *, home_dir: Path | None = None) -> bool:
+    """Return true for known local skill-doc roots without resolving user path text."""
+    if any(marker in target for marker in ("$", "`", "<", ">", "|", ";", "&")):
+        return False
+    expanded = os.path.expanduser(target)
+    normalized = os.path.normpath(expanded).replace("\\", "/")
+    home = os.path.normpath(str(home_dir or Path.home())).replace("\\", "/")
+    for suffix in KNOWN_SKILL_DOC_ROOT_SUFFIXES:
+        root = f"{home}/{suffix}"
+        if normalized == root or normalized.startswith(f"{root}/"):
+            return True
+    return False
 
 _FIND_MUTATING_FLAGS = re.compile(
     r"(?:^|[\s])-(?:delete|exec\s+rm|exec\s+unlink|exec\s+shred|execdir\s+rm)\b"

--- a/src/codex_plugin_scanner/guard/runtime/false_positive_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/false_positive_rules.py
@@ -74,6 +74,28 @@ KNOWN_SKILL_DOC_ROOT_SUFFIXES = (
     ".codex/skills",
     ".agents/skills",
 )
+FD_OPTION_VALUE_FLAGS = frozenset(
+    {
+        "-d",
+        "--max-depth",
+        "-E",
+        "--exclude",
+        "-e",
+        "--extension",
+        "-t",
+        "--type",
+        "-S",
+        "--size",
+        "-o",
+        "--owner",
+        "--changed-before",
+        "--changed-within",
+        "--changed-after",
+        "-j",
+        "--threads",
+        "--path-separator",
+    }
+)
 
 _SECRET_FILE_NAMES = re.compile(
     r"(?<![A-Za-z0-9_.-])"
@@ -115,6 +137,42 @@ def split_fd_args_and_exec(args: list[str]) -> tuple[list[str], list[str]] | Non
 def fd_exec_token_is_plain_sed(token: str) -> bool:
     shell_markers = ("/", "\\", ";", "&", "|", "<", ">", "`", "$")
     return Path(token).name == "sed" and not any(marker in token for marker in shell_markers)
+
+
+def fd_search_targets(args: list[str]) -> tuple[str, ...] | None:
+    parsed = split_fd_args_and_exec(args)
+    fd_args = parsed[0] if parsed is not None else args
+    positional: list[str] = []
+    search_paths: list[str] = []
+    skip_next = False
+    for index, arg in enumerate(fd_args):
+        if skip_next:
+            skip_next = False
+            continue
+        if arg == "--base-directory" or arg.startswith("--base-directory="):
+            return None
+        if arg == "--search-path":
+            if index + 1 >= len(fd_args):
+                return None
+            search_paths.append(fd_args[index + 1])
+            skip_next = True
+            continue
+        if arg.startswith("--search-path="):
+            search_paths.append(arg.split("=", 1)[1])
+            continue
+        if arg in FD_OPTION_VALUE_FLAGS:
+            skip_next = True
+            continue
+        if any(arg.startswith(f"{flag}=") for flag in FD_OPTION_VALUE_FLAGS if flag.startswith("--")):
+            continue
+        if arg.startswith("-"):
+            continue
+        positional.append(arg)
+    if search_paths:
+        return tuple(search_paths)
+    if len(positional) >= 2:
+        return tuple(positional[1:])
+    return ()
 
 
 _FIND_MUTATING_FLAGS = re.compile(

--- a/src/codex_plugin_scanner/guard/runtime/false_positive_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/false_positive_rules.py
@@ -119,14 +119,42 @@ def target_is_known_skill_doc_path(target: str, *, home_dir: Path | None = None)
         expanded = f"{home_dir or Path.home()}{target[1:]}"
     else:
         expanded = os.path.expanduser(target)
-    try:
-        normalized = Path(expanded).resolve(strict=False).as_posix()
-        home = Path(home_dir or Path.home()).resolve(strict=False).as_posix()
-    except RuntimeError:
-        return False
+    normalized = os.path.normpath(expanded).replace("\\", "/")
+    home = os.path.normpath(str(home_dir or Path.home())).replace("\\", "/")
     for suffix in KNOWN_SKILL_DOC_ROOT_SUFFIXES:
         root = f"{home}/{suffix}"
-        if normalized == root or normalized.startswith(f"{root}/"):
+        if (normalized == root or normalized.startswith(f"{root}/")) and not _path_has_symlink_component(
+            normalized,
+            root=root,
+        ):
+            return True
+    return False
+
+
+def _path_has_symlink_component(normalized_target: str, *, root: str) -> bool:
+    if normalized_target == root:
+        return os.path.islink(root)
+    relative = normalized_target.removeprefix(f"{root}/")
+    current = root
+    for part in relative.split("/"):
+        if not part:
+            return True
+        current = f"{current}/{part}"
+        if os.path.islink(current):
+            return True
+    return False
+
+
+def fd_arg_requests_exec(arg: str) -> bool:
+    if arg in {"-x", "-X", "--exec", "--exec-batch"} or arg.startswith(("-x", "-X", "--exec=", "--exec-batch=")):
+        return True
+    if not arg.startswith("-") or arg.startswith("--"):
+        return False
+    cluster = arg[1:]
+    for flag in cluster:
+        if flag in {"d", "E", "e", "j", "o", "S", "t"}:
+            return False
+        if flag in {"x", "X"}:
             return True
     return False
 
@@ -144,13 +172,15 @@ def split_fd_args_and_exec(args: list[str]) -> tuple[list[str], list[str]] | Non
             return args[:index], [exec_token, *args[index + 1 :]]
         if arg.startswith("-") and not arg.startswith("--"):
             cluster = arg[1:]
-            if "X" in cluster:
-                return None
-            exec_flag_index = cluster.find("x")
-            if exec_flag_index != -1:
-                exec_token = cluster[exec_flag_index + 1 :]
-                exec_parts = ([exec_token] if exec_token else []) + args[index + 1 :]
-                return args[:index], exec_parts
+            for flag_index, flag in enumerate(cluster):
+                if flag in {"d", "E", "e", "j", "o", "S", "t"}:
+                    break
+                if flag == "X":
+                    return None
+                if flag == "x":
+                    exec_token = cluster[flag_index + 1 :]
+                    exec_parts = ([exec_token] if exec_token else []) + args[index + 1 :]
+                    return args[:index], exec_parts
     return None
 
 

--- a/src/codex_plugin_scanner/guard/runtime/false_positive_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/false_positive_rules.py
@@ -119,8 +119,11 @@ def target_is_known_skill_doc_path(target: str, *, home_dir: Path | None = None)
         expanded = f"{home_dir or Path.home()}{target[1:]}"
     else:
         expanded = os.path.expanduser(target)
-    normalized = os.path.normpath(expanded).replace("\\", "/")
-    home = os.path.normpath(str(home_dir or Path.home())).replace("\\", "/")
+    try:
+        normalized = Path(expanded).resolve(strict=False).as_posix()
+        home = Path(home_dir or Path.home()).resolve(strict=False).as_posix()
+    except RuntimeError:
+        return False
     for suffix in KNOWN_SKILL_DOC_ROOT_SUFFIXES:
         root = f"{home}/{suffix}"
         if normalized == root or normalized.startswith(f"{root}/"):
@@ -139,6 +142,15 @@ def split_fd_args_and_exec(args: list[str]) -> tuple[list[str], list[str]] | Non
             if not exec_token:
                 return None
             return args[:index], [exec_token, *args[index + 1 :]]
+        if arg.startswith("-") and not arg.startswith("--"):
+            cluster = arg[1:]
+            if "X" in cluster:
+                return None
+            exec_flag_index = cluster.find("x")
+            if exec_flag_index != -1:
+                exec_token = cluster[exec_flag_index + 1 :]
+                exec_parts = ([exec_token] if exec_token else []) + args[index + 1 :]
+                return args[:index], exec_parts
     return None
 
 

--- a/src/codex_plugin_scanner/guard/runtime/false_positive_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/false_positive_rules.py
@@ -103,6 +103,20 @@ def target_is_known_skill_doc_path(target: str, *, home_dir: Path | None = None)
     return False
 
 
+def split_fd_args_and_exec(args: list[str]) -> tuple[list[str], list[str]] | None:
+    for index, arg in enumerate(args):
+        if arg in {"-X", "--exec-batch"} or arg.startswith(("--exec=", "--exec-batch=")):
+            return None
+        if arg in {"-x", "--exec"}:
+            return args[:index], args[index + 1 :]
+    return None
+
+
+def fd_exec_token_is_plain_sed(token: str) -> bool:
+    shell_markers = ("/", "\\", ";", "&", "|", "<", ">", "`", "$")
+    return Path(token).name == "sed" and not any(marker in token for marker in shell_markers)
+
+
 _FIND_MUTATING_FLAGS = re.compile(
     r"(?:^|[\s])-(?:delete|exec\s+rm|exec\s+unlink|exec\s+shred|execdir\s+rm)\b"
     r"|(?:^|[\s])-exec\s+\S+[^\r\n;&|]{0,100}\{.*\}\s*(?:\\;|;|\+)",

--- a/src/codex_plugin_scanner/guard/runtime/false_positive_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/false_positive_rules.py
@@ -127,10 +127,15 @@ def target_is_known_skill_doc_path(target: str, *, home_dir: Path | None = None)
 
 def split_fd_args_and_exec(args: list[str]) -> tuple[list[str], list[str]] | None:
     for index, arg in enumerate(args):
-        if arg in {"-X", "--exec-batch"} or arg.startswith(("--exec=", "--exec-batch=")):
+        if arg == "-X" or arg.startswith("-X") or arg == "--exec-batch" or arg.startswith(("--exec=", "--exec-batch=")):
             return None
         if arg in {"-x", "--exec"}:
             return args[:index], args[index + 1 :]
+        if arg.startswith("-x"):
+            exec_token = arg[2:]
+            if not exec_token:
+                return None
+            return args[:index], [exec_token, *args[index + 1 :]]
     return None
 
 

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -23,6 +23,7 @@ from .false_positive_rules import (
     SOURCE_INSPECTION_PARTS,
     SOURCE_INSPECTION_SENSITIVE_PARTS,
     fd_exec_token_is_plain_sed,
+    fd_search_targets,
     split_fd_args_and_exec,
     target_is_known_skill_doc_path,
 )
@@ -3979,7 +3980,7 @@ def _read_only_lookup_fd_args_are_safe(args: list[str]) -> bool:
         arg in {"-x", "-X", "--exec", "--exec-batch"} or arg.startswith(("--exec=", "--exec-batch=")) for arg in args
     ):
         return _fd_exec_sed_read_only_args_are_safe(args)
-    targets = _fd_search_targets(args)
+    targets = fd_search_targets(args)
     if targets is None:
         return False
     if not targets:
@@ -4001,60 +4002,6 @@ def _fd_exec_sed_read_only_args_are_safe(args: list[str]) -> bool:
         sed_args,
         require_target=False,
     )
-
-
-def _fd_search_targets(args: list[str]) -> list[str] | None:
-    positional: list[str] = []
-    search_paths: list[str] = []
-    skip_next = False
-    option_value_flags = {
-        "-d",
-        "--max-depth",
-        "-E",
-        "--exclude",
-        "-e",
-        "--extension",
-        "-t",
-        "--type",
-        "-S",
-        "--size",
-        "-o",
-        "--owner",
-        "--changed-before",
-        "--changed-within",
-        "--changed-after",
-        "-j",
-        "--threads",
-        "--path-separator",
-    }
-    for index, arg in enumerate(args):
-        if skip_next:
-            skip_next = False
-            continue
-        if arg in {"--base-directory"} or arg.startswith("--base-directory="):
-            return None
-        if arg == "--search-path":
-            if index + 1 >= len(args):
-                return None
-            search_paths.append(args[index + 1])
-            skip_next = True
-            continue
-        if arg.startswith("--search-path="):
-            search_paths.append(arg.split("=", 1)[1])
-            continue
-        if arg in option_value_flags:
-            skip_next = True
-            continue
-        if any(arg.startswith(f"{flag}=") for flag in option_value_flags if flag.startswith("--")):
-            continue
-        if arg.startswith("-"):
-            continue
-        positional.append(arg)
-    if search_paths:
-        return search_paths
-    if len(positional) >= 2:
-        return positional[1:]
-    return []
 
 
 def _read_only_lookup_find_args_are_safe(args: list[str]) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -791,7 +791,7 @@ def _destructive_shell_tool_action_request(
                 "`--body-file` for PR descriptions."
             ),
         )
-    if not _looks_destructive_shell_command(command_text, cwd=cwd):
+    if not _looks_destructive_shell_command(command_text, cwd=cwd, home_dir=home_dir):
         return None
     return ToolActionRequestMatch(
         tool_name=tool_name,
@@ -2999,7 +2999,7 @@ def _decoded_payload_looks_sensitive(
     visited_script_paths: frozenset[str],
 ) -> bool:
     lowered = payload.lower()
-    if _looks_destructive_shell_command(payload, cwd=cwd):
+    if _looks_destructive_shell_command(payload, cwd=cwd, home_dir=home_dir):
         return True
     if any(token in lowered for token in _SENSITIVE_DECODED_PAYLOAD_TOKENS):
         return True
@@ -3711,12 +3711,17 @@ def _docker_config_path_from_command(
     return match.normalized_path
 
 
-def _looks_destructive_shell_command(command_text: str, *, cwd: Path | None = None) -> bool:
+def _looks_destructive_shell_command(
+    command_text: str,
+    *,
+    cwd: Path | None = None,
+    home_dir: Path | None = None,
+) -> bool:
     normalized = command_text.strip()
     if not normalized:
         return False
     for substitution_payload in _shell_command_substitution_payloads(normalized):
-        if _looks_destructive_shell_command(substitution_payload, cwd=cwd):
+        if _looks_destructive_shell_command(substitution_payload, cwd=cwd, home_dir=home_dir):
             return True
     node_heredoc_script = _single_node_heredoc_script(normalized)
     if node_heredoc_script is not None:
@@ -3742,7 +3747,7 @@ def _looks_destructive_shell_command(command_text: str, *, cwd: Path | None = No
         return True
     if _contains_unsafe_pytest_environment_wrapper(parts, cwd=cwd):
         return True
-    if _looks_like_safe_read_only_lookup_command(normalized, parts):
+    if _looks_like_safe_read_only_lookup_command(normalized, parts, home_dir=home_dir):
         return False
     raw_command_names = list(_shell_command_names(redacted_command_text))
     parsed_command_names = list(_shell_command_names_from_parts(parts))
@@ -3764,7 +3769,7 @@ def _looks_destructive_shell_command(command_text: str, *, cwd: Path | None = No
         return True
     if _contains_destructive_git_command(parts):
         return True
-    if _find_or_fd_uses_write_or_exec_action(parts):
+    if _find_or_fd_uses_write_or_exec_action(parts, home_dir=home_dir):
         return True
     command_names = list(raw_command_names)
     command_names.extend(_shell_command_names_from_parts(parts))
@@ -3773,10 +3778,10 @@ def _looks_destructive_shell_command(command_text: str, *, cwd: Path | None = No
     if _find_command_uses_delete(parts):
         return True
     for env_split_string in _env_split_string_payloads(parts):
-        if _looks_destructive_shell_command(env_split_string, cwd=cwd):
+        if _looks_destructive_shell_command(env_split_string, cwd=cwd, home_dir=home_dir):
             return True
     for shell_script in _shell_command_scripts(parts):
-        if _looks_destructive_shell_command(shell_script, cwd=cwd):
+        if _looks_destructive_shell_command(shell_script, cwd=cwd, home_dir=home_dir):
             return True
     return any(
         command_name == "sed" and any(part == "-i" or part.startswith("-i") for part in parts[1:])
@@ -3784,7 +3789,12 @@ def _looks_destructive_shell_command(command_text: str, *, cwd: Path | None = No
     )
 
 
-def _looks_like_safe_read_only_lookup_command(command_text: str, parts: list[str]) -> bool:
+def _looks_like_safe_read_only_lookup_command(
+    command_text: str,
+    parts: list[str],
+    *,
+    home_dir: Path | None,
+) -> bool:
     if "$(" in command_text or "`" in command_text or "<(" in command_text or ">(" in command_text:
         return False
     if any(token in parts for token in {";", "&", "||", "|&"}):
@@ -3803,7 +3813,7 @@ def _looks_like_safe_read_only_lookup_command(command_text: str, parts: list[str
         if index == 0:
             if command not in _READ_ONLY_LOOKUP_COMMANDS:
                 return False
-            if not _read_only_lookup_primary_segment_is_safe(command, segment[1:]):
+            if not _read_only_lookup_primary_segment_is_safe(command, segment[1:], home_dir=home_dir):
                 return False
         elif not _read_only_lookup_filter_segment_is_safe(command, segment[1:]):
             return False
@@ -3835,21 +3845,21 @@ def _read_only_lookup_token_is_safe_stderr_discard(token: str) -> bool:
     return not prefix and fd == "2" and _normalized_redirect_target(target).lower() in _SAFE_SHELL_REDIRECT_TARGETS
 
 
-def _read_only_lookup_primary_segment_is_safe(command: str, args: list[str]) -> bool:
+def _read_only_lookup_primary_segment_is_safe(command: str, args: list[str], *, home_dir: Path | None) -> bool:
     if command == "sed":
-        return _read_only_lookup_sed_args_are_safe(args, require_target=True)
+        return _read_only_lookup_sed_args_are_safe(args, require_target=True, home_dir=home_dir)
     if command in {"head", "tail"}:
-        return _read_only_lookup_head_tail_args_are_safe(args, require_target=True)
+        return _read_only_lookup_head_tail_args_are_safe(args, require_target=True, home_dir=home_dir)
     if command == "cat":
-        return _read_only_lookup_plain_targets_are_safe(args, allow_dirs=False)
+        return _read_only_lookup_plain_targets_are_safe(args, allow_dirs=False, home_dir=home_dir)
     if command == "ls":
-        return _read_only_lookup_ls_args_are_safe(args)
+        return _read_only_lookup_ls_args_are_safe(args, home_dir=home_dir)
     if command in {"grep", "egrep", "fgrep", "rg"}:
-        return _read_only_lookup_search_args_are_safe(args)
+        return _read_only_lookup_search_args_are_safe(args, home_dir=home_dir)
     if command == "fd":
-        return _read_only_lookup_fd_args_are_safe(args)
+        return _read_only_lookup_fd_args_are_safe(args, home_dir=home_dir)
     if command == "find":
-        return _read_only_lookup_find_args_are_safe(args)
+        return _read_only_lookup_find_args_are_safe(args, home_dir=home_dir)
     return False
 
 
@@ -3863,7 +3873,12 @@ def _read_only_lookup_filter_segment_is_safe(command: str, args: list[str]) -> b
     return False
 
 
-def _read_only_lookup_sed_args_are_safe(args: list[str], *, require_target: bool) -> bool:
+def _read_only_lookup_sed_args_are_safe(
+    args: list[str],
+    *,
+    require_target: bool,
+    home_dir: Path | None = None,
+) -> bool:
     scripts: list[str] = []
     targets: list[str] = []
     saw_print_suppression = False
@@ -3905,7 +3920,9 @@ def _read_only_lookup_sed_args_are_safe(args: list[str], *, require_target: bool
     if not all(_read_only_lookup_sed_script_is_print_only(script) for script in scripts):
         return False
     if require_target:
-        return bool(targets) and all(_read_only_lookup_target_is_safe(target, allow_dirs=False) for target in targets)
+        return bool(targets) and all(
+            _read_only_lookup_target_is_safe(target, allow_dirs=False, home_dir=home_dir) for target in targets
+        )
     return not targets
 
 
@@ -3913,7 +3930,12 @@ def _read_only_lookup_sed_script_is_print_only(script: str) -> bool:
     return sed_script_is_bounded_print(script)
 
 
-def _read_only_lookup_head_tail_args_are_safe(args: list[str], *, require_target: bool) -> bool:
+def _read_only_lookup_head_tail_args_are_safe(
+    args: list[str],
+    *,
+    require_target: bool,
+    home_dir: Path | None = None,
+) -> bool:
     targets: list[str] = []
     skip_count = False
     after_options = False
@@ -3944,11 +3966,18 @@ def _read_only_lookup_head_tail_args_are_safe(args: list[str], *, require_target
     if skip_count:
         return False
     if require_target:
-        return bool(targets) and all(_read_only_lookup_target_is_safe(target, allow_dirs=False) for target in targets)
+        return bool(targets) and all(
+            _read_only_lookup_target_is_safe(target, allow_dirs=False, home_dir=home_dir) for target in targets
+        )
     return not targets
 
 
-def _read_only_lookup_plain_targets_are_safe(args: list[str], *, allow_dirs: bool) -> bool:
+def _read_only_lookup_plain_targets_are_safe(
+    args: list[str],
+    *,
+    allow_dirs: bool,
+    home_dir: Path | None = None,
+) -> bool:
     targets: list[str] = []
     after_options = False
     for arg in args:
@@ -3963,33 +3992,35 @@ def _read_only_lookup_plain_targets_are_safe(args: list[str], *, allow_dirs: boo
         if arg.startswith("-"):
             continue
         targets.append(arg)
-    return all(_read_only_lookup_target_is_safe(target, allow_dirs=allow_dirs) for target in targets)
+    return all(_read_only_lookup_target_is_safe(target, allow_dirs=allow_dirs, home_dir=home_dir) for target in targets)
 
 
-def _read_only_lookup_ls_args_are_safe(args: list[str]) -> bool:
-    return _read_only_lookup_plain_targets_are_safe(args, allow_dirs=True)
+def _read_only_lookup_ls_args_are_safe(args: list[str], *, home_dir: Path | None = None) -> bool:
+    return _read_only_lookup_plain_targets_are_safe(args, allow_dirs=True, home_dir=home_dir)
 
 
-def _read_only_lookup_search_args_are_safe(args: list[str]) -> bool:
+def _read_only_lookup_search_args_are_safe(args: list[str], *, home_dir: Path | None = None) -> bool:
     targets = [arg for arg in args if arg and not arg.startswith("-")]
-    return len(targets) < 2 or all(_read_only_lookup_target_is_safe(target, allow_dirs=True) for target in targets[1:])
+    return len(targets) < 2 or all(
+        _read_only_lookup_target_is_safe(target, allow_dirs=True, home_dir=home_dir) for target in targets[1:]
+    )
 
 
-def _read_only_lookup_fd_args_are_safe(args: list[str]) -> bool:
+def _read_only_lookup_fd_args_are_safe(args: list[str], *, home_dir: Path | None = None) -> bool:
     if any(
         arg in {"-x", "-X", "--exec", "--exec-batch"} or arg.startswith(("-x", "-X", "--exec=", "--exec-batch="))
         for arg in args
     ):
-        return _fd_exec_sed_read_only_args_are_safe(args)
+        return _fd_exec_sed_read_only_args_are_safe(args, home_dir=home_dir)
     targets = fd_search_targets(args)
     if targets is None:
         return False
     if not targets:
         return True
-    return all(_read_only_lookup_target_is_safe(target, allow_dirs=True) for target in targets)
+    return all(_read_only_lookup_target_is_safe(target, allow_dirs=True, home_dir=home_dir) for target in targets)
 
 
-def _fd_exec_sed_read_only_args_are_safe(args: list[str]) -> bool:
+def _fd_exec_sed_read_only_args_are_safe(args: list[str], *, home_dir: Path | None = None) -> bool:
     parsed = split_fd_args_and_exec(args)
     if parsed is None:
         return False
@@ -3999,13 +4030,14 @@ def _fd_exec_sed_read_only_args_are_safe(args: list[str]) -> bool:
     if exec_parts.count("{}") != 1:
         return False
     sed_args = [arg for arg in exec_parts[1:] if arg != "{}"]
-    return _read_only_lookup_fd_args_are_safe(fd_args) and _read_only_lookup_sed_args_are_safe(
+    return _read_only_lookup_fd_args_are_safe(fd_args, home_dir=home_dir) and _read_only_lookup_sed_args_are_safe(
         sed_args,
         require_target=False,
+        home_dir=home_dir,
     )
 
 
-def _read_only_lookup_find_args_are_safe(args: list[str]) -> bool:
+def _read_only_lookup_find_args_are_safe(args: list[str], *, home_dir: Path | None = None) -> bool:
     if any(_read_only_lookup_arg_is_redirection(arg) for arg in args):
         return False
     if _find_args_use_write_or_unsafe_exec_action(args):
@@ -4013,7 +4045,7 @@ def _read_only_lookup_find_args_are_safe(args: list[str]) -> bool:
     targets = [arg for arg in args if arg and not arg.startswith("-")]
     if not targets:
         return False
-    return _read_only_lookup_target_is_safe(targets[0], allow_dirs=True)
+    return _read_only_lookup_target_is_safe(targets[0], allow_dirs=True, home_dir=home_dir)
 
 
 def _read_only_lookup_filter_grep_args_are_safe(args: list[str]) -> bool:
@@ -4030,7 +4062,7 @@ def _read_only_lookup_arg_is_redirection(arg: str) -> bool:
     return _split_attached_redirection_token(arg) is not None
 
 
-def _read_only_lookup_target_is_safe(target: str, *, allow_dirs: bool) -> bool:
+def _read_only_lookup_target_is_safe(target: str, *, allow_dirs: bool, home_dir: Path | None = None) -> bool:
     stripped = target.strip().strip("'\"")
     if stripped in {"", "."}:
         return allow_dirs
@@ -4043,7 +4075,7 @@ def _read_only_lookup_target_is_safe(target: str, *, allow_dirs: bool) -> bool:
     lowered_parts = [part.lower() for part in parts]
     if not parts:
         return allow_dirs
-    if target_is_known_skill_doc_path(stripped):
+    if target_is_known_skill_doc_path(stripped, home_dir=home_dir):
         return True
     if any(part in SOURCE_INSPECTION_SENSITIVE_PARTS for part in lowered_parts):
         return False
@@ -4230,7 +4262,7 @@ def _contains_destructive_node_inline_eval(parts: list[str]) -> bool:
     return False
 
 
-def _find_or_fd_uses_write_or_exec_action(parts: list[str]) -> bool:
+def _find_or_fd_uses_write_or_exec_action(parts: list[str], *, home_dir: Path | None = None) -> bool:
     for segment in _iter_shell_command_segments(parts):
         command_name, command_index = _shell_segment_primary_command(segment)
         if (
@@ -4247,7 +4279,7 @@ def _find_or_fd_uses_write_or_exec_action(parts: list[str]) -> bool:
                 or arg.startswith(("-x", "-X", "--exec=", "--exec-batch="))
                 for arg in segment[command_index + 1 :]
             )
-            and not _fd_exec_sed_read_only_args_are_safe(segment[command_index + 1 :])
+            and not _fd_exec_sed_read_only_args_are_safe(segment[command_index + 1 :], home_dir=home_dir)
         ):
             return True
     return False

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -22,6 +22,7 @@ from .false_positive_rules import (
     SOURCE_INSPECTION_EXTENSIONS,
     SOURCE_INSPECTION_PARTS,
     SOURCE_INSPECTION_SENSITIVE_PARTS,
+    fd_arg_requests_exec,
     fd_exec_token_is_plain_sed,
     fd_search_targets,
     split_fd_args_and_exec,
@@ -4007,12 +4008,7 @@ def _read_only_lookup_search_args_are_safe(args: list[str], *, home_dir: Path | 
 
 
 def _read_only_lookup_fd_args_are_safe(args: list[str], *, home_dir: Path | None = None) -> bool:
-    if any(
-        arg in {"-x", "-X", "--exec", "--exec-batch"}
-        or arg.startswith(("-x", "-X", "--exec=", "--exec-batch="))
-        or (arg.startswith("-") and not arg.startswith("--") and ("x" in arg[1:] or "X" in arg[1:]))
-        for arg in args
-    ):
+    if any(fd_arg_requests_exec(arg) for arg in args):
         return _fd_exec_sed_read_only_args_are_safe(args, home_dir=home_dir)
     targets = fd_search_targets(args)
     if targets is None:
@@ -4281,12 +4277,7 @@ def _find_or_fd_uses_write_or_exec_action(parts: list[str], *, home_dir: Path | 
         if (
             command_name == "fd"
             and command_index is not None
-            and any(
-                arg in {"-x", "-X", "--exec", "--exec-batch"}
-                or arg.startswith(("-x", "-X", "--exec=", "--exec-batch="))
-                or (arg.startswith("-") and not arg.startswith("--") and ("x" in arg[1:] or "X" in arg[1:]))
-                for arg in segment[command_index + 1 :]
-            )
+            and any(fd_arg_requests_exec(arg) for arg in segment[command_index + 1 :])
             and not _fd_exec_sed_read_only_args_are_safe(segment[command_index + 1 :], home_dir=home_dir)
         ):
             return True

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -22,6 +22,8 @@ from .false_positive_rules import (
     SOURCE_INSPECTION_EXTENSIONS,
     SOURCE_INSPECTION_PARTS,
     SOURCE_INSPECTION_SENSITIVE_PARTS,
+    fd_exec_token_is_plain_sed,
+    split_fd_args_and_exec,
     target_is_known_skill_doc_path,
 )
 from .secret_sensitivity import SecretPathMatch as SensitivePathMatch
@@ -3986,11 +3988,11 @@ def _read_only_lookup_fd_args_are_safe(args: list[str]) -> bool:
 
 
 def _fd_exec_sed_read_only_args_are_safe(args: list[str]) -> bool:
-    parsed = _split_fd_args_and_exec(args)
+    parsed = split_fd_args_and_exec(args)
     if parsed is None:
         return False
     fd_args, exec_parts = parsed
-    if not exec_parts or Path(exec_parts[0]).name != "sed" or "/" in exec_parts[0] or "\\" in exec_parts[0]:
+    if not exec_parts or not fd_exec_token_is_plain_sed(exec_parts[0]):
         return False
     if exec_parts.count("{}") != 1:
         return False
@@ -3999,15 +4001,6 @@ def _fd_exec_sed_read_only_args_are_safe(args: list[str]) -> bool:
         sed_args,
         require_target=False,
     )
-
-
-def _split_fd_args_and_exec(args: list[str]) -> tuple[list[str], list[str]] | None:
-    for index, arg in enumerate(args):
-        if arg in {"-X", "--exec-batch"} or arg.startswith(("--exec=", "--exec-batch=")):
-            return None
-        if arg in {"-x", "--exec"}:
-            return args[:index], args[index + 1 :]
-    return None
 
 
 def _fd_search_targets(args: list[str]) -> list[str] | None:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -22,6 +22,7 @@ from .false_positive_rules import (
     SOURCE_INSPECTION_EXTENSIONS,
     SOURCE_INSPECTION_PARTS,
     SOURCE_INSPECTION_SENSITIVE_PARTS,
+    target_is_known_skill_doc_path,
 )
 from .secret_sensitivity import SecretPathMatch as SensitivePathMatch
 from .secret_sensitivity import classify_secret_path
@@ -4045,7 +4046,7 @@ def _read_only_lookup_target_is_safe(target: str, *, allow_dirs: bool) -> bool:
     lowered_parts = [part.lower() for part in parts]
     if not parts:
         return allow_dirs
-    if _read_only_lookup_target_is_known_skill_doc_path(stripped):
+    if target_is_known_skill_doc_path(stripped):
         return True
     if any(part in SOURCE_INSPECTION_SENSITIVE_PARTS for part in lowered_parts):
         return False
@@ -4057,25 +4058,6 @@ def _read_only_lookup_target_is_safe(target: str, *, allow_dirs: bool) -> bool:
     if Path(normalized).suffix.lower() in SOURCE_INSPECTION_EXTENSIONS:
         return True
     return allow_dirs
-
-
-def _read_only_lookup_target_is_known_skill_doc_path(target: str) -> bool:
-    if any(marker in target for marker in ("$", "`", "<", ">", "|", ";", "&")):
-        return False
-    expanded = Path(os.path.expanduser(target)).resolve(strict=False)
-    home = Path.home().resolve(strict=False)
-    allowed_roots = (
-        home / ".codex" / "superpowers" / "skills",
-        home / ".codex" / "skills",
-        home / ".agents" / "skills",
-    )
-    for root in allowed_roots:
-        try:
-            expanded.relative_to(root.resolve(strict=False))
-        except ValueError:
-            continue
-        return True
-    return False
 
 
 def _read_only_lookup_target_is_path_like(value: str) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -3975,11 +3975,36 @@ def _read_only_lookup_fd_args_are_safe(args: list[str]) -> bool:
     if any(
         arg in {"-x", "-X", "--exec", "--exec-batch"} or arg.startswith(("--exec=", "--exec-batch=")) for arg in args
     ):
-        return False
+        return _fd_exec_sed_read_only_args_are_safe(args)
     targets = [arg for arg in args if arg and not arg.startswith("-")]
     if not targets:
         return True
     return all(_read_only_lookup_target_is_safe(target, allow_dirs=True) for target in targets[1:])
+
+
+def _fd_exec_sed_read_only_args_are_safe(args: list[str]) -> bool:
+    parsed = _split_fd_args_and_exec(args)
+    if parsed is None:
+        return False
+    fd_args, exec_parts = parsed
+    if not exec_parts or Path(exec_parts[0]).name != "sed" or "/" in exec_parts[0] or "\\" in exec_parts[0]:
+        return False
+    if exec_parts.count("{}") != 1:
+        return False
+    sed_args = [arg for arg in exec_parts[1:] if arg != "{}"]
+    return _read_only_lookup_fd_args_are_safe(fd_args) and _read_only_lookup_sed_args_are_safe(
+        sed_args,
+        require_target=False,
+    )
+
+
+def _split_fd_args_and_exec(args: list[str]) -> tuple[list[str], list[str]] | None:
+    for index, arg in enumerate(args):
+        if arg in {"-X", "--exec-batch"} or arg.startswith(("--exec=", "--exec-batch=")):
+            return None
+        if arg in {"-x", "--exec"}:
+            return args[:index], args[index + 1 :]
+    return None
 
 
 def _read_only_lookup_find_args_are_safe(args: list[str]) -> bool:
@@ -4020,6 +4045,8 @@ def _read_only_lookup_target_is_safe(target: str, *, allow_dirs: bool) -> bool:
     lowered_parts = [part.lower() for part in parts]
     if not parts:
         return allow_dirs
+    if _read_only_lookup_target_is_known_skill_doc_path(stripped):
+        return True
     if any(part in SOURCE_INSPECTION_SENSITIVE_PARTS for part in lowered_parts):
         return False
     hidden_parts = [part for part in lowered_parts if part.startswith(".")]
@@ -4030,6 +4057,25 @@ def _read_only_lookup_target_is_safe(target: str, *, allow_dirs: bool) -> bool:
     if Path(normalized).suffix.lower() in SOURCE_INSPECTION_EXTENSIONS:
         return True
     return allow_dirs
+
+
+def _read_only_lookup_target_is_known_skill_doc_path(target: str) -> bool:
+    if any(marker in target for marker in ("$", "`", "<", ">", "|", ";", "&")):
+        return False
+    expanded = Path(os.path.expanduser(target)).resolve(strict=False)
+    home = Path.home().resolve(strict=False)
+    allowed_roots = (
+        home / ".codex" / "superpowers" / "skills",
+        home / ".codex" / "skills",
+        home / ".agents" / "skills",
+    )
+    for root in allowed_roots:
+        try:
+            expanded.relative_to(root.resolve(strict=False))
+        except ValueError:
+            continue
+        return True
+    return False
 
 
 def _read_only_lookup_target_is_path_like(value: str) -> bool:
@@ -4221,6 +4267,7 @@ def _find_or_fd_uses_write_or_exec_action(parts: list[str]) -> bool:
                 arg in {"-x", "-X", "--exec", "--exec-batch"} or arg.startswith(("--exec=", "--exec-batch="))
                 for arg in segment[command_index + 1 :]
             )
+            and not _fd_exec_sed_read_only_args_are_safe(segment[command_index + 1 :])
         ):
             return True
     return False

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -3977,10 +3977,12 @@ def _read_only_lookup_fd_args_are_safe(args: list[str]) -> bool:
         arg in {"-x", "-X", "--exec", "--exec-batch"} or arg.startswith(("--exec=", "--exec-batch=")) for arg in args
     ):
         return _fd_exec_sed_read_only_args_are_safe(args)
-    targets = [arg for arg in args if arg and not arg.startswith("-")]
+    targets = _fd_search_targets(args)
+    if targets is None:
+        return False
     if not targets:
         return True
-    return all(_read_only_lookup_target_is_safe(target, allow_dirs=True) for target in targets[1:])
+    return all(_read_only_lookup_target_is_safe(target, allow_dirs=True) for target in targets)
 
 
 def _fd_exec_sed_read_only_args_are_safe(args: list[str]) -> bool:
@@ -4006,6 +4008,60 @@ def _split_fd_args_and_exec(args: list[str]) -> tuple[list[str], list[str]] | No
         if arg in {"-x", "--exec"}:
             return args[:index], args[index + 1 :]
     return None
+
+
+def _fd_search_targets(args: list[str]) -> list[str] | None:
+    positional: list[str] = []
+    search_paths: list[str] = []
+    skip_next = False
+    option_value_flags = {
+        "-d",
+        "--max-depth",
+        "-E",
+        "--exclude",
+        "-e",
+        "--extension",
+        "-t",
+        "--type",
+        "-S",
+        "--size",
+        "-o",
+        "--owner",
+        "--changed-before",
+        "--changed-within",
+        "--changed-after",
+        "-j",
+        "--threads",
+        "--path-separator",
+    }
+    for index, arg in enumerate(args):
+        if skip_next:
+            skip_next = False
+            continue
+        if arg in {"--base-directory"} or arg.startswith("--base-directory="):
+            return None
+        if arg == "--search-path":
+            if index + 1 >= len(args):
+                return None
+            search_paths.append(args[index + 1])
+            skip_next = True
+            continue
+        if arg.startswith("--search-path="):
+            search_paths.append(arg.split("=", 1)[1])
+            continue
+        if arg in option_value_flags:
+            skip_next = True
+            continue
+        if any(arg.startswith(f"{flag}=") for flag in option_value_flags if flag.startswith("--")):
+            continue
+        if arg.startswith("-"):
+            continue
+        positional.append(arg)
+    if search_paths:
+        return search_paths
+    if len(positional) >= 2:
+        return positional[1:]
+    return []
 
 
 def _read_only_lookup_find_args_are_safe(args: list[str]) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -3977,7 +3977,8 @@ def _read_only_lookup_search_args_are_safe(args: list[str]) -> bool:
 
 def _read_only_lookup_fd_args_are_safe(args: list[str]) -> bool:
     if any(
-        arg in {"-x", "-X", "--exec", "--exec-batch"} or arg.startswith(("--exec=", "--exec-batch=")) for arg in args
+        arg in {"-x", "-X", "--exec", "--exec-batch"} or arg.startswith(("-x", "-X", "--exec=", "--exec-batch="))
+        for arg in args
     ):
         return _fd_exec_sed_read_only_args_are_safe(args)
     targets = fd_search_targets(args)
@@ -4242,7 +4243,8 @@ def _find_or_fd_uses_write_or_exec_action(parts: list[str]) -> bool:
             command_name == "fd"
             and command_index is not None
             and any(
-                arg in {"-x", "-X", "--exec", "--exec-batch"} or arg.startswith(("--exec=", "--exec-batch="))
+                arg in {"-x", "-X", "--exec", "--exec-batch"}
+                or arg.startswith(("-x", "-X", "--exec=", "--exec-batch="))
                 for arg in segment[command_index + 1 :]
             )
             and not _fd_exec_sed_read_only_args_are_safe(segment[command_index + 1 :])

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -4008,7 +4008,9 @@ def _read_only_lookup_search_args_are_safe(args: list[str], *, home_dir: Path | 
 
 def _read_only_lookup_fd_args_are_safe(args: list[str], *, home_dir: Path | None = None) -> bool:
     if any(
-        arg in {"-x", "-X", "--exec", "--exec-batch"} or arg.startswith(("-x", "-X", "--exec=", "--exec-batch="))
+        arg in {"-x", "-X", "--exec", "--exec-batch"}
+        or arg.startswith(("-x", "-X", "--exec=", "--exec-batch="))
+        or (arg.startswith("-") and not arg.startswith("--") and ("x" in arg[1:] or "X" in arg[1:]))
         for arg in args
     ):
         return _fd_exec_sed_read_only_args_are_safe(args, home_dir=home_dir)
@@ -4030,7 +4032,12 @@ def _fd_exec_sed_read_only_args_are_safe(args: list[str], *, home_dir: Path | No
     if exec_parts.count("{}") != 1:
         return False
     sed_args = [arg for arg in exec_parts[1:] if arg != "{}"]
-    return _read_only_lookup_fd_args_are_safe(fd_args, home_dir=home_dir) and _read_only_lookup_sed_args_are_safe(
+    fd_targets = fd_search_targets(fd_args)
+    if fd_targets is None or not fd_targets:
+        return False
+    return all(
+        _read_only_lookup_target_is_safe(target, allow_dirs=True, home_dir=home_dir) for target in fd_targets
+    ) and _read_only_lookup_sed_args_are_safe(
         sed_args,
         require_target=False,
         home_dir=home_dir,
@@ -4277,6 +4284,7 @@ def _find_or_fd_uses_write_or_exec_action(parts: list[str], *, home_dir: Path | 
             and any(
                 arg in {"-x", "-X", "--exec", "--exec-batch"}
                 or arg.startswith(("-x", "-X", "--exec=", "--exec-batch="))
+                or (arg.startswith("-") and not arg.startswith("--") and ("x" in arg[1:] or "X" in arg[1:]))
                 for arg in segment[command_index + 1 :]
             )
             and not _fd_exec_sed_read_only_args_are_safe(segment[command_index + 1 :], home_dir=home_dir)

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -776,6 +776,44 @@ clearer UX and an implementation plan with technical references.
         assert output["policy_action"] == "require-reapproval"
         assert "destructive shell command" in output["artifact_name"]
 
+    def test_codex_pre_tool_use_blocks_fd_search_path_sensitive_dir_exec(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        command = "fd --search-path ~/.ssh 'SKILL.md' -x sed -n '1,20p' {}"
+        event = {
+            "event": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 1
+        assert output["artifact_type"] == "tool_action_request"
+        assert output["policy_action"] == "require-reapproval"
+        assert "destructive shell command" in output["artifact_name"]
+
     def test_codex_post_tool_use_allows_fd_skill_docs_bounded_sed_output(
         self,
         monkeypatch,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -852,6 +852,125 @@ clearer UX and an implementation plan with technical references.
         assert output["policy_action"] == "require-reapproval"
         assert "destructive shell command" in output["artifact_name"]
 
+    def test_codex_pre_tool_use_blocks_fd_skill_docs_clustered_shell_exec(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        command = "fd -a 'SKILL.md' ~/.codex/superpowers/skills/using-git-worktrees -d 1 -Hx sh -c 'echo blocked' {}"
+        event = {
+            "event": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 1
+        assert output["artifact_type"] == "tool_action_request"
+        assert output["policy_action"] == "require-reapproval"
+        assert "destructive shell command" in output["artifact_name"]
+
+    def test_codex_pre_tool_use_blocks_fd_implicit_root_sed_exec(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        command = "fd 'SKILL.md' -x sed -n '1,20p' {}"
+        event = {
+            "event": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 1
+        assert output["artifact_type"] == "tool_action_request"
+        assert output["policy_action"] == "require-reapproval"
+        assert "destructive shell command" in output["artifact_name"]
+
+    def test_codex_pre_tool_use_blocks_fd_skill_doc_symlink_exec(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        ssh_dir = home_dir / ".ssh"
+        ssh_dir.mkdir(parents=True)
+        symlink_target = home_dir / ".codex" / "superpowers" / "skills" / "ssh-link"
+        symlink_target.parent.mkdir(parents=True, exist_ok=True)
+        symlink_target.symlink_to(ssh_dir, target_is_directory=True)
+        command = "fd -a 'SKILL.md' ~/.codex/superpowers/skills/ssh-link -d 1 -x sed -n '1,20p' {}"
+        event = {
+            "event": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 1
+        assert output["artifact_type"] == "tool_action_request"
+        assert output["policy_action"] == "require-reapproval"
+        assert "destructive shell command" in output["artifact_name"]
+
     def test_codex_pre_tool_use_blocks_fd_search_path_sensitive_dir_exec(
         self,
         monkeypatch,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -849,6 +849,45 @@ clearer UX and an implementation plan with technical references.
         assert output["policy_action"] == "require-reapproval"
         assert "destructive shell command" in output["artifact_name"]
 
+    def test_codex_pre_tool_use_allows_fd_path_separator_skill_docs_exec(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        command = (
+            "fd --path-separator / 'SKILL.md' ~/.codex/superpowers/skills/using-git-worktrees -d 1 -x sed -n '1,20p' {}"
+        )
+        event = {
+            "event": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["recorded"] is True
+        assert "approval_requests" not in output
+
     def test_codex_post_tool_use_allows_fd_skill_docs_bounded_sed_output(
         self,
         monkeypatch,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -744,10 +744,45 @@ clearer UX and an implementation plan with technical references.
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         _build_guard_fixture(home_dir, workspace_dir)
-        command = (
-            "fd -a 'SKILL.md' ~/.codex/superpowers/skills/using-git-worktrees "
-            "-d 1 -x sed -i '1,180p' {}"
+        command = "fd -a 'SKILL.md' ~/.codex/superpowers/skills/using-git-worktrees -d 1 -x sed -i '1,180p' {}"
+        event = {
+            "event": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
         )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 1
+        assert output["artifact_type"] == "tool_action_request"
+        assert output["policy_action"] == "require-reapproval"
+        assert "destructive shell command" in output["artifact_name"]
+
+    def test_codex_pre_tool_use_blocks_fd_skill_docs_metachar_sed_exec(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        command = "fd -a 'SKILL.md' ~/.codex/superpowers/skills/using-git-worktrees -d 1 -x 'sed;rm' -n '1,180p' {}"
         event = {
             "event": "PreToolUse",
             "tool_name": "Bash",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -1048,6 +1048,43 @@ clearer UX and an implementation plan with technical references.
         assert output["recorded"] is True
         assert "approval_requests" not in output
 
+    def test_codex_pre_tool_use_allows_fd_type_shorthand_skill_docs(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        command = "fd -tx 'SKILL.md' ~/.codex/superpowers/skills/using-git-worktrees"
+        event = {
+            "event": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["recorded"] is True
+        assert "approval_requests" not in output
+
     def test_codex_post_tool_use_allows_fd_skill_docs_bounded_sed_output(
         self,
         monkeypatch,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -692,6 +692,140 @@ clearer UX and an implementation plan with technical references.
         assert output["recorded"] is True
         assert "approval_requests" not in output
 
+    def test_codex_pre_tool_use_allows_fd_skill_docs_bounded_sed_exec(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        command = (
+            "fd -a 'SKILL.md' ~/.codex/superpowers/skills/using-git-worktrees "
+            "~/.codex/superpowers/skills/test-driven-development "
+            "~/.codex/superpowers/skills/verification-before-completion "
+            "-d 1 -x sed -n '1,180p' {}"
+        )
+        event = {
+            "event": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["recorded"] is True
+        assert output["policy_action"] == "warn"
+        assert "approval_requests" not in output
+
+    def test_codex_pre_tool_use_blocks_fd_skill_docs_mutating_sed_exec(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        command = (
+            "fd -a 'SKILL.md' ~/.codex/superpowers/skills/using-git-worktrees "
+            "-d 1 -x sed -i '1,180p' {}"
+        )
+        event = {
+            "event": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 1
+        assert output["artifact_type"] == "tool_action_request"
+        assert output["policy_action"] == "require-reapproval"
+        assert "destructive shell command" in output["artifact_name"]
+
+    def test_codex_post_tool_use_allows_fd_skill_docs_bounded_sed_output(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        command = (
+            "fd -a 'SKILL.md' ~/.codex/superpowers/skills/using-git-worktrees "
+            "~/.codex/superpowers/skills/test-driven-development "
+            "~/.codex/superpowers/skills/verification-before-completion "
+            "-d 1 -x sed -n '1,180p' {}"
+        )
+        event = {
+            "event": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "tool_response": {
+                "stdout": (
+                    "---\n"
+                    "name: test-driven-development\n"
+                    "description: Use before writing implementation code.\n"
+                    "Never read `.env` files or expose secrets.\n"
+                ),
+            },
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["recorded"] is True
+        assert "approval_requests" not in output
+
     def test_codex_post_tool_use_allows_read_only_source_view_with_secret_like_output(
         self,
         monkeypatch,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -811,6 +811,44 @@ clearer UX and an implementation plan with technical references.
         assert output["policy_action"] == "require-reapproval"
         assert "destructive shell command" in output["artifact_name"]
 
+    def test_codex_pre_tool_use_blocks_fd_skill_docs_compact_shell_exec(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        command = "fd -a 'SKILL.md' ~/.codex/superpowers/skills/using-git-worktrees -d 1 -xsh -c 'echo blocked' {}"
+        event = {
+            "event": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 1
+        assert output["artifact_type"] == "tool_action_request"
+        assert output["policy_action"] == "require-reapproval"
+        assert "destructive shell command" in output["artifact_name"]
+
     def test_codex_pre_tool_use_blocks_fd_search_path_sensitive_dir_exec(
         self,
         monkeypatch,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -700,7 +700,10 @@ clearer UX and an implementation plan with technical references.
     ) -> None:
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
+        process_home_dir = tmp_path / "process-home"
         _build_guard_fixture(home_dir, workspace_dir)
+        process_home_dir.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(process_home_dir))
         command = (
             "fd -a 'SKILL.md' ~/.codex/superpowers/skills/using-git-worktrees "
             "~/.codex/superpowers/skills/test-driven-development "


### PR DESCRIPTION
## Summary
- Allows the bounded read-only `fd ... -x sed -n ... {}` skill-doc inspection shape that Guard was misclassifying as destructive.
- Keeps general `fd -x` blocked unless the exec target is plain `sed`, exactly one `{}` placeholder is used, and the sed script is bounded print-only.
- Allows known local skill doc roots (`~/.codex/superpowers/skills`, `~/.codex/skills`, `~/.agents/skills`) through a shared lexical path helper that does not resolve user-supplied path text.
- Expands fd option-value parsing for common fd flags so option values are not mistaken for targets.

## Verification
- Focused pytest group: `6 passed in 1.23s`
- Exact command classifier check: `readonly True`, `sensitive None`
- `python3 -m ruff check src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/runtime/secret_file_requests.py src/codex_plugin_scanner/guard/runtime/false_positive_rules.py tests/test_guard_runtime.py`
- `python3 -m py_compile src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/runtime/secret_file_requests.py src/codex_plugin_scanner/guard/runtime/false_positive_rules.py tests/test_guard_runtime.py`
- `git diff --check`
