### PR TITLE
fix(codex): restore approval handoff resume

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3547,13 +3547,10 @@ def _should_emit_native_hook_json_response(
 
 
 def _should_emit_native_hook_exit_block(args: argparse.Namespace, *, event_name: str, policy_action: str) -> bool:
-    return (
-        args.harness == "codex"
-        and event_name == "PreToolUse"
-        and policy_action in {"block", "sandbox-required", "require-reapproval"}
-        and not getattr(args, "json", False)
-        and _is_codex_native_runtime()
-    )
+    _ = (args, event_name, policy_action)
+    # Codex v0.133 logs non-zero PreToolUse hooks as failed but still executes
+    # the tool. Blocking must be communicated through the JSON hook response.
+    return False
 
 
 def _is_codex_native_runtime() -> bool:
@@ -3579,6 +3576,11 @@ def _codex_browser_approval_decision(
     if policy_action not in {"block", "sandbox-required", "require-reapproval"}:
         return None
     if event_name == "PreToolUse" and not _is_codex_native_runtime():
+        return None
+    if event_name == "PreToolUse":
+        response_payload["review_hint"] = (
+            "Approval is pending in HOL Guard. Approve it in the browser, then continue this Codex thread."
+        )
         return None
     approval_requests = response_payload.get("approval_requests")
     if not isinstance(approval_requests, list):

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3547,7 +3547,7 @@ def _should_emit_native_hook_json_response(
 
 
 def _should_emit_native_hook_exit_block(args: argparse.Namespace, *, event_name: str, policy_action: str) -> bool:
-    _ = (args, event_name, policy_action)
+    del args, event_name, policy_action
     # Codex v0.133 logs non-zero PreToolUse hooks as failed but still executes
     # the tool. Blocking must be communicated through the JSON hook response.
     return False
@@ -3578,9 +3578,6 @@ def _codex_browser_approval_decision(
     if event_name == "PreToolUse" and not _is_codex_native_runtime():
         return None
     if event_name == "PreToolUse":
-        response_payload["review_hint"] = (
-            "Approval is pending in HOL Guard. Approve it in the browser, then continue this Codex thread."
-        )
         return None
     approval_requests = response_payload.get("approval_requests")
     if not isinstance(approval_requests, list):

--- a/src/codex_plugin_scanner/guard/codex_app_server.py
+++ b/src/codex_plugin_scanner/guard/codex_app_server.py
@@ -43,6 +43,8 @@ _CODEX_HOME_KEYS = ("codex_home", "codexHome")
 _COMMAND_TEXT_KEYS = ("command_text", "commandText")
 _WORKSPACE_KEYS = ("workspace", "cwd", "working_directory", "workingDirectory")
 _MODEL_KEYS = ("codex_model", "codexModel", "model")
+_NESTED_COMMAND_TEXT_KEYS = ("command", "cmd", "shell_command", "shellCommand")
+_NESTED_TOOL_INPUT_KEYS = ("tool_input", "toolInput", "arguments", "args")
 
 
 class _WebSocketClosedError(TimeoutError):
@@ -103,6 +105,12 @@ def codex_resume_metadata_from_hook_payload(
     model = _first_string(payload, _MODEL_KEYS)
     if model is not None:
         metadata["codex_model"] = model
+    workspace = _first_string(payload, _WORKSPACE_KEYS)
+    if workspace is not None:
+        metadata["workspace"] = workspace
+    command_text = _first_command_text(payload)
+    if command_text is not None:
+        metadata["command_text"] = command_text
     return metadata
 
 
@@ -630,6 +638,19 @@ def _first_string(payload: Mapping[str, object], keys: tuple[str, ...]) -> str |
         value = payload.get(key)
         if isinstance(value, str) and value.strip():
             return value.strip()
+    return None
+
+
+def _first_command_text(payload: Mapping[str, object]) -> str | None:
+    command_text = _first_string(payload, _COMMAND_TEXT_KEYS)
+    if command_text is not None:
+        return command_text
+    for key in _NESTED_TOOL_INPUT_KEYS:
+        value = payload.get(key)
+        if isinstance(value, Mapping):
+            command_text = _first_string(value, _NESTED_COMMAND_TEXT_KEYS)
+            if command_text is not None:
+                return command_text
     return None
 
 

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -4635,7 +4635,7 @@ curl --data-binary @"$1" http://127.0.0.1:8787/guard-canary
         assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
         assert "Approve it in HOL Guard, then retry." in output["hookSpecificOutput"]["permissionDecisionReason"]
 
-    def test_guard_codex_hook_exits_with_block_status_in_actual_codex_runtime(self, tmp_path, monkeypatch, capsys):
+    def test_guard_codex_hook_emits_json_denial_in_actual_codex_runtime(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         payload_path = workspace_dir / "hook-event.json"
@@ -4659,10 +4659,14 @@ curl --data-binary @"$1" http://127.0.0.1:8787/guard-canary
         )
         captured = capsys.readouterr()
 
-        assert rc == 2
-        assert captured.out == ""
-        assert "destructive shell command" in captured.err
-        assert "Approve it in HOL Guard, then retry." in captured.err
+        output = json.loads(captured.out)
+
+        assert rc == 0
+        assert captured.err == ""
+        assert output["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert "destructive shell command" in output["hookSpecificOutput"]["permissionDecisionReason"]
+        assert "Approve it in HOL Guard, then retry." in output["hookSpecificOutput"]["permissionDecisionReason"]
 
     def test_guard_codex_pretooluse_returns_without_browser_wait(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_codex_resume_commands.py
+++ b/tests/test_guard_codex_resume_commands.py
@@ -196,6 +196,29 @@ def test_default_codex_app_server_socket_probe_uses_codex_home(
     assert connect_paths == [str(socket_path)]
 
 
+def test_codex_resume_metadata_extracts_workspace_and_nested_command() -> None:
+    metadata = codex_app_server_module.codex_resume_metadata_from_hook_payload(
+        {
+            "session_id": "thread-123",
+            "turn_id": "turn-123",
+            "cwd": "/tmp/project",
+            "model": "gpt-5.3",
+            "tool_name": "Bash",
+            "tool_input": {"command": "npm install is-even"},
+        },
+        environ={"CODEX_HOME": "/tmp/codex-home"},
+    )
+
+    assert metadata == {
+        "codex_thread_id": "thread-123",
+        "codex_turn_id": "turn-123",
+        "codex_home": "/tmp/codex-home",
+        "codex_model": "gpt-5.3",
+        "workspace": "/tmp/project",
+        "command_text": "npm install is-even",
+    }
+
+
 def test_guard_doctor_codex_reports_resume_diagnostics(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/tests/test_guard_js_package_hook_phase11.py
+++ b/tests/test_guard_js_package_hook_phase11.py
@@ -206,8 +206,11 @@ def test_guard_hook_blocks_js_exec_flows_before_subprocess(
     )
     captured = capsys.readouterr()
 
-    assert rc == 2
-    assert "blocked" in captured.err.lower()
+    payload = json.loads(captured.out)
+    assert rc == 0
+    assert captured.err == ""
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "blocked" in payload["hookSpecificOutput"]["permissionDecisionReason"].lower()
     evidence = store.list_evidence()
     assert evidence
     assert evidence[0]["category"] == "supply-chain"

--- a/tests/test_guard_package_hook.py
+++ b/tests/test_guard_package_hook.py
@@ -236,8 +236,11 @@ def test_guard_hook_blocks_package_request_before_execution_and_queues_cloud_syn
     )
     captured = capsys.readouterr()
 
-    assert rc == 2
-    assert "blocked" in captured.err.lower()
+    payload = json.loads(captured.out)
+    assert rc == 0
+    assert captured.err == ""
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "blocked" in payload["hookSpecificOutput"]["permissionDecisionReason"].lower()
     evidence = store.list_evidence()
     assert evidence
     assert evidence[0]["category"] == "supply-chain"

--- a/tests/test_guard_phase04_failure_modes.py
+++ b/tests/test_guard_phase04_failure_modes.py
@@ -140,9 +140,12 @@ def test_gr098_codex_strict_daemon_failure_points_to_daemon_recovery(
         },
     )
 
-    stderr = capsys.readouterr().err
+    captured = capsys.readouterr()
+    payload = _json_line(output)
+    reason = str(payload["hookSpecificOutput"]["permissionDecisionReason"])
 
-    assert exit_code == 2
-    assert output == ""
-    assert "Restart HOL Guard" in stderr
-    assert "Approve it in HOL Guard" not in stderr
+    assert exit_code == 0
+    assert captured.err == ""
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "Restart HOL Guard" in reason
+    assert "Approve it in HOL Guard" not in reason

--- a/tests/test_guard_phase04_harness_ux.py
+++ b/tests/test_guard_phase04_harness_ux.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.opencode import OpenCodeHarnessAdapter
+from codex_plugin_scanner.guard.cli import commands as guard_commands_module
 from codex_plugin_scanner.guard.cli.commands import add_guard_root_parser, run_guard_command
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -208,12 +209,20 @@ def test_gr080_codex_permission_request_uses_native_review_message(tmp_path: Pat
     assert "HOL Guard" in str(payload["systemMessage"])
 
 
-def test_gr081_codex_native_runtime_hard_stops_yolo_shell_exfil(
+def test_gr081_codex_native_runtime_returns_json_denial_for_yolo_shell_exfil(
     tmp_path: Path,
     monkeypatch,
     capsys,
 ) -> None:
     monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex-home"))
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(parents=True, exist_ok=True)
+    (guard_home / "config.toml").write_text("approval_wait_timeout_seconds = 120\n", encoding="utf-8")
+
+    def fail_on_wait(**kwargs):
+        raise AssertionError("Codex PreToolUse must return JSON denial without waiting for browser approval")
+
+    monkeypatch.setattr(guard_commands_module, "wait_for_approval_requests", fail_on_wait)
 
     exit_code, output = _run_hook(
         tmp_path,
@@ -228,12 +237,16 @@ def test_gr081_codex_native_runtime_hard_stops_yolo_shell_exfil(
         },
     )
 
-    stderr = capsys.readouterr().err
+    captured = capsys.readouterr()
+    payload = _json_line(output)
+    hook_output = payload["hookSpecificOutput"]
 
-    assert exit_code == 2
-    assert output == ""
-    assert "HOL Guard" in stderr
-    assert "retry" in stderr.lower()
+    assert exit_code == 0
+    assert captured.err == ""
+    assert hook_output["hookEventName"] == "PreToolUse"
+    assert hook_output["permissionDecision"] == "deny"
+    assert "HOL Guard" in str(hook_output["permissionDecisionReason"])
+    assert "retry" in str(hook_output["permissionDecisionReason"]).lower()
 
 
 def test_gr082_claude_pretooluse_brands_native_prompt(tmp_path: Path) -> None:
@@ -439,4 +452,3 @@ def test_gr097_hook_reason_deduplicates_duplicate_copy() -> None:
     reason = _native_hook_reason("HOL Guard blocked this action.", "HOL Guard blocked this action.", "Retry.")
 
     assert reason == "HOL Guard blocked this action. Retry."
-

--- a/tests/test_guard_python_package_hook_phase12.py
+++ b/tests/test_guard_python_package_hook_phase12.py
@@ -110,8 +110,11 @@ def test_guard_hook_blocks_python_exec_flows_before_subprocess(
     )
     captured = capsys.readouterr()
 
-    assert rc == 2
-    assert "blocked" in captured.err.lower()
+    payload = json.loads(captured.out)
+    assert rc == 0
+    assert captured.err == ""
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "blocked" in payload["hookSpecificOutput"]["permissionDecisionReason"].lower()
     evidence = store.list_evidence()
     assert evidence
     assert evidence[0]["category"] == "supply-chain"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -8976,9 +8976,12 @@ def test_guard_hook_emits_codex_runtime_denial_with_guard_remediation(tmp_path, 
     )
     captured = capsys.readouterr()
 
-    assert rc == 2
-    assert captured.out == ""
-    assert "approve it in hol guard, then retry." in captured.err.lower()
+    payload = json.loads(captured.out)
+    reason = payload["hookSpecificOutput"]["permissionDecisionReason"].lower()
+    assert rc == 0
+    assert captured.err == ""
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "approve it in hol guard, then retry." in reason
 
 
 def test_runtime_artifact_native_reason_truncates_long_risk_summaries() -> None:
@@ -11710,10 +11713,13 @@ def test_guard_hook_codex_emits_native_deny_for_sensitive_bash_command(tmp_path,
     )
     captured = capsys.readouterr()
 
-    assert rc == 2
-    assert captured.out == ""
-    assert "HOL Guard" in captured.err
-    assert "Approve it in HOL Guard, then retry." in captured.err
+    payload = json.loads(captured.out)
+    reason = payload["hookSpecificOutput"]["permissionDecisionReason"]
+    assert rc == 0
+    assert captured.err == ""
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "HOL Guard" in reason
+    assert "Approve it in HOL Guard, then retry." in reason
 
 
 def test_guard_hook_codex_emits_no_native_output_for_safe_requests(tmp_path, capsys, monkeypatch):
@@ -11833,9 +11839,11 @@ def test_guard_hook_codex_queues_approval_before_native_deny_output(tmp_path, ca
     captured = capsys.readouterr()
     pending = GuardStore(home_dir).list_approval_requests(limit=10)
 
-    assert rc == 2
-    assert captured.out == ""
-    assert "Approve it in HOL Guard, then retry." in captured.err
+    payload = json.loads(captured.out)
+    assert rc == 0
+    assert captured.err == ""
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "Approve it in HOL Guard, then retry." in payload["hookSpecificOutput"]["permissionDecisionReason"]
     assert len(pending) == 1
     assert pending[0]["artifact_type"] == "tool_action_request"
 
@@ -11943,10 +11951,11 @@ def test_guard_hook_codex_pretooluse_browser_approval_resumes_original_tool(
     )
     captured = capsys.readouterr()
 
+    payload = json.loads(captured.out)
     assert rc == 0
-    assert captured.out == ""
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
     assert captured.err == ""
-    assert store.list_approval_requests(limit=10) == []
+    assert store.list_approval_requests(limit=10)
 
 
 def test_guard_hook_codex_pretooluse_browser_deny_keeps_tool_blocked(
@@ -12004,10 +12013,13 @@ def test_guard_hook_codex_pretooluse_browser_deny_keeps_tool_blocked(
     )
     captured = capsys.readouterr()
 
-    assert rc == 2
-    assert captured.out == ""
-    assert "HOL Guard" in captured.err
-    assert "blocked" in captured.err.lower()
+    payload = json.loads(captured.out)
+    reason = payload["hookSpecificOutput"]["permissionDecisionReason"]
+    assert rc == 0
+    assert captured.err == ""
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "HOL Guard" in reason
+    assert "blocked" in reason.lower()
 
 
 def test_guard_hook_claude_native_block_does_not_queue_approval_center_request(tmp_path, capsys, monkeypatch):
@@ -13573,12 +13585,15 @@ PY
     )
     captured = capsys.readouterr()
 
-    assert rc == 2
-    assert captured.out == ""
-    assert "HOL Guard" in captured.err
-    assert "credential exfiltration" in captured.err
-    assert "Open HOL Guard to approve or keep this blocked" in captured.err
-    assert "http://127.0.0.1:4455/approvals/" in captured.err
+    payload = json.loads(captured.out)
+    reason = payload["hookSpecificOutput"]["permissionDecisionReason"]
+    assert rc == 0
+    assert captured.err == ""
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "HOL Guard" in reason
+    assert "credential exfiltration" in reason
+    assert "Open HOL Guard to approve or keep this blocked" in reason
+    assert "http://127.0.0.1:4455/approvals/" in reason
 
 
 def test_guard_hook_codex_post_tool_use_blocks_credential_looking_output(
@@ -13819,8 +13834,8 @@ def test_codex_browser_approval_uses_configured_wait_timeout(tmp_path, monkeypat
     )
 
     assert decision is None
-    assert captured_timeout == [120]
-    assert statuses == [{"operation_id": "operation-1", "status": "approval_wait_timeout"}]
+    assert captured_timeout == []
+    assert statuses == []
 
 
 def test_codex_browser_approval_fallback_uses_configured_wait_timeout(tmp_path, monkeypatch):
@@ -13843,7 +13858,7 @@ def test_codex_browser_approval_fallback_uses_configured_wait_timeout(tmp_path, 
     )
 
     assert decision is None
-    assert captured_timeout == [120]
+    assert captured_timeout == []
 
 
 def test_guard_hook_codex_post_tool_use_blocks_named_secret_output(


### PR DESCRIPTION
## Summary
- restore Codex PreToolUse blocking by emitting Codex JSON denial instead of nonzero hook exit
- avoid waiting inside Codex PreToolUse hooks so browser approval cannot time out and fall through
- persist workspace and command metadata from Codex hook payloads so approval resolution can resume the original Codex thread
- update native Codex tests to assert JSON-deny semantics across package, runtime, and failure-mode paths

## Testing
- `python3 -m pytest -q tests/test_guard_cli.py::TestGuardCli::test_guard_codex_hook_emits_json_denial_in_actual_codex_runtime tests/test_guard_phase04_harness_ux.py::test_gr081_codex_native_runtime_returns_json_denial_for_yolo_shell_exfil tests/test_guard_codex_resume_commands.py`
- `python3 -m pytest -q tests/test_guard_js_package_hook_phase11.py tests/test_guard_package_hook.py tests/test_guard_phase04_failure_modes.py tests/test_guard_python_package_hook_phase12.py tests/test_guard_runtime.py --tb=short`
- `python3 -m ruff check src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/codex_app_server.py tests/test_guard_cli.py tests/test_guard_phase04_harness_ux.py tests/test_guard_codex_resume_commands.py tests/test_guard_js_package_hook_phase11.py tests/test_guard_package_hook.py tests/test_guard_phase04_failure_modes.py tests/test_guard_python_package_hook_phase12.py tests/test_guard_runtime.py`
- `git diff --check`
- local e2e: `codex exec` blocked `npm install is-odd`, printed `http://127.0.0.1:5481/approvals/df3229b91b18400ab0f6071966a61732`, did not create `node_modules`; after approval policy existed, `codex exec resume` resumed same thread and installed `is-odd`