### PR TITLE
fix(hol-guard): block pytest log-file addopts

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -6109,10 +6109,7 @@ def _pytest_addopts_text_has_unsafe_marker(addopts_text: str) -> bool:
         token = raw_token.strip("[],")
         if token in _PYTEST_CONFIG_MUTATING_ADDOPTS_MARKERS:
             return True
-        if any(
-            marker != "-p" and token.startswith(f"{marker}=")
-            for marker in _PYTEST_CONFIG_MUTATING_ADDOPTS_MARKERS
-        ):
+        if any(marker != "-p" and token.startswith(f"{marker}=") for marker in _PYTEST_CONFIG_MUTATING_ADDOPTS_MARKERS):
             return True
         if token.startswith("-p") and not token.startswith("--"):
             return True

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -130,6 +130,7 @@ _PYTEST_CONFIG_MUTATING_ADDOPTS_MARKERS = (
     "--debug",
     "--junitxml",
     "--junit-xml",
+    "--log-file",
     "-p",
 )
 _PYTEST_UNSAFE_ENV_KEYS = frozenset({"PYTEST_ADDOPTS", "PYTEST_PLUGINS", "PYTHONHOME", "PYTHONPATH", "PYTHONUSERBASE"})

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -6087,14 +6087,34 @@ def _pytest_config_text_has_unsafe_addopts(config_text: str) -> bool:
             continue
         if re.match(r"^log_file\s*=", line):
             return True
-        if "addopts" in line:
+        addopts_match = re.match(r"^addopts\s*=(.*)$", line)
+        if addopts_match is not None:
             in_addopts = True
-            if any(marker in line for marker in _PYTEST_CONFIG_MUTATING_ADDOPTS_MARKERS):
+            if _pytest_addopts_text_has_unsafe_marker(addopts_match.group(1)):
                 return True
             continue
         if in_addopts and (line.startswith("[") or re.match(r"^[a-z0-9_.-]+\s*=", line)):
             in_addopts = False
-        if in_addopts and any(marker in line for marker in _PYTEST_CONFIG_MUTATING_ADDOPTS_MARKERS):
+        if in_addopts and _pytest_addopts_text_has_unsafe_marker(line):
+            return True
+    return False
+
+
+def _pytest_addopts_text_has_unsafe_marker(addopts_text: str) -> bool:
+    try:
+        tokens = shlex.split(addopts_text, comments=True, posix=True)
+    except ValueError:
+        tokens = addopts_text.split()
+    for raw_token in tokens:
+        token = raw_token.strip("[],")
+        if token in _PYTEST_CONFIG_MUTATING_ADDOPTS_MARKERS:
+            return True
+        if any(
+            marker != "-p" and token.startswith(f"{marker}=")
+            for marker in _PYTEST_CONFIG_MUTATING_ADDOPTS_MARKERS
+        ):
+            return True
+        if token.startswith("-p") and not token.startswith("--"):
             return True
     return False
 

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13078,6 +13078,21 @@ def test_guard_runtime_blocks_pytest_config_addopts_log_file(tmp_path):
     assert binary_match.action_class == "destructive shell command"
 
 
+def test_guard_runtime_allows_pytest_config_addopts_log_formatting(tmp_path):
+    _write_text(
+        tmp_path / "pytest.ini",
+        "[pytest]\naddopts = --log-file-level INFO --log-file-format %(message)s --log-file-date-format %H:%M:%S\n",
+    )
+
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "python3 -m pytest tests/test_guard_harness_smoke.py -q"},
+        cwd=tmp_path,
+    )
+
+    assert match is None
+
+
 def test_guard_runtime_checks_absolute_selected_test_root_pytest_config_addopts(tmp_path):
     test_root = tmp_path / "sub"
     _write_text(test_root / "pytest.ini", "[pytest]\naddopts = -p evil\n")

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13058,6 +13058,26 @@ def test_guard_runtime_blocks_pytest_config_log_file(tmp_path):
     assert match.action_class == "destructive shell command"
 
 
+def test_guard_runtime_blocks_pytest_config_addopts_log_file(tmp_path):
+    _write_text(tmp_path / "pytest.ini", "[pytest]\naddopts = --log-file /tmp/guard.log\n")
+
+    module_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "python3 -m pytest tests/test_guard_harness_smoke.py -q"},
+        cwd=tmp_path,
+    )
+    binary_match = extract_sensitive_tool_action_request(
+        "Bash",
+        {"command": "pytest tests/test_guard_harness_smoke.py -q"},
+        cwd=tmp_path,
+    )
+
+    assert module_match is not None
+    assert module_match.action_class == "destructive shell command"
+    assert binary_match is not None
+    assert binary_match.action_class == "destructive shell command"
+
+
 def test_guard_runtime_checks_absolute_selected_test_root_pytest_config_addopts(tmp_path):
     test_root = tmp_path / "sub"
     _write_text(test_root / "pytest.ini", "[pytest]\naddopts = -p evil\n")


### PR DESCRIPTION
## Summary
- block pytest config addopts that inject --log-file
- add regression coverage for python -m pytest and pytest binary paths

## Verification
- uv run pytest tests/test_guard_runtime.py::test_guard_runtime_blocks_pytest_config_addopts_log_file -q --tb=short (red before fix)
- uv run pytest tests/test_guard_runtime.py::test_guard_runtime_blocks_pytest_config_addopts_log_file tests/test_guard_runtime.py::test_guard_runtime_blocks_pytest_config_log_file tests/test_guard_runtime.py::test_guard_runtime_blocks_pytest_config_junit_xml_alias tests/test_guard_runtime.py::test_guard_runtime_blocks_pytest_config_cache_clear tests/test_guard_runtime.py::test_guard_runtime_blocks_multiline_pytest_config_addopts tests/test_guard_runtime.py::test_guard_runtime_allows_pytest_config_without_addopts -q --tb=short
- uv run ruff check src/codex_plugin_scanner/guard/runtime/secret_file_requests.py tests/test_guard_runtime.py
- uv run pytest tests/test_guard_runtime.py -k 'pytest_config or pytest_env or pytest_binary or python_module_pytest' -q --tb=short