### PR TITLE
fix(hol-guard): use trusted notification helpers

### DIFF
--- a/src/codex_plugin_scanner/guard/desktop_notifications.py
+++ b/src/codex_plugin_scanner/guard/desktop_notifications.py
@@ -19,6 +19,15 @@ MACOS_TERMINAL_NOTIFIER_BUNDLE_ID = "fr.julienxx.oss.terminal-notifier"
 MACOS_NOTIFICATION_SETTINGS_URL = (
     f"x-apple.systempreferences:com.apple.Notifications-Settings.extension?id={MACOS_TERMINAL_NOTIFIER_BUNDLE_ID}"
 )
+MACOS_OSASCRIPT_PATH = "/usr/bin/osascript"
+MACOS_OPEN_PATH = "/usr/bin/open"
+WINDOWS_POWERSHELL_PATH = r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
+_TRUSTED_MACOS_TERMINAL_NOTIFIER_PATHS = frozenset(
+    {
+        "/opt/homebrew/bin/terminal-notifier",
+        "/usr/local/bin/terminal-notifier",
+    }
+)
 _NOTIFICATION_SETUP_STATE_FILE = "desktop-notifications.json"
 
 
@@ -220,7 +229,7 @@ def ensure_desktop_notification_setup(
         )
     state_path = guard_home / _NOTIFICATION_SETUP_STATE_FILE
     already_prompted = state_path.exists()
