### PR TITLE
fix(codex): resume after browser approval

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2727,6 +2727,12 @@ def run_guard_command(
                     metadata={
                         "tool_name": str(payload.get("tool_name", "")),
                         "hook_name": "permissionRequest",
+                        "hook_event_name": "PermissionRequest",
+                        "codex_hook_waits_for_browser_approval": _codex_hook_waits_for_browser_approval(
+                            args=args,
+                            event_name="PermissionRequest",
+                            policy_action=policy_action,
+                        ),
                         "command_text": _hook_command_text(payload),
                         "workspace": str(runtime_workspace) if runtime_workspace else None,
                         **codex_resume_metadata_from_hook_payload(payload),
@@ -3195,6 +3201,12 @@ def run_guard_command(
                             metadata={
                                 "tool_name": str(payload.get("tool_name", "")),
                                 "event": str(payload.get("event", "")),
+                                "hook_event_name": event_name,
+                                "codex_hook_waits_for_browser_approval": _codex_hook_waits_for_browser_approval(
+                                    args=args,
+                                    event_name=event_name,
+                                    policy_action=policy_action,
+                                ),
                                 "command_text": _hook_command_text(payload),
                                 "workspace": str(workspace) if workspace else None,
                                 **codex_resume_metadata_from_hook_payload(payload),
@@ -3600,13 +3612,7 @@ def _codex_browser_approval_decision(
     config: GuardConfig,
     daemon_client: object | None = None,
 ) -> str | None:
-    if _canonical_harness_name(args.harness) != "codex":
-        return None
-    if getattr(args, "json", False):
-        return None
-    if event_name not in {"PreToolUse", "PostToolUse", "UserPromptSubmit"}:
-        return None
-    if policy_action not in {"block", "sandbox-required", "require-reapproval"}:
+    if not _codex_can_use_browser_approval(args=args, event_name=event_name, policy_action=policy_action):
         return None
     if event_name == "PreToolUse" and not _is_codex_native_runtime():
         return None
@@ -3643,6 +3649,27 @@ def _codex_browser_approval_decision(
     _update_codex_browser_operation_status(response_payload, daemon_client, "completed")
     response_payload["review_hint"] = "Approval received in HOL Guard. Codex is resuming this action."
     return "allow"
+
+
+def _codex_can_use_browser_approval(args: argparse.Namespace, *, event_name: str, policy_action: str) -> bool:
+    return (
+        _canonical_harness_name(args.harness) == "codex"
+        and not getattr(args, "json", False)
+        and event_name in {"PreToolUse", "PostToolUse", "UserPromptSubmit"}
+        and policy_action in {"block", "sandbox-required", "require-reapproval"}
+    )
+
+
+def _codex_hook_waits_for_browser_approval(
+    args: argparse.Namespace,
+    *,
+    event_name: str,
+    policy_action: str,
+) -> bool:
+    return (
+        _codex_can_use_browser_approval(args=args, event_name=event_name, policy_action=policy_action)
+        and event_name != "PreToolUse"
+    )
 
 
 def _update_codex_browser_operation_status(

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3598,10 +3598,6 @@ def _should_emit_native_hook_exit_block(args: argparse.Namespace, *, event_name:
     return False
 
 
-def _is_codex_native_runtime() -> bool:
-    return bool(os.environ.get("CODEX_HOME", "").strip() or os.environ.get("CODEX_MANAGED_BY_BUN", "").strip())
-
-
 def _codex_browser_approval_decision(
     *,
     args: argparse.Namespace,
@@ -3613,8 +3609,6 @@ def _codex_browser_approval_decision(
     daemon_client: object | None = None,
 ) -> str | None:
     if not _codex_can_use_browser_approval(args=args, event_name=event_name, policy_action=policy_action):
-        return None
-    if event_name == "PreToolUse" and not _is_codex_native_runtime():
         return None
     if event_name == "PreToolUse":
         return None

--- a/src/codex_plugin_scanner/guard/codex_resume.py
+++ b/src/codex_plugin_scanner/guard/codex_resume.py
@@ -116,6 +116,9 @@ def defer_request_resume_to_live_hook(
         return None
     if str(operation.get("status")) != "waiting_on_approval":
         return None
+    metadata = operation.get("metadata")
+    if not isinstance(metadata, Mapping) or metadata.get("codex_hook_waits_for_browser_approval") is not True:
+        return None
     resume = get_request_resume_status(store, request_id=request_id, now=now)
     if resume is None:
         return None

--- a/tests/test_guard_codex_resume_endpoints.py
+++ b/tests/test_guard_codex_resume_endpoints.py
@@ -94,6 +94,8 @@ def _seed_codex_operation(
     workspace: str = "/workspace",
     codex_home: str | None = None,
     command_text: str | None = None,
+    hook_event_name: str | None = None,
+    waits_for_browser_approval: bool | None = None,
     status: str = "waiting_on_approval",
 ) -> None:
     session = store.upsert_guard_session(
@@ -119,6 +121,10 @@ def _seed_codex_operation(
         metadata["codex_home"] = codex_home
     if command_text is not None:
         metadata["command_text"] = command_text
+    if hook_event_name is not None:
+        metadata["hook_event_name"] = hook_event_name
+    if waits_for_browser_approval is not None:
+        metadata["codex_hook_waits_for_browser_approval"] = waits_for_browser_approval
     store.upsert_guard_operation(
         operation_id=f"operation-{request_id}",
         session_id=str(session["session_id"]),
@@ -208,6 +214,8 @@ def test_codex_approve_defers_headless_resume_while_live_hook_waits(
         request_id="req-live",
         socket_path=missing_socket,
         thread_id="live-session-1",
+        hook_event_name="PostToolUse",
+        waits_for_browser_approval=True,
         status="waiting_on_approval",
     )
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
@@ -229,6 +237,67 @@ def test_codex_approve_defers_headless_resume_while_live_hook_waits(
     assert "original Codex action continue" in payload["codex_resume"]["message"]
 
 
+def test_codex_approve_pretooluse_no_wait_starts_headless_resume(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    launched: list[dict[str, object]] = []
+
+    class _FakeProcess:
+        pid = 1007
+
+    def _fake_popen(command, **kwargs):
+        launched.append({"command": command, **kwargs})
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        codex_app_server_module.shutil,
+        "which",
+        lambda command: "/usr/bin/codex" if command == "codex" else None,
+    )
+    monkeypatch.setattr(codex_app_server_module.subprocess, "Popen", _fake_popen)
+
+    workspace = tmp_path / "workspace"
+    codex_home = tmp_path / "codex-home"
+    workspace.mkdir()
+    codex_home.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    store.add_approval_request(_request("req-pretool"), "2026-05-19T10:00:00+00:00")
+    _seed_codex_operation(
+        store,
+        request_id="req-pretool",
+        socket_path=None,
+        thread_id="pretool-session-1",
+        workspace=str(workspace),
+        codex_home=str(codex_home),
+        command_text="npm install minimist@1.2.8",
+        hook_event_name="PreToolUse",
+        waits_for_browser_approval=False,
+        status="waiting_on_approval",
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+
+    try:
+        payload = _post_json(
+            daemon.port,
+            daemon._server.auth_token,
+            "/v1/requests/req-pretool/approve",
+            {"scope": "artifact", "reason": "reviewed"},
+        )
+    finally:
+        daemon.stop()
+
+    assert payload["resolved"] is True
+    assert payload["codex_resume"]["status"] == "sent"
+    assert payload["codex_resume"]["reason"] == "headless_resume_started"
+    assert payload["codex_resume"]["strategy"] == "codex-headless-exec"
+    assert len(launched) == 1
+    assert launched[0]["cwd"] == workspace
+    assert launched[0]["command"][:5] == ["/usr/bin/codex", "exec", "resume", "--json", "--skip-git-repo-check"]
+    assert "pretool-session-1" in launched[0]["command"]
+
+
 def test_codex_deferred_live_hook_resume_retry_reports_missing_chat_channel(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -243,6 +312,8 @@ def test_codex_deferred_live_hook_resume_retry_reports_missing_chat_channel(
         request_id="req-live-retry",
         socket_path=missing_socket,
         thread_id="live-session-retry-1",
+        hook_event_name="PostToolUse",
+        waits_for_browser_approval=True,
         status="waiting_on_approval",
     )
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)


### PR DESCRIPTION
## Summary
- Resume Codex headless sessions immediately after browser approval for PreToolUse blocks.
- Mark queued Codex operations with whether the original hook is still waiting, so only live waiting hooks defer headless resume.
- Add regression coverage for PreToolUse no-wait approvals and existing live-hook deferral behavior.

## Testing
- `python3 -m pytest -q tests/test_guard_codex_resume_endpoints.py::test_codex_approve_pretooluse_no_wait_starts_headless_resume tests/test_guard_codex_resume_endpoints.py::test_codex_approve_defers_headless_resume_while_live_hook_waits tests/test_guard_runtime.py::test_codex_browser_approval_uses_configured_wait_timeout tests/test_guard_runtime.py::test_guard_hook_codex_pretooluse_browser_approval_resumes_original_tool`
- `python3 -m ruff check src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/codex_resume.py tests/test_guard_codex_resume_endpoints.py`
- `git diff --check`

## Notes
- Local e2e proof: approved request `fc2fb33453fe4f038e4ee7c730b12a95`, forced resume returned `status=sent`, `reason=headless_resume_started`, and nested workspace installed `is-buffer@2.0.5`.
