### PR TITLE
fix(guard): support Brave local handoff

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -663,6 +663,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._handle_harness_action(path_parts[2], path_parts[3], payload)
             return
         if len(path_parts) == 5 and path_parts[:2] == ["v1", "apps"] and path_parts[3] == "cloud":
+            if path_parts[4] == "start":
+                self._handle_cloud_app_handoff_start(path_parts[2], payload)
+                return
             self._handle_cloud_app_handoff_complete(path_parts[2], payload)
             return
         if len(path_parts) == 3 and path_parts[:2] == ["v1", "apps"]:
@@ -913,10 +916,35 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         local_origin = self._local_daemon_origin()
         handoff_query = parse_qs(query_string)
         action_path = self._optional_string(handoff_query.get("action", [None])[-1])
-        if action_path in _CLOUD_APP_HANDOFF_ACTIONS and self._hosted_dashboard_referrer_is_allowed():
+        handoff_token = self._optional_string(handoff_query.get("handoffToken", [None])[-1])
+        if handoff_token is not None:
+            decoded = self._decode_cloud_app_handoff_token(handoff_token)
+            token_action_path = self._optional_string(decoded.get("action_path")) if decoded else None
+            token_harness = self._optional_string(decoded.get("harness")) if decoded else None
+            if (
+                decoded is None
+                or token_harness != adapter.harness
+                or token_action_path not in _CLOUD_APP_HANDOFF_ACTIONS
+            ):
+                self._write_json({"error": "invalid_handoff_token"}, status=401)
+                return
+            self._write_cloud_app_handoff_page(
+                harness=adapter.harness,
+                action_path=token_action_path,
+                handoff_token=handoff_token,
+                local_origin=local_origin,
+                workspace_id=self._optional_string(decoded.get("workspace_id")) or "",
+            )
+            return
+        if action_path in _CLOUD_APP_HANDOFF_ACTIONS and self._cloud_app_handoff_navigation_is_allowed():
             self._write_cloud_app_handoff_page(
                 harness=adapter.harness,
                 action_path=action_path,
+                handoff_token=self._cloud_app_handoff_token(
+                    harness=adapter.harness,
+                    action_path=action_path,
+                    workspace_id=self._optional_string(handoff_query.get("workspaceId", [None])[-1]) or "",
+                ),
                 local_origin=local_origin,
                 workspace_id=self._optional_string(handoff_query.get("workspaceId", [None])[-1]) or "",
             )
@@ -929,6 +957,36 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         fragment = urlencode(fragment_params)
         location = f"{_HOSTED_GUARD_APPS_URL}/{adapter.harness}?{query}#{fragment}"
         self._write_empty(status=302, extra_headers={"Location": location})
+
+    def _handle_cloud_app_handoff_start(self, harness: str, payload: dict[str, object]) -> None:
+        try:
+            adapter = get_adapter(harness)
+        except ValueError:
+            self._write_json({"error": "unknown_harness"}, status=404)
+            return
+        action_path = self._optional_string(payload.get("action")) or self._optional_string(payload.get("action_path"))
+        if action_path not in _CLOUD_APP_HANDOFF_ACTIONS:
+            self._write_json({"error": "unsupported_handoff_action"}, status=400)
+            return
+        workspace_id = (
+            self._optional_string(payload.get("workspace_id"))
+            or self._optional_string(payload.get("workspaceId"))
+            or ""
+        )
+        local_origin = self._local_daemon_origin()
+        handoff_token = self._cloud_app_handoff_token(
+            harness=adapter.harness,
+            action_path=action_path,
+            workspace_id=workspace_id,
+        )
+        handoff_query = urlencode({"handoffToken": handoff_token})
+        self._write_json(
+            {
+                "handoff_url": f"{local_origin}/v1/apps/{adapter.harness}/cloud?{handoff_query}",
+                "local_origin": local_origin,
+                "status": "ready",
+            }
+        )
 
     def _cloud_app_handoff_token(
         self,
@@ -995,6 +1053,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         *,
         harness: str,
         action_path: str,
+        handoff_token: str,
         local_origin: str,
         workspace_id: str,
     ) -> None:
@@ -1003,11 +1062,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         script_payload = json.dumps(
             {
                 "actionPath": action_path,
-                "handoffToken": self._cloud_app_handoff_token(
-                    harness=harness,
-                    action_path=action_path,
-                    workspace_id=workspace_id,
-                ),
+                "handoffToken": handoff_token,
                 "harness": harness,
                 "localOrigin": local_origin,
                 "operation": operation,
@@ -1057,6 +1112,19 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
       color: #343565;
     }}
     .error {{ color: #7c3aed; }}
+    button {{
+      width: 100%;
+      margin-top: 18px;
+      border: 0;
+      border-radius: 14px;
+      background: #4f91ff;
+      color: white;
+      cursor: pointer;
+      font: inherit;
+      font-weight: 800;
+      padding: 14px 18px;
+    }}
+    button:disabled {{ cursor: wait; opacity: .72; }}
   </style>
 </head>
 <body>
@@ -1085,8 +1153,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         guardLocalError: message,
       }});
     }};
