### PR TITLE
fix(daemon): sync headless app proofs

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -58,7 +58,12 @@ from ..desktop_notifications import (
 )
 from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES, PolicyDecision
 from ..receipts.manager import build_receipt
-from ..runtime.runner import GuardSyncNotConfiguredError, sync_receipts, sync_supply_chain_bundle
+from ..runtime.runner import (
+    GuardSyncNotAvailableError,
+    GuardSyncNotConfiguredError,
+    sync_receipts,
+    sync_supply_chain_bundle,
+)
 from ..runtime.surface_server import GuardSurfaceRuntime
 from ..store import GuardStore
 from ..store_approvals import InvalidApprovalCursorError
@@ -284,7 +289,37 @@ def _headless_action_state_payload(
     }
 
 
-def _headless_cloud_sync_payload(
+def _run_headless_cloud_sync(
+    *,
+    store: GuardStore,
+) -> None:
+    recorded_at = _now()
+    try:
+        sync_payload = sync_receipts(store)
+        summary = {
+            "status": "synced",
+            "synced_at": sync_payload.get("synced_at"),
+            "receipts_stored": sync_payload.get("receipts_stored", 0),
+        }
+    except GuardSyncNotConfiguredError as error:
+        summary = {
+            "status": "not_configured",
+            "message": str(error),
+        }
+    except GuardSyncNotAvailableError as error:
+        summary = {
+            "status": "not_available",
+            "message": str(error),
+        }
+    except Exception as error:
+        summary = {
+            "status": "pending",
+            "message": str(error),
+        }
+    store.set_sync_payload("headless_app_sync_summary", summary, recorded_at)
+
+
+def _queue_headless_cloud_sync(
     *,
     store: GuardStore,
 ) -> dict[str, object]:
@@ -293,22 +328,15 @@ def _headless_cloud_sync_payload(
             "status": "not_configured",
             "message": "Guard Cloud sync is not paired on this machine.",
         }
-    try:
-        sync_payload = sync_receipts(store)
-    except GuardSyncNotConfiguredError as error:
-        return {
-            "status": "not_configured",
-            "message": str(error),
-        }
-    except Exception as error:
-        return {
-            "status": "pending",
-            "message": str(error),
-        }
+    threading.Thread(
+        target=_run_headless_cloud_sync,
+        kwargs={"store": store},
+        daemon=True,
+        name="guard-headless-app-cloud-sync",
+    ).start()
     return {
-        "status": "synced",
-        "synced_at": sync_payload.get("synced_at"),
-        "receipts_stored": sync_payload.get("receipts_stored", sync_payload.get("receipts", 0)),
+        "status": "queued",
+        "message": "Guard Cloud sync started.",
     }
 
 
@@ -930,7 +958,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             result=result,
             workspace_id=self._optional_string(payload.get("workspace_id")),
         )
-        cloud_sync = _headless_cloud_sync_payload(store=self.server.store)  # type: ignore[attr-defined]
+        cloud_sync = _queue_headless_cloud_sync(store=self.server.store)  # type: ignore[attr-defined]
         return 200, {
             "cloud_sync": cloud_sync,
             "harness": adapter.harness,

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -58,7 +58,7 @@ from ..desktop_notifications import (
 )
 from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES, PolicyDecision
 from ..receipts.manager import build_receipt
-from ..runtime.runner import GuardSyncNotConfiguredError, sync_supply_chain_bundle
+from ..runtime.runner import GuardSyncNotConfiguredError, sync_receipts, sync_supply_chain_bundle
 from ..runtime.surface_server import GuardSurfaceRuntime
 from ..store import GuardStore
 from ..store_approvals import InvalidApprovalCursorError
@@ -281,6 +281,34 @@ def _headless_action_state_payload(
             "timestamp": receipt.get("timestamp"),
         },
         "retryable": operation in {"install", "repair", "scan"},
+    }
+
+
+def _headless_cloud_sync_payload(
+    *,
+    store: GuardStore,
+) -> dict[str, object]:
+    if store.get_sync_credentials() is None:
+        return {
+            "status": "not_configured",
+            "message": "Guard Cloud sync is not paired on this machine.",
+        }
+    try:
+        sync_payload = sync_receipts(store)
+    except GuardSyncNotConfiguredError as error:
+        return {
+            "status": "not_configured",
+            "message": str(error),
+        }
+    except Exception as error:
+        return {
+            "status": "pending",
+            "message": str(error),
+        }
+    return {
+        "status": "synced",
+        "synced_at": sync_payload.get("synced_at"),
+        "receipts_stored": sync_payload.get("receipts_stored", sync_payload.get("receipts", 0)),
     }
 
 
