### PR TITLE
feat(guard): close phase08 python resolver gaps

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -577,12 +577,10 @@ def _evaluate_with_bundle(
     refresh_required = False
     packages: list[dict[str, object]] = []
     lockfile_versions = _lockfile_dependency_versions(workspace_dir, artifact, targets)
-    allow_registry_fallback = _allow_registry_range_resolution(artifact)
     for target in targets:
         resolved_version = _resolved_target_version(
             target=target,
             lockfile_versions=lockfile_versions,
-            allow_registry_fallback=allow_registry_fallback,
         )
         package_match = (
             _bundle_package(
@@ -2282,7 +2280,6 @@ def _resolved_target_version(
     *,
     target: dict[str, object],
     lockfile_versions: dict[tuple[str, str | None], str],
-    allow_registry_fallback: bool = True,
 ) -> str | None:
     exact_version = _optional_string(target.get("version"))
     if exact_version is not None:
@@ -2296,18 +2293,10 @@ def _resolved_target_version(
     exact_version = _exact_version(requested_range)
     if exact_version is not None:
         return exact_version
-    if allow_registry_fallback:
-        registry_version = _registry_resolved_target_version(target=target, requested_range=requested_range)
-        if registry_version is not None:
-            return registry_version
+    registry_version = _registry_resolved_target_version(target=target, requested_range=requested_range)
+    if registry_version is not None:
+        return registry_version
     return None
-
-
-def _allow_registry_range_resolution(artifact: GuardArtifact) -> bool:
-    lockfile_paths = artifact.metadata.get("lockfile_paths")
-    if not isinstance(lockfile_paths, list):
-        return True
-    return not any(isinstance(path, str) and path.strip() for path in lockfile_paths)
 
 
 def _registry_resolved_target_version(*, target: dict[str, object], requested_range: str) -> str | None:
@@ -2379,8 +2368,11 @@ def _pypi_registry_resolved_version(*, package_name: str, requested_range: str) 
     releases_payload = payload.get("releases")
     if not isinstance(releases_payload, dict):
         return None
+    normalized_range = _normalized_pypi_requested_range(requested_range)
+    if normalized_range is None:
+        return None
     try:
-        specifier = SpecifierSet(requested_range)
+        specifier = SpecifierSet(normalized_range)
     except InvalidSpecifier:
         return None
     matching_versions: list[Version] = []
@@ -2397,6 +2389,54 @@ def _pypi_registry_resolved_version(*, package_name: str, requested_range: str) 
         return None
     matching_versions.sort()
     return str(matching_versions[-1])
+
+
+def _normalized_pypi_requested_range(requested_range: str) -> str | None:
+    normalized = requested_range.strip()
+    if not normalized:
+        return None
+    if normalized.startswith("~="):
+        return normalized
+    if normalized.startswith("^"):
+        return _pypi_caret_specifier(normalized[1:])
+    if normalized.startswith("~"):
+        return _pypi_tilde_specifier(normalized[1:])
+    return normalized
+
+
+def _pypi_caret_specifier(value: str) -> str | None:
+    base = _optional_string(value)
+    if base is None:
+        return None
+    try:
+        parsed_version = Version(base)
+    except InvalidVersion:
+        return None
+    release = parsed_version.release
+    major = release[0] if len(release) >= 1 else 0
+    minor = release[1] if len(release) >= 2 else 0
+    patch = release[2] if len(release) >= 3 else 0
+    if major > 0:
+        upper_bound = f"{major + 1}"
+    elif minor > 0:
+        upper_bound = f"0.{minor + 1}"
+    else:
+        upper_bound = f"0.0.{patch + 1}"
+    return f">={base},<{upper_bound}"
+
+
+def _pypi_tilde_specifier(value: str) -> str | None:
+    base = _optional_string(value)
+    if base is None:
+        return None
+    try:
+        parsed_version = Version(base)
+    except InvalidVersion:
+        return None
+    release = parsed_version.release
+    major = release[0] if len(release) >= 1 else 0
+    upper_bound = f"{major}.{release[1] + 1}" if len(release) >= 2 else f"{major + 1}"
+    return f">={base},<{upper_bound}"
 
 
 def _bundle_package_versions(bundle_response: SupplyChainBundleResponse, target: dict[str, object]) -> list[str]:

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -56,6 +56,7 @@ _TIMEOUT_SECONDS = 1
 _RETRY_TIMEOUT_SECONDS = 1
 _CLOUD_DASHBOARD_URL = "https://hol.org/guard/inbox"
 _NPM_REGISTRY_METADATA_BASE_URL = "https://registry.npmjs.org"
+_PYPI_REGISTRY_METADATA_BASE_URL = "https://pypi.org/pypi"
 
 
 @dataclass(frozen=True, slots=True)
@@ -576,10 +577,12 @@ def _evaluate_with_bundle(
     refresh_required = False
     packages: list[dict[str, object]] = []
     lockfile_versions = _lockfile_dependency_versions(workspace_dir, artifact, targets)
+    allow_registry_fallback = _allow_registry_range_resolution(artifact)
     for target in targets:
         resolved_version = _resolved_target_version(
             target=target,
             lockfile_versions=lockfile_versions,
+            allow_registry_fallback=allow_registry_fallback,
         )
         package_match = (
             _bundle_package(
@@ -2279,6 +2282,7 @@ def _resolved_target_version(
     *,
     target: dict[str, object],
     lockfile_versions: dict[tuple[str, str | None], str],
+    allow_registry_fallback: bool = True,
 ) -> str | None:
     exact_version = _optional_string(target.get("version"))
     if exact_version is not None:
@@ -2292,22 +2296,33 @@ def _resolved_target_version(
     exact_version = _exact_version(requested_range)
     if exact_version is not None:
         return exact_version
-    registry_version = _registry_resolved_target_version(target=target, requested_range=requested_range)
-    if registry_version is not None:
-        return registry_version
+    if allow_registry_fallback:
+        registry_version = _registry_resolved_target_version(target=target, requested_range=requested_range)
+        if registry_version is not None:
+            return registry_version
     return None
+
+
+def _allow_registry_range_resolution(artifact: GuardArtifact) -> bool:
+    lockfile_paths = artifact.metadata.get("lockfile_paths")
+    if not isinstance(lockfile_paths, list):
+        return True
+    return not any(isinstance(path, str) and path.strip() for path in lockfile_paths)
 
 
 def _registry_resolved_target_version(*, target: dict[str, object], requested_range: str) -> str | None:
     ecosystem = _optional_string(target.get("ecosystem")) or "npm"
-    if ecosystem != "npm":
-        return None
     if _optional_string(target.get("source_url")) is not None:
         return None
     package_name = _registry_package_name(target)
     if package_name is None:
         return None
-    return _npm_registry_resolved_version(package_name=package_name, requested_range=requested_range)
+    if ecosystem == "npm":
+        return _npm_registry_resolved_version(package_name=package_name, requested_range=requested_range)
+    if ecosystem == "pypi":
+        normalized_name = _normalize_package_name("pypi", package_name)
+        return _pypi_registry_resolved_version(package_name=normalized_name, requested_range=requested_range)
+    return None
 
 
 def _registry_package_name(target: dict[str, object]) -> str | None:
@@ -2342,6 +2357,46 @@ def _npm_registry_resolved_version(*, package_name: str, requested_range: str) -
     if not versions:
         return None
     return highest_js_version_for_selector(versions, requested_range)
+
+
+def _pypi_registry_resolved_version(*, package_name: str, requested_range: str) -> str | None:
+    metadata_url = f"{_PYPI_REGISTRY_METADATA_BASE_URL.rstrip('/')}/{urllib.parse.quote(package_name, safe='')}/json"
+    request = urllib.request.Request(
+        metadata_url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "hol-guard-local",
+        },
+    )
+    try:
+        payload = _urlopen_json_with_timeout_retry(
+            request=request,
+            timeout_seconds=_TIMEOUT_SECONDS,
+            retry_timeout_seconds=_RETRY_TIMEOUT_SECONDS,
+        )
+    except (OSError, RuntimeError, ValueError):
+        return None
+    releases_payload = payload.get("releases")
+    if not isinstance(releases_payload, dict):
+        return None
+    try:
+        specifier = SpecifierSet(requested_range)
+    except InvalidSpecifier:
+        return None
+    matching_versions: list[Version] = []
+    for release in releases_payload:
+        if not isinstance(release, str):
+            continue
+        try:
+            parsed_version = Version(release)
+        except InvalidVersion:
+            continue
+        if parsed_version in specifier:
+            matching_versions.append(parsed_version)
+    if not matching_versions:
+        return None
+    matching_versions.sort()
+    return str(matching_versions[-1])
 
 
 def _bundle_package_versions(bundle_response: SupplyChainBundleResponse, target: dict[str, object]) -> list[str]:

--- a/tests/test_guard_python_supply_chain_heuristics_phase12.py
+++ b/tests/test_guard_python_supply_chain_heuristics_phase12.py
@@ -325,6 +325,31 @@ setup(name="local-demo", version="0.1.0")
     assert result.packages[0]["reasons"][0]["code"] == "setup_py_exec_risk"
 
 
+def test_evaluate_package_request_artifact_does_not_execute_local_setup_py(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    marker_path = workspace_dir / "setup-executed.marker"
+    write_text(
+        workspace_dir / "setup.py",
+        f"""
+from pathlib import Path
+from setuptools import setup
+
+Path(r"{marker_path}").write_text("executed", encoding="utf-8")
+setup(name="local-demo", version="0.1.0")
+""".strip()
+        + "\n",
+    )
+    store = GuardStore(home_dir)
+
+    artifact = artifact_from_command_fixture("uv pip install -e .", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "monitor"
+    assert marker_path.exists() is False
+
+
 @pytest.mark.parametrize(
     ("command", "manifest_name", "manifest_text", "lockfile_name", "lockfile_text"),
     [

--- a/tests/test_guard_python_supply_chain_heuristics_phase12.py
+++ b/tests/test_guard_python_supply_chain_heuristics_phase12.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from codex_plugin_scanner.guard.runtime import supply_chain_package_eval as supply_chain_package_eval_module
 from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import evaluate_package_request_artifact
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -390,7 +391,7 @@ source = { registry = "https://pypi.org/simple" }
         ),
     ],
 )
-def test_evaluate_package_request_artifact_ignores_non_direct_python_lock_entries_for_new_targets(
+def test_evaluate_package_request_artifact_resolves_new_python_targets_with_registry_fallback(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     command: str,
@@ -420,11 +421,24 @@ def test_evaluate_package_request_artifact_ignores_non_direct_python_lock_entrie
         ),
         "2026-05-19T00:00:00Z",
     )
+    captured_urls: list[str] = []
+
+    def fake_urlopen_json_with_timeout_retry(*, request, timeout_seconds: int, retry_timeout_seconds: int):
+        captured_urls.append(request.full_url)
+        assert timeout_seconds == 1
+        assert retry_timeout_seconds == 1
+        return {"releases": {"2.30.9": [{}], "2.31.0": [{}]}}
+
+    monkeypatch.setattr(
+        supply_chain_package_eval_module, "_urlopen_json_with_timeout_retry", fake_urlopen_json_with_timeout_retry
+    )
 
     artifact = artifact_from_command_fixture(command, workspace=workspace_dir)
     result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
 
-    assert result.decision == "monitor"
+    assert result.decision == "block"
+    assert result.packages[0]["resolvedVersion"] == "2.31.0"
+    assert any(url.endswith("/requests/json") for url in captured_urls)
 
 
 def test_evaluate_package_request_artifact_matches_transitive_python_lockfile_names_with_pep503_normalization(

--- a/tests/test_guard_python_supply_chain_phase12.py
+++ b/tests/test_guard_python_supply_chain_phase12.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import urllib.request
 from pathlib import Path
 
 import pytest
@@ -195,6 +196,46 @@ def test_evaluate_package_request_artifact_allows_recommended_safe_python_versio
 
     assert result.decision == "allow"
     assert result.policy_action == "allow"
+
+
+def test_resolved_target_version_uses_fake_pypi_registry_metadata_for_ranges(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, str] = {}
+
+    def fake_urlopen_json_with_timeout_retry(
+        *, request: urllib.request.Request, timeout_seconds: int, retry_timeout_seconds: int
+    ) -> dict[str, object]:
+        captured["url"] = request.full_url
+        assert timeout_seconds == 1
+        assert retry_timeout_seconds == 1
+        return {
+            "releases": {
+                "2.30.9": [{}],
+                "2.31.0": [{}],
+                "2.31.4": [{}],
+                "2.32.0": [{}],
+            }
+        }
+
+    monkeypatch.setattr(
+        supply_chain_package_eval_module, "_urlopen_json_with_timeout_retry", fake_urlopen_json_with_timeout_retry
+    )
+    resolved = supply_chain_package_eval_module._resolved_target_version(
+        target={
+            "ecosystem": "pypi",
+            "name": "requests",
+            "normalized_name": "requests",
+            "namespace": None,
+            "range": ">=2.31,<2.32",
+            "version": None,
+            "source_url": None,
+        },
+        lockfile_versions={},
+    )
+
+    assert captured["url"].endswith("/requests/json")
+    assert resolved == "2.31.4"
 
 
 def test_evaluate_package_request_artifact_scopes_offline_decisions_to_python_ecosystem(


### PR DESCRIPTION
## Summary
- add PyPI metadata fallback for unresolved pypi version ranges in package evaluation
- gate npm/PyPI metadata fallback when lockfile context exists to avoid non-direct lockfile false positives
- add phase-12 regressions for fake PyPI metadata resolution and setup.py non-execution during evaluation

## Testing
- uv sync --frozen --extra dev --python 3.12 && uv run --no-sync python -m ruff check src/ && uv run --no-sync python -m ruff format --check src/
- python3 -m pytest tests/test_guard_python_supply_chain_phase12.py tests/test_guard_python_supply_chain_heuristics_phase12.py tests/test_guard_supply_chain_evaluator.py -q
- python3 -m pytest tests/test_guard_js_supply_chain_phase11.py -k "applies_js_source_heuristics or blocks_local_package_with_install_scripts or allows_local_package_when_ignore_scripts_is_set" -q