### PR TITLE
fix(guard): notify original Codex chat after approval

### DIFF
--- a/dashboard/src/approval-center-layout.test.ts
+++ b/dashboard/src/approval-center-layout.test.ts
@@ -309,6 +309,6 @@ assert(uxFailedDefault.body !== null, "C13: failed has non-null body even withou
 
 const uxSkipped = buildCodexResumeUx(makeResume("skipped"));
 assert(uxSkipped.showRetry === false, "C13: skipped status has showRetry false");
-assert(uxSkipped.body !== null && uxSkipped.body.toLowerCase().includes("terminal"), "C13: skipped body mentions terminal");
+assert(uxSkipped.body !== null && uxSkipped.body.toLowerCase().includes("codex"), "C13: skipped body mentions Codex");
 
 console.log("approval-center-layout.test.ts: all tests passed");

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -629,21 +629,21 @@ export function buildCodexResumeUx(resume: GuardCodexResumeResult): CodexResumeU
   }
   if (resume.status === "sent" || resume.status === "already_sent") {
     return {
-      headline: "Codex resumed.",
-      body: "Watch the chat for the next HOL Guard message.",
+      headline: "Codex chat notified.",
+      body: resume.message ?? "HOL Guard sent Codex a continuation message in the original chat.",
       showRetry: false
     };
   }
   if (resume.status === "failed") {
     return {
-      headline: "Guard could not resume the Codex session.",
-      body: resume.last_error ?? resume.reason ?? "Resume attempt failed.",
+      headline: "Guard could not message the Codex chat.",
+      body: resume.message ?? resume.last_error ?? resume.reason ?? "Continuation message failed.",
       showRetry: true
     };
   }
   return {
-    headline: "Guard could not locate the Codex session.",
-    body: "Return to your terminal and continue manually.",
+    headline: "Guard could not locate the Codex chat.",
+    body: resume.message ?? "Return to Codex and retry the same request.",
     showRetry: false
   };
 }

--- a/scripts/codex-auto-resume-smoke.py
+++ b/scripts/codex-auto-resume-smoke.py
@@ -4,12 +4,17 @@
 from __future__ import annotations
 
 import argparse
+import base64
+import hashlib
 import json
 import os
 import shutil
+import socket
+import struct
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -25,6 +30,7 @@ if str(SRC_ROOT) not in sys.path:
 
 ALLOW_SENTINEL = "HOL_GUARD_ALLOW_PROOF_PRESENT"
 PROOF_FILE_NAME = "guard-proof.txt"
+_WEBSOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
 
 @dataclass
@@ -104,7 +110,6 @@ def _run_scenario(*, decision: str, args: argparse.Namespace) -> SmokeScenarioRe
 
 
 def _run_scenario_in_dir(*, decision: str, args: argparse.Namespace, temp_dir: Path) -> SmokeScenarioResult:
-    from codex_plugin_scanner.guard import codex_app_server as codex_app_server_module
     from codex_plugin_scanner.guard.daemon import GuardDaemonServer
     from codex_plugin_scanner.guard.store import GuardStore
 
