### PR TITLE
fix(codex): keep managed config global

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -41,6 +41,80 @@ def _read_toml(path: Path) -> dict[str, object]:
         return {}
 
 
+def _artifact_from_guard_proxy_args(
+    *,
+    args: tuple[str, ...],
+    fallback_name: str,
+    fallback_scope: str,
+    fallback_config_path: Path,
+    harness: str,
+) -> GuardArtifact | None:
+    """Expose the wrapped server for status/review without re-wrapping it."""
+
+    parsed = _parse_guard_proxy_args(args)
+    command = parsed.get("command")
+    if command is None:
+        return None
+    name = parsed.get("server-name") or fallback_name
+    source_scope = parsed.get("source-scope") or fallback_scope
+    config_path = parsed.get("config-path") or str(fallback_config_path)
+    transport = parsed.get("transport") or "stdio"
+    server_args = tuple(parsed.get("arg", ()))
+    env_keys = tuple(sorted(parsed.get("server-env-key", ())))
+    return GuardArtifact(
+        artifact_id=f"codex:{source_scope}:{name}",
+        name=name,
+        harness=harness,
+        artifact_type="mcp_server",
+        source_scope=source_scope,
+        config_path=config_path,
+        command=command,
+        args=server_args,
+        transport=transport,
+        metadata={
+            "env": {},
+            "env_keys": list(env_keys),
+            "guard_managed_proxy": True,
+        },
+    )
+
+
+def _parse_guard_proxy_args(args: tuple[str, ...]) -> dict[str, str | tuple[str, ...]]:
+    parsed: dict[str, str | tuple[str, ...]] = {}
+    repeated: dict[str, list[str]] = {"arg": [], "server-env-key": []}
+    index = 0
+    while index < len(args):
+        token = args[index]
+        if not token.startswith("--"):
+            index += 1
+            continue
+        key_value = token[2:]
+        if "=" in key_value:
+            key, value = key_value.split("=", 1)
+            if key in repeated:
+                repeated[key].append(value)
+            else:
+                parsed[key] = value
+            index += 1
+            continue
+        key = key_value
+        if key in repeated:
+            if index + 1 < len(args):
+                repeated[key].append(args[index + 1])
+                index += 2
+            else:
+                index += 1
+            continue
+        if index + 1 < len(args) and not args[index + 1].startswith("--"):
+            parsed[key] = args[index + 1]
+            index += 2
+        else:
+            index += 1
+    for key, values in repeated.items():
+        parsed[key] = tuple(values)
+    return parsed
+
+
 _MANAGED_HOOK_STATUS_MESSAGE = "HOL Guard checking tool action"
 _MANAGED_PROMPT_HOOK_STATUS_MESSAGE = "HOL Guard checking prompt"
 _MANAGED_PERMISSION_HOOK_STATUS_MESSAGE = "HOL Guard checking Codex approval request"
@@ -480,8 +554,6 @@ class CodexHarnessAdapter(HarnessAdapter):
         return "global"
 
     def policy_path(self, context: HarnessContext) -> Path:
-        if context.workspace_dir is not None:
-            return context.workspace_dir / ".codex" / "config.toml"
         return context.home_dir / ".codex" / "config.toml"
 
     @staticmethod
@@ -524,6 +596,15 @@ class CodexHarnessAdapter(HarnessAdapter):
                     command = server_config.get("command")
                     args = tuple(str(value) for value in server_config.get("args", []) if isinstance(value, str))
                     if is_guard_proxy_command(command if isinstance(command, str) else None, args):
+                        proxy_artifact = _artifact_from_guard_proxy_args(
+                            args=args,
+                            fallback_name=name,
+                            fallback_scope=scope,
+                            fallback_config_path=config_path,
+                            harness=self.harness,
+                        )
+                        if proxy_artifact is not None:
+                            artifacts.append(proxy_artifact)
                         continue
                     url = server_config.get("url")
                     env = server_config.get("env")
