### PR TITLE
fix(codex): install guard hooks globally

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -309,7 +309,10 @@ def _hooks_payload_has_unmanaged_entries(hooks_payload: dict[str, object]) -> bo
     if not isinstance(hooks, dict):
         return False
     cleaned_hooks, _ = _remove_managed_hook_events(hooks)
-    return any(isinstance(groups, list) and bool(groups) for groups in cleaned_hooks.values())
+    return any(
+        isinstance(cleaned_hooks.get(event_name), list) and bool(cleaned_hooks.get(event_name))
+        for event_name in ("PreToolUse", "PermissionRequest", "UserPromptSubmit", "PostToolUse")
+    )
 
 
 def _payload_has_hooks_feature_enabled(config_payload: dict[str, object]) -> bool:
@@ -395,7 +398,7 @@ end
 
 
 def codex_native_hook_state(context: HarnessContext) -> dict[str, object]:
-    config_path = CodexHarnessAdapter._target_config_path(context)
+    config_path = CodexHarnessAdapter._hook_config_path(context)
     hooks_path = CodexHarnessAdapter._hooks_path(context)
     config_payload = _read_toml(config_path)
     features = config_payload.get("features") if isinstance(config_payload, dict) else None
@@ -483,8 +486,6 @@ class CodexHarnessAdapter(HarnessAdapter):
 
     @staticmethod
     def _hooks_path(context: HarnessContext) -> Path:
-        if context.workspace_dir is not None:
-            return context.workspace_dir / ".codex" / "hooks.json"
         return context.home_dir / ".codex" / "hooks.json"
 
     @staticmethod
@@ -598,19 +599,31 @@ class CodexHarnessAdapter(HarnessAdapter):
         managed_servers = managed_stdio_servers(detection)
         skipped_servers = skipped_stdio_server_names(detection)
         target_config_path = self._target_config_path(context)
+        hook_config_path = self._hook_config_path(context)
         hook_payloads = self._load_hook_payloads(context)
         original_text = target_config_path.read_text(encoding="utf-8") if target_config_path.is_file() else None
         payload = read_toml_payload(target_config_path)
+        hook_payload = payload if hook_config_path == target_config_path else read_toml_payload(hook_config_path)
+        for config_path, hooks_path in self._config_hook_pairs(context):
+            json_hook_payload = hook_payloads.get(hooks_path, {})
+            if not json_hook_payload:
+                continue
+            if config_path == target_config_path:
+                hook_config_payload = payload
+            elif config_path == hook_config_path:
+                hook_config_payload = hook_payload
+            else:
+                hook_config_payload = read_toml_payload(config_path)
+            if not _payload_has_hooks_feature_enabled(hook_config_payload) and _hooks_payload_has_unmanaged_entries(
+                json_hook_payload
+            ):
+                raise RuntimeError(
+                    "Guard refused to enable existing Codex hook entries without explicit approval. "
+                    f"Review or remove unmanaged hooks in {hooks_path} before running install."
+                )
         target_hooks_path = self._hooks_path(context)
         target_hook_payload = hook_payloads.get(target_hooks_path, {})
-        if not _payload_has_hooks_feature_enabled(payload) and _hooks_payload_has_unmanaged_entries(
-            target_hook_payload
-        ):
-            raise RuntimeError(
-                "Guard refused to enable existing Codex hook entries without explicit approval. "
-                f"Review or remove unmanaged hooks in {target_hooks_path} before running install."
-            )
-        target_hooks_migrated = _migrate_hooks_json_into_config(payload, target_hook_payload)
+        target_hooks_migrated = _migrate_hooks_json_into_config(hook_payload, target_hook_payload)
         backup_path = self._backup_path(context)
         if not backup_path.exists():
             backup_path.parent.mkdir(parents=True, exist_ok=True)
@@ -619,13 +632,13 @@ class CodexHarnessAdapter(HarnessAdapter):
         mcp_servers = payload.get("mcp_servers")
         if not isinstance(mcp_servers, dict):
             mcp_servers = {}
