### PR TITLE
test: add executable harness package-interception matrix

### DIFF
--- a/tests/test_guard_phase07_harness_coverage_matrix.py
+++ b/tests/test_guard_phase07_harness_coverage_matrix.py
@@ -1,0 +1,85 @@
+"""Phase 07 executable harness coverage matrix for package interception."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.package_intent import extract_package_intent_request
+
+_HARNESS_COVERAGE_MATRIX = (
+    {
+        "harness": "codex",
+        "tool_name": "bash",
+        "command": "npm install minimist@1.2.8",
+        "proof_test": "tests/test_guard_package_hook_phase14.py::test_phase14_guard_hook_enriches_package_contract_for_managed_harnesses[codex]",
+    },
+    {
+        "harness": "claude-code",
+        "tool_name": "bash",
+        "command": "npm install minimist@1.2.8",
+        "proof_test": "tests/test_guard_package_hook_phase14.py::test_phase14_guard_hook_enriches_package_contract_for_managed_harnesses[claude-code]",
+    },
+    {
+        "harness": "copilot",
+        "tool_name": "bash",
+        "command": "npm install minimist@1.2.8",
+        "proof_test": "tests/test_guard_package_hook_phase14.py::test_phase14_guard_hook_enriches_package_contract_for_managed_harnesses[copilot]",
+    },
+    {
+        "harness": "gemini",
+        "tool_name": "bash",
+        "command": "npm install minimist@1.2.8",
+        "proof_test": "tests/test_guard_package_hook_phase14.py::test_phase14_guard_hook_enriches_package_contract_for_managed_harnesses[gemini]",
+    },
+    {
+        "harness": "cursor",
+        "tool_name": "run_terminal_command",
+        "command": "npm install minimist@1.2.8",
+        "proof_test": "tests/test_guard_mcp_package_proxy_phase14.py::test_phase14_runtime_mcp_proxy_queues_package_request_not_generic_tool_call[cursor]",
+    },
+    {
+        "harness": "opencode",
+        "tool_name": "run_terminal_command",
+        "command": "npm install minimist@1.2.8",
+        "proof_test": "tests/test_guard_mcp_package_proxy_phase14.py::test_phase14_runtime_mcp_proxy_queues_package_request_not_generic_tool_call[opencode]",
+    },
+    {
+        "harness": "hermes",
+        "tool_name": "run_terminal_command",
+        "command": "npm install minimist@1.2.8",
+        "proof_test": "tests/test_guard_mcp_package_proxy_phase14.py::test_phase14_runtime_mcp_proxy_queues_package_request_not_generic_tool_call[hermes]",
+    },
+    {
+        "harness": "openclaw",
+        "tool_name": "run_terminal_command",
+        "command": "npm install minimist@1.2.8",
+        "proof_test": "tests/test_guard_mcp_package_proxy_phase14.py::test_phase14_runtime_mcp_proxy_queues_package_request_not_generic_tool_call[openclaw]",
+    },
+)
+
+
+def _matrix_ids() -> list[str]:
+    return [entry["harness"] for entry in _HARNESS_COVERAGE_MATRIX]
+
+
+@pytest.mark.parametrize("entry", _HARNESS_COVERAGE_MATRIX, ids=_matrix_ids())
+def test_phase07_harness_coverage_matrix_extracts_package_intent(
+    entry: dict[str, str],
+    tmp_path: Path,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+
+    intent = extract_package_intent_request(
+        entry["tool_name"],
+        {"command": entry["command"]},
+        action_envelope_command=entry["command"],
+        workspace=workspace_dir,
+    )
+
+    assert intent is not None
+    assert intent.intent_kind == "install"
+    assert intent.package_manager in {"npm", "pnpm", "yarn", "bun", "pip", "uv", "poetry", "pipenv", "cargo"}
+    assert entry["proof_test"].startswith("tests/test_guard_")

--- a/tests/test_guard_phase07_harness_coverage_matrix.py
+++ b/tests/test_guard_phase07_harness_coverage_matrix.py
@@ -81,5 +81,6 @@ def test_phase07_harness_coverage_matrix_extracts_package_intent(
 
     assert intent is not None
     assert intent.intent_kind == "install"
-    assert intent.package_manager in {"npm", "pnpm", "yarn", "bun", "pip", "uv", "poetry", "pipenv", "cargo"}
+    assert intent.package_manager == "npm"
+    assert Path(entry["proof_test"].split("::")[0]).exists()
     assert entry["proof_test"].startswith("tests/test_guard_")


### PR DESCRIPTION
Summary:\n- add Phase 07 executable harness matrix test that asserts package intent extraction across supported hook/MCP harness surfaces\n- link each matrix row to concrete proof test command path for interception coverage\n- consolidate proof run for package hook, MCP proxy, and skill package-instruction interception suites\n\nValidation:\n- python3 -m pytest tests/test_guard_phase07_harness_coverage_matrix.py tests/test_guard_package_hook_phase14.py tests/test_guard_mcp_package_proxy_phase14.py tests/test_guard_skill_protection_phase14.py -q