### PR TITLE
fix(security): avoid hashing redacted secrets

### DIFF
--- a/src/codex_plugin_scanner/guard/redaction.py
+++ b/src/codex_plugin_scanner/guard/redaction.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -12,8 +11,9 @@ from pathlib import Path
 class RedactedText:
     """Safe text plus minimal metadata about removed secrets.
 
-    ``original_sha256`` is a legacy payload key. It fingerprints the redacted
-    output, not the original secret-bearing input.
+    ``original_sha256`` is a legacy payload key kept for response shape
+    compatibility. It is intentionally empty so secret-bearing input never
+    becomes a hash oracle.
     """
 
     text: str
@@ -116,7 +116,7 @@ def redact_text(value: str) -> RedactedText:
         text=redacted_value,
         count=total_count,
         classifiers=tuple(dict.fromkeys(classifiers)),
-        original_sha256=hashlib.sha256(redacted_value.encode("utf-8")).hexdigest(),
+        original_sha256="",
     )
 
 

--- a/src/codex_plugin_scanner/guard/redaction.py
+++ b/src/codex_plugin_scanner/guard/redaction.py
@@ -10,7 +10,11 @@ from pathlib import Path
 
 @dataclass(frozen=True, slots=True)
 class RedactedText:
-    """Safe text plus minimal metadata about removed secrets."""
+    """Safe text plus minimal metadata about removed secrets.
+
+    ``original_sha256`` is a legacy payload key. It fingerprints the redacted
+    output, not the original secret-bearing input.
+    """
 
     text: str
     count: int
@@ -112,7 +116,7 @@ def redact_text(value: str) -> RedactedText:
         text=redacted_value,
         count=total_count,
         classifiers=tuple(dict.fromkeys(classifiers)),
-        original_sha256=hashlib.sha256(value.encode("utf-8")).hexdigest(),
+        original_sha256=hashlib.sha256(redacted_value.encode("utf-8")).hexdigest(),
     )
 
 

--- a/tests/test_guard_redaction.py
+++ b/tests/test_guard_redaction.py
@@ -105,13 +105,14 @@ class TestRedactText:
         assert result.text == "Running build step: pnpm install"
         assert result.classifiers == ()
 
-    def test_result_preserves_sha256_of_original(self) -> None:
+    def test_result_hashes_redacted_text_not_secret_bearing_input(self) -> None:
         import hashlib
 
         original = "MY_TOKEN=abcdef"
         result = redact_text(original)
-        expected_sha = hashlib.sha256(original.encode("utf-8")).hexdigest()
+        expected_sha = hashlib.sha256(result.text.encode("utf-8")).hexdigest()
         assert result.original_sha256 == expected_sha
+        assert result.original_sha256 != hashlib.sha256(original.encode("utf-8")).hexdigest()
 
     def test_result_is_frozen(self) -> None:
         result = redact_text("clean text")

--- a/tests/test_guard_redaction.py
+++ b/tests/test_guard_redaction.py
@@ -105,14 +105,10 @@ class TestRedactText:
         assert result.text == "Running build step: pnpm install"
         assert result.classifiers == ()
 
-    def test_result_hashes_redacted_text_not_secret_bearing_input(self) -> None:
-        import hashlib
-
+    def test_result_does_not_hash_secret_bearing_input(self) -> None:
         original = "MY_TOKEN=abcdef"
         result = redact_text(original)
-        expected_sha = hashlib.sha256(result.text.encode("utf-8")).hexdigest()
-        assert result.original_sha256 == expected_sha
-        assert result.original_sha256 != hashlib.sha256(original.encode("utf-8")).hexdigest()
+        assert result.original_sha256 == ""
 
     def test_result_is_frozen(self) -> None:
         result = redact_text("clean text")


### PR DESCRIPTION
## Summary
- stop emitting secret-derived SHA-256 fingerprints from Guard redaction metadata
- keep legacy `original_sha256` response key empty for compatibility so it cannot act as a brute-force oracle
- add regression coverage for CodeQL alert 155 / PR alert 159

## Testing
- `env -u PYTHONPATH pytest tests/test_guard_redaction.py tests/test_guard_approval_gate.py::test_approval_gate_password_material_stays_out_of_public_payloads`
- GitHub CodeQL `Analyze (python)` passed on PR #506
- GitHub CI/Fuzzing/Kilo passed on PR #506
