### PR TITLE
fix: clear stale cloud policy on workspace switch

### DIFF
--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -3019,6 +3019,11 @@ class GuardStore:
             self._credential_payload_token_hash(previous_payload) if previous_payload is not None else None
         )
         previous_workspace_id = previous_payload.get("workspace_id") if previous_payload is not None else None
+        previous_workspace = (
+            previous_workspace_id.strip()
+            if isinstance(previous_workspace_id, str) and previous_workspace_id.strip()
+            else None
+        )
         effective_workspace_id = normalized_workspace_id
         can_preserve_workspace = (
             previous_sync_url == sync_url
@@ -3029,6 +3034,11 @@ class GuardStore:
         )
         if effective_workspace_id is None and can_preserve_workspace:
             effective_workspace_id = previous_workspace_id.strip()
+        workspace_changed = (
+            previous_workspace is not None
+            and effective_workspace_id is not None
+            and previous_workspace != effective_workspace_id
+        )
         payload = {
             "sync_url": sync_url,
             "token_ref": self._sync_token_ref,
@@ -3040,7 +3050,10 @@ class GuardStore:
             credentials_changed = True
         else:
             credentials_changed = (
-                previous_sync_url != sync_url or previous_token_hash is None or previous_token_hash != token_hash
+                previous_sync_url != sync_url
+                or previous_token_hash is None
+                or previous_token_hash != token_hash
+                or workspace_changed
             )
         self._secret_store.set_secret(self._sync_token_ref, token)
         connection.execute(

--- a/tests/test_guard_cloud_local_sync.py
+++ b/tests/test_guard_cloud_local_sync.py
@@ -15,7 +15,7 @@ from codex_plugin_scanner.guard.approvals import build_runtime_snapshot
 from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.consumer import evaluate_detection
 from codex_plugin_scanner.guard.edge_events import build_runtime_session_event
-from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
+from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection, PolicyDecision
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 from codex_plugin_scanner.guard.shims import install_package_shims
 from codex_plugin_scanner.guard.store import GuardStore
@@ -124,6 +124,38 @@ def test_sync_credentials_workspace_metadata_update_preserves_cached_policy(tmp_
 
     assert store.get_cloud_workspace_id() == "workspace-alpha"
     assert store.get_sync_payload("policy") == {"policy": "team"}
+
+
+def test_sync_credentials_workspace_switch_clears_stale_cloud_policy_allows(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "token-one",
+        "2026-04-24T00:00:00+00:00",
+        workspace_id="workspace-alpha",
+    )
+    store.set_sync_payload("policy", {"policy": "workspace-alpha"}, "2026-04-24T00:00:00+00:00")
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="harness",
+            action="allow",
+            source="cloud-sync",
+            reason="workspace alpha cloud allow",
+        ),
+        "2026-04-24T00:00:00+00:00",
+    )
+
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "token-one",
+        "2026-04-24T00:01:00+00:00",
+        workspace_id="workspace-beta",
+    )
+
+    assert store.get_cloud_workspace_id() == "workspace-beta"
+    assert store.get_sync_payload("policy") is None
+    assert not any(item["source"] in {"cloud-sync", "team-policy"} for item in store.list_policy_decisions())
 
 
 def test_evaluate_detection_queues_access_graph_snapshot_without_syncing(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary\n- treat a same-token workspace change as a credential boundary in local guard sync state\n- clear cached cloud policy payload and cloud/team policy decisions when workspace switches\n- add regression coverage proving stale cloud allows are purged on workspace switch\n\n## Verification\n- uv run pytest tests/test_guard_cloud_local_sync.py -k "sync_credentials_" -q\n- uv run pytest tests/test_guard_connect_flow.py -k "preserves_existing_workspace_for_same_token_retry or drops_workspace_for_rotated_token_without_workspace" -q\n- uv run ruff check src/codex_plugin_scanner/guard/store.py tests/test_guard_cloud_local_sync.py\n- uv run ruff format --check src/codex_plugin_scanner/guard/store.py tests/test_guard_cloud_local_sync.py