### PR TITLE
feat(guard): add supply chain decisions

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2608,6 +2608,11 @@ def run_guard_command(
                 if _guard_action_severity(data_flow_action) > _guard_action_severity(policy_action):
                     policy_action = data_flow_action
             _pre_scanner_policy_action = policy_action
+            package_controls_pre_scanner_summary = (
+                package_evaluation is not None
+                and _guard_action_severity(package_evaluation.policy_action)
+                >= _guard_action_severity(_pre_scanner_policy_action)
+            )
             if scanner_evidence and requested_policy_action not in VALID_GUARD_ACTIONS:
                 scanner_action = policy_action_for_cisco_signals(
                     scanner_evidence,
@@ -2632,7 +2637,7 @@ def run_guard_command(
             else:
                 risk_signals = list(artifact_risk_signals(runtime_artifact))
                 risk_summary = artifact_risk_summary(runtime_artifact)
-            if package_evaluation is not None:
+            if package_controls_pre_scanner_summary:
                 risk_signals = [
                     str(item.get("message") or item.get("code") or "")
                     for item in package_evaluation.reasons

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -150,6 +150,7 @@ from ..runtime.secret_sensitivity import (
 )
 from ..runtime.sed_scripts import sed_script_is_bounded_print
 from ..runtime.signals import RiskSignalV2
+from ..runtime.supply_chain_package_eval import evaluate_package_request_artifact
 from ..runtime.surface_server import GuardSurfaceRuntime
 from ..store import GuardStore
 from .approval_commands import (
@@ -2580,12 +2581,24 @@ def run_guard_command(
                 )
                 return 0
             changed_capabilities = [runtime_artifact.artifact_type]
+            package_evaluation = None
             scanner_evidence = (
                 scan_action_for_cisco_evidence(action_envelope, workspace=runtime_workspace)
                 if action_envelope is not None
                 else ()
             )
             scanner_evidence_payload = [signal.to_dict() for signal in scanner_evidence]
+            if (
+                runtime_artifact.artifact_type == "package_request"
+                and requested_policy_action not in VALID_GUARD_ACTIONS
+            ):
+                package_evaluation = evaluate_package_request_artifact(
+                    artifact=runtime_artifact,
+                    store=store,
+                    workspace_dir=runtime_workspace,
+                )
+                if _guard_action_severity(package_evaluation.policy_action) > _guard_action_severity(policy_action):
+                    policy_action = package_evaluation.policy_action
             if data_flow_signals:
                 data_flow_action = resolve_risk_action(
                     config,
@@ -2616,11 +2629,33 @@ def run_guard_command(
             else:
                 risk_signals = list(artifact_risk_signals(runtime_artifact))
                 risk_summary = artifact_risk_summary(runtime_artifact)
+            if package_evaluation is not None:
+                risk_signals = [
+                    str(item.get("message") or item.get("code") or "")
+                    for item in package_evaluation.reasons
+                ]
+                risk_summary = package_evaluation.risk_summary
+                scanner_evidence_payload.extend(
+                    {
+                        "decision": package_evaluation.decision,
+                        "enforcement": package_evaluation.enforcement,
+                        "exception_id": package_evaluation.exception_id,
+                        "matched_rule_id": package_evaluation.matched_rule_id,
+                        "package": package,
+                    }
+                    for package in package_evaluation.packages
+                )
             if scanner_risk_signals:
                 risk_signals.extend(scanner_risk_signals)
                 if scanner_raised_to_block:
                     risk_summary = scanner_risk_signals[0]
             decision_v2 = build_decision_v2(policy_action, reason=policy_action, signals=decision_signals)
+            decision_v2_payload = decision_v2.to_dict()
+            if package_evaluation is not None:
+                decision_v2_payload["user_title"] = package_evaluation.user_copy.title
+                decision_v2_payload["user_body"] = package_evaluation.user_copy.summary
+                decision_v2_payload["harness_message"] = package_evaluation.user_copy.harness_message
+                decision_v2_payload["dashboard_primary_detail"] = package_evaluation.user_copy.summary
             incident = build_incident_context(
                 harness=args.harness,
                 artifact=runtime_artifact,
@@ -2665,7 +2700,7 @@ def run_guard_command(
                 "risk_signals": risk_signals,
                 "risk_summary": risk_summary,
                 "scanner_evidence": scanner_evidence_payload,
-                "decision_v2_json": decision_v2.to_dict(),
+                "decision_v2_json": decision_v2_payload,
                 "artifact_label": incident["artifact_label"],
                 "source_label": incident["source_label"],
                 "trigger_summary": incident["trigger_summary"],
@@ -2674,6 +2709,8 @@ def run_guard_command(
                 "risk_headline": incident["risk_headline"],
                 "path_summary": _runtime_requested_path(runtime_artifact),
             }
+            if package_evaluation is not None:
+                response_payload["supply_chain_evaluation"] = package_evaluation.to_dict()
             if policy_action in {"block", "sandbox-required", "require-reapproval"}:
                 native_reason = _runtime_artifact_native_reason(runtime_artifact, response_payload)
                 additional_context = _claude_prompt_additional_context(
@@ -2745,6 +2782,25 @@ def run_guard_command(
                         policy_action=policy_action,
                     )
                     return 0
+                if (
+                    runtime_artifact.artifact_type == "package_request"
+                    and policy_action == "block"
+                    and _should_emit_native_hook_exit_block(args, event_name=event_name, policy_action=policy_action)
+                ):
+                    _emit_native_hook_block_stderr(
+                        _native_hook_reason_for_harness(
+                            args.harness,
+                            native_reason,
+                            _native_approval_center_context(response_payload, harness=args.harness),
+                        )
+                    )
+                    _record_harness_usage_for_hook(
+                        store=store,
+                        action_envelope=action_envelope,
+                        payload=payload,
+                        policy_action=policy_action,
+                    )
+                    return 2
                 if not _prompt_requires_hard_block(runtime_artifact):
                     approval_flow = get_adapter(args.harness).approval_flow(managed_install=managed_install)
                     approval_center_url = ensure_guard_daemon(guard_home)
@@ -2761,9 +2817,13 @@ def run_guard_command(
                                 "source_scope": runtime_artifact.source_scope,
                                 "config_path": runtime_artifact.config_path,
                                 "launch_target": _runtime_request_summary(runtime_artifact),
+                                "risk_summary": risk_summary,
                                 "action_envelope_json": _action_envelope_json(action_envelope),
-                                "decision_v2_json": decision_v2.to_dict(),
+                                "decision_v2_json": decision_v2_payload,
                                 "scanner_evidence": scanner_evidence_payload,
+                                "supply_chain_evaluation": package_evaluation.to_dict()
+                                if package_evaluation is not None
+                                else None,
                             }
                         ]
                     }

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2621,7 +2621,10 @@ def run_guard_command(
             )
             base_decision_signals = data_flow_signals or artifact_risk_signals_v2(runtime_artifact)
             scanner_decision_signals = tuple(cisco_risk_signal_v3_to_v2(signal) for signal in scanner_evidence)
-            decision_signals = (*base_decision_signals, *scanner_decision_signals)
+            if scanner_raised_to_block and scanner_decision_signals:
+                decision_signals = (*scanner_decision_signals, *base_decision_signals)
+            else:
+                decision_signals = (*base_decision_signals, *scanner_decision_signals)
             scanner_risk_signals = [signal.plain_language_summary for signal in scanner_evidence]
             if data_flow_signals:
                 risk_signals = [signal.plain_reason for signal in data_flow_signals]
@@ -2651,7 +2654,7 @@ def run_guard_command(
                     risk_summary = scanner_risk_signals[0]
             decision_v2 = build_decision_v2(policy_action, reason=policy_action, signals=decision_signals)
             decision_v2_payload = decision_v2.to_dict()
-            if package_evaluation is not None:
+            if package_evaluation is not None and package_evaluation.policy_action == policy_action:
                 decision_v2_payload["user_title"] = package_evaluation.user_copy.title
                 decision_v2_payload["user_body"] = package_evaluation.user_copy.summary
                 decision_v2_payload["harness_message"] = package_evaluation.user_copy.harness_message
@@ -2782,25 +2785,6 @@ def run_guard_command(
                         policy_action=policy_action,
                     )
                     return 0
-                if (
-                    runtime_artifact.artifact_type == "package_request"
-                    and policy_action == "block"
-                    and _should_emit_native_hook_exit_block(args, event_name=event_name, policy_action=policy_action)
-                ):
-                    _emit_native_hook_block_stderr(
-                        _native_hook_reason_for_harness(
-                            args.harness,
-                            native_reason,
-                            _native_approval_center_context(response_payload, harness=args.harness),
-                        )
-                    )
-                    _record_harness_usage_for_hook(
-                        store=store,
-                        action_envelope=action_envelope,
-                        payload=payload,
-                        policy_action=policy_action,
-                    )
-                    return 2
                 if not _prompt_requires_hard_block(runtime_artifact):
                     approval_flow = get_adapter(args.harness).approval_flow(managed_install=managed_install)
                     approval_center_url = ensure_guard_daemon(guard_home)

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -828,7 +828,7 @@ def _transitive_lockfile_results(
             continue
         try:
             lockfile_text = lockfile_path.read_text(encoding="utf-8")
-        except UnicodeDecodeError:
+        except (OSError, UnicodeDecodeError):
             continue
         dependency_map = _safe_dependency_map_for_path(
             str(lockfile_path.name),

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -11,6 +11,7 @@ import urllib.request
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
+from xml.etree import ElementTree as ET
 
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
@@ -18,7 +19,7 @@ from packaging.version import InvalidVersion, Version
 from ..models import GuardArtifact
 from ..store import GuardStore
 from ..store_evidence import EvidenceRecord
-from .package_manifest_diff import _dependency_map_for_path
+from .package_manifest_diff import _DeadlineExceededError, _dependency_map_for_path
 from .runner import (
     _guard_sync_headers,
     _normalized_receipts_sync_url,
@@ -683,8 +684,10 @@ def _targets_from_artifact(artifact: GuardArtifact) -> tuple[dict[str, object], 
         exact_version = _exact_version(requested)
         raw_spec = _optional_string(item.get("raw_spec")) or package_name
         source_url = _optional_string(item.get("source_url"))
-        if source_url is None and ("://" in raw_spec or raw_spec.startswith("git+")):
-            source_url = raw_spec.split("@", 1)[1] if "@" in raw_spec else raw_spec
+        if source_url is None:
+            source_url = _source_url_from_specifier(requested)
+        if source_url is None:
+            source_url = _source_url_from_raw_spec(raw_spec)
         parsed.append(
             {
                 "ecosystem": str(item.get("ecosystem") or "npm"),
@@ -777,7 +780,9 @@ def _lockfile_context(workspace_dir: Path | None, artifact: GuardArtifact) -> di
     if not lockfile_path.exists():
         return None
     lockfile_text = lockfile_path.read_text(encoding="utf-8")
-    dependencies = _dependency_map_for_path(str(lockfile_path.name), lockfile_text, deadline=time.monotonic() + 0.2)
+    dependencies = _safe_dependency_map_for_path(
+        str(lockfile_path.name), lockfile_text, deadline=time.monotonic() + 0.2
+    )
     manifest_hashes = _hash_paths(workspace_dir, artifact.metadata.get("manifest_paths"))
     return {
         "dependencyCount": len(dependencies),
@@ -801,7 +806,7 @@ def _transitive_lockfile_results(
         lockfile_path = workspace_dir / str(relative_path)
         if not lockfile_path.exists():
             continue
-        dependency_map = _dependency_map_for_path(
+        dependency_map = _safe_dependency_map_for_path(
             str(lockfile_path.name),
             lockfile_path.read_text(encoding="utf-8"),
             deadline=time.monotonic() + 0.2,
@@ -927,6 +932,44 @@ def _unknown_package_result(target: dict[str, object]) -> dict[str, object]:
             },
         ),
     }
+
+
+def _source_url_from_specifier(specifier: str | None) -> str | None:
+    if specifier is None:
+        return None
+    if "://" in specifier or specifier.startswith("git+"):
+        return specifier
+    return None
+
+
+def _source_url_from_raw_spec(raw_spec: str) -> str | None:
+    if raw_spec.startswith("@") and "@" in raw_spec[1:]:
+        candidate = raw_spec.rsplit("@", 1)[-1]
+    elif (
+        "@" in raw_spec
+        and not raw_spec.startswith("http://")
+        and not raw_spec.startswith("https://")
+        and not raw_spec.startswith("git+")
+    ):
+        candidate = raw_spec.split("@", 1)[1]
+    else:
+        candidate = raw_spec
+    if "://" in candidate or candidate.startswith("git+"):
+        return candidate
+    return None
+
+
+def _safe_dependency_map_for_path(path: str, text: str, *, deadline: float) -> dict[str, str]:
+    try:
+        return _dependency_map_for_path(path, text, deadline=deadline)
+    except (
+        _DeadlineExceededError,
+        ET.ParseError,
+        UnicodeDecodeError,
+        ValueError,
+        json.JSONDecodeError,
+    ):
+        return {}
 
 
 def _matching_policy_rule(

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -814,7 +814,7 @@ def _lockfile_context(workspace_dir: Path | None, artifact: GuardArtifact) -> di
 
 
 def _transitive_lockfile_results(
-    *, bundle_response, artifact: GuardArtifact, workspace_dir: Path | None
+    *, bundle_response: SupplyChainBundleResponse, artifact: GuardArtifact, workspace_dir: Path | None
 ) -> list[dict[str, object]]:
     if workspace_dir is None:
         return []

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -25,7 +25,11 @@ from .runner import (
     _normalized_receipts_sync_url,
     _urlopen_json_with_timeout_retry,
 )
-from .supply_chain_bundle import evaluate_cached_supply_chain_bundle, load_supply_chain_bundle_response
+from .supply_chain_bundle import (
+    SupplyChainBundleMalformedError,
+    evaluate_cached_supply_chain_bundle,
+    load_supply_chain_bundle_response,
+)
 from .supply_chain_bundle_models import (
     SupplyChainBundlePackage,
     SupplyChainBundlePolicyRule,
@@ -156,8 +160,15 @@ def evaluate_package_request_artifact(
     package_intent_hash = artifact.artifact_id.rsplit(":", 1)[-1]
     workspace_id = store.get_cloud_workspace_id()
     bundle_payload = store.get_cached_supply_chain_bundle(workspace_id) if workspace_id is not None else None
-    bundle_response = load_supply_chain_bundle_response(bundle_payload) if isinstance(bundle_payload, dict) else None
-    bundle_meta = _bundle_meta(bundle_payload) if isinstance(bundle_payload, dict) else None
+    bundle_response: SupplyChainBundleResponse | None = None
+    bundle_meta: dict[str, str] | None = None
+    if isinstance(bundle_payload, dict):
+        try:
+            bundle_response = load_supply_chain_bundle_response(bundle_payload)
+            bundle_meta = _bundle_meta(bundle_payload)
+        except (AssertionError, KeyError, SupplyChainBundleMalformedError, TypeError, ValueError):
+            bundle_response = None
+            bundle_meta = None
     workspace_fingerprint = (
         _workspace_fingerprint(workspace_id, workspace_dir=workspace_dir, artifact=artifact, bundle_meta=bundle_meta)
         if workspace_id is not None

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -26,6 +26,7 @@ from .runner import (
     _urlopen_json_with_timeout_retry,
 )
 from .supply_chain_bundle import evaluate_cached_supply_chain_bundle, load_supply_chain_bundle_response
+from .supply_chain_bundle_models import SupplyChainBundlePackage
 
 _DECISION_RANK = {"allow": 0, "monitor": 1, "warn": 2, "ask": 3, "block": 4}
 _SEVERITY_RANK = {"unknown": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
@@ -590,7 +591,7 @@ def _heuristic_result(*, artifact: GuardArtifact, targets: tuple[dict[str, objec
     packages: list[dict[str, object]] = []
     for target in targets:
         source_url = _optional_string(target.get("source_url"))
-        if source_url is not None and source_url.startswith("http://"):
+        if source_url is not None and source_url.lower().startswith("http://"):
             packages.append(
                 {
                     "decision": "block",
@@ -779,7 +780,10 @@ def _lockfile_context(workspace_dir: Path | None, artifact: GuardArtifact) -> di
     lockfile_path = workspace_dir / str(lockfile_paths[0])
     if not lockfile_path.exists():
         return None
-    lockfile_text = lockfile_path.read_text(encoding="utf-8")
+    try:
+        lockfile_text = lockfile_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return None
     dependencies = _safe_dependency_map_for_path(
         str(lockfile_path.name), lockfile_text, deadline=time.monotonic() + 0.2
     )
@@ -806,9 +810,13 @@ def _transitive_lockfile_results(
         lockfile_path = workspace_dir / str(relative_path)
         if not lockfile_path.exists():
             continue
+        try:
+            lockfile_text = lockfile_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
         dependency_map = _safe_dependency_map_for_path(
             str(lockfile_path.name),
-            lockfile_path.read_text(encoding="utf-8"),
+            lockfile_text,
             deadline=time.monotonic() + 0.2,
         )
         for dependency_path, version in dependency_map.items():
@@ -850,7 +858,12 @@ def _transitive_lockfile_results(
 
 
 def _bundle_package_result(
-    *, target: dict[str, object], package, decision: str, reason: str, stale: bool
+    *,
+    target: dict[str, object],
+    package: SupplyChainBundlePackage,
+    decision: str,
+    reason: str,
+    stale: bool,
 ) -> dict[str, object]:
     severity = package.normalized_severity if stale is False else "unknown"
     return {
@@ -1015,7 +1028,7 @@ def _matching_policy_rule(
         if rule.severity_threshold is not None:
             if package_severity is None:
                 continue
-            if _SEVERITY_RANK[package_severity] < _SEVERITY_RANK[rule.severity_threshold]:
+            if _severity_rank_value(package_severity) < _severity_rank_value(rule.severity_threshold):
                 continue
         return rule
     return None
@@ -1036,7 +1049,12 @@ def _selector_matches_version(selector: str, target: dict[str, object]) -> bool:
         return False
 
 
-def _bundle_package(bundle_response, *, package_name: str, package_version: str):
+def _bundle_package(
+    bundle_response,
+    *,
+    package_name: str,
+    package_version: str,
+) -> SupplyChainBundlePackage | None:
     normalized = package_name.lower()
     for item in bundle_response.bundle.packages:
         full_name = f"{item.namespace}/{item.name}".lower() if item.namespace is not None else item.name.lower()
@@ -1045,6 +1063,10 @@ def _bundle_package(bundle_response, *, package_name: str, package_version: str)
         if item.version == package_version:
             return item
     return None
+
+
+def _severity_rank_value(value: str) -> int:
+    return _SEVERITY_RANK.get(value.strip().lower(), _SEVERITY_RANK["unknown"])
 
 
 def _normalize_bundle_action(value: str) -> str:

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -798,7 +798,7 @@ def _lockfile_context(workspace_dir: Path | None, artifact: GuardArtifact) -> di
         return None
     try:
         lockfile_text = lockfile_path.read_text(encoding="utf-8")
-    except UnicodeDecodeError:
+    except (OSError, UnicodeDecodeError):
         return None
     dependencies = _safe_dependency_map_for_path(
         str(lockfile_path.name), lockfile_text, deadline=time.monotonic() + 0.2
@@ -902,7 +902,7 @@ def _bundle_package_result(
             {
                 "advisoryId": package.related_advisory_ids[0] if package.related_advisory_ids else None,
                 "code": reason,
-                "message": _bundle_reason_message(package, reason=reason, stale=stale),
+                "message": _bundle_reason_message(package, decision=decision, reason=reason, stale=stale),
                 "severity": severity,
                 "source": "bundle",
             },
@@ -1250,11 +1250,18 @@ def _cloud_fallback_reason(*, code: str, message: str) -> dict[str, object]:
 def _bundle_reason_message(
     package: SupplyChainBundlePackage,
     *,
+    decision: str,
     reason: str,
     stale: bool,
 ) -> str:
     package_label = f"{package.name}@{package.version}"
     if stale:
+        if decision == "block":
+            return f"Cached bundle is stale, but Guard still blocked {package_label} from advisory intelligence."
+        if decision == "ask":
+            return f"Cached bundle is stale, so Guard still requires approval for {package_label}."
+        if decision == "warn":
+            return f"Cached bundle is stale, so Guard still warns on {package_label}."
         return f"Cached bundle is stale, so Guard kept {package_label} in monitor mode."
     if reason == "known_malware_or_kev":
         return f"Cached bundle flagged {package_label} from advisory intelligence."

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -1,0 +1,1152 @@
+"""Local package-request evaluation for HOL Guard supply-chain protection."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from pathlib import Path
+
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import InvalidVersion, Version
+
+from ..models import GuardArtifact
+from ..store import GuardStore
+from ..store_evidence import EvidenceRecord
+from .package_manifest_diff import _dependency_map_for_path
+from .runner import (
+    _guard_sync_headers,
+    _normalized_receipts_sync_url,
+    _urlopen_json_with_timeout_retry,
+)
+from .supply_chain_bundle import evaluate_cached_supply_chain_bundle, load_supply_chain_bundle_response
+
+_DECISION_RANK = {"allow": 0, "monitor": 1, "warn": 2, "ask": 3, "block": 4}
+_SEVERITY_RANK = {"unknown": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
+_TIMEOUT_SECONDS = 1
+_RETRY_TIMEOUT_SECONDS = 1
+_CLOUD_DASHBOARD_URL = "https://hol.org/guard/inbox"
+
+
+@dataclass(frozen=True, slots=True)
+class SupplyChainUserCopy:
+    title: str
+    summary: str
+    next_step: str | None
+    dashboard_url: str | None
+    harness_message: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "title": self.title,
+            "summary": self.summary,
+            "next_step": self.next_step,
+            "dashboard_url": self.dashboard_url,
+            "harness_message": self.harness_message,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PackageRequestEvaluation:
+    decision: str
+    policy_action: str
+    enforcement: str
+    entitlement_state: str
+    cache_status: str
+    package_intent_hash: str
+    policy_version: str
+    bundle_version: str | None
+    workspace_fingerprint: str | None
+    reasons: tuple[dict[str, object], ...]
+    packages: tuple[dict[str, object], ...]
+    risk_summary: str
+    user_copy: SupplyChainUserCopy
+    matched_rule_id: str | None = None
+    exception_id: str | None = None
+    refresh_required: bool = False
+    record_monitor_evidence: bool = False
+    evidence_ids: tuple[str, ...] = ()
+
+    def to_cache_dict(self) -> dict[str, object]:
+        return {
+            "decision": self.decision,
+            "policy_action": self.policy_action,
+            "enforcement": self.enforcement,
+            "entitlement_state": self.entitlement_state,
+            "cache_status": self.cache_status,
+            "workspace_fingerprint": self.workspace_fingerprint,
+            "reasons": list(self.reasons),
+            "packages": list(self.packages),
+            "matched_rule_id": self.matched_rule_id,
+            "exception_id": self.exception_id,
+            "risk_summary": self.risk_summary,
+            "record_monitor_evidence": self.record_monitor_evidence,
+            "user_copy": self.user_copy.to_dict(),
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        payload = self.to_cache_dict()
+        payload["package_intent_hash"] = self.package_intent_hash
+        payload["policy_version"] = self.policy_version
+        payload["bundle_version"] = self.bundle_version
+        payload["workspace_fingerprint"] = self.workspace_fingerprint
+        payload["refresh_required"] = self.refresh_required
+        payload["evidence_ids"] = list(self.evidence_ids)
+        return payload
+
+    @classmethod
+    def from_cache_dict(
+        cls,
+        payload: dict[str, object],
+        *,
+        package_intent_hash: str,
+        policy_version: str,
+        bundle_version: str | None,
+        workspace_fingerprint: str | None,
+    ) -> PackageRequestEvaluation:
+        user_copy = payload.get("user_copy")
+        user_copy_map = user_copy if isinstance(user_copy, dict) else {}
+        return cls(
+            decision=str(payload.get("decision") or "monitor"),
+            policy_action=str(payload.get("policy_action") or "allow"),
+            enforcement=str(payload.get("enforcement") or "offline_cached"),
+            entitlement_state=str(payload.get("entitlement_state") or "premium"),
+            cache_status=str(payload.get("cache_status") or "hit"),
+            package_intent_hash=package_intent_hash,
+            policy_version=policy_version,
+            bundle_version=bundle_version,
+            workspace_fingerprint=workspace_fingerprint,
+            reasons=tuple(item for item in payload.get("reasons", []) if isinstance(item, dict)),
+            packages=tuple(item for item in payload.get("packages", []) if isinstance(item, dict)),
+            risk_summary=str(payload.get("risk_summary") or "HOL Guard recorded this package request."),
+            user_copy=SupplyChainUserCopy(
+                title=str(user_copy_map.get("title") or "Monitoring this package"),
+                summary=str(user_copy_map.get("summary") or "HOL Guard recorded this package request."),
+                next_step=_optional_string(user_copy_map.get("next_step")),
+                dashboard_url=_optional_string(user_copy_map.get("dashboard_url")),
+                harness_message=str(user_copy_map.get("harness_message") or payload.get("risk_summary") or ""),
+            ),
+            matched_rule_id=_optional_string(payload.get("matched_rule_id")),
+            exception_id=_optional_string(payload.get("exception_id")),
+            refresh_required=bool(payload.get("refresh_required")),
+            record_monitor_evidence=bool(payload.get("record_monitor_evidence")),
+        )
+
+
+def evaluate_package_request_artifact(
+    *,
+    artifact: GuardArtifact,
+    store: GuardStore,
+    workspace_dir: Path | None,
+    now: str | None = None,
+) -> PackageRequestEvaluation:
+    now_value = now or datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    targets = _targets_from_artifact(artifact)
+    package_intent_hash = artifact.artifact_id.rsplit(":", 1)[-1]
+    workspace_id = store.get_cloud_workspace_id()
+    bundle_payload = store.get_cached_supply_chain_bundle(workspace_id) if workspace_id is not None else None
+    bundle_response = load_supply_chain_bundle_response(bundle_payload) if isinstance(bundle_payload, dict) else None
+    bundle_meta = _bundle_meta(bundle_payload) if isinstance(bundle_payload, dict) else None
+    workspace_fingerprint = (
+        _workspace_fingerprint(workspace_id, workspace_dir=workspace_dir, artifact=artifact, bundle_meta=bundle_meta)
+        if workspace_id is not None
+        else None
+    )
+    if workspace_id is not None and bundle_meta is not None:
+        cached = store.get_cached_supply_chain_evaluation(
+            workspace_id=workspace_id,
+            package_intent_hash=package_intent_hash,
+            feed_snapshot_hash=bundle_meta["feed_snapshot_hash"],
+            policy_hash=bundle_meta["policy_hash"],
+            scoring_version=bundle_meta["scoring_version"],
+            bundle_version=bundle_meta["bundle_version"],
+        )
+        if isinstance(cached, dict):
+            cached_workspace_fingerprint = _optional_string(cached.get("workspace_fingerprint"))
+            if cached_workspace_fingerprint == workspace_fingerprint:
+                cached_result = PackageRequestEvaluation.from_cache_dict(
+                    cached,
+                    package_intent_hash=package_intent_hash,
+                    policy_version=bundle_meta["policy_hash"],
+                    bundle_version=bundle_meta["bundle_version"],
+                    workspace_fingerprint=workspace_fingerprint,
+                )
+                _persist_evidence(store=store, artifact=artifact, evaluation=cached_result, now=now_value)
+                return cached_result
+    bundle_evaluation = (
+        _evaluate_with_bundle(
+            artifact=artifact,
+            targets=targets,
+            bundle_response=bundle_response,
+            workspace_dir=workspace_dir,
+            workspace_id=workspace_id,
+        )
+        if bundle_response is not None
+        else None
+    )
+    if bundle_evaluation is not None and bundle_meta is not None and bundle_evaluation.decision != "monitor":
+        result = _finalize_evaluation(
+            bundle_evaluation, package_intent_hash=package_intent_hash, workspace_fingerprint=workspace_fingerprint
+        )
+        store.cache_supply_chain_evaluation(
+            workspace_id=workspace_id or bundle_payload["bundle"]["workspaceId"],
+            package_intent_hash=package_intent_hash,
+            feed_snapshot_hash=bundle_meta["feed_snapshot_hash"],
+            policy_hash=bundle_meta["policy_hash"],
+            scoring_version=bundle_meta["scoring_version"],
+            bundle_version=bundle_meta["bundle_version"],
+            decision=result.to_cache_dict(),
+            now=now_value,
+        )
+        _persist_evidence(store=store, artifact=artifact, evaluation=result, now=now_value)
+        if result.refresh_required:
+            store.add_event("supply_chain_bundle_refresh_requested", {"artifact_id": artifact.artifact_id}, now_value)
+        return result
+    if bundle_evaluation is not None and bundle_evaluation.refresh_required:
+        fallback = _finalize_evaluation(
+            bundle_evaluation,
+            package_intent_hash=package_intent_hash,
+            workspace_fingerprint=workspace_fingerprint,
+        )
+        _persist_evidence(store=store, artifact=artifact, evaluation=fallback, now=now_value)
+        store.add_event("supply_chain_bundle_refresh_requested", {"artifact_id": artifact.artifact_id}, now_value)
+        return fallback
+    cloud_result, cloud_timed_out = _evaluate_with_cloud(
+        artifact=artifact,
+        targets=targets,
+        workspace_dir=workspace_dir,
+        workspace_id=workspace_id,
+        workspace_fingerprint=workspace_fingerprint,
+        bundle_meta=bundle_meta,
+        store=store,
+    )
+    if cloud_result is not None:
+        upgraded = cloud_result
+        if cloud_result.enforcement == "upgrade_required":
+            heuristic = _heuristic_result(artifact=artifact, targets=targets)
+            if heuristic is not None and _decision_rank(heuristic.decision) > _decision_rank(cloud_result.decision):
+                upgraded = _finalize_evaluation(
+                    _EvaluationDraft(
+                        decision=heuristic.decision,
+                        enforcement="free_local",
+                        entitlement_state="free",
+                        cache_status="upgrade-gated",
+                        packages=heuristic.packages,
+                        reasons=heuristic.reasons,
+                        matched_rule_id=heuristic.matched_rule_id,
+                        exception_id=heuristic.exception_id,
+                        refresh_required=False,
+                        record_monitor_evidence=heuristic.record_monitor_evidence,
+                        bundle_version=None,
+                        policy_version=bundle_meta["policy_hash"] if bundle_meta is not None else "local:none",
+                    ),
+                    package_intent_hash=package_intent_hash,
+                    workspace_fingerprint=workspace_fingerprint,
+                )
+        _persist_evidence(store=store, artifact=artifact, evaluation=upgraded, now=now_value)
+        return upgraded
+    if bundle_evaluation is not None:
+        fallback = _finalize_evaluation(
+            bundle_evaluation, package_intent_hash=package_intent_hash, workspace_fingerprint=workspace_fingerprint
+        )
+        if cloud_timed_out:
+            fallback = _with_additional_reason(
+                fallback,
+                {
+                    "code": "cloud_timeout",
+                    "message": "Guard cloud evaluation timed out, so Guard fell back to local intelligence.",
+                    "severity": "unknown",
+                    "source": "guard-cloud",
+                },
+            )
+        _persist_evidence(store=store, artifact=artifact, evaluation=fallback, now=now_value)
+        if fallback.refresh_required:
+            store.add_event("supply_chain_bundle_refresh_requested", {"artifact_id": artifact.artifact_id}, now_value)
+        return fallback
+    heuristic = _heuristic_result(artifact=artifact, targets=targets)
+    if heuristic is None:
+        heuristic = _EvaluationDraft(
+            decision="monitor",
+            enforcement="free_local" if workspace_id is None else "local_fallback",
+            entitlement_state="free" if workspace_id is None else "premium",
+            cache_status="miss",
+            packages=tuple(_unknown_package_result(target) for target in targets),
+            reasons=(
+                {
+                    "code": "no_cached_match",
+                    "message": "Guard recorded this package request and will keep watching for new intelligence.",
+                    "severity": "unknown",
+                    "source": "guard-local",
+                },
+            ),
+            matched_rule_id=None,
+            exception_id=None,
+            refresh_required=False,
+            record_monitor_evidence=True,
+            bundle_version=None,
+            policy_version=bundle_meta["policy_hash"] if bundle_meta is not None else "local:none",
+        )
+    result = _finalize_evaluation(
+        heuristic, package_intent_hash=package_intent_hash, workspace_fingerprint=workspace_fingerprint
+    )
+    if cloud_timed_out:
+        result = _with_additional_reason(
+            result,
+            {
+                "code": "cloud_timeout",
+                "message": "Guard cloud evaluation timed out, so Guard fell back to local intelligence.",
+                "severity": "unknown",
+                "source": "guard-cloud",
+            },
+        )
+    _persist_evidence(store=store, artifact=artifact, evaluation=result, now=now_value)
+    return result
+
+
+@dataclass(frozen=True, slots=True)
+class _EvaluationDraft:
+    decision: str
+    enforcement: str
+    entitlement_state: str
+    cache_status: str
+    packages: tuple[dict[str, object], ...]
+    reasons: tuple[dict[str, object], ...]
+    matched_rule_id: str | None
+    exception_id: str | None
+    refresh_required: bool
+    record_monitor_evidence: bool
+    bundle_version: str | None
+    policy_version: str
+
+
+def _finalize_evaluation(
+    draft: _EvaluationDraft,
+    *,
+    package_intent_hash: str,
+    workspace_fingerprint: str | None,
+) -> PackageRequestEvaluation:
+    primary_package = draft.packages[0] if draft.packages else {}
+    package_display = _package_display_name(primary_package)
+    requested_version = _optional_string(primary_package.get("requestedVersion")) or _optional_string(
+        primary_package.get("resolvedVersion")
+    )
+    package_ref = f"{package_display}@{requested_version}" if requested_version else package_display
+    prefix = {
+        "block": "HOL Guard blocked",
+        "ask": "HOL Guard paused",
+        "warn": "HOL Guard found risk signals for",
+    }.get(draft.decision, "HOL Guard recorded")
+    risk_summary = {
+        "block": f"{prefix} `{package_ref}` before install.",
+        "ask": f"{prefix} `{package_ref}` for review before install.",
+        "warn": f"{prefix} `{package_ref}` before install.",
+        "monitor": f"{prefix} `{package_ref}` for continued monitoring.",
+        "allow": f"{prefix} `{package_ref}` as trusted by policy.",
+    }[draft.decision]
+    reason_message = _optional_string(draft.reasons[0].get("message")) if draft.reasons else None
+    fix_command = _fix_command(primary_package)
+    title = {
+        "block": "Critical install blocked",
+        "ask": "Review required",
+        "warn": "Proceed with caution",
+        "monitor": "Monitoring this package",
+        "allow": "Allowed by policy",
+    }[draft.decision]
+    summary = (
+        reason_message
+        or {
+            "block": f"{package_display} needs a safer version before you continue.",
+            "ask": f"{package_display} needs a human review before Guard allows it.",
+            "warn": f"Guard found risk signals for {package_display}. Proceed with caution.",
+            "monitor": "Guard recorded the package intent and will keep watching for new intelligence.",
+            "allow": "Guard matched a scoped allow rule for this package request.",
+        }[draft.decision]
+    )
+    if len(draft.packages) > 1:
+        others = ", ".join(_package_display_name(item) for item in draft.packages[1:3])
+        if others:
+            summary = f"{summary} Also flagged: {others}."
+    harness_parts = [risk_summary]
+    if reason_message:
+        harness_parts.append(f"Reason: {reason_message}.")
+    if fix_command:
+        harness_parts.append(f"Fix: install `{fix_command}` or choose a team exception.")
+    harness_parts.append(f"Review evidence: {_CLOUD_DASHBOARD_URL}.")
+    user_copy = SupplyChainUserCopy(
+        title=title,
+        summary=summary,
+        next_step=fix_command,
+        dashboard_url=_CLOUD_DASHBOARD_URL,
+        harness_message=" ".join(part.strip() for part in harness_parts if part.strip()),
+    )
+    return PackageRequestEvaluation(
+        decision=draft.decision,
+        policy_action={
+            "allow": "allow",
+            "monitor": "allow",
+            "warn": "warn",
+            "ask": "require-reapproval",
+            "block": "block",
+        }[draft.decision],
+        enforcement=draft.enforcement,
+        entitlement_state=draft.entitlement_state,
+        cache_status=draft.cache_status,
+        package_intent_hash=package_intent_hash,
+        policy_version=draft.policy_version,
+        bundle_version=draft.bundle_version,
+        workspace_fingerprint=workspace_fingerprint,
+        reasons=draft.reasons,
+        packages=draft.packages,
+        risk_summary=risk_summary,
+        user_copy=user_copy,
+        matched_rule_id=draft.matched_rule_id,
+        exception_id=draft.exception_id,
+        refresh_required=draft.refresh_required,
+        record_monitor_evidence=draft.record_monitor_evidence,
+        evidence_ids=tuple(
+            _evidence_id(package_intent_hash, item)
+            for item in draft.packages
+            if _should_record_package(item, draft.decision)
+        ),
+    )
+
+
+def _evaluate_with_cloud(
+    *,
+    artifact: GuardArtifact,
+    targets: tuple[dict[str, object], ...],
+    workspace_dir: Path | None,
+    workspace_id: str | None,
+    workspace_fingerprint: str | None,
+    bundle_meta: dict[str, str] | None,
+    store: GuardStore,
+) -> tuple[PackageRequestEvaluation | None, bool]:
+    if workspace_id is None or workspace_fingerprint is None:
+        return None, False
+    sync_credentials = store.get_sync_credentials()
+    if sync_credentials is None:
+        return None, False
+    request_payload = _build_request_payload(
+        artifact=artifact,
+        targets=targets,
+        workspace_dir=workspace_dir,
+        workspace_fingerprint=workspace_fingerprint,
+        policy_version=bundle_meta["policy_hash"] if bundle_meta is not None else "local:none",
+    )
+    request = urllib.request.Request(
+        _normalized_supply_chain_evaluate_url(sync_credentials["sync_url"], workspace_id),
+        data=json.dumps(request_payload).encode("utf-8"),
+        headers=_guard_sync_headers(sync_credentials["token"]),
+        method="POST",
+    )
+    try:
+        response_payload = _urlopen_json_with_timeout_retry(
+            request=request,
+            timeout_seconds=_TIMEOUT_SECONDS,
+            retry_timeout_seconds=_RETRY_TIMEOUT_SECONDS,
+        )
+    except urllib.error.HTTPError as error:
+        if error.code in {429, 500, 502, 503, 504}:
+            return None, True
+        raise
+    except OSError:
+        return None, True
+    if not isinstance(response_payload.get("packages"), list):
+        return None, False
+    packages = tuple(
+        _package_from_cloud_result(item) for item in response_payload["packages"] if isinstance(item, dict)
+    )
+    reasons = tuple(item for item in response_payload.get("reasons", []) if isinstance(item, dict))
+    draft = _EvaluationDraft(
+        decision=str(response_payload.get("decision") or "monitor"),
+        enforcement=str(response_payload.get("enforcement") or "premium_cloud"),
+        entitlement_state=str(response_payload.get("entitlementState") or "premium"),
+        cache_status=str(response_payload.get("cacheStatus") or "miss"),
+        packages=packages,
+        reasons=reasons,
+        matched_rule_id=None,
+        exception_id=None,
+        refresh_required=False,
+        record_monitor_evidence=str(response_payload.get("decision")) == "monitor",
+        bundle_version=bundle_meta["bundle_version"] if bundle_meta is not None else None,
+        policy_version=str(
+            response_payload.get("policyVersion")
+            or (bundle_meta["policy_hash"] if bundle_meta is not None else "local:none")
+        ),
+    )
+    evaluation = _finalize_evaluation(
+        draft,
+        package_intent_hash=artifact.artifact_id.rsplit(":", 1)[-1],
+        workspace_fingerprint=workspace_fingerprint,
+    )
+    copy_payload = response_payload.get("copy")
+    if isinstance(copy_payload, dict):
+        title = _optional_string(copy_payload.get("title"))
+        summary = _optional_string(copy_payload.get("summary"))
+        if title is not None or summary is not None:
+            updated_summary = summary or evaluation.user_copy.summary
+            harness_parts = [evaluation.risk_summary, updated_summary]
+            if evaluation.user_copy.next_step:
+                harness_parts.append(f"Fix: run `{evaluation.user_copy.next_step}`.")
+            harness_parts.append(f"Review evidence: {_CLOUD_DASHBOARD_URL}.")
+            evaluation = replace(
+                evaluation,
+                user_copy=SupplyChainUserCopy(
+                    title=title or evaluation.user_copy.title,
+                    summary=updated_summary,
+                    next_step=evaluation.user_copy.next_step,
+                    dashboard_url=evaluation.user_copy.dashboard_url,
+                    harness_message=" ".join(harness_parts),
+                ),
+            )
+    return evaluation, False
+
+
+def _evaluate_with_bundle(
+    *,
+    artifact: GuardArtifact,
+    targets: tuple[dict[str, object], ...],
+    bundle_response,
+    workspace_dir: Path | None,
+    workspace_id: str | None,
+) -> _EvaluationDraft | None:
+    bundle_meta = _bundle_meta(bundle_response.to_dict())
+    refresh_required = False
+    packages: list[dict[str, object]] = []
+    best_rule_id: str | None = None
+    exception_id: str | None = None
+    for target in targets:
+        exact_version = _exact_version(_optional_string(target.get("version")) or _optional_string(target.get("range")))
+        package_match = (
+            _bundle_package(
+                bundle_response,
+                package_name=str(target["normalized_name"]),
+                package_version=exact_version,
+            )
+            if exact_version is not None
+            else None
+        )
+        matched_rule = _matching_policy_rule(
+            bundle_response.bundle.policy_rules,
+            target=target,
+            harness=artifact.harness,
+            package_severity=package_match.normalized_severity if package_match is not None else None,
+        )
+        if matched_rule is not None:
+            decision = _normalize_bundle_action(matched_rule.action)
+            package = _policy_package_result(target, decision=decision, rule_id=matched_rule.rule_id)
+            packages.append(package)
+            best_rule_id = matched_rule.rule_id
+            if decision == "allow":
+                exception_id = matched_rule.rule_id
+            continue
+        if exact_version is None:
+            continue
+        offline = evaluate_cached_supply_chain_bundle(
+            bundle_response,
+            package_name=str(target["normalized_name"]),
+            package_version=exact_version,
+        )
+        if package_match is None:
+            continue
+        refresh_required = refresh_required or offline.stale
+        package = _bundle_package_result(
+            target=target,
+            package=package_match,
+            decision=_normalize_bundle_action(offline.action),
+            reason=offline.reason,
+            stale=offline.stale,
+        )
+        packages.append(package)
+    packages.extend(
+        _transitive_lockfile_results(bundle_response=bundle_response, artifact=artifact, workspace_dir=workspace_dir)
+    )
+    if not packages:
+        return None
+    packages.sort(key=lambda item: _decision_rank(str(item.get("decision") or "monitor")), reverse=True)
+    decision = str(packages[0].get("decision") or "monitor")
+    return _EvaluationDraft(
+        decision=decision,
+        enforcement="policy_override" if best_rule_id is not None else "offline_cached",
+        entitlement_state="premium" if workspace_id is not None else "free",
+        cache_status="stale" if refresh_required else "miss",
+        packages=tuple(packages),
+        reasons=tuple(
+            reason for package in packages for reason in package.get("reasons", []) if isinstance(reason, dict)
+        ),
+        matched_rule_id=best_rule_id,
+        exception_id=exception_id,
+        refresh_required=refresh_required,
+        record_monitor_evidence=decision == "monitor",
+        bundle_version=bundle_meta["bundle_version"],
+        policy_version=bundle_meta["policy_hash"],
+    )
+
+
+def _heuristic_result(*, artifact: GuardArtifact, targets: tuple[dict[str, object], ...]) -> _EvaluationDraft | None:
+    packages: list[dict[str, object]] = []
+    for target in targets:
+        source_url = _optional_string(target.get("source_url"))
+        if source_url is not None and source_url.startswith("http://"):
+            packages.append(
+                {
+                    "decision": "block",
+                    "ecosystem": target["ecosystem"],
+                    "name": target["name"],
+                    "namespace": target["namespace"],
+                    "requestedVersion": _optional_string(target.get("range"))
+                    or _optional_string(target.get("version")),
+                    "resolvedVersion": _optional_string(target.get("version")),
+                    "recommendedFixVersion": None,
+                    "riskScore": None,
+                    "dependencyPath": None,
+                    "reasons": (
+                        {
+                            "code": "insecure_source_url",
+                            "message": f"Insecure HTTP package source: {source_url}",
+                            "severity": "high",
+                            "source": "guard-local",
+                        },
+                    ),
+                }
+            )
+    if not packages:
+        return None
+    return _EvaluationDraft(
+        decision="block",
+        enforcement="free_local",
+        entitlement_state="free",
+        cache_status="miss",
+        packages=tuple(packages),
+        reasons=tuple(reason for package in packages for reason in package["reasons"]),
+        matched_rule_id=None,
+        exception_id=None,
+        refresh_required=False,
+        record_monitor_evidence=False,
+        bundle_version=None,
+        policy_version="local:none",
+    )
+
+
+def _persist_evidence(
+    *, store: GuardStore, artifact: GuardArtifact, evaluation: PackageRequestEvaluation, now: str
+) -> None:
+    if evaluation.decision == "allow":
+        return
+    if evaluation.decision == "monitor" and not evaluation.record_monitor_evidence:
+        return
+    for package in evaluation.packages:
+        if not _should_record_package(package, evaluation.decision):
+            continue
+        evidence_id = _evidence_id(evaluation.package_intent_hash, package)
+        store.add_evidence(
+            EvidenceRecord(
+                evidence_id=evidence_id,
+                action_id=artifact.artifact_id,
+                request_id=evaluation.package_intent_hash,
+                harness=artifact.harness,
+                workspace=artifact.source_scope,
+                signal_id=str(package.get("decision") or evaluation.decision),
+                category="supply-chain",
+                severity=_reason_severity(package),
+                confidence=1.0 if evaluation.decision in {"block", "ask"} else 0.6,
+                summary=evaluation.risk_summary,
+                details={
+                    "decision": evaluation.decision,
+                    "enforcement": evaluation.enforcement,
+                    "exception_id": evaluation.exception_id,
+                    "matched_rule_id": evaluation.matched_rule_id,
+                    "package": package,
+                    "reasons": package.get("reasons", []),
+                },
+                action_identity=evaluation.exception_id or evaluation.matched_rule_id,
+                created_at=now,
+            )
+        )
+
+
+def _targets_from_artifact(artifact: GuardArtifact) -> tuple[dict[str, object], ...]:
+    raw_targets = artifact.metadata.get("targets")
+    if not isinstance(raw_targets, list):
+        return ()
+    parsed: list[dict[str, object]] = []
+    for item in raw_targets:
+        if not isinstance(item, dict):
+            continue
+        package_name = _optional_string(item.get("package_name"))
+        if package_name is None:
+            continue
+        namespace, name = _split_namespace_name(package_name)
+        requested = _optional_string(item.get("requested_specifier"))
+        exact_version = _exact_version(requested)
+        raw_spec = _optional_string(item.get("raw_spec")) or package_name
+        source_url = _optional_string(item.get("source_url"))
+        if source_url is None and ("://" in raw_spec or raw_spec.startswith("git+")):
+            source_url = raw_spec.split("@", 1)[1] if "@" in raw_spec else raw_spec
+        parsed.append(
+            {
+                "ecosystem": str(item.get("ecosystem") or "npm"),
+                "package_name": package_name,
+                "normalized_name": package_name.lower(),
+                "namespace": namespace,
+                "name": name,
+                "raw_spec": raw_spec,
+                "version": exact_version,
+                "range": requested if exact_version is None else None,
+                "source_url": source_url,
+            }
+        )
+    return tuple(parsed)
+
+
+def _bundle_meta(bundle_payload: dict[str, object]) -> dict[str, str]:
+    bundle = bundle_payload["bundle"]
+    assert isinstance(bundle, dict)
+    return {
+        "bundle_version": str(bundle["bundleVersion"]),
+        "feed_snapshot_hash": str(bundle["feedSnapshotHash"]),
+        "policy_hash": str(bundle["policyHash"]),
+        "scoring_version": str(bundle["scoringVersion"]),
+    }
+
+
+def _workspace_fingerprint(
+    workspace_id: str,
+    *,
+    workspace_dir: Path | None,
+    artifact: GuardArtifact,
+    bundle_meta: dict[str, str] | None,
+) -> str:
+    manifest_hashes = _hash_paths(workspace_dir, artifact.metadata.get("manifest_paths"))
+    lockfile_hashes = _hash_paths(workspace_dir, artifact.metadata.get("lockfile_paths"))
+    return _stable_hash(
+        {
+            "workspace_id": workspace_id,
+            "workspace_name": workspace_dir.name if workspace_dir is not None else None,
+            "manifest_hashes": manifest_hashes,
+            "lockfile_hashes": lockfile_hashes,
+            "bundle_policy_hash": bundle_meta["policy_hash"] if bundle_meta is not None else None,
+        }
+    )
+
+
+def _build_request_payload(
+    *,
+    artifact: GuardArtifact,
+    targets: tuple[dict[str, object], ...],
+    workspace_dir: Path | None,
+    workspace_fingerprint: str,
+    policy_version: str,
+) -> dict[str, object]:
+    lockfile_context = _lockfile_context(workspace_dir, artifact)
+    return {
+        "commandShape": {
+            "argCount": len(str(artifact.metadata.get("redacted_command") or "").split()),
+            "flags": [item for item in artifact.metadata.get("flags", []) if isinstance(item, str)],
+            "packageManager": str(artifact.metadata.get("package_manager") or "unknown"),
+            "redacted": True,
+            "verb": str(artifact.metadata.get("intent_kind") or "install"),
+        },
+        "harness": artifact.harness,
+        "lockfileContext": lockfile_context,
+        "packages": [
+            {
+                "direct": True,
+                "ecosystem": str(target["ecosystem"]),
+                "name": str(target["name"]),
+                "namespace": target["namespace"],
+                **({"version": str(target["version"])} if target.get("version") else {}),
+                **({"range": str(target["range"])} if target.get("range") else {}),
+            }
+            for target in targets
+        ],
+        "policyVersion": policy_version,
+        "workspaceFingerprint": workspace_fingerprint,
+    }
+
+
+def _lockfile_context(workspace_dir: Path | None, artifact: GuardArtifact) -> dict[str, object] | None:
+    if workspace_dir is None:
+        return None
+    lockfile_paths = artifact.metadata.get("lockfile_paths")
+    if not isinstance(lockfile_paths, list) or not lockfile_paths:
+        return None
+    lockfile_path = workspace_dir / str(lockfile_paths[0])
+    if not lockfile_path.exists():
+        return None
+    lockfile_text = lockfile_path.read_text(encoding="utf-8")
+    dependencies = _dependency_map_for_path(str(lockfile_path.name), lockfile_text, deadline=time.monotonic() + 0.2)
+    manifest_hashes = _hash_paths(workspace_dir, artifact.metadata.get("manifest_paths"))
+    return {
+        "dependencyCount": len(dependencies),
+        "fileName": lockfile_path.name,
+        "lockfileHash": hashlib.sha256(lockfile_text.encode("utf-8")).hexdigest(),
+        "manifestHash": manifest_hashes[0] if manifest_hashes else None,
+        "repository": workspace_dir.name,
+    }
+
+
+def _transitive_lockfile_results(
+    *, bundle_response, artifact: GuardArtifact, workspace_dir: Path | None
+) -> list[dict[str, object]]:
+    if workspace_dir is None:
+        return []
+    lockfile_paths = artifact.metadata.get("lockfile_paths")
+    if not isinstance(lockfile_paths, list):
+        return []
+    results: list[dict[str, object]] = []
+    for relative_path in lockfile_paths:
+        lockfile_path = workspace_dir / str(relative_path)
+        if not lockfile_path.exists():
+            continue
+        dependency_map = _dependency_map_for_path(
+            str(lockfile_path.name),
+            lockfile_path.read_text(encoding="utf-8"),
+            deadline=time.monotonic() + 0.2,
+        )
+        for dependency_path, version in dependency_map.items():
+            if "node_modules/" not in dependency_path:
+                continue
+            package_name = dependency_path.rsplit("node_modules/", 1)[-1]
+            offline = evaluate_cached_supply_chain_bundle(
+                bundle_response, package_name=package_name, package_version=version
+            )
+            if _normalize_bundle_action(offline.action) not in {"ask", "block", "warn"}:
+                continue
+            package_match = _bundle_package(bundle_response, package_name=package_name, package_version=version)
+            if package_match is None:
+                continue
+            results.append(
+                {
+                    "decision": _normalize_bundle_action(offline.action),
+                    "ecosystem": package_match.ecosystem,
+                    "name": package_match.name,
+                    "namespace": package_match.namespace,
+                    "requestedVersion": version,
+                    "resolvedVersion": version,
+                    "recommendedFixVersion": package_match.recommended_fix_version,
+                    "riskScore": package_match.risk_score,
+                    "dependencyPath": dependency_path,
+                    "reasons": (
+                        {
+                            "code": "transitive_lockfile_match",
+                            "message": (
+                                f"Existing lockfile already includes vulnerable dependency path {dependency_path}."
+                            ),
+                            "severity": package_match.normalized_severity,
+                            "source": "lockfile",
+                        },
+                    ),
+                }
+            )
+    return results
+
+
+def _bundle_package_result(
+    *, target: dict[str, object], package, decision: str, reason: str, stale: bool
+) -> dict[str, object]:
+    severity = package.normalized_severity if stale is False else "unknown"
+    return {
+        "decision": decision,
+        "ecosystem": package.ecosystem,
+        "name": package.name,
+        "namespace": package.namespace,
+        "requestedVersion": _optional_string(target.get("version")) or _optional_string(target.get("range")),
+        "resolvedVersion": package.version,
+        "recommendedFixVersion": package.recommended_fix_version,
+        "riskScore": package.risk_score,
+        "dependencyPath": None,
+        "reasons": (
+            {
+                "advisoryId": package.related_advisory_ids[0] if package.related_advisory_ids else None,
+                "code": reason,
+                "message": "Prototype pollution in minimist"
+                if reason == "known_malware_or_kev"
+                else "Cached bundle matched this package version."
+                if reason == "bundle_match"
+                else "Cached bundle is stale, so Guard kept this package in monitor mode.",
+                "severity": severity,
+                "source": "bundle",
+            },
+        ),
+    }
+
+
+def _policy_package_result(target: dict[str, object], *, decision: str, rule_id: str) -> dict[str, object]:
+    return {
+        "decision": decision,
+        "ecosystem": target["ecosystem"],
+        "name": target["name"],
+        "namespace": target["namespace"],
+        "requestedVersion": _optional_string(target.get("version")) or _optional_string(target.get("range")),
+        "resolvedVersion": _optional_string(target.get("version")),
+        "recommendedFixVersion": None,
+        "riskScore": None,
+        "dependencyPath": None,
+        "reasons": (
+            {
+                "code": "policy_override",
+                "message": f"Local synced policy rule {rule_id} matched this package request.",
+                "severity": "low",
+                "source": "policy",
+            },
+        ),
+    }
+
+
+def _package_from_cloud_result(item: dict[str, object]) -> dict[str, object]:
+    return {
+        "decision": str(item.get("decision") or "monitor"),
+        "ecosystem": str(item.get("ecosystem") or "npm"),
+        "name": str(item.get("name") or "unknown"),
+        "namespace": _optional_string(item.get("namespace")),
+        "requestedVersion": _optional_string(item.get("requestedVersion")),
+        "resolvedVersion": _optional_string(item.get("resolvedVersion")),
+        "recommendedFixVersion": _optional_string(item.get("recommendedFixVersion")),
+        "riskScore": item.get("riskScore"),
+        "dependencyPath": None,
+        "reasons": tuple(reason for reason in item.get("reasons", []) if isinstance(reason, dict)),
+    }
+
+
+def _unknown_package_result(target: dict[str, object]) -> dict[str, object]:
+    return {
+        "decision": "monitor",
+        "ecosystem": target["ecosystem"],
+        "name": target["name"],
+        "namespace": target["namespace"],
+        "requestedVersion": _optional_string(target.get("range")) or _optional_string(target.get("version")),
+        "resolvedVersion": _optional_string(target.get("version")),
+        "recommendedFixVersion": None,
+        "riskScore": None,
+        "dependencyPath": None,
+        "reasons": (
+            {
+                "code": "no_cached_match",
+                "message": "Guard recorded this package request and will keep watching for new intelligence.",
+                "severity": "unknown",
+                "source": "guard-local",
+            },
+        ),
+    }
+
+
+def _matching_policy_rule(
+    rules,
+    *,
+    target: dict[str, object],
+    harness: str,
+    package_severity: str | None,
+):
+    current_time = datetime.now(timezone.utc).timestamp()
+    sorted_rules = sorted(
+        rules, key=lambda item: (item.priority if item.priority is not None else 10_000, item.rule_id)
+    )
+    for rule in sorted_rules:
+        if rule.enabled is False:
+            continue
+        if rule.expires_at is not None:
+            try:
+                if datetime.fromisoformat(rule.expires_at.replace("Z", "+00:00")).timestamp() <= current_time:
+                    continue
+            except ValueError:
+                pass
+        if rule.harness_selector is not None and rule.harness_selector != harness:
+            continue
+        if rule.ecosystem_selector is not None and rule.ecosystem_selector != target["ecosystem"]:
+            continue
+        if rule.package_selector is not None:
+            selector = rule.package_selector.strip().lower()
+            candidates = {
+                str(target["normalized_name"]),
+                str(target["name"]).lower(),
+                f"{target['namespace']}/{target['name']}".lower()
+                if target["namespace"] is not None
+                else str(target["name"]).lower(),
+                f"pkg:{target['ecosystem']}/{target['normalized_name']}",
+            }
+            if selector not in candidates:
+                continue
+        if rule.version_range_selector is not None and not _selector_matches_version(
+            rule.version_range_selector, target
+        ):
+            continue
+        if rule.severity_threshold is not None:
+            if package_severity is None:
+                continue
+            if _SEVERITY_RANK[package_severity] < _SEVERITY_RANK[rule.severity_threshold]:
+                continue
+        return rule
+    return None
+
+
+def _selector_matches_version(selector: str, target: dict[str, object]) -> bool:
+    version = _optional_string(target.get("version"))
+    requested_range = _optional_string(target.get("range"))
+    if requested_range is not None and requested_range == selector:
+        return True
+    if version is None:
+        return False
+    if selector in {version, f"={version}", f"=={version}"}:
+        return True
+    try:
+        return Version(version) in SpecifierSet(selector)
+    except (InvalidSpecifier, InvalidVersion):
+        return False
+
+
+def _bundle_package(bundle_response, *, package_name: str, package_version: str):
+    normalized = package_name.lower()
+    for item in bundle_response.bundle.packages:
+        full_name = f"{item.namespace}/{item.name}".lower() if item.namespace is not None else item.name.lower()
+        if normalized not in {item.name.lower(), full_name}:
+            continue
+        if item.version == package_version:
+            return item
+    return None
+
+
+def _normalize_bundle_action(value: str) -> str:
+    if value == "review":
+        return "ask"
+    if value in _DECISION_RANK:
+        return value
+    return "monitor"
+
+
+def _normalized_supply_chain_evaluate_url(sync_url: str, workspace_id: str) -> str:
+    parsed = urllib.parse.urlsplit(_normalized_receipts_sync_url(sync_url))
+    if parsed.path.rstrip("/") == "/api/guard/receipts/sync":
+        next_path = "/api/guard/supply-chain/evaluate"
+    elif parsed.path.rstrip("/") == "/guard/receipts/sync":
+        next_path = "/guard/supply-chain/evaluate"
+    else:
+        next_path = parsed.path.rstrip("/") + "/supply-chain/evaluate"
+    query_pairs = [
+        (key, value)
+        for key, value in urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+        if key != "workspaceId"
+    ]
+    query_pairs.append(("workspaceId", workspace_id))
+    return urllib.parse.urlunsplit(
+        (
+            parsed.scheme,
+            parsed.netloc,
+            next_path,
+            urllib.parse.urlencode(query_pairs),
+            "",
+        )
+    )
+
+
+def _hash_paths(workspace_dir: Path | None, raw_paths: object) -> list[str]:
+    if workspace_dir is None or not isinstance(raw_paths, list):
+        return []
+    hashes: list[str] = []
+    for item in raw_paths:
+        path = workspace_dir / str(item)
+        if not path.exists():
+            continue
+        hashes.append(hashlib.sha256(path.read_bytes()).hexdigest())
+    return hashes
+
+
+def _stable_hash(value: object) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+
+
+def _split_namespace_name(value: str) -> tuple[str | None, str]:
+    if value.startswith("@") and "/" in value:
+        namespace, name = value.split("/", 1)
+        return namespace, name
+    return None, value
+
+
+def _exact_version(value: str | None) -> str | None:
+    if value is None:
+        return None
+    if "://" in value or value.startswith("git+"):
+        return None
+    if value.startswith(("^", "~", "<", ">", "!", "*")):
+        return None
+    if any(token in value for token in ("||", " - ", ",")):
+        return None
+    return value
+
+
+def _optional_string(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _decision_rank(value: str) -> int:
+    return _DECISION_RANK.get(value, 1)
+
+
+def _fix_command(package: dict[str, object]) -> str | None:
+    package_name = _package_display_name(package)
+    fix_version = _optional_string(package.get("recommendedFixVersion"))
+    ecosystem = _optional_string(package.get("ecosystem")) or "npm"
+    if not fix_version:
+        return None
+    if ecosystem == "pypi":
+        return f"pip install {package_name}=={fix_version}"
+    return f"npm install {package_name}@{fix_version}"
+
+
+def _package_display_name(package: dict[str, object]) -> str:
+    namespace = _optional_string(package.get("namespace"))
+    name = _optional_string(package.get("name")) or "package"
+    return f"{namespace}/{name}" if namespace is not None else name
+
+
+def _reason_severity(package: dict[str, object]) -> str:
+    reasons = package.get("reasons")
+    if isinstance(reasons, tuple | list):
+        for item in reasons:
+            if isinstance(item, dict):
+                severity = _optional_string(item.get("severity"))
+                if severity is not None:
+                    return severity
+    return "unknown"
+
+
+def _should_record_package(package: dict[str, object], decision: str) -> bool:
+    package_decision = str(package.get("decision") or decision)
+    return package_decision in {"block", "ask", "warn"} or decision == "monitor"
+
+
+def _evidence_id(package_intent_hash: str, package: dict[str, object]) -> str:
+    package_name = _package_display_name(package)
+    decision = str(package.get("decision") or "monitor")
+    return f"evidence-{hashlib.sha256(f'{package_intent_hash}:{package_name}:{decision}'.encode()).hexdigest()[:16]}"
+
+
+def _with_additional_reason(
+    evaluation: PackageRequestEvaluation, reason: dict[str, object]
+) -> PackageRequestEvaluation:
+    updated_reasons = (*evaluation.reasons, reason)
+    updated_packages = []
+    appended = False
+    for package in evaluation.packages:
+        if appended:
+            updated_packages.append(package)
+            continue
+        package_reasons = package.get("reasons")
+        if isinstance(package_reasons, tuple | list):
+            updated_package = dict(package)
+            updated_package["reasons"] = (
+                *tuple(item for item in package_reasons if isinstance(item, dict)),
+                reason,
+            )
+            updated_packages.append(updated_package)
+            appended = True
+            continue
+        updated_packages.append(package)
+    return replace(evaluation, reasons=updated_reasons, packages=tuple(updated_packages))

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -26,7 +26,11 @@ from .runner import (
     _urlopen_json_with_timeout_retry,
 )
 from .supply_chain_bundle import evaluate_cached_supply_chain_bundle, load_supply_chain_bundle_response
-from .supply_chain_bundle_models import SupplyChainBundlePackage
+from .supply_chain_bundle_models import (
+    SupplyChainBundlePackage,
+    SupplyChainBundlePolicyRule,
+    SupplyChainBundleResponse,
+)
 
 _DECISION_RANK = {"allow": 0, "monitor": 1, "warn": 2, "ask": 3, "block": 4}
 _SEVERITY_RANK = {"unknown": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
@@ -446,6 +450,11 @@ def _evaluate_with_cloud(
             code="cloud_timeout",
             message="Guard cloud evaluation timed out, so Guard fell back to local intelligence.",
         )
+    except ValueError:
+        return None, _cloud_fallback_reason(
+            code="cloud_invalid_response",
+            message="Guard cloud evaluation returned an invalid response, so Guard fell back locally.",
+        )
     if not isinstance(response_payload, dict):
         return None, _cloud_fallback_reason(
             code="cloud_invalid_response",
@@ -517,8 +526,6 @@ def _evaluate_with_bundle(
     bundle_meta = _bundle_meta(bundle_response.to_dict())
     refresh_required = False
     packages: list[dict[str, object]] = []
-    best_rule_id: str | None = None
-    exception_id: str | None = None
     for target in targets:
         exact_version = _exact_version(_optional_string(target.get("version")) or _optional_string(target.get("range")))
         package_match = (
@@ -540,9 +547,6 @@ def _evaluate_with_bundle(
             decision = _normalize_bundle_action(matched_rule.action)
             package = _policy_package_result(target, decision=decision, rule_id=matched_rule.rule_id)
             packages.append(package)
-            best_rule_id = matched_rule.rule_id
-            if decision == "allow":
-                exception_id = matched_rule.rule_id
             continue
         if exact_version is None:
             continue
@@ -569,17 +573,18 @@ def _evaluate_with_bundle(
         return None
     packages.sort(key=lambda item: _decision_rank(str(item.get("decision") or "monitor")), reverse=True)
     decision = str(packages[0].get("decision") or "monitor")
+    winning_rule_id = _optional_string(packages[0].get("ruleId"))
     return _EvaluationDraft(
         decision=decision,
-        enforcement="policy_override" if best_rule_id is not None else "offline_cached",
+        enforcement="policy_override" if winning_rule_id is not None else "offline_cached",
         entitlement_state="premium" if workspace_id is not None else "free",
         cache_status="stale" if refresh_required else "miss",
         packages=tuple(packages),
         reasons=tuple(
             reason for package in packages for reason in package.get("reasons", []) if isinstance(reason, dict)
         ),
-        matched_rule_id=best_rule_id,
-        exception_id=exception_id,
+        matched_rule_id=winning_rule_id,
+        exception_id=winning_rule_id if decision == "allow" else None,
         refresh_required=refresh_required,
         record_monitor_evidence=decision == "monitor",
         bundle_version=bundle_meta["bundle_version"],
@@ -899,6 +904,7 @@ def _policy_package_result(target: dict[str, object], *, decision: str, rule_id:
         "recommendedFixVersion": None,
         "riskScore": None,
         "dependencyPath": None,
+        "ruleId": rule_id,
         "reasons": (
             {
                 "code": "policy_override",
@@ -986,12 +992,12 @@ def _safe_dependency_map_for_path(path: str, text: str, *, deadline: float) -> d
 
 
 def _matching_policy_rule(
-    rules,
+    rules: tuple[SupplyChainBundlePolicyRule, ...],
     *,
     target: dict[str, object],
     harness: str,
     package_severity: str | None,
-):
+) -> SupplyChainBundlePolicyRule | None:
     current_time = datetime.now(timezone.utc).timestamp()
     sorted_rules = sorted(
         rules, key=lambda item: (item.priority if item.priority is not None else 10_000, item.rule_id)
@@ -1050,7 +1056,7 @@ def _selector_matches_version(selector: str, target: dict[str, object]) -> bool:
 
 
 def _bundle_package(
-    bundle_response,
+    bundle_response: SupplyChainBundleResponse,
     *,
     package_name: str,
     package_version: str,
@@ -1221,7 +1227,12 @@ def _cloud_fallback_reason(*, code: str, message: str) -> dict[str, object]:
     }
 
 
-def _bundle_reason_message(package, *, reason: str, stale: bool) -> str:
+def _bundle_reason_message(
+    package: SupplyChainBundlePackage,
+    *,
+    reason: str,
+    stale: bool,
+) -> str:
     package_label = f"{package.name}@{package.version}"
     if stale:
         return f"Cached bundle is stale, so Guard kept {package_label} in monitor mode."

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -836,9 +836,15 @@ def _transitive_lockfile_results(
             deadline=time.monotonic() + 0.2,
         )
         for dependency_path, version in dependency_map.items():
-            if "node_modules/" not in dependency_path:
+            normalized_dependency_path = dependency_path.strip("/")
+            if not normalized_dependency_path:
                 continue
-            package_name = dependency_path.rsplit("node_modules/", 1)[-1]
+            if "node_modules/" in normalized_dependency_path:
+                package_name = normalized_dependency_path.rsplit("node_modules/", 1)[-1]
+            elif "/" not in normalized_dependency_path or normalized_dependency_path.startswith("@"):
+                package_name = normalized_dependency_path
+            else:
+                continue
             offline = evaluate_cached_supply_chain_bundle(
                 bundle_response, package_name=package_name, package_version=version
             )
@@ -1127,7 +1133,10 @@ def _hash_paths(workspace_dir: Path | None, raw_paths: object) -> list[str]:
         path = workspace_dir / str(item)
         if not path.exists():
             continue
-        hashes.append(hashlib.sha256(path.read_bytes()).hexdigest())
+        try:
+            hashes.append(hashlib.sha256(path.read_bytes()).hexdigest())
+        except OSError:
+            continue
     return hashes
 
 

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -216,7 +216,7 @@ def evaluate_package_request_artifact(
         _persist_evidence(store=store, artifact=artifact, evaluation=fallback, now=now_value)
         store.add_event("supply_chain_bundle_refresh_requested", {"artifact_id": artifact.artifact_id}, now_value)
         return fallback
-    cloud_result, cloud_timed_out = _evaluate_with_cloud(
+    cloud_result, cloud_fallback_reason = _evaluate_with_cloud(
         artifact=artifact,
         targets=targets,
         workspace_dir=workspace_dir,
@@ -254,16 +254,8 @@ def evaluate_package_request_artifact(
         fallback = _finalize_evaluation(
             bundle_evaluation, package_intent_hash=package_intent_hash, workspace_fingerprint=workspace_fingerprint
         )
-        if cloud_timed_out:
-            fallback = _with_additional_reason(
-                fallback,
-                {
-                    "code": "cloud_timeout",
-                    "message": "Guard cloud evaluation timed out, so Guard fell back to local intelligence.",
-                    "severity": "unknown",
-                    "source": "guard-cloud",
-                },
-            )
+        if cloud_fallback_reason is not None:
+            fallback = _with_additional_reason(fallback, cloud_fallback_reason)
         _persist_evidence(store=store, artifact=artifact, evaluation=fallback, now=now_value)
         if fallback.refresh_required:
             store.add_event("supply_chain_bundle_refresh_requested", {"artifact_id": artifact.artifact_id}, now_value)
@@ -294,16 +286,8 @@ def evaluate_package_request_artifact(
     result = _finalize_evaluation(
         heuristic, package_intent_hash=package_intent_hash, workspace_fingerprint=workspace_fingerprint
     )
-    if cloud_timed_out:
-        result = _with_additional_reason(
-            result,
-            {
-                "code": "cloud_timeout",
-                "message": "Guard cloud evaluation timed out, so Guard fell back to local intelligence.",
-                "severity": "unknown",
-                "source": "guard-cloud",
-            },
-        )
+    if cloud_fallback_reason is not None:
+        result = _with_additional_reason(result, cloud_fallback_reason)
     _persist_evidence(store=store, artifact=artifact, evaluation=result, now=now_value)
     return result
 
@@ -425,12 +409,12 @@ def _evaluate_with_cloud(
     workspace_fingerprint: str | None,
     bundle_meta: dict[str, str] | None,
     store: GuardStore,
-) -> tuple[PackageRequestEvaluation | None, bool]:
+) -> tuple[PackageRequestEvaluation | None, dict[str, object] | None]:
     if workspace_id is None or workspace_fingerprint is None:
-        return None, False
+        return None, None
     sync_credentials = store.get_sync_credentials()
     if sync_credentials is None:
-        return None, False
+        return None, None
     request_payload = _build_request_payload(
         artifact=artifact,
         targets=targets,
@@ -451,19 +435,32 @@ def _evaluate_with_cloud(
             retry_timeout_seconds=_RETRY_TIMEOUT_SECONDS,
         )
     except urllib.error.HTTPError as error:
-        if error.code in {429, 500, 502, 503, 504}:
-            return None, True
-        raise
+        return None, _cloud_fallback_reason(
+            code="cloud_http_error",
+            message=(f"Guard cloud evaluation returned HTTP {error.code}, so Guard fell back to local intelligence."),
+        )
     except OSError:
-        return None, True
+        return None, _cloud_fallback_reason(
+            code="cloud_timeout",
+            message="Guard cloud evaluation timed out, so Guard fell back to local intelligence.",
+        )
+    if not isinstance(response_payload, dict):
+        return None, _cloud_fallback_reason(
+            code="cloud_invalid_response",
+            message="Guard cloud evaluation returned an invalid response, so Guard fell back locally.",
+        )
     if not isinstance(response_payload.get("packages"), list):
-        return None, False
+        return None, _cloud_fallback_reason(
+            code="cloud_invalid_response",
+            message="Guard cloud evaluation returned an invalid package payload, so Guard fell back locally.",
+        )
     packages = tuple(
         _package_from_cloud_result(item) for item in response_payload["packages"] if isinstance(item, dict)
     )
     reasons = tuple(item for item in response_payload.get("reasons", []) if isinstance(item, dict))
+    normalized_decision = _normalize_bundle_action(str(response_payload.get("decision") or "monitor"))
     draft = _EvaluationDraft(
-        decision=str(response_payload.get("decision") or "monitor"),
+        decision=normalized_decision,
         enforcement=str(response_payload.get("enforcement") or "premium_cloud"),
         entitlement_state=str(response_payload.get("entitlementState") or "premium"),
         cache_status=str(response_payload.get("cacheStatus") or "miss"),
@@ -472,7 +469,7 @@ def _evaluate_with_cloud(
         matched_rule_id=None,
         exception_id=None,
         refresh_required=False,
-        record_monitor_evidence=str(response_payload.get("decision")) == "monitor",
+        record_monitor_evidence=normalized_decision == "monitor",
         bundle_version=bundle_meta["bundle_version"] if bundle_meta is not None else None,
         policy_version=str(
             response_payload.get("policyVersion")
@@ -504,7 +501,7 @@ def _evaluate_with_cloud(
                     harness_message=" ".join(harness_parts),
                 ),
             )
-    return evaluation, False
+    return evaluation, None
 
 
 def _evaluate_with_bundle(
@@ -865,11 +862,7 @@ def _bundle_package_result(
             {
                 "advisoryId": package.related_advisory_ids[0] if package.related_advisory_ids else None,
                 "code": reason,
-                "message": "Prototype pollution in minimist"
-                if reason == "known_malware_or_kev"
-                else "Cached bundle matched this package version."
-                if reason == "bundle_match"
-                else "Cached bundle is stale, so Guard kept this package in monitor mode.",
+                "message": _bundle_reason_message(package, reason=reason, stale=stale),
                 "severity": severity,
                 "source": "bundle",
             },
@@ -901,7 +894,7 @@ def _policy_package_result(target: dict[str, object], *, decision: str, rule_id:
 
 def _package_from_cloud_result(item: dict[str, object]) -> dict[str, object]:
     return {
-        "decision": str(item.get("decision") or "monitor"),
+        "decision": _normalize_bundle_action(str(item.get("decision") or "monitor")),
         "ecosystem": str(item.get("ecosystem") or "npm"),
         "name": str(item.get("name") or "unknown"),
         "namespace": _optional_string(item.get("namespace")),
@@ -1108,7 +1101,7 @@ def _package_display_name(package: dict[str, object]) -> str:
 
 def _reason_severity(package: dict[str, object]) -> str:
     reasons = package.get("reasons")
-    if isinstance(reasons, tuple | list):
+    if isinstance(reasons, (tuple, list)):
         for item in reasons:
             if isinstance(item, dict):
                 severity = _optional_string(item.get("severity"))
@@ -1125,7 +1118,12 @@ def _should_record_package(package: dict[str, object], decision: str) -> bool:
 def _evidence_id(package_intent_hash: str, package: dict[str, object]) -> str:
     package_name = _package_display_name(package)
     decision = str(package.get("decision") or "monitor")
-    return f"evidence-{hashlib.sha256(f'{package_intent_hash}:{package_name}:{decision}'.encode()).hexdigest()[:16]}"
+    resolved_version = _optional_string(package.get("resolvedVersion")) or _optional_string(
+        package.get("requestedVersion")
+    )
+    dependency_path = _optional_string(package.get("dependencyPath")) or "direct"
+    identity = f"{package_intent_hash}:{package_name}:{resolved_version}:{dependency_path}:{decision}"
+    return f"evidence-{hashlib.sha256(identity.encode()).hexdigest()[:16]}"
 
 
 def _with_additional_reason(
@@ -1133,20 +1131,35 @@ def _with_additional_reason(
 ) -> PackageRequestEvaluation:
     updated_reasons = (*evaluation.reasons, reason)
     updated_packages = []
-    appended = False
     for package in evaluation.packages:
-        if appended:
-            updated_packages.append(package)
-            continue
         package_reasons = package.get("reasons")
-        if isinstance(package_reasons, tuple | list):
+        if isinstance(package_reasons, (tuple, list)):
             updated_package = dict(package)
             updated_package["reasons"] = (
                 *tuple(item for item in package_reasons if isinstance(item, dict)),
                 reason,
             )
             updated_packages.append(updated_package)
-            appended = True
             continue
-        updated_packages.append(package)
+        updated_package = dict(package)
+        updated_package["reasons"] = (reason,)
+        updated_packages.append(updated_package)
     return replace(evaluation, reasons=updated_reasons, packages=tuple(updated_packages))
+
+
+def _cloud_fallback_reason(*, code: str, message: str) -> dict[str, object]:
+    return {
+        "code": code,
+        "message": message,
+        "severity": "unknown",
+        "source": "guard-cloud",
+    }
+
+
+def _bundle_reason_message(package, *, reason: str, stale: bool) -> str:
+    package_label = f"{package.name}@{package.version}"
+    if stale:
+        return f"Cached bundle is stale, so Guard kept {package_label} in monitor mode."
+    if reason == "known_malware_or_kev":
+        return f"Cached bundle flagged {package_label} from advisory intelligence."
+    return f"Cached bundle matched {package_label}."

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -99,11 +99,15 @@ from .store_connect import (
     mark_connect_result as persist_connect_result,
 )
 from .store_evidence import (
+    EvidenceRecord,
     evidence_index_statements,
     evidence_schema_statement,
 )
 from .store_evidence import (
     list_evidence as _list_evidence_impl,
+)
+from .store_evidence import (
+    store_evidence as _store_evidence_impl,
 )
 from .store_resume import (
     delete_request_resumes as purge_request_resumes,
@@ -3517,6 +3521,10 @@ class GuardStore:
             }
             for r in records
         ]
+
+    def add_evidence(self, record: EvidenceRecord) -> None:
+        with self._connect() as connection:
+            _store_evidence_impl(connection, record)
 
     @staticmethod
     def _advisory_cache_key(advisory: dict[str, object]) -> str:

--- a/tests/test_guard_package_hook.py
+++ b/tests/test_guard_package_hook.py
@@ -174,6 +174,23 @@ def _scanner_signal_v2() -> RiskSignalV2:
     )
 
 
+def _data_flow_signal_v2() -> RiskSignalV2:
+    return RiskSignalV2(
+        signal_id="data-flow:secret-pipe-http",
+        category="network",
+        severity="critical",
+        confidence="strong",
+        detector="data_flow.exfiltration",
+        title="Shell pipeline sends a local secret to a network host",
+        plain_reason="This command sends local secret to network host.",
+        technical_detail="source and sink were detected without retaining secret contents",
+        evidence_ref="command",
+        redaction_level="summary",
+        false_positive_hint="Allow only when the command intentionally moves non-sensitive data.",
+        advisory_id=None,
+    )
+
+
 def test_guard_hook_blocks_package_request_before_execution_and_queues_cloud_sync(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -336,8 +353,8 @@ def test_guard_hook_warns_for_package_request_without_blocking(
     assert rc == 0
     assert output["policy_action"] == "warn"
     assert output["risk_summary"]
-    assert "minimist@1.2.8" in output["risk_summary"]
-    assert output["scanner_evidence"]
+    assert "minimist@1.2.8" in output["supply_chain_evaluation"]["risk_summary"]
+    assert output["supply_chain_evaluation"]["packages"]
     assert "approval_requests" not in output
 
 
@@ -404,6 +421,72 @@ def test_guard_hook_keeps_block_copy_when_scanner_escalates_package_warning(
         output["decision_v2_json"]["dashboard_primary_detail"]
         == "Cisco scanner found a critical package exfiltration path."
     )
+
+
+def test_guard_hook_keeps_data_flow_summary_when_package_warning_is_weaker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    payload_path = workspace_dir / "hook-event.json"
+    _write_codex_pre_tool_payload(payload_path, workspace_dir, "npm install minimist@1.2.8")
+    store = GuardStore(home_dir)
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, _bundle_response(action="warn"), "2026-05-19T00:00:00Z")
+    (home_dir / "config.toml").write_text("approval_wait_timeout_seconds = 0\n", encoding="utf-8")
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+
+    def fail_daemon(_home: Path) -> object:
+        raise RuntimeError("no daemon client")
+
+    monkeypatch.setattr(guard_commands_module, "load_guard_surface_daemon_client", fail_daemon)
+    monkeypatch.setattr(
+        guard_commands_module,
+        "_runtime_action_data_flow_signals",
+        lambda *_args, **_kwargs: (_data_flow_signal_v2(),),
+    )
+    monkeypatch.setattr(
+        guard_commands_module,
+        "resolve_risk_action",
+        lambda _config, risk_class, harness=None: "block" if risk_class == "data_flow_exfiltration" else "allow",
+    )
+    monkeypatch.setattr(
+        guard_commands_module,
+        "scan_action_for_cisco_evidence",
+        lambda *_args, **_kwargs: (),
+    )
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--harness",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--event-file",
+            str(payload_path),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert output["policy_action"] == "block"
+    assert "network host" in output["risk_summary"]
+    assert output["decision_v2_json"]["user_title"] == "Blocked by policy"
+    assert (
+        output["decision_v2_json"]["dashboard_primary_detail"] == "Source-to-sink route: local secret -> network host. "
+        "This command sends local secret to network host without exposing the raw secret in Guard evidence."
+    )
+    assert output["decision_v2_json"]["dashboard_primary_detail"] != output["supply_chain_evaluation"]["risk_summary"]
     evidence = store.list_evidence()
     assert evidence
     assert evidence[0]["category"] == "supply-chain"

--- a/tests/test_guard_package_hook.py
+++ b/tests/test_guard_package_hook.py
@@ -1,0 +1,303 @@
+"""Package-request hook integration tests for HOL Guard."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generate_private_key
+
+from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+from codex_plugin_scanner.guard.store import GuardStore
+
+WORKSPACE_ID = "workspace-alpha"
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _generate_key_pair() -> tuple[bytes, bytes]:
+    private_key = generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem, public_pem
+
+
+def _fingerprint(public_key_pem: bytes) -> str:
+    return hashlib.sha256(public_key_pem.decode("utf-8").strip().encode("utf-8")).hexdigest()
+
+
+def _bundle_response(*, action: str, policy_rules: list[dict[str, object]] | None = None) -> dict[str, object]:
+    generated_at = datetime(2026, 5, 19, tzinfo=timezone.utc)
+    expires_at = generated_at + timedelta(hours=12)
+    bundle = {
+        "advisories": [
+            {
+                "advisoryId": "GHSA-vh95-rmgr-6w4m",
+                "aliases": ["CVE-2020-7598"],
+                "confidence": 990,
+                "exploitLevel": "active",
+                "knownExploited": True,
+                "malwareState": "known",
+                "normalizedSeverity": "critical",
+                "recommendedFixVersion": "1.2.9",
+                "sourceKey": "ghsa",
+                "summary": "Prototype pollution in minimist",
+                "title": "Prototype pollution in minimist",
+            }
+        ],
+        "bundleVersion": "1747612800000-deadbeef",
+        "expiresAt": _iso(expires_at),
+        "feedSnapshotHash": "feed-snapshot-1",
+        "generatedAt": _iso(generated_at),
+        "keyId": "guard-bundle-key-2026-05",
+        "packages": [
+            {
+                "confidence": 990,
+                "defaultAction": action,
+                "ecosystem": "npm",
+                "exploitLevel": "active",
+                "knownExploited": True,
+                "malwareState": "known",
+                "name": "minimist",
+                "namespace": None,
+                "normalizedSeverity": "critical",
+                "packageAgeState": "watch",
+                "purl": "pkg:npm/minimist@1.2.8",
+                "reachability": "reachable",
+                "recommendedFixVersion": "1.2.9",
+                "relatedAdvisoryIds": ["GHSA-vh95-rmgr-6w4m"],
+                "riskScore": 980,
+                "sourceIntegrityState": "high-risk",
+                "version": "1.2.8",
+            }
+        ],
+        "policyHash": "policy-hash-1",
+        "policyRules": policy_rules or [],
+        "scoringVersion": "scf-v1",
+        "sourceHashes": [{"payloadHash": "ghsa-feed-hash", "sourceKey": "ghsa", "staleStatus": "fresh"}],
+        "tier": "premium",
+        "workspaceId": WORKSPACE_ID,
+    }
+    private_key_pem, public_key_pem = _generate_key_pair()
+    loaded_key = serialization.load_pem_private_key(private_key_pem, password=None)
+    assert isinstance(loaded_key, RSAPrivateKey)
+    canonical_payload = json.dumps(bundle, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    payload_hash = hashlib.sha256(canonical_payload).hexdigest()
+    signature = loaded_key.sign(
+        canonical_payload,
+        padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+        hashes.SHA256(),
+    )
+    return {
+        "bundle": bundle,
+        "payloadHash": payload_hash,
+        "signature": base64.b64encode(signature).decode("utf-8"),
+        "signatureAlgorithm": "rsa-pss-sha256",
+        "verificationKeys": [
+            {
+                "fingerprintSha256": _fingerprint(public_key_pem),
+                "keyId": "guard-bundle-key-2026-05",
+                "publicKeyPem": public_key_pem.decode("utf-8").strip(),
+                "state": "active",
+                "validUntil": None,
+            }
+        ],
+    }
+
+
+def _write_codex_pre_tool_payload(path: Path, workspace_dir: Path, command: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "session_id": "session-1",
+                "turn_id": "turn-1",
+                "cwd": str(workspace_dir),
+                "hook_event_name": "PreToolUse",
+                "model": "gpt-5.4",
+                "permission_mode": "bypassPermissions",
+                "tool_name": "Bash",
+                "tool_input": {"command": command},
+                "tool_use_id": "call-1",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_guard_hook_blocks_package_request_before_execution_and_queues_cloud_sync(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    payload_path = workspace_dir / "hook-event.json"
+    _write_codex_pre_tool_payload(payload_path, workspace_dir, "npm install minimist@1.2.8")
+    store = GuardStore(home_dir)
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, _bundle_response(action="block"), "2026-05-19T00:00:00Z")
+    monkeypatch.setenv("CODEX_MANAGED_BY_BUN", "1")
+
+    def fail_subprocess(*args: object, **kwargs: object) -> object:
+        raise AssertionError("blocked package request must not launch a subprocess")
+
+    monkeypatch.setattr(guard_commands_module.subprocess, "run", fail_subprocess)
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--harness",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--event-file",
+            str(payload_path),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 2
+    assert "blocked" in captured.err.lower()
+    evidence = store.list_evidence()
+    assert evidence
+    assert evidence[0]["category"] == "supply-chain"
+    queued_events = store.list_guard_events_v1(uploaded=False)
+    assert queued_events
+    assert any(event["event_type"] == "receipt.created" for event in queued_events)
+
+
+def test_guard_hook_ask_queues_package_approval_with_advisory_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    payload_path = workspace_dir / "hook-event.json"
+    _write_codex_pre_tool_payload(payload_path, workspace_dir, "npm install minimist@1.2.8")
+    store = GuardStore(home_dir)
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
+    )
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(
+            action="block",
+            policy_rules=[
+                {
+                    "action": "review",
+                    "ruleId": "policy-review-1",
+                    "ecosystemSelector": "npm",
+                    "enabled": True,
+                    "expiresAt": "2099-01-01T00:00:00Z",
+                    "harnessSelector": "codex",
+                    "packageSelector": "minimist",
+                    "priority": 1,
+                    "severityThreshold": "low",
+                    "versionRangeSelector": "1.2.8",
+                }
+            ],
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+    (home_dir / "config.toml").write_text("approval_wait_timeout_seconds = 0\n", encoding="utf-8")
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+
+    def fail_daemon(_home: Path) -> object:
+        raise RuntimeError("no daemon client")
+
+    monkeypatch.setattr(guard_commands_module, "load_guard_surface_daemon_client", fail_daemon)
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--harness",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--event-file",
+            str(payload_path),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert output["policy_action"] == "require-reapproval"
+    assert output["approval_requests"]
+    pending = store.list_approval_requests(limit=5)
+    assert pending[0]["risk_summary"]
+    assert "minimist" in pending[0]["risk_summary"].lower()
+
+
+def test_guard_hook_warns_for_package_request_without_blocking(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    payload_path = workspace_dir / "hook-event.json"
+    _write_codex_pre_tool_payload(payload_path, workspace_dir, "npm install minimist@1.2.8")
+    store = GuardStore(home_dir)
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "demo-token",
+        "2026-05-19T00:00:00Z",
+        workspace_id=WORKSPACE_ID,
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, _bundle_response(action="warn"), "2026-05-19T00:00:00Z")
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--harness",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--event-file",
+            str(payload_path),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["policy_action"] == "warn"
+    assert output["risk_summary"]
+    assert "minimist@1.2.8" in output["risk_summary"]
+    assert output["scanner_evidence"]
+    assert "approval_requests" not in output
+    evidence = store.list_evidence()
+    assert evidence
+    assert evidence[0]["category"] == "supply-chain"

--- a/tests/test_guard_package_hook.py
+++ b/tests/test_guard_package_hook.py
@@ -15,6 +15,7 @@ from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generat
 
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+from codex_plugin_scanner.guard.runtime.signals import RiskSignalV2
 from codex_plugin_scanner.guard.store import GuardStore
 
 WORKSPACE_ID = "workspace-alpha"
@@ -141,6 +142,38 @@ def _write_codex_pre_tool_payload(path: Path, workspace_dir: Path, command: str)
     )
 
 
+class _CiscoSignalStub:
+    plain_language_summary = "Cisco scanner found a critical package exfiltration path."
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "signal_id": "cisco:package-exfiltration",
+            "category": "network",
+            "severity": "critical",
+            "confidence": "strong",
+            "detector": "cisco",
+            "title": "Cisco scanner found a critical package exfiltration path.",
+            "plain_language_summary": self.plain_language_summary,
+        }
+
+
+def _scanner_signal_v2() -> RiskSignalV2:
+    return RiskSignalV2(
+        signal_id="cisco:package-exfiltration",
+        category="network",
+        severity="critical",
+        confidence="strong",
+        detector="cisco",
+        title="Cisco scanner found a critical package exfiltration path.",
+        plain_reason="Cisco scanner found a critical package exfiltration path.",
+        technical_detail=None,
+        evidence_ref="artifact",
+        redaction_level="summary",
+        false_positive_hint=None,
+        advisory_id=None,
+    )
+
+
 def test_guard_hook_blocks_package_request_before_execution_and_queues_cloud_sync(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -156,7 +189,14 @@ def test_guard_hook_blocks_package_request_before_execution_and_queues_cloud_syn
         "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
     )
     store.cache_supply_chain_bundle(WORKSPACE_ID, _bundle_response(action="block"), "2026-05-19T00:00:00Z")
+    (home_dir / "config.toml").write_text("approval_wait_timeout_seconds = 0\n", encoding="utf-8")
     monkeypatch.setenv("CODEX_MANAGED_BY_BUN", "1")
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+
+    def fail_daemon(_home: Path) -> object:
+        raise RuntimeError("no daemon client")
+
+    monkeypatch.setattr(guard_commands_module, "load_guard_surface_daemon_client", fail_daemon)
 
     def fail_subprocess(*args: object, **kwargs: object) -> object:
         raise AssertionError("blocked package request must not launch a subprocess")
@@ -187,6 +227,7 @@ def test_guard_hook_blocks_package_request_before_execution_and_queues_cloud_syn
     queued_events = store.list_guard_events_v1(uploaded=False)
     assert queued_events
     assert any(event["event_type"] == "receipt.created" for event in queued_events)
+    assert store.list_approval_requests(limit=5)
 
 
 def test_guard_hook_ask_queues_package_approval_with_advisory_context(
@@ -298,6 +339,71 @@ def test_guard_hook_warns_for_package_request_without_blocking(
     assert "minimist@1.2.8" in output["risk_summary"]
     assert output["scanner_evidence"]
     assert "approval_requests" not in output
+
+
+def test_guard_hook_keeps_block_copy_when_scanner_escalates_package_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    payload_path = workspace_dir / "hook-event.json"
+    _write_codex_pre_tool_payload(payload_path, workspace_dir, "npm install minimist@1.2.8")
+    store = GuardStore(home_dir)
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, _bundle_response(action="warn"), "2026-05-19T00:00:00Z")
+    (home_dir / "config.toml").write_text("approval_wait_timeout_seconds = 0\n", encoding="utf-8")
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+
+    def fail_daemon(_home: Path) -> object:
+        raise RuntimeError("no daemon client")
+
+    monkeypatch.setattr(guard_commands_module, "load_guard_surface_daemon_client", fail_daemon)
+    monkeypatch.setattr(
+        guard_commands_module,
+        "scan_action_for_cisco_evidence",
+        lambda *_args, **_kwargs: (_CiscoSignalStub(),),
+    )
+    monkeypatch.setattr(
+        guard_commands_module,
+        "policy_action_for_cisco_signals",
+        lambda *_args, **_kwargs: "block",
+    )
+    monkeypatch.setattr(
+        guard_commands_module,
+        "cisco_risk_signal_v3_to_v2",
+        lambda _signal: _scanner_signal_v2(),
+    )
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--harness",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--event-file",
+            str(payload_path),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert output["policy_action"] == "block"
+    assert output["decision_v2_json"]["user_title"] == "Blocked by policy"
+    assert output["decision_v2_json"]["user_title"] != output["supply_chain_evaluation"]["user_copy"]["title"]
+    assert (
+        output["decision_v2_json"]["dashboard_primary_detail"]
+        == "Cisco scanner found a critical package exfiltration path."
+    )
     evidence = store.list_evidence()
     assert evidence
     assert evidence[0]["category"] == "supply-chain"

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -1133,6 +1133,54 @@ def test_evaluate_package_request_artifact_handles_unreadable_workspace_paths_wi
     assert result.policy_action == "allow"
 
 
+def test_evaluate_package_request_artifact_handles_unreadable_lockfile_context_without_crashing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "demo-token",
+        "2026-05-19T00:00:00Z",
+        workspace_id=WORKSPACE_ID,
+    )
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    lockfile_path = workspace_dir / "package-lock.json"
+    lockfile_path.write_text(
+        json.dumps({"packages": {"": {"name": "demo-app"}}}),
+        encoding="utf-8",
+    )
+    original_read_text = Path.read_text
+
+    def guarded_read_text(path: Path, *args: object, **kwargs: object) -> str:
+        if path == lockfile_path:
+            raise OSError("permission denied")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", guarded_read_text)
+    monkeypatch.setattr(
+        evaluator_module,
+        "_urlopen_json_with_timeout_retry",
+        lambda *args, **kwargs: _cloud_response(
+            decision="monitor",
+            enforcement="premium_cloud",
+            entitlement_state="active",
+            package_name="left-pad",
+        ),
+    )
+
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("left-pad@1.0.0", lockfile_paths=("package-lock.json",)),
+        store=store,
+        workspace_dir=workspace_dir,
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "monitor"
+    assert result.policy_action == "allow"
+    assert result.enforcement == "premium_cloud"
+
+
 def test_evaluate_package_request_artifact_range_only_timeout_falls_back_safely(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1265,3 +1313,28 @@ def test_evidence_id_distinguishes_versions_and_dependency_paths() -> None:
     }
 
     assert _evidence_id("intent-hash", direct_package) != _evidence_id("intent-hash", transitive_package)
+
+
+def test_bundle_reason_message_uses_block_copy_for_stale_blocked_bundle() -> None:
+    response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="minimist",
+                version="1.2.8",
+                default_action="block",
+                recommended_fix_version="1.2.9",
+            )
+        ]
+    )
+    package = evaluator_module.load_supply_chain_bundle_response(response).bundle.packages[0]
+
+    message = evaluator_module._bundle_reason_message(
+        package,
+        decision="block",
+        reason="known_malware_or_kev",
+        stale=True,
+    )
+
+    assert "blocked" in message.lower()
+    assert "monitor mode" not in message

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -584,6 +584,49 @@ def test_evaluate_package_request_artifact_falls_back_on_cloud_http_error(
     assert result.enforcement in {"offline_cached", "local_fallback"}
 
 
+def test_evaluate_package_request_artifact_falls_back_on_invalid_cloud_response(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "demo-token",
+        "2026-05-19T00:00:00Z",
+        workspace_id=WORKSPACE_ID,
+    )
+    response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="left-pad",
+                version="1.0.0",
+                default_action="monitor",
+                normalized_severity="low",
+                exploit_level="none",
+                known_exploited=False,
+                malware_state="none",
+                risk_score=220,
+            )
+        ]
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, response, "2026-05-19T00:00:00Z")
+
+    def raise_invalid_response(*args: object, **kwargs: object) -> object:
+        raise ValueError("not json")
+
+    monkeypatch.setattr(evaluator_module, "_urlopen_json_with_timeout_retry", raise_invalid_response)
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("left-pad@1.0.0"),
+        store=store,
+        workspace_dir=tmp_path / "workspace",
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "monitor"
+    assert result.policy_action == "allow"
+    assert result.enforcement in {"offline_cached", "local_fallback"}
+
+
 def test_evaluate_package_request_artifact_normalizes_cloud_review_decision(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -735,6 +778,62 @@ def test_evaluate_package_request_artifact_respects_policy_severity_threshold(
 
     assert result.decision == "monitor"
     assert result.matched_rule_id is None
+    assert result.enforcement == "offline_cached"
+
+
+def test_evaluate_package_request_artifact_keeps_policy_metadata_on_winning_package(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="minimist",
+                version="1.2.8",
+                default_action="block",
+                recommended_fix_version="1.2.9",
+            ),
+            _package(
+                ecosystem="npm",
+                name="left-pad",
+                version="1.0.0",
+                default_action="monitor",
+                normalized_severity="low",
+                exploit_level="none",
+                known_exploited=False,
+                malware_state="none",
+                risk_score=220,
+            ),
+        ],
+        policy_rules=[
+            {
+                "action": "allow",
+                "ruleId": "allow-left-pad",
+                "ecosystemSelector": "npm",
+                "enabled": True,
+                "expiresAt": "2099-01-01T00:00:00Z",
+                "harnessSelector": "codex",
+                "packageSelector": "left-pad",
+                "priority": 1,
+                "severityThreshold": None,
+                "versionRangeSelector": "1.0.0",
+            }
+        ],
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, response, "2026-05-19T00:00:00Z")
+
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("minimist@1.2.8", "left-pad@1.0.0"),
+        store=store,
+        workspace_dir=tmp_path / "workspace",
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "block"
+    assert result.matched_rule_id is None
+    assert result.exception_id is None
     assert result.enforcement == "offline_cached"
 
 

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -1,0 +1,810 @@
+"""Behavior tests for local supply-chain package evaluation."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import threading
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import ClassVar
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generate_private_key
+
+from codex_plugin_scanner.guard.runtime.package_intent_common import (
+    PackageIntent,
+    build_package_request_artifact,
+    js_target,
+)
+from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import (
+    _workspace_fingerprint,
+    evaluate_package_request_artifact,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+
+WORKSPACE_ID = "workspace-alpha"
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _generate_key_pair() -> tuple[bytes, bytes]:
+    private_key = generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem, public_pem
+
+
+def _fingerprint(public_key_pem: bytes) -> str:
+    return hashlib.sha256(public_key_pem.decode("utf-8").strip().encode("utf-8")).hexdigest()
+
+
+def _bundle_response(
+    *,
+    packages: list[dict[str, object]],
+    policy_rules: list[dict[str, object]] | None = None,
+    bundle_version: str = "1747612800000-deadbeef",
+    expires_at: datetime | None = None,
+    generated_at: datetime | None = None,
+    tier: str = "premium",
+) -> dict[str, object]:
+    generated = generated_at or datetime(2026, 5, 19, tzinfo=timezone.utc)
+    expires = expires_at or (generated + timedelta(hours=12))
+    bundle = {
+        "advisories": [
+            {
+                "advisoryId": "GHSA-vh95-rmgr-6w4m",
+                "aliases": ["CVE-2020-7598"],
+                "confidence": 990,
+                "exploitLevel": "active",
+                "knownExploited": True,
+                "malwareState": "known",
+                "normalizedSeverity": "critical",
+                "recommendedFixVersion": "1.2.9",
+                "sourceKey": "ghsa",
+                "summary": "Prototype pollution in minimist",
+                "title": "Prototype pollution in minimist",
+            }
+        ],
+        "bundleVersion": bundle_version,
+        "expiresAt": _iso(expires),
+        "feedSnapshotHash": "feed-snapshot-1",
+        "generatedAt": _iso(generated),
+        "keyId": "guard-bundle-key-2026-05",
+        "packages": packages,
+        "policyHash": "policy-hash-1",
+        "policyRules": policy_rules or [],
+        "scoringVersion": "scf-v1",
+        "sourceHashes": [{"payloadHash": "ghsa-feed-hash", "sourceKey": "ghsa", "staleStatus": "fresh"}],
+        "tier": tier,
+        "workspaceId": WORKSPACE_ID,
+    }
+    private_key_pem, public_key_pem = _generate_key_pair()
+    loaded_key = serialization.load_pem_private_key(private_key_pem, password=None)
+    assert isinstance(loaded_key, RSAPrivateKey)
+    canonical_payload = json.dumps(bundle, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    payload_hash = hashlib.sha256(canonical_payload).hexdigest()
+    signature = loaded_key.sign(
+        canonical_payload,
+        padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+        hashes.SHA256(),
+    )
+    return {
+        "bundle": bundle,
+        "payloadHash": payload_hash,
+        "signature": base64.b64encode(signature).decode("utf-8"),
+        "signatureAlgorithm": "rsa-pss-sha256",
+        "verificationKeys": [
+            {
+                "fingerprintSha256": _fingerprint(public_key_pem),
+                "keyId": "guard-bundle-key-2026-05",
+                "publicKeyPem": public_key_pem.decode("utf-8").strip(),
+                "state": "active",
+                "validUntil": None,
+            }
+        ],
+    }
+
+
+def _package(
+    *,
+    ecosystem: str,
+    name: str,
+    version: str,
+    default_action: str,
+    normalized_severity: str = "critical",
+    exploit_level: str = "active",
+    known_exploited: bool = True,
+    malware_state: str = "known",
+    namespace: str | None = None,
+    recommended_fix_version: str | None = None,
+    risk_score: int = 980,
+) -> dict[str, object]:
+    return {
+        "confidence": 990,
+        "defaultAction": default_action,
+        "ecosystem": ecosystem,
+        "exploitLevel": exploit_level,
+        "knownExploited": known_exploited,
+        "malwareState": malware_state,
+        "name": name,
+        "namespace": namespace,
+        "normalizedSeverity": normalized_severity,
+        "packageAgeState": "watch",
+        "purl": f"pkg:{ecosystem}/{name}@{version}",
+        "reachability": "reachable",
+        "recommendedFixVersion": recommended_fix_version,
+        "relatedAdvisoryIds": ["GHSA-vh95-rmgr-6w4m"],
+        "riskScore": risk_score,
+        "sourceIntegrityState": "high-risk",
+        "version": version,
+    }
+
+
+def _artifact_for_targets(
+    *targets: str,
+    harness: str = "codex",
+    package_manager: str = "npm",
+    intent_kind: str = "install",
+    manifest_paths: tuple[str, ...] = (),
+    lockfile_paths: tuple[str, ...] = (),
+    flags: tuple[str, ...] = (),
+    notes: tuple[str, ...] = (),
+) -> object:
+    command_tokens = tuple([package_manager, intent_kind, *targets])
+    intent = PackageIntent(
+        package_manager=package_manager,
+        intent_kind=intent_kind,
+        command_tokens=command_tokens,
+        redacted_command=" ".join(command_tokens),
+        targets=tuple(js_target(target) for target in targets),
+        manifest_paths=manifest_paths,
+        lockfile_paths=lockfile_paths,
+        flags=flags,
+        notes=notes,
+    )
+    return build_package_request_artifact(harness, intent, config_path="codex.json", source_scope="project")
+
+
+class _EvaluateHandler(BaseHTTPRequestHandler):
+    captured_headers: ClassVar[dict[str, str]] = {}
+    captured_requests: ClassVar[list[dict[str, object]]] = []
+    response_code: ClassVar[int] = 200
+    response_payload: ClassVar[dict[str, object]] = {}
+
+    def do_POST(self) -> None:
+        if self.path.startswith("/api/guard/supply-chain/evaluate"):
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length).decode("utf-8")
+            self.__class__.captured_headers = {
+                "Authorization": self.headers.get("Authorization", ""),
+                "Content-Type": self.headers.get("Content-Type", ""),
+            }
+            self.__class__.captured_requests.append(json.loads(body))
+            payload = json.dumps(self.__class__.response_payload).encode("utf-8")
+            self.send_response(self.__class__.response_code)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+        self.send_response(404)
+        self.end_headers()
+
+    def log_message(self, message_format: str, *args: object) -> None:
+        del message_format, args
+
+
+def _cloud_response(*, decision: str, enforcement: str, entitlement_state: str, package_name: str) -> dict[str, object]:
+    return {
+        "cacheStatus": "miss" if enforcement != "upgrade_required" else "upgrade-gated",
+        "copy": {
+            "ctaHref": "/guard/inbox",
+            "ctaLabel": "Review evidence",
+            "summary": f"{package_name} needs a safer version before you continue.",
+            "title": "Critical install blocked" if decision == "block" else "Upgrade required for cloud evaluation",
+        },
+        "decision": decision,
+        "enforcement": enforcement,
+        "entitlementState": entitlement_state,
+        "evidenceIds": ["evidence-1"],
+        "expiresAt": "2026-05-19T00:15:00Z",
+        "generatedAt": "2026-05-19T00:00:00Z",
+        "packages": [
+            {
+                "advisoryIds": ["GHSA-vh95-rmgr-6w4m"],
+                "decision": decision,
+                "ecosystem": "npm",
+                "name": package_name,
+                "namespace": None,
+                "reasons": [
+                    {
+                        "advisoryId": "GHSA-vh95-rmgr-6w4m",
+                        "code": "known_advisory",
+                        "message": "Prototype pollution in minimist",
+                        "packageName": package_name,
+                        "severity": "critical" if decision == "block" else "unknown",
+                        "source": "ghsa",
+                    }
+                ],
+                "recommendedFixVersion": "1.2.9" if decision == "block" else None,
+                "requestedVersion": "1.2.8" if decision == "block" else None,
+                "resolvedVersion": "1.2.8" if decision == "block" else None,
+                "riskScore": 980 if decision == "block" else None,
+                "sourceKeys": ["ghsa"] if decision == "block" else [],
+                "sourceStale": False,
+                "status": "known" if decision == "block" else "unknown",
+            }
+        ],
+        "policyId": f"workspace:{WORKSPACE_ID}:supply-chain",
+        "policyVersion": "policy-version-1",
+        "reasons": [
+            {
+                "advisoryId": "GHSA-vh95-rmgr-6w4m",
+                "code": "known_advisory" if decision == "block" else "upgrade_required",
+                "message": "Prototype pollution in minimist"
+                if decision == "block"
+                else "Upgrade to a paid Guard workspace to unlock cloud package intelligence.",
+                "packageName": package_name,
+                "severity": "critical" if decision == "block" else "unknown",
+                "source": "ghsa" if decision == "block" else "guard-cloud",
+            }
+        ],
+        "recommendation": decision,
+        "staleSources": [],
+        "workspaceId": WORKSPACE_ID,
+    }
+
+
+def test_evaluate_package_request_artifact_posts_cloud_request_and_maps_block_response(tmp_path: Path) -> None:
+    _EvaluateHandler.captured_headers = {}
+    _EvaluateHandler.captured_requests = []
+    _EvaluateHandler.response_payload = _cloud_response(
+        decision="block",
+        enforcement="premium_cloud",
+        entitlement_state="premium",
+        package_name="minimist",
+    )
+    server = HTTPServer(("127.0.0.1", 0), _EvaluateHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        store = GuardStore(tmp_path / "guard-home")
+        store.set_sync_credentials(
+            f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            "demo-token",
+            "2026-05-19T00:00:00Z",
+            workspace_id=WORKSPACE_ID,
+        )
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir()
+        (workspace_dir / "package-lock.json").write_text(
+            '{"packages":{"node_modules/minimist":{"version":"1.2.8"}}}', encoding="utf-8"
+        )
+        artifact = _artifact_for_targets("minimist@1.2.8", lockfile_paths=("package-lock.json",))
+
+        result = evaluate_package_request_artifact(
+            artifact=artifact,
+            store=store,
+            workspace_dir=workspace_dir,
+            now="2026-05-19T00:00:00Z",
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+    request_payload = _EvaluateHandler.captured_requests[0]
+    assert _EvaluateHandler.captured_headers["Authorization"] == "Bearer demo-token"
+    assert request_payload["commandShape"]["packageManager"] == "npm"
+    assert request_payload["commandShape"]["verb"] == "install"
+    assert request_payload["lockfileContext"]["fileName"] == "package-lock.json"
+    assert request_payload["packages"][0]["name"] == "minimist"
+    assert request_payload["policyVersion"]
+    assert request_payload["workspaceFingerprint"]
+    assert result.decision == "block"
+    assert result.policy_action == "block"
+    assert result.enforcement == "premium_cloud"
+    assert result.user_copy.title == "Critical install blocked"
+    assert result.user_copy.summary == "minimist needs a safer version before you continue."
+    assert result.user_copy.next_step == "npm install minimist@1.2.9"
+    assert result.user_copy.dashboard_url == "https://hol.org/guard/inbox"
+    assert "minimist@1.2.8" in result.user_copy.harness_message
+    assert "npm install minimist@1.2.9" in result.user_copy.harness_message
+
+
+def test_evaluate_package_request_artifact_uses_cached_eval_before_network(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
+    )
+    response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="minimist",
+                version="1.2.8",
+                default_action="block",
+                recommended_fix_version="1.2.9",
+            )
+        ]
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, response, "2026-05-19T00:00:00Z")
+    artifact = _artifact_for_targets("minimist@1.2.8")
+    workspace_dir = tmp_path / "workspace"
+    package_intent_hash = str(artifact.artifact_id).rsplit(":", 1)[-1]
+    store.cache_supply_chain_evaluation(
+        workspace_id=WORKSPACE_ID,
+        package_intent_hash=package_intent_hash,
+        feed_snapshot_hash="feed-snapshot-1",
+        policy_hash="policy-hash-1",
+        scoring_version="scf-v1",
+        bundle_version="1747612800000-deadbeef",
+        decision={
+            "decision": "block",
+            "policy_action": "block",
+            "enforcement": "offline_cached",
+            "entitlement_state": "premium",
+            "cache_status": "hit",
+            "workspace_fingerprint": _workspace_fingerprint(
+                WORKSPACE_ID,
+                workspace_dir=workspace_dir,
+                artifact=artifact,
+                bundle_meta={"policy_hash": "policy-hash-1"},
+            ),
+            "reasons": [{"code": "known_malware_or_kev", "message": "Prototype pollution in minimist"}],
+            "packages": [{"name": "minimist", "decision": "block", "recommendedFixVersion": "1.2.9"}],
+            "matched_rule_id": None,
+            "exception_id": None,
+            "risk_summary": "HOL Guard blocked `minimist@1.2.8` before install.",
+            "record_monitor_evidence": False,
+            "user_copy": {
+                "title": "Critical install blocked",
+                "summary": "minimist needs a safer version before you continue.",
+                "next_step": "npm install minimist@1.2.9",
+                "dashboard_url": "https://hol.org/guard/inbox",
+                "harness_message": (
+                    "HOL Guard blocked `minimist@1.2.8` before install. Fix: install `npm install minimist@1.2.9`."
+                ),
+            },
+        },
+        now="2026-05-19T00:00:00Z",
+    )
+
+    def fail_urlopen(*args: object, **kwargs: object) -> object:
+        raise AssertionError("cached evaluation should not call the network")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fail_urlopen)
+    result = evaluate_package_request_artifact(
+        artifact=artifact,
+        store=store,
+        workspace_dir=workspace_dir,
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "block"
+    assert result.cache_status == "hit"
+    assert result.user_copy.next_step == "npm install minimist@1.2.9"
+
+
+def test_evaluate_package_request_artifact_skips_cached_eval_when_workspace_fingerprint_changes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="minimist",
+                version="1.2.8",
+                default_action="block",
+                recommended_fix_version="1.2.9",
+            )
+        ]
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, response, "2026-05-19T00:00:00Z")
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    lockfile_path = workspace_dir / "package-lock.json"
+    lockfile_path.write_text(
+        '{"packages":{"node_modules/react":{"version":"18.0.0"},'
+        '"node_modules/react/node_modules/minimist":{"version":"1.2.8"}}}',
+        encoding="utf-8",
+    )
+    artifact = _artifact_for_targets("react@18.0.0", lockfile_paths=("package-lock.json",))
+
+    initial = evaluate_package_request_artifact(
+        artifact=artifact,
+        store=store,
+        workspace_dir=workspace_dir,
+        now="2026-05-19T00:00:00Z",
+    )
+    lockfile_path.write_text(
+        '{"packages":{"node_modules/react":{"version":"18.0.0"}}}',
+        encoding="utf-8",
+    )
+    refreshed = evaluate_package_request_artifact(
+        artifact=artifact,
+        store=store,
+        workspace_dir=workspace_dir,
+        now="2026-05-19T00:00:05Z",
+    )
+
+    assert initial.decision == "block"
+    assert any("react/node_modules/minimist" in reason["message"] for reason in initial.reasons)
+    assert refreshed.decision == "monitor"
+    assert refreshed.cache_status != "hit"
+    assert all("react/node_modules/minimist" not in reason["message"] for reason in refreshed.reasons)
+
+
+def test_evaluate_package_request_artifact_blocks_insecure_source_url_without_cloud(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    artifact = _artifact_for_targets("demo@http://packages.example.com/demo-1.0.0.tgz")
+
+    result = evaluate_package_request_artifact(
+        artifact=artifact,
+        store=store,
+        workspace_dir=workspace_dir,
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "block"
+    assert result.policy_action == "block"
+    assert result.enforcement == "free_local"
+    assert "http" in result.risk_summary.lower()
+
+
+def test_evaluate_package_request_artifact_handles_upgrade_required_with_premium_copy(tmp_path: Path) -> None:
+    _EvaluateHandler.captured_requests = []
+    _EvaluateHandler.response_payload = _cloud_response(
+        decision="monitor",
+        enforcement="upgrade_required",
+        entitlement_state="free",
+        package_name="left-pad",
+    )
+    server = HTTPServer(("127.0.0.1", 0), _EvaluateHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        store = GuardStore(tmp_path / "guard-home")
+        store.set_sync_credentials(
+            f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            "demo-token",
+            "2026-05-19T00:00:00Z",
+            workspace_id=WORKSPACE_ID,
+        )
+        artifact = _artifact_for_targets("left-pad@1.0.0")
+
+        result = evaluate_package_request_artifact(
+            artifact=artifact,
+            store=store,
+            workspace_dir=tmp_path / "workspace",
+            now="2026-05-19T00:00:00Z",
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+    assert result.decision == "monitor"
+    assert result.policy_action == "allow"
+    assert result.enforcement == "upgrade_required"
+    assert "upgrade" in result.user_copy.title.lower()
+
+
+def test_evaluate_package_request_artifact_applies_policy_rule_override(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
+    )
+    response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="minimist",
+                version="1.2.8",
+                default_action="block",
+                recommended_fix_version="1.2.9",
+            )
+        ],
+        policy_rules=[
+            {
+                "action": "warn",
+                "ruleId": "policy-rule-1",
+                "ecosystemSelector": "npm",
+                "enabled": True,
+                "expiresAt": "2099-01-01T00:00:00Z",
+                "harnessSelector": "codex",
+                "packageSelector": "minimist",
+                "priority": 1,
+                "severityThreshold": "low",
+                "versionRangeSelector": "1.2.8",
+            }
+        ],
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, response, "2026-05-19T00:00:00Z")
+
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("minimist@1.2.8"),
+        store=store,
+        workspace_dir=tmp_path / "workspace",
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "warn"
+    assert result.policy_action == "warn"
+    assert result.enforcement == "policy_override"
+    assert result.matched_rule_id == "policy-rule-1"
+
+
+def test_evaluate_package_request_artifact_respects_policy_severity_threshold(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="left-pad",
+                version="1.0.0",
+                default_action="monitor",
+                normalized_severity="low",
+                exploit_level="none",
+                known_exploited=False,
+                malware_state="none",
+                risk_score=220,
+            )
+        ],
+        policy_rules=[
+            {
+                "action": "allow",
+                "ruleId": "allow-high-only",
+                "ecosystemSelector": "npm",
+                "enabled": True,
+                "expiresAt": "2099-01-01T00:00:00Z",
+                "harnessSelector": "codex",
+                "packageSelector": "left-pad",
+                "priority": 1,
+                "severityThreshold": "high",
+                "versionRangeSelector": "1.0.0",
+            }
+        ],
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, response, "2026-05-19T00:00:00Z")
+
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("left-pad@1.0.0"),
+        store=store,
+        workspace_dir=tmp_path / "workspace",
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "monitor"
+    assert result.matched_rule_id is None
+    assert result.enforcement == "offline_cached"
+
+
+def test_evaluate_package_request_artifact_applies_allow_exception_rule(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
+    )
+    response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="minimist",
+                version="1.2.8",
+                default_action="block",
+                recommended_fix_version="1.2.9",
+            )
+        ],
+        policy_rules=[
+            {
+                "action": "allow",
+                "ruleId": "guard-exception-123",
+                "ecosystemSelector": "npm",
+                "enabled": True,
+                "expiresAt": "2099-01-01T00:00:00Z",
+                "harnessSelector": "codex",
+                "packageSelector": "minimist",
+                "priority": 1,
+                "severityThreshold": None,
+                "versionRangeSelector": "1.2.8",
+            }
+        ],
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, response, "2026-05-19T00:00:00Z")
+
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("minimist@1.2.8"),
+        store=store,
+        workspace_dir=tmp_path / "workspace",
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "allow"
+    assert result.policy_action == "allow"
+    assert result.exception_id == "guard-exception-123"
+
+
+def test_evaluate_package_request_artifact_summarizes_multi_package_and_safe_alternatives(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
+    )
+    response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="minimist",
+                version="1.2.8",
+                default_action="block",
+                recommended_fix_version="1.2.9",
+                risk_score=980,
+            ),
+            _package(
+                ecosystem="npm",
+                name="lodash",
+                version="4.17.20",
+                default_action="warn",
+                normalized_severity="high",
+                exploit_level="elevated",
+                known_exploited=False,
+                malware_state="none",
+                recommended_fix_version="4.17.21",
+                risk_score=720,
+            ),
+        ]
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, response, "2026-05-19T00:00:00Z")
+
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("minimist@1.2.8", "lodash@4.17.20"),
+        store=store,
+        workspace_dir=tmp_path / "workspace",
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "block"
+    assert len(result.packages) == 2
+    assert "lodash" in result.user_copy.summary.lower()
+    assert "1.2.9" in (result.user_copy.next_step or "")
+
+
+def test_evaluate_package_request_artifact_blocks_transitive_lockfile_match_with_dependency_path(
+    tmp_path: Path,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
+    )
+    response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="minimist",
+                version="1.2.8",
+                default_action="block",
+                recommended_fix_version="1.2.9",
+            )
+        ]
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, response, "2026-05-19T00:00:00Z")
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    (workspace_dir / "package-lock.json").write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "": {"name": "react-app"},
+                    "node_modules/react": {"version": "18.0.0"},
+                    "node_modules/react/node_modules/minimist": {"version": "1.2.8"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("react@18.0.0", lockfile_paths=("package-lock.json",)),
+        store=store,
+        workspace_dir=workspace_dir,
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "block"
+    assert any("react/node_modules/minimist" in reason["message"] for reason in result.reasons)
+
+
+def test_evaluate_package_request_artifact_range_only_timeout_falls_back_safely(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
+    )
+    response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="minimist",
+                version="1.2.8",
+                default_action="block",
+                recommended_fix_version="1.2.9",
+            )
+        ]
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, response, "2026-05-19T00:00:00Z")
+
+    def timeout_urlopen(*args: object, **kwargs: object) -> object:
+        raise TimeoutError("timed out")
+
+    monkeypatch.setattr(urllib.request, "urlopen", timeout_urlopen)
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("minimist@^1.2.0"),
+        store=store,
+        workspace_dir=tmp_path / "workspace",
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "monitor"
+    assert result.policy_action == "allow"
+    assert result.enforcement in {"local_fallback", "offline_cached"}
+    assert any(reason["code"] == "cloud_timeout" for reason in result.reasons)
+
+
+def test_evaluate_package_request_artifact_stale_bundle_requests_refresh_and_records_monitor(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
+    )
+    stale_response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="left-pad",
+                version="1.0.0",
+                default_action="monitor",
+                normalized_severity="low",
+                exploit_level="none",
+                known_exploited=False,
+                malware_state="none",
+                risk_score=220,
+            )
+        ],
+        generated_at=datetime(2026, 5, 18, tzinfo=timezone.utc),
+        expires_at=datetime(2026, 5, 18, 1, tzinfo=timezone.utc),
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, stale_response, "2026-05-18T01:00:00Z")
+
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("left-pad@1.0.0"),
+        store=store,
+        workspace_dir=tmp_path / "workspace",
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "monitor"
+    assert result.refresh_required is True
+    assert store.list_events(event_name="supply_chain_bundle_refresh_requested")
+    evidence = store.list_evidence()
+    assert evidence
+    assert evidence[0]["category"] == "supply-chain"

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -1133,6 +1133,54 @@ def test_evaluate_package_request_artifact_handles_unreadable_workspace_paths_wi
     assert result.policy_action == "allow"
 
 
+def test_evaluate_package_request_artifact_handles_unreadable_transitive_lockfile_without_crashing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="left-pad",
+                version="1.0.0",
+                default_action="monitor",
+                normalized_severity="low",
+                exploit_level="none",
+                known_exploited=False,
+                malware_state="none",
+                risk_score=220,
+            )
+        ]
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, response, "2026-05-19T00:00:00Z")
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    lockfile_path = workspace_dir / "package-lock.json"
+    lockfile_path.write_text(
+        json.dumps({"packages": {"": {"name": "demo-app"}}}),
+        encoding="utf-8",
+    )
+    original_read_text = Path.read_text
+
+    def guarded_read_text(path: Path, *args: object, **kwargs: object) -> str:
+        if path == lockfile_path:
+            raise OSError("permission denied")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", guarded_read_text)
+
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("left-pad@1.0.0", lockfile_paths=("package-lock.json",)),
+        store=store,
+        workspace_dir=workspace_dir,
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "monitor"
+    assert result.policy_action == "allow"
+
+
 def test_evaluate_package_request_artifact_handles_unreadable_lockfile_context_without_crashing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -1008,6 +1008,51 @@ def test_evaluate_package_request_artifact_blocks_transitive_lockfile_match_with
     assert any("react/node_modules/minimist" in reason["message"] for reason in result.reasons)
 
 
+def test_evaluate_package_request_artifact_blocks_hoisted_lockfile_match(
+    tmp_path: Path,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
+    )
+    response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="minimist",
+                version="1.2.8",
+                default_action="block",
+                recommended_fix_version="1.2.9",
+            )
+        ]
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, response, "2026-05-19T00:00:00Z")
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    (workspace_dir / "package-lock.json").write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "": {"name": "react-app"},
+                    "node_modules/react": {"version": "18.0.0"},
+                    "node_modules/minimist": {"version": "1.2.8"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("react@18.0.0", lockfile_paths=("package-lock.json",)),
+        store=store,
+        workspace_dir=workspace_dir,
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "block"
+    assert any("minimist" in reason["message"] for reason in result.reasons)
+
+
 def test_evaluate_package_request_artifact_handles_invalid_lockfile_bytes_without_crashing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1031,6 +1076,54 @@ def test_evaluate_package_request_artifact_handles_invalid_lockfile_bytes_withou
 
     result = evaluate_package_request_artifact(
         artifact=_artifact_for_targets("react@18.0.0", lockfile_paths=("package-lock.json",)),
+        store=store,
+        workspace_dir=workspace_dir,
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "monitor"
+    assert result.policy_action == "allow"
+
+
+def test_evaluate_package_request_artifact_handles_unreadable_workspace_paths_without_crashing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="left-pad",
+                version="1.0.0",
+                default_action="monitor",
+                normalized_severity="low",
+                exploit_level="none",
+                known_exploited=False,
+                malware_state="none",
+                risk_score=220,
+            )
+        ]
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, response, "2026-05-19T00:00:00Z")
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    lockfile_path = workspace_dir / "package-lock.json"
+    lockfile_path.write_text(
+        json.dumps({"packages": {"": {"name": "demo-app"}}}),
+        encoding="utf-8",
+    )
+    original_read_bytes = Path.read_bytes
+
+    def guarded_read_bytes(path: Path) -> bytes:
+        if path == lockfile_path:
+            raise OSError("permission denied")
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", guarded_read_bytes)
+
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("left-pad@1.0.0", lockfile_paths=("package-lock.json",)),
         store=store,
         workspace_dir=workspace_dir,
         now="2026-05-19T00:00:00Z",

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -483,7 +483,7 @@ def test_evaluate_package_request_artifact_blocks_scoped_insecure_source_url_wit
     store = GuardStore(tmp_path / "guard-home")
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir()
-    artifact = _artifact_for_targets("@scope/demo@http://packages.example.com/demo-1.0.0.tgz")
+    artifact = _artifact_for_targets("@scope/demo@HTTP://packages.example.com/demo-1.0.0.tgz")
 
     result = evaluate_package_request_artifact(
         artifact=artifact,
@@ -871,7 +871,7 @@ def test_evaluate_package_request_artifact_blocks_transitive_lockfile_match_with
     assert any("react/node_modules/minimist" in reason["message"] for reason in result.reasons)
 
 
-def test_evaluate_package_request_artifact_handles_malformed_lockfile_without_crashing(
+def test_evaluate_package_request_artifact_handles_invalid_lockfile_bytes_without_crashing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
@@ -890,7 +890,7 @@ def test_evaluate_package_request_artifact_handles_malformed_lockfile_without_cr
     store.cache_supply_chain_bundle(WORKSPACE_ID, response, "2026-05-19T00:00:00Z")
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir()
-    (workspace_dir / "package-lock.json").write_text("{not-json", encoding="utf-8")
+    (workspace_dir / "package-lock.json").write_bytes(b"\xff\xfe\xfd")
 
     result = evaluate_package_request_artifact(
         artifact=_artifact_for_targets("react@18.0.0", lockfile_paths=("package-lock.json",)),

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -477,6 +477,27 @@ def test_evaluate_package_request_artifact_blocks_insecure_source_url_without_cl
     assert "http" in result.risk_summary.lower()
 
 
+def test_evaluate_package_request_artifact_blocks_scoped_insecure_source_url_without_cloud(
+    tmp_path: Path,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    artifact = _artifact_for_targets("@scope/demo@http://packages.example.com/demo-1.0.0.tgz")
+
+    result = evaluate_package_request_artifact(
+        artifact=artifact,
+        store=store,
+        workspace_dir=workspace_dir,
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "block"
+    assert result.policy_action == "block"
+    assert result.enforcement == "free_local"
+    assert "http" in result.risk_summary.lower()
+
+
 def test_evaluate_package_request_artifact_handles_upgrade_required_with_premium_copy(tmp_path: Path) -> None:
     _EvaluateHandler.captured_requests = []
     _EvaluateHandler.response_payload = _cloud_response(
@@ -848,6 +869,38 @@ def test_evaluate_package_request_artifact_blocks_transitive_lockfile_match_with
 
     assert result.decision == "block"
     assert any("react/node_modules/minimist" in reason["message"] for reason in result.reasons)
+
+
+def test_evaluate_package_request_artifact_handles_malformed_lockfile_without_crashing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="minimist",
+                version="1.2.8",
+                default_action="block",
+                recommended_fix_version="1.2.9",
+            )
+        ]
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, response, "2026-05-19T00:00:00Z")
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    (workspace_dir / "package-lock.json").write_text("{not-json", encoding="utf-8")
+
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("react@18.0.0", lockfile_paths=("package-lock.json",)),
+        store=store,
+        workspace_dir=workspace_dir,
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "monitor"
+    assert result.policy_action == "allow"
 
 
 def test_evaluate_package_request_artifact_range_only_timeout_falls_back_safely(

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -6,6 +6,7 @@ import base64
 import hashlib
 import json
 import threading
+import urllib.error
 import urllib.request
 from datetime import datetime, timedelta, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -17,12 +18,17 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generate_private_key
 
+import codex_plugin_scanner.guard.runtime.supply_chain_package_eval as evaluator_module
 from codex_plugin_scanner.guard.runtime.package_intent_common import (
     PackageIntent,
     build_package_request_artifact,
     js_target,
 )
 from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import (
+    PackageRequestEvaluation,
+    SupplyChainUserCopy,
+    _evidence_id,
+    _with_additional_reason,
     _workspace_fingerprint,
     evaluate_package_request_artifact,
 )
@@ -508,6 +514,116 @@ def test_evaluate_package_request_artifact_handles_upgrade_required_with_premium
     assert "upgrade" in result.user_copy.title.lower()
 
 
+def test_evaluate_package_request_artifact_falls_back_on_cloud_http_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "demo-token",
+        "2026-05-19T00:00:00Z",
+        workspace_id=WORKSPACE_ID,
+    )
+    response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="left-pad",
+                version="1.0.0",
+                default_action="monitor",
+                normalized_severity="low",
+                exploit_level="none",
+                known_exploited=False,
+                malware_state="none",
+                risk_score=220,
+            )
+        ]
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, response, "2026-05-19T00:00:00Z")
+
+    def raise_http_error(*args: object, **kwargs: object) -> object:
+        raise urllib.error.HTTPError(
+            "https://hol.org/guard/supply-chain/evaluate",
+            401,
+            "unauthorized",
+            {},
+            None,
+        )
+
+    monkeypatch.setattr(evaluator_module, "_urlopen_json_with_timeout_retry", raise_http_error)
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("left-pad@1.0.0"),
+        store=store,
+        workspace_dir=tmp_path / "workspace",
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "monitor"
+    assert result.policy_action == "allow"
+    assert result.enforcement in {"offline_cached", "local_fallback"}
+
+
+def test_evaluate_package_request_artifact_normalizes_cloud_review_decision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "demo-token",
+        "2026-05-19T00:00:00Z",
+        workspace_id=WORKSPACE_ID,
+    )
+
+    monkeypatch.setattr(
+        evaluator_module,
+        "_urlopen_json_with_timeout_retry",
+        lambda **_: {
+            "cacheStatus": "miss",
+            "decision": "review",
+            "enforcement": "premium_cloud",
+            "entitlementState": "premium",
+            "packages": [
+                {
+                    "decision": "review",
+                    "ecosystem": "npm",
+                    "name": "minimist",
+                    "namespace": None,
+                    "requestedVersion": "1.2.8",
+                    "resolvedVersion": "1.2.8",
+                    "recommendedFixVersion": "1.2.9",
+                    "riskScore": 980,
+                    "reasons": [
+                        {
+                            "code": "known_advisory",
+                            "message": "Prototype pollution in minimist",
+                            "severity": "critical",
+                            "source": "ghsa",
+                        }
+                    ],
+                }
+            ],
+            "policyVersion": "policy-version-1",
+            "reasons": [
+                {
+                    "code": "known_advisory",
+                    "message": "Prototype pollution in minimist",
+                    "severity": "critical",
+                    "source": "ghsa",
+                }
+            ],
+        },
+    )
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("minimist@1.2.8"),
+        store=store,
+        workspace_dir=tmp_path / "workspace",
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "ask"
+    assert result.policy_action == "require-reapproval"
+
+
 def test_evaluate_package_request_artifact_applies_policy_rule_override(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     store.set_sync_credentials(
@@ -808,3 +924,61 @@ def test_evaluate_package_request_artifact_stale_bundle_requests_refresh_and_rec
     evidence = store.list_evidence()
     assert evidence
     assert evidence[0]["category"] == "supply-chain"
+
+
+def test_with_additional_reason_updates_all_packages() -> None:
+    evaluation = PackageRequestEvaluation(
+        decision="warn",
+        policy_action="warn",
+        enforcement="offline_cached",
+        entitlement_state="premium",
+        cache_status="miss",
+        package_intent_hash="intent-hash",
+        policy_version="policy-v1",
+        bundle_version="bundle-v1",
+        workspace_fingerprint="workspace-fingerprint",
+        reasons=({"code": "known_advisory", "message": "base"},),
+        packages=(
+            {"name": "minimist", "decision": "warn", "reasons": ({"code": "known_advisory"},)},
+            {"name": "lodash", "decision": "warn", "reasons": ({"code": "known_advisory"},)},
+        ),
+        risk_summary="HOL Guard warned about this package request.",
+        user_copy=SupplyChainUserCopy(
+            title="Warn",
+            summary="Warn",
+            next_step=None,
+            dashboard_url="https://hol.org/guard/inbox",
+            harness_message="Warn",
+        ),
+    )
+
+    updated = _with_additional_reason(
+        evaluation,
+        {
+            "code": "cloud_timeout",
+            "message": "Guard cloud evaluation timed out, so Guard fell back locally.",
+            "severity": "unknown",
+            "source": "guard-cloud",
+        },
+    )
+
+    assert all(any(reason["code"] == "cloud_timeout" for reason in package["reasons"]) for package in updated.packages)
+
+
+def test_evidence_id_distinguishes_versions_and_dependency_paths() -> None:
+    direct_package = {
+        "name": "minimist",
+        "resolvedVersion": "1.2.8",
+        "requestedVersion": "1.2.8",
+        "dependencyPath": None,
+        "decision": "block",
+    }
+    transitive_package = {
+        "name": "minimist",
+        "resolvedVersion": "1.2.8",
+        "requestedVersion": "1.2.8",
+        "dependencyPath": "react/node_modules/minimist",
+        "decision": "block",
+    }
+
+    assert _evidence_id("intent-hash", direct_package) != _evidence_id("intent-hash", transitive_package)

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -627,6 +627,44 @@ def test_evaluate_package_request_artifact_falls_back_on_invalid_cloud_response(
     assert result.enforcement in {"offline_cached", "local_fallback"}
 
 
+def test_evaluate_package_request_artifact_ignores_malformed_cached_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "demo-token",
+        "2026-05-19T00:00:00Z",
+        workspace_id=WORKSPACE_ID,
+    )
+    monkeypatch.setattr(
+        store,
+        "get_cached_supply_chain_bundle",
+        lambda workspace_id: {"bundle": "corrupted"},
+    )
+    monkeypatch.setattr(
+        evaluator_module,
+        "_urlopen_json_with_timeout_retry",
+        lambda *args, **kwargs: _cloud_response(
+            decision="monitor",
+            enforcement="premium_cloud",
+            entitlement_state="active",
+            package_name="left-pad",
+        ),
+    )
+
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("left-pad@1.0.0"),
+        store=store,
+        workspace_dir=tmp_path / "workspace",
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "monitor"
+    assert result.policy_action == "allow"
+    assert result.enforcement == "premium_cloud"
+
+
 def test_evaluate_package_request_artifact_normalizes_cloud_review_decision(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- add local supply-chain package evaluation with cache-first bundle/cloud fallback
- wire package-request decisions into the hook path with block/ask/warn handling and evidence persistence
- add focused evaluator and hook regression coverage for copy, policy, transitive, timeout, and cache-busting behavior

## Validation
- python3 -m ruff check src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py src/codex_plugin_scanner/guard/store.py src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_supply_chain_evaluator.py tests/test_guard_package_hook.py
- python3 -m pytest tests/test_guard_supply_chain_evaluator.py tests/test_guard_package_hook.py tests/test_guard_supply_chain_bundle.py tests/test_guard_runtime_decisions.py -q
- python3 -m pytest tests/test_guard_cli.py -q -k "test_guard_codex_hook_exits_with_block_status_in_actual_codex_runtime or test_guard_codex_pretooluse_returns_without_browser_wait"