### PR TITLE
fix(guard): add cloud app local handoff

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1098,7 +1098,11 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         }});
         const payload = await response.json().catch(() => ({{}}));
         if (!response.ok) {{
-          fail(payload.error || `Local Guard returned HTTP ${{response.status}}`);
+          const error = payload.error;
+          const message = error && typeof error === 'object'
+            ? error.message || error.code
+            : error;
+          fail(message || `Local Guard returned HTTP ${{response.status}}`);
           return;
         }}
         const state = payload.state || {{}};

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -6,6 +6,7 @@ import argparse
 import base64
 import hashlib
 import hmac
+import html
 import io
 import json
 import mimetypes
@@ -891,49 +892,180 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "status": "completed",
         }
 
+    def _local_daemon_origin(self) -> str:
+        host = self.server.server_address[0]  # type: ignore[attr-defined]
+        port = self.server.server_address[1]  # type: ignore[attr-defined]
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        return f"http://{host}:{port}"
+
     def _handle_cloud_app_handoff(self, harness: str, query_string: str) -> None:
         try:
             adapter = get_adapter(harness)
         except ValueError:
             self._write_json({"error": "unknown_harness"}, status=404)
             return
-        local_origin = f"http://{self.server.server_address[0]}:{self.server.server_address[1]}"  # type: ignore[attr-defined]
+        local_origin = self._local_daemon_origin()
         handoff_query = parse_qs(query_string)
         action_path = self._optional_string(handoff_query.get("action", [None])[-1])
+        if action_path in _HEADLESS_APP_ACTIONS and self._hosted_dashboard_referrer_is_allowed():
+            self._write_cloud_app_handoff_page(
+                harness=adapter.harness,
+                action_path=action_path,
+                local_origin=local_origin,
+                workspace_id=self._optional_string(handoff_query.get("workspaceId", [None])[-1]) or "",
+            )
+            return
         cloud_params: dict[str, str] = {"guardDaemon": local_origin}
         fragment_params: dict[str, str] = {
             "guardDaemon": local_origin,
             "guard-token": self.server.auth_token,  # type: ignore[attr-defined]
         }
-        if action_path in _HEADLESS_APP_ACTIONS and self._hosted_dashboard_referrer_is_allowed():
-            status, action_payload = self._headless_app_action_payload(
-                action_path=action_path,
-                payload={
-                    "harness": adapter.harness,
-                    "operation": _HEADLESS_APP_ACTIONS[action_path][0],
-                    "workspace_id": self._optional_string(handoff_query.get("workspaceId", [None])[-1]) or "",
-                },
-            )
-            state = action_payload.get("state")
-            receipt = action_payload.get("receipt")
-            cloud_params["guardLocalAction"] = action_path
-            cloud_params["guardLocalStatus"] = "completed" if status == 200 else "failed"
-            if isinstance(state, dict):
-                app_status = self._optional_string(state.get("app_status"))
-                proof_status = self._optional_string(state.get("proof_status"))
-                if app_status:
-                    cloud_params["guardAppStatus"] = app_status
-                if proof_status:
-                    cloud_params["guardProofStatus"] = proof_status
-            if isinstance(receipt, dict):
-                receipt_id = self._optional_string(receipt.get("id"))
-                if receipt_id:
-                    cloud_params["guardReceipt"] = receipt_id
-            fragment_params.update(cloud_params)
         query = urlencode(cloud_params)
         fragment = urlencode(fragment_params)
         location = f"{_HOSTED_GUARD_APPS_URL}/{adapter.harness}?{query}#{fragment}"
         self._write_empty(status=302, extra_headers={"Location": location})
