### PR TITLE
chore: bump guard route fix release

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To force a specific release, use Python package specifier syntax:
 pipx install --force 'hol-guard==2.0.345'
 ```
 
-Do not use `hol-guard@2.0.345`; pipx treats that as a separate app name, not a package version.
+Do not use `hol-guard@<version>`; pipx treats that as a separate app name, not a package version.
 
 `hol-guard init` is the first-run guided setup. It shows a progressive plan first, then gates each side effect: approve dashboard, Guard completes it, then approve app protection, Guard completes it, then approve Cloud connect and notifications. Nothing opens or changes until you approve that checkpoint. Use `hol-guard init --yes` only for automation when you already trust the plan.
 

--- a/README.md
+++ b/README.md
@@ -47,17 +47,17 @@ For a local wheel build, install into the pipx-managed `hol-guard` environment. 
 
 ```bash
 python3 -m build --wheel
-~/.local/pipx/venvs/hol-guard/bin/python -m pip install --force-reinstall dist/hol_guard-<version>-py3-none-any.whl
+pipx runpip hol-guard install --force-reinstall dist/hol_guard-<version>-py3-none-any.whl
 hol-guard --version
 ```
 
 To force a specific release, use Python package specifier syntax:
 
 ```bash
-pipx install --force 'hol-guard==2.0.342'
+pipx install --force 'hol-guard==2.0.345'
 ```
 
-Do not use `hol-guard@2.0.342`; pipx treats that as a separate app name, not a package version.
+Do not use `hol-guard@2.0.345`; pipx treats that as a separate app name, not a package version.
 
 `hol-guard init` is the first-run guided setup. It shows a progressive plan first, then gates each side effect: approve dashboard, Guard completes it, then approve app protection, Guard completes it, then approve Cloud connect and notifications. Nothing opens or changes until you approve that checkpoint. Use `hol-guard init --yes` only for automation when you already trust the plan.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hol-guard"
-version = "2.0.342"
+version = "2.0.345"
 description = "Protect local AI harnesses with HOL Guard and run scanner checks for Codex, Claude, Cursor, Gemini, and OpenCode."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/codex_plugin_scanner/version.py
+++ b/src/codex_plugin_scanner/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for tool version."""
 
-__version__ = "2.0.342"
+__version__ = "2.0.345"


### PR DESCRIPTION
## Summary
- bump `hol-guard` package version to `2.0.345`, above current PyPI latest `2.0.344`, so the merged local route fix can ship over existing installs
- update README local wheel verification to use `pipx runpip hol-guard ...` instead of a machine-specific pipx venv path
- update forced-install examples to the corrected release version

## Verification
- `pytest tests/test_versioning.py tests/test_guard_surface_server.py::TestGuardSurfaceServer::test_guard_daemon_serves_dashboard_shell_for_home_and_section_routes tests/test_guard_product_model_contracts.py::test_local_route_and_api_ownership_contracts_are_explicit`
- `python3 -m build --wheel`
- `pipx runpip hol-guard install --force-reinstall dist/hol_guard-2.0.345-py3-none-any.whl && hol-guard --version` -> `hol-guard 2.0.345`
- normal user daemon command: `/Users/michaelkantor/.local/bin/hol-guard daemon --serve --guard-home /Users/michaelkantor/.hol-guard --port 5474`
- HTTP route check: `/home`, `/supply-chain`, `/audit`, `/policy`, `/feed-health` all returned `200`
- In-app Browser exact URL: `http://127.0.0.1:5474/supply-chain#guard-token=db2db22afe5641838885b88430e7b52e` rendered `h1 = Supply Chain`, included `ACTIVE APPS`, `PACKAGE MANAGER FIREWALL`, and `FEED HEALTH`, with no `404`, `not found`, `failed to load`, or `application error` text