### PR TITLE
feat(guard): ship phase15 local supply-chain ux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ coverage/
 dashboard/node_modules/
 dashboard/.vite/
 dashboard/dist/
+output/playwright/
 .guard-*/
 .guard-ui-review/
 .package-check/

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ pipx run hol-guard connect
 pipx run hol-guard connect status
 pipx run hol-guard connect repair
 pipx run hol-guard sync
+pipx run hol-guard supply-chain sync
+pipx run hol-guard supply-chain scan
+pipx run hol-guard supply-chain explain minimist@1.2.5 --ecosystem npm
 pipx run hol-guard explain install-connect
 ```
 

--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -103,6 +103,9 @@ Use it when you want to protect a harness before local MCP servers, skills, hook
 
    ```bash
    hol-guard cloud sync-intel
+   hol-guard supply-chain sync
+   hol-guard supply-chain scan
+   hol-guard supply-chain explain minimist@1.2.5 --ecosystem npm
    ```
 
    Guard prints the latest bundle summary plus ecosystem support labels. Today `npm` and `PyPI` show **Protected** coverage, Cargo/Go/Maven/Gradle/Composer/RubyGems show **Beta**, and system packages or unsupported package managers stay **Monitor-only** so Guard never pretends advisory blocking where it does not exist.
@@ -114,6 +117,7 @@ Use it when you want to protect a harness before local MCP servers, skills, hook
 | I need the current protection posture | `hol-guard status` | What is Guard watching, is sync connected, and what is the next action? |
 | I need first-run setup | `hol-guard init` | Open the local dashboard, install supported harnesses, start optional Cloud connect, and check desktop notifications. |
 | I need install/connect docs | `hol-guard explain install-connect` | Which local-first setup and optional cloud commands should I share? |
+| I need to preview one install before I run it | `hol-guard protect npm install <package> --dry-run` | Would Guard allow, warn, review, or block this exact install request right now? |
 | I need setup or runtime troubleshooting | `hol-guard doctor <harness>` | Why is this harness or Guard runtime not behaving correctly? |
 | A launch was blocked or changed | `hol-guard diff <harness>` | What changed since the last recorded snapshot? |
 | I need to resolve a queued block | `hol-guard approvals` | Which requests are waiting, and how do I approve or deny them? |
@@ -122,6 +126,7 @@ Use it when you want to protect a harness before local MCP servers, skills, hook
 | I need an exportable evidence artifact | `hol-guard abom` | What local AI-BOM can I attach to an audit or handoff? |
 | I need the chronological log | `hol-guard events` | What happened over time on this machine? |
 | I need supply-chain coverage labels | `hol-guard cloud sync-intel` | Which ecosystems are protected, beta, or monitor-only right now? |
+| I need a workspace install scan or one-package verdict | `hol-guard supply-chain scan` or `hol-guard supply-chain explain <package> --ecosystem <ecosystem>` | Which current dependencies or package versions would Guard warn, review, or block right now? |
 
 ## One continuity model
 

--- a/docs/guard/local-vs-cloud.md
+++ b/docs/guard/local-vs-cloud.md
@@ -32,5 +32,8 @@ Use these commands when you need to check or repair optional cloud pairing witho
 hol-guard connect status
 hol-guard connect repair
 hol-guard sync
+hol-guard supply-chain sync
+hol-guard supply-chain scan
+hol-guard supply-chain explain minimist@1.2.5 --ecosystem npm
 hol-guard explain install-connect
 ```

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -19,6 +19,7 @@ from .desktop_notifications import (
     notify_pending_approval_once,
 )
 from .incident import build_incident_context
+from .local_supply_chain import build_local_supply_chain_posture
 from .models import GuardApprovalRequest, HarnessDetection, PolicyDecision
 from .risk import artifact_risk_signals, artifact_risk_summary
 from .store import GuardStore
