### PR TITLE
fix(guard): batch connect receipt sync

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -865,13 +865,13 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
         if isinstance(advisories, list):
             advisories_payload.extend(item for item in advisories if isinstance(item, dict))
         policy = payload.get("policy")
-        if isinstance(policy, dict):
+        if isinstance(policy, dict) and (policy or policy_payload is None):
             policy_payload = policy
         alert_preferences = payload.get("alertPreferences")
-        if isinstance(alert_preferences, dict):
+        if isinstance(alert_preferences, dict) and (alert_preferences or alert_preferences_payload is None):
             alert_preferences_payload = alert_preferences
         team_policy_pack = payload.get("teamPolicyPack")
-        if isinstance(team_policy_pack, dict):
+        if isinstance(team_policy_pack, dict) and (team_policy_pack or team_policy_pack_payload is None):
             team_policy_pack_payload = team_policy_pack
         exceptions = payload.get("exceptions")
         if isinstance(exceptions, list):

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -820,8 +820,23 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
     inventory = store.list_inventory()
     payload: dict[str, object] = {}
     receipts_stored_total = 0
+    advisories_payload: list[dict[str, object]] = []
+    exceptions_payload: list[dict[str, object]] = []
+    policy_payload: dict[str, object] | None = None
+    alert_preferences_payload: dict[str, object] | None = None
+    team_policy_pack_payload: dict[str, object] | None = None
+    remote_decisions: set[PolicyDecision] = set()
+    device_id, device_name = _guard_device_metadata(store)
     for receipt_batch in _iter_receipt_sync_batches(receipts):
