### PR TITLE
fix: bound headless cloud sync queue (SA048)

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -106,6 +106,13 @@ from .manager import (
     write_guard_daemon_state,
 )
 
+_HEADLESS_CLOUD_SYNC_STATE_LOCK = threading.Lock()
+_HEADLESS_CLOUD_SYNC_IN_FLIGHT: set[str] = set()
+
+
+def _headless_cloud_sync_store_key(store: GuardStore) -> str:
+    return str(store.guard_home.expanduser().resolve())
+
 
 def _build_snapshot_payload(context: HarnessContext) -> dict[str, object]:
     """Return a lightweight snapshot dict including package manager shim coverage."""
@@ -363,9 +370,24 @@ def _queue_headless_cloud_sync(
             "status": "not_configured",
             "message": "Guard Cloud sync is not paired on this machine.",
         }
+    store_key = _headless_cloud_sync_store_key(store)
+    with _HEADLESS_CLOUD_SYNC_STATE_LOCK:
+        if store_key in _HEADLESS_CLOUD_SYNC_IN_FLIGHT:
+            return {
+                "status": "in_progress",
+                "message": "Guard Cloud sync already running.",
+            }
+        _HEADLESS_CLOUD_SYNC_IN_FLIGHT.add(store_key)
+
+    def _run_and_finalize() -> None:
+        try:
+            _run_headless_cloud_sync(store=store)
+        finally:
+            with _HEADLESS_CLOUD_SYNC_STATE_LOCK:
+                _HEADLESS_CLOUD_SYNC_IN_FLIGHT.discard(store_key)
+
     threading.Thread(
-        target=_run_headless_cloud_sync,
-        kwargs={"store": store},
+        target=_run_and_finalize,
         daemon=True,
         name="guard-headless-app-cloud-sync",
     ).start()

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -734,6 +734,79 @@ def test_headless_app_scan_syncs_receipt_to_cloud_when_connected(
     assert sync_calls == [True]
 
 
+def test_headless_app_scan_does_not_spawn_unbounded_cloud_sync_threads(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "cloud-token",
+        "2026-05-23T17:18:00.000Z",
+        workspace_id="workspace-1",
+    )
+    sync_calls: list[int] = []
+    sync_started = threading.Event()
+    sync_release = threading.Event()
+
+    def blocking_sync_receipts(current_store: GuardStore) -> dict[str, object]:
+        assert current_store is store
+        sync_calls.append(1)
+        sync_started.set()
+        sync_release.wait(timeout=5)
+        return {
+            "synced_at": "2026-05-23T17:18:40.061Z",
+            "receipts_stored": 1,
+        }
+
+    monkeypatch.setattr(daemon_server, "sync_receipts", blocking_sync_receipts, raising=False)
+
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        first_status, first_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/apps/test",
+                token=token,
+                payload={
+                    "harness": "opencode",
+                    "operation": "scan",
+                    "workspace_id": "workspace-1",
+                },
+            ),
+        )
+        assert sync_started.wait(timeout=2)
+        second_status, second_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/apps/test",
+                token=token,
+                payload={
+                    "harness": "opencode",
+                    "operation": "scan",
+                    "workspace_id": "workspace-1",
+                },
+            ),
+        )
+    finally:
+        sync_release.set()
+        daemon.stop()
+
+    assert first_status == 200
+    assert first_payload["cloud_sync"] == {
+        "status": "queued",
+        "message": "Guard Cloud sync started.",
+    }
+    assert second_status == 200
+    assert second_payload["cloud_sync"] == {
+        "status": "in_progress",
+        "message": "Guard Cloud sync already running.",
+    }
+    assert len(sync_calls) == 1
+
+
 def test_headless_policy_sync_persists_policy_and_receipt(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)


### PR DESCRIPTION
## Summary
- prevent unbounded Guard Cloud sync thread fanout from repeated headless app handoff requests
- track per-Guard-home in-flight headless sync work and return an in_progress cloud_sync status when a sync is already running
- add regression coverage that reproduces repeated scan requests while sync is blocked and asserts only one sync worker starts

## Validation
- uv run pytest tests/test_guard_headless_daemon_api.py -k does_not_spawn_unbounded_cloud_sync_threads -q
- uv run pytest tests/test_guard_headless_daemon_api.py -q
- uv run ruff check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_headless_daemon_api.py
- uv run ruff format --check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_headless_daemon_api.py