### PR TITLE
feat(guard): add workspace audit CLI

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -105,6 +105,7 @@ from ..local_supply_chain import (
     build_local_supply_chain_posture,
     build_supply_chain_explain_payload,
     build_supply_chain_status_payload,
+    build_workspace_audit_payload,
     build_workspace_scan_payload,
 )
 from ..mcp_tool_calls import (
@@ -882,6 +883,17 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     )
     _add_guard_common_args(supply_chain_scan_parser)
     supply_chain_scan_parser.add_argument("--json", action="store_true")
+    supply_chain_audit_parser = supply_chain_subparsers.add_parser(
+        "audit",
+        help="Audit workspace dependencies with local inventory extraction and Guard Cloud batch evaluation",
+    )
+    _add_guard_common_args(supply_chain_audit_parser)
+    supply_chain_audit_parser.add_argument("--after-workspace")
+    supply_chain_audit_parser.add_argument("--before-workspace")
+    supply_chain_audit_parser.add_argument("--ci", action="store_true")
+    supply_chain_audit_parser.add_argument("--fail-on", choices=("low", "medium", "high", "critical"), default="high")
+    supply_chain_audit_parser.add_argument("--sbom", action="append", default=[])
+    supply_chain_audit_parser.add_argument("--json", action="store_true")
     supply_chain_sync_parser = supply_chain_subparsers.add_parser(
         "sync",
         help="Fetch and verify the latest signed supply-chain bundle for this workspace",
@@ -2375,6 +2387,27 @@ def run_guard_command(
                 now=_now(),
             )
             _emit("supply-chain-scan", payload, getattr(args, "json", False))
+            return exit_code
+        if supply_chain_command == "audit":
+            before_workspace = getattr(args, "before_workspace", None)
+            after_workspace = getattr(args, "after_workspace", None)
+            payload, exit_code = build_workspace_audit_payload(
+                store=store,
+                config=config,
+                workspace_dir=workspace_dir,
+                now=_now(),
+                command_name="audit",
+                sbom_paths=tuple(str(item) for item in getattr(args, "sbom", []) if isinstance(item, str)),
+                ci=bool(getattr(args, "ci", False)),
+                fail_on=str(getattr(args, "fail_on", "high")),
+                before_workspace_dir=(
+                    Path(str(before_workspace)).expanduser() if isinstance(before_workspace, str) else None
+                ),
+                after_workspace_dir=(
+                    Path(str(after_workspace)).expanduser() if isinstance(after_workspace, str) else None
+                ),
+            )
+            _emit("supply-chain-audit", payload, getattr(args, "json", False))
             return exit_code
         if supply_chain_command == "sync":
             try:

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -97,6 +97,8 @@ _DEFAULT_BUNDLE_REFRESH_INTERVAL_SECONDS = 15 * 60
 _STALE_REFRESH_GRACE_SECONDS = 5 * 60
 _CLOUD_AUDIT_TIMEOUT_SECONDS = 20
 _CLOUD_AUDIT_PAGE_SIZE = 500
+_CLOUD_AUDIT_MAX_PAGES = 100
+_MAX_SBOM_BYTES = 10 * 1024 * 1024
 _ECOSYSTEM_BY_LOCKFILE = {
     "package-lock.json": "npm",
     "pnpm-lock.yaml": "npm",
@@ -766,9 +768,12 @@ def _workspace_audit_inventory(
     inventory_map = {_inventory_key(item): dict(item) for item in inventory}
     for sbom_path in normalized_sbom_paths:
         disk_path = workspace_dir / sbom_path
+        sbom_text = _read_sbom_text(disk_path)
+        if sbom_text is None:
+            continue
         try:
-            parsed_items = _inventory_from_sbom_text(disk_path.read_text(encoding="utf-8"))
-        except (OSError, UnicodeDecodeError, ValueError):
+            parsed_items = _inventory_from_sbom_text(sbom_text)
+        except ValueError:
             continue
         for item in parsed_items:
             _merge_inventory_item(inventory_map, item)
@@ -825,9 +830,12 @@ def _workspace_diff_audit_inventory(
             )
     for sbom_path in normalized_sbom_paths:
         disk_path = after_workspace_dir / sbom_path
+        sbom_text = _read_sbom_text(disk_path)
+        if sbom_text is None:
+            continue
         try:
-            parsed_items = _inventory_from_sbom_text(disk_path.read_text(encoding="utf-8"))
-        except (OSError, UnicodeDecodeError, ValueError):
+            parsed_items = _inventory_from_sbom_text(sbom_text)
+        except ValueError:
             continue
         for item in parsed_items:
             _merge_inventory_item(inventory_map, item)
@@ -982,6 +990,15 @@ def _inventory_from_sbom_text(text: str) -> tuple[dict[str, object], ...]:
     raise ValueError("Unsupported SBOM format")
 
 
+def _read_sbom_text(disk_path: Path) -> str | None:
+    try:
+        if disk_path.stat().st_size > _MAX_SBOM_BYTES:
+            return None
+        return disk_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
 def _inventory_from_cyclonedx(payload: dict[str, object]) -> tuple[dict[str, object], ...]:
     components = payload.get("components")
     if not isinstance(components, list):
@@ -1077,15 +1094,15 @@ def _inventory_from_purl(purl: str | None) -> dict[str, object] | None:
         namespace, _, name = package_path.rpartition("/")
         return {
             "ecosystem": ecosystem,
-            "namespace": namespace or None,
-            "name": name,
-            "version": package_version or None,
+            "namespace": urllib.parse.unquote(namespace) if namespace else None,
+            "name": urllib.parse.unquote(name),
+            "version": urllib.parse.unquote(package_version) if package_version else None,
         }
     return {
         "ecosystem": ecosystem,
         "namespace": None,
-        "name": package_path,
-        "version": package_version or None,
+        "name": urllib.parse.unquote(package_path),
+        "version": urllib.parse.unquote(package_version) if package_version else None,
     }
 
 
@@ -1119,7 +1136,7 @@ def _run_cloud_workspace_audit(
     aggregated_reasons: list[dict[str, object]] = []
     cursor: str | None = None
     last_response: dict[str, object] | None = None
-    while True:
+    for _ in range(_CLOUD_AUDIT_MAX_PAGES):
         page_payload = dict(request_payload)
         if cursor is not None:
             page_payload["cursor"] = cursor
@@ -1131,7 +1148,7 @@ def _run_cloud_workspace_audit(
         )
         try:
             with urllib.request.urlopen(request, timeout=_CLOUD_AUDIT_TIMEOUT_SECONDS) as response:
-                response_payload = json.loads(response.read().decode("utf-8"))
+                response_payload = json.load(response)
         except urllib.error.HTTPError as error:
             return (
                 None,
@@ -1167,6 +1184,14 @@ def _run_cloud_workspace_audit(
         if not isinstance(next_cursor, str) or not next_cursor:
             break
         cursor = next_cursor
+    else:
+        return (
+            None,
+            {
+                "code": "cloud_page_limit",
+                "message": "Guard cloud evaluation exceeded the maximum page count, so Guard fell back locally.",
+            },
+        )
     if last_response is None:
         return (None, None)
     merged_response = dict(last_response)

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import shlex
 import shutil
 import subprocess
+import urllib.error
+import urllib.parse
+import urllib.request
 from collections.abc import Sequence
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
@@ -27,7 +31,7 @@ from .runtime.package_intent_common import (
     python_target,
     version_target,
 )
-from .runtime.package_manifest_diff import parse_manifest_dependencies
+from .runtime.package_manifest_diff import parse_manifest_dependencies, parse_manifest_dependency_changes
 from .runtime.supply_chain_package_eval import evaluate_package_request_artifact
 from .runtime.supply_chain_support import ecosystem_support_matrix
 from .shims import package_shim_status, package_shim_supported_managers
@@ -91,6 +95,39 @@ _ECOSYSTEM_BY_MANIFEST = {
 }
 _DEFAULT_BUNDLE_REFRESH_INTERVAL_SECONDS = 15 * 60
 _STALE_REFRESH_GRACE_SECONDS = 5 * 60
+_CLOUD_AUDIT_TIMEOUT_SECONDS = 20
+_CLOUD_AUDIT_PAGE_SIZE = 500
+_ECOSYSTEM_BY_LOCKFILE = {
+    "package-lock.json": "npm",
+    "pnpm-lock.yaml": "npm",
+    "yarn.lock": "npm",
+    "bun.lock": "npm",
+    "bun.lockb": "npm",
+    "poetry.lock": "pypi",
+    "uv.lock": "pypi",
+    "Pipfile.lock": "pypi",
+    "Cargo.lock": "cargo",
+    "go.sum": "go",
+    "gradle.lockfile": "maven",
+    "composer.lock": "packagist",
+    "Gemfile.lock": "rubygems",
+}
+_ECOSYSTEM_BY_PURL = {
+    "cargo": "cargo",
+    "composer": "packagist",
+    "gem": "rubygems",
+    "golang": "go",
+    "maven": "maven",
+    "npm": "npm",
+    "pypi": "pypi",
+}
+_SEVERITY_RANK = {
+    "unknown": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+    "critical": 4,
+}
 
 
 def build_local_supply_chain_posture(
@@ -217,19 +254,143 @@ def build_workspace_scan_payload(
     workspace_dir: Path,
     now: str,
 ) -> tuple[dict[str, object], int]:
+    return build_workspace_audit_payload(
+        store=store,
+        config=config,
+        workspace_dir=workspace_dir,
+        now=now,
+        command_name="scan",
+        sbom_paths=(),
+    )
+
+
+def build_workspace_audit_payload(
+    *,
+    store: GuardStore,
+    config: GuardConfig,
+    workspace_dir: Path,
+    now: str,
+    command_name: str,
+    sbom_paths: Sequence[str],
+    ci: bool = False,
+    fail_on: str = "high",
+    before_workspace_dir: Path | None = None,
+    after_workspace_dir: Path | None = None,
+) -> tuple[dict[str, object], int]:
+    target_workspace_dir = after_workspace_dir or workspace_dir
     posture = build_local_supply_chain_posture(store, config, now=now)
-    intent = _workspace_scan_intent(workspace_dir)
-    if intent is None:
+    diff_summary: dict[str, object] | None = None
+    if before_workspace_dir is not None and after_workspace_dir is not None:
+        manifest_paths, lockfile_paths, resolved_sbom_paths, inventory, diff_summary = _workspace_diff_audit_inventory(
+            before_workspace_dir=before_workspace_dir,
+            after_workspace_dir=after_workspace_dir,
+            sbom_paths=sbom_paths,
+        )
+    else:
+        manifest_paths, lockfile_paths, resolved_sbom_paths, inventory = _workspace_audit_inventory(
+            target_workspace_dir,
+            sbom_paths=sbom_paths,
+        )
+    if not inventory:
         return (
             {
                 "generated_at": now,
-                "manifest_paths": [],
-                "lockfile_paths": [],
+                "mode": command_name,
+                "manifest_paths": list(manifest_paths),
+                "lockfile_paths": list(lockfile_paths),
+                "sbom_paths": list(resolved_sbom_paths),
                 "message": "No supported manifests or lockfiles found in this workspace.",
                 "supply_chain": posture,
             },
             0,
         )
+    evaluation: dict[str, object]
+    source = "local"
+    fallback_reason: dict[str, object] | None = None
+    if _should_use_cloud_workspace_audit(store=store, posture=posture):
+        sync_credentials = store.get_sync_credentials()
+        workspace_id = store.get_cloud_workspace_id()
+        assert sync_credentials is not None
+        assert workspace_id is not None
+        request_payload = _build_cloud_audit_payload(
+            workspace_dir=target_workspace_dir,
+            workspace_id=workspace_id,
+            store=store,
+            manifest_paths=manifest_paths,
+            lockfile_paths=lockfile_paths,
+            inventory=inventory,
+        )
+        cloud_response, fallback_reason = _run_cloud_workspace_audit(
+            request_payload=request_payload,
+            sync_url=str(sync_credentials["sync_url"]),
+            token=str(sync_credentials["token"]),
+            workspace_id=workspace_id,
+        )
+        if cloud_response is not None:
+            evaluation = _normalize_cloud_audit_response(cloud_response)
+            source = "cloud"
+        else:
+            evaluation = _workspace_local_evaluation(
+                store=store,
+                workspace_dir=target_workspace_dir,
+                inventory=inventory,
+                manifest_paths=manifest_paths,
+                lockfile_paths=lockfile_paths,
+                command_name=command_name,
+                now=now,
+            )
+    else:
+        evaluation = _workspace_local_evaluation(
+            store=store,
+            workspace_dir=target_workspace_dir,
+            inventory=inventory,
+            manifest_paths=manifest_paths,
+            lockfile_paths=lockfile_paths,
+            command_name=command_name,
+            now=now,
+        )
+    payload = {
+        "generated_at": now,
+        "mode": command_name,
+        "source": source,
+        "manifest_paths": list(manifest_paths),
+        "lockfile_paths": list(lockfile_paths),
+        "sbom_paths": list(resolved_sbom_paths),
+        "inventory": _inventory_summary(inventory),
+        "evaluation": evaluation,
+        "supply_chain": posture,
+    }
+    if diff_summary is not None:
+        payload["diff"] = diff_summary
+    if fallback_reason is not None:
+        payload["fallback_reason"] = fallback_reason
+    exit_code = _evaluation_exit_code(str(evaluation.get("decision") or "monitor"))
+    if ci:
+        ci_result = _ci_gate_result(evaluation, threshold=fail_on)
+        payload["ci"] = ci_result
+        if ci_result["matched"]:
+            exit_code = 3
+    return (payload, exit_code)
+
+
+def _workspace_local_evaluation(
+    *,
+    store: GuardStore,
+    workspace_dir: Path,
+    inventory: tuple[dict[str, object], ...],
+    manifest_paths: tuple[str, ...],
+    lockfile_paths: tuple[str, ...],
+    command_name: str,
+    now: str,
+) -> dict[str, object]:
+    intent = _workspace_scan_intent(
+        workspace_dir,
+        command_name=command_name,
+        inventory=inventory,
+        manifest_paths=manifest_paths,
+        lockfile_paths=lockfile_paths,
+    )
+    assert intent is not None
     artifact = build_package_request_artifact(
         _LOCAL_SUPPLY_CHAIN_HARNESS,
         intent,
@@ -242,14 +403,7 @@ def build_workspace_scan_payload(
         workspace_dir=workspace_dir,
         now=now,
     )
-    payload = {
-        "generated_at": now,
-        "manifest_paths": list(intent.manifest_paths),
-        "lockfile_paths": list(intent.lockfile_paths),
-        "evaluation": evaluation.to_dict(),
-        "supply_chain": posture,
-    }
-    return (payload, _evaluation_exit_code(evaluation.decision))
+    return evaluation.to_dict()
 
 
 def build_supply_chain_explain_payload(
@@ -538,20 +692,33 @@ def _paths_match(left: str | Path, right: str | Path) -> bool:
         return os.path.normcase(os.path.abspath(left_path)) == os.path.normcase(os.path.abspath(right_path))
 
 
-def _workspace_scan_intent(workspace_dir: Path) -> PackageIntent | None:
-    manifest_paths, lockfile_paths = _workspace_files(workspace_dir)
-    if not manifest_paths and not lockfile_paths:
+def _workspace_scan_intent(
+    workspace_dir: Path,
+    *,
+    command_name: str,
+    inventory: tuple[dict[str, object], ...] | None = None,
+    manifest_paths: tuple[str, ...] | None = None,
+    lockfile_paths: tuple[str, ...] | None = None,
+) -> PackageIntent | None:
+    resolved_manifest_paths, resolved_lockfile_paths = (
+        _workspace_files(workspace_dir)
+        if manifest_paths is None or lockfile_paths is None
+        else (manifest_paths, lockfile_paths)
+    )
+    if inventory is None:
+        inventory = _workspace_inventory_from_paths(workspace_dir, resolved_manifest_paths, resolved_lockfile_paths)
+    if not inventory and not resolved_manifest_paths and not resolved_lockfile_paths:
         return None
-    targets = _targets_from_workspace_manifests(workspace_dir, manifest_paths)
-    package_manager = _package_manager_for_scan(manifest_paths)
+    targets = tuple(_target_from_inventory_item(item) for item in inventory)
+    package_manager = _package_manager_for_scan(resolved_manifest_paths)
     return PackageIntent(
         package_manager=package_manager,
         intent_kind="install",
-        command_tokens=("hol-guard", "supply-chain", "scan"),
-        redacted_command="hol-guard supply-chain scan",
+        command_tokens=("hol-guard", "supply-chain", command_name),
+        redacted_command=f"hol-guard supply-chain {command_name}",
         targets=targets,
-        manifest_paths=manifest_paths,
-        lockfile_paths=lockfile_paths,
+        manifest_paths=resolved_manifest_paths,
+        lockfile_paths=resolved_lockfile_paths,
     )
 
 
@@ -586,6 +753,637 @@ def _targets_from_workspace_manifests(
             seen.add(fingerprint)
             targets.append(target)
     return tuple(targets)
+
+
+def _workspace_audit_inventory(
+    workspace_dir: Path,
+    *,
+    sbom_paths: Sequence[str],
+) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...], tuple[dict[str, object], ...]]:
+    manifest_paths, lockfile_paths = _workspace_files(workspace_dir)
+    normalized_sbom_paths = _resolve_sbom_paths(workspace_dir, sbom_paths)
+    inventory = _workspace_inventory_from_paths(workspace_dir, manifest_paths, lockfile_paths)
+    inventory_map = {_inventory_key(item): dict(item) for item in inventory}
+    for sbom_path in normalized_sbom_paths:
+        disk_path = workspace_dir / sbom_path
+        try:
+            parsed_items = _inventory_from_sbom_text(disk_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, ValueError):
+            continue
+        for item in parsed_items:
+            _merge_inventory_item(inventory_map, item)
+    return (manifest_paths, lockfile_paths, normalized_sbom_paths, tuple(inventory_map.values()))
+
+
+def _workspace_diff_audit_inventory(
+    *,
+    before_workspace_dir: Path,
+    after_workspace_dir: Path,
+    sbom_paths: Sequence[str],
+) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...], tuple[dict[str, object], ...], dict[str, object]]:
+    manifest_paths, lockfile_paths = _workspace_files(after_workspace_dir)
+    normalized_sbom_paths = _resolve_sbom_paths(after_workspace_dir, sbom_paths)
+    inventory_map: dict[tuple[str, str | None, str], dict[str, object]] = {}
+    changed_paths: list[str] = []
+    changed_packages: list[str] = []
+    for relative_path in (*manifest_paths, *lockfile_paths):
+        before_path = before_workspace_dir / relative_path
+        after_path = after_workspace_dir / relative_path
+        before_text = before_path.read_text(encoding="utf-8") if before_path.exists() else None
+        after_text = after_path.read_text(encoding="utf-8") if after_path.exists() else None
+        if before_text is None and after_text is None:
+            continue
+        change_result = parse_manifest_dependency_changes(
+            path=relative_path,
+            before_text=before_text,
+            after_text=after_text,
+        )
+        if not change_result.changes:
+            continue
+        changed_paths.append(relative_path)
+        ecosystem = _ECOSYSTEM_BY_MANIFEST.get(Path(relative_path).name) or _ECOSYSTEM_BY_LOCKFILE.get(
+            Path(relative_path).name
+        )
+        if ecosystem is None:
+            continue
+        direct = Path(relative_path).name in _ECOSYSTEM_BY_MANIFEST
+        for change in change_result.changes:
+            if change.after is None:
+                continue
+            namespace, name = _split_namespace_name(change.package_name)
+            changed_packages.append(change.package_name)
+            _merge_inventory_item(
+                inventory_map,
+                {
+                    "ecosystem": ecosystem,
+                    "namespace": namespace,
+                    "name": name,
+                    "direct": direct,
+                    "range": change.after if direct else None,
+                    "version": None if direct else change.after,
+                },
+            )
+    for sbom_path in normalized_sbom_paths:
+        disk_path = after_workspace_dir / sbom_path
+        try:
+            parsed_items = _inventory_from_sbom_text(disk_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, ValueError):
+            continue
+        for item in parsed_items:
+            _merge_inventory_item(inventory_map, item)
+    summary = {
+        "changed_package_count": len({item for item in changed_packages}),
+        "changed_paths": changed_paths,
+    }
+    return (manifest_paths, lockfile_paths, normalized_sbom_paths, tuple(inventory_map.values()), summary)
+
+
+def _workspace_inventory_from_paths(
+    workspace_dir: Path,
+    manifest_paths: Sequence[str],
+    lockfile_paths: Sequence[str],
+) -> tuple[dict[str, object], ...]:
+    inventory_map: dict[tuple[str, str | None, str], dict[str, object]] = {}
+    for manifest_path in manifest_paths:
+        ecosystem = _ECOSYSTEM_BY_MANIFEST.get(Path(manifest_path).name)
+        if ecosystem is None:
+            continue
+        disk_path = workspace_dir / manifest_path
+        try:
+            manifest_text = disk_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for package_name, version in parse_manifest_dependencies(path=manifest_path, text=manifest_text).items():
+            namespace, name = _split_namespace_name(package_name)
+            _merge_inventory_item(
+                inventory_map,
+                {
+                    "ecosystem": ecosystem,
+                    "namespace": namespace,
+                    "name": name,
+                    "direct": True,
+                    "range": version.strip() or None,
+                    "version": None,
+                },
+            )
+    for lockfile_path in lockfile_paths:
+        ecosystem = _ECOSYSTEM_BY_LOCKFILE.get(Path(lockfile_path).name)
+        if ecosystem is None:
+            continue
+        disk_path = workspace_dir / lockfile_path
+        try:
+            lockfile_text = disk_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for package_name, version in parse_manifest_dependencies(path=lockfile_path, text=lockfile_text).items():
+            namespace, name = _split_namespace_name(package_name)
+            _merge_inventory_item(
+                inventory_map,
+                {
+                    "ecosystem": ecosystem,
+                    "namespace": namespace,
+                    "name": name,
+                    "direct": False,
+                    "range": None,
+                    "version": version.strip() or None,
+                },
+            )
+    return tuple(inventory_map.values())
+
+
+def _merge_inventory_item(
+    inventory_map: dict[tuple[str, str | None, str], dict[str, object]],
+    item: dict[str, object],
+) -> None:
+    key = _inventory_key(item)
+    existing = inventory_map.get(key)
+    if existing is None:
+        inventory_map[key] = {
+            "ecosystem": str(item["ecosystem"]),
+            "namespace": item.get("namespace"),
+            "name": str(item["name"]),
+            "direct": bool(item.get("direct")),
+            "range": item.get("range"),
+            "version": item.get("version"),
+        }
+        return
+    existing["direct"] = bool(existing.get("direct")) or bool(item.get("direct"))
+    if existing.get("range") is None and item.get("range") is not None:
+        existing["range"] = item["range"]
+    if existing.get("version") is None and item.get("version") is not None:
+        existing["version"] = item["version"]
+
+
+def _inventory_key(item: dict[str, object]) -> tuple[str, str | None, str]:
+    namespace = item.get("namespace")
+    return (str(item["ecosystem"]), namespace if isinstance(namespace, str) else None, str(item["name"]))
+
+
+def _split_namespace_name(package_name: str) -> tuple[str | None, str]:
+    cleaned = package_name.strip()
+    if cleaned.startswith("@") and "/" in cleaned:
+        namespace, _, name = cleaned.partition("/")
+        return (namespace, name)
+    return (None, cleaned)
+
+
+def _target_from_inventory_item(item: dict[str, object]) -> PackageIntentTarget:
+    qualified_name = (
+        f"{item['namespace']}/{item['name']}" if isinstance(item.get("namespace"), str) else str(item["name"])
+    )
+    version = item.get("version")
+    version_range = item.get("range")
+    ecosystem = str(item["ecosystem"])
+    if ecosystem == "npm":
+        suffix = str(version) if isinstance(version, str) else str(version_range or "")
+        spec = qualified_name if not suffix else f"{qualified_name}@{suffix}"
+        return js_target(spec)
+    if ecosystem == "pypi":
+        suffix = str(version) if isinstance(version, str) else str(version_range or "")
+        spec = qualified_name if not suffix else f"{qualified_name}{suffix}"
+        return python_target(spec)
+    if ecosystem == "maven":
+        suffix = str(version) if isinstance(version, str) else str(version_range or "")
+        spec = qualified_name if not suffix else f"{qualified_name}:{suffix}"
+        return coordinate_target(ecosystem, spec)
+    if ecosystem == "packagist":
+        suffix = str(version) if isinstance(version, str) else str(version_range or "")
+        spec = qualified_name if not suffix else f"{qualified_name}:{suffix}"
+        return composer_target(spec)
+    suffix = str(version) if isinstance(version, str) else str(version_range or "")
+    spec = qualified_name if not suffix else f"{qualified_name}@{suffix}"
+    return version_target(ecosystem, spec)
+
+
+def _resolve_sbom_paths(workspace_dir: Path, sbom_paths: Sequence[str]) -> tuple[str, ...]:
+    resolved: list[str] = []
+    for raw_path in sbom_paths:
+        candidate = Path(raw_path)
+        disk_path = candidate if candidate.is_absolute() else workspace_dir / candidate
+        if not disk_path.exists():
+            continue
+        try:
+            normalized = str(disk_path.relative_to(workspace_dir))
+        except ValueError:
+            normalized = disk_path.name
+        if normalized not in resolved:
+            resolved.append(normalized)
+    return tuple(resolved)
+
+
+def _inventory_from_sbom_text(text: str) -> tuple[dict[str, object], ...]:
+    payload = json.loads(text)
+    if not isinstance(payload, dict):
+        raise ValueError("SBOM payload must be an object")
+    if payload.get("bomFormat") == "CycloneDX":
+        return _inventory_from_cyclonedx(payload)
+    if payload.get("spdxVersion"):
+        return _inventory_from_spdx(payload)
+    raise ValueError("Unsupported SBOM format")
+
+
+def _inventory_from_cyclonedx(payload: dict[str, object]) -> tuple[dict[str, object], ...]:
+    components = payload.get("components")
+    if not isinstance(components, list):
+        return ()
+    inventory: dict[tuple[str, str | None, str], dict[str, object]] = {}
+    for component in components:
+        if not isinstance(component, dict):
+            continue
+        item = _inventory_item_from_sbom_component(
+            name=component.get("name"),
+            version=component.get("version"),
+            purl=component.get("purl"),
+        )
+        if item is None:
+            continue
+        _merge_inventory_item(inventory, item)
+    return tuple(inventory.values())
+
+
+def _inventory_from_spdx(payload: dict[str, object]) -> tuple[dict[str, object], ...]:
+    packages = payload.get("packages")
+    if not isinstance(packages, list):
+        return ()
+    inventory: dict[tuple[str, str | None, str], dict[str, object]] = {}
+    for package in packages:
+        if not isinstance(package, dict):
+            continue
+        purl = None
+        external_refs = package.get("externalRefs")
+        if isinstance(external_refs, list):
+            for external_ref in external_refs:
+                if not isinstance(external_ref, dict):
+                    continue
+                if str(external_ref.get("referenceType") or "").lower() != "purl":
+                    continue
+                locator = external_ref.get("referenceLocator")
+                if isinstance(locator, str) and locator:
+                    purl = locator
+                    break
+        item = _inventory_item_from_sbom_component(
+            name=package.get("name"),
+            version=package.get("versionInfo"),
+            purl=purl,
+        )
+        if item is None:
+            continue
+        _merge_inventory_item(inventory, item)
+    return tuple(inventory.values())
+
+
+def _inventory_item_from_sbom_component(
+    *,
+    name: object,
+    version: object,
+    purl: object,
+) -> dict[str, object] | None:
+    purl_values = _inventory_from_purl(purl if isinstance(purl, str) else None)
+    if purl_values is None and not isinstance(name, str):
+        return None
+    ecosystem = purl_values["ecosystem"] if purl_values is not None else "unsupported"
+    namespace = purl_values["namespace"] if purl_values is not None else None
+    package_name = purl_values["name"] if purl_values is not None else str(name).strip()
+    package_version = (
+        purl_values["version"]
+        if purl_values is not None
+        else (str(version).strip() if isinstance(version, str) else None)
+    )
+    if not package_name:
+        return None
+    return {
+        "ecosystem": ecosystem,
+        "namespace": namespace,
+        "name": package_name,
+        "direct": False,
+        "range": None,
+        "version": package_version,
+    }
+
+
+def _inventory_from_purl(purl: str | None) -> dict[str, object] | None:
+    if purl is None or not purl.startswith("pkg:"):
+        return None
+    without_prefix = purl[4:]
+    package_type, _, remainder = without_prefix.partition("/")
+    ecosystem = _ECOSYSTEM_BY_PURL.get(package_type)
+    if ecosystem is None or not remainder:
+        return None
+    package_ref = remainder.split("?", 1)[0].split("#", 1)[0]
+    package_path, _, package_version = package_ref.partition("@")
+    if not package_path:
+        return None
+    if "/" in package_path:
+        namespace, _, name = package_path.rpartition("/")
+        return {
+            "ecosystem": ecosystem,
+            "namespace": namespace or None,
+            "name": name,
+            "version": package_version or None,
+        }
+    return {
+        "ecosystem": ecosystem,
+        "namespace": None,
+        "name": package_path,
+        "version": package_version or None,
+    }
+
+
+def _should_use_cloud_workspace_audit(
+    *,
+    store: GuardStore,
+    posture: dict[str, object],
+) -> bool:
+    if store.get_sync_credentials() is None or store.get_cloud_workspace_id() is None:
+        return False
+    bundle = posture.get("bundle")
+    if not isinstance(bundle, dict):
+        return False
+    return str(bundle.get("tier") or "").strip().lower() == "premium"
+
+
+def _run_cloud_workspace_audit(
+    *,
+    request_payload: dict[str, object],
+    sync_url: str,
+    token: str,
+    workspace_id: str,
+) -> tuple[dict[str, object] | None, dict[str, object] | None]:
+    request_url = _normalized_supply_chain_batch_url(sync_url, workspace_id)
+    request_headers = {
+        "Accept": "application/json",
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    aggregated_packages: list[dict[str, object]] = []
+    aggregated_reasons: list[dict[str, object]] = []
+    cursor: str | None = None
+    last_response: dict[str, object] | None = None
+    while True:
+        page_payload = dict(request_payload)
+        if cursor is not None:
+            page_payload["cursor"] = cursor
+        request = urllib.request.Request(
+            request_url,
+            data=json.dumps(page_payload).encode("utf-8"),
+            headers=request_headers,
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=_CLOUD_AUDIT_TIMEOUT_SECONDS) as response:
+                response_payload = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as error:
+            return (
+                None,
+                {
+                    "code": "cloud_http_error",
+                    "message": f"Guard cloud evaluation returned HTTP {error.code}, so Guard fell back locally.",
+                },
+            )
+        except (OSError, ValueError, json.JSONDecodeError):
+            return (
+                None,
+                {
+                    "code": "cloud_timeout",
+                    "message": "Guard cloud evaluation timed out, so Guard fell back locally.",
+                },
+            )
+        if not isinstance(response_payload, dict):
+            return (
+                None,
+                {
+                    "code": "cloud_invalid_response",
+                    "message": "Guard cloud evaluation returned an invalid response, so Guard fell back locally.",
+                },
+            )
+        last_response = response_payload
+        response_packages = response_payload.get("packages")
+        if isinstance(response_packages, list):
+            aggregated_packages.extend(item for item in response_packages if isinstance(item, dict))
+        response_reasons = response_payload.get("reasons")
+        if isinstance(response_reasons, list):
+            aggregated_reasons.extend(item for item in response_reasons if isinstance(item, dict))
+        next_cursor = response_payload.get("nextCursor")
+        if not isinstance(next_cursor, str) or not next_cursor:
+            break
+        cursor = next_cursor
+    if last_response is None:
+        return (None, None)
+    merged_response = dict(last_response)
+    merged_response["packages"] = aggregated_packages
+    merged_response["reasons"] = aggregated_reasons
+    return (merged_response, None)
+
+
+def _build_cloud_audit_payload(
+    *,
+    workspace_dir: Path,
+    workspace_id: str,
+    store: GuardStore,
+    manifest_paths: tuple[str, ...],
+    lockfile_paths: tuple[str, ...],
+    inventory: tuple[dict[str, object], ...],
+) -> dict[str, object]:
+    summary = store.get_sync_payload("supply_chain_bundle_summary")
+    policy_version = "local:none"
+    if isinstance(summary, dict):
+        policy_hash = summary.get("policy_hash")
+        if isinstance(policy_hash, str) and policy_hash:
+            policy_version = policy_hash
+    workspace_fingerprint = _workspace_audit_fingerprint(
+        workspace_id=workspace_id,
+        workspace_dir=workspace_dir,
+        manifest_paths=manifest_paths,
+        lockfile_paths=lockfile_paths,
+        policy_version=policy_version,
+    )
+    payload: dict[str, object] = {
+        "commandShape": {
+            "argCount": 3,
+            "flags": [],
+            "packageManager": _package_manager_for_scan(manifest_paths),
+            "redacted": True,
+            "verb": "audit",
+        },
+        "harness": _LOCAL_SUPPLY_CHAIN_HARNESS,
+        "lockfileContext": _workspace_audit_lockfile_context(workspace_dir, manifest_paths, lockfile_paths, inventory),
+        "mode": "paged",
+        "pageSize": min(_CLOUD_AUDIT_PAGE_SIZE, max(len(inventory), 1)),
+        "packages": [
+            {
+                "direct": bool(item.get("direct")),
+                "ecosystem": str(item["ecosystem"]),
+                "name": str(item["name"]),
+                "namespace": item.get("namespace"),
+                **({"version": str(item["version"])} if isinstance(item.get("version"), str) else {}),
+                **({"range": str(item["range"])} if isinstance(item.get("range"), str) else {}),
+            }
+            for item in inventory
+        ],
+        "policyVersion": policy_version,
+        "workspaceFingerprint": workspace_fingerprint,
+    }
+    if payload["lockfileContext"] is None:
+        payload.pop("lockfileContext")
+    return payload
+
+
+def _workspace_audit_lockfile_context(
+    workspace_dir: Path,
+    manifest_paths: tuple[str, ...],
+    lockfile_paths: tuple[str, ...],
+    inventory: tuple[dict[str, object], ...],
+) -> dict[str, object] | None:
+    if not lockfile_paths:
+        return None
+    lockfile_path = workspace_dir / lockfile_paths[0]
+    if not lockfile_path.exists():
+        return None
+    try:
+        lockfile_text = lockfile_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    manifest_hash = None
+    if manifest_paths:
+        manifest_path = workspace_dir / manifest_paths[0]
+        try:
+            manifest_hash = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+        except OSError:
+            manifest_hash = None
+    return {
+        "dependencyCount": len(inventory),
+        "fileName": lockfile_path.name,
+        "lockfileHash": hashlib.sha256(lockfile_text.encode("utf-8")).hexdigest(),
+        "manifestHash": manifest_hash,
+    }
+
+
+def _workspace_audit_fingerprint(
+    *,
+    workspace_id: str,
+    workspace_dir: Path,
+    manifest_paths: tuple[str, ...],
+    lockfile_paths: tuple[str, ...],
+    policy_version: str,
+) -> str:
+    manifest_hashes = _hash_existing_paths(workspace_dir, manifest_paths)
+    lockfile_hashes = _hash_existing_paths(workspace_dir, lockfile_paths)
+    return hashlib.sha256(
+        json.dumps(
+            {
+                "workspace_id": workspace_id,
+                "workspace_name": workspace_dir.name,
+                "manifest_hashes": manifest_hashes,
+                "lockfile_hashes": lockfile_hashes,
+                "policy_version": policy_version,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _hash_existing_paths(workspace_dir: Path, relative_paths: Sequence[str]) -> list[str]:
+    hashes: list[str] = []
+    for relative_path in relative_paths:
+        disk_path = workspace_dir / relative_path
+        if not disk_path.exists():
+            continue
+        try:
+            hashes.append(hashlib.sha256(disk_path.read_bytes()).hexdigest())
+        except OSError:
+            continue
+    return hashes
+
+
+def _normalize_cloud_audit_response(response: dict[str, object]) -> dict[str, object]:
+    return {
+        "decision": str(response.get("decision") or "monitor"),
+        "packages": [item for item in response.get("packages", []) if isinstance(item, dict)],
+        "reasons": [item for item in response.get("reasons", []) if isinstance(item, dict)],
+        "enforcement": str(response.get("enforcement") or "premium_cloud"),
+        "entitlement_state": str(response.get("entitlementState") or "premium"),
+        "cache_status": str(response.get("cacheStatus") or "miss"),
+        "processed_count": int(response.get("processedCount") or 0),
+        "total_packages": int(response.get("totalPackages") or 0),
+        "status": str(response.get("status") or "completed"),
+        "workspace_id": str(response.get("workspaceId") or ""),
+    }
+
+
+def _ci_gate_result(evaluation: dict[str, object], *, threshold: str) -> dict[str, object]:
+    threshold_rank = _SEVERITY_RANK.get(threshold, _SEVERITY_RANK["high"])
+    matched_packages: list[str] = []
+    packages = evaluation.get("packages")
+    if isinstance(packages, list):
+        for package in packages:
+            if not isinstance(package, dict):
+                continue
+            if _package_severity_rank(package) < threshold_rank:
+                continue
+            package_name = package.get("name")
+            if isinstance(package_name, str) and package_name:
+                matched_packages.append(package_name)
+    return {
+        "matched": bool(matched_packages),
+        "matched_packages": matched_packages,
+        "threshold": threshold,
+    }
+
+
+def _package_severity_rank(package: dict[str, object]) -> int:
+    normalized_severity = package.get("normalized_severity")
+    if isinstance(normalized_severity, str):
+        return _SEVERITY_RANK.get(normalized_severity, _SEVERITY_RANK["unknown"])
+    reasons = package.get("reasons")
+    if not isinstance(reasons, list):
+        return _SEVERITY_RANK["unknown"]
+    highest = _SEVERITY_RANK["unknown"]
+    for reason in reasons:
+        if not isinstance(reason, dict):
+            continue
+        severity = reason.get("severity")
+        if not isinstance(severity, str):
+            continue
+        highest = max(highest, _SEVERITY_RANK.get(severity, _SEVERITY_RANK["unknown"]))
+    return highest
+
+
+def _inventory_summary(inventory: tuple[dict[str, object], ...]) -> dict[str, int]:
+    direct_count = sum(1 for item in inventory if bool(item.get("direct")))
+    transitive_count = len(inventory) - direct_count
+    sbom_count = sum(1 for item in inventory if not bool(item.get("direct")))
+    return {
+        "direct_package_count": direct_count,
+        "sbom_package_count": sbom_count,
+        "total_packages": len(inventory),
+        "transitive_package_count": transitive_count,
+    }
+
+
+def _normalized_supply_chain_batch_url(sync_url: str, workspace_id: str) -> str:
+    parsed = urllib.parse.urlsplit(sync_url)
+    if parsed.path.rstrip("/") == "/api/guard/receipts/sync":
+        next_path = "/api/guard/supply-chain/evaluate/batch"
+    elif parsed.path.rstrip("/") == "/guard/receipts/sync":
+        next_path = "/guard/supply-chain/evaluate/batch"
+    else:
+        next_path = parsed.path.rstrip("/") + "/supply-chain/evaluate/batch"
+    query_pairs = [
+        (key, value)
+        for key, value in urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+        if key != "workspaceId"
+    ]
+    query_pairs.append(("workspaceId", workspace_id))
+    return urllib.parse.urlunsplit(
+        (
+            parsed.scheme,
+            parsed.netloc,
+            next_path,
+            urllib.parse.urlencode(query_pairs),
+            "",
+        )
+    )
 
 
 def _target_from_manifest_dependency(ecosystem: str, package_name: str, version: str) -> PackageIntentTarget:

--- a/tests/test_guard_local_supply_chain_audit_phase16.py
+++ b/tests/test_guard_local_supply_chain_audit_phase16.py
@@ -1,0 +1,462 @@
+"""Phase 16 workspace audit CLI coverage."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard import local_supply_chain as local_supply_chain_module
+from codex_plugin_scanner.guard.store import GuardStore
+
+WORKSPACE_ID = "2de4fcb4-a5b2-447a-a67f-21c6eb4c5f3c"
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _seed_premium_pairing(store: GuardStore, *, now: str) -> None:
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "demo-token",
+        now,
+        workspace_id=WORKSPACE_ID,
+    )
+    store.set_sync_payload(
+        "supply_chain_bundle_summary",
+        {
+            "advisory_count": 2,
+            "bundle_version": "1747612800000-deadbeef",
+            "ecosystem_support": [
+                {"ecosystem": "npm", "support_level": "protected", "label": "Protected"},
+                {"ecosystem": "pypi", "support_level": "protected", "label": "Protected"},
+            ],
+            "feed_snapshot_hash": "feed-snapshot-1",
+            "package_count": 2,
+            "policy_hash": "policy-hash-1",
+            "status": "synced",
+            "synced_at": now,
+            "tier": "premium",
+            "workspace_id": WORKSPACE_ID,
+        },
+        now,
+    )
+
+
+class _FakeEvaluation:
+    def __init__(self, *, decision: str) -> None:
+        self.decision = decision
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "decision": self.decision,
+            "packages": [{"name": "minimist", "decision": self.decision}],
+            "reasons": [{"code": "local_fallback", "message": "local fallback"}],
+            "enforcement": "local_fallback",
+        }
+
+
+def test_guard_supply_chain_scan_uses_cloud_batch_for_premium_workspaces(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(
+        workspace_dir / "package.json",
+        '{"name":"demo","dependencies":{"minimist":"^1.2.0","chalk":"^5.3.0"}}\n',
+    )
+    _write_text(
+        workspace_dir / "package-lock.json",
+        json.dumps(
+            {
+                "name": "demo",
+                "lockfileVersion": 3,
+                "packages": {
+                    "": {"dependencies": {"minimist": "^1.2.0", "chalk": "^5.3.0"}},
+                    "node_modules/minimist": {"version": "1.2.5"},
+                    "node_modules/chalk": {"version": "5.3.0"},
+                },
+            }
+        )
+        + "\n",
+    )
+    store = GuardStore(home_dir)
+    _seed_premium_pairing(store, now="2026-05-25T10:00:00+00:00")
+    captured: dict[str, object] = {}
+
+    def _fake_cloud_audit(**kwargs: object) -> tuple[dict[str, object] | None, dict[str, object] | None]:
+        captured.update(kwargs)
+        return (
+            {
+                "decision": "block",
+                "packages": [
+                    {
+                        "name": "minimist",
+                        "ecosystem": "npm",
+                        "namespace": None,
+                        "decision": "block",
+                        "reasons": [{"code": "known_malware", "message": "known malware"}],
+                        "status": "known",
+                        "requestedVersion": "^1.2.0",
+                        "resolvedVersion": "1.2.5",
+                        "recommendedFixVersion": "1.2.9",
+                        "riskScore": 980,
+                        "advisoryIds": ["GHSA-vh95-rmgr-6w4m"],
+                        "sourceKeys": ["ghsa"],
+                        "sourceStale": False,
+                    }
+                ],
+                "reasons": [{"code": "known_malware", "message": "known malware"}],
+                "enforcement": "premium_cloud",
+                "entitlementState": "premium",
+                "cacheStatus": "miss",
+                "processedCount": 2,
+                "totalPackages": 2,
+                "status": "completed",
+                "workspaceId": WORKSPACE_ID,
+            },
+            None,
+        )
+
+    monkeypatch.setattr(local_supply_chain_module, "_run_cloud_workspace_audit", _fake_cloud_audit)
+
+    rc = main(
+        [
+            "guard",
+            "supply-chain",
+            "scan",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 2
+    assert output["mode"] == "scan"
+    assert output["source"] == "cloud"
+    assert output["evaluation"]["decision"] == "block"
+    assert output["inventory"]["total_packages"] == 2
+    assert {item["name"] for item in captured["request_payload"]["packages"]} == {"minimist", "chalk"}
+
+
+def test_guard_supply_chain_audit_alias_accepts_sbom_input(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    sbom_path = workspace_dir / "sbom.json"
+    _write_text(
+        sbom_path,
+        json.dumps(
+            {
+                "bomFormat": "CycloneDX",
+                "specVersion": "1.5",
+                "components": [
+                    {"type": "library", "name": "minimist", "version": "1.2.5", "purl": "pkg:npm/minimist@1.2.5"}
+                ],
+            }
+        )
+        + "\n",
+    )
+    store = GuardStore(home_dir)
+    _seed_premium_pairing(store, now="2026-05-25T10:00:00+00:00")
+    captured: dict[str, object] = {}
+
+    def _fake_cloud_audit(**kwargs: object) -> tuple[dict[str, object] | None, dict[str, object] | None]:
+        captured.update(kwargs)
+        return (
+            {
+                "decision": "warn",
+                "packages": [],
+                "reasons": [],
+                "enforcement": "premium_cloud",
+                "entitlementState": "premium",
+                "cacheStatus": "miss",
+                "processedCount": 1,
+                "totalPackages": 1,
+                "status": "completed",
+                "workspaceId": WORKSPACE_ID,
+            },
+            None,
+        )
+
+    monkeypatch.setattr(local_supply_chain_module, "_run_cloud_workspace_audit", _fake_cloud_audit)
+
+    rc = main(
+        [
+            "guard",
+            "supply-chain",
+            "audit",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--sbom",
+            str(sbom_path),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["mode"] == "audit"
+    assert output["sbom_paths"] == ["sbom.json"]
+    assert output["inventory"]["sbom_package_count"] == 1
+    assert captured["request_payload"]["packages"] == [
+        {"direct": False, "ecosystem": "npm", "name": "minimist", "namespace": None, "version": "1.2.5"}
+    ]
+
+
+def test_guard_supply_chain_scan_falls_back_locally_when_cloud_audit_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo","dependencies":{"minimist":"^1.2.0"}}\n')
+    store = GuardStore(home_dir)
+    _seed_premium_pairing(store, now="2026-05-25T10:00:00+00:00")
+
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "_run_cloud_workspace_audit",
+        lambda **_kwargs: (
+            None,
+            {"code": "cloud_timeout", "message": "Guard cloud evaluation timed out, so Guard fell back locally."},
+        ),
+    )
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "evaluate_package_request_artifact",
+        lambda **_kwargs: _FakeEvaluation(decision="block"),
+    )
+
+    rc = main(
+        [
+            "guard",
+            "supply-chain",
+            "scan",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 2
+    assert output["source"] == "local"
+    assert output["fallback_reason"]["code"] == "cloud_timeout"
+    assert output["evaluation"]["decision"] == "block"
+
+
+def test_guard_supply_chain_audit_payload_excludes_source_snippets(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(
+        workspace_dir / "package.json",
+        json.dumps(
+            {
+                "name": "demo",
+                "description": "do-not-upload-this-description",
+                "scripts": {"postinstall": "echo super-secret-token"},
+                "dependencies": {"minimist": "^1.2.0"},
+            }
+        )
+        + "\n",
+    )
+    _write_text(
+        workspace_dir / "package-lock.json",
+        json.dumps(
+            {
+                "name": "demo",
+                "lockfileVersion": 3,
+                "packages": {
+                    "": {"dependencies": {"minimist": "^1.2.0"}},
+                    "node_modules/minimist": {"version": "1.2.5"},
+                },
+            }
+        )
+        + "\n",
+    )
+    store = GuardStore(home_dir)
+    _seed_premium_pairing(store, now="2026-05-25T10:00:00+00:00")
+    captured: dict[str, object] = {}
+
+    def _fake_cloud_audit(**kwargs: object) -> tuple[dict[str, object] | None, dict[str, object] | None]:
+        captured.update(kwargs)
+        return (
+            {
+                "decision": "monitor",
+                "packages": [],
+                "reasons": [],
+                "enforcement": "premium_cloud",
+                "entitlementState": "premium",
+                "cacheStatus": "miss",
+                "processedCount": 1,
+                "totalPackages": 1,
+                "status": "completed",
+                "workspaceId": WORKSPACE_ID,
+            },
+            None,
+        )
+
+    monkeypatch.setattr(local_supply_chain_module, "_run_cloud_workspace_audit", _fake_cloud_audit)
+
+    rc = main(
+        [
+            "guard",
+            "supply-chain",
+            "audit",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+    request_json = json.dumps(captured["request_payload"], sort_keys=True)
+
+    assert rc == 0
+    assert "super-secret-token" not in request_json
+    assert "do-not-upload-this-description" not in request_json
+    assert str(workspace_dir) not in request_json
+
+
+def test_guard_supply_chain_audit_ci_fail_on_high_returns_distinct_exit_code(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo","dependencies":{"minimist":"^1.2.0"}}\n')
+    store = GuardStore(home_dir)
+    _seed_premium_pairing(store, now="2026-05-25T10:00:00+00:00")
+
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "_run_cloud_workspace_audit",
+        lambda **_kwargs: (
+            {
+                "decision": "warn",
+                "packages": [
+                    {
+                        "name": "minimist",
+                        "ecosystem": "npm",
+                        "namespace": None,
+                        "decision": "warn",
+                        "reasons": [{"code": "high_risk", "message": "high risk", "severity": "high"}],
+                        "status": "known",
+                    }
+                ],
+                "reasons": [{"code": "high_risk", "message": "high risk", "severity": "high"}],
+                "enforcement": "premium_cloud",
+                "entitlementState": "premium",
+                "cacheStatus": "miss",
+                "processedCount": 1,
+                "totalPackages": 1,
+                "status": "completed",
+                "workspaceId": WORKSPACE_ID,
+            },
+            None,
+        ),
+    )
+
+    rc = main(
+        [
+            "guard",
+            "supply-chain",
+            "audit",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--ci",
+            "--fail-on",
+            "high",
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 3
+    assert output["ci"]["matched"] is True
+    assert output["ci"]["threshold"] == "high"
+    assert output["ci"]["matched_packages"] == ["minimist"]
+
+
+def test_guard_supply_chain_audit_before_after_limits_inventory_to_changed_dependencies(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    before_dir = tmp_path / "before"
+    after_dir = tmp_path / "after"
+    before_dir.mkdir()
+    after_dir.mkdir()
+    _write_text(
+        before_dir / "package.json",
+        '{"name":"demo","dependencies":{"minimist":"^1.2.0","chalk":"^5.3.0"}}\n',
+    )
+    _write_text(
+        after_dir / "package.json",
+        '{"name":"demo","dependencies":{"minimist":"^1.2.8","chalk":"^5.3.0"}}\n',
+    )
+    store = GuardStore(home_dir)
+    _seed_premium_pairing(store, now="2026-05-25T10:00:00+00:00")
+    captured: dict[str, object] = {}
+
+    def _fake_cloud_audit(**kwargs: object) -> tuple[dict[str, object] | None, dict[str, object] | None]:
+        captured.update(kwargs)
+        return (
+            {
+                "decision": "monitor",
+                "packages": [],
+                "reasons": [],
+                "enforcement": "premium_cloud",
+                "entitlementState": "premium",
+                "cacheStatus": "miss",
+                "processedCount": 1,
+                "totalPackages": 1,
+                "status": "completed",
+                "workspaceId": WORKSPACE_ID,
+            },
+            None,
+        )
+
+    monkeypatch.setattr(local_supply_chain_module, "_run_cloud_workspace_audit", _fake_cloud_audit)
+
+    rc = main(
+        [
+            "guard",
+            "supply-chain",
+            "audit",
+            "--home",
+            str(home_dir),
+            "--before-workspace",
+            str(before_dir),
+            "--after-workspace",
+            str(after_dir),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["diff"]["changed_package_count"] == 1
+    assert captured["request_payload"]["packages"] == [
+        {"direct": True, "ecosystem": "npm", "name": "minimist", "namespace": None, "range": "^1.2.8"}
+    ]

--- a/tests/test_guard_local_supply_chain_audit_phase16.py
+++ b/tests/test_guard_local_supply_chain_audit_phase16.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import json
 from pathlib import Path
 
@@ -161,7 +162,12 @@ def test_guard_supply_chain_audit_alias_accepts_sbom_input(
                 "bomFormat": "CycloneDX",
                 "specVersion": "1.5",
                 "components": [
-                    {"type": "library", "name": "minimist", "version": "1.2.5", "purl": "pkg:npm/minimist@1.2.5"}
+                    {
+                        "type": "library",
+                        "name": "@scope/left-pad",
+                        "version": "1.2.5",
+                        "purl": "pkg:npm/%40scope/left-pad@1.2.5",
+                    }
                 ],
             }
         )
@@ -212,7 +218,7 @@ def test_guard_supply_chain_audit_alias_accepts_sbom_input(
     assert output["sbom_paths"] == ["sbom.json"]
     assert output["inventory"]["sbom_package_count"] == 1
     assert captured["request_payload"]["packages"] == [
-        {"direct": False, "ecosystem": "npm", "name": "minimist", "namespace": None, "version": "1.2.5"}
+        {"direct": False, "ecosystem": "npm", "name": "left-pad", "namespace": "@scope", "version": "1.2.5"}
     ]
 
 
@@ -460,3 +466,68 @@ def test_guard_supply_chain_audit_before_after_limits_inventory_to_changed_depen
     assert captured["request_payload"]["packages"] == [
         {"direct": True, "ecosystem": "npm", "name": "minimist", "namespace": None, "range": "^1.2.8"}
     ]
+
+
+def test_read_sbom_text_rejects_oversized_files(tmp_path: Path) -> None:
+    sbom_path = tmp_path / "oversized-sbom.json"
+    sbom_path.write_text("x" * ((10 * 1024 * 1024) + 1), encoding="utf-8")
+
+    assert local_supply_chain_module._read_sbom_text(sbom_path) is None
+
+
+def test_run_cloud_workspace_audit_falls_back_after_page_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeResponse(io.StringIO):
+        def __enter__(self) -> _FakeResponse:
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            self.close()
+
+    monkeypatch.setattr(
+        local_supply_chain_module.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: _FakeResponse(
+            json.dumps(
+                {
+                    "decision": "monitor",
+                    "packages": [],
+                    "reasons": [],
+                    "enforcement": "premium_cloud",
+                    "entitlementState": "premium",
+                    "cacheStatus": "miss",
+                    "processedCount": 1,
+                    "totalPackages": 1,
+                    "status": "completed",
+                    "workspaceId": WORKSPACE_ID,
+                    "nextCursor": "repeat",
+                }
+            )
+        ),
+    )
+
+    response, fallback_reason = local_supply_chain_module._run_cloud_workspace_audit(
+        request_payload={
+            "commandShape": {
+                "argCount": 3,
+                "flags": [],
+                "packageManager": "npm",
+                "redacted": True,
+                "verb": "audit",
+            },
+            "harness": "guard-cli",
+            "mode": "paged",
+            "pageSize": 1,
+            "packages": [{"direct": True, "ecosystem": "npm", "name": "minimist", "version": "1.2.5"}],
+            "policyVersion": "policy-hash-1",
+            "workspaceFingerprint": "workspace-fingerprint",
+        },
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        token="demo-token",
+        workspace_id=WORKSPACE_ID,
+    )
+
+    assert response is None
+    assert fallback_reason == {
+        "code": "cloud_page_limit",
+        "message": "Guard cloud evaluation exceeded the maximum page count, so Guard fell back locally.",
+    }


### PR DESCRIPTION
## Summary
- add local workspace audit inventory extraction for manifests, lockfiles, and optional CycloneDX/SPDX SBOM inputs
- route supply-chain scan/audit through Guard Cloud batch evaluation for premium paired workspaces with explicit local fallback
- add audit CI severity gating and before/after dependency diff coverage

## Testing
- python3 -m pytest tests/test_guard_local_supply_chain_phase15.py tests/test_guard_local_supply_chain_audit_phase16.py -q
- python3 -m ruff check src/codex_plugin_scanner/guard/local_supply_chain.py src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_local_supply_chain_audit_phase16.py