@@ -136,19 +141,9 @@ def _run_scenario_in_dir(*, decision: str, args: argparse.Namespace, temp_dir: P
     store = GuardStore(guard_home)
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     captured_payloads: list[dict[str, object]] = []
-    socket_path = workspace_dir / "codex-app-server.sock"
-    socket_path.write_text("", encoding="utf-8")
+    socket_path = temp_dir / "c.sock"
+    codex_server = _start_fake_codex_app_server(socket_path, captured_payloads, f"thread-smoke-{decision}")
 
-    original_send = codex_app_server_module._send_app_server_websocket_messages
-
-    def _fake_send(**kwargs):
-        payloads = kwargs.get("payloads")
-        if not isinstance(payloads, list):
-            raise AssertionError("fake Codex app-server expected a payloads list")
-        captured_payloads.extend(payloads)
-        return {"id": 2, "result": {"turnId": "turn-smoke"}}, "turn_completed"
-
-    codex_app_server_module._send_app_server_websocket_messages = _fake_send
     daemon.start()
     try:
         thread_id = f"thread-smoke-{decision}"
@@ -176,7 +171,7 @@ def _run_scenario_in_dir(*, decision: str, args: argparse.Namespace, temp_dir: P
             raise RuntimeError(f"approval response did not include codex_resume: {approval_payload}")
     finally:
         daemon.stop()
-        codex_app_server_module._send_app_server_websocket_messages = original_send
+        codex_server.join(timeout=1.0)
 
     transcript = "\n".join(json.dumps(payload, sort_keys=True) for payload in captured_payloads)
     proof_created = proof_path.is_file()
@@ -238,6 +233,127 @@ def _start_headless_codex_thread(
     if thread_id is None:
         raise RuntimeError(f"codex exec did not emit a thread id:\n{result.stdout}")
     return thread_id, result.stdout
+
+
+def _start_fake_codex_app_server(
+    socket_path: Path,
+    received: list[dict[str, object]],
+    thread_id: str,
+) -> threading.Thread:
+    def server() -> None:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as listener:
+            listener.bind(str(socket_path))
+            listener.listen(1)
+            connection, _ = listener.accept()
+            with connection:
+                headers = _recv_until(connection, b"\r\n\r\n").decode("iso-8859-1")
+                key = ""
+                for line in headers.split("\r\n"):
+                    if line.lower().startswith("sec-websocket-key:"):
+                        key = line.split(":", 1)[1].strip()
+                        break
+                accept = base64.b64encode(hashlib.sha1((key + _WEBSOCKET_GUID).encode("ascii")).digest()).decode(
+                    "ascii"
+                )
+                connection.sendall(
+                    (
+                        "HTTP/1.1 101 Switching Protocols\r\n"
+                        "Connection: Upgrade\r\n"
+                        "Upgrade: websocket\r\n"
+                        f"Sec-WebSocket-Accept: {accept}\r\n"
+                        "\r\n"
+                    ).encode("ascii")
+                )
+                while True:
+                    opcode, payload = _recv_websocket_frame(connection)
+                    if opcode != 0x1:
+                        continue
+                    message = json.loads(payload.decode("utf-8"))
+                    received.append(message)
+                    if message.get("id") == 1:
+                        _send_websocket_text(
+                            connection,
+                            {
+                                "id": 1,
+                                "result": {
+                                    "userAgent": "smoke",
+                                    "codexHome": "/tmp",
+                                    "platformFamily": "unix",
+                                    "platformOs": "macos",
+                                },
+                            },
+                        )
+                    if message.get("id") == 2:
+                        _send_websocket_text(connection, {"id": 2, "result": {"turnId": "turn-smoke"}})
+                        time.sleep(0.05)
+                        _send_websocket_text(
+                            connection,
+                            {
+                                "method": "turn/completed",
+                                "params": {
+                                    "threadId": thread_id,
+                                    "turn": {
+                                        "id": "turn-smoke",
+                                        "status": "completed",
+                                    },
+                                },
+                            },
+                        )
+                        break
+
+    thread = threading.Thread(target=server, name="codex-app-server-smoke", daemon=True)
+    thread.start()
+    for _ in range(50):
+        if socket_path.exists():
+            break
+        time.sleep(0.01)
+    return thread
+
+
+def _recv_until(connection: socket.socket, marker: bytes) -> bytes:
+    data = b""
+    while marker not in data:
+        chunk = connection.recv(4096)
+        if not chunk:
+            raise RuntimeError("socket closed before marker")
+        data += chunk
+    return data
+
+
+def _recv_exact(connection: socket.socket, length: int) -> bytes:
+    data = b""
+    while len(data) < length:
+        chunk = connection.recv(length - len(data))
+        if not chunk:
+            raise RuntimeError("socket closed before frame completed")
+        data += chunk
+    return data
+
+
+def _recv_websocket_frame(connection: socket.socket) -> tuple[int, bytes]:
+    first, second = _recv_exact(connection, 2)
+    length = second & 0x7F
+    if length == 126:
+        length = struct.unpack("!H", _recv_exact(connection, 2))[0]
+    elif length == 127:
+        length = struct.unpack("!Q", _recv_exact(connection, 8))[0]
+    mask = _recv_exact(connection, 4) if second & 0x80 else None
+    payload = _recv_exact(connection, length) if length else b""
+    if mask is not None:
+        payload = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+    return first & 0x0F, payload
+
+
+def _send_websocket_text(connection: socket.socket, payload: dict[str, object]) -> None:
+    data = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    length = len(data)
+    if length < 126:
+        header = bytes([0x81, length])
+    elif length < 65_536:
+        header = bytes([0x81, 126]) + struct.pack("!H", length)
+    else:
+        header = bytes([0x81, 127]) + struct.pack("!Q", length)
+    connection.sendall(header + data)
 
 
 def _scenario_env(*, home_dir: Path, codex_home: str | None, guard_daemon_port: int | None = None) -> dict[str, str]:

--- a/scripts/codex-auto-resume-smoke.py
+++ b/scripts/codex-auto-resume-smoke.py
@@ -142,7 +142,9 @@ def _run_scenario_in_dir(*, decision: str, args: argparse.Namespace, temp_dir: P
     original_send = codex_app_server_module._send_app_server_websocket_messages
 
     def _fake_send(**kwargs):
-        payloads = kwargs["payloads"]
+        payloads = kwargs.get("payloads")
+        if not isinstance(payloads, list):
+            raise AssertionError("fake Codex app-server expected a payloads list")
         captured_payloads.extend(payloads)
         return {"id": 2, "result": {"turnId": "turn-smoke"}}, "turn_completed"
 

--- a/scripts/codex-auto-resume-smoke.py
+++ b/scripts/codex-auto-resume-smoke.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Real headless Codex browser-approval auto-resume smoke test."""
+"""Codex app-server browser-approval continuation smoke test."""
 
 from __future__ import annotations
 
@@ -51,8 +51,6 @@ class SmokeScenarioResult:
 
 def main() -> int:
     args = _parse_args()
-    if shutil.which("codex") is None:
-        raise SystemExit("codex binary not found in PATH")
     allow_result = _run_scenario(decision="allow", args=args)
     block_result = _run_scenario(decision="block", args=args)
     payload = {
@@ -66,7 +64,7 @@ def main() -> int:
 
 
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run the real Codex browser-approval auto-resume smoke flow.")
+    parser = argparse.ArgumentParser(description="Run the Codex same-thread browser-approval continuation smoke flow.")
     parser.add_argument(
         "--codex-home",
         help="Optional CODEX_HOME override. Leave unset to keep the current authenticated Codex home.",
@@ -106,14 +104,13 @@ def _run_scenario(*, decision: str, args: argparse.Namespace) -> SmokeScenarioRe
 
 
 def _run_scenario_in_dir(*, decision: str, args: argparse.Namespace, temp_dir: Path) -> SmokeScenarioResult:
+    from codex_plugin_scanner.guard import codex_app_server as codex_app_server_module
     from codex_plugin_scanner.guard.daemon import GuardDaemonServer
     from codex_plugin_scanner.guard.store import GuardStore
 
     home_dir = temp_dir / "home"
     workspace_dir = temp_dir / "workspace"
     guard_home = home_dir
-    stdout_path = temp_dir / f"{decision}-codex.stdout.jsonl"
-    stderr_path = temp_dir / f"{decision}-codex.stderr.txt"
     proof_path = workspace_dir / PROOF_FILE_NAME
 
     _write_text(home_dir / ".codex" / "config.toml", 'model = "gpt-5"\n')
@@ -138,15 +135,21 @@ def _run_scenario_in_dir(*, decision: str, args: argparse.Namespace, temp_dir: P
 
     store = GuardStore(guard_home)
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    captured_payloads: list[dict[str, object]] = []
+    socket_path = workspace_dir / "codex-app-server.sock"
+    socket_path.write_text("", encoding="utf-8")
+
+    original_send = codex_app_server_module._send_app_server_websocket_messages
+
+    def _fake_send(**kwargs):
+        payloads = kwargs["payloads"]
+        captured_payloads.extend(payloads)
+        return {"id": 2, "result": {"turnId": "turn-smoke"}}, "turn_completed"
+
+    codex_app_server_module._send_app_server_websocket_messages = _fake_send
     daemon.start()
     try:
-        thread_id, initial_transcript = _start_headless_codex_thread(
-            workspace_dir=workspace_dir,
-            home_dir=home_dir,
-            codex_home=args.codex_home,
-            stdout_path=stdout_path,
-            stderr_path=stderr_path,
-        )
+        thread_id = f"thread-smoke-{decision}"
         request_id = uuid.uuid4().hex
         _queue_pending_request(
             store=store,
@@ -155,6 +158,7 @@ def _run_scenario_in_dir(*, decision: str, args: argparse.Namespace, temp_dir: P
             workspace_dir=workspace_dir,
             daemon_port=daemon.port,
             codex_home=args.codex_home,
+            socket_path=socket_path,
             operation_status="approval_wait_timeout",
         )
         action_path = "approve" if decision == "allow" else "block"
@@ -170,17 +174,17 @@ def _run_scenario_in_dir(*, decision: str, args: argparse.Namespace, temp_dir: P
             raise RuntimeError(f"approval response did not include codex_resume: {approval_payload}")
     finally:
         daemon.stop()
+        codex_app_server_module._send_app_server_websocket_messages = original_send
 
-    transcript = initial_transcript
-    proof_created = _wait_for_proof_state(proof_path=proof_path, should_exist=decision == "allow", timeout_seconds=20.0)
-    stderr_text = stderr_path.read_text(encoding="utf-8")
+    transcript = "\n".join(json.dumps(payload, sort_keys=True) for payload in captured_payloads)
+    proof_created = proof_path.is_file()
     resume_message = str(resume_payload.get("message") or "")
     _assert_expected_outcome(
         decision=decision,
         final_message=resume_message,
         approval_payload=approval_payload,
         proof_created=proof_created,
-        stderr_text=stderr_text,
+        transcript=transcript,
     )
 
     return SmokeScenarioResult(
@@ -296,7 +300,7 @@ def _assert_expected_outcome(
     final_message: str,
     approval_payload: dict[str, object],
     proof_created: bool,
-    stderr_text: str,
+    transcript: str,
 ) -> None:
     codex_resume = approval_payload.get("codex_resume")
     if not isinstance(codex_resume, dict):
@@ -304,16 +308,18 @@ def _assert_expected_outcome(
     status = str(codex_resume.get("status") or "")
     if status not in {"in_progress", "sent", "already_sent"}:
         raise AssertionError(f"expected codex_resume status to show live continuation, got {status!r}")
+    if "turn/start" not in transcript:
+        raise AssertionError(f"same-thread Codex app-server prompt was not sent:\n{transcript}")
     if decision == "allow":
-        if not proof_created:
-            raise AssertionError("allow flow did not create the proof file")
+        if proof_created:
+            raise AssertionError("allow smoke must not start a separate headless Codex proof run")
         if not final_message.strip():
             raise AssertionError("allow flow returned an empty resume message")
         return
     if proof_created:
         raise AssertionError("block flow unexpectedly created the proof file")
     if not final_message.strip():
-        raise AssertionError(f"block flow returned an empty message\nstderr:\n{stderr_text}")
+        raise AssertionError(f"block flow returned an empty message\ntranscript:\n{transcript}")
     normalized = final_message.lower()
     if not any(keyword in normalized for keyword in ("codex", "guard", "retry", "alternative", "blocked")):
         raise AssertionError(f"block flow did not return resume guidance: {final_message!r}")
@@ -355,6 +361,7 @@ def _queue_pending_request(
     workspace_dir: Path,
     daemon_port: int,
     codex_home: str | None,
+    socket_path: Path,
     operation_status: str = "waiting_on_approval",
 ) -> None:
     from codex_plugin_scanner.guard.consumer import artifact_hash
@@ -404,7 +411,7 @@ def _queue_pending_request(
             "codex_thread_id": thread_id,
             "session_id": thread_id,
             "codex_home": codex_home,
-            "codex_app_server_socket": str(workspace_dir / "missing-codex-app-server.sock"),
+            "codex_app_server_socket": str(socket_path),
             "command_text": _proof_command(),
             "tool_name": "Bash",
             "event": "PreToolUse",
@@ -437,7 +444,7 @@ def _queue_pending_request(
             artifact_label="Native shell action",
             source_label="Codex remembered command",
             trigger_summary=str(
-                artifact.metadata.get("request_summary") or "Queued for Codex exec resume verification."
+                artifact.metadata.get("request_summary") or "Queued for Codex same-thread continuation verification."
             ),
             why_now="This verifies browser approval auto-resume for Codex exec sessions.",
             launch_summary="Writes a proof file only after approval.",
@@ -469,6 +476,8 @@ def _write_text(path: Path, text: str) -> None:
 
 
 def _codex_version() -> str:
+    if shutil.which("codex") is None:
+        return "codex not found"
     result = subprocess.run(["codex", "--version"], capture_output=True, text=True, timeout=10, check=False)
     return result.stdout.strip() or result.stderr.strip() or "unknown"
 

--- a/src/codex_plugin_scanner/guard/codex_app_server.py
+++ b/src/codex_plugin_scanner/guard/codex_app_server.py
@@ -45,6 +45,12 @@ class _WebSocketClosedError(TimeoutError):
     """Raised when the app-server closes without a websocket close frame."""
 
 
+def default_codex_app_server_socket_available() -> bool:
+    """Return whether the current Codex app-server control socket is reachable."""
+
+    return _DEFAULT_SOCKET_PATH.exists()
+
+
 def codex_resume_metadata_from_hook_payload(
     payload: Mapping[str, object],
     *,

--- a/src/codex_plugin_scanner/guard/codex_app_server.py
+++ b/src/codex_plugin_scanner/guard/codex_app_server.py
@@ -48,7 +48,15 @@ class _WebSocketClosedError(TimeoutError):
 def default_codex_app_server_socket_available() -> bool:
     """Return whether the current Codex app-server control socket is reachable."""
 
-    return _DEFAULT_SOCKET_PATH.exists()
+    if not _DEFAULT_SOCKET_PATH.exists():
+        return False
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.settimeout(0.2)
+            client.connect(str(_DEFAULT_SOCKET_PATH))
+    except OSError:
+        return False
+    return True
 
 
 def codex_resume_metadata_from_hook_payload(

--- a/src/codex_plugin_scanner/guard/codex_app_server.py
+++ b/src/codex_plugin_scanner/guard/codex_app_server.py
@@ -45,15 +45,26 @@ class _WebSocketClosedError(TimeoutError):
     """Raised when the app-server closes without a websocket close frame."""
 
 
-def default_codex_app_server_socket_available() -> bool:
+def default_codex_app_server_socket_path(*, environ: Mapping[str, str] | None = None) -> Path:
+    """Return the default Codex app-server socket path for the active Codex home."""
+
+    env = environ or os.environ
+    codex_home = env.get("CODEX_HOME", "").strip()
+    if not codex_home:
+        return _DEFAULT_SOCKET_PATH
+    return Path(codex_home).expanduser() / "app-server-control" / "app-server-control.sock"
+
+
+def default_codex_app_server_socket_available(*, environ: Mapping[str, str] | None = None) -> bool:
     """Return whether the current Codex app-server control socket is reachable."""
 
-    if not _DEFAULT_SOCKET_PATH.exists():
+    socket_path = default_codex_app_server_socket_path(environ=environ)
+    if not socket_path.exists():
         return False
     try:
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
             client.settimeout(0.2)
-            client.connect(str(_DEFAULT_SOCKET_PATH))
+            client.connect(str(socket_path))
     except OSError:
         return False
     return True
@@ -106,7 +117,10 @@ def resume_codex_thread_for_request(
     thread_id = _first_string(metadata, ("codex_thread_id", "thread_id", "threadId", "session_id", "sessionId"))
     if thread_id is None:
         return None
-    socket_path = _first_string(metadata, _SOCKET_KEYS) or str(_DEFAULT_SOCKET_PATH)
+    codex_home = _first_string(metadata, _CODEX_HOME_KEYS)
+    socket_path = _first_string(metadata, _SOCKET_KEYS) or str(
+        default_codex_app_server_socket_path(environ={"CODEX_HOME": codex_home or ""})
+    )
     if not _is_safe_local_socket_path(socket_path):
         return {
             "status": "skipped",

--- a/src/codex_plugin_scanner/guard/codex_resume.py
+++ b/src/codex_plugin_scanner/guard/codex_resume.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import shutil
-import subprocess
 from collections.abc import Mapping
 
 from .codex_app_server import resume_codex_thread_for_request
@@ -144,17 +143,10 @@ def defer_request_resume_to_live_hook(
 
 def inspect_codex_resume_capabilities(store: GuardStore) -> dict[str, object]:
     binary_path = shutil.which("codex")
-    app_server_support = (
-        _command_available(["codex", "debug", "app-server", "send-message-v2", "--help"]) if binary_path else False
-    )
-    remote_control_support = _command_available(["codex", "remote-control", "--help"]) if binary_path else False
-    headless_resume_support = _command_available(["codex", "exec", "resume", "--help"]) if binary_path else False
     latest_attempt = store.get_latest_request_resume(harness="codex")
     return {
         "codex_binary_found": binary_path is not None,
-        "app_server_support": app_server_support,
-        "remote_control_support": remote_control_support,
-        "headless_resume_support": headless_resume_support,
+        "app_server_support": binary_path is not None,
         "latest_attempt": latest_attempt,
     }
 
@@ -244,7 +236,7 @@ def _dispatch_resume_attempt(
             "reason": "session_not_found",
             "thread_id": thread_id,
             "strategy": strategy,
-            "supported": False,
+            "supported": True,
         }
     return app_server_result
 
@@ -336,17 +328,3 @@ def _first_string(mapping: Mapping[str, object], keys: tuple[str, ...]) -> str |
         if isinstance(value, str) and value.strip():
             return value
     return None
-
-
-def _command_available(command: list[str]) -> bool:
-    try:
-        result = subprocess.run(
-            command,
-            capture_output=True,
-            check=False,
-            text=True,
-            timeout=5,
-        )
-    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
-        return False
-    return result.returncode == 0

--- a/src/codex_plugin_scanner/guard/codex_resume.py
+++ b/src/codex_plugin_scanner/guard/codex_resume.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import shutil
-import subprocess
 from collections.abc import Mapping
 
 from .codex_app_server import default_codex_app_server_socket_available, resume_codex_thread_for_request
@@ -145,11 +144,14 @@ def defer_request_resume_to_live_hook(
 def inspect_codex_resume_capabilities(store: GuardStore) -> dict[str, object]:
     binary_path = shutil.which("codex")
     socket_available = default_codex_app_server_socket_available()
-    app_server_support = _command_available(["codex", "--version"]) if binary_path else False
     latest_attempt = store.get_latest_request_resume(harness="codex")
     return {
         "codex_binary_found": binary_path is not None,
-        "app_server_support": app_server_support,
+        "app_server_support": None,
+        "app_server_support_reason": (
+            "Codex does not expose a stable public app-server capability probe; "
+            "same-thread continuation uses the local app-server socket when it is active."
+        ),
         "app_server_socket_available": socket_available,
         "latest_attempt": latest_attempt,
     }
@@ -332,17 +334,3 @@ def _first_string(mapping: Mapping[str, object], keys: tuple[str, ...]) -> str |
         if isinstance(value, str) and value.strip():
             return value
     return None
-
-
-def _command_available(command: list[str]) -> bool:
-    try:
-        result = subprocess.run(
-            command,
-            capture_output=True,
-            check=False,
-            text=True,
-            timeout=5,
-        )
-    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
-        return False
-    return result.returncode == 0

--- a/src/codex_plugin_scanner/guard/codex_resume.py
+++ b/src/codex_plugin_scanner/guard/codex_resume.py
@@ -2,14 +2,11 @@
 
 from __future__ import annotations
 
-import os
-import re
 import shutil
 import subprocess
 from collections.abc import Mapping
-from pathlib import Path
 
-from .codex_app_server import build_codex_continuation_prompt, resume_codex_thread_for_request
+from .codex_app_server import resume_codex_thread_for_request
 from .store import GuardStore
 
 _THREAD_ID_KEYS = (
@@ -21,11 +18,6 @@ _THREAD_ID_KEYS = (
     "session_id",
     "sessionId",
 )
-_SOCKET_KEYS = ("codex_app_server_socket", "app_server_socket", "appServerSocket")
-_CODEX_HOME_KEYS = ("codex_home", "codexHome")
-_COMMAND_TEXT_KEYS = ("command_text", "commandText")
-_CODEX_EXEC_RESUME_TIMEOUT_SECONDS = 120.0
-_SAFE_CODEX_SESSION_ID_PATTERN = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
 
 
 def seed_request_resume_record(store: GuardStore, *, request_id: str, now: str) -> dict[str, object] | None:
@@ -79,7 +71,7 @@ def retry_request_resume(
         return {
             **resume,
             "status": "already_sent",
-            "message": "Codex was already resumed for this request.",
+            "message": "HOL Guard already sent Codex a continuation message for this request.",
         }
     if str(resume.get("status")) == "in_progress":
         return resume
@@ -91,7 +83,7 @@ def retry_request_resume(
         supported=bool(resume.get("supported")) if resume.get("supported") is not None else None,
         status="in_progress",
         reason="attempting_resume",
-        message="Resuming Codex...",
+        message="Sending Codex a continuation message...",
         last_error=None,
         attempt_count=attempt_count,
         last_attempt_at=now,
@@ -152,7 +144,9 @@ def defer_request_resume_to_live_hook(
 
 def inspect_codex_resume_capabilities(store: GuardStore) -> dict[str, object]:
     binary_path = shutil.which("codex")
-    app_server_support = _command_available(["codex", "app-server", "--help"]) if binary_path else False
+    app_server_support = (
+        _command_available(["codex", "debug", "app-server", "send-message-v2", "--help"]) if binary_path else False
+    )
     remote_control_support = _command_available(["codex", "remote-control", "--help"]) if binary_path else False
     headless_resume_support = _command_available(["codex", "exec", "resume", "--help"]) if binary_path else False
     latest_attempt = store.get_latest_request_resume(harness="codex")
@@ -242,19 +236,17 @@ def _dispatch_resume_attempt(
 ) -> dict[str, object] | None:
     if thread_id is None:
         return None
-    if strategy == "codex-exec-resume":
-        return _resume_codex_exec_session(store=store, request_id=request_id, action=action, thread_id=thread_id)
 
     app_server_result = resume_codex_thread_for_request(store=store, request_id=request_id, action=action)
     if app_server_result is None:
-        return _resume_codex_exec_session(store=store, request_id=request_id, action=action, thread_id=thread_id)
-    if str(app_server_result.get("status") or "") == "sent":
-        return app_server_result
-
-    exec_result = _resume_codex_exec_session(store=store, request_id=request_id, action=action, thread_id=thread_id)
-    if exec_result is not None and str(exec_result.get("status") or "") == "sent":
-        return exec_result
-    return exec_result or app_server_result
+        return {
+            "status": "skipped",
+            "reason": "session_not_found",
+            "thread_id": thread_id,
+            "strategy": strategy,
+            "supported": False,
+        }
+    return app_server_result
 
 
 def _normalize_dispatch_result(
@@ -285,7 +277,7 @@ def _normalize_dispatch_result(
         return {
             "status": "sent",
             "reason": raw_reason,
-            "message": "Codex resumed. Watch the chat for the next HOL Guard message.",
+            "message": "HOL Guard sent Codex a continuation message in the original chat.",
             "last_error": None,
             "thread_id": raw_thread_id,
             "strategy": effective_strategy,
@@ -314,171 +306,27 @@ def _normalize_dispatch_result(
     }
 
 
-def _resume_codex_exec_session(
-    *,
-    store: GuardStore,
-    request_id: str,
-    action: str,
-    thread_id: str,
-) -> dict[str, object]:
-    operation = store.get_guard_operation_for_approval_request(request_id)
-    metadata = operation.get("metadata") if isinstance(operation, dict) else None
-    session_id = (
-        str(operation["session_id"])
-        if isinstance(operation, dict) and operation.get("session_id") is not None
-        else None
-    )
-    session = store.get_guard_session(session_id) if session_id is not None else None
-    workspace = (
-        str(session["workspace"]) if isinstance(session, dict) and session.get("workspace") is not None else None
-    )
-    if not _is_safe_codex_session_id(thread_id):
-        return {
-            "status": "failed",
-            "reason": "unsafe_thread_id",
-            "message": "Codex session metadata was not safe to resume automatically.",
-            "last_error": "unsafe Codex session id",
-            "thread_id": thread_id,
-            "strategy": "codex-exec-resume",
-            "supported": True,
-        }
-    if shutil.which("codex") is None:
-        return {
-            "status": "failed",
-            "reason": "codex_not_found",
-            "message": "The codex binary is not available for automatic resume.",
-            "last_error": "codex binary not found",
-            "thread_id": thread_id,
-            "strategy": "codex-exec-resume",
-            "supported": True,
-        }
-    command_text = _first_string(metadata, _COMMAND_TEXT_KEYS) if isinstance(metadata, Mapping) else None
-    if command_text is not None and not _is_safe_resume_prompt_text(command_text):
-        command_text = None
-    prompt = build_codex_continuation_prompt(
-        action,
-        request_id=request_id,
-        command_text=command_text,
-    )
-    command = [
-        "codex",
-        "exec",
-        "resume",
-        "--json",
-        "--dangerously-bypass-approvals-and-sandbox",
-        "--dangerously-bypass-hook-trust",
-        "--ignore-user-config",
-        "--skip-git-repo-check",
-        thread_id,
-        "-",
-    ]
-    env = os.environ.copy()
-    codex_home = _first_string(metadata, _CODEX_HOME_KEYS) if isinstance(metadata, Mapping) else None
-    if codex_home is not None and _is_safe_local_directory(codex_home):
-        env["CODEX_HOME"] = codex_home
-    cwd = workspace if workspace is not None and _is_safe_local_directory(workspace) else None
-    try:
-        result = subprocess.run(
-            command,
-            capture_output=True,
-            check=False,
-            cwd=cwd,
-            env=env,
-            input=prompt,
-            text=True,
-            timeout=_CODEX_EXEC_RESUME_TIMEOUT_SECONDS,
-        )
-    except FileNotFoundError:
-        return {
-            "status": "failed",
-            "reason": "codex_not_found",
-            "message": "The codex binary is not available for automatic resume.",
-            "last_error": "codex binary not found",
-            "thread_id": thread_id,
-            "strategy": "codex-exec-resume",
-            "supported": True,
-        }
-    except OSError as error:
-        return {
-            "status": "failed",
-            "reason": "exec_resume_launch_failed",
-            "message": "Guard could not start Codex for automatic resume.",
-            "last_error": str(error),
-            "thread_id": thread_id,
-            "strategy": "codex-exec-resume",
-            "supported": True,
-        }
-    except subprocess.TimeoutExpired:
-        return {
-            "status": "failed",
-            "reason": "exec_resume_timeout",
-            "message": "Codex did not finish the automatic resume prompt in time.",
-            "last_error": "timed out waiting for codex exec resume",
-            "thread_id": thread_id,
-            "strategy": "codex-exec-resume",
-            "supported": True,
-        }
-    if result.returncode == 0:
-        return {
-            "status": "sent",
-            "reason": "exec_resume_sent",
-            "thread_id": thread_id,
-            "strategy": "codex-exec-resume",
-            "supported": True,
-        }
-    failure_output = (result.stderr or result.stdout or "").strip()
-    return {
-        "status": "failed",
-        "reason": "exec_resume_failed",
-        "message": "Codex rejected the automatic resume prompt.",
-        "last_error": failure_output or "codex exec resume exited with a non-zero status",
-        "thread_id": thread_id,
-        "strategy": "codex-exec-resume",
-        "supported": True,
-    }
-
-
-def _is_safe_codex_session_id(value: str) -> bool:
-    return bool(_SAFE_CODEX_SESSION_ID_PATTERN.fullmatch(value))
-
-
-def _is_safe_resume_prompt_text(value: str) -> bool:
-    if "\x00" in value or len(value) > 4000:
-        return False
-    return all(character in "\n\r\t" or 32 <= ord(character) <= 126 for character in value)
-
-
-def _is_safe_local_directory(raw_path: str) -> bool:
-    if "\x00" in raw_path or not raw_path.strip():
-        return False
-    try:
-        path = Path(raw_path).expanduser().resolve(strict=False)
-    except (OSError, RuntimeError, ValueError):
-        return False
-    return path.is_dir()
-
-
 def _manual_resume_message(action: str) -> str:
     if action == "block":
         return (
-            "Decision saved. HOL Guard could not find the Codex session to resume. "
+            "Decision saved. HOL Guard could not find the original Codex chat to message. "
             "Do not retry that action in Codex. Ask for a safe alternative instead."
         )
     return (
-        "Decision saved. HOL Guard could not find the Codex session to resume. "
-        "Retry the same request in Codex; it should pass because this approval is now saved."
+        "Decision saved. HOL Guard could not find the original Codex chat to message. "
+        "Return to Codex and retry the same request; this approval is now saved."
     )
 
 
 def _failed_resume_message(action: str) -> str:
     if action == "block":
         return (
-            "Decision saved. HOL Guard could not resume Codex automatically. "
+            "Decision saved. HOL Guard could not send Codex a continuation message in the original chat. "
             "Do not retry that action in Codex. Ask for a safe alternative instead."
         )
     return (
-        "Decision saved. HOL Guard could not resume Codex automatically. "
-        "Retry the same request in Codex; it should pass because this approval is now saved."
+        "Decision saved. HOL Guard could not send Codex a continuation message in the original chat. "
+        "Return to Codex and retry the same request; this approval is now saved."
     )
 
 

--- a/src/codex_plugin_scanner/guard/codex_resume.py
+++ b/src/codex_plugin_scanner/guard/codex_resume.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import shutil
+import subprocess
 from collections.abc import Mapping
 
 from .codex_app_server import default_codex_app_server_socket_available, resume_codex_thread_for_request
@@ -144,10 +145,11 @@ def defer_request_resume_to_live_hook(
 def inspect_codex_resume_capabilities(store: GuardStore) -> dict[str, object]:
     binary_path = shutil.which("codex")
     socket_available = default_codex_app_server_socket_available()
+    app_server_support = _command_available(["codex", "--version"]) if binary_path else False
     latest_attempt = store.get_latest_request_resume(harness="codex")
     return {
         "codex_binary_found": binary_path is not None,
-        "app_server_support": socket_available,
+        "app_server_support": app_server_support,
         "app_server_socket_available": socket_available,
         "latest_attempt": latest_attempt,
     }
@@ -330,3 +332,17 @@ def _first_string(mapping: Mapping[str, object], keys: tuple[str, ...]) -> str |
         if isinstance(value, str) and value.strip():
             return value
     return None
+
+
+def _command_available(command: list[str]) -> bool:
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0

--- a/src/codex_plugin_scanner/guard/codex_resume.py
+++ b/src/codex_plugin_scanner/guard/codex_resume.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import shutil
 from collections.abc import Mapping
 
-from .codex_app_server import resume_codex_thread_for_request
+from .codex_app_server import default_codex_app_server_socket_available, resume_codex_thread_for_request
 from .store import GuardStore
 
 _THREAD_ID_KEYS = (
@@ -143,10 +143,12 @@ def defer_request_resume_to_live_hook(
 
 def inspect_codex_resume_capabilities(store: GuardStore) -> dict[str, object]:
     binary_path = shutil.which("codex")
+    socket_available = default_codex_app_server_socket_available()
     latest_attempt = store.get_latest_request_resume(harness="codex")
     return {
         "codex_binary_found": binary_path is not None,
-        "app_server_support": binary_path is not None,
+        "app_server_support": socket_available,
+        "app_server_socket_available": socket_available,
         "latest_attempt": latest_attempt,
     }
 
@@ -236,7 +238,7 @@ def _dispatch_resume_attempt(
             "reason": "session_not_found",
             "thread_id": thread_id,
             "strategy": strategy,
-            "supported": True,
+            "supported": False,
         }
     return app_server_result
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1507,10 +1507,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         message = str(codex_resume.get("message") or "")
         if status == "sent":
             updated["resolution_summary"] = (
-                "Decision saved. HOL Guard sent Codex a continue prompt in the original thread."
+                "Decision saved. HOL Guard sent Codex a continuation message in the original chat."
             )
             copy = {
-                "title": "Decision saved. Codex is continuing.",
+                "title": "Decision saved. Codex chat was notified.",
                 "body": message,
             }
         elif status in {"pending", "in_progress"}:
@@ -1520,9 +1520,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 "body": message or "Return to Codex; the original action should continue automatically.",
             }
         elif status == "already_sent":
-            updated["resolution_summary"] = "Decision saved. Codex was already resumed for this request."
+            updated["resolution_summary"] = "Decision saved. Codex was already notified for this request."
             copy = {
-                "title": "Decision saved. Codex already resumed.",
+                "title": "Decision saved. Codex already notified.",
                 "body": message,
             }
         else:
@@ -1531,7 +1531,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 "title": (
                     "Decision saved. Return to Codex."
                     if status == "skipped"
-                    else "Decision saved. Codex could not be resumed."
+                    else "Decision saved. Codex chat could not be notified."
                 ),
                 "body": message or copy["body"],
             }

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1507,7 +1507,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         message = str(codex_resume.get("message") or "")
         if status == "sent":
             updated["resolution_summary"] = (
-                "Decision saved. HOL Guard sent Codex a continuation message in the original chat."
+                "Decision saved. HOL Guard sent Codex a continue prompt in the original thread."
             )
             copy = {
                 "title": "Decision saved. Codex chat was notified.",

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -14286,25 +14286,29 @@ function isCodexHarness(harness) {
 }
 function buildCodexResumeUx(resume) {
   if (resume.status === "pending" || resume.status === "in_progress") {
-    return { headline: "Resuming Codex...", body: null, showRetry: false };
+    return {
+      headline: "Codex is continuing.",
+      body: resume.message ?? "HOL Guard saved your choice and the original Codex action is still waiting for it.",
+      showRetry: false
+    };
   }
   if (resume.status === "sent" || resume.status === "already_sent") {
     return {
-      headline: "Codex resumed.",
-      body: "Watch the chat for the next HOL Guard message.",
+      headline: "Codex chat notified.",
+      body: resume.message ?? "HOL Guard sent Codex a continuation message in the original chat.",
       showRetry: false
     };
   }
   if (resume.status === "failed") {
     return {
-      headline: "Guard could not resume the Codex session.",
-      body: resume.last_error ?? resume.reason ?? "Resume attempt failed.",
+      headline: "Guard could not message the Codex chat.",
+      body: resume.message ?? resume.last_error ?? resume.reason ?? "Continuation message failed.",
       showRetry: true
     };
   }
   return {
-    headline: "Guard could not locate the Codex session.",
-    body: "Return to your terminal and continue manually.",
+    headline: "Guard could not locate the Codex chat.",
+    body: resume.message ?? "Return to Codex and retry the same request.",
     showRetry: false
   };
 }

--- a/tests/test_guard_codex_auto_resume_smoke.py
+++ b/tests/test_guard_codex_auto_resume_smoke.py
@@ -5,8 +5,6 @@ import importlib.util
 import sys
 from pathlib import Path
 
-import pytest
-
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "codex-auto-resume-smoke.py"
 MODULE_NAME = "guard_codex_auto_resume_smoke"
 
@@ -21,8 +19,7 @@ def _load_smoke_module():
     return module
 
 
-@pytest.mark.slow
-def test_codex_auto_resume_smoke_script_runs_real_allow_and_block_flows() -> None:
+def test_codex_auto_resume_smoke_script_sends_same_thread_app_server_messages() -> None:
     module = _load_smoke_module()
     args = argparse.Namespace(
         codex_home=None,
@@ -36,9 +33,13 @@ def test_codex_auto_resume_smoke_script_runs_real_allow_and_block_flows() -> Non
 
     assert allow_result.resume_status == "sent"
     assert allow_result.request_id
-    assert allow_result.proof_created is True
+    assert allow_result.resume_strategy == "codex-app-server-thread"
+    assert allow_result.proof_created is False
     assert allow_result.assistant_message
+    assert "turn/start" in allow_result.transcript_excerpt
     assert block_result.resume_status == "sent"
     assert block_result.request_id
+    assert block_result.resume_strategy == "codex-app-server-thread"
     assert block_result.proof_created is False
     assert block_result.assistant_message
+    assert "turn/start" in block_result.transcript_excerpt

--- a/tests/test_guard_codex_resume_commands.py
+++ b/tests/test_guard_codex_resume_commands.py
@@ -162,7 +162,7 @@ def test_guard_doctor_codex_handles_launch_oserror(
     assert output["codex_resume"]["headless_resume_support"] is False
 
 
-def test_guard_approvals_resume_rejects_unsafe_thread_id(
+def test_guard_approvals_resume_reports_missing_same_thread_channel(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -192,31 +192,18 @@ def test_guard_approvals_resume_rejects_unsafe_thread_id(
 
     assert rc == 0
     assert output["status"] == "failed"
-    assert output["reason"] == "unsafe_thread_id"
+    assert output["reason"] == "socket_not_available"
+    assert output["strategy"] == "codex-app-server-thread"
+    assert "original chat" in output["message"]
 
 
-def test_guard_approvals_resume_falls_back_to_exec_resume_when_app_server_unavailable(
+def test_guard_approvals_resume_does_not_start_headless_codex_when_app_server_unavailable(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    recorded: dict[str, object] = {}
-    _stub_codex_binary(monkeypatch)
-
     def _fake_run(command, **kwargs):
-        recorded["command"] = command
-        recorded["cwd"] = kwargs.get("cwd")
-        recorded["env"] = kwargs.get("env")
-        recorded["input"] = kwargs.get("input")
-        return type(
-            "CompletedProcess",
-            (),
-            {
-                "returncode": 0,
-                "stdout": '{"type":"item.completed","item":{"type":"agent_message","text":"done"}}\n',
-                "stderr": "",
-            },
-        )()
+        raise AssertionError("same-thread resume must not start a separate headless Codex run")
 
     monkeypatch.setattr(codex_resume_module.subprocess, "run", _fake_run)
 
@@ -244,12 +231,7 @@ def test_guard_approvals_resume_falls_back_to_exec_resume_when_app_server_unavai
     output = json.loads(capsys.readouterr().out)
 
     assert rc == 0
-    assert output["status"] == "sent"
-    assert output["strategy"] == "codex-exec-resume"
-    assert recorded["command"][:3] == ["codex", "exec", "resume"]
-    assert "--dangerously-bypass-approvals-and-sandbox" in recorded["command"]
-    assert "thread-1" in recorded["command"]
-    assert recorded["command"][-1] == "-"
-    assert isinstance(recorded["input"], str)
-    assert "approved request `req-cli-exec`" in recorded["input"]
-    assert recorded["cwd"] == str(workspace)
+    assert output["status"] == "failed"
+    assert output["reason"] == "socket_not_available"
+    assert output["strategy"] == "codex-app-server-thread"
+    assert "retry the same request" in output["message"]

--- a/tests/test_guard_codex_resume_commands.py
+++ b/tests/test_guard_codex_resume_commands.py
@@ -132,6 +132,7 @@ def test_guard_doctor_codex_reports_resume_diagnostics(
     assert rc == 0
     assert output["codex_resume"]["codex_binary_found"] in {True, False}
     assert output["codex_resume"]["app_server_support"] in {True, False}
+    assert output["codex_resume"]["app_server_socket_available"] in {True, False}
     assert output["codex_resume"]["latest_attempt"] is None
 
 
@@ -150,7 +151,8 @@ def test_guard_doctor_codex_reports_app_server_support_from_codex_binary(
 
     assert rc == 0
     assert output["codex_resume"]["codex_binary_found"] is True
-    assert output["codex_resume"]["app_server_support"] is True
+    assert output["codex_resume"]["app_server_support"] in {True, False}
+    assert output["codex_resume"]["app_server_socket_available"] in {True, False}
     assert "remote_control_support" not in output["codex_resume"]
     assert "headless_resume_support" not in output["codex_resume"]
 

--- a/tests/test_guard_codex_resume_commands.py
+++ b/tests/test_guard_codex_resume_commands.py
@@ -132,12 +132,10 @@ def test_guard_doctor_codex_reports_resume_diagnostics(
     assert rc == 0
     assert output["codex_resume"]["codex_binary_found"] in {True, False}
     assert output["codex_resume"]["app_server_support"] in {True, False}
-    assert output["codex_resume"]["remote_control_support"] in {True, False}
-    assert output["codex_resume"]["headless_resume_support"] in {True, False}
     assert output["codex_resume"]["latest_attempt"] is None
 
 
-def test_guard_doctor_codex_handles_launch_oserror(
+def test_guard_doctor_codex_reports_app_server_support_from_codex_binary(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
@@ -147,19 +145,14 @@ def test_guard_doctor_codex_handles_launch_oserror(
     GuardStore(guard_home)
     _stub_codex_binary(monkeypatch)
 
-    def _raise_oserror(command, **kwargs):
-        raise PermissionError("exec denied")
-
-    monkeypatch.setattr(codex_resume_module.subprocess, "run", _raise_oserror)
-
     rc = main(["guard", "doctor", "codex", "--home", str(home_dir), "--guard-home", str(guard_home), "--json"])
     output = json.loads(capsys.readouterr().out)
 
     assert rc == 0
     assert output["codex_resume"]["codex_binary_found"] is True
-    assert output["codex_resume"]["app_server_support"] is False
-    assert output["codex_resume"]["remote_control_support"] is False
-    assert output["codex_resume"]["headless_resume_support"] is False
+    assert output["codex_resume"]["app_server_support"] is True
+    assert "remote_control_support" not in output["codex_resume"]
+    assert "headless_resume_support" not in output["codex_resume"]
 
 
 def test_guard_approvals_resume_reports_missing_same_thread_channel(
@@ -200,13 +193,7 @@ def test_guard_approvals_resume_reports_missing_same_thread_channel(
 def test_guard_approvals_resume_does_not_start_headless_codex_when_app_server_unavailable(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def _fake_run(command, **kwargs):
-        raise AssertionError("same-thread resume must not start a separate headless Codex run")
-
-    monkeypatch.setattr(codex_resume_module.subprocess, "run", _fake_run)
-
     home_dir = tmp_path / "guard-home"
     workspace = tmp_path / "workspace"
     workspace.mkdir()

--- a/tests/test_guard_codex_resume_commands.py
+++ b/tests/test_guard_codex_resume_commands.py
@@ -118,6 +118,83 @@ def test_guard_approvals_resume_retries_failed_codex_resume(
     assert send_calls == 1
 
 
+def test_guard_approvals_resume_uses_codex_home_default_socket(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    socket_paths: list[str] = []
+
+    def _fake_send(**kwargs):
+        socket_paths.append(str(kwargs["socket_path"]))
+        return {"id": 2, "result": {"turnId": "turn-2"}}, "turn_completed"
+
+    monkeypatch.setattr(codex_app_server_module, "_send_app_server_websocket_messages", _fake_send)
+
+    home_dir = tmp_path / "guard-home"
+    codex_home = tmp_path / "codex-home"
+    socket_path = codex_home / "app-server-control" / "app-server-control.sock"
+    socket_path.parent.mkdir(parents=True)
+    socket_path.write_text("", encoding="utf-8")
+    store = GuardStore(home_dir)
+    store.add_approval_request(_request("req-cli-home"), "2026-05-19T10:00:00+00:00")
+    _seed_codex_operation(
+        store,
+        request_id="req-cli-home",
+        socket_path=None,
+        codex_home=str(codex_home),
+    )
+    store.resolve_approval_request(
+        "req-cli-home",
+        resolution_action="allow",
+        resolution_scope="artifact",
+        reason="reviewed",
+        resolved_at="2026-05-19T10:01:00+00:00",
+    )
+
+    rc = main(["guard", "approvals", "resume", "req-cli-home", "--home", str(home_dir), "--json"])
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["status"] == "sent"
+    assert socket_paths == [str(socket_path)]
+
+
+def test_default_codex_app_server_socket_probe_uses_codex_home(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    codex_home = tmp_path / "custom-codex-home"
+    socket_path = codex_home / "app-server-control" / "app-server-control.sock"
+    socket_path.parent.mkdir(parents=True)
+    socket_path.write_text("", encoding="utf-8")
+    connect_paths: list[str] = []
+
+    class _FakeSocket:
+        def __enter__(self) -> _FakeSocket:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def settimeout(self, _timeout: float) -> None:
+            return None
+
+        def connect(self, path: str) -> None:
+            connect_paths.append(path)
+
+    monkeypatch.setattr(codex_app_server_module.socket, "socket", lambda *_args, **_kwargs: _FakeSocket())
+
+    assert (
+        codex_app_server_module.default_codex_app_server_socket_path(environ={"CODEX_HOME": str(codex_home)})
+        == socket_path
+    )
+    assert codex_app_server_module.default_codex_app_server_socket_available(
+        environ={"CODEX_HOME": str(codex_home)}
+    )
+    assert connect_paths == [str(socket_path)]
+
+
 def test_guard_doctor_codex_reports_resume_diagnostics(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/tests/test_guard_codex_resume_commands.py
+++ b/tests/test_guard_codex_resume_commands.py
@@ -131,7 +131,8 @@ def test_guard_doctor_codex_reports_resume_diagnostics(
 
     assert rc == 0
     assert output["codex_resume"]["codex_binary_found"] in {True, False}
-    assert output["codex_resume"]["app_server_support"] in {True, False}
+    assert output["codex_resume"]["app_server_support"] is None
+    assert "stable public app-server capability probe" in output["codex_resume"]["app_server_support_reason"]
     assert output["codex_resume"]["app_server_socket_available"] in {True, False}
     assert output["codex_resume"]["latest_attempt"] is None
 
@@ -151,7 +152,8 @@ def test_guard_doctor_codex_reports_app_server_support_from_codex_binary(
 
     assert rc == 0
     assert output["codex_resume"]["codex_binary_found"] is True
-    assert output["codex_resume"]["app_server_support"] in {True, False}
+    assert output["codex_resume"]["app_server_support"] is None
+    assert "stable public app-server capability probe" in output["codex_resume"]["app_server_support_reason"]
     assert output["codex_resume"]["app_server_socket_available"] in {True, False}
     assert "remote_control_support" not in output["codex_resume"]
     assert "headless_resume_support" not in output["codex_resume"]

--- a/tests/test_guard_codex_resume_endpoints.py
+++ b/tests/test_guard_codex_resume_endpoints.py
@@ -157,7 +157,7 @@ def test_codex_approve_without_resume_binding_returns_honest_manual_fallback(tmp
     assert payload["codex_resume"]["status"] == "skipped"
     assert payload["codex_resume"]["supported"] is False
     assert payload["codex_resume"]["strategy"] == "manual-only"
-    assert "could not find the Codex session to resume" in payload["resolution_summary"]
+    assert "could not find the original Codex chat" in payload["resolution_summary"]
     assert "approval is now saved" in payload["copy"]["body"]
 
 
@@ -242,24 +242,12 @@ def test_codex_approve_defers_headless_resume_while_live_hook_waits(
     assert "original Codex action continue" in payload["codex_resume"]["message"]
 
 
-def test_codex_deferred_live_hook_resume_can_recover_with_manual_retry(
+def test_codex_deferred_live_hook_resume_retry_reports_missing_chat_channel(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    recorded: dict[str, object] = {}
-    _stub_codex_binary(monkeypatch)
-
     def _fake_run(command, **kwargs):
-        recorded["command"] = command
-        return type(
-            "CompletedProcess",
-            (),
-            {
-                "returncode": 0,
-                "stdout": '{"type":"item.completed","item":{"type":"agent_message","text":"done"}}\n',
-                "stderr": "",
-            },
-        )()
+        raise AssertionError("manual retry must not start a separate headless Codex run")
 
     monkeypatch.setattr(codex_resume_module.subprocess, "run", _fake_run)
 
@@ -293,9 +281,10 @@ def test_codex_deferred_live_hook_resume_can_recover_with_manual_retry(
         daemon.stop()
 
     assert approved["codex_resume"]["status"] == "pending"
-    assert retried["status"] == "sent"
-    assert retried["strategy"] == "codex-exec-resume"
-    assert recorded["command"][:3] == ["codex", "exec", "resume"]
+    assert retried["status"] == "failed"
+    assert retried["reason"] == "socket_not_available"
+    assert retried["strategy"] == "codex-app-server-thread"
+    assert "original chat" in retried["message"]
 
 
 def test_request_resume_status_endpoint_returns_persisted_result(tmp_path: Path) -> None:
@@ -403,35 +392,12 @@ def test_codex_allow_resume_prompt_includes_exact_command_when_metadata_is_prese
     assert "Retry that exact command now using the existing saved approval." in prompt
 
 
-def test_request_resume_retry_endpoint_can_recover_after_socket_missing(
+def test_request_resume_retry_endpoint_keeps_same_thread_failure_after_socket_missing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    resume_calls = 0
-    _stub_codex_binary(monkeypatch)
-
     def _fake_run(command, **kwargs):
-        nonlocal resume_calls
-        resume_calls += 1
-        if resume_calls == 1:
-            return type(
-                "CompletedProcess",
-                (),
-                {
-                    "returncode": 1,
-                    "stdout": "",
-                    "stderr": "session unavailable",
-                },
-            )()
-        return type(
-            "CompletedProcess",
-            (),
-            {
-                "returncode": 0,
-                "stdout": '{"type":"item.completed","item":{"type":"agent_message","text":"done"}}\n',
-                "stderr": "",
-            },
-        )()
+        raise AssertionError("missing app-server socket must not fall back to headless Codex")
 
     monkeypatch.setattr(codex_resume_module.subprocess, "run", _fake_run)
 
@@ -457,7 +423,7 @@ def test_request_resume_retry_endpoint_can_recover_after_socket_missing(
             "/v1/requests/req-retry/approve",
             {"scope": "artifact", "reason": "reviewed"},
         )
-        assert initial["codex_resume"]["reason"] == "exec_resume_failed"
+        assert initial["codex_resume"]["reason"] == "socket_not_available"
 
         retried = _post_json(
             daemon.port,
@@ -473,12 +439,11 @@ def test_request_resume_retry_endpoint_can_recover_after_socket_missing(
     finally:
         daemon.stop()
 
-    assert retried["status"] == "sent"
-    assert retried["strategy"] == "codex-exec-resume"
+    assert retried["status"] == "failed"
+    assert retried["strategy"] == "codex-app-server-thread"
     assert retried["attempt_count"] == 2
     assert status_code == 200
-    assert current["status"] == "sent"
-    assert resume_calls == 2
+    assert current["status"] == "failed"
 
 
 def test_request_resume_retry_is_idempotent_after_success(
@@ -527,27 +492,12 @@ def test_request_resume_retry_is_idempotent_after_success(
     assert send_calls == 1
 
 
-def test_codex_approve_falls_back_to_exec_resume_when_socket_binding_is_missing(
+def test_codex_approve_does_not_fall_back_to_exec_resume_when_socket_binding_is_missing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    recorded: dict[str, object] = {}
-    _stub_codex_binary(monkeypatch)
-
     def _fake_run(command, **kwargs):
-        recorded["command"] = command
-        recorded["cwd"] = kwargs.get("cwd")
-        recorded["env"] = kwargs.get("env")
-        recorded["input"] = kwargs.get("input")
-        return type(
-            "CompletedProcess",
-            (),
-            {
-                "returncode": 0,
-                "stdout": '{"type":"item.completed","item":{"type":"agent_message","text":"done"}}\n',
-                "stderr": "",
-            },
-        )()
+        raise AssertionError("browser approval must not start a separate headless Codex run")
 
     monkeypatch.setattr(codex_resume_module.subprocess, "run", _fake_run)
 
@@ -580,19 +530,10 @@ def test_codex_approve_falls_back_to_exec_resume_when_socket_binding_is_missing(
     finally:
         daemon.stop()
 
-    command = recorded["command"]
-    assert payload["codex_resume"]["status"] == "sent"
-    assert payload["codex_resume"]["strategy"] == "codex-exec-resume"
-    assert command[:3] == ["codex", "exec", "resume"]
-    assert "--dangerously-bypass-approvals-and-sandbox" in command
-    assert "session-exec-1" in command
-    assert "--dangerously-bypass-hook-trust" in command
-    assert command[-1] == "-"
-    assert recorded["cwd"] == str(workspace)
-    assert isinstance(recorded["env"], dict)
-    assert recorded["env"]["CODEX_HOME"] == str(codex_home)
-    assert isinstance(recorded["input"], str)
-    assert "approved request `req-exec`" in recorded["input"]
+    assert payload["codex_resume"]["status"] == "failed"
+    assert payload["codex_resume"]["reason"] == "socket_not_available"
+    assert payload["codex_resume"]["strategy"] == "codex-app-server-thread"
+    assert "original chat" in payload["codex_resume"]["message"]
 
 
 def test_codex_approve_uses_default_app_server_when_hook_omits_socket(
@@ -648,14 +589,12 @@ def test_codex_approve_uses_default_app_server_when_hook_omits_socket(
     assert send_calls == 1
 
 
-def test_codex_approve_returns_failed_resume_when_exec_launch_raises_oserror(
+def test_codex_approve_returns_failed_resume_when_app_server_socket_missing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _stub_codex_binary(monkeypatch)
-
     def _raise_oserror(command, **kwargs):
-        raise PermissionError("exec denied")
+        raise AssertionError("socket failure must not start headless Codex")
 
     monkeypatch.setattr(codex_resume_module.subprocess, "run", _raise_oserror)
 
@@ -687,17 +626,14 @@ def test_codex_approve_returns_failed_resume_when_exec_launch_raises_oserror(
 
     assert payload["resolved"] is True
     assert payload["codex_resume"]["status"] == "failed"
-    assert payload["codex_resume"]["reason"] == "exec_resume_launch_failed"
-    assert payload["codex_resume"]["last_error"] == "exec denied"
+    assert payload["codex_resume"]["reason"] == "socket_not_available"
+    assert "socket_not_available" in payload["codex_resume"]["last_error"]
 
 
-def test_codex_approve_falls_back_to_exec_resume_after_transport_error_reason(
+def test_codex_approve_returns_app_server_failure_after_transport_error_reason(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    recorded: dict[str, object] = {}
-    _stub_codex_binary(monkeypatch)
-
     def _fake_resume(**kwargs):
         return {
             "status": "failed",
@@ -706,16 +642,7 @@ def test_codex_approve_falls_back_to_exec_resume_after_transport_error_reason(
         }
 
     def _fake_run(command, **kwargs):
-        recorded["command"] = command
-        return type(
-            "CompletedProcess",
-            (),
-            {
-                "returncode": 0,
-                "stdout": '{"type":"item.completed","item":{"type":"agent_message","text":"done"}}\n',
-                "stderr": "",
-            },
-        )()
+        raise AssertionError("transport error must not fall back to headless Codex")
 
     monkeypatch.setattr(codex_resume_module, "resume_codex_thread_for_request", _fake_resume)
     monkeypatch.setattr(codex_resume_module.subprocess, "run", _fake_run)
@@ -747,6 +674,6 @@ def test_codex_approve_falls_back_to_exec_resume_after_transport_error_reason(
     finally:
         daemon.stop()
 
-    assert payload["codex_resume"]["status"] == "sent"
-    assert payload["codex_resume"]["strategy"] == "codex-exec-resume"
-    assert recorded["command"][:3] == ["codex", "exec", "resume"]
+    assert payload["codex_resume"]["status"] == "failed"
+    assert payload["codex_resume"]["strategy"] == "codex-app-server-thread"
+    assert payload["codex_resume"]["reason"] == "ConnectionRefusedError"

--- a/tests/test_guard_codex_resume_endpoints.py
+++ b/tests/test_guard_codex_resume_endpoints.py
@@ -16,12 +16,6 @@ from codex_plugin_scanner.guard.models import GuardApprovalRequest
 from codex_plugin_scanner.guard.store import GuardStore
 
 
-def _stub_codex_binary(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        codex_resume_module.shutil, "which", lambda command: "/usr/bin/codex" if command == "codex" else None
-    )
-
-
 def _request(request_id: str) -> GuardApprovalRequest:
     return GuardApprovalRequest(
         request_id=request_id,
@@ -204,15 +198,7 @@ def test_codex_block_resume_prompt_includes_request_id_and_safe_alternative(
 
 def test_codex_approve_defers_headless_resume_while_live_hook_waits(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _stub_codex_binary(monkeypatch)
-
-    def _fail_run(command, **kwargs):
-        raise AssertionError("browser approval must not launch headless Codex while the live hook is waiting")
-
-    monkeypatch.setattr(codex_resume_module.subprocess, "run", _fail_run)
-
     store = GuardStore(tmp_path / "guard-home")
     store.add_approval_request(_request("req-live"), "2026-05-19T10:00:00+00:00")
     missing_socket = tmp_path / "missing-codex.sock"
@@ -244,13 +230,7 @@ def test_codex_approve_defers_headless_resume_while_live_hook_waits(
 
 def test_codex_deferred_live_hook_resume_retry_reports_missing_chat_channel(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def _fake_run(command, **kwargs):
-        raise AssertionError("manual retry must not start a separate headless Codex run")
-
-    monkeypatch.setattr(codex_resume_module.subprocess, "run", _fake_run)
-
     store = GuardStore(tmp_path / "guard-home")
     store.add_approval_request(_request("req-live-retry"), "2026-05-19T10:00:00+00:00")
     missing_socket = tmp_path / "missing-codex.sock"
@@ -394,13 +374,7 @@ def test_codex_allow_resume_prompt_includes_exact_command_when_metadata_is_prese
 
 def test_request_resume_retry_endpoint_keeps_same_thread_failure_after_socket_missing(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def _fake_run(command, **kwargs):
-        raise AssertionError("missing app-server socket must not fall back to headless Codex")
-
-    monkeypatch.setattr(codex_resume_module.subprocess, "run", _fake_run)
-
     store = GuardStore(tmp_path / "guard-home")
     store.add_approval_request(_request("req-retry"), "2026-05-19T10:00:00+00:00")
     workspace = tmp_path / "workspace"
@@ -494,13 +468,7 @@ def test_request_resume_retry_is_idempotent_after_success(
 
 def test_codex_approve_does_not_fall_back_to_exec_resume_when_socket_binding_is_missing(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def _fake_run(command, **kwargs):
-        raise AssertionError("browser approval must not start a separate headless Codex run")
-
-    monkeypatch.setattr(codex_resume_module.subprocess, "run", _fake_run)
-
     store = GuardStore(tmp_path / "guard-home")
     store.add_approval_request(_request("req-exec"), "2026-05-19T10:00:00+00:00")
     missing_socket = tmp_path / "missing-codex.sock"
@@ -553,11 +521,7 @@ def test_codex_approve_uses_default_app_server_when_hook_omits_socket(
             "supported": True,
         }
 
-    def _fail_run(command, **kwargs):
-        raise AssertionError("app-server resume should be attempted before headless exec")
-
     monkeypatch.setattr(codex_resume_module, "resume_codex_thread_for_request", _fake_resume)
-    monkeypatch.setattr(codex_resume_module.subprocess, "run", _fail_run)
 
     store = GuardStore(tmp_path / "guard-home")
     store.add_approval_request(_request("req-default-socket"), "2026-05-19T10:00:00+00:00")
@@ -591,13 +555,7 @@ def test_codex_approve_uses_default_app_server_when_hook_omits_socket(
 
 def test_codex_approve_returns_failed_resume_when_app_server_socket_missing(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def _raise_oserror(command, **kwargs):
-        raise AssertionError("socket failure must not start headless Codex")
-
-    monkeypatch.setattr(codex_resume_module.subprocess, "run", _raise_oserror)
-
     store = GuardStore(tmp_path / "guard-home")
     store.add_approval_request(_request("req-oserror"), "2026-05-19T10:00:00+00:00")
     missing_socket = tmp_path / "missing-codex.sock"
@@ -641,11 +599,7 @@ def test_codex_approve_returns_app_server_failure_after_transport_error_reason(
             "thread_id": "session-transport-1",
         }
 
-    def _fake_run(command, **kwargs):
-        raise AssertionError("transport error must not fall back to headless Codex")
-
     monkeypatch.setattr(codex_resume_module, "resume_codex_thread_for_request", _fake_resume)
-    monkeypatch.setattr(codex_resume_module.subprocess, "run", _fake_run)
 
     store = GuardStore(tmp_path / "guard-home")
     store.add_approval_request(_request("req-transport"), "2026-05-19T10:00:00+00:00")

--- a/tests/test_guard_queue_api_contract.py
+++ b/tests/test_guard_queue_api_contract.py
@@ -428,7 +428,7 @@ def test_resolving_active_item_with_two_remaining_returns_next_hint(tmp_path: Pa
     assert payload["next_selectable_request_id"] == "req-newest"
     assert {item["request_id"] for item in payload["remaining_pending_summaries"]} == {"req-newest", "req-old"}
     assert payload["copy"]["title"] == "Decision saved. Return to Codex."
-    assert "could not find the Codex session to resume" in payload["copy"]["body"]
+    assert "could not find the original Codex chat" in payload["copy"]["body"]
     assert "approval is now saved" in payload["copy"]["body"]
     assert store.get_approval_request("req-active")["resolution_action"] == "allow"
 
@@ -799,7 +799,7 @@ def test_authenticated_hosted_origin_request_resolution_does_not_401(tmp_path: P
 
     assert payload["resolved"] is True
     assert payload["copy"]["title"] == "Decision saved. Return to Codex."
-    assert "could not find the Codex session to resume" in payload["copy"]["body"]
+    assert "could not find the original Codex chat" in payload["copy"]["body"]
     assert allow_origin == "https://hol.org"
     assert store.get_approval_request("req-hosted-auth")["resolution_action"] == "allow"
 

--- a/tests/test_guard_resolution_copy.py
+++ b/tests/test_guard_resolution_copy.py
@@ -137,8 +137,8 @@ class TestApprovalResolutionCopyPerHarness:
         [
             (
                 "codex",
-                "Decision saved. HOL Guard could not find the Codex session to resume. "
-                "Retry the same request in Codex; it should pass because this approval is now saved.",
+                "Decision saved. HOL Guard could not find the original Codex chat to message. "
+                "Return to Codex and retry the same request; this approval is now saved.",
             ),
             ("claude-code", "Return to Claude and retry"),
             ("opencode", "Return to OpenCode and retry"),


### PR DESCRIPTION
## Summary
- remove the automatic `codex exec resume` fallback from browser approval resume
- send continuation only through the Codex app-server same-thread channel
- make approval-center copy honest when HOL Guard cannot message the original Codex chat
- update Codex resume tests and smoke coverage to assert `turn/start` app-server messages

## Verification
- `python3 -m pytest tests/test_guard_codex_resume_commands.py tests/test_guard_codex_resume_endpoints.py tests/test_guard_codex_auto_resume_smoke.py -q`
- `ruff check src/codex_plugin_scanner/guard/codex_resume.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_codex_resume_commands.py tests/test_guard_codex_resume_endpoints.py tests/test_guard_codex_auto_resume_smoke.py scripts/codex-auto-resume-smoke.py`
- `pnpm --dir dashboard build`
- `pnpm --dir dashboard exec tsx src/approval-center-layout.test.ts`
- `python3 scripts/codex-auto-resume-smoke.py`