### PR TITLE
fix(guard): persist cloud workspace on connect

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1943,9 +1943,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         request_id = self._optional_string(payload.get("request_id"))
         pairing_secret = self._optional_string(payload.get("pairing_secret"))
         token = self._optional_string(payload.get("token"))
-        workspace_id = (
-            self._optional_string(payload.get("workspace_id"))
-            or self._optional_string(payload.get("workspaceId"))
+        workspace_id = self._optional_string(payload.get("workspace_id")) or self._optional_string(
+            payload.get("workspaceId")
         )
         if origin is None or request_id is None or pairing_secret is None or token is None:
             self._write_json(

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1943,6 +1943,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         request_id = self._optional_string(payload.get("request_id"))
         pairing_secret = self._optional_string(payload.get("pairing_secret"))
         token = self._optional_string(payload.get("token"))
+        workspace_id = (
+            self._optional_string(payload.get("workspace_id"))
+            or self._optional_string(payload.get("workspaceId"))
+        )
         if origin is None or request_id is None or pairing_secret is None or token is None:
             self._write_json(
                 {"error": "missing_required_fields"},
@@ -1967,6 +1971,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 pairing_secret=pairing_secret,
                 token=token,
                 now=_now(),
+                workspace_id=workspace_id,
             )
         except ValueError as error:
             error_code = str(error)

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -2795,6 +2795,7 @@ class GuardStore:
         pairing_secret: str,
         token: str,
         now: str,
+        workspace_id: str | None = None,
     ) -> dict[str, object]:
         with self._connect() as connection:
             request = persist_connect_request_completion(
@@ -2813,7 +2814,27 @@ class GuardStore:
                     expires_at=str(request["expires_at"]),
                     updated_at=now,
                 )
-            self._set_sync_credentials_in_connection(connection, str(request["sync_url"]), token, now)
+            effective_workspace_id = workspace_id
+            if effective_workspace_id is None:
+                previous_row = connection.execute(
+                    "select payload_json from sync_state where state_key = 'credentials'"
+                ).fetchone()
+                if previous_row is not None:
+                    previous_payload = json.loads(str(previous_row["payload_json"]))
+                    if (
+                        isinstance(previous_payload, dict)
+                        and previous_payload.get("sync_url") == str(request["sync_url"])
+                    ):
+                        previous_workspace_id = previous_payload.get("workspace_id")
+                        if isinstance(previous_workspace_id, str) and previous_workspace_id.strip():
+                            effective_workspace_id = previous_workspace_id.strip()
+            self._set_sync_credentials_in_connection(
+                connection,
+                str(request["sync_url"]),
+                token,
+                now,
+                workspace_id=effective_workspace_id,
+            )
             connection.execute(
                 """
                 insert into guard_events (event_name, payload_json, occurred_at)

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -2816,7 +2816,7 @@ class GuardStore:
                 )
             self._set_sync_credentials_in_connection(
                 connection,
-                request["sync_url"],
+                str(request["sync_url"]),
                 token,
                 now,
                 workspace_id=workspace_id,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -2814,26 +2814,12 @@ class GuardStore:
                     expires_at=str(request["expires_at"]),
                     updated_at=now,
                 )
-            effective_workspace_id = workspace_id
-            if effective_workspace_id is None:
-                previous_row = connection.execute(
-                    "select payload_json from sync_state where state_key = 'credentials'"
-                ).fetchone()
-                if previous_row is not None:
-                    previous_payload = json.loads(previous_row["payload_json"])
-                    if (
-                        isinstance(previous_payload, dict)
-                        and previous_payload.get("sync_url") == request["sync_url"]
-                    ):
-                        previous_workspace_id = previous_payload.get("workspace_id")
-                        if isinstance(previous_workspace_id, str) and previous_workspace_id.strip():
-                            effective_workspace_id = previous_workspace_id.strip()
             self._set_sync_credentials_in_connection(
                 connection,
                 request["sync_url"],
                 token,
                 now,
-                workspace_id=effective_workspace_id,
+                workspace_id=workspace_id,
             )
             connection.execute(
                 """

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -2820,17 +2820,17 @@ class GuardStore:
                     "select payload_json from sync_state where state_key = 'credentials'"
                 ).fetchone()
                 if previous_row is not None:
-                    previous_payload = json.loads(str(previous_row["payload_json"]))
+                    previous_payload = json.loads(previous_row["payload_json"])
                     if (
                         isinstance(previous_payload, dict)
-                        and previous_payload.get("sync_url") == str(request["sync_url"])
+                        and previous_payload.get("sync_url") == request["sync_url"]
                     ):
                         previous_workspace_id = previous_payload.get("workspace_id")
                         if isinstance(previous_workspace_id, str) and previous_workspace_id.strip():
                             effective_workspace_id = previous_workspace_id.strip()
             self._set_sync_credentials_in_connection(
                 connection,
-                str(request["sync_url"]),
+                request["sync_url"],
                 token,
                 now,
                 workspace_id=effective_workspace_id,

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -450,7 +450,14 @@ class TestGuardApprovals:
             lifetime_seconds=600,
         )
 
-        def fail_credentials_write(connection, sync_url: str, token: str, now: str) -> None:
+        def fail_credentials_write(
+            connection,
+            sync_url: str,
+            token: str,
+            now: str,
+            *,
+            workspace_id: str | None = None,
+        ) -> None:
             raise RuntimeError("credentials unavailable")
 
         monkeypatch.setattr(store, "_set_sync_credentials_in_connection", fail_credentials_write)

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -260,7 +260,37 @@ def test_guard_daemon_connect_complete_persists_cloud_workspace_id(tmp_path) -> 
     assert store.get_cloud_workspace_id() == "workspace-alpha"
 
 
-def test_guard_connect_completion_preserves_existing_workspace_when_missing_from_retry(tmp_path) -> None:
+def test_guard_connect_completion_preserves_existing_workspace_for_same_token_retry(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    first_request = store.create_guard_connect_request(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now="2026-04-15T00:00:00+00:00",
+    )
+    store.complete_guard_connect_request(
+        request_id=str(first_request["request_id"]),
+        pairing_secret=str(first_request["pairing_secret"]),
+        token="guard-live-runtime-token-one",
+        now="2026-04-15T00:00:01+00:00",
+        workspace_id="workspace-alpha",
+    )
+    second_request = store.create_guard_connect_request(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now="2026-04-15T00:01:00+00:00",
+    )
+
+    store.complete_guard_connect_request(
+        request_id=str(second_request["request_id"]),
+        pairing_secret=str(second_request["pairing_secret"]),
+        token="guard-live-runtime-token-one",
+        now="2026-04-15T00:01:01+00:00",
+    )
+
+    assert store.get_cloud_workspace_id() == "workspace-alpha"
+
+
+def test_guard_connect_completion_drops_workspace_for_rotated_token_without_workspace(tmp_path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     first_request = store.create_guard_connect_request(
         sync_url="https://hol.org/api/guard/receipts/sync",
@@ -287,7 +317,7 @@ def test_guard_connect_completion_preserves_existing_workspace_when_missing_from
         now="2026-04-15T00:01:01+00:00",
     )
 
-    assert store.get_cloud_workspace_id() == "workspace-alpha"
+    assert store.get_cloud_workspace_id() is None
 
 
 def test_guard_connect_status_reports_retry_recovery_command(tmp_path, capsys) -> None:

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -197,6 +197,99 @@ def test_guard_connect_preserves_pairing_when_first_sync_fails(
     assert payload["proof"]["first_synced_at"] is None
 
 
+def test_guard_daemon_connect_complete_persists_cloud_workspace_id(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+
+    try:
+        initialize_request = urllib.request.Request(
+            f"http://127.0.0.1:{daemon.port}/v1/initialize",
+            data=json.dumps(
+                {
+                    "client_name": "hol-guard-cli",
+                    "surface": "cli",
+                    "supported_protocol_versions": ["1.1"],
+                }
+            ).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(initialize_request, timeout=5) as response:
+            initialize_payload = json.loads(response.read().decode("utf-8"))
+
+        create_request = urllib.request.Request(
+            f"http://127.0.0.1:{daemon.port}/v1/connect/requests",
+            data=json.dumps(
+                {
+                    "sync_url": "https://hol.org/api/guard/receipts/sync",
+                    "allowed_origin": "https://hol.org",
+                }
+            ).encode("utf-8"),
+            headers={
+                "Content-Type": "application/json",
+                "X-Guard-Token": initialize_payload["auth_token"],
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(create_request, timeout=5) as response:
+            created_payload = json.loads(response.read().decode("utf-8"))
+
+        complete_request = urllib.request.Request(
+            f"http://127.0.0.1:{daemon.port}/v1/connect/complete",
+            data=urllib.parse.urlencode(
+                {
+                    "request_id": created_payload["request_id"],
+                    "pairing_secret": created_payload["pairing_secret"],
+                    "token": "guard-live-runtime-token",
+                    "workspace_id": "workspace-alpha",
+                }
+            ).encode("utf-8"),
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Origin": "https://hol.org",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(complete_request, timeout=5) as response:
+            completed_payload = json.loads(response.read().decode("utf-8"))
+    finally:
+        daemon.stop()
+
+    assert completed_payload["completed"] is True
+    assert store.get_cloud_workspace_id() == "workspace-alpha"
+
+
+def test_guard_connect_completion_preserves_existing_workspace_when_missing_from_retry(tmp_path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    first_request = store.create_guard_connect_request(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now="2026-04-15T00:00:00+00:00",
+    )
+    store.complete_guard_connect_request(
+        request_id=str(first_request["request_id"]),
+        pairing_secret=str(first_request["pairing_secret"]),
+        token="guard-live-runtime-token-one",
+        now="2026-04-15T00:00:01+00:00",
+        workspace_id="workspace-alpha",
+    )
+    second_request = store.create_guard_connect_request(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now="2026-04-15T00:01:00+00:00",
+    )
+
+    store.complete_guard_connect_request(
+        request_id=str(second_request["request_id"]),
+        pairing_secret=str(second_request["pairing_secret"]),
+        token="guard-live-runtime-token-two",
+        now="2026-04-15T00:01:01+00:00",
+    )
+
+    assert store.get_cloud_workspace_id() == "workspace-alpha"
+
+
 def test_guard_connect_status_reports_retry_recovery_command(tmp_path, capsys) -> None:
     guard_home = tmp_path / "guard-home"
     store = GuardStore(guard_home)


### PR DESCRIPTION
## Summary\n- accept workspace_id/workspaceId on local /v1/connect/complete\n- persist the resolved Guard Cloud workspace into local sync credentials\n- preserve existing workspace attribution when a retry omits workspace metadata\n\n## Verification\n- uv run ruff check src tests/test_guard_connect_flow.py tests/test_guard_cloud_local_sync.py\n- uv run pytest tests/test_guard_connect_flow.py tests/test_guard_cloud_local_sync.py -q\n- uv build