+
+    def _write_cloud_app_handoff_page(
+        self,
+        *,
+        harness: str,
+        action_path: str,
+        local_origin: str,
+        workspace_id: str,
+    ) -> None:
+        operation = _HEADLESS_APP_ACTIONS[action_path][0]
+        redirect_base = f"{_HOSTED_GUARD_APPS_URL}/{harness}"
+        script_payload = json.dumps(
+            {
+                "actionPath": action_path,
+                "harness": harness,
+                "localOrigin": local_origin,
+                "operation": operation,
+                "redirectBase": redirect_base,
+                "token": self.server.auth_token,  # type: ignore[attr-defined]
+                "workspaceId": workspace_id,
+            },
+            separators=(",", ":"),
+        ).replace("</", "<\\/")
+        title = f"Connecting {harness} with HOL Guard"
+        body = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{html.escape(title)}</title>
+  <style>
+    :root {{
+      color-scheme: light;
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }}
+    body {{
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      background: linear-gradient(135deg, #f8fbff, #eef5ff 48%, #f4fff8);
+      color: #343565;
+    }}
+    main {{
+      width: min(92vw, 560px);
+      border: 1px solid #d8e6ff;
+      border-radius: 28px;
+      background: rgba(255,255,255,.92);
+      box-shadow: 0 24px 80px rgba(47,70,120,.18);
+      padding: 32px;
+    }}
+    .eyebrow {{ color: #4f91ff; font-size: 12px; font-weight: 800; letter-spacing: .28em; text-transform: uppercase; }}
+    h1 {{ margin: 12px 0; font-size: clamp(28px, 5vw, 42px); line-height: 1.05; }}
+    p {{ color: #5d668f; font-size: 16px; line-height: 1.6; }}
+    .status {{
+      margin-top: 20px;
+      padding: 14px 16px;
+      border-radius: 16px;
+      background: #f4f8ff;
+      border: 1px solid #d8e6ff;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      color: #343565;
+    }}
+    .error {{ color: #7c3aed; }}
+  </style>
+</head>
+<body>
+  <main>
+    <div class="eyebrow">HOL Guard local handoff</div>
+    <h1>Connecting {html.escape(harness)}.</h1>
+    <p>Guard is using this local page to complete setup with your daemon, then it will return you to HOL Cloud.</p>
+    <div id="status" class="status">Starting local Guard setup...</div>
+  </main>
+  <script id="guard-handoff-data" type="application/json">{script_payload}</script>
+  <script>
+    const data = JSON.parse(document.getElementById('guard-handoff-data').textContent);
+    const statusNode = document.getElementById('status');
+    const finish = (params) => {{
+      const query = new URLSearchParams(params);
+      const fragment = new URLSearchParams(params);
+      fragment.set('guard-token', data.token);
+      window.location.assign(`${{data.redirectBase}}?${{query.toString()}}#${{fragment.toString()}}`);
+    }};
+    const fail = (message) => {{
+      statusNode.textContent = message;
+      statusNode.className = 'status error';
+      finish({{
+        guardDaemon: data.localOrigin,
+        guardLocalAction: data.actionPath,
+        guardLocalStatus: 'failed',
+        guardLocalError: message,
+      }});
+    }};
+    (async () => {{
+      try {{
+        const response = await fetch(`${{data.localOrigin}}/v1/apps/${{data.actionPath}}`, {{
+          method: 'POST',
+          headers: {{
+            'Authorization': `Bearer ${{data.token}}`,
+            'Content-Type': 'application/json',
+            'X-Guard-Dashboard-Session': data.token,
+            'X-Guard-Token': data.token,
+          }},
+          body: JSON.stringify({{
+            harness: data.harness,
+            operation: data.operation,
+            workspace_id: data.workspaceId,
+          }}),
+        }});
+        const payload = await response.json().catch(() => ({{}}));
+        if (!response.ok) {{
+          fail(payload.error || `Local Guard returned HTTP ${{response.status}}`);
+          return;
+        }}
+        const state = payload.state || {{}};
+        const receipt = payload.receipt || {{}};
+        statusNode.textContent = 'Setup complete. Returning to HOL Cloud...';
+        finish({{
+          guardDaemon: data.localOrigin,
+          guardLocalAction: data.actionPath,
+          guardLocalStatus: 'completed',
+          guardAppStatus: state.app_status || 'unknown',
+          guardProofStatus: state.proof_status || 'unknown',
+          guardReceipt: receipt.id || '',
+        }});
+      }} catch (error) {{
+        fail(error instanceof Error ? error.message : 'Local Guard setup failed');
+      }}
+    }})();
+  </script>
+</body>
+</html>"""
+        encoded = body.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.send_header("Cache-Control", "no-store, max-age=0")
+        self.send_header("Pragma", "no-cache")
+        self.send_header("Expires", "0")
+        self.end_headers()
+        self.wfile.write(encoded)
 
     def _hosted_dashboard_referrer_is_allowed(self) -> bool:
         referrer = self.headers.get("Referer")

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -101,6 +101,7 @@ _DEFAULT_GUARD_DAEMON_IDLE_TIMEOUT_SECONDS = 30 * 60
 _EPHEMERAL_GUARD_DAEMON_IDLE_TIMEOUT_SECONDS = 5
 _GUARD_DAEMON_IDLE_POLL_INTERVAL_SECONDS = 0.5
 _HOSTED_GUARD_DASHBOARD_ORIGINS = frozenset({"https://hol.org", "https://www.hol.org"})
+_HOSTED_GUARD_APPS_URL = "https://hol.org/guard/apps"
 _HEADLESS_APP_ACTIONS = {
     "connect": ("install", "install"),
     "repair": ("repair", "repair"),
@@ -330,6 +331,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if parsed.path == "/v1/harnesses":
             context = self._harness_context({})
             self._write_json({"items": list_harness_setup_items(context, self.server.store)})  # type: ignore[attr-defined]
+            return
+        if len(path_parts) == 4 and path_parts[:2] == ["v1", "apps"] and path_parts[3] == "cloud":
+            self._handle_cloud_app_handoff(path_parts[2], parsed.query)
             return
         if parsed.path == "/v1/inventory":
             from ..adapters.contracts import HARNESS_CONTRACTS
@@ -828,34 +832,33 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             }
         )
 
-    def _handle_headless_app_action(self, action_path: str, payload: dict[str, object]) -> None:
-        mapping = _HEADLESS_APP_ACTIONS.get(action_path)
-        if mapping is None:
-            status, error_payload = _headless_action_error_payload(
+    def _headless_app_action_payload(
+        self,
+        *,
+        action_path: str,
+        payload: dict[str, object],
+    ) -> tuple[int, dict[str, object]]:
+        try:
+            mapping = _HEADLESS_APP_ACTIONS[action_path]
+        except KeyError:
+            return _headless_action_error_payload(
                 operation=action_path,
                 error_code="unsupported_operation",
             )
-            self._write_json(error_payload, status=status)
-            return
         operation, harness_action = mapping
         harness = self._optional_string(payload.get("harness"))
         if harness is None:
-            status, error_payload = _headless_action_error_payload(
+            return _headless_action_error_payload(
                 operation=operation,
                 error_code="missing_harness",
             )
-            self._write_json(error_payload, status=status)
-            return
         try:
             adapter = get_adapter(harness)
         except ValueError:
-            status, error_payload = _headless_action_error_payload(
+            return _headless_action_error_payload(
                 operation=operation,
                 error_code="unknown_harness",
             )
-            self._write_json(error_payload, status=status)
-            return
-
         context = self._harness_context(payload)
         try:
             if harness_action == "verify":
@@ -863,13 +866,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             else:
                 result = self._run_headless_managed_action(adapter.harness, harness_action, payload, context)
         except ValueError as error:
-            status, error_payload = _headless_action_error_payload(
+            return _headless_action_error_payload(
                 operation=operation,
                 error_code=str(error),
             )
-            self._write_json(error_payload, status=status)
-            return
-
         receipt = self._record_headless_receipt(
             harness=adapter.harness,
             operation=operation,
@@ -877,21 +877,85 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             result=result,
             workspace_id=self._optional_string(payload.get("workspace_id")),
         )
-        self._write_json(
-            {
-                "harness": adapter.harness,
-                "operation": operation,
-                "result": result,
-                "receipt": receipt,
-                "state": _headless_action_state_payload(
-                    harness=adapter.harness,
-                    operation=operation,
-                    result=result,
-                    receipt=receipt,
-                ),
-                "status": "completed",
-            }
-        )
+        return 200, {
+            "harness": adapter.harness,
+            "operation": operation,
+            "result": result,
+            "receipt": receipt,
+            "state": _headless_action_state_payload(
+                harness=adapter.harness,
+                operation=operation,
+                result=result,
+                receipt=receipt,
+            ),
+            "status": "completed",
+        }
+
+    def _handle_cloud_app_handoff(self, harness: str, query_string: str) -> None:
+        try:
+            adapter = get_adapter(harness)
+        except ValueError:
+            self._write_json({"error": "unknown_harness"}, status=404)
+            return
+        local_origin = f"http://{self.server.server_address[0]}:{self.server.server_address[1]}"  # type: ignore[attr-defined]
+        handoff_query = parse_qs(query_string)
+        action_path = self._optional_string(handoff_query.get("action", [None])[-1])
+        cloud_params: dict[str, str] = {"guardDaemon": local_origin}
+        fragment_params: dict[str, str] = {
+            "guardDaemon": local_origin,
+            "guard-token": self.server.auth_token,  # type: ignore[attr-defined]
+        }
+        if action_path in _HEADLESS_APP_ACTIONS and self._hosted_dashboard_referrer_is_allowed():
+            status, action_payload = self._headless_app_action_payload(
+                action_path=action_path,
+                payload={
+                    "harness": adapter.harness,
+                    "operation": _HEADLESS_APP_ACTIONS[action_path][0],
+                    "workspace_id": self._optional_string(handoff_query.get("workspaceId", [None])[-1]) or "",
+                },
+            )
+            state = action_payload.get("state")
+            receipt = action_payload.get("receipt")
+            cloud_params["guardLocalAction"] = action_path
+            cloud_params["guardLocalStatus"] = "completed" if status == 200 else "failed"
+            if isinstance(state, dict):
+                app_status = self._optional_string(state.get("app_status"))
+                proof_status = self._optional_string(state.get("proof_status"))
+                if app_status:
+                    cloud_params["guardAppStatus"] = app_status
+                if proof_status:
+                    cloud_params["guardProofStatus"] = proof_status
+            if isinstance(receipt, dict):
+                receipt_id = self._optional_string(receipt.get("id"))
+                if receipt_id:
+                    cloud_params["guardReceipt"] = receipt_id
+            fragment_params.update(cloud_params)
+        query = urlencode(cloud_params)
+        fragment = urlencode(fragment_params)
+        location = f"{_HOSTED_GUARD_APPS_URL}/{adapter.harness}?{query}#{fragment}"
+        self._write_empty(status=302, extra_headers={"Location": location})
+
+    def _hosted_dashboard_referrer_is_allowed(self) -> bool:
+        referrer = self.headers.get("Referer")
+        if not isinstance(referrer, str) or not referrer.strip():
+            return False
+        parsed = urlparse(referrer.strip())
+        if parsed.scheme not in {"http", "https"} or parsed.hostname is None:
+            return False
+        host = parsed.hostname
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        default_port = 80 if parsed.scheme == "http" else 443
+        try:
+            port = parsed.port
+        except ValueError:
+            return False
+        port_suffix = f":{port}" if port not in {None, default_port} else ""
+        return f"{parsed.scheme}://{host}{port_suffix}" in _HOSTED_GUARD_DASHBOARD_ORIGINS
+
+    def _handle_headless_app_action(self, action_path: str, payload: dict[str, object]) -> None:
+        status, payload = self._headless_app_action_payload(action_path=action_path, payload=payload)
+        self._write_json(payload, status=status)
 
     def _run_headless_managed_action(
         self,
@@ -2132,6 +2196,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "Access-Control-Allow-Methods",
             "Access-Control-Allow-Headers",
             "Access-Control-Allow-Private-Network",
+            "Location",
             "Vary",
         }
         validated: dict[str, str] = {}

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -111,6 +111,7 @@ _HEADLESS_APP_ACTIONS = {
     "status": ("status", "verify"),
     "test": ("scan", "verify"),
 }
+_CLOUD_APP_HANDOFF_ACTIONS = frozenset({"connect", "repair", "status", "test"})
 _HEADLESS_OPERATIONS = ("install", "repair", "remove", "status", "scan", "policy_sync")
 
 
@@ -912,7 +913,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         local_origin = self._local_daemon_origin()
         handoff_query = parse_qs(query_string)
         action_path = self._optional_string(handoff_query.get("action", [None])[-1])
-        if action_path in _HEADLESS_APP_ACTIONS and self._hosted_dashboard_referrer_is_allowed():
+        if action_path in _CLOUD_APP_HANDOFF_ACTIONS and self._hosted_dashboard_referrer_is_allowed():
             self._write_cloud_app_handoff_page(
                 harness=adapter.harness,
                 action_path=action_path,
@@ -976,7 +977,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         action_path = self._optional_string(decoded.get("action_path"))
         token_harness = self._optional_string(decoded.get("harness"))
-        if token_harness != harness or action_path not in _HEADLESS_APP_ACTIONS:
+        if token_harness != harness or action_path not in _CLOUD_APP_HANDOFF_ACTIONS:
             self._write_json({"error": "invalid_handoff_scope"}, status=403)
             return
         status, action_payload = self._headless_app_action_payload(

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -103,6 +103,7 @@ _EPHEMERAL_GUARD_DAEMON_IDLE_TIMEOUT_SECONDS = 5
 _GUARD_DAEMON_IDLE_POLL_INTERVAL_SECONDS = 0.5
 _HOSTED_GUARD_DASHBOARD_ORIGINS = frozenset({"https://hol.org", "https://www.hol.org"})
 _HOSTED_GUARD_APPS_URL = "https://hol.org/guard/apps"
+_CLOUD_APP_HANDOFF_TOKEN_TTL_SECONDS = 120
 _HEADLESS_APP_ACTIONS = {
     "connect": ("install", "install"),
     "repair": ("repair", "repair"),
@@ -660,6 +661,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if len(path_parts) == 4 and path_parts[:2] == ["v1", "harnesses"]:
             self._handle_harness_action(path_parts[2], path_parts[3], payload)
             return
+        if len(path_parts) == 5 and path_parts[:2] == ["v1", "apps"] and path_parts[3] == "cloud":
+            self._handle_cloud_app_handoff_complete(path_parts[2], payload)
+            return
         if len(path_parts) == 3 and path_parts[:2] == ["v1", "apps"]:
             self._handle_headless_app_action(path_parts[2], payload)
             return
@@ -919,12 +923,71 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         cloud_params: dict[str, str] = {"guardDaemon": local_origin}
         fragment_params: dict[str, str] = {
             "guardDaemon": local_origin,
-            "guard-token": self.server.auth_token,  # type: ignore[attr-defined]
         }
         query = urlencode(cloud_params)
         fragment = urlencode(fragment_params)
         location = f"{_HOSTED_GUARD_APPS_URL}/{adapter.harness}?{query}#{fragment}"
         self._write_empty(status=302, extra_headers={"Location": location})
+
+    def _cloud_app_handoff_token(
+        self,
+        *,
+        harness: str,
+        action_path: str,
+        workspace_id: str,
+    ) -> str:
+        payload_json = json.dumps(
+            {
+                "action_path": action_path,
+                "expires_at": int(time.time()) + _CLOUD_APP_HANDOFF_TOKEN_TTL_SECONDS,
+                "harness": harness,
+                "nonce": secrets.token_urlsafe(16),
+                "version": "guard-cloud-app-handoff.v1",
+                "workspace_id": workspace_id,
+            },
+            separators=(",", ":"),
+        )
+        payload = base64.urlsafe_b64encode(payload_json.encode("utf-8")).decode("ascii").rstrip("=")
+        signature = _dashboard_session_signature(payload, self.server.auth_token)  # type: ignore[attr-defined]
+        return f"gch1.{payload}.{signature}"
+
+    def _decode_cloud_app_handoff_token(self, token: object) -> dict[str, object] | None:
+        if not isinstance(token, str) or not token.startswith("gch1."):
+            return None
+        parts = token.split(".")
+        if len(parts) != 3:
+            return None
+        _, payload, signature = parts
+        expected_signature = _dashboard_session_signature(payload, self.server.auth_token)  # type: ignore[attr-defined]
+        if not hmac.compare_digest(signature, expected_signature):
+            return None
+        parsed = _decode_dashboard_session_payload(payload)
+        if parsed.get("version") != "guard-cloud-app-handoff.v1":
+            return None
+        expires_at = parsed.get("expires_at")
+        if not isinstance(expires_at, int) or expires_at < int(time.time()):
+            return None
+        return parsed
+
+    def _handle_cloud_app_handoff_complete(self, harness: str, payload: dict[str, object]) -> None:
+        decoded = self._decode_cloud_app_handoff_token(payload.get("handoff_token"))
+        if decoded is None:
+            self._write_json({"error": "invalid_handoff_token"}, status=401)
+            return
+        action_path = self._optional_string(decoded.get("action_path"))
+        token_harness = self._optional_string(decoded.get("harness"))
+        if token_harness != harness or action_path not in _HEADLESS_APP_ACTIONS:
+            self._write_json({"error": "invalid_handoff_scope"}, status=403)
+            return
+        status, action_payload = self._headless_app_action_payload(
+            action_path=action_path,
+            payload={
+                "harness": harness,
+                "operation": _HEADLESS_APP_ACTIONS[action_path][0],
+                "workspace_id": self._optional_string(decoded.get("workspace_id")) or "",
+            },
+        )
+        self._write_json(action_payload, status=status)
 
     def _write_cloud_app_handoff_page(
         self,
@@ -939,11 +1002,15 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         script_payload = json.dumps(
             {
                 "actionPath": action_path,
+                "handoffToken": self._cloud_app_handoff_token(
+                    harness=harness,
+                    action_path=action_path,
+                    workspace_id=workspace_id,
+                ),
                 "harness": harness,
                 "localOrigin": local_origin,
                 "operation": operation,
                 "redirectBase": redirect_base,
-                "token": self.server.auth_token,  # type: ignore[attr-defined]
                 "workspaceId": workspace_id,
             },
             separators=(",", ":"),
@@ -1005,7 +1072,6 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
     const finish = (params) => {{
       const query = new URLSearchParams(params);
       const fragment = new URLSearchParams(params);
-      fragment.set('guard-token', data.token);
       window.location.assign(`${{data.redirectBase}}?${{query.toString()}}#${{fragment.toString()}}`);
     }};
     const fail = (message) => {{
@@ -1020,18 +1086,13 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
     }};
     (async () => {{
       try {{
-        const response = await fetch(`${{data.localOrigin}}/v1/apps/${{data.actionPath}}`, {{
+        const response = await fetch(`${{data.localOrigin}}/v1/apps/${{data.harness}}/cloud/complete`, {{
           method: 'POST',
           headers: {{
-            'Authorization': `Bearer ${{data.token}}`,
             'Content-Type': 'application/json',
-            'X-Guard-Dashboard-Session': data.token,
-            'X-Guard-Token': data.token,
           }},
           body: JSON.stringify({{
-            harness: data.harness,
-            operation: data.operation,
-            workspace_id: data.workspaceId,
+            handoff_token: data.handoffToken,
           }}),
         }});
         const payload = await response.json().catch(() => ({{}}));

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -10,12 +10,13 @@ import urllib.error
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
-from codex_plugin_scanner.guard.daemon.server import _headless_action_error_payload
 from codex_plugin_scanner.guard.daemon.manager import load_guard_daemon_auth_token
+from codex_plugin_scanner.guard.daemon.server import _headless_action_error_payload
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -27,6 +28,20 @@ def _read_json_response(request: urllib.request.Request) -> tuple[int, dict[str,
         return error.code, json.loads(error.read().decode("utf-8"))
 
 
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        return None
+
+
+def _read_redirect_response(request: urllib.request.Request) -> tuple[int, str]:
+    opener = urllib.request.build_opener(_NoRedirectHandler)
+    try:
+        with opener.open(request, timeout=5) as response:
+            return response.status, response.headers.get("Location", "")
+    except urllib.error.HTTPError as error:
+        return error.code, error.headers.get("Location", "")
+
+
 def _request(
     port: int,
     path: str,
@@ -36,13 +51,17 @@ def _request(
     token: str | None = None,
     authorization_token: str | None = None,
     dashboard_session_token: str | None = None,
-    origin: str = "https://hol.org",
+    origin: str | None = "https://hol.org",
+    referer: str | None = None,
 ) -> urllib.request.Request:
     data = json.dumps(payload or {}).encode("utf-8") if method != "GET" else None
     headers = {
         "Content-Type": "application/json",
-        "Origin": origin,
     }
+    if origin is not None:
+        headers["Origin"] = origin
+    if referer is not None:
+        headers["Referer"] = referer
     if token is not None:
         headers["Authorization"] = f"Bearer {token}"
         headers["X-Guard-Dashboard-Session"] = token
@@ -106,6 +125,38 @@ def test_headless_capabilities_endpoint_reports_safe_action_contract(tmp_path: P
     assert codex_item["display_name"] == "Codex"
     assert codex_item["headless_actions"] == ["install", "repair", "remove", "status", "scan"]
     assert codex_item["status"] in {"inactive", "observed", "protected"}
+
+
+def test_cloud_app_handoff_redirects_to_guard_cloud_with_local_token(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        auth_token = load_guard_daemon_auth_token(store.guard_home)
+        assert auth_token is not None
+        status, location = _read_redirect_response(
+            _request(
+                daemon.port,
+                "/v1/apps/codex/cloud?action=connect",
+                method="GET",
+                origin=None,
+                referer="https://hol.org/guard/apps/codex",
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 302
+    parsed = urlparse(location)
+    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == "https://hol.org/guard/apps/codex"
+    assert parse_qs(parsed.query)["guardDaemon"] == [f"http://127.0.0.1:{daemon.port}"]
+    assert parse_qs(parsed.query)["guardLocalAction"] == ["connect"]
+    assert parse_qs(parsed.query)["guardLocalStatus"] == ["completed"]
+    assert parse_qs(parsed.query)["guardAppStatus"] == ["protected"]
+    fragment = parse_qs(parsed.fragment)
+    assert fragment["guardDaemon"] == [f"http://127.0.0.1:{daemon.port}"]
+    assert fragment["guard-token"] == [auth_token]
+    assert fragment["guardReceipt"]
 
 
 def test_headless_app_operations_write_receipts_without_cli_copy(

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -42,6 +42,11 @@ def _read_redirect_response(request: urllib.request.Request) -> tuple[int, str]:
         return error.code, error.headers.get("Location", "")
 
 
+def _read_text_response(request: urllib.request.Request) -> tuple[int, str]:
+    with urllib.request.urlopen(request, timeout=5) as response:
+        return response.status, response.read().decode("utf-8")
+
+
 def _request(
     port: int,
     path: str,
@@ -127,7 +132,34 @@ def test_headless_capabilities_endpoint_reports_safe_action_contract(tmp_path: P
     assert codex_item["status"] in {"inactive", "observed", "protected"}
 
 
-def test_cloud_app_handoff_redirects_to_guard_cloud_with_local_token(tmp_path: Path) -> None:
+def test_cloud_app_handoff_serves_token_authenticated_local_action_page(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        auth_token = load_guard_daemon_auth_token(store.guard_home)
+        assert auth_token is not None
+        status, body = _read_text_response(
+            _request(
+                daemon.port,
+                "/v1/apps/codex/cloud?action=connect",
+                method="GET",
+                origin=None,
+                referer="https://hol.org/guard/apps/codex",
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert "HOL Guard local handoff" in body
+    assert f"http://127.0.0.1:{daemon.port}" in body
+    assert "/v1/apps/${data.actionPath}" in body
+    assert "Authorization" in body
+    assert auth_token in body
+
+
+def test_cloud_app_handoff_redirects_to_guard_cloud_without_side_effect_when_untrusted(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
@@ -140,7 +172,6 @@ def test_cloud_app_handoff_redirects_to_guard_cloud_with_local_token(tmp_path: P
                 "/v1/apps/codex/cloud?action=connect",
                 method="GET",
                 origin=None,
-                referer="https://hol.org/guard/apps/codex",
             ),
         )
     finally:
@@ -150,13 +181,10 @@ def test_cloud_app_handoff_redirects_to_guard_cloud_with_local_token(tmp_path: P
     parsed = urlparse(location)
     assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == "https://hol.org/guard/apps/codex"
     assert parse_qs(parsed.query)["guardDaemon"] == [f"http://127.0.0.1:{daemon.port}"]
-    assert parse_qs(parsed.query)["guardLocalAction"] == ["connect"]
-    assert parse_qs(parsed.query)["guardLocalStatus"] == ["completed"]
-    assert parse_qs(parsed.query)["guardAppStatus"] == ["protected"]
+    assert "guardLocalAction" not in parse_qs(parsed.query)
     fragment = parse_qs(parsed.fragment)
     assert fragment["guardDaemon"] == [f"http://127.0.0.1:{daemon.port}"]
     assert fragment["guard-token"] == [auth_token]
-    assert fragment["guardReceipt"]
 
 
 def test_headless_app_operations_write_receipts_without_cli_copy(

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -229,6 +229,29 @@ def test_cloud_app_handoff_redirects_to_guard_cloud_without_side_effect_when_unt
     assert "guard-token" not in fragment
 
 
+def test_cloud_app_handoff_rejects_confirmation_required_actions(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, location = _read_redirect_response(
+            _request(
+                daemon.port,
+                "/v1/apps/codex/cloud?action=disconnect",
+                method="GET",
+                origin=None,
+                referer="https://hol.org/guard/apps/codex",
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 302
+    parsed = urlparse(location)
+    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == "https://hol.org/guard/apps/codex"
+    assert "guardLocalAction" not in parse_qs(parsed.query)
+
+
 def test_headless_app_operations_write_receipts_without_cli_copy(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -6,6 +6,7 @@ import base64
 import hashlib
 import hmac
 import json
+import re
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
@@ -154,9 +155,50 @@ def test_cloud_app_handoff_serves_token_authenticated_local_action_page(tmp_path
     assert status == 200
     assert "HOL Guard local handoff" in body
     assert f"http://127.0.0.1:{daemon.port}" in body
-    assert "/v1/apps/${data.actionPath}" in body
-    assert "Authorization" in body
-    assert auth_token in body
+    assert "/v1/apps/${data.harness}/cloud/complete" in body
+    assert "handoffToken" in body
+    assert auth_token not in body
+
+
+def test_cloud_app_handoff_completion_runs_scoped_action_without_daemon_auth_token(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        auth_token = load_guard_daemon_auth_token(store.guard_home)
+        assert auth_token is not None
+        status, body = _read_text_response(
+            _request(
+                daemon.port,
+                "/v1/apps/codex/cloud?action=connect",
+                method="GET",
+                origin=None,
+                referer="https://hol.org/guard/apps/codex",
+            ),
+        )
+        assert status == 200
+        match = re.search(
+            r'<script id="guard-handoff-data" type="application/json">([^<]+)</script>',
+            body,
+        )
+        assert match is not None
+        handoff_token = json.loads(match.group(1))["handoffToken"]
+        action_status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/apps/codex/cloud/complete",
+                payload={"handoff_token": handoff_token},
+                token=None,
+                origin=f"http://127.0.0.1:{daemon.port}",
+            )
+        )
+    finally:
+        daemon.stop()
+
+    assert action_status == 200
+    assert payload["status"] == "completed"
+    assert payload["state"]["app_status"] == "protected"
+    assert payload["receipt"]["operation"] == "install"
 
 
 def test_cloud_app_handoff_redirects_to_guard_cloud_without_side_effect_when_untrusted(tmp_path: Path) -> None:
@@ -184,7 +226,7 @@ def test_cloud_app_handoff_redirects_to_guard_cloud_without_side_effect_when_unt
     assert "guardLocalAction" not in parse_qs(parsed.query)
     fragment = parse_qs(parsed.fragment)
     assert fragment["guardDaemon"] == [f"http://127.0.0.1:{daemon.port}"]
-    assert fragment["guard-token"] == [auth_token]
+    assert "guard-token" not in fragment
 
 
 def test_headless_app_operations_write_receipts_without_cli_copy(


### PR DESCRIPTION
## Summary
- add a local daemon cloud handoff route for Guard app setup
- let localhost perform referrer-bound connect/status handoffs and return browser token plus result to Guard Cloud
- cover the redirect contract in headless daemon API tests

## Verification
- pytest tests/test_guard_headless_daemon_api.py -k 'cloud_app_handoff or capabilities_endpoint or headless_app_operations'
- ruff check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_headless_daemon_api.py