### PR TITLE
fix(dashboard): redistribute home cards from cramped sidebar to balanced layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To force a specific release, use Python package specifier syntax:
 pipx install --force 'hol-guard==2.0.345'
 ```
 
-Do not use `hol-guard@2.0.345`; pipx treats that as a separate app name, not a package version.
+Do not use `hol-guard@<version>`; pipx treats that as a separate app name, not a package version.
 
 `hol-guard init` is the first-run guided setup. It shows a progressive plan first, then gates each side effect: approve dashboard, Guard completes it, then approve app protection, Guard completes it, then approve Cloud connect and notifications. Nothing opens or changes until you approve that checkpoint. Use `hol-guard init --yes` only for automation when you already trust the plan.
 

--- a/README.md
+++ b/README.md
@@ -47,17 +47,17 @@ For a local wheel build, install into the pipx-managed `hol-guard` environment. 
 
 ```bash
 python3 -m build --wheel
-~/.local/pipx/venvs/hol-guard/bin/python -m pip install --force-reinstall dist/hol_guard-<version>-py3-none-any.whl
+pipx runpip hol-guard install --force-reinstall dist/hol_guard-<version>-py3-none-any.whl
 hol-guard --version
 ```
 
 To force a specific release, use Python package specifier syntax:
 
 ```bash
-pipx install --force 'hol-guard==2.0.342'
+pipx install --force 'hol-guard==2.0.345'
 ```
 
-Do not use `hol-guard@2.0.342`; pipx treats that as a separate app name, not a package version.
+Do not use `hol-guard@2.0.345`; pipx treats that as a separate app name, not a package version.
 
 `hol-guard init` is the first-run guided setup. It shows a progressive plan first, then gates each side effect: approve dashboard, Guard completes it, then approve app protection, Guard completes it, then approve Cloud connect and notifications. Nothing opens or changes until you approve that checkpoint. Use `hol-guard init --yes` only for automation when you already trust the plan.
 

--- a/dashboard/src/home-dashboard.tsx
+++ b/dashboard/src/home-dashboard.tsx
@@ -314,6 +314,13 @@ export function HomeWorkspace(props: {
             onOpenAppDetail={props.onOpenAppDetail}
           />
 
+          <HomeProtectionModule
+            snapshot={snapshot}
+            managedInstalls={managedInstalls}
+            onOpenFleet={props.onOpenFleet}
+            onOpenSupplyChain={props.onOpenSupplyChain}
+          />
+
           {dailyStory && (
             <CollapsibleCard
               id="daily-brief"
@@ -339,23 +346,6 @@ export function HomeWorkspace(props: {
         </section>
 
         <section className="space-y-6">
-          <HomeProtectionModule
-            snapshot={snapshot}
-            managedInstalls={managedInstalls}
-            onOpenFleet={props.onOpenFleet}
-            onOpenSupplyChain={props.onOpenSupplyChain}
-          />
-
-          <DeviceProofCard device={snapshot.device} proofStatus={snapshot.proof_status} />
-
-          <CloudStatusCard
-            snapshot={snapshot}
-            showUpsell={cloudUpsellVisible}
-            onOpenSettings={props.onOpenSettings}
-          />
-
-          <KeyboardHelpCard onOpenHelp={props.onOpenHelp} />
-
           {snapshot.latest_receipts.length > 0 && (
             <RecentProtectionSection receipts={snapshot.latest_receipts} />
           )}
@@ -378,6 +368,18 @@ export function HomeWorkspace(props: {
             </div>
           )}
         </section>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <DeviceProofCard device={snapshot.device} proofStatus={snapshot.proof_status} />
+
+        <CloudStatusCard
+          snapshot={snapshot}
+          showUpsell={cloudUpsellVisible}
+          onOpenSettings={props.onOpenSettings}
+        />
+
+        <KeyboardHelpCard onOpenHelp={props.onOpenHelp} />
       </div>
 
       {props.clearConfirm && (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hol-guard"
-version = "2.0.342"
+version = "2.0.345"
 description = "Protect local AI harnesses with HOL Guard and run scanner checks for Codex, Claude, Cursor, Gemini, and OpenCode."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/home-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/home-dashboard.js
@@ -361,6 +361,15 @@ function HomeWorkspace(props) {
             onOpenAppDetail: props.onOpenAppDetail
           }
         ),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          HomeProtectionModule,
+          {
+            snapshot,
+            managedInstalls,
+            onOpenFleet: props.onOpenFleet,
+            onOpenSupplyChain: props.onOpenSupplyChain
+          }
+        ),
         dailyStory && /* @__PURE__ */ jsxRuntimeExports.jsxs(
           CollapsibleCard,
           {
@@ -387,25 +396,6 @@ function HomeWorkspace(props) {
         )
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "space-y-6", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          HomeProtectionModule,
-          {
-            snapshot,
-            managedInstalls,
-            onOpenFleet: props.onOpenFleet,
-            onOpenSupplyChain: props.onOpenSupplyChain
-          }
-        ),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(DeviceProofCard, { device: snapshot.device, proofStatus: snapshot.proof_status }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          CloudStatusCard,
-          {
-            snapshot,
-            showUpsell: cloudUpsellVisible,
-            onOpenSettings: props.onOpenSettings
-          }
-        ),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(KeyboardHelpCard, { onOpenHelp: props.onOpenHelp }),
         snapshot.latest_receipts.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(RecentProtectionSection, { receipts: snapshot.latest_receipts }),
         policyItems.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Reset remembered decisions" }),
@@ -420,6 +410,18 @@ function HomeWorkspace(props) {
           )) })
         ] })
       ] })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 sm:grid-cols-2 lg:grid-cols-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(DeviceProofCard, { device: snapshot.device, proofStatus: snapshot.proof_status }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        CloudStatusCard,
+        {
+          snapshot,
+          showUpsell: cloudUpsellVisible,
+          onOpenSettings: props.onOpenSettings
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(KeyboardHelpCard, { onOpenHelp: props.onOpenHelp })
     ] }),
     props.clearConfirm && /* @__PURE__ */ jsxRuntimeExports.jsx(
       ClearConfirmDialog,

--- a/src/codex_plugin_scanner/version.py
+++ b/src/codex_plugin_scanner/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for tool version."""
 
-__version__ = "2.0.342"
+__version__ = "2.0.345"


### PR DESCRIPTION
## Problem
The Home dashboard crammed 6 cards into a narrow right sidebar (0.9fr), causing poor UX.

## Solution
- Moved HomeProtectionModule to primary left column
- Extracted utility cards into full-width 3-column grid below
- Right sidebar now only holds context-aware cards

## Verification
- Dashboard builds successfully
- Built assets refreshed