### PR TITLE
feat(guard): add inbox date filters

### DIFF
--- a/dashboard/src/queue-state.test.ts
+++ b/dashboard/src/queue-state.test.ts
@@ -16,6 +16,8 @@ import {
   isDuplicateGroup,
   bulkBlockEligibleGroups,
   bulkBlockPrimaryIds,
+  filterQueueByDateRange,
+  formatQueueRequestDate,
 } from "./queue-state";
 
 function assert(condition: boolean, message: string): void {
@@ -161,6 +163,39 @@ const oldestFirst = sortQueue([oldItem, recentItem, midItem], "oldest");
 
 assert(oldestFirst[0].request_id === "req-old", "T-QS-16: sortQueue puts oldest item first when direction is oldest");
 assert(oldestFirst[2].request_id === "req-recent", "T-QS-17: sortQueue puts newest item last when direction is oldest");
+
+const dateRangeFiltered = filterQueueByDateRange([oldItem, midItem, recentItem], {
+  from: "2026-02-01",
+  to: "2026-02-01",
+});
+assert(
+  dateRangeFiltered.length === 1 && dateRangeFiltered[0].request_id === "req-mid",
+  "T-QS-17A: filterQueueByDateRange filters requests by inclusive same-day date range"
+);
+
+const fromOnlyFiltered = filterQueueByDateRange([oldItem, midItem, recentItem], {
+  from: "2026-02-01",
+  to: "",
+});
+assert(
+  fromOnlyFiltered.map((item) => item.request_id).join(",") === "req-mid,req-recent",
+  "T-QS-17B: filterQueueByDateRange keeps requests on or after from date"
+);
+
+const toOnlyFiltered = filterQueueByDateRange([oldItem, midItem, recentItem], {
+  from: "",
+  to: "2026-02-01",
+});
+assert(
+  toOnlyFiltered.map((item) => item.request_id).join(",") === "req-old,req-mid",
+  "T-QS-17C: filterQueueByDateRange keeps requests on or before to date"
+);
+
+const requestDateLabel = formatQueueRequestDate(midItem);
+assert(
+  requestDateLabel.includes("2026") && requestDateLabel.includes("Feb"),
+  "T-QS-17D: formatQueueRequestDate exposes a human-readable request date with year"
+);
 
 const recentlySeenOldItem: GuardApprovalRequest = {
   ...oldItem,

--- a/dashboard/src/queue-state.ts
+++ b/dashboard/src/queue-state.ts
@@ -5,6 +5,11 @@ export type QueueSortDirection = "newest" | "oldest" | "category" | "highest_ris
 
 export type SemanticGroupId = "all" | "files" | "shell" | "network" | "tools" | "other";
 
+export type QueueDateRange = {
+  from: string;
+  to: string;
+};
+
 export const REVIEW_SEMANTIC_GROUPS: { id: SemanticGroupId; label: string; matches: QueueCategoryId[] }[] = [
   { id: "all", label: "All", matches: [] },
   {
@@ -444,7 +449,52 @@ export function groupDuplicates(items: GuardApprovalRequest[]): QueueGroup[] {
 }
 
 function queueTimestamp(item: GuardApprovalRequest): number {
-  return new Date(item.last_seen_at ?? item.created_at).getTime();
+  const timestamp = new Date(item.last_seen_at ?? item.created_at).getTime();
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function dateInputToBoundary(value: string, boundary: "start" | "end"): number | null {
+  if (value.trim().length === 0) {
+    return null;
+  }
+  const suffix = boundary === "start" ? "T00:00:00.000Z" : "T23:59:59.999Z";
+  const timestamp = new Date(`${value}${suffix}`).getTime();
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+export function filterQueueByDateRange(
+  items: GuardApprovalRequest[],
+  range: QueueDateRange
+): GuardApprovalRequest[] {
+  const from = dateInputToBoundary(range.from, "start");
+  const to = dateInputToBoundary(range.to, "end");
+  if (from === null && to === null) {
+    return items;
+  }
+  return items.filter((item) => {
+    const timestamp = queueTimestamp(item);
+    if (from !== null && timestamp < from) {
+      return false;
+    }
+    if (to !== null && timestamp > to) {
+      return false;
+    }
+    return true;
+  });
+}
+
+export function formatQueueRequestDate(item: GuardApprovalRequest): string {
+  const timestamp = queueTimestamp(item);
+  if (timestamp === 0) {
+    return "Date unknown";
+  }
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(timestamp));
 }
 
 export function queueCategoryById(id: QueueCategoryId): QueueCategory {

--- a/dashboard/src/queue-state.ts
+++ b/dashboard/src/queue-state.ts
@@ -457,8 +457,17 @@ function dateInputToBoundary(value: string, boundary: "start" | "end"): number |
   if (value.trim().length === 0) {
     return null;
   }
-  const suffix = boundary === "start" ? "T00:00:00.000Z" : "T23:59:59.999Z";
-  const timestamp = new Date(`${value}${suffix}`).getTime();
+  const [year, month, day] = value.split("-").map((part) => Number.parseInt(part, 10));
+  if (!year || !month || !day) {
+    return null;
+  }
+  const date = new Date(year, month - 1, day);
+  if (boundary === "start") {
+    date.setHours(0, 0, 0, 0);
+  } else {
+    date.setHours(23, 59, 59, 999);
+  }
+  const timestamp = date.getTime();
   return Number.isFinite(timestamp) ? timestamp : null;
 }
 
@@ -483,18 +492,20 @@ export function filterQueueByDateRange(
   });
 }
 
+const queueDateFormatter = new Intl.DateTimeFormat("en", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+});
+
 export function formatQueueRequestDate(item: GuardApprovalRequest): string {
   const timestamp = queueTimestamp(item);
   if (timestamp === 0) {
     return "Date unknown";
   }
-  return new Intl.DateTimeFormat("en", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  }).format(new Date(timestamp));
+  return queueDateFormatter.format(new Date(timestamp));
 }
 
 export function queueCategoryById(id: QueueCategoryId): QueueCategory {

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -72,6 +72,8 @@ import type {
 } from "./guard-types";
 import {
   filterQueueByCategory,
+  filterQueueByDateRange,
+  formatQueueRequestDate,
   queueCategoriesForItems,
   resolveQueueCategory,
   searchQueue,
@@ -152,6 +154,8 @@ export function ReviewWorkspace(props: ReviewWorkspaceProps) {
   const [categoryFilter, setCategoryFilter] = useState<QueueCategoryId | "all">("all");
   const [sortDirection, setSortDirection] = useState<QueueSortDirection>("newest");
   const [semanticFilter, setSemanticFilter] = useState<SemanticGroupId>("all");
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
   const [mobileQueueOpen, setMobileQueueOpen] = useState(false);
   const [page, setPage] = useState(1);
 
@@ -174,13 +178,14 @@ export function ReviewWorkspace(props: ReviewWorkspaceProps) {
     } else if (categoryFilter !== "all") {
       items = filterQueueByCategory(items, categoryFilter);
     }
+    items = filterQueueByDateRange(items, { from: dateFrom, to: dateTo });
     const searched = searchQueue(items, searchTerm);
     return sortQueue(searched, sortDirection);
-  }, [categoryFilter, requests, searchTerm, sortDirection, semanticFilter]);
+  }, [categoryFilter, dateFrom, dateTo, requests, searchTerm, sortDirection, semanticFilter]);
 
   useEffect(() => {
     setPage(1);
-  }, [searchTerm, categoryFilter, sortDirection, semanticFilter]);
+  }, [searchTerm, categoryFilter, sortDirection, semanticFilter, dateFrom, dateTo]);
 
   const totalPages = Math.max(1, Math.ceil(filteredRequests.length / QUEUE_PAGE_SIZE));
   const currentPage = Math.min(page, totalPages);
