### PR TITLE
feat(guard): add package intent parser

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -124,6 +124,7 @@ from ..runtime.false_positive_rules import (
     split_fd_args_and_exec,
     target_is_known_skill_doc_path,
 )
+from ..runtime.package_intent import build_package_request_artifact, extract_package_intent_request
 from ..runtime.runner import (
     GuardSyncNotConfiguredError,
     extract_prompt_requests,
@@ -4240,6 +4241,8 @@ def _guard_action_severity(action: str) -> int:
 def _runtime_artifact_risk_classes(artifact: GuardArtifact) -> list[str]:
     if artifact.artifact_type == "file_read_request":
         return ["local_secret_read"]
+    if artifact.artifact_type == "package_request":
+        return ["package_script"]
     if artifact.artifact_type == "prompt_request":
         prompt_classes = _prompt_request_classes(artifact)
         risk_classes: list[str] = []
@@ -5394,6 +5397,19 @@ def _hook_runtime_artifact(
         return build_file_read_request_artifact(
             harness=harness,
             request=request,
+            config_path=config_path,
+            source_scope=source_scope,
+        )
+    package_intent = extract_package_intent_request(
+        payload.get("tool_name"),
+        payload.get("tool_input", payload.get("arguments")),
+        action_envelope_command=action_envelope.command if action_envelope is not None else None,
+        workspace=workspace,
+    )
+    if package_intent is not None:
+        return build_package_request_artifact(
+            harness=harness,
+            intent=package_intent,
             config_path=config_path,
             source_scope=source_scope,
         )
@@ -7821,6 +7837,11 @@ def _runtime_detection(harness: str, artifact: GuardArtifact) -> HarnessDetectio
 
 
 def _runtime_capabilities_summary(artifact: GuardArtifact) -> str:
+    if artifact.artifact_type == "package_request":
+        package_manager = artifact.metadata.get("package_manager")
+        if isinstance(package_manager, str) and package_manager:
+            return f"package request • {package_manager}"
+        return "package request"
     tool_name = artifact.metadata.get("tool_name")
     if isinstance(tool_name, str) and tool_name:
         if artifact.artifact_type == "tool_action_request":

--- a/src/codex_plugin_scanner/guard/incident.py
+++ b/src/codex_plugin_scanner/guard/incident.py
@@ -21,6 +21,7 @@ _ARTIFACT_LABELS = {
     "hook": "Hook",
     "agent": "Agent",
     "command": "Command",
+    "package_request": "Package request",
     "prompt_request": "Prompt request",
     "file_read_request": "File read request",
     "artifact": "Artifact",
@@ -62,6 +63,12 @@ def build_incident_context(
             f"HOL Guard paused the native tool action `{artifact_name or artifact_id}` from an active "
             f"{harness_label} tool call."
         )
+    elif artifact_type == "package_request":
+        source_label = f"{harness_label} runtime tool call"
+        trigger_summary = (
+            f"HOL Guard paused the package request `{artifact_name or artifact_id}` from an active "
+            f"{harness_label} tool call."
+        )
     else:
         short_config_path = _short_config_path(config_path)
         source_label = f"{normalized_scope} {harness_label} config"
@@ -101,6 +108,8 @@ def _why_now_text(
         return "The tool requested a protected local secret file, so HOL Guard paused the read until you approve it."
     if artifact_type == "tool_action_request" or "tool_action_request" in normalized:
         return "HOL Guard paused this native tool action because it can change the local machine before you confirm it."
+    if artifact_type == "package_request" or "package_request" in normalized:
+        return "HOL Guard paused this package change until you confirm the dependency action."
     if "first_seen" in normalized:
         return f"It is new in this {harness_label.lower()} workspace, so HOL Guard paused it for review."
     if "removed" in normalized:

--- a/src/codex_plugin_scanner/guard/runtime/package_intent.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent.py
@@ -1,0 +1,24 @@
+"""Public package intent parser interface."""
+
+from __future__ import annotations
+
+from .package_intent_common import (
+    ManifestDependencyChange,
+    ManifestParseResult,
+    PackageIntent,
+    PackageIntentTarget,
+    build_package_request_artifact,
+)
+from .package_intent_parser import extract_package_intent_request, parse_package_intent
+from .package_manifest_diff import parse_manifest_dependency_changes
+
+__all__ = [
+    "ManifestDependencyChange",
+    "ManifestParseResult",
+    "PackageIntent",
+    "PackageIntentTarget",
+    "build_package_request_artifact",
+    "extract_package_intent_request",
+    "parse_manifest_dependency_changes",
+    "parse_package_intent",
+]

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_common.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_common.py
@@ -1,0 +1,328 @@
+"""Shared package intent models and artifact builders."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import shlex
+from dataclasses import asdict, dataclass
+from pathlib import Path, PurePath
+from typing import Literal
+
+from ..models import GuardArtifact
+from .mcp_protection import _split_package_token
+
+IntentKind = Literal["install", "execute", "sync"]
+_EXTRAS_RE = re.compile(r"^(?P<name>[A-Za-z0-9_.-]+)\[(?P<extras>[A-Za-z0-9_,.-]+)\]$")
+_EGG_FRAGMENT_RE = re.compile(r"(?:^|[#&])egg=([^&#]+)")
+_PYTHON_VERSION_RE = re.compile(r"(?P<name>[^<>=!~\s]+)(?P<op>===|==|~=|!=|<=|>=|<|>|=)?(?P<version>.*)")
+
+
+@dataclass(frozen=True, slots=True)
+class PackageIntentTarget:
+    ecosystem: str
+    package_name: str | None
+    raw_spec: str
+    requested_specifier: str | None
+    source_url: str | None = None
+    alias: str | None = None
+    dependency_group: str | None = None
+    extras: tuple[str, ...] = ()
+    editable: bool = False
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class PackageIntent:
+    package_manager: str
+    intent_kind: IntentKind
+    command_tokens: tuple[str, ...]
+    redacted_command: str
+    targets: tuple[PackageIntentTarget, ...]
+    manifest_paths: tuple[str, ...] = ()
+    lockfile_paths: tuple[str, ...] = ()
+    flags: tuple[str, ...] = ()
+    notes: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        payload = asdict(self)
+        payload["targets"] = [target.to_dict() for target in self.targets]
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestDependencyChange:
+    manifest_path: str
+    package_name: str
+    before: str | None
+    after: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestParseResult:
+    changes: tuple[ManifestDependencyChange, ...]
+    truncated: bool = False
+    parse_errors: tuple[str, ...] = ()
+
+
+def build_package_request_artifact(
+    harness: str,
+    intent: PackageIntent,
+    *,
+    config_path: str,
+    source_scope: str,
+) -> GuardArtifact:
+    fingerprint = hashlib.sha256(
+        json.dumps(
+            {
+                "harness": harness,
+                "package_manager": intent.package_manager,
+                "intent_kind": intent.intent_kind,
+                "redacted_command": intent.redacted_command,
+                "targets": [target.to_dict() for target in intent.targets],
+                "manifest_paths": list(intent.manifest_paths),
+                "lockfile_paths": list(intent.lockfile_paths),
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+    ).hexdigest()
+    target_label = intent.targets[0].package_name if intent.targets else intent.package_manager
+    return GuardArtifact(
+        artifact_id=f"{harness}:{source_scope}:package-request:{fingerprint}",
+        name=f"{intent.package_manager} {intent.intent_kind} {target_label}",
+        harness=harness,
+        artifact_type="package_request",
+        source_scope=source_scope,
+        config_path=config_path,
+        metadata={
+            "package_manager": intent.package_manager,
+            "intent_kind": intent.intent_kind,
+            "targets": [target.to_dict() for target in intent.targets],
+            "manifest_paths": list(intent.manifest_paths),
+            "lockfile_paths": list(intent.lockfile_paths),
+            "flags": list(intent.flags),
+            "notes": list(intent.notes),
+            "redacted_command": intent.redacted_command,
+            "request_summary": package_request_summary(intent),
+            "runtime_request_signals": [f"invokes a package {intent.intent_kind} request via {intent.package_manager}"],
+            "runtime_request_summary": package_runtime_summary(intent),
+            "runtime_request_reason": package_runtime_reason(intent),
+        },
+    )
+
+
+def package_request_summary(intent: PackageIntent) -> str:
+    if intent.targets:
+        target_names = ", ".join(target.package_name or target.raw_spec for target in intent.targets[:3])
+        return f"Requested `{intent.package_manager}` {intent.intent_kind} for {target_names}."
+    if intent.lockfile_paths:
+        return (
+            f"Requested `{intent.package_manager}` {intent.intent_kind} using existing project "
+            "manifest and lockfile context."
+        )
+    return f"Requested `{intent.package_manager}` {intent.intent_kind} using existing project manifest context."
+
+
+def package_runtime_summary(intent: PackageIntent) -> str:
+    if intent.intent_kind == "execute":
+        return f"Executes a remote package through {intent.package_manager} before it is trusted locally."
+    if intent.lockfile_paths:
+        return (
+            f"Mutates project dependencies through {intent.package_manager} using "
+            "existing manifest and lockfile context."
+        )
+    return f"Mutates project dependencies through {intent.package_manager}."
+
+
+def package_runtime_reason(intent: PackageIntent) -> str:
+    return (
+        f"Guard parsed this command as a package {intent.intent_kind} request and "
+        "kept only package metadata plus a redacted command shape."
+    )
+
+
+def redacted_command(tokens: tuple[str, ...]) -> str:
+    redacted: list[str] = []
+    skip_hash = False
+    for token in tokens:
+        if skip_hash:
+            redacted.append("<hash>")
+            skip_hash = False
+            continue
+        if token == "--hash":
+            redacted.append(token)
+            skip_hash = True
+            continue
+        if token.startswith("--hash="):
+            redacted.append("--hash=<hash>")
+            continue
+        if "://" in token or token.startswith("git+"):
+            redacted.append(_sanitize_url(token))
+            continue
+        redacted.append(token)
+    return shlex.join(redacted)
+
+
+def flag_tokens(tokens: tuple[str, ...]) -> tuple[str, ...]:
+    flags: list[str] = []
+    for token in tokens:
+        if token.startswith("-"):
+            flags.append(token.split("=", 1)[0] if token.startswith("--") and "=" in token else token)
+    return tuple(dict.fromkeys(flags))
+
+
+def existing_relative_paths(workspace: Path | None, candidates: tuple[str, ...] | list[str]) -> tuple[str, ...]:
+    if workspace is None:
+        return ()
+    resolved: list[str] = []
+    for candidate in candidates:
+        if not candidate:
+            continue
+        path = Path(candidate)
+        disk_path = path if path.is_absolute() else workspace / path
+        if disk_path.exists():
+            normalized = candidate if not path.is_absolute() else path.name
+            if normalized not in resolved:
+                resolved.append(normalized)
+    return tuple(resolved)
+
+
+def first_positional(tokens: tuple[str, ...], *, skip_value_options: set[str]) -> str | None:
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token in skip_value_options and index + 1 < len(tokens):
+            index += 2
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        return token
+    return None
+
+
+def option_value(tokens: tuple[str, ...], option: str) -> str | None:
+    for index, token in enumerate(tokens):
+        if token == option and index + 1 < len(tokens):
+            return tokens[index + 1]
+        if token.startswith(f"{option}="):
+            return token.partition("=")[2]
+    return None
+
+
+def property_value(tokens: tuple[str, ...], property_name: str) -> str | None:
+    prefix = f"-D{property_name}="
+    for token in tokens:
+        if token.startswith(prefix):
+            return token[len(prefix) :]
+    return None
+
+
+def js_target(spec: str) -> PackageIntentTarget:
+    alias = None
+    normalized_spec = spec
+    if "@npm:" in spec and not spec.startswith("@npm:"):
+        alias, _, normalized_spec = spec.partition("@npm:")
+    package_name, requested_specifier = _split_package_token(normalized_spec)
+    return PackageIntentTarget("npm", package_name, spec, requested_specifier, alias=alias)
+
+
+def python_target(
+    spec: str,
+    *,
+    editable: bool = False,
+    dependency_group: str | None = None,
+    extras: tuple[str, ...] = (),
+) -> PackageIntentTarget:
+    if " @ " in spec:
+        package_name, _, source = spec.partition(" @ ")
+        return PackageIntentTarget("pypi", package_name.strip(), spec, None, source_url=source.strip())
+    if "://" in spec or spec.startswith("git+"):
+        match = _EGG_FRAGMENT_RE.search(spec)
+        sanitized_source = spec.split("?", 1)[0].split("#", 1)[0]
+        package_name = match.group(1) if match else PurePath(sanitized_source).name.removesuffix(".git")
+        return PackageIntentTarget(
+            "pypi",
+            package_name or None,
+            spec,
+            None,
+            source_url=sanitized_source,
+            editable=editable,
+        )
+    if "@" in spec and not spec.startswith(("./", "../", "/")):
+        package_name, requested_specifier = spec.rsplit("@", 1)
+        normalized_name, detected_extras = split_python_extras(package_name)
+        return PackageIntentTarget(
+            "pypi",
+            normalized_name or None,
+            spec,
+            requested_specifier or None,
+            dependency_group=dependency_group,
+            extras=extras or detected_extras,
+            editable=editable,
+        )
+    normalized_name, requested_specifier = split_python_specifier(spec)
+    package_name, detected_extras = split_python_extras(normalized_name)
+    if package_name.startswith(("./", "../", "/")):
+        package_name = Path(package_name).name or package_name
+    return PackageIntentTarget(
+        "pypi",
+        package_name or None,
+        spec,
+        requested_specifier,
+        dependency_group=dependency_group,
+        extras=extras or detected_extras,
+        editable=editable,
+    )
+
+
+def version_target(ecosystem: str, spec: str, *, source_url: str | None = None) -> PackageIntentTarget:
+    package_name, requested_specifier = _split_package_token(spec)
+    return PackageIntentTarget(ecosystem, package_name, spec, requested_specifier, source_url=source_url)
+
+
+def coordinate_target(ecosystem: str, spec: str) -> PackageIntentTarget:
+    parts = spec.split(":")
+    if len(parts) < 3:
+        return PackageIntentTarget(ecosystem, spec or None, spec, None)
+    return PackageIntentTarget(ecosystem, ":".join(parts[:2]), spec, parts[-1] or None)
+
+
+def composer_target(spec: str) -> PackageIntentTarget:
+    package_name, requested_specifier = spec.split(":", 1) if ":" in spec else (spec, None)
+    return PackageIntentTarget("packagist", package_name, spec, requested_specifier)
+
+
+def split_python_specifier(spec: str) -> tuple[str, str | None]:
+    matched = _PYTHON_VERSION_RE.match(spec.strip())
+    if matched is None:
+        return spec, None
+    name = matched.group("name") or spec
+    operator = matched.group("op")
+    version = (matched.group("version") or "").strip()
+    if operator and version:
+        return name, version if operator in {"==", "==="} else f"{operator}{version}"
+    return name, None
+
+
+def split_python_extras(name: str) -> tuple[str, tuple[str, ...]]:
+    matched = _EXTRAS_RE.match(name)
+    if matched is None:
+        return name, ()
+    return matched.group("name"), tuple(item for item in matched.group("extras").split(",") if item)
+
+
+def _sanitize_url(value: str) -> str:
+    if "://" not in value and not value.startswith("git+"):
+        return value
+    scheme_split = value.split("://", 1)
+    if len(scheme_split) == 2 and "@" in scheme_split[1].split("/", 1)[0]:
+        scheme, remainder = scheme_split
+        authority, *tail = remainder.split("/", 1)
+        authority = authority.split("@", 1)[1]
+        suffix = f"/{tail[0]}" if tail else ""
+        return f"{scheme}://{authority}{suffix}".split("?", 1)[0].split("#", 1)[0]
+    return value.split("?", 1)[0].split("#", 1)[0]

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
@@ -178,6 +178,18 @@ def _parse_pip_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> Pac
             manifest_paths.append(tokens[index + 1])
             index += 2
             continue
+        if token.startswith("--requirement=") or token.startswith("--constraint="):
+            manifest_paths.append(token.partition("=")[2])
+            index += 1
+            continue
+        if token.startswith("-r") and token != "-r":
+            manifest_paths.append(token[2:])
+            index += 1
+            continue
+        if token.startswith("-c") and token != "-c":
+            manifest_paths.append(token[2:])
+            index += 1
+            continue
         if token in {"-e", "--editable"} and index + 1 < len(tokens):
             targets.append(python_target(tokens[index + 1], editable=True))
             index += 2
@@ -475,11 +487,10 @@ def _exec_package_spec(tokens: tuple[str, ...]) -> str | None:
         if positional_package and explicit_package:
             positional_target = js_target(positional_package)
             explicit_target = js_target(explicit_package)
-            positional_name = positional_target.package_name
-            explicit_name = explicit_target.package_name
-            if positional_name == explicit_name:
+            if positional_target.package_name == explicit_target.package_name:
                 return positional_package
-        return positional_package or explicit_package
+            return explicit_package
+        return explicit_package or positional_package
     if command_name == "pipx" and len(tokens) >= 2 and tokens[1] == "run":
         return first_positional(tokens[2:], skip_value_options={"--python"})
     if command_name in {"pnpm", "yarn"} and len(tokens) >= 2 and tokens[1] == "dlx":
@@ -499,10 +510,62 @@ def _normalized_command_tokens(command_text: str) -> tuple[str, ...]:
         if token in _CONTROL_TOKENS:
             break
         segment.append(token)
-    while segment and (
-        _command_name(segment[0]) in {"command", "env", "sudo", "time"} or _ENV_ASSIGNMENT_RE.match(segment[0])
-    ):
-        segment.pop(0)
+    segment = _strip_wrapper_tokens(segment)
     if len(segment) >= 3 and _command_name(segment[0]) in _PYTHON_EXECUTABLES and segment[1] == "-m":
         segment = [segment[2], *segment[3:]]
     return tuple(segment)
+
+
+def _strip_wrapper_tokens(segment: list[str]) -> list[str]:
+    while segment:
+        if _ENV_ASSIGNMENT_RE.match(segment[0]):
+            segment.pop(0)
+            continue
+        command_name = _command_name(segment[0])
+        if command_name == "sudo":
+            segment = _strip_sudo_prefix(segment[1:])
+            continue
+        if command_name == "env":
+            segment = _strip_env_prefix(segment[1:])
+            continue
+        if command_name in {"command", "time"}:
+            segment = _strip_plain_wrapper_flags(segment[1:])
+            continue
+        break
+    return segment
+
+
+def _strip_sudo_prefix(tokens: list[str]) -> list[str]:
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if not token.startswith("-"):
+            break
+        if token in {"-u", "-g", "-h", "-p", "-r", "-t", "-C"} and index + 1 < len(tokens):
+            index += 2
+            continue
+        index += 1
+    return tokens[index:]
+
+
+def _strip_env_prefix(tokens: list[str]) -> list[str]:
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if _ENV_ASSIGNMENT_RE.match(token):
+            index += 1
+            continue
+        if not token.startswith("-"):
+            break
+        if token in {"-u", "-C", "-S"} and index + 1 < len(tokens):
+            index += 2
+            continue
+        index += 1
+    return tokens[index:]
+
+
+def _strip_plain_wrapper_flags(tokens: list[str]) -> list[str]:
+    index = 0
+    while index < len(tokens) and tokens[index].startswith("-"):
+        index += 1
+    return tokens[index:]

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
@@ -1,0 +1,508 @@
+"""Parse package install and execute shell intents."""
+
+from __future__ import annotations
+
+import re
+import shlex
+from pathlib import Path
+
+from ..protect import _collect_package_specs
+from .mcp_protection import _command_name, _package_token
+from .package_intent_common import (
+    PackageIntent,
+    PackageIntentTarget,
+    composer_target,
+    coordinate_target,
+    existing_relative_paths,
+    first_positional,
+    flag_tokens,
+    js_target,
+    option_value,
+    property_value,
+    python_target,
+    redacted_command,
+    version_target,
+)
+from .secret_file_requests import _SHELL_TOOL_NAMES, _candidate_command_texts, _normalize_tool_name
+
+_CONTROL_TOKENS = {"&&", "||", ";", "|", "|&"}
+_ENV_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*$")
+_PYTHON_EXECUTABLES = {"py", "python", "python3", "python3.11", "python3.12", "python3.13", "python3.14"}
+
+
+def parse_package_intent(command_text: str, *, workspace: Path | None = None) -> PackageIntent | None:
+    command_tokens = _normalized_command_tokens(command_text)
+    if not command_tokens:
+        return None
+    command_name = _command_name(command_tokens[0])
+    handlers = {
+        "npm": _parse_npm_intent,
+        "npx": _parse_exec_intent,
+        "pnpm": _parse_pnpm_intent,
+        "yarn": _parse_yarn_intent,
+        "bun": _parse_bun_intent,
+        "bunx": _parse_exec_intent,
+        "pip": _parse_pip_intent,
+        "pipx": _parse_pipx_intent,
+        "uv": _parse_uv_intent,
+        "uvx": _parse_exec_intent,
+        "poetry": _parse_poetry_intent,
+        "pipenv": _parse_pipenv_intent,
+        "cargo": _parse_cargo_intent,
+        "go": _parse_go_intent,
+        "mvn": _parse_maven_intent,
+        "mvnw": _parse_maven_intent,
+        "gradle": _parse_gradle_intent,
+        "gradlew": _parse_gradle_intent,
+        "composer": _parse_composer_intent,
+        "bundle": _parse_bundle_intent,
+        "bundler": _parse_bundle_intent,
+        "gem": _parse_gem_intent,
+    }
+    handler = handlers.get(command_name)
+    if handler is None:
+        return None
+    return handler(command_tokens, workspace=workspace)
+
+
+def extract_package_intent_request(
+    tool_name: object,
+    arguments: object,
+    *,
+    action_envelope_command: str | None,
+    workspace: Path | None = None,
+) -> PackageIntent | None:
+    normalized_tool_name = _normalize_tool_name(tool_name)
+    if normalized_tool_name in _SHELL_TOOL_NAMES:
+        for command_text in _candidate_command_texts(arguments):
+            intent = parse_package_intent(command_text, workspace=workspace)
+            if intent is not None:
+                return intent
+    if action_envelope_command:
+        return parse_package_intent(action_envelope_command, workspace=workspace)
+    return None
+
+
+def _parse_npm_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
+    if len(tokens) < 2:
+        return None
+    if tokens[1] in {"install", "i", "add", "update"}:
+        return _build_intent(
+            "npm",
+            "install",
+            tokens,
+            tuple(js_target(spec) for spec in _collect_package_specs(list(tokens[2:]))),
+            workspace=workspace,
+            manifest_candidates=("package.json",),
+            lockfile_candidates=("package-lock.json",),
+        )
+    if tokens[1] in {"exec", "x"}:
+        return _parse_exec_intent(tokens, workspace=workspace)
+    return None
+
+
+def _parse_pnpm_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
+    if len(tokens) < 2:
+        return None
+    if tokens[1] in {"add", "install"}:
+        return _build_intent(
+            "pnpm",
+            "install",
+            tokens,
+            tuple(js_target(spec) for spec in _collect_specs(tokens[2:], skip_value_options={"--filter", "-F"})),
+            workspace=workspace,
+            manifest_candidates=("package.json", "pnpm-workspace.yaml"),
+            lockfile_candidates=("pnpm-lock.yaml",),
+        )
+    if tokens[1] == "dlx":
+        return _parse_exec_intent(tokens, workspace=workspace)
+    return None
+
+
+def _parse_yarn_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
+    notes: tuple[str, ...] = ()
+    working_tokens = tokens
+    if len(tokens) >= 4 and tokens[1] == "workspace":
+        notes = (f"workspace:{tokens[2]}",)
+        working_tokens = (tokens[0], *tokens[3:])
+    if len(working_tokens) < 2:
+        return None
+    if working_tokens[1] in {"add", "install", "up"}:
+        return _build_intent(
+            "yarn",
+            "install",
+            tokens,
+            tuple(js_target(spec) for spec in _collect_package_specs(list(working_tokens[2:]))),
+            workspace=workspace,
+            manifest_candidates=("package.json",),
+            lockfile_candidates=("yarn.lock",),
+            notes=notes,
+        )
+    if working_tokens[1] == "dlx":
+        return _parse_exec_intent(working_tokens, workspace=workspace)
+    return None
+
+
+def _parse_bun_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
+    if len(tokens) < 2 or tokens[1] not in {"add", "install"}:
+        return None
+    return _build_intent(
+        "bun",
+        "install",
+        tokens,
+        tuple(js_target(spec) for spec in _collect_package_specs(list(tokens[2:]))),
+        workspace=workspace,
+        manifest_candidates=("package.json",),
+        lockfile_candidates=("bun.lock", "bun.lockb"),
+    )
+
+
+def _parse_exec_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
+    package_token = _exec_package_spec(tokens)
+    if package_token is None:
+        return None
+    ecosystem = "pypi" if _command_name(tokens[0]) in {"uvx", "pipx"} else "npm"
+    target = python_target(package_token) if ecosystem == "pypi" else js_target(package_token)
+    return _build_intent(_command_name(tokens[0]), "execute", tokens, (target,), workspace=workspace)
+
+
+def _parse_pip_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
+    if len(tokens) < 2 or tokens[1] != "install":
+        return None
+    targets: list[PackageIntentTarget] = []
+    manifest_paths: list[str] = []
+    index = 2
+    while index < len(tokens):
+        token = tokens[index]
+        if token in {"-r", "--requirement", "-c", "--constraint"} and index + 1 < len(tokens):
+            manifest_paths.append(tokens[index + 1])
+            index += 2
+            continue
+        if token in {"-e", "--editable"} and index + 1 < len(tokens):
+            targets.append(python_target(tokens[index + 1], editable=True))
+            index += 2
+            continue
+        if token in {"--index-url", "--extra-index-url", "--hash"} and index + 1 < len(tokens):
+            index += 2
+            continue
+        if token.startswith("--hash=") or token.startswith("-"):
+            index += 1
+            continue
+        targets.append(python_target(token))
+        index += 1
+    return _build_intent(
+        "pip",
+        "install",
+        tokens,
+        tuple(targets),
+        workspace=workspace,
+        manifest_paths=tuple(existing_relative_paths(workspace, manifest_paths)),
+    )
+
+
+def _parse_pipx_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
+    if len(tokens) < 3 or tokens[1] not in {"install", "run"}:
+        return None
+    target_spec = first_positional(tokens[2:], skip_value_options={"--python"})
+    if target_spec is None:
+        return None
+    return _build_intent(
+        "pipx",
+        "execute" if tokens[1] == "run" else "install",
+        tokens,
+        (python_target(target_spec),),
+        workspace=workspace,
+    )
+
+
+def _parse_uv_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
+    if len(tokens) < 2:
+        return None
+    if tokens[1] == "add":
+        return _build_intent(
+            "uv",
+            "install",
+            tokens,
+            tuple(python_target(spec) for spec in _collect_package_specs(list(tokens[2:]))),
+            workspace=workspace,
+            manifest_candidates=("pyproject.toml",),
+            lockfile_candidates=("uv.lock",),
+        )
+    if len(tokens) >= 3 and tokens[1:3] == ("pip", "install"):
+        return _build_intent(
+            "uv",
+            "install",
+            tokens,
+            tuple(python_target(spec) for spec in _collect_package_specs(list(tokens[3:]))),
+            workspace=workspace,
+            manifest_candidates=("pyproject.toml",),
+            lockfile_candidates=("uv.lock",),
+        )
+    if tokens[1] == "sync":
+        return _build_intent(
+            "uv",
+            "sync",
+            tokens,
+            (),
+            workspace=workspace,
+            manifest_candidates=("pyproject.toml",),
+            lockfile_candidates=("uv.lock",),
+        )
+    return None
+
+
+def _parse_poetry_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
+    if len(tokens) < 2:
+        return None
+    if tokens[1] == "install":
+        return _build_intent(
+            "poetry",
+            "sync",
+            tokens,
+            (),
+            workspace=workspace,
+            manifest_candidates=("pyproject.toml",),
+            lockfile_candidates=("poetry.lock",),
+        )
+    if tokens[1] != "add":
+        return None
+    group = option_value(tokens, "--group") or option_value(tokens, "-G")
+    extras_value = option_value(tokens, "--extras")
+    extras = tuple(item for item in (extras_value or "").split(",") if item)
+    targets = tuple(
+        python_target(spec, dependency_group=group, extras=extras) for spec in _collect_package_specs(list(tokens[2:]))
+    )
+    return _build_intent(
+        "poetry",
+        "install",
+        tokens,
+        targets,
+        workspace=workspace,
+        manifest_candidates=("pyproject.toml",),
+        lockfile_candidates=("poetry.lock",),
+    )
+
+
+def _parse_pipenv_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
+    if len(tokens) < 2:
+        return None
+    if tokens[1] == "sync":
+        return _build_intent(
+            "pipenv",
+            "sync",
+            tokens,
+            (),
+            workspace=workspace,
+            manifest_candidates=("Pipfile",),
+            lockfile_candidates=("Pipfile.lock",),
+        )
+    if tokens[1] != "install":
+        return None
+    return _build_intent(
+        "pipenv",
+        "install",
+        tokens,
+        tuple(python_target(spec) for spec in _collect_package_specs(list(tokens[2:]))),
+        workspace=workspace,
+        manifest_candidates=("Pipfile",),
+        lockfile_candidates=("Pipfile.lock",),
+    )
+
+
+def _parse_cargo_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
+    if len(tokens) < 2 or tokens[1] not in {"add", "install"}:
+        return None
+    source_url = option_value(tokens, "--git")
+    targets = tuple(
+        version_target("cargo", spec, source_url=source_url) for spec in _collect_package_specs(list(tokens[2:]))
+    )
+    return _build_intent(
+        "cargo",
+        "install",
+        tokens,
+        targets,
+        workspace=workspace,
+        manifest_candidates=("Cargo.toml",),
+        lockfile_candidates=("Cargo.lock",),
+    )
+
+
+def _parse_go_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
+    if len(tokens) < 2 or tokens[1] not in {"get", "install"}:
+        return None
+    return _build_intent(
+        "go",
+        "install",
+        tokens,
+        tuple(version_target("go", spec) for spec in _collect_package_specs(list(tokens[2:]))),
+        workspace=workspace,
+        manifest_candidates=("go.mod",),
+    )
+
+
+def _parse_maven_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
+    artifact_value = property_value(tokens, "artifact")
+    if artifact_value is None:
+        includes = property_value(tokens, "includes")
+        dep_version = property_value(tokens, "depVersion")
+        artifact_value = f"{includes}:{dep_version}" if includes and dep_version else None
+    if artifact_value is None:
+        return None
+    return _build_intent(
+        "maven",
+        "install",
+        tokens,
+        (coordinate_target("maven", artifact_value),),
+        workspace=workspace,
+        manifest_candidates=("pom.xml",),
+    )
+
+
+def _parse_gradle_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
+    dependency_value = option_value(tokens, "--dependency")
+    if dependency_value is None:
+        return None
+    return _build_intent(
+        "gradle",
+        "install",
+        tokens,
+        (coordinate_target("maven", dependency_value),),
+        workspace=workspace,
+        manifest_candidates=("build.gradle", "build.gradle.kts"),
+    )
+
+
+def _parse_composer_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
+    if len(tokens) < 2 or tokens[1] not in {"require", "install", "update"}:
+        return None
+    return _build_intent(
+        "composer",
+        "install",
+        tokens,
+        tuple(composer_target(spec) for spec in _collect_package_specs(list(tokens[2:]))),
+        workspace=workspace,
+        manifest_candidates=("composer.json",),
+        lockfile_candidates=("composer.lock",),
+    )
+
+
+def _parse_bundle_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
+    if len(tokens) < 2:
+        return None
+    if tokens[1] == "install":
+        return _build_intent(
+            "bundle",
+            "sync",
+            tokens,
+            (),
+            workspace=workspace,
+            manifest_candidates=("Gemfile",),
+            lockfile_candidates=("Gemfile.lock",),
+        )
+    if tokens[1] != "add" or len(tokens) < 3:
+        return None
+    version = option_value(tokens, "--version")
+    return _build_intent(
+        "bundle",
+        "install",
+        tokens,
+        (PackageIntentTarget("rubygems", tokens[2], tokens[2], version),),
+        workspace=workspace,
+        manifest_candidates=("Gemfile",),
+        lockfile_candidates=("Gemfile.lock",),
+    )
+
+
+def _parse_gem_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
+    if len(tokens) < 3 or tokens[1] != "install":
+        return None
+    version = option_value(tokens, "-v") or option_value(tokens, "--version")
+    return _build_intent(
+        "gem",
+        "install",
+        tokens,
+        (PackageIntentTarget("rubygems", tokens[2], tokens[2], version),),
+        workspace=workspace,
+    )
+
+
+def _build_intent(
+    package_manager: str,
+    intent_kind: str,
+    command_tokens: tuple[str, ...],
+    targets: tuple[PackageIntentTarget, ...],
+    *,
+    workspace: Path | None,
+    manifest_candidates: tuple[str, ...] = (),
+    lockfile_candidates: tuple[str, ...] = (),
+    manifest_paths: tuple[str, ...] = (),
+    notes: tuple[str, ...] = (),
+) -> PackageIntent:
+    return PackageIntent(
+        package_manager=package_manager,
+        intent_kind=intent_kind,  # type: ignore[arg-type]
+        command_tokens=command_tokens,
+        redacted_command=redacted_command(command_tokens),
+        targets=targets,
+        manifest_paths=manifest_paths or existing_relative_paths(workspace, manifest_candidates),
+        lockfile_paths=existing_relative_paths(workspace, lockfile_candidates),
+        flags=flag_tokens(command_tokens[1:]),
+        notes=notes,
+    )
+
+
+def _collect_specs(tokens: tuple[str, ...], *, skip_value_options: set[str]) -> tuple[str, ...]:
+    specs: list[str] = []
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token in skip_value_options and index + 1 < len(tokens):
+            index += 2
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        specs.append(token)
+        index += 1
+    return tuple(specs)
+
+
+def _exec_package_spec(tokens: tuple[str, ...]) -> str | None:
+    command_name = _command_name(tokens[0])
+    if command_name == "npm" and len(tokens) >= 2 and tokens[1] in {"exec", "x"}:
+        explicit_package = option_value(tokens, "--package")
+        positional_package = first_positional(tokens[2:], skip_value_options={"--package"})
+        if positional_package and explicit_package:
+            positional_target = js_target(positional_package)
+            explicit_target = js_target(explicit_package)
+            positional_name = positional_target.package_name
+            explicit_name = explicit_target.package_name
+            if positional_name == explicit_name:
+                return positional_package
+        return positional_package or explicit_package
+    if command_name == "pipx" and len(tokens) >= 2 and tokens[1] == "run":
+        return first_positional(tokens[2:], skip_value_options={"--python"})
+    if command_name in {"pnpm", "yarn"} and len(tokens) >= 2 and tokens[1] == "dlx":
+        return first_positional(tokens[2:], skip_value_options=set())
+    if command_name in {"npx", "bunx", "uvx"}:
+        return first_positional(tokens[1:], skip_value_options=set())
+    return _package_token(command_name=command_name, args=tokens[1:])
+
+
+def _normalized_command_tokens(command_text: str) -> tuple[str, ...]:
+    try:
+        tokens = shlex.split(command_text, posix=True)
+    except ValueError:
+        return ()
+    segment: list[str] = []
+    for token in tokens:
+        if token in _CONTROL_TOKENS:
+            break
+        segment.append(token)
+    while segment and (
+        _command_name(segment[0]) in {"command", "env", "sudo", "time"} or _ENV_ASSIGNMENT_RE.match(segment[0])
+    ):
+        segment.pop(0)
+    if len(segment) >= 3 and _command_name(segment[0]) in _PYTHON_EXECUTABLES and segment[1] == "-m":
+        segment = [segment[2], *segment[3:]]
+    return tuple(segment)

--- a/src/codex_plugin_scanner/guard/runtime/package_manifest_diff.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_manifest_diff.py
@@ -7,7 +7,10 @@ import re
 import time
 from xml.etree import ElementTree as ET
 
-import tomllib
+try:
+    import tomllib  # type: ignore[attr-defined]
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redef]
 
 from .package_intent_common import (
     ManifestDependencyChange,

--- a/src/codex_plugin_scanner/guard/runtime/package_manifest_diff.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_manifest_diff.py
@@ -33,7 +33,7 @@ def parse_manifest_dependency_changes(
     path: str,
     before_text: str | None,
     after_text: str | None,
-    byte_limit: int = 262_144,
+    byte_limit: int = 2_097_152,
     deadline_ms: int = 50,
 ) -> ManifestParseResult:
     before_text = before_text or ""
@@ -184,11 +184,11 @@ def _pom_dependency_map(text: str, deadline: float) -> dict[str, str]:
     _ensure_within_deadline(deadline)
     root = ET.fromstring(text or "<project />")
     dependencies: dict[str, str] = {}
-    for dependency in root.findall(".//dependency"):
+    for dependency in root.findall(".//{*}dependency"):
         _ensure_within_deadline(deadline)
-        group_id = dependency.findtext("groupId")
-        artifact_id = dependency.findtext("artifactId")
-        version = dependency.findtext("version")
+        group_id = dependency.findtext("{*}groupId")
+        artifact_id = dependency.findtext("{*}artifactId")
+        version = dependency.findtext("{*}version")
         if group_id and artifact_id and version:
             dependencies[f"{group_id}:{artifact_id}"] = version
     return dependencies

--- a/src/codex_plugin_scanner/guard/runtime/package_manifest_diff.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_manifest_diff.py
@@ -1,0 +1,215 @@
+"""Parse dependency changes from manifests and lockfiles."""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from xml.etree import ElementTree as ET
+
+import tomllib
+
+from .package_intent_common import (
+    ManifestDependencyChange,
+    ManifestParseResult,
+    PackageIntentTarget,
+    python_target,
+)
+
+_GRADLE_DEP_RE = re.compile(r"([A-Za-z0-9_.-]+):([A-Za-z0-9_.-]+):([A-Za-z0-9+_.-]+)")
+_GEMFILE_RE = re.compile(r"""gem\s+["']([^"']+)["'](?:\s*,\s*["']([^"']+)["'])?""")
+_GO_REQUIRE_RE = re.compile(r"^\s*([A-Za-z0-9./_-]+)\s+(v[^\s]+)\s*$")
+
+
+class _DeadlineExceededError(RuntimeError):
+    pass
+
+
+def parse_manifest_dependency_changes(
+    *,
+    path: str,
+    before_text: str | None,
+    after_text: str | None,
+    byte_limit: int = 262_144,
+    deadline_ms: int = 50,
+) -> ManifestParseResult:
+    before_text = before_text or ""
+    after_text = after_text or ""
+    if len(before_text.encode("utf-8")) + len(after_text.encode("utf-8")) > byte_limit:
+        return ManifestParseResult((), truncated=True, parse_errors=("byte_limit_exceeded",))
+    deadline = time.monotonic() + (deadline_ms / 1000)
+    try:
+        before_deps = _dependency_map_for_path(path, before_text, deadline=deadline)
+        after_deps = _dependency_map_for_path(path, after_text, deadline=deadline)
+    except _DeadlineExceededError:
+        return ManifestParseResult((), truncated=True, parse_errors=("deadline_exceeded",))
+    except Exception:
+        return ManifestParseResult((), parse_errors=("parse_error",))
+    changes = tuple(
+        ManifestDependencyChange(path, package_name, before_deps.get(package_name), after_deps.get(package_name))
+        for package_name in sorted(set(before_deps) | set(after_deps))
+        if before_deps.get(package_name) != after_deps.get(package_name)
+    )
+    return ManifestParseResult(changes)
+
+
+def _dependency_map_for_path(path: str, text: str, *, deadline: float) -> dict[str, str]:
+    lower_path = path.lower()
+    if lower_path.endswith("package.json"):
+        return _json_dependency_map(
+            text,
+            ("dependencies", "devDependencies", "optionalDependencies", "peerDependencies"),
+            deadline,
+        )
+    if lower_path.endswith("package-lock.json"):
+        return _package_lock_dependency_map(text, deadline)
+    if lower_path.endswith("composer.json"):
+        return _json_dependency_map(text, ("require", "require-dev"), deadline)
+    if lower_path.endswith("requirements.txt"):
+        return _requirements_dependency_map(text, deadline)
+    if lower_path.endswith("pyproject.toml"):
+        return _pyproject_dependency_map(text, deadline)
+    if lower_path.endswith("cargo.toml"):
+        return _toml_table_dependency_map(text, ("dependencies", "dev-dependencies", "build-dependencies"), deadline)
+    if lower_path.endswith("go.mod"):
+        return _go_mod_dependency_map(text, deadline)
+    if lower_path.endswith("pom.xml"):
+        return _pom_dependency_map(text, deadline)
+    if lower_path.endswith("build.gradle") or lower_path.endswith("build.gradle.kts"):
+        return _gradle_dependency_map(text, deadline)
+    if lower_path.endswith("gemfile"):
+        return _gemfile_dependency_map(text, deadline)
+    return {}
+
+
+def _json_dependency_map(text: str, sections: tuple[str, ...], deadline: float) -> dict[str, str]:
+    _ensure_within_deadline(deadline)
+    payload = json.loads(text or "{}")
+    dependencies: dict[str, str] = {}
+    for section in sections:
+        values = payload.get(section)
+        if isinstance(values, dict):
+            for package_name, version in values.items():
+                if isinstance(version, str):
+                    dependencies[str(package_name)] = version
+    return dependencies
+
+
+def _package_lock_dependency_map(text: str, deadline: float) -> dict[str, str]:
+    payload = json.loads(text or "{}")
+    dependencies: dict[str, str] = {}
+    packages = payload.get("packages")
+    if isinstance(packages, dict):
+        for package_path, value in packages.items():
+            _ensure_within_deadline(deadline)
+            if not isinstance(package_path, str) or not package_path.startswith("node_modules/"):
+                continue
+            version = value.get("version") if isinstance(value, dict) else None
+            if isinstance(version, str):
+                dependencies[package_path.removeprefix("node_modules/")] = version
+    return dependencies
+
+
+def _requirements_dependency_map(text: str, deadline: float) -> dict[str, str]:
+    dependencies: dict[str, str] = {}
+    for line in text.splitlines():
+        _ensure_within_deadline(deadline)
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or stripped.startswith("-"):
+            continue
+        target: PackageIntentTarget = python_target(stripped)
+        if target.package_name is not None:
+            dependencies[target.package_name] = target.requested_specifier or ""
+    return dependencies
+
+
+def _pyproject_dependency_map(text: str, deadline: float) -> dict[str, str]:
+    _ensure_within_deadline(deadline)
+    payload = tomllib.loads(text or "")
+    dependencies: dict[str, str] = {}
+    project = payload.get("project")
+    if isinstance(project, dict):
+        values = project.get("dependencies")
+        if isinstance(values, list):
+            for value in values:
+                target = python_target(str(value))
+                if target.package_name is not None:
+                    dependencies[target.package_name] = target.requested_specifier or ""
+    return dependencies
+
+
+def _toml_table_dependency_map(text: str, sections: tuple[str, ...], deadline: float) -> dict[str, str]:
+    _ensure_within_deadline(deadline)
+    payload = tomllib.loads(text or "")
+    dependencies: dict[str, str] = {}
+    for section in sections:
+        values = payload.get(section)
+        if not isinstance(values, dict):
+            continue
+        for package_name, value in values.items():
+            _ensure_within_deadline(deadline)
+            if isinstance(value, str):
+                dependencies[str(package_name)] = value
+            elif isinstance(value, dict) and isinstance(value.get("version"), str):
+                dependencies[str(package_name)] = str(value["version"])
+    return dependencies
+
+
+def _go_mod_dependency_map(text: str, deadline: float) -> dict[str, str]:
+    dependencies: dict[str, str] = {}
+    in_require_block = False
+    for raw_line in text.splitlines():
+        _ensure_within_deadline(deadline)
+        line = raw_line.strip()
+        if line.startswith("require ("):
+            in_require_block = True
+            continue
+        if in_require_block and line == ")":
+            in_require_block = False
+            continue
+        if line.startswith("require "):
+            line = line.removeprefix("require ").strip()
+        elif not in_require_block:
+            continue
+        match = _GO_REQUIRE_RE.match(line)
+        if match is not None:
+            dependencies[match.group(1)] = match.group(2)
+    return dependencies
+
+
+def _pom_dependency_map(text: str, deadline: float) -> dict[str, str]:
+    _ensure_within_deadline(deadline)
+    root = ET.fromstring(text or "<project />")
+    dependencies: dict[str, str] = {}
+    for dependency in root.findall(".//dependency"):
+        _ensure_within_deadline(deadline)
+        group_id = dependency.findtext("groupId")
+        artifact_id = dependency.findtext("artifactId")
+        version = dependency.findtext("version")
+        if group_id and artifact_id and version:
+            dependencies[f"{group_id}:{artifact_id}"] = version
+    return dependencies
+
+
+def _gradle_dependency_map(text: str, deadline: float) -> dict[str, str]:
+    dependencies: dict[str, str] = {}
+    for line in text.splitlines():
+        _ensure_within_deadline(deadline)
+        for match in _GRADLE_DEP_RE.finditer(line):
+            dependencies[f"{match.group(1)}:{match.group(2)}"] = match.group(3)
+    return dependencies
+
+
+def _gemfile_dependency_map(text: str, deadline: float) -> dict[str, str]:
+    dependencies: dict[str, str] = {}
+    for line in text.splitlines():
+        _ensure_within_deadline(deadline)
+        match = _GEMFILE_RE.search(line)
+        if match is not None:
+            dependencies[match.group(1)] = match.group(2) or ""
+    return dependencies
+
+
+def _ensure_within_deadline(deadline: float) -> None:
+    if time.monotonic() > deadline:
+        raise _DeadlineExceededError("deadline_exceeded")

--- a/tests/test_guard_package_intent.py
+++ b/tests/test_guard_package_intent.py
@@ -309,6 +309,12 @@ def test_parse_manifest_dependency_changes_supports_primary_manifests_lockfiles_
             {"org.example:demo": ("1.0.0", "1.2.0"), "org.example:extra": (None, "2.0.0")},
         ),
         (
+            "pom.xml",
+            '<project xmlns="http://maven.apache.org/POM/4.0.0"><dependencies><dependency><groupId>org.example</groupId><artifactId>demo</artifactId><version>1.0.0</version></dependency></dependencies></project>',
+            '<project xmlns="http://maven.apache.org/POM/4.0.0"><dependencies><dependency><groupId>org.example</groupId><artifactId>demo</artifactId><version>1.1.0</version></dependency></dependencies></project>',
+            {"org.example:demo": ("1.0.0", "1.1.0")},
+        ),
+        (
             "build.gradle.kts",
             'dependencies { implementation("org.example:demo:1.0.0") }\n',
             'dependencies { implementation("org.example:demo:1.2.0") implementation("org.example:extra:2.0.0") }\n',

--- a/tests/test_guard_package_intent.py
+++ b/tests/test_guard_package_intent.py
@@ -102,6 +102,15 @@ def test_parse_package_intent_exec_commands_are_classified_as_execute_requests()
         assert intent.targets[0].requested_specifier == requested_specifier
 
 
+def test_parse_package_intent_npm_exec_prefers_explicit_package_when_command_differs() -> None:
+    intent = parse_package_intent("npm exec --package cowsay hello")
+
+    assert intent is not None
+    assert intent.package_manager == "npm"
+    assert intent.intent_kind == "execute"
+    assert intent.targets[0].package_name == "cowsay"
+
+
 def test_parse_package_intent_pip_install_supports_requirements_constraints_vcs_editable_and_redaction(
     tmp_path: Path,
 ) -> None:
@@ -125,6 +134,20 @@ def test_parse_package_intent_pip_install_supports_requirements_constraints_vcs_
     assert "user:pass" not in intent.redacted_command
     assert "token@" not in intent.redacted_command
     assert "deadbeef" not in intent.redacted_command
+
+
+def test_parse_package_intent_pip_install_supports_inline_requirement_flag_forms(tmp_path: Path) -> None:
+    _write_text(tmp_path / "requirements.txt", "flask==3.0.0\n")
+    _write_text(tmp_path / "constraints.txt", "werkzeug==3.0.0\n")
+
+    intent = parse_package_intent(
+        "pip install --requirement=requirements.txt -cconstraints.txt demo==1.0.0",
+        workspace=tmp_path,
+    )
+
+    assert intent is not None
+    assert intent.manifest_paths == ("requirements.txt", "constraints.txt")
+    assert intent.targets[0].package_name == "demo"
 
 
 def test_parse_package_intent_pipx_install_and_run_are_supported() -> None:
@@ -166,6 +189,18 @@ def test_parse_package_intent_uv_add_sync_and_execute_are_supported(tmp_path: Pa
     assert sync_intent.intent_kind == "sync"
     assert sync_intent.manifest_paths == ("pyproject.toml",)
     assert sync_intent.lockfile_paths == ("uv.lock",)
+
+
+def test_parse_package_intent_skips_wrapper_flags_before_manager_detection() -> None:
+    npm_intent = parse_package_intent("sudo -E npm install react")
+    pip_intent = parse_package_intent("env -i pip install flask==3.0.0")
+
+    assert npm_intent is not None
+    assert npm_intent.package_manager == "npm"
+    assert npm_intent.targets[0].package_name == "react"
+    assert pip_intent is not None
+    assert pip_intent.package_manager == "pip"
+    assert pip_intent.targets[0].package_name == "flask"
 
 
 def test_parse_package_intent_poetry_and_pipenv_use_project_lockfile_context(tmp_path: Path) -> None:

--- a/tests/test_guard_package_intent.py
+++ b/tests/test_guard_package_intent.py
@@ -1,0 +1,332 @@
+"""Package intent parser tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_plugin_scanner.guard.runtime.package_intent import (
+    parse_manifest_dependency_changes,
+    parse_package_intent,
+)
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_parse_package_intent_npm_install_supports_aliases_tags_versions_and_flags(tmp_path: Path) -> None:
+    _write_text(tmp_path / "package.json", '{"name":"demo"}\n')
+
+    intent = parse_package_intent(
+        "npm add @scope/widget@1.2.3 alias@npm:real-widget@latest plain --save-dev --registry https://registry.npmjs.org",
+        workspace=tmp_path,
+    )
+
+    assert intent is not None
+    assert intent.package_manager == "npm"
+    assert intent.intent_kind == "install"
+    assert intent.flags == ("--save-dev", "--registry")
+    assert intent.manifest_paths == ("package.json",)
+    assert [target.package_name for target in intent.targets] == ["@scope/widget", "real-widget", "plain"]
+    assert [target.requested_specifier for target in intent.targets] == ["1.2.3", "latest", None]
+    assert intent.targets[1].alias == "alias"
+
+
+def test_parse_package_intent_pnpm_install_tracks_workspace_flags_and_lockfile_context(tmp_path: Path) -> None:
+    _write_text(tmp_path / "package.json", '{"name":"demo"}\n')
+    _write_text(tmp_path / "pnpm-workspace.yaml", "packages:\n  - apps/*\n")
+    _write_text(tmp_path / "pnpm-lock.yaml", "lockfileVersion: '9.0'\n")
+
+    intent = parse_package_intent(
+        "pnpm install --filter @apps/web --workspace-root --lockfile-only",
+        workspace=tmp_path,
+    )
+
+    assert intent is not None
+    assert intent.package_manager == "pnpm"
+    assert intent.intent_kind == "install"
+    assert intent.targets == ()
+    assert intent.flags == ("--filter", "--workspace-root", "--lockfile-only")
+    assert intent.manifest_paths == ("package.json", "pnpm-workspace.yaml")
+    assert intent.lockfile_paths == ("pnpm-lock.yaml",)
+
+
+def test_parse_package_intent_yarn_supports_classic_and_workspace_berry_forms(tmp_path: Path) -> None:
+    _write_text(tmp_path / "package.json", '{"name":"demo"}\n')
+
+    classic = parse_package_intent("yarn add react@18.3.0", workspace=tmp_path)
+    berry = parse_package_intent("yarn workspace web add @types/node@latest lodash", workspace=tmp_path)
+
+    assert classic is not None
+    assert classic.package_manager == "yarn"
+    assert classic.intent_kind == "install"
+    assert classic.targets[0].package_name == "react"
+    assert classic.targets[0].requested_specifier == "18.3.0"
+    assert berry is not None
+    assert berry.package_manager == "yarn"
+    assert berry.intent_kind == "install"
+    assert berry.notes == ("workspace:web",)
+    assert [target.package_name for target in berry.targets] == ["@types/node", "lodash"]
+
+
+def test_parse_package_intent_bun_install_uses_bun_lock_context(tmp_path: Path) -> None:
+    _write_text(tmp_path / "package.json", '{"name":"demo"}\n')
+    _write_text(tmp_path / "bun.lock", "{ }\n")
+
+    intent = parse_package_intent("bun install --lockfile-only", workspace=tmp_path)
+
+    assert intent is not None
+    assert intent.package_manager == "bun"
+    assert intent.intent_kind == "install"
+    assert intent.lockfile_paths == ("bun.lock",)
+    assert intent.flags == ("--lockfile-only",)
+
+
+def test_parse_package_intent_exec_commands_are_classified_as_execute_requests() -> None:
+    commands = {
+        "npx create-vite@latest": ("npx", "create-vite", "latest"),
+        "npm exec --package=create-vite create-vite@latest": ("npm", "create-vite", "latest"),
+        "pnpm dlx create-next-app@latest": ("pnpm", "create-next-app", "latest"),
+        "yarn dlx @redwoodjs/create-redwood-app@latest": ("yarn", "@redwoodjs/create-redwood-app", "latest"),
+        "bunx @angular/cli@next": ("bunx", "@angular/cli", "next"),
+    }
+
+    for command, (manager, package_name, requested_specifier) in commands.items():
+        intent = parse_package_intent(command)
+
+        assert intent is not None
+        assert intent.package_manager == manager
+        assert intent.intent_kind == "execute"
+        assert intent.targets[0].package_name == package_name
+        assert intent.targets[0].requested_specifier == requested_specifier
+
+
+def test_parse_package_intent_pip_install_supports_requirements_constraints_vcs_editable_and_redaction(
+    tmp_path: Path,
+) -> None:
+    _write_text(tmp_path / "requirements.txt", "flask==3.0.0\n")
+    _write_text(tmp_path / "constraints.txt", "werkzeug==3.0.0\n")
+
+    intent = parse_package_intent(
+        "pip install -r requirements.txt -c constraints.txt demo[cli]==2.0 "
+        "git+https://user:pass@example.com/org/private.git#egg=private-demo "
+        "-e ../editable --index-url https://token@example.com/simple --hash sha256:deadbeef",
+        workspace=tmp_path,
+    )
+
+    assert intent is not None
+    assert intent.package_manager == "pip"
+    assert intent.intent_kind == "install"
+    assert intent.manifest_paths == ("requirements.txt", "constraints.txt")
+    assert [target.package_name for target in intent.targets] == ["demo", "private-demo", "editable"]
+    assert intent.targets[0].extras == ("cli",)
+    assert intent.targets[2].editable is True
+    assert "user:pass" not in intent.redacted_command
+    assert "token@" not in intent.redacted_command
+    assert "deadbeef" not in intent.redacted_command
+
+
+def test_parse_package_intent_pipx_install_and_run_are_supported() -> None:
+    install_intent = parse_package_intent("pipx install black --python 3.12")
+    run_intent = parse_package_intent("pipx run --python 3.11 httpie==3.2.2")
+
+    assert install_intent is not None
+    assert install_intent.package_manager == "pipx"
+    assert install_intent.intent_kind == "install"
+    assert install_intent.targets[0].package_name == "black"
+    assert run_intent is not None
+    assert run_intent.package_manager == "pipx"
+    assert run_intent.intent_kind == "execute"
+    assert run_intent.targets[0].package_name == "httpie"
+    assert run_intent.targets[0].requested_specifier == "3.2.2"
+
+
+def test_parse_package_intent_uv_add_sync_and_execute_are_supported(tmp_path: Path) -> None:
+    _write_text(tmp_path / "pyproject.toml", "[project]\nname = 'demo'\n")
+    _write_text(tmp_path / "uv.lock", "version = 1\n")
+
+    add_intent = parse_package_intent("uv add fastapi==0.115.0", workspace=tmp_path)
+    pip_intent = parse_package_intent("uv pip install httpx==0.27.0", workspace=tmp_path)
+    run_intent = parse_package_intent("uvx ruff==0.6.9")
+    sync_intent = parse_package_intent("uv sync --locked", workspace=tmp_path)
+
+    assert add_intent is not None
+    assert add_intent.package_manager == "uv"
+    assert add_intent.intent_kind == "install"
+    assert add_intent.targets[0].package_name == "fastapi"
+    assert pip_intent is not None
+    assert pip_intent.intent_kind == "install"
+    assert pip_intent.targets[0].package_name == "httpx"
+    assert run_intent is not None
+    assert run_intent.package_manager == "uvx"
+    assert run_intent.intent_kind == "execute"
+    assert run_intent.targets[0].package_name == "ruff"
+    assert sync_intent is not None
+    assert sync_intent.intent_kind == "sync"
+    assert sync_intent.manifest_paths == ("pyproject.toml",)
+    assert sync_intent.lockfile_paths == ("uv.lock",)
+
+
+def test_parse_package_intent_poetry_and_pipenv_use_project_lockfile_context(tmp_path: Path) -> None:
+    _write_text(tmp_path / "pyproject.toml", "[tool.poetry]\nname = 'demo'\n")
+    _write_text(tmp_path / "poetry.lock", "[[package]]\nname='requests'\nversion='2.32.0'\n")
+    _write_text(tmp_path / "Pipfile", "[packages]\nrequests = '*'\n")
+    _write_text(tmp_path / "Pipfile.lock", '{"default":{"requests":{"version":"==2.32.0"}}}\n')
+
+    poetry_intent = parse_package_intent("poetry add requests@^2.32 --group dev --extras socks", workspace=tmp_path)
+    poetry_install = parse_package_intent("poetry install --sync", workspace=tmp_path)
+    pipenv_intent = parse_package_intent("pipenv install flask~=3.0", workspace=tmp_path)
+    pipenv_sync = parse_package_intent("pipenv sync", workspace=tmp_path)
+
+    assert poetry_intent is not None
+    assert poetry_intent.package_manager == "poetry"
+    assert poetry_intent.targets[0].package_name == "requests"
+    assert poetry_intent.targets[0].requested_specifier == "^2.32"
+    assert poetry_intent.targets[0].extras == ("socks",)
+    assert poetry_intent.targets[0].dependency_group == "dev"
+    assert poetry_install is not None
+    assert poetry_install.intent_kind == "sync"
+    assert poetry_install.lockfile_paths == ("poetry.lock",)
+    assert pipenv_intent is not None
+    assert pipenv_intent.package_manager == "pipenv"
+    assert pipenv_intent.targets[0].package_name == "flask"
+    assert pipenv_sync is not None
+    assert pipenv_sync.intent_kind == "sync"
+    assert pipenv_sync.lockfile_paths == ("Pipfile.lock",)
+
+
+def test_parse_package_intent_cargo_go_maven_gradle_composer_and_ruby_are_supported() -> None:
+    cargo_add = parse_package_intent("cargo add clap@4.5.7 --features derive")
+    cargo_install = parse_package_intent("cargo install cargo-audit --git https://github.com/RustSec/rustsec.git")
+    go_get = parse_package_intent("go get github.com/gin-gonic/gin@v1.10.0")
+    go_install = parse_package_intent("go install example.com/cmd/tool@latest")
+    maven = parse_package_intent("mvn dependency:get -Dartifact=org.example:demo:1.2.3")
+    gradle = parse_package_intent("./gradlew addDependency --dependency org.example:demo:1.2.3")
+    composer = parse_package_intent("composer require laravel/framework:^11.0")
+    bundler = parse_package_intent("bundle add rspec --version 3.13.0")
+    gem = parse_package_intent("gem install rails -v 7.1.3")
+
+    assert cargo_add is not None
+    assert cargo_add.package_manager == "cargo"
+    assert cargo_add.targets[0].package_name == "clap"
+    assert cargo_add.targets[0].requested_specifier == "4.5.7"
+    assert cargo_install is not None
+    assert cargo_install.targets[0].source_url == "https://github.com/RustSec/rustsec.git"
+    assert go_get is not None
+    assert go_get.targets[0].package_name == "github.com/gin-gonic/gin"
+    assert go_install is not None
+    assert go_install.targets[0].requested_specifier == "latest"
+    assert maven is not None
+    assert maven.targets[0].package_name == "org.example:demo"
+    assert gradle is not None
+    assert gradle.targets[0].package_name == "org.example:demo"
+    assert composer is not None
+    assert composer.targets[0].package_name == "laravel/framework"
+    assert bundler is not None
+    assert bundler.targets[0].package_name == "rspec"
+    assert gem is not None
+    assert gem.targets[0].package_name == "rails"
+
+
+def test_parse_manifest_dependency_changes_supports_primary_manifests_lockfiles_and_tier2_formats() -> None:
+    cases = [
+        (
+            "package.json",
+            '{"dependencies":{"react":"18.2.0"}}',
+            '{"dependencies":{"react":"18.3.0","lodash":"4.17.21"}}',
+            {"react": ("18.2.0", "18.3.0"), "lodash": (None, "4.17.21")},
+        ),
+        (
+            "pyproject.toml",
+            '[project]\ndependencies = ["fastapi==0.110.0"]\n',
+            '[project]\ndependencies = ["fastapi==0.115.0", "httpx>=0.27"]\n',
+            {"fastapi": ("0.110.0", "0.115.0"), "httpx": (None, ">=0.27")},
+        ),
+        (
+            "requirements.txt",
+            "flask==3.0.0\n",
+            "flask==3.1.0\nrequests==2.32.0\n",
+            {"flask": ("3.0.0", "3.1.0"), "requests": (None, "2.32.0")},
+        ),
+        (
+            "package-lock.json",
+            '{"packages":{"node_modules/react":{"version":"18.2.0"}}}',
+            '{"packages":{"node_modules/react":{"version":"18.3.0"},"node_modules/lodash":{"version":"4.17.21"}}}',
+            {"react": ("18.2.0", "18.3.0"), "lodash": (None, "4.17.21")},
+        ),
+        (
+            "Cargo.toml",
+            '[dependencies]\nclap = "4.4"\n',
+            '[dependencies]\nclap = "4.5"\nserde = "1.0"\n',
+            {"clap": ("4.4", "4.5"), "serde": (None, "1.0")},
+        ),
+        (
+            "go.mod",
+            "require github.com/gin-gonic/gin v1.9.0\n",
+            "require (\n github.com/gin-gonic/gin v1.10.0\n github.com/spf13/cobra v1.8.0\n)\n",
+            {"github.com/gin-gonic/gin": ("v1.9.0", "v1.10.0"), "github.com/spf13/cobra": (None, "v1.8.0")},
+        ),
+        (
+            "pom.xml",
+            "<project><dependencies><dependency><groupId>org.example</groupId><artifactId>demo</artifactId><version>1.0.0</version></dependency></dependencies></project>",
+            "<project><dependencies><dependency><groupId>org.example</groupId><artifactId>demo</artifactId><version>1.2.0</version></dependency><dependency><groupId>org.example</groupId><artifactId>extra</artifactId><version>2.0.0</version></dependency></dependencies></project>",
+            {"org.example:demo": ("1.0.0", "1.2.0"), "org.example:extra": (None, "2.0.0")},
+        ),
+        (
+            "build.gradle.kts",
+            'dependencies { implementation("org.example:demo:1.0.0") }\n',
+            'dependencies { implementation("org.example:demo:1.2.0") implementation("org.example:extra:2.0.0") }\n',
+            {"org.example:demo": ("1.0.0", "1.2.0"), "org.example:extra": (None, "2.0.0")},
+        ),
+        (
+            "composer.json",
+            '{"require":{"laravel/framework":"^10.0"}}',
+            '{"require":{"laravel/framework":"^11.0","guzzlehttp/guzzle":"^7.0"}}',
+            {"laravel/framework": ("^10.0", "^11.0"), "guzzlehttp/guzzle": (None, "^7.0")},
+        ),
+        (
+            "Gemfile",
+            'gem "rails", "7.1.2"\n',
+            'gem "rails", "7.1.3"\ngem "rspec", "3.13.0"\n',
+            {"rails": ("7.1.2", "7.1.3"), "rspec": (None, "3.13.0")},
+        ),
+    ]
+
+    for path, before_text, after_text, expected in cases:
+        result = parse_manifest_dependency_changes(path=path, before_text=before_text, after_text=after_text)
+
+        assert result.truncated is False
+        assert result.parse_errors == ()
+        actual = {change.package_name: (change.before, change.after) for change in result.changes}
+        assert actual == expected
+
+
+def test_parse_manifest_dependency_changes_truncates_large_lockfiles_safely() -> None:
+    before_text = '{"packages":{}}'
+    package_entries = ",".join(f'"node_modules/pkg-{index}":{{"version":"1.0.{index}"}}' for index in range(500))
+    after_text = f'{{"packages":{{{package_entries}}}}}'
+
+    result = parse_manifest_dependency_changes(
+        path="package-lock.json",
+        before_text=before_text,
+        after_text=after_text,
+        byte_limit=256,
+    )
+
+    assert result.changes == ()
+    assert result.truncated is True
+    assert result.parse_errors == ("byte_limit_exceeded",)
+
+
+def test_parse_package_intent_only_emits_package_metadata_and_redacted_command_shape() -> None:
+    intent = parse_package_intent(
+        "PIP_INDEX_URL=https://user:pass@example.com/simple pip install private-demo==1.2.3 --hash sha256:deadbeef",
+    )
+
+    assert intent is not None
+    assert intent.targets[0].package_name == "private-demo"
+    assert intent.targets[0].requested_specifier == "1.2.3"
+    assert "user:pass" not in intent.redacted_command
+    assert "deadbeef" not in intent.redacted_command
+    assert "private-demo==1.2.3" in intent.redacted_command

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -8621,6 +8621,59 @@ def test_hook_runtime_artifact_prefers_raw_file_read_path_over_redacted_action_p
     assert artifact.metadata["normalized_path"] == str(outside_secret)
 
 
+def test_hook_runtime_artifact_routes_package_installs_to_package_request(tmp_path):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _write_text(home_dir / "config.toml", '[risk_actions]\npackage_script = "block"\ndestructive_shell = "allow"\n')
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "npm install react@18.3.0"},
+        "source_scope": "project",
+    }
+    action = guard_commands_module._hook_action_envelope(
+        harness="codex",
+        payload=payload,
+        home_dir=home_dir,
+        workspace=workspace_dir,
+    )
+    artifact = guard_commands_module._hook_runtime_artifact(
+        harness="codex",
+        payload=payload,
+        action_envelope=action,
+        home_dir=home_dir,
+        guard_home=home_dir,
+        workspace=workspace_dir,
+    )
+
+    assert artifact is not None
+    assert artifact.artifact_type == "package_request"
+    assert artifact.metadata["package_manager"] == "npm"
+    assert (
+        guard_commands_module._runtime_artifact_policy_action(
+            load_guard_config(home_dir),
+            artifact,
+            "codex",
+        )
+        == "block"
+    )
+
+
+def test_runtime_capabilities_summary_uses_package_request_label() -> None:
+    artifact = GuardArtifact(
+        artifact_id="codex:test:package-request",
+        name="npm install react",
+        harness="codex",
+        artifact_type="package_request",
+        source_scope="project",
+        config_path="/dev/null",
+        metadata={"package_manager": "npm"},
+    )
+
+    assert guard_commands_module._runtime_capabilities_summary(artifact) == "package request • npm"
+
+
 def test_guard_hook_claude_alias_reuses_legacy_alias_policy_keys(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
@@ -14923,7 +14976,7 @@ def test_sync_receipts_preserves_batch_metadata_and_reuses_device_metadata(tmp_p
     monkeypatch.setattr(
         guard_runner_module,
         "_guard_device_metadata",
-        lambda _store: (metadata_calls.append(True) or ("device-1", "MacBook Pro")),
+        lambda _store: metadata_calls.append(True) or ("device-1", "MacBook Pro"),
     )
     monkeypatch.setattr(guard_runner_module, "sync_pain_signals", lambda _store: 0)
 


### PR DESCRIPTION
## Summary
- add runtime package intent parsing for package install and execute requests across package managers
- parse manifest and lockfile dependency diffs with bounded safe-failure behavior
- route package requests through package-script policy handling and add focused runtime coverage

## Testing
- ruff check src/codex_plugin_scanner/guard/runtime/package_intent.py src/codex_plugin_scanner/guard/runtime/package_intent_common.py src/codex_plugin_scanner/guard/runtime/package_intent_parser.py src/codex_plugin_scanner/guard/runtime/package_manifest_diff.py src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/incident.py tests/test_guard_package_intent.py tests/test_guard_runtime.py
- ruff format --check src/codex_plugin_scanner/guard/runtime/package_intent.py src/codex_plugin_scanner/guard/runtime/package_intent_common.py src/codex_plugin_scanner/guard/runtime/package_intent_parser.py src/codex_plugin_scanner/guard/runtime/package_manifest_diff.py src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/incident.py tests/test_guard_package_intent.py tests/test_guard_runtime.py
- pytest tests/test_guard_package_intent.py tests/test_guard_runtime.py -k package