### PR TITLE
feat(dashboard): modal-based approval password and 2FA flow

### DIFF
--- a/dashboard/src/approval-center-layout.tsx
+++ b/dashboard/src/approval-center-layout.tsx
@@ -62,10 +62,12 @@ import {
   isCodexHarness,
   buildCodexResumeUx,
 } from "./approval-center-utils";
+import { requiresApprovalPasswordPrompt } from "./approval-gate-utils";
 import {
   WhyThisPaused,
   ApproveConsequence,
   BlockConsequence,
+  ApprovalPasswordModal,
 } from "./approval-center-review-cards";
 import {
   buildProgressCopy,
@@ -473,6 +475,7 @@ function QueueWorkspace(props: {
               detail={props.detail}
               onGoHome={props.onGoHome}
               onResolve={props.onResolve}
+              approvalGate={props.approvalGate ?? null}
             />
           </div>
         </div>
@@ -490,6 +493,7 @@ function QueueWorkspace(props: {
             detail={props.detail}
             onGoHome={props.onGoHome}
             onResolve={props.onResolve}
+            approvalGate={props.approvalGate ?? null}
           />
         </div>
       )}
@@ -1135,6 +1139,7 @@ function DecisionWorkspace(props: {
   detail: DetailState;
   onGoHome: () => void;
   onResolve: LayoutProps["onResolve"];
+  approvalGate?: GuardApprovalGatePublicConfig | null;
 }) {
   const [scope, setScope] = useState<DecisionScope>("artifact");
   const [reason, setReason] = useState("approved in local approval center");
@@ -1142,8 +1147,21 @@ function DecisionWorkspace(props: {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [resolvedBanner, setResolvedBanner] = useState<"allow" | "block" | null>(null);
   const [resolvedState, setResolvedState] = useState<"idle" | "decided" | "loaded">("idle");
+  const [approvalPassword, setApprovalPassword] = useState("");
+  const [approvalTotpCode, setApprovalTotpCode] = useState("");
+  const [useCooldown, setUseCooldown] = useState(false);
+  const [pendingAction, setPendingAction] = useState<"allow" | "block" | null>(null);
   const bannerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevRequestIdRef = useRef<string | null>(null);
+
+  const gateRequiresPassword = useMemo(() => {
+    const gate = props.approvalGate;
+    return (
+      gate?.enabled === true &&
+      gate?.configured === true &&
+      requiresApprovalPasswordPrompt(gate.cooldown_active, gate.strict_all_decisions, scope)
+    );
+  }, [props.approvalGate, scope]);
 
   useEffect(() => {
     if (props.detail.kind === "ready") {
@@ -1152,6 +1170,10 @@ function DecisionWorkspace(props: {
       if (isNewItem) {
         setResolvedBanner(null);
         setResolvedState("loaded");
+        setApprovalPassword("");
+        setApprovalTotpCode("");
+        setUseCooldown(false);
+        setPendingAction(null);
         if (bannerTimerRef.current !== null) {
           clearTimeout(bannerTimerRef.current);
           bannerTimerRef.current = null;
@@ -1179,14 +1201,30 @@ function DecisionWorkspace(props: {
       setSubmitting(action);
       setErrorMessage(null);
       try {
-        await props.onResolve(buildDecisionPayload({
-          item: readyItem,
-          action,
-          scope,
-          reason,
-        }));
+        const gate = props.approvalGate;
+        const includeGateFields =
+          gate?.enabled === true &&
+          gate?.configured === true &&
+          requiresApprovalPasswordPrompt(gate.cooldown_active, gate.strict_all_decisions, scope);
+        await props.onResolve({
+          ...buildDecisionPayload({
+            item: readyItem,
+            action,
+            scope,
+            reason,
+          }),
+          ...(includeGateFields ? { approval_password: approvalPassword } : {}),
+          ...(includeGateFields && gate?.totp_enabled === true
+            ? { approval_totp_code: approvalTotpCode }
+            : {}),
+          ...(includeGateFields ? { approval_gate_use_cooldown: useCooldown } : {}),
+        });
         setResolvedState("decided");
         setResolvedBanner(action);
+        setApprovalPassword("");
+        setApprovalTotpCode("");
+        setUseCooldown(false);
+        setPendingAction(null);
         bannerTimerRef.current = setTimeout(() => {
           setResolvedBanner(null);
         }, 1500);
@@ -1195,23 +1233,51 @@ function DecisionWorkspace(props: {
         setSubmitting(null);
       }
     },
-    [props.onResolve, readyItem, reason, scope]
+    [props.onResolve, props.approvalGate, readyItem, reason, scope, approvalPassword, approvalTotpCode, useCooldown]
   );
 
   const handleRequestResolve = useCallback(
     (action: "allow" | "block") => {
+      if (gateRequiresPassword) {
+        setPendingAction(action);
+        setErrorMessage(null);
+        return;
+      }
       void handleResolve(action);
     },
-    [handleResolve]
+    [handleResolve, gateRequiresPassword]
   );
 
   const handleAllowDirect = useCallback(() => handleRequestResolve("allow"), [handleRequestResolve]);
   const handleBlockDirect = useCallback(() => handleRequestResolve("block"), [handleRequestResolve]);
 
+  const handleModalSubmit = useCallback(() => {
+    if (pendingAction !== null) {
+      void handleResolve(pendingAction);
+    }
+  }, [pendingAction, handleResolve]);
+
+  const handleModalCancel = useCallback(() => {
+    setPendingAction(null);
+    setApprovalPassword("");
+    setApprovalTotpCode("");
+    setUseCooldown(false);
+  }, []);
+
+  const handleApprovalPasswordChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setApprovalPassword(event.target.value);
+  }, []);
+  const handleApprovalTotpCodeChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setApprovalTotpCode(event.target.value);
+  }, []);
+  const handleUseCooldownChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setUseCooldown(event.target.checked);
+  }, []);
+
   useEffect(() => {
     if (props.detail.kind !== "ready") return;
     const onKeyDown = (event: KeyboardEvent) => {
-      if (submitting !== null) return;
+      if (submitting !== null || pendingAction !== null) return;
       const target = event.target as HTMLElement;
       if (
         target.tagName === "INPUT" ||
@@ -1224,7 +1290,7 @@ function DecisionWorkspace(props: {
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [props.detail.kind, submitting, handleRequestResolve]);
+  }, [props.detail.kind, submitting, pendingAction, handleRequestResolve]);
 
   if (props.detail.kind === "loading") {
     return (
@@ -1333,6 +1399,20 @@ function DecisionWorkspace(props: {
       />
       <ScannerEvidenceSectionFull item={item} />
       <WhatChanged item={item} diff={diff} receipt={receipt} policy={policy} />
+      {pendingAction !== null && props.approvalGate != null && (
+        <ApprovalPasswordModal
+          gate={props.approvalGate}
+          approvalPassword={approvalPassword}
+          approvalTotpCode={approvalTotpCode}
+          useCooldown={useCooldown}
+          onApprovalPasswordChange={handleApprovalPasswordChange}
+          onApprovalTotpCodeChange={handleApprovalTotpCodeChange}
+          onUseCooldownChange={handleUseCooldownChange}
+          onSubmit={handleModalSubmit}
+          onCancel={handleModalCancel}
+          submitLabel={pendingAction === "allow" ? allowLabel : "Keep blocked"}
+        />
+      )}
     </div>
   );
 }

--- a/dashboard/src/approval-center-review-cards.tsx
+++ b/dashboard/src/approval-center-review-cards.tsx
@@ -1,6 +1,7 @@
-import { useCallback } from "react";
-import { HiMiniCheck, HiMiniXMark } from "react-icons/hi2";
-import type { GuardApprovalRequest } from "./guard-types";
+import { useCallback, useEffect, useRef, type ChangeEvent } from "react";
+import { HiMiniCheck, HiMiniXMark, HiMiniKey } from "react-icons/hi2";
+import type { GuardApprovalRequest, GuardApprovalGatePublicConfig } from "./guard-types";
+import { approvalGateCooldownLabel } from "./approval-gate-utils";
 
 type WhyThisPausedProps = {
   item: GuardApprovalRequest;
@@ -90,6 +91,136 @@ export function KeyboardHints() {
       </span>
       <span className="text-slate-400">·</span>
       <span>Keyboard shortcuts available after reviewing above</span>
+    </div>
+  );
+}
+
+type ApprovalPasswordModalProps = {
+  gate: GuardApprovalGatePublicConfig;
+  approvalPassword: string;
+  approvalTotpCode: string;
+  useCooldown: boolean;
+  onApprovalPasswordChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onApprovalTotpCodeChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onUseCooldownChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+  submitLabel: string;
+};
+
+export function ApprovalPasswordModal(props: ApprovalPasswordModalProps) {
+  const passwordRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      passwordRef.current?.focus();
+    }, 50);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const showCooldownOption =
+    props.gate.cooldown_seconds > 0 &&
+    !props.gate.cooldown_active &&
+    props.gate.totp_enabled !== true;
+
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (e.target === e.currentTarget) props.onCancel();
+    },
+    [props.onCancel]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        props.onSubmit();
+      }
+    },
+    [props.onSubmit]
+  );
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4 backdrop-blur-sm"
+      onClick={handleBackdropClick}
+      onKeyDown={handleKeyDown}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="approval-password-modal-title"
+    >
+      <div className="w-full max-w-md rounded-2xl border border-slate-200 bg-white p-6 shadow-2xl">
+        <div className="flex items-center gap-3">
+          <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-brand-blue/10">
+            <HiMiniKey className="h-5 w-5 text-brand-blue" aria-hidden="true" />
+          </span>
+          <div>
+            <h2
+              id="approval-password-modal-title"
+              className="text-lg font-semibold tracking-tight text-brand-dark"
+            >
+              Approval password required
+            </h2>
+            <p className="text-sm text-brand-dark/70">
+              Guard needs a fresh proof before it can save this decision.
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-5 space-y-3">
+          <label className="block">
+            <span className="text-sm font-semibold text-brand-dark">Approval password</span>
+            <input
+              ref={passwordRef}
+              type="password"
+              autoComplete="current-password"
+              value={props.approvalPassword}
+              onChange={props.onApprovalPasswordChange}
+              className="mt-1 min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+            />
+          </label>
+          {props.gate.totp_enabled === true && (
+            <label className="block">
+              <span className="text-sm font-semibold text-brand-dark">Authenticator code</span>
+              <input
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                value={props.approvalTotpCode}
+                onChange={props.onApprovalTotpCodeChange}
+                className="mt-1 min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+              />
+            </label>
+          )}
+          {showCooldownOption && (
+            <label className="flex cursor-pointer items-center gap-2 text-sm text-brand-dark">
+              <input
+                type="checkbox"
+                checked={props.useCooldown}
+                onChange={props.onUseCooldownChange}
+                className="h-4 w-4 accent-brand-blue"
+              />
+              Skip password for next {approvalGateCooldownLabel(props.gate.cooldown_seconds).toLowerCase()} (use cooldown)
+            </label>
+          )}
+        </div>
+
+        <div className="mt-6 flex flex-col gap-2 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            onClick={props.onCancel}
+            className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-brand-dark transition-colors hover:bg-slate-50"
+          >
+            Go back
+          </button>
+          <button
+            type="button"
+            onClick={props.onSubmit}
+            className="rounded-full bg-brand-blue px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand-blue/90"
+          >
+            {props.submitLabel}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -85,7 +85,8 @@ import {
   type SemanticGroupId,
 } from "./queue-state";
 import { plainEnglishRequestTitle, whyPaused } from "./evidence/plain-english";
-import { approvalGateCooldownLabel, requiresApprovalPasswordPrompt } from "./approval-gate-utils";
+import { requiresApprovalPasswordPrompt } from "./approval-gate-utils";
+import { ApprovalPasswordModal } from "./approval-center-review-cards";
 
 export type ReviewViewModel = {
   item: GuardApprovalRequest;
@@ -766,6 +767,7 @@ function ReviewDecisionCard(props: {
   const [approvalPassword, setApprovalPassword] = useState("");
   const [approvalTotpCode, setApprovalTotpCode] = useState("");
   const [useCooldown, setUseCooldown] = useState(false);
+  const [pendingAction, setPendingAction] = useState<"allow" | "block" | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const allowButtonRef = useRef<HTMLButtonElement>(null);
   const availableScopeChoices = useMemo(
@@ -785,6 +787,15 @@ function ReviewDecisionCard(props: {
     [item]
   );
 
+  const gateRequiresPassword = useMemo(() => {
+    const gate = props.approvalGate;
+    return (
+      gate?.enabled === true &&
+      gate?.configured === true &&
+      requiresApprovalPasswordPrompt(gate.cooldown_active, gate.strict_all_decisions, scope)
+    );
+  }, [props.approvalGate, scope]);
+
   useEffect(() => {
     if (item) {
       setScope(normalizeDecisionScope(item, item.recommended_scope));
@@ -795,6 +806,7 @@ function ReviewDecisionCard(props: {
       setApprovalPassword("");
       setApprovalTotpCode("");
       setUseCooldown(false);
+      setPendingAction(null);
     }
   }, [item?.request_id]);
 
@@ -806,7 +818,7 @@ function ReviewDecisionCard(props: {
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
-      if (submitting !== null) return;
+      if (submitting !== null || pendingAction !== null) return;
       const target = event.target as HTMLElement;
       if (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable) return;
 
@@ -826,7 +838,7 @@ function ReviewDecisionCard(props: {
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [submitting, scope, item?.request_id, availableScopeChoices]);
+  }, [submitting, pendingAction, scope, item?.request_id, availableScopeChoices]);
 
   const handleResolve = useCallback(
     async (action: "allow" | "block") => {
@@ -856,6 +868,7 @@ function ReviewDecisionCard(props: {
         setApprovalPassword("");
         setApprovalTotpCode("");
         setUseCooldown(false);
+        setPendingAction(null);
         timerRef.current = setTimeout(() => setResolved(null), 2000);
       } catch (err) {
         setErrorMessage(err instanceof Error ? err.message : "Something went wrong. Try again.");
@@ -869,16 +882,36 @@ function ReviewDecisionCard(props: {
   const handleRequestResolve = useCallback(
     (action: "allow" | "block") => {
       setLastAction(action);
+      if (gateRequiresPassword) {
+        setPendingAction(action);
+        setErrorMessage(null);
+        return;
+      }
       void handleResolve(action);
     },
-    [handleResolve]
+    [handleResolve, gateRequiresPassword]
   );
+
   const handleAllow = useCallback(() => {
     handleRequestResolve("allow");
   }, [handleRequestResolve]);
   const handleBlock = useCallback(() => {
     handleRequestResolve("block");
   }, [handleRequestResolve]);
+
+  const handleModalSubmit = useCallback(() => {
+    if (pendingAction !== null) {
+      void handleResolve(pendingAction);
+    }
+  }, [pendingAction, handleResolve]);
+
+  const handleModalCancel = useCallback(() => {
+    setPendingAction(null);
+    setApprovalPassword("");
+    setApprovalTotpCode("");
+    setUseCooldown(false);
+  }, []);
+
   const handleToggleConsequences = useCallback(() => {
     setShowConsequences((visible) => !visible);
   }, []);
@@ -1067,30 +1100,12 @@ function ReviewDecisionCard(props: {
           </div>
         )}
 
-        {props.approvalGate?.enabled === true &&
-          props.approvalGate?.configured === true &&
-          requiresApprovalPasswordPrompt(
-            props.approvalGate.cooldown_active,
-            props.approvalGate.strict_all_decisions,
-            scope
-          ) && (
-          <ApprovalPasswordPrompt
-            gate={props.approvalGate}
-            approvalPassword={approvalPassword}
-            approvalTotpCode={approvalTotpCode}
-            useCooldown={useCooldown}
-            onApprovalPasswordChange={handleApprovalPasswordChange}
-            onApprovalTotpCodeChange={handleApprovalTotpCodeChange}
-            onUseCooldownChange={handleUseCooldownChange}
-          />
-        )}
-
         <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
           <ActionButton
             ref={allowButtonRef}
             variant="success"
             onClick={handleAllow}
-            disabled={submitting !== null}
+            disabled={submitting !== null || pendingAction !== null}
           >
             {submitting === "allow" ? (
               <span className="flex items-center gap-2">
@@ -1107,7 +1122,7 @@ function ReviewDecisionCard(props: {
           <ActionButton
             variant="outline"
             onClick={handleBlock}
-            disabled={submitting !== null}
+            disabled={submitting !== null || pendingAction !== null}
           >
             {submitting === "block" ? (
               <span className="flex items-center gap-2">
@@ -1178,6 +1193,21 @@ function ReviewDecisionCard(props: {
             </div>
           )}
         </div>
+      )}
+
+      {pendingAction !== null && props.approvalGate !== null && (
+        <ApprovalPasswordModal
+          gate={props.approvalGate}
+          approvalPassword={approvalPassword}
+          approvalTotpCode={approvalTotpCode}
+          useCooldown={useCooldown}
+          onApprovalPasswordChange={handleApprovalPasswordChange}
+          onApprovalTotpCodeChange={handleApprovalTotpCodeChange}
+          onUseCooldownChange={handleUseCooldownChange}
+          onSubmit={handleModalSubmit}
+          onCancel={handleModalCancel}
+          submitLabel={pendingAction === "allow" ? allowButtonLabel(scope) : "Keep blocked"}
+        />
       )}
     </div>
   );
@@ -1335,90 +1365,6 @@ function ReviewEmptyState({ runtime, resolutionMessage, codexResume, onRetryResu
           </ul>
         </div>
       </div>
-    </div>
-  );
-}
-
-type ApprovalPasswordPromptProps = {
-  gate: GuardApprovalGatePublicConfig;
-  approvalPassword: string;
-  approvalTotpCode: string;
-  useCooldown: boolean;
-  onApprovalPasswordChange: (event: ChangeEvent<HTMLInputElement>) => void;
-  onApprovalTotpCodeChange: (event: ChangeEvent<HTMLInputElement>) => void;
-  onUseCooldownChange: (event: ChangeEvent<HTMLInputElement>) => void;
-};
-
-function ApprovalPasswordPrompt(props: ApprovalPasswordPromptProps) {
-  const showCooldownOption =
-    props.gate.cooldown_seconds > 0 &&
-    !props.gate.cooldown_active &&
-    props.gate.totp_enabled !== true;
-  const codePreview = (props.approvalTotpCode ?? "").padEnd(6, " ").slice(0, 6).split("");
-
-  return (
-    <div className="mt-5 overflow-hidden rounded-2xl border border-brand-blue/20 bg-white shadow-sm">
-      <div className="flex items-start gap-3 border-b border-brand-blue/10 bg-brand-blue/[0.04] p-4">
-        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-brand-blue/10 text-brand-blue">
-          <HiMiniKey className="h-5 w-5" aria-hidden="true" />
-        </span>
-        <div>
-          <p className="text-sm font-semibold text-brand-dark">
-            {props.gate.totp_enabled === true ? "Authenticator check required" : "Approval password required"}
-          </p>
-          <p className="mt-1 text-sm text-slate-600">
-            Guard needs a fresh proof before it can save this decision.
-          </p>
-        </div>
-      </div>
-      <div className="grid gap-4 p-4 md:grid-cols-[1fr_220px]">
-        <label className="block">
-          <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Approval password</span>
-          <input
-            type="password"
-            autoComplete="current-password"
-            value={props.approvalPassword}
-            onChange={props.onApprovalPasswordChange}
-            className="mt-2 min-h-11 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
-          />
-        </label>
-        {props.gate.totp_enabled === true && (
-          <div>
-            <div className="block">
-              <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">Authenticator code</span>
-            </div>
-            <div className="mt-2 grid grid-cols-6 gap-1.5" aria-hidden="true">
-              {codePreview.map((digit, index) => (
-                <span key={`${index}-${digit}`} className="flex h-11 items-center justify-center rounded-xl border border-slate-200 bg-slate-50 text-lg font-semibold text-brand-dark">
-                  {digit.trim() ? digit : "•"}
-                </span>
-              ))}
-            </div>
-            <input
-              type="text"
-              inputMode="numeric"
-              pattern="[0-9]*"
-              maxLength={6}
-              value={props.approvalTotpCode}
-              onChange={props.onApprovalTotpCodeChange}
-              placeholder="123456"
-              className="mt-2 min-h-10 w-full rounded-xl border border-slate-200 bg-white px-3 text-center text-sm tracking-[0.28em] text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
-              aria-label="Enter authenticator code"
-            />
-          </div>
-        )}
-      </div>
-      {showCooldownOption && (
-        <label className="mx-4 mb-4 flex cursor-pointer items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-brand-dark">
-          <input
-            type="checkbox"
-            checked={props.useCooldown}
-            onChange={props.onUseCooldownChange}
-            className="h-4 w-4 accent-brand-blue"
-          />
-          Skip password for next {approvalGateCooldownLabel(props.gate.cooldown_seconds).toLowerCase()} (use cooldown)
-        </label>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add modal-based approval password/2FA flow in hol-guard dashboard
- User clicks Approve/Block first, modal opens if gate password is required
- Replaces clunky inline password prompt that showed before any action was taken

## Testing
- `pnpm run build` passes
- `pnpm test` passes (all tests including approval-gate)
- Verified keyboard shortcuts disabled while modal is open

## Notes
- Bulk actions in queue sidebar still use inline fields (different UX pattern for batch ops)
- Backdrop click and Escape key cancel the modal and clear pending action
