### PR TITLE
fix(hol-guard): stop blocked Codex resume

### DIFF
--- a/scripts/codex-auto-resume-smoke.py
+++ b/scripts/codex-auto-resume-smoke.py
@@ -426,16 +426,22 @@ def _assert_expected_outcome(
     if not isinstance(codex_resume, dict):
         raise AssertionError("approval payload did not include codex_resume")
     status = str(codex_resume.get("status") or "")
-    if status not in {"in_progress", "sent", "already_sent"}:
-        raise AssertionError(f"expected codex_resume status to show live continuation, got {status!r}")
-    if "turn/start" not in transcript:
-        raise AssertionError(f"same-thread Codex app-server prompt was not sent:\n{transcript}")
     if decision == "allow":
+        if status not in {"in_progress", "sent", "already_sent"}:
+            raise AssertionError(f"expected codex_resume status to show live continuation, got {status!r}")
+        if "turn/start" not in transcript:
+            raise AssertionError(f"same-thread Codex app-server prompt was not sent:\n{transcript}")
         if proof_created:
             raise AssertionError("allow smoke must not start a separate headless Codex proof run")
         if not final_message.strip():
             raise AssertionError("allow flow returned an empty resume message")
         return
+    if status != "skipped":
+        raise AssertionError(f"expected blocked Codex request not to resume, got {status!r}")
+    if str(codex_resume.get("reason") or "") != "blocked_not_resumed":
+        raise AssertionError(f"block flow returned unexpected resume reason: {codex_resume!r}")
+    if "turn/start" in transcript:
+        raise AssertionError(f"block flow must not send a same-thread Codex prompt:\n{transcript}")
     if proof_created:
         raise AssertionError("block flow unexpectedly created the proof file")
     if not final_message.strip():

--- a/src/codex_plugin_scanner/guard/codex_resume.py
+++ b/src/codex_plugin_scanner/guard/codex_resume.py
@@ -197,14 +197,6 @@ def _finalize_resume_attempt(
     supported = bool(resume["supported"])
     thread_id = str(resume["thread_id"]) if resume.get("thread_id") is not None else None
     attempt_count = int(resume["attempt_count"])
-    if action == "block":
-        return _skip_blocked_resume(
-            store=store,
-            request_id=request_id,
-            resume=resume,
-            attempt_count=attempt_count,
-            now=now,
-        )
     if strategy == "manual-only" or not supported:
         message = _manual_resume_message(action)
         store.update_request_resume(

--- a/src/codex_plugin_scanner/guard/codex_resume.py
+++ b/src/codex_plugin_scanner/guard/codex_resume.py
@@ -370,8 +370,6 @@ def _normalize_dispatch_result(
 
 
 def _manual_resume_message(action: str) -> str:
-    if action == "block":
-        return _blocked_resume_message()
     return (
         "Decision saved. HOL Guard could not find the original Codex chat to message. "
         "Return to Codex and retry the same request; this approval is now saved."
@@ -379,8 +377,6 @@ def _manual_resume_message(action: str) -> str:
 
 
 def _failed_resume_message(action: str) -> str:
-    if action == "block":
-        return _blocked_resume_message()
     return (
         "Decision saved. HOL Guard could not send Codex a continuation message in the original chat. "
         "Return to Codex and retry the same request; this approval is now saved."

--- a/src/codex_plugin_scanner/guard/codex_resume.py
+++ b/src/codex_plugin_scanner/guard/codex_resume.py
@@ -390,7 +390,7 @@ def _failed_resume_message(action: str) -> str:
 def _blocked_resume_message() -> str:
     return (
         "Decision saved. HOL Guard blocked this Codex request and will not resume or retry it. "
-        "Ask for a safe alternative instead."
+        "Do not retry that action in Codex. Ask for a safe alternative instead."
     )
 
 

--- a/src/codex_plugin_scanner/guard/codex_resume.py
+++ b/src/codex_plugin_scanner/guard/codex_resume.py
@@ -66,6 +66,15 @@ def retry_request_resume(
     resume = get_request_resume_status(store, request_id=request_id, now=now)
     if resume is None:
         raise ValueError("resume_not_supported")
+    if action == "block":
+        attempt_count = int(resume.get("attempt_count") or 0) + 1
+        return _skip_blocked_resume(
+            store=store,
+            request_id=request_id,
+            resume=resume,
+            attempt_count=attempt_count,
+            now=now,
+        )
     if str(resume.get("status")) == "sent" and not force:
         return {
             **resume,
@@ -123,6 +132,14 @@ def defer_request_resume_to_live_hook(
     if resume is None:
         return None
     attempt_count = int(resume.get("attempt_count") or 0)
+    if action == "block":
+        return _skip_blocked_resume(
+            store=store,
+            request_id=request_id,
+            resume=resume,
+            attempt_count=attempt_count,
+            now=now,
+        )
     message = (
         "Decision saved. Codex is still waiting for this browser decision, "
         "so HOL Guard will let the original Codex action continue without starting a second headless run."
@@ -180,6 +197,14 @@ def _finalize_resume_attempt(
     supported = bool(resume["supported"])
     thread_id = str(resume["thread_id"]) if resume.get("thread_id") is not None else None
     attempt_count = int(resume["attempt_count"])
+    if action == "block":
+        return _skip_blocked_resume(
+            store=store,
+            request_id=request_id,
+            resume=resume,
+            attempt_count=attempt_count,
+            now=now,
+        )
     if strategy == "manual-only" or not supported:
         message = _manual_resume_message(action)
         store.update_request_resume(
@@ -227,6 +252,34 @@ def _finalize_resume_attempt(
         attempt_count=attempt_count,
         last_attempt_at=now,
         sent_at=sent_at,
+        now=now,
+    )
+    result = store.get_request_resume(request_id)
+    if result is None:
+        raise ValueError("resume_not_supported")
+    return result
+
+
+def _skip_blocked_resume(
+    *,
+    store: GuardStore,
+    request_id: str,
+    resume: dict[str, object],
+    attempt_count: int,
+    now: str,
+) -> dict[str, object]:
+    store.update_request_resume(
+        request_id=request_id,
+        resolution_action="block",
+        strategy=str(resume.get("strategy")) if isinstance(resume.get("strategy"), str) else None,
+        supported=False,
+        status="skipped",
+        reason="blocked_not_resumed",
+        message=_blocked_resume_message(),
+        last_error=None,
+        attempt_count=attempt_count,
+        last_attempt_at=now,
+        sent_at=None,
         now=now,
     )
     result = store.get_request_resume(request_id)
@@ -326,10 +379,7 @@ def _normalize_dispatch_result(
 
 def _manual_resume_message(action: str) -> str:
     if action == "block":
-        return (
-            "Decision saved. HOL Guard could not find the original Codex chat to message. "
-            "Do not retry that action in Codex. Ask for a safe alternative instead."
-        )
+        return _blocked_resume_message()
     return (
         "Decision saved. HOL Guard could not find the original Codex chat to message. "
         "Return to Codex and retry the same request; this approval is now saved."
@@ -338,13 +388,17 @@ def _manual_resume_message(action: str) -> str:
 
 def _failed_resume_message(action: str) -> str:
     if action == "block":
-        return (
-            "Decision saved. HOL Guard could not send Codex a continuation message in the original chat. "
-            "Do not retry that action in Codex. Ask for a safe alternative instead."
-        )
+        return _blocked_resume_message()
     return (
         "Decision saved. HOL Guard could not send Codex a continuation message in the original chat. "
         "Return to Codex and retry the same request; this approval is now saved."
+    )
+
+
+def _blocked_resume_message() -> str:
+    return (
+        "Decision saved. HOL Guard blocked this Codex request and will not resume or retry it. "
+        "Ask for a safe alternative instead."
     )
 
 

--- a/tests/test_guard_codex_auto_resume_smoke.py
+++ b/tests/test_guard_codex_auto_resume_smoke.py
@@ -19,7 +19,7 @@ def _load_smoke_module():
     return module
 
 
-def test_codex_auto_resume_smoke_script_sends_same_thread_app_server_messages() -> None:
+def test_codex_auto_resume_smoke_script_resumes_only_allowed_requests() -> None:
     module = _load_smoke_module()
     args = argparse.Namespace(
         codex_home=None,
@@ -37,9 +37,9 @@ def test_codex_auto_resume_smoke_script_sends_same_thread_app_server_messages() 
     assert allow_result.proof_created is False
     assert allow_result.assistant_message
     assert "turn/start" in allow_result.transcript_excerpt
-    assert block_result.resume_status == "sent"
+    assert block_result.resume_status == "skipped"
     assert block_result.request_id
     assert block_result.resume_strategy == "codex-app-server-thread"
     assert block_result.proof_created is False
     assert block_result.assistant_message
-    assert "turn/start" in block_result.transcript_excerpt
+    assert "turn/start" not in block_result.transcript_excerpt

--- a/tests/test_guard_codex_resume_commands.py
+++ b/tests/test_guard_codex_resume_commands.py
@@ -360,6 +360,54 @@ def test_guard_approvals_resume_starts_headless_codex_when_app_server_unavailabl
     assert launched[0]["env"]["CODEX_HOME"] == str(codex_home)
 
 
+def test_guard_approvals_resume_does_not_start_headless_codex_for_blocked_request(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        codex_app_server_module.shutil,
+        "which",
+        lambda command: "/usr/local/bin/codex" if command == "codex" else None,
+    )
+    monkeypatch.setattr(
+        codex_app_server_module.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: pytest.fail("blocked requests must not start codex exec resume"),
+    )
+
+    home_dir = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    codex_home = tmp_path / "codex-home"
+    workspace.mkdir()
+    codex_home.mkdir()
+    store = GuardStore(home_dir)
+    store.add_approval_request(_request("req-cli-block"), "2026-05-19T10:00:00+00:00")
+    _seed_codex_operation(
+        store,
+        request_id="req-cli-block",
+        socket_path=None,
+        workspace=str(workspace),
+        codex_home=str(codex_home),
+    )
+    store.resolve_approval_request(
+        "req-cli-block",
+        resolution_action="block",
+        resolution_scope="artifact",
+        reason="blocked",
+        resolved_at="2026-05-19T10:01:00+00:00",
+    )
+
+    rc = main(["guard", "approvals", "resume", "req-cli-block", "--home", str(home_dir), "--json"])
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["status"] == "skipped"
+    assert output["reason"] == "blocked_not_resumed"
+    assert output["supported"] is False
+    assert "blocked this Codex request" in output["message"]
+
+
 def test_guard_approvals_resume_reports_missing_codex_home_without_spawning(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/tests/test_guard_codex_resume_endpoints.py
+++ b/tests/test_guard_codex_resume_endpoints.py
@@ -162,7 +162,7 @@ def test_codex_approve_without_resume_binding_returns_honest_manual_fallback(tmp
     assert "approval is now saved" in payload["copy"]["body"]
 
 
-def test_codex_block_resume_prompt_includes_request_id_and_safe_alternative(
+def test_codex_block_does_not_resume_codex_thread(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -198,15 +198,66 @@ def test_codex_block_resume_prompt_includes_request_id_and_safe_alternative(
     finally:
         daemon.stop()
 
-    assert payload["codex_resume"]["status"] == "sent"
-    assert [payload["method"] for payload in captured_payloads] == [
-        "initialize",
-        "initialized",
-        "thread/resume",
-        "turn/start",
-    ]
-    prompt = captured_payloads[3]["params"]["input"][0]["text"]
-    assert prompt == "HOL Guard blocked request `req-block`. Do not retry that action. Explain a safe alternative."
+    assert payload["codex_resume"]["status"] == "skipped"
+    assert payload["codex_resume"]["reason"] == "blocked_not_resumed"
+    assert payload["codex_resume"]["supported"] is False
+    assert captured_payloads == []
+
+
+def test_codex_block_with_missing_socket_does_not_start_headless_resume(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        codex_app_server_module.shutil,
+        "which",
+        lambda command: "/usr/bin/codex" if command == "codex" else None,
+    )
+    monkeypatch.setattr(
+        codex_app_server_module.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: pytest.fail("blocked requests must not start codex exec resume"),
+    )
+
+    workspace = tmp_path / "workspace"
+    codex_home = tmp_path / "codex-home"
+    workspace.mkdir()
+    codex_home.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    store.add_approval_request(_request("req-block-headless"), "2026-05-19T10:00:00+00:00")
+    _seed_codex_operation(
+        store,
+        request_id="req-block-headless",
+        socket_path=None,
+        thread_id="blocked-session-1",
+        workspace=str(workspace),
+        codex_home=str(codex_home),
+        command_text="cat ~/.npmrc",
+        status="approval_wait_timeout",
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+
+    try:
+        blocked = _post_json(
+            daemon.port,
+            daemon._server.auth_token,
+            "/v1/requests/req-block-headless/block",
+            {"scope": "artifact", "reason": "blocked"},
+        )
+        retried = _post_json(
+            daemon.port,
+            daemon._server.auth_token,
+            "/v1/requests/req-block-headless/resume",
+            {},
+        )
+    finally:
+        daemon.stop()
+
+    assert blocked["codex_resume"]["status"] == "skipped"
+    assert blocked["codex_resume"]["reason"] == "blocked_not_resumed"
+    assert retried["status"] == "skipped"
+    assert retried["reason"] == "blocked_not_resumed"
 
 
 def test_codex_approve_defers_headless_resume_while_live_hook_waits(
@@ -241,6 +292,40 @@ def test_codex_approve_defers_headless_resume_while_live_hook_waits(
     assert payload["codex_resume"]["status"] == "pending"
     assert payload["codex_resume"]["reason"] == "live_hook_waiting"
     assert "original Codex action continue" in payload["codex_resume"]["message"]
+
+
+def test_codex_block_does_not_defer_to_live_hook_waiting_on_browser_decision(
+    tmp_path: Path,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.add_approval_request(_request("req-live-block"), "2026-05-19T10:00:00+00:00")
+    missing_socket = tmp_path / "missing-codex.sock"
+    _seed_codex_operation(
+        store,
+        request_id="req-live-block",
+        socket_path=missing_socket,
+        thread_id="live-block-session-1",
+        hook_event_name="PostToolUse",
+        waits_for_browser_approval=True,
+        status="waiting_on_approval",
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+
+    try:
+        payload = _post_json(
+            daemon.port,
+            daemon._server.auth_token,
+            "/v1/requests/req-live-block/block",
+            {"scope": "artifact", "reason": "blocked"},
+        )
+    finally:
+        daemon.stop()
+
+    assert payload["resolved"] is True
+    assert payload["codex_resume"]["status"] == "skipped"
+    assert payload["codex_resume"]["reason"] == "blocked_not_resumed"
+    assert payload["codex_resume"]["supported"] is False
 
 
 def test_codex_approve_pretooluse_no_wait_starts_headless_resume(


### PR DESCRIPTION
## Summary
- treat blocked Codex browser approval decisions as terminal instead of prompt-mediated continuation
- prevent blocked decisions from app-server thread resumes, headless `codex exec resume`, live-hook defer, and CLI retry
- update the Codex auto-resume smoke flow to assert only allowed requests resume

## Verification
- uv run pytest tests/test_guard_codex_resume_endpoints.py tests/test_guard_codex_resume_commands.py tests/test_guard_codex_auto_resume_smoke.py -q --tb=short
- uv run pytest tests/test_guard_approval_continuity.py tests/test_guard_approval_copy_commands.py tests/test_guard_approval_decisions.py tests/test_guard_approval_gate.py tests/test_guard_approval_store_dedup.py tests/test_guard_approval_store_phase14.py tests/test_guard_approval_store_scale.py tests/test_guard_approvals.py tests/test_guard_codex_auto_resume_smoke.py tests/test_guard_codex_e2e.py tests/test_guard_codex_install.py tests/test_guard_codex_proxy.py tests/test_guard_codex_resume_commands.py tests/test_guard_codex_resume_endpoints.py tests/test_guard_daemon_cli.py tests/test_guard_daemon_manager.py tests/test_guard_daemon_registry.py tests/test_guard_daemon_wake.py tests/test_guard_headless_daemon_api.py -q
- uv run ruff check src/codex_plugin_scanner/guard/codex_resume.py tests/test_guard_codex_resume_endpoints.py tests/test_guard_codex_resume_commands.py tests/test_guard_codex_auto_resume_smoke.py scripts/codex-auto-resume-smoke.py

Notes: full `uv run pytest -q` was attempted but the OS killed the process at ~37%; not counted as passing. Focused Codex/approval/daemon suites passed.