### PR TITLE
fix(codex): surface prompt approval handoff

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5302,6 +5302,13 @@ def _emit_native_hook_response(
         if policy_action in {"block", "sandbox-required", "require-reapproval"} and not additional_context:
             payload["decision"] = "block"
             payload["reason"] = reason
+            if _canonical_harness_name(harness) == "codex":
+                payload["continue"] = False
+                payload["stopReason"] = reason
+                payload["hookSpecificOutput"] = {
+                    "hookEventName": event_name,
+                    "additionalContext": reason,
+                }
         elif additional_context:
             payload["hookSpecificOutput"] = {
                 "hookEventName": event_name,

--- a/tests/test_guard_phase04_harness_ux.py
+++ b/tests/test_guard_phase04_harness_ux.py
@@ -131,6 +131,10 @@ def _answer_claude_guard_question(tmp_path: Path, *, session_id: str, answer: st
 
 
 def test_gr076_codex_prompt_secret_read_returns_branded_approval_context(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(parents=True, exist_ok=True)
+    (guard_home / "config.toml").write_text("approval_wait_timeout_seconds = 0\n", encoding="utf-8")
+
     exit_code, output = _run_hook(
         tmp_path,
         harness="codex",
@@ -145,8 +149,14 @@ def test_gr076_codex_prompt_secret_read_returns_branded_approval_context(tmp_pat
 
     assert exit_code == 0
     assert payload["decision"] == "block"
+    assert payload["continue"] is False
     assert "HOL Guard stopped this Codex prompt" in str(payload["reason"])
     assert "/approvals/" in str(payload["reason"])
+    assert payload["stopReason"] == payload["reason"]
+    assert payload["hookSpecificOutput"] == {
+        "hookEventName": "UserPromptSubmit",
+        "additionalContext": payload["reason"],
+    }
 
 
 def test_gr077_codex_shell_exfil_canary_gets_native_denial(tmp_path: Path) -> None:

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12278,8 +12278,12 @@ def test_guard_hook_blocks_codex_user_prompt_submit_sensitive_file_read(
     assert "HOL Guard" in payload["reason"]
     assert "sensitive local file" in payload["reason"]
     assert "Codex does not expose native approval prompts for Read-tool file reads" in payload["reason"]
-    assert "stopReason" not in payload
-    assert "continue" not in payload
+    assert payload["stopReason"] == payload["reason"]
+    assert payload["continue"] is False
+    assert payload["hookSpecificOutput"] == {
+        "hookEventName": "UserPromptSubmit",
+        "additionalContext": payload["reason"],
+    }
 
 
 def test_guard_hook_allows_codex_user_prompt_submit_negative_dotenv_guardrail(


### PR DESCRIPTION
## Summary
- Surface Codex prompt approval links through hookSpecificOutput.additionalContext in addition to the hard block response.
- Preserve block semantics while giving Codex App a visible handoff path for HOL Guard approval.
- Update runtime and phase-04 regression coverage for the new Codex prompt handoff contract.

## Testing
- `python3 -m pytest -q tests/test_guard_runtime.py::test_guard_hook_blocks_codex_user_prompt_submit_sensitive_file_read`
- `python3 -m pytest -q tests/test_guard_phase04_harness_ux.py tests/test_guard_claude_adapter.py`
- `python3 -m ruff check src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_phase04_harness_ux.py tests/test_guard_runtime.py`
- `git diff --check`