-        body = json.dumps({"receipts": _cloud_sync_receipts_payload(store, receipt_batch)}).encode("utf-8")
+        body = json.dumps(
+            {
+                "receipts": _cloud_sync_receipts_payload(
+                    receipt_batch,
+                    device_id=device_id,
+                    device_name=device_name,
+                )
+            }
+        ).encode("utf-8")
         request = urllib.request.Request(
             sync_url,
             data=body,
@@ -846,35 +861,46 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
         batch_receipts_stored = payload.get("receiptsStored")
         if isinstance(batch_receipts_stored, int):
             receipts_stored_total += batch_receipts_stored
+        advisories = payload.get("advisories")
+        if isinstance(advisories, list):
+            advisories_payload.extend(item for item in advisories if isinstance(item, dict))
+        policy = payload.get("policy")
+        if isinstance(policy, dict):
+            policy_payload = policy
+        alert_preferences = payload.get("alertPreferences")
+        if isinstance(alert_preferences, dict):
+            alert_preferences_payload = alert_preferences
+        team_policy_pack = payload.get("teamPolicyPack")
+        if isinstance(team_policy_pack, dict):
+            team_policy_pack_payload = team_policy_pack
+        exceptions = payload.get("exceptions")
+        if isinstance(exceptions, list):
+            exceptions_payload.extend(item for item in exceptions if isinstance(item, dict))
+        remote_decisions.update(_build_remote_policy_decisions(payload))
     now = _sync_timestamp(payload)
-    advisories = payload.get("advisories")
+    deduped_advisories = _dedupe_sync_payload_items(advisories_payload)
+    deduped_exceptions = _dedupe_sync_payload_items(exceptions_payload)
     advisories_stored = 0
-    if isinstance(advisories, list):
-        advisory_items = [item for item in advisories if isinstance(item, dict)]
-        advisories_stored = store.cache_advisories(advisory_items, now)
-    policy = payload.get("policy")
-    if isinstance(policy, dict):
-        store.set_sync_payload("policy", policy, now)
+    if deduped_advisories:
+        advisories_stored = store.cache_advisories(deduped_advisories, now)
+    if policy_payload is not None:
+        store.set_sync_payload("policy", policy_payload, now)
     else:
         store.set_sync_payload("policy", {}, now)
-    alert_preferences = payload.get("alertPreferences")
-    if isinstance(alert_preferences, dict):
-        store.set_sync_payload("alert_preferences", alert_preferences, now)
+    if alert_preferences_payload is not None:
+        store.set_sync_payload("alert_preferences", alert_preferences_payload, now)
     else:
         store.set_sync_payload("alert_preferences", {}, now)
-    team_policy_pack = payload.get("teamPolicyPack")
-    if isinstance(team_policy_pack, dict):
-        store.set_sync_payload("team_policy_pack", team_policy_pack, now)
+    if team_policy_pack_payload is not None:
+        store.set_sync_payload("team_policy_pack", team_policy_pack_payload, now)
     else:
         store.set_sync_payload("team_policy_pack", {}, now)
-    exceptions = payload.get("exceptions")
-    remote_decisions = _build_remote_policy_decisions(payload)
-    store.replace_remote_policies(remote_decisions, now)
+    store.replace_remote_policies(list(remote_decisions), now)
     _record_synced_alert_events(
         store=store,
-        advisories=advisories if isinstance(advisories, list) else [],
-        alert_preferences=alert_preferences if isinstance(alert_preferences, dict) else None,
-        exceptions=exceptions if isinstance(exceptions, list) else [],
+        advisories=deduped_advisories,
+        alert_preferences=alert_preferences_payload,
+        exceptions=deduped_exceptions,
         now=now,
     )
     pain_signals_uploaded = sync_pain_signals(store)
@@ -882,7 +908,7 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
         "synced_at": payload.get("syncedAt"),
         "receipts_stored": receipts_stored_total,
         "advisories_stored": advisories_stored,
-        "exceptions_stored": len(exceptions) if isinstance(exceptions, list) else 0,
+        "exceptions_stored": len(deduped_exceptions),
         "remote_policies_stored": len(remote_decisions),
         "pain_signals_uploaded": pain_signals_uploaded,
         "receipts": len(receipts),
@@ -1566,9 +1592,25 @@ def _completed_guard_event_ids(payload: dict[str, object]) -> list[str]:
     return completed
 
 
-def _cloud_sync_receipts_payload(store: GuardStore, receipts: list[dict[str, object]]) -> list[dict[str, object]]:
-    device_id, device_name = _guard_device_metadata(store)
+def _cloud_sync_receipts_payload(
+    receipts: list[dict[str, object]],
+    *,
+    device_id: str,
+    device_name: str,
+) -> list[dict[str, object]]:
     return [_cloud_sync_receipt_payload(receipt, device_id=device_id, device_name=device_name) for receipt in receipts]
+
+
+def _dedupe_sync_payload_items(items: list[dict[str, object]]) -> list[dict[str, object]]:
+    seen: set[str] = set()
+    deduped: list[dict[str, object]] = []
+    for item in items:
+        fingerprint = json.dumps(item, sort_keys=True)
+        if fingerprint in seen:
+            continue
+        seen.add(fingerprint)
+        deduped.append(item)
+    return deduped
 
 
 def _iter_receipt_sync_batches(receipts: list[dict[str, object]]) -> tuple[list[dict[str, object]], ...]:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -194,6 +194,7 @@ _SYNC_HTTP_TIMEOUT_SECONDS = 20
 _SYNC_HTTP_RETRY_TIMEOUT_SECONDS = 120
 _RUNTIME_SYNC_TIMEOUT_SECONDS = 10
 _RUNTIME_SYNC_RETRY_TIMEOUT_SECONDS = 90
+_RECEIPT_SYNC_BATCH_SIZE = 50
 _PAIN_SIGNAL_TIMEOUT_SECONDS = 10
 _PAIN_SIGNAL_RETRY_TIMEOUT_SECONDS = 90
 _GUARD_EVENTS_ENDPOINT_UNAVAILABLE_RETRY_HOURS = 24
@@ -817,28 +818,34 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
     sync_url = _normalized_receipts_sync_url(str(credentials["sync_url"]))
     receipts = store.list_receipts(limit=200)
     inventory = store.list_inventory()
-    body = json.dumps({"receipts": _cloud_sync_receipts_payload(store, receipts)}).encode("utf-8")
-    request = urllib.request.Request(
-        sync_url,
-        data=body,
-        method="POST",
-        headers=_guard_sync_headers(str(credentials["token"])),
-    )
-    try:
-        payload = _urlopen_json_with_timeout_retry(
-            request=request,
-            timeout_seconds=_SYNC_HTTP_TIMEOUT_SECONDS,
-            retry_timeout_seconds=_SYNC_HTTP_RETRY_TIMEOUT_SECONDS,
+    payload: dict[str, object] = {}
+    receipts_stored_total = 0
+    for receipt_batch in _iter_receipt_sync_batches(receipts):
+        body = json.dumps({"receipts": _cloud_sync_receipts_payload(store, receipt_batch)}).encode("utf-8")
+        request = urllib.request.Request(
+            sync_url,
+            data=body,
+            method="POST",
+            headers=_guard_sync_headers(str(credentials["token"])),
         )
-    except urllib.error.HTTPError as error:
-        if error.code == 403:
-            _is_plan, _msg = _check_plan_restriction_403(error)
-            if _is_plan:
-                raise GuardSyncNotAvailableError(_msg) from error
-            raise RuntimeError(_msg) from error
-        raise RuntimeError(_sync_http_error_message(error)) from error
-    except OSError as error:
-        raise RuntimeError(_sync_url_error_message(error)) from error
+        try:
+            payload = _urlopen_json_with_timeout_retry(
+                request=request,
+                timeout_seconds=_SYNC_HTTP_TIMEOUT_SECONDS,
+                retry_timeout_seconds=_SYNC_HTTP_RETRY_TIMEOUT_SECONDS,
+            )
+        except urllib.error.HTTPError as error:
+            if error.code == 403:
+                _is_plan, _msg = _check_plan_restriction_403(error)
+                if _is_plan:
+                    raise GuardSyncNotAvailableError(_msg) from error
+                raise RuntimeError(_msg) from error
+            raise RuntimeError(_sync_http_error_message(error)) from error
+        except OSError as error:
+            raise RuntimeError(_sync_url_error_message(error)) from error
+        batch_receipts_stored = payload.get("receiptsStored")
+        if isinstance(batch_receipts_stored, int):
+            receipts_stored_total += batch_receipts_stored
     now = _sync_timestamp(payload)
     advisories = payload.get("advisories")
     advisories_stored = 0
@@ -873,7 +880,7 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
     pain_signals_uploaded = sync_pain_signals(store)
     summary = {
         "synced_at": payload.get("syncedAt"),
-        "receipts_stored": payload.get("receiptsStored"),
+        "receipts_stored": receipts_stored_total,
         "advisories_stored": advisories_stored,
         "exceptions_stored": len(exceptions) if isinstance(exceptions, list) else 0,
         "remote_policies_stored": len(remote_decisions),
@@ -1562,6 +1569,15 @@ def _completed_guard_event_ids(payload: dict[str, object]) -> list[str]:
 def _cloud_sync_receipts_payload(store: GuardStore, receipts: list[dict[str, object]]) -> list[dict[str, object]]:
     device_id, device_name = _guard_device_metadata(store)
     return [_cloud_sync_receipt_payload(receipt, device_id=device_id, device_name=device_name) for receipt in receipts]
+
+
+def _iter_receipt_sync_batches(receipts: list[dict[str, object]]) -> tuple[list[dict[str, object]], ...]:
+    if not receipts:
+        return ([],)
+    return tuple(
+        receipts[index : index + _RECEIPT_SYNC_BATCH_SIZE]
+        for index in range(0, len(receipts), _RECEIPT_SYNC_BATCH_SIZE)
+    )
 
 
 def _cloud_sync_receipt_payload(

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -16,7 +16,7 @@ from codex_plugin_scanner.guard.cli.connect_flow import (
 )
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.daemon.client import GuardDaemonTransportError
-from codex_plugin_scanner.guard.models import PolicyDecision
+from codex_plugin_scanner.guard.models import GuardReceipt, PolicyDecision
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -974,3 +974,150 @@ def test_guard_connect_registers_runtime_session_before_first_sync(
     guard_event = observed_requests[2][1]["events"][0]
     assert guard_event["eventType"] == "runtime.session"
     assert guard_event["payload"]["sessionId"] == runtime_session["sessionId"]
+
+
+def test_guard_connect_batches_receipts_for_first_sync(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+
+    observed_requests: list[tuple[str, dict[str, object]]] = []
+
+    class SyncHandler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            content_length = int(self.headers.get("Content-Length", "0"))
+            payload = json.loads(self.rfile.read(content_length).decode("utf-8"))
+            observed_requests.append((self.path, payload))
+            if self.path == "/api/guard/runtime/sessions/sync":
+                response = {
+                    "generatedAt": "2026-04-16T00:00:02.000Z",
+                    "items": [payload["session"]],
+                }
+                status = 200
+            elif self.path == "/api/guard/receipts/sync":
+                receipt_count = len(payload.get("receipts", []))
+                if receipt_count > 50:
+                    response = {"error": "Invalid Guard receipt sync payload."}
+                    status = 400
+                else:
+                    response = {
+                        "syncedAt": "2026-04-16T00:00:03.000Z",
+                        "receiptsStored": receipt_count,
+                        "advisories": [],
+                        "policy": {},
+                        "alertPreferences": {},
+                        "teamPolicyPack": {},
+                        "exceptions": [],
+                    }
+                    status = 200
+            elif self.path == "/api/v1/guard/events":
+                response = {
+                    "accepted": len(payload.get("events", [])),
+                    "rejected": 0,
+                    "statuses": [
+                        {
+                            "eventId": event["eventId"],
+                            "status": "accepted",
+                        }
+                        for event in payload.get("events", [])
+                    ],
+                }
+                status = 200
+            else:
+                self.send_response(404)
+                self.end_headers()
+                return
+            body = json.dumps(response).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, message_format: str, *args: object) -> None:
+            return
+
+    sync_server = ThreadingHTTPServer(("127.0.0.1", 0), SyncHandler)
+    sync_thread = threading.Thread(target=sync_server.serve_forever, daemon=True)
+    sync_thread.start()
+
+    store = GuardStore(home_dir)
+    for index in range(51):
+        store.add_receipt(
+            GuardReceipt(
+                receipt_id=f"receipt-{index}",
+                timestamp="2026-04-16T00:00:00+00:00",
+                harness="codex",
+                artifact_id=f"artifact-{index}",
+                artifact_hash=f"sha256:{index:064x}",
+                policy_decision="review",
+                capabilities_summary="requests file write",
+                changed_capabilities=("fs_write",),
+                provenance_summary="local codex workspace",
+                artifact_name=f"artifact-{index}",
+                source_scope="workspace",
+            )
+        )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.connect_flow.ensure_guard_daemon",
+        lambda guard_home: f"http://127.0.0.1:{daemon.port}",
+    )
+
+    def open_browser(url: str) -> bool:
+        parsed = urllib.parse.urlparse(url)
+        query = urllib.parse.parse_qs(parsed.query)
+        fragment = urllib.parse.parse_qs(parsed.fragment)
+        request_id = query["guardPairRequest"][-1]
+        daemon_url = query["guardDaemon"][-1]
+        pairing_secret = fragment["guardPairSecret"][-1]
+
+        def complete_pairing() -> None:
+            request = urllib.request.Request(
+                f"{daemon_url}/v1/connect/complete",
+                data=urllib.parse.urlencode(
+                    {
+                        "request_id": request_id,
+                        "pairing_secret": pairing_secret,
+                        "token": "session-token-123",
+                    }
+                ).encode("utf-8"),
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "Origin": f"http://127.0.0.1:{sync_server.server_port}",
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=5):
+                pass
+
+        threading.Thread(target=complete_pairing, daemon=True).start()
+        return True
+
+    try:
+        payload = run_guard_connect_command(
+            guard_home=home_dir,
+            store=store,
+            sync_url=f"http://127.0.0.1:{sync_server.server_port}/api/guard/receipts/sync",
+            connect_url=f"http://127.0.0.1:{sync_server.server_port}/guard/connect",
+            opener=open_browser,
+            wait_timeout_seconds=5,
+        )
+    finally:
+        daemon.stop()
+        sync_server.shutdown()
+        sync_server.server_close()
+
+    receipt_batches = [
+        len(request_payload.get("receipts", []))
+        for path, request_payload in observed_requests
+        if path == "/api/guard/receipts/sync"
+    ]
+    assert payload["connected"] is True
+    assert payload["status"] == "connected"
+    assert payload["milestone"] == "first_sync_succeeded"
+    assert receipt_batches == [50, 1]

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -14970,7 +14970,7 @@ def test_sync_receipts_preserves_batch_metadata_and_reuses_device_metadata(tmp_p
                         "reason": "Batch two advisory",
                     }
                 ],
-                "policy": {"mode": "enforce"},
+                "policy": {},
                 "alertPreferences": {"advisoriesEnabled": True},
                 "teamPolicyPack": {
                     "name": "Team policy",
@@ -15021,6 +15021,7 @@ def test_sync_receipts_preserves_batch_metadata_and_reuses_device_metadata(tmp_p
     assert payload["advisories_stored"] == 2
     assert payload["exceptions_stored"] == 2
     assert payload["remote_policies_stored"] == 6
+    assert store.get_sync_payload("policy") == {"mode": "enforce"}
     assert {item["artifactId"] for item in store.list_cached_advisories(limit=None)} == {"artifact-a", "artifact-b"}
     assert {item["artifact_id"] for item in store.list_policy_decisions() if item["artifact_id"]} >= {
         "allowed-one",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -28,7 +28,13 @@ from codex_plugin_scanner.guard.cli.render import emit_guard_payload
 from codex_plugin_scanner.guard.config import GuardConfig, load_guard_config
 from codex_plugin_scanner.guard.consumer import artifact_hash, evaluate_detection
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
-from codex_plugin_scanner.guard.models import GuardApprovalRequest, GuardArtifact, HarnessDetection, PolicyDecision
+from codex_plugin_scanner.guard.models import (
+    GuardApprovalRequest,
+    GuardArtifact,
+    GuardReceipt,
+    HarnessDetection,
+    PolicyDecision,
+)
 from codex_plugin_scanner.guard.policy import decide_action, decide_action_with_v2
 from codex_plugin_scanner.guard.proxy import RemoteGuardProxy, StdioGuardProxy
 from codex_plugin_scanner.guard.receipts import build_receipt
@@ -14823,6 +14829,70 @@ def test_sync_receipts_retries_once_after_timeout(tmp_path, monkeypatch):
 
     assert timeouts == [20, 120]
     assert payload["synced_at"] == "2026-04-19T00:00:10+00:00"
+
+
+def test_sync_receipts_batches_large_local_history(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "guard-live-token",
+        "2026-04-19T00:00:00+00:00",
+    )
+    for index in range(65):
+        store.add_receipt(
+            GuardReceipt(
+                receipt_id=f"receipt-{index}",
+                timestamp="2026-04-19T00:00:00+00:00",
+                harness="codex",
+                artifact_id=f"artifact-{index}",
+                artifact_hash=f"sha256:{index:064x}",
+                policy_decision="review",
+                capabilities_summary="requests file write",
+                changed_capabilities=("fs_write",),
+                provenance_summary="local codex workspace",
+                artifact_name=f"artifact-{index}",
+                source_scope="workspace",
+            )
+        )
+    observed_batch_sizes: list[int] = []
+
+    class _Response:
+        def __init__(self, receipts_stored: int) -> None:
+            self._receipts_stored = receipts_stored
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "syncedAt": "2026-04-19T00:00:10+00:00",
+                    "receiptsStored": self._receipts_stored,
+                    "advisories": [],
+                    "policy": {},
+                    "alertPreferences": {},
+                    "teamPolicyPack": {},
+                    "exceptions": [],
+                }
+            ).encode("utf-8")
+
+    def _fake_urlopen(request, timeout):
+        payload = json.loads(request.data.decode("utf-8"))
+        if request.full_url.endswith("/api/v1/guard/events"):
+            return _Response(0)
+        observed_batch_sizes.append(len(payload["receipts"]))
+        return _Response(len(payload["receipts"]))
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+
+    payload = guard_runner_module.sync_receipts(store)
+
+    assert observed_batch_sizes == [50, 15]
+    assert payload["receipts"] == 65
+    assert payload["receipts_stored"] == 65
 
 
 def test_sync_runtime_session_retries_once_after_timeout(tmp_path, monkeypatch):

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -14895,6 +14895,147 @@ def test_sync_receipts_batches_large_local_history(tmp_path, monkeypatch):
     assert payload["receipts_stored"] == 65
 
 
+def test_sync_receipts_preserves_batch_metadata_and_reuses_device_metadata(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "guard-live-token",
+        "2026-04-19T00:00:00+00:00",
+    )
+    for index in range(65):
+        store.add_receipt(
+            GuardReceipt(
+                receipt_id=f"receipt-{index}",
+                timestamp="2026-04-19T00:00:00+00:00",
+                harness="codex",
+                artifact_id=f"artifact-{index}",
+                artifact_hash=f"sha256:{index:064x}",
+                policy_decision="review",
+                capabilities_summary="requests file write",
+                changed_capabilities=("fs_write",),
+                provenance_summary="local codex workspace",
+                artifact_name=f"artifact-{index}",
+                source_scope="workspace",
+            )
+        )
+
+    metadata_calls: list[bool] = []
+    monkeypatch.setattr(
+        guard_runner_module,
+        "_guard_device_metadata",
+        lambda _store: (metadata_calls.append(True) or ("device-1", "MacBook Pro")),
+    )
+    monkeypatch.setattr(guard_runner_module, "sync_pain_signals", lambda _store: 0)
+
+    sync_payloads = iter(
+        [
+            {
+                "syncedAt": "2026-04-19T00:00:10+00:00",
+                "receiptsStored": 50,
+                "advisories": [
+                    {
+                        "artifactId": "artifact-a",
+                        "artifactName": "Artifact A",
+                        "severity": "high",
+                        "reason": "Batch one advisory",
+                    }
+                ],
+                "policy": {"mode": "enforce"},
+                "alertPreferences": {"advisoriesEnabled": True},
+                "teamPolicyPack": {
+                    "name": "Team policy",
+                    "blockedArtifacts": ["blocked-one"],
+                    "allowedPublishers": ["trusted-one"],
+                },
+                "exceptions": [
+                    {
+                        "scope": "artifact",
+                        "harness": "*",
+                        "artifactId": "allowed-one",
+                        "artifactName": "Allowed One",
+                        "reason": "Batch one exception",
+                        "owner": "owner@example.com",
+                        "expiresAt": "2026-04-19T06:00:00+00:00",
+                    }
+                ],
+            },
+            {
+                "syncedAt": "2026-04-19T00:00:11+00:00",
+                "receiptsStored": 15,
+                "advisories": [
+                    {
+                        "artifactId": "artifact-b",
+                        "artifactName": "Artifact B",
+                        "severity": "medium",
+                        "reason": "Batch two advisory",
+                    }
+                ],
+                "policy": {"mode": "enforce"},
+                "alertPreferences": {"advisoriesEnabled": True},
+                "teamPolicyPack": {
+                    "name": "Team policy",
+                    "blockedArtifacts": ["blocked-two"],
+                    "allowedPublishers": ["trusted-two"],
+                },
+                "exceptions": [
+                    {
+                        "scope": "artifact",
+                        "harness": "*",
+                        "artifactId": "allowed-two",
+                        "artifactName": "Allowed Two",
+                        "reason": "Batch two exception",
+                        "owner": "owner@example.com",
+                        "expiresAt": "2026-04-19T08:00:00+00:00",
+                    }
+                ],
+            },
+        ]
+    )
+
+    class _Response:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(self._payload).encode("utf-8")
+
+    def _fake_urlopen(request, timeout):
+        payload = json.loads(request.data.decode("utf-8"))
+        if request.full_url.endswith("/api/v1/guard/events"):
+            return _Response({"accepted": 0, "rejected": 0, "statuses": []})
+        assert len(payload["receipts"]) in {50, 15}
+        return _Response(next(sync_payloads))
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+
+    payload = guard_runner_module.sync_receipts(store)
+
+    assert metadata_calls == [True]
+    assert payload["receipts_stored"] == 65
+    assert payload["advisories_stored"] == 2
+    assert payload["exceptions_stored"] == 2
+    assert payload["remote_policies_stored"] == 6
+    assert {item["artifactId"] for item in store.list_cached_advisories(limit=None)} == {"artifact-a", "artifact-b"}
+    assert {item["artifact_id"] for item in store.list_policy_decisions() if item["artifact_id"]} >= {
+        "allowed-one",
+        "allowed-two",
+        "blocked-one",
+        "blocked-two",
+    }
+    assert {item["publisher"] for item in store.list_policy_decisions() if item["publisher"]} == {
+        "trusted-one",
+        "trusted-two",
+    }
+    assert len(store.list_events(event_name="premium_advisory")) == 2
+    assert len(store.list_events(event_name="exception_expiring")) == 2
+
+
 def test_sync_runtime_session_retries_once_after_timeout(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
     store.set_sync_credentials(


### PR DESCRIPTION
## Summary
- batch `hol-guard connect` receipt sync requests to the 50-receipt cloud contract limit
- keep first-sync moving once receipts sync successfully
- add focused runtime and connect regressions for batched first-sync uploads

## Verification
- `pytest tests/test_guard_connect_flow.py tests/test_guard_runtime.py -q`
- live production `uv run --no-sync hol-guard connect --guard-home /Users/michaelkantor/.hol-guard --json --wait-timeout-seconds 180`
