### PR TITLE
fix(guard): polish authenticator setup flow

### DIFF
--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -411,9 +411,9 @@ export function App() {
     setClearConfirm(scope);
   }, []);
 
-  const handleConfirmClear = useCallback(async () => {
+  const handleConfirmClear = useCallback(async (credentials?: { approval_password?: string; approval_totp_code?: string }) => {
     if (clearConfirm === null) return;
-    await clearPolicy(clearConfirm);
+    await clearPolicy({ ...clearConfirm, ...credentials });
     setClearConfirm(null);
     const [snapshotResult, policiesResult] = await Promise.allSettled([fetchRuntimeSnapshot(), fetchPolicies()]);
     if (snapshotResult.status === "fulfilled") {
@@ -658,6 +658,7 @@ export function App() {
             onClearPolicies={handleClearPolicies}
             onOpenAppDetail={handleOpenAppDetail}
             clearConfirm={clearConfirm}
+            approvalGate={approvalGate}
             onConfirmClear={handleConfirmClear}
             onCancelClear={handleCancelClear}
             onOpenHelp={handleOpenHelp}

--- a/dashboard/src/home-dashboard.tsx
+++ b/dashboard/src/home-dashboard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type ReactNode } from "react";
 import {
   HiMiniCheckCircle,
   HiMiniMinusCircle,
@@ -25,6 +25,7 @@ import { harnessDisplayName, formatRelativeTime, formatNumber, isDisplayableHarn
 import { useFocusTrap } from "./use-focus-trap";
 import { DeviceProofCard, resolveCloudIntelCopy } from "./runtime-overview";
 import type {
+  GuardApprovalGatePublicConfig,
   GuardApprovalRequest,
   GuardManagedInstall,
   GuardPolicyDecision,
@@ -130,11 +131,16 @@ export function HomeWorkspace(props: {
   onClearPolicies: (scope: { harness?: string; all?: boolean }) => void;
   onOpenAppDetail: (harness: string) => void;
   clearConfirm: { harness?: string; all?: boolean } | null;
-  onConfirmClear: () => Promise<void>;
+  approvalGate: GuardApprovalGatePublicConfig | null;
+  onConfirmClear: (credentials?: { approval_password?: string; approval_totp_code?: string }) => Promise<void>;
   onCancelClear: () => void;
   onOpenHelp?: () => void;
 }) {
   const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const [clearPassword, setClearPassword] = useState("");
+  const [clearTotpCode, setClearTotpCode] = useState("");
+  const [clearError, setClearError] = useState<string | null>(null);
+  const [clearSubmitting, setClearSubmitting] = useState(false);
   const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -153,15 +159,38 @@ export function HomeWorkspace(props: {
     props.onClearPolicies(scope);
   }, [props.onClearPolicies]);
 
+  const handleClearPasswordChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setClearPassword(event.target.value);
+    setClearError(null);
+  }, []);
+
+  const handleClearTotpCodeChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setClearTotpCode(event.target.value);
+    setClearError(null);
+  }, []);
+
   const handleConfirmClearWithToast = useCallback(async () => {
     const confirm = props.clearConfirm;
-    await props.onConfirmClear();
-    if (confirm?.harness) {
-      showToast(`Cleared for ${harnessDisplayName(confirm.harness)}`);
-    } else if (confirm?.all) {
-      showToast("Cleared all decisions");
+    setClearSubmitting(true);
+    setClearError(null);
+    try {
+      await props.onConfirmClear({
+        ...(clearPassword ? { approval_password: clearPassword } : {}),
+        ...(clearTotpCode ? { approval_totp_code: clearTotpCode } : {}),
+      });
+      setClearPassword("");
+      setClearTotpCode("");
+      if (confirm?.harness) {
+        showToast(`Cleared for ${harnessDisplayName(confirm.harness)}`);
+      } else if (confirm?.all) {
+        showToast("Cleared all decisions");
+      }
+    } catch (error) {
+      setClearError(error instanceof Error ? error.message : "Unable to clear remembered decisions.");
+    } finally {
+      setClearSubmitting(false);
     }
-  }, [props.clearConfirm, props.onConfirmClear, showToast]);
+  }, [clearPassword, clearTotpCode, props.clearConfirm, props.onConfirmClear, showToast]);
 
   const snapshot = props.runtime.kind === "ready" ? props.runtime.snapshot : null;
   const queuedCount = props.requests.kind === "ready" ? props.requests.items.length : 0;
@@ -345,6 +374,13 @@ export function HomeWorkspace(props: {
       {props.clearConfirm && (
         <ClearConfirmDialog
           clearConfirm={props.clearConfirm}
+          approvalGate={props.approvalGate}
+          clearPassword={clearPassword}
+          clearTotpCode={clearTotpCode}
+          clearError={clearError}
+          clearSubmitting={clearSubmitting}
+          onClearPasswordChange={handleClearPasswordChange}
+          onClearTotpCodeChange={handleClearTotpCodeChange}
           onCancelClear={props.onCancelClear}
           onConfirmClear={handleConfirmClearWithToast}
         />
@@ -355,11 +391,19 @@ export function HomeWorkspace(props: {
 
 function ClearConfirmDialog(props: {
   clearConfirm: { harness?: string; all?: boolean };
+  approvalGate: GuardApprovalGatePublicConfig | null;
+  clearPassword: string;
+  clearTotpCode: string;
+  clearError: string | null;
+  clearSubmitting: boolean;
+  onClearPasswordChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onClearTotpCodeChange: (event: ChangeEvent<HTMLInputElement>) => void;
   onCancelClear: () => void;
   onConfirmClear: () => Promise<void>;
 }) {
   const dialogRef = useRef<HTMLDivElement>(null);
   useFocusTrap(true, dialogRef);
+  const needsProof = props.approvalGate?.enabled === true && props.approvalGate.configured === true;
 
   return (
     <div className="guard-fade-in fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4 backdrop-blur-sm" role="dialog" aria-modal="true" aria-label="Confirm clear decisions">
@@ -373,6 +417,40 @@ function ClearConfirmDialog(props: {
                 <p className="mt-2 text-sm text-muted-foreground">
                   This will remove {props.clearConfirm.all ? "all saved approvals" : `decisions for ${props.clearConfirm.harness ?? "this app"}`}. Guard will ask again next time matching actions run.
                 </p>
+                {needsProof && (
+                  <div className="mt-4 grid gap-3">
+                    <label className="block">
+                      <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Approval password</span>
+                      <input
+                        type="password"
+                        autoComplete="current-password"
+                        value={props.clearPassword}
+                        onChange={props.onClearPasswordChange}
+                        className="mt-1 min-h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+                      />
+                    </label>
+                    {props.approvalGate?.totp_enabled === true && (
+                      <label className="block">
+                        <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Authenticator code</span>
+                        <input
+                          type="text"
+                          inputMode="numeric"
+                          pattern="[0-9]*"
+                          maxLength={6}
+                          value={props.clearTotpCode}
+                          onChange={props.onClearTotpCodeChange}
+                          placeholder="123456"
+                          className="mt-1 min-h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm tracking-[0.28em] text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+                        />
+                      </label>
+                    )}
+                  </div>
+                )}
+                {props.clearError !== null && (
+                  <p className="mt-3 rounded-xl border border-brand-attention/20 bg-brand-attention/[0.04] px-3 py-2 text-sm text-brand-dark">
+                    {props.clearError}
+                  </p>
+                )}
               </div>
             </div>
             <div className="mt-5 flex flex-col gap-2 sm:flex-row sm:justify-end">
@@ -386,9 +464,10 @@ function ClearConfirmDialog(props: {
               <button
                 type="button"
                 onClick={props.onConfirmClear}
-                className="inline-flex min-h-11 items-center justify-center rounded-lg bg-brand-attention px-4 text-sm font-semibold text-white transition-colors hover:bg-brand-attention/90"
+                disabled={props.clearSubmitting}
+                className="inline-flex min-h-11 items-center justify-center rounded-lg bg-brand-attention px-4 text-sm font-semibold text-white transition-colors hover:bg-brand-attention/90 disabled:opacity-60"
               >
-                Clear decisions
+                {props.clearSubmitting ? "Clearing..." : "Clear decisions"}
               </button>
             </div>
           </div>

--- a/dashboard/src/settings-workspace.tsx
+++ b/dashboard/src/settings-workspace.tsx
@@ -10,6 +10,7 @@ import {
   HiMiniChevronDown,
   HiMiniChevronUp,
   HiMiniMagnifyingGlass,
+  HiMiniXMark,
 } from "react-icons/hi2";
 
 import {
@@ -39,6 +40,7 @@ import {
 import { approvalGateCooldownLabel } from "./approval-gate-utils";
 import { resolveProtectionLevelCopy } from "./runtime-overview";
 import { RISK_CONTROL_CONSEQUENCES, filterSettingsBySearch, securityLevelLabel } from "./apps/app-catalog";
+import { useFocusTrap } from "./use-focus-trap";
 export {
   buildTotpQrImageOptions,
   formatTotpEnrollmentExpiry,
@@ -367,6 +369,7 @@ export function SettingsWorkspace({ onApprovalGateChange }: SettingsWorkspacePro
   const [approvalGateStrictAllDecisions, setApprovalGateStrictAllDecisions] = useState(false);
   const [approvalGateCooldown, setApprovalGateCooldown] = useState(0);
   const [totpEnrollment, setTotpEnrollment] = useState<GuardApprovalGateTotpEnrollment | null>(null);
+  const [totpSetupOpen, setTotpSetupOpen] = useState(false);
   const [totpActionPending, setTotpActionPending] = useState<"enroll" | "verify" | "disable" | null>(null);
   const [totpActionError, setTotpActionError] = useState<string | null>(null);
   const [revokingCooldown, setRevokingCooldown] = useState(false);
@@ -546,6 +549,12 @@ export function SettingsWorkspace({ onApprovalGateChange }: SettingsWorkspacePro
     setApprovalGateTotpDeviceLabel(event.target.value);
     setTotpActionError(null);
   }, []);
+  const handleOpenTotpSetup = useCallback(() => {
+    setTotpSetupOpen(true);
+  }, []);
+  const handleCloseTotpSetup = useCallback(() => {
+    setTotpSetupOpen(false);
+  }, []);
 
   const handleApprovalGateCooldownChange = useCallback((event: ChangeEvent<HTMLSelectElement>) => {
     const next = Number(event.target.value);
@@ -638,6 +647,7 @@ export function SettingsWorkspace({ onApprovalGateChange }: SettingsWorkspacePro
         onApprovalGateChange?.(gate);
       }
       setTotpEnrollment(payload.enrollment ?? null);
+      setTotpSetupOpen(payload.enrollment !== undefined && payload.enrollment !== null);
       setActionMessage("TOTP enrollment started. Verify with your authenticator code.");
       setActionMessageKind("success");
     } catch (error) {
@@ -673,6 +683,7 @@ export function SettingsWorkspace({ onApprovalGateChange }: SettingsWorkspacePro
       }
       setApprovalGateTotpCode("");
       setTotpEnrollment(null);
+      setTotpSetupOpen(false);
       setActionMessage("TOTP verified and enabled.");
       setActionMessageKind("success");
     } catch (error) {
@@ -708,6 +719,7 @@ export function SettingsWorkspace({ onApprovalGateChange }: SettingsWorkspacePro
       }
       setApprovalGateTotpCode("");
       setTotpEnrollment(null);
+      setTotpSetupOpen(false);
       setActionMessage("TOTP disabled.");
       setActionMessageKind("success");
     } catch (error) {
@@ -1038,6 +1050,7 @@ export function SettingsWorkspace({ onApprovalGateChange }: SettingsWorkspacePro
               strictAllDecisions={approvalGateStrictAllDecisions}
               cooldownSeconds={approvalGateCooldown}
               totpEnrollment={totpEnrollment}
+              totpSetupOpen={totpSetupOpen}
               totpActionPending={totpActionPending}
               totpActionError={totpActionError}
               revokingCooldown={revokingCooldown}
@@ -1049,6 +1062,8 @@ export function SettingsWorkspace({ onApprovalGateChange }: SettingsWorkspacePro
               onCurrentPasswordChange={handleApprovalGateCurrentPassword}
               onTotpCodeChange={handleApprovalGateTotpCode}
               onTotpDeviceLabelChange={handleApprovalGateTotpDeviceLabel}
+              onOpenTotpSetup={handleOpenTotpSetup}
+              onCloseTotpSetup={handleCloseTotpSetup}
               onStrictAllDecisionsChange={handleApprovalGateStrictAllDecisions}
               onCooldownChange={handleApprovalGateCooldownChange}
               onStartTotpEnrollment={handleStartTotpEnrollment}
@@ -1530,6 +1545,7 @@ type ApprovalGateCardProps = {
   strictAllDecisions: boolean;
   cooldownSeconds: number;
   totpEnrollment: GuardApprovalGateTotpEnrollment | null;
+  totpSetupOpen: boolean;
   totpActionPending: "enroll" | "verify" | "disable" | null;
   totpActionError: string | null;
   revokingCooldown: boolean;
@@ -1541,6 +1557,8 @@ type ApprovalGateCardProps = {
   onCurrentPasswordChange: (event: ChangeEvent<HTMLInputElement>) => void;
   onTotpCodeChange: (event: ChangeEvent<HTMLInputElement>) => void;
   onTotpDeviceLabelChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onOpenTotpSetup: () => void;
+  onCloseTotpSetup: () => void;
   onStrictAllDecisionsChange: (event: ChangeEvent<HTMLInputElement>) => void;
   onCooldownChange: (event: ChangeEvent<HTMLSelectElement>) => void;
   onStartTotpEnrollment: () => void;
@@ -1633,71 +1651,86 @@ function ApprovalGateCard(props: ApprovalGateCardProps) {
               </p>
             </div>
           )}
-          <div className="space-y-2 rounded-lg border border-slate-200 bg-white px-3 py-3">
+          <div className="overflow-hidden rounded-xl border border-brand-blue/15 bg-white">
             <div className="flex items-center justify-between gap-2">
-              <SectionLabel>TOTP authenticator</SectionLabel>
-              <Tag tone={totpEnabled ? "green" : totpPending ? "blue" : "slate"}>
-                {totpEnabled ? "Enabled" : totpPending ? "Pending verification" : "Disabled"}
-              </Tag>
+              <div className="px-4 py-3">
+                <SectionLabel>Authenticator app</SectionLabel>
+                <p className="mt-1 max-w-xl text-xs leading-5 text-slate-500">
+                  Add a six-digit code from Google Authenticator, 1Password, Authy, or iCloud Passwords for high-risk approvals.
+                </p>
+              </div>
+              <div className="px-4">
+                <Tag tone={totpEnabled ? "green" : totpPending ? "blue" : "slate"}>
+                  {totpEnabled ? "Enabled" : totpPending ? "Pending verification" : "Not connected"}
+                </Tag>
+              </div>
             </div>
-            <p className="text-xs text-slate-500">
-              Add an authenticator code as a second factor for high-risk approvals and settings writes.
-            </p>
-            {!totpEnabled && (
-              <label className="block">
-                <span className="text-xs font-medium text-slate-500">Device label</span>
-                <input
-                  type="text"
-                  value={props.totpDeviceLabel}
-                  onChange={props.onTotpDeviceLabelChange}
-                  className="mt-1 min-h-9 w-full rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-1 focus:ring-brand-blue/20"
-                />
-              </label>
-            )}
-            <label className="block">
-              <span className="text-xs font-medium text-slate-500">Authenticator code</span>
-              <input
-                type="text"
-                inputMode="numeric"
-                pattern="[0-9]*"
-                value={props.totpCode}
-                onChange={props.onTotpCodeChange}
-                className="mt-1 min-h-9 w-full rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-1 focus:ring-brand-blue/20"
-              />
-            </label>
-            {totpPending && props.totpEnrollment !== null && <TotpEnrollmentQrPanel enrollment={props.totpEnrollment} />}
-            {props.totpActionError !== null && (
-              <p className="text-xs text-brand-purple">{props.totpActionError}</p>
-            )}
-            <div className="flex flex-wrap gap-2">
-              {!totpEnabled && (
-                <ActionButton
-                  onClick={props.onStartTotpEnrollment}
-                  disabled={props.totpActionPending !== null}
-                  variant="outline"
-                >
-                  {props.totpActionPending === "enroll" ? "Starting…" : "Start enrollment"}
-                </ActionButton>
+            <div className="border-t border-slate-100 bg-slate-50/50 px-4 py-3">
+              {!totpEnabled && !totpPending && (
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <p className="text-sm font-medium text-brand-dark">Scan a QR code to connect an authenticator app.</p>
+                  <ActionButton
+                    onClick={props.onStartTotpEnrollment}
+                    disabled={props.totpActionPending !== null}
+                    variant="outline"
+                  >
+                    {props.totpActionPending === "enroll" ? "Opening setup..." : "Set up authenticator"}
+                  </ActionButton>
+                </div>
               )}
               {totpPending && (
-                <ActionButton
-                  onClick={props.onVerifyTotpEnrollment}
-                  disabled={props.totpActionPending !== null}
-                  variant="outline"
-                >
-                  {props.totpActionPending === "verify" ? "Verifying…" : "Verify code"}
-                </ActionButton>
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <p className="text-sm font-medium text-brand-dark">
+                    Setup pending. Open the QR screen and enter the current code to finish.
+                  </p>
+                  <ActionButton
+                    onClick={props.totpEnrollment ? props.onOpenTotpSetup : props.onStartTotpEnrollment}
+                    disabled={props.totpActionPending !== null}
+                    variant="outline"
+                  >
+                    {props.totpEnrollment ? "Open setup" : "Restart setup"}
+                  </ActionButton>
+                </div>
               )}
               {totpEnabled && (
-                <ActionButton
-                  onClick={props.onDisableTotp}
-                  disabled={props.totpActionPending !== null}
-                  variant="outline"
-                >
-                  {props.totpActionPending === "disable" ? "Disabling…" : "Disable authenticator"}
-                </ActionButton>
+                <div className="space-y-3">
+                  <label className="block">
+                    <span className="text-xs font-medium text-slate-500">Authenticator code to disable</span>
+                    <input
+                      type="text"
+                      inputMode="numeric"
+                      pattern="[0-9]*"
+                      value={props.totpCode}
+                      onChange={props.onTotpCodeChange}
+                      className="mt-1 min-h-9 w-full rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-1 focus:ring-brand-blue/20"
+                    />
+                  </label>
+                  <ActionButton
+                    onClick={props.onDisableTotp}
+                    disabled={props.totpActionPending !== null}
+                    variant="outline"
+                  >
+                    {props.totpActionPending === "disable" ? "Disabling..." : "Disable authenticator"}
+                  </ActionButton>
+                </div>
+              )}
+              {props.totpActionError !== null && (
+                <p className="mt-2 text-xs text-brand-purple">{props.totpActionError}</p>
               )}
             </div>
+            {props.totpSetupOpen && props.totpEnrollment !== null && (
+              <TotpSetupModal
+                enrollment={props.totpEnrollment}
+                deviceLabel={props.totpDeviceLabel}
+                totpCode={props.totpCode}
+                pending={props.totpActionPending}
+                error={props.totpActionError}
+                onDeviceLabelChange={props.onTotpDeviceLabelChange}
+                onTotpCodeChange={props.onTotpCodeChange}
+                onVerify={props.onVerifyTotpEnrollment}
+                onClose={props.onCloseTotpSetup}
+              />
+            )}
           </div>
 
           {cooldownActive && cooldownLabel !== null && (
@@ -1738,6 +1771,85 @@ function ApprovalGateCard(props: ApprovalGateCardProps) {
           )}
         </div>
       )}
+    </div>
+  );
+}
+
+function TotpSetupModal(props: {
+  enrollment: GuardApprovalGateTotpEnrollment;
+  deviceLabel: string;
+  totpCode: string;
+  pending: "enroll" | "verify" | "disable" | null;
+  error: string | null;
+  onDeviceLabelChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onTotpCodeChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onVerify: () => void;
+  onClose: () => void;
+}) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(true, modalRef);
+
+  return (
+    <div
+      className="guard-fade-in fixed inset-0 z-50 flex items-center justify-center bg-brand-dark/45 p-4 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Set up authenticator app"
+    >
+      <div ref={modalRef} className="w-full max-w-3xl overflow-hidden rounded-3xl border border-brand-blue/15 bg-white shadow-2xl">
+        <div className="flex items-start justify-between gap-4 border-b border-slate-100 px-6 py-5">
+          <div>
+            <SectionLabel>Authenticator setup</SectionLabel>
+            <h3 className="mt-2 text-2xl font-semibold tracking-tight text-brand-dark">Scan this QR code</h3>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+              Open your authenticator app, add account, scan code, then enter current six-digit code to finish.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={props.onClose}
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-500 transition-colors hover:bg-slate-50 hover:text-brand-dark"
+            aria-label="Close authenticator setup"
+          >
+            <HiMiniXMark className="h-5 w-5" aria-hidden="true" />
+          </button>
+        </div>
+        <div className="grid gap-5 p-6 lg:grid-cols-[minmax(0,1fr)_260px]">
+          <TotpEnrollmentQrPanel enrollment={props.enrollment} />
+          <div className="space-y-4 rounded-2xl border border-slate-100 bg-slate-50/70 p-4">
+            <label className="block">
+              <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Device label</span>
+              <input
+                type="text"
+                value={props.deviceLabel}
+                onChange={props.onDeviceLabelChange}
+                className="mt-2 min-h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+              />
+            </label>
+            <label className="block">
+              <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Six-digit code</span>
+              <input
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                maxLength={6}
+                value={props.totpCode}
+                onChange={props.onTotpCodeChange}
+                placeholder="123456"
+                className="mt-2 min-h-12 w-full rounded-xl border border-slate-200 bg-white px-3 text-center text-lg font-semibold tracking-[0.35em] text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+              />
+            </label>
+            {props.error !== null && (
+              <p className="rounded-xl border border-brand-attention/20 bg-brand-attention/[0.04] px-3 py-2 text-xs text-brand-dark">
+                {props.error}
+              </p>
+            )}
+            <ActionButton onClick={props.onVerify} disabled={props.pending !== null}>
+              {props.pending === "verify" ? "Verifying..." : "Finish setup"}
+            </ActionButton>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/home-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/home-dashboard.js
@@ -59,6 +59,10 @@ function buildRecentProtectionCopy(receipt) {
 }
 function HomeWorkspace(props) {
   const [toastMessage, setToastMessage] = reactExports.useState(null);
+  const [clearPassword, setClearPassword] = reactExports.useState("");
+  const [clearTotpCode, setClearTotpCode] = reactExports.useState("");
+  const [clearError, setClearError] = reactExports.useState(null);
+  const [clearSubmitting, setClearSubmitting] = reactExports.useState(false);
   const toastTimerRef = reactExports.useRef(null);
   reactExports.useEffect(() => {
     return () => {
@@ -73,15 +77,36 @@ function HomeWorkspace(props) {
   const handleClearPolicies = reactExports.useCallback((scope) => {
     props.onClearPolicies(scope);
   }, [props.onClearPolicies]);
+  const handleClearPasswordChange = reactExports.useCallback((event) => {
+    setClearPassword(event.target.value);
+    setClearError(null);
+  }, []);
+  const handleClearTotpCodeChange = reactExports.useCallback((event) => {
+    setClearTotpCode(event.target.value);
+    setClearError(null);
+  }, []);
   const handleConfirmClearWithToast = reactExports.useCallback(async () => {
     const confirm = props.clearConfirm;
-    await props.onConfirmClear();
-    if (confirm?.harness) {
-      showToast(`Cleared for ${harnessDisplayName(confirm.harness)}`);
-    } else if (confirm?.all) {
-      showToast("Cleared all decisions");
+    setClearSubmitting(true);
+    setClearError(null);
+    try {
+      await props.onConfirmClear({
+        ...clearPassword ? { approval_password: clearPassword } : {},
+        ...clearTotpCode ? { approval_totp_code: clearTotpCode } : {}
+      });
+      setClearPassword("");
+      setClearTotpCode("");
+      if (confirm?.harness) {
+        showToast(`Cleared for ${harnessDisplayName(confirm.harness)}`);
+      } else if (confirm?.all) {
+        showToast("Cleared all decisions");
+      }
+    } catch (error) {
+      setClearError(error instanceof Error ? error.message : "Unable to clear remembered decisions.");
+    } finally {
+      setClearSubmitting(false);
     }
-  }, [props.clearConfirm, props.onConfirmClear, showToast]);
+  }, [clearPassword, clearTotpCode, props.clearConfirm, props.onConfirmClear, showToast]);
   const snapshot = props.runtime.kind === "ready" ? props.runtime.snapshot : null;
   const queuedCount = props.requests.kind === "ready" ? props.requests.items.length : 0;
   const policyItems = props.policies.kind === "ready" ? props.policies.items : [];
@@ -238,6 +263,13 @@ function HomeWorkspace(props) {
       ClearConfirmDialog,
       {
         clearConfirm: props.clearConfirm,
+        approvalGate: props.approvalGate,
+        clearPassword,
+        clearTotpCode,
+        clearError,
+        clearSubmitting,
+        onClearPasswordChange: handleClearPasswordChange,
+        onClearTotpCodeChange: handleClearTotpCodeChange,
         onCancelClear: props.onCancelClear,
         onConfirmClear: handleConfirmClearWithToast
       }
@@ -247,6 +279,7 @@ function HomeWorkspace(props) {
 function ClearConfirmDialog(props) {
   const dialogRef = reactExports.useRef(null);
   useFocusTrap(true, dialogRef);
+  const needsProof = props.approvalGate?.enabled === true && props.approvalGate.configured === true;
   return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-fade-in fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4 backdrop-blur-sm", role: "dialog", "aria-modal": "true", "aria-label": "Confirm clear decisions", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { ref: dialogRef, className: "guard-fade-in w-full max-w-md rounded-2xl border border-brand-attention/20 bg-white p-6 shadow-2xl", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-attention", "aria-hidden": "true" }),
@@ -256,7 +289,39 @@ function ClearConfirmDialog(props) {
           "This will remove ",
           props.clearConfirm.all ? "all saved approvals" : `decisions for ${props.clearConfirm.harness ?? "this app"}`,
           ". Guard will ask again next time matching actions run."
-        ] })
+        ] }),
+        needsProof && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 grid gap-3", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs font-semibold uppercase tracking-[0.18em] text-slate-500", children: "Approval password" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "input",
+              {
+                type: "password",
+                autoComplete: "current-password",
+                value: props.clearPassword,
+                onChange: props.onClearPasswordChange,
+                className: "mt-1 min-h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+              }
+            )
+          ] }),
+          props.approvalGate?.totp_enabled === true && /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs font-semibold uppercase tracking-[0.18em] text-slate-500", children: "Authenticator code" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "input",
+              {
+                type: "text",
+                inputMode: "numeric",
+                pattern: "[0-9]*",
+                maxLength: 6,
+                value: props.clearTotpCode,
+                onChange: props.onClearTotpCodeChange,
+                placeholder: "123456",
+                className: "mt-1 min-h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm tracking-[0.28em] text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+              }
+            )
+          ] })
+        ] }),
+        props.clearError !== null && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-3 rounded-xl border border-brand-attention/20 bg-brand-attention/[0.04] px-3 py-2 text-sm text-brand-dark", children: props.clearError })
       ] })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 flex flex-col gap-2 sm:flex-row sm:justify-end", children: [
@@ -274,8 +339,9 @@ function ClearConfirmDialog(props) {
         {
           type: "button",
           onClick: props.onConfirmClear,
-          className: "inline-flex min-h-11 items-center justify-center rounded-lg bg-brand-attention px-4 text-sm font-semibold text-white transition-colors hover:bg-brand-attention/90",
-          children: "Clear decisions"
+          disabled: props.clearSubmitting,
+          className: "inline-flex min-h-11 items-center justify-center rounded-lg bg-brand-attention px-4 text-sm font-semibold text-white transition-colors hover:bg-brand-attention/90 disabled:opacity-60",
+          children: props.clearSubmitting ? "Clearing..." : "Clear decisions"
         }
       )
     ] })

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/settings-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/settings-workspace.js
@@ -1,6 +1,7 @@
-import { x as requireReact, y as getDefaultExportFromCjs, j as jsxRuntimeExports, r as reactExports, z as fetchSettings, C as fetchRuntimeSnapshot, D as revokeApprovalGateCooldown, F as enrollApprovalGateTotp, I as verifyApprovalGateTotp, J as disableApprovalGateTotp, K as updateSettings, L as clearPolicy, M as clearReviewQueue, N as clearEvidence, O as exportDiagnostics, Q as repairApprovalCenter, R as setupDesktopNotifications, E as EmptyState, G as GuardHero, T as Tag, U as HiMiniMagnifyingGlass, S as SectionLabel, a as HiMiniShieldCheck, V as HiMiniLockClosed, W as HiMiniCog6Tooth, B as Badge, A as ActionButton, H as HiMiniCheckCircle, m as HiMiniExclamationTriangle, e as HiMiniChevronUp, g as HiMiniChevronDown, X as HiMiniBellAlert, Y as approvalGateCooldownLabel } from "../guard-dashboard.js";
+import { x as requireReact, y as getDefaultExportFromCjs, j as jsxRuntimeExports, r as reactExports, z as fetchSettings, C as fetchRuntimeSnapshot, D as revokeApprovalGateCooldown, F as enrollApprovalGateTotp, I as verifyApprovalGateTotp, J as disableApprovalGateTotp, K as updateSettings, L as clearPolicy, M as clearReviewQueue, N as clearEvidence, O as exportDiagnostics, Q as repairApprovalCenter, R as setupDesktopNotifications, E as EmptyState, G as GuardHero, T as Tag, U as HiMiniMagnifyingGlass, S as SectionLabel, a as HiMiniShieldCheck, V as HiMiniLockClosed, W as HiMiniCog6Tooth, B as Badge, A as ActionButton, H as HiMiniCheckCircle, m as HiMiniExclamationTriangle, e as HiMiniChevronUp, g as HiMiniChevronDown, X as HiMiniBellAlert, Y as approvalGateCooldownLabel, d as HiMiniXMark } from "../guard-dashboard.js";
 import { a as resolveProtectionLevelCopy } from "./runtime-overview.js";
 import { f as filterSettingsBySearch, R as RISK_CONTROL_CONSEQUENCES, s as securityLevelLabel } from "./app-catalog.js";
+import { u as useFocusTrap } from "./use-focus-trap.js";
 var lib = {};
 var propTypes = { exports: {} };
 var ReactPropTypesSecret_1;
@@ -1537,6 +1538,7 @@ function SettingsWorkspace({ onApprovalGateChange }) {
   const [approvalGateStrictAllDecisions, setApprovalGateStrictAllDecisions] = reactExports.useState(false);
   const [approvalGateCooldown, setApprovalGateCooldown] = reactExports.useState(0);
   const [totpEnrollment, setTotpEnrollment] = reactExports.useState(null);
+  const [totpSetupOpen, setTotpSetupOpen] = reactExports.useState(false);
   const [totpActionPending, setTotpActionPending] = reactExports.useState(null);
   const [totpActionError, setTotpActionError] = reactExports.useState(null);
   const [revokingCooldown, setRevokingCooldown] = reactExports.useState(false);
@@ -1703,6 +1705,12 @@ function SettingsWorkspace({ onApprovalGateChange }) {
     setApprovalGateTotpDeviceLabel(event.target.value);
     setTotpActionError(null);
   }, []);
+  const handleOpenTotpSetup = reactExports.useCallback(() => {
+    setTotpSetupOpen(true);
+  }, []);
+  const handleCloseTotpSetup = reactExports.useCallback(() => {
+    setTotpSetupOpen(false);
+  }, []);
   const handleApprovalGateCooldownChange = reactExports.useCallback((event) => {
     const next = Number(event.target.value);
     setApprovalGateCooldown(next);
@@ -1787,6 +1795,7 @@ function SettingsWorkspace({ onApprovalGateChange }) {
         onApprovalGateChange?.(gate);
       }
       setTotpEnrollment(payload.enrollment ?? null);
+      setTotpSetupOpen(payload.enrollment !== void 0 && payload.enrollment !== null);
       setActionMessage("TOTP enrollment started. Verify with your authenticator code.");
       setActionMessageKind("success");
     } catch (error) {
@@ -1821,6 +1830,7 @@ function SettingsWorkspace({ onApprovalGateChange }) {
       }
       setApprovalGateTotpCode("");
       setTotpEnrollment(null);
+      setTotpSetupOpen(false);
       setActionMessage("TOTP verified and enabled.");
       setActionMessageKind("success");
     } catch (error) {
@@ -1855,6 +1865,7 @@ function SettingsWorkspace({ onApprovalGateChange }) {
       }
       setApprovalGateTotpCode("");
       setTotpEnrollment(null);
+      setTotpSetupOpen(false);
       setActionMessage("TOTP disabled.");
       setActionMessageKind("success");
     } catch (error) {
@@ -2158,6 +2169,7 @@ function SettingsWorkspace({ onApprovalGateChange }) {
                 strictAllDecisions: approvalGateStrictAllDecisions,
                 cooldownSeconds: approvalGateCooldown,
                 totpEnrollment,
+                totpSetupOpen,
                 totpActionPending,
                 totpActionError,
                 revokingCooldown,
@@ -2169,6 +2181,8 @@ function SettingsWorkspace({ onApprovalGateChange }) {
                 onCurrentPasswordChange: handleApprovalGateCurrentPassword,
                 onTotpCodeChange: handleApprovalGateTotpCode,
                 onTotpDeviceLabelChange: handleApprovalGateTotpDeviceLabel,
+                onOpenTotpSetup: handleOpenTotpSetup,
+                onCloseTotpSetup: handleCloseTotpSetup,
                 onStrictAllDecisionsChange: handleApprovalGateStrictAllDecisions,
                 onCooldownChange: handleApprovalGateCooldownChange,
                 onStartTotpEnrollment: handleStartTotpEnrollment,
@@ -2610,69 +2624,80 @@ function ApprovalGateCard(props) {
         )
       ] }),
       failClosed && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-lg border border-brand-purple/20 bg-brand-purple/[0.04] px-3 py-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-brand-purple", children: "Guard is in fail-closed mode. Fix approval gate state before making trust or policy changes." }) }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2 rounded-lg border border-slate-200 bg-white px-3 py-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "overflow-hidden rounded-xl border border-brand-blue/15 bg-white", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between gap-2", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "TOTP authenticator" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: totpEnabled ? "green" : totpPending ? "blue" : "slate", children: totpEnabled ? "Enabled" : totpPending ? "Pending verification" : "Disabled" })
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "px-4 py-3", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Authenticator app" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 max-w-xl text-xs leading-5 text-slate-500", children: "Add a six-digit code from Google Authenticator, 1Password, Authy, or iCloud Passwords for high-risk approvals." })
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "px-4", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: totpEnabled ? "green" : totpPending ? "blue" : "slate", children: totpEnabled ? "Enabled" : totpPending ? "Pending verification" : "Not connected" }) })
         ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Add an authenticator code as a second factor for high-risk approvals and settings writes." }),
-        !totpEnabled && /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs font-medium text-slate-500", children: "Device label" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "input",
-            {
-              type: "text",
-              value: props.totpDeviceLabel,
-              onChange: props.onTotpDeviceLabelChange,
-              className: "mt-1 min-h-9 w-full rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-1 focus:ring-brand-blue/20"
-            }
-          )
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "border-t border-slate-100 bg-slate-50/50 px-4 py-3", children: [
+          !totpEnabled && !totpPending && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center justify-between gap-3", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: "Scan a QR code to connect an authenticator app." }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              ActionButton,
+              {
+                onClick: props.onStartTotpEnrollment,
+                disabled: props.totpActionPending !== null,
+                variant: "outline",
+                children: props.totpActionPending === "enroll" ? "Opening setup..." : "Set up authenticator"
+              }
+            )
+          ] }),
+          totpPending && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center justify-between gap-3", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: "Setup pending. Open the QR screen and enter the current code to finish." }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              ActionButton,
+              {
+                onClick: props.totpEnrollment ? props.onOpenTotpSetup : props.onStartTotpEnrollment,
+                disabled: props.totpActionPending !== null,
+                variant: "outline",
+                children: props.totpEnrollment ? "Open setup" : "Restart setup"
+              }
+            )
+          ] }),
+          totpEnabled && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-3", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs font-medium text-slate-500", children: "Authenticator code to disable" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "input",
+                {
+                  type: "text",
+                  inputMode: "numeric",
+                  pattern: "[0-9]*",
+                  value: props.totpCode,
+                  onChange: props.onTotpCodeChange,
+                  className: "mt-1 min-h-9 w-full rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-1 focus:ring-brand-blue/20"
+                }
+              )
+            ] }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              ActionButton,
+              {
+                onClick: props.onDisableTotp,
+                disabled: props.totpActionPending !== null,
+                variant: "outline",
+                children: props.totpActionPending === "disable" ? "Disabling..." : "Disable authenticator"
+              }
+            )
+          ] }),
+          props.totpActionError !== null && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-xs text-brand-purple", children: props.totpActionError })
         ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs font-medium text-slate-500", children: "Authenticator code" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "input",
