### PR TITLE
feat: harden supply-chain key-state and daemon cache tests

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_base.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_base.py
@@ -12,7 +12,7 @@ _SEVERITY_VALUES = frozenset({"unknown", "low", "medium", "high", "critical"})
 _EXPLOIT_LEVEL_VALUES = frozenset({"none", "elevated", "active"})
 _MALWARE_STATE_VALUES = frozenset({"none", "suspected", "known"})
 _STALE_STATUS_VALUES = frozenset({"fresh", "stale", "unknown"})
-_VERIFICATION_KEY_STATE_VALUES = frozenset({"active", "grace"})
+_VERIFICATION_KEY_STATE_VALUES = frozenset({"active", "grace", "revoked"})
 
 
 class SupplyChainBundleError(Exception):

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
@@ -160,6 +160,8 @@ def verify_supply_chain_bundle_response(
     if trusted_keys and not _response_keyring_is_anchored(response, trusted_keys):
         raise SupplyChainBundleKeyringError("Bundle verification keyring is not anchored to the trusted keyring")
     current_time = now if now is not None else time.time()
+    if signing_key.state == "revoked":
+        raise SupplyChainBundleKeyringError("Revoked verification key cannot sign supply-chain bundles")
     if (
         signing_key.state == "grace"
         and signing_key.valid_until_timestamp is not None

--- a/tests/test_guard_supply_chain_bundle.py
+++ b/tests/test_guard_supply_chain_bundle.py
@@ -125,6 +125,8 @@ def _sign_bundle_response(
     *,
     private_key_pem: bytes,
     previous_keys: list[dict[str, object]] | None = None,
+    signing_key_state: str = "active",
+    signing_key_valid_until: str | None = None,
 ) -> dict[str, object]:
     loaded_key = serialization.load_pem_private_key(private_key_pem, password=None)
     assert isinstance(loaded_key, RSAPrivateKey)
@@ -144,8 +146,8 @@ def _sign_bundle_response(
             "fingerprintSha256": _fingerprint(public_key_pem),
             "keyId": str(bundle["keyId"]),
             "publicKeyPem": public_key_pem.decode("utf-8").strip(),
-            "state": "active",
-            "validUntil": None,
+            "state": signing_key_state,
+            "validUntil": signing_key_valid_until,
         }
     ]
     if previous_keys:
@@ -228,6 +230,36 @@ def test_supply_chain_bundle_rejects_payload_hash_mismatch_and_rollback() -> Non
             rollback_payload,
             cached_bundle_version="1747616400000-newerhash",
             now=rollback_payload.bundle.generated_at_timestamp + 5,
+        )
+
+
+def test_supply_chain_bundle_rejects_revoked_or_expired_grace_signing_keys() -> None:
+    private_key, _public_key = _generate_key_pair()
+    grace_expired_payload = _sign_bundle_response(
+        _bundle_dict(),
+        private_key_pem=private_key,
+        signing_key_state="grace",
+        signing_key_valid_until="2026-05-18T00:00:00Z",
+    )
+    grace_expired_response = load_supply_chain_bundle_response(json.dumps(grace_expired_payload))
+
+    with pytest.raises(SupplyChainBundleKeyringError):
+        verify_supply_chain_bundle_response(
+            grace_expired_response,
+            now=datetime(2026, 5, 19, tzinfo=timezone.utc).timestamp(),
+        )
+
+    revoked_payload = _sign_bundle_response(
+        _bundle_dict(bundle_version="1747621200000-revoked"),
+        private_key_pem=private_key,
+        signing_key_state="revoked",
+    )
+    revoked_response = load_supply_chain_bundle_response(json.dumps(revoked_payload))
+
+    with pytest.raises(SupplyChainBundleKeyringError):
+        verify_supply_chain_bundle_response(
+            revoked_response,
+            now=revoked_response.bundle.generated_at_timestamp + 5,
         )
 
 

--- a/tests/test_guard_supply_chain_sync.py
+++ b/tests/test_guard_supply_chain_sync.py
@@ -179,6 +179,23 @@ def test_sync_supply_chain_bundle_fetches_and_caches_bundle(tmp_path: Path) -> N
     assert isinstance(keyring, dict)
     assert keyring["workspace_id"] == WORKSPACE_ID
     assert _BundleSyncHandler.captured_accept_encodings[0] == "identity"
