### PR TITLE
feat(guard): close phase08 transitive schema gaps

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -2325,7 +2325,7 @@ def _npm_registry_resolved_version(*, package_name: str, requested_range: str) -
     request = urllib.request.Request(
         metadata_url,
         headers={
-            "Accept": "application/json",
+            "Accept": "application/vnd.npm.install-v1+json",
             "User-Agent": "hol-guard-local",
         },
     )

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -2319,9 +2319,7 @@ def _registry_package_name(target: dict[str, object]) -> str | None:
 
 
 def _npm_registry_resolved_version(*, package_name: str, requested_range: str) -> str | None:
-    metadata_url = (
-        f"{_NPM_REGISTRY_METADATA_BASE_URL.rstrip('/')}/{urllib.parse.quote(package_name, safe='')}"
-    )
+    metadata_url = f"{_NPM_REGISTRY_METADATA_BASE_URL.rstrip('/')}/{urllib.parse.quote(package_name, safe='')}"
     request = urllib.request.Request(
         metadata_url,
         headers={

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -2340,7 +2340,7 @@ def _npm_registry_resolved_version(*, package_name: str, requested_range: str) -
     versions_payload = payload.get("versions")
     if not isinstance(versions_payload, dict):
         return None
-    versions = [version for version in versions_payload.keys() if isinstance(version, str)]
+    versions = [version for version in versions_payload if isinstance(version, str)]
     if not versions:
         return None
     return highest_js_version_for_selector(versions, requested_range)

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -25,7 +25,7 @@ from packaging.version import InvalidVersion, Version
 from ..models import GuardArtifact
 from ..store import GuardStore
 from ..store_evidence import EvidenceRecord
-from .js_semver import version_matches_js_selector
+from .js_semver import highest_js_version_for_selector, version_matches_js_selector
 from .package_intent_common import split_python_extras
 from .package_manifest_diff import (
     _DeadlineExceededError,
@@ -55,6 +55,7 @@ _SEVERITY_RANK = {"unknown": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
 _TIMEOUT_SECONDS = 1
 _RETRY_TIMEOUT_SECONDS = 1
 _CLOUD_DASHBOARD_URL = "https://hol.org/guard/inbox"
+_NPM_REGISTRY_METADATA_BASE_URL = "https://registry.npmjs.org"
 
 
 @dataclass(frozen=True, slots=True)
@@ -930,6 +931,7 @@ def _build_request_payload(
         "packages": [
             {
                 "direct": True,
+                "dependencyPath": None,
                 "ecosystem": str(target["ecosystem"]),
                 "name": str(target["name"]),
                 "namespace": target["namespace"],
@@ -1060,6 +1062,7 @@ def _transitive_lockfile_results(
                     "resolvedVersion": version,
                     "recommendedFixVersion": package_match.recommended_fix_version,
                     "riskScore": package_match.risk_score,
+                    "direct": False,
                     "dependencyPath": dependency_path,
                     "packageManager": str(artifact.metadata.get("package_manager") or "npm"),
                     "redactedCommand": _optional_string(artifact.metadata.get("redacted_command")),
@@ -1117,6 +1120,7 @@ def _bundle_package_result(
         "resolvedVersion": resolved_version,
         "recommendedFixVersion": package.recommended_fix_version,
         "riskScore": package.risk_score,
+        "direct": True,
         "dependencyPath": None,
         "packageManager": _optional_string(target.get("package_manager")) or "npm",
         "redactedCommand": _optional_string(target.get("redacted_command")),
@@ -1202,6 +1206,7 @@ def _policy_package_result(target: dict[str, object], *, decision: str, rule_id:
         "resolvedVersion": _optional_string(target.get("version")),
         "recommendedFixVersion": None,
         "riskScore": None,
+        "direct": True,
         "dependencyPath": None,
         "packageManager": _optional_string(target.get("package_manager")) or "npm",
         "redactedCommand": _optional_string(target.get("redacted_command")),
@@ -1219,6 +1224,9 @@ def _policy_package_result(target: dict[str, object], *, decision: str, rule_id:
 
 
 def _package_from_cloud_result(item: dict[str, object]) -> dict[str, object]:
+    dependency_path = _optional_string(item.get("dependencyPath"))
+    direct_value = item.get("direct")
+    direct = direct_value if isinstance(direct_value, bool) else dependency_path is None
     return {
         "decision": _normalize_bundle_action(str(item.get("decision") or "monitor")),
         "ecosystem": str(item.get("ecosystem") or "npm"),
@@ -1228,7 +1236,8 @@ def _package_from_cloud_result(item: dict[str, object]) -> dict[str, object]:
         "resolvedVersion": _optional_string(item.get("resolvedVersion")),
         "recommendedFixVersion": _optional_string(item.get("recommendedFixVersion")),
         "riskScore": item.get("riskScore"),
-        "dependencyPath": None,
+        "direct": direct,
+        "dependencyPath": dependency_path,
         "reasons": tuple(reason for reason in item.get("reasons", []) if isinstance(reason, dict)),
     }
 
@@ -1243,6 +1252,7 @@ def _unknown_package_result(target: dict[str, object]) -> dict[str, object]:
         "resolvedVersion": _optional_string(target.get("version")),
         "recommendedFixVersion": None,
         "riskScore": None,
+        "direct": True,
         "dependencyPath": None,
         "packageManager": _optional_string(target.get("package_manager")) or "npm",
         "redactedCommand": _optional_string(target.get("redacted_command")),
@@ -1546,6 +1556,7 @@ def _dependency_confusion_policy_package_result(
             "resolvedVersion": _optional_string(target.get("version")),
             "recommendedFixVersion": None,
             "riskScore": None,
+            "direct": True,
             "dependencyPath": None,
             "packageManager": _optional_string(target.get("package_manager")) or "npm",
             "redactedCommand": _optional_string(target.get("redacted_command")),
@@ -1594,6 +1605,7 @@ def _heuristic_package_result(
         "resolvedVersion": _optional_string(target.get("version")),
         "recommendedFixVersion": None,
         "riskScore": None,
+        "direct": True,
         "dependencyPath": None,
         "packageManager": _optional_string(target.get("package_manager")) or "npm",
         "redactedCommand": _optional_string(target.get("redacted_command")),
@@ -2277,7 +2289,61 @@ def _resolved_target_version(
     requested_range = _optional_string(target.get("range"))
     if requested_range is None:
         return None
-    return _exact_version(requested_range)
+    exact_version = _exact_version(requested_range)
+    if exact_version is not None:
+        return exact_version
+    registry_version = _registry_resolved_target_version(target=target, requested_range=requested_range)
+    if registry_version is not None:
+        return registry_version
+    return None
+
+
+def _registry_resolved_target_version(*, target: dict[str, object], requested_range: str) -> str | None:
+    ecosystem = _optional_string(target.get("ecosystem")) or "npm"
+    if ecosystem != "npm":
+        return None
+    if _optional_string(target.get("source_url")) is not None:
+        return None
+    package_name = _registry_package_name(target)
+    if package_name is None:
+        return None
+    return _npm_registry_resolved_version(package_name=package_name, requested_range=requested_range)
+
+
+def _registry_package_name(target: dict[str, object]) -> str | None:
+    package_name = _optional_string(target.get("name"))
+    if package_name is None:
+        return None
+    namespace = _optional_string(target.get("namespace"))
+    return f"{namespace}/{package_name}" if namespace is not None else package_name
+
+
+def _npm_registry_resolved_version(*, package_name: str, requested_range: str) -> str | None:
+    metadata_url = (
+        f"{_NPM_REGISTRY_METADATA_BASE_URL.rstrip('/')}/{urllib.parse.quote(package_name, safe='')}"
+    )
+    request = urllib.request.Request(
+        metadata_url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "hol-guard-local",
+        },
+    )
+    try:
+        payload = _urlopen_json_with_timeout_retry(
+            request=request,
+            timeout_seconds=_TIMEOUT_SECONDS,
+            retry_timeout_seconds=_RETRY_TIMEOUT_SECONDS,
+        )
+    except (OSError, RuntimeError, ValueError):
+        return None
+    versions_payload = payload.get("versions")
+    if not isinstance(versions_payload, dict):
+        return None
+    versions = [version for version in versions_payload.keys() if isinstance(version, str)]
+    if not versions:
+        return None
+    return highest_js_version_for_selector(versions, requested_range)
 
 
 def _bundle_package_versions(bundle_response: SupplyChainBundleResponse, target: dict[str, object]) -> list[str]:
@@ -2324,6 +2390,7 @@ def _recommended_fix_allow_package_result(
             "resolvedVersion": resolved_version,
             "recommendedFixVersion": None,
             "riskScore": None,
+            "direct": True,
             "dependencyPath": None,
             "packageManager": _optional_string(target.get("package_manager")) or "npm",
             "redactedCommand": _optional_string(target.get("redacted_command")),

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -318,6 +318,8 @@ def test_evaluate_package_request_artifact_posts_cloud_request_and_maps_block_re
     assert request_payload["commandShape"]["verb"] == "install"
     assert request_payload["lockfileContext"]["fileName"] == "package-lock.json"
     assert request_payload["packages"][0]["name"] == "minimist"
+    assert request_payload["packages"][0]["direct"] is True
+    assert request_payload["packages"][0]["dependencyPath"] is None
     assert request_payload["policyVersion"]
     assert request_payload["workspaceFingerprint"]
     assert result.decision == "block"
@@ -1005,7 +1007,79 @@ def test_evaluate_package_request_artifact_blocks_transitive_lockfile_match_with
     )
 
     assert result.decision == "block"
+    transitive_match = next(package for package in result.packages if package["name"] == "minimist")
+    assert transitive_match["dependencyPath"] == "react/node_modules/minimist"
+    assert transitive_match["direct"] is False
     assert any("react/node_modules/minimist" in reason["message"] for reason in result.reasons)
+
+
+def test_package_from_cloud_result_preserves_direct_and_dependency_path_schema() -> None:
+    transitive_item = evaluator_module._package_from_cloud_result(
+        {
+            "decision": "block",
+            "ecosystem": "npm",
+            "name": "minimist",
+            "namespace": None,
+            "requestedVersion": "^1.2.0",
+            "resolvedVersion": "1.2.8",
+            "recommendedFixVersion": "1.2.9",
+            "riskScore": 980,
+            "dependencyPath": "react/node_modules/minimist",
+            "direct": False,
+            "reasons": [{"code": "known_advisory", "message": "Prototype pollution", "severity": "critical"}],
+        }
+    )
+    direct_item = evaluator_module._package_from_cloud_result(
+        {
+            "decision": "allow",
+            "ecosystem": "npm",
+            "name": "react",
+            "requestedVersion": "18.0.0",
+            "resolvedVersion": "18.0.0",
+            "reasons": [],
+        }
+    )
+
+    assert transitive_item["dependencyPath"] == "react/node_modules/minimist"
+    assert transitive_item["direct"] is False
+    assert direct_item["dependencyPath"] is None
+    assert direct_item["direct"] is True
+
+
+def test_resolved_target_version_uses_registry_metadata_for_npm_ranges(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, str] = {}
+
+    def fake_urlopen_json_with_timeout_retry(
+        *, request: urllib.request.Request, timeout_seconds: int, retry_timeout_seconds: int
+    ) -> dict[str, object]:
+        captured["url"] = request.full_url
+        assert timeout_seconds == 1
+        assert retry_timeout_seconds == 1
+        return {
+            "versions": {
+                "1.1.9": {},
+                "1.2.0": {},
+                "1.4.2": {},
+                "2.0.0": {},
+            }
+        }
+
+    monkeypatch.setattr(evaluator_module, "_urlopen_json_with_timeout_retry", fake_urlopen_json_with_timeout_retry)
+    resolved = evaluator_module._resolved_target_version(
+        target={
+            "ecosystem": "npm",
+            "name": "minimist",
+            "normalized_name": "minimist",
+            "namespace": None,
+            "range": "^1.2.0",
+            "version": None,
+            "source_url": None,
+        },
+        lockfile_versions={},
+    )
+
+    assert captured["url"].endswith("/minimist")
+    assert resolved == "1.4.2"
 
 
 def test_evaluate_package_request_artifact_blocks_hoisted_lockfile_match(


### PR DESCRIPTION
## Summary
- add explicit direct/dependencyPath schema for package request and evaluation payloads
- preserve cloud-provided transitive dependency metadata in package mapping
- add npm registry metadata fallback for semver range resolution when lockfile/exact version is unavailable

## Testing
- python3 -m pytest tests/test_guard_supply_chain_evaluator.py -k "resolved_target_version_uses_registry_metadata_for_npm_ranges or posts_cloud_request_and_maps_block_response or blocks_transitive_lockfile_match_with_dependency_path or package_from_cloud_result_preserves_direct_and_dependency_path_schema" -q
- python3 -m pytest tests/test_guard_js_supply_chain_phase11.py tests/test_guard_js_lockfile_resolution_phase11.py tests/test_guard_supply_chain_evaluator.py -q
- python3 -m pytest tests/test_guard_local_supply_chain_phase15.py -q