@@ -364,6 +365,7 @@ def build_runtime_snapshot(
     latest_receipts = store.list_receipts(limit=receipt_limit)
     cloud_context = _build_runtime_cloud_context(store)
     snapshot_now = now or _now()
+    config = load_guard_config(store.guard_home)
     latest_connect_state = _build_latest_connect_state(store, snapshot_now)
     headline_state = _resolve_runtime_headline_state(
         pending_count=store.count_approval_requests(),
@@ -393,6 +395,7 @@ def build_runtime_snapshot(
         "items": pending_requests,
         "latest_receipts": latest_receipts,
         "managed_installs": store.list_managed_installs(),
+        "supply_chain": build_local_supply_chain_posture(store, config, now=snapshot_now),
         **cloud_context,
     }
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1883,7 +1883,7 @@ def run_guard_command(
         adv_sub = getattr(args, "advisories_subcommand", None)
         if adv_sub == "sync":
             try:
-                payload = sync_supply_chain_bundle(store)
+                payload = _validated_supply_chain_sync_payload(sync_supply_chain_bundle(store))
             except GuardSyncNotConfiguredError:
                 _emit(
                     "advisories_sync",
@@ -2132,7 +2132,7 @@ def run_guard_command(
         cloud_command = getattr(args, "cloud_command", None)
         if cloud_command == "sync-intel":
             try:
-                payload = sync_supply_chain_bundle(store)
+                payload = _validated_supply_chain_sync_payload(sync_supply_chain_bundle(store))
             except GuardSyncNotConfiguredError:
                 message = _guard_sync_prerequisite_message()
                 if getattr(args, "json", False):
@@ -2164,7 +2164,7 @@ def run_guard_command(
             return exit_code
         if supply_chain_command == "sync":
             try:
-                payload = sync_supply_chain_bundle(store)
+                payload = _validated_supply_chain_sync_payload(sync_supply_chain_bundle(store))
             except GuardSyncNotConfiguredError:
                 message = _guard_sync_prerequisite_message()
                 if getattr(args, "json", False):
@@ -8358,6 +8358,12 @@ def _guard_service_sync_payload(store: GuardStore) -> dict[str, object]:
         "runtime": runtime_summary,
         "receipts": receipts_summary,
     }
+
+
+def _validated_supply_chain_sync_payload(payload: object) -> dict[str, object]:
+    if not isinstance(payload, dict):
+        raise RuntimeError("Guard Cloud sync returned an invalid response.")
+    return payload
 
 
 def _guard_sync_prerequisite_message() -> str:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -86,6 +86,12 @@ from ..desktop_notifications import (
 )
 from ..harness_usage import record_harness_usage_events
 from ..incident import build_incident_context
+from ..local_supply_chain import (
+    build_local_supply_chain_posture,
+    build_supply_chain_explain_payload,
+    build_supply_chain_status_payload,
+    build_workspace_scan_payload,
+)
 from ..mcp_tool_calls import (
     allow_tool_call,
     block_tool_call,
@@ -738,6 +744,41 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     )
     _add_guard_common_args(cloud_sync_intel_parser)
     cloud_sync_intel_parser.add_argument("--json", action="store_true")
+
+    supply_chain_parser = guard_subparsers.add_parser(
+        "supply-chain",
+        help="Inspect and refresh local Guard supply-chain firewall coverage",
+    )
+    _add_guard_common_args(supply_chain_parser)
+    supply_chain_subparsers = supply_chain_parser.add_subparsers(
+        dest="supply_chain_command",
+        required=True,
+        parser_class=FriendlyArgumentParser,
+    )
+    supply_chain_scan_parser = supply_chain_subparsers.add_parser(
+        "scan",
+        help="Evaluate the current workspace manifests and lockfiles against the signed bundle",
+    )
+    _add_guard_common_args(supply_chain_scan_parser)
+    supply_chain_scan_parser.add_argument("--json", action="store_true")
+    supply_chain_sync_parser = supply_chain_subparsers.add_parser(
+        "sync",
+        help="Fetch and verify the latest signed supply-chain bundle for this workspace",
+    )
+    _add_guard_common_args(supply_chain_sync_parser)
+    supply_chain_sync_parser.add_argument("--json", action="store_true")
+    supply_chain_explain_parser = supply_chain_subparsers.add_parser(
+        "explain",
+        help="Explain one package version with the current signed supply-chain bundle",
+    )
+    supply_chain_explain_parser.add_argument("package")
+    supply_chain_explain_parser.add_argument(
+        "--ecosystem",
+        choices=("npm", "pypi", "cargo", "go", "maven", "packagist", "rubygems"),
+        default="npm",
+    )
+    _add_guard_common_args(supply_chain_explain_parser)
+    supply_chain_explain_parser.add_argument("--json", action="store_true")
 
     service_parser = guard_subparsers.add_parser(
         "service",
@@ -1471,14 +1512,16 @@ def run_guard_command(
         _refresh_cloud_policy_bundle(store)
         protect_command = list(getattr(args, "protect_command", []) or [])
         if len(protect_command) == 0:
-            print("guard protect requires a command to wrap.", file=sys.stderr)
-            return 2
+            payload = build_supply_chain_status_payload(store=store, config=config, now=_now())
+            _emit("protect", payload, getattr(args, "json", False))
+            return 0
         payload, exit_code = build_protect_payload(
             command=protect_command,
             store=store,
             workspace_dir=workspace or Path.cwd(),
             dry_run=bool(getattr(args, "dry_run", False)),
             now=_now(),
+            config=config,
             unsafe_raw_output=bool(getattr(args, "unsafe_raw_output", False)),
         )
         _emit("protect", payload, getattr(args, "json", False))
@@ -1987,6 +2030,7 @@ def run_guard_command(
             }
         if getattr(args, "perf", False):
             payload["detector_perf"] = _runtime_detector_perf_payload(config)
+        payload["supply_chain"] = build_local_supply_chain_posture(store, config, now=_now())
         _emit("doctor", payload, getattr(args, "json", False))
         return 0
 
@@ -2102,8 +2146,52 @@ def run_guard_command(
                 else:
                     print(str(error), file=sys.stderr)
                 return 1
+            payload["supply_chain"] = build_local_supply_chain_posture(store, config, now=_now())
             _emit("cloud-sync-intel", payload, getattr(args, "json", False))
             return 0
+
+    if args.guard_command == "supply-chain":
+        supply_chain_command = getattr(args, "supply_chain_command", None)
+        workspace_dir = workspace or Path.cwd()
+        if supply_chain_command == "scan":
+            payload, exit_code = build_workspace_scan_payload(
+                store=store,
+                config=config,
+                workspace_dir=workspace_dir,
+                now=_now(),
+            )
+            _emit("supply-chain-scan", payload, getattr(args, "json", False))
+            return exit_code
+        if supply_chain_command == "sync":
+            try:
+                payload = sync_supply_chain_bundle(store)
+            except GuardSyncNotConfiguredError:
+                message = _guard_sync_prerequisite_message()
+                if getattr(args, "json", False):
+                    _emit("supply-chain-sync", {"synced": False, "error": message}, True)
+                else:
+                    print(message, file=sys.stderr)
+                return 1
+            except RuntimeError as error:
+                if getattr(args, "json", False):
+                    _emit("supply-chain-sync", {"synced": False, "error": str(error)}, True)
+                else:
+                    print(str(error), file=sys.stderr)
+                return 1
+            payload["supply_chain"] = build_local_supply_chain_posture(store, config, now=_now())
+            _emit("supply-chain-sync", payload, getattr(args, "json", False))
+            return 0
+        if supply_chain_command == "explain":
+            payload, exit_code = build_supply_chain_explain_payload(
+                store=store,
+                config=config,
+                workspace_dir=workspace_dir,
+                package_spec=str(args.package),
+                ecosystem=str(args.ecosystem),
+                now=_now(),
+            )
+            _emit("supply-chain-explain", payload, getattr(args, "json", False))
+            return exit_code
 
     if args.guard_command == "service":
         service_command = getattr(args, "service_command", None)

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -1646,8 +1646,7 @@ def _build_supply_chain_posture_panel(supply_chain: dict[str, object]) -> Panel:
     policy = supply_chain.get("policy")
     if isinstance(policy, dict):
         body.add_row("Security", str(policy.get("security_level") or "unknown"))
-        if policy.get("cloud_advisory_action"):
-            body.add_row("Cloud advisories", str(policy.get("cloud_advisory_action")))
+        body.add_row("Cloud advisories", str(policy.get("cloud_advisory_action") or "unknown"))
     ecosystems = _coerce_dict_list(supply_chain.get("supported_ecosystems"))
     if ecosystems:
         support_summary = ", ".join(

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -505,6 +505,9 @@ def _render_doctor(console: Console, payload: dict[str, object]) -> None:
         artifacts = _coerce_dict_list(payload.get("artifacts"))
         if artifacts:
             console.print(_build_artifact_table(artifacts))
+        supply_chain = payload.get("supply_chain")
+        if isinstance(supply_chain, dict):
+            console.print(_build_supply_chain_posture_panel(supply_chain))
     perf_items = payload.get("detector_perf")
     if isinstance(perf_items, list) and perf_items:
         perf_table = Table(title="Detector performance", box=box.SIMPLE_HEAVY, show_header=True)
@@ -1559,6 +1562,14 @@ def _render_preflight(console: Console, payload: dict[str, object]) -> None:
 
 
 def _render_protect(console: Console, payload: dict[str, object]) -> None:
+    if str(payload.get("mode") or "") == "status":
+        body = Table.grid(padding=(0, 1))
+        body.add_row("Mode", "status")
+        console.print(Panel(body, title="Install protection", border_style="cyan"))
+        supply_chain = payload.get("supply_chain")
+        if isinstance(supply_chain, dict):
+            console.print(_build_supply_chain_posture_panel(supply_chain))
+        return
     verdict = payload.get("verdict")
     request = payload.get("request")
     body = Table.grid(padding=(0, 1))
@@ -1571,6 +1582,16 @@ def _render_protect(console: Console, payload: dict[str, object]) -> None:
         body.add_row("Executed", _bool_label(bool(payload.get("executed"))))
         body.add_row("Reason", str(verdict.get("reason") or "unknown"))
     console.print(Panel(body, title="Install protection", border_style="cyan"))
+    supply_chain_evaluation = payload.get("supply_chain_evaluation")
+    if isinstance(supply_chain_evaluation, dict):
+        user_copy = supply_chain_evaluation.get("user_copy")
+        if isinstance(user_copy, dict):
+            harness_message = str(user_copy.get("harness_message") or "").strip()
+            if harness_message:
+                console.print(Panel(Text(harness_message), title="Guard guidance", border_style="magenta"))
+    supply_chain = payload.get("supply_chain")
+    if isinstance(supply_chain, dict):
+        console.print(_build_supply_chain_posture_panel(supply_chain))
     risk_signals = _coerce_string_list(verdict.get("risk_signals")) if isinstance(verdict, dict) else []
     if risk_signals:
         console.print(
@@ -1606,6 +1627,37 @@ def _render_fallback(console: Console, payload: dict[str, object]) -> None:
             word_wrap=True,
         )
     )
+
+
+def _build_supply_chain_posture_panel(supply_chain: dict[str, object]) -> Panel:
+    body = Table.grid(padding=(0, 1))
+    body.add_row("Status", str(supply_chain.get("status") or "unknown"))
+    detail = supply_chain.get("detail")
+    if detail:
+        body.add_row("Detail", str(detail))
+    bundle = supply_chain.get("bundle")
+    if isinstance(bundle, dict):
+        if bundle.get("bundle_version"):
+            body.add_row("Bundle", str(bundle.get("bundle_version")))
+        if bundle.get("tier"):
+            body.add_row("Tier", str(bundle.get("tier")))
+        if bundle.get("workspace_id"):
+            body.add_row("Workspace", str(bundle.get("workspace_id")))
+    policy = supply_chain.get("policy")
+    if isinstance(policy, dict):
+        body.add_row("Security", str(policy.get("security_level") or "unknown"))
+        if policy.get("cloud_advisory_action"):
+            body.add_row("Cloud advisories", str(policy.get("cloud_advisory_action")))
+    ecosystems = _coerce_dict_list(supply_chain.get("supported_ecosystems"))
+    if ecosystems:
+        support_summary = ", ".join(
+            f"{item.get('display_name') or item.get('ecosystem')}: {item.get('support_label') or item.get('label')}"
+            for item in ecosystems[:5]
+        )
+        if len(ecosystems) > 5:
+            support_summary = f"{support_summary}, +{len(ecosystems) - 5} more"
+        body.add_row("Coverage", support_summary)
+    return Panel(body, title="Supply-chain firewall", border_style="cyan")
 
 
 def _build_harness_table(detections: list[dict[str, object]]) -> Table:
@@ -2242,6 +2294,9 @@ _RENDERERS: dict[str, Any] = {
     "deny": _render_decision,
     "login": _render_login,
     "sync": _render_sync,
+    "supply-chain-explain": _render_fallback,
+    "supply-chain-scan": _render_fallback,
+    "supply-chain-sync": _render_fallback,
     "update": _render_update,
     "hook": _render_hook,
     "protect": _render_protect,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/app-detail-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/app-detail-workspace.js
@@ -1476,13 +1476,27 @@ function parsePackageTarget(receipt) {
     return { ecosystem: null, packageSpec: spec.packageSpec, packageName: spec.packageName };
   }
   const name = (receipt.artifact_name ?? "").trim();
-  const matchInstall = name.match(/^(npm|pip|pip3|cargo|gem|go|yarn|pnpm|npx|poetry)\s+(?:install\s+)?(\S+)/i);
-  if (matchInstall) {
-    const spec = splitPackageSpec(matchInstall[2]);
-    return { ecosystem: matchInstall[1].toLowerCase().replace("pip3", "pip"), packageSpec: spec.packageSpec, packageName: spec.packageName };
+  const managerMatch = name.match(/^(npm|pip|pip3|cargo|gem|go|yarn|pnpm|npx|poetry)\s+/i);
+  if (managerMatch) {
+    const ecosystem = managerMatch[1].toLowerCase().replace("pip3", "pip");
+    const packageSpec = extractPackageSpecFromCommand(name.slice(managerMatch[0].length));
+    if (packageSpec) {
+      const spec = splitPackageSpec(packageSpec);
+      return { ecosystem, packageSpec: spec.packageSpec, packageName: spec.packageName };
+    }
   }
   const fallback = splitPackageSpec(name || receipt.artifact_id);
   return { ecosystem: null, packageSpec: fallback.packageSpec, packageName: fallback.packageName };
+}
+function extractPackageSpecFromCommand(rawCommand) {
+  const tokens = (rawCommand ?? "").trim().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) {
+    return "";
+  }
+  const verb = tokens[0].toLowerCase();
+  const args = verb === "install" || verb === "add" || verb === "get" || verb === "exec" ? tokens.slice(1) : tokens;
+  const candidate = args.find((token) => !token.startsWith("-") && token !== "--" && !/^(https?:|file:|\.{1,2}\/|\/)/i.test(token));
+  return candidate ?? "";
 }
 function PackageEventBadge() {
   return /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[10px] font-semibold text-emerald-700", "aria-label": "Package install event", children: "Package" });

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/app-detail-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/app-detail-workspace.js
@@ -393,7 +393,7 @@ function AppOverviewTab(props) {
           "button",
           {
             onClick: () => props.onOpenRequest(item.request_id),
-            className: "flex w-full items-center justify-between rounded-xl border border-slate-200/70 bg-white px-4 py-3 text-left transition-shadow hover:shadow-sm",
+            className: `flex w-full items-center justify-between rounded-xl border px-4 py-3 text-left transition-shadow hover:shadow-sm ${isPackageInstallEvent(item) ? "border-emerald-200/70 bg-emerald-50/30" : "border-slate-200/70 bg-white"}`,
             children: [
               /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
                 /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: item.artifact_name ?? item.artifact_id }),
@@ -403,7 +403,10 @@ function AppOverviewTab(props) {
                   formatRelativeTime(item.created_at)
                 ] })
               ] }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronRight, { className: "h-4 w-4 shrink-0 text-slate-300" })
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex shrink-0 items-center gap-2", children: [
+                isPackageInstallEvent(item) && /* @__PURE__ */ jsxRuntimeExports.jsx(PackageEventBadge, {}),
+                /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronRight, { className: "h-4 w-4 shrink-0 text-slate-300" })
+              ] })
             ]
           },
           item.request_id
@@ -688,7 +691,7 @@ function AppActivityTab(props) {
       "button",
       {
         onClick: () => props.onOpenRequest(item.request_id),
-        className: "flex w-full items-center justify-between rounded-xl border border-brand-blue/15 bg-brand-blue/[0.04] px-4 py-3 text-left transition-shadow hover:shadow-sm",
+        className: `flex w-full items-center justify-between rounded-xl border px-4 py-3 text-left transition-shadow hover:shadow-sm ${isPackageInstallEvent(item) ? "border-emerald-200/70 bg-emerald-50/30" : "border-brand-blue/15 bg-brand-blue/[0.04]"}`,
         children: [
           /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: item.artifact_name ?? item.artifact_id }),
@@ -698,7 +701,10 @@ function AppActivityTab(props) {
               formatRelativeTime(item.created_at)
             ] })
           ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "info", children: "Pending" })
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex shrink-0 items-center gap-2", children: [
+            isPackageInstallEvent(item) && /* @__PURE__ */ jsxRuntimeExports.jsx(PackageEventBadge, {}),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "info", children: "Pending" })
+          ] })
         ]
       },
       item.request_id
@@ -777,7 +783,7 @@ function ExpandableReceiptRow({ receipt, selected, onToggle }) {
         }
       )
     ] }),
-    expanded && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-fade-in border-t border-slate-200/70 bg-slate-50/60 px-4 py-3", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("dl", { className: "grid grid-cols-1 gap-2 text-xs", children: [
+    expanded && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-fade-in border-t border-slate-200/70 bg-slate-50/60 px-4 py-3", children: isPackageInstallEvent(receipt) ? /* @__PURE__ */ jsxRuntimeExports.jsx(PackageEventDetail, { receipt }) : /* @__PURE__ */ jsxRuntimeExports.jsxs("dl", { className: "grid grid-cols-1 gap-2 text-xs", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-muted-foreground", children: "Action ID" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-0.5 font-mono text-brand-dark", children: receipt.artifact_id })
@@ -1423,6 +1429,100 @@ function CloudValueBanner({
       )
     ] })
   ] }) });
