### PR TITLE
fix(guard): tighten transitive lockfile decisions

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -39,7 +39,9 @@ from .runner import (
 )
 from .supply_chain import detect_supply_chain_risk
 from .supply_chain_bundle import (
+    SupplyChainBundleExpiredError,
     SupplyChainBundleMalformedError,
+    check_supply_chain_bundle_freshness,
     evaluate_cached_supply_chain_bundle,
     load_supply_chain_bundle_response,
 )
@@ -968,7 +970,7 @@ def _lockfile_context(workspace_dir: Path | None, artifact: GuardArtifact) -> di
     except (OSError, UnicodeDecodeError):
         return None
     dependencies = _safe_dependency_map_for_path(
-        str(lockfile_path.name), lockfile_text, deadline=time.monotonic() + 0.2
+        str(lockfile_path.name), lockfile_text, deadline=time.monotonic() + _LOCKFILE_PARSE_BUDGET_SECONDS
     )
     manifest_hashes = _hash_paths(workspace_dir, artifact.metadata.get("manifest_paths"))
     return {
@@ -993,9 +995,12 @@ def _transitive_lockfile_results(
     if not isinstance(lockfile_paths, list):
         return []
     results: list[dict[str, object]] = []
+    bundle_stale = _is_bundle_stale(bundle_response, now_timestamp=now_timestamp)
+    bundle_index = _bundle_package_index(bundle_response)
     direct_target_names_by_ecosystem: dict[str, set[str]] = {}
     all_direct_target_names: set[str] = set()
-    for target in _targets_from_artifact(artifact):
+    direct_targets = _targets_from_artifact(artifact)
+    for target in direct_targets:
         ecosystem = _optional_string(target.get("ecosystem")) or "npm"
         candidate_names = {str(target["normalized_name"]), *_target_candidate_names(target)}
         direct_target_names_by_ecosystem.setdefault(ecosystem, set()).update(candidate_names)
@@ -1016,60 +1021,65 @@ def _transitive_lockfile_results(
             continue
         dependency_entries: list[tuple[str, str, str, bool]] = []
         parse_deadline = time.monotonic() + _LOCKFILE_PARSE_BUDGET_SECONDS
-        if lockfile_path.name == "package-lock.json":
-            dependency_entries = [
-                (
-                    dependency_path,
-                    package_name,
-                    version,
-                    dependency_path in direct_target_names,
-                )
-                for dependency_path, package_name, version, _direct in _package_lock_entries(
-                    lockfile_text, deadline=parse_deadline
-                )
-            ]
-        else:
-            dependency_map = _safe_dependency_map_for_path(
-                str(lockfile_path.name),
-                lockfile_text,
-                deadline=parse_deadline,
-            )
-            for dependency_path, version in dependency_map.items():
-                normalized_dependency_path = dependency_path.strip("/")
-                if not normalized_dependency_path:
-                    continue
-                package_name = _dependency_package_name(normalized_dependency_path)
-                if package_name is None:
-                    continue
-                dependency_entries.append(
+        try:
+            if lockfile_path.name == "package-lock.json":
+                dependency_entries = [
                     (
                         dependency_path,
                         package_name,
                         version,
-                        normalized_dependency_path in direct_target_names,
+                        dependency_path in direct_target_names,
                     )
+                    for dependency_path, package_name, version, _direct in _package_lock_entries(
+                        lockfile_text, deadline=parse_deadline
+                    )
+                ]
+            else:
+                dependency_map = _safe_dependency_map_for_path(
+                    str(lockfile_path.name),
+                    lockfile_text,
+                    deadline=parse_deadline,
                 )
+                for dependency_path, version in dependency_map.items():
+                    normalized_dependency_path = dependency_path.strip("/")
+                    if not normalized_dependency_path:
+                        continue
+                    package_name = _dependency_package_name(normalized_dependency_path)
+                    if package_name is None:
+                        continue
+                    dependency_entries.append(
+                        (
+                            dependency_path,
+                            package_name,
+                            version,
+                            normalized_dependency_path in direct_target_names,
+                        )
+                    )
+        except _DeadlineExceededError:
+            timeout_warning = _transitive_lockfile_timeout_warning(
+                targets=direct_targets,
+                lockfile_name=lockfile_path.name,
+            )
+            if timeout_warning is not None:
+                results.append(timeout_warning)
+            continue
         for dependency_path, package_name, version, direct in dependency_entries:
             if direct:
                 continue
-            offline = evaluate_cached_supply_chain_bundle(
-                bundle_response,
-                package_name=package_name,
-                package_version=version,
-                ecosystem=lockfile_ecosystem,
-                now=now_timestamp,
-            )
-            package_match = _bundle_package(
-                bundle_response,
+            package_match = _bundle_package_from_index(
+                bundle_index,
                 package_name=package_name,
                 package_version=version,
                 ecosystem=lockfile_ecosystem,
             )
             if package_match is None:
                 continue
-            decision = _transitive_lockfile_decision(package=package_match, offline_action=offline.action)
+            decision = _transitive_lockfile_decision(package=package_match, stale=bundle_stale)
             if decision not in {"ask", "block", "warn"}:
                 continue
+            downgraded_low_confidence = (
+                decision == "warn" and _normalize_bundle_action(package_match.default_action) == "block"
+            )
             results.append(
                 {
                     "decision": decision,
@@ -1086,17 +1096,15 @@ def _transitive_lockfile_results(
                     "redactedCommand": _optional_string(artifact.metadata.get("redacted_command")),
                     "reasons": (
                         {
-                            "code": (
-                                "transitive_low_confidence_match"
-                                if decision == "warn" and _normalize_bundle_action(offline.action) == "block"
-                                else "transitive_lockfile_match"
-                            ),
+                            "code": "transitive_low_confidence_match"
+                            if downgraded_low_confidence
+                            else "transitive_lockfile_match",
                             "message": (
                                 (
                                     "Existing lockfile includes transitive dependency path "
                                     f"{dependency_path} with lower-confidence risk signals."
                                 )
-                                if decision == "warn" and _normalize_bundle_action(offline.action) == "block"
+                                if downgraded_low_confidence
                                 else f"Existing lockfile already includes vulnerable dependency path {dependency_path}."
                             ),
                             "severity": package_match.normalized_severity,
@@ -1108,8 +1116,10 @@ def _transitive_lockfile_results(
     return results
 
 
-def _transitive_lockfile_decision(*, package: SupplyChainBundlePackage, offline_action: str) -> str:
-    decision = _normalize_bundle_action(offline_action)
+def _transitive_lockfile_decision(*, package: SupplyChainBundlePackage, stale: bool) -> str:
+    decision = _normalize_bundle_action(package.default_action if package.default_action != "allow" else "monitor")
+    if stale and not _is_high_confidence_block(package):
+        return "warn" if decision in {"block", "ask", "warn"} else "monitor"
     if decision != "block":
         return decision
     if _is_high_confidence_block(package):
@@ -1117,6 +1127,59 @@ def _transitive_lockfile_decision(*, package: SupplyChainBundlePackage, offline_
     if package.confidence >= _TRANSITIVE_BLOCK_CONFIDENCE_THRESHOLD:
         return "block"
     return "warn"
+
+
+def _is_bundle_stale(bundle_response: SupplyChainBundleResponse, *, now_timestamp: float | None) -> bool:
+    try:
+        check_supply_chain_bundle_freshness(bundle_response.bundle, now=now_timestamp)
+    except SupplyChainBundleExpiredError:
+        return True
+    return False
+
+
+def _bundle_package_index(
+    bundle_response: SupplyChainBundleResponse,
+) -> dict[tuple[str, str, str], SupplyChainBundlePackage]:
+    index: dict[tuple[str, str, str], SupplyChainBundlePackage] = {}
+    for package in bundle_response.bundle.packages:
+        normalized_name = _normalize_package_name(package.ecosystem, package.name)
+        index[(package.ecosystem, normalized_name, package.version)] = package
+        if package.namespace is not None:
+            qualified_name = _normalize_package_name(package.ecosystem, f"{package.namespace}/{package.name}")
+            index[(package.ecosystem, qualified_name, package.version)] = package
+    return index
+
+
+def _bundle_package_from_index(
+    index: dict[tuple[str, str, str], SupplyChainBundlePackage],
+    *,
+    package_name: str,
+    package_version: str,
+    ecosystem: str | None = None,
+) -> SupplyChainBundlePackage | None:
+    if ecosystem is None:
+        return None
+    normalized_name = _normalize_package_name(ecosystem, package_name)
+    return index.get((ecosystem, normalized_name, package_version))
+
+
+def _transitive_lockfile_timeout_warning(
+    *,
+    targets: tuple[dict[str, object], ...],
+    lockfile_name: str,
+) -> dict[str, object] | None:
+    if not targets:
+        return None
+    return _heuristic_package_result(
+        target=targets[0],
+        decision="warn",
+        code="transitive_lockfile_timeout",
+        message=(
+            f"Guard only partially scanned {lockfile_name} before the resolver deadline; "
+            "transitive dependency results may be incomplete."
+        ),
+        severity="unknown",
+    )
 
 
 def _parse_evaluation_timestamp(now_value: str) -> float | None:
@@ -1915,7 +1978,10 @@ def _package_lock_target_versions(
     text: str,
     targets: tuple[dict[str, object], ...],
 ) -> dict[tuple[str, str | None], str]:
-    entries = _package_lock_entries(text, deadline=time.monotonic() + _LOCKFILE_PARSE_BUDGET_SECONDS)
+    try:
+        entries = _package_lock_entries(text, deadline=time.monotonic() + _LOCKFILE_PARSE_BUDGET_SECONDS)
+    except _DeadlineExceededError:
+        return {}
     versions: dict[tuple[str, str | None], str] = {}
     for target in targets:
         target_key = _lockfile_target_key(target)

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -48,6 +48,7 @@ from .supply_chain_bundle_models import (
     SupplyChainBundlePolicyRule,
     SupplyChainBundleResponse,
 )
+from .supply_chain_bundle_runtime import _is_high_confidence_block
 from .supply_chain_support import ecosystem_support_metadata
 
 _DECISION_RANK = {"allow": 0, "monitor": 1, "warn": 2, "ask": 3, "block": 4}
@@ -55,6 +56,8 @@ _SEVERITY_RANK = {"unknown": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
 _TIMEOUT_SECONDS = 1
 _RETRY_TIMEOUT_SECONDS = 1
 _CLOUD_DASHBOARD_URL = "https://hol.org/guard/inbox"
+_LOCKFILE_PARSE_BUDGET_SECONDS = 0.2
+_TRANSITIVE_BLOCK_CONFIDENCE_THRESHOLD = 900
 _NPM_REGISTRY_METADATA_BASE_URL = "https://registry.npmjs.org"
 _PYPI_REGISTRY_METADATA_BASE_URL = "https://pypi.org/pypi"
 
@@ -175,6 +178,7 @@ def evaluate_package_request_artifact(
     now: str | None = None,
 ) -> PackageRequestEvaluation:
     now_value = now or datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    now_timestamp = _parse_evaluation_timestamp(now_value)
     targets = _targets_from_artifact(artifact)
     package_intent_hash = artifact.artifact_id.rsplit(":", 1)[-1]
     workspace_id = store.get_cloud_workspace_id()
@@ -221,6 +225,7 @@ def evaluate_package_request_artifact(
             bundle_response=bundle_response,
             workspace_dir=workspace_dir,
             workspace_id=workspace_id,
+            now_timestamp=now_timestamp,
         )
         if bundle_response is not None
         else None
@@ -572,6 +577,7 @@ def _evaluate_with_bundle(
     bundle_response,
     workspace_dir: Path | None,
     workspace_id: str | None,
+    now_timestamp: float | None,
 ) -> _EvaluationDraft | None:
     bundle_meta = _bundle_meta(bundle_response.to_dict())
     refresh_required = False
@@ -617,6 +623,7 @@ def _evaluate_with_bundle(
             package_name=str(target["normalized_name"]),
             package_version=resolved_version,
             ecosystem=_optional_string(target.get("ecosystem")) or "npm",
+            now=now_timestamp,
         )
         if package_match is None:
             safe_allow = _recommended_fix_allow_package_result(
@@ -652,6 +659,7 @@ def _evaluate_with_bundle(
             bundle_response=bundle_response,
             artifact=artifact,
             workspace_dir=workspace_dir,
+            now_timestamp=now_timestamp,
         )
         if (
             _optional_string(package.get("namespace")),
@@ -973,7 +981,11 @@ def _lockfile_context(workspace_dir: Path | None, artifact: GuardArtifact) -> di
 
 
 def _transitive_lockfile_results(
-    *, bundle_response: SupplyChainBundleResponse, artifact: GuardArtifact, workspace_dir: Path | None
+    *,
+    bundle_response: SupplyChainBundleResponse,
+    artifact: GuardArtifact,
+    workspace_dir: Path | None,
+    now_timestamp: float | None = None,
 ) -> list[dict[str, object]]:
     if workspace_dir is None:
         return []
@@ -1003,6 +1015,7 @@ def _transitive_lockfile_results(
         except (OSError, UnicodeDecodeError):
             continue
         dependency_entries: list[tuple[str, str, str, bool]] = []
+        parse_deadline = time.monotonic() + _LOCKFILE_PARSE_BUDGET_SECONDS
         if lockfile_path.name == "package-lock.json":
             dependency_entries = [
                 (
@@ -1011,13 +1024,15 @@ def _transitive_lockfile_results(
                     version,
                     dependency_path in direct_target_names,
                 )
-                for dependency_path, package_name, version, _direct in _package_lock_entries(lockfile_text)
+                for dependency_path, package_name, version, _direct in _package_lock_entries(
+                    lockfile_text, deadline=parse_deadline
+                )
             ]
         else:
             dependency_map = _safe_dependency_map_for_path(
                 str(lockfile_path.name),
                 lockfile_text,
-                deadline=time.monotonic() + 0.2,
+                deadline=parse_deadline,
             )
             for dependency_path, version in dependency_map.items():
                 normalized_dependency_path = dependency_path.strip("/")
@@ -1042,9 +1057,8 @@ def _transitive_lockfile_results(
                 package_name=package_name,
                 package_version=version,
                 ecosystem=lockfile_ecosystem,
+                now=now_timestamp,
             )
-            if _normalize_bundle_action(offline.action) not in {"ask", "block", "warn"}:
-                continue
             package_match = _bundle_package(
                 bundle_response,
                 package_name=package_name,
@@ -1053,9 +1067,12 @@ def _transitive_lockfile_results(
             )
             if package_match is None:
                 continue
+            decision = _transitive_lockfile_decision(package=package_match, offline_action=offline.action)
+            if decision not in {"ask", "block", "warn"}:
+                continue
             results.append(
                 {
-                    "decision": _normalize_bundle_action(offline.action),
+                    "decision": decision,
                     "ecosystem": package_match.ecosystem,
                     "name": package_match.name,
                     "namespace": package_match.namespace,
@@ -1069,9 +1086,18 @@ def _transitive_lockfile_results(
                     "redactedCommand": _optional_string(artifact.metadata.get("redacted_command")),
                     "reasons": (
                         {
-                            "code": "transitive_lockfile_match",
+                            "code": (
+                                "transitive_low_confidence_match"
+                                if decision == "warn" and _normalize_bundle_action(offline.action) == "block"
+                                else "transitive_lockfile_match"
+                            ),
                             "message": (
-                                f"Existing lockfile already includes vulnerable dependency path {dependency_path}."
+                                (
+                                    "Existing lockfile includes transitive dependency path "
+                                    f"{dependency_path} with lower-confidence risk signals."
+                                )
+                                if decision == "warn" and _normalize_bundle_action(offline.action) == "block"
+                                else f"Existing lockfile already includes vulnerable dependency path {dependency_path}."
                             ),
                             "severity": package_match.normalized_severity,
                             "source": "lockfile",
@@ -1080,6 +1106,24 @@ def _transitive_lockfile_results(
                 }
             )
     return results
+
+
+def _transitive_lockfile_decision(*, package: SupplyChainBundlePackage, offline_action: str) -> str:
+    decision = _normalize_bundle_action(offline_action)
+    if decision != "block":
+        return decision
+    if _is_high_confidence_block(package):
+        return "block"
+    if package.confidence >= _TRANSITIVE_BLOCK_CONFIDENCE_THRESHOLD:
+        return "block"
+    return "warn"
+
+
+def _parse_evaluation_timestamp(now_value: str) -> float | None:
+    try:
+        return datetime.fromisoformat(now_value.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
 
 
 def _lockfile_ecosystem(lockfile_name: str) -> str | None:
@@ -1871,7 +1915,7 @@ def _package_lock_target_versions(
     text: str,
     targets: tuple[dict[str, object], ...],
 ) -> dict[tuple[str, str | None], str]:
-    entries = _package_lock_entries(text)
+    entries = _package_lock_entries(text, deadline=time.monotonic() + _LOCKFILE_PARSE_BUDGET_SECONDS)
     versions: dict[tuple[str, str | None], str] = {}
     for target in targets:
         target_key = _lockfile_target_key(target)
@@ -1886,12 +1930,14 @@ def _package_lock_target_versions(
     return versions
 
 
-def _package_lock_entries(text: str) -> list[tuple[str, str, str, bool]]:
+def _package_lock_entries(text: str, *, deadline: float | None = None) -> list[tuple[str, str, str, bool]]:
     payload = json.loads(text or "{}")
     entries: list[tuple[str, str, str, bool]] = []
     packages = payload.get("packages")
     if isinstance(packages, dict):
         for package_path, value in packages.items():
+            if deadline is not None and time.monotonic() > deadline:
+                break
             if not isinstance(package_path, str) or not package_path.startswith("node_modules/"):
                 continue
             version = value.get("version") if isinstance(value, dict) else None
@@ -1910,7 +1956,7 @@ def _package_lock_entries(text: str) -> list[tuple[str, str, str, bool]]:
         return entries
     legacy_dependencies = payload.get("dependencies")
     if isinstance(legacy_dependencies, dict):
-        _walk_package_lock_entries(legacy_dependencies, entries, prefix=None)
+        _walk_package_lock_entries(legacy_dependencies, entries, prefix=None, deadline=deadline)
     return entries
 
 
@@ -1919,8 +1965,11 @@ def _walk_package_lock_entries(
     entries: list[tuple[str, str, str, bool]],
     *,
     prefix: str | None,
+    deadline: float | None,
 ) -> None:
     for package_name, value in payload.items():
+        if deadline is not None and time.monotonic() > deadline:
+            return
         if not isinstance(package_name, str) or not isinstance(value, dict):
             continue
         version = value.get("version")
@@ -1936,7 +1985,7 @@ def _walk_package_lock_entries(
             )
         nested_dependencies = value.get("dependencies")
         if isinstance(nested_dependencies, dict):
-            _walk_package_lock_entries(nested_dependencies, entries, prefix=dependency_path)
+            _walk_package_lock_entries(nested_dependencies, entries, prefix=dependency_path, deadline=deadline)
 
 
 def _package_lock_candidate_names(target: dict[str, object]) -> tuple[str, ...]:

--- a/tests/test_guard_python_supply_chain_phase12.py
+++ b/tests/test_guard_python_supply_chain_phase12.py
@@ -378,7 +378,10 @@ source = { registry = "https://pypi.org/simple" }
         workspace_dir=workspace_dir,
     )
 
-    assert results == []
+    assert len(results) == 1
+    assert results[0]["ecosystem"] == "pypi"
+    assert results[0]["name"] == "requests"
+    assert results[0]["decision"] == "warn"
 
 
 def test_evaluate_package_request_artifact_uses_manager_specific_fix_commands_for_python_transitives(

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -19,6 +19,7 @@ from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generate_private_key
 
 import codex_plugin_scanner.guard.runtime.supply_chain_package_eval as evaluator_module
+from codex_plugin_scanner.guard.runtime.package_manifest_diff import _DeadlineExceededError
 from codex_plugin_scanner.guard.runtime.package_intent_common import (
     PackageIntent,
     build_package_request_artifact,
@@ -1111,6 +1112,47 @@ def test_transitive_lockfile_resolution_uses_bounded_deadline(
     )
 
     assert captured["deadline"] == pytest.approx(100.2)
+
+
+def test_transitive_lockfile_timeout_surfaces_warn_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="minimist",
+                version="1.2.8",
+                default_action="block",
+                recommended_fix_version="1.2.9",
+            )
+        ]
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, response, "2026-05-19T00:00:00Z")
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    (workspace_dir / "package-lock.json").write_text(
+        json.dumps({"packages": {"": {"name": "demo-app"}, "node_modules/react/node_modules/minimist": {"version": "1.2.8"}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        evaluator_module,
+        "_package_lock_entries",
+        lambda _text, *, deadline=None: (_ for _ in ()).throw(_DeadlineExceededError("deadline_exceeded")),
+    )
+
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("react@18.0.0", lockfile_paths=("package-lock.json",)),
+        store=store,
+        workspace_dir=workspace_dir,
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "warn"
+    assert any(reason["code"] == "transitive_lockfile_timeout" for reason in result.reasons)
+    assert "package-lock.json" in result.user_copy.harness_message
 
 
 def test_package_from_cloud_result_preserves_direct_and_dependency_path_schema() -> None:

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -132,6 +132,7 @@ def _package(
     name: str,
     version: str,
     default_action: str,
+    confidence: int = 990,
     normalized_severity: str = "critical",
     exploit_level: str = "active",
     known_exploited: bool = True,
@@ -141,7 +142,7 @@ def _package(
     risk_score: int = 980,
 ) -> dict[str, object]:
     return {
-        "confidence": 990,
+        "confidence": confidence,
         "defaultAction": default_action,
         "ecosystem": ecosystem,
         "exploitLevel": exploit_level,
@@ -1011,6 +1012,105 @@ def test_evaluate_package_request_artifact_blocks_transitive_lockfile_match_with
     assert transitive_match["dependencyPath"] == "react/node_modules/minimist"
     assert transitive_match["direct"] is False
     assert any("react/node_modules/minimist" in reason["message"] for reason in result.reasons)
+
+
+def test_evaluate_package_request_artifact_warns_for_low_confidence_transitive_lockfile_match(
+    tmp_path: Path,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
+    )
+    response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="debug",
+                version="4.3.4",
+                default_action="block",
+                confidence=650,
+                normalized_severity="high",
+                exploit_level="none",
+                known_exploited=False,
+                malware_state="none",
+                recommended_fix_version="4.3.5",
+                risk_score=610,
+            )
+        ]
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, response, "2026-05-19T00:00:00Z")
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    (workspace_dir / "package-lock.json").write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "": {"name": "demo-app"},
+                    "node_modules/react": {"version": "18.0.0"},
+                    "node_modules/react/node_modules/debug": {"version": "4.3.4"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("react@18.0.0", lockfile_paths=("package-lock.json",)),
+        store=store,
+        workspace_dir=workspace_dir,
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "warn"
+    transitive_match = next(package for package in result.packages if package["name"] == "debug")
+    assert transitive_match["decision"] == "warn"
+    assert transitive_match["dependencyPath"] == "react/node_modules/debug"
+    assert "react/node_modules/debug" in result.user_copy.harness_message
+
+
+def test_transitive_lockfile_resolution_uses_bounded_deadline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="minimist",
+                version="1.2.8",
+                default_action="block",
+                recommended_fix_version="1.2.9",
+            )
+        ]
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, response, "2026-05-19T00:00:00Z")
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    (workspace_dir / "package-lock.json").write_text(
+        json.dumps({"packages": {"": {"name": "demo-app"}, "node_modules/react/node_modules/minimist": {"version": "1.2.8"}}}),
+        encoding="utf-8",
+    )
+    captured: dict[str, float] = {}
+
+    def fake_package_lock_entries(
+        lockfile_text: str, *, deadline: float | None = None
+    ) -> list[tuple[str, str, str, bool]]:
+        captured["deadline"] = deadline
+        assert "minimist" in lockfile_text
+        return [("react/node_modules/minimist", "minimist", "1.2.8", False)]
+
+    monkeypatch.setattr(evaluator_module.time, "monotonic", lambda: 100.0)
+    monkeypatch.setattr(evaluator_module, "_package_lock_entries", fake_package_lock_entries)
+
+    evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("react@18.0.0", lockfile_paths=("package-lock.json",)),
+        store=store,
+        workspace_dir=workspace_dir,
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert captured["deadline"] == pytest.approx(100.2)
 
 
 def test_package_from_cloud_result_preserves_direct_and_dependency_path_schema() -> None:


### PR DESCRIPTION
## Summary\n- tighten transitive lockfile evaluation so lower-confidence hits warn instead of disappearing behind stale monitor fallbacks\n- pass the requested evaluation time into offline bundle checks and add an explicit package-lock parse budget\n- cover low-confidence transitive warnings, dependency-path terminal copy, and bounded parse deadlines with regressions\n\n## Testing\n- python3 -m pytest tests/test_guard_supply_chain_evaluator.py tests/test_guard_js_supply_chain_phase11.py tests/test_guard_js_lockfile_resolution_phase11.py tests/test_guard_python_supply_chain_phase12.py tests/test_guard_python_supply_chain_heuristics_phase12.py -q\n- uv sync --frozen --extra dev --python 3.12\n- uv run --no-sync python -m ruff check src/\n- uv run --no-sync python -m ruff format --check src/