### PR TITLE
fix(codex): block secret reads in shell

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -54,6 +54,8 @@ _LEGACY_MANAGED_HOOK_STATUS_MESSAGES = {
     _MANAGED_PERMISSION_HOOK_STATUS_MESSAGE,
     _MANAGED_POST_TOOL_HOOK_STATUS_MESSAGE,
 }
+_ZSHENV_GUARD_BEGIN = "# >>> HOL Guard Codex shell guard >>>"
+_ZSHENV_GUARD_END = "# <<< HOL Guard Codex shell guard <<<"
 
 
 def _json_object(path: Path) -> dict[str, object]:
@@ -273,13 +275,45 @@ def _remove_managed_hook_events(hooks: dict[str, object]) -> tuple[dict[str, obj
     return updated_hooks, changed
 
 
+def _remove_managed_zshenv_block(text: str) -> str:
+    pattern = re.compile(
+        rf"\n?{re.escape(_ZSHENV_GUARD_BEGIN)}.*?{re.escape(_ZSHENV_GUARD_END)}\n?",
+        re.DOTALL,
+    )
+    return pattern.sub("\n", text).strip("\n")
+
+
+def _codex_zshenv_guard_script() -> str:
+    return """# Managed by HOL Guard. Loaded by zsh only for Codex-owned shell commands.
+if [[ -n "${CODEX_MANAGED_BY_BUN:-}" || -n "${CODEX_MANAGED_PACKAGE_ROOT:-}" ]]; then
+  function TRAPDEBUG() {
+    emulate -L zsh
+    local cmd="${ZSH_DEBUG_CMD:-}"
+    [[ -z "$cmd" ]] && return 0
+    [[ "$cmd" == "TRAPDEBUG () {"* ]] && return 0
+    [[ "$cmd" == *"codex-zshenv-guard.zsh"* ]] && return 0
+    case "$cmd" in
+      *".npmrc"*|*".pypirc"*|*".netrc"*|*"id_rsa"*|*"id_ed25519"*|*"npm_token"*|*"NPM_TOKEN"*|*"_authToken"*|*".env"* )
+        print -u2 "HOL Guard blocked Codex before it could read a secret-looking local file."
+        print -u2 "Blocked command: ${cmd}"
+        return 1
+        ;;
+    esac
+    return 0
+  }
+fi
+"""
+
+
 def codex_native_hook_state(context: HarnessContext) -> dict[str, object]:
     config_path = CodexHarnessAdapter._target_config_path(context)
     hooks_path = CodexHarnessAdapter._hooks_path(context)
     config_payload = _read_toml(config_path)
     features = config_payload.get("features") if isinstance(config_payload, dict) else None
+    toml_hooks = config_payload.get("hooks") if isinstance(config_payload, dict) else None
     hooks_payload = _json_object(hooks_path)
-    hooks = hooks_payload.get("hooks") if isinstance(hooks_payload, dict) else None
+    json_hooks = hooks_payload.get("hooks") if isinstance(hooks_payload, dict) else None
+    hooks = toml_hooks if isinstance(toml_hooks, dict) else json_hooks
     pre_tool_groups = hooks.get("PreToolUse") if isinstance(hooks, dict) else None
     permission_groups = hooks.get("PermissionRequest") if isinstance(hooks, dict) else None
     prompt_groups = hooks.get("UserPromptSubmit") if isinstance(hooks, dict) else None
@@ -300,13 +334,21 @@ def codex_native_hook_state(context: HarnessContext) -> dict[str, object]:
         pre_tool_hook_installed and permission_hook_installed and prompt_hook_installed and post_tool_hook_installed
     )
     features_is_table = isinstance(features, dict)
-    hooks_feature_enabled = features_is_table and features.get("hooks") is True
+    hooks_feature_enabled = not features_is_table or features.get("hooks") is not False
     legacy_codex_hooks_enabled = features_is_table and features.get("codex_hooks") is True
     return {
         "config_path": str(config_path),
         "config_present": config_path.is_file(),
         "hooks_path": str(hooks_path),
         "hooks_present": hooks_path.is_file(),
+        "toml_hooks_present": isinstance(toml_hooks, dict) and any(
+            bool(toml_hooks.get(event_name))
+            for event_name in ("PreToolUse", "PermissionRequest", "UserPromptSubmit", "PostToolUse")
+        ),
+        "json_hooks_present": isinstance(json_hooks, dict) and any(
+            bool(json_hooks.get(event_name))
+            for event_name in ("PreToolUse", "PermissionRequest", "UserPromptSubmit", "PostToolUse")
+        ),
         "hooks_enabled": hooks_feature_enabled,
         "codex_hooks_enabled": hooks_feature_enabled,
         "legacy_codex_hooks_enabled": legacy_codex_hooks_enabled,
@@ -472,6 +514,7 @@ class CodexHarnessAdapter(HarnessAdapter):
         features.pop("codex_hooks", None)
         features["hooks"] = True
         payload["features"] = features
+        self._install_config_hooks(payload, context)
         existing_workspace_server_names = {
             name for name, value in mcp_servers.items() if isinstance(name, str) and isinstance(value, dict)
         }
@@ -486,6 +529,7 @@ class CodexHarnessAdapter(HarnessAdapter):
         payload["mcp_servers"] = mcp_servers
         write_toml_payload(target_config_path, payload)
         hooks_path = self._install_hooks(context, payloads=hook_payloads)
+        shell_guard_path = self._install_shell_guard(context)
         shim_manifest = install_guard_shim(self.harness, context)
         return {
             "harness": self.harness,
@@ -495,6 +539,7 @@ class CodexHarnessAdapter(HarnessAdapter):
             "mode": "codex-mcp-proxy",
             "managed_config_path": str(target_config_path),
             "managed_hooks_path": str(hooks_path),
+            "managed_shell_guard_path": str(shell_guard_path),
             "backup_path": str(backup_path),
             "managed_servers": [server.name for server in managed_servers],
             "skipped_servers": list(skipped_servers),
@@ -595,7 +640,6 @@ class CodexHarnessAdapter(HarnessAdapter):
 
     def _install_hooks(self, context: HarnessContext, *, payloads: dict[Path, dict[str, object]] | None = None) -> Path:
         target_hooks_path = self._hooks_path(context)
-        managed_groups = _managed_hook_groups(context)
         hook_payloads = payloads or self._load_hook_payloads(context)
         for hooks_path in self._all_hook_paths(context):
             original_payload = deepcopy(hook_payloads.get(hooks_path, {}))
@@ -604,19 +648,48 @@ class CodexHarnessAdapter(HarnessAdapter):
             if not isinstance(hooks, dict):
                 hooks = {}
             cleaned_hooks, managed_removed = _remove_managed_hook_events(hooks)
-            if hooks_path == target_hooks_path:
-                for event_name, managed_group in managed_groups.items():
-                    cleaned_hooks[event_name] = _merge_hook_groups(cleaned_hooks.get(event_name), managed_group)
-                payload["hooks"] = cleaned_hooks
-            elif not managed_removed:
+            if not managed_removed:
                 payload = deepcopy(original_payload)
+            elif cleaned_hooks:
+                payload["hooks"] = cleaned_hooks
             else:
-                if cleaned_hooks:
-                    payload["hooks"] = cleaned_hooks
-                else:
-                    payload.pop("hooks", None)
+                payload.pop("hooks", None)
             self._write_hooks_payload(hooks_path, payload, original_payload=original_payload)
         return target_hooks_path
+
+    @staticmethod
+    def _install_config_hooks(payload: dict[str, object], context: HarnessContext) -> None:
+        hooks = payload.get("hooks")
+        if not isinstance(hooks, dict):
+            hooks = {}
+        cleaned_hooks, _ = _remove_managed_hook_events(hooks)
+        for event_name, managed_group in _managed_hook_groups(context).items():
+            cleaned_hooks[event_name] = _merge_hook_groups(cleaned_hooks.get(event_name), managed_group)
+        payload["hooks"] = cleaned_hooks
+
+    @staticmethod
+    def _install_shell_guard(context: HarnessContext) -> Path:
+        guard_path = context.guard_home / "managed" / "codex" / "codex-zshenv-guard.zsh"
+        guard_path.parent.mkdir(parents=True, exist_ok=True)
+        guard_path.write_text(_codex_zshenv_guard_script(), encoding="utf-8")
+
+        zshenv_path = context.home_dir / ".zshenv"
+        original = zshenv_path.read_text(encoding="utf-8") if zshenv_path.is_file() else ""
+        source_block = "\n".join(
+            [
+                _ZSHENV_GUARD_BEGIN,
+                f'if [ -r "{guard_path}" ]; then',
+                f'  source "{guard_path}"',
+                "fi",
+                _ZSHENV_GUARD_END,
+            ]
+        )
+        cleaned = _remove_managed_zshenv_block(original).rstrip()
+        updated = f"{cleaned}\n\n{source_block}\n" if cleaned else f"{source_block}\n"
+        if updated != original:
+            zshenv_path.parent.mkdir(parents=True, exist_ok=True)
+            zshenv_path.write_text(updated, encoding="utf-8")
+        return guard_path
 
     def _remove_hooks(self, context: HarnessContext, *, payloads: dict[Path, dict[str, object]] | None = None) -> Path:
         target_hooks_path = self._hooks_path(context)

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -292,7 +292,9 @@ if [[ -n "${CODEX_MANAGED_BY_BUN:-}" || -n "${CODEX_MANAGED_PACKAGE_ROOT:-}" ]];
     [[ -z "$cmd" ]] && return 0
     [[ "$cmd" == "TRAPDEBUG () {"* ]] && return 0
     [[ "$cmd" == *"codex-zshenv-guard.zsh"* ]] && return 0
-    case "$cmd" in
+    local normalized_cmd="${cmd//\\\"/}"
+    normalized_cmd="${normalized_cmd//\\'/}"
+    case "$normalized_cmd" in
       *".npmrc"*|*".pypirc"*|*".netrc"*|*"id_rsa"*|*"id_ed25519"*|*"npm_token"*|*"NPM_TOKEN"*|*"_authToken"*|*".env"* )
         print -u2 "HOL Guard blocked Codex before it could read a secret-looking local file."
         print -u2 "Blocked command: ${cmd}"
@@ -341,11 +343,13 @@ def codex_native_hook_state(context: HarnessContext) -> dict[str, object]:
         "config_present": config_path.is_file(),
         "hooks_path": str(hooks_path),
         "hooks_present": hooks_path.is_file(),
-        "toml_hooks_present": isinstance(toml_hooks, dict) and any(
+        "toml_hooks_present": isinstance(toml_hooks, dict)
+        and any(
             bool(toml_hooks.get(event_name))
             for event_name in ("PreToolUse", "PermissionRequest", "UserPromptSubmit", "PostToolUse")
         ),
-        "json_hooks_present": isinstance(json_hooks, dict) and any(
+        "json_hooks_present": isinstance(json_hooks, dict)
+        and any(
             bool(json_hooks.get(event_name))
             for event_name in ("PreToolUse", "PermissionRequest", "UserPromptSubmit", "PostToolUse")
         ),
@@ -558,6 +562,7 @@ class CodexHarnessAdapter(HarnessAdapter):
                 target_config_path.unlink()
             backup_path.unlink()
         hooks_path = self._remove_hooks(context)
+        self._uninstall_shell_guard(context)
         shim_manifest = remove_guard_shim(self.harness, context)
         return {
             "harness": self.harness,
@@ -690,6 +695,22 @@ class CodexHarnessAdapter(HarnessAdapter):
             zshenv_path.parent.mkdir(parents=True, exist_ok=True)
             zshenv_path.write_text(updated, encoding="utf-8")
         return guard_path
+
+    @staticmethod
+    def _uninstall_shell_guard(context: HarnessContext) -> None:
+        guard_path = context.guard_home / "managed" / "codex" / "codex-zshenv-guard.zsh"
+        if guard_path.is_file():
+            guard_path.unlink()
+
+        zshenv_path = context.home_dir / ".zshenv"
+        if not zshenv_path.is_file():
+            return
+        original = zshenv_path.read_text(encoding="utf-8")
+        cleaned = _remove_managed_zshenv_block(original).rstrip()
+        if cleaned:
+            zshenv_path.write_text(f"{cleaned}\n", encoding="utf-8")
+        else:
+            zshenv_path.unlink()
 
     def _remove_hooks(self, context: HarnessContext, *, payloads: dict[Path, dict[str, object]] | None = None) -> Path:
         target_hooks_path = self._hooks_path(context)

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -17,6 +17,11 @@ from typing import ClassVar
 import pytest
 from rich.console import Console
 
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.adapters import claude_code as claude_adapter_module
 from codex_plugin_scanner.guard.adapters import cursor as cursor_adapter_module
@@ -50,6 +55,17 @@ def _write_json(path: Path, payload: dict[str, object]) -> None:
 def _write_text(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
+
+
+def _read_codex_config(path: Path) -> dict[str, object]:
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def _read_codex_hooks(config_path: Path) -> dict[str, object]:
+    hooks = _read_codex_config(config_path).get("hooks")
+    assert isinstance(hooks, dict)
+    return hooks
 
 
 def _write_codex_pre_tool_payload(path: Path, workspace_dir: Path, command: str) -> None:
@@ -3943,7 +3959,7 @@ args = ["-lc", "echo hi"]
         rc = main(["guard", "update", "--home", str(home_dir), "--json"])
         output = json.loads(capsys.readouterr().out)
         config_text = (home_dir / ".codex" / "config.toml").read_text(encoding="utf-8")
-        hooks_payload = json.loads((home_dir / ".codex" / "hooks.json").read_text(encoding="utf-8"))
+        hooks_payload = _read_codex_hooks(home_dir / ".codex" / "config.toml")
 
         assert rc == 0
         assert output["status"] == "current"
@@ -3951,7 +3967,7 @@ args = ["-lc", "echo hi"]
         assert output["managed_install"]["active"] is True
         assert "hooks = true" in config_text
         assert "codex_hooks" not in config_text
-        assert hooks_payload["hooks"]["PreToolUse"]
+        assert hooks_payload["PreToolUse"]
 
     def test_guard_update_repairs_missing_codex_config_for_managed_install(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"
@@ -3980,7 +3996,7 @@ args = ["-lc", "echo hi"]
         rc = main(["guard", "update", "--home", str(home_dir), "--json"])
         output = json.loads(capsys.readouterr().out)
         config_text = (home_dir / ".codex" / "config.toml").read_text(encoding="utf-8")
-        hooks_payload = json.loads((home_dir / ".codex" / "hooks.json").read_text(encoding="utf-8"))
+        hooks_payload = _read_codex_hooks(home_dir / ".codex" / "config.toml")
 
         assert rc == 0
         assert output["status"] == "current"
@@ -3988,7 +4004,7 @@ args = ["-lc", "echo hi"]
         assert output["managed_install"]["active"] is True
         assert "hooks = true" in config_text
         assert "codex_hooks" not in config_text
-        assert hooks_payload["hooks"]["PreToolUse"]
+        assert hooks_payload["PreToolUse"]
 
     def test_guard_update_repairs_workspace_codex_install_in_recorded_workspace(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"
@@ -4018,14 +4034,14 @@ args = ["-lc", "echo hi"]
         rc = main(["guard", "update", "--home", str(home_dir), "--json"])
         output = json.loads(capsys.readouterr().out)
         config_text = (workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8")
-        hooks_payload = json.loads((workspace_dir / ".codex" / "hooks.json").read_text(encoding="utf-8"))
+        hooks_payload = _read_codex_hooks(workspace_dir / ".codex" / "config.toml")
 
         assert rc == 0
         assert output["status"] == "current"
         assert output["managed_install"]["workspace"] == str(workspace_dir)
         assert "hooks = true" in config_text
         assert "codex_hooks" not in config_text
-        assert hooks_payload["hooks"]["PreToolUse"]
+        assert hooks_payload["PreToolUse"]
         assert (home_dir / ".codex" / "config.toml").exists() is False
 
     def test_guard_update_repairs_malformed_codex_config(self, tmp_path, monkeypatch, capsys):
@@ -4235,7 +4251,7 @@ args = ["-lc", "echo hi"]
         assert output["status"] == "current"
         assert output["managed_install"]["harness"] == "codex"
         assert output["managed_install"]["active"] is True
-        assert (home_dir / ".codex" / "hooks.json").is_file()
+        assert _read_codex_hooks(home_dir / ".codex" / "config.toml")["PreToolUse"]
 
     def test_guard_update_repairs_workspace_codex_when_lookup_fails_from_home_scoped_context(
         self, tmp_path, monkeypatch, capsys
@@ -4291,7 +4307,7 @@ args = ["-lc", "echo hi"]
         assert output["status"] == "current"
         assert output["managed_install"]["workspace"] == str(workspace_dir)
         assert output["managed_install"]["active"] is True
-        assert (workspace_dir / ".codex" / "hooks.json").is_file()
+        assert _read_codex_hooks(workspace_dir / ".codex" / "config.toml")["PreToolUse"]
         assert (home_dir / ".codex" / "config.toml").exists() is False
 
     def test_guard_update_repairs_workspace_codex_without_existing_codex_directory(self, tmp_path, monkeypatch, capsys):
@@ -4337,7 +4353,7 @@ args = ["-lc", "echo hi"]
         assert output["managed_install"]["workspace"] == str(workspace_dir)
         assert output["managed_install"]["active"] is True
         assert (workspace_dir / ".codex" / "config.toml").is_file()
-        assert (workspace_dir / ".codex" / "hooks.json").is_file()
+        assert _read_codex_hooks(workspace_dir / ".codex" / "config.toml")["PreToolUse"]
 
     def test_guard_doctor_warns_when_codex_native_hooks_are_missing(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"
@@ -4359,7 +4375,6 @@ args = ["-lc", "echo hi"]
 
         assert rc == 0
         assert output["native_hook_state"]["protection_active"] is False
-        assert any("native hooks are disabled" in warning for warning in output["warnings"])
         assert any("managed Codex hooks are missing" in warning for warning in output["warnings"])
 
     def test_guard_doctor_reports_runtime_detector_registry_state(self, tmp_path, monkeypatch, capsys):

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -71,14 +71,16 @@ def test_guard_install_codex_rewrites_workspace_config_with_proxy_entries(tmp_pa
     managed_install = output["managed_install"]
     manifest = managed_install["manifest"]
     config_text = (workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8")
+    config_payload = tomllib.loads(config_text)
     hooks_path = workspace_dir / ".codex" / "hooks.json"
-    hooks_payload = json.loads(hooks_path.read_text(encoding="utf-8"))
+    hooks_payload = config_payload["hooks"]
 
     assert rc == 0
     assert managed_install["active"] is True
     assert manifest["mode"] == "codex-mcp-proxy"
     assert manifest["managed_config_path"] == str(workspace_dir / ".codex" / "config.toml")
     assert manifest["managed_hooks_path"] == str(hooks_path)
+    assert manifest["managed_shell_guard_path"] == str(home_dir / "managed" / "codex" / "codex-zshenv-guard.zsh")
     assert set(manifest["managed_servers"]) == {"global_tools", "workspace_skill"}
     assert "--server-name" in config_text
     assert "guard" in config_text
@@ -86,30 +88,77 @@ def test_guard_install_codex_rewrites_workspace_config_with_proxy_entries(tmp_pa
     assert 'approval_policy = "never"' in config_text
     assert "hooks = true" in config_text
     assert "codex_hooks" not in config_text
+    assert hooks_path.exists() is False
     assert 'API_BASE = "https://hol.org"' in config_text
     assert 'FEATURE_FLAG = "1"' in config_text
-    assert hooks_payload["hooks"]["PreToolUse"][0]["matcher"] == codex_adapter._CODEX_GUARD_TOOL_MATCHER
+    assert hooks_payload["PreToolUse"][0]["matcher"] == codex_adapter._CODEX_GUARD_TOOL_MATCHER
     assert (
-        hooks_payload["hooks"]["PermissionRequest"][0]["matcher"]
+        hooks_payload["PermissionRequest"][0]["matcher"]
         == codex_adapter._CODEX_GUARD_PERMISSION_MATCHER
     )
-    assert "UserPromptSubmit" in hooks_payload["hooks"]
-    assert "matcher" not in hooks_payload["hooks"]["UserPromptSubmit"][0]
-    prompt_handler = hooks_payload["hooks"]["UserPromptSubmit"][0]["hooks"][0]
+    assert "UserPromptSubmit" in hooks_payload
+    assert "matcher" not in hooks_payload["UserPromptSubmit"][0]
+    prompt_handler = hooks_payload["UserPromptSubmit"][0]["hooks"][0]
     assert prompt_handler["type"] == "command"
     assert "codex_plugin_scanner.cli" in prompt_handler["command"]
     assert "hook" in prompt_handler["command"]
     assert "codex" in prompt_handler["command"]
-    handler = hooks_payload["hooks"]["PreToolUse"][0]["hooks"][0]
+    handler = hooks_payload["PreToolUse"][0]["hooks"][0]
     assert handler["type"] == "command"
     assert "codex_plugin_scanner.cli" in handler["command"]
     assert "hook" in handler["command"]
     assert "codex" in handler["command"]
-    permission_handler = hooks_payload["hooks"]["PermissionRequest"][0]["hooks"][0]
+    permission_handler = hooks_payload["PermissionRequest"][0]["hooks"][0]
     assert permission_handler["type"] == "command"
     assert "codex_plugin_scanner.cli" in permission_handler["command"]
     assert "hook" in permission_handler["command"]
     assert "codex" in permission_handler["command"]
+    zshenv_text = (home_dir / ".zshenv").read_text(encoding="utf-8")
+    shell_guard_text = (home_dir / "managed" / "codex" / "codex-zshenv-guard.zsh").read_text(
+        encoding="utf-8"
+    )
+    assert "HOL Guard Codex shell guard" in zshenv_text
+    assert "TRAPDEBUG" in shell_guard_text
+    assert ".npmrc" in shell_guard_text
+
+
+def test_guard_install_codex_replaces_existing_zshenv_guard_block(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
+    _write_text(
+        home_dir / ".zshenv",
+        "\n".join(
+            [
+                "export KEEP_ME=1",
+                "",
+                "# >>> HOL Guard Codex shell guard >>>",
+                "source /tmp/old",
+                "# <<< HOL Guard Codex shell guard <<<",
+                "",
+            ]
+        ),
+    )
+
+    rc = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+    zshenv_text = (home_dir / ".zshenv").read_text(encoding="utf-8")
+
+    assert rc == 0
+    assert "export KEEP_ME=1" in zshenv_text
+    assert "/tmp/old" not in zshenv_text
+    assert zshenv_text.count("HOL Guard Codex shell guard") == 2
 
 
 def test_guard_apps_connect_codex_defaults_to_project_scope_when_local_codex_config_exists(
@@ -268,6 +317,7 @@ def test_guard_install_codex_merges_managed_hooks_without_removing_existing_entr
         ]
     )
     json.loads(capsys.readouterr().out)
+    config_payload = tomllib.loads((workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
     hooks_payload = json.loads((workspace_dir / ".codex" / "hooks.json").read_text(encoding="utf-8"))
 
     uninstall_rc = main(
@@ -287,9 +337,9 @@ def test_guard_install_codex_merges_managed_hooks_without_removing_existing_entr
 
     assert install_rc == 0
     assert uninstall_rc == 0
-    assert len(hooks_payload["hooks"]["PreToolUse"]) == 2
+    assert len(config_payload["hooks"]["PreToolUse"]) == 1
     assert hooks_payload["hooks"]["PreToolUse"][0]["hooks"][0]["command"] == "python3 custom-pre.py"
-    managed_group = hooks_payload["hooks"]["PreToolUse"][1]
+    managed_group = config_payload["hooks"]["PreToolUse"][0]
     assert managed_group["matcher"] == codex_adapter._CODEX_GUARD_TOOL_MATCHER
     assert "codex_plugin_scanner.cli" in managed_group["hooks"][0]["command"]
     assert "hook" in managed_group["hooks"][0]["command"]
@@ -345,15 +395,16 @@ def test_guard_install_codex_migrates_legacy_bash_only_managed_hook(tmp_path, ca
         ]
     )
     json.loads(capsys.readouterr().out)
-    hooks_payload = json.loads((workspace_dir / ".codex" / "hooks.json").read_text(encoding="utf-8"))
+    config_payload = tomllib.loads((workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
 
     assert install_rc == 0
-    assert len(hooks_payload["hooks"]["PreToolUse"]) == 1
-    assert len(hooks_payload["hooks"]["PermissionRequest"]) == 1
-    assert len(hooks_payload["hooks"]["UserPromptSubmit"]) == 1
-    assert hooks_payload["hooks"]["PreToolUse"][0]["matcher"] == codex_adapter._CODEX_GUARD_TOOL_MATCHER
-    assert hooks_payload["hooks"]["PreToolUse"][0]["hooks"][0]["statusMessage"] == "HOL Guard checking tool action"
-    assert len(hooks_payload["hooks"]["UserPromptSubmit"]) == 1
+    assert (workspace_dir / ".codex" / "hooks.json").exists() is False
+    assert len(config_payload["hooks"]["PreToolUse"]) == 1
+    assert len(config_payload["hooks"]["PermissionRequest"]) == 1
+    assert len(config_payload["hooks"]["UserPromptSubmit"]) == 1
+    assert config_payload["hooks"]["PreToolUse"][0]["matcher"] == codex_adapter._CODEX_GUARD_TOOL_MATCHER
+    assert config_payload["hooks"]["PreToolUse"][0]["hooks"][0]["statusMessage"] == "HOL Guard checking tool action"
+    assert len(config_payload["hooks"]["UserPromptSubmit"]) == 1
 
 
 def test_guard_install_codex_migrates_stale_python_c_managed_hooks(tmp_path, capsys):
@@ -424,14 +475,15 @@ def test_guard_install_codex_migrates_stale_python_c_managed_hooks(tmp_path, cap
         ]
     )
     json.loads(capsys.readouterr().out)
-    hooks_payload = json.loads((workspace_dir / ".codex" / "hooks.json").read_text(encoding="utf-8"))
+    config_payload = tomllib.loads((workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
 
     assert install_rc == 0
-    assert len(hooks_payload["hooks"]["PreToolUse"]) == 1
-    assert len(hooks_payload["hooks"]["UserPromptSubmit"]) == 1
-    assert len(hooks_payload["hooks"]["PermissionRequest"]) == 1
-    assert len(hooks_payload["hooks"]["PostToolUse"]) == 1
-    all_commands = json.dumps(hooks_payload)
+    assert (workspace_dir / ".codex" / "hooks.json").exists() is False
+    assert len(config_payload["hooks"]["PreToolUse"]) == 1
+    assert len(config_payload["hooks"]["UserPromptSubmit"]) == 1
+    assert len(config_payload["hooks"]["PermissionRequest"]) == 1
+    assert len(config_payload["hooks"]["PostToolUse"]) == 1
+    all_commands = json.dumps(config_payload["hooks"])
     assert str(stale_worktree) not in all_commands
 
 
@@ -503,14 +555,15 @@ def test_guard_install_codex_migrates_legacy_wrapper_script_hook(tmp_path, capsy
         ]
     )
     json.loads(capsys.readouterr().out)
-    hooks_payload = json.loads((workspace_dir / ".codex" / "hooks.json").read_text(encoding="utf-8"))
+    config_payload = tomllib.loads((workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
 
     assert install_rc == 0
-    assert len(hooks_payload["hooks"]["PreToolUse"]) == 1
-    assert len(hooks_payload["hooks"]["PermissionRequest"]) == 1
-    assert len(hooks_payload["hooks"]["UserPromptSubmit"]) == 1
-    assert len(hooks_payload["hooks"]["PostToolUse"]) == 1
-    all_commands = json.dumps(hooks_payload)
+    assert (workspace_dir / ".codex" / "hooks.json").exists() is False
+    assert len(config_payload["hooks"]["PreToolUse"]) == 1
+    assert len(config_payload["hooks"]["PermissionRequest"]) == 1
+    assert len(config_payload["hooks"]["UserPromptSubmit"]) == 1
+    assert len(config_payload["hooks"]["PostToolUse"]) == 1
+    all_commands = json.dumps(config_payload["hooks"])
     assert wrapper_command not in all_commands
 
 
@@ -550,14 +603,14 @@ def test_guard_install_codex_workspace_cleans_stale_global_managed_hook(tmp_path
     json.loads(capsys.readouterr().out)
 
     home_hooks_path = home_dir / ".codex" / "hooks.json"
-    workspace_hooks_path = workspace_dir / ".codex" / "hooks.json"
-    workspace_hooks = json.loads(workspace_hooks_path.read_text(encoding="utf-8"))
+    workspace_config = tomllib.loads((workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
+    workspace_hooks = workspace_config["hooks"]
 
     assert global_install_rc == 0
     assert workspace_install_rc == 0
     assert home_hooks_path.exists() is False
-    assert len(workspace_hooks["hooks"]["PreToolUse"]) == 1
-    managed_group = workspace_hooks["hooks"]["PreToolUse"][0]
+    assert len(workspace_hooks["PreToolUse"]) == 1
+    managed_group = workspace_hooks["PreToolUse"][0]
     assert managed_group["matcher"] == codex_adapter._CODEX_GUARD_TOOL_MATCHER
     assert "codex_plugin_scanner.cli" in managed_group["hooks"][0]["command"]
 
@@ -581,9 +634,23 @@ def test_guard_uninstall_codex_preserves_user_hooks_in_managed_bash_group(tmp_pa
     )
     json.loads(capsys.readouterr().out)
     hooks_path = workspace_dir / ".codex" / "hooks.json"
-    hooks_payload = json.loads(hooks_path.read_text(encoding="utf-8"))
-    hooks_payload["hooks"]["PreToolUse"][0]["hooks"].append({"type": "command", "command": "python3 custom-pre.py"})
-    hooks_path.write_text(json.dumps(hooks_payload, indent=2) + "\n", encoding="utf-8")
+    hooks_path.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": codex_adapter._CODEX_GUARD_TOOL_MATCHER,
+                            "hooks": [{"type": "command", "command": "python3 custom-pre.py"}],
+                        }
+                    ]
+                }
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
     uninstall_rc = main(
         [

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -92,10 +92,7 @@ def test_guard_install_codex_rewrites_workspace_config_with_proxy_entries(tmp_pa
     assert 'API_BASE = "https://hol.org"' in config_text
     assert 'FEATURE_FLAG = "1"' in config_text
     assert hooks_payload["PreToolUse"][0]["matcher"] == codex_adapter._CODEX_GUARD_TOOL_MATCHER
-    assert (
-        hooks_payload["PermissionRequest"][0]["matcher"]
-        == codex_adapter._CODEX_GUARD_PERMISSION_MATCHER
-    )
+    assert hooks_payload["PermissionRequest"][0]["matcher"] == codex_adapter._CODEX_GUARD_PERMISSION_MATCHER
     assert "UserPromptSubmit" in hooks_payload
     assert "matcher" not in hooks_payload["UserPromptSubmit"][0]
     prompt_handler = hooks_payload["UserPromptSubmit"][0]["hooks"][0]
@@ -114,9 +111,7 @@ def test_guard_install_codex_rewrites_workspace_config_with_proxy_entries(tmp_pa
     assert "hook" in permission_handler["command"]
     assert "codex" in permission_handler["command"]
     zshenv_text = (home_dir / ".zshenv").read_text(encoding="utf-8")
-    shell_guard_text = (home_dir / "managed" / "codex" / "codex-zshenv-guard.zsh").read_text(
-        encoding="utf-8"
-    )
+    shell_guard_text = (home_dir / "managed" / "codex" / "codex-zshenv-guard.zsh").read_text(encoding="utf-8")
     assert "HOL Guard Codex shell guard" in zshenv_text
     assert "TRAPDEBUG" in shell_guard_text
     assert ".npmrc" in shell_guard_text
@@ -161,6 +156,85 @@ def test_guard_install_codex_replaces_existing_zshenv_guard_block(tmp_path, caps
     assert zshenv_text.count("HOL Guard Codex shell guard") == 2
 
 
+def test_guard_uninstall_codex_removes_zshenv_guard_block(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / ".zshenv", "export KEEP_ME=1\n")
+
+    install_rc = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+    guard_path = home_dir / "managed" / "codex" / "codex-zshenv-guard.zsh"
+
+    uninstall_rc = main(
+        [
+            "guard",
+            "uninstall",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+
+    assert install_rc == 0
+    assert uninstall_rc == 0
+    assert guard_path.exists() is False
+    assert (home_dir / ".zshenv").read_text(encoding="utf-8") == "export KEEP_ME=1\n"
+
+
+def test_guard_uninstall_codex_deletes_managed_only_zshenv(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+
+    install_rc = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+
+    uninstall_rc = main(
+        [
+            "guard",
+            "uninstall",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+
+    assert install_rc == 0
+    assert uninstall_rc == 0
+    assert (home_dir / ".zshenv").exists() is False
+
+
 def test_guard_apps_connect_codex_defaults_to_project_scope_when_local_codex_config_exists(
     tmp_path,
     monkeypatch,
@@ -189,9 +263,7 @@ def test_guard_apps_connect_codex_defaults_to_project_scope_when_local_codex_con
     assert rc == 0
     assert output["managed_install"]["active"] is True
     assert output["managed_install"]["workspace"] == str(workspace_dir)
-    assert output["managed_install"]["manifest"]["managed_config_path"] == str(
-        workspace_dir / ".codex" / "config.toml"
-    )
+    assert output["managed_install"]["manifest"]["managed_config_path"] == str(workspace_dir / ".codex" / "config.toml")
 
 
 def test_guard_apps_connect_codex_stays_global_without_local_codex_config(
@@ -231,9 +303,7 @@ args = ["-m", "http.server", "9000"]
     assert rc == 0
     assert output["managed_install"]["active"] is True
     assert output["managed_install"]["workspace"] is None
-    assert output["managed_install"]["manifest"]["managed_config_path"] == str(
-        home_dir / ".codex" / "config.toml"
-    )
+    assert output["managed_install"]["manifest"]["managed_config_path"] == str(home_dir / ".codex" / "config.toml")
 
 
 def test_guard_uninstall_codex_restores_original_workspace_config(tmp_path, capsys):
@@ -287,7 +357,7 @@ def test_guard_install_codex_merges_managed_hooks_without_removing_existing_entr
                 "hooks": {
                     "PreToolUse": [
                         {
-                "matcher": codex_adapter._CODEX_GUARD_TOOL_MATCHER,
+                            "matcher": codex_adapter._CODEX_GUARD_TOOL_MATCHER,
                             "hooks": [{"type": "command", "command": "python3 custom-pre.py"}],
                         }
                     ],
@@ -369,8 +439,7 @@ def test_guard_install_codex_migrates_legacy_bash_only_managed_hook(tmp_path, ca
             {
                 "type": "command",
                 "command": (
-                    "python -m codex_plugin_scanner.cli guard hook "
-                    f"--guard-home {context.guard_home} --harness codex"
+                    f"python -m codex_plugin_scanner.cli guard hook --guard-home {context.guard_home} --harness codex"
                 ),
                 "timeoutSec": 30,
                 "statusMessage": "HOL Guard checking Bash command",
@@ -412,18 +481,15 @@ def test_guard_install_codex_migrates_stale_python_c_managed_hooks(tmp_path, cap
     workspace_dir = tmp_path / "workspace"
     stale_worktree = tmp_path / "deleted-worktree"
     _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
-    stale_command = (
-        f"{sys.executable} -c "
-        + shlex.quote(
-            "import sys;"
-            f"sys.path[:0]=[{str(stale_worktree / 'src')!r}];"
-            "from codex_plugin_scanner.cli import main;"
-            "raise SystemExit(main(["
-            '"guard", "hook", "--guard-home", '
-            f"{str(home_dir / '.hol-guard')!r}, "
-            '"--harness", "codex"'
-            "]))"
-        )
+    stale_command = f"{sys.executable} -c " + shlex.quote(
+        "import sys;"
+        f"sys.path[:0]=[{str(stale_worktree / 'src')!r}];"
+        "from codex_plugin_scanner.cli import main;"
+        "raise SystemExit(main(["
+        '"guard", "hook", "--guard-home", '
+        f"{str(home_dir / '.hol-guard')!r}, "
+        '"--harness", "codex"'
+        "]))"
     )
     _write_text(
         workspace_dir / ".codex" / "hooks.json",

--- a/tests/test_guard_phase04_harness_contracts.py
+++ b/tests/test_guard_phase04_harness_contracts.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.claude_code import (
     CLAUDE_GUARD_DAEMON_HOOK_MARKER,
@@ -28,6 +33,13 @@ def _context(tmp_path: Path) -> HarnessContext:
         workspace_dir=workspace_dir,
         guard_home=tmp_path / "guard-home",
     )
+
+
+def _read_codex_hooks(config_path: Path) -> dict[str, object]:
+    with config_path.open("rb") as handle:
+        hooks = tomllib.load(handle).get("hooks")
+    assert isinstance(hooks, dict)
+    return hooks
 
 
 def test_gr091_cursor_adapter_detects_workspace_mcp_smoke(tmp_path: Path) -> None:
@@ -126,10 +138,10 @@ def test_gr096_managed_hook_json_matches_each_harness_schema(tmp_path: Path) -> 
     opencode_manifest = OpenCodeHarnessAdapter().install(context)
     CopilotHarnessAdapter().install(context)
 
-    codex_hooks = json.loads(Path(str(codex_manifest["managed_hooks_path"])).read_text(encoding="utf-8"))["hooks"]
-    claude_hooks = json.loads(
-        (context.workspace_dir / ".claude" / "settings.local.json").read_text(encoding="utf-8")
-    )["hooks"]
+    codex_hooks = _read_codex_hooks(Path(str(codex_manifest["managed_config_path"])))
+    claude_hooks = json.loads((context.workspace_dir / ".claude" / "settings.local.json").read_text(encoding="utf-8"))[
+        "hooks"
+    ]
     opencode_runtime = json.loads(Path(str(opencode_manifest["runtime_config_path"])).read_text(encoding="utf-8"))
     copilot_hooks = json.loads((context.workspace_dir / ".github" / "hooks" / "hol-guard-copilot.json").read_text())
 
@@ -137,9 +149,7 @@ def test_gr096_managed_hook_json_matches_each_harness_schema(tmp_path: Path) -> 
     assert claude_hooks["PreToolUse"][0]["hooks"][0]["type"] == "command"
     assert CLAUDE_GUARD_DAEMON_HOOK_MARKER in claude_hooks["PreToolUse"][0]["hooks"][0]["command"]
     assert opencode_runtime["permission"]
-    assert {"preToolUse", "postToolUse", "permissionRequest", "userPromptSubmitted"}.issubset(
-        copilot_hooks["hooks"]
-    )
+    assert {"preToolUse", "postToolUse", "permissionRequest", "userPromptSubmitted"}.issubset(copilot_hooks["hooks"])
 
 
 def test_gr099_managed_hooks_use_lightweight_cli_entrypoints(tmp_path: Path) -> None:
@@ -149,10 +159,10 @@ def test_gr099_managed_hooks_use_lightweight_cli_entrypoints(tmp_path: Path) -> 
     ClaudeCodeHarnessAdapter().install(context)
     CopilotHarnessAdapter().install(context)
 
-    codex_hooks = json.loads(Path(str(codex_manifest["managed_hooks_path"])).read_text(encoding="utf-8"))["hooks"]
-    claude_hooks = json.loads(
-        (context.workspace_dir / ".claude" / "settings.local.json").read_text(encoding="utf-8")
-    )["hooks"]
+    codex_hooks = _read_codex_hooks(Path(str(codex_manifest["managed_config_path"])))
+    claude_hooks = json.loads((context.workspace_dir / ".claude" / "settings.local.json").read_text(encoding="utf-8"))[
+        "hooks"
+    ]
     copilot_hooks = json.loads(
         (context.workspace_dir / ".github" / "hooks" / "hol-guard-copilot.json").read_text(encoding="utf-8")
     )["hooks"]


### PR DESCRIPTION
## Summary
- Install Codex managed hooks inline in `config.toml`, which Codex 0.133 parses during config-layer discovery.
- Clean stale managed `hooks.json` entries so old commands do not survive reinstall.
- Add a Codex-owned zsh shell guard that blocks secret-looking local file reads before shell output can print tokens.

## Testing
- `python3 -m pytest -q tests/test_guard_codex_install.py tests/test_guard_phase03_remainder.py::test_codex_doctor_marks_partial_native_hook_install_as_broken`
- `python3 -m ruff check src/codex_plugin_scanner/guard/adapters/codex.py tests/test_guard_codex_install.py`
- `git diff --check`
- Live `codex exec` fake-token proof: fake token was not printed; `cat` and Python reads of `.npmrc` were blocked by HOL Guard.
