### PR TITLE
fix(release): align pipx package metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ pipx install hol-guard
 hol-guard init
 ```
 
+To update an existing pipx install from PyPI:
+
+```bash
+pipx upgrade hol-guard
+```
+
+To force a specific release, use Python package specifier syntax:
+
+```bash
+pipx install --force 'hol-guard==2.0.323'
+```
+
+Do not use `hol-guard@2.0.323`; pipx treats that as a separate app name, not a package version.
+
 `hol-guard init` is the first-run guided setup. It shows a progressive plan first, then gates each side effect: approve dashboard, Guard completes it, then approve app protection, Guard completes it, then approve Cloud connect and notifications. Nothing opens or changes until you approve that checkpoint. Use `hol-guard init --yes` only for automation when you already trust the plan.
 
 Manual and follow-up commands:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hol-guard"
-version = "2.0.303"
+version = "2.0.323"
 description = "Protect local AI harnesses with HOL Guard and run scanner checks for Codex, Claude, Cursor, Gemini, and OpenCode."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/codex_plugin_scanner/version.py
+++ b/src/codex_plugin_scanner/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for tool version."""
 
-__version__ = "2.0.303"
+__version__ = "2.0.323"

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,9 +1,21 @@
 """Tests for package/CLI version consistency."""
 
+from pathlib import Path
+
 import pytest
 
 from codex_plugin_scanner import __version__ as package_version
 from codex_plugin_scanner.cli import main
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
+    import tomli as tomllib
+
+
+def test_pyproject_version_matches_package_version():
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    assert pyproject["project"]["version"] == package_version
 
 
 def test_cli_version_matches_package_version(capsys: pytest.CaptureFixture[str]):

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -14,7 +14,8 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
 
 
 def test_pyproject_version_matches_package_version():
-    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
+    pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
     assert pyproject["project"]["version"] == package_version
 
 


### PR DESCRIPTION
## Summary
- Align committed HOL Guard package metadata with the current published release, 2.0.323.
- Document correct pipx upgrade and forced-version syntax.
- Add regression coverage so pyproject and runtime __version__ stay in sync.

## Testing
- `python3 -m pytest -q tests/test_versioning.py`
- `python3 -m ruff check tests/test_versioning.py`
- `python3 -m build --wheel`
- temp venv install of `dist/hol_guard-2.0.323-py3-none-any.whl` then `hol-guard --version` returned `hol-guard 2.0.323`
- `git diff --check`

## Notes
- Local pipx was already corrected with `pipx install --force 'hol-guard==2.0.323'`; `pipx upgrade hol-guard` now reports latest 2.0.323.
