### PR TITLE
fix(codex): distinguish background resume

### DIFF
--- a/dashboard/src/approval-center-layout.test.ts
+++ b/dashboard/src/approval-center-layout.test.ts
@@ -297,6 +297,15 @@ const uxAlreadySent = buildCodexResumeUx(makeResume("already_sent"));
 assert(uxAlreadySent.showRetry === false, "C13: already_sent status has showRetry false");
 assert(uxAlreadySent.headline === uxSent.headline, "C13: already_sent and sent have same headline");
 
+const uxHeadlessSent = buildCodexResumeUx(
+  makeResume("sent", { reason: "headless_resume_started", strategy: "codex-headless-exec" })
+);
+assert(uxHeadlessSent.showRetry === false, "C13: headless sent status has showRetry false");
+assert(
+  uxHeadlessSent.headline.toLowerCase().includes("background"),
+  "C13: headless sent headline makes background resume explicit"
+);
+
 const uxFailed = buildCodexResumeUx(makeResume("failed", { last_error: "connection lost" }));
 assert(uxFailed.showRetry === true, "C13: failed status has showRetry true");
 assert(uxFailed.body === "connection lost", "C13: failed uses last_error for body");

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -628,6 +628,15 @@ export function buildCodexResumeUx(resume: GuardCodexResumeResult): CodexResumeU
     };
   }
   if (resume.status === "sent" || resume.status === "already_sent") {
+    if (resume.strategy === "codex-headless-exec" || resume.reason === "headless_resume_started") {
+      return {
+        headline: "Codex resumed in background.",
+        body:
+          resume.message ??
+          "HOL Guard started a background Codex resume. This open Codex App chat may not visibly continue until Codex remote control is enabled.",
+        showRetry: false
+      };
+    }
     return {
       headline: "Codex chat notified.",
       body: resume.message ?? "HOL Guard sent Codex a continuation message in the original chat.",

--- a/scripts/codex-auto-resume-smoke.py
+++ b/scripts/codex-auto-resume-smoke.py
@@ -284,7 +284,9 @@ def _start_fake_codex_app_server(
                             },
                         )
                     if message.get("id") == 2:
-                        _send_websocket_text(connection, {"id": 2, "result": {"turnId": "turn-smoke"}})
+                        _send_websocket_text(connection, {"id": 2, "result": {"threadId": thread_id}})
+                    if message.get("id") == 3:
+                        _send_websocket_text(connection, {"id": 3, "result": {"turnId": "turn-smoke"}})
                         time.sleep(0.05)
                         _send_websocket_text(
                             connection,

--- a/src/codex_plugin_scanner/guard/codex_app_server.py
+++ b/src/codex_plugin_scanner/guard/codex_app_server.py
@@ -171,10 +171,18 @@ def resume_codex_thread_for_request(
                 },
             },
         },