+    assert store.list_approval_requests() == []
+
+
+def test_supply_chain_bundle_cache_persists_across_store_restart(tmp_path: Path) -> None:
+    private_key_pem, public_key_pem = _generate_key_pair()
+    response_payload = _bundle_response(private_key_pem, public_key_pem)
+    guard_home = tmp_path / "guard-home"
+    first_store = GuardStore(guard_home)
+    first_store.cache_supply_chain_bundle(WORKSPACE_ID, response_payload, "2026-05-19T00:00:00Z")
+
+    restarted_store = GuardStore(guard_home)
+    cached = restarted_store.get_cached_supply_chain_bundle(WORKSPACE_ID)
+
+    assert isinstance(cached, dict)
+    bundle = cached.get("bundle")
+    assert isinstance(bundle, dict)
+    assert bundle["bundleVersion"] == "1747612800000-deadbeef"
 
 
 def test_supply_chain_cache_and_eval_cache_clear_on_sync_token_rotation(tmp_path: Path) -> None:

--- a/tests/test_guard_supply_chain_sync.py
+++ b/tests/test_guard_supply_chain_sync.py
@@ -44,7 +44,12 @@ def _fingerprint(public_key_pem: bytes) -> str:
     return hashlib.sha256(public_key_pem.decode("utf-8").strip().encode("utf-8")).hexdigest()
 
 
-def _bundle_response(private_key_pem: bytes, public_key_pem: bytes) -> dict[str, object]:
+def _bundle_response(
+    private_key_pem: bytes,
+    public_key_pem: bytes,
+    *,
+    bundle_version: str = "1747612800000-deadbeef",
+) -> dict[str, object]:
     generated_at = datetime.now(timezone.utc) - timedelta(minutes=5)
     expires_at = generated_at + timedelta(hours=12)
     bundle = {
@@ -63,7 +68,7 @@ def _bundle_response(private_key_pem: bytes, public_key_pem: bytes) -> dict[str,
                 "title": "Prototype pollution in minimist",
             }
         ],
-        "bundleVersion": "1747612800000-deadbeef",
+        "bundleVersion": bundle_version,
         "expiresAt": _iso(expires_at),
         "feedSnapshotHash": "feed-snapshot-1",
         "generatedAt": _iso(generated_at),
@@ -196,6 +201,41 @@ def test_supply_chain_bundle_cache_persists_across_store_restart(tmp_path: Path)
     bundle = cached.get("bundle")
     assert isinstance(bundle, dict)
     assert bundle["bundleVersion"] == "1747612800000-deadbeef"
+
+
+def test_supply_chain_bundle_refresh_keeps_approval_queue_quiet(tmp_path: Path) -> None:
+    private_key_pem, public_key_pem = _generate_key_pair()
+    _BundleSyncHandler.captured_accept_encodings = []
+    _BundleSyncHandler.response_payload = _bundle_response(
+        private_key_pem,
+        public_key_pem,
+        bundle_version="1747616400000-refresh",
+    )
+    server = HTTPServer(("127.0.0.1", 0), _BundleSyncHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        store = GuardStore(tmp_path / "guard-home")
+        store.set_sync_credentials(
+            f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            "demo-token",
+            "2026-05-19T00:00:00Z",
+            workspace_id=WORKSPACE_ID,
+        )
+        store.cache_supply_chain_bundle(
+            WORKSPACE_ID,
+            _bundle_response(private_key_pem, public_key_pem),
+            "2026-05-19T00:00:00Z",
+        )
+
+        summary = sync_supply_chain_bundle(store)
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+    assert summary["bundle_version"] == "1747616400000-refresh"
+    assert store.get_cached_supply_chain_bundle(WORKSPACE_ID)["bundle"]["bundleVersion"] == "1747616400000-refresh"
+    assert store.list_approval_requests() == []
 
 
 def test_supply_chain_cache_and_eval_cache_clear_on_sync_token_rotation(tmp_path: Path) -> None:


### PR DESCRIPTION
Summary:\n- allow bundle verification key state parsing for active/grace/revoked and reject revoked signing keys during verification\n- add crypto regression for expired grace keys and revoked signing keys\n- add daemon cache persistence regression proving cached bundle survives store restart\n- assert bundle sync path does not create approval requests during refresh\n\nValidation:\n- python3 -m pytest tests/test_guard_supply_chain_bundle.py tests/test_guard_supply_chain_sync.py -q\n- python3 -m pytest tests/test_guard_supply_chain_daemon.py -q