### PR TITLE
fix(guard): allow connect tokens to run proof

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -116,6 +116,12 @@ _HEADLESS_APP_ACTIONS = {
     "status": ("status", "verify"),
     "test": ("scan", "verify"),
 }
+_CLOUD_APP_DASHBOARD_SESSION_ACTIONS = {
+    "connect": frozenset({"connect", "status", "test"}),
+    "repair": frozenset({"repair", "status", "test"}),
+    "status": frozenset({"status"}),
+    "test": frozenset({"status", "test"}),
+}
 _CLOUD_APP_HANDOFF_ACTIONS = frozenset({"connect", "repair", "status", "test"})
 _HEADLESS_OPERATIONS = ("install", "repair", "remove", "status", "scan", "policy_sync")
 
@@ -128,6 +134,10 @@ def _headless_safe_failure_reasons() -> dict[str, str]:
         "unsupported": "Harness is not supported by this daemon.",
         "confirmation_required": "Remove actions need the harness confirmation phrase.",
     }
+
+
+def _cloud_app_dashboard_session_actions(action_path: str) -> frozenset[str]:
+    return _CLOUD_APP_DASHBOARD_SESSION_ACTIONS.get(action_path, frozenset({action_path}))
 
 
 def _headless_detection_status_to_app_status(value: object) -> str:
@@ -1241,6 +1251,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         payload_json = json.dumps(
             {
                 "action_path": action_path,
+                "allowed_action_paths": sorted(_cloud_app_dashboard_session_actions(action_path)),
                 "expires_at": expires_at.isoformat(),
                 "harness": harness,
                 "version": "guard-local-daemon-session.v1",
@@ -2154,7 +2165,11 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         path_parts = [part for part in path.split("/") if part]
         if path in {"/v1/capabilities", "/v1/harnesses", "/v1/inventory", "/v1/runtime"}:
             return True
-        if len(path_parts) == 3 and path_parts[:2] == ["v1", "apps"] and path_parts[2] == action_path:
+        if (
+            len(path_parts) == 3
+            and path_parts[:2] == ["v1", "apps"]
+            and path_parts[2] in _cloud_app_dashboard_session_actions(action_path)
+        ):
             if payload is None:
                 return False
             harness = self._optional_string(claims.get("harness"))

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -333,6 +333,7 @@ def test_cloud_app_handoff_page_mints_scoped_browser_session_token(tmp_path: Pat
     assert decoded["harness"] == "codex"
     assert decoded["workspace_id"] == "workspace-1"
     assert decoded["action_path"] == "connect"
+    assert decoded["allowed_action_paths"] == ["connect", "status", "test"]
 
 
 def test_cloud_app_handoff_referrer_page_does_not_mint_browser_session_token(tmp_path: Path) -> None:
@@ -401,6 +402,96 @@ def test_cloud_app_handoff_scoped_session_rejects_settings_reset(tmp_path: Path)
 
     assert reset_status == 401
     assert reset_payload["error"] == "unauthorized"
+
+
+def test_cloud_app_handoff_connect_session_can_run_same_app_proof(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        start_status, start_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/apps/codex/cloud/start",
+                payload={"action": "connect", "workspace_id": "workspace-1"},
+                origin="https://hol.org",
+                token=_dashboard_token_for(store),
+            ),
+        )
+        assert start_status == 200
+        handoff_url = start_payload["handoff_url"]
+        assert isinstance(handoff_url, str)
+        page_status, body = _read_text_response(
+            _request(
+                daemon.port,
+                handoff_url.removeprefix(f"http://127.0.0.1:{daemon.port}"),
+                method="GET",
+                origin=None,
+            )
+        )
+        assert page_status == 200
+        script_payload = _handoff_script_payload(body)
+        browser_token = script_payload["dashboardSessionToken"]
+        assert isinstance(browser_token, str)
+        proof_status, proof_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/apps/test",
+                payload={"harness": "codex", "operation": "scan", "workspace_id": "workspace-1"},
+                origin="https://hol.org",
+                dashboard_session_token=browser_token,
+            )
+        )
+    finally:
+        daemon.stop()
+
+    assert proof_status == 200
+    assert proof_payload["state"]["app_status"] in {"inactive", "observed", "protected"}
+
+
+def test_cloud_app_handoff_connect_session_rejects_other_workspace_proof(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        start_status, start_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/apps/codex/cloud/start",
+                payload={"action": "connect", "workspace_id": "workspace-1"},
+                origin="https://hol.org",
+                token=_dashboard_token_for(store),
+            ),
+        )
+        assert start_status == 200
+        handoff_url = start_payload["handoff_url"]
+        assert isinstance(handoff_url, str)
+        page_status, body = _read_text_response(
+            _request(
+                daemon.port,
+                handoff_url.removeprefix(f"http://127.0.0.1:{daemon.port}"),
+                method="GET",
+                origin=None,
+            )
+        )
+        assert page_status == 200
+        script_payload = _handoff_script_payload(body)
+        browser_token = script_payload["dashboardSessionToken"]
+        assert isinstance(browser_token, str)
+        proof_status, proof_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/apps/test",
+                payload={"harness": "codex", "operation": "scan", "workspace_id": "workspace-2"},
+                origin="https://hol.org",
+                dashboard_session_token=browser_token,
+            )
+        )
+    finally:
+        daemon.stop()
+
+    assert proof_status == 401
+    assert proof_payload["error"] == "unauthorized"
 
 
 def test_cloud_app_handoff_completion_runs_scoped_action_without_daemon_auth_token(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- allow scoped connect dashboard sessions to run same-app status and proof checks
- include allowed action paths in minted browser session payloads
- add daemon regressions for same-workspace proof and workspace isolation

## Verification
- pytest tests/test_guard_headless_daemon_api.py -q
- git diff --check
- python3 -m py_compile src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_headless_daemon_api.py