### PR TITLE
test: add manager shim pre-download blocking proofs

### DIFF
--- a/tests/test_guard_package_shims.py
+++ b/tests/test_guard_package_shims.py
@@ -2,11 +2,223 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import json
 import os
+import subprocess
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generate_private_key
+
 from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.store import GuardStore
+
+WORKSPACE_ID = "workspace-alpha"
+
+
+def _generate_key_pair() -> tuple[bytes, bytes]:
+    private_key = generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem, public_pem
+
+
+def _fingerprint(public_key_pem: bytes) -> str:
+    return hashlib.sha256(public_key_pem.decode("utf-8").strip().encode("utf-8")).hexdigest()
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _bundle_response(
+    *,
+    action: str,
+    ecosystem: str,
+    package_name: str,
+    package_version: str,
+) -> dict[str, object]:
+    generated_at = datetime(2026, 5, 19, tzinfo=timezone.utc)
+    expires_at = generated_at + timedelta(hours=12)
+    advisory_id = f"GHSA-{ecosystem}-{package_name}"
+    bundle = {
+        "advisories": [
+            {
+                "advisoryId": advisory_id,
+                "aliases": [],
+                "confidence": 990,
+                "exploitLevel": "active",
+                "knownExploited": True,
+                "malwareState": "known",
+                "normalizedSeverity": "critical",
+                "recommendedFixVersion": None,
+                "sourceKey": "ghsa",
+                "summary": f"High-risk package: {package_name}",
+                "title": f"High-risk package: {package_name}",
+            }
+        ],
+        "bundleVersion": "1747612800000-shim-proof",
+        "expiresAt": _iso(expires_at),
+        "feedSnapshotHash": "feed-snapshot-shim-proof",
+        "generatedAt": _iso(generated_at),
+        "keyId": "guard-bundle-key-2026-05",
+        "packages": [
+            {
+                "confidence": 990,
+                "defaultAction": action,
+                "ecosystem": ecosystem,
+                "exploitLevel": "active",
+                "knownExploited": True,
+                "malwareState": "known",
+                "name": package_name,
+                "namespace": None,
+                "normalizedSeverity": "critical",
+                "packageAgeState": "watch",
+                "purl": f"pkg:{ecosystem}/{package_name}@{package_version}",
+                "reachability": "reachable",
+                "recommendedFixVersion": None,
+                "relatedAdvisoryIds": [advisory_id],
+                "riskScore": 980,
+                "sourceIntegrityState": "high-risk",
+                "version": package_version,
+            }
+        ],
+        "policyHash": "policy-hash-shim-proof",
+        "policyRules": [],
+        "scoringVersion": "scf-v1",
+        "sourceHashes": [{"payloadHash": "ghsa-feed-hash", "sourceKey": "ghsa", "staleStatus": "fresh"}],
+        "tier": "premium",
+        "workspaceId": WORKSPACE_ID,
+    }
+    private_key_pem, public_key_pem = _generate_key_pair()
+    loaded_key = serialization.load_pem_private_key(private_key_pem, password=None)
+    assert isinstance(loaded_key, RSAPrivateKey)
+    canonical_payload = json.dumps(bundle, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    payload_hash = hashlib.sha256(canonical_payload).hexdigest()
+    signature = loaded_key.sign(
+        canonical_payload,
+        padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+        hashes.SHA256(),
+    )
+    return {
+        "bundle": bundle,
+        "payloadHash": payload_hash,
+        "signature": base64.b64encode(signature).decode("utf-8"),
+        "signatureAlgorithm": "rsa-pss-sha256",
+        "verificationKeys": [
+            {
+                "fingerprintSha256": _fingerprint(public_key_pem),
+                "keyId": "guard-bundle-key-2026-05",
+                "publicKeyPem": public_key_pem.decode("utf-8").strip(),
+                "state": "active",
+                "validUntil": None,
+            }
+        ],
+    }
+
+
+def _seed_bundle(
+    *,
+    home_dir: Path,
+    ecosystem: str,
+    package_name: str,
+    package_version: str,
+    action: str,
+) -> None:
+    store = GuardStore(home_dir)
+    now = "2026-05-19T00:00:00Z"
+    store.set_sync_credentials("https://hol.org/api/guard/receipts/sync", "demo-token", now, workspace_id=WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(action=action, ecosystem=ecosystem, package_name=package_name, package_version=package_version),
+        now,
+    )
+
+
+def _install_single_manager_shim(
+    *,
+    home_dir: Path,
+    workspace_dir: Path,
+    manager: str,
+    capsys,
+) -> Path:
+    rc = main(
+        [
+            "guard",
+            "package-shims",
+            "install",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--manager",
+            manager,
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    return Path(str(payload["shim_dir"])) / manager
+
+
+def _write_fake_manager_script(*, fake_bin: Path, manager: str, marker_path: Path, exit_code: int) -> None:
+    script_path = fake_bin / manager
+    script_path.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "from __future__ import annotations",
+                "import json",
+                "import os",
+                "import sys",
+                f"marker_path = {str(marker_path)!r}",
+                "payload = {",
+                "    'argv': sys.argv,",
+                "    'cwd': os.getcwd(),",
+                "    'path': os.environ.get('PATH', ''),",
+                "    'shim_var': os.environ.get('SHIM_TEST_VAR'),",
+                "}",
+                "with open(marker_path, 'w', encoding='utf-8') as handle:",
+                "    json.dump(payload, handle)",
+                f"raise SystemExit({exit_code})",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    script_path.chmod(script_path.stat().st_mode | 0o755)
+
+
+_BLOCKING_SHIM_CASES = (
+    ("npm", ("install", "minimist@1.2.8"), "npm", "minimist", "1.2.8"),
+    ("pnpm", ("add", "minimist@1.2.8"), "npm", "minimist", "1.2.8"),
+    ("yarn", ("add", "minimist@1.2.8"), "npm", "minimist", "1.2.8"),
+    ("bun", ("add", "minimist@1.2.8"), "npm", "minimist", "1.2.8"),
+    ("pip", ("install", "requests==2.32.0"), "pypi", "requests", "2.32.0"),
+    ("uv", ("add", "requests==2.32.0"), "pypi", "requests", "2.32.0"),
+    ("poetry", ("add", "requests@2.32.0"), "pypi", "requests", "2.32.0"),
+    ("pipenv", ("install", "requests==2.32.0"), "pypi", "requests", "2.32.0"),
+    ("pipx", ("install", "requests==2.32.0"), "pypi", "requests", "2.32.0"),
+    ("uvx", ("requests==2.32.0",), "pypi", "requests", "2.32.0"),
+    ("cargo", ("add", "serde@1.0.203"), "cargo", "serde", "1.0.203"),
+    ("go", ("install", "github.com/pkg/errors@v0.9.1"), "go", "github.com/pkg/errors", "v0.9.1"),
+    ("mvn", ("dependency:get", "-Dartifact=org.apache.commons:commons-lang3:3.14.0"), "maven", "commons-lang3", "3.14.0"),
+    ("gradle", ("dependencies", "--dependency", "org.apache.commons:commons-lang3:3.14.0"), "maven", "commons-lang3", "3.14.0"),
+    ("composer", ("require", "monolog/monolog:3.6.0"), "packagist", "monolog/monolog", "3.6.0"),
+    ("bundle", ("add", "rails", "--version", "7.1.3"), "rubygems", "rails", "7.1.3"),
+)
 
 
 def test_guard_package_shims_install_status_uninstall_roundtrip(tmp_path: Path, capsys) -> None:
@@ -182,3 +394,53 @@ def test_guard_package_shim_wrapper_routes_commands_through_guard_protect(tmp_pa
     assert "guard" in shim_source
     assert "protect" in shim_source
     assert "'npm'" in shim_source
+
+
+@pytest.mark.parametrize(
+    "manager,shim_args,ecosystem,package_name,package_version",
+    _BLOCKING_SHIM_CASES,
+)
+def test_guard_package_shims_block_before_manager_execution(
+    tmp_path: Path,
+    capsys,
+    manager: str,
+    shim_args: tuple[str, ...],
+    ecosystem: str,
+    package_name: str,
+    package_version: str,
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir(parents=True, exist_ok=True)
+    marker_path = tmp_path / f"{manager}-marker.json"
+    _write_fake_manager_script(fake_bin=fake_bin, manager=manager, marker_path=marker_path, exit_code=0)
+    _seed_bundle(
+        home_dir=home_dir,
+        ecosystem=ecosystem,
+        package_name=package_name,
+        package_version=package_version,
+        action="block",
+    )
+    shim_path = _install_single_manager_shim(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        manager=manager,
+        capsys=capsys,
+    )
+
+    env = dict(os.environ)
+    env["PATH"] = f"{fake_bin}:{env.get('PATH', '')}"
+    result = subprocess.run(
+        [str(shim_path), *shim_args],
+        cwd=workspace_dir,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert marker_path.exists() is False
+

--- a/tests/test_guard_package_shims.py
+++ b/tests/test_guard_package_shims.py
@@ -43,6 +43,11 @@ def _iso(value: datetime) -> str:
     return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+_PRIVATE_KEY_PEM, _PUBLIC_KEY_PEM = _generate_key_pair()
+_LOADED_PRIVATE_KEY = serialization.load_pem_private_key(_PRIVATE_KEY_PEM, password=None)
+assert isinstance(_LOADED_PRIVATE_KEY, RSAPrivateKey)
+
+
 def _bundle_response(
     *,
     action: str,
@@ -102,12 +107,9 @@ def _bundle_response(
         "tier": "premium",
         "workspaceId": WORKSPACE_ID,
     }
-    private_key_pem, public_key_pem = _generate_key_pair()
-    loaded_key = serialization.load_pem_private_key(private_key_pem, password=None)
-    assert isinstance(loaded_key, RSAPrivateKey)
     canonical_payload = json.dumps(bundle, sort_keys=True, separators=(",", ":")).encode("utf-8")
     payload_hash = hashlib.sha256(canonical_payload).hexdigest()
-    signature = loaded_key.sign(
+    signature = _LOADED_PRIVATE_KEY.sign(
         canonical_payload,
         padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
         hashes.SHA256(),
@@ -119,9 +121,9 @@ def _bundle_response(
         "signatureAlgorithm": "rsa-pss-sha256",
         "verificationKeys": [
             {
-                "fingerprintSha256": _fingerprint(public_key_pem),
+                "fingerprintSha256": _fingerprint(_PUBLIC_KEY_PEM),
                 "keyId": "guard-bundle-key-2026-05",
-                "publicKeyPem": public_key_pem.decode("utf-8").strip(),
+                "publicKeyPem": _PUBLIC_KEY_PEM.decode("utf-8").strip(),
                 "state": "active",
                 "validUntil": None,
             }
@@ -344,7 +346,7 @@ def test_guard_package_shims_install_does_not_mutate_path_environment(
     home_dir = tmp_path / "guard-home"
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir(parents=True, exist_ok=True)
-    original_path = "/tmp/guard-a:/tmp/guard-b"
+    original_path = os.pathsep.join(["guard-a", "guard-b"])
     monkeypatch.setenv("PATH", original_path)
 
     rc = main(
@@ -431,7 +433,7 @@ def test_guard_package_shims_block_before_manager_execution(
     )
 
     env = dict(os.environ)
-    env["PATH"] = f"{fake_bin}:{env.get('PATH', '')}"
+    env["PATH"] = os.pathsep.join(filter(None, [str(fake_bin), env.get("PATH")]))
     result = subprocess.run(
         [str(shim_path), *shim_args],
         cwd=workspace_dir,
@@ -443,4 +445,3 @@ def test_guard_package_shims_block_before_manager_execution(
 
     assert result.returncode != 0
     assert marker_path.exists() is False
-


### PR DESCRIPTION
Summary:
- extend package-shim tests with execution-level blocking proofs across npm/pnpm/yarn/bun, pip/uv/poetry/pipenv/pipx/uvx, and cargo/go/mvn/gradle/composer/bundle wrappers
- verify each shim blocks before handing off to the underlying package-manager binary when Guard policy blocks the package request
- keep lifecycle and PATH-safety coverage in place while adding manager-level interception assertions

Validation:
- python3 -m pytest tests/test_guard_package_shims.py tests/test_guard_harness_setup.py -q