-        features = payload.get("features")
+        features = hook_payload.get("features")
         if not isinstance(features, dict):
             features = {}
         features.pop("codex_hooks", None)
         features["hooks"] = True
-        payload["features"] = features
-        self._install_config_hooks(payload, context)
+        hook_payload["features"] = features
+        self._install_config_hooks(hook_payload, context)
         existing_workspace_server_names = {
             name for name, value in mcp_servers.items() if isinstance(name, str) and isinstance(value, dict)
         }
@@ -639,12 +652,14 @@ class CodexHarnessAdapter(HarnessAdapter):
             mcp_servers[server.name] = self._proxy_server_entry(context, server)
         payload["mcp_servers"] = mcp_servers
         write_toml_payload(target_config_path, payload)
+        if hook_config_path != target_config_path:
+            write_toml_payload(hook_config_path, hook_payload)
         self._migrate_alternate_hook_configs(
             context,
             payloads=hook_payloads,
-            skip_config_path=target_config_path,
+            skip_config_path=hook_config_path,
         )
-        self._remove_managed_hooks_from_alternate_configs(context, skip_config_path=target_config_path)
+        self._remove_managed_hooks_from_alternate_configs(context, skip_config_path=hook_config_path)
         hooks_path = self._remove_json_hook_files(context, payloads=hook_payloads)
         shell_guard_paths = self._install_shell_guards(context)
         shim_manifest = install_guard_shim(self.harness, context)
@@ -655,6 +670,7 @@ class CodexHarnessAdapter(HarnessAdapter):
             **shim_manifest,
             "mode": "codex-mcp-proxy",
             "managed_config_path": str(target_config_path),
+            "managed_hook_config_path": str(hook_config_path),
             "managed_hooks_path": str(hooks_path),
             "managed_shell_guard_path": str(shell_guard_paths["zsh"]),
             "managed_shell_guard_paths": {shell: str(path) for shell, path in shell_guard_paths.items()},
@@ -666,6 +682,7 @@ class CodexHarnessAdapter(HarnessAdapter):
 
     def uninstall(self, context: HarnessContext) -> dict[str, object]:
         target_config_path = self._target_config_path(context)
+        hook_config_path = self._hook_config_path(context)
         backup_path = self._backup_path(context)
         if backup_path.is_file():
             original_text = backup_path.read_text(encoding="utf-8")
@@ -676,6 +693,7 @@ class CodexHarnessAdapter(HarnessAdapter):
                 target_config_path.unlink()
             backup_path.unlink()
         hooks_path = self._remove_hooks(context)
+        self._remove_managed_hooks_from_alternate_configs(context, skip_config_path=target_config_path)
         self._uninstall_shell_guard(context)
         shim_manifest = remove_guard_shim(self.harness, context)
         return {
@@ -685,6 +703,7 @@ class CodexHarnessAdapter(HarnessAdapter):
             **shim_manifest,
             "mode": "codex-mcp-proxy",
             "managed_config_path": str(target_config_path),
+            "managed_hook_config_path": str(hook_config_path),
             "managed_hooks_path": str(hooks_path),
             "backup_path": str(backup_path),
         }
@@ -713,6 +732,10 @@ class CodexHarnessAdapter(HarnessAdapter):
     def _target_config_path(context: HarnessContext) -> Path:
         if context.workspace_dir is not None:
             return context.workspace_dir / ".codex" / "config.toml"
+        return context.home_dir / ".codex" / "config.toml"
+
+    @staticmethod
+    def _hook_config_path(context: HarnessContext) -> Path:
         return context.home_dir / ".codex" / "config.toml"
 
     @staticmethod

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -4033,8 +4033,8 @@ args = ["-lc", "echo hi"]
 
         rc = main(["guard", "update", "--home", str(home_dir), "--json"])
         output = json.loads(capsys.readouterr().out)
