### PR TITLE
fix(guard): mark connect sync success

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -941,6 +941,7 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
         summary["remote_policy_sync_blocked"] = True
     summary["guard_events_v1"] = sync_guard_events(store)
     store.set_sync_payload("sync_summary", summary, now)
+    store.record_latest_guard_connect_sync_success(sync_payload=summary, now=now)
     return summary
 
 

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -2932,6 +2932,40 @@ class GuardStore:
                 sync_payload=sync_payload,
             )
 
+    def record_latest_guard_connect_sync_success(
+        self,
+        *,
+        sync_payload: dict[str, object],
+        now: str,
+    ) -> dict[str, object] | None:
+        with self._connect() as connection:
+            row = connection.execute(
+                """
+                select request_id
+                from guard_connect_states
+                where status = 'connected'
+                  and milestone != 'first_sync_succeeded'
+                order by updated_at desc
+                limit 1
+                """
+            ).fetchone()
+            if row is None:
+                return None
+            latest_state = load_connect_state(connection, str(row["request_id"]), now=now)
+            if latest_state is None:
+                return None
+            if latest_state.get("status") != "connected":
+                return latest_state
+            return persist_connect_result(
+                connection,
+                request_id=str(latest_state["request_id"]),
+                status="connected",
+                milestone="first_sync_succeeded",
+                updated_at=now,
+                reason=None,
+                sync_payload=sync_payload,
+            )
+
     def verify_guard_connect_access(
         self,
         *,

--- a/src/codex_plugin_scanner/guard/store_connect.py
+++ b/src/codex_plugin_scanner/guard/store_connect.py
@@ -280,13 +280,18 @@ def mark_connect_result(
         raise ValueError("connect_state_not_found")
     proof = _coerce_proof(state.get("proof"))
     if sync_payload is not None:
-        proof["first_synced_at"] = sync_payload.get("synced_at")
-        proof["receipts_stored"] = _coerce_non_negative_int(sync_payload.get("receipts_stored"))
-        proof["inventory_items"] = _coerce_non_negative_int(
-            sync_payload.get("inventory_tracked", sync_payload.get("inventory"))
-        )
-        proof["runtime_session_id"] = sync_payload.get("runtime_session_id")
-        proof["runtime_session_synced_at"] = sync_payload.get("runtime_session_synced_at")
+        if "synced_at" in sync_payload:
+            proof["first_synced_at"] = sync_payload.get("synced_at")
+        if "receipts_stored" in sync_payload:
+            proof["receipts_stored"] = _coerce_non_negative_int(sync_payload.get("receipts_stored"))
+        if "inventory_tracked" in sync_payload or "inventory" in sync_payload:
+            proof["inventory_items"] = _coerce_non_negative_int(
+                sync_payload.get("inventory_tracked", sync_payload.get("inventory"))
+            )
+        if "runtime_session_id" in sync_payload:
+            proof["runtime_session_id"] = sync_payload.get("runtime_session_id")
+        if "runtime_session_synced_at" in sync_payload:
+            proof["runtime_session_synced_at"] = sync_payload.get("runtime_session_synced_at")
     connection.execute(
         """
         update guard_connect_states

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -14948,6 +14948,86 @@ def test_sync_receipts_batches_large_local_history(tmp_path, monkeypatch):
     assert payload["receipts_stored"] == 65
 
 
+def test_sync_receipts_marks_latest_connect_first_sync_succeeded(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    connect_request = store.create_guard_connect_request(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now="2026-05-23T19:20:00+00:00",
+    )
+    request_id = str(connect_request["request_id"])
+    store.complete_guard_connect_request(
+        request_id=request_id,
+        pairing_secret=str(connect_request["pairing_secret"]),
+        token="guard-live-token",
+        now="2026-05-23T19:21:00+00:00",
+    )
+    store.record_guard_connect_result(
+        request_id=request_id,
+        status="connected",
+        milestone="first_sync_pending",
+        now="2026-05-23T19:21:10+00:00",
+        reason="waiting_for_first_sync",
+        sync_payload={
+            "runtime_session_id": "runtime-session-1",
+            "runtime_session_synced_at": "2026-05-23T19:21:05+00:00",
+        },
+    )
+    store.create_guard_connect_request(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now="2026-05-23T19:21:30+00:00",
+    )
+    store.add_receipt(
+        GuardReceipt(
+            receipt_id="receipt-1",
+            timestamp="2026-05-23T19:22:00+00:00",
+            harness="codex",
+            artifact_id="artifact-1",
+            artifact_hash="sha256:receipt",
+            policy_decision="review",
+            artifact_name="Bash",
+            capabilities_summary="runs shell commands",
+            changed_capabilities=("shell_exec",),
+            provenance_summary="local codex workspace",
+        )
+    )
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "syncedAt": "2026-05-23T19:22:36.076Z",
+                    "receiptsStored": 1,
+                    "advisories": [],
+                    "policy": {},
+                    "alertPreferences": {},
+                    "teamPolicyPack": {},
+                    "exceptions": [],
+                }
+            ).encode("utf-8")
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", lambda request, timeout: _Response())
+
+    payload = guard_runner_module.sync_receipts(store)
+    latest_state = store.get_guard_connect_state(request_id, now="2026-05-23T19:23:00+00:00")
+
+    assert payload["receipts_stored"] == 1
+    assert latest_state is not None
+    assert latest_state["request_id"] == request_id
+    assert latest_state["milestone"] == "first_sync_succeeded"
+    assert latest_state["proof"]["first_synced_at"] == "2026-05-23T19:22:36.076Z"
+    assert latest_state["proof"]["receipts_stored"] == 1
+    assert latest_state["proof"]["runtime_session_id"] == "runtime-session-1"
+    assert latest_state["proof"]["runtime_session_synced_at"] == "2026-05-23T19:21:05+00:00"
+
+
 def test_sync_receipts_preserves_batch_metadata_and_reuses_device_metadata(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
     store.set_sync_credentials(


### PR DESCRIPTION
## Summary
- mark the latest paired Guard Cloud connect request as `first_sync_succeeded` when a later `hol-guard sync` stores receipts
- preserve existing runtime-session proof fields when later receipt sync payloads do not include runtime fields
- add regression coverage for the connect status state transition

## Verification
- `uv run pytest tests/test_guard_runtime.py -k 'sync_receipts_marks_latest_connect_first_sync_succeeded or sync_receipts_batches_large_local_history'`
- `uv run ruff check src/codex_plugin_scanner/guard/runtime/runner.py src/codex_plugin_scanner/guard/store.py src/codex_plugin_scanner/guard/store_connect.py tests/test_guard_runtime.py`
- production against paid test account: `uv run hol-guard sync --json` exits 0, then `uv run hol-guard connect status --json` reports `milestone: first_sync_succeeded`, `receipts_stored: 200`, `inventory_items: 207`
