### PR TITLE
fix(guard): include local identity in cloud sync

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2155,6 +2155,7 @@ def _cloud_runtime_session_payload(store: GuardStore, session: dict[str, object]
         "clientVersion": _optional_string(session.get("client_version") or session.get("clientVersion")) or __version__,
         "deviceId": device_id,
         "deviceName": device_name,
+        "localIdentity": _cloud_local_identity_payload(device_id),
         "packageManagerCoverage": package_manager_coverage,
         "workspace": workspace,
         "capabilities": capabilities,
@@ -2162,6 +2163,44 @@ def _cloud_runtime_session_payload(store: GuardStore, session: dict[str, object]
         "createdAt": created_at,
         "updatedAt": updated_at,
     }
+
+
+def _cloud_local_identity_payload(device_id: str) -> dict[str, object]:
+    hostname = _safe_hostname()
+    private_ip = _safe_private_ip()
+    payload: dict[str, object] = {
+        "daemonId": device_id,
+        "daemonStatus": "healthy",
+        "relayState": "online",
+    }
+    if hostname is not None:
+        payload["hostname"] = hostname
+    if private_ip is not None:
+        payload["ipAddress"] = private_ip
+        payload["privateIpAddress"] = private_ip
+    return payload
+
+
+def _safe_hostname() -> str | None:
+    with suppress(OSError):
+        hostname = socket.gethostname().strip()
+        if hostname:
+            return hostname[:255]
+    return None
+
+
+def _safe_private_ip() -> str | None:
+    with suppress(OSError):
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.connect(("8.8.8.8", 80))
+            address = sock.getsockname()[0]
+            if isinstance(address, str) and address and not address.startswith("127."):
+                return address[:128]
+    with suppress(OSError):
+        address = socket.gethostbyname(socket.gethostname())
+        if address and not address.startswith("127."):
+            return address[:128]
+    return None
 
 
 def _cloud_sync_receipt_fingerprint(receipt: dict[str, object]) -> str:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2190,12 +2190,11 @@ def _safe_hostname() -> str | None:
 
 
 def _safe_private_ip() -> str | None:
-    with suppress(OSError):
-        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
-            sock.connect(("8.8.8.8", 80))
-            address = sock.getsockname()[0]
-            if isinstance(address, str) and address and not address.startswith("127."):
-                return address[:128]
+    with suppress(OSError), socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.connect(("8.8.8.8", 80))
+        address = sock.getsockname()[0]
+        if isinstance(address, str) and address and not address.startswith("127."):
+            return address[:128]
     with suppress(OSError):
         address = socket.gethostbyname(socket.gethostname())
         if address and not address.startswith("127."):

--- a/tests/test_guard_cloud_local_sync.py
+++ b/tests/test_guard_cloud_local_sync.py
@@ -646,6 +646,9 @@ def test_sync_runtime_session_emits_package_manager_coverage_payload(
     assert isinstance(session_payload, dict)
     assert session_payload["deviceId"] == store.get_or_create_installation_id()
     assert session_payload["deviceName"] == store.get_device_metadata()["device_label"]
+    assert session_payload["localIdentity"]["daemonId"] == store.get_or_create_installation_id()
+    assert session_payload["localIdentity"]["daemonStatus"] == "healthy"
+    assert session_payload["localIdentity"]["relayState"] == "online"
     assert session_payload["packageManagerCoverage"] == {
         "generatedAt": "2026-04-24T00:01:00+00:00",
         "configuredManagers": ["npm"],


### PR DESCRIPTION
## Summary
- include hostname and private IP identity in Guard runtime-session cloud sync
- mark synced daemon identity healthy so cloud Protect can show current machine proof
- add regression coverage for runtime session local identity payloads

## Testing
- `python3 -m pytest tests/test_guard_cloud_local_sync.py tests/test_guard_connect_flow.py -q -k 'runtime_session'`
- `python3 -m compileall -q src/codex_plugin_scanner/guard/runtime/runner.py`
- `git diff --check`
