### PR TITLE
fix(codex): guard multiple shells

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -340,11 +340,7 @@ if set -q CODEX_MANAGED_BY_BUN; or set -q CODEX_MANAGED_PACKAGE_ROOT
     set -l normalized_cmd (string replace -a '"' '' -- "$cmd")
     set normalized_cmd (string replace -a "'" "" -- "$normalized_cmd")
     switch "$normalized_cmd"
-      case "*.npmrc*" "*.pypirc*" "*.netrc*" "*id_rsa*" "*id_ed25519*"
-        echo "HOL Guard blocked Codex before it could read a secret-looking local file." >&2
-        echo "Blocked command: $cmd" >&2
-        exit 126
-      case "*npm_token*" "*NPM_TOKEN*" "*_authToken*" "*.env*"
+      case "*.npmrc*" "*.pypirc*" "*.netrc*" "*id_rsa*" "*id_ed25519*" "*token*" "*TOKEN*" "*authToken*" "*.env*"
         echo "HOL Guard blocked Codex before it could read a secret-looking local file." >&2
         echo "Blocked command: $cmd" >&2
         exit 126
@@ -752,11 +748,18 @@ class CodexHarnessAdapter(HarnessAdapter):
             "fi",
             _SHELL_GUARD_END,
         ]
-        for bash_startup_path in (
-            context.home_dir / ".bashrc",
+        bash_login_files = [
             context.home_dir / ".bash_profile",
+            context.home_dir / ".bash_login",
             context.home_dir / ".profile",
-        ):
+        ]
+        bash_startup_paths = [path for path in bash_login_files if path.is_file()]
+        bashrc_path = context.home_dir / ".bashrc"
+        if bashrc_path.is_file():
+            bash_startup_paths.append(bashrc_path)
+        if not bash_startup_paths:
+            bash_startup_paths = [context.home_dir / ".bash_profile", bashrc_path]
+        for bash_startup_path in bash_startup_paths:
             CodexHarnessAdapter._install_shell_guard_block(bash_startup_path, bash_block)
         fish_conf_path = context.home_dir / ".config" / "fish" / "conf.d" / "hol-guard-codex.fish"
         fish_conf_path.parent.mkdir(parents=True, exist_ok=True)
@@ -805,6 +808,7 @@ class CodexHarnessAdapter(HarnessAdapter):
             context.home_dir / ".zshenv",
             context.home_dir / ".bashrc",
             context.home_dir / ".bash_profile",
+            context.home_dir / ".bash_login",
             context.home_dir / ".profile",
             context.home_dir / ".config" / "fish" / "conf.d" / "hol-guard-codex.fish",
         ):

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -54,8 +54,8 @@ _LEGACY_MANAGED_HOOK_STATUS_MESSAGES = {
     _MANAGED_PERMISSION_HOOK_STATUS_MESSAGE,
     _MANAGED_POST_TOOL_HOOK_STATUS_MESSAGE,
 }
-_ZSHENV_GUARD_BEGIN = "# >>> HOL Guard Codex shell guard >>>"
-_ZSHENV_GUARD_END = "# <<< HOL Guard Codex shell guard <<<"
+_SHELL_GUARD_BEGIN = "# >>> HOL Guard Codex shell guard >>>"
+_SHELL_GUARD_END = "# <<< HOL Guard Codex shell guard <<<"
 
 
 def _json_object(path: Path) -> dict[str, object]:
@@ -275,9 +275,9 @@ def _remove_managed_hook_events(hooks: dict[str, object]) -> tuple[dict[str, obj
     return updated_hooks, changed
 
 
-def _remove_managed_zshenv_block(text: str) -> str:
+def _remove_managed_shell_guard_block(text: str) -> str:
     pattern = re.compile(
-        rf"\n?{re.escape(_ZSHENV_GUARD_BEGIN)}.*?{re.escape(_ZSHENV_GUARD_END)}\n?",
+        rf"\n?{re.escape(_SHELL_GUARD_BEGIN)}.*?{re.escape(_SHELL_GUARD_END)}\n?",
         re.DOTALL,
     )
     return pattern.sub("\n", text).strip("\n")
@@ -304,6 +304,53 @@ if [[ -n "${CODEX_MANAGED_BY_BUN:-}" || -n "${CODEX_MANAGED_PACKAGE_ROOT:-}" ]];
     return 0
   }
 fi
+"""
+
+
+def _codex_bashenv_guard_script() -> str:
+    return """# Managed by HOL Guard. Loaded by bash only for Codex-owned shell commands.
+if [[ -n "${CODEX_MANAGED_BY_BUN:-}" || -n "${CODEX_MANAGED_PACKAGE_ROOT:-}" ]]; then
+  shopt -s extdebug 2>/dev/null || true
+  __hol_guard_codex_bash_debug_trap() {
+    local cmd="${BASH_COMMAND:-}"
+    [[ -z "$cmd" ]] && return 0
+    [[ "$cmd" == "__hol_guard_codex_bash_debug_trap"* ]] && return 0
+    [[ "$cmd" == *"codex-bashenv-guard.bash"* ]] && return 0
+    local normalized_cmd="${cmd//\\\"/}"
+    normalized_cmd="${normalized_cmd//\\'/}"
+    case "$normalized_cmd" in
+      *".npmrc"*|*".pypirc"*|*".netrc"*|*"id_rsa"*|*"id_ed25519"*|*"npm_token"*|*"NPM_TOKEN"*|*"_authToken"*|*".env"* )
+        printf '%s\\n' "HOL Guard blocked Codex before it could read a secret-looking local file." >&2
+        printf '%s\\n' "Blocked command: ${cmd}" >&2
+        exit 126
+        ;;
+    esac
+    return 0
+  }
+  trap '__hol_guard_codex_bash_debug_trap' DEBUG
+fi
+"""
+
+
+def _codex_fish_guard_script() -> str:
+    return """# Managed by HOL Guard. Loaded by fish only for Codex-owned shell commands.
+if set -q CODEX_MANAGED_BY_BUN; or set -q CODEX_MANAGED_PACKAGE_ROOT
+  function __hol_guard_codex_fish_preexec --on-event fish_preexec
+    set -l cmd "$argv"
+    set -l normalized_cmd (string replace -a '"' '' -- "$cmd")
+    set normalized_cmd (string replace -a "'" "" -- "$normalized_cmd")
+    switch "$normalized_cmd"
+      case "*.npmrc*" "*.pypirc*" "*.netrc*" "*id_rsa*" "*id_ed25519*"
+        echo "HOL Guard blocked Codex before it could read a secret-looking local file." >&2
+        echo "Blocked command: $cmd" >&2
+        exit 126
+      case "*npm_token*" "*NPM_TOKEN*" "*_authToken*" "*.env*"
+        echo "HOL Guard blocked Codex before it could read a secret-looking local file." >&2
+        echo "Blocked command: $cmd" >&2
+        exit 126
+    end
+  end
+end
 """
 
 
@@ -533,7 +580,7 @@ class CodexHarnessAdapter(HarnessAdapter):
         payload["mcp_servers"] = mcp_servers
         write_toml_payload(target_config_path, payload)
         hooks_path = self._install_hooks(context, payloads=hook_payloads)
-        shell_guard_path = self._install_shell_guard(context)
+        shell_guard_paths = self._install_shell_guards(context)
         shim_manifest = install_guard_shim(self.harness, context)
         return {
             "harness": self.harness,
@@ -543,7 +590,8 @@ class CodexHarnessAdapter(HarnessAdapter):
             "mode": "codex-mcp-proxy",
             "managed_config_path": str(target_config_path),
             "managed_hooks_path": str(hooks_path),
-            "managed_shell_guard_path": str(shell_guard_path),
+            "managed_shell_guard_path": str(shell_guard_paths["zsh"]),
+            "managed_shell_guard_paths": {shell: str(path) for shell, path in shell_guard_paths.items()},
             "backup_path": str(backup_path),
             "managed_servers": [server.name for server in managed_servers],
             "skipped_servers": list(skipped_servers),
@@ -673,44 +721,105 @@ class CodexHarnessAdapter(HarnessAdapter):
         payload["hooks"] = cleaned_hooks
 
     @staticmethod
-    def _install_shell_guard(context: HarnessContext) -> Path:
-        guard_path = context.guard_home / "managed" / "codex" / "codex-zshenv-guard.zsh"
-        guard_path.parent.mkdir(parents=True, exist_ok=True)
-        guard_path.write_text(_codex_zshenv_guard_script(), encoding="utf-8")
+    def _install_shell_guards(context: HarnessContext) -> dict[str, Path]:
+        guard_root = context.guard_home / "managed" / "codex"
+        guard_root.mkdir(parents=True, exist_ok=True)
+        zsh_guard_path = guard_root / "codex-zshenv-guard.zsh"
+        bash_guard_path = guard_root / "codex-bashenv-guard.bash"
+        fish_guard_path = guard_root / "codex-fish-guard.fish"
 
-        zshenv_path = context.home_dir / ".zshenv"
-        original = zshenv_path.read_text(encoding="utf-8") if zshenv_path.is_file() else ""
-        source_block = "\n".join(
+        zsh_guard_path.write_text(_codex_zshenv_guard_script(), encoding="utf-8")
+        bash_guard_path.write_text(_codex_bashenv_guard_script(), encoding="utf-8")
+        fish_guard_path.write_text(_codex_fish_guard_script(), encoding="utf-8")
+
+        CodexHarnessAdapter._install_shell_guard_block(
+            context.home_dir / ".zshenv",
             [
-                _ZSHENV_GUARD_BEGIN,
-                f'if [ -r "{guard_path}" ]; then',
-                f'  source "{guard_path}"',
+                _SHELL_GUARD_BEGIN,
+                f'if [ -r "{zsh_guard_path}" ]; then',
+                f'  source "{zsh_guard_path}"',
                 "fi",
-                _ZSHENV_GUARD_END,
-            ]
+                _SHELL_GUARD_END,
+            ],
         )
-        cleaned = _remove_managed_zshenv_block(original).rstrip()
+        bash_block = [
+            _SHELL_GUARD_BEGIN,
+            f'if [ -r "{bash_guard_path}" ]; then',
+            f'  export BASH_ENV="{bash_guard_path}"',
+            '  if [ -n "${BASH_VERSION:-}" ]; then',
+            f'    . "{bash_guard_path}"',
+            "  fi",
+            "fi",
+            _SHELL_GUARD_END,
+        ]
+        for bash_startup_path in (
+            context.home_dir / ".bashrc",
+            context.home_dir / ".bash_profile",
+            context.home_dir / ".profile",
+        ):
+            CodexHarnessAdapter._install_shell_guard_block(bash_startup_path, bash_block)
+        fish_conf_path = context.home_dir / ".config" / "fish" / "conf.d" / "hol-guard-codex.fish"
+        fish_conf_path.parent.mkdir(parents=True, exist_ok=True)
+        fish_conf_path.write_text(
+            "\n".join(
+                [
+                    _SHELL_GUARD_BEGIN,
+                    f'if test -r "{fish_guard_path}"',
+                    f'  source "{fish_guard_path}"',
+                    "end",
+                    _SHELL_GUARD_END,
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        return {
+            "zsh": zsh_guard_path,
+            "bash": bash_guard_path,
+            "fish": fish_guard_path,
+            "fish_conf": fish_conf_path,
+        }
+
+    @staticmethod
+    def _install_shell_guard_block(path: Path, block_lines: list[str]) -> None:
+        original = path.read_text(encoding="utf-8") if path.is_file() else ""
+        source_block = "\n".join(block_lines)
+        cleaned = _remove_managed_shell_guard_block(original).rstrip()
         updated = f"{cleaned}\n\n{source_block}\n" if cleaned else f"{source_block}\n"
         if updated != original:
-            zshenv_path.parent.mkdir(parents=True, exist_ok=True)
-            zshenv_path.write_text(updated, encoding="utf-8")
-        return guard_path
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(updated, encoding="utf-8")
 
     @staticmethod
     def _uninstall_shell_guard(context: HarnessContext) -> None:
-        guard_path = context.guard_home / "managed" / "codex" / "codex-zshenv-guard.zsh"
-        if guard_path.is_file():
-            guard_path.unlink()
+        guard_root = context.guard_home / "managed" / "codex"
+        for guard_path in (
+            guard_root / "codex-zshenv-guard.zsh",
+            guard_root / "codex-bashenv-guard.bash",
+            guard_root / "codex-fish-guard.fish",
+        ):
+            if guard_path.is_file():
+                guard_path.unlink()
 
-        zshenv_path = context.home_dir / ".zshenv"
-        if not zshenv_path.is_file():
+        for startup_path in (
+            context.home_dir / ".zshenv",
+            context.home_dir / ".bashrc",
+            context.home_dir / ".bash_profile",
+            context.home_dir / ".profile",
+            context.home_dir / ".config" / "fish" / "conf.d" / "hol-guard-codex.fish",
+        ):
+            CodexHarnessAdapter._remove_shell_guard_block(startup_path)
+
+    @staticmethod
+    def _remove_shell_guard_block(path: Path) -> None:
+        if not path.is_file():
             return
-        original = zshenv_path.read_text(encoding="utf-8")
-        cleaned = _remove_managed_zshenv_block(original).rstrip()
+        original = path.read_text(encoding="utf-8")
+        cleaned = _remove_managed_shell_guard_block(original).rstrip()
         if cleaned:
-            zshenv_path.write_text(f"{cleaned}\n", encoding="utf-8")
+            path.write_text(f"{cleaned}\n", encoding="utf-8")
         else:
-            zshenv_path.unlink()
+            path.unlink()
 
     def _remove_hooks(self, context: HarnessContext, *, payloads: dict[Path, dict[str, object]] | None = None) -> Path:
         target_hooks_path = self._hooks_path(context)

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -81,6 +81,12 @@ def test_guard_install_codex_rewrites_workspace_config_with_proxy_entries(tmp_pa
     assert manifest["managed_config_path"] == str(workspace_dir / ".codex" / "config.toml")
     assert manifest["managed_hooks_path"] == str(hooks_path)
     assert manifest["managed_shell_guard_path"] == str(home_dir / "managed" / "codex" / "codex-zshenv-guard.zsh")
+    assert manifest["managed_shell_guard_paths"] == {
+        "zsh": str(home_dir / "managed" / "codex" / "codex-zshenv-guard.zsh"),
+        "bash": str(home_dir / "managed" / "codex" / "codex-bashenv-guard.bash"),
+        "fish": str(home_dir / "managed" / "codex" / "codex-fish-guard.fish"),
+        "fish_conf": str(home_dir / ".config" / "fish" / "conf.d" / "hol-guard-codex.fish"),
+    }
     assert set(manifest["managed_servers"]) == {"global_tools", "workspace_skill"}
     assert "--server-name" in config_text
     assert "guard" in config_text
@@ -112,8 +118,17 @@ def test_guard_install_codex_rewrites_workspace_config_with_proxy_entries(tmp_pa
     assert "codex" in permission_handler["command"]
     zshenv_text = (home_dir / ".zshenv").read_text(encoding="utf-8")
     shell_guard_text = (home_dir / "managed" / "codex" / "codex-zshenv-guard.zsh").read_text(encoding="utf-8")
+    bash_guard_text = (home_dir / "managed" / "codex" / "codex-bashenv-guard.bash").read_text(encoding="utf-8")
+    fish_guard_text = (home_dir / "managed" / "codex" / "codex-fish-guard.fish").read_text(encoding="utf-8")
+    fish_conf_text = (home_dir / ".config" / "fish" / "conf.d" / "hol-guard-codex.fish").read_text(encoding="utf-8")
     assert "HOL Guard Codex shell guard" in zshenv_text
     assert "TRAPDEBUG" in shell_guard_text
+    assert "BASH_ENV" in (home_dir / ".bash_profile").read_text(encoding="utf-8")
+    assert "BASH_ENV" in (home_dir / ".bashrc").read_text(encoding="utf-8")
+    assert "BASH_ENV" in (home_dir / ".profile").read_text(encoding="utf-8")
+    assert "extdebug" in bash_guard_text
+    assert "fish_preexec" in fish_guard_text
+    assert "codex-fish-guard.fish" in fish_conf_text
     assert ".npmrc" in shell_guard_text
 
 
@@ -156,11 +171,14 @@ def test_guard_install_codex_replaces_existing_zshenv_guard_block(tmp_path, caps
     assert zshenv_text.count("HOL Guard Codex shell guard") == 2
 
 
-def test_guard_uninstall_codex_removes_zshenv_guard_block(tmp_path, capsys):
+def test_guard_uninstall_codex_removes_shell_guard_blocks(tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
     _write_text(home_dir / ".zshenv", "export KEEP_ME=1\n")
+    _write_text(home_dir / ".bashrc", "export KEEP_BASHRC=1\n")
+    _write_text(home_dir / ".bash_profile", "export KEEP_BASH_PROFILE=1\n")
+    _write_text(home_dir / ".profile", "export KEEP_PROFILE=1\n")
 
     install_rc = main(
         [
@@ -176,6 +194,8 @@ def test_guard_uninstall_codex_removes_zshenv_guard_block(tmp_path, capsys):
     )
     json.loads(capsys.readouterr().out)
     guard_path = home_dir / "managed" / "codex" / "codex-zshenv-guard.zsh"
+    bash_guard_path = home_dir / "managed" / "codex" / "codex-bashenv-guard.bash"
+    fish_guard_path = home_dir / "managed" / "codex" / "codex-fish-guard.fish"
 
     uninstall_rc = main(
         [
@@ -194,10 +214,16 @@ def test_guard_uninstall_codex_removes_zshenv_guard_block(tmp_path, capsys):
     assert install_rc == 0
     assert uninstall_rc == 0
     assert guard_path.exists() is False
+    assert bash_guard_path.exists() is False
+    assert fish_guard_path.exists() is False
     assert (home_dir / ".zshenv").read_text(encoding="utf-8") == "export KEEP_ME=1\n"
+    assert (home_dir / ".bashrc").read_text(encoding="utf-8") == "export KEEP_BASHRC=1\n"
+    assert (home_dir / ".bash_profile").read_text(encoding="utf-8") == "export KEEP_BASH_PROFILE=1\n"
+    assert (home_dir / ".profile").read_text(encoding="utf-8") == "export KEEP_PROFILE=1\n"
+    assert (home_dir / ".config" / "fish" / "conf.d" / "hol-guard-codex.fish").exists() is False
 
 
-def test_guard_uninstall_codex_deletes_managed_only_zshenv(tmp_path, capsys):
+def test_guard_uninstall_codex_deletes_managed_only_shell_startup_files(tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
@@ -233,6 +259,54 @@ def test_guard_uninstall_codex_deletes_managed_only_zshenv(tmp_path, capsys):
     assert install_rc == 0
     assert uninstall_rc == 0
     assert (home_dir / ".zshenv").exists() is False
+    assert (home_dir / ".bashrc").exists() is False
+    assert (home_dir / ".bash_profile").exists() is False
+    assert (home_dir / ".profile").exists() is False
+    assert (home_dir / ".config" / "fish" / "conf.d" / "hol-guard-codex.fish").exists() is False
+
+
+def test_guard_codex_shell_guards_block_zsh_and_bash_secret_reads(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+
+    rc = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+    npmrc_path = home_dir / ".npmrc"
+    _write_text(npmrc_path, "FAKE_HOL_GUARD_SHOULD_NOT_PRINT\n")
+
+    assert rc == 0
+    shell_commands = []
+    if Path("/bin/zsh").is_file():
+        shell_commands.append(("/bin/zsh", ["/bin/zsh", "-lc", "cat ~/.np''mrc"]))
+    if Path("/bin/bash").is_file():
+        shell_commands.append(("/bin/bash", ["/bin/bash", "-lc", "cat ~/.np''mrc"]))
+    if not shell_commands:
+        return
+
+    for shell_name, command in shell_commands:
+        result = subprocess.run(
+            command,
+            cwd=workspace_dir,
+            env={**os.environ, "HOME": str(home_dir), "CODEX_MANAGED_BY_BUN": "1"},
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        combined = f"{result.stdout}\n{result.stderr}"
+        assert "FAKE_HOL_GUARD_SHOULD_NOT_PRINT" not in combined, shell_name
+        assert "HOL Guard blocked Codex before it could read a secret-looking local file." in combined, shell_name
 
 
 def test_guard_apps_connect_codex_defaults_to_project_scope_when_local_codex_config_exists(

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import shlex
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -125,7 +126,8 @@ def test_guard_install_codex_rewrites_workspace_config_with_proxy_entries(tmp_pa
     assert "TRAPDEBUG" in shell_guard_text
     assert "BASH_ENV" in (home_dir / ".bash_profile").read_text(encoding="utf-8")
     assert "BASH_ENV" in (home_dir / ".bashrc").read_text(encoding="utf-8")
-    assert "BASH_ENV" in (home_dir / ".profile").read_text(encoding="utf-8")
+    assert (home_dir / ".bash_login").exists() is False
+    assert (home_dir / ".profile").exists() is False
     assert "extdebug" in bash_guard_text
     assert "fish_preexec" in fish_guard_text
     assert "codex-fish-guard.fish" in fish_conf_text
@@ -171,6 +173,33 @@ def test_guard_install_codex_replaces_existing_zshenv_guard_block(tmp_path, caps
     assert zshenv_text.count("HOL Guard Codex shell guard") == 2
 
 
+def test_guard_install_codex_does_not_shadow_existing_bash_profile_precedence(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
+    _write_text(home_dir / ".profile", "export KEEP_PROFILE=1\n")
+
+    rc = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert (home_dir / ".bash_profile").exists() is False
+    assert (home_dir / ".bash_login").exists() is False
+    assert "export KEEP_PROFILE=1" in (home_dir / ".profile").read_text(encoding="utf-8")
+    assert "BASH_ENV" in (home_dir / ".profile").read_text(encoding="utf-8")
+
+
 def test_guard_uninstall_codex_removes_shell_guard_blocks(tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
@@ -178,6 +207,7 @@ def test_guard_uninstall_codex_removes_shell_guard_blocks(tmp_path, capsys):
     _write_text(home_dir / ".zshenv", "export KEEP_ME=1\n")
     _write_text(home_dir / ".bashrc", "export KEEP_BASHRC=1\n")
     _write_text(home_dir / ".bash_profile", "export KEEP_BASH_PROFILE=1\n")
+    _write_text(home_dir / ".bash_login", "export KEEP_BASH_LOGIN=1\n")
     _write_text(home_dir / ".profile", "export KEEP_PROFILE=1\n")
 
     install_rc = main(
@@ -219,6 +249,7 @@ def test_guard_uninstall_codex_removes_shell_guard_blocks(tmp_path, capsys):
     assert (home_dir / ".zshenv").read_text(encoding="utf-8") == "export KEEP_ME=1\n"
     assert (home_dir / ".bashrc").read_text(encoding="utf-8") == "export KEEP_BASHRC=1\n"
     assert (home_dir / ".bash_profile").read_text(encoding="utf-8") == "export KEEP_BASH_PROFILE=1\n"
+    assert (home_dir / ".bash_login").read_text(encoding="utf-8") == "export KEEP_BASH_LOGIN=1\n"
     assert (home_dir / ".profile").read_text(encoding="utf-8") == "export KEEP_PROFILE=1\n"
     assert (home_dir / ".config" / "fish" / "conf.d" / "hol-guard-codex.fish").exists() is False
 
@@ -261,6 +292,7 @@ def test_guard_uninstall_codex_deletes_managed_only_shell_startup_files(tmp_path
     assert (home_dir / ".zshenv").exists() is False
     assert (home_dir / ".bashrc").exists() is False
     assert (home_dir / ".bash_profile").exists() is False
+    assert (home_dir / ".bash_login").exists() is False
     assert (home_dir / ".profile").exists() is False
     assert (home_dir / ".config" / "fish" / "conf.d" / "hol-guard-codex.fish").exists() is False
 
@@ -288,10 +320,12 @@ def test_guard_codex_shell_guards_block_zsh_and_bash_secret_reads(tmp_path, caps
 
     assert rc == 0
     shell_commands = []
-    if Path("/bin/zsh").is_file():
-        shell_commands.append(("/bin/zsh", ["/bin/zsh", "-lc", "cat ~/.np''mrc"]))
-    if Path("/bin/bash").is_file():
-        shell_commands.append(("/bin/bash", ["/bin/bash", "-lc", "cat ~/.np''mrc"]))
+    zsh_path = shutil.which("zsh")
+    if zsh_path:
+        shell_commands.append((zsh_path, [zsh_path, "-lc", "cat ~/.np''mrc"]))
+    bash_path = shutil.which("bash")
+    if bash_path:
+        shell_commands.append((bash_path, [bash_path, "-lc", "cat ~/.np''mrc"]))
     if not shell_commands:
         return
 


### PR DESCRIPTION
## Summary
- Expand the Codex shell secret-read guard from zsh-only to managed zsh, bash, and fish startup coverage.
- Preserve the existing zsh manifest path while adding explicit multi-shell guard paths and uninstall cleanup.
- Add regression coverage that proves zsh/bash obfuscated `.npmrc` reads do not print token content.

## Testing
- `python3 -m pytest -q tests/test_guard_codex_install.py tests/test_guard_phase03_remainder.py::test_codex_doctor_marks_partial_native_hook_install_as_broken`
- `python3 -m ruff check src/codex_plugin_scanner/guard/adapters/codex.py tests/test_guard_codex_install.py`
- `python3 -m ruff format --check src/codex_plugin_scanner/guard/adapters/codex.py tests/test_guard_codex_install.py`
- `git diff --check`
