### PR TITLE
feat(guard): surface package-manager bypass posture

### DIFF
--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -275,6 +275,22 @@ export type GuardProofStatus = GuardConnectProof & {
   request_id: string | null;
 };
 
+export type PackageManagerProtection = {
+  path_status: "in_path" | "missing_from_path";
+  path_contains_shim_dir: boolean;
+  shim_dir: string;
+  supported_managers: string[];
+  installed_managers: string[];
+  active_managers: string[];
+  missing_shims: string[];
+  protected_managers: string[];
+  unprotected_managers: string[];
+};
+
+export type SupplyChainSnapshot = {
+  package_manager_protection: PackageManagerProtection;
+};
+
 export type GuardRuntimeSnapshot = {
   generated_at: string;
   approval_center_url: string | null;
@@ -304,6 +320,7 @@ export type GuardRuntimeSnapshot = {
   managed_installs?: GuardManagedInstall[];
   inventory?: GuardInventoryItem[];
   security_level?: "balanced" | "strict" | "custom";
+  supply_chain?: SupplyChainSnapshot;
 };
 
 export type GuardReceipt = {

--- a/dashboard/src/runtime-overview.test.ts
+++ b/dashboard/src/runtime-overview.test.ts
@@ -1,5 +1,5 @@
-import { resolveCloudIntelCopy, resolveCloudSyncHealthCopy, resolveProtectionLevelCopy, resolveApprovalCenterHealth, resolveProofStatusCopy } from "./runtime-overview";
-import type { GuardCloudSyncHealth, GuardProofStatus, GuardRuntimeSnapshot } from "./guard-types";
+import { resolveCloudIntelCopy, resolveCloudSyncHealthCopy, resolveProtectionLevelCopy, resolveApprovalCenterHealth, resolveProofStatusCopy, resolvePackageManagerProtectionCopy } from "./runtime-overview";
+import type { GuardCloudSyncHealth, GuardProofStatus, GuardRuntimeSnapshot, PackageManagerProtection } from "./guard-types";
 
 function assert(condition: boolean, message: string): void {
   if (!condition) {
@@ -178,3 +178,53 @@ assert(
   unavailableCopy.detail.toLowerCase().includes("cloud") || unavailableCopy.detail.toLowerCase().includes("connect"),
   `P7: sync_unavailable detail should mention cloud or connect (upgrade path) — got: "${unavailableCopy.detail}"`
 );
+
+const baseProtection: PackageManagerProtection = {
+  path_status: "in_path",
+  path_contains_shim_dir: true,
+  shim_dir: "/home/user/.hol/shims",
+  supported_managers: ["npm", "pip", "cargo"],
+  installed_managers: ["npm", "pip"],
+  active_managers: ["npm", "pip"],
+  missing_shims: [],
+  protected_managers: ["npm", "pip"],
+  unprotected_managers: [],
+};
+
+const inPathCopy = resolvePackageManagerProtectionCopy(baseProtection);
+assert(inPathCopy.pathTone === "green", "SC1: in_path tone should be green");
+assert(inPathCopy.pathLabel.toLowerCase().includes("in path") || inPathCopy.pathLabel.toLowerCase().includes("in path"), "SC1: in_path label should indicate shim is in PATH");
+assert(inPathCopy.pathDetail.includes(baseProtection.shim_dir), "SC1: in_path detail should include the shim directory");
+assert(inPathCopy.protectedList.length === 2, "SC1: protected list should reflect protected_managers");
+assert(inPathCopy.protectedList.includes("npm"), "SC1: npm should appear in protected list");
+assert(inPathCopy.protectedList.includes("pip"), "SC1: pip should appear in protected list");
+assert(inPathCopy.unprotectedList.length === 0, "SC1: unprotected list should be empty when all managers are protected");
+
+const missingFromPathProtection: PackageManagerProtection = {
+  ...baseProtection,
+  path_status: "missing_from_path",
+  path_contains_shim_dir: false,
+  protected_managers: ["npm"],
+  unprotected_managers: ["pip", "cargo"],
+};
+
+const missingFromPathCopy = resolvePackageManagerProtectionCopy(missingFromPathProtection);
+assert(missingFromPathCopy.pathTone === "attention", "SC2: missing_from_path tone should be attention");
+assert(
+  missingFromPathCopy.pathLabel.toLowerCase().includes("missing") || missingFromPathCopy.pathLabel.toLowerCase().includes("not"),
+  `SC2: missing_from_path label should signal a warning — got: "${missingFromPathCopy.pathLabel}"`
+);
+assert(
+  missingFromPathCopy.pathDetail.toLowerCase().includes("bypass") || missingFromPathCopy.pathDetail.toLowerCase().includes("not on path") || missingFromPathCopy.pathDetail.toLowerCase().includes("missing"),
+  `SC2: missing_from_path detail should describe the bypass risk — got: "${missingFromPathCopy.pathDetail}"`
+);
+assert(missingFromPathCopy.unprotectedList.includes("pip"), "SC2: pip should appear in unprotected list");
+assert(missingFromPathCopy.unprotectedList.includes("cargo"), "SC2: cargo should appear in unprotected list");
+assert(missingFromPathCopy.protectedList.includes("npm"), "SC2: npm should still appear in protected list");
+assert(missingFromPathCopy.protectedList.length === 1, "SC2: protected list should contain only npm");
+
+const absentCopy = resolvePackageManagerProtectionCopy(undefined);
+assert(absentCopy.pathTone === "slate", "SC3: absent supply-chain data should use slate tone (no crash)");
+assert(absentCopy.pathLabel.length > 0, "SC3: absent supply-chain data should still produce a non-empty label");
+assert(absentCopy.protectedList.length === 0, "SC3: absent supply-chain data should return empty protected list");
+assert(absentCopy.unprotectedList.length === 0, "SC3: absent supply-chain data should return empty unprotected list");

--- a/dashboard/src/runtime-overview.tsx
+++ b/dashboard/src/runtime-overview.tsx
@@ -1,6 +1,6 @@
 import { ActionButton, Badge, KeyValueGrid, SectionLabel, Surface, Tag, ProofStrip } from "./approval-center-primitives";
 import { harnessDisplayName, formatRelativeTime } from "./approval-center-utils";
-import type { GuardCloudSyncHealth, GuardInventoryItem, GuardProofStatus, GuardReceipt, GuardRuntimeDevice, GuardRuntimeSnapshot } from "./guard-types";
+import type { GuardCloudSyncHealth, GuardInventoryItem, GuardProofStatus, GuardReceipt, GuardRuntimeDevice, GuardRuntimeSnapshot, PackageManagerProtection } from "./guard-types";
 
 const WATCHED_HARNESSES = ["codex", "claude-code", "opencode", "copilot", "gemini", "cursor", "hermes", "openclaw"] as const;
 
@@ -258,6 +258,84 @@ export function DeviceProofCard(props: DeviceProofCardProps) {
 
 
 
+export type PackageManagerProtectionCopy = {
+  pathLabel: string;
+  pathDetail: string;
+  pathTone: "green" | "attention" | "slate";
+  protectedList: string[];
+  unprotectedList: string[];
+};
+
+export function resolvePackageManagerProtectionCopy(
+  protection: PackageManagerProtection | undefined,
+): PackageManagerProtectionCopy {
+  if (protection === undefined) {
+    return {
+      pathLabel: "Status unknown",
+      pathDetail: "Supply-chain protection data is not available for this session.",
+      pathTone: "slate",
+      protectedList: [],
+      unprotectedList: [],
+    };
+  }
+  const pathInPath = protection.path_status === "in_path";
+  return {
+    pathLabel: pathInPath ? "Guard shim directory is in PATH" : "Guard shim directory missing from PATH",
+    pathDetail: pathInPath
+      ? `Package manager commands are intercepted via ${protection.shim_dir}.`
+      : `The shim directory (${protection.shim_dir}) is not on PATH. Install bypass is possible for package managers that are not otherwise protected.`,
+    pathTone: pathInPath ? "green" : "attention",
+    protectedList: protection.protected_managers,
+    unprotectedList: protection.unprotected_managers,
+  };
+}
+
+function PackageManagerProtectionCard(props: { snapshot: GuardRuntimeSnapshot }) {
+  const protection = props.snapshot.supply_chain?.package_manager_protection;
+  const copy = resolvePackageManagerProtectionCopy(protection);
+  return (
+    <div className="rounded-xl border border-border bg-white px-5 py-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-brand-blue">
+          Package manager protection
+        </p>
+        <Tag tone={copy.pathTone}>{copy.pathLabel}</Tag>
+      </div>
+      <p className="mt-2 text-sm leading-relaxed text-brand-dark/80">{copy.pathDetail}</p>
+      {copy.protectedList.length > 0 || copy.unprotectedList.length > 0 ? (
+        <div className="mt-3 space-y-2">
+          {copy.protectedList.length > 0 ? (
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span className="text-xs font-medium text-slate-500">Protected:</span>
+              {copy.protectedList.map((mgr) => (
+                <span
+                  key={mgr}
+                  className="inline-flex items-center rounded-full border border-brand-green/25 bg-brand-green-bg/50 px-2.5 py-0.5 text-xs font-medium text-brand-green-text"
+                >
+                  {mgr}
+                </span>
+              ))}
+            </div>
+          ) : null}
+          {copy.unprotectedList.length > 0 ? (
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span className="text-xs font-medium text-slate-500">Unprotected:</span>
+              {copy.unprotectedList.map((mgr) => (
+                <span
+                  key={mgr}
+                  className="inline-flex items-center rounded-full border border-amber-200 bg-amber-50 px-2.5 py-0.5 text-xs font-medium text-amber-700"
+                >
+                  {mgr}
+                </span>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 export function RuntimeOverview(props: RuntimeOverviewProps) {
   const { snapshot, inventory } = props;
   const securityLevel = snapshot.security_level;
@@ -312,10 +390,11 @@ export function RuntimeOverview(props: RuntimeOverviewProps) {
           ]}
         />
 
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-4">
           <CloudSyncHealthCard health={snapshot.cloud_sync_health} />
           <ApprovalCenterHealthCard snapshot={snapshot} />
           <DeviceProofCard device={snapshot.device} proofStatus={snapshot.proof_status} />
+          <PackageManagerProtectionCard snapshot={snapshot} />
         </div>
 
         <div className="rounded-xl border border-border bg-white px-5 py-4">

--- a/docs/guard/testing-matrix.md
+++ b/docs/guard/testing-matrix.md
@@ -45,6 +45,34 @@ Repo-scoped gap:
 
 - Goose has no adapter, config surface, binary harness, or MCP proxy integration in this repository today, so there is no local Phase 14 package-install proof to run for Goose yet.
 
+## CI wrapper examples
+
+Use `hol-guard protect` in CI whenever a workflow installs dependencies directly:
+
+```yaml
+- name: Install dependencies through HOL Guard
+  run: hol-guard protect -- npm ci
+```
+
+Example `.github/workflows` sequence with the scanner action:
+
+```yaml
+jobs:
+  guard-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install dependencies through HOL Guard
+        run: hol-guard protect -- npm ci
+      - name: Run scanner action
+        uses: hashgraph-online/ai-plugin-scanner-action@v1
+        with:
+          plugin_dir: "."
+```
+
 ## Supply-chain ecosystem support labels
 
 Use `hol-guard cloud sync-intel` after a successful bundle refresh to inspect current package-manager coverage:

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -1479,6 +1479,10 @@
     }
   }
 
+  .border-amber-200 {
+    border-color: var(--color-amber-200);
+  }
+
   .border-amber-200\/40 {
     border-color: #fee68566;
   }
@@ -4469,6 +4473,10 @@
 
     .xl\:grid-cols-1 {
       grid-template-columns: repeat(1, minmax(0, 1fr));
+    }
+
+    .xl\:grid-cols-4 {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
     }
 
     .xl\:grid-cols-\[300px_minmax\(0\,1fr\)\] {

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import shlex
+import shutil
 import subprocess
 from collections.abc import Sequence
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from .adapters.base import HarnessContext
 from .config import GuardConfig, resolve_risk_action
 from .receipts import build_receipt
 from .redaction import redact_text
@@ -27,6 +30,7 @@ from .runtime.package_intent_common import (
 from .runtime.package_manifest_diff import parse_manifest_dependencies
 from .runtime.supply_chain_package_eval import evaluate_package_request_artifact
 from .runtime.supply_chain_support import ecosystem_support_matrix
+from .shims import package_shim_status, package_shim_supported_managers
 from .store import GuardStore
 
 _LOCAL_SUPPLY_CHAIN_HARNESS = "guard-cli"
@@ -186,6 +190,7 @@ def build_local_supply_chain_posture(
             "managed_updated_at": managed_updated_at,
         },
         "supported_ecosystems": supported_ecosystems,
+        "package_manager_protection": _build_package_manager_protection(store),
     }
 
 
@@ -490,6 +495,48 @@ def _coerce_command_error_output(error: subprocess.TimeoutExpired | OSError) -> 
     if message:
         parts.append(message)
     return "\n".join(part for part in parts if part)
+
+
+def _build_package_manager_protection(store: GuardStore) -> dict[str, object]:
+    context = HarnessContext(
+        home_dir=store.guard_home,
+        workspace_dir=None,
+        guard_home=store.guard_home,
+    )
+    status = package_shim_status(context)
+    shim_dir = Path(str(status.get("shim_dir") or store.guard_home / "package-shims" / "bin"))
+    installed_managers = sorted({str(item) for item in status.get("installed_managers", []) if isinstance(item, str)})
+    active_managers = sorted({str(item) for item in status.get("active_managers", []) if isinstance(item, str)})
+    missing_shims = sorted({str(item) for item in status.get("missing_managers", []) if isinstance(item, str)})
+    supported_managers = list(package_shim_supported_managers())
+    path_entries = [entry for entry in os.environ.get("PATH", "").split(os.pathsep) if entry]
+    path_contains_shim_dir = any(_paths_match(entry, shim_dir) for entry in path_entries)
+    protected_managers: list[str] = []
+    unprotected_managers: list[str] = []
+    for manager in supported_managers:
+        shim_target = shim_dir / manager
+        resolved = shutil.which(manager)
+        if resolved is not None and _paths_match(resolved, shim_target):
+            protected_managers.append(manager)
+        else:
+            unprotected_managers.append(manager)
+    return {
+        "path_status": "in_path" if path_contains_shim_dir else "missing_from_path",
+        "path_contains_shim_dir": path_contains_shim_dir,
+        "shim_dir": str(shim_dir),
+        "supported_managers": supported_managers,
+        "installed_managers": installed_managers,
+        "active_managers": active_managers,
+        "missing_shims": missing_shims,
+        "protected_managers": protected_managers,
+        "unprotected_managers": unprotected_managers,
+    }
+
+
+def _paths_match(left: str | Path, right: str | Path) -> bool:
+    left_path = Path(str(left)).expanduser()
+    right_path = Path(str(right)).expanduser()
+    return os.path.normcase(os.path.abspath(left_path)) == os.path.normcase(os.path.abspath(right_path))
 
 
 def _workspace_scan_intent(workspace_dir: Path) -> PackageIntent | None:

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -534,9 +534,14 @@ def _build_package_manager_protection(store: GuardStore) -> dict[str, object]:
 
 
 def _paths_match(left: str | Path, right: str | Path) -> bool:
-    left_path = Path(str(left)).expanduser()
-    right_path = Path(str(right)).expanduser()
-    return os.path.normcase(os.path.abspath(left_path)) == os.path.normcase(os.path.abspath(right_path))
+    try:
+        left_path = Path(str(left)).expanduser().resolve()
+        right_path = Path(str(right)).expanduser().resolve()
+        return left_path == right_path
+    except (OSError, RuntimeError):
+        left_path = Path(str(left)).expanduser()
+        right_path = Path(str(right)).expanduser()
+        return os.path.normcase(os.path.abspath(left_path)) == os.path.normcase(os.path.abspath(right_path))
 
 
 def _workspace_scan_intent(workspace_dir: Path) -> PackageIntent | None:

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -252,6 +252,10 @@ def uninstall_package_shims(
     }
 
 
+def package_shim_supported_managers() -> tuple[str, ...]:
+    return tuple(sorted(_PACKAGE_SHIM_COMMANDS.keys()))
+
+
 def _build_package_manager_python_shim(context: HarnessContext, command: str) -> str:
     workspace_args: list[str] = []
     if context.workspace_dir is not None:
@@ -346,6 +350,7 @@ def _path_export_hint(shim_dir: Path) -> str:
 __all__ = [
     "install_guard_shim",
     "install_package_shims",
+    "package_shim_supported_managers",
     "package_shim_status",
     "remove_guard_shim",
     "uninstall_package_shims",

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -350,8 +350,8 @@ def _path_export_hint(shim_dir: Path) -> str:
 __all__ = [
     "install_guard_shim",
     "install_package_shims",
-    "package_shim_supported_managers",
     "package_shim_status",
+    "package_shim_supported_managers",
     "remove_guard_shim",
     "uninstall_package_shims",
 ]

--- a/tests/test_guard_docs.py
+++ b/tests/test_guard_docs.py
@@ -107,3 +107,17 @@ def test_static_docs_cover_local_supply_chain_firewall_commands() -> None:
     assert "hol-guard supply-chain scan" in docs_text
     assert "hol-guard supply-chain explain" in docs_text
     assert "hol-guard protect" in docs_text
+
+
+def test_static_docs_cover_ci_wrapper_examples() -> None:
+    docs_text = "\n".join(
+        [
+            _read_repo_file("README.md"),
+            _read_repo_file("docs/guard/get-started.md"),
+            _read_repo_file("docs/guard/testing-matrix.md"),
+        ]
+    ).lower()
+
+    assert "hol-guard protect -- npm ci" in docs_text
+    assert "install dependencies through hol guard" in docs_text
+    assert ".github/workflows" in docs_text

--- a/tests/test_guard_local_supply_chain_phase15.py
+++ b/tests/test_guard_local_supply_chain_phase15.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import os
 import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -308,6 +309,76 @@ def test_supply_chain_posture_reports_protected_degraded_stale_and_next_refresh(
     assert degraded_posture["health_status"] == "degraded"
 
 
+def test_supply_chain_posture_reports_package_shim_path_and_unprotected_managers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    store = GuardStore(home_dir)
+    _seed_supply_chain_bundle(
+        store,
+        packages=[_package(name="minimist", version="1.2.5", default_action="block")],
+        now="2026-05-19T12:00:00+00:00",
+    )
+    shim_root = home_dir / "package-shims"
+    shim_dir = shim_root / "bin"
+    shim_dir.mkdir(parents=True, exist_ok=True)
+    (shim_dir / "npm").write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    (shim_dir / "npm").chmod(0o755)
+    (shim_root / "manifest.json").write_text(
+        json.dumps({"installed_managers": ["npm", "pnpm"], "shim_dir": str(shim_dir)}, sort_keys=True),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PATH", f"{shim_dir}{os.pathsep}{tmp_path}")
+
+    posture = local_supply_chain_module.build_local_supply_chain_posture(
+        store,
+        load_guard_config(home_dir),
+        now="2026-05-19T12:04:00+00:00",
+    )
+
+    protection = posture["package_manager_protection"]
+    assert protection["path_status"] == "in_path"
+    assert protection["path_contains_shim_dir"] is True
+    assert protection["protected_managers"] == ["npm"]
+    assert "pnpm" in protection["unprotected_managers"]
+    assert protection["missing_shims"] == ["pnpm"]
+
+
+def test_supply_chain_posture_marks_shim_path_missing_from_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    store = GuardStore(home_dir)
+    _seed_supply_chain_bundle(
+        store,
+        packages=[_package(name="minimist", version="1.2.5", default_action="block")],
+        now="2026-05-19T12:00:00+00:00",
+    )
+    shim_root = home_dir / "package-shims"
+    shim_dir = shim_root / "bin"
+    shim_dir.mkdir(parents=True, exist_ok=True)
+    (shim_dir / "npm").write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    (shim_dir / "npm").chmod(0o755)
+    (shim_root / "manifest.json").write_text(
+        json.dumps({"installed_managers": ["npm"], "shim_dir": str(shim_dir)}, sort_keys=True),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+    posture = local_supply_chain_module.build_local_supply_chain_posture(
+        store,
+        load_guard_config(home_dir),
+        now="2026-05-19T12:04:00+00:00",
+    )
+
+    protection = posture["package_manager_protection"]
+    assert protection["path_status"] == "missing_from_path"
+    assert protection["path_contains_shim_dir"] is False
+    assert "npm" in protection["unprotected_managers"]
+
+
 def test_guard_supply_chain_scan_uses_manifest_and_lockfile_context(tmp_path: Path, capsys) -> None:
     home_dir = tmp_path / "guard-home"
     workspace_dir = tmp_path / "workspace"
@@ -506,6 +577,7 @@ def test_runtime_snapshot_includes_supply_chain_block(tmp_path: Path) -> None:
     assert snapshot["supply_chain"]["bundle"]["bundle_version"] == "1747612800000-deadbeef"
     assert snapshot["supply_chain"]["policy"]["cloud_advisory_action"] == "warn"
     assert snapshot["supply_chain"]["policy"]["managed_by_cloud"] is False
+    assert "package_manager_protection" in snapshot["supply_chain"]
 
 
 def test_runtime_snapshot_marks_supply_chain_policy_as_cloud_managed(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add runtime supply-chain package-manager protection posture to local snapshots
- show protected versus unprotected package managers and PATH shim status in Runtime Overview
- document CI wrapper usage for install interception with hol-guard protect -- npm ci

## Testing
- python3 -m pytest tests/test_guard_local_supply_chain_phase15.py tests/test_guard_package_shims.py tests/test_guard_docs.py -q
- pnpm --dir dashboard test
- pnpm --dir dashboard build