### PR TITLE
fix(sync): harden receipt freshness cursor

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -206,6 +206,8 @@ _SYNC_HTTP_RETRY_TIMEOUT_SECONDS = 120
 _RUNTIME_SYNC_TIMEOUT_SECONDS = 10
 _RUNTIME_SYNC_RETRY_TIMEOUT_SECONDS = 90
 _RECEIPT_SYNC_BATCH_SIZE = 50
+_RECEIPT_SYNC_CURSOR_PAGE_SIZE = 200
+_RECEIPT_SYNC_CURSOR_BACKFILL_ROWS = 200
 _PAIN_SIGNAL_TIMEOUT_SECONDS = 10
 _PAIN_SIGNAL_RETRY_TIMEOUT_SECONDS = 90
 _GUARD_EVENTS_ENDPOINT_UNAVAILABLE_RETRY_HOURS = 24
@@ -827,7 +829,8 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
     if credentials is None:
         raise GuardSyncNotConfiguredError("Guard is not logged in.")
     sync_url = _normalized_receipts_sync_url(str(credentials["sync_url"]))
-    receipts = store.list_receipts(limit=200)
+    prior_receipt_cursor = _receipt_sync_cursor_rowid(store)
+    receipts = _receipt_sync_rows_for_upload(store, cursor_rowid=prior_receipt_cursor)
     inventory = store.list_inventory()
     payload: dict[str, object] = {}
     receipts_stored_total = 0
@@ -838,6 +841,9 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
     team_policy_pack_payload: dict[str, object] | None = None
     remote_decisions: set[PolicyDecision] = set()
     device_id, device_name = _guard_device_metadata(store)