-            {
-              type: "text",
-              inputMode: "numeric",
-              pattern: "[0-9]*",
-              value: props.totpCode,
-              onChange: props.onTotpCodeChange,
-              className: "mt-1 min-h-9 w-full rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-1 focus:ring-brand-blue/20"
-            }
-          )
-        ] }),
-        totpPending && props.totpEnrollment !== null && /* @__PURE__ */ jsxRuntimeExports.jsx(TotpEnrollmentQrPanel, { enrollment: props.totpEnrollment }),
-        props.totpActionError !== null && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-brand-purple", children: props.totpActionError }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap gap-2", children: [
-          !totpEnabled && /* @__PURE__ */ jsxRuntimeExports.jsx(
-            ActionButton,
-            {
-              onClick: props.onStartTotpEnrollment,
-              disabled: props.totpActionPending !== null,
-              variant: "outline",
-              children: props.totpActionPending === "enroll" ? "Starting…" : "Start enrollment"
-            }
-          ),
-          totpPending && /* @__PURE__ */ jsxRuntimeExports.jsx(
-            ActionButton,
-            {
-              onClick: props.onVerifyTotpEnrollment,
-              disabled: props.totpActionPending !== null,
-              variant: "outline",
-              children: props.totpActionPending === "verify" ? "Verifying…" : "Verify code"
-            }
-          ),
-          totpEnabled && /* @__PURE__ */ jsxRuntimeExports.jsx(
-            ActionButton,
-            {
-              onClick: props.onDisableTotp,
-              disabled: props.totpActionPending !== null,
-              variant: "outline",
-              children: props.totpActionPending === "disable" ? "Disabling…" : "Disable authenticator"
-            }
-          )
-        ] })
+        props.totpSetupOpen && props.totpEnrollment !== null && /* @__PURE__ */ jsxRuntimeExports.jsx(
+          TotpSetupModal,
+          {
+            enrollment: props.totpEnrollment,
+            deviceLabel: props.totpDeviceLabel,
+            totpCode: props.totpCode,
+            pending: props.totpActionPending,
+            error: props.totpActionError,
+            onDeviceLabelChange: props.onTotpDeviceLabelChange,
+            onTotpCodeChange: props.onTotpCodeChange,
+            onVerify: props.onVerifyTotpEnrollment,
+            onClose: props.onCloseTotpSetup
+          }
+        )
       ] }),
       cooldownActive && cooldownLabel !== null && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-lg border border-brand-blue/15 bg-brand-blue/[0.04] px-3 py-2", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-xs text-brand-dark", children: [
@@ -2713,6 +2738,73 @@ function ApprovalGateCard(props) {
       ] })
     ] })
   ] });
