### PR TITLE
fix(guard): expose daemon version for cloud handoff

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1000,6 +1000,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         handoff_query = urlencode({"handoffToken": handoff_token})
         self._write_json(
             {
+                "daemon_version": __version__,
                 "handoff_url": f"{local_origin}/v1/apps/{adapter.harness}/cloud?{handoff_query}",
                 "local_origin": local_origin,
                 "status": "ready",

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -280,6 +280,8 @@ def test_cloud_app_handoff_start_response_is_not_cacheable(tmp_path: Path) -> No
 
     assert status == 200
     assert payload["local_origin"] == f"http://127.0.0.1:{daemon.port}"
+    assert isinstance(payload["daemon_version"], str)
+    assert payload["daemon_version"]
     assert headers["Cache-Control"] == "no-store, max-age=0"
     assert headers["Pragma"] == "no-cache"
     assert headers["Expires"] == "0"


### PR DESCRIPTION
## Summary\n- include daemon_version in local cloud handoff start responses\n- cover the response field in the daemon handoff API tests\n\n## Verification\n- uv run pytest tests/test_guard_headless_daemon_api.py\n- uv run pytest tests/test_guard_headless_daemon_api.py tests/test_guard_connect_flow.py