### PR TITLE
fix(guard): preserve cloud handoff browser token

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -104,6 +104,7 @@ _GUARD_DAEMON_IDLE_POLL_INTERVAL_SECONDS = 0.5
 _HOSTED_GUARD_DASHBOARD_ORIGINS = frozenset({"https://hol.org", "https://www.hol.org"})
 _HOSTED_GUARD_APPS_URL = "https://hol.org/guard/apps"
 _CLOUD_APP_HANDOFF_TOKEN_TTL_SECONDS = 120
+_CLOUD_APP_DASHBOARD_SESSION_TTL_SECONDS = 10 * 60
 _HEADLESS_APP_ACTIONS = {
     "connect": ("install", "install"),
     "repair": ("repair", "repair"),
@@ -1062,6 +1063,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         script_payload = json.dumps(
             {
                 "actionPath": action_path,
+                "dashboardSessionToken": self._cloud_app_dashboard_session_token(
+                    harness=harness,
+                    workspace_id=workspace_id,
+                ),
                 "handoffToken": handoff_token,
                 "harness": harness,
                 "localOrigin": local_origin,
@@ -1138,9 +1143,14 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
   <script>
     const data = JSON.parse(document.getElementById('guard-handoff-data').textContent);
     const statusNode = document.getElementById('status');
-    const finish = (params) => {{
+    const finish = (params, fragmentOnlyParams = {{}}) => {{
       const query = new URLSearchParams(params);
       const fragment = new URLSearchParams(params);
+      for (const [key, value] of Object.entries(fragmentOnlyParams)) {{
+        if (typeof value === 'string' && value.length > 0) {{
+          fragment.set(key, value);
+        }}
+      }}
       window.location.assign(`${{data.redirectBase}}?${{query.toString()}}#${{fragment.toString()}}`);
     }};
     const fail = (message) => {{
@@ -1184,6 +1194,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
           guardAppStatus: state.app_status || 'unknown',
           guardProofStatus: state.proof_status || 'unknown',
           guardReceipt: receipt.id || '',
+        }}, {{
+          'guard-token': data.dashboardSessionToken,
         }});
       }} catch (error) {{
         fail(error instanceof Error ? error.message : 'Local Guard setup failed');
@@ -1202,6 +1214,23 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         self.send_header("Expires", "0")
         self.end_headers()
         self.wfile.write(encoded)
+
+    def _cloud_app_dashboard_session_token(self, *, harness: str, workspace_id: str) -> str:
+        from datetime import datetime, timedelta, timezone
+
+        expires_at = datetime.now(timezone.utc) + timedelta(seconds=_CLOUD_APP_DASHBOARD_SESSION_TTL_SECONDS)
+        payload_json = json.dumps(
+            {
+                "expires_at": expires_at.isoformat(),
+                "harness": harness,
+                "version": "guard-local-daemon-session.v1",
+                "workspace_id": workspace_id,
+            },
+            separators=(",", ":"),
+        )
+        payload = base64.urlsafe_b64encode(payload_json.encode("utf-8")).decode("ascii").rstrip("=")
+        signature = _dashboard_session_signature(payload, self.server.auth_token)  # type: ignore[attr-defined]
+        return f"gld1.{payload}.{signature}"
 
     def _cloud_app_handoff_navigation_is_allowed(self) -> bool:
         return self._hosted_dashboard_referrer_is_allowed()
@@ -2055,12 +2084,15 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
 
     def _dashboard_session_token_is_valid(self) -> bool:
         session_token = self.headers.get("X-Guard-Dashboard-Session")
+        guard_token = self.headers.get("X-Guard-Token")
         authorization = self.headers.get("Authorization")
         bearer_token = None
         if isinstance(authorization, str) and authorization.lower().startswith("bearer "):
             bearer_token = authorization[7:].strip()
         candidates = [
-            candidate for candidate in (session_token, bearer_token) if isinstance(candidate, str) and candidate.strip()
+            candidate
+            for candidate in (session_token, bearer_token, guard_token)
+            if isinstance(candidate, str) and candidate.strip()
         ]
         return any(self._dashboard_session_token_matches(candidate) for candidate in candidates)
 

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -136,6 +136,27 @@ def test_headless_capabilities_endpoint_reports_safe_action_contract(tmp_path: P
     assert codex_item["status"] in {"inactive", "observed", "protected"}
 
 
+def test_headless_capabilities_accepts_dashboard_session_from_guard_token_header(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/capabilities",
+                method="GET",
+                extra_headers={"X-Guard-Token": token},
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert payload["auth_state"] == "dashboard_session"
+
+
 def test_cloud_app_handoff_serves_token_authenticated_local_action_page(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
@@ -160,6 +181,8 @@ def test_cloud_app_handoff_serves_token_authenticated_local_action_page(tmp_path
     assert f"http://127.0.0.1:{daemon.port}" in body
     assert "/v1/apps/${data.harness}/cloud/complete" in body
     assert "handoffToken" in body
+    assert "dashboardSessionToken" in body
+    assert "guard-token" in body
     assert auth_token not in body
 
 
@@ -197,6 +220,51 @@ def test_cloud_app_handoff_start_mints_handoff_url_for_hosted_dashboard(tmp_path
     assert token_status == 200
     assert "HOL Guard local handoff" in body
     assert "handoffToken" in body
+    assert "dashboardSessionToken" in body
+
+
+def test_cloud_app_handoff_page_mints_scoped_browser_session_token(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        auth_token = load_guard_daemon_auth_token(store.guard_home)
+        assert auth_token is not None
+        status, body = _read_text_response(
+            _request(
+                daemon.port,
+                "/v1/apps/codex/cloud?action=connect",
+                method="GET",
+                origin=None,
+                referer="https://hol.org/guard/apps/codex",
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    match = re.search(
+        r'<script id="guard-handoff-data" type="application/json">([^<]+)</script>',
+        body,
+    )
+    assert match is not None
+    script_payload = json.loads(match.group(1))
+    browser_token = script_payload["dashboardSessionToken"]
+    assert isinstance(browser_token, str)
+    assert browser_token.startswith("gld1.")
+    assert auth_token not in browser_token
+    _, encoded_payload, encoded_signature = browser_token.split(".")
+    expected_signature = hmac.new(
+        auth_token.encode("utf-8"),
+        encoded_payload.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    assert encoded_signature == base64.urlsafe_b64encode(expected_signature).decode("ascii").rstrip("=")
+    decoded = json.loads(
+        base64.urlsafe_b64decode(f"{encoded_payload}{'=' * (-len(encoded_payload) % 4)}").decode("utf-8"),
+    )
+    assert decoded["version"] == "guard-local-daemon-session.v1"
+    assert decoded["harness"] == "codex"
 
 
 def test_cloud_app_handoff_completion_runs_scoped_action_without_daemon_auth_token(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- mint a short-lived scoped dashboard session token during hosted Guard app handoff
- return that token only in the redirect fragment so HOL Cloud can call the local daemon after Brave returns from localhost
- keep raw daemon auth token out of the hosted page and add regression coverage

## Verification
- pytest tests/test_guard_headless_daemon_api.py -k 'cloud_app_handoff'
- ruff check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_headless_daemon_api.py
- Verified in production Brave: https://hol.org/guard/apps/codex -> Open local Guard setup -> returned with guard-token fragment -> page advanced to Run Codex proof test -> proof passed and advanced to first protected action.