@@ -639,15 +720,24 @@ class CodexHarnessAdapter(HarnessAdapter):
         features["hooks"] = True
         hook_payload["features"] = features
         self._install_config_hooks(hook_payload, context)
-        existing_workspace_server_names = {
-            name for name, value in mcp_servers.items() if isinstance(name, str) and isinstance(value, dict)
-        }
+        workspace_payload = (
+            read_toml_payload(context.workspace_dir / ".codex" / "config.toml")
+            if context.workspace_dir is not None
+            else {}
+        )
+        workspace_servers = workspace_payload.get("mcp_servers")
+        existing_workspace_server_names = (
+            {name for name, value in workspace_servers.items() if isinstance(name, str) and isinstance(value, dict)}
+            if isinstance(workspace_servers, dict)
+            else set()
+        )
         for server in managed_servers:
             if self._should_skip_workspace_override(
                 context=context,
                 server=server,
                 existing_workspace_server_names=existing_workspace_server_names,
             ):
+                mcp_servers.pop(server.name, None)
                 continue
             mcp_servers[server.name] = self._proxy_server_entry(context, server)
         payload["mcp_servers"] = mcp_servers
@@ -660,6 +750,11 @@ class CodexHarnessAdapter(HarnessAdapter):
             skip_config_path=hook_config_path,
         )
         self._remove_managed_hooks_from_alternate_configs(context, skip_config_path=hook_config_path)
+        self._remove_managed_mcp_servers_from_alternate_configs(
+            context,
+            managed_servers=managed_servers,
+            skip_config_path=target_config_path,
+        )
         hooks_path = self._remove_json_hook_files(context, payloads=hook_payloads)
         shell_guard_paths = self._install_shell_guards(context)
         shim_manifest = install_guard_shim(self.harness, context)
@@ -694,6 +789,11 @@ class CodexHarnessAdapter(HarnessAdapter):
             backup_path.unlink()
         hooks_path = self._remove_hooks(context)
         self._remove_managed_hooks_from_alternate_configs(context, skip_config_path=target_config_path)
