### PR TITLE
fix(daemon): harden cloud handoff start response

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -993,7 +993,12 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 "handoff_url": f"{local_origin}/v1/apps/{adapter.harness}/cloud?{handoff_query}",
                 "local_origin": local_origin,
                 "status": "ready",
-            }
+            },
+            extra_headers={
+                "Cache-Control": "no-store, max-age=0",
+                "Pragma": "no-cache",
+                "Expires": "0",
+            },
         )
 
     def _cloud_app_handoff_token(
@@ -2548,7 +2553,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "Access-Control-Allow-Methods",
             "Access-Control-Allow-Headers",
             "Access-Control-Allow-Private-Network",
+            "Cache-Control",
+            "Expires",
             "Location",
+            "Pragma",
             "Vary",
         }
         validated: dict[str, str] = {}

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -21,15 +21,7 @@ from codex_plugin_scanner.guard.daemon.server import _headless_action_error_payl
 from codex_plugin_scanner.guard.store import GuardStore
 
 
-def _read_json_response(request: urllib.request.Request) -> tuple[int, dict[str, object]]:
-    try:
-        with urllib.request.urlopen(request, timeout=5) as response:
-            return response.status, json.loads(response.read().decode("utf-8"))
-    except urllib.error.HTTPError as error:
-        return error.code, json.loads(error.read().decode("utf-8"))
-
-
-def _read_json_response_with_headers(
+def _read_json_response_details(
     request: urllib.request.Request,
 ) -> tuple[int, dict[str, object], dict[str, str]]:
     try:
@@ -41,6 +33,17 @@ def _read_json_response_with_headers(
             )
     except urllib.error.HTTPError as error:
         return error.code, json.loads(error.read().decode("utf-8")), dict(error.headers.items())
+
+
+def _read_json_response(request: urllib.request.Request) -> tuple[int, dict[str, object]]:
+    status, payload, _headers = _read_json_response_details(request)
+    return status, payload
+
+
+def _read_json_response_with_headers(
+    request: urllib.request.Request,
+) -> tuple[int, dict[str, object], dict[str, str]]:
+    return _read_json_response_details(request)
 
 
 class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -29,6 +29,20 @@ def _read_json_response(request: urllib.request.Request) -> tuple[int, dict[str,
         return error.code, json.loads(error.read().decode("utf-8"))
 
 
+def _read_json_response_with_headers(
+    request: urllib.request.Request,
+) -> tuple[int, dict[str, object], dict[str, str]]:
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            return (
+                response.status,
+                json.loads(response.read().decode("utf-8")),
+                dict(response.headers.items()),
+            )
+    except urllib.error.HTTPError as error:
+        return error.code, json.loads(error.read().decode("utf-8")), dict(error.headers.items())
+
+
 class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
     def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
         return None
@@ -242,6 +256,30 @@ def test_cloud_app_handoff_start_mints_handoff_url_for_hosted_dashboard(tmp_path
     assert "HOL Guard local handoff" in body
     assert "handoffToken" in body
     assert "dashboardSessionToken" in body
+
+
+def test_cloud_app_handoff_start_response_is_not_cacheable(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, payload, headers = _read_json_response_with_headers(
+            _request(
+                daemon.port,
+                "/v1/apps/codex/cloud/start",
+                payload={"action": "connect", "workspace_id": "local-browser"},
+                origin="https://hol.org",
+                token=_dashboard_token_for(store),
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert payload["local_origin"] == f"http://127.0.0.1:{daemon.port}"
+    assert headers["Cache-Control"] == "no-store, max-age=0"
+    assert headers["Pragma"] == "no-cache"
+    assert headers["Expires"] == "0"
 
 
 def test_cloud_app_handoff_page_mints_scoped_browser_session_token(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary\n- mark cloud handoff start responses no-store so signed handoff URLs are not cached\n- keep the local_origin contract explicit for hosted dashboard recovery flows\n- add regression coverage for the handoff start response headers\n\n## Verification\n- python3 -c 'import pytest, sys; sys.exit(pytest.main(["tests/test_guard_headless_daemon_api.py"]))'