### PR TITLE
fix(codex): clean legacy wrapper hooks

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -181,6 +181,8 @@ def _is_managed_hook_command(command: object) -> bool:
         tokens = shlex.split(command)
     except ValueError:
         return False
+    if len(tokens) == 1 and Path(tokens[0]).name == "hol-guard-codex-hook.sh":
+        return True
     if len(tokens) < 3:
         return False
     executable = Path(tokens[0]).name.lower()

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -181,7 +181,7 @@ def _is_managed_hook_command(command: object) -> bool:
         tokens = shlex.split(command)
     except ValueError:
         return False
-    if len(tokens) == 1 and Path(tokens[0]).name == "hol-guard-codex-hook.sh":
+    if tokens and Path(tokens[0]).name == "hol-guard-codex-hook.sh":
         return True
     if len(tokens) < 3:
         return False

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -431,6 +431,85 @@ def test_guard_install_codex_migrates_stale_python_c_managed_hooks(tmp_path, cap
     assert str(stale_worktree) not in all_commands
 
 
+def test_guard_install_codex_migrates_legacy_wrapper_script_hook(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
+    wrapper_command = str(home_dir / ".codex" / "hooks" / "hol-guard-codex-hook.sh")
+    managed_events = {
+        "PreToolUse": {
+            "matcher": "Bash",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": wrapper_command,
+                    "timeout": 30,
+                    "statusMessage": "HOL Guard checking tool action",
+                }
+            ],
+        },
+        "PermissionRequest": {
+            "matcher": "Bash|^apply_patch$|Edit|Write|mcp__.*",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": wrapper_command,
+                    "timeout": 30,
+                    "statusMessage": "HOL Guard checking Codex approval request",
+                }
+            ],
+        },
+        "UserPromptSubmit": {
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": wrapper_command,
+                    "timeout": 30,
+                    "statusMessage": "HOL Guard checking prompt",
+                }
+            ],
+        },
+        "PostToolUse": {
+            "matcher": "Bash",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": wrapper_command,
+                    "timeout": 30,
+                    "statusMessage": "HOL Guard checking tool result",
+                }
+            ],
+        },
+    }
+    _write_text(
+        workspace_dir / ".codex" / "hooks.json",
+        json.dumps({"hooks": {key: [value] for key, value in managed_events.items()}}, indent=2) + "\n",
+    )
+
+    install_rc = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+    hooks_payload = json.loads((workspace_dir / ".codex" / "hooks.json").read_text(encoding="utf-8"))
+
+    assert install_rc == 0
+    assert len(hooks_payload["hooks"]["PreToolUse"]) == 1
+    assert len(hooks_payload["hooks"]["PermissionRequest"]) == 1
+    assert len(hooks_payload["hooks"]["UserPromptSubmit"]) == 1
+    assert len(hooks_payload["hooks"]["PostToolUse"]) == 1
+    all_commands = json.dumps(hooks_payload)
+    assert wrapper_command not in all_commands
+
+
 def test_guard_install_codex_workspace_cleans_stale_global_managed_hook(tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -435,7 +435,7 @@ def test_guard_install_codex_migrates_legacy_wrapper_script_hook(tmp_path, capsy
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
-    wrapper_command = str(home_dir / ".codex" / "hooks" / "hol-guard-codex-hook.sh")
+    wrapper_command = shlex.join([str(home_dir / ".codex" / "hooks" / "hol-guard-codex-hook.sh"), "--legacy"])
     managed_events = {
         "PreToolUse": {
             "matcher": "Bash",


### PR DESCRIPTION
## Summary
- Clean legacy `hol-guard-codex-hook.sh` wrapper entries during Codex install so stale/double prompt hooks cannot break Codex App handoff.
- Add regression coverage for wrapper-script hook migration across prompt, permission, pre-tool, and post-tool events.

## Testing
- `python3 -m pytest -q tests/test_guard_codex_install.py::test_guard_install_codex_migrates_legacy_wrapper_script_hook tests/test_guard_codex_install.py::test_guard_install_codex_migrates_stale_python_c_managed_hooks`
- `python3 -m pytest -q tests/test_guard_codex_install.py`
- `python3 -m ruff check src/codex_plugin_scanner/guard/adapters/codex.py tests/test_guard_codex_install.py`
- `git diff --check`
- Installed-hook contract check: Codex `UserPromptSubmit` returns approval URL, `stopReason`, and `hookSpecificOutput.additionalContext`.