+    local_guard_online_at = _now()
+    sync_context = _receipt_sync_context(store=store, local_guard_online_at=local_guard_online_at)
+    latest_uploaded_rowid: int | None = None
     for receipt_batch in _iter_receipt_sync_batches(receipts):
         body = json.dumps(
             {
@@ -845,7 +851,8 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
                     receipt_batch,
                     device_id=device_id,
                     device_name=device_name,
-                )
+                ),
+                "syncContext": sync_context,
             }
         ).encode("utf-8")
         request = urllib.request.Request(
@@ -869,6 +876,10 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
             raise RuntimeError(_sync_http_error_message(error)) from error
         except OSError as error:
             raise RuntimeError(_sync_url_error_message(error)) from error
+        batch_rowids = [item.get("receipt_rowid") for item in receipt_batch]
+        for rowid in batch_rowids:
+            if isinstance(rowid, int) and (latest_uploaded_rowid is None or rowid > latest_uploaded_rowid):
+                latest_uploaded_rowid = rowid
         batch_receipts_stored = payload.get("receiptsStored")
         if isinstance(batch_receipts_stored, int):
             receipts_stored_total += batch_receipts_stored
@@ -889,6 +900,12 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
             exceptions_payload.extend(item for item in exceptions if isinstance(item, dict))
         remote_decisions.update(_build_remote_policy_decisions(payload))
     now = _sync_timestamp(payload)
+    persisted_cursor_rowid = latest_uploaded_rowid if latest_uploaded_rowid is not None else prior_receipt_cursor
+    _persist_receipt_sync_cursor(
+        store=store,
+        latest_uploaded_rowid=persisted_cursor_rowid,
+        synced_at=now,
+    )
     deduped_advisories = _dedupe_sync_payload_items(advisories_payload)
     deduped_exceptions = _dedupe_sync_payload_items(exceptions_payload)
     advisories_stored = 0
@@ -939,6 +956,13 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
         "remote_policies_stored": remote_policies_stored,
         "pain_signals_uploaded": pain_signals_uploaded,
         "receipts": len(receipts),
+        "receipt_cursor_rowid": persisted_cursor_rowid,
+        "receipt_cursor_backfill": bool(
+            prior_receipt_cursor is not None and len(receipts) > 0 and not any(
+                isinstance(item.get("receipt_rowid"), int) and int(item.get("receipt_rowid")) > prior_receipt_cursor
+                for item in receipts
+            )
+        ),
         "inventory": 0,
         "inventory_tracked": len(inventory),
         "value_metrics": value_metrics,
@@ -1400,6 +1424,11 @@ def sync_runtime_session(
                 "runtime_sessions_visible": 0,
                 "runtime_session_sync_skipped": True,
                 "runtime_session_sync_reason": "runtime_session_endpoint_unavailable",
+                "local_guard_online_at": recorded_at,
+                "runtime_harness": session_payload["harness"],
+                "runtime_surface": session_payload["surface"],
+                "runtime_workspace": session_payload["workspace"],
+                "runtime_device_id": session_payload["deviceId"],
             }
             store.set_sync_payload("runtime_session_summary", summary, recorded_at)
             return summary
@@ -1414,6 +1443,11 @@ def sync_runtime_session(
         "runtime_session_synced_at": synced_at,
         "runtime_session_id": session_payload["sessionId"],
         "runtime_sessions_visible": len(payload.get("items", [])) if isinstance(payload.get("items"), list) else 0,
+        "local_guard_online_at": synced_at,
+        "runtime_harness": session_payload["harness"],
+        "runtime_surface": session_payload["surface"],
+        "runtime_workspace": session_payload["workspace"],
+        "runtime_device_id": session_payload["deviceId"],
     }
     store.set_sync_payload("runtime_session_summary", summary, synced_at)
     workspace_id = store.get_cloud_workspace_id()
@@ -2076,6 +2110,72 @@ def _iter_receipt_sync_batches(receipts: list[dict[str, object]]) -> tuple[list[
         receipts[index : index + _RECEIPT_SYNC_BATCH_SIZE]
         for index in range(0, len(receipts), _RECEIPT_SYNC_BATCH_SIZE)
     )
+
+
+def _receipt_sync_cursor_rowid(store: GuardStore) -> int | None:
+    payload = store.get_sync_payload("receipt_sync_cursor")
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get("last_rowid")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped.isdigit():
+            return int(stripped)
+    return None
+
+
+def _receipt_sync_rows_for_upload(store: GuardStore, *, cursor_rowid: int | None) -> list[dict[str, object]]:
+    if cursor_rowid is None:
+        return store.list_receipts(limit=_RECEIPT_SYNC_CURSOR_PAGE_SIZE)
+    latest_rowid = store.latest_receipt_rowid()
+    if latest_rowid is None:
+        return []
+    if cursor_rowid > latest_rowid:
+        backfill_after = max(latest_rowid - _RECEIPT_SYNC_CURSOR_BACKFILL_ROWS, 0)
+        return store.list_receipts_since_rowid(after_rowid=backfill_after, limit=_RECEIPT_SYNC_CURSOR_PAGE_SIZE)
+    return store.list_receipts_since_rowid(after_rowid=cursor_rowid, limit=_RECEIPT_SYNC_CURSOR_PAGE_SIZE)
+
+
+def _receipt_sync_context(store: GuardStore, *, local_guard_online_at: str) -> dict[str, object]:
+    runtime_summary = store.get_sync_payload("runtime_session_summary")
+    runtime_synced_at = (
+        _optional_string(runtime_summary.get("runtime_session_synced_at"))
+        if isinstance(runtime_summary, dict)
+        else None
+    )
+    prior_summary = store.get_sync_payload("sync_summary")
+    receipt_synced_at = (
+        _optional_string(prior_summary.get("synced_at") or prior_summary.get("syncedAt"))
+        if isinstance(prior_summary, dict)
+        else None
+    )
+    sync_health = "healthy" if runtime_synced_at is not None else "degraded"
+    context: dict[str, object] = {
+        "localGuardOnlineAt": local_guard_online_at,
+        "syncHealth": sync_health,
+    }
+    if runtime_synced_at is not None:
+        context["lastRuntimeSyncAt"] = runtime_synced_at
+    if receipt_synced_at is not None:
+        context["lastReceiptSyncAt"] = receipt_synced_at
+    return context
+
+
+def _persist_receipt_sync_cursor(
+    *,
+    store: GuardStore,
+    latest_uploaded_rowid: int | None,
+    synced_at: str,
+) -> None:
+    if latest_uploaded_rowid is None:
+        return
+    payload = {
+        "last_rowid": latest_uploaded_rowid,
+        "synced_at": synced_at,
+    }
+    store.set_sync_payload("receipt_sync_cursor", payload, synced_at)
 
 
 def _cloud_sync_receipt_payload(

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -880,6 +880,13 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
         for rowid in batch_rowids:
             if isinstance(rowid, int) and (latest_uploaded_rowid is None or rowid > latest_uploaded_rowid):
                 latest_uploaded_rowid = rowid
+        batch_synced_at = _sync_timestamp(payload)
+        if latest_uploaded_rowid is not None:
+            _persist_receipt_sync_cursor(
+                store=store,
+                latest_uploaded_rowid=latest_uploaded_rowid,
+                synced_at=batch_synced_at,
+            )
         batch_receipts_stored = payload.get("receiptsStored")
         if isinstance(batch_receipts_stored, int):
             receipts_stored_total += batch_receipts_stored
@@ -958,7 +965,9 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
         "receipts": len(receipts),
         "receipt_cursor_rowid": persisted_cursor_rowid,
         "receipt_cursor_backfill": bool(
-            prior_receipt_cursor is not None and len(receipts) > 0 and not any(
+            prior_receipt_cursor is not None
+            and len(receipts) > 0
+            and not any(
                 isinstance(item.get("receipt_rowid"), int) and int(item.get("receipt_rowid")) > prior_receipt_cursor
                 for item in receipts
             )
@@ -2117,7 +2126,7 @@ def _receipt_sync_cursor_rowid(store: GuardStore) -> int | None:
     if not isinstance(payload, dict):
         return None
     value = payload.get("last_rowid")
-    if isinstance(value, int):
+    if isinstance(value, int) and not isinstance(value, bool):
         return value
     if isinstance(value, str):
         stripped = value.strip()

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2156,7 +2156,7 @@ def _receipt_sync_context(store: GuardStore, *, local_guard_online_at: str) -> d
     )
     prior_summary = store.get_sync_payload("sync_summary")
     receipt_synced_at = (
-        _optional_string(prior_summary.get("synced_at") or prior_summary.get("syncedAt"))
+        _optional_string(prior_summary.get("synced_at")) or _optional_string(prior_summary.get("syncedAt"))
         if isinstance(prior_summary, dict)
         else None
     )

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1583,8 +1583,9 @@ class GuardStore:
     def list_receipts(self, limit: int = 50, harness: str | None = None) -> list[dict[str, object]]:
         if harness is not None:
             query = """
-                select receipt_id, harness, artifact_id, artifact_hash, policy_decision, capabilities_summary,
-                        changed_capabilities_json,
+                select rowid as receipt_rowid, receipt_id, harness, artifact_id, artifact_hash, policy_decision,
+                       capabilities_summary,
+                       changed_capabilities_json,
                        provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json,
                        diff_summary, approval_source, timestamp
                 from runtime_receipts
@@ -1595,8 +1596,9 @@ class GuardStore:
             params: tuple[object, ...] = (harness, limit)
         else:
             query = """
-                select receipt_id, harness, artifact_id, artifact_hash, policy_decision, capabilities_summary,
-                        changed_capabilities_json,
+                select rowid as receipt_rowid, receipt_id, harness, artifact_id, artifact_hash, policy_decision,
+                       capabilities_summary,
+                       changed_capabilities_json,
                        provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json,
                        diff_summary, approval_source, timestamp
                 from runtime_receipts
@@ -1608,6 +1610,7 @@ class GuardStore:
             rows = connection.execute(query, params).fetchall()
         return [
             {
+                "receipt_rowid": int(row["receipt_rowid"]),
                 "receipt_id": str(row["receipt_id"]),
                 "harness": str(row["harness"]),
                 "artifact_id": str(row["artifact_id"]),
@@ -1626,6 +1629,76 @@ class GuardStore:
             }
             for row in rows
         ]
+
+    def list_receipts_since_rowid(
+        self,
+        *,
+        after_rowid: int | None,
+        limit: int = 200,
+        harness: str | None = None,
+    ) -> list[dict[str, object]]:
+        if harness is not None:
+            query = """
+                select rowid as receipt_rowid, receipt_id, harness, artifact_id, artifact_hash, policy_decision,
+                       capabilities_summary, changed_capabilities_json, provenance_summary, user_override,
+                       artifact_name, source_scope, scanner_evidence_json, diff_summary, approval_source, timestamp
+                from runtime_receipts
+                where rowid > ? and harness = ?
+                order by rowid asc
+                limit ?
+                """
+            params: tuple[object, ...] = (after_rowid or 0, harness, limit)
+        else:
+            query = """
+                select rowid as receipt_rowid, receipt_id, harness, artifact_id, artifact_hash, policy_decision,
+                       capabilities_summary, changed_capabilities_json, provenance_summary, user_override,
+                       artifact_name, source_scope, scanner_evidence_json, diff_summary, approval_source, timestamp
+                from runtime_receipts
+                where rowid > ?
+                order by rowid asc
+                limit ?
+                """
+            params = (after_rowid or 0, limit)
+        with self._connect() as connection:
+            rows = connection.execute(query, params).fetchall()
+        return [
+            {
+                "receipt_rowid": int(row["receipt_rowid"]),
+                "receipt_id": str(row["receipt_id"]),
+                "harness": str(row["harness"]),
+                "artifact_id": str(row["artifact_id"]),
+                "artifact_hash": str(row["artifact_hash"]),
+                "policy_decision": str(row["policy_decision"]),
+                "capabilities_summary": str(row["capabilities_summary"]),
+                "changed_capabilities": json.loads(str(row["changed_capabilities_json"])),
+                "provenance_summary": str(row["provenance_summary"]),
+                "user_override": row["user_override"],
+                "artifact_name": row["artifact_name"],
+                "source_scope": row["source_scope"],
+                "scanner_evidence": _json_object_list(row["scanner_evidence_json"]),
+                "diff_summary": row["diff_summary"],
+                "approval_source": row["approval_source"],
+                "timestamp": str(row["timestamp"]),
+            }
+            for row in rows
+        ]
+
+    def latest_receipt_rowid(self, *, harness: str | None = None) -> int | None:
+        query = "select max(rowid) as max_rowid from runtime_receipts"
+        params: tuple[object, ...] = ()
+        if harness is not None:
+            query += " where harness = ?"
+            params = (harness,)
+        with self._connect() as connection:
+            row = connection.execute(query, params).fetchone()
+        if row is None:
+            return None
+        max_rowid = row["max_rowid"]
+        if isinstance(max_rowid, int):
+            return max_rowid
+        if isinstance(max_rowid, str) and max_rowid.isdigit():
+            return int(max_rowid)
+        return None
 
     def get_receipt(self, receipt_id: str) -> dict[str, object] | None:
         with self._connect() as connection:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1647,7 +1647,11 @@ class GuardStore:
                 order by rowid asc
                 limit ?
                 """
-            params: tuple[object, ...] = (after_rowid or 0, harness, limit)
+            params: tuple[object, ...] = (
+                after_rowid if after_rowid is not None else 0,
+                harness,
+                limit,
+            )
         else:
             query = """
                 select rowid as receipt_rowid, receipt_id, harness, artifact_id, artifact_hash, policy_decision,
@@ -1658,7 +1662,7 @@ class GuardStore:
                 order by rowid asc
                 limit ?
                 """
-            params = (after_rowid or 0, limit)
+            params = (after_rowid if after_rowid is not None else 0, limit)
         with self._connect() as connection:
             rows = connection.execute(query, params).fetchall()
         return [

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -15046,6 +15046,172 @@ def test_sync_receipts_batches_large_local_history(tmp_path, monkeypatch):
     assert payload["receipts_stored"] == 65
 
 
+def test_sync_receipts_uses_rowid_cursor_and_sync_context(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "guard-live-token",
+        "2026-04-19T00:00:00+00:00",
+    )
+    for index in range(3):
+        store.add_receipt(
+            GuardReceipt(
+                receipt_id=f"receipt-{index}",
+                timestamp="2026-04-19T00:00:00+00:00",
+                harness="codex",
+                artifact_id=f"artifact-{index}",
+                artifact_hash=f"sha256:{index:064x}",
+                policy_decision="review",
+                capabilities_summary="requests file write",
+                changed_capabilities=("fs_write",),
+                provenance_summary="local codex workspace",
+                artifact_name=f"artifact-{index}",
+                source_scope="workspace",
+            )
+        )
+
+    sync_payloads: list[dict[str, object]] = []
+
+    class _Response:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(self._payload).encode("utf-8")
+
+    def _fake_urlopen(request, timeout):
+        payload = json.loads(request.data.decode("utf-8"))
+        if request.full_url.endswith("/api/v1/guard/events"):
+            return _Response({"statuses": []})
+        sync_payloads.append(payload)
+        return _Response(
+            {
+                "syncedAt": "2026-04-19T00:00:10+00:00",
+                "receiptsStored": len(payload["receipts"]),
+                "advisories": [],
+                "policy": {},
+                "alertPreferences": {},
+                "teamPolicyPack": {},
+                "exceptions": [],
+            }
+        )
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+
+    first_summary = guard_runner_module.sync_receipts(store)
+    cursor_payload = store.get_sync_payload("receipt_sync_cursor")
+    assert isinstance(cursor_payload, dict)
+    first_cursor_rowid = cursor_payload["last_rowid"]
+    assert isinstance(first_cursor_rowid, int)
+    assert first_summary["receipts"] == 3
+    assert "syncContext" in sync_payloads[0]
+    assert sync_payloads[0]["syncContext"]["localGuardOnlineAt"]
+
+    store.add_receipt(
+        GuardReceipt(
+            receipt_id="receipt-late",
+            timestamp="2026-04-18T23:59:00+00:00",
+            harness="codex",
+            artifact_id="artifact-late",
+            artifact_hash="sha256:late",
+            policy_decision="review",
+            capabilities_summary="late insert",
+            changed_capabilities=("fs_write",),
+            provenance_summary="local codex workspace",
+            artifact_name="artifact-late",
+            source_scope="workspace",
+        )
+    )
+
+    second_summary = guard_runner_module.sync_receipts(store)
+    assert second_summary["receipts"] == 1
+    assert len(sync_payloads) == 2
+    assert sync_payloads[1]["receipts"][0]["receiptId"] == "receipt-late"
+    assert sync_payloads[1]["syncContext"]["lastReceiptSyncAt"] == "2026-04-19T00:00:10+00:00"
+    latest_cursor = store.get_sync_payload("receipt_sync_cursor")
+    assert isinstance(latest_cursor, dict)
+    assert isinstance(latest_cursor["last_rowid"], int)
+    assert latest_cursor["last_rowid"] > first_cursor_rowid
+
+
+def test_sync_receipts_backfills_when_cursor_is_ahead_of_local_rows(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "guard-live-token",
+        "2026-04-19T00:00:00+00:00",
+    )
+    for index in range(2):
+        store.add_receipt(
+            GuardReceipt(
+                receipt_id=f"receipt-{index}",
+                timestamp="2026-04-19T00:00:00+00:00",
+                harness="codex",
+                artifact_id=f"artifact-{index}",
+                artifact_hash=f"sha256:{index:064x}",
+                policy_decision="review",
+                capabilities_summary="requests file write",
+                changed_capabilities=("fs_write",),
+                provenance_summary="local codex workspace",
+                artifact_name=f"artifact-{index}",
+                source_scope="workspace",
+            )
+        )
+    store.set_sync_payload(
+        "receipt_sync_cursor",
+        {"last_rowid": 9999, "synced_at": "2026-04-19T00:00:05+00:00"},
+        "2026-04-19T00:00:05+00:00",
+    )
+
+    uploaded_sizes: list[int] = []
+
+    class _Response:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(self._payload).encode("utf-8")
+
+    def _fake_urlopen(request, timeout):
+        payload = json.loads(request.data.decode("utf-8"))
+        if request.full_url.endswith("/api/v1/guard/events"):
+            return _Response({"statuses": []})
+        uploaded_sizes.append(len(payload["receipts"]))
+        return _Response(
+            {
+                "syncedAt": "2026-04-19T00:00:10+00:00",
+                "receiptsStored": len(payload["receipts"]),
+                "advisories": [],
+                "policy": {},
+                "alertPreferences": {},
+                "teamPolicyPack": {},
+                "exceptions": [],
+            }
+        )
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+
+    summary = guard_runner_module.sync_receipts(store)
+
+    assert uploaded_sizes == [2]
+    assert summary["receipt_cursor_backfill"] is True
+    cursor_payload = store.get_sync_payload("receipt_sync_cursor")
+    assert isinstance(cursor_payload, dict)
+    assert cursor_payload["last_rowid"] == store.latest_receipt_rowid()
+
+
 def test_sync_receipts_marks_latest_connect_first_sync_succeeded(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
     connect_request = store.create_guard_connect_request(


### PR DESCRIPTION
## Summary
- add receipt rowid cursor/backfill support in hol-guard sync path to avoid stale `capturedAt`-only batching and recover when cursor drifts
- send `syncContext` heartbeat metadata with receipt sync requests and persist receipt cursor state for subsequent sync cycles
- extend runtime/session summary freshness identity fields and add focused runtime tests for cursor progression and drift-backfill behavior

## Testing
- `ruff check src tests/test_guard_runtime.py`
- `pytest -q tests/test_guard_runtime.py`
