### PR TITLE
fix(codex): guard secret file reads

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import re
 import shlex
 import sys
@@ -46,6 +45,8 @@ _MANAGED_HOOK_STATUS_MESSAGE = "HOL Guard checking tool action"
 _MANAGED_PROMPT_HOOK_STATUS_MESSAGE = "HOL Guard checking prompt"
 _MANAGED_PERMISSION_HOOK_STATUS_MESSAGE = "HOL Guard checking Codex approval request"
 _MANAGED_POST_TOOL_HOOK_STATUS_MESSAGE = "HOL Guard checking tool result"
+_CODEX_GUARD_TOOL_MATCHER = "Bash|Read|Write|Edit|MultiEdit|^apply_patch$|mcp__.*"
+_CODEX_GUARD_PERMISSION_MATCHER = "Bash|Read|Write|Edit|MultiEdit|^apply_patch$|mcp__.*"
 _LEGACY_MANAGED_HOOK_STATUS_MESSAGES = {
     "HOL Guard checking Bash command",
     _MANAGED_HOOK_STATUS_MESSAGE,
@@ -92,18 +93,7 @@ def _hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
         guard_args.extend(["--home", str(context.home_dir)])
     if context.workspace_dir is not None:
         guard_args.extend(["--workspace", str(context.workspace_dir)])
-    launcher_env = merge_guard_launcher_env()
-    pythonpath = launcher_env.get("PYTHONPATH", "")
-    if not pythonpath.strip():
-        return (sys.executable, "-m", "codex_plugin_scanner.cli", *guard_args)
-    path_entries = [entry for entry in pythonpath.split(os.pathsep) if entry.strip()]
-    code = (
-        "import sys;"
-        f"sys.path[:0]={path_entries!r};"
-        "from codex_plugin_scanner.cli import main;"
-        f"raise SystemExit(main({guard_args!r}))"
-    )
-    return (sys.executable, "-c", code)
+    return (sys.executable, "-m", "codex_plugin_scanner.cli", *guard_args)
 
 
 def _hook_command(context: HarnessContext) -> str:
@@ -112,7 +102,7 @@ def _hook_command(context: HarnessContext) -> str:
 
 def _pre_tool_hook_group(context: HarnessContext) -> dict[str, object]:
     return {
-        "matcher": "Bash",
+        "matcher": _CODEX_GUARD_TOOL_MATCHER,
         "hooks": [
             {
                 "type": "command",
@@ -139,7 +129,7 @@ def _prompt_hook_group(context: HarnessContext) -> dict[str, object]:
 
 def _permission_request_hook_group(context: HarnessContext) -> dict[str, object]:
     return {
-        "matcher": "Bash|^apply_patch$|Edit|Write|mcp__.*",
+        "matcher": _CODEX_GUARD_PERMISSION_MATCHER,
         "hooks": [
             {
                 "type": "command",

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5076,7 +5076,7 @@ def _runtime_artifact_native_reason(artifact: GuardArtifact, response_payload: d
                 "secrets. The approval flow came from HOL Guard, not from Claude alone. HOL Guard will ask you to "
                 "choose Allow once, Allow during this session, or Keep blocked before Claude retries this action."
             )
-        harness_label = {"claude-code": "Claude", "codex": "Codex"}.get(str(harness), "the harness")
+        harness_label = {"claude-code": "Claude", "codex": "Codex"}.get(harness, "the harness")
         return (
             f"HOL Guard blocked {harness_label}'s attempt to use {tool_name} for {path_class} to protect your "
             "local secrets. "

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -5076,8 +5076,10 @@ def _runtime_artifact_native_reason(artifact: GuardArtifact, response_payload: d
                 "secrets. The approval flow came from HOL Guard, not from Claude alone. HOL Guard will ask you to "
                 "choose Allow once, Allow during this session, or Keep blocked before Claude retries this action."
             )
+        harness_label = {"claude-code": "Claude", "codex": "Codex"}.get(str(harness), "the harness")
         return (
-            f"HOL Guard blocked Claude's attempt to use {tool_name} for {path_class} to protect your local secrets. "
+            f"HOL Guard blocked {harness_label}'s attempt to use {tool_name} for {path_class} to protect your "
+            "local secrets. "
             "This request cannot continue in the current approval flow."
         )
     risk_summary = response_payload.get("risk_summary")

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -13,6 +13,7 @@ except ModuleNotFoundError:
     import tomli as tomllib  # type: ignore[no-redef]
 
 from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.adapters import codex as codex_adapter
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.codex import CodexHarnessAdapter
 
@@ -87,8 +88,11 @@ def test_guard_install_codex_rewrites_workspace_config_with_proxy_entries(tmp_pa
     assert "codex_hooks" not in config_text
     assert 'API_BASE = "https://hol.org"' in config_text
     assert 'FEATURE_FLAG = "1"' in config_text
-    assert hooks_payload["hooks"]["PreToolUse"][0]["matcher"] == "Bash"
-    assert hooks_payload["hooks"]["PermissionRequest"][0]["matcher"] == "Bash|^apply_patch$|Edit|Write|mcp__.*"
+    assert hooks_payload["hooks"]["PreToolUse"][0]["matcher"] == codex_adapter._CODEX_GUARD_TOOL_MATCHER
+    assert (
+        hooks_payload["hooks"]["PermissionRequest"][0]["matcher"]
+        == codex_adapter._CODEX_GUARD_PERMISSION_MATCHER
+    )
     assert "UserPromptSubmit" in hooks_payload["hooks"]
     assert "matcher" not in hooks_payload["hooks"]["UserPromptSubmit"][0]
     prompt_handler = hooks_payload["hooks"]["UserPromptSubmit"][0]["hooks"][0]
@@ -234,7 +238,7 @@ def test_guard_install_codex_merges_managed_hooks_without_removing_existing_entr
                 "hooks": {
                     "PreToolUse": [
                         {
-                            "matcher": "Bash",
+                "matcher": codex_adapter._CODEX_GUARD_TOOL_MATCHER,
                             "hooks": [{"type": "command", "command": "python3 custom-pre.py"}],
                         }
                     ],
@@ -286,13 +290,13 @@ def test_guard_install_codex_merges_managed_hooks_without_removing_existing_entr
     assert len(hooks_payload["hooks"]["PreToolUse"]) == 2
     assert hooks_payload["hooks"]["PreToolUse"][0]["hooks"][0]["command"] == "python3 custom-pre.py"
     managed_group = hooks_payload["hooks"]["PreToolUse"][1]
-    assert managed_group["matcher"] == "Bash"
+    assert managed_group["matcher"] == codex_adapter._CODEX_GUARD_TOOL_MATCHER
     assert "codex_plugin_scanner.cli" in managed_group["hooks"][0]["command"]
     assert "hook" in managed_group["hooks"][0]["command"]
     assert "codex" in managed_group["hooks"][0]["command"]
     assert restored_hooks["hooks"]["PreToolUse"] == [
         {
-            "matcher": "Bash",
+            "matcher": codex_adapter._CODEX_GUARD_TOOL_MATCHER,
             "hooks": [{"type": "command", "command": "python3 custom-pre.py"}],
         }
     ]
@@ -347,7 +351,7 @@ def test_guard_install_codex_migrates_legacy_bash_only_managed_hook(tmp_path, ca
     assert len(hooks_payload["hooks"]["PreToolUse"]) == 1
     assert len(hooks_payload["hooks"]["PermissionRequest"]) == 1
     assert len(hooks_payload["hooks"]["UserPromptSubmit"]) == 1
-    assert hooks_payload["hooks"]["PreToolUse"][0]["matcher"] == "Bash"
+    assert hooks_payload["hooks"]["PreToolUse"][0]["matcher"] == codex_adapter._CODEX_GUARD_TOOL_MATCHER
     assert hooks_payload["hooks"]["PreToolUse"][0]["hooks"][0]["statusMessage"] == "HOL Guard checking tool action"
     assert len(hooks_payload["hooks"]["UserPromptSubmit"]) == 1
 
@@ -438,7 +442,7 @@ def test_guard_install_codex_migrates_legacy_wrapper_script_hook(tmp_path, capsy
     wrapper_command = shlex.join([str(home_dir / ".codex" / "hooks" / "hol-guard-codex-hook.sh"), "--legacy"])
     managed_events = {
         "PreToolUse": {
-            "matcher": "Bash",
+            "matcher": codex_adapter._CODEX_GUARD_TOOL_MATCHER,
             "hooks": [
                 {
                     "type": "command",
@@ -554,7 +558,7 @@ def test_guard_install_codex_workspace_cleans_stale_global_managed_hook(tmp_path
     assert home_hooks_path.exists() is False
     assert len(workspace_hooks["hooks"]["PreToolUse"]) == 1
     managed_group = workspace_hooks["hooks"]["PreToolUse"][0]
-    assert managed_group["matcher"] == "Bash"
+    assert managed_group["matcher"] == codex_adapter._CODEX_GUARD_TOOL_MATCHER
     assert "codex_plugin_scanner.cli" in managed_group["hooks"][0]["command"]
 
 
@@ -600,7 +604,7 @@ def test_guard_uninstall_codex_preserves_user_hooks_in_managed_bash_group(tmp_pa
     assert uninstall_rc == 0
     assert restored_hooks["hooks"]["PreToolUse"] == [
         {
-            "matcher": "Bash",
+            "matcher": codex_adapter._CODEX_GUARD_TOOL_MATCHER,
             "hooks": [{"type": "command", "command": "python3 custom-pre.py"}],
         }
     ]

--- a/tests/test_guard_phase04_harness_ux.py
+++ b/tests/test_guard_phase04_harness_ux.py
@@ -183,6 +183,30 @@ def test_gr077_codex_shell_exfil_canary_gets_native_denial(tmp_path: Path) -> No
     assert "network" in str(hook_output["permissionDecisionReason"]).lower()
 
 
+def test_gr077b_codex_read_secret_file_gets_native_denial(tmp_path: Path) -> None:
+    exit_code, output = _run_hook(
+        tmp_path,
+        harness="codex",
+        payload={
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Read",
+            "tool_input": {"file_path": "~/.npmrc"},
+        },
+    )
+
+    payload = _json_line(output)
+    hook_output = payload["hookSpecificOutput"]
+
+    assert exit_code == 0
+    assert isinstance(hook_output, dict)
+    assert hook_output["hookEventName"] == "PreToolUse"
+    assert hook_output["permissionDecision"] == "deny"
+    assert "HOL Guard" in str(hook_output["permissionDecisionReason"])
+    assert "Codex" in str(hook_output["permissionDecisionReason"])
+    assert "Claude" not in str(hook_output["permissionDecisionReason"])
+    assert "secret" in str(hook_output["permissionDecisionReason"]).lower()
+
+
 def test_gr078_codex_safe_read_allows_without_native_denial(tmp_path: Path) -> None:
     exit_code, output = _run_hook(
         tmp_path,


### PR DESCRIPTION
## Summary
- Expand Codex native PreToolUse and PermissionRequest coverage beyond Bash so Read/Edit/MCP actions go through HOL Guard.
- Add regression coverage proving Codex Read of ~/.npmrc is denied while normal file reads remain allowed.
- Stop Codex hook install from embedding ambient PYTHONPATH/dev worktree paths into hook commands.
- Correct Codex secret-read denial copy so it names Codex, not Claude.

## Testing
- `python3 -m pytest -q tests/test_guard_codex_install.py`
- `python3 -m pytest -q tests/test_guard_phase04_harness_ux.py`
- `python3 -m ruff check src/codex_plugin_scanner/guard/adapters/codex.py src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_phase04_harness_ux.py tests/test_guard_codex_install.py`
- `git diff --check`
- Live hook smoke: installed `hol-guard hook` denies Codex `PreToolUse` Read of `~/.npmrc` before tool execution.