-    terminal_notifier = which("terminal-notifier")
+    terminal_notifier = _trusted_macos_terminal_notifier_path(which)
     if already_prompted and not force:
         return DesktopNotificationSetupResult(
             platform=system,
@@ -295,7 +304,7 @@ def _send_macos_notification(
     run: Callable[..., subprocess.CompletedProcess[object]],
     which: Callable[[str], str | None],
 ) -> bool:
-    terminal_notifier = which("terminal-notifier")
+    terminal_notifier = _trusted_macos_terminal_notifier_path(which)
     if terminal_notifier:
         return _run_notification_command(
             run,
@@ -321,7 +330,7 @@ def _send_macos_notification(
     return _run_notification_command(
         run,
         [
-            "osascript",
+            MACOS_OSASCRIPT_PATH,
             "-e",
             (
                 f'display notification "{_escape_osascript(_macos_fallback_message(notification))}" '
@@ -343,7 +352,7 @@ def _send_windows_notification(
     return _run_notification_command(
         run,
         [
-            "powershell",
+            WINDOWS_POWERSHELL_PATH,
             "-NoProfile",
             "-ExecutionPolicy",
             "Bypass",
@@ -361,10 +370,17 @@ def _open_macos_notification_settings(
 ) -> bool:
     return _run_notification_command(
         run,
-        ["open", MACOS_NOTIFICATION_SETTINGS_URL],
+        [MACOS_OPEN_PATH, MACOS_NOTIFICATION_SETTINGS_URL],
         check=False,
         timeout=3,
     )
+
+
+def _trusted_macos_terminal_notifier_path(which: Callable[[str], str | None]) -> str | None:
+    notifier_path = which("terminal-notifier")
+    if notifier_path in _TRUSTED_MACOS_TERMINAL_NOTIFIER_PATHS:
+        return notifier_path
+    return None
 
 
 def _windows_toast_script(notification: DesktopApprovalNotification) -> str:

--- a/src/codex_plugin_scanner/guard/desktop_notifications.py
+++ b/src/codex_plugin_scanner/guard/desktop_notifications.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import html
 import json
+import ntpath
 import os
 import platform
 import shutil
@@ -21,7 +22,7 @@ MACOS_NOTIFICATION_SETTINGS_URL = (
 )
 MACOS_OSASCRIPT_PATH = "/usr/bin/osascript"
 MACOS_OPEN_PATH = "/usr/bin/open"
-WINDOWS_POWERSHELL_PATH = r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
+_DEFAULT_WINDOWS_SYSTEM_ROOT = r"C:\Windows"
 _TRUSTED_MACOS_TERMINAL_NOTIFIER_PATHS = frozenset(
     {
         "/opt/homebrew/bin/terminal-notifier",
@@ -381,6 +382,22 @@ def _trusted_macos_terminal_notifier_path(which: Callable[[str], str | None]) ->
     if notifier_path in _TRUSTED_MACOS_TERMINAL_NOTIFIER_PATHS:
         return notifier_path
     return None
+
+
+def _windows_powershell_path(system_root: str | None = None) -> str:
+    root = _trusted_windows_system_root(system_root)
+    return ntpath.join(root, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+
+
+def _trusted_windows_system_root(system_root: str | None = None) -> str:
+    candidate = ntpath.normpath(system_root or os.environ.get("SYSTEMROOT", _DEFAULT_WINDOWS_SYSTEM_ROOT))
+    drive, tail = ntpath.splitdrive(candidate)
+    if drive and tail.lower() == r"\windows":
+        return candidate
+    return _DEFAULT_WINDOWS_SYSTEM_ROOT
+
+
+WINDOWS_POWERSHELL_PATH = _windows_powershell_path()
 
 
 def _windows_toast_script(notification: DesktopApprovalNotification) -> str:

--- a/tests/test_guard_desktop_notifications.py
+++ b/tests/test_guard_desktop_notifications.py
@@ -11,7 +11,9 @@ from codex_plugin_scanner.guard.desktop_notifications import (
     _NOTIFICATION_SETUP_PATHS_IN_FLIGHT,
     _NOTIFIED_APPROVAL_IDS,
     _NOTIFIED_APPROVAL_IDS_LOCK,
+    WINDOWS_POWERSHELL_PATH,
     DesktopApprovalNotification,
+    _windows_powershell_path,
     ensure_desktop_notification_setup,
     ensure_desktop_notification_setup_async,
     notify_pending_approval_once,
@@ -113,7 +115,7 @@ def test_windows_notification_uses_powershell_toast() -> None:
 
     assert sent is True
     assert calls[0][:4] == [
-        r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+        WINDOWS_POWERSHELL_PATH,
         "-NoProfile",
         "-ExecutionPolicy",
         "Bypass",
@@ -123,6 +125,16 @@ def test_windows_notification_uses_powershell_toast() -> None:
     assert "$OpenAction.SetAttribute('arguments', $Url)" in calls[0][-1]
     assert "CreateToastNotifier()" in calls[0][-1]
     assert "http://127.0.0.1:5474/approvals/req-native" in calls[0][-1]
+
+
+def test_windows_powershell_path_uses_valid_system_root() -> None:
+    assert _windows_powershell_path(r"D:\Windows") == (r"D:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe")
+
+
+def test_windows_powershell_path_rejects_untrusted_system_root() -> None:
+    assert _windows_powershell_path(r"C:\Users\alice\Windows") == (
+        r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
+    )
 
 
 def test_unsupported_platform_is_noop() -> None:

--- a/tests/test_guard_desktop_notifications.py
+++ b/tests/test_guard_desktop_notifications.py
@@ -72,11 +72,30 @@ def test_macos_notification_falls_back_to_osascript() -> None:
     )
 
     assert sent is True
-    assert calls[0][0] == "osascript"
+    assert calls[0][0] == "/usr/bin/osascript"
     assert "display notification" in calls[0][2]
     assert "HOL Guard needs approval" in calls[0][2]
     assert 'sound name "default"' in calls[0][2]
     assert "http://127.0.0.1:5474/approvals/req-native" in calls[0][2]
+
+
+def test_macos_notification_rejects_untrusted_terminal_notifier_path() -> None:
+    calls: list[list[str]] = []
+
+    def run(command: list[str], **_: Any) -> subprocess.CompletedProcess[object]:
+        calls.append(command)
+        return _Completed()  # type: ignore[return-value]
+
+    sent = send_desktop_approval_notification(
+        _notification(),
+        system_name="Darwin",
+        run=run,
+        which=lambda name: "/tmp/evil/terminal-notifier" if name == "terminal-notifier" else None,
+    )
+
+    assert sent is True
+    assert calls[0][0] == "/usr/bin/osascript"
+    assert "/tmp/evil/terminal-notifier" not in calls[0]
 
 
 def test_windows_notification_uses_powershell_toast() -> None:
@@ -93,7 +112,12 @@ def test_windows_notification_uses_powershell_toast() -> None:
     )
 
     assert sent is True
-    assert calls[0][:4] == ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass"]
+    assert calls[0][:4] == [
+        r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+    ]
     assert "ToastNotificationManager" in calls[0][-1]
     assert "$OpenAction.SetAttribute('activationType', 'protocol')" in calls[0][-1]
     assert "$OpenAction.SetAttribute('arguments', $Url)" in calls[0][-1]
@@ -133,7 +157,7 @@ def test_notification_command_nonzero_exit_is_failure() -> None:
     )
 
     assert sent is False
-    assert calls[0][0] == "osascript"
+    assert calls[0][0] == "/usr/bin/osascript"
 
 
 def test_notification_command_launch_failure_is_best_effort() -> None:
@@ -265,7 +289,7 @@ def test_macos_setup_sends_preview_opens_settings_and_records_state(tmp_path) ->
     assert result.notifier_path == "/usr/local/bin/terminal-notifier"
     assert calls[0][0] == "/usr/local/bin/terminal-notifier"
     assert calls[1] == [
-        "open",
+        "/usr/bin/open",
         "x-apple.systempreferences:com.apple.Notifications-Settings.extension?id=fr.julienxx.oss.terminal-notifier",
     ]
     assert (tmp_path / "guard-home" / "desktop-notifications.json").exists()


### PR DESCRIPTION
## Summary
- reject PATH-discovered terminal-notifier paths outside trusted Homebrew locations
- use absolute system helper paths for macOS fallback/setup and Windows toast notifications
- keep notification delivery best-effort when helpers are unavailable

## Verification
- uv run pytest tests/test_guard_desktop_notifications.py::test_macos_notification_falls_back_to_osascript tests/test_guard_desktop_notifications.py::test_macos_notification_rejects_untrusted_terminal_notifier_path tests/test_guard_desktop_notifications.py::test_windows_notification_uses_powershell_toast tests/test_guard_desktop_notifications.py::test_macos_setup_sends_preview_opens_settings_and_records_state -q --tb=short (red before fix)
- uv run pytest tests/test_guard_desktop_notifications.py tests/test_guard_approvals.py -q --tb=short
- uv run ruff check src/codex_plugin_scanner/guard/desktop_notifications.py tests/test_guard_desktop_notifications.py
- uv run ruff format --check src/codex_plugin_scanner/guard/desktop_notifications.py tests/test_guard_desktop_notifications.py