### PR TITLE
chore(release): bump hol-guard to 2.0.303

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hol-guard"
-version = "2.0.0"
+version = "2.0.303"
 description = "Protect local AI harnesses with HOL Guard and run scanner checks for Codex, Claude, Cursor, Gemini, and OpenCode."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/codex_plugin_scanner/version.py
+++ b/src/codex_plugin_scanner/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for tool version."""
 
-__version__ = "2.0.0"
+__version__ = "2.0.303"

--- a/uv.lock
+++ b/uv.lock
@@ -1077,7 +1077,7 @@ wheels = [
 
 [[package]]
 name = "hol-guard"
-version = "2.0.0"
+version = "2.0.303"
 source = { editable = "." }
 dependencies = [
     { name = "cisco-ai-skill-scanner" },


### PR DESCRIPTION
## Summary
- Bump hol-guard package metadata to 2.0.303 for the headless proof sync release

## Verification
- uv run pytest tests/test_guard_headless_daemon_api.py -k headless_app_scan_syncs_receipt_to_cloud_when_connected
- uv run --with ruff python -m ruff check pyproject.toml src/codex_plugin_scanner/version.py