### PR TITLE
feat(guard): sync package coverage payload

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2128,6 +2128,7 @@ def _cloud_runtime_session_payload(store: GuardStore, session: dict[str, object]
     capabilities = [str(item) for item in session.get("capabilities", []) if isinstance(item, str)]
     package_manager_coverage = _cloud_package_manager_coverage(
         store,
+        workspace=workspace,
         generated_at=updated_at,
     )
     return {
@@ -2158,12 +2159,13 @@ def _cloud_sync_receipt_fingerprint(receipt: dict[str, object]) -> str:
 def _cloud_package_manager_coverage(
     store: GuardStore,
     *,
+    workspace: str,
     generated_at: str,
 ) -> dict[str, object]:
     coverage = package_shim_cloud_coverage(
         HarnessContext(
             home_dir=Path.home(),
-            workspace_dir=Path.cwd(),
+            workspace_dir=Path(workspace),
             guard_home=store.guard_home,
         ),
         generated_at=generated_at,

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -27,6 +27,7 @@ from ..consumer import detect_harness, evaluate_detection
 from ..edge_events import build_runtime_session_event
 from ..models import GuardArtifact, HarnessDetection, PolicyDecision
 from ..redaction import redact_sensitive_text
+from ..shims import package_shim_cloud_coverage
 from ..store import GuardStore
 from ..types import PromptRequest, RemediationAction
 from .actions import GuardActionEnvelope, redacted_workspace_label
@@ -2125,6 +2126,10 @@ def _cloud_runtime_session_payload(store: GuardStore, session: dict[str, object]
     created_at = _optional_string(session.get("created_at") or session.get("createdAt")) or _now()
     updated_at = _optional_string(session.get("updated_at") or session.get("updatedAt")) or created_at
     capabilities = [str(item) for item in session.get("capabilities", []) if isinstance(item, str)]
+    package_manager_coverage = _cloud_package_manager_coverage(
+        store,
+        generated_at=updated_at,
+    )
     return {
         "sessionId": session_id,
         "harness": _optional_string(session.get("harness")) or "hol-guard",
@@ -2134,6 +2139,9 @@ def _cloud_runtime_session_payload(store: GuardStore, session: dict[str, object]
         "clientTitle": _optional_string(session.get("client_title") or session.get("clientTitle"))
         or f"HOL Guard on {device_name}",
         "clientVersion": _optional_string(session.get("client_version") or session.get("clientVersion")) or __version__,
+        "deviceId": device_id,
+        "deviceName": device_name,
+        "packageManagerCoverage": package_manager_coverage,
         "workspace": workspace,
         "capabilities": capabilities,
         "operations": [],
@@ -2145,6 +2153,47 @@ def _cloud_runtime_session_payload(store: GuardStore, session: dict[str, object]
 def _cloud_sync_receipt_fingerprint(receipt: dict[str, object]) -> str:
     encoded_receipt = json.dumps(receipt, sort_keys=True, separators=(",", ":"), default=str)
     return hashlib.sha256(encoded_receipt.encode("utf-8")).hexdigest()
+
+
+def _cloud_package_manager_coverage(
+    store: GuardStore,
+    *,
+    generated_at: str,
+) -> dict[str, object]:
+    coverage = package_shim_cloud_coverage(
+        HarnessContext(
+            home_dir=Path.home(),
+            workspace_dir=Path.cwd(),
+            guard_home=store.guard_home,
+        ),
+        generated_at=generated_at,
+    )
+    summary = store.get_sync_payload("supply_chain_bundle_summary")
+    synced_at = None
+    next_refresh_at = None
+    if isinstance(summary, dict):
+        synced_at = _optional_string(summary.get("synced_at") or summary.get("syncedAt"))
+        next_refresh_at = _optional_string(
+            summary.get("next_refresh_at") or summary.get("nextRefreshAt")
+        )
+    reference_timestamp = _parse_iso_timestamp(generated_at) or datetime.now(timezone.utc)
+    stale_status = "unknown"
+    if synced_at is not None:
+        stale_status = "fresh"
+    next_refresh_timestamp = _parse_iso_timestamp(next_refresh_at) if next_refresh_at is not None else None
+    if next_refresh_timestamp is None and synced_at is not None:
+        next_refresh_timestamp = _parse_iso_timestamp(synced_at)
+        if next_refresh_timestamp is not None:
+            next_refresh_timestamp += timedelta(minutes=15)
+            next_refresh_at = next_refresh_timestamp.isoformat()
+    if next_refresh_timestamp is not None and next_refresh_timestamp <= reference_timestamp:
+        stale_status = "stale"
+    coverage["staleIntel"] = {
+        "status": stale_status,
+        "lastSyncedAt": synced_at,
+        "nextRefreshAt": next_refresh_at,
+    }
+    return coverage
 
 
 def _cloud_sync_artifact_type(artifact_id: str) -> str:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2175,9 +2175,7 @@ def _cloud_package_manager_coverage(
     next_refresh_at = None
     if isinstance(summary, dict):
         synced_at = _optional_string(summary.get("synced_at") or summary.get("syncedAt"))
-        next_refresh_at = _optional_string(
-            summary.get("next_refresh_at") or summary.get("nextRefreshAt")
-        )
+        next_refresh_at = _optional_string(summary.get("next_refresh_at") or summary.get("nextRefreshAt"))
     reference_timestamp = _parse_iso_timestamp(generated_at) or datetime.now(timezone.utc)
     stale_status = "unknown"
     if synced_at is not None:

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -300,12 +301,15 @@ def package_shim_status(context: HarnessContext) -> dict[str, object]:
     shim_dir = context.guard_home / "package-shims" / "bin"
     stored_hashes: dict[str, str] = manifest.get("content_hashes", {})
     active_managers: list[str] = []
+    protected_managers: list[str] = []
     missing_managers: list[str] = []
+    bypasses: list[dict[str, str]] = []
     manager_details: list[dict[str, object]] = []
     for manager in installed_managers:
         command = _PACKAGE_SHIM_COMMANDS[manager]
         shim_path = shim_dir / command
         exists = shim_path.exists()
+        path_status = get_path_order_status(context, manager=manager)
         if exists:
             active_managers.append(manager)
             current_hash = build_shim_content_hash(shim_path.read_bytes())
@@ -323,16 +327,46 @@ def package_shim_status(context: HarnessContext) -> dict[str, object]:
             {
                 "integrity": integrity,
                 "manager": manager,
+                "path_active": bool(path_status.get("shim_precedes_real")),
+                "path_status": path_status,
                 "shim_path": str(shim_path),
             }
         )
+        if exists and bool(path_status.get("shim_precedes_real")):
+            protected_managers.append(manager)
+        elif exists:
+            bypasses.append(
+                {
+                    "manager": manager,
+                    "reason": "path_inactive",
+                }
+            )
     return {
         "active_managers": active_managers,
         "installed_managers": installed_managers,
+        "protected_managers": protected_managers,
+        "path_active": bool(installed_managers) and len(protected_managers) == len(installed_managers),
+        "bypasses": bypasses,
         "manager_details": manager_details,
         "manifest_path": str(_package_shim_manifest_path(context)),
         "missing_managers": missing_managers,
         "shim_dir": str(shim_dir),
+    }
+
+
+def package_shim_cloud_coverage(
+    context: HarnessContext,
+    *,
+    generated_at: str | None = None,
+) -> dict[str, object]:
+    status = package_shim_status(context)
+    return {
+        "generatedAt": generated_at or datetime.now(timezone.utc).isoformat(),
+        "configuredManagers": list(status["installed_managers"]),
+        "protectedManagers": list(status["protected_managers"]),
+        "missingManagers": list(status["missing_managers"]),
+        "pathActive": bool(status["path_active"]),
+        "bypasses": list(status["bypasses"]),
     }
 
 
@@ -508,6 +542,7 @@ def _path_export_hint(shim_dir: Path) -> str:
 __all__ = [
     "install_guard_shim",
     "install_package_shims",
+    "package_shim_cloud_coverage",
     "package_shim_status",
     "package_shim_supported_managers",
     "remove_guard_shim",

--- a/tests/test_guard_cloud_local_sync.py
+++ b/tests/test_guard_cloud_local_sync.py
@@ -3,18 +3,21 @@
 from __future__ import annotations
 
 import json
+import os
 import urllib.error
 from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.approvals import build_runtime_snapshot
 from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.consumer import evaluate_detection
 from codex_plugin_scanner.guard.edge_events import build_runtime_session_event
 from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+from codex_plugin_scanner.guard.shims import install_package_shims
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -583,3 +586,76 @@ def test_runtime_session_sync_skips_v1_event_when_ingest_was_recently_unavailabl
 
     assert result["runtime_session_synced_at"] == "2026-04-24T00:01:00+00:00"
     assert store.list_guard_events_v1(uploaded=False, limit=10) == []
+
+
+def test_sync_runtime_session_emits_package_manager_coverage_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "token-one",
+        "2026-04-24T00:00:00+00:00",
+        workspace_id="workspace-alpha",
+    )
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    context = HarnessContext(
+        home_dir=store.guard_home,
+        workspace_dir=workspace_dir,
+        guard_home=store.guard_home,
+    )
+    install_payload = install_package_shims(context, managers=("npm",))
+    shim_dir = Path(str(install_payload["shim_dir"]))
+    original_path = os.environ.get("PATH", "")
+    monkeypatch.setenv("PATH", f"{shim_dir}{os.pathsep}{original_path}")
+    store.set_sync_payload(
+        "supply_chain_bundle_summary",
+        {
+            "synced_at": "2026-04-24T00:00:00+00:00",
+        },
+        "2026-04-24T00:00:00+00:00",
+    )
+
+    captured_body: dict[str, object] = {}
+
+    def _runtime_sync_response(**kwargs):
+        request = kwargs["request"]
+        captured_body.update(json.loads(request.data.decode("utf-8")))
+        return {"syncedAt": "2026-04-24T00:01:00+00:00", "items": []}
+
+    monkeypatch.setattr(
+        guard_runner_module,
+        "_urlopen_json_with_timeout_retry",
+        _runtime_sync_response,
+    )
+
+    guard_runner_module.sync_runtime_session(
+        store,
+        session={
+            "harness": "codex",
+            "surface": "cli",
+            "status": "active",
+            "updatedAt": "2026-04-24T00:01:00+00:00",
+            "workspace": str(workspace_dir),
+        },
+    )
+
+    session_payload = captured_body["session"]
+    assert isinstance(session_payload, dict)
+    assert session_payload["deviceId"] == store.get_or_create_installation_id()
+    assert session_payload["deviceName"] == store.get_device_metadata()["device_label"]
+    assert session_payload["packageManagerCoverage"] == {
+        "generatedAt": "2026-04-24T00:01:00+00:00",
+        "configuredManagers": ["npm"],
+        "protectedManagers": ["npm"],
+        "missingManagers": [],
+        "pathActive": True,
+        "bypasses": [],
+        "staleIntel": {
+            "status": "fresh",
+            "lastSyncedAt": "2026-04-24T00:00:00+00:00",
+            "nextRefreshAt": "2026-04-24T00:15:00+00:00",
+        },
+    }

--- a/tests/test_guard_package_shims.py
+++ b/tests/test_guard_package_shims.py
@@ -16,7 +16,9 @@ from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generate_private_key
 
 from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.protect import build_protect_payload
+from codex_plugin_scanner.guard.shims import install_package_shims, package_shim_status
 from codex_plugin_scanner.guard.store import GuardStore
 
 WORKSPACE_ID = "workspace-alpha"
@@ -523,6 +525,66 @@ def test_guard_package_shim_wrapper_routes_commands_through_guard_protect(tmp_pa
     assert "guard" in shim_source
     assert "protect" in shim_source
     assert "'npm'" in shim_source
+
+
+def test_guard_package_shim_status_reports_protected_managers_when_shims_win_on_path(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    context = HarnessContext(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        guard_home=home_dir,
+    )
+
+    install_payload = install_package_shims(context, managers=("npm", "pip"))
+    shim_dir = Path(str(install_payload["shim_dir"]))
+    original_path = os.environ.get("PATH", "")
+    monkeypatch.setenv("PATH", f"{shim_dir}{os.pathsep}{original_path}")
+
+    status_payload = package_shim_status(context)
+
+    assert status_payload["protected_managers"] == ["npm", "pip"]
+    assert status_payload["path_active"] is True
+    assert status_payload["bypasses"] == []
+
+
+def test_guard_package_shim_status_reports_bypasses_when_system_binary_beats_shim(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    context = HarnessContext(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        guard_home=home_dir,
+    )
+
+    install_payload = install_package_shims(context, managers=("npm",))
+    shim_dir = Path(str(install_payload["shim_dir"]))
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir(parents=True, exist_ok=True)
+    fake_npm = fake_bin / "npm"
+    fake_npm.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_npm.chmod(0o755)
+    original_path = os.environ.get("PATH", "")
+    monkeypatch.setenv("PATH", f"{fake_bin}{os.pathsep}{shim_dir}{os.pathsep}{original_path}")
+
+    status_payload = package_shim_status(context)
+
+    assert status_payload["protected_managers"] == []
+    assert status_payload["path_active"] is False
+    assert status_payload["bypasses"] == [
+        {
+            "manager": "npm",
+            "reason": "path_inactive",
+        }
+    ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- emit device-aware package-manager coverage in Guard runtime session sync payloads
- report shim protection truth with protected managers, PATH activity, and bypass reasons

## Testing
- `ruff check src/codex_plugin_scanner/guard/shims.py src/codex_plugin_scanner/guard/runtime/runner.py tests/test_guard_package_shims.py tests/test_guard_cloud_local_sync.py`
- `pytest tests/test_guard_package_shims.py tests/test_guard_cloud_local_sync.py`
