### PR TITLE
feat(guard): add tier2 supply-chain coverage

### DIFF
--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -99,6 +99,14 @@ Use it when you want to protect a harness before local MCP servers, skills, hook
    hol-guard device rotate
    ```
 
+12. Check supply-chain bundle coverage after sync when you want to see which ecosystems are fully protected, beta, or monitor-only:
+
+   ```bash
+   hol-guard cloud sync-intel
+   ```
+
+   Guard prints the latest bundle summary plus ecosystem support labels. Today `npm` and `PyPI` show **Protected** coverage, Cargo/Go/Maven/Gradle/Composer/RubyGems show **Beta**, and system packages or unsupported package managers stay **Monitor-only** so Guard never pretends advisory blocking where it does not exist.
+
 ## Which command should I use?
 
 | Situation | Command | What it answers |
@@ -113,6 +121,7 @@ Use it when you want to protect a harness before local MCP servers, skills, hook
 | I need the tracked catalog | `hol-guard inventory` | Which artifacts are currently tracked and present? |
 | I need an exportable evidence artifact | `hol-guard abom` | What local AI-BOM can I attach to an audit or handoff? |
 | I need the chronological log | `hol-guard events` | What happened over time on this machine? |
+| I need supply-chain coverage labels | `hol-guard cloud sync-intel` | Which ecosystems are protected, beta, or monitor-only right now? |
 
 ## One continuity model
 

--- a/docs/guard/testing-matrix.md
+++ b/docs/guard/testing-matrix.md
@@ -12,6 +12,18 @@ Automated coverage in this phase includes:
 - scheduled self-hosted harness smoke through `.github/workflows/harness-smoke.yml`
 - CLI DX contract tests for summary-first `run`, `explain`, `doctor`, `scan`, `lint`, and `verify` output
 - scanner command consistency tests for nonexistent target handling across `scan`, `lint`, `verify`, `doctor`, and `submit`
+- tier 2 package-request regressions for Cargo, Go, Maven, Gradle, Composer, RubyGems, system package managers, and unsupported-manager fallback
+- support-matrix assertions for `hol-guard cloud sync-intel` so CLI and Cloud surface `Protected`, `Beta`, and `Monitor-only` labels consistently
+
+## Supply-chain ecosystem support labels
+
+Use `hol-guard cloud sync-intel` after a successful bundle refresh to inspect current package-manager coverage:
+
+- **Protected**: `npm`, `PyPI`
+- **Beta**: `Cargo`, `Go modules`, `Maven/Gradle`, `Composer`, `RubyGems`
+- **Monitor-only**: Docker base images, GitHub Actions, system packages, and unsupported package managers
+
+Monitor-only means Guard still records the request and runs generic risk detection, but it does not claim signed-advisory blocking where no exact ecosystem coverage exists yet.
 
 Manual verification should include:
 
@@ -39,6 +51,7 @@ Manual verification should include:
 - `hol-guard connect status`
 - `hol-guard connect repair`
 - `hol-guard sync`
+- `hol-guard cloud sync-intel`
 - `hol-guard explain install-connect`
 - `hol-guard explain codex:project:<artifact-name>`
 - `hol-guard diff codex`

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -1157,10 +1157,25 @@ def _render_sync(console: Console, payload: dict[str, object]) -> None:
     if pain_signals_uploaded is not None:
         body.add_row("Pain signals uploaded", str(pain_signals_uploaded or 0))
     console.print(Panel(body, title="Guard sync complete", border_style="green"))
+    ecosystem_support = _coerce_dict_list(payload.get("ecosystem_support"))
+    if ecosystem_support:
+        console.print(_build_ecosystem_support_table(ecosystem_support))
 
 
 def _managed_install_state_text(managed_install: dict[str, object]) -> str:
     return "Installed" if bool(managed_install.get("active")) else "Removed"
+
+
+def _build_ecosystem_support_table(items: list[dict[str, object]]) -> Table:
+    table = Table(title="Ecosystem support", box=box.SIMPLE_HEAVY, show_header=True)
+    table.add_column("Ecosystem", style="bold")
+    table.add_column("Coverage")
+    for item in items:
+        table.add_row(
+            str(item.get("display_name") or item.get("ecosystem") or "unknown"),
+            str(item.get("support_label") or "Monitor-only"),
+        )
+    return table
 
 
 def _managed_install_mode_text(mode: object) -> str | None:

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
@@ -483,7 +483,7 @@ def _parse_system_package_intent(tokens: tuple[str, ...], *, workspace: Path | N
         "apt-get": {"install"},
         "brew": {"install"},
         "dnf": {"install"},
-        "pacman": {"-s", "-sy", "-suy"},
+        "pacman": {"-s", "-sy", "-syu", "-suy"},
         "yum": {"install"},
         "zypper": {"install", "in"},
     }
@@ -654,6 +654,10 @@ def _redact_local_source_tokens(segment: list[str]) -> list[str]:
         if token in path_flags and index + 1 < len(segment):
             redacted.extend((token, "<local-path>"))
             index += 2
+            continue
+        if token.startswith("--path="):
+            redacted.append("--path=<local-path>")
+            index += 1
             continue
         if token.startswith("file:"):
             redacted.append("file:<local-path>")

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
@@ -59,6 +59,15 @@ def parse_package_intent(command_text: str, *, workspace: Path | None = None) ->
         "bundle": _parse_bundle_intent,
         "bundler": _parse_bundle_intent,
         "gem": _parse_gem_intent,
+        "brew": _parse_system_package_intent,
+        "apt": _parse_system_package_intent,
+        "apt-get": _parse_system_package_intent,
+        "yum": _parse_system_package_intent,
+        "dnf": _parse_system_package_intent,
+        "apk": _parse_system_package_intent,
+        "pacman": _parse_system_package_intent,
+        "zypper": _parse_system_package_intent,
+        "helm": _parse_helm_intent,
     }
     handler = handlers.get(command_name)
     if handler is None:
@@ -338,9 +347,21 @@ def _parse_pipenv_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> 
 def _parse_cargo_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
     if len(tokens) < 2 or tokens[1] not in {"add", "install"}:
         return None
-    source_url = option_value(tokens, "--git")
+    source_url = option_value(tokens, "--path")
+    if source_url is not None:
+        source_url = f"file:{source_url}"
+    if source_url is None:
+        source_url = option_value(tokens, "--git")
     targets = tuple(
-        version_target("cargo", spec, source_url=source_url) for spec in _collect_package_specs(list(tokens[2:]))
+        version_target(
+            "cargo",
+            spec,
+            source_url=source_url,
+        )
+        for spec in _collect_specs(
+            tokens[2:],
+            skip_value_options={"--branch", "--git", "--index", "--path", "--registry", "--rev", "--tag"},
+        )
     )
     return _build_intent(
         "cargo",
@@ -452,6 +473,41 @@ def _parse_gem_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> Pac
     )
 
 
+def _parse_system_package_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
+    if len(tokens) < 2:
+        return None
+    command_name = _command_name(tokens[0])
+    install_verbs = {
+        "apk": {"add"},
+        "apt": {"install"},
+        "apt-get": {"install"},
+        "brew": {"install"},
+        "dnf": {"install"},
+        "pacman": {"-s", "-sy", "-suy"},
+        "yum": {"install"},
+        "zypper": {"install", "in"},
+    }
+    verb = tokens[1].lower()
+    if verb not in install_verbs.get(command_name, set()):
+        return None
+    targets = tuple(
+        PackageIntentTarget("system", package_name=spec, raw_spec=spec, requested_specifier=None)
+        for spec in _collect_specs(tokens[2:], skip_value_options={"--repo", "--repository", "-c"})
+    )
+    return _build_intent(command_name, "install", tokens, targets, workspace=workspace)
+
+
+def _parse_helm_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
+    if len(tokens) < 4 or tokens[1] != "install":
+        return None
+    chart = first_positional(tokens[3:], skip_value_options={"--version", "--repo", "-n", "--namespace"})
+    if chart is None:
+        chart = tokens[3]
+    version = option_value(tokens, "--version")
+    target = PackageIntentTarget("unsupported", package_name=chart, raw_spec=chart, requested_specifier=version)
+    return _build_intent("helm", "install", tokens, (target,), workspace=workspace)
+
+
 def _build_intent(
     package_manager: str,
     intent_kind: str,
@@ -547,6 +603,7 @@ def _redacted_command_text(command_text: str) -> str:
     segment = _strip_redaction_wrappers(segment)
     if len(segment) >= 3 and _command_name(segment[0]) in _PYTHON_EXECUTABLES and segment[1] == "-m":
         segment = [segment[2], *segment[3:]]
+    segment = _redact_local_source_tokens(segment)
     return redacted_command(tuple(segment))
 
 
@@ -586,6 +643,25 @@ def _strip_wrapper_tokens(segment: list[str]) -> list[str]:
             continue
         break
     return segment
+
+
+def _redact_local_source_tokens(segment: list[str]) -> list[str]:
+    redacted: list[str] = []
+    path_flags = {"--path"}
+    index = 0
+    while index < len(segment):
+        token = segment[index]
+        if token in path_flags and index + 1 < len(segment):
+            redacted.extend((token, "<local-path>"))
+            index += 2
+            continue
+        if token.startswith("file:"):
+            redacted.append("file:<local-path>")
+            index += 1
+            continue
+        redacted.append(token)
+        index += 1
+    return redacted
 
 
 def _strip_sudo_prefix(tokens: list[str]) -> list[str]:

--- a/src/codex_plugin_scanner/guard/runtime/package_manifest_diff.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_manifest_diff.py
@@ -110,15 +110,23 @@ def _dependency_map_for_path(path: str, text: str, *, deadline: float) -> dict[s
     if lower_path.endswith("pipfile.lock"):
         return _pipfile_lock_dependency_map(text, deadline)
     if lower_path.endswith("cargo.toml"):
-        return _toml_table_dependency_map(text, ("dependencies", "dev-dependencies", "build-dependencies"), deadline)
+        return _cargo_toml_dependency_map(text, deadline)
+    if lower_path.endswith("cargo.lock"):
+        return _cargo_lock_dependency_map(text, deadline)
     if lower_path.endswith("go.mod"):
         return _go_mod_dependency_map(text, deadline)
     if lower_path.endswith("pom.xml"):
         return _pom_dependency_map(text, deadline)
     if lower_path.endswith("build.gradle") or lower_path.endswith("build.gradle.kts"):
         return _gradle_dependency_map(text, deadline)
+    if lower_path.endswith("gradle.lockfile"):
+        return _gradle_lockfile_dependency_map(text, deadline)
+    if lower_path.endswith("composer.lock"):
+        return _composer_lock_dependency_map(text, deadline)
     if lower_path.endswith("gemfile"):
         return _gemfile_dependency_map(text, deadline)
+    if lower_path.endswith("gemfile.lock"):
+        return _gemfile_lock_dependency_map(text, deadline)
     return {}
 
 
@@ -469,6 +477,60 @@ def _toml_table_dependency_map(text: str, sections: tuple[str, ...], deadline: f
     return dependencies
 
 
+def _cargo_toml_dependency_map(text: str, deadline: float) -> dict[str, str]:
+    _ensure_within_deadline(deadline)
+    payload = tomllib.loads(text or "")
+    dependencies: dict[str, str] = {}
+    for section in ("dependencies", "dev-dependencies", "build-dependencies"):
+        _collect_toml_dependency_table(dependencies, payload.get(section), deadline)
+    workspace = payload.get("workspace")
+    if isinstance(workspace, dict):
+        _collect_toml_dependency_table(dependencies, workspace.get("dependencies"), deadline)
+    target = payload.get("target")
+    if isinstance(target, dict):
+        for section_payload in target.values():
+            _ensure_within_deadline(deadline)
+            if not isinstance(section_payload, dict):
+                continue
+            for section in ("dependencies", "dev-dependencies", "build-dependencies"):
+                _collect_toml_dependency_table(dependencies, section_payload.get(section), deadline)
+    return dependencies
+
+
+def _collect_toml_dependency_table(
+    dependencies: dict[str, str],
+    values: object,
+    deadline: float,
+) -> None:
+    if not isinstance(values, dict):
+        return
+    for package_name, value in values.items():
+        _ensure_within_deadline(deadline)
+        if isinstance(value, str):
+            dependencies[str(package_name)] = value
+            continue
+        if isinstance(value, dict) and isinstance(value.get("version"), str):
+            dependencies[str(package_name)] = str(value["version"])
+
+
+def _cargo_lock_dependency_map(text: str, deadline: float) -> dict[str, str]:
+    _ensure_within_deadline(deadline)
+    payload = tomllib.loads(text or "")
+    packages = payload.get("package")
+    dependencies: dict[str, str] = {}
+    if not isinstance(packages, list):
+        return dependencies
+    for package in packages:
+        _ensure_within_deadline(deadline)
+        if not isinstance(package, dict):
+            continue
+        name = package.get("name")
+        version = package.get("version")
+        if isinstance(name, str) and isinstance(version, str):
+            dependencies[name] = version
+    return dependencies
+
+
 def _go_mod_dependency_map(text: str, deadline: float) -> dict[str, str]:
     dependencies: dict[str, str] = {}
     in_require_block = False
@@ -514,6 +576,38 @@ def _gradle_dependency_map(text: str, deadline: float) -> dict[str, str]:
     return dependencies
 
 
+def _gradle_lockfile_dependency_map(text: str, deadline: float) -> dict[str, str]:
+    dependencies: dict[str, str] = {}
+    for raw_line in text.splitlines():
+        _ensure_within_deadline(deadline)
+        line = raw_line.strip()
+        if not line or line.startswith(("#", "empty=")) or "=" not in line:
+            continue
+        package_name, _, version = line.rpartition(":")
+        if package_name and version:
+            dependencies[package_name] = version
+    return dependencies
+
+
+def _composer_lock_dependency_map(text: str, deadline: float) -> dict[str, str]:
+    _ensure_within_deadline(deadline)
+    payload = json.loads(text or "{}")
+    dependencies: dict[str, str] = {}
+    for section in ("packages", "packages-dev"):
+        packages = payload.get(section)
+        if not isinstance(packages, list):
+            continue
+        for package in packages:
+            _ensure_within_deadline(deadline)
+            if not isinstance(package, dict):
+                continue
+            name = package.get("name")
+            version = package.get("version")
+            if isinstance(name, str) and isinstance(version, str):
+                dependencies[name] = version
+    return dependencies
+
+
 def _gemfile_dependency_map(text: str, deadline: float) -> dict[str, str]:
     dependencies: dict[str, str] = {}
     for line in text.splitlines():
@@ -521,6 +615,26 @@ def _gemfile_dependency_map(text: str, deadline: float) -> dict[str, str]:
         match = _GEMFILE_RE.search(line)
         if match is not None:
             dependencies[match.group(1)] = match.group(2) or ""
+    return dependencies
+
+
+def _gemfile_lock_dependency_map(text: str, deadline: float) -> dict[str, str]:
+    dependencies: dict[str, str] = {}
+    in_specs_block = False
+    for raw_line in text.splitlines():
+        _ensure_within_deadline(deadline)
+        stripped = raw_line.strip()
+        if stripped == "specs:":
+            in_specs_block = True
+            continue
+        if re.fullmatch(r"[A-Z][A-Z0-9_ ]+", stripped or ""):
+            in_specs_block = False
+            continue
+        if not in_specs_block:
+            continue
+        match = re.match(r"^\s{4}([A-Za-z0-9_.:-]+) \(([^)]+)\)", raw_line)
+        if match is not None:
+            dependencies[match.group(1)] = match.group(2)
     return dependencies
 
 

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -38,6 +38,7 @@ from .supply_chain_bundle import (
     load_supply_chain_verification_keys,
     verify_supply_chain_bundle_response,
 )
+from .supply_chain_support import ecosystem_support_matrix
 
 _APPROVAL_METADATA_KEYS = (
     "approval_center_url",
@@ -996,6 +997,7 @@ def sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
     summary = {
         "advisory_count": len(response.bundle.advisories),
         "bundle_version": response.bundle.bundle_version,
+        "ecosystem_support": list(ecosystem_support_matrix()),
         "feed_snapshot_hash": response.bundle.feed_snapshot_hash,
         "package_count": len(response.bundle.packages),
         "policy_hash": response.bundle.policy_hash,

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain.py
@@ -67,6 +67,10 @@ _DOCKER_IMAGE_LATEST = re.compile(
     r"FROM\s+[A-Za-z0-9._/:-]+:latest\b",
     re.IGNORECASE,
 )
+_DOCKER_BASE_IMAGE = re.compile(
+    r"^\s*FROM\s+([A-Za-z0-9._/-]+:[A-Za-z0-9._-]+)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
 _LOCKFILE_SOURCE_DRIFT = re.compile(
     r"\"resolved\"\s*:\s*\"(?!https://registry\.npmjs\.org/)[^\"]+\"",
     re.IGNORECASE,
@@ -96,6 +100,16 @@ _PUBLISH_WITH_TOKEN = re.compile(
     r"|(?:npm|pnpm|yarn|bun)\s+publish\b.*?(?:NPM_TOKEN|NODE_AUTH_TOKEN)\s*=\s*\S+",
     re.IGNORECASE | re.DOTALL,
 )
+_KNOWN_CRITICAL_BASE_IMAGES: dict[str, tuple[str, str]] = {
+    "python:3.6.15": (
+        "Python 3.6 base image is end-of-life",
+        "This exact Python base image tag is end-of-life and no longer receives security fixes.",
+    ),
+    "node:12.22.12": (
+        "Node.js 12 base image is end-of-life",
+        "This exact Node.js base image tag is end-of-life and no longer receives security fixes.",
+    ),
+}
 
 
 def detect_supply_chain_risk(
@@ -115,6 +129,7 @@ def detect_supply_chain_risk(
     _check_shell_curl_pipe_exec(content, signals)
     _check_gh_action_unpinned(content, signals)
     _check_docker_image_latest(content, signals)
+    _check_known_critical_docker_base_image(content, signals)
     _check_lockfile_source_drift(content, signals)
     _check_lockfile_integrity_missing(content, signals)
     _check_script_shell_profile(content, signals)
@@ -315,6 +330,27 @@ def _check_docker_image_latest(content: str, signals: list[RiskSignalV2]) -> Non
                 "FROM image:latest",
             )
         )
+
+
+def _check_known_critical_docker_base_image(content: str, signals: list[RiskSignalV2]) -> None:
+    for match in _DOCKER_BASE_IMAGE.finditer(content):
+        image_ref = match.group(1).lower()
+        title_reason = _KNOWN_CRITICAL_BASE_IMAGES.get(image_ref)
+        if title_reason is None:
+            continue
+        title, plain_reason = title_reason
+        signals.append(
+            _sc_signal(
+                "supply-chain.docker-base-image-known-critical",
+                "supply_chain",
+                "high",
+                "strong",
+                title,
+                plain_reason,
+                f"FROM {image_ref}",
+            )
+        )
+        return
 
 
 def _check_lockfile_source_drift(content: str, signals: list[RiskSignalV2]) -> None:

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -135,6 +135,9 @@ class PackageRequestEvaluation:
     ) -> PackageRequestEvaluation:
         user_copy = payload.get("user_copy")
         user_copy_map = user_copy if isinstance(user_copy, dict) else {}
+        cached_packages = tuple(
+            _with_support_metadata(item) for item in payload.get("packages", []) if isinstance(item, dict)
+        )
         return cls(
             decision=str(payload.get("decision") or "monitor"),
             policy_action=str(payload.get("policy_action") or "allow"),
@@ -146,11 +149,7 @@ class PackageRequestEvaluation:
             bundle_version=bundle_version,
             workspace_fingerprint=workspace_fingerprint,
             reasons=tuple(item for item in payload.get("reasons", []) if isinstance(item, dict)),
-            packages=tuple(
-                _with_support_metadata(item)
-                for item in payload.get("packages", [])
-                if isinstance(item, dict)
-            ),
+            packages=cached_packages,
             risk_summary=str(payload.get("risk_summary") or "HOL Guard recorded this package request."),
             user_copy=SupplyChainUserCopy(
                 title=str(user_copy_map.get("title") or "Monitoring this package"),

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -48,6 +48,7 @@ from .supply_chain_bundle_models import (
     SupplyChainBundlePolicyRule,
     SupplyChainBundleResponse,
 )
+from .supply_chain_support import ecosystem_support_metadata
 
 _DECISION_RANK = {"allow": 0, "monitor": 1, "warn": 2, "ask": 3, "block": 4}
 _SEVERITY_RANK = {"unknown": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
@@ -145,7 +146,11 @@ class PackageRequestEvaluation:
             bundle_version=bundle_version,
             workspace_fingerprint=workspace_fingerprint,
             reasons=tuple(item for item in payload.get("reasons", []) if isinstance(item, dict)),
-            packages=tuple(item for item in payload.get("packages", []) if isinstance(item, dict)),
+            packages=tuple(
+                _with_support_metadata(item)
+                for item in payload.get("packages", [])
+                if isinstance(item, dict)
+            ),
             risk_summary=str(payload.get("risk_summary") or "HOL Guard recorded this package request."),
             user_copy=SupplyChainUserCopy(
                 title=str(user_copy_map.get("title") or "Monitoring this package"),
@@ -355,7 +360,8 @@ def _finalize_evaluation(
     package_intent_hash: str,
     workspace_fingerprint: str | None,
 ) -> PackageRequestEvaluation:
-    primary_package = draft.packages[0] if draft.packages else {}
+    packages = tuple(_with_support_metadata(item) for item in draft.packages)
+    primary_package = packages[0] if packages else {}
     package_display = _package_display_name(primary_package)
     requested_version = _optional_string(primary_package.get("requestedVersion")) or _optional_string(
         primary_package.get("resolvedVersion")
@@ -434,7 +440,7 @@ def _finalize_evaluation(
         bundle_version=draft.bundle_version,
         workspace_fingerprint=workspace_fingerprint,
         reasons=draft.reasons,
-        packages=draft.packages,
+        packages=packages,
         risk_summary=risk_summary,
         user_copy=user_copy,
         matched_rule_id=draft.matched_rule_id,
@@ -702,6 +708,14 @@ def _heuristic_result(
 ) -> _EvaluationDraft | None:
     packages: list[dict[str, object]] = []
     for target in targets:
+        lockfile_parse_warning = _lockfile_parse_warning_result(
+            target=target,
+            artifact=artifact,
+            workspace_dir=workspace_dir,
+        )
+        if lockfile_parse_warning is not None:
+            packages.append(lockfile_parse_warning)
+            continue
         local_package_result = _local_package_manifest_result(
             target=target,
             artifact=artifact,
@@ -714,6 +728,21 @@ def _heuristic_result(
         if local_python_result is not None:
             packages.append(local_python_result)
             continue
+        ecosystem = _optional_string(target.get("ecosystem")) or "npm"
+        if ecosystem == "system":
+            packages.append(_system_package_monitor_result(target))
+            continue
+        if ecosystem == "unsupported":
+            packages.append(_unsupported_ecosystem_result(target))
+            continue
+        go_replace_result = _go_replace_result(target=target, artifact=artifact, workspace_dir=workspace_dir)
+        if go_replace_result is not None:
+            packages.append(go_replace_result)
+            continue
+        local_source_result = _local_source_dependency_result(target)
+        if local_source_result is not None:
+            packages.append(local_source_result)
+            continue
         source_url = _optional_string(target.get("source_url"))
         if source_url is not None and source_url.lower().startswith("http://"):
             packages.append(
@@ -721,7 +750,7 @@ def _heuristic_result(
                     target=target,
                     decision="block",
                     code="insecure_source_url",
-                    message=f"Insecure HTTP package source: {source_url}",
+                    message="Package source uses insecure HTTP transport.",
                     severity="high",
                 )
             )
@@ -732,7 +761,7 @@ def _heuristic_result(
                     target=target,
                     decision="warn",
                     code="git_dependency_source",
-                    message=f"Git package source requires review before install: {source_url}",
+                    message="Git package source requires review before install.",
                     severity="high",
                 )
             )
@@ -743,7 +772,7 @@ def _heuristic_result(
                     target=target,
                     decision="warn",
                     code="external_tarball_source",
-                    message=f"External HTTPS tarball source requires review before install: {source_url}",
+                    message="External tarball source requires review before install.",
                     severity="medium",
                 )
             )
@@ -1056,6 +1085,16 @@ def _lockfile_ecosystem(lockfile_name: str) -> str | None:
         return "npm"
     if lower_name in {"poetry.lock", "uv.lock", "pipfile.lock"}:
         return "pypi"
+    if lower_name == "cargo.lock":
+        return "cargo"
+    if lower_name == "composer.lock":
+        return "packagist"
+    if lower_name == "gemfile.lock":
+        return "rubygems"
+    if lower_name == "go.sum":
+        return "go"
+    if lower_name == "gradle.lockfile":
+        return "maven"
     return None
 
 
@@ -1093,6 +1132,65 @@ def _bundle_package_result(
             },
         ),
     }
+
+
+def _system_package_monitor_result(target: dict[str, object]) -> dict[str, object]:
+    command = _optional_string(target.get("redacted_command")) or ""
+    signals = detect_supply_chain_risk(command)
+    if signals:
+        strongest = sorted(signals, key=lambda item: _severity_rank_value(item.severity), reverse=True)[0]
+        return _heuristic_package_result(
+            target=target,
+            decision="warn",
+            code="system_package_manager_generic_risk",
+            message=strongest.plain_reason,
+            severity=strongest.severity,
+        )
+    return _heuristic_package_result(
+        target=target,
+        decision="warn",
+        code="system_package_manager_monitor_only",
+        message=(
+            "Guard treats system package managers as monitor-only coverage today and will not "
+            "pretend advisory blocking."
+        ),
+        severity="low",
+    )
+
+
+def _unsupported_ecosystem_result(target: dict[str, object]) -> dict[str, object]:
+    command = _optional_string(target.get("redacted_command")) or ""
+    signals = detect_supply_chain_risk(command)
+    if signals:
+        strongest = sorted(signals, key=lambda item: _severity_rank_value(item.severity), reverse=True)[0]
+        decision = "block" if strongest.severity in {"critical", "high"} else "warn"
+        return _heuristic_package_result(
+            target=target,
+            decision=decision,
+            code="unsupported_ecosystem_generic_risk",
+            message=strongest.plain_reason,
+            severity=strongest.severity,
+        )
+    return _heuristic_package_result(
+        target=target,
+        decision="monitor",
+        code="unsupported_ecosystem_monitor_only",
+        message="Guard recorded this unsupported package-manager request and applied generic risk detection only.",
+        severity="low",
+    )
+
+
+def _local_source_dependency_result(target: dict[str, object]) -> dict[str, object] | None:
+    source_url = _optional_string(target.get("source_url"))
+    if source_url is None or not source_url.startswith("file:"):
+        return None
+    return _heuristic_package_result(
+        target=target,
+        decision="warn",
+        code="local_path_dependency_source",
+        message="Local path dependency requires review before install.",
+        severity="medium",
+    )
 
 
 def _policy_package_result(target: dict[str, object], *, decision: str, rule_id: str) -> dict[str, object]:
@@ -1512,10 +1610,85 @@ def _heuristic_package_result(
     }
 
 
+def _go_replace_result(
+    *,
+    target: dict[str, object],
+    artifact: GuardArtifact,
+    workspace_dir: Path | None,
+) -> dict[str, object] | None:
+    if workspace_dir is None or (_optional_string(target.get("ecosystem")) or "npm") != "go":
+        return None
+    manifest_paths = artifact.metadata.get("manifest_paths")
+    if not isinstance(manifest_paths, list):
+        return None
+    go_mod_path = next((workspace_dir / str(path) for path in manifest_paths if Path(str(path)).name == "go.mod"), None)
+    if go_mod_path is None or not go_mod_path.exists():
+        return None
+    try:
+        go_mod_text = go_mod_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    replacements = _go_mod_replace_map(go_mod_text)
+    for candidate in _target_candidate_names(target):
+        replacement = replacements.get(candidate)
+        if replacement is None:
+            continue
+        if replacement.startswith(("file:", "./", "../", "/", "~", ".\\", "..\\")):
+            return _heuristic_package_result(
+                target=target,
+                decision="warn",
+                code="go_replace_local_source",
+                message="Go replace directive reroutes this module to a local path.",
+                severity="medium",
+            )
+        if _exact_version(replacement) is None:
+            return _heuristic_package_result(
+                target=target,
+                decision="warn",
+                code="go_replace_mutable_source",
+                message="Go replace directive reroutes this module away from proxy-pinned version resolution.",
+                severity="medium",
+            )
+    return None
+
+
+def _go_mod_replace_map(text: str) -> dict[str, str]:
+    replacements: dict[str, str] = {}
+    in_replace_block = False
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if line.startswith("replace ("):
+            in_replace_block = True
+            continue
+        if in_replace_block and line == ")":
+            in_replace_block = False
+            continue
+        if line.startswith("replace "):
+            line = line.removeprefix("replace ").strip()
+        elif not in_replace_block:
+            continue
+        if "=>" not in line:
+            continue
+        original, _, replacement = line.partition("=>")
+        normalized_original = original.strip().split()[0]
+        normalized_replacement = replacement.strip().split()[0]
+        if normalized_original and normalized_replacement:
+            replacements[_normalize_package_name("go", normalized_original)] = normalized_replacement
+    return replacements
+
+
 def _is_git_source_url(source_url: str) -> bool:
     normalized = source_url.lower()
     if normalized.startswith(("git+", "github:", "gitlab:", "bitbucket:")):
         return True
+    parsed = urllib.parse.urlsplit(source_url)
+    if (
+        parsed.scheme.lower() in {"http", "https"}
+        and parsed.hostname is not None
+        and parsed.hostname.lower() in {"github.com", "gitlab.com", "bitbucket.org"}
+    ):
+        path_parts = [part for part in parsed.path.split("/") if part]
+        return len(path_parts) >= 2
     return (
         "/" in source_url
         and not normalized.startswith(("http://", "https://"))
@@ -1570,6 +1743,15 @@ def _lockfile_dependency_versions(
             continue
         if lockfile_path.name == "bun.lock":
             versions.update(_bun_lock_target_versions(lockfile_text, targets))
+            continue
+        if lockfile_path.name == "Cargo.lock":
+            versions.update(_cargo_lock_target_versions(lockfile_text, targets))
+            continue
+        if lockfile_path.name == "composer.lock":
+            versions.update(_composer_lock_target_versions(lockfile_text, targets))
+            continue
+        if lockfile_path.name == "Gemfile.lock":
+            versions.update(_gemfile_lock_target_versions(lockfile_text, targets))
             continue
         if lockfile_path.name == "poetry.lock":
             versions.update(_poetry_lock_target_versions(lockfile_text, targets, python_manifest_names))
@@ -1627,7 +1809,7 @@ def _manifest_dependency_versions(
     if not isinstance(manifest_paths, list):
         return {}
     package_manager = str(artifact.metadata.get("package_manager") or "npm")
-    python_targets = {target_key: target for target in targets if (target_key := _lockfile_target_key(target))}
+    keyed_targets = {target_key: target for target in targets if (target_key := _lockfile_target_key(target))}
     versions: dict[tuple[str, str | None], str] = {}
     for relative_path in manifest_paths:
         manifest_path = workspace_dir / str(relative_path)
@@ -1644,17 +1826,20 @@ def _manifest_dependency_versions(
         )
         if not dependency_map:
             continue
-        normalized_dependencies = {
-            _normalize_package_name("pypi", package_name): specifier
-            for package_name, specifier in dependency_map.items()
-        }
-        for target_key, target in python_targets.items():
-            if (_optional_string(target.get("ecosystem")) or "npm") != "pypi" or target_key in versions:
+        for target_key, target in keyed_targets.items():
+            if target_key in versions:
                 continue
-            specifier = normalized_dependencies.get(str(target["normalized_name"]))
-            exact_version = _python_lockfile_version(specifier)
-            if exact_version is not None:
-                versions[target_key] = exact_version
+            ecosystem = _optional_string(target.get("ecosystem")) or "npm"
+            normalized_dependencies = {
+                _normalize_package_name(ecosystem, package_name): specifier
+                for package_name, specifier in dependency_map.items()
+            }
+            for candidate in _target_candidate_names(target):
+                specifier = normalized_dependencies.get(_normalize_package_name(ecosystem, candidate))
+                exact_version = _manifest_exact_version(ecosystem, specifier)
+                if exact_version is not None:
+                    versions[target_key] = exact_version
+                    break
     return versions
 
 
@@ -1753,6 +1938,38 @@ def _package_lock_candidate_names(target: dict[str, object]) -> tuple[str, ...]:
     if qualified_name not in candidates:
         candidates.append(qualified_name)
     return tuple(candidates)
+
+
+def _cargo_lock_target_versions(
+    text: str,
+    targets: tuple[dict[str, object], ...],
+) -> dict[tuple[str, str | None], str]:
+    direct_versions, _error = _safe_dependency_map_result_for_path("Cargo.lock", text, deadline=time.monotonic() + 0.2)
+    return _target_versions_from_direct_map(targets, direct_versions)
+
+
+def _composer_lock_target_versions(
+    text: str,
+    targets: tuple[dict[str, object], ...],
+) -> dict[tuple[str, str | None], str]:
+    direct_versions, _error = _safe_dependency_map_result_for_path(
+        "composer.lock",
+        text,
+        deadline=time.monotonic() + 0.2,
+    )
+    return _target_versions_from_direct_map(targets, direct_versions)
+
+
+def _gemfile_lock_target_versions(
+    text: str,
+    targets: tuple[dict[str, object], ...],
+) -> dict[tuple[str, str | None], str]:
+    direct_versions, _error = _safe_dependency_map_result_for_path(
+        "Gemfile.lock",
+        text,
+        deadline=time.monotonic() + 0.2,
+    )
+    return _target_versions_from_direct_map(targets, direct_versions)
 
 
 def _pnpm_lock_target_versions(
@@ -2055,14 +2272,11 @@ def _resolved_target_version(
     exact_version = _optional_string(target.get("version"))
     if exact_version is not None:
         return exact_version
+    lockfile_version = lockfile_versions.get(_lockfile_target_key(target))
+    if lockfile_version is not None:
+        return lockfile_version
     requested_range = _optional_string(target.get("range"))
     if requested_range is None:
-        return None
-    ecosystem = _optional_string(target.get("ecosystem")) or "npm"
-    if ecosystem in {"npm", "pypi"}:
-        lockfile_version = lockfile_versions.get(_lockfile_target_key(target))
-        if lockfile_version is not None:
-            return lockfile_version
         return None
     return _exact_version(requested_range)
 
@@ -2156,8 +2370,18 @@ def _source_url_from_raw_spec(raw_spec: str) -> str | None:
 
 
 def _safe_dependency_map_for_path(path: str, text: str, *, deadline: float) -> dict[str, str]:
+    dependency_map, _error = _safe_dependency_map_result_for_path(path, text, deadline=deadline)
+    return dependency_map
+
+
+def _safe_dependency_map_result_for_path(
+    path: str,
+    text: str,
+    *,
+    deadline: float,
+) -> tuple[dict[str, str], str | None]:
     try:
-        return _dependency_map_for_path(path, text, deadline=deadline)
+        return _dependency_map_for_path(path, text, deadline=deadline), None
     except (
         _DeadlineExceededError,
         ET.ParseError,
@@ -2165,7 +2389,71 @@ def _safe_dependency_map_for_path(path: str, text: str, *, deadline: float) -> d
         ValueError,
         json.JSONDecodeError,
     ):
-        return {}
+        return {}, "parse_error"
+
+
+def _lockfile_parse_warning_result(
+    *,
+    target: dict[str, object],
+    artifact: GuardArtifact,
+    workspace_dir: Path | None,
+) -> dict[str, object] | None:
+    if workspace_dir is None:
+        return None
+    lockfile_paths = artifact.metadata.get("lockfile_paths")
+    if not isinstance(lockfile_paths, list):
+        return None
+    target_ecosystem = _optional_string(target.get("ecosystem")) or "npm"
+    for relative_path in lockfile_paths:
+        lockfile_path = workspace_dir / str(relative_path)
+        if not lockfile_path.exists():
+            continue
+        lockfile_ecosystem = _lockfile_ecosystem(lockfile_path.name)
+        if lockfile_ecosystem is not None and lockfile_ecosystem != target_ecosystem:
+            continue
+        try:
+            lockfile_text = lockfile_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        _dependency_map, error = _safe_dependency_map_result_for_path(
+            lockfile_path.name,
+            lockfile_text,
+            deadline=time.monotonic() + 0.2,
+        )
+        if error is None:
+            continue
+        return _heuristic_package_result(
+            target=target,
+            decision="monitor",
+            code="lockfile_parse_error",
+            message=(
+                "Guard could not parse the existing lockfile and fell back to monitor-only "
+                "coverage. Repair the lockfile, then retry."
+            ),
+            severity="low",
+        )
+    return None
+
+
+def _manifest_exact_version(ecosystem: str, value: str | None) -> str | None:
+    if ecosystem == "pypi":
+        return _python_lockfile_version(value)
+    if ecosystem == "cargo":
+        normalized = _optional_string(value)
+        if normalized is None:
+            return None
+        if normalized.startswith("="):
+            return _exact_version(normalized.lstrip("="))
+        return None
+    return _exact_version(value)
+
+
+def _with_support_metadata(package: dict[str, object]) -> dict[str, object]:
+    metadata = ecosystem_support_metadata(_optional_string(package.get("ecosystem")) or "unsupported")
+    enriched = dict(package)
+    enriched["supportLevel"] = metadata["support_level"]
+    enriched["supportLabel"] = metadata["support_label"]
+    return enriched
 
 
 def _matching_policy_rule(

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -713,69 +713,63 @@ def _heuristic_result(
             artifact=artifact,
             workspace_dir=workspace_dir,
         )
-        if lockfile_parse_warning is not None:
-            packages.append(lockfile_parse_warning)
-            continue
+        package_result: dict[str, object] | None = None
         local_package_result = _local_package_manifest_result(
             target=target,
             artifact=artifact,
             workspace_dir=workspace_dir,
         )
         if local_package_result is not None:
-            packages.append(local_package_result)
-            continue
-        local_python_result = _local_python_build_result(target=target, workspace_dir=workspace_dir)
-        if local_python_result is not None:
-            packages.append(local_python_result)
-            continue
+            package_result = local_package_result
+        if package_result is None:
+            local_python_result = _local_python_build_result(target=target, workspace_dir=workspace_dir)
+            if local_python_result is not None:
+                package_result = local_python_result
         ecosystem = _optional_string(target.get("ecosystem")) or "npm"
-        if ecosystem == "system":
-            packages.append(_system_package_monitor_result(target))
-            continue
-        if ecosystem == "unsupported":
-            packages.append(_unsupported_ecosystem_result(target))
-            continue
-        go_replace_result = _go_replace_result(target=target, artifact=artifact, workspace_dir=workspace_dir)
-        if go_replace_result is not None:
-            packages.append(go_replace_result)
-            continue
-        local_source_result = _local_source_dependency_result(target)
-        if local_source_result is not None:
-            packages.append(local_source_result)
-            continue
+        if package_result is None and ecosystem == "system":
+            package_result = _system_package_monitor_result(target)
+        if package_result is None and ecosystem == "unsupported":
+            package_result = _unsupported_ecosystem_result(target)
+        if package_result is None:
+            go_replace_result = _go_replace_result(target=target, artifact=artifact, workspace_dir=workspace_dir)
+            if go_replace_result is not None:
+                package_result = go_replace_result
+        if package_result is None:
+            local_source_result = _local_source_dependency_result(target)
+            if local_source_result is not None:
+                package_result = local_source_result
         source_url = _optional_string(target.get("source_url"))
-        if source_url is not None and source_url.lower().startswith("http://"):
-            packages.append(
-                _heuristic_package_result(
-                    target=target,
-                    decision="block",
-                    code="insecure_source_url",
-                    message="Package source uses insecure HTTP transport.",
-                    severity="high",
-                )
+        if package_result is None and source_url is not None and source_url.lower().startswith("http://"):
+            package_result = _heuristic_package_result(
+                target=target,
+                decision="block",
+                code="insecure_source_url",
+                message="Package source uses insecure HTTP transport.",
+                severity="high",
             )
+        if package_result is None and source_url is not None and _is_git_source_url(source_url):
+            package_result = _heuristic_package_result(
+                target=target,
+                decision="warn",
+                code="git_dependency_source",
+                message="Git package source requires review before install.",
+                severity="high",
+            )
+        if package_result is None and source_url is not None and _is_external_https_tarball_source(source_url):
+            package_result = _heuristic_package_result(
+                target=target,
+                decision="warn",
+                code="external_tarball_source",
+                message="External tarball source requires review before install.",
+                severity="medium",
+            )
+        if package_result is None:
+            if lockfile_parse_warning is not None:
+                packages.append(lockfile_parse_warning)
             continue
-        if source_url is not None and _is_git_source_url(source_url):
-            packages.append(
-                _heuristic_package_result(
-                    target=target,
-                    decision="warn",
-                    code="git_dependency_source",
-                    message="Git package source requires review before install.",
-                    severity="high",
-                )
-            )
-            continue
-        if source_url is not None and _is_external_https_tarball_source(source_url):
-            packages.append(
-                _heuristic_package_result(
-                    target=target,
-                    decision="warn",
-                    code="external_tarball_source",
-                    message="External tarball source requires review before install.",
-                    severity="medium",
-                )
-            )
+        if lockfile_parse_warning is not None:
+            package_result = _with_package_reason(package_result, lockfile_parse_warning["reasons"][0])
+        packages.append(package_result)
     if not packages:
         return None
     packages.sort(key=lambda item: _decision_rank(str(item.get("decision") or "monitor")), reverse=True)
@@ -2454,6 +2448,16 @@ def _with_support_metadata(package: dict[str, object]) -> dict[str, object]:
     enriched["supportLevel"] = metadata["support_level"]
     enriched["supportLabel"] = metadata["support_label"]
     return enriched
+
+
+def _with_package_reason(package: dict[str, object], reason: dict[str, object]) -> dict[str, object]:
+    package_reasons = package.get("reasons")
+    updated = dict(package)
+    if isinstance(package_reasons, (tuple, list)):
+        updated["reasons"] = (*tuple(item for item in package_reasons if isinstance(item, dict)), reason)
+    else:
+        updated["reasons"] = (reason,)
+    return updated
 
 
 def _matching_policy_rule(

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_support.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_support.py
@@ -1,0 +1,53 @@
+"""Shared ecosystem support labels for Guard local supply-chain coverage."""
+
+from __future__ import annotations
+
+_SUPPORT_LEVELS: dict[str, tuple[str, str, str]] = {
+    "npm": ("npm", "protected", "Protected"),
+    "pypi": ("PyPI", "protected", "Protected"),
+    "cargo": ("Cargo", "beta", "Beta"),
+    "go": ("Go modules", "beta", "Beta"),
+    "maven": ("Maven/Gradle", "beta", "Beta"),
+    "packagist": ("Composer", "beta", "Beta"),
+    "rubygems": ("RubyGems", "beta", "Beta"),
+    "docker": ("Docker base images", "monitor-only", "Monitor-only"),
+    "github-actions": ("GitHub Actions", "monitor-only", "Monitor-only"),
+    "system": ("System packages", "monitor-only", "Monitor-only"),
+    "unsupported": ("Unsupported managers", "monitor-only", "Monitor-only"),
+}
+
+_SUPPORT_ORDER = (
+    "npm",
+    "pypi",
+    "cargo",
+    "go",
+    "maven",
+    "packagist",
+    "rubygems",
+    "docker",
+    "github-actions",
+    "system",
+    "unsupported",
+)
+
+
+def ecosystem_support_metadata(ecosystem: str) -> dict[str, str]:
+    display_name, support_level, support_label = _SUPPORT_LEVELS.get(
+        ecosystem,
+        (ecosystem.replace("-", " ").title(), "monitor-only", "Monitor-only"),
+    )
+    return {
+        "display_name": display_name,
+        "support_level": support_level,
+        "support_label": support_label,
+    }
+
+
+def ecosystem_support_matrix() -> tuple[dict[str, str], ...]:
+    return tuple(
+        {
+            "ecosystem": ecosystem,
+            **ecosystem_support_metadata(ecosystem),
+        }
+        for ecosystem in _SUPPORT_ORDER
+    )

--- a/tests/fixtures/supply-chain/critical-base-image-Dockerfile
+++ b/tests/fixtures/supply-chain/critical-base-image-Dockerfile
@@ -1,0 +1,1 @@
+FROM python:3.6.15

--- a/tests/fixtures/tier2/cargo-safe/Cargo.lock
+++ b/tests/fixtures/tier2/cargo-safe/Cargo.lock
@@ -1,0 +1,9 @@
+version = 3
+
+[[package]]
+name = "demo"
+version = "0.1.0"
+
+[[package]]
+name = "clap"
+version = "4.5.8"

--- a/tests/fixtures/tier2/cargo-safe/Cargo.toml
+++ b/tests/fixtures/tier2/cargo-safe/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "demo"
+version = "0.1.0"
+
+[dependencies]
+clap = "4.5"

--- a/tests/fixtures/tier2/cargo-vulnerable/Cargo.lock
+++ b/tests/fixtures/tier2/cargo-vulnerable/Cargo.lock
@@ -1,0 +1,9 @@
+version = 3
+
+[[package]]
+name = "demo"
+version = "0.1.0"
+
+[[package]]
+name = "clap"
+version = "4.5.7"

--- a/tests/fixtures/tier2/cargo-vulnerable/Cargo.toml
+++ b/tests/fixtures/tier2/cargo-vulnerable/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "demo"
+version = "0.1.0"
+
+[dependencies]
+clap = "4.5"

--- a/tests/fixtures/tier2/composer-safe/composer.json
+++ b/tests/fixtures/tier2/composer-safe/composer.json
@@ -1,0 +1,5 @@
+{
+  "require": {
+    "laravel/framework": "^11.0"
+  }
+}

--- a/tests/fixtures/tier2/composer-safe/composer.lock
+++ b/tests/fixtures/tier2/composer-safe/composer.lock
@@ -1,0 +1,8 @@
+{
+  "packages": [
+    {
+      "name": "laravel/framework",
+      "version": "11.2.0"
+    }
+  ]
+}

--- a/tests/fixtures/tier2/composer-vulnerable/composer.json
+++ b/tests/fixtures/tier2/composer-vulnerable/composer.json
@@ -1,0 +1,5 @@
+{
+  "require": {
+    "laravel/framework": "^11.0"
+  }
+}

--- a/tests/fixtures/tier2/composer-vulnerable/composer.lock
+++ b/tests/fixtures/tier2/composer-vulnerable/composer.lock
@@ -1,0 +1,8 @@
+{
+  "packages": [
+    {
+      "name": "laravel/framework",
+      "version": "11.1.0"
+    }
+  ]
+}

--- a/tests/fixtures/tier2/go-safe/go.mod
+++ b/tests/fixtures/tier2/go-safe/go.mod
@@ -1,0 +1,5 @@
+module example.com/demo
+
+go 1.23
+
+require github.com/gin-gonic/gin v1.11.0

--- a/tests/fixtures/tier2/go-vulnerable/go.mod
+++ b/tests/fixtures/tier2/go-vulnerable/go.mod
@@ -1,0 +1,5 @@
+module example.com/demo
+
+go 1.23
+
+require github.com/gin-gonic/gin v1.10.0

--- a/tests/fixtures/tier2/gradle-safe/build.gradle
+++ b/tests/fixtures/tier2/gradle-safe/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+  implementation("org.example:demo:1.2.4")
+}

--- a/tests/fixtures/tier2/gradle-safe/gradle.lockfile
+++ b/tests/fixtures/tier2/gradle-safe/gradle.lockfile
@@ -1,0 +1,1 @@
+org.example:demo:1.2.4=compileClasspath

--- a/tests/fixtures/tier2/gradle-vulnerable/build.gradle
+++ b/tests/fixtures/tier2/gradle-vulnerable/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+  implementation("org.example:demo:1.2.3")
+}

--- a/tests/fixtures/tier2/gradle-vulnerable/gradle.lockfile
+++ b/tests/fixtures/tier2/gradle-vulnerable/gradle.lockfile
@@ -1,0 +1,1 @@
+org.example:demo:1.2.3=compileClasspath

--- a/tests/fixtures/tier2/maven-safe/pom.xml
+++ b/tests/fixtures/tier2/maven-safe/pom.xml
@@ -1,0 +1,9 @@
+<project>
+  <dependencies>
+    <dependency>
+      <groupId>org.example</groupId>
+      <artifactId>demo</artifactId>
+      <version>1.2.4</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/tests/fixtures/tier2/maven-vulnerable/pom.xml
+++ b/tests/fixtures/tier2/maven-vulnerable/pom.xml
@@ -1,0 +1,9 @@
+<project>
+  <dependencies>
+    <dependency>
+      <groupId>org.example</groupId>
+      <artifactId>demo</artifactId>
+      <version>1.2.3</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/tests/fixtures/tier2/rubygems-safe/Gemfile
+++ b/tests/fixtures/tier2/rubygems-safe/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "rspec"

--- a/tests/fixtures/tier2/rubygems-safe/Gemfile.lock
+++ b/tests/fixtures/tier2/rubygems-safe/Gemfile.lock
@@ -1,0 +1,3 @@
+GEM
+  specs:
+    rspec (3.13.1)

--- a/tests/fixtures/tier2/rubygems-vulnerable/Gemfile
+++ b/tests/fixtures/tier2/rubygems-vulnerable/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "rspec"

--- a/tests/fixtures/tier2/rubygems-vulnerable/Gemfile.lock
+++ b/tests/fixtures/tier2/rubygems-vulnerable/Gemfile.lock
@@ -1,0 +1,3 @@
+GEM
+  specs:
+    rspec (3.13.0)

--- a/tests/guard_tier2_phase13_support.py
+++ b/tests/guard_tier2_phase13_support.py
@@ -1,0 +1,144 @@
+"""Shared Phase 13 tier2 supply-chain test helpers."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generate_private_key
+
+from codex_plugin_scanner.guard.runtime.package_intent import (
+    build_package_request_artifact,
+    parse_package_intent,
+)
+
+WORKSPACE_ID = "workspace-alpha"
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def package_fixture(
+    *,
+    ecosystem: str,
+    name: str,
+    version: str,
+    default_action: str,
+    recommended_fix_version: str | None,
+    namespace: str | None = None,
+    related_advisory_ids: list[str] | None = None,
+) -> dict[str, object]:
+    purl_name = f"{namespace}/{name}" if namespace is not None else name
+    return {
+        "confidence": 990,
+        "defaultAction": default_action,
+        "ecosystem": ecosystem,
+        "exploitLevel": "active",
+        "knownExploited": True,
+        "malwareState": "known",
+        "name": name,
+        "namespace": namespace,
+        "normalizedSeverity": "critical",
+        "packageAgeState": "watch",
+        "purl": f"pkg:{ecosystem}/{purl_name}@{version}",
+        "reachability": "reachable",
+        "recommendedFixVersion": recommended_fix_version,
+        "relatedAdvisoryIds": related_advisory_ids or ["GHSA-tier2-demo-1"],
+        "riskScore": 980,
+        "sourceIntegrityState": "high-risk",
+        "version": version,
+    }
+
+
+def bundle_response_fixture(*, packages: list[dict[str, object]]) -> dict[str, object]:
+    generated_at = datetime(2026, 5, 19, tzinfo=timezone.utc)
+    expires_at = generated_at + timedelta(hours=12)
+    bundle = {
+        "advisories": [
+            {
+                "advisoryId": "GHSA-tier2-demo-1",
+                "aliases": ["CVE-2026-tier2-1"],
+                "confidence": 990,
+                "exploitLevel": "active",
+                "knownExploited": True,
+                "malwareState": "known",
+                "normalizedSeverity": "critical",
+                "recommendedFixVersion": "0.0.0",
+                "sourceKey": "ghsa",
+                "summary": "Tier2 package vulnerability",
+                "title": "Tier2 package vulnerability",
+            }
+        ],
+        "bundleVersion": "1747612800000-deadbeef",
+        "expiresAt": iso_fixture(expires_at),
+        "feedSnapshotHash": "feed-snapshot-1",
+        "generatedAt": iso_fixture(generated_at),
+        "keyId": "guard-bundle-key-2026-05",
+        "packages": packages,
+        "policyHash": "policy-hash-1",
+        "policyRules": [],
+        "scoringVersion": "scf-v1",
+        "sourceHashes": [{"payloadHash": "feed-hash", "sourceKey": "ghsa", "staleStatus": "fresh"}],
+        "tier": "premium",
+        "workspaceId": WORKSPACE_ID,
+    }
+    private_key_pem, public_key_pem = generate_key_pair_fixture()
+    loaded_key = serialization.load_pem_private_key(private_key_pem, password=None)
+    assert isinstance(loaded_key, RSAPrivateKey)
+    canonical_payload = json.dumps(bundle, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    payload_hash = hashlib.sha256(canonical_payload).hexdigest()
+    signature = loaded_key.sign(
+        canonical_payload,
+        padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+        hashes.SHA256(),
+    )
+    return {
+        "bundle": bundle,
+        "payloadHash": payload_hash,
+        "signature": base64.b64encode(signature).decode("utf-8"),
+        "signatureAlgorithm": "rsa-pss-sha256",
+        "verificationKeys": [
+            {
+                "fingerprintSha256": fingerprint_fixture(public_key_pem),
+                "keyId": "guard-bundle-key-2026-05",
+                "publicKeyPem": public_key_pem.decode("utf-8").strip(),
+                "state": "active",
+                "validUntil": None,
+            }
+        ],
+    }
+
+
+def artifact_from_command_fixture(command: str, *, workspace: Path) -> object:
+    intent = parse_package_intent(command, workspace=workspace)
+    assert intent is not None
+    return build_package_request_artifact("codex", intent, config_path="codex.json", source_scope="project")
+
+
+def iso_fixture(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def generate_key_pair_fixture() -> tuple[bytes, bytes]:
+    private_key = generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem, public_pem
+
+
+def fingerprint_fixture(public_key_pem: bytes) -> str:
+    return hashlib.sha256(public_key_pem.decode("utf-8").strip().encode("utf-8")).hexdigest()

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -8535,6 +8535,26 @@ url = http://127.0.0.1:8787/guard-canary
                 "bundle_version": "1747612800000-deadbeef",
                 "package_count": 1,
                 "advisory_count": 1,
+                "ecosystem_support": [
+                    {
+                        "ecosystem": "npm",
+                        "display_name": "npm",
+                        "support_level": "protected",
+                        "support_label": "Protected",
+                    },
+                    {
+                        "ecosystem": "cargo",
+                        "display_name": "Cargo",
+                        "support_level": "beta",
+                        "support_label": "Beta",
+                    },
+                    {
+                        "ecosystem": "system",
+                        "display_name": "System packages",
+                        "support_level": "monitor-only",
+                        "support_label": "Monitor-only",
+                    },
+                ],
             }
 
         monkeypatch.setattr(guard_commands_module, "sync_supply_chain_bundle", _fake_sync_intel)
@@ -8546,6 +8566,8 @@ url = http://127.0.0.1:8787/guard-canary
         assert output["status"] == "synced"
         assert output["bundle_version"] == "1747612800000-deadbeef"
         assert output["workspace_id"] == "workspace-alpha"
+        assert output["ecosystem_support"][0]["support_level"] == "protected"
+        assert output["ecosystem_support"][1]["support_label"] == "Beta"
 
     def test_guard_cloud_sync_intel_without_login_returns_cli_error(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_docs.py
+++ b/tests/test_guard_docs.py
@@ -79,3 +79,17 @@ def test_static_docs_explain_safe_decode_sandbox_guarantee() -> None:
     assert "never executes decoded payloads" in docs_text
     assert "base64" in docs_text
     assert "powershell" in docs_text
+
+
+def test_static_docs_cover_supply_chain_support_levels() -> None:
+    docs_text = "\n".join(
+        [
+            _read_repo_file("docs/guard/get-started.md"),
+            _read_repo_file("docs/guard/testing-matrix.md"),
+        ]
+    ).lower()
+
+    assert "hol-guard cloud sync-intel" in docs_text
+    assert "protected" in docs_text
+    assert "beta" in docs_text
+    assert "monitor-only" in docs_text

--- a/tests/test_guard_render.py
+++ b/tests/test_guard_render.py
@@ -771,3 +771,29 @@ def test_approvals_render_error_shows_panel(capsys) -> None:
     )
     output = capsys.readouterr().out
     assert "not_found" in output
+
+
+def test_sync_render_shows_ecosystem_support_table(capsys) -> None:
+    emit_guard_payload(
+        "sync",
+        {
+            "status": "synced",
+            "synced_at": "2026-05-19T00:00:00Z",
+            "ecosystem_support": [
+                {"ecosystem": "npm", "display_name": "npm", "support_level": "protected", "support_label": "Protected"},
+                {"ecosystem": "cargo", "display_name": "Cargo", "support_level": "beta", "support_label": "Beta"},
+                {
+                    "ecosystem": "system",
+                    "display_name": "System packages",
+                    "support_level": "monitor-only",
+                    "support_label": "Monitor-only",
+                },
+            ],
+        },
+        False,
+    )
+    output = capsys.readouterr().out
+    assert "Ecosystem support" in output
+    assert "Protected" in output
+    assert "Beta" in output
+    assert "Monitor-only" in output

--- a/tests/test_guard_supply_chain.py
+++ b/tests/test_guard_supply_chain.py
@@ -89,6 +89,12 @@ def test_docker_image_latest_detected() -> None:
     assert any("docker-image-latest" in s.signal_id for s in signals)
 
 
+def test_known_critical_docker_base_image_detected() -> None:
+    content = _fixture("critical-base-image-Dockerfile")
+    signals = detect_supply_chain_risk(content)
+    assert any("docker-base-image-known-critical" in s.signal_id for s in signals)
+
+
 def test_lockfile_source_drift_detected() -> None:
     content = '"resolved": "https://evil-registry.example.com/pkg/-/pkg-1.0.0.tgz"'
     signals = detect_supply_chain_risk(content)

--- a/tests/test_guard_tier2_labs_phase13.py
+++ b/tests/test_guard_tier2_labs_phase13.py
@@ -1,0 +1,131 @@
+"""Phase 13 tier2 fixture-lab coverage."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import evaluate_package_request_artifact
+from codex_plugin_scanner.guard.store import GuardStore
+
+from .guard_tier2_phase13_support import (
+    WORKSPACE_ID,
+    artifact_from_command_fixture,
+    bundle_response_fixture,
+    package_fixture,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "tier2"
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "command", "ecosystem", "package_name", "blocked_version", "expected_decision"),
+    [
+        ("cargo-vulnerable", "cargo add clap@^4.5", "cargo", "clap", "4.5.7", "block"),
+        ("cargo-safe", "cargo add clap@^4.5", "cargo", "clap", "4.5.7", "monitor"),
+        (
+            "go-vulnerable",
+            "go get github.com/gin-gonic/gin",
+            "go",
+            "github.com/gin-gonic/gin",
+            "v1.10.0",
+            "block",
+        ),
+        (
+            "go-safe",
+            "go get github.com/gin-gonic/gin",
+            "go",
+            "github.com/gin-gonic/gin",
+            "v1.10.0",
+            "monitor",
+        ),
+        (
+            "maven-vulnerable",
+            "mvn dependency:get -Dartifact=org.example:demo",
+            "maven",
+            "org.example:demo",
+            "1.2.3",
+            "block",
+        ),
+        (
+            "maven-safe",
+            "mvn dependency:get -Dartifact=org.example:demo",
+            "maven",
+            "org.example:demo",
+            "1.2.3",
+            "monitor",
+        ),
+        (
+            "gradle-vulnerable",
+            "./gradlew addDependency --dependency org.example:demo",
+            "maven",
+            "org.example:demo",
+            "1.2.3",
+            "block",
+        ),
+        (
+            "gradle-safe",
+            "./gradlew addDependency --dependency org.example:demo",
+            "maven",
+            "org.example:demo",
+            "1.2.3",
+            "monitor",
+        ),
+        (
+            "composer-vulnerable",
+            "composer require laravel/framework",
+            "packagist",
+            "laravel/framework",
+            "11.1.0",
+            "block",
+        ),
+        (
+            "composer-safe",
+            "composer require laravel/framework",
+            "packagist",
+            "laravel/framework",
+            "11.1.0",
+            "monitor",
+        ),
+        ("rubygems-vulnerable", "bundle add rspec", "rubygems", "rspec", "3.13.0", "block"),
+        ("rubygems-safe", "bundle add rspec", "rubygems", "rspec", "3.13.0", "monitor"),
+    ],
+)
+def test_tier2_fixture_labs_cover_safe_and_vulnerable_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fixture_name: str,
+    command: str,
+    ecosystem: str,
+    package_name: str,
+    blocked_version: str,
+    expected_decision: str,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    shutil.copytree(FIXTURES / fixture_name, workspace_dir)
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        bundle_response_fixture(
+            packages=[
+                package_fixture(
+                    ecosystem=ecosystem,
+                    name=package_name,
+                    version=blocked_version,
+                    default_action="block",
+                    recommended_fix_version=None,
+                )
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = artifact_from_command_fixture(command, workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == expected_decision
+    assert result.packages[0]["supportLevel"] == "beta"

--- a/tests/test_guard_tier2_package_intent_phase13.py
+++ b/tests/test_guard_tier2_package_intent_phase13.py
@@ -10,14 +10,19 @@ from codex_plugin_scanner.guard.runtime.package_intent import (
 
 def test_parse_package_intent_supports_cargo_path_system_and_unsupported_package_managers() -> None:
     cargo_path = parse_package_intent("cargo add demo --path crates/demo")
+    cargo_path_equals = parse_package_intent("cargo add demo --path=crates/demo")
     brew = parse_package_intent("brew install ripgrep fd")
     apt = parse_package_intent("apt-get install jq")
+    pacman = parse_package_intent("pacman -Syu jq")
     helm = parse_package_intent("helm install ingress ingress-nginx/ingress-nginx")
 
     assert cargo_path is not None
     assert cargo_path.package_manager == "cargo"
     assert cargo_path.targets[0].package_name == "demo"
     assert cargo_path.targets[0].source_url == "file:crates/demo"
+    assert cargo_path_equals is not None
+    assert "<local-path>" in cargo_path_equals.redacted_command
+    assert "crates/demo" not in cargo_path_equals.redacted_command
 
     assert brew is not None
     assert brew.package_manager == "brew"
@@ -29,6 +34,9 @@ def test_parse_package_intent_supports_cargo_path_system_and_unsupported_package
     assert apt.package_manager == "apt-get"
     assert apt.targets[0].ecosystem == "system"
     assert apt.targets[0].package_name == "jq"
+    assert pacman is not None
+    assert pacman.package_manager == "pacman"
+    assert pacman.targets[0].package_name == "jq"
 
     assert helm is not None
     assert helm.package_manager == "helm"

--- a/tests/test_guard_tier2_package_intent_phase13.py
+++ b/tests/test_guard_tier2_package_intent_phase13.py
@@ -1,0 +1,131 @@
+"""Phase 13 tier2 parser and manifest-diff behavior tests."""
+
+from __future__ import annotations
+
+from codex_plugin_scanner.guard.runtime.package_intent import (
+    parse_manifest_dependency_changes,
+    parse_package_intent,
+)
+
+
+def test_parse_package_intent_supports_cargo_path_system_and_unsupported_package_managers() -> None:
+    cargo_path = parse_package_intent("cargo add demo --path crates/demo")
+    brew = parse_package_intent("brew install ripgrep fd")
+    apt = parse_package_intent("apt-get install jq")
+    helm = parse_package_intent("helm install ingress ingress-nginx/ingress-nginx")
+
+    assert cargo_path is not None
+    assert cargo_path.package_manager == "cargo"
+    assert cargo_path.targets[0].package_name == "demo"
+    assert cargo_path.targets[0].source_url == "file:crates/demo"
+
+    assert brew is not None
+    assert brew.package_manager == "brew"
+    assert brew.targets[0].ecosystem == "system"
+    assert brew.targets[0].package_name == "ripgrep"
+    assert brew.targets[1].package_name == "fd"
+
+    assert apt is not None
+    assert apt.package_manager == "apt-get"
+    assert apt.targets[0].ecosystem == "system"
+    assert apt.targets[0].package_name == "jq"
+
+    assert helm is not None
+    assert helm.package_manager == "helm"
+    assert helm.targets[0].ecosystem == "unsupported"
+    assert helm.targets[0].package_name == "ingress-nginx/ingress-nginx"
+
+
+def test_parse_manifest_dependency_changes_supports_tier2_lockfiles_and_cargo_workspaces() -> None:
+    cases = [
+        (
+            "Cargo.toml",
+            """
+[workspace]
+members = ["cli"]
+
+[workspace.dependencies]
+clap = "4.4"
+""".strip(),
+            """
+[workspace]
+members = ["cli", "worker"]
+
+[workspace.dependencies]
+clap = "4.5"
+serde = "1.0"
+""".strip(),
+            {"clap": ("4.4", "4.5"), "serde": (None, "1.0")},
+        ),
+        (
+            "Cargo.lock",
+            """
+version = 3
+
+[[package]]
+name = "clap"
+version = "4.5.6"
+""".strip(),
+            """
+version = 3
+
+[[package]]
+name = "clap"
+version = "4.5.7"
+
+[[package]]
+name = "serde"
+version = "1.0.218"
+""".strip(),
+            {"clap": ("4.5.6", "4.5.7"), "serde": (None, "1.0.218")},
+        ),
+        (
+            "composer.lock",
+            '{"packages":[{"name":"laravel/framework","version":"11.0.0"}]}',
+            '{"packages":[{"name":"laravel/framework","version":"11.1.0"},{"name":"guzzlehttp/guzzle","version":"7.9.2"}]}',
+            {"laravel/framework": ("11.0.0", "11.1.0"), "guzzlehttp/guzzle": (None, "7.9.2")},
+        ),
+        (
+            "Gemfile.lock",
+            """
+GEM
+  specs:
+    rails (7.1.2)
+""".strip(),
+            """
+GEM
+  specs:
+    rails (7.1.3)
+    rspec (3.13.0)
+""".strip(),
+            {"rails": ("7.1.2", "7.1.3"), "rspec": (None, "3.13.0")},
+        ),
+    ]
+
+    for path, before_text, after_text, expected in cases:
+        result = parse_manifest_dependency_changes(path=path, before_text=before_text, after_text=after_text)
+
+        assert result.truncated is False
+        assert result.parse_errors == ()
+        actual = {change.package_name: (change.before, change.after) for change in result.changes}
+        assert actual == expected
+
+
+def test_parse_manifest_dependency_changes_truncates_large_cargo_workspace_safely() -> None:
+    workspace_dependencies = "\n".join(f'crate{index} = "1.0.{index}"' for index in range(500))
+    before_text = "[workspace]\nmembers = [\"cli\"]\n[workspace.dependencies]\nclap = \"4.4\"\n"
+    after_text = (
+        "[workspace]\nmembers = [\"cli\", \"worker\"]\n[workspace.dependencies]\n"
+        f"{workspace_dependencies}\n"
+    )
+
+    result = parse_manifest_dependency_changes(
+        path="Cargo.toml",
+        before_text=before_text,
+        after_text=after_text,
+        byte_limit=256,
+    )
+
+    assert result.changes == ()
+    assert result.truncated is True
+    assert result.parse_errors == ("byte_limit_exceeded",)

--- a/tests/test_guard_tier2_supply_chain_phase13.py
+++ b/tests/test_guard_tier2_supply_chain_phase13.py
@@ -1,0 +1,368 @@
+"""Phase 13 tier2 evaluator behavior tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import evaluate_package_request_artifact
+from codex_plugin_scanner.guard.store import GuardStore
+
+from .guard_tier2_phase13_support import (
+    WORKSPACE_ID,
+    artifact_from_command_fixture,
+    bundle_response_fixture,
+    package_fixture,
+    write_text,
+)
+
+
+def test_evaluate_package_request_artifact_blocks_vulnerable_cargo_version_from_cargo_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    write_text(
+        workspace_dir / "Cargo.toml",
+        """
+[package]
+name = "demo"
+version = "0.1.0"
+
+[dependencies]
+clap = "4.5"
+""".strip()
+        + "\n",
+    )
+    write_text(
+        workspace_dir / "Cargo.lock",
+        """
+version = 3
+
+[[package]]
+name = "demo"
+version = "0.1.0"
+
+[[package]]
+name = "clap"
+version = "4.5.7"
+""".strip()
+        + "\n",
+    )
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        bundle_response_fixture(
+            packages=[
+                package_fixture(
+                    ecosystem="cargo",
+                    name="clap",
+                    version="4.5.7",
+                    default_action="block",
+                    recommended_fix_version="4.5.8",
+                )
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = artifact_from_command_fixture("cargo add clap@^4.5", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.packages[0]["resolvedVersion"] == "4.5.7"
+    assert result.packages[0]["supportLevel"] == "beta"
+
+
+def test_evaluate_package_request_artifact_warns_on_cargo_local_path_without_leaking_path(
+    tmp_path: Path,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+
+    artifact = artifact_from_command_fixture("cargo add demo --path crates/demo", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(
+        artifact=artifact,
+        store=GuardStore(tmp_path / "home"),
+        workspace_dir=workspace_dir,
+    )
+
+    payload = json.dumps(result.to_dict())
+
+    assert result.decision == "warn"
+    assert result.packages[0]["reasons"][0]["code"] == "local_path_dependency_source"
+    assert result.packages[0]["supportLevel"] == "beta"
+    assert "crates/demo" not in payload
+
+
+def test_evaluate_package_request_artifact_warns_on_cargo_git_sources(
+    tmp_path: Path,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+
+    artifact = artifact_from_command_fixture(
+        "cargo add demo --git https://github.com/serde-rs/serde",
+        workspace=workspace_dir,
+    )
+    result = evaluate_package_request_artifact(
+        artifact=artifact,
+        store=GuardStore(tmp_path / "home"),
+        workspace_dir=workspace_dir,
+    )
+
+    assert result.decision == "warn"
+    assert result.packages[0]["reasons"][0]["code"] == "git_dependency_source"
+    assert result.packages[0]["supportLevel"] == "beta"
+
+
+def test_evaluate_package_request_artifact_blocks_vulnerable_go_version_from_go_mod(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    write_text(
+        workspace_dir / "go.mod",
+        """
+module example.com/demo
+
+go 1.23
+
+require github.com/gin-gonic/gin v1.10.0
+""".strip()
+        + "\n",
+    )
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        bundle_response_fixture(
+            packages=[
+                package_fixture(
+                    ecosystem="go",
+                    name="github.com/gin-gonic/gin",
+                    version="v1.10.0",
+                    default_action="block",
+                    recommended_fix_version="v1.11.0",
+                )
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = artifact_from_command_fixture("go get github.com/gin-gonic/gin", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.packages[0]["resolvedVersion"] == "v1.10.0"
+    assert result.packages[0]["supportLevel"] == "beta"
+
+
+def test_evaluate_package_request_artifact_warns_on_go_replace_local_path_without_leaking_path(
+    tmp_path: Path,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    write_text(
+        workspace_dir / "go.mod",
+        """
+module example.com/demo
+
+go 1.23
+
+require github.com/gin-gonic/gin v1.10.0
+
+replace github.com/gin-gonic/gin => ../forks/gin
+""".strip()
+        + "\n",
+    )
+
+    artifact = artifact_from_command_fixture("go get github.com/gin-gonic/gin", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(
+        artifact=artifact,
+        store=GuardStore(tmp_path / "home"),
+        workspace_dir=workspace_dir,
+    )
+
+    payload = json.dumps(result.to_dict())
+
+    assert result.decision == "warn"
+    assert result.packages[0]["reasons"][0]["code"] == "go_replace_local_source"
+    assert result.packages[0]["supportLevel"] == "beta"
+    assert "../forks/gin" not in payload
+
+
+@pytest.mark.parametrize(
+    (
+        "command",
+        "manifest_name",
+        "manifest_text",
+        "lockfile_name",
+        "lockfile_text",
+        "ecosystem",
+        "package_name",
+        "version",
+    ),
+    [
+        (
+            "mvn dependency:get -Dartifact=org.example:demo",
+            "pom.xml",
+            "<project><dependencies><dependency><groupId>org.example</groupId><artifactId>demo</artifactId><version>1.2.3</version></dependency></dependencies></project>\n",
+            None,
+            None,
+            "maven",
+            "org.example:demo",
+            "1.2.3",
+        ),
+        (
+            "./gradlew addDependency --dependency org.example:demo",
+            "build.gradle",
+            'dependencies { implementation("org.example:demo:1.2.3") }\n',
+            None,
+            None,
+            "maven",
+            "org.example:demo",
+            "1.2.3",
+        ),
+        (
+            "composer require laravel/framework",
+            "composer.json",
+            '{"require":{"laravel/framework":"^11.0"}}\n',
+            "composer.lock",
+            '{"packages":[{"name":"laravel/framework","version":"11.1.0"}]}\n',
+            "packagist",
+            "laravel/framework",
+            "11.1.0",
+        ),
+        (
+            "bundle add rspec",
+            "Gemfile",
+            'source "https://rubygems.org"\ngem "rspec"\n',
+            "Gemfile.lock",
+            "GEM\n  specs:\n    rspec (3.13.0)\n",
+            "rubygems",
+            "rspec",
+            "3.13.0",
+        ),
+    ],
+)
+def test_evaluate_package_request_artifact_blocks_tier2_versions_from_manifest_or_lockfile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    manifest_name: str,
+    manifest_text: str,
+    lockfile_name: str | None,
+    lockfile_text: str | None,
+    ecosystem: str,
+    package_name: str,
+    version: str,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    write_text(workspace_dir / manifest_name, manifest_text)
+    if lockfile_name is not None and lockfile_text is not None:
+        write_text(workspace_dir / lockfile_name, lockfile_text)
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        bundle_response_fixture(
+            packages=[
+                package_fixture(
+                    ecosystem=ecosystem,
+                    name=package_name,
+                    version=version,
+                    default_action="block",
+                    recommended_fix_version=None,
+                )
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = artifact_from_command_fixture(command, workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.packages[0]["resolvedVersion"] == version
+    assert result.packages[0]["supportLevel"] == "beta"
+
+
+def test_evaluate_package_request_artifact_warns_for_system_package_managers_in_monitor_only_mode(
+    tmp_path: Path,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+
+    artifact = artifact_from_command_fixture("brew install jq", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(
+        artifact=artifact,
+        store=GuardStore(tmp_path / "home"),
+        workspace_dir=workspace_dir,
+    )
+
+    assert result.decision == "warn"
+    assert result.policy_action == "warn"
+    assert result.packages[0]["supportLevel"] == "monitor-only"
+    assert result.packages[0]["reasons"][0]["code"] == "system_package_manager_monitor_only"
+
+
+def test_evaluate_package_request_artifact_uses_monitor_only_fallback_for_unsupported_ecosystems(
+    tmp_path: Path,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+
+    artifact = artifact_from_command_fixture(
+        "helm install ingress ingress-nginx/ingress-nginx",
+        workspace=workspace_dir,
+    )
+    result = evaluate_package_request_artifact(
+        artifact=artifact,
+        store=GuardStore(tmp_path / "home"),
+        workspace_dir=workspace_dir,
+    )
+
+    assert result.decision == "monitor"
+    assert result.packages[0]["supportLevel"] == "monitor-only"
+    assert result.packages[0]["reasons"][0]["code"] == "unsupported_ecosystem_monitor_only"
+
+
+def test_evaluate_package_request_artifact_surfaces_malformed_tier2_lockfiles_without_crashing(
+    tmp_path: Path,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    write_text(
+        workspace_dir / "Cargo.toml",
+        """
+[package]
+name = "demo"
+version = "0.1.0"
+
+[dependencies]
+clap = "4.5"
+""".strip()
+        + "\n",
+    )
+    write_text(workspace_dir / "Cargo.lock", "version = [\n")
+
+    artifact = artifact_from_command_fixture("cargo add clap@^4.5", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(
+        artifact=artifact,
+        store=GuardStore(tmp_path / "home"),
+        workspace_dir=workspace_dir,
+    )
+
+    assert result.decision == "monitor"
+    assert any(reason["code"] == "lockfile_parse_error" for reason in result.reasons)
+    assert result.packages[0]["supportLevel"] == "beta"


### PR DESCRIPTION
## Summary
- add tier2 package-manager coverage for Cargo, Go, Maven, Gradle, Composer, and RubyGems
- add monitor-only support labels and fallback handling for system packages, unsupported managers, and exact Docker base-image warnings
- add docs, render, and fixture-lab coverage for the new Guard local supply-chain behavior

## Validation
- `ruff check`
- `pytest tests/test_guard_tier2_package_intent_phase13.py tests/test_guard_tier2_supply_chain_phase13.py tests/test_guard_tier2_labs_phase13.py tests/test_guard_supply_chain.py -q`
- `python3 -m build`