@@ -902,7 +930,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             result=result,
             workspace_id=self._optional_string(payload.get("workspace_id")),
         )
+        cloud_sync = _headless_cloud_sync_payload(store=self.server.store)  # type: ignore[attr-defined]
         return 200, {
+            "cloud_sync": cloud_sync,
             "harness": adapter.harness,
             "operation": operation,
             "result": result,

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -7,6 +7,7 @@ import hashlib
 import hmac
 import json
 import re
+import threading
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
@@ -691,10 +692,12 @@ def test_headless_app_scan_syncs_receipt_to_cloud_when_connected(
         workspace_id="workspace-1",
     )
     sync_calls: list[bool] = []
+    sync_finished = threading.Event()
 
     def fake_sync_receipts(current_store: GuardStore) -> dict[str, object]:
         assert current_store is store
         sync_calls.append(True)
+        sync_finished.set()
         return {
             "synced_at": "2026-05-23T17:18:40.061Z",
             "receipts_stored": 1,
@@ -722,13 +725,13 @@ def test_headless_app_scan_syncs_receipt_to_cloud_when_connected(
         daemon.stop()
 
     assert status == 200
-    assert sync_calls == [True]
     assert payload["receipt"]["operation"] == "scan"
     assert payload["cloud_sync"] == {
-        "status": "synced",
-        "synced_at": "2026-05-23T17:18:40.061Z",
-        "receipts_stored": 1,
+        "status": "queued",
+        "message": "Guard Cloud sync started.",
     }
+    assert sync_finished.wait(timeout=2)
+    assert sync_calls == [True]
 
 
 def test_headless_policy_sync_persists_policy_and_receipt(tmp_path: Path) -> None:

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -16,6 +16,7 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
+from codex_plugin_scanner.guard.daemon import server as daemon_server
 from codex_plugin_scanner.guard.daemon.manager import load_guard_daemon_auth_token
 from codex_plugin_scanner.guard.daemon.server import _headless_action_error_payload
 from codex_plugin_scanner.guard.store import GuardStore
@@ -676,6 +677,58 @@ def test_headless_app_operations_write_receipts_without_cli_copy(
         "Headless scan",
         "Headless remove",
     }.issubset(receipt_operations)
+
+
+def test_headless_app_scan_syncs_receipt_to_cloud_when_connected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "cloud-token",
+        "2026-05-23T17:18:00.000Z",
+        workspace_id="workspace-1",
+    )
+    sync_calls: list[bool] = []
+
+    def fake_sync_receipts(current_store: GuardStore) -> dict[str, object]:
+        assert current_store is store
+        sync_calls.append(True)
+        return {
+            "synced_at": "2026-05-23T17:18:40.061Z",
+            "receipts_stored": 1,
+        }
+
+    monkeypatch.setattr(daemon_server, "sync_receipts", fake_sync_receipts, raising=False)
+
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/apps/test",
+                token=token,
+                payload={
+                    "harness": "opencode",
+                    "operation": "scan",
+                    "workspace_id": "workspace-1",
+                },
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert sync_calls == [True]
+    assert payload["receipt"]["operation"] == "scan"
+    assert payload["cloud_sync"] == {
+        "status": "synced",
+        "synced_at": "2026-05-23T17:18:40.061Z",
+        "receipts_stored": 1,
+    }
 
 
 def test_headless_policy_sync_persists_policy_and_receipt(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Sync local headless app proof receipts to Guard Cloud when paired
- Return Cloud sync status in daemon app action responses
- Cover scan proof sync through the headless daemon API test

## Verification
- uv run pytest tests/test_guard_headless_daemon_api.py -k "headless_app_operations_write_receipts_without_cli_copy or headless_app_scan_syncs_receipt_to_cloud_when_connected or headless_api_does_not_read_env_files"
- uv run --with ruff python -m ruff check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_headless_daemon_api.py