-        config_text = (workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8")
-        hooks_payload = _read_codex_hooks(workspace_dir / ".codex" / "config.toml")
+        config_text = (home_dir / ".codex" / "config.toml").read_text(encoding="utf-8")
+        hooks_payload = _read_codex_hooks(home_dir / ".codex" / "config.toml")
 
         assert rc == 0
         assert output["status"] == "current"
@@ -4042,7 +4042,7 @@ args = ["-lc", "echo hi"]
         assert "hooks = true" in config_text
         assert "codex_hooks" not in config_text
         assert hooks_payload["PreToolUse"]
-        assert (home_dir / ".codex" / "config.toml").exists() is False
+        assert "hooks" not in _read_codex_config(workspace_dir / ".codex" / "config.toml")
 
     def test_guard_update_repairs_malformed_codex_config(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"
@@ -4307,8 +4307,8 @@ args = ["-lc", "echo hi"]
         assert output["status"] == "current"
         assert output["managed_install"]["workspace"] == str(workspace_dir)
         assert output["managed_install"]["active"] is True
-        assert _read_codex_hooks(workspace_dir / ".codex" / "config.toml")["PreToolUse"]
-        assert (home_dir / ".codex" / "config.toml").exists() is False
+        assert _read_codex_hooks(home_dir / ".codex" / "config.toml")["PreToolUse"]
+        assert "hooks" not in _read_codex_config(workspace_dir / ".codex" / "config.toml")
 
     def test_guard_update_repairs_workspace_codex_without_existing_codex_directory(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"
@@ -4353,7 +4353,8 @@ args = ["-lc", "echo hi"]
         assert output["managed_install"]["workspace"] == str(workspace_dir)
         assert output["managed_install"]["active"] is True
         assert (workspace_dir / ".codex" / "config.toml").is_file()
-        assert _read_codex_hooks(workspace_dir / ".codex" / "config.toml")["PreToolUse"]
+        assert _read_codex_hooks(home_dir / ".codex" / "config.toml")["PreToolUse"]
+        assert "hooks" not in _read_codex_config(workspace_dir / ".codex" / "config.toml")
 
     def test_guard_doctor_warns_when_codex_native_hooks_are_missing(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -73,8 +73,10 @@ def test_guard_install_codex_rewrites_workspace_config_with_proxy_entries(tmp_pa
     managed_install = output["managed_install"]
     manifest = managed_install["manifest"]
     config_text = (workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8")
-    config_payload = tomllib.loads(config_text)
-    hooks_path = workspace_dir / ".codex" / "hooks.json"
+    hook_config_text = (home_dir / ".codex" / "config.toml").read_text(encoding="utf-8")
+    config_payload = tomllib.loads(hook_config_text)
+    workspace_config = tomllib.loads(config_text)
+    hooks_path = home_dir / ".codex" / "hooks.json"
     hooks_payload = config_payload["hooks"]
 
     assert rc == 0
@@ -93,10 +95,12 @@ def test_guard_install_codex_rewrites_workspace_config_with_proxy_entries(tmp_pa
     assert "--server-name" in config_text
     assert "guard" in config_text
     assert "codex-mcp-proxy" in config_text
-    assert 'approval_policy = "never"' in config_text
-    assert "hooks = true" in config_text
-    assert "codex_hooks" not in config_text
+    assert "hooks = true" in hook_config_text
+    assert "codex_hooks" not in hook_config_text
+    assert workspace_config["approval_policy"] == "never"
+    assert "hooks" not in workspace_config
     assert hooks_path.exists() is False
+    assert (workspace_dir / ".codex" / "hooks.json").exists() is False
     assert 'API_BASE = "https://hol.org"' in config_text
     assert 'FEATURE_FLAG = "1"' in config_text
     assert hooks_payload["PreToolUse"][0]["matcher"] == codex_adapter._CODEX_GUARD_TOOL_MATCHER
@@ -551,13 +555,15 @@ hooks = true
         ]
     )
     json.loads(capsys.readouterr().out)
-    config_payload = tomllib.loads((workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
+    home_config = tomllib.loads((home_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
+    workspace_config = tomllib.loads((workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
 
     assert rc == 0
     assert (workspace_dir / ".codex" / "hooks.json").exists() is False
-    assert len(config_payload["hooks"]["PreToolUse"]) == 2
-    assert config_payload["hooks"]["PreToolUse"][0]["hooks"][0]["command"] == "python3 custom-pre.py"
-    assert config_payload["hooks"]["PreToolUse"][1]["matcher"] == codex_adapter._CODEX_GUARD_TOOL_MATCHER
+    assert len(workspace_config["hooks"]["PreToolUse"]) == 1
+    assert workspace_config["hooks"]["PreToolUse"][0]["hooks"][0]["command"] == "python3 custom-pre.py"
+    assert len(home_config["hooks"]["PreToolUse"]) == 1
+    assert home_config["hooks"]["PreToolUse"][0]["matcher"] == codex_adapter._CODEX_GUARD_TOOL_MATCHER
 
 
 def test_guard_install_codex_migrates_global_and_workspace_hooks_to_toml(tmp_path, capsys):
@@ -620,9 +626,10 @@ def test_guard_install_codex_migrates_global_and_workspace_hooks_to_toml(tmp_pat
     assert (workspace_dir / ".codex" / "hooks.json").exists() is False
     assert home_config["model"] == "gpt-5.3-codex"
     assert home_config["hooks"]["SessionStart"][0]["hooks"][0]["command"] == "python3 global-start.py"
-    assert len(workspace_config["hooks"]["PreToolUse"]) == 1
-    assert workspace_config["hooks"]["PreToolUse"][0]["matcher"] == codex_adapter._CODEX_GUARD_TOOL_MATCHER
-    assert "codex_plugin_scanner.cli" in workspace_config["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+    assert "hooks" not in workspace_config
+    assert len(home_config["hooks"]["PreToolUse"]) == 1
+    assert home_config["hooks"]["PreToolUse"][0]["matcher"] == codex_adapter._CODEX_GUARD_TOOL_MATCHER
+    assert "codex_plugin_scanner.cli" in home_config["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
 
 
 def test_guard_install_codex_migrates_legacy_bash_only_managed_hook(tmp_path, capsys):
@@ -661,10 +668,12 @@ def test_guard_install_codex_migrates_legacy_bash_only_managed_hook(tmp_path, ca
         ]
     )
     json.loads(capsys.readouterr().out)
-    config_payload = tomllib.loads((workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
+    config_payload = tomllib.loads((home_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
+    workspace_config = tomllib.loads((workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
 
     assert install_rc == 0
     assert (workspace_dir / ".codex" / "hooks.json").exists() is False
+    assert "hooks" not in workspace_config
     assert len(config_payload["hooks"]["PreToolUse"]) == 1
     assert len(config_payload["hooks"]["PermissionRequest"]) == 1
     assert len(config_payload["hooks"]["UserPromptSubmit"]) == 1
@@ -738,10 +747,12 @@ def test_guard_install_codex_migrates_stale_python_c_managed_hooks(tmp_path, cap
         ]
     )
     json.loads(capsys.readouterr().out)
-    config_payload = tomllib.loads((workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
+    config_payload = tomllib.loads((home_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
+    workspace_config = tomllib.loads((workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
 
     assert install_rc == 0
     assert (workspace_dir / ".codex" / "hooks.json").exists() is False
+    assert "hooks" not in workspace_config
     assert len(config_payload["hooks"]["PreToolUse"]) == 1
     assert len(config_payload["hooks"]["UserPromptSubmit"]) == 1
     assert len(config_payload["hooks"]["PermissionRequest"]) == 1
@@ -818,10 +829,12 @@ def test_guard_install_codex_migrates_legacy_wrapper_script_hook(tmp_path, capsy
         ]
     )
     json.loads(capsys.readouterr().out)
-    config_payload = tomllib.loads((workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
+    config_payload = tomllib.loads((home_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
+    workspace_config = tomllib.loads((workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
 
     assert install_rc == 0
     assert (workspace_dir / ".codex" / "hooks.json").exists() is False
+    assert "hooks" not in workspace_config
     assert len(config_payload["hooks"]["PreToolUse"]) == 1
     assert len(config_payload["hooks"]["PermissionRequest"]) == 1
     assert len(config_payload["hooks"]["UserPromptSubmit"]) == 1
@@ -868,17 +881,16 @@ def test_guard_install_codex_workspace_cleans_stale_global_managed_hook(tmp_path
     home_hooks_path = home_dir / ".codex" / "hooks.json"
     home_config = tomllib.loads((home_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
     workspace_config = tomllib.loads((workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
-    workspace_hooks = workspace_config["hooks"]
 
     assert global_install_rc == 0
     assert workspace_install_rc == 0
     assert home_hooks_path.exists() is False
-    assert "UserPromptSubmit" not in home_config.get("hooks", {})
-    assert "PermissionRequest" not in home_config.get("hooks", {})
-    assert "PostToolUse" not in home_config.get("hooks", {})
-    assert "PreToolUse" not in home_config.get("hooks", {})
-    assert len(workspace_hooks["PreToolUse"]) == 1
-    managed_group = workspace_hooks["PreToolUse"][0]
+    assert "hooks" not in workspace_config
+    assert len(home_config["hooks"]["PreToolUse"]) == 1
+    assert len(home_config["hooks"]["PermissionRequest"]) == 1
+    assert len(home_config["hooks"]["UserPromptSubmit"]) == 1
+    assert len(home_config["hooks"]["PostToolUse"]) == 1
+    managed_group = home_config["hooks"]["PreToolUse"][0]
     assert managed_group["matcher"] == codex_adapter._CODEX_GUARD_TOOL_MATCHER
     assert "codex_plugin_scanner.cli" in managed_group["hooks"][0]["command"]
 
@@ -932,19 +944,22 @@ def test_guard_install_codex_workspace_preserves_global_user_hooks_while_removin
     assert global_install_rc == 0
     assert workspace_install_rc == 0
     assert final_home_config["model"] == "gpt-5.3-codex"
-    assert final_home_config["hooks"] == {
-        "SessionStart": [
-            {
-                "hooks": [
-                    {
-                        "type": "command",
-                        "command": "python3 user-session-start.py",
-                        "statusMessage": "User session start",
-                    }
-                ]
-            }
-        ]
-    }
+    hooks = final_home_config["hooks"]
+    assert hooks["SessionStart"] == [
+        {
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "python3 user-session-start.py",
+                    "statusMessage": "User session start",
+                }
+            ]
+        }
+    ]
+    assert len(hooks["PreToolUse"]) == 1
+    assert len(hooks["PermissionRequest"]) == 1
+    assert len(hooks["UserPromptSubmit"]) == 1
+    assert len(hooks["PostToolUse"]) == 1
 
 
 def test_guard_uninstall_codex_preserves_user_hooks_in_managed_bash_group(tmp_path, capsys):
@@ -1151,6 +1166,7 @@ def test_guard_uninstall_codex_preserves_invalid_target_hook_file(tmp_path, caps
 def test_guard_install_codex_migrates_read_only_alternate_hook_file(tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
+    _write_text(home_dir / ".codex" / "config.toml", "[features]\nhooks = true\n")
     _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
     home_hooks_path = home_dir / ".codex" / "hooks.json"
     original_hooks = json.dumps(
@@ -1192,6 +1208,7 @@ def test_guard_install_codex_migrates_read_only_alternate_hook_file(tmp_path, ca
 def test_guard_uninstall_codex_preserves_migrated_alternate_hook_config(tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
+    _write_text(home_dir / ".codex" / "config.toml", "[features]\nhooks = true\n")
     _write_text(workspace_dir / ".codex" / "config.toml", 'approval_policy = "never"\n')
     home_hooks_path = home_dir / ".codex" / "hooks.json"
     original_hooks = json.dumps(

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -217,8 +217,8 @@ def test_doctor_does_not_mark_harness_command_presence_as_guard_active(
 
 def test_codex_doctor_marks_partial_native_hook_install_as_broken(tmp_path: Path) -> None:
     context = _context(tmp_path)
-    config_path = context.workspace_dir / ".codex" / "config.toml"
-    hooks_path = context.workspace_dir / ".codex" / "hooks.json"
+    config_path = context.home_dir / ".codex" / "config.toml"
+    hooks_path = context.home_dir / ".codex" / "hooks.json"
     config_path.parent.mkdir(parents=True, exist_ok=True)
     config_path.write_text("[features]\nhooks = true\n", encoding="utf-8")
     hooks_path.write_text(

--- a/tests/test_guard_phase04_harness_contracts.py
+++ b/tests/test_guard_phase04_harness_contracts.py
@@ -138,7 +138,7 @@ def test_gr096_managed_hook_json_matches_each_harness_schema(tmp_path: Path) -> 
     opencode_manifest = OpenCodeHarnessAdapter().install(context)
     CopilotHarnessAdapter().install(context)
 
-    codex_hooks = _read_codex_hooks(Path(str(codex_manifest["managed_config_path"])))
+    codex_hooks = _read_codex_hooks(Path(str(codex_manifest["managed_hook_config_path"])))
     claude_hooks = json.loads((context.workspace_dir / ".claude" / "settings.local.json").read_text(encoding="utf-8"))[
         "hooks"
     ]
@@ -159,7 +159,7 @@ def test_gr099_managed_hooks_use_lightweight_cli_entrypoints(tmp_path: Path) -> 
     ClaudeCodeHarnessAdapter().install(context)
     CopilotHarnessAdapter().install(context)
 
-    codex_hooks = _read_codex_hooks(Path(str(codex_manifest["managed_config_path"])))
+    codex_hooks = _read_codex_hooks(Path(str(codex_manifest["managed_hook_config_path"])))
     claude_hooks = json.loads((context.workspace_dir / ".claude" / "settings.local.json").read_text(encoding="utf-8"))[
         "hooks"
     ]


### PR DESCRIPTION
## Summary
- Install HOL Guard Codex native hooks in the global `~/.codex/config.toml` even when workspace scope is provided.
- Keep workspace Codex config responsible for MCP proxy entries and workspace install state.
- Remove stale Guard-managed workspace hooks and `hooks.json` files so Codex does not load duplicate hook layers.

## Testing
- `python3 -m pytest tests/test_guard_phase04_harness_contracts.py::test_gr096_managed_hook_json_matches_each_harness_schema tests/test_guard_phase04_harness_contracts.py::test_gr099_managed_hooks_use_lightweight_cli_entrypoints tests/test_guard_codex_install.py tests/test_guard_cli.py::TestGuardCli::test_guard_update_repairs_workspace_codex_install_in_recorded_workspace tests/test_guard_cli.py::TestGuardCli::test_guard_update_repairs_workspace_codex_when_lookup_fails_from_home_scoped_context tests/test_guard_cli.py::TestGuardCli::test_guard_update_repairs_workspace_codex_without_existing_codex_directory tests/test_guard_launch_env.py::test_guard_install_codex_keeps_workspace_override_when_global_server_shares_name tests/test_guard_phase03_remainder.py::test_codex_doctor_marks_partial_native_hook_install_as_broken tests/test_guard_phase04_harness_ux.py::test_gr076b_codex_prompt_secret_read_caps_browser_approval_wait tests/test_guard_runtime.py::test_guard_hook_codex_user_prompt_submit_browser_approval_resumes_prompt -q`
- `python3 -m pytest tests/test_guard_cli.py tests/test_guard_launch_env.py tests/test_guard_phase03_remainder.py tests/test_guard_phase04_harness_contracts.py tests/test_guard_codex_install.py -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/adapters/codex.py tests/test_guard_codex_install.py tests/test_guard_cli.py tests/test_guard_phase03_remainder.py tests/test_guard_phase04_harness_contracts.py`
- Temp install smoke with `PYTHONPATH=src python3 -m codex_plugin_scanner.cli guard install codex --home <tmp-home> --guard-home <tmp-home>/.hol-guard --workspace <tmp-workspace> --json`, verifying four managed hook events live in global config and workspace hooks are removed.