+        self._remove_managed_mcp_servers_from_alternate_configs(
+            context,
+            managed_servers=(),
+            skip_config_path=target_config_path,
+        )
         self._uninstall_shell_guard(context)
         shim_manifest = remove_guard_shim(self.harness, context)
         return {
@@ -730,8 +830,6 @@ class CodexHarnessAdapter(HarnessAdapter):
 
     @staticmethod
     def _target_config_path(context: HarnessContext) -> Path:
-        if context.workspace_dir is not None:
-            return context.workspace_dir / ".codex" / "config.toml"
         return context.home_dir / ".codex" / "config.toml"
 
     @staticmethod
@@ -809,6 +907,15 @@ class CodexHarnessAdapter(HarnessAdapter):
             config_payload = read_toml_payload(config_path)
             hooks = config_payload.get("hooks")
             if not isinstance(hooks, dict):
+                features = config_payload.get("features")
+                if isinstance(features, dict):
+                    features.pop("hooks", None)
+                    features.pop("codex_hooks", None)
+                    if features:
+                        config_payload["features"] = features
+                    else:
+                        config_payload.pop("features", None)
+                    write_toml_payload(config_path, config_payload)
                 continue
             cleaned_hooks, managed_removed = _remove_managed_hook_events(hooks)
             if not managed_removed:
@@ -817,6 +924,53 @@ class CodexHarnessAdapter(HarnessAdapter):
                 config_payload["hooks"] = cleaned_hooks
             else:
                 config_payload.pop("hooks", None)
+                features = config_payload.get("features")
+                if isinstance(features, dict):
+                    features.pop("hooks", None)
+                    features.pop("codex_hooks", None)
+                    if not features:
+                        config_payload.pop("features", None)
+            write_toml_payload(config_path, config_payload)
+
+    def _remove_managed_mcp_servers_from_alternate_configs(
+        self,
+        context: HarnessContext,
+        *,
+        managed_servers: tuple[ManagedMcpServer, ...],
+        skip_config_path: Path,
+    ) -> None:
+        managed_names_by_path: dict[Path, set[str]] = {}
+        for server in managed_servers:
+            managed_names_by_path.setdefault(Path(server.config_path), set()).add(server.name)
+        for config_path, _hooks_path in self._config_hook_pairs(context):
+            if config_path == skip_config_path or not config_path.is_file():
+                continue
+            config_payload = read_toml_payload(config_path)
+            mcp_servers = config_payload.get("mcp_servers")
+            if not isinstance(mcp_servers, dict):
+                continue
+            names = managed_names_by_path.get(config_path, set())
+            changed = False
+            cleaned_servers: dict[str, object] = {}
+            for name, server_config in mcp_servers.items():
+                if (
+                    isinstance(name, str)
+                    and name in names
+                    and isinstance(server_config, dict)
+                    and not is_guard_proxy_command(
+                        server_config.get("command") if isinstance(server_config.get("command"), str) else None,
+                        tuple(str(value) for value in server_config.get("args", []) if isinstance(value, str)),
+                    )
+                ):
+                    changed = True
+                    continue
+                cleaned_servers[name] = server_config
+            if not changed:
+                continue
+            if cleaned_servers:
+                config_payload["mcp_servers"] = cleaned_servers
+            else:
+                config_payload.pop("mcp_servers", None)
             write_toml_payload(config_path, config_payload)
 
     def _remove_json_hook_files(

--- a/src/codex_plugin_scanner/guard/adapters/mcp_servers.py
+++ b/src/codex_plugin_scanner/guard/adapters/mcp_servers.py
@@ -157,6 +157,8 @@ def proxy_process_env(server_env: dict[str, str]) -> dict[str, str]:
 def _managed_stdio_server(artifact: GuardArtifact) -> ManagedMcpServer | None:
     if artifact.artifact_type != "mcp_server":
         return None
+    if _bool_metadata(artifact.metadata.get("guard_managed_proxy"), default=False):
+        return None
     if artifact.command is None or not artifact.name.strip():
         return None
     if is_guard_proxy_command(artifact.command, artifact.args):

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -418,9 +418,9 @@ def _codex_backup_repair_target(context: HarnessContext) -> tuple[HarnessContext
 
 
 def _codex_backup_repair_contexts(context: HarnessContext) -> tuple[HarnessContext, ...]:
-    contexts: list[HarnessContext] = [context]
     if context.workspace_dir is not None:
-        return tuple(contexts)
+        return (context,)
+    contexts: list[HarnessContext] = []
     home_dir = context.home_dir.resolve()
     seen_workspaces: set[Path] = set()
     current_dir = Path.cwd().resolve()
@@ -435,6 +435,7 @@ def _codex_backup_repair_contexts(context: HarnessContext) -> tuple[HarnessConte
                 guard_home=context.guard_home,
             )
         )
+    contexts.append(context)
     return tuple(contexts)
 
 

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -4042,7 +4042,7 @@ args = ["-lc", "echo hi"]
         assert "hooks = true" in config_text
         assert "codex_hooks" not in config_text
         assert hooks_payload["PreToolUse"]
-        assert "hooks" not in _read_codex_config(workspace_dir / ".codex" / "config.toml")
+        assert (workspace_dir / ".codex" / "config.toml").exists() is False
 
     def test_guard_update_repairs_malformed_codex_config(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"
@@ -4352,9 +4352,8 @@ args = ["-lc", "echo hi"]
         assert output["status"] == "current"
         assert output["managed_install"]["workspace"] == str(workspace_dir)
         assert output["managed_install"]["active"] is True
-        assert (workspace_dir / ".codex" / "config.toml").is_file()
         assert _read_codex_hooks(home_dir / ".codex" / "config.toml")["PreToolUse"]
-        assert "hooks" not in _read_codex_config(workspace_dir / ".codex" / "config.toml")
+        assert (workspace_dir / ".codex" / "config.toml").exists() is False
 
     def test_guard_doctor_warns_when_codex_native_hooks_are_missing(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -17,6 +17,7 @@ from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.adapters import codex as codex_adapter
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.codex import CodexHarnessAdapter
+from codex_plugin_scanner.guard.adapters.mcp_servers import managed_stdio_servers
 from codex_plugin_scanner.guard.codex_config import dump_toml
 
 
@@ -72,17 +73,17 @@ def test_guard_install_codex_rewrites_workspace_config_with_proxy_entries(tmp_pa
     output = json.loads(capsys.readouterr().out)
     managed_install = output["managed_install"]
     manifest = managed_install["manifest"]
-    config_text = (workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8")
-    hook_config_text = (home_dir / ".codex" / "config.toml").read_text(encoding="utf-8")
-    config_payload = tomllib.loads(hook_config_text)
-    workspace_config = tomllib.loads(config_text)
+    config_text = (home_dir / ".codex" / "config.toml").read_text(encoding="utf-8")
+    config_payload = tomllib.loads(config_text)
+    workspace_config = tomllib.loads((workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
     hooks_path = home_dir / ".codex" / "hooks.json"
     hooks_payload = config_payload["hooks"]
 
     assert rc == 0
     assert managed_install["active"] is True
     assert manifest["mode"] == "codex-mcp-proxy"
-    assert manifest["managed_config_path"] == str(workspace_dir / ".codex" / "config.toml")
+    assert manifest["managed_config_path"] == str(home_dir / ".codex" / "config.toml")
+    assert manifest["managed_hook_config_path"] == str(home_dir / ".codex" / "config.toml")
     assert manifest["managed_hooks_path"] == str(hooks_path)
     assert manifest["managed_shell_guard_path"] == str(home_dir / "managed" / "codex" / "codex-zshenv-guard.zsh")
     assert manifest["managed_shell_guard_paths"] == {
@@ -95,10 +96,12 @@ def test_guard_install_codex_rewrites_workspace_config_with_proxy_entries(tmp_pa
     assert "--server-name" in config_text
     assert "guard" in config_text
     assert "codex-mcp-proxy" in config_text
-    assert "hooks = true" in hook_config_text
-    assert "codex_hooks" not in hook_config_text
+    assert "hooks = true" in config_text
+    assert "codex_hooks" not in config_text
     assert workspace_config["approval_policy"] == "never"
+    assert "features" not in workspace_config
     assert "hooks" not in workspace_config
+    assert "mcp_servers" not in workspace_config
     assert hooks_path.exists() is False
     assert (workspace_dir / ".codex" / "hooks.json").exists() is False
     assert 'API_BASE = "https://hol.org"' in config_text
@@ -137,6 +140,43 @@ def test_guard_install_codex_rewrites_workspace_config_with_proxy_entries(tmp_pa
     assert "fish_preexec" in fish_guard_text
     assert "codex-fish-guard.fish" in fish_conf_text
     assert ".npmrc" in shell_guard_text
+
+
+def test_guard_install_codex_detects_wrapped_servers_without_rewrapping(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+
+    rc = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+
+    detection = CodexHarnessAdapter().detect(
+        HarnessContext(
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+            guard_home=home_dir,
+        )
+    )
+    artifacts = {artifact.artifact_id: artifact for artifact in detection.artifacts}
+
+    assert rc == 0
+    assert "codex:global:global_tools" in artifacts
+    assert "codex:project:workspace_skill" in artifacts
+    assert artifacts["codex:project:workspace_skill"].command == "node"
+    assert artifacts["codex:project:workspace_skill"].args == ("workspace-skill.js",)
+    assert artifacts["codex:project:workspace_skill"].metadata["guard_managed_proxy"] is True
+    assert managed_stdio_servers(detection) == ()
 
 
 def test_guard_install_codex_replaces_existing_zshenv_guard_block(tmp_path, capsys):
@@ -376,7 +416,7 @@ def test_guard_apps_connect_codex_defaults_to_project_scope_when_local_codex_con
     assert rc == 0
     assert output["managed_install"]["active"] is True
     assert output["managed_install"]["workspace"] == str(workspace_dir)
-    assert output["managed_install"]["manifest"]["managed_config_path"] == str(workspace_dir / ".codex" / "config.toml")
+    assert output["managed_install"]["manifest"]["managed_config_path"] == str(home_dir / ".codex" / "config.toml")
 
 
 def test_guard_apps_connect_codex_stays_global_without_local_codex_config(
@@ -423,7 +463,6 @@ def test_guard_uninstall_codex_restores_original_workspace_config(tmp_path, caps
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
-    original_text = (workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8")
 
     install_rc = main(
         [
@@ -455,7 +494,8 @@ def test_guard_uninstall_codex_restores_original_workspace_config(tmp_path, caps
     assert install_rc == 0
     assert uninstall_rc == 0
     assert uninstall_output["managed_install"]["active"] is False
-    assert (workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8") == original_text
+    workspace_payload = tomllib.loads((workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
+    assert workspace_payload == {"approval_policy": "never"}
     assert (workspace_dir / ".codex" / "hooks.json").exists() is False
 
 
@@ -1413,7 +1453,7 @@ args = ["server.py", "--marker-path", "marker.json"]
         ]
     )
     json.loads(capsys.readouterr().out)
-    config_text = (workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8")
+    config_text = (home_dir / ".codex" / "config.toml").read_text(encoding="utf-8")
 
     assert rc == 0
     assert "--arg=--marker-path" in config_text
@@ -1423,7 +1463,6 @@ def test_guard_reinstall_codex_preserves_original_backup(tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_guard_fixture(home_dir, workspace_dir)
-    original_text = (workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8")
 
     first_install = main(
         [
@@ -1470,7 +1509,8 @@ def test_guard_reinstall_codex_preserves_original_backup(tmp_path, capsys):
     assert second_install == 0
     assert uninstall_rc == 0
     assert backup_path.exists() is False
-    assert (workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8") == original_text
+    workspace_payload = tomllib.loads((workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
+    assert workspace_payload == {"approval_policy": "never"}
 
 
 def test_guard_install_codex_preserves_inline_tables_inside_arrays(tmp_path, capsys):
@@ -1504,13 +1544,17 @@ args = ["workspace-skill.js"]
     json.loads(capsys.readouterr().out)
 
     with (workspace_dir / ".codex" / "config.toml").open("rb") as handle:
-        payload = tomllib.load(handle)
+        workspace_payload = tomllib.load(handle)
+    with (home_dir / ".codex" / "config.toml").open("rb") as handle:
+        global_payload = tomllib.load(handle)
 
     assert rc == 0
-    assert payload["profiles"] == [
+    assert workspace_payload["profiles"] == [
         {"name": "default", "mode": "safe"},
         {"name": "strict", "mode": "review"},
     ]
+    assert "mcp_servers" not in workspace_payload
+    assert "workspace_skill" in global_payload["mcp_servers"]
 
 
 def test_guard_reinstall_codex_refreshes_backup_after_completed_uninstall(tmp_path, capsys):
@@ -1590,7 +1634,8 @@ args = ["edited-workspace-skill.js"]
     assert second_uninstall == 0
     assert backup_path == Path(second_output["managed_install"]["manifest"]["backup_path"])
     assert backup_path.exists() is False
-    assert "edited-workspace-skill.js" in (workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8")
+    workspace_payload = tomllib.loads((workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
+    assert workspace_payload == {"approval_policy": "never"}
 
 
 def test_guard_install_codex_proxy_entry_boots_outside_dev_shell_when_pythonpath_is_required(
@@ -1627,7 +1672,7 @@ args = [{str(canary_path)!r}, "--marker-path", {str(marker_path)!r}]
     )
     json.loads(capsys.readouterr().out)
 
-    with (workspace_dir / ".codex" / "config.toml").open("rb") as handle:
+    with (home_dir / ".codex" / "config.toml").open("rb") as handle:
         payload = tomllib.load(handle)
     proxy_entry = payload["mcp_servers"]["danger_lab"]
     proxy_env = dict(proxy_entry.get("env", {}))
@@ -1682,7 +1727,7 @@ env = { PYTHONPATH = "app/src", API_BASE = "https://hol.org" }
     )
     json.loads(capsys.readouterr().out)
 
-    with (workspace_dir / ".codex" / "config.toml").open("rb") as handle:
+    with (home_dir / ".codex" / "config.toml").open("rb") as handle:
         payload = tomllib.load(handle)
     proxy_env = payload["mcp_servers"]["danger_lab"]["env"]
 
@@ -1722,7 +1767,7 @@ env = { PYTHONPATH = "" }
     )
     json.loads(capsys.readouterr().out)
 
-    with (workspace_dir / ".codex" / "config.toml").open("rb") as handle:
+    with (home_dir / ".codex" / "config.toml").open("rb") as handle:
         payload = tomllib.load(handle)
     proxy_env = payload["mcp_servers"]["danger_lab"]["env"]
 

--- a/tests/test_guard_launch_env.py
+++ b/tests/test_guard_launch_env.py
@@ -675,13 +675,15 @@ url = "https://workspace.example/mcp"
         ]
     )
     json.loads(capsys.readouterr().out)
-    with (workspace_dir / ".codex" / "config.toml").open("rb") as handle:
+    with (home_dir / ".codex" / "config.toml").open("rb") as handle:
         payload = tomllib.load(handle)
-    workspace_servers = payload["mcp_servers"]
+    global_servers = payload["mcp_servers"]
+    workspace_payload = tomllib.loads((workspace_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
 
     assert rc == 0
-    assert workspace_servers["shared"]["url"] == "https://workspace.example/mcp"
-    assert workspace_servers["global_only"]["command"] == os.sys.executable
+    assert workspace_payload["mcp_servers"]["shared"]["url"] == "https://workspace.example/mcp"
+    assert "shared" not in global_servers
+    assert global_servers["global_only"]["command"] == os.sys.executable
 
 
 def test_guard_run_launches_hermes_with_guard_overlay_paths(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## Summary
- Move Codex managed hooks and MCP proxy config to the global `~/.codex/config.toml` so workspace config only keeps user-owned settings.
- Strip Guard-managed workspace hook/MCP artifacts during install/update/uninstall while preserving workspace overrides and non-Guard config.
- Keep wrapped MCP servers visible to Guard review/status without re-wrapping managed proxy entries.

## Testing
- `python3 -m ruff format --check src/codex_plugin_scanner/guard/adapters/codex.py src/codex_plugin_scanner/guard/adapters/mcp_servers.py src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_guard_codex_install.py tests/test_guard_cli.py tests/test_guard_launch_env.py tests/test_guard_phase04_harness_contracts.py`
- `python3 -m ruff check src/codex_plugin_scanner/guard/adapters/codex.py src/codex_plugin_scanner/guard/adapters/mcp_servers.py src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_guard_codex_install.py tests/test_guard_cli.py tests/test_guard_launch_env.py tests/test_guard_phase04_harness_contracts.py`
- `uv run --no-sync pytest tests/test_guard_product_flow.py::TestGuardProductFlow::test_guard_status_reports_managed_launch_and_review_queue tests/test_guard_codex_install.py -q`
- `uv run --no-sync pytest tests/test_guard_cli.py tests/test_guard_launch_env.py tests/test_guard_phase03_remainder.py tests/test_guard_phase04_harness_contracts.py tests/test_guard_codex_install.py tests/test_guard_product_flow.py::TestGuardProductFlow::test_guard_status_reports_managed_launch_and_review_queue -q`
- Temp install smoke: global config owns managed Codex hooks/MCP proxies, workspace config retains only user settings, `guard run codex --dry-run` sees wrapped servers and records receipts.
