### PR TITLE
fix(hol-guard): require approval for docker push

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -76,7 +76,7 @@ _SHELL_CONTROL_PREFIX_TOKENS = frozenset(
     {"!", "(", "{", "case", "do", "elif", "else", "for", "if", "select", "then", "until", "while"}
 )
 _COMMAND_LIST_KEYS = ("argv", "command_args", "commandArgs")
-_DOCKER_ALWAYS_SENSITIVE_SUBCOMMANDS = frozenset({"compose", "login", "run"})
+_DOCKER_ALWAYS_SENSITIVE_SUBCOMMANDS = frozenset({"compose", "login", "push", "run"})
 _DOCKER_BUILD_SUBCOMMANDS = frozenset({"build"})
 _DOCKER_BUILDX_BUILD_SUBCOMMANDS = frozenset({"b", "build"})
 _DOCKER_BUILD_SECRET_FLAGS = frozenset({"--allow", "--secret", "--ssh"})

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -80,7 +80,9 @@ _DOCKER_ALWAYS_SENSITIVE_SUBCOMMANDS = frozenset({"compose", "login", "push", "r
 _DOCKER_BUILD_SUBCOMMANDS = frozenset({"build"})
 _DOCKER_BUILDX_BUILD_SUBCOMMANDS = frozenset({"b", "build"})
 _DOCKER_BUILD_SECRET_FLAGS = frozenset({"--allow", "--secret", "--ssh"})
-_DOCKER_BUILD_OUTPUT_FLAGS = frozenset({"--cache-to", "--iidfile", "--load", "--metadata-file", "--output", "-o"})
+_DOCKER_BUILD_OUTPUT_FLAGS = frozenset(
+    {"--cache-to", "--iidfile", "--load", "--metadata-file", "--output", "--push", "-o"}
+)
 _DOCKER_BUILD_METADATA_FLAGS = frozenset({"--annotation", "--label"})
 _DOCKER_GLOBAL_OPTIONS_WITH_VALUES = frozenset(
     {
@@ -717,7 +719,8 @@ def _docker_sensitive_tool_action_request(
         command_text=command_text,
         action_class="docker-sensitive command",
         reason=(
-            "Guard treats Docker login, run, compose, and credential-bearing build actions as sensitive because they "
+            "Guard treats Docker login, run, compose, push, and credential-bearing build "
+            "actions as sensitive because they "
             "can expose credentials or execute privileged container workflows."
         ),
     )

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -803,7 +803,7 @@ def test_tool_action_request_classifier_allows_simple_project_deploy_script():
     assert request is None
 
 
-def test_tool_action_request_classifier_allows_routine_docker_build_and_push():
+def test_tool_action_request_classifier_allows_routine_docker_build():
     build_request = extract_sensitive_tool_action_request(
         "bash",
         {"command": "docker build --platform linux/amd64 -t registry.example.com/app:v1 ."},
@@ -812,10 +812,6 @@ def test_tool_action_request_classifier_allows_routine_docker_build_and_push():
         "bash",
         {"command": "docker buildx build --platform linux/amd64 -t registry.example.com/app:v1 ."},
     )
-    push_request = extract_sensitive_tool_action_request(
-        "bash",
-        {"command": "docker push registry.example.com/app:v1"},
-    )
     build_arg_request = extract_sensitive_tool_action_request(
         "bash",
         {"command": "docker build --build-arg FOO=disk-space -t registry.example.com/app:v1 ."},
@@ -823,8 +819,23 @@ def test_tool_action_request_classifier_allows_routine_docker_build_and_push():
 
     assert build_request is None
     assert buildx_request is None
-    assert push_request is None
     assert build_arg_request is None
+
+
+def test_tool_action_request_classifier_blocks_docker_push():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "docker push registry.example.com/app:v1"},
+    )
+    context_request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "docker --context prod push registry.example.com/app:v1"},
+    )
+
+    assert request is not None
+    assert request.action_class == "docker-sensitive command"
+    assert context_request is not None
+    assert context_request.action_class == "docker-sensitive command"
 
 
 def test_tool_action_request_classifier_blocks_python_test_module_invocation():

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -831,11 +831,23 @@ def test_tool_action_request_classifier_blocks_docker_push():
         "bash",
         {"command": "docker --context prod push registry.example.com/app:v1"},
     )
+    build_push_request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "docker build --push -t registry.example.com/app:v1 ."},
+    )
+    buildx_push_request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "docker buildx build --push -t registry.example.com/app:v1 ."},
+    )
 
     assert request is not None
     assert request.action_class == "docker-sensitive command"
     assert context_request is not None
     assert context_request.action_class == "docker-sensitive command"
+    assert build_push_request is not None
+    assert build_push_request.action_class == "docker-sensitive command"
+    assert buildx_push_request is not None
+    assert buildx_push_request.action_class == "docker-sensitive command"
 
 
 def test_tool_action_request_classifier_blocks_python_test_module_invocation():


### PR DESCRIPTION
## Summary
- classify docker push as a docker-sensitive action requiring approval
- keep routine docker build/buildx flows allowed when no sensitive flags are used
- add regression tests covering direct and context-qualified docker push commands

## Verification
- uv run pytest tests/test_guard_risk.py::test_tool_action_request_classifier_blocks_docker_push -q --tb=short (red before fix)
- uv run pytest tests/test_guard_risk.py::test_tool_action_request_classifier_blocks_docker_push tests/test_guard_risk.py::test_tool_action_request_classifier_allows_routine_docker_build tests/test_guard_risk.py::test_tool_action_request_classifier_keeps_sensitive_docker_actions_blocked -q --tb=short
- uv run pytest tests/test_guard_risk.py -k 'docker' -q --tb=short
- uv run ruff check src/codex_plugin_scanner/guard/runtime/secret_file_requests.py tests/test_guard_risk.py
- uv run ruff format --check src/codex_plugin_scanner/guard/runtime/secret_file_requests.py tests/test_guard_risk.py