### PR TITLE
feat: sync signed supply-chain bundles locally

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -131,6 +131,7 @@ from ..runtime.runner import (
     prompt_requests_to_artifacts,
     sync_receipts,
     sync_runtime_session,
+    sync_supply_chain_bundle,
 )
 from ..runtime.secret_file_requests import (
     build_file_read_request_artifact,
@@ -719,6 +720,22 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     sync_parser.add_argument("--home")
     sync_parser.add_argument("--guard-home")
     sync_parser.add_argument("--json", action="store_true")
+
+    cloud_parser = guard_subparsers.add_parser(
+        "cloud",
+        help="Sync Guard Cloud supply-chain intelligence and diagnostics",
+    )
+    cloud_subparsers = cloud_parser.add_subparsers(
+        dest="cloud_command",
+        required=True,
+        parser_class=FriendlyArgumentParser,
+    )
+    cloud_sync_intel_parser = cloud_subparsers.add_parser(
+        "sync-intel",
+        help="Fetch and verify the latest Guard supply-chain bundle for this workspace",
+    )
+    _add_guard_common_args(cloud_sync_intel_parser)
+    cloud_sync_intel_parser.add_argument("--json", action="store_true")
 
     service_parser = guard_subparsers.add_parser(
         "service",
@@ -1820,19 +1837,22 @@ def run_guard_command(
     if args.guard_command == "advisories":
         adv_sub = getattr(args, "advisories_subcommand", None)
         if adv_sub == "sync":
-            credentials = store.get_sync_credentials()
-            if credentials is None:
+            try:
+                payload = sync_supply_chain_bundle(store)
+            except GuardSyncNotConfiguredError:
                 _emit(
                     "advisories_sync",
                     {"generated_at": _now(), "status": "no_cloud_sync_configured"},
                     getattr(args, "json", False),
                 )
-            else:
+            except RuntimeError as error:
                 _emit(
                     "advisories_sync",
-                    {"generated_at": _now(), "status": "advisory_sync_not_available", "synced": False},
+                    {"generated_at": _now(), "status": "supply_chain_sync_failed", "error": str(error)},
                     getattr(args, "json", False),
                 )
+            else:
+                _emit("advisories_sync", payload, getattr(args, "json", False))
         elif adv_sub == "explain":
             target_id = getattr(args, "advisory_id", None)
             all_advs = store.list_cached_advisories(limit=None)
@@ -2061,6 +2081,27 @@ def run_guard_command(
             return 1
         _emit("sync", payload, getattr(args, "json", False))
         return 0
+
+    if args.guard_command == "cloud":
+        cloud_command = getattr(args, "cloud_command", None)
+        if cloud_command == "sync-intel":
+            try:
+                payload = sync_supply_chain_bundle(store)
+            except GuardSyncNotConfiguredError:
+                message = _guard_sync_prerequisite_message()
+                if getattr(args, "json", False):
+                    _emit("cloud-sync-intel", {"synced": False, "error": message}, True)
+                else:
+                    print(message, file=sys.stderr)
+                return 1
+            except RuntimeError as error:
+                if getattr(args, "json", False):
+                    _emit("cloud-sync-intel", {"synced": False, "error": str(error)}, True)
+                else:
+                    print(str(error), file=sys.stderr)
+                return 1
+            _emit("cloud-sync-intel", payload, getattr(args, "json", False))
+            return 0
 
     if args.guard_command == "service":
         service_command = getattr(args, "service_command", None)
@@ -7963,7 +8004,11 @@ def _refresh_cloud_policy_bundle(store: GuardStore) -> None:
         return
     try:
         sync_receipts(store)
-    except Exception:
+    except (GuardSyncNotConfiguredError, RuntimeError):
+        return
+    try:
+        sync_supply_chain_bundle(store)
+    except (GuardSyncNotConfiguredError, RuntimeError):
         return
 
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2707,9 +2707,7 @@ class GuardDaemonServer:
         if interval_seconds is None or interval_seconds <= 0:
             return
         backoff_seconds = (
-            self._bundle_refresh_backoff_seconds
-            if self._bundle_refresh_backoff_seconds > 0
-            else interval_seconds
+            self._bundle_refresh_backoff_seconds if self._bundle_refresh_backoff_seconds > 0 else interval_seconds
         )
         while not self._shutdown_started.is_set():
             refreshed_at = _now()

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -57,6 +57,7 @@ from ..desktop_notifications import (
 )
 from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES, PolicyDecision
 from ..receipts.manager import build_receipt
+from ..runtime.runner import GuardSyncNotConfiguredError, sync_supply_chain_bundle
 from ..runtime.surface_server import GuardSurfaceRuntime
 from ..store import GuardStore
 from ..store_approvals import InvalidApprovalCursorError
@@ -99,6 +100,8 @@ _ROOT_STATIC_FILES = {
 }
 _CLAUDE_HOOK_EXECUTION_LOCK = threading.Lock()
 _DEFAULT_GUARD_DAEMON_IDLE_TIMEOUT_SECONDS = 30 * 60
+_DEFAULT_SUPPLY_CHAIN_REFRESH_BACKOFF_SECONDS = 60.0
+_DEFAULT_SUPPLY_CHAIN_REFRESH_INTERVAL_SECONDS = 15 * 60.0
 _EPHEMERAL_GUARD_DAEMON_IDLE_TIMEOUT_SECONDS = 5
 _GUARD_DAEMON_IDLE_POLL_INTERVAL_SECONDS = 0.5
 _HOSTED_GUARD_DASHBOARD_ORIGINS = frozenset({"https://hol.org", "https://www.hol.org"})
@@ -2579,6 +2582,8 @@ class GuardDaemonServer:
         host: str = "127.0.0.1",
         port: int = 0,
         *,
+        bundle_refresh_backoff_seconds: float = _DEFAULT_SUPPLY_CHAIN_REFRESH_BACKOFF_SECONDS,
+        bundle_refresh_interval_seconds: float | None = _DEFAULT_SUPPLY_CHAIN_REFRESH_INTERVAL_SECONDS,
         idle_timeout_seconds: float | None = None,
     ) -> None:
         _validate_dashboard_bundle()
@@ -2598,6 +2603,9 @@ class GuardDaemonServer:
         self._server.active_stream_clients = 0
         self._server.active_stream_clients_lock = threading.Lock()
         self.port = int(self._server.server_address[1])
+        self._bundle_refresh_backoff_seconds = bundle_refresh_backoff_seconds
+        self._bundle_refresh_interval_seconds = bundle_refresh_interval_seconds
+        self._bundle_refresh_thread: threading.Thread | None = None
         self._thread: threading.Thread | None = None
         self._watchdog_thread: threading.Thread | None = None
         self._shutdown_started = threading.Event()
@@ -2624,6 +2632,9 @@ class GuardDaemonServer:
         if self._watchdog_thread is not None:
             self._watchdog_thread.join(timeout=5)
             self._watchdog_thread = None
+        if self._bundle_refresh_thread is not None:
+            self._bundle_refresh_thread.join(timeout=5)
+            self._bundle_refresh_thread = None
 
     def _begin_service(self) -> None:
         self._shutdown_started.clear()
@@ -2637,6 +2648,7 @@ class GuardDaemonServer:
             last_heartbeat_at=_now(),
         )
         self._start_watchdog()
+        self._start_supply_chain_bundle_refresh()
 
     def _serve_forever(self) -> None:
         try:
@@ -2678,6 +2690,57 @@ class GuardDaemonServer:
                 self._server.shutdown()
                 return
             time.sleep(_GUARD_DAEMON_IDLE_POLL_INTERVAL_SECONDS)
+
+    def _start_supply_chain_bundle_refresh(self) -> None:
+        if self._bundle_refresh_interval_seconds is None or self._bundle_refresh_interval_seconds <= 0:
+            return
+        if self._bundle_refresh_thread is not None and self._bundle_refresh_thread.is_alive():
+            return
+        self._bundle_refresh_thread = threading.Thread(
+            target=self._refresh_supply_chain_bundle_loop,
+            daemon=True,
+        )
+        self._bundle_refresh_thread.start()
+
+    def _refresh_supply_chain_bundle_loop(self) -> None:
+        interval_seconds = self._bundle_refresh_interval_seconds
+        if interval_seconds is None or interval_seconds <= 0:
+            return
+        backoff_seconds = (
+            self._bundle_refresh_backoff_seconds
+            if self._bundle_refresh_backoff_seconds > 0
+            else interval_seconds
+        )
+        while not self._shutdown_started.is_set():
+            refreshed_at = _now()
+            try:
+                summary = sync_supply_chain_bundle(self._server.store)
+                self._server.store.set_sync_payload(
+                    "supply_chain_bundle_daemon",
+                    {**summary, "status": "synced"},
+                    refreshed_at,
+                )
+                wait_seconds = interval_seconds
+            except GuardSyncNotConfiguredError:
+                self._server.store.set_sync_payload(
+                    "supply_chain_bundle_daemon",
+                    {"status": "not_configured", "refreshed_at": refreshed_at},
+                    refreshed_at,
+                )
+                wait_seconds = backoff_seconds
+            except RuntimeError as error:
+                self._server.store.set_sync_payload(
+                    "supply_chain_bundle_daemon",
+                    {
+                        "error": str(error),
+                        "refreshed_at": refreshed_at,
+                        "status": "error",
+                    },
+                    refreshed_at,
+                )
+                wait_seconds = backoff_seconds
+            if self._shutdown_started.wait(wait_seconds):
+                return
 
 
 def _approval_center_browser_url(approval_center_url: str, auth_token: str) -> str:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2728,7 +2728,7 @@ class GuardDaemonServer:
                     refreshed_at,
                 )
                 wait_seconds = backoff_seconds
-            except RuntimeError as error:
+            except Exception as error:
                 self._server.store.set_sync_payload(
                     "supply_chain_bundle_daemon",
                     {

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -964,9 +964,7 @@ def sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
                 cached_bundle_version = existing_version
     response = load_supply_chain_bundle_response(payload)
     try:
-        trusted_keys = load_supply_chain_verification_keys(
-            store.get_sync_payload("supply_chain_bundle_keyring")
-        )
+        trusted_keys = load_supply_chain_verification_keys(store.get_sync_payload("supply_chain_bundle_keyring"))
         verify_supply_chain_bundle_response(
             response,
             trusted_keys=trusted_keys or None,

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -32,6 +32,12 @@ from .actions import GuardActionEnvelope, redacted_workspace_label
 from .composition_rules import compose_action_from_signals
 from .detectors import DetectorContext, DetectorRegistry, DetectorRunResult, register_default_detectors
 from .prompt_injection import detect_prompt_injection_requests
+from .supply_chain_bundle import (
+    SupplyChainBundleError,
+    load_supply_chain_bundle_response,
+    load_supply_chain_verification_keys,
+    verify_supply_chain_bundle_response,
+)
 
 _APPROVAL_METADATA_KEYS = (
     "approval_center_url",
@@ -920,6 +926,90 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
     return summary
 
 
+def sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
+    """Fetch, verify, and persist the active supply-chain bundle for the cloud workspace."""
+
+    credentials = store.get_sync_credentials()
+    if credentials is None:
+        raise GuardSyncNotConfiguredError("Guard is not logged in.")
+    workspace_id = store.get_cloud_workspace_id()
+    if workspace_id is None:
+        raise GuardSyncNotConfiguredError("Guard Cloud workspace is not connected.")
+    bundle_url = _normalized_supply_chain_bundle_url(str(credentials["sync_url"]), workspace_id)
+    headers = _guard_sync_headers(str(credentials["token"]))
+    headers["Accept-Encoding"] = "identity"
+    request = urllib.request.Request(bundle_url, method="GET", headers=headers)
+    try:
+        payload = _urlopen_json_with_timeout_retry(
+            request=request,
+            timeout_seconds=_SYNC_HTTP_TIMEOUT_SECONDS,
+            retry_timeout_seconds=_SYNC_HTTP_RETRY_TIMEOUT_SECONDS,
+        )
+    except urllib.error.HTTPError as error:
+        if error.code == 403:
+            is_plan_restricted, message = _check_plan_restriction_403(error)
+            if is_plan_restricted:
+                raise GuardSyncNotAvailableError(message) from error
+            raise RuntimeError(message) from error
+        raise RuntimeError(_sync_http_error_message(error)) from error
+    except OSError as error:
+        raise RuntimeError(_sync_url_error_message(error)) from error
+    cached_bundle = store.get_cached_supply_chain_bundle(workspace_id)
+    cached_bundle_version = None
+    if isinstance(cached_bundle, dict):
+        cached_payload = cached_bundle.get("bundle")
+        if isinstance(cached_payload, dict):
+            existing_version = cached_payload.get("bundleVersion")
+            if isinstance(existing_version, str) and existing_version:
+                cached_bundle_version = existing_version
+    response = load_supply_chain_bundle_response(payload)
+    try:
+        trusted_keys = load_supply_chain_verification_keys(
+            store.get_sync_payload("supply_chain_bundle_keyring")
+        )
+        verify_supply_chain_bundle_response(
+            response,
+            trusted_keys=trusted_keys or None,
+            cached_bundle_version=cached_bundle_version,
+        )
+    except SupplyChainBundleError as error:
+        raise RuntimeError(f"Guard supply-chain bundle sync failed: {error}") from error
+    synced_at = _now()
+    store.cache_supply_chain_bundle(workspace_id, response.to_dict(), synced_at)
+    store.set_sync_payload(
+        "supply_chain_bundle_keyring",
+        {
+            "workspace_id": workspace_id,
+            "keys": [item.to_dict() for item in response.verification_keys],
+        },
+        synced_at,
+    )
+    store.set_sync_payload(
+        "supply_chain_bundle_entitlement",
+        {
+            "bundle_version": response.bundle.bundle_version,
+            "key_id": response.bundle.key_id,
+            "policy_hash": response.bundle.policy_hash,
+            "tier": response.bundle.tier,
+            "workspace_id": workspace_id,
+        },
+        synced_at,
+    )
+    summary = {
+        "advisory_count": len(response.bundle.advisories),
+        "bundle_version": response.bundle.bundle_version,
+        "feed_snapshot_hash": response.bundle.feed_snapshot_hash,
+        "package_count": len(response.bundle.packages),
+        "policy_hash": response.bundle.policy_hash,
+        "status": "synced",
+        "synced_at": synced_at,
+        "tier": response.bundle.tier,
+        "workspace_id": workspace_id,
+    }
+    store.set_sync_payload("supply_chain_bundle_summary", summary, synced_at)
+    return summary
+
+
 def sync_guard_events(store: GuardStore) -> dict[str, object]:
     """Push pending GuardEventV1 envelopes to Guard Cloud."""
 
@@ -1548,6 +1638,32 @@ def _normalized_runtime_sessions_sync_url(sync_url: str) -> str:
             parsed.netloc,
             parsed.path.rstrip("/") + "/runtime/sessions/sync",
             parsed.query,
+            "",
+        )
+    )
+
+
+def _normalized_supply_chain_bundle_url(sync_url: str, workspace_id: str) -> str:
+    normalized_receipts_url = _normalized_receipts_sync_url(sync_url)
+    parsed = urllib.parse.urlsplit(normalized_receipts_url)
+    if parsed.path.rstrip("/") == "/api/guard/receipts/sync":
+        next_path = "/api/guard/supply-chain/bundle"
+    elif parsed.path.rstrip("/") == "/guard/receipts/sync":
+        next_path = "/guard/supply-chain/bundle"
+    else:
+        next_path = parsed.path.rstrip("/") + "/supply-chain/bundle"
+    query_pairs = [
+        (key, value)
+        for key, value in urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+        if key != "workspaceId"
+    ]
+    query_pairs.append(("workspaceId", workspace_id))
+    return urllib.parse.urlunsplit(
+        (
+            parsed.scheme,
+            parsed.netloc,
+            next_path,
+            urllib.parse.urlencode(query_pairs),
             "",
         )
     )

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle.py
@@ -1,0 +1,59 @@
+"""HOL Guard supply-chain bundle verification and offline evaluation."""
+
+from __future__ import annotations
+
+from .supply_chain_bundle_base import (
+    SupplyChainBundleError,
+    SupplyChainBundleExpiredError,
+    SupplyChainBundleKeyringError,
+    SupplyChainBundleMalformedError,
+    SupplyChainBundlePayloadHashError,
+    SupplyChainBundleRollbackError,
+    SupplyChainBundleSignatureError,
+)
+from .supply_chain_bundle_models import (
+    SupplyChainBundle,
+    SupplyChainBundleAdvisory,
+    SupplyChainBundlePackage,
+    SupplyChainBundlePolicyRule,
+    SupplyChainBundleResponse,
+    SupplyChainBundleSourceHash,
+    SupplyChainVerificationKey,
+)
+from .supply_chain_bundle_runtime import (
+    OfflineSupplyChainDecision,
+    canonical_supply_chain_bundle_payload,
+    check_supply_chain_bundle_freshness,
+    check_supply_chain_bundle_rollback,
+    evaluate_cached_supply_chain_bundle,
+    load_supply_chain_bundle_response,
+    load_supply_chain_verification_keys,
+    payload_hash_for_supply_chain_bundle,
+    verify_supply_chain_bundle_response,
+)
+
+__all__ = [
+    "OfflineSupplyChainDecision",
+    "SupplyChainBundle",
+    "SupplyChainBundleAdvisory",
+    "SupplyChainBundleError",
+    "SupplyChainBundleExpiredError",
+    "SupplyChainBundleKeyringError",
+    "SupplyChainBundleMalformedError",
+    "SupplyChainBundlePackage",
+    "SupplyChainBundlePayloadHashError",
+    "SupplyChainBundlePolicyRule",
+    "SupplyChainBundleResponse",
+    "SupplyChainBundleRollbackError",
+    "SupplyChainBundleSignatureError",
+    "SupplyChainBundleSourceHash",
+    "SupplyChainVerificationKey",
+    "canonical_supply_chain_bundle_payload",
+    "check_supply_chain_bundle_freshness",
+    "check_supply_chain_bundle_rollback",
+    "evaluate_cached_supply_chain_bundle",
+    "load_supply_chain_bundle_response",
+    "load_supply_chain_verification_keys",
+    "payload_hash_for_supply_chain_bundle",
+    "verify_supply_chain_bundle_response",
+]

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_base.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_base.py
@@ -1,0 +1,107 @@
+"""Shared parsing primitives for supply-chain bundle handling."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Final
+
+_BUNDLE_MAX_AGE_SECONDS: Final[int] = 86_400 * 7
+_BUNDLE_CLOCK_SKEW_SECONDS: Final[int] = 300
+_PACKAGE_ACTION_VALUES = frozenset({"allow", "monitor", "warn", "ask", "block"})
+_SEVERITY_VALUES = frozenset({"unknown", "low", "medium", "high", "critical"})
+_EXPLOIT_LEVEL_VALUES = frozenset({"none", "elevated", "active"})
+_MALWARE_STATE_VALUES = frozenset({"none", "suspected", "known"})
+_STALE_STATUS_VALUES = frozenset({"fresh", "stale", "unknown"})
+_VERIFICATION_KEY_STATE_VALUES = frozenset({"active", "grace"})
+
+
+class SupplyChainBundleError(Exception):
+    """Base error for supply-chain bundle failures."""
+
+
+class SupplyChainBundleSignatureError(SupplyChainBundleError):
+    """Bundle signature did not verify."""
+
+
+class SupplyChainBundleExpiredError(SupplyChainBundleError):
+    """Bundle freshness window has elapsed."""
+
+
+class SupplyChainBundleRollbackError(SupplyChainBundleError):
+    """Bundle version is older than the cached version."""
+
+
+class SupplyChainBundleMalformedError(SupplyChainBundleError):
+    """Bundle response is missing required fields or invalid values."""
+
+
+class SupplyChainBundlePayloadHashError(SupplyChainBundleError):
+    """Bundle payload hash does not match the canonical payload."""
+
+
+class SupplyChainBundleKeyringError(SupplyChainBundleError):
+    """Bundle key rotation is not anchored to the trusted keyring."""
+
+
+def _require_string(data: dict[str, object], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise SupplyChainBundleMalformedError(f"Missing required string field: {key!r}")
+    return value.strip()
+
+
+def _optional_string(data: dict[str, object], key: str) -> str | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise SupplyChainBundleMalformedError(f"Field must be a string when present: {key!r}")
+    normalized = value.strip()
+    return normalized or None
+
+
+def _require_int(data: dict[str, object], key: str) -> int:
+    value = data.get(key)
+    if not isinstance(value, int):
+        raise SupplyChainBundleMalformedError(f"Missing required int field: {key!r}")
+    return value
+
+
+def _require_bool(data: dict[str, object], key: str) -> bool:
+    value = data.get(key)
+    if not isinstance(value, bool):
+        raise SupplyChainBundleMalformedError(f"Missing required boolean field: {key!r}")
+    return value
+
+
+def _require_string_array(data: dict[str, object], key: str) -> tuple[str, ...]:
+    value = data.get(key)
+    if not isinstance(value, list):
+        raise SupplyChainBundleMalformedError(f"Missing required list field: {key!r}")
+    items: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item.strip():
+            raise SupplyChainBundleMalformedError(f"Field contains invalid string item: {key!r}")
+        items.append(item.strip())
+    return tuple(items)
+
+
+def _parse_iso_timestamp(value: str, *, field_name: str) -> float:
+    normalized = value.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise SupplyChainBundleMalformedError(f"Invalid ISO timestamp for {field_name!r}") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).timestamp()
+
+
+def _bundle_version_timestamp(bundle_version: str) -> int:
+    try:
+        prefix = bundle_version.split("-", 1)[0]
+        return int(prefix)
+    except (TypeError, ValueError) as exc:
+        raise SupplyChainBundleMalformedError(
+            "bundleVersion must start with a unix-ms timestamp prefix"
+        ) from exc

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_base.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_base.py
@@ -102,6 +102,4 @@ def _bundle_version_timestamp(bundle_version: str) -> int:
         prefix = bundle_version.split("-", 1)[0]
         return int(prefix)
     except (TypeError, ValueError) as exc:
-        raise SupplyChainBundleMalformedError(
-            "bundleVersion must start with a unix-ms timestamp prefix"
-        ) from exc
+        raise SupplyChainBundleMalformedError("bundleVersion must start with a unix-ms timestamp prefix") from exc

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_models.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_models.py
@@ -1,0 +1,421 @@
+"""Dataclasses for supply-chain bundle payloads."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .supply_chain_bundle_base import (
+    _EXPLOIT_LEVEL_VALUES,
+    _MALWARE_STATE_VALUES,
+    _PACKAGE_ACTION_VALUES,
+    _SEVERITY_VALUES,
+    _STALE_STATUS_VALUES,
+    _VERIFICATION_KEY_STATE_VALUES,
+    SupplyChainBundleMalformedError,
+    _bundle_version_timestamp,
+    _optional_string,
+    _parse_iso_timestamp,
+    _require_bool,
+    _require_int,
+    _require_string,
+    _require_string_array,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SupplyChainVerificationKey:
+    """Verification key advertised by the cloud bundle route."""
+
+    key_id: str
+    public_key_pem: str
+    fingerprint_sha256: str
+    state: str
+    valid_until: str | None
+
+    @property
+    def valid_until_timestamp(self) -> float | None:
+        if self.valid_until is None:
+            return None
+        return _parse_iso_timestamp(self.valid_until, field_name="validUntil")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "fingerprintSha256": self.fingerprint_sha256,
+            "keyId": self.key_id,
+            "publicKeyPem": self.public_key_pem,
+            "state": self.state,
+            "validUntil": self.valid_until,
+        }
+
+    @staticmethod
+    def from_dict(data: dict[str, object]) -> SupplyChainVerificationKey:
+        state = _require_string(data, "state")
+        if state not in _VERIFICATION_KEY_STATE_VALUES:
+            raise SupplyChainBundleMalformedError(f"Unsupported verification key state: {state!r}")
+        valid_until = _optional_string(data, "validUntil")
+        if valid_until is not None:
+            _parse_iso_timestamp(valid_until, field_name="validUntil")
+        return SupplyChainVerificationKey(
+            key_id=_require_string(data, "keyId"),
+            public_key_pem=_require_string(data, "publicKeyPem"),
+            fingerprint_sha256=_require_string(data, "fingerprintSha256"),
+            state=state,
+            valid_until=valid_until,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SupplyChainBundleAdvisory:
+    """Advisory record inside the supply-chain bundle."""
+
+    advisory_id: str
+    aliases: tuple[str, ...]
+    confidence: int
+    exploit_level: str
+    known_exploited: bool
+    malware_state: str
+    normalized_severity: str
+    recommended_fix_version: str | None
+    source_key: str
+    summary: str
+    title: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "advisoryId": self.advisory_id,
+            "aliases": list(self.aliases),
+            "confidence": self.confidence,
+            "exploitLevel": self.exploit_level,
+            "knownExploited": self.known_exploited,
+            "malwareState": self.malware_state,
+            "normalizedSeverity": self.normalized_severity,
+            "recommendedFixVersion": self.recommended_fix_version,
+            "sourceKey": self.source_key,
+            "summary": self.summary,
+            "title": self.title,
+        }
+
+    @staticmethod
+    def from_dict(data: dict[str, object]) -> SupplyChainBundleAdvisory:
+        exploit_level = _require_string(data, "exploitLevel")
+        if exploit_level not in _EXPLOIT_LEVEL_VALUES:
+            raise SupplyChainBundleMalformedError(f"Unsupported advisory exploitLevel: {exploit_level!r}")
+        malware_state = _require_string(data, "malwareState")
+        if malware_state not in _MALWARE_STATE_VALUES:
+            raise SupplyChainBundleMalformedError(f"Unsupported advisory malwareState: {malware_state!r}")
+        normalized_severity = _require_string(data, "normalizedSeverity")
+        if normalized_severity not in _SEVERITY_VALUES:
+            raise SupplyChainBundleMalformedError(
+                f"Unsupported advisory normalizedSeverity: {normalized_severity!r}"
+            )
+        return SupplyChainBundleAdvisory(
+            advisory_id=_require_string(data, "advisoryId"),
+            aliases=_require_string_array(data, "aliases"),
+            confidence=_require_int(data, "confidence"),
+            exploit_level=exploit_level,
+            known_exploited=_require_bool(data, "knownExploited"),
+            malware_state=malware_state,
+            normalized_severity=normalized_severity,
+            recommended_fix_version=_optional_string(data, "recommendedFixVersion"),
+            source_key=_require_string(data, "sourceKey"),
+            summary=_require_string(data, "summary"),
+            title=_require_string(data, "title"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SupplyChainBundlePackage:
+    """Package record inside the supply-chain bundle."""
+
+    confidence: int
+    default_action: str
+    ecosystem: str
+    exploit_level: str
+    known_exploited: bool
+    malware_state: str
+    name: str
+    namespace: str | None
+    normalized_severity: str
+    package_age_state: str
+    purl: str
+    reachability: str
+    recommended_fix_version: str | None
+    related_advisory_ids: tuple[str, ...]
+    risk_score: int
+    source_integrity_state: str
+    version: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "confidence": self.confidence,
+            "defaultAction": self.default_action,
+            "ecosystem": self.ecosystem,
+            "exploitLevel": self.exploit_level,
+            "knownExploited": self.known_exploited,
+            "malwareState": self.malware_state,
+            "name": self.name,
+            "namespace": self.namespace,
+            "normalizedSeverity": self.normalized_severity,
+            "packageAgeState": self.package_age_state,
+            "purl": self.purl,
+            "reachability": self.reachability,
+            "recommendedFixVersion": self.recommended_fix_version,
+            "relatedAdvisoryIds": list(self.related_advisory_ids),
+            "riskScore": self.risk_score,
+            "sourceIntegrityState": self.source_integrity_state,
+            "version": self.version,
+        }
+
+    @staticmethod
+    def from_dict(data: dict[str, object]) -> SupplyChainBundlePackage:
+        default_action = _require_string(data, "defaultAction")
+        if default_action not in _PACKAGE_ACTION_VALUES:
+            raise SupplyChainBundleMalformedError(f"Unsupported package defaultAction: {default_action!r}")
+        exploit_level = _require_string(data, "exploitLevel")
+        if exploit_level not in _EXPLOIT_LEVEL_VALUES:
+            raise SupplyChainBundleMalformedError(f"Unsupported package exploitLevel: {exploit_level!r}")
+        malware_state = _require_string(data, "malwareState")
+        if malware_state not in _MALWARE_STATE_VALUES:
+            raise SupplyChainBundleMalformedError(f"Unsupported package malwareState: {malware_state!r}")
+        normalized_severity = _require_string(data, "normalizedSeverity")
+        if normalized_severity not in _SEVERITY_VALUES:
+            raise SupplyChainBundleMalformedError(
+                f"Unsupported package normalizedSeverity: {normalized_severity!r}"
+            )
+        return SupplyChainBundlePackage(
+            confidence=_require_int(data, "confidence"),
+            default_action=default_action,
+            ecosystem=_require_string(data, "ecosystem"),
+            exploit_level=exploit_level,
+            known_exploited=_require_bool(data, "knownExploited"),
+            malware_state=malware_state,
+            name=_require_string(data, "name"),
+            namespace=_optional_string(data, "namespace"),
+            normalized_severity=normalized_severity,
+            package_age_state=_require_string(data, "packageAgeState"),
+            purl=_require_string(data, "purl"),
+            reachability=_require_string(data, "reachability"),
+            recommended_fix_version=_optional_string(data, "recommendedFixVersion"),
+            related_advisory_ids=_require_string_array(data, "relatedAdvisoryIds"),
+            risk_score=_require_int(data, "riskScore"),
+            source_integrity_state=_require_string(data, "sourceIntegrityState"),
+            version=_require_string(data, "version"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SupplyChainBundlePolicyRule:
+    """Policy rule record inside the supply-chain bundle."""
+
+    action: str
+    rule_id: str
+    ecosystem_selector: str | None
+    enabled: bool | None
+    expires_at: str | None
+    harness_selector: str | None
+    package_selector: str | None
+    priority: int | None
+    severity_threshold: str | None
+    version_range_selector: str | None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "action": self.action,
+            "ruleId": self.rule_id,
+            "ecosystemSelector": self.ecosystem_selector,
+            "enabled": self.enabled,
+            "expiresAt": self.expires_at,
+            "harnessSelector": self.harness_selector,
+            "packageSelector": self.package_selector,
+            "priority": self.priority,
+            "severityThreshold": self.severity_threshold,
+            "versionRangeSelector": self.version_range_selector,
+        }
+
+    @staticmethod
+    def from_dict(data: dict[str, object]) -> SupplyChainBundlePolicyRule:
+        action = _require_string(data, "action")
+        if action not in _PACKAGE_ACTION_VALUES | {"review"}:
+            raise SupplyChainBundleMalformedError(f"Unsupported policy action: {action!r}")
+        severity_threshold = _optional_string(data, "severityThreshold")
+        if severity_threshold is not None and severity_threshold not in _SEVERITY_VALUES:
+            raise SupplyChainBundleMalformedError(
+                f"Unsupported policy severityThreshold: {severity_threshold!r}"
+            )
+        expires_at = _optional_string(data, "expiresAt")
+        if expires_at is not None:
+            _parse_iso_timestamp(expires_at, field_name="expiresAt")
+        enabled = data.get("enabled")
+        if enabled is not None and not isinstance(enabled, bool):
+            raise SupplyChainBundleMalformedError("Policy enabled must be a boolean when present")
+        priority = data.get("priority")
+        if priority is not None and not isinstance(priority, int):
+            raise SupplyChainBundleMalformedError("Policy priority must be an int when present")
+        return SupplyChainBundlePolicyRule(
+            action=action,
+            rule_id=_require_string(data, "ruleId"),
+            ecosystem_selector=_optional_string(data, "ecosystemSelector"),
+            enabled=enabled,
+            expires_at=expires_at,
+            harness_selector=_optional_string(data, "harnessSelector"),
+            package_selector=_optional_string(data, "packageSelector"),
+            priority=priority,
+            severity_threshold=severity_threshold,
+            version_range_selector=_optional_string(data, "versionRangeSelector"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SupplyChainBundleSourceHash:
+    """Source-hash metadata inside the supply-chain bundle."""
+
+    payload_hash: str | None
+    source_key: str
+    stale_status: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "payloadHash": self.payload_hash,
+            "sourceKey": self.source_key,
+            "staleStatus": self.stale_status,
+        }
+
+    @staticmethod
+    def from_dict(data: dict[str, object]) -> SupplyChainBundleSourceHash:
+        payload_hash = _optional_string(data, "payloadHash")
+        stale_status = _require_string(data, "staleStatus")
+        if stale_status not in _STALE_STATUS_VALUES:
+            raise SupplyChainBundleMalformedError(f"Unsupported source staleStatus: {stale_status!r}")
+        return SupplyChainBundleSourceHash(
+            payload_hash=payload_hash,
+            source_key=_require_string(data, "sourceKey"),
+            stale_status=stale_status,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SupplyChainBundle:
+    """Verified supply-chain bundle payload."""
+
+    advisories: tuple[SupplyChainBundleAdvisory, ...]
+    bundle_version: str
+    expires_at: str
+    feed_snapshot_hash: str
+    generated_at: str
+    key_id: str
+    packages: tuple[SupplyChainBundlePackage, ...]
+    policy_hash: str
+    policy_rules: tuple[SupplyChainBundlePolicyRule, ...]
+    scoring_version: str
+    source_hashes: tuple[SupplyChainBundleSourceHash, ...]
+    tier: str
+    workspace_id: str
+
+    @property
+    def generated_at_timestamp(self) -> float:
+        return _parse_iso_timestamp(self.generated_at, field_name="generatedAt")
+
+    @property
+    def expires_at_timestamp(self) -> float:
+        return _parse_iso_timestamp(self.expires_at, field_name="expiresAt")
+
+    @property
+    def version_timestamp(self) -> int:
+        return _bundle_version_timestamp(self.bundle_version)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "advisories": [item.to_dict() for item in self.advisories],
+            "bundleVersion": self.bundle_version,
+            "expiresAt": self.expires_at,
+            "feedSnapshotHash": self.feed_snapshot_hash,
+            "generatedAt": self.generated_at,
+            "keyId": self.key_id,
+            "packages": [item.to_dict() for item in self.packages],
+            "policyHash": self.policy_hash,
+            "policyRules": [item.to_dict() for item in self.policy_rules],
+            "scoringVersion": self.scoring_version,
+            "sourceHashes": [item.to_dict() for item in self.source_hashes],
+            "tier": self.tier,
+            "workspaceId": self.workspace_id,
+        }
+
+    @staticmethod
+    def from_dict(data: dict[str, object]) -> SupplyChainBundle:
+        raw_advisories = data.get("advisories")
+        raw_packages = data.get("packages")
+        raw_policy_rules = data.get("policyRules")
+        raw_source_hashes = data.get("sourceHashes")
+        if not isinstance(raw_advisories, list):
+            raise SupplyChainBundleMalformedError("Bundle advisories must be a list")
+        if not isinstance(raw_packages, list):
+            raise SupplyChainBundleMalformedError("Bundle packages must be a list")
+        if not isinstance(raw_policy_rules, list):
+            raise SupplyChainBundleMalformedError("Bundle policyRules must be a list")
+        if not isinstance(raw_source_hashes, list):
+            raise SupplyChainBundleMalformedError("Bundle sourceHashes must be a list")
+        bundle = SupplyChainBundle(
+            advisories=tuple(
+                SupplyChainBundleAdvisory.from_dict(item)
+                for item in raw_advisories
+                if isinstance(item, dict)
+            ),
+            bundle_version=_require_string(data, "bundleVersion"),
+            expires_at=_require_string(data, "expiresAt"),
+            feed_snapshot_hash=_require_string(data, "feedSnapshotHash"),
+            generated_at=_require_string(data, "generatedAt"),
+            key_id=_require_string(data, "keyId"),
+            packages=tuple(
+                SupplyChainBundlePackage.from_dict(item)
+                for item in raw_packages
+                if isinstance(item, dict)
+            ),
+            policy_hash=_require_string(data, "policyHash"),
+            policy_rules=tuple(
+                SupplyChainBundlePolicyRule.from_dict(item)
+                for item in raw_policy_rules
+                if isinstance(item, dict)
+            ),
+            scoring_version=_require_string(data, "scoringVersion"),
+            source_hashes=tuple(
+                SupplyChainBundleSourceHash.from_dict(item)
+                for item in raw_source_hashes
+                if isinstance(item, dict)
+            ),
+            tier=_require_string(data, "tier"),
+            workspace_id=_require_string(data, "workspaceId"),
+        )
+        if len(bundle.advisories) != len(raw_advisories):
+            raise SupplyChainBundleMalformedError("Bundle advisories must contain only objects")
+        if len(bundle.packages) != len(raw_packages):
+            raise SupplyChainBundleMalformedError("Bundle packages must contain only objects")
+        if len(bundle.policy_rules) != len(raw_policy_rules):
+            raise SupplyChainBundleMalformedError("Bundle policyRules must contain only objects")
+        if len(bundle.source_hashes) != len(raw_source_hashes):
+            raise SupplyChainBundleMalformedError("Bundle sourceHashes must contain only objects")
+        _ = (
+            bundle.generated_at_timestamp,
+            bundle.expires_at_timestamp,
+            bundle.version_timestamp,
+        )
+        return bundle
+
+
+@dataclass(frozen=True, slots=True)
+class SupplyChainBundleResponse:
+    """Signed supply-chain bundle response from Guard Cloud."""
+
+    bundle: SupplyChainBundle
+    payload_hash: str
+    signature: str
+    signature_algorithm: str
+    verification_keys: tuple[SupplyChainVerificationKey, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "bundle": self.bundle.to_dict(),
+            "payloadHash": self.payload_hash,
+            "signature": self.signature,
+            "signatureAlgorithm": self.signature_algorithm,
+            "verificationKeys": [item.to_dict() for item in self.verification_keys],
+        }

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_models.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_models.py
@@ -105,9 +105,7 @@ class SupplyChainBundleAdvisory:
             raise SupplyChainBundleMalformedError(f"Unsupported advisory malwareState: {malware_state!r}")
         normalized_severity = _require_string(data, "normalizedSeverity")
         if normalized_severity not in _SEVERITY_VALUES:
-            raise SupplyChainBundleMalformedError(
-                f"Unsupported advisory normalizedSeverity: {normalized_severity!r}"
-            )
+            raise SupplyChainBundleMalformedError(f"Unsupported advisory normalizedSeverity: {normalized_severity!r}")
         return SupplyChainBundleAdvisory(
             advisory_id=_require_string(data, "advisoryId"),
             aliases=_require_string_array(data, "aliases"),
@@ -179,9 +177,7 @@ class SupplyChainBundlePackage:
             raise SupplyChainBundleMalformedError(f"Unsupported package malwareState: {malware_state!r}")
         normalized_severity = _require_string(data, "normalizedSeverity")
         if normalized_severity not in _SEVERITY_VALUES:
-            raise SupplyChainBundleMalformedError(
-                f"Unsupported package normalizedSeverity: {normalized_severity!r}"
-            )
+            raise SupplyChainBundleMalformedError(f"Unsupported package normalizedSeverity: {normalized_severity!r}")
         return SupplyChainBundlePackage(
             confidence=_require_int(data, "confidence"),
             default_action=default_action,
@@ -239,9 +235,7 @@ class SupplyChainBundlePolicyRule:
             raise SupplyChainBundleMalformedError(f"Unsupported policy action: {action!r}")
         severity_threshold = _optional_string(data, "severityThreshold")
         if severity_threshold is not None and severity_threshold not in _SEVERITY_VALUES:
-            raise SupplyChainBundleMalformedError(
-                f"Unsupported policy severityThreshold: {severity_threshold!r}"
-            )
+            raise SupplyChainBundleMalformedError(f"Unsupported policy severityThreshold: {severity_threshold!r}")
         expires_at = _optional_string(data, "expiresAt")
         if expires_at is not None:
             _parse_iso_timestamp(expires_at, field_name="expiresAt")
@@ -356,31 +350,21 @@ class SupplyChainBundle:
             raise SupplyChainBundleMalformedError("Bundle sourceHashes must be a list")
         bundle = SupplyChainBundle(
             advisories=tuple(
-                SupplyChainBundleAdvisory.from_dict(item)
-                for item in raw_advisories
-                if isinstance(item, dict)
+                SupplyChainBundleAdvisory.from_dict(item) for item in raw_advisories if isinstance(item, dict)
             ),
             bundle_version=_require_string(data, "bundleVersion"),
             expires_at=_require_string(data, "expiresAt"),
             feed_snapshot_hash=_require_string(data, "feedSnapshotHash"),
             generated_at=_require_string(data, "generatedAt"),
             key_id=_require_string(data, "keyId"),
-            packages=tuple(
-                SupplyChainBundlePackage.from_dict(item)
-                for item in raw_packages
-                if isinstance(item, dict)
-            ),
+            packages=tuple(SupplyChainBundlePackage.from_dict(item) for item in raw_packages if isinstance(item, dict)),
             policy_hash=_require_string(data, "policyHash"),
             policy_rules=tuple(
-                SupplyChainBundlePolicyRule.from_dict(item)
-                for item in raw_policy_rules
-                if isinstance(item, dict)
+                SupplyChainBundlePolicyRule.from_dict(item) for item in raw_policy_rules if isinstance(item, dict)
             ),
             scoring_version=_require_string(data, "scoringVersion"),
             source_hashes=tuple(
-                SupplyChainBundleSourceHash.from_dict(item)
-                for item in raw_source_hashes
-                if isinstance(item, dict)
+                SupplyChainBundleSourceHash.from_dict(item) for item in raw_source_hashes if isinstance(item, dict)
             ),
             tier=_require_string(data, "tier"),
             workspace_id=_require_string(data, "workspaceId"),

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
@@ -110,9 +110,7 @@ def check_supply_chain_bundle_freshness(bundle: SupplyChainBundle, now: float | 
             f"Bundle expired at {bundle.expires_at}, current time is {current_time:.0f}"
         )
     if current_time < bundle.generated_at_timestamp - _BUNDLE_CLOCK_SKEW_SECONDS:
-        raise SupplyChainBundleExpiredError(
-            f"Bundle generatedAt {bundle.generated_at} is in the future"
-        )
+        raise SupplyChainBundleExpiredError(f"Bundle generatedAt {bundle.generated_at} is in the future")
     age = current_time - bundle.generated_at_timestamp
     if age > _BUNDLE_MAX_AGE_SECONDS:
         raise SupplyChainBundleExpiredError(
@@ -192,9 +190,7 @@ def _package_matches(package: SupplyChainBundlePackage, package_name: str, packa
     normalized_name = package_name.strip().lower()
     if package.name.lower() != normalized_name:
         namespace_name = (
-            f"{package.namespace.lower()}/{package.name.lower()}"
-            if package.namespace is not None
-            else None
+            f"{package.namespace.lower()}/{package.name.lower()}" if package.namespace is not None else None
         )
         if namespace_name != normalized_name:
             return False
@@ -223,9 +219,7 @@ def evaluate_cached_supply_chain_bundle(
         check_supply_chain_bundle_freshness(response.bundle, now=now)
     except SupplyChainBundleExpiredError:
         stale = True
-    matches = [
-        item for item in response.bundle.packages if _package_matches(item, package_name, package_version)
-    ]
+    matches = [item for item in response.bundle.packages if _package_matches(item, package_name, package_version)]
     if not matches:
         return OfflineSupplyChainDecision(
             action="monitor",

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
@@ -1,0 +1,259 @@
+"""Verification and offline evaluation for supply-chain bundles."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import time
+from dataclasses import dataclass
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+
+from .supply_chain_bundle_base import (
+    _BUNDLE_CLOCK_SKEW_SECONDS,
+    _BUNDLE_MAX_AGE_SECONDS,
+    SupplyChainBundleExpiredError,
+    SupplyChainBundleKeyringError,
+    SupplyChainBundleMalformedError,
+    SupplyChainBundlePayloadHashError,
+    SupplyChainBundleRollbackError,
+    SupplyChainBundleSignatureError,
+    _bundle_version_timestamp,
+    _require_string,
+)
+from .supply_chain_bundle_models import (
+    SupplyChainBundle,
+    SupplyChainBundlePackage,
+    SupplyChainBundleResponse,
+    SupplyChainVerificationKey,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class OfflineSupplyChainDecision:
+    """Offline decision derived from a cached supply-chain bundle."""
+
+    action: str
+    bundle_version: str
+    matched_advisory_ids: tuple[str, ...]
+    reason: str
+    stale: bool
+
+
+def canonical_supply_chain_bundle_payload(bundle: SupplyChainBundle | dict[str, object]) -> bytes:
+    """Return the canonical payload used for payloadHash and RSA-PSS signing."""
+
+    payload = bundle.to_dict() if isinstance(bundle, SupplyChainBundle) else bundle
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def payload_hash_for_supply_chain_bundle(bundle: SupplyChainBundle | dict[str, object]) -> str:
+    return hashlib.sha256(canonical_supply_chain_bundle_payload(bundle)).hexdigest()
+
+
+def load_supply_chain_verification_keys(raw: object) -> tuple[SupplyChainVerificationKey, ...]:
+    """Load verification keys from a list payload or sync_state wrapper."""
+
+    raw_keys = raw
+    if isinstance(raw, dict):
+        raw_keys = raw.get("keys")
+    if not isinstance(raw_keys, list):
+        return ()
+    parsed: list[SupplyChainVerificationKey] = []
+    for item in raw_keys:
+        if not isinstance(item, dict):
+            raise SupplyChainBundleMalformedError("verificationKeys must contain objects")
+        parsed.append(SupplyChainVerificationKey.from_dict(item))
+    return tuple(parsed)
+
+
+def load_supply_chain_bundle_response(raw_json: str | dict[str, object]) -> SupplyChainBundleResponse:
+    """Parse and validate a raw supply-chain bundle response."""
+
+    if isinstance(raw_json, str):
+        try:
+            data = json.loads(raw_json)
+        except json.JSONDecodeError as exc:
+            raise SupplyChainBundleMalformedError(f"Bundle JSON is invalid: {exc}") from exc
+    else:
+        data = raw_json
+    if not isinstance(data, dict):
+        raise SupplyChainBundleMalformedError("Bundle root must be a JSON object")
+    raw_bundle = data.get("bundle")
+    if not isinstance(raw_bundle, dict):
+        raise SupplyChainBundleMalformedError("Bundle response missing bundle object")
+    signature_algorithm = _require_string(data, "signatureAlgorithm")
+    if signature_algorithm != "rsa-pss-sha256":
+        raise SupplyChainBundleMalformedError("Unsupported bundle signature algorithm")
+    verification_keys = load_supply_chain_verification_keys(data.get("verificationKeys"))
+    if not verification_keys:
+        raise SupplyChainBundleMalformedError("Bundle response must include verification keys")
+    return SupplyChainBundleResponse(
+        bundle=SupplyChainBundle.from_dict(raw_bundle),
+        payload_hash=_require_string(data, "payloadHash"),
+        signature=_require_string(data, "signature"),
+        signature_algorithm=signature_algorithm,
+        verification_keys=verification_keys,
+    )
+
+
+def check_supply_chain_bundle_freshness(bundle: SupplyChainBundle, now: float | None = None) -> None:
+    """Raise if the bundle is outside its freshness window."""
+
+    current_time = now if now is not None else time.time()
+    if current_time > bundle.expires_at_timestamp + _BUNDLE_CLOCK_SKEW_SECONDS:
+        raise SupplyChainBundleExpiredError(
+            f"Bundle expired at {bundle.expires_at}, current time is {current_time:.0f}"
+        )
+    if current_time < bundle.generated_at_timestamp - _BUNDLE_CLOCK_SKEW_SECONDS:
+        raise SupplyChainBundleExpiredError(
+            f"Bundle generatedAt {bundle.generated_at} is in the future"
+        )
+    age = current_time - bundle.generated_at_timestamp
+    if age > _BUNDLE_MAX_AGE_SECONDS:
+        raise SupplyChainBundleExpiredError(
+            f"Bundle age {age:.0f}s exceeds maximum allowed age of {_BUNDLE_MAX_AGE_SECONDS}s"
+        )
+
+
+def check_supply_chain_bundle_rollback(bundle: SupplyChainBundle, cached_bundle_version: str) -> None:
+    """Raise if the bundle version timestamp regresses."""
+
+    if bundle.version_timestamp < _bundle_version_timestamp(cached_bundle_version):
+        raise SupplyChainBundleRollbackError(
+            f"Bundle version {bundle.bundle_version} is older than cached version {cached_bundle_version}"
+        )
+
+
+def _response_keyring_is_anchored(
+    response: SupplyChainBundleResponse,
+    trusted_keys: tuple[SupplyChainVerificationKey, ...],
+) -> bool:
+    trusted_fingerprints = {item.fingerprint_sha256 for item in trusted_keys}
+    return any(item.fingerprint_sha256 in trusted_fingerprints for item in response.verification_keys)
+
+
+def verify_supply_chain_bundle_response(
+    response: SupplyChainBundleResponse,
+    *,
+    trusted_keys: tuple[SupplyChainVerificationKey, ...] | None = None,
+    cached_bundle_version: str | None = None,
+    now: float | None = None,
+) -> None:
+    """Verify payload hash, freshness, rollback, keyring anchor, and RSA-PSS signature."""
+
+    if payload_hash_for_supply_chain_bundle(response.bundle) != response.payload_hash:
+        raise SupplyChainBundlePayloadHashError("Bundle payloadHash does not match the canonical payload")
+    if cached_bundle_version is not None:
+        check_supply_chain_bundle_rollback(response.bundle, cached_bundle_version)
+    check_supply_chain_bundle_freshness(response.bundle, now=now)
+    signing_key = next(
+        (item for item in response.verification_keys if item.key_id == response.bundle.key_id),
+        None,
+    )
+    if signing_key is None:
+        raise SupplyChainBundleKeyringError("Bundle keyId is not present in the advertised verification keyring")
+    if trusted_keys and not _response_keyring_is_anchored(response, trusted_keys):
+        raise SupplyChainBundleKeyringError("Bundle verification keyring is not anchored to the trusted keyring")
+    current_time = now if now is not None else time.time()
+    if (
+        signing_key.state == "grace"
+        and signing_key.valid_until_timestamp is not None
+        and current_time > signing_key.valid_until_timestamp
+    ):
+        raise SupplyChainBundleKeyringError("Grace verification key is expired")
+    try:
+        public_key = serialization.load_pem_public_key(signing_key.public_key_pem.encode("utf-8"))
+    except (ValueError, TypeError) as exc:
+        raise SupplyChainBundleSignatureError(f"Failed to load verification key: {exc}") from exc
+    if not isinstance(public_key, RSAPublicKey):
+        raise SupplyChainBundleSignatureError("Verification key must be RSA")
+    try:
+        signature_bytes = base64.b64decode(response.signature)
+    except Exception as exc:
+        raise SupplyChainBundleSignatureError(f"Signature is not valid base64: {exc}") from exc
+    try:
+        public_key.verify(
+            signature_bytes,
+            canonical_supply_chain_bundle_payload(response.bundle),
+            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+            hashes.SHA256(),
+        )
+    except InvalidSignature as exc:
+        raise SupplyChainBundleSignatureError("Supply-chain bundle signature verification failed") from exc
+
+
+def _package_matches(package: SupplyChainBundlePackage, package_name: str, package_version: str | None) -> bool:
+    normalized_name = package_name.strip().lower()
+    if package.name.strip().lower() != normalized_name:
+        namespace_name = (
+            f"{package.namespace.strip().lower()}/{package.name.strip().lower()}"
+            if package.namespace is not None
+            else None
+        )
+        if namespace_name != normalized_name:
+            return False
+    return package_version is None or package.version == package_version
+
+
+def _is_high_confidence_block(package: SupplyChainBundlePackage) -> bool:
+    return package.default_action == "block" and (
+        package.known_exploited
+        or package.malware_state == "known"
+        or (package.normalized_severity == "critical" and package.exploit_level == "active")
+    )
+
+
+def evaluate_cached_supply_chain_bundle(
+    response: SupplyChainBundleResponse,
+    *,
+    package_name: str,
+    package_version: str | None = None,
+    now: float | None = None,
+) -> OfflineSupplyChainDecision:
+    """Evaluate one package against the cached supply-chain bundle."""
+
+    stale = False
+    try:
+        check_supply_chain_bundle_freshness(response.bundle, now=now)
+    except SupplyChainBundleExpiredError:
+        stale = True
+    matches = [
+        item for item in response.bundle.packages if _package_matches(item, package_name, package_version)
+    ]
+    if not matches:
+        return OfflineSupplyChainDecision(
+            action="monitor",
+            bundle_version=response.bundle.bundle_version,
+            matched_advisory_ids=(),
+            reason="no_cached_match",
+            stale=stale,
+        )
+    package = max(matches, key=lambda item: item.risk_score)
+    if _is_high_confidence_block(package):
+        return OfflineSupplyChainDecision(
+            action="block",
+            bundle_version=response.bundle.bundle_version,
+            matched_advisory_ids=package.related_advisory_ids,
+            reason="known_malware_or_kev",
+            stale=stale,
+        )
+    if stale:
+        return OfflineSupplyChainDecision(
+            action="monitor",
+            bundle_version=response.bundle.bundle_version,
+            matched_advisory_ids=package.related_advisory_ids,
+            reason="stale_low_confidence",
+            stale=True,
+        )
+    return OfflineSupplyChainDecision(
+        action=package.default_action if package.default_action != "allow" else "monitor",
+        bundle_version=response.bundle.bundle_version,
+        matched_advisory_ids=package.related_advisory_ids,
+        reason="bundle_match",
+        stale=False,
+    )

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
@@ -146,7 +146,8 @@ def verify_supply_chain_bundle_response(
 ) -> None:
     """Verify payload hash, freshness, rollback, keyring anchor, and RSA-PSS signature."""
 
-    if payload_hash_for_supply_chain_bundle(response.bundle) != response.payload_hash:
+    canonical_payload = canonical_supply_chain_bundle_payload(response.bundle)
+    if hashlib.sha256(canonical_payload).hexdigest() != response.payload_hash:
         raise SupplyChainBundlePayloadHashError("Bundle payloadHash does not match the canonical payload")
     if cached_bundle_version is not None:
         check_supply_chain_bundle_rollback(response.bundle, cached_bundle_version)
@@ -179,7 +180,7 @@ def verify_supply_chain_bundle_response(
     try:
         public_key.verify(
             signature_bytes,
-            canonical_supply_chain_bundle_payload(response.bundle),
+            canonical_payload,
             padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
             hashes.SHA256(),
         )
@@ -189,9 +190,9 @@ def verify_supply_chain_bundle_response(
 
 def _package_matches(package: SupplyChainBundlePackage, package_name: str, package_version: str | None) -> bool:
     normalized_name = package_name.strip().lower()
-    if package.name.strip().lower() != normalized_name:
+    if package.name.lower() != normalized_name:
         namespace_name = (
-            f"{package.namespace.strip().lower()}/{package.name.strip().lower()}"
+            f"{package.namespace.lower()}/{package.name.lower()}"
             if package.namespace is not None
             else None
         )

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -123,6 +123,23 @@ from .store_resume import (
 from .store_resume import (
     update_request_resume as persist_request_resume_update,
 )
+from .store_supply_chain import (
+    get_supply_chain_bundle as load_supply_chain_bundle,
+)
+from .store_supply_chain import (
+    get_supply_chain_evaluation as load_supply_chain_evaluation,
+)
+from .store_supply_chain import (
+    supply_chain_bundle_schema_statement,
+    supply_chain_eval_cache_schema_statement,
+    supply_chain_index_statements,
+)
+from .store_supply_chain import (
+    upsert_supply_chain_bundle as persist_supply_chain_bundle,
+)
+from .store_supply_chain import (
+    upsert_supply_chain_evaluation as persist_supply_chain_evaluation,
+)
 from .store_threat_intel import (
     threat_intel_bundle_schema_statement,
     threat_intel_index_statements,
@@ -740,6 +757,8 @@ class GuardStore:
             connect_state_schema_statement(),
             approval_schema_statement(),
             evidence_schema_statement(),
+            supply_chain_bundle_schema_statement(),
+            supply_chain_eval_cache_schema_statement(),
             threat_intel_bundle_schema_statement(),
             threat_intel_matches_schema_statement(),
         )
@@ -750,6 +769,8 @@ class GuardStore:
                 self._ensure_column(connection, "guard_evidence", "action_identity", "text")
                 self._record_schema_version(connection, version=4)
             for idx_stmt in evidence_index_statements():
+                connection.execute(idx_stmt)
+            for idx_stmt in supply_chain_index_statements():
                 connection.execute(idx_stmt)
             for idx_stmt in threat_intel_index_statements():
                 connection.execute(idx_stmt)
@@ -2350,6 +2371,70 @@ class GuardStore:
             )
         return items
 
+    def cache_supply_chain_bundle(
+        self,
+        workspace_id: str,
+        response: dict[str, object],
+        now: str,
+    ) -> None:
+        with self._connect() as connection:
+            persist_supply_chain_bundle(
+                connection,
+                workspace_id=workspace_id,
+                response=response,
+                cached_at=now,
+            )
+
+    def get_cached_supply_chain_bundle(self, workspace_id: str) -> dict[str, object] | None:
+        with self._connect() as connection:
+            return load_supply_chain_bundle(connection, workspace_id=workspace_id)
+
+    def cache_supply_chain_evaluation(
+        self,
+        *,
+        workspace_id: str,
+        package_intent_hash: str,
+        feed_snapshot_hash: str,
+        policy_hash: str,
+        scoring_version: str,
+        bundle_version: str,
+        decision: dict[str, object],
+        now: str,
+    ) -> None:
+        with self._connect() as connection:
+            persist_supply_chain_evaluation(
+                connection,
+                workspace_id=workspace_id,
+                package_intent_hash=package_intent_hash,
+                feed_snapshot_hash=feed_snapshot_hash,
+                policy_hash=policy_hash,
+                scoring_version=scoring_version,
+                bundle_version=bundle_version,
+                decision=decision,
+                updated_at=now,
+            )
+
+    def get_cached_supply_chain_evaluation(
+        self,
+        *,
+        workspace_id: str,
+        package_intent_hash: str,
+        feed_snapshot_hash: str,
+        policy_hash: str,
+        scoring_version: str,
+        bundle_version: str,
+    ) -> dict[str, object] | None:
+        with self._connect() as connection:
+            return load_supply_chain_evaluation(
+                connection,
+                workspace_id=workspace_id,
+                package_intent_hash=package_intent_hash,
+                feed_snapshot_hash=feed_snapshot_hash,
+                policy_hash=policy_hash,
+                scoring_version=scoring_version,
+                bundle_version=bundle_version,
+            )
+
     def set_sync_credentials(self, sync_url: str, token: str, now: str, workspace_id: str | None = None) -> None:
         with self._connect() as connection:
             self._set_sync_credentials_in_connection(connection, sync_url, token, now, workspace_id=workspace_id)
@@ -2849,6 +2934,8 @@ class GuardStore:
         )
         if credentials_changed:
             connection.execute("delete from sync_state where state_key != 'credentials'")
+            connection.execute("delete from guard_supply_chain_bundle_cache")
+            connection.execute("delete from guard_supply_chain_eval_cache")
             connection.execute("delete from publisher_cache")
             connection.execute("delete from policy_decisions where source in ('cloud-sync', 'team-policy')")
 

--- a/src/codex_plugin_scanner/guard/store_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/store_supply_chain.py
@@ -1,0 +1,209 @@
+"""Local storage helpers for HOL Guard supply-chain bundle caching."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+
+def supply_chain_bundle_schema_statement() -> str:
+    """CREATE TABLE IF NOT EXISTS for cached supply-chain bundles."""
+
+    return """
+    CREATE TABLE IF NOT EXISTS guard_supply_chain_bundle_cache (
+        workspace_id text primary key,
+        bundle_version text not null,
+        key_id text not null,
+        tier text not null,
+        policy_hash text not null,
+        feed_snapshot_hash text not null,
+        scoring_version text not null,
+        payload_hash text not null,
+        response_json text not null,
+        cached_at text not null
+    )
+    """
+
+
+def supply_chain_eval_cache_schema_statement() -> str:
+    """CREATE TABLE IF NOT EXISTS for local supply-chain evaluation cache."""
+
+    return """
+    CREATE TABLE IF NOT EXISTS guard_supply_chain_eval_cache (
+        workspace_id text not null,
+        package_intent_hash text not null,
+        feed_snapshot_hash text not null,
+        policy_hash text not null,
+        scoring_version text not null,
+        bundle_version text not null,
+        decision_json text not null,
+        updated_at text not null,
+        primary key (
+            workspace_id,
+            package_intent_hash,
+            feed_snapshot_hash,
+            policy_hash,
+            scoring_version,
+            bundle_version
+        )
+    )
+    """
+
+
+def supply_chain_index_statements() -> tuple[str, ...]:
+    """Index statements for supply-chain cache tables."""
+
+    return (
+        "CREATE INDEX IF NOT EXISTS idx_supply_chain_bundle_cached_at ON guard_supply_chain_bundle_cache(cached_at)",
+        (
+            "CREATE INDEX IF NOT EXISTS idx_supply_chain_eval_bundle_version ON "
+            "guard_supply_chain_eval_cache(bundle_version)"
+        ),
+        "CREATE INDEX IF NOT EXISTS idx_supply_chain_eval_updated_at ON guard_supply_chain_eval_cache(updated_at)",
+    )
+
+
+def upsert_supply_chain_bundle(
+    conn: sqlite3.Connection,
+    *,
+    workspace_id: str,
+    response: dict[str, object],
+    cached_at: str,
+) -> None:
+    """Insert or replace the latest cached supply-chain bundle for a workspace."""
+
+    bundle = response.get("bundle")
+    if not isinstance(bundle, dict):
+        raise ValueError("response must include a bundle object")
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO guard_supply_chain_bundle_cache (
+            workspace_id,
+            bundle_version,
+            key_id,
+            tier,
+            policy_hash,
+            feed_snapshot_hash,
+            scoring_version,
+            payload_hash,
+            response_json,
+            cached_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            workspace_id,
+            str(bundle["bundleVersion"]),
+            str(bundle["keyId"]),
+            str(bundle["tier"]),
+            str(bundle["policyHash"]),
+            str(bundle["feedSnapshotHash"]),
+            str(bundle["scoringVersion"]),
+            str(response["payloadHash"]),
+            json.dumps(response),
+            cached_at,
+        ),
+    )
+
+
+def get_supply_chain_bundle(conn: sqlite3.Connection, *, workspace_id: str) -> dict[str, object] | None:
+    """Return the cached supply-chain bundle payload for a workspace."""
+
+    row = conn.execute(
+        """
+        SELECT response_json, cached_at
+        FROM guard_supply_chain_bundle_cache
+        WHERE workspace_id = ?
+        """,
+        (workspace_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    payload = json.loads(str(row["response_json"]))
+    if not isinstance(payload, dict):
+        return None
+    payload["cached_at"] = str(row["cached_at"])
+    return payload
+
+
+def upsert_supply_chain_evaluation(
+    conn: sqlite3.Connection,
+    *,
+    workspace_id: str,
+    package_intent_hash: str,
+    feed_snapshot_hash: str,
+    policy_hash: str,
+    scoring_version: str,
+    bundle_version: str,
+    decision: dict[str, object],
+    updated_at: str,
+) -> None:
+    """Insert or replace a cached local evaluation decision."""
+
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO guard_supply_chain_eval_cache (
+            workspace_id,
+            package_intent_hash,
+            feed_snapshot_hash,
+            policy_hash,
+            scoring_version,
+            bundle_version,
+            decision_json,
+            updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            workspace_id,
+            package_intent_hash,
+            feed_snapshot_hash,
+            policy_hash,
+            scoring_version,
+            bundle_version,
+            json.dumps(decision),
+            updated_at,
+        ),
+    )
+
+
+def get_supply_chain_evaluation(
+    conn: sqlite3.Connection,
+    *,
+    workspace_id: str,
+    package_intent_hash: str,
+    feed_snapshot_hash: str,
+    policy_hash: str,
+    scoring_version: str,
+    bundle_version: str,
+) -> dict[str, object] | None:
+    """Return a cached local evaluation decision."""
+
+    row = conn.execute(
+        """
+        SELECT bundle_version, decision_json, updated_at
+        FROM guard_supply_chain_eval_cache
+        WHERE workspace_id = ?
+          AND package_intent_hash = ?
+          AND feed_snapshot_hash = ?
+          AND policy_hash = ?
+          AND scoring_version = ?
+          AND bundle_version = ?
+        """,
+        (
+            workspace_id,
+            package_intent_hash,
+            feed_snapshot_hash,
+            policy_hash,
+            scoring_version,
+            bundle_version,
+        ),
+    ).fetchone()
+    if row is None:
+        return None
+    decision = json.loads(str(row["decision_json"]))
+    if not isinstance(decision, dict):
+        return None
+    decision["bundle_version"] = str(row["bundle_version"])
+    decision["updated_at"] = str(row["updated_at"])
+    return decision

--- a/src/codex_plugin_scanner/guard/store_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/store_supply_chain.py
@@ -119,10 +119,10 @@ def get_supply_chain_bundle(conn: sqlite3.Connection, *, workspace_id: str) -> d
     ).fetchone()
     if row is None:
         return None
-    payload = json.loads(str(row["response_json"]))
+    payload = json.loads(row["response_json"])
     if not isinstance(payload, dict):
         return None
-    payload["cached_at"] = str(row["cached_at"])
+    payload["cached_at"] = row["cached_at"]
     return payload
 
 
@@ -201,9 +201,9 @@ def get_supply_chain_evaluation(
     ).fetchone()
     if row is None:
         return None
-    decision = json.loads(str(row["decision_json"]))
+    decision = json.loads(row["decision_json"])
     if not isinstance(decision, dict):
         return None
-    decision["bundle_version"] = str(row["bundle_version"])
-    decision["updated_at"] = str(row["updated_at"])
+    decision["bundle_version"] = row["bundle_version"]
+    decision["updated_at"] = row["updated_at"]
     return decision

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -28,7 +28,7 @@ from codex_plugin_scanner.guard.cli import connect_flow as guard_connect_flow_mo
 from codex_plugin_scanner.guard.cli import prompt as guard_prompt_module
 from codex_plugin_scanner.guard.cli import update_commands as guard_update_commands_module
 from codex_plugin_scanner.guard.cli.render import emit_guard_payload
-from codex_plugin_scanner.guard.config import load_guard_config, resolve_risk_action
+from codex_plugin_scanner.guard.config import GuardConfig, load_guard_config, resolve_risk_action
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.desktop_notifications import DesktopNotificationSetupResult
 from codex_plugin_scanner.guard.store import GuardStore
@@ -7194,7 +7194,7 @@ url = http://127.0.0.1:8787/guard-canary
             approval_center_url: str,
             *,
             store: GuardStore,
-            config: RuntimeConfig,
+            config: GuardConfig,
             open_key: str | None = None,
             force_open: bool = False,
         ) -> dict[str, object]:
@@ -8512,6 +8512,45 @@ url = http://127.0.0.1:8787/guard-canary
                 str(home_dir),
             ]
         )
+
+        assert rc == 1
+        stderr = capsys.readouterr().err
+        assert "Guard Cloud is not connected yet." in stderr
+        assert "Run `hol-guard connect`" in stderr
+
+    def test_guard_cloud_sync_intel_emits_bundle_summary(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        store = GuardStore(home_dir)
+        store.set_sync_credentials(
+            "https://hol.org/api/guard/receipts/sync",
+            "demo-token",
+            "2026-05-19T00:00:00Z",
+            workspace_id="workspace-alpha",
+        )
+
+        def _fake_sync_intel(_store: GuardStore) -> dict[str, object]:
+            return {
+                "status": "synced",
+                "workspace_id": "workspace-alpha",
+                "bundle_version": "1747612800000-deadbeef",
+                "package_count": 1,
+                "advisory_count": 1,
+            }
+
+        monkeypatch.setattr(guard_commands_module, "sync_supply_chain_bundle", _fake_sync_intel)
+
+        rc = main(["guard", "cloud", "sync-intel", "--home", str(home_dir), "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["status"] == "synced"
+        assert output["bundle_version"] == "1747612800000-deadbeef"
+        assert output["workspace_id"] == "workspace-alpha"
+
+    def test_guard_cloud_sync_intel_without_login_returns_cli_error(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+
+        rc = main(["guard", "cloud", "sync-intel", "--home", str(home_dir)])
 
         assert rc == 1
         stderr = capsys.readouterr().err

--- a/tests/test_guard_supply_chain_bundle.py
+++ b/tests/test_guard_supply_chain_bundle.py
@@ -1,0 +1,294 @@
+"""Tests for HOL Guard supply-chain bundle verification and offline decisions."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generate_private_key
+
+from codex_plugin_scanner.guard.runtime.supply_chain_bundle import (
+    SupplyChainBundleExpiredError,
+    SupplyChainBundleKeyringError,
+    SupplyChainBundleMalformedError,
+    SupplyChainBundlePayloadHashError,
+    SupplyChainBundleRollbackError,
+    canonical_supply_chain_bundle_payload,
+    evaluate_cached_supply_chain_bundle,
+    load_supply_chain_bundle_response,
+    verify_supply_chain_bundle_response,
+)
+
+WORKSPACE_ID = "workspace-alpha"
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _generate_key_pair() -> tuple[bytes, bytes]:
+    private_key = generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem, public_pem
+
+
+def _fingerprint(public_key_pem: bytes) -> str:
+    return hashlib.sha256(public_key_pem.decode("utf-8").strip().encode("utf-8")).hexdigest()
+
+
+def _bundle_dict(
+    *,
+    bundle_version: str = "1747612800000-deadbeef",
+    default_action: str = "block",
+    exploit_level: str = "active",
+    expires_at: datetime | None = None,
+    generated_at: datetime | None = None,
+    known_exploited: bool = True,
+    malware_state: str = "known",
+    normalized_severity: str = "critical",
+    risk_score: int = 980,
+) -> dict[str, object]:
+    generated = generated_at or datetime(2026, 5, 19, tzinfo=timezone.utc)
+    expires = expires_at or (generated + timedelta(hours=12))
+    return {
+        "advisories": [
+            {
+                "advisoryId": "GHSA-vh95-rmgr-6w4m",
+                "aliases": ["CVE-2020-7598"],
+                "confidence": 990,
+                "exploitLevel": exploit_level,
+                "knownExploited": known_exploited,
+                "malwareState": "none",
+                "normalizedSeverity": normalized_severity,
+                "recommendedFixVersion": "1.2.9",
+                "sourceKey": "ghsa",
+                "summary": "Prototype pollution in minimist",
+                "title": "Prototype pollution in minimist",
+            }
+        ],
+        "bundleVersion": bundle_version,
+        "expiresAt": _iso(expires),
+        "feedSnapshotHash": "feed-snapshot-1",
+        "generatedAt": _iso(generated),
+        "keyId": "guard-bundle-key-2026-05",
+        "packages": [
+            {
+                "confidence": 990,
+                "defaultAction": default_action,
+                "ecosystem": "npm",
+                "exploitLevel": exploit_level,
+                "knownExploited": known_exploited,
+                "malwareState": malware_state,
+                "name": "minimist",
+                "namespace": None,
+                "normalizedSeverity": normalized_severity,
+                "packageAgeState": "watch",
+                "purl": "pkg:npm/minimist@1.2.8",
+                "reachability": "reachable",
+                "recommendedFixVersion": "1.2.9",
+                "relatedAdvisoryIds": ["GHSA-vh95-rmgr-6w4m"],
+                "riskScore": risk_score,
+                "sourceIntegrityState": "high-risk",
+                "version": "1.2.8",
+            }
+        ],
+        "policyHash": "policy-hash-1",
+        "policyRules": [],
+        "scoringVersion": "scf-v1",
+        "sourceHashes": [
+            {
+                "payloadHash": "ghsa-feed-hash",
+                "sourceKey": "ghsa",
+                "staleStatus": "fresh",
+            }
+        ],
+        "tier": "premium",
+        "workspaceId": WORKSPACE_ID,
+    }
+
+
+def _sign_bundle_response(
+    bundle: dict[str, object],
+    *,
+    private_key_pem: bytes,
+    previous_keys: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    loaded_key = serialization.load_pem_private_key(private_key_pem, password=None)
+    assert isinstance(loaded_key, RSAPrivateKey)
+    canonical_payload = canonical_supply_chain_bundle_payload(bundle)
+    payload_hash = hashlib.sha256(canonical_payload).hexdigest()
+    signature = loaded_key.sign(
+        canonical_payload,
+        padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+        hashes.SHA256(),
+    )
+    public_key_pem = loaded_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    verification_keys = [
+        {
+            "fingerprintSha256": _fingerprint(public_key_pem),
+            "keyId": str(bundle["keyId"]),
+            "publicKeyPem": public_key_pem.decode("utf-8").strip(),
+            "state": "active",
+            "validUntil": None,
+        }
+    ]
+    if previous_keys:
+        verification_keys.extend(previous_keys)
+    return {
+        "bundle": bundle,
+        "payloadHash": payload_hash,
+        "signature": base64.b64encode(signature).decode("utf-8"),
+        "signatureAlgorithm": "rsa-pss-sha256",
+        "verificationKeys": verification_keys,
+    }
+
+
+def test_supply_chain_bundle_verification_accepts_rotated_keyring() -> None:
+    old_private_key, old_public_key = _generate_key_pair()
+    first_response = load_supply_chain_bundle_response(
+        json.dumps(_sign_bundle_response(_bundle_dict(), private_key_pem=old_private_key))
+    )
+    verify_supply_chain_bundle_response(first_response, now=first_response.bundle.generated_at_timestamp + 5)
+
+    new_private_key, new_public_key = _generate_key_pair()
+    rotated_response = load_supply_chain_bundle_response(
+        json.dumps(
+            _sign_bundle_response(
+                _bundle_dict(bundle_version="1747616400000-rotated"),
+                private_key_pem=new_private_key,
+                previous_keys=[
+                    {
+                        "fingerprintSha256": _fingerprint(old_public_key),
+                        "keyId": "guard-bundle-key-2026-04",
+                        "publicKeyPem": old_public_key.decode("utf-8").strip(),
+                        "state": "grace",
+                        "validUntil": "2026-06-01T00:00:00Z",
+                    }
+                ],
+            )
+        )
+    )
+
+    verify_supply_chain_bundle_response(
+        rotated_response,
+        trusted_keys=first_response.verification_keys,
+        cached_bundle_version=first_response.bundle.bundle_version,
+        now=rotated_response.bundle.generated_at_timestamp + 5,
+    )
+
+    unanchored = load_supply_chain_bundle_response(
+        json.dumps(
+            _sign_bundle_response(
+                _bundle_dict(bundle_version="1747620000000-untrusted"),
+                private_key_pem=new_private_key,
+            )
+        )
+    )
+
+    with pytest.raises(SupplyChainBundleKeyringError):
+        verify_supply_chain_bundle_response(
+            unanchored,
+            trusted_keys=first_response.verification_keys,
+            cached_bundle_version=first_response.bundle.bundle_version,
+            now=unanchored.bundle.generated_at_timestamp + 5,
+        )
+
+    assert _fingerprint(new_public_key)
+
+
+def test_supply_chain_bundle_rejects_payload_hash_mismatch_and_rollback() -> None:
+    private_key, _public_key = _generate_key_pair()
+    response_payload = _sign_bundle_response(_bundle_dict(), private_key_pem=private_key)
+    mismatched_payload = dict(response_payload)
+    mismatched_payload["payloadHash"] = "bad-payload-hash"
+    response = load_supply_chain_bundle_response(json.dumps(mismatched_payload))
+
+    with pytest.raises(SupplyChainBundlePayloadHashError):
+        verify_supply_chain_bundle_response(response, now=response.bundle.generated_at_timestamp + 5)
+
+    rollback_payload = load_supply_chain_bundle_response(json.dumps(response_payload))
+    with pytest.raises(SupplyChainBundleRollbackError):
+        verify_supply_chain_bundle_response(
+            rollback_payload,
+            cached_bundle_version="1747616400000-newerhash",
+            now=rollback_payload.bundle.generated_at_timestamp + 5,
+        )
+
+
+def test_supply_chain_bundle_rejects_expired_and_malformed_payloads() -> None:
+    private_key, _public_key = _generate_key_pair()
+    expired_bundle = _bundle_dict(
+        generated_at=datetime(2026, 5, 18, tzinfo=timezone.utc),
+        expires_at=datetime(2026, 5, 18, 1, tzinfo=timezone.utc),
+    )
+    expired_response = load_supply_chain_bundle_response(
+        json.dumps(_sign_bundle_response(expired_bundle, private_key_pem=private_key))
+    )
+
+    with pytest.raises(SupplyChainBundleExpiredError):
+        verify_supply_chain_bundle_response(
+            expired_response,
+            now=datetime(2026, 5, 19, tzinfo=timezone.utc).timestamp(),
+        )
+
+    malformed_payload = _sign_bundle_response(_bundle_dict(), private_key_pem=private_key)
+    del malformed_payload["bundle"]["packages"]  # type: ignore[index]
+
+    with pytest.raises(SupplyChainBundleMalformedError):
+        load_supply_chain_bundle_response(json.dumps(malformed_payload))
+
+
+def test_supply_chain_bundle_offline_evaluation_blocks_high_confidence_and_monitors_stale_low_risk() -> None:
+    private_key, _public_key = _generate_key_pair()
+    blocking_response = load_supply_chain_bundle_response(
+        json.dumps(_sign_bundle_response(_bundle_dict(), private_key_pem=private_key))
+    )
+    blocking_decision = evaluate_cached_supply_chain_bundle(
+        blocking_response,
+        package_name="minimist",
+        package_version="1.2.8",
+        now=blocking_response.bundle.generated_at_timestamp + 60,
+    )
+
+    assert blocking_decision.action == "block"
+    assert blocking_decision.stale is False
+    assert blocking_decision.reason == "known_malware_or_kev"
+
+    low_risk_bundle = _bundle_dict(
+        default_action="monitor",
+        exploit_level="none",
+        expires_at=datetime(2026, 5, 18, 1, tzinfo=timezone.utc),
+        known_exploited=False,
+        malware_state="none",
+        normalized_severity="low",
+        risk_score=220,
+    )
+    low_risk_response = load_supply_chain_bundle_response(
+        json.dumps(_sign_bundle_response(low_risk_bundle, private_key_pem=private_key))
+    )
+    stale_decision = evaluate_cached_supply_chain_bundle(
+        low_risk_response,
+        package_name="minimist",
+        package_version="1.2.8",
+        now=datetime(2026, 5, 19, tzinfo=timezone.utc).timestamp(),
+    )
+
+    assert stale_decision.action == "monitor"
+    assert stale_decision.stale is True
+    assert stale_decision.reason == "stale_low_confidence"

--- a/tests/test_guard_supply_chain_daemon.py
+++ b/tests/test_guard_supply_chain_daemon.py
@@ -1,0 +1,86 @@
+"""Tests for HOL Guard daemon supply-chain intel refresh."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from codex_plugin_scanner.guard.daemon import server as guard_daemon_module
+from codex_plugin_scanner.guard.runtime.runner import GuardSyncNotConfiguredError
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def test_daemon_refreshes_supply_chain_bundle_on_start_and_interval(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "demo-token",
+        "2026-05-19T00:00:00Z",
+        workspace_id="workspace-alpha",
+    )
+    calls: list[float] = []
+
+    def _fake_sync(_store: GuardStore) -> dict[str, object]:
+        calls.append(time.monotonic())
+        return {
+            "status": "synced",
+            "bundle_version": f"1747612800000-refresh-{len(calls)}",
+            "workspace_id": "workspace-alpha",
+        }
+
+    monkeypatch.setattr(guard_daemon_module, "sync_supply_chain_bundle", _fake_sync)
+    daemon = guard_daemon_module.GuardDaemonServer(
+        store,
+        host="127.0.0.1",
+        port=0,
+        idle_timeout_seconds=60,
+        bundle_refresh_interval_seconds=0.05,
+        bundle_refresh_backoff_seconds=0.05,
+    )
+    daemon.start()
+    try:
+        deadline = time.time() + 1
+        while len(calls) < 2 and time.time() < deadline:
+            time.sleep(0.02)
+    finally:
+        daemon.stop()
+
+    assert len(calls) >= 2
+    summary = store.get_sync_payload("supply_chain_bundle_daemon")
+    assert isinstance(summary, dict)
+    assert summary["status"] == "synced"
+    assert summary["workspace_id"] == "workspace-alpha"
+
+
+def test_daemon_bundle_refresh_stays_quiet_when_not_configured(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+
+    def _fail_sync(_store: GuardStore) -> dict[str, object]:
+        raise GuardSyncNotConfiguredError("Guard is not logged in.")
+
+    monkeypatch.setattr(guard_daemon_module, "sync_supply_chain_bundle", _fail_sync)
+    daemon = guard_daemon_module.GuardDaemonServer(
+        store,
+        host="127.0.0.1",
+        port=0,
+        idle_timeout_seconds=60,
+        bundle_refresh_interval_seconds=0.05,
+        bundle_refresh_backoff_seconds=0.05,
+    )
+    daemon.start()
+    try:
+        time.sleep(0.12)
+    finally:
+        daemon.stop()
+
+    summary = store.get_sync_payload("supply_chain_bundle_daemon")
+    assert isinstance(summary, dict)
+    assert summary["status"] == "not_configured"
+    assert store.list_approval_requests() == []
+    assert store.list_events(limit=5) == []

--- a/tests/test_guard_supply_chain_sync.py
+++ b/tests/test_guard_supply_chain_sync.py
@@ -1,0 +1,238 @@
+"""Tests for HOL Guard supply-chain bundle sync and local cache persistence."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import threading
+from datetime import datetime, timedelta, timezone
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import ClassVar
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generate_private_key
+
+from codex_plugin_scanner.guard.runtime.runner import sync_supply_chain_bundle
+from codex_plugin_scanner.guard.runtime.supply_chain_bundle import canonical_supply_chain_bundle_payload
+from codex_plugin_scanner.guard.store import GuardStore
+
+WORKSPACE_ID = "workspace-alpha"
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _generate_key_pair() -> tuple[bytes, bytes]:
+    private_key = generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem, public_pem
+
+
+def _fingerprint(public_key_pem: bytes) -> str:
+    return hashlib.sha256(public_key_pem.decode("utf-8").strip().encode("utf-8")).hexdigest()
+
+
+def _bundle_response(private_key_pem: bytes, public_key_pem: bytes) -> dict[str, object]:
+    generated_at = datetime.now(timezone.utc) - timedelta(minutes=5)
+    expires_at = generated_at + timedelta(hours=12)
+    bundle = {
+        "advisories": [
+            {
+                "advisoryId": "GHSA-vh95-rmgr-6w4m",
+                "aliases": ["CVE-2020-7598"],
+                "confidence": 990,
+                "exploitLevel": "active",
+                "knownExploited": True,
+                "malwareState": "none",
+                "normalizedSeverity": "critical",
+                "recommendedFixVersion": "1.2.9",
+                "sourceKey": "ghsa",
+                "summary": "Prototype pollution in minimist",
+                "title": "Prototype pollution in minimist",
+            }
+        ],
+        "bundleVersion": "1747612800000-deadbeef",
+        "expiresAt": _iso(expires_at),
+        "feedSnapshotHash": "feed-snapshot-1",
+        "generatedAt": _iso(generated_at),
+        "keyId": "guard-bundle-key-2026-05",
+        "packages": [
+            {
+                "confidence": 990,
+                "defaultAction": "block",
+                "ecosystem": "npm",
+                "exploitLevel": "active",
+                "knownExploited": True,
+                "malwareState": "known",
+                "name": "minimist",
+                "namespace": None,
+                "normalizedSeverity": "critical",
+                "packageAgeState": "watch",
+                "purl": "pkg:npm/minimist@1.2.8",
+                "reachability": "reachable",
+                "recommendedFixVersion": "1.2.9",
+                "relatedAdvisoryIds": ["GHSA-vh95-rmgr-6w4m"],
+                "riskScore": 980,
+                "sourceIntegrityState": "high-risk",
+                "version": "1.2.8",
+            }
+        ],
+        "policyHash": "policy-hash-1",
+        "policyRules": [],
+        "scoringVersion": "scf-v1",
+        "sourceHashes": [{"payloadHash": "ghsa-feed-hash", "sourceKey": "ghsa", "staleStatus": "fresh"}],
+        "tier": "premium",
+        "workspaceId": WORKSPACE_ID,
+    }
+    canonical_payload = canonical_supply_chain_bundle_payload(bundle)
+    payload_hash = hashlib.sha256(canonical_payload).hexdigest()
+    loaded_key = serialization.load_pem_private_key(private_key_pem, password=None)
+    assert isinstance(loaded_key, RSAPrivateKey)
+    signature = loaded_key.sign(
+        canonical_payload,
+        padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+        hashes.SHA256(),
+    )
+    return {
+        "bundle": bundle,
+        "payloadHash": payload_hash,
+        "signature": base64.b64encode(signature).decode("utf-8"),
+        "signatureAlgorithm": "rsa-pss-sha256",
+        "verificationKeys": [
+            {
+                "fingerprintSha256": _fingerprint(public_key_pem),
+                "keyId": "guard-bundle-key-2026-05",
+                "publicKeyPem": public_key_pem.decode("utf-8").strip(),
+                "state": "active",
+                "validUntil": None,
+            }
+        ],
+    }
+
+
+class _BundleSyncHandler(BaseHTTPRequestHandler):
+    captured_accept_encodings: ClassVar[list[str | None]] = []
+    response_payload: ClassVar[dict[str, object]] = {}
+
+    def do_GET(self) -> None:
+        self.__class__.captured_accept_encodings.append(self.headers.get("Accept-Encoding"))
+        if self.path.startswith("/api/guard/supply-chain/bundle"):
+            body = json.dumps(self.__class__.response_payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        self.send_response(404)
+        self.end_headers()
+
+    def log_message(self, message_format: str, *args: object) -> None:
+        del message_format, args
+        return
+
+
+def test_sync_supply_chain_bundle_fetches_and_caches_bundle(tmp_path: Path) -> None:
+    private_key_pem, public_key_pem = _generate_key_pair()
+    _BundleSyncHandler.captured_accept_encodings = []
+    _BundleSyncHandler.response_payload = _bundle_response(private_key_pem, public_key_pem)
+    server = HTTPServer(("127.0.0.1", 0), _BundleSyncHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        store = GuardStore(tmp_path / "guard-home")
+        store.set_sync_credentials(
+            f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            "demo-token",
+            "2026-05-19T00:00:00Z",
+            workspace_id=WORKSPACE_ID,
+        )
+
+        summary = sync_supply_chain_bundle(store)
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+    assert summary["status"] == "synced"
+    assert summary["bundle_version"] == "1747612800000-deadbeef"
+    assert summary["workspace_id"] == WORKSPACE_ID
+    assert store.get_cached_supply_chain_bundle(WORKSPACE_ID)["bundle"]["bundleVersion"] == "1747612800000-deadbeef"
+    assert store.get_sync_payload("supply_chain_bundle_entitlement") == {
+        "bundle_version": "1747612800000-deadbeef",
+        "key_id": "guard-bundle-key-2026-05",
+        "policy_hash": "policy-hash-1",
+        "tier": "premium",
+        "workspace_id": WORKSPACE_ID,
+    }
+    keyring = store.get_sync_payload("supply_chain_bundle_keyring")
+    assert isinstance(keyring, dict)
+    assert keyring["workspace_id"] == WORKSPACE_ID
+    assert _BundleSyncHandler.captured_accept_encodings[0] == "identity"
+
+
+def test_supply_chain_cache_and_eval_cache_clear_on_sync_token_rotation(tmp_path: Path) -> None:
+    private_key_pem, public_key_pem = _generate_key_pair()
+    response_payload = _bundle_response(private_key_pem, public_key_pem)
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "token-one",
+        "2026-05-19T00:00:00Z",
+        workspace_id=WORKSPACE_ID,
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, response_payload, "2026-05-19T00:00:00Z")
+    store.cache_supply_chain_evaluation(
+        workspace_id=WORKSPACE_ID,
+        package_intent_hash="intent-1",
+        feed_snapshot_hash="feed-snapshot-1",
+        policy_hash="policy-hash-1",
+        scoring_version="scf-v1",
+        bundle_version="1747612800000-deadbeef",
+        decision={"action": "block", "reason": "known_malware_or_kev"},
+        now="2026-05-19T00:00:00Z",
+    )
+    store.set_sync_payload("supply_chain_bundle_keyring", {"workspace_id": WORKSPACE_ID}, "2026-05-19T00:00:00Z")
+
+    assert store.get_cached_supply_chain_bundle(WORKSPACE_ID) is not None
+    assert (
+        store.get_cached_supply_chain_evaluation(
+            workspace_id=WORKSPACE_ID,
+            package_intent_hash="intent-1",
+            feed_snapshot_hash="feed-snapshot-1",
+            policy_hash="policy-hash-1",
+            scoring_version="scf-v1",
+            bundle_version="1747612800000-deadbeef",
+        )
+        is not None
+    )
+
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "token-two",
+        "2026-05-19T00:01:00Z",
+    )
+
+    assert store.get_cached_supply_chain_bundle(WORKSPACE_ID) is None
+    assert (
+        store.get_cached_supply_chain_evaluation(
+            workspace_id=WORKSPACE_ID,
+            package_intent_hash="intent-1",
+            feed_snapshot_hash="feed-snapshot-1",
+            policy_hash="policy-hash-1",
+            scoring_version="scf-v1",
+            bundle_version="1747612800000-deadbeef",
+        )
+        is None
+    )
+    assert store.get_sync_payload("supply_chain_bundle_keyring") is None


### PR DESCRIPTION
## Summary
- add signed supply-chain bundle verification, local cache tables, and offline evaluation for Guard Cloud bundle sync
- wire bundle sync into guard cloud sync-intel, advisories sync, and daemon background refresh state
- cover freshness, rollback, malformed bundles, cache rotation, CLI sync, and daemon refresh with focused tests

## Verification
- ruff check src/codex_plugin_scanner/guard/runtime/supply_chain_bundle.py src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_base.py src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_models.py src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py src/codex_plugin_scanner/guard/store_supply_chain.py src/codex_plugin_scanner/guard/store.py src/codex_plugin_scanner/guard/runtime/runner.py src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_supply_chain_bundle.py tests/test_guard_supply_chain_sync.py tests/test_guard_supply_chain_daemon.py tests/test_guard_cli.py
- pytest tests/test_guard_supply_chain_bundle.py tests/test_guard_supply_chain_sync.py tests/test_guard_supply_chain_daemon.py tests/test_guard_threat_intel.py tests/test_guard_cloud_local_sync.py tests/test_guard_headless_daemon_api.py tests/test_guard_cli.py -k "cloud_sync_intel or advisories"