-        {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+        {"jsonrpc": "2.0", "method": "initialized", "params": {}},
         {
             "jsonrpc": "2.0",
             "id": 2,
+            "method": "thread/resume",
+            "params": {
+                "threadId": thread_id,
+            },
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
             "method": "turn/start",
             "params": {
                 "threadId": thread_id,
@@ -193,7 +201,7 @@ def resume_codex_thread_for_request(
         kwargs={
             "socket_path": socket_path,
             "payloads": request_payloads,
-            "response_id": 2,
+            "response_id": 3,
             "thread_id": thread_id,
             "timeout_seconds": timeout_seconds,
             "completion_timeout_seconds": _DEFAULT_COMPLETION_TIMEOUT_SECONDS,

--- a/src/codex_plugin_scanner/guard/codex_resume.py
+++ b/src/codex_plugin_scanner/guard/codex_resume.py
@@ -150,16 +150,17 @@ def inspect_codex_resume_capabilities(store: GuardStore) -> dict[str, object]:
     latest_attempt = store.get_latest_request_resume(harness="codex")
     return {
         "codex_binary_found": binary_path is not None,
-        "app_server_support": None,
+        "app_server_support": socket_available,
         "app_server_support_reason": (
-            "Codex does not expose a stable public app-server capability probe; "
-            "same-thread continuation uses the local app-server socket when it is active."
+            "Same-chat continuation requires the Codex app-server remote-control socket. "
+            "When the socket is missing, HOL Guard cannot visibly continue the open Codex App chat."
         ),
         "app_server_socket_available": socket_available,
         "headless_resume_support": binary_path is not None,
         "headless_resume_support_reason": (
             "When the live app-server socket is gone, HOL Guard resumes saved Codex exec threads with "
-            "`codex exec resume` from the original workspace."
+            "`codex exec resume` from the original workspace. This is a background retry, not a visible "
+            "message in the open Codex App chat."
             if binary_path is not None
             else "`codex` was not found on PATH, so HOL Guard can only save the approval for manual retry."
         ),
@@ -282,10 +283,19 @@ def _normalize_dispatch_result(
     raw_supported = raw_result.get("supported")
     supported = raw_supported if isinstance(raw_supported, bool) else raw_status != "skipped"
     if raw_status == "sent":
+        message = (
+            "HOL Guard sent Codex a continuation message in the original chat."
+            if effective_strategy != "codex-headless-exec"
+            else (
+                "HOL Guard started a background `codex exec resume` retry for this saved thread. "
+                "The command can complete in Codex history, but this open Codex App chat will not visibly "
+                "continue unless the Codex app-server remote-control socket is enabled."
+            )
+        )
         return {
             "status": "sent",
             "reason": raw_reason,
-            "message": "HOL Guard sent Codex a continuation message in the original chat.",
+            "message": message,
             "last_error": None,
             "thread_id": raw_thread_id,
             "strategy": effective_strategy,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -14420,6 +14420,13 @@ function buildCodexResumeUx(resume) {
     };
   }
   if (resume.status === "sent" || resume.status === "already_sent") {
+    if (resume.strategy === "codex-headless-exec" || resume.reason === "headless_resume_started") {
+      return {
+        headline: "Codex resumed in background.",
+        body: resume.message ?? "HOL Guard started a background Codex resume. This open Codex App chat may not visibly continue until Codex remote control is enabled.",
+        showRetry: false
+      };
+    }
     return {
       headline: "Codex chat notified.",
       body: resume.message ?? "HOL Guard sent Codex a continuation message in the original chat.",

--- a/tests/test_guard_codex_resume_commands.py
+++ b/tests/test_guard_codex_resume_commands.py
@@ -232,8 +232,8 @@ def test_guard_doctor_codex_reports_resume_diagnostics(
 
     assert rc == 0
     assert output["codex_resume"]["codex_binary_found"] in {True, False}
-    assert output["codex_resume"]["app_server_support"] is None
-    assert "stable public app-server capability probe" in output["codex_resume"]["app_server_support_reason"]
+    assert output["codex_resume"]["app_server_support"] in {True, False}
+    assert "remote-control socket" in output["codex_resume"]["app_server_support_reason"]
     assert output["codex_resume"]["app_server_socket_available"] in {True, False}
     assert output["codex_resume"]["headless_resume_support"] in {True, False}
     assert "codex exec resume" in output["codex_resume"]["headless_resume_support_reason"] or (
@@ -257,8 +257,8 @@ def test_guard_doctor_codex_reports_app_server_support_from_codex_binary(
 
     assert rc == 0
     assert output["codex_resume"]["codex_binary_found"] is True
-    assert output["codex_resume"]["app_server_support"] is None
-    assert "stable public app-server capability probe" in output["codex_resume"]["app_server_support_reason"]
+    assert output["codex_resume"]["app_server_support"] in {True, False}
+    assert "remote-control socket" in output["codex_resume"]["app_server_support_reason"]
     assert output["codex_resume"]["app_server_socket_available"] in {True, False}
     assert output["codex_resume"]["headless_resume_support"] is True
     assert "codex exec resume" in output["codex_resume"]["headless_resume_support_reason"]
@@ -350,6 +350,8 @@ def test_guard_approvals_resume_starts_headless_codex_when_app_server_unavailabl
     assert output["status"] == "sent"
     assert output["reason"] == "headless_resume_started"
     assert output["strategy"] == "codex-headless-exec"
+    assert "background" in output["message"]
+    assert "open Codex App chat" in output["message"]
     assert len(launched) == 1
     assert launched[0]["cwd"] == workspace
     assert launched[0]["command"][:5] == ["/usr/local/bin/codex", "exec", "resume", "--json", "--skip-git-repo-check"]

--- a/tests/test_guard_codex_resume_endpoints.py
+++ b/tests/test_guard_codex_resume_endpoints.py
@@ -171,7 +171,7 @@ def test_codex_block_resume_prompt_includes_request_id_and_safe_alternative(
     def _fake_send(**kwargs):
         payloads = kwargs["payloads"]
         captured_payloads.extend(payloads)
-        return {"id": 2, "result": {"turnId": "turn-2"}}, "turn_completed"
+        return {"id": 3, "result": {"turnId": "turn-2"}}, "turn_completed"
 
     monkeypatch.setattr(codex_app_server_module, "_send_app_server_websocket_messages", _fake_send)
 
@@ -199,7 +199,13 @@ def test_codex_block_resume_prompt_includes_request_id_and_safe_alternative(
         daemon.stop()
 
     assert payload["codex_resume"]["status"] == "sent"
-    prompt = captured_payloads[2]["params"]["input"][0]["text"]
+    assert [payload["method"] for payload in captured_payloads] == [
+        "initialize",
+        "initialized",
+        "thread/resume",
+        "turn/start",
+    ]
+    prompt = captured_payloads[3]["params"]["input"][0]["text"]
     assert prompt == "HOL Guard blocked request `req-block`. Do not retry that action. Explain a safe alternative."
 
 
@@ -441,7 +447,7 @@ def test_codex_allow_resume_prompt_includes_exact_command_when_metadata_is_prese
         daemon.stop()
 
     assert payload["codex_resume"]["status"] == "sent"
-    prompt = captured_payloads[2]["params"]["input"][0]["text"]
+    prompt = captured_payloads[3]["params"]["input"][0]["text"]
     assert "HOL Guard approved request `req-allow-command` for this exact command:" in prompt
     assert "python - <<'PY'" in prompt
     assert "Retry that exact command now using the existing saved approval." in prompt
@@ -593,7 +599,8 @@ def test_codex_approve_falls_back_to_exec_resume_when_socket_binding_is_missing(
     assert payload["codex_resume"]["status"] == "sent"
     assert payload["codex_resume"]["reason"] == "headless_resume_started"
     assert payload["codex_resume"]["strategy"] == "codex-headless-exec"
-    assert "original chat" in payload["codex_resume"]["message"]
+    assert "background" in payload["codex_resume"]["message"]
+    assert "open Codex App chat" in payload["codex_resume"]["message"]
     assert launched[0][:5] == ["/usr/local/bin/codex", "exec", "resume", "--json", "--skip-git-repo-check"]
     assert "--" in launched[0]
 

--- a/tests/test_guard_queue_api_contract.py
+++ b/tests/test_guard_queue_api_contract.py
@@ -191,7 +191,9 @@ def _start_fake_codex_app_server(socket_path: Path, received: list[dict[str, obj
                             },
                         )
                     if message.get("id") == 2:
-                        _send_websocket_text(connection, {"id": 2, "result": {"turnId": "turn-next"}})
+                        _send_websocket_text(connection, {"id": 2, "result": {"threadId": "thread-1"}})
+                    if message.get("id") == 3:
+                        _send_websocket_text(connection, {"id": 3, "result": {"turnId": "turn-next"}})
                         time.sleep(0.05)
                         _send_websocket_text(
                             connection,
@@ -493,6 +495,12 @@ def test_codex_resolution_sends_continue_prompt_to_original_thread(tmp_path: Pat
         codex_server.join(timeout=2)
         socket_path.unlink(missing_ok=True)
 
+    assert [message["method"] for message in received_messages[-4:]] == [
+        "initialize",
+        "initialized",
+        "thread/resume",
+        "turn/start",
+    ]
     turn_start = received_messages[-1]
     assert payload["codex_resume"]["status"] == "sent"
     assert payload["resolution_summary"] == (


### PR DESCRIPTION
## Summary
- Use the current Codex app-server resume protocol before sending a continuation turn.
- Stop reporting background `codex exec resume` as a visible original-chat notification.
- Update local Guard UI copy and regression coverage for headless/background resume.

## Testing
- `python3 -m pytest -q tests/test_guard_codex_resume_endpoints.py tests/test_guard_codex_resume_commands.py tests/test_guard_queue_api_contract.py`
- `pnpm test` (dashboard)
- `pnpm build` (dashboard)
- `python3 -m ruff check src/codex_plugin_scanner/guard/codex_app_server.py src/codex_plugin_scanner/guard/codex_resume.py tests/test_guard_codex_resume_endpoints.py tests/test_guard_codex_resume_commands.py tests/test_guard_queue_api_contract.py`
- `git diff --check`

## Notes
- Local Codex App remote-control proof: `codex app-server daemon version` fails because `/Users/michaelkantor/.codex/app-server-control/app-server-control.sock` is missing.
- `codex app-server daemon bootstrap --remote-control` also fails because the standalone Codex install is not present at `/Users/michaelkantor/.codex/packages/standalone/current/codex`.