@@ -276,12 +281,16 @@ export function ReviewWorkspace(props: ReviewWorkspaceProps) {
             searchTerm={searchTerm}
             sortDirection={sortDirection}
             semanticFilter={semanticFilter}
+            dateFrom={dateFrom}
+            dateTo={dateTo}
             page={currentPage}
             totalPages={totalPages}
             onCategoryFilterChange={setCategoryFilter}
             onSearchTermChange={setSearchTerm}
             onSortDirectionChange={setSortDirection}
             onSemanticFilterChange={setSemanticFilter}
+            onDateFromChange={setDateFrom}
+            onDateToChange={setDateTo}
             onPageChange={setPage}
             onOpenRequest={handleOpenRequest}
             ref={queueRef}
@@ -343,12 +352,16 @@ const ReviewQueueList = forwardRef<HTMLDivElement, {
   searchTerm: string;
   sortDirection: QueueSortDirection;
   semanticFilter: SemanticGroupId;
+  dateFrom: string;
+  dateTo: string;
   page: number;
   totalPages: number;
   onCategoryFilterChange: (category: QueueCategoryId | "all") => void;
   onSearchTermChange: (term: string) => void;
   onSortDirectionChange: (direction: QueueSortDirection) => void;
   onSemanticFilterChange: (group: SemanticGroupId) => void;
+  onDateFromChange: (date: string) => void;
+  onDateToChange: (date: string) => void;
   onPageChange: (page: number) => void;
   onOpenRequest: (requestId: string) => void;
 }>(({
@@ -362,12 +375,16 @@ const ReviewQueueList = forwardRef<HTMLDivElement, {
   searchTerm,
   sortDirection,
   semanticFilter,
+  dateFrom,
+  dateTo,
   page,
   totalPages,
   onCategoryFilterChange,
   onSearchTermChange,
   onSortDirectionChange,
   onSemanticFilterChange,
+  onDateFromChange,
+  onDateToChange,
   onPageChange,
   onOpenRequest,
 }, ref) => {
@@ -382,6 +399,12 @@ const ReviewQueueList = forwardRef<HTMLDivElement, {
   const handleSortChange = useCallback((event: ChangeEvent<HTMLSelectElement>) => {
     onSortDirectionChange(event.target.value as QueueSortDirection);
   }, [onSortDirectionChange]);
+  const handleDateFromChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    onDateFromChange(event.target.value);
+  }, [onDateFromChange]);
+  const handleDateToChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    onDateToChange(event.target.value);
+  }, [onDateToChange]);
   const handleToggleFilters = useCallback(() => {
     setShowFilters((visible) => !visible);
   }, []);
@@ -390,7 +413,16 @@ const ReviewQueueList = forwardRef<HTMLDivElement, {
     onCategoryFilterChange("all");
     onSortDirectionChange("newest");
     onSemanticFilterChange("all");
-  }, [onCategoryFilterChange, onSearchTermChange, onSemanticFilterChange, onSortDirectionChange]);
+    onDateFromChange("");
+    onDateToChange("");
+  }, [
+    onCategoryFilterChange,
+    onDateFromChange,
+    onDateToChange,
+    onSearchTermChange,
+    onSemanticFilterChange,
+    onSortDirectionChange,
+  ]);
   const handlePreviousPage = useCallback(() => {
     onPageChange(Math.max(1, page - 1));
   }, [page, onPageChange]);
