### PR TITLE
feat: clarify supply-chain posture with health state and next refresh

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -1632,6 +1632,10 @@ def _render_fallback(console: Console, payload: dict[str, object]) -> None:
 def _build_supply_chain_posture_panel(supply_chain: dict[str, object]) -> Panel:
     body = Table.grid(padding=(0, 1))
     body.add_row("Status", str(supply_chain.get("status") or "unknown"))
+    body.add_row(
+        "Protection",
+        str(supply_chain.get("health_status") or supply_chain.get("status") or "unknown"),
+    )
     detail = supply_chain.get("detail")
     if detail:
         body.add_row("Detail", str(detail))
@@ -1643,6 +1647,8 @@ def _build_supply_chain_posture_panel(supply_chain: dict[str, object]) -> Panel:
             body.add_row("Tier", str(bundle.get("tier")))
         if bundle.get("workspace_id"):
             body.add_row("Workspace", str(bundle.get("workspace_id")))
+        if bundle.get("next_refresh_at"):
+            body.add_row("Next refresh", str(bundle.get("next_refresh_at")))
     policy = supply_chain.get("policy")
     if isinstance(policy, dict):
         body.add_row("Security", str(policy.get("security_level") or "unknown"))

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -121,7 +121,6 @@ def build_local_supply_chain_posture(
     )
     health_status = _posture_health_status(
         status=status,
-        expires_at=expires_at,
         next_refresh_at=next_refresh_at,
         snapshot_now=snapshot_now,
     )
@@ -707,7 +706,6 @@ def _posture_detail(status: str) -> str:
 def _posture_health_status(
     *,
     status: str,
-    expires_at: datetime | None,
     next_refresh_at: str | None,
     snapshot_now: datetime,
 ) -> str:
@@ -715,13 +713,11 @@ def _posture_health_status(
         return "stale"
     if status in {"not_connected", "workspace_required", "sync_required", "degraded"}:
         return "degraded"
-    if expires_at is not None and expires_at <= snapshot_now:
-        return "stale"
     next_refresh_timestamp = _parse_timestamp(next_refresh_at)
     if (
         status == "synced"
         and next_refresh_timestamp is not None
-        and next_refresh_timestamp + timedelta(seconds=_STALE_REFRESH_GRACE_SECONDS) < snapshot_now
+        and next_refresh_timestamp + timedelta(seconds=_STALE_REFRESH_GRACE_SECONDS) <= snapshot_now
     ):
         return "stale"
     if status == "synced":

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -7,7 +7,7 @@ import shlex
 import subprocess
 from collections.abc import Sequence
 from dataclasses import replace
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from .config import GuardConfig, resolve_risk_action
@@ -85,6 +85,8 @@ _ECOSYSTEM_BY_MANIFEST = {
     "composer.json": "packagist",
     "Gemfile": "rubygems",
 }
+_DEFAULT_BUNDLE_REFRESH_INTERVAL_SECONDS = 15 * 60
+_STALE_REFRESH_GRACE_SECONDS = 5 * 60
 
 
 def build_local_supply_chain_posture(
@@ -112,6 +114,17 @@ def build_local_supply_chain_posture(
         expires_at=expires_at,
         snapshot_now=snapshot_now,
     )
+    synced_at = _string_value(summary.get("synced_at"))
+    next_refresh_at = _resolve_next_refresh_at(
+        summary=summary,
+        synced_at=synced_at,
+    )
+    health_status = _posture_health_status(
+        status=status,
+        expires_at=expires_at,
+        next_refresh_at=next_refresh_at,
+        snapshot_now=snapshot_now,
+    )
     support = summary.get("ecosystem_support")
     supported_ecosystems = support if isinstance(support, list) and support else list(ecosystem_support_matrix())
     bundle_version = (
@@ -137,6 +150,7 @@ def build_local_supply_chain_posture(
     )
     return {
         "status": status,
+        "health_status": health_status,
         "detail": _posture_detail(status),
         "connection": {
             "logged_in": credentials is not None,
@@ -150,7 +164,8 @@ def build_local_supply_chain_posture(
             "policy_hash": _string_value(summary.get("policy_hash"))
             or _string_value(entitlement.get("policy_hash"))
             or _string_value(bundle_payload.get("policyHash")),
-            "synced_at": _string_value(summary.get("synced_at")),
+            "synced_at": synced_at,
+            "next_refresh_at": next_refresh_at,
             "expires_at": expires_at_text,
             "tier": tier,
             "workspace_id": _string_value(summary.get("workspace_id"))
@@ -687,6 +702,45 @@ def _posture_detail(status: str) -> str:
         "degraded": "Supply-chain protection is degraded. Refresh the signed bundle before trusting new installs.",
     }
     return details.get(status, "Supply-chain protection status is available.")
+
+
+def _posture_health_status(
+    *,
+    status: str,
+    expires_at: datetime | None,
+    next_refresh_at: str | None,
+    snapshot_now: datetime,
+) -> str:
+    if status == "expired":
+        return "stale"
+    if status in {"not_connected", "workspace_required", "sync_required", "degraded"}:
+        return "degraded"
+    if expires_at is not None and expires_at <= snapshot_now:
+        return "stale"
+    next_refresh_timestamp = _parse_timestamp(next_refresh_at)
+    if (
+        status == "synced"
+        and next_refresh_timestamp is not None
+        and next_refresh_timestamp + timedelta(seconds=_STALE_REFRESH_GRACE_SECONDS) < snapshot_now
+    ):
+        return "stale"
+    if status == "synced":
+        return "protected"
+    return "degraded"
+
+
+def _resolve_next_refresh_at(
+    *,
+    summary: dict[str, object],
+    synced_at: str | None,
+) -> str | None:
+    explicit_next_refresh = _parse_timestamp(_string_value(summary.get("next_refresh_at")))
+    if explicit_next_refresh is not None:
+        return explicit_next_refresh.isoformat()
+    synced_timestamp = _parse_timestamp(synced_at)
+    if synced_timestamp is None:
+        return None
+    return (synced_timestamp + timedelta(seconds=_DEFAULT_BUNDLE_REFRESH_INTERVAL_SECONDS)).isoformat()
 
 
 def _dict_payload(value: object) -> dict[str, object]:

--- a/tests/test_guard_local_supply_chain_phase15.py
+++ b/tests/test_guard_local_supply_chain_phase15.py
@@ -18,6 +18,7 @@ from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard import local_supply_chain as local_supply_chain_module
 from codex_plugin_scanner.guard.approvals import build_runtime_snapshot
 from codex_plugin_scanner.guard.cli import commands as commands_module
+from codex_plugin_scanner.guard.config import load_guard_config
 from codex_plugin_scanner.guard.protect import build_protect_payload
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -272,6 +273,39 @@ def test_guard_doctor_includes_supply_chain_posture(tmp_path: Path, capsys) -> N
     assert output["supply_chain"]["status"] == "synced"
     assert output["supply_chain"]["bundle"]["workspace_id"] == WORKSPACE_ID
     assert output["supply_chain"]["policy"]["security_level"] == "balanced"
+
+
+def test_supply_chain_posture_reports_protected_degraded_stale_and_next_refresh(tmp_path: Path) -> None:
+    home_dir = tmp_path / "guard-home"
+    store = GuardStore(home_dir)
+    _seed_supply_chain_bundle(
+        store,
+        packages=[_package(name="minimist", version="1.2.5", default_action="block")],
+        now="2026-05-19T12:00:00+00:00",
+    )
+    config = load_guard_config(home_dir)
+
+    protected_posture = local_supply_chain_module.build_local_supply_chain_posture(
+        store,
+        config,
+        now="2026-05-19T12:04:00+00:00",
+    )
+    stale_posture = local_supply_chain_module.build_local_supply_chain_posture(
+        store,
+        config,
+        now="2026-05-19T12:25:01+00:00",
+    )
+    degraded_store = GuardStore(tmp_path / "guard-home-degraded")
+    degraded_posture = local_supply_chain_module.build_local_supply_chain_posture(
+        degraded_store,
+        load_guard_config(degraded_store.guard_home),
+        now="2026-05-19T12:04:00+00:00",
+    )
+
+    assert protected_posture["health_status"] == "protected"
+    assert protected_posture["bundle"]["next_refresh_at"] == "2026-05-19T12:15:00+00:00"
+    assert stale_posture["health_status"] == "stale"
+    assert degraded_posture["health_status"] == "degraded"
 
 
 def test_guard_supply_chain_scan_uses_manifest_and_lockfile_context(tmp_path: Path, capsys) -> None:

--- a/tests/test_guard_render.py
+++ b/tests/test_guard_render.py
@@ -429,6 +429,37 @@ def test_supply_chain_posture_panel_shows_unknown_cloud_advisories_consistently(
     assert "unknown" in output
 
 
+def test_supply_chain_posture_panel_snapshot_shows_health_state_and_next_refresh() -> None:
+    panel = render._build_supply_chain_posture_panel(
+        {
+            "status": "synced",
+            "health_status": "stale",
+            "detail": "Signed supply-chain bundle is ready for local install protection.",
+            "bundle": {
+                "bundle_version": "1747612800000-deadbeef",
+                "next_refresh_at": "2026-05-19T12:15:00+00:00",
+                "tier": "premium",
+                "workspace_id": "workspace-alpha",
+            },
+            "policy": {
+                "security_level": "balanced",
+                "cloud_advisory_action": "warn",
+            },
+        }
+    )
+    console = Console(record=True, width=120)
+
+    console.print(panel)
+
+    output = _normalize_render_output(console.export_text())
+    assert "Supply-chain firewall" in output
+    assert "Status" in output
+    assert "Protection" in output
+    assert "stale" in output
+    assert "Next refresh" in output
+    assert "2026-05-19T12:15:00+00:00" in output
+
+
 def test_guard_status_render_rewrites_internal_next_action_labels(capsys) -> None:
     emit_guard_payload(
         "status",


### PR DESCRIPTION
Summary:\n- add supply-chain posture health status (protected/degraded/stale) alongside legacy status\n- compute and expose bundle next refresh timestamp in local posture payload\n- surface health state + next refresh in supply-chain posture panel output\n- add posture and render snapshot regressions for protected/degraded/stale and next-refresh UX\n\nValidation:\n- python3 -m pytest tests/test_guard_local_supply_chain_phase15.py tests/test_guard_render.py -q