### PR TITLE
feat: add package-manager shim lifecycle commands

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -173,6 +173,7 @@ from ..runtime.sed_scripts import sed_script_is_bounded_print
 from ..runtime.signals import RiskSignalV2
 from ..runtime.supply_chain_package_eval import evaluate_package_request_artifact
 from ..runtime.surface_server import GuardSurfaceRuntime
+from ..shims import install_package_shims, package_shim_status, uninstall_package_shims
 from ..store import GuardStore
 from .approval_commands import (
     add_approval_parser,
@@ -376,7 +377,7 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
         required=True,
         parser_class=FriendlyArgumentParser,
         metavar=(
-            "{start,status,dashboard,init,apps,bootstrap,detect,install,update,uninstall,run,protect,preflight,scan,diff,"
+            "{start,status,dashboard,init,apps,bootstrap,detect,install,update,uninstall,package-shims,run,protect,preflight,scan,diff,"
             "receipts,inventory,abom,approvals,explain,allow,deny,policies,exceptions,advisories,events,doctor,connect,"
             "login,sync,device,bridge}"
         ),
@@ -480,6 +481,25 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     uninstall_parser.add_argument("--all", action="store_true")
     _add_guard_common_args(uninstall_parser)
     uninstall_parser.add_argument("--json", action="store_true")
+
+    package_shims_parser = guard_subparsers.add_parser(
+        "package-shims",
+        help="Install, inspect, or remove package-manager PATH shims routed through Guard protect",
+    )
+    package_shims_parser.add_argument(
+        "package_shims_command",
+        nargs="?",
+        choices=("install", "status", "uninstall"),
+        default="status",
+    )
+    package_shims_parser.add_argument(
+        "--manager",
+        action="append",
+        dest="package_shim_managers",
+        default=[],
+    )
+    _add_guard_common_args(package_shims_parser)
+    package_shims_parser.add_argument("--json", action="store_true")
 
     run_parser = guard_subparsers.add_parser("run", help="Evaluate local policy, then launch the harness")
     run_parser.add_argument("harness")
@@ -1809,6 +1829,23 @@ def run_guard_command(
             print(str(error), file=sys.stderr)
             return 2
         _emit("uninstall", payload, getattr(args, "json", False))
+        return 0
+
+    if args.guard_command == "package-shims":
+        requested_managers = tuple(
+            manager
+            for manager in getattr(args, "package_shim_managers", [])
+            if isinstance(manager, str) and manager.strip()
+        )
+        shim_command = getattr(args, "package_shims_command", "status")
+        if shim_command == "install":
+            payload = install_package_shims(context, managers=requested_managers or None)
+        elif shim_command == "uninstall":
+            payload = uninstall_package_shims(context, managers=requested_managers or None)
+        else:
+            payload = package_shim_status(context)
+        payload["generated_at"] = _now()
+        _emit("package-shims", payload, getattr(args, "json", False))
         return 0
 
     if args.guard_command == "run":

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -10,6 +11,26 @@ from .launcher import merge_guard_launcher_env
 
 if TYPE_CHECKING:
     from .adapters.base import HarnessContext
+
+_PACKAGE_SHIM_COMMANDS = {
+    "bun": "bun",
+    "bundle": "bundle",
+    "cargo": "cargo",
+    "composer": "composer",
+    "go": "go",
+    "gradle": "gradle",
+    "mvn": "mvn",
+    "npm": "npm",
+    "pip": "pip",
+    "pipenv": "pipenv",
+    "pipx": "pipx",
+    "pnpm": "pnpm",
+    "poetry": "poetry",
+    "uv": "uv",
+    "uvx": "uvx",
+    "yarn": "yarn",
+}
+_PACKAGE_SHIM_MANIFEST = "manifest.json"
 
 
 def install_guard_shim(
@@ -126,4 +147,158 @@ def _home_override_args(context: HarnessContext) -> list[str]:
     return ["--home", str(context.home_dir)]
 
 
-__all__ = ["install_guard_shim", "remove_guard_shim"]
+def install_package_shims(
+    context: HarnessContext,
+    *,
+    managers: tuple[str, ...] | None = None,
+) -> dict[str, object]:
+    shim_root = context.guard_home / "package-shims"
+    shim_dir = shim_root / "bin"
+    shim_dir.mkdir(parents=True, exist_ok=True)
+    normalized_managers = _normalize_package_shim_managers(managers)
+    installed: list[str] = []
+    for manager in normalized_managers:
+        command = _PACKAGE_SHIM_COMMANDS[manager]
+        posix_path = shim_dir / command
+        windows_path = shim_dir / f"{command}.cmd"
+        posix_path.write_text(_build_package_manager_python_shim(context, command), encoding="utf-8")
+        posix_path.chmod(posix_path.stat().st_mode | 0o755)
+        windows_path.write_text(_build_windows_script(posix_path), encoding="utf-8")
+        installed.append(manager)
+    manifest_payload = {
+        "installed_managers": installed,
+        "shim_dir": str(shim_dir),
+    }
+    _package_shim_manifest_path(context).write_text(json.dumps(manifest_payload, sort_keys=True), encoding="utf-8")
+    return {
+        "installed_managers": installed,
+        "installed_count": len(installed),
+        "shim_dir": str(shim_dir),
+        "manifest_path": str(_package_shim_manifest_path(context)),
+        "path_export_hint": f'export PATH="{shim_dir}:$PATH"',
+        "status_command": "hol-guard package-shims status --json",
+        "uninstall_command": "hol-guard package-shims uninstall --json",
+    }
+
+
+def package_shim_status(context: HarnessContext) -> dict[str, object]:
+    manifest = _load_package_shim_manifest(context)
+    installed_managers = [
+        manager
+        for manager in manifest.get("installed_managers", [])
+        if isinstance(manager, str) and manager in _PACKAGE_SHIM_COMMANDS
+    ]
+    shim_dir = context.guard_home / "package-shims" / "bin"
+    active_managers = [manager for manager in installed_managers if (shim_dir / _PACKAGE_SHIM_COMMANDS[manager]).exists()]
+    missing_managers = [manager for manager in installed_managers if manager not in active_managers]
+    return {
+        "installed_managers": installed_managers,
+        "active_managers": active_managers,
+        "missing_managers": missing_managers,
+        "shim_dir": str(shim_dir),
+        "manifest_path": str(_package_shim_manifest_path(context)),
+    }
+
+
+def uninstall_package_shims(
+    context: HarnessContext,
+    *,
+    managers: tuple[str, ...] | None = None,
+) -> dict[str, object]:
+    manifest = _load_package_shim_manifest(context)
+    manifest_managers = tuple(
+        manager
+        for manager in manifest.get("installed_managers", [])
+        if isinstance(manager, str) and manager in _PACKAGE_SHIM_COMMANDS
+    )
+    requested_managers = _normalize_package_shim_managers(managers) if managers else manifest_managers
+    shim_dir = context.guard_home / "package-shims" / "bin"
+    removed_paths: list[str] = []
+    for manager in requested_managers:
+        command = _PACKAGE_SHIM_COMMANDS[manager]
+        for suffix in ("", ".cmd"):
+            candidate = shim_dir / f"{command}{suffix}"
+            if candidate.exists():
+                candidate.unlink()
+                removed_paths.append(str(candidate))
+    remaining = [manager for manager in manifest_managers if manager not in requested_managers]
+    manifest_path = _package_shim_manifest_path(context)
+    if remaining:
+        manifest_path.write_text(
+            json.dumps({"installed_managers": remaining, "shim_dir": str(shim_dir)}, sort_keys=True),
+            encoding="utf-8",
+        )
+    elif manifest_path.exists():
+        manifest_path.unlink()
+    return {
+        "removed_managers": list(requested_managers),
+        "removed_paths": removed_paths,
+        "remaining_managers": remaining,
+        "manifest_path": str(manifest_path),
+        "shim_dir": str(shim_dir),
+    }
+
+
+def _build_package_manager_python_shim(context: HarnessContext, command: str) -> str:
+    workspace_args: list[str] = []
+    if context.workspace_dir is not None:
+        workspace_args = ["--workspace", str(context.workspace_dir)]
+    command_args = [
+        sys.executable,
+        "-m",
+        "codex_plugin_scanner.cli",
+        "guard",
+        "protect",
+        "--guard-home",
+        str(context.guard_home),
+        *_home_override_args(context),
+        *workspace_args,
+        "--",
+        command,
+    ]
+    return "\n".join(
+        (
+            f"#!{sys.executable}",
+            "from __future__ import annotations",
+            "import subprocess",
+            "import sys",
+            f"base_command = {command_args!r}",
+            "raise SystemExit(subprocess.call([*base_command, *sys.argv[1:]]))",
+            "",
+        )
+    )
+
+
+def _normalize_package_shim_managers(managers: tuple[str, ...] | None) -> tuple[str, ...]:
+    if managers is None or len(managers) == 0:
+        return tuple(sorted(_PACKAGE_SHIM_COMMANDS.keys()))
+    normalized = []
+    for manager in managers:
+        key = manager.strip().lower()
+        if key in _PACKAGE_SHIM_COMMANDS and key not in normalized:
+            normalized.append(key)
+    return tuple(normalized)
+
+
+def _package_shim_manifest_path(context: HarnessContext) -> Path:
+    return context.guard_home / "package-shims" / _PACKAGE_SHIM_MANIFEST
+
+
+def _load_package_shim_manifest(context: HarnessContext) -> dict[str, object]:
+    manifest_path = _package_shim_manifest_path(context)
+    if not manifest_path.exists():
+        return {}
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+__all__ = [
+    "install_guard_shim",
+    "remove_guard_shim",
+    "install_package_shims",
+    "package_shim_status",
+    "uninstall_package_shims",
+]

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -201,9 +201,7 @@ def package_shim_status(context: HarnessContext) -> dict[str, object]:
     ]
     shim_dir = context.guard_home / "package-shims" / "bin"
     active_managers = [
-        manager
-        for manager in installed_managers
-        if (shim_dir / _PACKAGE_SHIM_COMMANDS[manager]).exists()
+        manager for manager in installed_managers if (shim_dir / _PACKAGE_SHIM_COMMANDS[manager]).exists()
     ]
     missing_managers = [manager for manager in installed_managers if manager not in active_managers]
     return {

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -200,7 +200,11 @@ def package_shim_status(context: HarnessContext) -> dict[str, object]:
         if isinstance(manager, str) and manager in _PACKAGE_SHIM_COMMANDS
     ]
     shim_dir = context.guard_home / "package-shims" / "bin"
-    active_managers = [manager for manager in installed_managers if (shim_dir / _PACKAGE_SHIM_COMMANDS[manager]).exists()]
+    active_managers = [
+        manager
+        for manager in installed_managers
+        if (shim_dir / _PACKAGE_SHIM_COMMANDS[manager]).exists()
+    ]
     missing_managers = [manager for manager in installed_managers if manager not in active_managers]
     return {
         "installed_managers": installed_managers,
@@ -321,8 +325,8 @@ def _path_export_hint(shim_dir: Path) -> str:
 
 __all__ = [
     "install_guard_shim",
-    "remove_guard_shim",
     "install_package_shims",
     "package_shim_status",
+    "remove_guard_shim",
     "uninstall_package_shims",
 ]

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -156,6 +157,13 @@ def install_package_shims(
     shim_dir = shim_root / "bin"
     shim_dir.mkdir(parents=True, exist_ok=True)
     normalized_managers = _normalize_package_shim_managers(managers)
+    existing_manifest = _load_package_shim_manifest(context)
+    existing_managers = tuple(
+        manager
+        for manager in existing_manifest.get("installed_managers", [])
+        if isinstance(manager, str) and manager in _PACKAGE_SHIM_COMMANDS
+    )
+    tracked_managers = tuple(dict.fromkeys([*existing_managers, *normalized_managers]))
     installed: list[str] = []
     for manager in normalized_managers:
         command = _PACKAGE_SHIM_COMMANDS[manager]
@@ -166,18 +174,21 @@ def install_package_shims(
         windows_path.write_text(_build_windows_script(posix_path), encoding="utf-8")
         installed.append(manager)
     manifest_payload = {
-        "installed_managers": installed,
+        "installed_managers": list(tracked_managers),
         "shim_dir": str(shim_dir),
     }
     _package_shim_manifest_path(context).write_text(json.dumps(manifest_payload, sort_keys=True), encoding="utf-8")
+    program_name = _command_program_name()
     return {
-        "installed_managers": installed,
-        "installed_count": len(installed),
+        "installed_managers": list(tracked_managers),
+        "installed_count": len(tracked_managers),
+        "installed_now": installed,
+        "installed_now_count": len(installed),
         "shim_dir": str(shim_dir),
         "manifest_path": str(_package_shim_manifest_path(context)),
-        "path_export_hint": f'export PATH="{shim_dir}:$PATH"',
-        "status_command": "hol-guard package-shims status --json",
-        "uninstall_command": "hol-guard package-shims uninstall --json",
+        "path_export_hint": _path_export_hint(shim_dir),
+        "status_command": f"{program_name} package-shims status --json",
+        "uninstall_command": f"{program_name} package-shims uninstall --json",
     }
 
 
@@ -290,9 +301,22 @@ def _load_package_shim_manifest(context: HarnessContext) -> dict[str, object]:
         return {}
     try:
         payload = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, OSError):
         return {}
     return payload if isinstance(payload, dict) else {}
+
+
+def _command_program_name() -> str:
+    if not sys.argv:
+        return "hol-guard"
+    candidate = Path(sys.argv[0]).name.strip()
+    return candidate or "hol-guard"
+
+
+def _path_export_hint(shim_dir: Path) -> str:
+    if os.name == "nt":
+        return f"set PATH={shim_dir};%PATH%"
+    return f'export PATH="{shim_dir}:$PATH"'
 
 
 __all__ = [

--- a/tests/test_guard_package_shims.py
+++ b/tests/test_guard_package_shims.py
@@ -35,6 +35,7 @@ def test_guard_package_shims_install_status_uninstall_roundtrip(tmp_path: Path, 
     assert install_rc == 0
     assert install_payload["installed_count"] == 2
     assert install_payload["installed_managers"] == ["npm", "pip"]
+    assert install_payload["installed_now"] == ["npm", "pip"]
     shim_dir = Path(str(install_payload["shim_dir"]))
     manifest_path = Path(str(install_payload["manifest_path"]))
     assert (shim_dir / "npm").exists()
@@ -78,6 +79,49 @@ def test_guard_package_shims_install_status_uninstall_roundtrip(tmp_path: Path, 
     assert sorted(uninstall_payload["removed_managers"]) == ["npm", "pip"]
     assert uninstall_payload["remaining_managers"] == []
     assert manifest_path.exists() is False
+
+
+def test_guard_package_shims_install_merges_manifest_entries(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+
+    first_rc = main(
+        [
+            "guard",
+            "package-shims",
+            "install",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--manager",
+            "npm",
+            "--json",
+        ]
+    )
+    first_payload = json.loads(capsys.readouterr().out)
+    second_rc = main(
+        [
+            "guard",
+            "package-shims",
+            "install",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--manager",
+            "pip",
+            "--json",
+        ]
+    )
+    second_payload = json.loads(capsys.readouterr().out)
+
+    assert first_rc == 0
+    assert second_rc == 0
+    assert first_payload["installed_managers"] == ["npm"]
+    assert second_payload["installed_managers"] == ["npm", "pip"]
+    assert second_payload["installed_now"] == ["pip"]
 
 
 def test_guard_package_shims_install_does_not_mutate_path_environment(

--- a/tests/test_guard_package_shims.py
+++ b/tests/test_guard_package_shims.py
@@ -1,0 +1,140 @@
+"""Regression coverage for package-manager shim lifecycle commands."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from codex_plugin_scanner.cli import main
+
+
+def test_guard_package_shims_install_status_uninstall_roundtrip(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+
+    install_rc = main(
+        [
+            "guard",
+            "package-shims",
+            "install",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--manager",
+            "npm",
+            "--manager",
+            "pip",
+            "--json",
+        ]
+    )
+    install_payload = json.loads(capsys.readouterr().out)
+
+    assert install_rc == 0
+    assert install_payload["installed_count"] == 2
+    assert install_payload["installed_managers"] == ["npm", "pip"]
+    shim_dir = Path(str(install_payload["shim_dir"]))
+    manifest_path = Path(str(install_payload["manifest_path"]))
+    assert (shim_dir / "npm").exists()
+    assert (shim_dir / "pip").exists()
+    assert manifest_path.exists()
+
+    status_rc = main(
+        [
+            "guard",
+            "package-shims",
+            "status",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    status_payload = json.loads(capsys.readouterr().out)
+
+    assert status_rc == 0
+    assert status_payload["installed_managers"] == ["npm", "pip"]
+    assert status_payload["active_managers"] == ["npm", "pip"]
+    assert status_payload["missing_managers"] == []
+
+    uninstall_rc = main(
+        [
+            "guard",
+            "package-shims",
+            "uninstall",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    uninstall_payload = json.loads(capsys.readouterr().out)
+
+    assert uninstall_rc == 0
+    assert sorted(uninstall_payload["removed_managers"]) == ["npm", "pip"]
+    assert uninstall_payload["remaining_managers"] == []
+    assert manifest_path.exists() is False
+
+
+def test_guard_package_shims_install_does_not_mutate_path_environment(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    original_path = "/tmp/guard-a:/tmp/guard-b"
+    monkeypatch.setenv("PATH", original_path)
+
+    rc = main(
+        [
+            "guard",
+            "package-shims",
+            "install",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--manager",
+            "npm",
+            "--json",
+        ]
+    )
+    capsys.readouterr()
+
+    assert rc == 0
+    assert os.environ["PATH"] == original_path
+
+
+def test_guard_package_shim_wrapper_routes_commands_through_guard_protect(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+
+    rc = main(
+        [
+            "guard",
+            "package-shims",
+            "install",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--manager",
+            "npm",
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    shim_path = Path(str(payload["shim_dir"])) / "npm"
+    shim_source = shim_path.read_text(encoding="utf-8")
+    assert "guard" in shim_source
+    assert "protect" in shim_source
+    assert "'npm'" in shim_source


### PR DESCRIPTION
Summary:
- add guard package-shims install/status/uninstall command family for workspace-local package-manager wrappers
- generate reversible per-manager wrappers that route through guard protect before command execution
- persist shim manifest for safe status/uninstall behavior without mutating PATH
- add regression coverage for install/status/uninstall lifecycle, PATH safety, and wrapper routing behavior

Validation:
- python3 -m pytest tests/test_guard_package_shims.py tests/test_guard_harness_setup.py -q