@@ -408,7 +440,13 @@ const ReviewQueueList = forwardRef<HTMLDivElement, {
     return REVIEW_SEMANTIC_GROUPS.filter((g) => g.id === "all" || available.has(g.id));
   }, [allFilteredRequests]);
 
-  const isFiltered = searchTerm || semanticFilter !== "all" || categoryFilter !== "all" || sortDirection !== "newest";
+  const isFiltered =
+    searchTerm ||
+    semanticFilter !== "all" ||
+    categoryFilter !== "all" ||
+    sortDirection !== "newest" ||
+    dateFrom ||
+    dateTo;
   const showPagination = filteredCount > QUEUE_PAGE_SIZE;
 
   return (
@@ -453,10 +491,13 @@ const ReviewQueueList = forwardRef<HTMLDivElement, {
               ))}
             </div>
             <label className="block">
-              <span className="sr-only">Sort review queue</span>
+              <span className="mb-1 block text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                Sort by date
+              </span>
               <select
                 value={sortDirection}
                 onChange={handleSortChange}
+                aria-label="Sort review queue"
                 className="min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
               >
                 <option value="newest">Newest first</option>
@@ -465,6 +506,32 @@ const ReviewQueueList = forwardRef<HTMLDivElement, {
                 <option value="category">Category</option>
               </select>
             </label>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <label className="block">
+                <span className="mb-1 block text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                  From date
+                </span>
+                <input
+                  type="date"
+                  value={dateFrom}
+                  onChange={handleDateFromChange}
+                  aria-label="Filter requests from date"
+                  className="min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+                />
+              </label>
+              <label className="block">
+                <span className="mb-1 block text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                  To date
+                </span>
+                <input
+                  type="date"
+                  value={dateTo}
+                  onChange={handleDateToChange}
+                  aria-label="Filter requests to date"
+                  className="min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+                />
+              </label>
+            </div>
             {isFiltered && (
               <button
                 type="button"
@@ -594,7 +661,7 @@ function QueueItemRow({ item, active, index, onOpenRequest }: {
           <div className="min-w-0">
             <p className="truncate text-sm font-medium text-brand-dark">{preview}</p>
             <p className="truncate text-[11px] text-muted-foreground">
-              {harnessDisplayName(item.harness)} · {category.shortLabel}
+              {harnessDisplayName(item.harness)} · {category.shortLabel} · {formatQueueRequestDate(item)}
             </p>
           </div>
         </div>

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -18177,7 +18177,46 @@ function groupDuplicates(items) {
   return groups;
 }
 function queueTimestamp(item) {
-  return new Date(item.last_seen_at ?? item.created_at).getTime();
+  const timestamp = new Date(item.last_seen_at ?? item.created_at).getTime();
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+function dateInputToBoundary(value, boundary) {
+  if (value.trim().length === 0) {
+    return null;
+  }
+  const suffix = boundary === "start" ? "T00:00:00.000Z" : "T23:59:59.999Z";
+  const timestamp = (/* @__PURE__ */ new Date(`${value}${suffix}`)).getTime();
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+function filterQueueByDateRange(items, range) {
+  const from = dateInputToBoundary(range.from, "start");
+  const to = dateInputToBoundary(range.to, "end");
+  if (from === null && to === null) {
+    return items;
+  }
+  return items.filter((item) => {
+    const timestamp = queueTimestamp(item);
+    if (from !== null && timestamp < from) {
+      return false;
+    }
+    if (to !== null && timestamp > to) {
+      return false;
+    }
+    return true;
+  });
+}
+function formatQueueRequestDate(item) {
+  const timestamp = queueTimestamp(item);
+  if (timestamp === 0) {
+    return "Date unknown";
+  }
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit"
+  }).format(new Date(timestamp));
 }
 function queueCategoryById(id) {
   return QUEUE_CATEGORY_BY_ID.get(id) ?? QUEUE_CATEGORIES[QUEUE_CATEGORIES.length - 1];
@@ -18627,6 +18666,8 @@ function ReviewWorkspace(props) {
   const [categoryFilter, setCategoryFilter] = reactExports.useState("all");
   const [sortDirection, setSortDirection] = reactExports.useState("newest");
   const [semanticFilter, setSemanticFilter] = reactExports.useState("all");
+  const [dateFrom, setDateFrom] = reactExports.useState("");
+  const [dateTo, setDateTo] = reactExports.useState("");
   const [mobileQueueOpen, setMobileQueueOpen] = reactExports.useState(false);
   const [page, setPage] = reactExports.useState(1);
   const handleOpenRequest = reactExports.useCallback((id) => {
@@ -18646,12 +18687,13 @@ function ReviewWorkspace(props) {
     } else if (categoryFilter !== "all") {
       items = filterQueueByCategory(items, categoryFilter);
     }
+    items = filterQueueByDateRange(items, { from: dateFrom, to: dateTo });
     const searched = searchQueue(items, searchTerm);
     return sortQueue(searched, sortDirection);
-  }, [categoryFilter, requests, searchTerm, sortDirection, semanticFilter]);
+  }, [categoryFilter, dateFrom, dateTo, requests, searchTerm, sortDirection, semanticFilter]);
   reactExports.useEffect(() => {
     setPage(1);
-  }, [searchTerm, categoryFilter, sortDirection, semanticFilter]);
+  }, [searchTerm, categoryFilter, sortDirection, semanticFilter, dateFrom, dateTo]);
   const totalPages = Math.max(1, Math.ceil(filteredRequests.length / QUEUE_PAGE_SIZE));
   const currentPage = Math.min(page, totalPages);
   const pageStart = (currentPage - 1) * QUEUE_PAGE_SIZE;
@@ -18738,12 +18780,16 @@ function ReviewWorkspace(props) {
           searchTerm,
           sortDirection,
           semanticFilter,
+          dateFrom,
+          dateTo,
           page: currentPage,
           totalPages,
           onCategoryFilterChange: setCategoryFilter,
           onSearchTermChange: setSearchTerm,
           onSortDirectionChange: setSortDirection,
           onSemanticFilterChange: setSemanticFilter,
+          onDateFromChange: setDateFrom,
+          onDateToChange: setDateTo,
           onPageChange: setPage,
           onOpenRequest: handleOpenRequest,
           ref: queueRef
@@ -18798,12 +18844,16 @@ const ReviewQueueList = reactExports.forwardRef(({
   searchTerm,
   sortDirection,
   semanticFilter,
+  dateFrom,
+  dateTo,
   page,
   totalPages,
   onCategoryFilterChange,
   onSearchTermChange,
   onSortDirectionChange,
   onSemanticFilterChange,
+  onDateFromChange,
+  onDateToChange,
   onPageChange,
   onOpenRequest
 }, ref) => {
@@ -18817,6 +18867,12 @@ const ReviewQueueList = reactExports.forwardRef(({
   const handleSortChange = reactExports.useCallback((event) => {
     onSortDirectionChange(event.target.value);
   }, [onSortDirectionChange]);
+  const handleDateFromChange = reactExports.useCallback((event) => {
+    onDateFromChange(event.target.value);
+  }, [onDateFromChange]);
+  const handleDateToChange = reactExports.useCallback((event) => {
+    onDateToChange(event.target.value);
+  }, [onDateToChange]);
   const handleToggleFilters = reactExports.useCallback(() => {
     setShowFilters((visible) => !visible);
   }, []);
@@ -18825,7 +18881,16 @@ const ReviewQueueList = reactExports.forwardRef(({
     onCategoryFilterChange("all");
     onSortDirectionChange("newest");
     onSemanticFilterChange("all");
-  }, [onCategoryFilterChange, onSearchTermChange, onSemanticFilterChange, onSortDirectionChange]);
+    onDateFromChange("");
+    onDateToChange("");
+  }, [
+    onCategoryFilterChange,
+    onDateFromChange,
+    onDateToChange,
+    onSearchTermChange,
+    onSemanticFilterChange,
+    onSortDirectionChange
+  ]);
   const handlePreviousPage = reactExports.useCallback(() => {
     onPageChange(Math.max(1, page - 1));
   }, [page, onPageChange]);
@@ -18840,7 +18905,7 @@ const ReviewQueueList = reactExports.forwardRef(({
     }
     return REVIEW_SEMANTIC_GROUPS.filter((g) => g.id === "all" || available.has(g.id));
   }, [allFilteredRequests]);
-  const isFiltered = searchTerm || semanticFilter !== "all" || categoryFilter !== "all" || sortDirection !== "newest";
+  const isFiltered = searchTerm || semanticFilter !== "all" || categoryFilter !== "all" || sortDirection !== "newest" || dateFrom || dateTo;
   const showPagination = filteredCount > QUEUE_PAGE_SIZE;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("aside", { className: "space-y-3", ref, children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between gap-3", children: [
@@ -18890,12 +18955,13 @@ const ReviewQueueList = reactExports.forwardRef(({
           group.id
         )) }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "sr-only", children: "Sort review queue" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mb-1 block text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground", children: "Sort by date" }),
           /* @__PURE__ */ jsxRuntimeExports.jsxs(
             "select",
             {
               value: sortDirection,
               onChange: handleSortChange,
+              "aria-label": "Sort review queue",
               className: "min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20",
               children: [
                 /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "newest", children: "Newest first" }),
@@ -18905,6 +18971,34 @@ const ReviewQueueList = reactExports.forwardRef(({
               ]
             }
           )
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-2 sm:grid-cols-2", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mb-1 block text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground", children: "From date" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "input",
+              {
+                type: "date",
+                value: dateFrom,
+                onChange: handleDateFromChange,
+                "aria-label": "Filter requests from date",
+                className: "min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+              }
+            )
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mb-1 block text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground", children: "To date" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "input",
+              {
+                type: "date",
+                value: dateTo,
+                onChange: handleDateToChange,
+                "aria-label": "Filter requests to date",
+                className: "min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+              }
+            )
+          ] })
         ] }),
         isFiltered && /* @__PURE__ */ jsxRuntimeExports.jsx(
           "button",
@@ -19021,7 +19115,9 @@ function QueueItemRow({ item, active, index, onOpenRequest }) {
             /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "truncate text-[11px] text-muted-foreground", children: [
               harnessDisplayName(item.harness),
               " · ",
-              category.shortLabel
+              category.shortLabel,
+              " · ",
+              formatQueueRequestDate(item)
             ] })
           ] })
         ] }),

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -18184,8 +18184,17 @@ function dateInputToBoundary(value, boundary) {
   if (value.trim().length === 0) {
     return null;
   }
-  const suffix = boundary === "start" ? "T00:00:00.000Z" : "T23:59:59.999Z";
-  const timestamp = (/* @__PURE__ */ new Date(`${value}${suffix}`)).getTime();
+  const [year, month, day] = value.split("-").map((part) => Number.parseInt(part, 10));
+  if (!year || !month || !day) {
+    return null;
+  }
+  const date = new Date(year, month - 1, day);
+  if (boundary === "start") {
+    date.setHours(0, 0, 0, 0);
+  } else {
+    date.setHours(23, 59, 59, 999);
+  }
+  const timestamp = date.getTime();
   return Number.isFinite(timestamp) ? timestamp : null;
 }
 function filterQueueByDateRange(items, range) {
@@ -18205,18 +18214,19 @@ function filterQueueByDateRange(items, range) {
     return true;
   });
 }
