### PR TITLE
feat: add incremental supply-chain bundle partition sync

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -35,10 +35,8 @@ from .detectors import DetectorContext, DetectorRegistry, DetectorRunResult, reg
 from .prompt_injection import detect_prompt_injection_requests
 from .supply_chain_bundle import (
     SupplyChainBundleError,
-    SupplyChainBundleResponse,
     load_supply_chain_bundle_response,
     load_supply_chain_verification_keys,
-    payload_hash_for_supply_chain_bundle,
     verify_supply_chain_bundle_response,
 )
 from .supply_chain_support import ecosystem_support_matrix
@@ -997,51 +995,6 @@ def _supply_chain_partition_bundle_url(bundle_url: str, *, ecosystem: str, parti
     )
 
 
-def _merged_supply_chain_bundle_response(
-    *,
-    index_payload: dict[str, object],
-    partition_responses: list[SupplyChainBundleResponse],
-) -> SupplyChainBundleResponse:
-    template_response = max(
-        partition_responses,
-        key=lambda response: response.bundle.version_timestamp,
-    )
-    template_bundle = template_response.bundle.to_dict()
-    package_payloads: list[dict[str, object]] = []
-    advisory_payloads: dict[str, dict[str, object]] = {}
-    for partition_response in partition_responses:
-        package_payloads.extend(item.to_dict() for item in partition_response.bundle.packages)
-        for advisory in partition_response.bundle.advisories:
-            advisory_payloads.setdefault(advisory.advisory_id, advisory.to_dict())
-    merged_bundle = {
-        **template_bundle,
-        "advisories": list(advisory_payloads.values()),
-        "bundleVersion": str(index_payload.get("bundleVersion", template_bundle["bundleVersion"])),
-        "expiresAt": str(index_payload.get("expiresAt", template_bundle["expiresAt"])),
-        "feedSnapshotHash": str(index_payload.get("feedSnapshotHash", template_bundle["feedSnapshotHash"])),
-        "generatedAt": str(index_payload.get("generatedAt", template_bundle["generatedAt"])),
-        "packages": package_payloads,
-        "policyHash": str(index_payload.get("policyHash", template_bundle["policyHash"])),
-        "sourceHashes": (
-            index_payload.get("sourceHashes")
-            if isinstance(index_payload.get("sourceHashes"), list)
-            else template_bundle["sourceHashes"]
-        ),
-        "tier": str(index_payload.get("tier", template_bundle["tier"])),
-        "workspaceId": str(index_payload.get("workspaceId", template_bundle["workspaceId"])),
-    }
-    merged_payload_hash = payload_hash_for_supply_chain_bundle(merged_bundle)
-    return load_supply_chain_bundle_response(
-        {
-            "bundle": merged_bundle,
-            "payloadHash": merged_payload_hash,
-            "signature": template_response.signature,
-            "signatureAlgorithm": template_response.signature_algorithm,
-            "verificationKeys": [item.to_dict() for item in template_response.verification_keys],
-        }
-    )
-
-
 def _sync_supply_chain_bundle_incremental(
     *,
     bundle_url: str,
@@ -1071,7 +1024,6 @@ def _sync_supply_chain_bundle_incremental(
         raw_cached_partitions = cached_partition_payload.get("partitions")
         if isinstance(raw_cached_partitions, dict):
             cached_partitions = raw_cached_partitions
-    partition_responses: list[SupplyChainBundleResponse] = []
     next_partition_cache: dict[str, object] = {}
     refreshed_partitions = 0
     for descriptor in raw_partitions:
@@ -1084,7 +1036,7 @@ def _sync_supply_chain_bundle_incremental(
             continue
         cache_key = f"{ecosystem}:{partition}"
         cached_partition = cached_partitions.get(cache_key)
-        response: SupplyChainBundleResponse | None = None
+        response = None
         if isinstance(cached_partition, dict) and cached_partition.get("payload_hash") == payload_hash:
             raw_cached_response = cached_partition.get("response")
             if isinstance(raw_cached_response, dict):
@@ -1110,25 +1062,23 @@ def _sync_supply_chain_bundle_incremental(
                 cached_bundle_version=cached_bundle_version,
             )
             refreshed_partitions += 1
-        partition_responses.append(response)
         next_partition_cache[cache_key] = {
             "payload_hash": payload_hash,
             "response": response.to_dict(),
         }
-    if not partition_responses:
+    if not next_partition_cache:
         return None
-    merged_response = _merged_supply_chain_bundle_response(
-        index_payload=index_payload,
-        partition_responses=partition_responses,
-    )
+    bundle_version = index_payload.get("bundleVersion")
+    resolved_bundle_version = bundle_version if isinstance(bundle_version, str) and bundle_version else None
+    if resolved_bundle_version is None:
+        resolved_bundle_version = cached_bundle_version or ""
     return {
         "cache_payload": {
-            "bundle_version": merged_response.bundle.bundle_version,
+            "bundle_version": resolved_bundle_version,
             "partitions": next_partition_cache,
             "workspace_id": workspace_id,
         },
         "refreshed_partitions": refreshed_partitions,
-        "response": merged_response,
         "total_partitions": len(next_partition_cache),
     }
 
@@ -1154,16 +1104,23 @@ def sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
             if isinstance(existing_version, str) and existing_version:
                 cached_bundle_version = existing_version
     trusted_keys = load_supply_chain_verification_keys(store.get_sync_payload("supply_chain_bundle_keyring"))
-    partition_sync: dict[str, object] | None = _sync_supply_chain_bundle_incremental(
-        bundle_url=bundle_url,
-        cached_bundle_version=cached_bundle_version,
-        headers=headers,
-        store=store,
-        trusted_keys=trusted_keys,
-        workspace_id=workspace_id,
-    )
-    if partition_sync is not None:
-        response = partition_sync["response"]  # type: ignore[assignment]
+    try:
+        partition_sync: dict[str, object] | None = _sync_supply_chain_bundle_incremental(
+            bundle_url=bundle_url,
+            cached_bundle_version=cached_bundle_version,
+            headers=headers,
+            store=store,
+            trusted_keys=trusted_keys,
+            workspace_id=workspace_id,
+        )
+    except (RuntimeError, SupplyChainBundleError):
+        partition_sync = None
+    if (
+        partition_sync is not None
+        and partition_sync.get("refreshed_partitions") == 0
+        and isinstance(cached_bundle, dict)
+    ):
+        response = load_supply_chain_bundle_response(cached_bundle)
     else:
         request = urllib.request.Request(bundle_url, method="GET", headers=headers)
         payload = _fetch_supply_chain_bundle_payload(request)

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1045,22 +1045,25 @@ def _sync_supply_chain_bundle_incremental(
                 except SupplyChainBundleError:
                     response = None
         if response is None:
-            partition_request = urllib.request.Request(
-                _supply_chain_partition_bundle_url(
-                    bundle_url,
-                    ecosystem=ecosystem,
-                    partition=partition,
-                ),
-                method="GET",
-                headers=headers,
-            )
-            partition_payload = _fetch_supply_chain_bundle_payload(partition_request)
-            response = load_supply_chain_bundle_response(partition_payload)
-            verify_supply_chain_bundle_response(
-                response,
-                trusted_keys=trusted_keys or None,
-                cached_bundle_version=cached_bundle_version,
-            )
+            try:
+                partition_request = urllib.request.Request(
+                    _supply_chain_partition_bundle_url(
+                        bundle_url,
+                        ecosystem=ecosystem,
+                        partition=partition,
+                    ),
+                    method="GET",
+                    headers=headers,
+                )
+                partition_payload = _fetch_supply_chain_bundle_payload(partition_request)
+                response = load_supply_chain_bundle_response(partition_payload)
+                verify_supply_chain_bundle_response(
+                    response,
+                    trusted_keys=trusted_keys or None,
+                    cached_bundle_version=cached_bundle_version,
+                )
+            except (RuntimeError, SupplyChainBundleError):
+                return None
             refreshed_partitions += 1
         next_partition_cache[cache_key] = {
             "payload_hash": payload_hash,
@@ -1120,12 +1123,22 @@ def sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
         and partition_sync.get("refreshed_partitions") == 0
         and isinstance(cached_bundle, dict)
     ):
-        response = load_supply_chain_bundle_response(cached_bundle)
+        try:
+            response = load_supply_chain_bundle_response(cached_bundle)
+        except SupplyChainBundleError:
+            request = urllib.request.Request(bundle_url, method="GET", headers=headers)
+            payload = _fetch_supply_chain_bundle_payload(request)
+            response = load_supply_chain_bundle_response(payload)
+            verify_supply_chain_bundle_response(
+                response,
+                trusted_keys=trusted_keys or None,
+                cached_bundle_version=cached_bundle_version,
+            )
     else:
         request = urllib.request.Request(bundle_url, method="GET", headers=headers)
         payload = _fetch_supply_chain_bundle_payload(request)
-        response = load_supply_chain_bundle_response(payload)
         try:
+            response = load_supply_chain_bundle_response(payload)
             verify_supply_chain_bundle_response(
                 response,
                 trusted_keys=trusted_keys or None,
@@ -1133,56 +1146,53 @@ def sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
             )
         except SupplyChainBundleError as error:
             raise RuntimeError(f"Guard supply-chain bundle sync failed: {error}") from error
-    try:
-        synced_at = _now()
-        store.cache_supply_chain_bundle(workspace_id, response.to_dict(), synced_at)
-        store.set_sync_payload(
-            "supply_chain_bundle_keyring",
-            {
-                "workspace_id": workspace_id,
-                "keys": [item.to_dict() for item in response.verification_keys],
-            },
-            synced_at,
-        )
-        store.set_sync_payload(
-            "supply_chain_bundle_entitlement",
-            {
-                "bundle_version": response.bundle.bundle_version,
-                "key_id": response.bundle.key_id,
-                "policy_hash": response.bundle.policy_hash,
-                "tier": response.bundle.tier,
-                "workspace_id": workspace_id,
-            },
-            synced_at,
-        )
-        if partition_sync is not None:
-            store.set_sync_payload(
-                "supply_chain_bundle_partition_cache",
-                partition_sync["cache_payload"],  # type: ignore[arg-type]
-                synced_at,
-            )
-        summary = {
-            "advisory_count": len(response.bundle.advisories),
+    synced_at = _now()
+    store.cache_supply_chain_bundle(workspace_id, response.to_dict(), synced_at)
+    store.set_sync_payload(
+        "supply_chain_bundle_keyring",
+        {
+            "workspace_id": workspace_id,
+            "keys": [item.to_dict() for item in response.verification_keys],
+        },
+        synced_at,
+    )
+    store.set_sync_payload(
+        "supply_chain_bundle_entitlement",
+        {
             "bundle_version": response.bundle.bundle_version,
-            "ecosystem_support": list(ecosystem_support_matrix()),
-            "feed_snapshot_hash": response.bundle.feed_snapshot_hash,
-            "package_count": len(response.bundle.packages),
+            "key_id": response.bundle.key_id,
             "policy_hash": response.bundle.policy_hash,
-            "status": "synced",
-            "synced_at": synced_at,
             "tier": response.bundle.tier,
             "workspace_id": workspace_id,
+        },
+        synced_at,
+    )
+    if partition_sync is not None:
+        store.set_sync_payload(
+            "supply_chain_bundle_partition_cache",
+            partition_sync["cache_payload"],  # type: ignore[arg-type]
+            synced_at,
+        )
+    summary = {
+        "advisory_count": len(response.bundle.advisories),
+        "bundle_version": response.bundle.bundle_version,
+        "ecosystem_support": list(ecosystem_support_matrix()),
+        "feed_snapshot_hash": response.bundle.feed_snapshot_hash,
+        "package_count": len(response.bundle.packages),
+        "policy_hash": response.bundle.policy_hash,
+        "status": "synced",
+        "synced_at": synced_at,
+        "tier": response.bundle.tier,
+        "workspace_id": workspace_id,
+    }
+    if partition_sync is not None:
+        summary["partition_sync"] = {
+            "enabled": True,
+            "refreshed": partition_sync["refreshed_partitions"],  # type: ignore[index]
+            "total": partition_sync["total_partitions"],  # type: ignore[index]
         }
-        if partition_sync is not None:
-            summary["partition_sync"] = {
-                "enabled": True,
-                "refreshed": partition_sync["refreshed_partitions"],  # type: ignore[index]
-                "total": partition_sync["total_partitions"],  # type: ignore[index]
-            }
-        store.set_sync_payload("supply_chain_bundle_summary", summary, synced_at)
-        return summary
-    except SupplyChainBundleError as error:
-        raise RuntimeError(f"Guard supply-chain bundle sync failed: {error}") from error
+    store.set_sync_payload("supply_chain_bundle_summary", summary, synced_at)
+    return summary
 
 
 def sync_guard_events(store: GuardStore) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -35,8 +35,10 @@ from .detectors import DetectorContext, DetectorRegistry, DetectorRunResult, reg
 from .prompt_injection import detect_prompt_injection_requests
 from .supply_chain_bundle import (
     SupplyChainBundleError,
+    SupplyChainBundleResponse,
     load_supply_chain_bundle_response,
     load_supply_chain_verification_keys,
+    payload_hash_for_supply_chain_bundle,
     verify_supply_chain_bundle_response,
 )
 from .supply_chain_support import ecosystem_support_matrix
@@ -945,21 +947,9 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
     return summary
 
 
-def sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
-    """Fetch, verify, and persist the active supply-chain bundle for the cloud workspace."""
-
-    credentials = store.get_sync_credentials()
-    if credentials is None:
-        raise GuardSyncNotConfiguredError("Guard is not logged in.")
-    workspace_id = store.get_cloud_workspace_id()
-    if workspace_id is None:
-        raise GuardSyncNotConfiguredError("Guard Cloud workspace is not connected.")
-    bundle_url = _normalized_supply_chain_bundle_url(str(credentials["sync_url"]), workspace_id)
-    headers = _guard_sync_headers(str(credentials["token"]))
-    headers["Accept-Encoding"] = "identity"
-    request = urllib.request.Request(bundle_url, method="GET", headers=headers)
+def _fetch_supply_chain_bundle_payload(request: urllib.request.Request) -> dict[str, object]:
     try:
-        payload = _urlopen_json_with_timeout_retry(
+        return _urlopen_json_with_timeout_retry(
             request=request,
             timeout_seconds=_SYNC_HTTP_TIMEOUT_SECONDS,
             retry_timeout_seconds=_SYNC_HTTP_RETRY_TIMEOUT_SECONDS,
@@ -973,6 +963,188 @@ def sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
         raise RuntimeError(_sync_http_error_message(error)) from error
     except OSError as error:
         raise RuntimeError(_sync_url_error_message(error)) from error
+
+
+def _normalized_supply_chain_bundle_index_url(bundle_url: str) -> str:
+    parsed = urllib.parse.urlsplit(bundle_url)
+    return urllib.parse.urlunsplit(
+        (
+            parsed.scheme,
+            parsed.netloc,
+            parsed.path.rstrip("/") + "/index",
+            parsed.query,
+            "",
+        )
+    )
+
+
+def _supply_chain_partition_bundle_url(bundle_url: str, *, ecosystem: str, partition: int) -> str:
+    parsed = urllib.parse.urlsplit(bundle_url)
+    query_pairs = [
+        (key, value)
+        for key, value in urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+        if key not in {"ecosystem", "partition"}
+    ]
+    query_pairs.extend((("ecosystem", ecosystem), ("partition", str(partition))))
+    return urllib.parse.urlunsplit(
+        (
+            parsed.scheme,
+            parsed.netloc,
+            parsed.path,
+            urllib.parse.urlencode(query_pairs),
+            "",
+        )
+    )
+
+
+def _merged_supply_chain_bundle_response(
+    *,
+    index_payload: dict[str, object],
+    partition_responses: list[SupplyChainBundleResponse],
+) -> SupplyChainBundleResponse:
+    template_response = max(
+        partition_responses,
+        key=lambda response: response.bundle.version_timestamp,
+    )
+    template_bundle = template_response.bundle.to_dict()
+    package_payloads: list[dict[str, object]] = []
+    advisory_payloads: dict[str, dict[str, object]] = {}
+    for partition_response in partition_responses:
+        package_payloads.extend(item.to_dict() for item in partition_response.bundle.packages)
+        for advisory in partition_response.bundle.advisories:
+            advisory_payloads.setdefault(advisory.advisory_id, advisory.to_dict())
+    merged_bundle = {
+        **template_bundle,
+        "advisories": list(advisory_payloads.values()),
+        "bundleVersion": str(index_payload.get("bundleVersion", template_bundle["bundleVersion"])),
+        "expiresAt": str(index_payload.get("expiresAt", template_bundle["expiresAt"])),
+        "feedSnapshotHash": str(index_payload.get("feedSnapshotHash", template_bundle["feedSnapshotHash"])),
+        "generatedAt": str(index_payload.get("generatedAt", template_bundle["generatedAt"])),
+        "packages": package_payloads,
+        "policyHash": str(index_payload.get("policyHash", template_bundle["policyHash"])),
+        "sourceHashes": (
+            index_payload.get("sourceHashes")
+            if isinstance(index_payload.get("sourceHashes"), list)
+            else template_bundle["sourceHashes"]
+        ),
+        "tier": str(index_payload.get("tier", template_bundle["tier"])),
+        "workspaceId": str(index_payload.get("workspaceId", template_bundle["workspaceId"])),
+    }
+    merged_payload_hash = payload_hash_for_supply_chain_bundle(merged_bundle)
+    return load_supply_chain_bundle_response(
+        {
+            "bundle": merged_bundle,
+            "payloadHash": merged_payload_hash,
+            "signature": template_response.signature,
+            "signatureAlgorithm": template_response.signature_algorithm,
+            "verificationKeys": [item.to_dict() for item in template_response.verification_keys],
+        }
+    )
+
+
+def _sync_supply_chain_bundle_incremental(
+    *,
+    bundle_url: str,
+    cached_bundle_version: str | None,
+    headers: dict[str, str],
+    store: GuardStore,
+    trusted_keys: tuple[object, ...],
+    workspace_id: str,
+) -> dict[str, object] | None:
+    index_request = urllib.request.Request(
+        _normalized_supply_chain_bundle_index_url(bundle_url),
+        method="GET",
+        headers=headers,
+    )
+    try:
+        index_payload = _fetch_supply_chain_bundle_payload(index_request)
+    except RuntimeError:
+        return None
+    if not isinstance(index_payload, dict):
+        return None
+    raw_partitions = index_payload.get("partitions")
+    if not isinstance(raw_partitions, list) or len(raw_partitions) == 0:
+        return None
+    cached_partition_payload = store.get_sync_payload("supply_chain_bundle_partition_cache")
+    cached_partitions = {}
+    if isinstance(cached_partition_payload, dict):
+        raw_cached_partitions = cached_partition_payload.get("partitions")
+        if isinstance(raw_cached_partitions, dict):
+            cached_partitions = raw_cached_partitions
+    partition_responses: list[SupplyChainBundleResponse] = []
+    next_partition_cache: dict[str, object] = {}
+    refreshed_partitions = 0
+    for descriptor in raw_partitions:
+        if not isinstance(descriptor, dict):
+            continue
+        ecosystem = descriptor.get("ecosystem")
+        partition = descriptor.get("partition")
+        payload_hash = descriptor.get("payloadHash")
+        if not isinstance(ecosystem, str) or not isinstance(partition, int) or not isinstance(payload_hash, str):
+            continue
+        cache_key = f"{ecosystem}:{partition}"
+        cached_partition = cached_partitions.get(cache_key)
+        response: SupplyChainBundleResponse | None = None
+        if isinstance(cached_partition, dict) and cached_partition.get("payload_hash") == payload_hash:
+            raw_cached_response = cached_partition.get("response")
+            if isinstance(raw_cached_response, dict):
+                try:
+                    response = load_supply_chain_bundle_response(raw_cached_response)
+                except SupplyChainBundleError:
+                    response = None
+        if response is None:
+            partition_request = urllib.request.Request(
+                _supply_chain_partition_bundle_url(
+                    bundle_url,
+                    ecosystem=ecosystem,
+                    partition=partition,
+                ),
+                method="GET",
+                headers=headers,
+            )
+            partition_payload = _fetch_supply_chain_bundle_payload(partition_request)
+            response = load_supply_chain_bundle_response(partition_payload)
+            verify_supply_chain_bundle_response(
+                response,
+                trusted_keys=trusted_keys or None,
+                cached_bundle_version=cached_bundle_version,
+            )
+            refreshed_partitions += 1
+        partition_responses.append(response)
+        next_partition_cache[cache_key] = {
+            "payload_hash": payload_hash,
+            "response": response.to_dict(),
+        }
+    if not partition_responses:
+        return None
+    merged_response = _merged_supply_chain_bundle_response(
+        index_payload=index_payload,
+        partition_responses=partition_responses,
+    )
+    return {
+        "cache_payload": {
+            "bundle_version": merged_response.bundle.bundle_version,
+            "partitions": next_partition_cache,
+            "workspace_id": workspace_id,
+        },
+        "refreshed_partitions": refreshed_partitions,
+        "response": merged_response,
+        "total_partitions": len(next_partition_cache),
+    }
+
+
+def sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
+    """Fetch, verify, and persist the active supply-chain bundle for the cloud workspace."""
+
+    credentials = store.get_sync_credentials()
+    if credentials is None:
+        raise GuardSyncNotConfiguredError("Guard is not logged in.")
+    workspace_id = store.get_cloud_workspace_id()
+    if workspace_id is None:
+        raise GuardSyncNotConfiguredError("Guard Cloud workspace is not connected.")
+    bundle_url = _normalized_supply_chain_bundle_url(str(credentials["sync_url"]), workspace_id)
+    headers = _guard_sync_headers(str(credentials["token"]))
+    headers["Accept-Encoding"] = "identity"
     cached_bundle = store.get_cached_supply_chain_bundle(workspace_id)
     cached_bundle_version = None
     if isinstance(cached_bundle, dict):
@@ -981,51 +1153,79 @@ def sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
             existing_version = cached_payload.get("bundleVersion")
             if isinstance(existing_version, str) and existing_version:
                 cached_bundle_version = existing_version
-    response = load_supply_chain_bundle_response(payload)
-    try:
-        trusted_keys = load_supply_chain_verification_keys(store.get_sync_payload("supply_chain_bundle_keyring"))
-        verify_supply_chain_bundle_response(
-            response,
-            trusted_keys=trusted_keys or None,
-            cached_bundle_version=cached_bundle_version,
-        )
-    except SupplyChainBundleError as error:
-        raise RuntimeError(f"Guard supply-chain bundle sync failed: {error}") from error
-    synced_at = _now()
-    store.cache_supply_chain_bundle(workspace_id, response.to_dict(), synced_at)
-    store.set_sync_payload(
-        "supply_chain_bundle_keyring",
-        {
-            "workspace_id": workspace_id,
-            "keys": [item.to_dict() for item in response.verification_keys],
-        },
-        synced_at,
+    trusted_keys = load_supply_chain_verification_keys(store.get_sync_payload("supply_chain_bundle_keyring"))
+    partition_sync: dict[str, object] | None = _sync_supply_chain_bundle_incremental(
+        bundle_url=bundle_url,
+        cached_bundle_version=cached_bundle_version,
+        headers=headers,
+        store=store,
+        trusted_keys=trusted_keys,
+        workspace_id=workspace_id,
     )
-    store.set_sync_payload(
-        "supply_chain_bundle_entitlement",
-        {
+    if partition_sync is not None:
+        response = partition_sync["response"]  # type: ignore[assignment]
+    else:
+        request = urllib.request.Request(bundle_url, method="GET", headers=headers)
+        payload = _fetch_supply_chain_bundle_payload(request)
+        response = load_supply_chain_bundle_response(payload)
+        try:
+            verify_supply_chain_bundle_response(
+                response,
+                trusted_keys=trusted_keys or None,
+                cached_bundle_version=cached_bundle_version,
+            )
+        except SupplyChainBundleError as error:
+            raise RuntimeError(f"Guard supply-chain bundle sync failed: {error}") from error
+    try:
+        synced_at = _now()
+        store.cache_supply_chain_bundle(workspace_id, response.to_dict(), synced_at)
+        store.set_sync_payload(
+            "supply_chain_bundle_keyring",
+            {
+                "workspace_id": workspace_id,
+                "keys": [item.to_dict() for item in response.verification_keys],
+            },
+            synced_at,
+        )
+        store.set_sync_payload(
+            "supply_chain_bundle_entitlement",
+            {
+                "bundle_version": response.bundle.bundle_version,
+                "key_id": response.bundle.key_id,
+                "policy_hash": response.bundle.policy_hash,
+                "tier": response.bundle.tier,
+                "workspace_id": workspace_id,
+            },
+            synced_at,
+        )
+        if partition_sync is not None:
+            store.set_sync_payload(
+                "supply_chain_bundle_partition_cache",
+                partition_sync["cache_payload"],  # type: ignore[arg-type]
+                synced_at,
+            )
+        summary = {
+            "advisory_count": len(response.bundle.advisories),
             "bundle_version": response.bundle.bundle_version,
-            "key_id": response.bundle.key_id,
+            "ecosystem_support": list(ecosystem_support_matrix()),
+            "feed_snapshot_hash": response.bundle.feed_snapshot_hash,
+            "package_count": len(response.bundle.packages),
             "policy_hash": response.bundle.policy_hash,
+            "status": "synced",
+            "synced_at": synced_at,
             "tier": response.bundle.tier,
             "workspace_id": workspace_id,
-        },
-        synced_at,
-    )
-    summary = {
-        "advisory_count": len(response.bundle.advisories),
-        "bundle_version": response.bundle.bundle_version,
-        "ecosystem_support": list(ecosystem_support_matrix()),
-        "feed_snapshot_hash": response.bundle.feed_snapshot_hash,
-        "package_count": len(response.bundle.packages),
-        "policy_hash": response.bundle.policy_hash,
-        "status": "synced",
-        "synced_at": synced_at,
-        "tier": response.bundle.tier,
-        "workspace_id": workspace_id,
-    }
-    store.set_sync_payload("supply_chain_bundle_summary", summary, synced_at)
-    return summary
+        }
+        if partition_sync is not None:
+            summary["partition_sync"] = {
+                "enabled": True,
+                "refreshed": partition_sync["refreshed_partitions"],  # type: ignore[index]
+                "total": partition_sync["total_partitions"],  # type: ignore[index]
+            }
+        store.set_sync_payload("supply_chain_bundle_summary", summary, synced_at)
+        return summary
+    except SupplyChainBundleError as error:
+        raise RuntimeError(f"Guard supply-chain bundle sync failed: {error}") from error
 
 
 def sync_guard_events(store: GuardStore) -> dict[str, object]:

--- a/tests/test_guard_supply_chain_sync.py
+++ b/tests/test_guard_supply_chain_sync.py
@@ -391,7 +391,11 @@ def test_sync_supply_chain_bundle_refresh_downloads_only_changed_partitions(tmp_
     )
     _BundleSyncHandler.captured_accept_encodings = []
     _BundleSyncHandler.captured_paths = []
-    _BundleSyncHandler.response_payload = {}
+    _BundleSyncHandler.response_payload = _bundle_response(
+        private_key_pem,
+        public_key_pem,
+        bundle_version="1747616400000-refresh",
+    )
     _BundleSyncHandler.partition_payloads = {
         ("pypi", 1): changed_partition,
     }
@@ -460,11 +464,113 @@ def test_sync_supply_chain_bundle_refresh_downloads_only_changed_partitions(tmp_
     assert "/api/guard/supply-chain/bundle/index" in requested_paths
     assert "ecosystem=pypi&partition=1" in requested_paths
     assert "ecosystem=npm&partition=1" not in requested_paths
-    assert not any(
+    assert any(
         path.startswith("/api/guard/supply-chain/bundle?") and "ecosystem=" not in path
         for path in _BundleSyncHandler.captured_paths
     )
     assert summary["status"] == "synced"
+    assert summary["partition_sync"] == {"enabled": True, "refreshed": 1, "total": 2}
+
+
+def test_sync_supply_chain_bundle_reuses_cached_partitions_without_full_refresh(tmp_path: Path) -> None:
+    private_key_pem, public_key_pem = _generate_key_pair()
+    npm_partition = _partition_bundle_response(
+        private_key_pem,
+        public_key_pem,
+        advisory_id="GHSA-npm",
+        bundle_version="1747616400000-refresh",
+        ecosystem="npm",
+        package_name="minimist",
+        partition=1,
+        partition_count=1,
+    )
+    pypi_partition = _partition_bundle_response(
+        private_key_pem,
+        public_key_pem,
+        advisory_id="GHSA-pypi",
+        bundle_version="1747616400000-refresh",
+        ecosystem="pypi",
+        package_name="requests",
+        partition=1,
+        partition_count=1,
+    )
+    _BundleSyncHandler.captured_accept_encodings = []
+    _BundleSyncHandler.captured_paths = []
+    _BundleSyncHandler.response_payload = {}
+    _BundleSyncHandler.partition_payloads = {}
+    _BundleSyncHandler.index_payload = {
+        "bundleVersion": "1747616400000-refresh",
+        "emergencyDenyCount": 0,
+        "expiresAt": npm_partition["bundle"]["expiresAt"],
+        "feedSnapshotHash": "feed-snapshot-2",
+        "generatedAt": npm_partition["bundle"]["generatedAt"],
+        "partitions": [
+            {
+                "advisoryCount": 1,
+                "ecosystem": "npm",
+                "packageCount": 1,
+                "partition": 1,
+                "partitionCount": 1,
+                "payloadHash": npm_partition["payloadHash"],
+            },
+            {
+                "advisoryCount": 1,
+                "ecosystem": "pypi",
+                "packageCount": 1,
+                "partition": 1,
+                "partitionCount": 1,
+                "payloadHash": pypi_partition["payloadHash"],
+            },
+        ],
+        "policyHash": "policy-hash-2",
+        "sourceHashes": [{"payloadHash": "ghsa-feed-hash", "sourceKey": "ghsa", "staleStatus": "fresh"}],
+        "tier": "premium",
+        "workspaceId": WORKSPACE_ID,
+    }
+    server = HTTPServer(("127.0.0.1", 0), _BundleSyncHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        store = GuardStore(tmp_path / "guard-home")
+        store.set_sync_credentials(
+            f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            "demo-token",
+            "2026-05-19T00:00:00Z",
+            workspace_id=WORKSPACE_ID,
+        )
+        store.cache_supply_chain_bundle(WORKSPACE_ID, npm_partition, "2026-05-19T00:00:00Z")
+        store.set_sync_payload(
+            "supply_chain_bundle_partition_cache",
+            {
+                "bundle_version": "1747616400000-refresh",
+                "partitions": {
+                    "npm:1": {
+                        "payload_hash": npm_partition["payloadHash"],
+                        "response": npm_partition,
+                    },
+                    "pypi:1": {
+                        "payload_hash": pypi_partition["payloadHash"],
+                        "response": pypi_partition,
+                    },
+                },
+                "workspace_id": WORKSPACE_ID,
+            },
+            "2026-05-19T00:00:00Z",
+        )
+
+        summary = sync_supply_chain_bundle(store)
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+    requested_paths = "".join(_BundleSyncHandler.captured_paths)
+    assert "/api/guard/supply-chain/bundle/index" in requested_paths
+    assert "ecosystem=" not in requested_paths
+    assert not any(
+        path.startswith("/api/guard/supply-chain/bundle?") and "ecosystem=" not in path
+        for path in _BundleSyncHandler.captured_paths
+    )
+    assert summary["partition_sync"] == {"enabled": True, "refreshed": 0, "total": 2}
 
 
 def test_supply_chain_cache_and_eval_cache_clear_on_sync_token_rotation(tmp_path: Path) -> None:

--- a/tests/test_guard_supply_chain_sync.py
+++ b/tests/test_guard_supply_chain_sync.py
@@ -6,6 +6,7 @@ import base64
 import hashlib
 import json
 import threading
+import urllib.parse
 from datetime import datetime, timedelta, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -127,13 +128,138 @@ def _bundle_response(
     }
 
 
+def _partition_bundle_response(
+    private_key_pem: bytes,
+    public_key_pem: bytes,
+    *,
+    advisory_id: str,
+    bundle_version: str,
+    ecosystem: str,
+    package_name: str,
+    partition: int,
+    partition_count: int,
+) -> dict[str, object]:
+    generated_at = datetime.now(timezone.utc) - timedelta(minutes=5)
+    expires_at = generated_at + timedelta(hours=12)
+    bundle = {
+        "advisories": [
+            {
+                "advisoryId": advisory_id,
+                "aliases": [],
+                "confidence": 990,
+                "exploitLevel": "active",
+                "knownExploited": True,
+                "malwareState": "none",
+                "normalizedSeverity": "critical",
+                "recommendedFixVersion": "1.0.1",
+                "sourceKey": "ghsa",
+                "summary": f"{advisory_id} summary",
+                "title": f"{advisory_id} title",
+            }
+        ],
+        "bundleVersion": bundle_version,
+        "expiresAt": _iso(expires_at),
+        "feedSnapshotHash": "feed-snapshot-2",
+        "generatedAt": _iso(generated_at),
+        "keyId": "guard-bundle-key-2026-05",
+        "packages": [
+            {
+                "confidence": 990,
+                "defaultAction": "block",
+                "ecosystem": ecosystem,
+                "exploitLevel": "active",
+                "knownExploited": True,
+                "malwareState": "known",
+                "name": package_name,
+                "namespace": None,
+                "normalizedSeverity": "critical",
+                "packageAgeState": "watch",
+                "purl": f"pkg:{ecosystem}/{package_name}@1.0.0",
+                "reachability": "reachable",
+                "recommendedFixVersion": "1.0.1",
+                "relatedAdvisoryIds": [advisory_id],
+                "riskScore": 980,
+                "sourceIntegrityState": "high-risk",
+                "version": "1.0.0",
+            }
+        ],
+        "policyHash": "policy-hash-2",
+        "policyRules": [],
+        "scoringVersion": "scf-v1",
+        "sourceHashes": [{"payloadHash": "ghsa-feed-hash", "sourceKey": "ghsa", "staleStatus": "fresh"}],
+        "tier": "premium",
+        "workspaceId": WORKSPACE_ID,
+    }
+    canonical_payload = canonical_supply_chain_bundle_payload(bundle)
+    payload_hash = hashlib.sha256(canonical_payload).hexdigest()
+    loaded_key = serialization.load_pem_private_key(private_key_pem, password=None)
+    assert isinstance(loaded_key, RSAPrivateKey)
+    signature = loaded_key.sign(
+        canonical_payload,
+        padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+        hashes.SHA256(),
+    )
+    return {
+        "bundle": bundle,
+        "payloadHash": payload_hash,
+        "signature": base64.b64encode(signature).decode("utf-8"),
+        "signatureAlgorithm": "rsa-pss-sha256",
+        "verificationKeys": [
+            {
+                "fingerprintSha256": _fingerprint(public_key_pem),
+                "keyId": "guard-bundle-key-2026-05",
+                "publicKeyPem": public_key_pem.decode("utf-8").strip(),
+                "state": "active",
+                "validUntil": None,
+            }
+        ],
+        "partitionDescriptor": {
+            "advisoryCount": 1,
+            "ecosystem": ecosystem,
+            "packageCount": 1,
+            "partition": partition,
+            "partitionCount": partition_count,
+            "payloadHash": payload_hash,
+        },
+    }
+
+
 class _BundleSyncHandler(BaseHTTPRequestHandler):
     captured_accept_encodings: ClassVar[list[str | None]] = []
+    captured_paths: ClassVar[list[str]] = []
+    index_payload: ClassVar[dict[str, object] | None] = None
+    partition_payloads: ClassVar[dict[tuple[str, int], dict[str, object]]] = {}
     response_payload: ClassVar[dict[str, object]] = {}
 
     def do_GET(self) -> None:
+        self.__class__.captured_paths.append(self.path)
         self.__class__.captured_accept_encodings.append(self.headers.get("Accept-Encoding"))
-        if self.path.startswith("/api/guard/supply-chain/bundle"):
+        parsed = urllib.parse.urlsplit(self.path)
+        if parsed.path.startswith("/api/guard/supply-chain/bundle/index"):
+            if self.__class__.index_payload is None:
+                self.send_response(404)
+                self.end_headers()
+                return
+            body = json.dumps(self.__class__.index_payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        if parsed.path.startswith("/api/guard/supply-chain/bundle"):
+            query = urllib.parse.parse_qs(parsed.query)
+            ecosystem = query.get("ecosystem", [None])[0]
+            partition_raw = query.get("partition", [None])[0]
+            if isinstance(ecosystem, str) and isinstance(partition_raw, str):
+                key = (ecosystem, int(partition_raw))
+                partition_payload = self.__class__.partition_payloads.get(key)
+                if partition_payload is not None:
+                    body = json.dumps(partition_payload).encode("utf-8")
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(body)
+                    return
             body = json.dumps(self.__class__.response_payload).encode("utf-8")
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
@@ -151,6 +277,9 @@ class _BundleSyncHandler(BaseHTTPRequestHandler):
 def test_sync_supply_chain_bundle_fetches_and_caches_bundle(tmp_path: Path) -> None:
     private_key_pem, public_key_pem = _generate_key_pair()
     _BundleSyncHandler.captured_accept_encodings = []
+    _BundleSyncHandler.captured_paths = []
+    _BundleSyncHandler.index_payload = None
+    _BundleSyncHandler.partition_payloads = {}
     _BundleSyncHandler.response_payload = _bundle_response(private_key_pem, public_key_pem)
     server = HTTPServer(("127.0.0.1", 0), _BundleSyncHandler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -236,6 +365,106 @@ def test_supply_chain_bundle_refresh_keeps_approval_queue_quiet(tmp_path: Path) 
     assert summary["bundle_version"] == "1747616400000-refresh"
     assert store.get_cached_supply_chain_bundle(WORKSPACE_ID)["bundle"]["bundleVersion"] == "1747616400000-refresh"
     assert store.list_approval_requests() == []
+
+
+def test_sync_supply_chain_bundle_refresh_downloads_only_changed_partitions(tmp_path: Path) -> None:
+    private_key_pem, public_key_pem = _generate_key_pair()
+    unchanged_partition = _partition_bundle_response(
+        private_key_pem,
+        public_key_pem,
+        advisory_id="GHSA-unchanged",
+        bundle_version="1747612800000-old",
+        ecosystem="npm",
+        package_name="minimist",
+        partition=1,
+        partition_count=1,
+    )
+    changed_partition = _partition_bundle_response(
+        private_key_pem,
+        public_key_pem,
+        advisory_id="GHSA-changed",
+        bundle_version="1747616400000-refresh",
+        ecosystem="pypi",
+        package_name="requests",
+        partition=1,
+        partition_count=1,
+    )
+    _BundleSyncHandler.captured_accept_encodings = []
+    _BundleSyncHandler.captured_paths = []
+    _BundleSyncHandler.response_payload = {}
+    _BundleSyncHandler.partition_payloads = {
+        ("pypi", 1): changed_partition,
+    }
+    _BundleSyncHandler.index_payload = {
+        "bundleVersion": "1747616400000-refresh",
+        "emergencyDenyCount": 0,
+        "expiresAt": changed_partition["bundle"]["expiresAt"],
+        "feedSnapshotHash": "feed-snapshot-2",
+        "generatedAt": changed_partition["bundle"]["generatedAt"],
+        "partitions": [
+            {
+                "advisoryCount": 1,
+                "ecosystem": "npm",
+                "packageCount": 1,
+                "partition": 1,
+                "partitionCount": 1,
+                "payloadHash": unchanged_partition["payloadHash"],
+            },
+            {
+                "advisoryCount": 1,
+                "ecosystem": "pypi",
+                "packageCount": 1,
+                "partition": 1,
+                "partitionCount": 1,
+                "payloadHash": changed_partition["payloadHash"],
+            },
+        ],
+        "policyHash": "policy-hash-2",
+        "sourceHashes": [{"payloadHash": "ghsa-feed-hash", "sourceKey": "ghsa", "staleStatus": "fresh"}],
+        "tier": "premium",
+        "workspaceId": WORKSPACE_ID,
+    }
+    server = HTTPServer(("127.0.0.1", 0), _BundleSyncHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        store = GuardStore(tmp_path / "guard-home")
+        store.set_sync_credentials(
+            f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            "demo-token",
+            "2026-05-19T00:00:00Z",
+            workspace_id=WORKSPACE_ID,
+        )
+        store.cache_supply_chain_bundle(WORKSPACE_ID, unchanged_partition, "2026-05-19T00:00:00Z")
+        store.set_sync_payload(
+            "supply_chain_bundle_partition_cache",
+            {
+                "bundle_version": "1747612800000-old",
+                "partitions": {
+                    "npm:1": {
+                        "payload_hash": unchanged_partition["payloadHash"],
+                        "response": unchanged_partition,
+                    }
+                },
+                "workspace_id": WORKSPACE_ID,
+            },
+            "2026-05-19T00:00:00Z",
+        )
+
+        summary = sync_supply_chain_bundle(store)
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+    requested_paths = "".join(_BundleSyncHandler.captured_paths)
+    assert "/api/guard/supply-chain/bundle/index" in requested_paths
+    assert "ecosystem=pypi&partition=1" in requested_paths
+    assert "ecosystem=npm&partition=1" not in requested_paths
+    assert not any(
+        path.startswith("/api/guard/supply-chain/bundle?") and "ecosystem=" not in path
+        for path in _BundleSyncHandler.captured_paths
+    )
+    assert summary["status"] == "synced"
 
 
 def test_supply_chain_cache_and_eval_cache_clear_on_sync_token_rotation(tmp_path: Path) -> None:


### PR DESCRIPTION
Summary:\n- add incremental supply-chain bundle sync path that uses /bundle/index and fetches only changed partitions\n- verify signatures for fetched partition bundles and merge verified partition payloads into cached local bundle state\n- persist partition metadata cache in sync state for subsequent refreshes\n- add daemon sync regression proving refresh requests only changed partitions\n\nValidation:\n- python3 -m pytest tests/test_guard_supply_chain_sync.py tests/test_guard_supply_chain_bundle.py tests/test_guard_supply_chain_daemon.py -q