### PR TITLE
fix(guard): harden package firewall decisions

### DIFF
--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -311,12 +311,6 @@ def build_package_protect_payload(
 ) -> tuple[dict[str, object], int] | None:
     from .runtime.package_intent_parser import parse_package_intent
 
-    workspace_id = store.get_cloud_workspace_id()
-    if workspace_id is None:
-        return None
-    cached_bundle = store.get_cached_supply_chain_bundle(workspace_id)
-    if not isinstance(cached_bundle, dict):
-        return None
     intent = parse_package_intent(shlex.join(command), workspace=workspace_dir)
     if intent is None:
         return None

--- a/src/codex_plugin_scanner/guard/protect.py
+++ b/src/codex_plugin_scanner/guard/protect.py
@@ -122,18 +122,6 @@ def build_protect_payload(
 
     if len(command) == 0:
         raise ValueError("Guard protect requires a command to wrap.")
-    package_payload = build_package_protect_payload(
-        command=command,
-        store=store,
-        workspace_dir=workspace_dir,
-        dry_run=dry_run,
-        now=now,
-        config=config,
-        unsafe_raw_output=unsafe_raw_output,
-        timeout_seconds=_protect_command_timeout_seconds(),
-    )
-    if package_payload is not None:
-        return package_payload
     request = parse_protect_command(command)
     advisories = store.list_cached_advisories(limit=None)
     verdict = evaluate_protect_request(request, advisories)
@@ -148,6 +136,33 @@ def build_protect_payload(
         "receipt": receipt.to_dict(),
         "matched_advisories": list(verdict.matched_advisories),
     }
+    if verdict.blocking:
+        store.add_receipt(receipt)
+        store.add_event(
+            f"install_time_{verdict.action}",
+            {
+                "artifact_id": request.targets[0].artifact_id,
+                "artifact_name": request.targets[0].artifact_name,
+                "executor": request.executor,
+                "install_kind": request.install_kind,
+                "action": verdict.action,
+                "risk_signals": list(verdict.risk_signals),
+            },
+            now,
+        )
+        return (payload, 2)
+    package_payload = build_package_protect_payload(
+        command=command,
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=dry_run,
+        now=now,
+        config=config,
+        unsafe_raw_output=unsafe_raw_output,
+        timeout_seconds=_protect_command_timeout_seconds(),
+    )
+    if package_payload is not None:
+        return package_payload
     if verdict.blocking or dry_run:
         store.add_receipt(receipt)
         store.add_event(

--- a/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
+++ b/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
@@ -33,6 +33,22 @@ from ..runtime.supply_chain_package_eval import evaluate_package_request_artifac
 from ..store import GuardStore
 from .stdio import _blocked_tool_response, _redact_json
 
+_PACKAGE_POLICY_ACTION_RANK = {
+    "allow": 0,
+    "warn": 1,
+    "review": 2,
+    "require-reapproval": 2,
+    "block": 3,
+}
+
+
+def _most_restrictive_package_policy_action(stored_action: str | None, current_action: str) -> str:
+    if stored_action is None:
+        return current_action
+    stored_rank = _PACKAGE_POLICY_ACTION_RANK.get(stored_action, -1)
+    current_rank = _PACKAGE_POLICY_ACTION_RANK.get(current_action, -1)
+    return stored_action if stored_rank >= current_rank else current_action
+
 
 class RuntimeMcpGuardProxy:
     """Guard-managed MCP proxy for harnesses that talk stdio MCP to local servers."""
@@ -487,8 +503,9 @@ class RuntimeMcpGuardProxy:
             store=self.store,
             workspace_dir=self.context.workspace_dir,
         )
-        policy_action = (
-            stored_policy_action if isinstance(stored_policy_action, str) else package_evaluation.policy_action
+        policy_action = _most_restrictive_package_policy_action(
+            stored_policy_action if isinstance(stored_policy_action, str) else None,
+            package_evaluation.policy_action,
         )
         queue_policy_action = "require-reapproval" if policy_action == "review" else policy_action
         if queue_policy_action in {"allow", "warn"}:

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -749,7 +749,7 @@ def _heuristic_result(
         if package_result is None and source_url is not None and _is_git_source_url(source_url):
             package_result = _heuristic_package_result(
                 target=target,
-                decision="warn",
+                decision="ask",
                 code="git_dependency_source",
                 message="Git package source requires review before install.",
                 severity="high",
@@ -757,7 +757,7 @@ def _heuristic_result(
         if package_result is None and source_url is not None and _is_external_https_tarball_source(source_url):
             package_result = _heuristic_package_result(
                 target=target,
-                decision="warn",
+                decision="ask",
                 code="external_tarball_source",
                 message="External tarball source requires review before install.",
                 severity="medium",
@@ -1185,7 +1185,7 @@ def _local_source_dependency_result(target: dict[str, object]) -> dict[str, obje
         return None
     return _heuristic_package_result(
         target=target,
-        decision="warn",
+        decision="ask",
         code="local_path_dependency_source",
         message="Local path dependency requires review before install.",
         severity="medium",
@@ -1424,7 +1424,7 @@ def _local_python_build_result(target: dict[str, object], workspace_dir: Path | 
                 )
             return _heuristic_package_result(
                 target=target,
-                decision="warn",
+                decision="ask",
                 code="local_build_backend_risk",
                 message="Editable local Python installs can invoke pyproject build backend hooks from this workspace.",
                 severity="medium",
@@ -1635,7 +1635,7 @@ def _go_replace_result(
         if replacement.startswith(("file:", "./", "../", "/", "~", ".\\", "..\\")):
             return _heuristic_package_result(
                 target=target,
-                decision="warn",
+                decision="ask",
                 code="go_replace_local_source",
                 message="Go replace directive reroutes this module to a local path.",
                 severity="medium",
@@ -1643,7 +1643,7 @@ def _go_replace_result(
         if _exact_version(replacement) is None:
             return _heuristic_package_result(
                 target=target,
-                decision="warn",
+                decision="ask",
                 code="go_replace_mutable_source",
                 message="Go replace directive reroutes this module away from proxy-pinned version resolution.",
                 severity="medium",

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -32,6 +32,14 @@ _PACKAGE_SHIM_COMMANDS = {
     "yarn": "yarn",
 }
 _PACKAGE_SHIM_MANIFEST = "manifest.json"
+_TRUSTED_CLI_LAUNCHER = (
+    "import os, runpy, sys; "
+    "trusted_root = sys.argv.pop(1); "
+    "module_name = sys.argv.pop(1); "
+    "cwd = os.getcwd(); "
+    "sys.path = [trusted_root, *[entry for entry in sys.path if entry not in ('', cwd, trusted_root)]]; "
+    "runpy.run_module(module_name, run_name='__main__')"
+)
 
 
 def install_guard_shim(
@@ -101,7 +109,9 @@ def remove_guard_shim(
 def _build_python_shim(harness: str, context: HarnessContext, workspace_args: list[str]) -> str:
     command_args = [
         sys.executable,
-        "-m",
+        "-c",
+        _TRUSTED_CLI_LAUNCHER,
+        str(_trusted_import_root()),
         "codex_plugin_scanner.cli",
         "guard",
         "run",
@@ -263,11 +273,14 @@ def _build_package_manager_python_shim(context: HarnessContext, command: str) ->
     shim_dir = context.guard_home / "package-shims" / "bin"
     command_args = [
         sys.executable,
-        "-m",
+        "-c",
+        _TRUSTED_CLI_LAUNCHER,
+        str(_trusted_import_root()),
         "codex_plugin_scanner.cli",
         "guard",
         "protect",
         "--json",
+        "--dry-run",
         "--guard-home",
         str(context.guard_home),
         *_home_override_args(context),
@@ -285,7 +298,11 @@ def _build_package_manager_python_shim(context: HarnessContext, command: str) ->
             f"base_command = {command_args!r}",
             f"command_name = {command!r}",
             f"shim_dir = {str(shim_dir.resolve())!r}",
-            "guard_process = subprocess.run([*base_command, *sys.argv[1:]], capture_output=True, text=True)",
+            "guard_env = dict(os.environ)",
+            "guard_env.pop('PYTHONPATH', None)",
+            "guard_process = subprocess.run(",
+            "    [*base_command, *sys.argv[1:]], capture_output=True, text=True, env=guard_env",
+            ")",
             "if guard_process.stdout:",
             "    sys.stdout.write(guard_process.stdout)",
             "if guard_process.stderr:",
@@ -317,6 +334,10 @@ def _normalize_package_shim_managers(managers: tuple[str, ...] | None) -> tuple[
         if key in _PACKAGE_SHIM_COMMANDS and key not in normalized:
             normalized.append(key)
     return tuple(normalized)
+
+
+def _trusted_import_root() -> Path:
+    return Path(__file__).resolve().parents[2]
 
 
 def _package_shim_manifest_path(context: HarnessContext) -> Path:

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -37,7 +37,8 @@ _TRUSTED_CLI_LAUNCHER = (
     "trusted_root = sys.argv.pop(1); "
     "module_name = sys.argv.pop(1); "
     "cwd = os.getcwd(); "
-    "sys.path = [trusted_root, *[entry for entry in sys.path if entry not in ('', cwd, trusted_root)]]; "
+    "blocked_entries = ('', '.', os.curdir, cwd, trusted_root); "
+    "sys.path = [trusted_root, *[entry for entry in sys.path if entry not in blocked_entries]]; "
     "runpy.run_module(module_name, run_name='__main__')"
 )
 

--- a/tests/test_guard_js_supply_chain_phase11.py
+++ b/tests/test_guard_js_supply_chain_phase11.py
@@ -236,13 +236,13 @@ def test_evaluate_package_request_artifact_uses_manager_specific_fix_command(
 @pytest.mark.parametrize(
     ("command", "expected_decision", "expected_code"),
     [
-        ("npm install guard-github@github:hashgraph-online/hol-guard", "warn", "git_dependency_source"),
+        ("npm install guard-github@github:hashgraph-online/hol-guard", "ask", "git_dependency_source"),
         ("npm install guard-http@http://example.com/guard.tgz", "block", "insecure_source_url"),
-        ("npm install guard-https@https://example.com/guard.tgz", "warn", "external_tarball_source"),
-        ("npm install guard-query@https://example.com/guard.tgz?token=demo", "warn", "external_tarball_source"),
+        ("npm install guard-https@https://example.com/guard.tgz", "ask", "external_tarball_source"),
+        ("npm install guard-query@https://example.com/guard.tgz?token=demo", "ask", "external_tarball_source"),
         (
             "npm install guard-lookalike@https://registry.npmjs.org.evil.com/guard.tgz",
-            "warn",
+            "ask",
             "external_tarball_source",
         ),
     ],
@@ -266,7 +266,7 @@ def test_evaluate_package_request_artifact_applies_js_source_heuristics(
     assert result.packages[0]["reasons"][0]["code"] == expected_code
 
 
-def test_evaluate_package_request_artifact_uses_source_specific_risk_summary_for_warned_tarballs(
+def test_evaluate_package_request_artifact_uses_source_specific_risk_summary_for_reviewed_tarballs(
     tmp_path: Path,
 ) -> None:
     home_dir = tmp_path / "home"
@@ -280,7 +280,7 @@ def test_evaluate_package_request_artifact_uses_source_specific_risk_summary_for
     )
     result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
 
-    assert result.decision == "warn"
+    assert result.decision == "ask"
     assert "external tarball source" in result.risk_summary.lower()
 
 

--- a/tests/test_guard_mcp_package_proxy_phase14.py
+++ b/tests/test_guard_mcp_package_proxy_phase14.py
@@ -319,7 +319,7 @@ def test_phase14_runtime_mcp_proxy_forwards_allowed_package_call(
     assert store.list_approval_requests(limit=5) == []
 
 
-def test_phase14_runtime_mcp_proxy_honors_stored_allow_override(
+def test_phase14_runtime_mcp_proxy_rejects_stored_allow_when_current_package_blocks(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -389,12 +389,12 @@ def test_phase14_runtime_mcp_proxy_honors_stored_allow_override(
         ]
     )
 
-    assert marker_path.exists() is True
-    assert "error" not in result["responses"][2]
-    assert store.list_approval_requests(limit=5) == []
+    assert marker_path.exists() is False
+    assert result["responses"][2]["error"]["code"] == -32001
+    assert store.list_approval_requests(limit=5)
 
 
-def test_phase14_runtime_mcp_proxy_honors_stored_allow_override_without_workspace(
+def test_phase14_runtime_mcp_proxy_rejects_stored_allow_without_workspace_when_current_package_blocks(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -464,9 +464,9 @@ def test_phase14_runtime_mcp_proxy_honors_stored_allow_override_without_workspac
         ]
     )
 
-    assert marker_path.exists() is True
-    assert "error" not in result["responses"][2]
-    assert store.list_approval_requests(limit=5) == []
+    assert marker_path.exists() is False
+    assert result["responses"][2]["error"]["code"] == -32001
+    assert store.list_approval_requests(limit=5)
 
 
 def test_phase14_runtime_mcp_proxy_skips_requeue_for_stored_package_block(

--- a/tests/test_guard_package_shims.py
+++ b/tests/test_guard_package_shims.py
@@ -211,6 +211,7 @@ def test_package_manager_shim_uses_trusted_guard_import_path(tmp_path: Path, cap
     )
     env = dict(os.environ)
     env["PATH"] = f"{shim_path.parent}{os.pathsep}{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, [".", env.get("PYTHONPATH", "")]))
 
     result = subprocess.run(
         [str(shim_path), "install", "guard-github@git+https://example.com/guard.git"],

--- a/tests/test_guard_package_shims.py
+++ b/tests/test_guard_package_shims.py
@@ -16,6 +16,7 @@ from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generate_private_key
 
 from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.protect import build_protect_payload
 from codex_plugin_scanner.guard.store import GuardStore
 
 WORKSPACE_ID = "workspace-alpha"
@@ -144,7 +145,12 @@ def _seed_bundle(
     store.set_sync_credentials("https://hol.org/api/guard/receipts/sync", "demo-token", now, workspace_id=WORKSPACE_ID)
     store.cache_supply_chain_bundle(
         WORKSPACE_ID,
-        _bundle_response(action=action, ecosystem=ecosystem, package_name=package_name, package_version=package_version),
+        _bundle_response(
+            action=action,
+            ecosystem=ecosystem,
+            package_name=package_name,
+            package_version=package_version,
+        ),
         now,
     )
 
@@ -173,6 +179,116 @@ def _install_single_manager_shim(
     payload = json.loads(capsys.readouterr().out)
     assert rc == 0
     return Path(str(payload["shim_dir"])) / manager
+
+
+def test_package_manager_shim_uses_trusted_guard_import_path(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    malicious_package = workspace_dir / "codex_plugin_scanner"
+    malicious_package.mkdir()
+    (malicious_package / "__init__.py").write_text("", encoding="utf-8")
+    (malicious_package / "cli.py").write_text(
+        "\n".join(
+            [
+                "from pathlib import Path",
+                f"Path({str(tmp_path / 'malicious-imported')!r}).write_text('owned', encoding='utf-8')",
+                "raise SystemExit(66)",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    marker_path = tmp_path / "npm-ran.json"
+    _write_fake_manager_script(fake_bin=fake_bin, manager="npm", marker_path=marker_path, exit_code=0)
+    shim_path = _install_single_manager_shim(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        manager="npm",
+        capsys=capsys,
+    )
+    env = dict(os.environ)
+    env["PATH"] = f"{shim_path.parent}{os.pathsep}{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+
+    result = subprocess.run(
+        [str(shim_path), "install", "guard-github@git+https://example.com/guard.git"],
+        cwd=workspace_dir,
+        env=env,
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 2
+    assert (tmp_path / "malicious-imported").exists() is False
+    assert marker_path.exists() is False
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        ["npm", "install", "guard-github@git+https://example.com/guard.git"],
+        ["npm", "install", "guard-tarball@https://example.com/guard.tgz"],
+        ["npm", "install", "file:./vendor/guard"],
+    ],
+)
+def test_guard_protect_requires_review_for_untrusted_package_sources_without_cloud(
+    tmp_path: Path,
+    command: list[str],
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    store = GuardStore(home_dir)
+
+    payload, exit_code = build_protect_payload(
+        command=command,
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=False,
+        now="2026-05-25T00:00:00Z",
+    )
+
+    assert exit_code == 2
+    assert payload["executed"] is False
+    assert payload["verdict"]["blocking"] is True
+    assert payload["verdict"]["action"] == "review"
+
+
+def test_package_manager_shim_runs_allowed_command_once_when_shim_dir_is_on_path(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    marker_path = tmp_path / "npm-allowed.json"
+    _write_fake_manager_script(fake_bin=fake_bin, manager="npm", marker_path=marker_path, exit_code=0)
+    shim_path = _install_single_manager_shim(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        manager="npm",
+        capsys=capsys,
+    )
+    env = dict(os.environ)
+    env["PATH"] = f"{shim_path.parent}{os.pathsep}{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+
+    result = subprocess.run(
+        [str(shim_path), "install", "minimist@1.2.9"],
+        cwd=workspace_dir,
+        env=env,
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=30,
+    )
+    marker_payload = json.loads(marker_path.read_text(encoding="utf-8"))
+
+    assert result.returncode == 0
+    assert marker_payload["argv"][1:] == ["install", "minimist@1.2.9"]
+    assert marker_payload["cwd"] == str(workspace_dir)
 
 
 def _write_fake_manager_script(

--- a/tests/test_guard_python_lab_phase12.py
+++ b/tests/test_guard_python_lab_phase12.py
@@ -172,7 +172,7 @@ def test_python_simple_index_lab_blocks_vulnerable_version_and_serves_safe_wheel
             workspace_dir=workspace_dir,
         )
 
-        assert vcs_result.decision == "warn"
+        assert vcs_result.decision == "ask"
         assert vcs_result.packages[0]["reasons"][0]["code"] == "git_dependency_source"
 
         download_dir = tmp_path / "downloads"

--- a/tests/test_guard_python_supply_chain_heuristics_phase12.py
+++ b/tests/test_guard_python_supply_chain_heuristics_phase12.py
@@ -86,7 +86,7 @@ def test_evaluate_package_request_artifact_ignores_cross_ecosystem_bundle_matche
         "pip install https://example.com/packages/private-demo-1.0.0.tar.gz",
     ],
 )
-def test_evaluate_package_request_artifact_warns_on_python_vcs_and_direct_url_sources(
+def test_evaluate_package_request_artifact_requires_review_for_python_vcs_and_direct_url_sources(
     tmp_path: Path,
     command: str,
 ) -> None:
@@ -98,7 +98,7 @@ def test_evaluate_package_request_artifact_warns_on_python_vcs_and_direct_url_so
     artifact = artifact_from_command_fixture(command, workspace=workspace_dir)
     result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
 
-    assert result.decision == "warn"
+    assert result.decision == "ask"
     assert result.packages[0]["reasons"][0]["code"] in {"git_dependency_source", "external_tarball_source"}
 
 
@@ -115,11 +115,11 @@ def test_evaluate_package_request_artifact_prefers_editable_vcs_urls_over_local_
         'pip install -e "private-demo @ git+https://example.com/org/private-demo.git"', workspace=workspace_dir
     )
     result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
-    assert result.decision == "warn"
+    assert result.decision == "ask"
     assert result.packages[0]["reasons"][0]["code"] == "git_dependency_source"
 
 
-def test_evaluate_package_request_artifact_warns_on_editable_local_python_builds(tmp_path: Path) -> None:
+def test_evaluate_package_request_artifact_requires_review_for_editable_local_python_builds(tmp_path: Path) -> None:
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir()
@@ -137,7 +137,7 @@ build-backend = "setuptools.build_meta"
     artifact = artifact_from_command_fixture("pip install -e .", workspace=workspace_dir)
     result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
 
-    assert result.decision == "warn"
+    assert result.decision == "ask"
     assert result.packages[0]["reasons"][0]["code"] == "local_build_backend_risk"
 
 
@@ -190,7 +190,7 @@ build-backend = "setuptools.build_meta"
     artifact = artifact_from_command_fixture("pip install -e ~/local-demo", workspace=workspace_dir)
     result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
 
-    assert result.decision == "warn"
+    assert result.decision == "ask"
     assert result.packages[0]["reasons"][0]["code"] == "local_build_backend_risk"
 
 
@@ -216,7 +216,7 @@ build-backend = "setuptools.build_meta"
     artifact = artifact_from_command_fixture("pip install path/to/local-demo", workspace=workspace_dir)
     result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
 
-    assert result.decision == "warn"
+    assert result.decision == "ask"
     assert result.packages[0]["reasons"][0]["code"] == "local_build_backend_risk"
 
 
@@ -240,11 +240,11 @@ build-backend = "setuptools.build_meta"
     artifact = artifact_from_command_fixture("pip install .[pdf]", workspace=workspace_dir)
     result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
 
-    assert result.decision == "warn"
+    assert result.decision == "ask"
     assert result.packages[0]["reasons"][0]["code"] == "local_build_backend_risk"
 
 
-def test_evaluate_package_request_artifact_keeps_benign_pyproject_urls_as_warn_only(tmp_path: Path) -> None:
+def test_evaluate_package_request_artifact_requires_review_for_benign_pyproject_url_editable(tmp_path: Path) -> None:
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir()
@@ -270,7 +270,7 @@ Repository = "https://example.com/demo.git"
     artifact = artifact_from_command_fixture("pip install -e .", workspace=workspace_dir)
     result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
 
-    assert result.decision == "warn"
+    assert result.decision == "ask"
     assert result.packages[0]["reasons"][0]["code"] == "local_build_backend_risk"
 
 

--- a/tests/test_guard_tier2_supply_chain_phase13.py
+++ b/tests/test_guard_tier2_supply_chain_phase13.py
@@ -79,7 +79,7 @@ version = "4.5.7"
     assert result.packages[0]["supportLevel"] == "beta"
 
 
-def test_evaluate_package_request_artifact_warns_on_cargo_local_path_without_leaking_path(
+def test_evaluate_package_request_artifact_requires_review_on_cargo_local_path_without_leaking_path(
     tmp_path: Path,
 ) -> None:
     workspace_dir = tmp_path / "workspace"
@@ -94,13 +94,13 @@ def test_evaluate_package_request_artifact_warns_on_cargo_local_path_without_lea
 
     payload = json.dumps(result.to_dict())
 
-    assert result.decision == "warn"
+    assert result.decision == "ask"
     assert result.packages[0]["reasons"][0]["code"] == "local_path_dependency_source"
     assert result.packages[0]["supportLevel"] == "beta"
     assert "crates/demo" not in payload
 
 
-def test_evaluate_package_request_artifact_warns_on_cargo_git_sources(
+def test_evaluate_package_request_artifact_requires_review_on_cargo_git_sources(
     tmp_path: Path,
 ) -> None:
     workspace_dir = tmp_path / "workspace"
@@ -116,7 +116,7 @@ def test_evaluate_package_request_artifact_warns_on_cargo_git_sources(
         workspace_dir=workspace_dir,
     )
 
-    assert result.decision == "warn"
+    assert result.decision == "ask"
     assert result.packages[0]["reasons"][0]["code"] == "git_dependency_source"
     assert result.packages[0]["supportLevel"] == "beta"
 
@@ -165,7 +165,7 @@ require github.com/gin-gonic/gin v1.10.0
     assert result.packages[0]["supportLevel"] == "beta"
 
 
-def test_evaluate_package_request_artifact_warns_on_go_replace_local_path_without_leaking_path(
+def test_evaluate_package_request_artifact_requires_review_on_go_replace_local_path_without_leaking_path(
     tmp_path: Path,
 ) -> None:
     workspace_dir = tmp_path / "workspace"
@@ -193,7 +193,7 @@ replace github.com/gin-gonic/gin => ../forks/gin
 
     payload = json.dumps(result.to_dict())
 
-    assert result.decision == "warn"
+    assert result.decision == "ask"
     assert result.packages[0]["reasons"][0]["code"] == "go_replace_local_source"
     assert result.packages[0]["supportLevel"] == "beta"
     assert "../forks/gin" not in payload


### PR DESCRIPTION
## Summary
- pin Guard package shim imports to the trusted installed package root and strip PYTHONPATH for Guard checks
- run package-shim Guard checks as dry-run gates before invoking the real package manager
- require review for untrusted git, external tarball, local path, editable backend, and mutable Go replace sources
- prevent stored MCP package allow decisions from overriding current supply-chain blocks

## Security alerts
- SA001 valid-fixed: package shims no longer load Guard from untrusted cwd
- SA003 valid-fixed: warn-only risky package sources no longer execute without review
- SA004 valid-fixed: MCP stored allow no longer overrides current package block
- SA007 valid-fixed: git URL npm specs now require review
- SA009 valid-fixed: cached/stored package allows no longer bypass current MCP supply-chain blocks

## Verification
- uv run ruff check src/codex_plugin_scanner/guard/shims.py src/codex_plugin_scanner/guard/local_supply_chain.py src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py src/codex_plugin_scanner/guard/proxy/runtime_mcp.py tests/test_guard_package_shims.py tests/test_guard_js_supply_chain_phase11.py tests/test_guard_mcp_package_proxy_phase14.py tests/test_guard_tier2_supply_chain_phase13.py
- uv run pytest tests/test_guard_package_shims.py tests/test_guard_js_supply_chain_phase11.py tests/test_guard_mcp_package_proxy_phase14.py tests/test_guard_python_supply_chain_phase12.py tests/test_guard_tier2_supply_chain_phase13.py -q

## Notes
- Full repo ruff is currently blocked by pre-existing E501 issues in tests/test_guard_phase07_harness_coverage_matrix.py.
- Full pytest reached 74% before the local process was killed with exit 137; focused package-firewall suites passed.