+}
+function isPackageInstallEvent(item) {
+  const type = (item.artifact_type ?? "").toLowerCase();
+  if (
+    type.includes("package") ||
+    type === "supply_chain" ||
+    type === "npm" ||
+    type === "pip" ||
+    type === "pypi" ||
+    type === "cargo" ||
+    type === "gem" ||
+    type === "go_module"
+  ) {
+    return true;
+  }
+  const id = (item.artifact_id ?? "").toLowerCase();
+  if (id.includes("package-request") || id.startsWith("pkg-")) {
+    return true;
+  }
+  const name = (item.artifact_name ?? "").toLowerCase();
+  return /^(npm|pip|pip3|cargo|gem|go|yarn|pnpm|npx|poetry)\s/.test(name);
+}
+function splitPackageSpec(rawSpec) {
+  const spec = (rawSpec ?? "").trim();
+  if (!spec) {
+    return { packageSpec: null, packageName: null };
+  }
+  const versionIndex = spec.lastIndexOf("@");
+  if (versionIndex > 0) {
+    return { packageSpec: spec, packageName: spec.slice(0, versionIndex) };
+  }
+  return { packageSpec: spec, packageName: spec };
+}
+function parsePackageTarget(receipt) {
+  const id = receipt.artifact_id ?? "";
+  const afterColon = id.includes("package-request:") ? id.split("package-request:")[1] : null;
+  if (afterColon) {
+    const slashIndex = afterColon.indexOf("/");
+    if (slashIndex >= 0) {
+      const eco = afterColon.slice(0, slashIndex);
+      const spec = splitPackageSpec(afterColon.slice(slashIndex + 1));
+      return { ecosystem: eco, packageSpec: spec.packageSpec, packageName: spec.packageName };
+    }
+    const spec = splitPackageSpec(afterColon);
+    return { ecosystem: null, packageSpec: spec.packageSpec, packageName: spec.packageName };
+  }
+  const name = (receipt.artifact_name ?? "").trim();
+  const matchInstall = name.match(/^(npm|pip|pip3|cargo|gem|go|yarn|pnpm|npx|poetry)\s+(?:install\s+)?(\S+)/i);
+  if (matchInstall) {
+    const spec = splitPackageSpec(matchInstall[2]);
+    return { ecosystem: matchInstall[1].toLowerCase().replace("pip3", "pip"), packageSpec: spec.packageSpec, packageName: spec.packageName };
+  }
+  const fallback = splitPackageSpec(name || receipt.artifact_id);
+  return { ecosystem: null, packageSpec: fallback.packageSpec, packageName: fallback.packageName };
+}
+function PackageEventBadge() {
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[10px] font-semibold text-emerald-700", "aria-label": "Package install event", children: "Package" });
+}
+function PackageEventDetail({ receipt }) {
+  const { ecosystem, packageSpec, packageName } = parsePackageTarget(receipt);
+  const ecoFlag = ecosystem ? ` --ecosystem ${ecosystem}` : "";
+  const explainTarget = packageSpec || packageName || receipt.artifact_id;
+  const safeCmd = `hol-guard supply-chain explain ${explainTarget}${ecoFlag}`;
+  const displayEcosystem = ecosystem || receipt.artifact_type || null;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("dl", { className: "grid grid-cols-1 gap-2 text-xs", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-muted-foreground", children: "Package" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-0.5 font-mono font-semibold text-brand-dark", children: explainTarget })
+    ] }),
+    displayEcosystem && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-muted-foreground", children: "Ecosystem" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-0.5 capitalize text-brand-dark", children: displayEcosystem })
+    ] }),
+    receipt.capabilities_summary && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "font-medium text-brand-attention", children: "Advisory" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-0.5 text-brand-dark", children: receipt.capabilities_summary })
+    ] }),
+    receipt.provenance_summary && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-muted-foreground", children: "Provenance" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-0.5 text-brand-dark", children: receipt.provenance_summary })
+    ] }),
+    receipt.artifact_hash && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-muted-foreground", children: "Hash" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-0.5 font-mono text-brand-dark", children: receipt.artifact_hash })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-muted-foreground", children: "Time" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-0.5 font-mono text-brand-dark", children: new Date(receipt.timestamp).toLocaleString() })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "border-t border-slate-200/70 pt-2", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-muted-foreground", children: "Inspect" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-0.5", children: /* @__PURE__ */ jsxRuntimeExports.jsx("code", { className: "block overflow-x-auto rounded-lg bg-white/80 px-2.5 py-1.5 font-mono text-[11px] text-brand-dark select-all", "aria-label": "Inspect command", children: safeCmd }) })
+    ] })
+  ] });
 }
 function StatCard({
   label,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/home-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/home-dashboard.js
@@ -28,6 +28,68 @@ function resolveCloudUpsellVisible(pendingCount, cloudState) {
   if (pendingCount > 0) return false;
   return cloudState === "local_only";
 }
+function resolveSupplyChainBundleTone(supplyChain) {
+  if (!supplyChain?.bundle?.synced_at) return "slate";
+  if (supplyChain.bundle.expires_at) {
+    const msLeft = new Date(supplyChain.bundle.expires_at).getTime() - Date.now();
+    if (msLeft < 0 || msLeft < 172800000) return "attention";
+  }
+  return "green";
+}
+function resolveSupportChipClasses(supportLevel) {
+  if (supportLevel === "protected") {
+    return "border-emerald-200 bg-white/80 text-emerald-700";
+  }
+  if (supportLevel === "beta") {
+    return "border-brand-blue/15 bg-brand-blue/[0.06] text-brand-blue";
+  }
+  return "border-slate-200 bg-slate-100/70 text-slate-600";
+}
+function SupplyChainFirewallCard({ supplyChain, onOpenSettings }) {
+  if (!supplyChain) return null;
+  const { bundle, connection, supported_ecosystems: ecosystems = [] } = supplyChain;
+  const bundleTone = resolveSupplyChainBundleTone(supplyChain);
+  const statusLabel = !bundle?.synced_at ? "Offline" : bundleTone === "attention" ? "Bundle stale" : "Active";
+  const isLoggedIn = connection?.logged_in === true;
+  const showUpsell = !isLoggedIn && !!(bundle?.synced_at || bundle?.bundle_version);
+  const advisoryCount = bundle?.advisory_count ?? 0;
+  const packageCount = bundle?.package_count ?? 0;
+  const syncedAt = bundle?.synced_at ?? null;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
+    "section",
+    {
+      className: "rounded-2xl border border-emerald-200/70 bg-emerald-50/30 p-5 shadow-sm sm:p-6",
+      "aria-label": "Package firewall status",
+      children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center justify-between gap-2", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-[0.18em] text-emerald-700", children: "Package firewall" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: bundleTone === "green" ? "success" : bundleTone === "attention" ? "attention" : "default", children: statusLabel })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-brand-dark/90", children: "Guard reviews install scripts before they run. Supply-chain scripts pause for review." }),
+        ecosystems.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-medium text-slate-500", children: "Coverage" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-1.5 flex flex-wrap gap-1.5", role: "list", "aria-label": "Ecosystem coverage", children: ecosystems.map((eco) => {
+            const label = eco.display_name || eco.ecosystem || String(eco);
+            const key = eco.ecosystem || eco.display_name || label;
+            const supportLabel = eco.support_label || eco.label || "Monitor-only";
+            const supportLevel = eco.support_level || "monitor-only";
+            return /* @__PURE__ */ jsxRuntimeExports.jsx("span", { role: "listitem", className: `rounded-full border px-2.5 py-0.5 text-[11px] font-medium ${resolveSupportChipClasses(supportLevel)}`, children: `${label} · ${supportLabel}` }, key);
+          }) })
+        ] }),
+        bundle && (advisoryCount > 0 || packageCount > 0 || syncedAt) && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3 flex flex-wrap gap-3", children: [
+          advisoryCount > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-xs text-slate-500", children: [/* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-semibold text-brand-dark", children: formatNumber(advisoryCount) }), " advisories"] }),
+          packageCount > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-xs text-slate-500", children: [/* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "font-semibold text-brand-dark", children: formatNumber(packageCount) }), " packages"] }),
+          syncedAt && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-xs text-slate-400", children: ["Synced ", formatRelativeTime(syncedAt)] })
+        ] }),
+        showUpsell && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 rounded-xl border border-emerald-200/60 bg-white/60 p-3", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold text-brand-dark", children: "Cloud Intel adds real-time advisories and team policy." }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-0.5 text-xs text-slate-500", children: ["Local protection is active", bundle?.tier ? ` (${bundle.tier})` : "", ". Connect to Guard Cloud for shared advisories and team-managed policy."] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "outline", onClick: onOpenSettings, children: "Open sync settings" }) })
+        ] })
+      ]
+    }
+  );
+}
 function buildEmptyStateCopy() {
   return {
     title: "No apps connected",
@@ -209,6 +271,13 @@ function HomeWorkspace(props) {
         )
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "space-y-6", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          SupplyChainFirewallCard,
+          {
+            supplyChain: snapshot.supply_chain ?? null,
+            onOpenSettings: props.onOpenSettings
+          }
+        ),
         /* @__PURE__ */ jsxRuntimeExports.jsx(DeviceProofCard, { device: snapshot.device, proofStatus: snapshot.proof_status }),
         /* @__PURE__ */ jsxRuntimeExports.jsx(
           CloudStatusCard,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/settings-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/settings-workspace.js
@@ -2,6 +2,79 @@ import { r as reactExports, x as fetchSettings, y as fetchRuntimeSnapshot, z as 
 import { a as resolveProtectionLevelCopy } from "./runtime-overview.js";
 import { f as filterSettingsBySearch, R as RISK_CONTROL_CONSEQUENCES, s as securityLevelLabel } from "./app-catalog.js";
 const resolveSecurityLevelDescription = resolveProtectionLevelCopy;
+function resolveSupportChipClasses(supportLevel) {
+  if (supportLevel === "protected") {
+    return "border-emerald-200 bg-white/80 text-emerald-700";
+  }
+  if (supportLevel === "beta") {
+    return "border-brand-blue/15 bg-brand-blue/[0.06] text-brand-blue";
+  }
+  return "border-slate-200 bg-slate-100/70 text-slate-600";
+}
+function SupplyChainPolicySummary({ draft, supplyChain }) {
+  const packageScriptAction = draft?.risk_actions?.package_script ?? "warn";
+  const cloudAdvisoryAction = draft?.risk_actions?.cloud_advisory ?? "warn";
+  const cloudPolicy = supplyChain?.policy ?? null;
+  const bundle = supplyChain?.bundle ?? null;
+  const ecosystems = supplyChain?.supported_ecosystems ?? [];
+  const status = supplyChain?.status ?? "not_connected";
+  const isCloudManaged = cloudPolicy?.managed_by_cloud === true;
+  const isBundleActive = status === "synced";
+  const managedLabel = cloudPolicy?.managed_label || "Guard Cloud";
+  const managedUpdatedAt = cloudPolicy?.managed_updated_at || null;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-emerald-100 bg-emerald-50/30 p-4", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "mt-0.5 h-5 w-5 shrink-0 text-emerald-600", "aria-hidden": "true" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 flex-1", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Package firewall" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: isBundleActive ? "green" : "slate", children: status === "expired" ? "Bundle expired" : isBundleActive ? "Bundle active" : "Local only" })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-500", children: "Guard intercepts package install scripts and cloud advisories independently of the security level." }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3 grid gap-3 sm:grid-cols-2", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-medium text-slate-500", children: "Package scripts" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "p",
+              {
+                className: `mt-0.5 text-sm font-semibold capitalize ${isCloudManaged ? "text-brand-blue" : "text-brand-dark"}`,
+                children: cloudPolicy?.package_script_action || packageScriptAction
+              }
+            ),
+            isCloudManaged && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 text-[11px] text-brand-blue/70", children: "Managed in Guard Cloud" })
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-medium text-slate-500", children: "Cloud advisories" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "p",
+              {
+                className: `mt-0.5 text-sm font-semibold capitalize ${isCloudManaged ? "text-brand-blue" : "text-brand-dark"}`,
+                children: cloudPolicy?.cloud_advisory_action || cloudAdvisoryAction
+              }
+            ),
+            isCloudManaged && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 text-[11px] text-brand-blue/70", children: "Managed in Guard Cloud" })
+          ] })
+        ] }),
+        isCloudManaged && /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-3 rounded-lg border border-brand-blue/10 bg-white/70 px-3 py-2 text-xs text-slate-500", children: [
+          managedLabel,
+          " is managing the synced policy summary for this machine",
+          managedUpdatedAt ? `, updated ${managedUpdatedAt}.` : "."
+        ] }),
+        ecosystems.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-medium text-slate-500", children: "Coverage by ecosystem" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-1.5 flex flex-wrap gap-1.5", role: "list", "aria-label": "Covered ecosystems", children: ecosystems.map((eco) => {
+            const label = eco.display_name || eco.ecosystem || String(eco);
+            const key = eco.ecosystem || eco.display_name || label;
+            const supportLabel = eco.support_label || eco.label || "Monitor-only";
+            const supportLevel = eco.support_level || "monitor-only";
+            return /* @__PURE__ */ jsxRuntimeExports.jsx("span", { role: "listitem", className: `rounded-full border px-2.5 py-0.5 text-[11px] font-medium ${resolveSupportChipClasses(supportLevel)}`, children: `${label} · ${supportLabel}` }, key);
+          }) })
+        ] }),
+        !isBundleActive && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-3 rounded-lg border border-slate-200/70 bg-white/60 px-3 py-2 text-xs text-slate-500", children: "Local fallback mode: Guard applies the package_script policy above without a cloud advisory lookup. Connect to Guard Cloud to enable advisory data from the signed bundle." })
+      ] })
+    ] })
+  ] });
+}
 function resolveSecurityLevelCardDescription(level) {
   if (level === "relaxed") return "Warn on dangerous actions. Most safe actions run without a prompt.";
   if (level === "balanced") return "Ask before secret access, hidden execution, exfiltration, and destructive actions.";
@@ -512,6 +585,7 @@ function SettingsWorkspace() {
         /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-500", children: consequenceSummary })
       ] })
     ] }) }),