+}
+function TotpSetupModal(props) {
+  const modalRef = reactExports.useRef(null);
+  useFocusTrap(true, modalRef);
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(
+    "div",
+    {
+      className: "guard-fade-in fixed inset-0 z-50 flex items-center justify-center bg-brand-dark/45 p-4 backdrop-blur-sm",
+      role: "dialog",
+      "aria-modal": "true",
+      "aria-label": "Set up authenticator app",
+      children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { ref: modalRef, className: "w-full max-w-3xl overflow-hidden rounded-3xl border border-brand-blue/15 bg-white shadow-2xl", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start justify-between gap-4 border-b border-slate-100 px-6 py-5", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Authenticator setup" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "mt-2 text-2xl font-semibold tracking-tight text-brand-dark", children: "Scan this QR code" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 max-w-2xl text-sm leading-6 text-slate-600", children: "Open your authenticator app, add account, scan code, then enter current six-digit code to finish." })
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "button",
+            {
+              type: "button",
+              onClick: props.onClose,
+              className: "inline-flex h-10 w-10 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-500 transition-colors hover:bg-slate-50 hover:text-brand-dark",
+              "aria-label": "Close authenticator setup",
+              children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniXMark, { className: "h-5 w-5", "aria-hidden": "true" })
+            }
+          )
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-5 p-6 lg:grid-cols-[minmax(0,1fr)_260px]", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(TotpEnrollmentQrPanel, { enrollment: props.enrollment }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4 rounded-2xl border border-slate-100 bg-slate-50/70 p-4", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs font-semibold uppercase tracking-[0.18em] text-slate-500", children: "Device label" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "input",
+                {
+                  type: "text",
+                  value: props.deviceLabel,
+                  onChange: props.onDeviceLabelChange,
+                  className: "mt-2 min-h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+                }
+              )
+            ] }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs font-semibold uppercase tracking-[0.18em] text-slate-500", children: "Six-digit code" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "input",
+                {
+                  type: "text",
+                  inputMode: "numeric",
+                  pattern: "[0-9]*",
+                  maxLength: 6,
+                  value: props.totpCode,
+                  onChange: props.onTotpCodeChange,
+                  placeholder: "123456",
+                  className: "mt-2 min-h-12 w-full rounded-xl border border-slate-200 bg-white px-3 text-center text-lg font-semibold tracking-[0.35em] text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+                }
+              )
+            ] }),
+            props.error !== null && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "rounded-xl border border-brand-attention/20 bg-brand-attention/[0.04] px-3 py-2 text-xs text-brand-dark", children: props.error }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: props.onVerify, disabled: props.pending !== null, children: props.pending === "verify" ? "Verifying..." : "Finish setup" })
+          ] })
+        ] })
+      ] })
+    }
+  );
 }
 export {
   SettingsWorkspace,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -21609,7 +21609,7 @@ function useRouteFocus(view, mainSelector = "main#main-content") {
 }
 const HomeWorkspace = reactExports.lazy(() => __vitePreload(() => import("./chunks/home-dashboard.js"), true ? __vite__mapDeps([0,1,2]) : void 0).then((m) => ({ default: m.HomeWorkspace })));
 const FleetWorkspace = reactExports.lazy(() => __vitePreload(() => import("./chunks/fleet-workspace.js"), true ? __vite__mapDeps([3,4]) : void 0).then((m) => ({ default: m.FleetWorkspace })));
-const SettingsWorkspace = reactExports.lazy(() => __vitePreload(() => import("./chunks/settings-workspace.js"), true ? __vite__mapDeps([5,2,4]) : void 0).then((m) => ({ default: m.SettingsWorkspace })));
+const SettingsWorkspace = reactExports.lazy(() => __vitePreload(() => import("./chunks/settings-workspace.js"), true ? __vite__mapDeps([5,2,4,1]) : void 0).then((m) => ({ default: m.SettingsWorkspace })));
 const AppDetailWorkspace = reactExports.lazy(() => __vitePreload(() => import("./chunks/app-detail-workspace.js"), true ? __vite__mapDeps([6,1]) : void 0).then((m) => ({ default: m.AppDetailWorkspace })));
 const HelpModal = reactExports.lazy(() => __vitePreload(() => import("./chunks/help-modal.js"), true ? __vite__mapDeps([7,1]) : void 0).then((m) => ({ default: m.HelpModal })));
 function LazyFallback() {
@@ -21904,9 +21904,9 @@ function App() {
   const handleClearPolicies = reactExports.useCallback(async (scope) => {
     setClearConfirm(scope);
   }, []);
-  const handleConfirmClear = reactExports.useCallback(async () => {
+  const handleConfirmClear = reactExports.useCallback(async (credentials) => {
     if (clearConfirm === null) return;
-    await clearPolicy(clearConfirm);
+    await clearPolicy({ ...clearConfirm, ...credentials });
     setClearConfirm(null);
     const [snapshotResult, policiesResult] = await Promise.allSettled([fetchRuntimeSnapshot(), fetchPolicies()]);
     if (snapshotResult.status === "fulfilled") {
@@ -22116,6 +22116,7 @@ function App() {
             onClearPolicies: handleClearPolicies,
             onOpenAppDetail: handleOpenAppDetail,
             clearConfirm,
+            approvalGate,
             onConfirmClear: handleConfirmClear,
             onCancelClear: handleCancelClear,
             onOpenHelp: handleOpenHelp

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -161,6 +161,7 @@
     --radius-lg: .5rem;
     --radius-xl: .75rem;
     --radius-2xl: 1rem;
+    --radius-3xl: 1.5rem;
     --animate-spin: spin 1s linear infinite;
     --blur-sm: 8px;
     --blur-3xl: 64px;
@@ -929,6 +930,10 @@
     min-height: calc(var(--spacing) * 11);
   }
 
+  .min-h-12 {
+    min-height: calc(var(--spacing) * 12);
+  }
+
   .min-h-16 {
     min-height: calc(var(--spacing) * 16);
   }
@@ -1238,6 +1243,10 @@
     gap: calc(var(--spacing) * 4);
   }
 
+  .gap-5 {
+    gap: calc(var(--spacing) * 5);
+  }
+
   .gap-6 {
     gap: calc(var(--spacing) * 6);
   }
@@ -1393,6 +1402,10 @@
 
   .rounded-2xl {
     border-radius: var(--radius-2xl);
+  }
+
+  .rounded-3xl {
+    border-radius: var(--radius-3xl);
   }
 
   .rounded-\[1\.35rem\] {
@@ -2087,8 +2100,14 @@
     }
   }
 
-  .bg-brand-dark {
+  .bg-brand-dark, .bg-brand-dark\/45 {
     background-color: var(--brand-dark);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .bg-brand-dark\/45 {
+      background-color: color-mix(in oklab, var(--brand-dark) 45%, transparent);
+    }
   }
 
   .bg-brand-green {
@@ -2358,6 +2377,16 @@
   @supports (color: color-mix(in lab, red, red)) {
     .bg-slate-50\/60 {
       background-color: color-mix(in oklab, var(--color-slate-50) 60%, transparent);
+    }
+  }
+
+  .bg-slate-50\/70 {
+    background-color: #f8fafcb3;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .bg-slate-50\/70 {
+      background-color: color-mix(in oklab, var(--color-slate-50) 70%, transparent);
     }
   }
 
@@ -3104,6 +3133,11 @@
   .tracking-\[0\.28em\] {
     --tw-tracking: .28em;
     letter-spacing: .28em;
+  }
+
+  .tracking-\[0\.35em\] {
+    --tw-tracking: .35em;
+    letter-spacing: .35em;
   }
 
   .tracking-tight {
@@ -4418,6 +4452,10 @@
 
     .lg\:grid-cols-\[minmax\(0\,1\.4fr\)_minmax\(0\,0\.8fr\)\] {
       grid-template-columns: minmax(0, 1.4fr) minmax(0, .8fr);
+    }
+
+    .lg\:grid-cols-\[minmax\(0\,1fr\)_260px\] {
+      grid-template-columns: minmax(0, 1fr) 260px;
     }
 
     .lg\:grid-cols-\[minmax\(0\,1fr\)_minmax\(0\,0\.8fr\)\] {


### PR DESCRIPTION
## Summary
- Replace inline TOTP fields with an authenticator setup dialog that opens after enrollment and shows the QR/manual setup flow.
- Require and submit approval password/TOTP proof when clearing remembered decisions so the confirmation dialog no longer hangs silently.
- Rebuild local dashboard assets for the packaged HOL Guard dashboard.

## Testing
- `pnpm --dir dashboard test`
- `pnpm --dir dashboard build`
- `git diff --check`
- Browser proof on `http://127.0.0.1:5488/settings`: setup authenticator opens QR dialog, verifies code, closes, and shows enabled state.
- Browser proof on `http://127.0.0.1:5488/`: clear remembered decisions prompts for password/TOTP, posts proof to `/v1/policy/clear`, closes dialog.