+const queueDateFormatter = new Intl.DateTimeFormat("en", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  hour: "numeric",
+  minute: "2-digit"
+});
 function formatQueueRequestDate(item) {
   const timestamp = queueTimestamp(item);
   if (timestamp === 0) {
     return "Date unknown";
   }
-  return new Intl.DateTimeFormat("en", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    hour: "numeric",
-    minute: "2-digit"
-  }).format(new Date(timestamp));
+  return queueDateFormatter.format(new Date(timestamp));
 }
 function queueCategoryById(id) {
   return QUEUE_CATEGORY_BY_ID.get(id) ?? QUEUE_CATEGORIES[QUEUE_CATEGORIES.length - 1];

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -701,6 +701,10 @@
     margin-top: auto;
   }
 
+  .mb-1 {
+    margin-bottom: calc(var(--spacing) * 1);
+  }
+
   .mb-2 {
     margin-bottom: calc(var(--spacing) * 2);
   }


### PR DESCRIPTION
## Summary
- show request date on every local HOL Guard inbox queue item
- add from/to date filters to the local inbox filter panel
- keep existing newest/oldest date sort explicit and covered by tests
- rebuild packaged daemon dashboard assets

## Verification
- dashboard: pnpm run test
- dashboard: pnpm run build
- python: python3 -m pytest tests/test_guard_queue_contract.py tests/test_guard_queue_api_contract.py -q
- python: python3 -m pytest -q (3998 passed, 11 skipped, 4 deselected)
- browser: local Guard daemon with 3 seeded requests, /inbox shows dates + sort/from/to controls, filtering 2026-05-10 to 2026-05-20 keeps only middle request; screenshot /tmp/hol-guard-local-inbox-date-filter.png
- git diff --check

## Notes
- No .env files read.
- Work done in dedicated clean worktree from origin/main.
- dashboard pnpm install was blocked by local HOL Guard; reused existing local dashboard node_modules only for verification, not committed.
- dashboard tsc --noEmit has existing unrelated baseline type errors; packaged dashboard test and Vite build pass.