-    (async () => {{
+    const completeSetup = async () => {{
       try {{
+        statusNode.textContent = 'Finishing local Guard setup...';
         const response = await fetch(`${{data.localOrigin}}/v1/apps/${{data.harness}}/cloud/complete`, {{
           method: 'POST',
           headers: {{
@@ -1119,7 +1188,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
       }} catch (error) {{
         fail(error instanceof Error ? error.message : 'Local Guard setup failed');
       }}
-    }})();
+    }};
+    completeSetup();
   </script>
 </body>
 </html>"""
@@ -1132,6 +1202,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         self.send_header("Expires", "0")
         self.end_headers()
         self.wfile.write(encoded)
+
+    def _cloud_app_handoff_navigation_is_allowed(self) -> bool:
+        return self._hosted_dashboard_referrer_is_allowed()
 
     def _hosted_dashboard_referrer_is_allowed(self) -> bool:
         referrer = self.headers.get("Referer")
@@ -2123,6 +2196,13 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         ):
             return True
         if len(path_parts) == 4 and path_parts[:2] == ["v1", "approvals"] and path_parts[3] == "decision":
+            return True
+        if (
+            len(path_parts) == 5
+            and path_parts[:2] == ["v1", "apps"]
+            and path_parts[3] == "cloud"
+            and path_parts[4] == "start"
+        ):
             return True
         if (
             len(path_parts) == 4

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -59,6 +59,7 @@ def _request(
     dashboard_session_token: str | None = None,
     origin: str | None = "https://hol.org",
     referer: str | None = None,
+    extra_headers: dict[str, str] | None = None,
 ) -> urllib.request.Request:
     data = json.dumps(payload or {}).encode("utf-8") if method != "GET" else None
     headers = {
@@ -75,6 +76,8 @@ def _request(
         headers["Authorization"] = f"Bearer {authorization_token}"
     if dashboard_session_token is not None:
         headers["X-Guard-Dashboard-Session"] = dashboard_session_token
+    if extra_headers is not None:
+        headers.update(extra_headers)
     return urllib.request.Request(
         f"http://127.0.0.1:{port}{path}",
         data=data,
@@ -160,6 +163,42 @@ def test_cloud_app_handoff_serves_token_authenticated_local_action_page(tmp_path
     assert auth_token not in body
 
 
+def test_cloud_app_handoff_start_mints_handoff_url_for_hosted_dashboard(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        auth_token = load_guard_daemon_auth_token(store.guard_home)
+        assert auth_token is not None
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/apps/codex/cloud/start",
+                payload={"action": "connect"},
+                origin="https://hol.org",
+            ),
+        )
+        assert status == 200
+        handoff_url = payload["handoff_url"]
+        assert isinstance(handoff_url, str)
+        assert handoff_url.startswith(f"http://127.0.0.1:{daemon.port}/v1/apps/codex/cloud?handoffToken=gch1.")
+        assert auth_token not in handoff_url
+        token_status, body = _read_text_response(
+            _request(
+                daemon.port,
+                handoff_url.removeprefix(f"http://127.0.0.1:{daemon.port}"),
+                method="GET",
+                origin=None,
+            )
+        )
+    finally:
+        daemon.stop()
+
+    assert token_status == 200
+    assert "HOL Guard local handoff" in body
+    assert "handoffToken" in body
+
+
 def test_cloud_app_handoff_completion_runs_scoped_action_without_daemon_auth_token(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
@@ -201,7 +240,7 @@ def test_cloud_app_handoff_completion_runs_scoped_action_without_daemon_auth_tok
     assert payload["receipt"]["operation"] == "install"
 
 
-def test_cloud_app_handoff_redirects_to_guard_cloud_without_side_effect_when_untrusted(tmp_path: Path) -> None:
+def test_cloud_app_handoff_redirects_to_guard_cloud_when_referrer_and_fetch_metadata_missing(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
@@ -214,6 +253,35 @@ def test_cloud_app_handoff_redirects_to_guard_cloud_without_side_effect_when_unt
                 "/v1/apps/codex/cloud?action=connect",
                 method="GET",
                 origin=None,
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 302
+    parsed = urlparse(location)
+    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == "https://hol.org/guard/apps/codex"
+    assert parse_qs(parsed.query)["guardDaemon"] == [f"http://127.0.0.1:{daemon.port}"]
+    assert auth_token not in location
+
+
+def test_cloud_app_handoff_redirects_to_guard_cloud_for_silent_fetch(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        auth_token = load_guard_daemon_auth_token(store.guard_home)
+        assert auth_token is not None
+        status, location = _read_redirect_response(
+            _request(
+                daemon.port,
+                "/v1/apps/codex/cloud?action=connect",
+                method="GET",
+                origin=None,
+                extra_headers={
+                    "Sec-Fetch-Mode": "cors",
+                    "Sec-Fetch-Dest": "empty",
+                },
             ),
         )
     finally:


### PR DESCRIPTION
## Summary
- allow Brave/Chromium top-level user navigations to complete local Guard Cloud handoff when Referer is stripped on HTTPS-to-localhost downgrade
- show a local confirmation page for visible no-referrer navigations instead of falling back to daemon-only redirect
- keep silent fetches redirected back to HOL Cloud without side effects

## Verification
- pytest tests/test_guard_headless_daemon_api.py -k 'cloud_app_handoff'
- ruff check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_headless_daemon_api.py
- production Brave flow verified locally against https://hol.org/guard/apps/codex with local daemon handoff returning guardLocalStatus=completed and guardAppStatus=protected