### PR TITLE
fix(guard): repair codex approval resume

### DIFF
--- a/dashboard/src/approval-center-layout.test.ts
+++ b/dashboard/src/approval-center-layout.test.ts
@@ -283,11 +283,11 @@ function makeResume(status: GuardCodexResumeResult["status"], extras?: Partial<G
 
 const uxPending = buildCodexResumeUx(makeResume("pending"));
 assert(uxPending.showRetry === false, "C13: pending status has showRetry false");
-assert(uxPending.headline.toLowerCase().includes("resum"), "C13: pending headline mentions resuming");
+assert(uxPending.headline.toLowerCase().includes("continu"), "C13: pending headline mentions continuing");
 
 const uxInProgress = buildCodexResumeUx(makeResume("in_progress"));
 assert(uxInProgress.showRetry === false, "C13: in_progress status has showRetry false");
-assert(uxInProgress.headline.toLowerCase().includes("resum"), "C13: in_progress headline mentions resuming");
+assert(uxInProgress.headline.toLowerCase().includes("continu"), "C13: in_progress headline mentions continuing");
 
 const uxSent = buildCodexResumeUx(makeResume("sent"));
 assert(uxSent.showRetry === false, "C13: sent status has showRetry false");

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -621,7 +621,11 @@ export function isCodexHarness(harness: string): boolean {
 
 export function buildCodexResumeUx(resume: GuardCodexResumeResult): CodexResumeUx {
   if (resume.status === "pending" || resume.status === "in_progress") {
-    return { headline: "Resuming Codex...", body: null, showRetry: false };
+    return {
+      headline: "Codex is continuing.",
+      body: resume.message ?? "HOL Guard saved your choice and the original Codex action is still waiting for it.",
+      showRetry: false
+    };
   }
   if (resume.status === "sent" || resume.status === "already_sent") {
     return {

--- a/scripts/codex-auto-resume-smoke.py
+++ b/scripts/codex-auto-resume-smoke.py
@@ -4,12 +4,8 @@
 from __future__ import annotations
 
 import argparse
-import errno
 import json
 import os
-import pty
-import re
-import select
 import shutil
 import subprocess
 import sys
@@ -27,11 +23,8 @@ SRC_ROOT = REPO_ROOT / "src"
 if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
-from codex_plugin_scanner.guard.store import GuardStore  # noqa: E402
-
 ALLOW_SENTINEL = "HOL_GUARD_ALLOW_PROOF_PRESENT"
 PROOF_FILE_NAME = "guard-proof.txt"
-_APPROVAL_URL_PATTERN = re.compile(r"http://127\.0\.0\.1:(?P<port>\d+)/approvals/(?P<request_id>[0-9a-f]+)")
 
 
 @dataclass
@@ -121,7 +114,6 @@ def _run_scenario_in_dir(*, decision: str, args: argparse.Namespace, temp_dir: P
     guard_home = home_dir
     stdout_path = temp_dir / f"{decision}-codex.stdout.jsonl"
     stderr_path = temp_dir / f"{decision}-codex.stderr.txt"
-    message_path = temp_dir / f"{decision}-last-message.txt"
     proof_path = workspace_dir / PROOF_FILE_NAME
 
     _write_text(home_dir / ".codex" / "config.toml", 'model = "gpt-5"\n')
@@ -180,12 +172,12 @@ def _run_scenario_in_dir(*, decision: str, args: argparse.Namespace, temp_dir: P
         daemon.stop()
 
     transcript = initial_transcript
-    final_message = message_path.read_text(encoding="utf-8").strip() if message_path.is_file() else ""
     proof_created = _wait_for_proof_state(proof_path=proof_path, should_exist=decision == "allow", timeout_seconds=20.0)
     stderr_text = stderr_path.read_text(encoding="utf-8")
+    resume_message = str(resume_payload.get("message") or "")
     _assert_expected_outcome(
         decision=decision,
-        final_message=str(resume_payload.get("message") or final_message),
+        final_message=resume_message,
         approval_payload=approval_payload,
         proof_created=proof_created,
         stderr_text=stderr_text,
@@ -197,58 +189,9 @@ def _run_scenario_in_dir(*, decision: str, args: argparse.Namespace, temp_dir: P
         resume_status=str(resume_payload["status"]),
         resume_strategy=_optional_string(resume_payload.get("strategy")),
         proof_created=proof_created,
-        assistant_message=str(resume_payload.get("message") or final_message),
+        assistant_message=resume_message,
         transcript_excerpt=_sanitize_excerpt(transcript),
     )
-
-
-def _start_codex_exec(
-    *,
-    decision: str,
-    home_dir: Path,
-    workspace_dir: Path,
-    message_path: Path,
-    codex_home: str | None,
-    guard_daemon_port: int,
-    prompt_marker: str,
-) -> tuple[subprocess.Popen[bytes], int]:
-    prompt = _codex_prompt(decision, prompt_marker=prompt_marker)
-    command = [
-        "codex",
-        "exec",
-        "--json",
-        "--skip-git-repo-check",
-        "--dangerously-bypass-approvals-and-sandbox",
-        "--dangerously-bypass-hook-trust",
-        "--enable",
-        "hooks",
-        "-c",
-        f'projects."{workspace_dir.resolve()}".trust_level="trusted"',
-        "--output-last-message",
-        str(message_path),
-        prompt,
-    ]
-    master_fd, slave_fd = pty.openpty()
-    try:
-        process = subprocess.Popen(
-            command,
-            cwd=workspace_dir.resolve(),
-            env=_scenario_env(
-                home_dir=home_dir,
-                codex_home=codex_home,
-                guard_daemon_port=guard_daemon_port,
-            ),
-            stdin=slave_fd,
-            stdout=slave_fd,
-            stderr=slave_fd,
-            close_fds=True,
-        )
-        return process, master_fd
-    except Exception:
-        os.close(master_fd)
-        raise
-    finally:
-        os.close(slave_fd)
 
 
 def _start_headless_codex_thread(
@@ -329,82 +272,6 @@ def _run_guard_cli(argv: list[str], *, home_dir: Path, codex_home: str | None) -
         raise RuntimeError(f"guard CLI returned non-JSON output:\n{stdout}") from error
 
 
-def _wait_for_pending_request(
-    *,
-    guard_home: Path,
-    process: subprocess.Popen[bytes],
-    master_fd: int,
-    transcript_chunks: list[str],
-    timeout_seconds: float,
-) -> dict[str, object]:
-    store = GuardStore(guard_home)
-    deadline = time.monotonic() + timeout_seconds
-    while time.monotonic() < deadline:
-        _drain_pty(master_fd=master_fd, transcript_chunks=transcript_chunks, block=False)
-        if process.poll() is not None:
-            raise RuntimeError(
-                f"codex exec exited before Guard queued a pending request\nstdout:\n{''.join(transcript_chunks)}\n"
-            )
-        pending = store.list_approval_requests(status="pending", limit=10)
-        if pending:
-            return pending[0]
-        time.sleep(0.5)
-    raise TimeoutError(f"Codex did not queue a pending Guard request within {timeout_seconds:.1f}s")
-
-
-def _wait_for_process_exit(
-    *,
-    process: subprocess.Popen[bytes],
-    master_fd: int,
-    transcript_chunks: list[str],
-    timeout_seconds: float,
-) -> None:
-    deadline = time.monotonic() + timeout_seconds
-    while time.monotonic() < deadline:
-        _drain_pty(master_fd=master_fd, transcript_chunks=transcript_chunks, block=False)
-        if process.poll() is not None:
-            return
-        time.sleep(0.2)
-    raise TimeoutError(f"codex exec did not finish within {timeout_seconds:.1f}s")
-
-
-def _drain_pty(*, master_fd: int, transcript_chunks: list[str], block: bool) -> None:
-    timeout = 0.2 if block else 0.0
-    while True:
-        ready, _, _ = select.select([master_fd], [], [], timeout)
-        if not ready:
-            return
-        try:
-            data = os.read(master_fd, 4096)
-        except OSError as error:
-            if error.errno == errno.EIO:
-                return
-            raise
-        if not data:
-            return
-        transcript_chunks.append(data.decode("utf-8", errors="ignore"))
-        timeout = 0.0
-
-
-def _request_from_transcript(transcript: str) -> dict[str, object] | None:
-    match = None
-    for candidate in _APPROVAL_URL_PATTERN.finditer(transcript):
-        match = candidate
-    if match is None:
-        return None
-    return {
-        "request_id": match.group("request_id"),
-        "approval_port": int(match.group("port")),
-    }
-
-
-def _approval_port_from_transcript(transcript: str) -> int | None:
-    request = _request_from_transcript(transcript)
-    if request is None:
-        return None
-    return int(request["approval_port"])
-
-
 def _post_json(
     *,
     port: int,
@@ -421,43 +288,6 @@ def _post_json(
     )
     with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
         return json.loads(response.read().decode("utf-8"))
-
-
-def _get_json(*, port: int, token: str, path: str, timeout_seconds: float = 10.0) -> dict[str, object]:
-    request = urllib.request.Request(
-        f"http://127.0.0.1:{port}{path}",
-        headers={"X-Guard-Token": token},
-        method="GET",
-    )
-    try:
-        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
-            return json.loads(response.read().decode("utf-8"))
-    except urllib.error.HTTPError as error:
-        body = error.read().decode("utf-8")
-        raise RuntimeError(f"resume status request failed: {error.code} {body}") from error
-
-
-def _daemon_auth_token(guard_home: Path) -> str | None:
-    try:
-        token = (guard_home / "daemon-auth-token").read_text(encoding="utf-8").strip()
-    except OSError:
-        return None
-    return token or None
-
-
-def _codex_prompt(decision: str, *, prompt_marker: str) -> str:
-    command = _proof_command()
-    if decision == "allow":
-        return (
-            f"Run this exact shell command now for HOL Guard smoke marker `{prompt_marker}`:\n"
-            f"{command}\n"
-            f"After the command succeeds, respond with ONLY {ALLOW_SENTINEL}."
-        )
-    return (
-        f"Run this exact shell command now for HOL Guard smoke marker `{prompt_marker}`:\n"
-        f"{command}\n"
-        "If HOL Guard blocks the command, do not retry it. Explain one safe alternative in one short sentence."
-    )
 
 
 def _assert_expected_outcome(

--- a/scripts/codex-auto-resume-smoke.py
+++ b/scripts/codex-auto-resume-smoke.py
@@ -27,7 +27,9 @@ SRC_ROOT = REPO_ROOT / "src"
 if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
-ALLOW_SENTINEL = "HOL_GUARD_CANARY_TOKEN_PRESENT"
+from codex_plugin_scanner.guard.store import GuardStore  # noqa: E402
+
+ALLOW_SENTINEL = "HOL_GUARD_ALLOW_PROOF_PRESENT"
 PROOF_FILE_NAME = "guard-proof.txt"
 _APPROVAL_URL_PATTERN = re.compile(r"http://127\.0\.0\.1:(?P<port>\d+)/approvals/(?P<request_id>[0-9a-f]+)")
 
@@ -123,10 +125,7 @@ def _run_scenario_in_dir(*, decision: str, args: argparse.Namespace, temp_dir: P
     proof_path = workspace_dir / PROOF_FILE_NAME
 
     _write_text(home_dir / ".codex" / "config.toml", 'model = "gpt-5"\n')
-    _write_text(
-        workspace_dir / ".codex" / "config.toml",
-        'approval_policy = "never"\n\n[features]\ncodex_hooks = true\n',
-    )
+    _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n\n[features]\nhooks = true\n')
     workspace_dir.mkdir(parents=True, exist_ok=True)
     subprocess.run(["git", "init", "-q"], cwd=workspace_dir, check=True, capture_output=True, text=True)
 
@@ -149,67 +148,38 @@ def _run_scenario_in_dir(*, decision: str, args: argparse.Namespace, temp_dir: P
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
     try:
-        transcript_chunks: list[str] = []
-        request_id = uuid.uuid4().hex
-        process, master_fd = _start_codex_exec(
-            decision=decision,
-            home_dir=home_dir,
+        thread_id, initial_transcript = _start_headless_codex_thread(
             workspace_dir=workspace_dir,
-            message_path=message_path,
+            home_dir=home_dir,
             codex_home=args.codex_home,
-            guard_daemon_port=daemon.port,
-            request_id=request_id,
+            stdout_path=stdout_path,
+            stderr_path=stderr_path,
         )
-        try:
-            _wait_for_process_exit(
-                process=process,
-                master_fd=master_fd,
-                transcript_chunks=transcript_chunks,
-                timeout_seconds=args.request_timeout_seconds,
-            )
-            transcript = "".join(transcript_chunks)
-            thread_id = _thread_id_from_transcript(transcript)
-            if thread_id is None:
-                raise RuntimeError(f"codex exec did not emit a resumable thread id\nstdout:\n{transcript}\n")
-            _queue_pending_request(
-                store=store,
-                request_id=request_id,
-                thread_id=thread_id,
-                workspace_dir=workspace_dir,
-                daemon_port=daemon.port,
-                codex_home=_scenario_env(home_dir=home_dir, codex_home=args.codex_home).get("CODEX_HOME"),
-            )
-            action_path = "approve" if decision == "allow" else "block"
-            approval_payload = _post_json(
-                port=daemon.port,
-                token=daemon._server.auth_token,
-                path=f"/v1/requests/{request_id}/{action_path}",
-                payload={"scope": "artifact", "reason": f"{decision}-smoke"},
-                timeout_seconds=args.timeout_seconds,
-            )
-            resume_payload = _get_json(
-                port=daemon.port,
-                token=daemon._server.auth_token,
-                path=f"/v1/requests/{request_id}/resume",
-                timeout_seconds=30.0,
-            )
-        finally:
-            if process.poll() is None:
-                process.kill()
-                process.wait(timeout=10)
-            _drain_pty(master_fd=master_fd, transcript_chunks=transcript_chunks, block=False)
-            os.close(master_fd)
+        request_id = uuid.uuid4().hex
+        _queue_pending_request(
+            store=store,
+            request_id=request_id,
+            thread_id=thread_id,
+            workspace_dir=workspace_dir,
+            daemon_port=daemon.port,
+            codex_home=args.codex_home,
+            operation_status="approval_wait_timeout",
+        )
+        action_path = "approve" if decision == "allow" else "block"
+        approval_payload = _post_json(
+            port=daemon.port,
+            token=daemon._server.auth_token,
+            path=f"/v1/requests/{request_id}/{action_path}",
+            payload={"scope": "artifact", "reason": f"{decision}-smoke"},
+            timeout_seconds=args.timeout_seconds,
+        )
+        resume_payload = approval_payload.get("codex_resume") if isinstance(approval_payload, dict) else None
+        if not isinstance(resume_payload, dict):
+            raise RuntimeError(f"approval response did not include codex_resume: {approval_payload}")
     finally:
         daemon.stop()
 
-    transcript = "".join(transcript_chunks)
-    stdout_path.write_text("".join(transcript_chunks), encoding="utf-8")
-    stderr_path.write_text("", encoding="utf-8")
-    if process.returncode != 0:
-        raise RuntimeError(
-            f"codex exec failed for {decision}: rc={process.returncode}\n"
-            f"stdout:\n{stdout_path.read_text(encoding='utf-8')}\n"
-        )
+    transcript = initial_transcript
     final_message = message_path.read_text(encoding="utf-8").strip() if message_path.is_file() else ""
     proof_created = _wait_for_proof_state(proof_path=proof_path, should_exist=decision == "allow", timeout_seconds=20.0)
     stderr_text = stderr_path.read_text(encoding="utf-8")
@@ -240,16 +210,20 @@ def _start_codex_exec(
     message_path: Path,
     codex_home: str | None,
     guard_daemon_port: int,
-    request_id: str,
+    prompt_marker: str,
 ) -> tuple[subprocess.Popen[bytes], int]:
-    prompt = _codex_prompt(decision, request_id=request_id)
+    prompt = _codex_prompt(decision, prompt_marker=prompt_marker)
     command = [
         "codex",
         "exec",
         "--json",
         "--skip-git-repo-check",
+        "--dangerously-bypass-approvals-and-sandbox",
         "--dangerously-bypass-hook-trust",
-        "--ignore-user-config",
+        "--enable",
+        "hooks",
+        "-c",
+        f'projects."{workspace_dir.resolve()}".trust_level="trusted"',
         "--output-last-message",
         str(message_path),
         prompt,
@@ -258,7 +232,7 @@ def _start_codex_exec(
     try:
         process = subprocess.Popen(
             command,
-            cwd=workspace_dir,
+            cwd=workspace_dir.resolve(),
             env=_scenario_env(
                 home_dir=home_dir,
                 codex_home=codex_home,
@@ -275,6 +249,46 @@ def _start_codex_exec(
         raise
     finally:
         os.close(slave_fd)
+
+
+def _start_headless_codex_thread(
+    *,
+    workspace_dir: Path,
+    home_dir: Path,
+    codex_home: str | None,
+    stdout_path: Path,
+    stderr_path: Path,
+) -> tuple[str, str]:
+    command = [
+        "codex",
+        "exec",
+        "--json",
+        "--skip-git-repo-check",
+        "--sandbox",
+        "danger-full-access",
+        "-c",
+        'approval_policy="never"',
+        "-C",
+        str(workspace_dir.resolve()),
+        "Say exactly HOL_GUARD_RESUME_READY.",
+    ]
+    result = subprocess.run(
+        command,
+        cwd=workspace_dir.resolve(),
+        env=_scenario_env(home_dir=home_dir, codex_home=codex_home),
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    stdout_path.write_text(result.stdout, encoding="utf-8")
+    stderr_path.write_text(result.stderr, encoding="utf-8")
+    if result.returncode != 0:
+        raise RuntimeError(f"codex exec failed to create a resumable thread: rc={result.returncode}\n{result.stderr}")
+    thread_id = _thread_id_from_transcript(result.stdout)
+    if thread_id is None:
+        raise RuntimeError(f"codex exec did not emit a thread id:\n{result.stdout}")
+    return thread_id, result.stdout
 
 
 def _scenario_env(*, home_dir: Path, codex_home: str | None, guard_daemon_port: int | None = None) -> dict[str, str]:
@@ -323,6 +337,7 @@ def _wait_for_pending_request(
     transcript_chunks: list[str],
     timeout_seconds: float,
 ) -> dict[str, object]:
+    store = GuardStore(guard_home)
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:
         _drain_pty(master_fd=master_fd, transcript_chunks=transcript_chunks, block=False)
@@ -330,8 +345,11 @@ def _wait_for_pending_request(
             raise RuntimeError(
                 f"codex exec exited before Guard queued a pending request\nstdout:\n{''.join(transcript_chunks)}\n"
             )
+        pending = store.list_approval_requests(status="pending", limit=10)
+        if pending:
+            return pending[0]
         time.sleep(0.5)
-    raise TimeoutError(f"Codex did not finish the seed session within {timeout_seconds:.1f}s")
+    raise TimeoutError(f"Codex did not queue a pending Guard request within {timeout_seconds:.1f}s")
 
 
 def _wait_for_process_exit(
@@ -427,22 +445,18 @@ def _daemon_auth_token(guard_home: Path) -> str | None:
     return token or None
 
 
-def _codex_prompt(decision: str, *, request_id: str) -> str:
+def _codex_prompt(decision: str, *, prompt_marker: str) -> str:
     command = _proof_command()
     if decision == "allow":
         return (
-            f"Remember this exact shell command for HOL Guard request `{request_id}`, but do not run it yet:\n"
+            f"Run this exact shell command now for HOL Guard smoke marker `{prompt_marker}`:\n"
             f"{command}\n"
-            f"If a later HOL Guard message says HOL Guard approved request `{request_id}`, "
-            f"run that exact command and then respond with ONLY {ALLOW_SENTINEL}. "
-            "For now, respond with ONLY READY."
+            f"After the command succeeds, respond with ONLY {ALLOW_SENTINEL}."
         )
     return (
-        f"Remember this exact shell command for HOL Guard request `{request_id}`, but do not run it yet:\n"
+        f"Run this exact shell command now for HOL Guard smoke marker `{prompt_marker}`:\n"
         f"{command}\n"
-        f"If a later HOL Guard message says HOL Guard blocked request `{request_id}`, "
-        "do not run that command and explain one safe alternative in one short sentence. "
-        "For now, respond with ONLY READY."
+        "If HOL Guard blocks the command, do not retry it. Explain one safe alternative in one short sentence."
     )
 
 
@@ -458,8 +472,8 @@ def _assert_expected_outcome(
     if not isinstance(codex_resume, dict):
         raise AssertionError("approval payload did not include codex_resume")
     status = str(codex_resume.get("status") or "")
-    if status != "sent":
-        raise AssertionError(f"expected codex_resume status 'sent', got {status!r}")
+    if status not in {"in_progress", "sent", "already_sent"}:
+        raise AssertionError(f"expected codex_resume status to show live continuation, got {status!r}")
     if decision == "allow":
         if not proof_created:
             raise AssertionError("allow flow did not create the proof file")
@@ -511,6 +525,7 @@ def _queue_pending_request(
     workspace_dir: Path,
     daemon_port: int,
     codex_home: str | None,
+    operation_status: str = "waiting_on_approval",
 ) -> None:
     from codex_plugin_scanner.guard.consumer import artifact_hash
     from codex_plugin_scanner.guard.models import GuardApprovalRequest
@@ -552,13 +567,14 @@ def _queue_pending_request(
         session_id=str(session["session_id"]),
         harness="codex",
         operation_type="tool_call",
-        status="waiting_on_approval",
+        status=operation_status,
         approval_request_ids=[request_id],
         resume_token=f"resume-{request_id}",
         metadata={
             "codex_thread_id": thread_id,
             "session_id": thread_id,
             "codex_home": codex_home,
+            "codex_app_server_socket": str(workspace_dir / "missing-codex-app-server.sock"),
             "command_text": _proof_command(),
             "tool_name": "Bash",
             "event": "PreToolUse",

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3181,8 +3181,7 @@ def _codex_browser_approval_decision(
     ]
     if not request_ids:
         return None
-    has_daemon_operation = isinstance(response_payload.get("operation_id"), str)
-    wait_timeout_seconds = min(config.approval_wait_timeout_seconds, 25 if has_daemon_operation else 5)
+    wait_timeout_seconds = max(config.approval_wait_timeout_seconds, 0)
     wait_result = wait_for_approval_requests(
         store=store,
         request_ids=request_ids,
@@ -3190,6 +3189,7 @@ def _codex_browser_approval_decision(
     )
     response_payload["approval_wait"] = wait_result
     if not bool(wait_result.get("resolved")):
+        _update_codex_browser_operation_status(response_payload, daemon_client, "approval_wait_timeout")
         response_payload["review_hint"] = (
             "Approval is still pending in HOL Guard. Approve it in the browser, then retry the same Codex action."
         )

--- a/src/codex_plugin_scanner/guard/codex_resume.py
+++ b/src/codex_plugin_scanner/guard/codex_resume.py
@@ -138,7 +138,7 @@ def defer_request_resume_to_live_hook(
         resolution_action=action,
         strategy=str(resume.get("strategy")) if isinstance(resume.get("strategy"), str) else None,
         supported=bool(resume.get("supported")) if resume.get("supported") is not None else None,
-        status="in_progress",
+        status="pending",
         reason="live_hook_waiting",
         message=message,
         last_error=None,

--- a/src/codex_plugin_scanner/guard/codex_resume.py
+++ b/src/codex_plugin_scanner/guard/codex_resume.py
@@ -35,10 +35,9 @@ def seed_request_resume_record(store: GuardStore, *, request_id: str, now: str) 
     operation = store.get_guard_operation_for_approval_request(request_id)
     metadata = operation.get("metadata") if isinstance(operation, dict) else None
     thread_id = _first_string(metadata, _THREAD_ID_KEYS) if isinstance(metadata, Mapping) else None
-    socket_path = _first_string(metadata, _SOCKET_KEYS) if isinstance(metadata, Mapping) else None
     strategy = "manual-only"
     if thread_id is not None:
-        strategy = "codex-app-server-thread" if socket_path is not None else "codex-exec-resume"
+        strategy = "codex-app-server-thread"
     store.seed_request_resume(
         request_id=request_id,
         operation_id=str(operation["operation_id"]) if isinstance(operation, dict) else None,
@@ -110,6 +109,45 @@ def retry_request_resume(
         now=now,
     )
     return final
+
+
+def defer_request_resume_to_live_hook(
+    store: GuardStore,
+    *,
+    request_id: str,
+    action: str,
+    now: str,
+) -> dict[str, object] | None:
+    """Let an active Codex hook consume the saved browser decision itself."""
+
+    operation = store.get_guard_operation_for_approval_request(request_id)
+    if operation is None or str(operation.get("harness")) != "codex":
+        return None
+    if str(operation.get("status")) != "waiting_on_approval":
+        return None
+    resume = get_request_resume_status(store, request_id=request_id, now=now)
+    if resume is None:
+        return None
+    attempt_count = int(resume.get("attempt_count") or 0)
+    message = (
+        "Decision saved. Codex is still waiting for this browser decision, "
+        "so HOL Guard will let the original Codex action continue without starting a second headless run."
+    )
+    store.update_request_resume(
+        request_id=request_id,
+        resolution_action=action,
+        strategy=str(resume.get("strategy")) if isinstance(resume.get("strategy"), str) else None,
+        supported=bool(resume.get("supported")) if resume.get("supported") is not None else None,
+        status="in_progress",
+        reason="live_hook_waiting",
+        message=message,
+        last_error=None,
+        attempt_count=attempt_count,
+        last_attempt_at=now,
+        sent_at=str(resume.get("sent_at")) if isinstance(resume.get("sent_at"), str) else None,
+        now=now,
+    )
+    return store.get_request_resume(request_id)
 
 
 def inspect_codex_resume_capabilities(store: GuardStore) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -38,6 +38,7 @@ from ..cli.install_commands import (
     uninstall_confirmation_token,
 )
 from ..codex_resume import (
+    defer_request_resume_to_live_hook,
     get_request_resume_status,
     retry_request_resume,
 )
@@ -731,11 +732,18 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         copy = _build_resolution_copy(action, harness_str or harness)
         codex_resume = None
         if harness_str == "codex" and action in {"allow", "block"}:
-            codex_resume = retry_request_resume(
+            codex_resume = defer_request_resume_to_live_hook(
                 self.server.store,  # type: ignore[attr-defined]
                 request_id=request_id,
+                action=action,
                 now=_now(),
             )
+            if codex_resume is None:
+                codex_resume = retry_request_resume(
+                    self.server.store,  # type: ignore[attr-defined]
+                    request_id=request_id,
+                    now=_now(),
+                )
         if codex_resume is not None:
             updated = self._apply_codex_resume_result(
                 updated=updated,
@@ -1504,6 +1512,12 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             copy = {
                 "title": "Decision saved. Codex is continuing.",
                 "body": message,
+            }
+        elif status in {"pending", "in_progress"}:
+            updated["resolution_summary"] = message or "Decision saved. Codex is still waiting for HOL Guard."
+            copy = {
+                "title": "Decision saved. Codex is continuing.",
+                "body": message or "Return to Codex; the original action should continue automatically.",
             }
         elif status == "already_sent":
             updated["resolution_summary"] = "Decision saved. Codex was already resumed for this request."

--- a/tests/test_guard_codex_resume_commands.py
+++ b/tests/test_guard_codex_resume_commands.py
@@ -195,7 +195,7 @@ def test_guard_approvals_resume_rejects_unsafe_thread_id(
     assert output["reason"] == "unsafe_thread_id"
 
 
-def test_guard_approvals_resume_uses_exec_resume_when_only_session_binding_exists(
+def test_guard_approvals_resume_falls_back_to_exec_resume_when_app_server_unavailable(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_guard_codex_resume_endpoints.py
+++ b/tests/test_guard_codex_resume_endpoints.py
@@ -237,9 +237,65 @@ def test_codex_approve_defers_headless_resume_while_live_hook_waits(
         daemon.stop()
 
     assert payload["resolved"] is True
-    assert payload["codex_resume"]["status"] == "in_progress"
+    assert payload["codex_resume"]["status"] == "pending"
     assert payload["codex_resume"]["reason"] == "live_hook_waiting"
     assert "original Codex action continue" in payload["codex_resume"]["message"]
+
+
+def test_codex_deferred_live_hook_resume_can_recover_with_manual_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded: dict[str, object] = {}
+    _stub_codex_binary(monkeypatch)
+
+    def _fake_run(command, **kwargs):
+        recorded["command"] = command
+        return type(
+            "CompletedProcess",
+            (),
+            {
+                "returncode": 0,
+                "stdout": '{"type":"item.completed","item":{"type":"agent_message","text":"done"}}\n',
+                "stderr": "",
+            },
+        )()
+
+    monkeypatch.setattr(codex_resume_module.subprocess, "run", _fake_run)
+
+    store = GuardStore(tmp_path / "guard-home")
+    store.add_approval_request(_request("req-live-retry"), "2026-05-19T10:00:00+00:00")
+    missing_socket = tmp_path / "missing-codex.sock"
+    _seed_codex_operation(
+        store,
+        request_id="req-live-retry",
+        socket_path=missing_socket,
+        thread_id="live-session-retry-1",
+        status="waiting_on_approval",
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+
+    try:
+        approved = _post_json(
+            daemon.port,
+            daemon._server.auth_token,
+            "/v1/requests/req-live-retry/approve",
+            {"scope": "artifact", "reason": "reviewed"},
+        )
+        retried = _post_json(
+            daemon.port,
+            daemon._server.auth_token,
+            "/v1/requests/req-live-retry/resume",
+            {},
+        )
+    finally:
+        daemon.stop()
+
+    assert approved["codex_resume"]["status"] == "pending"
+    assert retried["status"] == "sent"
+    assert retried["strategy"] == "codex-exec-resume"
+    assert recorded["command"][:3] == ["codex", "exec", "resume"]
 
 
 def test_request_resume_status_endpoint_returns_persisted_result(tmp_path: Path) -> None:

--- a/tests/test_guard_codex_resume_endpoints.py
+++ b/tests/test_guard_codex_resume_endpoints.py
@@ -100,12 +100,13 @@ def _seed_codex_operation(
     workspace: str = "/workspace",
     codex_home: str | None = None,
     command_text: str | None = None,
+    status: str = "waiting_on_approval",
 ) -> None:
     session = store.upsert_guard_session(
         session_id=f"session-{request_id}",
         harness="codex",
         surface="harness-adapter",
-        status="waiting_on_approval",
+        status=status,
         client_name="codex-hook",
         client_title="Codex hook",
         client_version="1.0.0",
@@ -128,7 +129,7 @@ def _seed_codex_operation(
         session_id=str(session["session_id"]),
         harness="codex",
         operation_type="tool_call",
-        status="waiting_on_approval",
+        status=status,
         approval_request_ids=[request_id],
         resume_token=f"resume-{request_id}",
         metadata=metadata,
@@ -177,7 +178,12 @@ def test_codex_block_resume_prompt_includes_request_id_and_safe_alternative(
     store.add_approval_request(_request("req-block"), "2026-05-19T10:00:00+00:00")
     socket_path = tmp_path / "codex-control.sock"
     socket_path.write_text("", encoding="utf-8")
-    _seed_codex_operation(store, request_id="req-block", socket_path=socket_path)
+    _seed_codex_operation(
+        store,
+        request_id="req-block",
+        socket_path=socket_path,
+        status="approval_wait_timeout",
+    )
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
 
@@ -194,6 +200,46 @@ def test_codex_block_resume_prompt_includes_request_id_and_safe_alternative(
     assert payload["codex_resume"]["status"] == "sent"
     prompt = captured_payloads[2]["params"]["input"][0]["text"]
     assert prompt == "HOL Guard blocked request `req-block`. Do not retry that action. Explain a safe alternative."
+
+
+def test_codex_approve_defers_headless_resume_while_live_hook_waits(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_codex_binary(monkeypatch)
+
+    def _fail_run(command, **kwargs):
+        raise AssertionError("browser approval must not launch headless Codex while the live hook is waiting")
+
+    monkeypatch.setattr(codex_resume_module.subprocess, "run", _fail_run)
+
+    store = GuardStore(tmp_path / "guard-home")
+    store.add_approval_request(_request("req-live"), "2026-05-19T10:00:00+00:00")
+    missing_socket = tmp_path / "missing-codex.sock"
+    _seed_codex_operation(
+        store,
+        request_id="req-live",
+        socket_path=missing_socket,
+        thread_id="live-session-1",
+        status="waiting_on_approval",
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+
+    try:
+        payload = _post_json(
+            daemon.port,
+            daemon._server.auth_token,
+            "/v1/requests/req-live/approve",
+            {"scope": "artifact", "reason": "reviewed"},
+        )
+    finally:
+        daemon.stop()
+
+    assert payload["resolved"] is True
+    assert payload["codex_resume"]["status"] == "in_progress"
+    assert payload["codex_resume"]["reason"] == "live_hook_waiting"
+    assert "original Codex action continue" in payload["codex_resume"]["message"]
 
 
 def test_request_resume_status_endpoint_returns_persisted_result(tmp_path: Path) -> None:
@@ -279,6 +325,7 @@ def test_codex_allow_resume_prompt_includes_exact_command_when_metadata_is_prese
         request_id="req-allow-command",
         socket_path=socket_path,
         command_text="python - <<'PY'\nprint('guard')\nPY",
+        status="approval_wait_timeout",
     )
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
@@ -342,6 +389,7 @@ def test_request_resume_retry_endpoint_can_recover_after_socket_missing(
         socket_path=None,
         workspace=str(workspace),
         codex_home="/tmp/codex-home",
+        status="approval_wait_timeout",
     )
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
@@ -394,7 +442,12 @@ def test_request_resume_retry_is_idempotent_after_success(
     store.add_approval_request(_request("req-idempotent"), "2026-05-19T10:00:00+00:00")
     socket_path = tmp_path / "codex-idempotent.sock"
     socket_path.write_text("", encoding="utf-8")
-    _seed_codex_operation(store, request_id="req-idempotent", socket_path=socket_path)
+    _seed_codex_operation(
+        store,
+        request_id="req-idempotent",
+        socket_path=socket_path,
+        status="approval_wait_timeout",
+    )
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
 
@@ -456,6 +509,7 @@ def test_codex_approve_falls_back_to_exec_resume_when_socket_binding_is_missing(
         thread_id="session-exec-1",
         workspace=str(workspace),
         codex_home=str(codex_home),
+        status="approval_wait_timeout",
     )
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
@@ -485,6 +539,59 @@ def test_codex_approve_falls_back_to_exec_resume_when_socket_binding_is_missing(
     assert "approved request `req-exec`" in recorded["input"]
 
 
+def test_codex_approve_uses_default_app_server_when_hook_omits_socket(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    send_calls = 0
+
+    def _fake_resume(**kwargs):
+        nonlocal send_calls
+        send_calls += 1
+        return {
+            "status": "sent",
+            "reason": "turn_start_sent",
+            "thread_id": "session-default-socket-1",
+            "strategy": "codex-app-server-thread",
+            "supported": True,
+        }
+
+    def _fail_run(command, **kwargs):
+        raise AssertionError("app-server resume should be attempted before headless exec")
+
+    monkeypatch.setattr(codex_resume_module, "resume_codex_thread_for_request", _fake_resume)
+    monkeypatch.setattr(codex_resume_module.subprocess, "run", _fail_run)
+
+    store = GuardStore(tmp_path / "guard-home")
+    store.add_approval_request(_request("req-default-socket"), "2026-05-19T10:00:00+00:00")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _seed_codex_operation(
+        store,
+        request_id="req-default-socket",
+        socket_path=None,
+        thread_id="session-default-socket-1",
+        workspace=str(workspace),
+        status="approval_wait_timeout",
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+
+    try:
+        payload = _post_json(
+            daemon.port,
+            daemon._server.auth_token,
+            "/v1/requests/req-default-socket/approve",
+            {"scope": "artifact", "reason": "reviewed"},
+        )
+    finally:
+        daemon.stop()
+
+    assert payload["codex_resume"]["status"] == "sent"
+    assert payload["codex_resume"]["strategy"] == "codex-app-server-thread"
+    assert send_calls == 1
+
+
 def test_codex_approve_returns_failed_resume_when_exec_launch_raises_oserror(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -507,6 +614,7 @@ def test_codex_approve_returns_failed_resume_when_exec_launch_raises_oserror(
         socket_path=missing_socket,
         thread_id="session-oserror-1",
         workspace=str(workspace),
+        status="approval_wait_timeout",
     )
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
@@ -568,6 +676,7 @@ def test_codex_approve_falls_back_to_exec_resume_after_transport_error_reason(
         socket_path=socket_path,
         thread_id="session-transport-1",
         workspace=str(workspace),
+        status="approval_wait_timeout",
     )
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()

--- a/tests/test_guard_queue_api_contract.py
+++ b/tests/test_guard_queue_api_contract.py
@@ -456,7 +456,7 @@ def test_codex_resolution_sends_continue_prompt_to_original_thread(tmp_path: Pat
         session_id=str(session["session_id"]),
         harness="codex",
         operation_type="tool_call",
-        status="waiting_on_approval",
+        status="approval_wait_timeout",
         approval_request_ids=["req-active"],
         resume_token="resume-token",
         metadata={

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13734,13 +13734,18 @@ def test_codex_browser_block_decision_updates_daemon_operation_status(tmp_path):
     assert statuses == [{"operation_id": "operation-1", "status": "blocked"}]
 
 
-def test_codex_browser_approval_caps_wait_below_hook_timeout(tmp_path, monkeypatch):
+def test_codex_browser_approval_uses_configured_wait_timeout(tmp_path, monkeypatch):
     captured_timeout: list[int] = []
+    statuses: list[dict[str, object]] = []
     monkeypatch.setenv("CODEX_HOME", str(tmp_path / ".codex"))
 
     def _fake_wait_for_approval_requests(**kwargs) -> dict[str, object]:
         captured_timeout.append(int(kwargs["timeout_seconds"]))
         return {"resolved": False, "pending_request_ids": ["request-1"], "items": []}
+
+    class _FakeDaemonClient:
+        def update_operation_status(self, **kwargs) -> None:
+            statuses.append(dict(kwargs))
 
     monkeypatch.setattr(guard_commands_module, "wait_for_approval_requests", _fake_wait_for_approval_requests)
 
@@ -13751,13 +13756,15 @@ def test_codex_browser_approval_caps_wait_below_hook_timeout(tmp_path, monkeypat
         response_payload={"operation_id": "operation-1", "approval_requests": [{"request_id": "request-1"}]},
         store=GuardStore(tmp_path / "home"),
         config=GuardConfig(tmp_path / "home", None, approval_wait_timeout_seconds=120),
+        daemon_client=_FakeDaemonClient(),
     )
 
     assert decision is None
-    assert captured_timeout == [25]
+    assert captured_timeout == [120]
+    assert statuses == [{"operation_id": "operation-1", "status": "approval_wait_timeout"}]
 
 
-def test_codex_browser_approval_caps_fallback_wait(tmp_path, monkeypatch):
+def test_codex_browser_approval_fallback_uses_configured_wait_timeout(tmp_path, monkeypatch):
     captured_timeout: list[int] = []
     monkeypatch.setenv("CODEX_HOME", str(tmp_path / ".codex"))
 
@@ -13777,7 +13784,7 @@ def test_codex_browser_approval_caps_fallback_wait(tmp_path, monkeypatch):
     )
 
     assert decision is None
-    assert captured_timeout == [5]
+    assert captured_timeout == [120]
 
 
 def test_guard_hook_codex_post_tool_use_blocks_named_secret_output(


### PR DESCRIPTION
## Summary
- keep live Codex hooks waiting for browser approval instead of launching duplicate headless resumes
- prefer Codex app-server resume for any known Codex thread, even when hook metadata omits a socket, with exec fallback
- extend Codex browser approval wait to the configured timeout and update approval-center copy for continuing actions
- update the Codex auto-resume smoke to prove browser approval drives real headless Codex resume allow/block outcomes

## Verification
- pytest tests/test_guard_codex_resume_endpoints.py tests/test_guard_codex_resume_commands.py tests/test_guard_queue_api_contract.py -k 'codex'
- pytest tests/test_guard_runtime.py -k 'codex_browser_approval or guard_hook_codex'
- ruff check src/codex_plugin_scanner/guard/codex_resume.py src/codex_plugin_scanner/guard/daemon/server.py src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_codex_resume_endpoints.py tests/test_guard_codex_resume_commands.py tests/test_guard_queue_api_contract.py tests/test_guard_runtime.py scripts/codex-auto-resume-smoke.py
- pnpm --dir dashboard test -- approval-center-layout.test.ts
- python3 scripts/codex-auto-resume-smoke.py --timeout-seconds 90