### PR TITLE
test(guard): fix verification lint regressions

### DIFF
--- a/tests/test_guard_phase07_harness_coverage_matrix.py
+++ b/tests/test_guard_phase07_harness_coverage_matrix.py
@@ -13,49 +13,73 @@ _HARNESS_COVERAGE_MATRIX = (
         "harness": "codex",
         "tool_name": "bash",
         "command": "npm install minimist@1.2.8",
-        "proof_test": "tests/test_guard_package_hook_phase14.py::test_phase14_guard_hook_enriches_package_contract_for_managed_harnesses[codex]",
+        "proof_test": (
+            "tests/test_guard_package_hook_phase14.py::"
+            "test_phase14_guard_hook_enriches_package_contract_for_managed_harnesses[codex]"
+        ),
     },
     {
         "harness": "claude-code",
         "tool_name": "bash",
         "command": "npm install minimist@1.2.8",
-        "proof_test": "tests/test_guard_package_hook_phase14.py::test_phase14_guard_hook_enriches_package_contract_for_managed_harnesses[claude-code]",
+        "proof_test": (
+            "tests/test_guard_package_hook_phase14.py::"
+            "test_phase14_guard_hook_enriches_package_contract_for_managed_harnesses[claude-code]"
+        ),
     },
     {
         "harness": "copilot",
         "tool_name": "bash",
         "command": "npm install minimist@1.2.8",
-        "proof_test": "tests/test_guard_package_hook_phase14.py::test_phase14_guard_hook_enriches_package_contract_for_managed_harnesses[copilot]",
+        "proof_test": (
+            "tests/test_guard_package_hook_phase14.py::"
+            "test_phase14_guard_hook_enriches_package_contract_for_managed_harnesses[copilot]"
+        ),
     },
     {
         "harness": "gemini",
         "tool_name": "bash",
         "command": "npm install minimist@1.2.8",
-        "proof_test": "tests/test_guard_package_hook_phase14.py::test_phase14_guard_hook_enriches_package_contract_for_managed_harnesses[gemini]",
+        "proof_test": (
+            "tests/test_guard_package_hook_phase14.py::"
+            "test_phase14_guard_hook_enriches_package_contract_for_managed_harnesses[gemini]"
+        ),
     },
     {
         "harness": "cursor",
         "tool_name": "run_terminal_command",
         "command": "npm install minimist@1.2.8",
-        "proof_test": "tests/test_guard_mcp_package_proxy_phase14.py::test_phase14_runtime_mcp_proxy_queues_package_request_not_generic_tool_call[cursor]",
+        "proof_test": (
+            "tests/test_guard_mcp_package_proxy_phase14.py::"
+            "test_phase14_runtime_mcp_proxy_queues_package_request_not_generic_tool_call[cursor]"
+        ),
     },
     {
         "harness": "opencode",
         "tool_name": "run_terminal_command",
         "command": "npm install minimist@1.2.8",
-        "proof_test": "tests/test_guard_mcp_package_proxy_phase14.py::test_phase14_runtime_mcp_proxy_queues_package_request_not_generic_tool_call[opencode]",
+        "proof_test": (
+            "tests/test_guard_mcp_package_proxy_phase14.py::"
+            "test_phase14_runtime_mcp_proxy_queues_package_request_not_generic_tool_call[opencode]"
+        ),
     },
     {
         "harness": "hermes",
         "tool_name": "run_terminal_command",
         "command": "npm install minimist@1.2.8",
-        "proof_test": "tests/test_guard_mcp_package_proxy_phase14.py::test_phase14_runtime_mcp_proxy_queues_package_request_not_generic_tool_call[hermes]",
+        "proof_test": (
+            "tests/test_guard_mcp_package_proxy_phase14.py::"
+            "test_phase14_runtime_mcp_proxy_queues_package_request_not_generic_tool_call[hermes]"
+        ),
     },
     {
         "harness": "openclaw",
         "tool_name": "run_terminal_command",
         "command": "npm install minimist@1.2.8",
-        "proof_test": "tests/test_guard_mcp_package_proxy_phase14.py::test_phase14_runtime_mcp_proxy_queues_package_request_not_generic_tool_call[openclaw]",
+        "proof_test": (
+            "tests/test_guard_mcp_package_proxy_phase14.py::"
+            "test_phase14_runtime_mcp_proxy_queues_package_request_not_generic_tool_call[openclaw]"
+        ),
     },
 )
 

--- a/tests/test_guard_shim_truth.py
+++ b/tests/test_guard_shim_truth.py
@@ -1,13 +1,7 @@
 """SCRG264-270: shim status, PATH verification, tamper detection, repair, daemon coverage."""
 from __future__ import annotations
 
-import hashlib
-import json
-import os
-import stat
-import sys
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 


### PR DESCRIPTION
## Summary
- fix clean-worktree lint regressions blocking `SCRG234` verification
- re-run focused and broad `hol-guard` verification from fresh `origin/main` worktree

## Testing
- `ruff check tests/test_guard_phase07_harness_coverage_matrix.py tests/test_guard_shim_truth.py`
- `pytest -q tests/test_guard_phase07_harness_coverage_matrix.py tests/test_guard_shim_truth.py tests/test_guard_package_shims.py tests/test_guard_supply_chain_evaluator.py tests/test_guard_docs.py tests/test_guard_redaction.py`
- `ruff check src tests`
- `pytest -q`
