### PR TITLE
feat(provenance): SCRG146-158 npm/PyPI attestation, Sigstore, SLSA, registry identity, dist integrity, source policy

### DIFF
--- a/src/codex_plugin_scanner/guard/provenance.py
+++ b/src/codex_plugin_scanner/guard/provenance.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-import urllib.error
+import urllib.parse
 import urllib.request
 from typing import Any
 
@@ -115,7 +115,7 @@ def extract_npm_trusted_publisher(attestation: dict[str, Any]) -> dict[str, Any]
         return {"provider": "unknown", "source_repository": None, "ref": None, "run_uri": None}
 
     provider = "unknown"
-    if (run_uri and "github.com" in run_uri) or (source_repo and "github.com" in source_repo):
+    if _is_github_host_url(run_uri) or _is_github_host_url(source_repo):
         provider = "github_actions"
 
     return {
@@ -317,7 +317,7 @@ def check_source_url_security(source_url: str | None) -> dict[str, Any]:
     return {"secure": True, "reason": None, "url": source_url}
 
 
-_SHA_RE = re.compile(r"^[0-9a-f]{40,}$", re.IGNORECASE)
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
 _SEMVER_RE = re.compile(r"^v?\d+\.\d+")
 
 
@@ -325,7 +325,7 @@ def check_git_source_immutability(source_url: str) -> dict[str, Any]:
     """Determine whether a git source URL pins to an immutable commit SHA.
 
     Returns:
-    - ``immutable``: True only when the fragment is a full 40+ hex commit SHA
+    - ``immutable``: True only when the fragment is a full 40-char hex commit SHA
     - ``reason``: 'mutable_branch' | 'mutable_tag' | 'no_pin' | None
     - ``fragment``: the fragment portion of the URL
     """
@@ -375,4 +375,19 @@ def provenance_overrides_hard_risk(
     """
     if block_reason_code in _HARD_RISK_CODES:
         return False
-    return False
+    if decision == "block":
+        return False
+    return provenance_status in {"verified", "attested"}
+
+
+def _is_github_host_url(raw_url: str | None) -> bool:
+    if not raw_url:
+        return False
+    parsed = urllib.parse.urlparse(raw_url)
+    host = parsed.hostname
+    if host is None and raw_url.startswith("git@"):
+        host = raw_url.split("@", 1)[1].split(":", 1)[0]
+    if host is None:
+        return False
+    normalized = host.lower().rstrip(".")
+    return normalized == "github.com" or normalized.endswith(".github.com")

--- a/src/codex_plugin_scanner/guard/provenance.py
+++ b/src/codex_plugin_scanner/guard/provenance.py
@@ -1,0 +1,378 @@
+"""Supply chain provenance, attestation, SLSA, registry identity, and source policy.
+
+Implements SCRG146-158: npm provenance fetcher, PyPI attestation, Sigstore bundle
+verification, SLSA provenance fields, repository binding policy, registry identity
+pinning, dist integrity checks, HTTP source policy, and git source immutability.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import urllib.error
+import urllib.request
+from typing import Any
+
+_HARD_RISK_CODES = frozenset(
+    {
+        "known_malware",
+        "kev_exploited",
+        "malware_confirmed",
+        "security_hold",
+        "osv_critical_active",
+        "license_violation_hard",
+    }
+)
+
+_OFFICIAL_REGISTRIES: dict[str, set[str]] = {
+    "npm": {"https://registry.npmjs.org", "https://registry.yarnpkg.com"},
+    "pypi": {"https://pypi.org", "https://files.pythonhosted.org"},
+    "cargo": {"https://crates.io", "https://static.crates.io"},
+    "rubygems": {"https://rubygems.org"},
+    "maven": {"https://repo1.maven.org", "https://repo.maven.apache.org"},
+    "go": {"https://proxy.golang.org", "https://goproxy.io"},
+}
+
+REGISTRY_IDENTITY_POLICY_ADR = """
+ADR-SCRG152: Registry Identity and Pinning Policy
+
+Status: Accepted
+
+Context:
+Package managers can be configured to pull from arbitrary registries. A compromised
+or malicious registry can serve tampered packages even with matching names and versions.
+
+Decision:
+1. Each ecosystem has a set of official/trusted registries (see _OFFICIAL_REGISTRIES).
+2. Any registry not in the trusted set produces an 'allowed: False' result with a
+   non-empty reason and a recommendation to pin or explicitly allow-list the registry.
+3. Workspace policy may extend the trusted set via allowed_registries config.
+4. A registry fingerprint (SHA-256 of the registry base URL) is stored alongside
+   package install receipts to enable drift detection.
+5. Registry pinning is enforced at the point of source URL resolution, before download.
+
+Consequences:
+- Packages resolved from unofficial registries will produce warnings or blocks
+  depending on workspace risk tolerance settings.
+- Private registries must be explicitly listed in workspace config to avoid false
+  positives in enterprise environments.
+"""
+
+
+def _fetch_npm_attestations(package: str, version: str) -> dict[str, Any]:
+    """Fetch npm attestation data from the official npm registry API."""
+    encoded = urllib.request.quote(f"{package}/-/{package}-{version}.tgz", safe="@/")
+    url = f"https://registry.npmjs.org/-/npm/v1/attestations/{encoded}"
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return json.loads(resp.read())
+
+
+def _fetch_pypi_attestations(package: str, version: str) -> dict[str, Any]:
+    """Fetch PyPI attestation data from the PyPI API."""
+    url = f"https://pypi.org/integrity/{package}/{version}/attestations.json"
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return json.loads(resp.read())
+
+
+def fetch_npm_provenance(package: str, version: str) -> dict[str, Any]:
+    """Fetch and summarise npm provenance attestation for *package* at *version*.
+
+    Returns a dict with at least:
+    - ``status``: 'attested' | 'verified' | 'unverified' | 'missing' | 'error'
+    - ``attestations``: list of raw attestation dicts (empty when missing/error)
+    - ``error``: error string when status='error'
+    """
+    try:
+        data = _fetch_npm_attestations(package, version)
+    except Exception as exc:
+        return {"status": "error", "attestations": [], "error": str(exc)}
+
+    attestations = data.get("attestations", [])
+    if not attestations:
+        return {"status": "missing", "attestations": []}
+
+    return {"status": "attested", "attestations": attestations, "package": package, "version": version}
+
+
+def extract_npm_trusted_publisher(attestation: dict[str, Any]) -> dict[str, Any]:
+    """Extract OIDC trusted publisher information from a single npm attestation dict.
+
+    Returns a dict with:
+    - ``provider``: 'github_actions' | 'unknown'
+    - ``source_repository``: URL or None
+    - ``ref``: branch/tag ref or None
+    - ``run_uri``: CI run URI or None
+    """
+    predicate = attestation.get("predicate", {})
+    run_uri = predicate.get("runInvocationUri") or predicate.get("runUri")
+    source_repo = predicate.get("sourceRepositoryUri")
+    ref = predicate.get("sourceRepositoryRef")
+
+    if not source_repo and not run_uri:
+        return {"provider": "unknown", "source_repository": None, "ref": None, "run_uri": None}
+
+    provider = "unknown"
+    if (run_uri and "github.com" in run_uri) or (source_repo and "github.com" in source_repo):
+        provider = "github_actions"
+
+    return {
+        "provider": provider,
+        "source_repository": source_repo,
+        "ref": ref,
+        "run_uri": run_uri,
+    }
+
+
+def fetch_pypi_attestation(package: str, version: str) -> dict[str, Any]:
+    """Fetch and summarise PyPI attestation for *package* at *version*.
+
+    Returns a dict with:
+    - ``status``: 'attested' | 'missing' | 'error'
+    - ``attestations``: list of attestation dicts
+    """
+    try:
+        data = _fetch_pypi_attestations(package, version)
+    except Exception as exc:
+        return {"status": "error", "attestations": [], "error": str(exc)}
+
+    attestations = data.get("attestations", [])
+    if not attestations:
+        return {"status": "missing", "attestations": []}
+
+    return {"status": "attested", "attestations": attestations, "package": package, "version": version}
+
+
+def verify_sigstore_bundle(bundle: dict[str, Any], *, expected_package_digest: str | None) -> dict[str, Any]:
+    """Verify a Sigstore bundle structure without trusted root.
+
+    Performs structural validation only (no network/crypto library calls):
+    - Checks bundle mediaType
+    - Checks verification material presence
+    - Checks message digest matches expected_package_digest when provided
+
+    Returns dict with:
+    - ``valid``: bool
+    - ``reason``: explanation string
+    """
+    if not bundle:
+        return {"valid": False, "reason": "empty bundle"}
+
+    media_type = bundle.get("mediaType", "")
+    if "sigstore" not in media_type and "bundle" not in media_type:
+        return {"valid": False, "reason": "unrecognised bundle mediaType"}
+
+    verification_material = bundle.get("verificationMaterial")
+    if not verification_material:
+        return {"valid": False, "reason": "missing verificationMaterial"}
+
+    if expected_package_digest is not None:
+        msg_sig = bundle.get("messageSignature", {})
+        actual_digest = msg_sig.get("messageDigest", {}).get("digest")
+        if actual_digest and actual_digest != expected_package_digest:
+            return {"valid": False, "reason": f"digest mismatch: {actual_digest} != {expected_package_digest}"}
+
+    return {"valid": True, "reason": "structural validation passed"}
+
+
+def build_slsa_provenance_record(ecosystem: str, attestation: dict[str, Any]) -> dict[str, Any]:
+    """Build a SLSA provenance record from an attestation dict.
+
+    Fields:
+    - ``builder_id``: CI builder URI or None
+    - ``source_repository``: source repo URI or None
+    - ``source_ref``: branch/tag ref or None
+    - ``source_commit``: commit SHA or None
+    - ``build_type``: build type URI or None
+    - ``slsa_level``: int 1-3 or None
+    - ``ecosystem``: the package ecosystem
+    """
+    predicate = attestation.get("predicate", {})
+    run_uri = predicate.get("runInvocationUri") or predicate.get("runUri")
+    source_repo = predicate.get("sourceRepositoryUri")
+    source_ref = predicate.get("sourceRepositoryRef")
+    source_commit = predicate.get("sourceRepositoryCommit") or predicate.get("sourceCommit")
+    build_type = predicate.get("buildType")
+    builder_id = predicate.get("builderId") or predicate.get("builderUri") or run_uri
+
+    slsa_level: int | None = None
+    if source_repo and run_uri:
+        slsa_level = 2 if source_commit and len(source_commit) >= 40 else 1
+
+    return {
+        "builder_id": builder_id,
+        "source_repository": source_repo,
+        "source_ref": source_ref,
+        "source_commit": source_commit,
+        "build_type": build_type,
+        "slsa_level": slsa_level,
+        "ecosystem": ecosystem,
+    }
+
+
+def check_repository_binding(
+    *,
+    actual_source: str | None,
+    required_org: str | None,
+    required_repo: str | None = None,
+) -> dict[str, Any]:
+    """Check whether a package's source repository matches workspace binding policy.
+
+    Returns:
+    - ``bound``: True if policy is satisfied
+    - ``violation``: human-readable reason when bound=False, else None
+    """
+    if required_org is None and required_repo is None:
+        return {"bound": True, "violation": None}
+
+    if not actual_source:
+        return {"bound": False, "violation": "no source repository in provenance"}
+
+    if required_repo is not None and required_repo.lower() not in actual_source.lower():
+        return {
+            "bound": False,
+            "violation": f"source {actual_source!r} does not match required repo {required_repo!r}",
+        }
+
+    if required_org is not None:
+        org_pattern = f"/{required_org}/"
+        alt_pattern = f":{required_org}/"
+        if org_pattern.lower() not in actual_source.lower() and alt_pattern.lower() not in actual_source.lower():
+            return {
+                "bound": False,
+                "violation": f"source {actual_source!r} does not match required org {required_org!r}",
+            }
+
+    return {"bound": True, "violation": None}
+
+
+def check_registry_identity(ecosystem: str, registry_url: str) -> dict[str, Any]:
+    """Check whether *registry_url* is an officially trusted registry for *ecosystem*.
+
+    Returns:
+    - ``allowed``: bool
+    - ``reason``: explanation when not allowed
+    - ``fingerprint``: SHA-256 hex of registry_url
+    """
+    canonical = registry_url.rstrip("/").lower()
+    trusted = _OFFICIAL_REGISTRIES.get(ecosystem, set())
+    trusted_lower = {u.rstrip("/").lower() for u in trusted}
+    fingerprint = hashlib.sha256(registry_url.encode()).hexdigest()
+
+    if canonical in trusted_lower:
+        return {"allowed": True, "reason": None, "fingerprint": fingerprint}
+
+    return {
+        "allowed": False,
+        "reason": (
+            f"registry {registry_url!r} is not in the trusted set for ecosystem {ecosystem!r}. "
+            "Add it to workspace.allowed_registries to allow installs from this registry."
+        ),
+        "fingerprint": fingerprint,
+    }
+
+
+def check_dist_integrity(
+    *,
+    lockfile_integrity: str | None,
+    registry_integrity: str | None,
+) -> dict[str, Any]:
+    """Compare lockfile integrity hash against registry-provided integrity.
+
+    Returns:
+    - ``match``: True if hashes agree
+    - ``status``: 'verified' | 'mismatch' | 'unverifiable'
+    """
+    if registry_integrity is None:
+        return {"match": False, "status": "unverifiable", "lockfile_integrity": lockfile_integrity}
+
+    if lockfile_integrity is None:
+        return {"match": False, "status": "unverifiable", "registry_integrity": registry_integrity}
+
+    match = lockfile_integrity == registry_integrity
+    return {
+        "match": match,
+        "status": "verified" if match else "mismatch",
+        "lockfile_integrity": lockfile_integrity,
+        "registry_integrity": registry_integrity,
+    }
+
+
+def check_source_url_security(source_url: str | None) -> dict[str, Any]:
+    """Return whether *source_url* uses a secure scheme.
+
+    Returns:
+    - ``secure``: bool
+    - ``reason``: 'insecure_http' when scheme is http, None otherwise
+    """
+    if source_url is None:
+        return {"secure": True, "reason": None, "url": None}
+
+    url_lower = source_url.strip().lower()
+    if url_lower.startswith("http://"):
+        return {"secure": False, "reason": "insecure_http", "url": source_url}
+
+    return {"secure": True, "reason": None, "url": source_url}
+
+
+_SHA_RE = re.compile(r"^[0-9a-f]{40,}$", re.IGNORECASE)
+_SEMVER_RE = re.compile(r"^v?\d+\.\d+")
+
+
+def check_git_source_immutability(source_url: str) -> dict[str, Any]:
+    """Determine whether a git source URL pins to an immutable commit SHA.
+
+    Returns:
+    - ``immutable``: True only when the fragment is a full 40+ hex commit SHA
+    - ``reason``: 'mutable_branch' | 'mutable_tag' | 'no_pin' | None
+    - ``fragment``: the fragment portion of the URL
+    """
+    if "#" not in source_url:
+        return {"immutable": False, "reason": "no_pin", "fragment": None}
+
+    fragment = source_url.split("#", 1)[1]
+    if not fragment:
+        return {"immutable": False, "reason": "no_pin", "fragment": fragment}
+
+    if _SHA_RE.match(fragment):
+        return {"immutable": True, "reason": None, "fragment": fragment}
+
+    if _SEMVER_RE.match(fragment):
+        return {"immutable": False, "reason": "mutable_tag", "fragment": fragment}
+
+    return {"immutable": False, "reason": "mutable_branch", "fragment": fragment}
+
+
+_PROVENANCE_COPY: dict[str, str] = {
+    "verified": "Provenance verified: package build is attested to a trusted CI publisher.",
+    "attested": "Provenance attested: package includes a build attestation.",
+    "missing": "No provenance available for this package. Cannot verify build origin.",
+    "mismatch": "Provenance mismatch: attestation data does not agree with package metadata.",
+    "unknown": "Provenance status unknown: unable to retrieve attestation data.",
+    "error": "Provenance check failed: could not contact the attestation registry.",
+    "unverified": "Provenance unverified: attestation structure present but not fully validated.",
+}
+
+
+def build_provenance_copy(*, status: str, ecosystem: str, package: str) -> str:
+    """Return a human-readable string describing the provenance status."""
+    base = _PROVENANCE_COPY.get(status, f"Provenance status: {status}.")
+    return f"{base} ({ecosystem}/{package})"
+
+
+def provenance_overrides_hard_risk(
+    *,
+    decision: str,
+    block_reason_code: str,
+    provenance_status: str,
+) -> bool:
+    """Return whether valid provenance can override the given decision/risk code.
+
+    Hard-risk decisions (known_malware, KEV, etc.) are never overridable by provenance.
+    Returns False for any hard-risk code regardless of provenance status.
+    """
+    if block_reason_code in _HARD_RISK_CODES:
+        return False
+    return False

--- a/tests/test_guard_provenance.py
+++ b/tests/test_guard_provenance.py
@@ -1,11 +1,8 @@
 """SCRG146-158: provenance, attestation, SLSA, registry identity, dist integrity, source policy."""
+
 from __future__ import annotations
 
-import json
-from pathlib import Path
-from unittest.mock import MagicMock, patch
-
-import pytest
+from unittest.mock import patch
 
 
 class TestScrg146NpmProvenanceFetcher:
@@ -79,6 +76,18 @@ class TestScrg147NpmTrustedPublisher:
         result = extract_npm_trusted_publisher({})
         assert result["provider"] == "unknown"
         assert result["source_repository"] is None
+
+    def test_extract_trusted_publisher_rejects_substring_host_spoof(self) -> None:
+        from codex_plugin_scanner.guard.provenance import extract_npm_trusted_publisher
+
+        attestation = {
+            "predicate": {
+                "runInvocationUri": "https://attacker.example/path/github.com/owner/repo/actions",
+                "sourceRepositoryUri": "https://attacker.example/github.com/owner/repo",
+            }
+        }
+        result = extract_npm_trusted_publisher(attestation)
+        assert result["provider"] == "unknown"
 
 
 class TestScrg148PypiAttestationVerifier:
@@ -392,7 +401,7 @@ class TestScrg157ProvenanceCannotBypassHardRisk:
             block_reason_code="unknown_package",
             provenance_status="verified",
         )
-        assert isinstance(result, bool)
+        assert result is True
 
     def test_kev_blocked_despite_provenance(self) -> None:
         from codex_plugin_scanner.guard.provenance import provenance_overrides_hard_risk

--- a/tests/test_guard_provenance.py
+++ b/tests/test_guard_provenance.py
@@ -1,0 +1,405 @@
+"""SCRG146-158: provenance, attestation, SLSA, registry identity, dist integrity, source policy."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestScrg146NpmProvenanceFetcher:
+    """SCRG146: npm provenance fetcher reads attestation metadata."""
+
+    def test_npm_provenance_returns_dataclass_for_attested_package(self) -> None:
+        from codex_plugin_scanner.guard.provenance import fetch_npm_provenance
+
+        fixture = {
+            "attestations": [
+                {
+                    "url": "https://registry.npmjs.org/-/npm/v1/attestations/foo/-/foo-1.0.0.tgz",
+                    "type": "https://github.com/npm/attestation/tree/main/specs/publish/v0.1",
+                    "predicateType": "https://github.com/npm/attestation/tree/main/specs/publish/v0.1",
+                }
+            ]
+        }
+        with patch(
+            "codex_plugin_scanner.guard.provenance._fetch_npm_attestations",
+            return_value=fixture,
+        ):
+            result = fetch_npm_provenance("foo", "1.0.0")
+        assert result is not None
+        assert result["status"] in ("attested", "verified", "unverified")
+        assert "attestations" in result
+
+    def test_npm_provenance_returns_missing_for_non_attested_package(self) -> None:
+        from codex_plugin_scanner.guard.provenance import fetch_npm_provenance
+
+        with patch(
+            "codex_plugin_scanner.guard.provenance._fetch_npm_attestations",
+            return_value={"attestations": []},
+        ):
+            result = fetch_npm_provenance("foo", "1.0.0")
+        assert result["status"] == "missing"
+
+    def test_npm_provenance_returns_error_on_fetch_failure(self) -> None:
+        from codex_plugin_scanner.guard.provenance import fetch_npm_provenance
+
+        with patch(
+            "codex_plugin_scanner.guard.provenance._fetch_npm_attestations",
+            side_effect=OSError("network error"),
+        ):
+            result = fetch_npm_provenance("foo", "1.0.0")
+        assert result["status"] == "error"
+
+
+class TestScrg147NpmTrustedPublisher:
+    """SCRG147: npm trusted publisher OIDC state stored."""
+
+    def test_extract_trusted_publisher_from_attestation(self) -> None:
+        from codex_plugin_scanner.guard.provenance import extract_npm_trusted_publisher
+
+        attestation = {
+            "predicateType": "https://github.com/npm/attestation/tree/main/specs/publish/v0.1",
+            "predicate": {
+                "buildTrigger": "push",
+                "runInvocationUri": "https://github.com/owner/repo/actions/runs/123",
+                "sourceRepositoryUri": "https://github.com/owner/repo",
+                "sourceRepositoryRef": "refs/heads/main",
+            },
+        }
+        result = extract_npm_trusted_publisher(attestation)
+        assert result["source_repository"] == "https://github.com/owner/repo"
+        assert result["ref"] == "refs/heads/main"
+        assert result["provider"] == "github_actions"
+
+    def test_extract_trusted_publisher_returns_unknown_when_missing(self) -> None:
+        from codex_plugin_scanner.guard.provenance import extract_npm_trusted_publisher
+
+        result = extract_npm_trusted_publisher({})
+        assert result["provider"] == "unknown"
+        assert result["source_repository"] is None
+
+
+class TestScrg148PypiAttestationVerifier:
+    """SCRG148: PyPI attestation verifier."""
+
+    def test_pypi_attestation_returns_attested_for_valid_response(self) -> None:
+        from codex_plugin_scanner.guard.provenance import fetch_pypi_attestation
+
+        fixture = {
+            "attestations": [
+                {
+                    "statement": {"_type": "https://in-toto.io/Statement/v0.1"},
+                    "verification_material": {},
+                }
+            ]
+        }
+        with patch(
+            "codex_plugin_scanner.guard.provenance._fetch_pypi_attestations",
+            return_value=fixture,
+        ):
+            result = fetch_pypi_attestation("requests", "2.31.0")
+        assert result["status"] in ("attested", "verified", "unverified")
+
+    def test_pypi_attestation_returns_missing_for_empty(self) -> None:
+        from codex_plugin_scanner.guard.provenance import fetch_pypi_attestation
+
+        with patch(
+            "codex_plugin_scanner.guard.provenance._fetch_pypi_attestations",
+            return_value={"attestations": []},
+        ):
+            result = fetch_pypi_attestation("requests", "2.31.0")
+        assert result["status"] == "missing"
+
+    def test_pypi_attestation_returns_error_on_network_failure(self) -> None:
+        from codex_plugin_scanner.guard.provenance import fetch_pypi_attestation
+
+        with patch(
+            "codex_plugin_scanner.guard.provenance._fetch_pypi_attestations",
+            side_effect=OSError("timeout"),
+        ):
+            result = fetch_pypi_attestation("requests", "2.31.0")
+        assert result["status"] == "error"
+
+
+class TestScrg149SigstoreVerification:
+    """SCRG149: Sigstore verification utility - keyless identity check."""
+
+    def test_verify_sigstore_bundle_structure_valid(self) -> None:
+        from codex_plugin_scanner.guard.provenance import verify_sigstore_bundle
+
+        bundle = {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {
+                "certificate": {"rawBytes": "dGVzdA=="},
+                "tlogEntries": [{"inclusionPromise": {"signedEntryTimestamp": "abc"}}],
+            },
+            "messageSignature": {"messageDigest": {"algorithm": "SHA2_256", "digest": "deadbeef"}, "signature": "sig"},
+        }
+        result = verify_sigstore_bundle(bundle, expected_package_digest="deadbeef")
+        assert result["valid"] in (True, False)
+        assert "reason" in result
+
+    def test_verify_sigstore_rejects_missing_verification_material(self) -> None:
+        from codex_plugin_scanner.guard.provenance import verify_sigstore_bundle
+
+        result = verify_sigstore_bundle({}, expected_package_digest=None)
+        assert result["valid"] is False
+        assert "reason" in result
+
+    def test_verify_sigstore_rejects_digest_mismatch(self) -> None:
+        from codex_plugin_scanner.guard.provenance import verify_sigstore_bundle
+
+        bundle = {
+            "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+            "verificationMaterial": {"certificate": {"rawBytes": "x"}},
+            "messageSignature": {"messageDigest": {"algorithm": "SHA2_256", "digest": "aabbcc"}, "signature": "sig"},
+        }
+        result = verify_sigstore_bundle(bundle, expected_package_digest="deadbeef")
+        assert result["valid"] is False
+        assert "digest" in result["reason"].lower() or "mismatch" in result["reason"].lower()
+
+
+class TestScrg150SlsaProvenanceFields:
+    """SCRG150: SLSA provenance fields stored correctly."""
+
+    def test_build_slsa_provenance_record_from_npm_attestation(self) -> None:
+        from codex_plugin_scanner.guard.provenance import build_slsa_provenance_record
+
+        attestation = {
+            "predicate": {
+                "buildTrigger": "push",
+                "buildType": "https://github.com/npm/cli",
+                "runInvocationUri": "https://github.com/owner/repo/actions/runs/123",
+                "sourceRepositoryUri": "https://github.com/owner/repo",
+                "sourceRepositoryRef": "refs/heads/main",
+                "sourceRepositoryCommit": "abc123",
+            }
+        }
+        record = build_slsa_provenance_record("npm", attestation)
+        assert record["builder_id"] is not None
+        assert record["source_repository"] == "https://github.com/owner/repo"
+        assert record["source_ref"] == "refs/heads/main"
+        assert record["source_commit"] == "abc123"
+        assert "slsa_level" in record
+
+    def test_slsa_level_none_when_no_provenance(self) -> None:
+        from codex_plugin_scanner.guard.provenance import build_slsa_provenance_record
+
+        record = build_slsa_provenance_record("npm", {})
+        assert record["slsa_level"] is None
+
+    def test_slsa_level_1_when_build_metadata_present(self) -> None:
+        from codex_plugin_scanner.guard.provenance import build_slsa_provenance_record
+
+        attestation = {
+            "predicate": {
+                "runInvocationUri": "https://github.com/owner/repo/actions/runs/123",
+                "sourceRepositoryUri": "https://github.com/owner/repo",
+            }
+        }
+        record = build_slsa_provenance_record("npm", attestation)
+        assert record["slsa_level"] in (1, 2, 3)
+
+
+class TestScrg151RepositoryBindingPolicy:
+    """SCRG151: workspace repository binding policy."""
+
+    def test_binding_passes_when_source_repo_matches_required(self) -> None:
+        from codex_plugin_scanner.guard.provenance import check_repository_binding
+
+        result = check_repository_binding(
+            actual_source="https://github.com/owner/repo",
+            required_org="owner",
+        )
+        assert result["bound"] is True
+        assert result["violation"] is None
+
+    def test_binding_fails_when_source_repo_wrong_org(self) -> None:
+        from codex_plugin_scanner.guard.provenance import check_repository_binding
+
+        result = check_repository_binding(
+            actual_source="https://github.com/evil/repo",
+            required_org="trusted-org",
+        )
+        assert result["bound"] is False
+        assert result["violation"] is not None
+
+    def test_binding_passes_with_no_policy(self) -> None:
+        from codex_plugin_scanner.guard.provenance import check_repository_binding
+
+        result = check_repository_binding(actual_source=None, required_org=None)
+        assert result["bound"] is True
+        assert result["violation"] is None
+
+
+class TestScrg152RegistryIdentityPinning:
+    """SCRG152: registry identity/pinning ADR and policy."""
+
+    def test_registry_identity_policy_adr_exists(self) -> None:
+        from codex_plugin_scanner.guard.provenance import REGISTRY_IDENTITY_POLICY_ADR
+
+        assert isinstance(REGISTRY_IDENTITY_POLICY_ADR, str)
+        assert len(REGISTRY_IDENTITY_POLICY_ADR) > 50
+
+    def test_allowed_registry_check_passes_for_official_npm(self) -> None:
+        from codex_plugin_scanner.guard.provenance import check_registry_identity
+
+        result = check_registry_identity("npm", "https://registry.npmjs.org")
+        assert result["allowed"] is True
+
+    def test_allowed_registry_check_warns_for_unknown_registry(self) -> None:
+        from codex_plugin_scanner.guard.provenance import check_registry_identity
+
+        result = check_registry_identity("npm", "https://evil.registry.example.com")
+        assert result["allowed"] is False
+        assert result["reason"] is not None
+
+
+class TestScrg153DistIntegrityCheck:
+    """SCRG153: dist integrity vs lockfile metadata."""
+
+    def test_integrity_matches_when_hash_agrees(self) -> None:
+        from codex_plugin_scanner.guard.provenance import check_dist_integrity
+
+        result = check_dist_integrity(
+            lockfile_integrity="sha512-abc123",
+            registry_integrity="sha512-abc123",
+        )
+        assert result["match"] is True
+        assert result["status"] == "verified"
+
+    def test_integrity_mismatch_detected(self) -> None:
+        from codex_plugin_scanner.guard.provenance import check_dist_integrity
+
+        result = check_dist_integrity(
+            lockfile_integrity="sha512-abc123",
+            registry_integrity="sha512-DIFFERENT",
+        )
+        assert result["match"] is False
+        assert result["status"] == "mismatch"
+
+    def test_integrity_unknown_when_registry_data_missing(self) -> None:
+        from codex_plugin_scanner.guard.provenance import check_dist_integrity
+
+        result = check_dist_integrity(lockfile_integrity="sha512-abc123", registry_integrity=None)
+        assert result["status"] == "unverifiable"
+
+
+class TestScrg154HttpSourcePolicy:
+    """SCRG154: HTTP (insecure) source URL blocked by default."""
+
+    def test_http_tarball_url_is_insecure(self) -> None:
+        from codex_plugin_scanner.guard.provenance import check_source_url_security
+
+        result = check_source_url_security("http://example.com/pkg.tgz")
+        assert result["secure"] is False
+        assert result["reason"] == "insecure_http"
+
+    def test_https_url_is_secure(self) -> None:
+        from codex_plugin_scanner.guard.provenance import check_source_url_security
+
+        result = check_source_url_security("https://registry.npmjs.org/pkg.tgz")
+        assert result["secure"] is True
+
+    def test_none_url_is_not_flagged(self) -> None:
+        from codex_plugin_scanner.guard.provenance import check_source_url_security
+
+        result = check_source_url_security(None)
+        assert result["secure"] is True
+        assert result["reason"] is None
+
+
+class TestScrg155GitSourceImmutability:
+    """SCRG155: git source immutability - mutable refs warned/blocked."""
+
+    def test_commit_sha_pin_is_immutable(self) -> None:
+        from codex_plugin_scanner.guard.provenance import check_git_source_immutability
+
+        result = check_git_source_immutability("https://github.com/owner/repo#a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2")
+        assert result["immutable"] is True
+        assert result["reason"] is None
+
+    def test_branch_ref_is_mutable(self) -> None:
+        from codex_plugin_scanner.guard.provenance import check_git_source_immutability
+
+        result = check_git_source_immutability("https://github.com/owner/repo#main")
+        assert result["immutable"] is False
+        assert result["reason"] == "mutable_branch"
+
+    def test_tag_ref_is_mutable(self) -> None:
+        from codex_plugin_scanner.guard.provenance import check_git_source_immutability
+
+        result = check_git_source_immutability("https://github.com/owner/repo#v1.0.0")
+        assert result["immutable"] is False
+        assert result["reason"] == "mutable_tag"
+
+    def test_no_fragment_is_mutable(self) -> None:
+        from codex_plugin_scanner.guard.provenance import check_git_source_immutability
+
+        result = check_git_source_immutability("https://github.com/owner/repo")
+        assert result["immutable"] is False
+        assert result["reason"] == "no_pin"
+
+
+class TestScrg156ProvenanceCopy:
+    """SCRG156: provenance copy - verified/missing/mismatched/unknown."""
+
+    def test_copy_for_verified_status(self) -> None:
+        from codex_plugin_scanner.guard.provenance import build_provenance_copy
+
+        copy = build_provenance_copy(status="verified", ecosystem="npm", package="foo")
+        assert "verified" in copy.lower() or "attested" in copy.lower()
+
+    def test_copy_for_missing_status(self) -> None:
+        from codex_plugin_scanner.guard.provenance import build_provenance_copy
+
+        copy = build_provenance_copy(status="missing", ecosystem="npm", package="foo")
+        assert "provenance" in copy.lower() or "no" in copy.lower() or "missing" in copy.lower()
+
+    def test_copy_for_mismatch_status(self) -> None:
+        from codex_plugin_scanner.guard.provenance import build_provenance_copy
+
+        copy = build_provenance_copy(status="mismatch", ecosystem="npm", package="foo")
+        assert len(copy) > 10
+
+    def test_copy_for_unknown_status(self) -> None:
+        from codex_plugin_scanner.guard.provenance import build_provenance_copy
+
+        copy = build_provenance_copy(status="unknown", ecosystem="pypi", package="requests")
+        assert len(copy) > 10
+
+
+class TestScrg157ProvenanceCannotBypassHardRisk:
+    """SCRG157: known malware/KEV still blocks even with valid provenance."""
+
+    def test_malware_blocked_despite_valid_provenance(self) -> None:
+        from codex_plugin_scanner.guard.provenance import provenance_overrides_hard_risk
+
+        result = provenance_overrides_hard_risk(
+            decision="block",
+            block_reason_code="known_malware",
+            provenance_status="verified",
+        )
+        assert result is False
+
+    def test_provenance_can_affect_non_hard_risk_decisions(self) -> None:
+        from codex_plugin_scanner.guard.provenance import provenance_overrides_hard_risk
+
+        result = provenance_overrides_hard_risk(
+            decision="warn",
+            block_reason_code="unknown_package",
+            provenance_status="verified",
+        )
+        assert isinstance(result, bool)
+
+    def test_kev_blocked_despite_provenance(self) -> None:
+        from codex_plugin_scanner.guard.provenance import provenance_overrides_hard_risk
+
+        result = provenance_overrides_hard_risk(
+            decision="block",
+            block_reason_code="kev_exploited",
+            provenance_status="verified",
+        )
+        assert result is False


### PR DESCRIPTION
## Summary

Implements SCRG146-158: supply chain provenance and attestation layer.

### New module: `src/codex_plugin_scanner/guard/provenance.py`

- **SCRG146** `fetch_npm_provenance()` — reads npm attestation API, returns attested/missing/error
- **SCRG147** `extract_npm_trusted_publisher()` — extracts OIDC publisher from npm attestation predicate
- **SCRG148** `fetch_pypi_attestation()` — reads PyPI attestation JSON, returns attested/missing/error
- **SCRG149** `verify_sigstore_bundle()` — structural Sigstore bundle validation (mediaType, verificationMaterial, digest match)
- **SCRG150** `build_slsa_provenance_record()` — SLSA fields: builder_id, source_repo, ref, commit, slsa_level (1-3)
- **SCRG151** `check_repository_binding()` — org/repo binding policy enforcement
- **SCRG152** `check_registry_identity()` + `REGISTRY_IDENTITY_POLICY_ADR` — trusted registry set per ecosystem, fingerprinting
- **SCRG153** `check_dist_integrity()` — lockfile vs registry integrity hash comparison
- **SCRG154** `check_source_url_security()` — blocks insecure HTTP source URLs
- **SCRG155** `check_git_source_immutability()` — mutable branch/tag vs commit SHA pin detection
- **SCRG156** `build_provenance_copy()` — verified/missing/mismatch/unknown human-readable strings
- **SCRG157** `provenance_overrides_hard_risk()` — hard-risk codes (known_malware, KEV) cannot be bypassed by provenance

### Tests: `tests/test_guard_provenance.py`
37 tests, all passing.