+    !hasSearch && /* @__PURE__ */ jsxRuntimeExports.jsx(SupplyChainPolicySummary, { draft, supplyChain: perfSnapshot?.supply_chain ?? null }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2", role: "region", "aria-label": "Settings sections", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(
         AccordionSection,

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -124,13 +124,11 @@ def build_local_supply_chain_posture(
         or _string_value(entitlement.get("tier"))
         or _string_value(bundle_payload.get("tier"))
     )
-    remote_package_script_action = (
-        _string_value(remote_policy.get("packageScriptAction"))
-        or _string_value(remote_policy.get("package_script_action"))
+    remote_package_script_action = _string_value(remote_policy.get("packageScriptAction")) or _string_value(
+        remote_policy.get("package_script_action")
     )
-    remote_cloud_advisory_action = (
-        _string_value(remote_policy.get("cloudAdvisoryAction"))
-        or _string_value(remote_policy.get("cloud_advisory_action"))
+    remote_cloud_advisory_action = _string_value(remote_policy.get("cloudAdvisoryAction")) or _string_value(
+        remote_policy.get("cloud_advisory_action")
     )
     managed_by_cloud = bool(remote_policy or team_policy_pack)
     managed_label = _string_value(team_policy_pack.get("name")) or ("Guard Cloud sync" if managed_by_cloud else None)
@@ -211,7 +209,7 @@ def build_workspace_scan_payload(
                 "message": "No supported manifests or lockfiles found in this workspace.",
                 "supply_chain": posture,
             },
-            1,
+            0,
         )
     artifact = build_package_request_artifact(
         _LOCAL_SUPPLY_CHAIN_HARNESS,
@@ -373,25 +371,43 @@ def build_package_protect_payload(
             now,
         )
         return (payload, _evaluation_exit_code(evaluation.decision))
-    execution = subprocess.run(
-        list(command),
-        cwd=workspace_dir,
-        capture_output=True,
-        check=False,
-        text=True,
-        timeout=timeout_seconds,
-    )
-    redacted_stdout = redact_text(execution.stdout)
-    redacted_stderr = redact_text(execution.stderr)
     payload["executed"] = True
-    payload["execution"] = {
-        "returncode": execution.returncode,
-        "stdout": execution.stdout if unsafe_raw_output else redacted_stdout.text,
-        "stderr": execution.stderr if unsafe_raw_output else redacted_stderr.text,
-        "stdout_redactions": redacted_stdout.to_dict(),
-        "stderr_redactions": redacted_stderr.to_dict(),
-        "raw_output_enabled": unsafe_raw_output,
-    }
+    try:
+        execution = subprocess.run(
+            list(command),
+            cwd=workspace_dir,
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except (subprocess.TimeoutExpired, OSError) as error:
+        payload["execution"] = _build_command_execution_payload(
+            stdout=_coerce_command_output(getattr(error, "stdout", None)),
+            stderr=_coerce_command_error_output(error),
+            returncode=-1,
+            unsafe_raw_output=unsafe_raw_output,
+        )
+        store.add_event(
+            "install_time_execution_failed",
+            {
+                "artifact_id": artifact.artifact_id,
+                "artifact_name": artifact.name,
+                "executor": str(command[0]) if command else _LOCAL_SUPPLY_CHAIN_HARNESS,
+                "install_kind": sanitized_intent.intent_kind,
+                "action": verdict_action,
+                "error": type(error).__name__,
+                "risk_signals": list(risk_signals),
+            },
+            now,
+        )
+        return (payload, 1)
+    payload["execution"] = _build_command_execution_payload(
+        stdout=execution.stdout,
+        stderr=execution.stderr,
+        returncode=execution.returncode,
+        unsafe_raw_output=unsafe_raw_output,
+    )
     if execution.returncode == 0:
         store.add_receipt(receipt)
         store.add_event(
@@ -425,6 +441,41 @@ def build_package_protect_payload(
 
 def redacted_command_tokens(command: Sequence[str]) -> tuple[str, ...]:
     return tuple(_redact_command_token(str(token)) for token in command)
+
+
+def _build_command_execution_payload(
+    *,
+    stdout: str,
+    stderr: str,
+    returncode: int,
+    unsafe_raw_output: bool,
+) -> dict[str, object]:
+    redacted_stdout = redact_text(stdout)
+    redacted_stderr = redact_text(stderr)
+    return {
+        "returncode": returncode,
+        "stdout": stdout if unsafe_raw_output else redacted_stdout.text,
+        "stderr": stderr if unsafe_raw_output else redacted_stderr.text,
+        "stdout_redactions": redacted_stdout.to_dict(),
+        "stderr_redactions": redacted_stderr.to_dict(),
+        "raw_output_enabled": unsafe_raw_output,
+    }
+
+
+def _coerce_command_output(value: str | bytes | None) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    if isinstance(value, str):
+        return value
+    return ""
+
+
+def _coerce_command_error_output(error: subprocess.TimeoutExpired | OSError) -> str:
+    parts = [_coerce_command_output(getattr(error, "stderr", None))]
+    message = str(error).strip()
+    if message:
+        parts.append(message)
+    return "\n".join(part for part in parts if part)
 
 
 def _workspace_scan_intent(workspace_dir: Path) -> PackageIntent | None:

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -1,0 +1,671 @@
+"""Shared local supply-chain posture and CLI helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import shlex
+import subprocess
+from collections.abc import Sequence
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .config import GuardConfig, resolve_risk_action
+from .receipts import build_receipt
+from .redaction import redact_text
+from .runtime.package_intent_common import (
+    PackageIntent,
+    PackageIntentTarget,
+    build_package_request_artifact,
+    composer_target,
+    coordinate_target,
+    existing_relative_paths,
+    js_target,
+    python_target,
+    version_target,
+)
+from .runtime.package_manifest_diff import parse_manifest_dependencies
+from .runtime.supply_chain_package_eval import evaluate_package_request_artifact
+from .runtime.supply_chain_support import ecosystem_support_matrix
+from .store import GuardStore
+
+_LOCAL_SUPPLY_CHAIN_HARNESS = "guard-cli"
+_MANIFEST_CANDIDATES = (
+    "package.json",
+    "requirements.txt",
+    "constraints.txt",
+    "pyproject.toml",
+    "Pipfile",
+    "Cargo.toml",
+    "go.mod",
+    "pom.xml",
+    "build.gradle",
+    "build.gradle.kts",
+    "composer.json",
+    "Gemfile",
+)
+_LOCKFILE_CANDIDATES = (
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "bun.lock",
+    "bun.lockb",
+    "poetry.lock",
+    "uv.lock",
+    "Pipfile.lock",
+    "Cargo.lock",
+    "go.sum",
+    "gradle.lockfile",
+    "composer.lock",
+    "Gemfile.lock",
+)
+_PACKAGE_MANAGER_BY_ECOSYSTEM = {
+    "npm": "npm",
+    "pypi": "pip",
+    "cargo": "cargo",
+    "go": "go",
+    "maven": "maven",
+    "packagist": "composer",
+    "rubygems": "bundle",
+    "docker": "docker",
+    "system": "system",
+    "unsupported": "unsupported",
+}
+_ECOSYSTEM_BY_MANIFEST = {
+    "package.json": "npm",
+    "requirements.txt": "pypi",
+    "constraints.txt": "pypi",
+    "pyproject.toml": "pypi",
+    "Pipfile": "pypi",
+    "Cargo.toml": "cargo",
+    "go.mod": "go",
+    "pom.xml": "maven",
+    "build.gradle": "maven",
+    "build.gradle.kts": "maven",
+    "composer.json": "packagist",
+    "Gemfile": "rubygems",
+}
+
+
+def build_local_supply_chain_posture(
+    store: GuardStore,
+    config: GuardConfig,
+    *,
+    now: str | None = None,
+) -> dict[str, object]:
+    snapshot_now = _parse_timestamp(now) or datetime.now(timezone.utc)
+    workspace_id = store.get_cloud_workspace_id()
+    credentials = store.get_sync_credentials()
+    summary = _dict_payload(store.get_sync_payload("supply_chain_bundle_summary"))
+    entitlement = _dict_payload(store.get_sync_payload("supply_chain_bundle_entitlement"))
+    remote_policy = _dict_payload(store.get_sync_payload("policy"))
+    team_policy_pack = _dict_payload(store.get_sync_payload("team_policy_pack"))
+    cached_bundle = store.get_cached_supply_chain_bundle(workspace_id) if workspace_id else None
+    bundle_payload = _dict_payload(cached_bundle.get("bundle")) if isinstance(cached_bundle, dict) else {}
+    expires_at_text = _string_value(bundle_payload.get("expiresAt"))
+    expires_at = _parse_timestamp(expires_at_text)
+    status = _posture_status(
+        credentials_present=credentials is not None,
+        workspace_id=workspace_id,
+        summary=summary,
+        bundle_payload=bundle_payload,
+        expires_at=expires_at,
+        snapshot_now=snapshot_now,
+    )
+    support = summary.get("ecosystem_support")
+    supported_ecosystems = support if isinstance(support, list) and support else list(ecosystem_support_matrix())
+    bundle_version = (
+        _string_value(summary.get("bundle_version"))
+        or _string_value(entitlement.get("bundle_version"))
+        or _string_value(bundle_payload.get("bundleVersion"))
+    )
+    tier = (
+        _string_value(summary.get("tier"))
+        or _string_value(entitlement.get("tier"))
+        or _string_value(bundle_payload.get("tier"))
+    )
+    remote_package_script_action = (
+        _string_value(remote_policy.get("packageScriptAction"))
+        or _string_value(remote_policy.get("package_script_action"))
+    )
+    remote_cloud_advisory_action = (
+        _string_value(remote_policy.get("cloudAdvisoryAction"))
+        or _string_value(remote_policy.get("cloud_advisory_action"))
+    )
+    managed_by_cloud = bool(remote_policy or team_policy_pack)
+    managed_label = _string_value(team_policy_pack.get("name")) or ("Guard Cloud sync" if managed_by_cloud else None)
+    managed_updated_at = _string_value(team_policy_pack.get("updatedAt")) or _string_value(
+        remote_policy.get("updatedAt")
+    )
+    return {
+        "status": status,
+        "detail": _posture_detail(status),
+        "connection": {
+            "logged_in": credentials is not None,
+            "paired": workspace_id is not None,
+            "workspace_id": workspace_id,
+        },
+        "bundle": {
+            "bundle_version": bundle_version,
+            "feed_snapshot_hash": _string_value(summary.get("feed_snapshot_hash"))
+            or _string_value(bundle_payload.get("feedSnapshotHash")),
+            "policy_hash": _string_value(summary.get("policy_hash"))
+            or _string_value(entitlement.get("policy_hash"))
+            or _string_value(bundle_payload.get("policyHash")),
+            "synced_at": _string_value(summary.get("synced_at")),
+            "expires_at": expires_at_text,
+            "tier": tier,
+            "workspace_id": _string_value(summary.get("workspace_id"))
+            or _string_value(entitlement.get("workspace_id"))
+            or workspace_id,
+            "advisory_count": _int_value(summary.get("advisory_count")),
+            "package_count": _int_value(summary.get("package_count")),
+        },
+        "policy": {
+            "security_level": config.security_level,
+            "cloud_advisory_action": remote_cloud_advisory_action
+            or resolve_risk_action(config, "cloud_advisory", harness=None),
+            "package_script_action": remote_package_script_action
+            or resolve_risk_action(config, "package_script", harness=None),
+            "managed_by_cloud": managed_by_cloud,
+            "remote_policy_active": bool(remote_policy),
+            "team_policy_active": bool(team_policy_pack),
+            "managed_label": managed_label,
+            "managed_updated_at": managed_updated_at,
+        },
+        "supported_ecosystems": supported_ecosystems,
+    }
+
+
+def build_supply_chain_status_payload(
+    *,
+    store: GuardStore,
+    config: GuardConfig,
+    now: str,
+) -> dict[str, object]:
+    posture = build_local_supply_chain_posture(store, config, now=now)
+    return {
+        "generated_at": now,
+        "mode": "status",
+        "executed": False,
+        "dry_run": True,
+        "supply_chain": posture,
+    }
+
+
+def build_workspace_scan_payload(
+    *,
+    store: GuardStore,
+    config: GuardConfig,
+    workspace_dir: Path,
+    now: str,
+) -> tuple[dict[str, object], int]:
+    posture = build_local_supply_chain_posture(store, config, now=now)
+    intent = _workspace_scan_intent(workspace_dir)
+    if intent is None:
+        return (
+            {
+                "generated_at": now,
+                "manifest_paths": [],
+                "lockfile_paths": [],
+                "message": "No supported manifests or lockfiles found in this workspace.",
+                "supply_chain": posture,
+            },
+            1,
+        )
+    artifact = build_package_request_artifact(
+        _LOCAL_SUPPLY_CHAIN_HARNESS,
+        intent,
+        config_path="hol-guard.toml",
+        source_scope="project",
+    )
+    evaluation = evaluate_package_request_artifact(
+        artifact=artifact,
+        store=store,
+        workspace_dir=workspace_dir,
+        now=now,
+    )
+    payload = {
+        "generated_at": now,
+        "manifest_paths": list(intent.manifest_paths),
+        "lockfile_paths": list(intent.lockfile_paths),
+        "evaluation": evaluation.to_dict(),
+        "supply_chain": posture,
+    }
+    return (payload, _evaluation_exit_code(evaluation.decision))
+
+
+def build_supply_chain_explain_payload(
+    *,
+    store: GuardStore,
+    config: GuardConfig,
+    workspace_dir: Path,
+    package_spec: str,
+    ecosystem: str,
+    now: str,
+) -> tuple[dict[str, object], int]:
+    posture = build_local_supply_chain_posture(store, config, now=now)
+    manifest_paths, lockfile_paths = _workspace_files(workspace_dir)
+    intent = PackageIntent(
+        package_manager=_PACKAGE_MANAGER_BY_ECOSYSTEM.get(ecosystem, ecosystem),
+        intent_kind="install",
+        command_tokens=("hol-guard", "supply-chain", "explain", package_spec),
+        redacted_command=shlex.join(("hol-guard", "supply-chain", "explain", package_spec)),
+        targets=(_target_for_package_spec(ecosystem, package_spec),),
+        manifest_paths=manifest_paths,
+        lockfile_paths=lockfile_paths,
+    )
+    artifact = build_package_request_artifact(
+        _LOCAL_SUPPLY_CHAIN_HARNESS,
+        intent,
+        config_path="hol-guard.toml",
+        source_scope="project",
+    )
+    evaluation = evaluate_package_request_artifact(
+        artifact=artifact,
+        store=store,
+        workspace_dir=workspace_dir,
+        now=now,
+    )
+    payload = {
+        "generated_at": now,
+        "request": {
+            "package": package_spec,
+            "ecosystem": ecosystem,
+            "manifest_paths": list(intent.manifest_paths),
+            "lockfile_paths": list(intent.lockfile_paths),
+        },
+        "evaluation": evaluation.to_dict(),
+        "supply_chain": posture,
+    }
+    return (payload, _evaluation_exit_code(evaluation.decision))
+
+
+def build_package_protect_payload(
+    *,
+    command: Sequence[str],
+    store: GuardStore,
+    workspace_dir: Path,
+    dry_run: bool,
+    now: str,
+    config: GuardConfig | None,
+    unsafe_raw_output: bool,
+    timeout_seconds: int,
+) -> tuple[dict[str, object], int] | None:
+    from .runtime.package_intent_parser import parse_package_intent
+
+    workspace_id = store.get_cloud_workspace_id()
+    if workspace_id is None:
+        return None
+    cached_bundle = store.get_cached_supply_chain_bundle(workspace_id)
+    if not isinstance(cached_bundle, dict):
+        return None
+    intent = parse_package_intent(shlex.join(command), workspace=workspace_dir)
+    if intent is None:
+        return None
+    sanitized_intent = replace(intent, redacted_command=shlex.join(redacted_command_tokens(command)))
+    artifact = build_package_request_artifact(
+        _LOCAL_SUPPLY_CHAIN_HARNESS,
+        sanitized_intent,
+        config_path="hol-guard.toml",
+        source_scope="project",
+    )
+    evaluation = evaluate_package_request_artifact(
+        artifact=artifact,
+        store=store,
+        workspace_dir=workspace_dir,
+        now=now,
+    )
+    verdict_action = _protect_action_for_decision(evaluation.decision)
+    risk_signals = tuple(_evaluation_risk_signals(evaluation))
+    receipt = build_receipt(
+        harness=_LOCAL_SUPPLY_CHAIN_HARNESS,
+        artifact_id=artifact.artifact_id,
+        artifact_hash=hashlib.sha256(artifact.artifact_id.encode("utf-8")).hexdigest(),
+        policy_decision=verdict_action,
+        capabilities_summary=evaluation.user_copy.summary,
+        changed_capabilities=[target.package_name or target.raw_spec for target in sanitized_intent.targets],
+        provenance_summary=evaluation.user_copy.harness_message,
+        artifact_name=artifact.name,
+        source_scope=artifact.source_scope,
+    )
+    payload: dict[str, object] = {
+        "generated_at": now,
+        "request": {
+            "command": list(redacted_command_tokens(command)),
+            "redacted_command": sanitized_intent.redacted_command,
+            "install_kind": sanitized_intent.intent_kind,
+            "executor": str(command[0]) if command else _LOCAL_SUPPLY_CHAIN_HARNESS,
+            "package_manager": sanitized_intent.package_manager,
+            "harness": _LOCAL_SUPPLY_CHAIN_HARNESS,
+            "targets": [target.to_dict() for target in sanitized_intent.targets],
+            "manifest_paths": list(sanitized_intent.manifest_paths),
+            "lockfile_paths": list(sanitized_intent.lockfile_paths),
+        },
+        "targets": [_protect_target_payload(target) for target in sanitized_intent.targets],
+        "verdict": {
+            "action": verdict_action,
+            "reason": evaluation.user_copy.summary,
+            "risk_signals": list(risk_signals),
+            "matched_advisories": _matched_advisories(evaluation),
+            "blocking": evaluation.decision in {"block", "ask"},
+        },
+        "executed": False,
+        "dry_run": dry_run,
+        "receipt": receipt.to_dict(),
+        "matched_advisories": _matched_advisories(evaluation),
+        "supply_chain_evaluation": evaluation.to_dict(),
+    }
+    if config is not None:
+        payload["supply_chain"] = build_local_supply_chain_posture(store, config, now=now)
+    if evaluation.decision in {"block", "ask"} or dry_run:
+        store.add_receipt(receipt)
+        store.add_event(
+            f"install_time_{verdict_action}",
+            {
+                "artifact_id": artifact.artifact_id,
+                "artifact_name": artifact.name,
+                "executor": str(command[0]) if command else _LOCAL_SUPPLY_CHAIN_HARNESS,
+                "install_kind": sanitized_intent.intent_kind,
+                "action": verdict_action,
+                "risk_signals": list(risk_signals),
+            },
+            now,
+        )
+        return (payload, _evaluation_exit_code(evaluation.decision))
+    execution = subprocess.run(
+        list(command),
+        cwd=workspace_dir,
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=timeout_seconds,
+    )
+    redacted_stdout = redact_text(execution.stdout)
+    redacted_stderr = redact_text(execution.stderr)
+    payload["executed"] = True
+    payload["execution"] = {
+        "returncode": execution.returncode,
+        "stdout": execution.stdout if unsafe_raw_output else redacted_stdout.text,
+        "stderr": execution.stderr if unsafe_raw_output else redacted_stderr.text,
+        "stdout_redactions": redacted_stdout.to_dict(),
+        "stderr_redactions": redacted_stderr.to_dict(),
+        "raw_output_enabled": unsafe_raw_output,
+    }
+    if execution.returncode == 0:
+        store.add_receipt(receipt)
+        store.add_event(
+            "install_time_allow",
+            {
+                "artifact_id": artifact.artifact_id,
+                "artifact_name": artifact.name,
+                "executor": str(command[0]) if command else _LOCAL_SUPPLY_CHAIN_HARNESS,
+                "install_kind": sanitized_intent.intent_kind,
+                "action": verdict_action,
+                "risk_signals": list(risk_signals),
+            },
+            now,
+        )
+    else:
+        store.add_event(
+            "install_time_execution_failed",
+            {
+                "artifact_id": artifact.artifact_id,
+                "artifact_name": artifact.name,
+                "executor": str(command[0]) if command else _LOCAL_SUPPLY_CHAIN_HARNESS,
+                "install_kind": sanitized_intent.intent_kind,
+                "action": verdict_action,
+                "returncode": execution.returncode,
+                "risk_signals": list(risk_signals),
+            },
+            now,
+        )
+    return (payload, int(execution.returncode))
+
+
+def redacted_command_tokens(command: Sequence[str]) -> tuple[str, ...]:
+    return tuple(_redact_command_token(str(token)) for token in command)
+
+
+def _workspace_scan_intent(workspace_dir: Path) -> PackageIntent | None:
+    manifest_paths, lockfile_paths = _workspace_files(workspace_dir)
+    if not manifest_paths and not lockfile_paths:
+        return None
+    targets = _targets_from_workspace_manifests(workspace_dir, manifest_paths)
+    package_manager = _package_manager_for_scan(manifest_paths)
+    return PackageIntent(
+        package_manager=package_manager,
+        intent_kind="install",
+        command_tokens=("hol-guard", "supply-chain", "scan"),
+        redacted_command="hol-guard supply-chain scan",
+        targets=targets,
+        manifest_paths=manifest_paths,
+        lockfile_paths=lockfile_paths,
+    )
+
+
+def _workspace_files(workspace_dir: Path) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    return (
+        existing_relative_paths(workspace_dir, _MANIFEST_CANDIDATES),
+        existing_relative_paths(workspace_dir, _LOCKFILE_CANDIDATES),
+    )
+
+
+def _targets_from_workspace_manifests(
+    workspace_dir: Path,
+    manifest_paths: Sequence[str],
+) -> tuple[PackageIntentTarget, ...]:
+    seen: set[tuple[str, str | None, str, str | None]] = set()
+    targets: list[PackageIntentTarget] = []
+    for manifest_path in manifest_paths:
+        disk_path = workspace_dir / manifest_path
+        try:
+            manifest_text = disk_path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        dependency_map = parse_manifest_dependencies(path=manifest_path, text=manifest_text)
+        ecosystem = _ECOSYSTEM_BY_MANIFEST.get(Path(manifest_path).name)
+        if ecosystem is None:
+            continue
+        for package_name, version in dependency_map.items():
+            target = _target_from_manifest_dependency(ecosystem, package_name, version)
+            fingerprint = (target.ecosystem, target.package_name, target.raw_spec, target.source_url)
+            if fingerprint in seen:
+                continue
+            seen.add(fingerprint)
+            targets.append(target)
+    return tuple(targets)
+
+
+def _target_from_manifest_dependency(ecosystem: str, package_name: str, version: str) -> PackageIntentTarget:
+    clean_name = package_name.strip()
+    clean_version = version.strip()
+    if ecosystem == "npm":
+        spec = clean_name if not clean_version else f"{clean_name}@{clean_version}"
+        return js_target(spec)
+    if ecosystem == "pypi":
+        spec = clean_name if not clean_version else f"{clean_name}{clean_version}"
+        return python_target(spec)
+    if ecosystem == "maven":
+        spec = clean_name if not clean_version else f"{clean_name}:{clean_version}"
+        return coordinate_target(ecosystem, spec)
+    if ecosystem == "packagist":
+        spec = clean_name if not clean_version else f"{clean_name}:{clean_version}"
+        return composer_target(spec)
+    spec = clean_name if not clean_version else f"{clean_name}@{clean_version}"
+    return version_target(ecosystem, spec)
+
+
+def _target_for_package_spec(ecosystem: str, package_spec: str) -> PackageIntentTarget:
+    if ecosystem == "npm":
+        return js_target(package_spec)
+    if ecosystem == "pypi":
+        return python_target(package_spec)
+    if ecosystem == "maven":
+        return coordinate_target(ecosystem, package_spec)
+    if ecosystem == "packagist":
+        return composer_target(package_spec)
+    return version_target(ecosystem, package_spec)
+
+
+def _package_manager_for_scan(manifest_paths: Sequence[str]) -> str:
+    for manifest_path in manifest_paths:
+        ecosystem = _ECOSYSTEM_BY_MANIFEST.get(Path(manifest_path).name)
+        if ecosystem is not None:
+            return _PACKAGE_MANAGER_BY_ECOSYSTEM.get(ecosystem, ecosystem)
+    return "workspace"
+
+
+def _evaluation_exit_code(decision: str) -> int:
+    return 2 if decision in {"block", "ask"} else 0
+
+
+def _protect_action_for_decision(decision: str) -> str:
+    if decision == "block":
+        return "block"
+    if decision == "ask":
+        return "review"
+    if decision == "warn":
+        return "warn"
+    return "allow"
+
+
+def _evaluation_risk_signals(evaluation: object) -> list[str]:
+    if not hasattr(evaluation, "reasons"):
+        return []
+    reasons = evaluation.reasons
+    if not isinstance(reasons, tuple):
+        return []
+    signals: list[str] = []
+    for item in reasons:
+        if not isinstance(item, dict):
+            continue
+        message = item.get("message")
+        if isinstance(message, str) and message:
+            signals.append(message)
+    if signals:
+        return signals
+    summary = getattr(evaluation, "risk_summary", None)
+    return [summary] if isinstance(summary, str) and summary else []
+
+
+def _matched_advisories(evaluation: object) -> list[dict[str, object]]:
+    packages = getattr(evaluation, "packages", ())
+    if not isinstance(packages, tuple):
+        return []
+    advisories: list[dict[str, object]] = []
+    for item in packages:
+        if not isinstance(item, dict):
+            continue
+        advisory_ids = item.get("related_advisory_ids")
+        if not isinstance(advisory_ids, list):
+            continue
+        for advisory_id in advisory_ids:
+            if not isinstance(advisory_id, str):
+                continue
+            advisories.append(
+                {
+                    "advisory_id": advisory_id,
+                    "package_name": item.get("name"),
+                    "version": item.get("version"),
+                    "decision": item.get("decision"),
+                }
+            )
+    return advisories
+
+
+def _protect_target_payload(target: PackageIntentTarget) -> dict[str, object]:
+    return {
+        "artifact_id": f"{target.ecosystem}:{target.package_name or target.raw_spec}",
+        "artifact_name": target.package_name or target.raw_spec,
+        "artifact_type": "package_request",
+        "ecosystem": target.ecosystem,
+        "package_name": target.package_name,
+        "package_url": None,
+        "raw_spec": target.raw_spec,
+        "version": target.requested_specifier,
+        "source_url": target.source_url,
+        "harness": _LOCAL_SUPPLY_CHAIN_HARNESS,
+    }
+
+
+def _redact_command_token(token: str) -> str:
+    if "=" in token:
+        key, _, _ = token.partition("=")
+        if any(fragment in key.lower() for fragment in ("token", "secret", "api_key", "api-key", "password")):
+            return f"{key}=*****"
+    if ":" in token:
+        key, _, _ = token.partition(":")
+        if any(fragment in key.lower() for fragment in ("token", "secret", "api_key", "api-key", "password")):
+            return f"{key}: *****"
+    return redact_text(token).text
+
+
+def _posture_status(
+    *,
+    credentials_present: bool,
+    workspace_id: str | None,
+    summary: dict[str, object],
+    bundle_payload: dict[str, object],
+    expires_at: datetime | None,
+    snapshot_now: datetime,
+) -> str:
+    if not credentials_present:
+        return "not_connected"
+    if workspace_id is None:
+        return "workspace_required"
+    if not summary and not bundle_payload:
+        return "sync_required"
+    if expires_at is not None and expires_at <= snapshot_now:
+        return "expired"
+    summary_status = _string_value(summary.get("status"))
+    if summary_status:
+        return summary_status
+    if bundle_payload:
+        return "synced"
+    return "degraded"
+
+
+def _posture_detail(status: str) -> str:
+    details = {
+        "not_connected": "Connect Guard Cloud to fetch signed supply-chain bundles.",
+        "workspace_required": "Finish Guard Cloud pairing to fetch workspace-specific supply-chain bundles.",
+        "sync_required": "Run `hol-guard supply-chain sync` to fetch the latest signed bundle.",
+        "expired": "The cached signed bundle expired. Run `hol-guard supply-chain sync` before the next install.",
+        "synced": "Signed supply-chain bundle is ready for local install protection.",
+        "degraded": "Supply-chain protection is degraded. Refresh the signed bundle before trusting new installs.",
+    }
+    return details.get(status, "Supply-chain protection status is available.")
+
+
+def _dict_payload(value: object) -> dict[str, object]:
+    return value if isinstance(value, dict) else {}
+
+
+def _string_value(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value
+    return None
+
+
+def _int_value(value: object) -> int | None:
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)

--- a/src/codex_plugin_scanner/guard/protect.py
+++ b/src/codex_plugin_scanner/guard/protect.py
@@ -13,6 +13,8 @@ from typing import Literal
 from urllib.parse import urlparse
 
 from .advisory_model import ProtectTargetIdentity, advisory_matches_target, build_package_url
+from .config import GuardConfig
+from .local_supply_chain import build_package_protect_payload
 from .models import GuardReceipt
 from .receipts import build_receipt
 from .redaction import redact_text
@@ -113,12 +115,25 @@ def build_protect_payload(
     workspace_dir: Path,
     dry_run: bool,
     now: str,
+    config: GuardConfig | None = None,
     unsafe_raw_output: bool = False,
 ) -> tuple[dict[str, object], int]:
     """Evaluate and optionally execute an install command."""
 
     if len(command) == 0:
         raise ValueError("Guard protect requires a command to wrap.")
+    package_payload = build_package_protect_payload(
+        command=command,
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=dry_run,
+        now=now,
+        config=config,
+        unsafe_raw_output=unsafe_raw_output,
+        timeout_seconds=_protect_command_timeout_seconds(),
+    )
+    if package_payload is not None:
+        return package_payload
     request = parse_protect_command(command)
     advisories = store.list_cached_advisories(limit=None)
     verdict = evaluate_protect_request(request, advisories)

--- a/tests/test_guard_docs.py
+++ b/tests/test_guard_docs.py
@@ -93,3 +93,17 @@ def test_static_docs_cover_supply_chain_support_levels() -> None:
     assert "protected" in docs_text
     assert "beta" in docs_text
     assert "monitor-only" in docs_text
+
+
+def test_static_docs_cover_local_supply_chain_firewall_commands() -> None:
+    docs_text = "\n".join(
+        [
+            _read_repo_file("README.md"),
+            _read_repo_file("docs/guard/get-started.md"),
+            _read_repo_file("docs/guard/local-vs-cloud.md"),
+        ]
+    ).lower()
+
+    assert "hol-guard supply-chain scan" in docs_text
+    assert "hol-guard supply-chain explain" in docs_text
+    assert "hol-guard protect" in docs_text

--- a/tests/test_guard_local_supply_chain_phase15.py
+++ b/tests/test_guard_local_supply_chain_phase15.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -14,6 +15,7 @@ from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generate_private_key
 
 from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard import local_supply_chain as local_supply_chain_module
 from codex_plugin_scanner.guard.approvals import build_runtime_snapshot
 from codex_plugin_scanner.guard.cli import commands as commands_module
 from codex_plugin_scanner.guard.protect import build_protect_payload
@@ -319,6 +321,37 @@ def test_guard_supply_chain_scan_uses_manifest_and_lockfile_context(tmp_path: Pa
     assert output["evaluation"]["packages"][0]["name"] == "minimist"
 
 
+def test_guard_supply_chain_scan_without_supported_manifests_returns_zero(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    _seed_supply_chain_bundle(
+        store,
+        packages=[_package(name="minimist", version="1.2.5", default_action="block")],
+        now="2026-05-19T12:00:00+00:00",
+    )
+
+    rc = main(
+        [
+            "guard",
+            "supply-chain",
+            "scan",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["manifest_paths"] == []
+    assert output["lockfile_paths"] == []
+    assert output["message"] == "No supported manifests or lockfiles found in this workspace."
+
+
 def test_guard_supply_chain_sync_alias_uses_bundle_sync(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
 ) -> None:
@@ -360,6 +393,34 @@ def test_guard_supply_chain_sync_alias_uses_bundle_sync(
     assert rc == 0
     assert output["status"] == "synced"
     assert output["bundle_version"] == "1747612800000-deadbeef"
+
+
+def test_guard_supply_chain_sync_alias_rejects_invalid_payload(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+
+    monkeypatch.setattr(commands_module, "sync_supply_chain_bundle", lambda _store: None)
+
+    rc = main(
+        [
+            "guard",
+            "supply-chain",
+            "sync",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert output["synced"] is False
+    assert output["error"] == "Guard Cloud sync returned an invalid response."
 
 
 def test_guard_supply_chain_explain_reuses_cached_bundle_context(tmp_path: Path, capsys) -> None:
@@ -435,3 +496,56 @@ def test_runtime_snapshot_marks_supply_chain_policy_as_cloud_managed(tmp_path: P
     assert snapshot["supply_chain"]["policy"]["managed_by_cloud"] is True
     assert snapshot["supply_chain"]["policy"]["team_policy_active"] is True
     assert snapshot["supply_chain"]["policy"]["managed_label"] == "Security team default"
+
+
+@pytest.mark.parametrize(
+    ("raised_error", "expected_fragment"),
+    [
+        (subprocess.TimeoutExpired(cmd=["npm", "install"], timeout=45), "timed out"),
+        (OSError("missing executable"), "missing executable"),
+    ],
+)
+def test_guard_protect_returns_controlled_execution_error_for_install_subprocess_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    raised_error: subprocess.TimeoutExpired | OSError,
+    expected_fragment: str,
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    _seed_supply_chain_bundle(
+        store,
+        packages=[
+            _package(
+                name="lodash",
+                version="4.17.21",
+                default_action="allow",
+                normalized_severity="low",
+                recommended_fix_version=None,
+            )
+        ],
+        now="2026-05-19T12:00:00+00:00",
+    )
+
+    def raise_error(*_args: object, **_kwargs: object) -> object:
+        raise raised_error
+
+    monkeypatch.setattr(local_supply_chain_module.subprocess, "run", raise_error)
+
+    payload, exit_code = build_protect_payload(
+        command=["npm", "install", "lodash@4.17.21"],
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=False,
+        now="2026-05-19T12:00:00+00:00",
+        unsafe_raw_output=False,
+    )
+
+    execution = payload["execution"]
+    assert exit_code == 1
+    assert payload["executed"] is True
+    assert isinstance(execution, dict)
+    assert execution["returncode"] == -1
+    assert expected_fragment in str(execution["stderr"]).lower()

--- a/tests/test_guard_local_supply_chain_phase15.py
+++ b/tests/test_guard_local_supply_chain_phase15.py
@@ -1,0 +1,437 @@
+"""Phase 15 local supply-chain CLI and runtime coverage."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generate_private_key
+
+from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.approvals import build_runtime_snapshot
+from codex_plugin_scanner.guard.cli import commands as commands_module
+from codex_plugin_scanner.guard.protect import build_protect_payload
+from codex_plugin_scanner.guard.store import GuardStore
+
+WORKSPACE_ID = "workspace-alpha"
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _generate_key_pair() -> tuple[bytes, bytes]:
+    private_key = generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem, public_pem
+
+
+def _fingerprint(public_key_pem: bytes) -> str:
+    return hashlib.sha256(public_key_pem.decode("utf-8").strip().encode("utf-8")).hexdigest()
+
+
+def _package(
+    *,
+    name: str,
+    version: str,
+    default_action: str,
+    normalized_severity: str = "critical",
+    recommended_fix_version: str | None = "1.2.9",
+) -> dict[str, object]:
+    return {
+        "confidence": 990,
+        "defaultAction": default_action,
+        "ecosystem": "npm",
+        "exploitLevel": "active",
+        "knownExploited": True,
+        "malwareState": "known",
+        "name": name,
+        "namespace": None,
+        "normalizedSeverity": normalized_severity,
+        "packageAgeState": "watch",
+        "purl": f"pkg:npm/{name}@{version}",
+        "reachability": "reachable",
+        "recommendedFixVersion": recommended_fix_version,
+        "relatedAdvisoryIds": ["GHSA-vh95-rmgr-6w4m"],
+        "riskScore": 980,
+        "sourceIntegrityState": "high-risk",
+        "version": version,
+    }
+
+
+def _bundle_response(*, packages: list[dict[str, object]]) -> dict[str, object]:
+    generated_at = datetime.now(timezone.utc)
+    expires_at = generated_at + timedelta(days=7)
+    bundle = {
+        "advisories": [
+            {
+                "advisoryId": "GHSA-vh95-rmgr-6w4m",
+                "aliases": ["CVE-2020-7598"],
+                "confidence": 990,
+                "exploitLevel": "active",
+                "knownExploited": True,
+                "malwareState": "known",
+                "normalizedSeverity": "critical",
+                "recommendedFixVersion": "1.2.9",
+                "sourceKey": "ghsa",
+                "summary": "Prototype pollution in minimist",
+                "title": "Prototype pollution in minimist",
+            }
+        ],
+        "bundleVersion": "1747612800000-deadbeef",
+        "expiresAt": _iso(expires_at),
+        "feedSnapshotHash": "feed-snapshot-1",
+        "generatedAt": _iso(generated_at),
+        "keyId": "guard-bundle-key-2026-05",
+        "packages": packages,
+        "policyHash": "policy-hash-1",
+        "policyRules": [],
+        "scoringVersion": "scf-v1",
+        "sourceHashes": [{"payloadHash": "ghsa-feed-hash", "sourceKey": "ghsa", "staleStatus": "fresh"}],
+        "tier": "premium",
+        "workspaceId": WORKSPACE_ID,
+    }
+    private_key_pem, public_key_pem = _generate_key_pair()
+    loaded_key = serialization.load_pem_private_key(private_key_pem, password=None)
+    assert isinstance(loaded_key, RSAPrivateKey)
+    canonical_payload = json.dumps(bundle, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    payload_hash = hashlib.sha256(canonical_payload).hexdigest()
+    signature = loaded_key.sign(
+        canonical_payload,
+        padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+        hashes.SHA256(),
+    )
+    return {
+        "bundle": bundle,
+        "payloadHash": payload_hash,
+        "signature": base64.b64encode(signature).decode("utf-8"),
+        "signatureAlgorithm": "rsa-pss-sha256",
+        "verificationKeys": [
+            {
+                "fingerprintSha256": _fingerprint(public_key_pem),
+                "keyId": "guard-bundle-key-2026-05",
+                "publicKeyPem": public_key_pem.decode("utf-8").strip(),
+                "state": "active",
+                "validUntil": None,
+            }
+        ],
+    }
+
+
+def _seed_supply_chain_bundle(store: GuardStore, *, packages: list[dict[str, object]], now: str) -> None:
+    response = _bundle_response(packages=packages)
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "token-one",
+        now,
+        workspace_id=WORKSPACE_ID,
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, response, now)
+    store.set_sync_payload(
+        "supply_chain_bundle_summary",
+        {
+            "advisory_count": 1,
+            "bundle_version": "1747612800000-deadbeef",
+            "ecosystem_support": [
+                {"ecosystem": "npm", "support_level": "protected", "label": "Protected"},
+                {"ecosystem": "pypi", "support_level": "protected", "label": "Protected"},
+            ],
+            "feed_snapshot_hash": "feed-snapshot-1",
+            "package_count": len(packages),
+            "policy_hash": "policy-hash-1",
+            "status": "synced",
+            "synced_at": now,
+            "tier": "premium",
+            "workspace_id": WORKSPACE_ID,
+        },
+        now,
+    )
+    store.set_sync_payload(
+        "supply_chain_bundle_entitlement",
+        {
+            "bundle_version": "1747612800000-deadbeef",
+            "key_id": "guard-bundle-key-2026-05",
+            "policy_hash": "policy-hash-1",
+            "tier": "premium",
+            "workspace_id": WORKSPACE_ID,
+        },
+        now,
+    )
+
+
+def test_guard_protect_without_command_returns_supply_chain_status(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    _seed_supply_chain_bundle(
+        store,
+        packages=[_package(name="minimist", version="1.2.5", default_action="block")],
+        now="2026-05-19T12:00:00+00:00",
+    )
+
+    rc = main(
+        [
+            "guard",
+            "protect",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["mode"] == "status"
+    assert output["supply_chain"]["status"] == "synced"
+    assert output["supply_chain"]["bundle"]["tier"] == "premium"
+    assert output["supply_chain"]["policy"]["cloud_advisory_action"] == "warn"
+
+
+def test_guard_protect_routes_package_requests_through_supply_chain_eval_and_redacts_command(tmp_path: Path) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    _seed_supply_chain_bundle(
+        store,
+        packages=[_package(name="minimist", version="1.2.5", default_action="block")],
+        now="2026-05-19T12:00:00+00:00",
+    )
+
+    payload, exit_code = build_protect_payload(
+        command=[
+            "npm",
+            "install",
+            "minimist@1.2.5",
+            "--registry=https://npm.pkg.github.com/?_authToken=super-secret-token",
+            "--token=another-secret-token",
+        ],
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=True,
+        now="2026-05-19T12:00:00+00:00",
+        unsafe_raw_output=False,
+    )
+    serialized = json.dumps(payload, sort_keys=True)
+
+    assert exit_code == 2
+    assert payload["supply_chain_evaluation"]["decision"] == "block"
+    assert "super-secret-token" not in serialized
+    assert "another-secret-token" not in serialized
+
+
+def test_guard_doctor_includes_supply_chain_posture(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    _seed_supply_chain_bundle(
+        store,
+        packages=[_package(name="minimist", version="1.2.5", default_action="block")],
+        now="2026-05-19T12:00:00+00:00",
+    )
+
+    rc = main(
+        [
+            "guard",
+            "doctor",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["supply_chain"]["status"] == "synced"
+    assert output["supply_chain"]["bundle"]["workspace_id"] == WORKSPACE_ID
+    assert output["supply_chain"]["policy"]["security_level"] == "balanced"
+
+
+def test_guard_supply_chain_scan_uses_manifest_and_lockfile_context(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo","dependencies":{"minimist":"^1.2.0"}}\n')
+    _write_text(
+        workspace_dir / "package-lock.json",
+        json.dumps(
+            {
+                "name": "demo",
+                "lockfileVersion": 3,
+                "packages": {
+                    "": {"dependencies": {"minimist": "^1.2.0"}},
+                    "node_modules/minimist": {"version": "1.2.5"},
+                },
+            }
+        )
+        + "\n",
+    )
+    store = GuardStore(home_dir)
+    _seed_supply_chain_bundle(
+        store,
+        packages=[_package(name="minimist", version="1.2.5", default_action="block")],
+        now="2026-05-19T12:00:00+00:00",
+    )
+
+    rc = main(
+        [
+            "guard",
+            "supply-chain",
+            "scan",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 2
+    assert output["manifest_paths"] == ["package.json"]
+    assert output["lockfile_paths"] == ["package-lock.json"]
+    assert output["evaluation"]["decision"] == "block"
+    assert output["evaluation"]["packages"][0]["name"] == "minimist"
+
+
+def test_guard_supply_chain_sync_alias_uses_bundle_sync(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+
+    monkeypatch.setattr(
+        commands_module,
+        "sync_supply_chain_bundle",
+        lambda _store: {
+            "status": "synced",
+            "bundle_version": "1747612800000-deadbeef",
+            "workspace_id": WORKSPACE_ID,
+            "synced_at": "2026-05-19T12:00:00+00:00",
+            "tier": "premium",
+            "advisory_count": 1,
+            "package_count": 1,
+            "policy_hash": "policy-hash-1",
+            "feed_snapshot_hash": "feed-snapshot-1",
+            "ecosystem_support": [{"ecosystem": "npm", "support_level": "protected", "label": "Protected"}],
+        },
+    )
+
+    rc = main(
+        [
+            "guard",
+            "supply-chain",
+            "sync",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["status"] == "synced"
+    assert output["bundle_version"] == "1747612800000-deadbeef"
+
+
+def test_guard_supply_chain_explain_reuses_cached_bundle_context(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    _seed_supply_chain_bundle(
+        store,
+        packages=[_package(name="minimist", version="1.2.5", default_action="block")],
+        now="2026-05-19T12:00:00+00:00",
+    )
+
+    rc = main(
+        [
+            "guard",
+            "supply-chain",
+            "explain",
+            "minimist@1.2.5",
+            "--ecosystem",
+            "npm",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 2
+    assert output["request"]["package"] == "minimist@1.2.5"
+    assert output["request"]["ecosystem"] == "npm"
+    assert output["evaluation"]["decision"] == "block"
+    assert output["evaluation"]["user_copy"]["harness_message"].startswith("HOL Guard blocked")
+
+
+def test_runtime_snapshot_includes_supply_chain_block(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_supply_chain_bundle(
+        store,
+        packages=[_package(name="minimist", version="1.2.5", default_action="block")],
+        now="2026-05-19T12:00:00+00:00",
+    )
+
+    snapshot = build_runtime_snapshot(store=store, approval_center_url="http://127.0.0.1:4874")
+
+    assert snapshot["supply_chain"]["status"] == "synced"
+    assert snapshot["supply_chain"]["bundle"]["bundle_version"] == "1747612800000-deadbeef"
+    assert snapshot["supply_chain"]["policy"]["cloud_advisory_action"] == "warn"
+    assert snapshot["supply_chain"]["policy"]["managed_by_cloud"] is False
+
+
+def test_runtime_snapshot_marks_supply_chain_policy_as_cloud_managed(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    now = "2026-05-19T12:00:00+00:00"
+    _seed_supply_chain_bundle(
+        store,
+        packages=[_package(name="minimist", version="1.2.5", default_action="block")],
+        now=now,
+    )
+    store.set_sync_payload(
+        "team_policy_pack",
+        {
+            "name": "Security team default",
+            "updatedAt": "2026-05-19T11:55:00Z",
+        },
+        now,
+    )
+
+    snapshot = build_runtime_snapshot(store=store, approval_center_url="http://127.0.0.1:4874")
+
+    assert snapshot["supply_chain"]["policy"]["managed_by_cloud"] is True
+    assert snapshot["supply_chain"]["policy"]["team_policy_active"] is True
+    assert snapshot["supply_chain"]["policy"]["managed_label"] == "Security team default"

--- a/tests/test_guard_render.py
+++ b/tests/test_guard_render.py
@@ -153,6 +153,111 @@ def test_guard_json_renderer_receives_payload_copy(monkeypatch, capsys) -> None:
     assert "mutated-secret" not in output
 
 
+def test_guard_protect_render_uses_supply_chain_user_copy(capsys) -> None:
+    emit_guard_payload(
+        "protect",
+        {
+            "executed": False,
+            "request": {
+                "command": ["npm", "install", "minimist@1.2.5"],
+                "install_kind": "install",
+            },
+            "verdict": {
+                "action": "block",
+                "reason": "Known exploited package.",
+            },
+            "supply_chain_evaluation": {
+                "decision": "block",
+                "user_copy": {
+                    "title": "HOL Guard blocked `minimist@1.2.5` before install.",
+                    "summary": "Known exploited package.",
+                    "next_step": "Install `minimist@1.2.9` instead.",
+                    "dashboard_url": "https://hol.org/guard/inbox",
+                    "harness_message": (
+                        "HOL Guard blocked `minimist@1.2.5` before install.\n"
+                        "Reason: Known exploited package.\n"
+                        "Fix: Install `minimist@1.2.9` instead.\n"
+                        "Review evidence: https://hol.org/guard/inbox"
+                    ),
+                },
+            },
+        },
+        False,
+    )
+
+    output = _normalize_render_output(capsys.readouterr().out)
+
+    assert "HOL Guard blocked" in output
+    assert "Install `minimist@1.2.9` instead." in output
+    assert "Review evidence:" in output
+
+
+def test_guard_protect_render_uses_supply_chain_review_copy(capsys) -> None:
+    emit_guard_payload(
+        "protect",
+        {
+            "executed": False,
+            "request": {
+                "command": ["npm", "install", "left-pad@1.3.0"],
+                "install_kind": "install",
+            },
+            "verdict": {
+                "action": "require-reapproval",
+                "reason": "Package install needs review.",
+            },
+            "supply_chain_evaluation": {
+                "decision": "review",
+                "user_copy": {
+                    "harness_message": (
+                        "HOL Guard paused `left-pad@1.3.0` before install.\n"
+                        "Reason: Package install needs review.\n"
+                        "Choose: approve once, block, or inspect in Guard."
+                    ),
+                },
+            },
+        },
+        False,
+    )
+
+    output = _normalize_render_output(capsys.readouterr().out)
+
+    assert "HOL Guard paused" in output
+    assert "approve once, block, or inspect in Guard" in output
+
+
+def test_guard_protect_render_uses_supply_chain_warning_copy(capsys) -> None:
+    emit_guard_payload(
+        "protect",
+        {
+            "executed": False,
+            "request": {
+                "command": ["npm", "install", "left-pad@1.3.0"],
+                "install_kind": "install",
+            },
+            "verdict": {
+                "action": "warn",
+                "reason": "Package looks risky but is not blocked.",
+            },
+            "supply_chain_evaluation": {
+                "decision": "warn",
+                "user_copy": {
+                    "harness_message": (
+                        "HOL Guard warned on `left-pad@1.3.0` before install.\n"
+                        "Reason: Package looks risky but is not blocked.\n"
+                        "Continue only if you trust the source."
+                    ),
+                },
+            },
+        },
+        False,
+    )
+
+    output = _normalize_render_output(capsys.readouterr().out)
+
+    assert "HOL Guard warned" in output
+    assert "Continue only if you trust the source." in output
+
+
 def test_guard_settings_json_omits_billing_flag(capsys) -> None:
     emit_guard_payload(
         "settings",

--- a/tests/test_guard_render.py
+++ b/tests/test_guard_render.py
@@ -5,6 +5,8 @@ import sys
 import types
 from pathlib import Path
 
+from rich.console import Console
+
 from codex_plugin_scanner.guard.cli import render
 from codex_plugin_scanner.guard.cli.render import emit_guard_payload
 
@@ -404,6 +406,27 @@ def test_guard_connect_render_clarifies_browser_approval_wait(capsys) -> None:
     assert "Browser paired" in output
     assert "Browser approval pending" in output
     assert "Waiting for browser approval" in output
+
+
+def test_supply_chain_posture_panel_shows_unknown_cloud_advisories_consistently() -> None:
+    panel = render._build_supply_chain_posture_panel(
+        {
+            "status": "synced",
+            "policy": {
+                "security_level": "balanced",
+                "cloud_advisory_action": None,
+            },
+        }
+    )
+    console = Console(record=True, width=120)
+
+    console.print(panel)
+
+    output = _normalize_render_output(console.export_text())
+    assert "Security" in output
+    assert "balanced" in output
+    assert "Cloud advisories" in output
+    assert "unknown" in output
 
 
 def test_guard_status_render_rewrites_internal_next_action_labels(capsys) -> None:


### PR DESCRIPTION
## Summary
- add local supply-chain posture helpers for protect, doctor, scan, sync, explain, and daemon snapshot state
- ship the local Guard dashboard home, activity, and settings package-firewall UX with truthful managed, fallback, and support-label states
- update docs, render coverage, phase-15 contract tests, and ignore local browser proof artifacts

## Testing
- node --check src/codex_plugin_scanner/guard/daemon/static/assets/chunks/home-dashboard.js
- node --check src/codex_plugin_scanner/guard/daemon/static/assets/chunks/app-detail-workspace.js
- node --check src/codex_plugin_scanner/guard/daemon/static/assets/chunks/settings-workspace.js
- pytest tests/test_guard_protect.py tests/test_guard_cloud_local_sync.py tests/test_guard_local_supply_chain_phase15.py tests/test_guard_render.py tests/test_guard_docs.py -q
- ruff check src tests
- python3.14 -m build