### PR TITLE
fix(codex): avoid stale approval daemon ports

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -160,13 +160,16 @@ def _hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
     guard_args = [
         "guard",
         "hook",
-        "--guard-home",
-        str(context.guard_home),
         "--harness",
         "codex",
     ]
     if context.home_dir.resolve() != Path.home().resolve():
         guard_args.extend(["--home", str(context.home_dir)])
+    if (
+        context.home_dir.resolve() != Path.home().resolve()
+        and context.guard_home.resolve() != context.home_dir.resolve()
+    ):
+        guard_args.extend(["--guard-home", str(context.guard_home)])
     if context.workspace_dir is not None:
         guard_args.extend(["--workspace", str(context.workspace_dir)])
     return (sys.executable, "-m", "codex_plugin_scanner.cli", *guard_args)

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -157,19 +157,18 @@ def _strict_json_object(path: Path, *, label: str) -> dict[str, object]:
 
 
 def _hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
+    resolved_home = context.home_dir.resolve()
+    resolved_user_home = Path.home().resolve()
     guard_args = [
         "guard",
         "hook",
         "--harness",
         "codex",
     ]
-    if context.home_dir.resolve() != Path.home().resolve():
+    if resolved_home != resolved_user_home:
         guard_args.extend(["--home", str(context.home_dir)])
-    if (
-        context.home_dir.resolve() != Path.home().resolve()
-        and context.guard_home.resolve() != context.home_dir.resolve()
-    ):
-        guard_args.extend(["--guard-home", str(context.guard_home)])
+        if context.guard_home.resolve() != resolved_home:
+            guard_args.extend(["--guard-home", str(context.guard_home)])
     if context.workspace_dir is not None:
         guard_args.extend(["--workspace", str(context.workspace_dir)])
     return (sys.executable, "-m", "codex_plugin_scanner.cli", *guard_args)

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -133,11 +133,7 @@ def load_guard_daemon_url(guard_home: Path) -> str | None:
     if not isinstance(port, int):
         return None
     pid = payload.get("pid")
-    if (
-        not isinstance(pid, int)
-        or pid <= 0
-        or not _guard_daemon_pid_is_running(pid)
-    ):
+    if not isinstance(pid, int) or pid <= 0 or not _guard_daemon_pid_is_running(pid):
         return None
     url = f"http://127.0.0.1:{port}"
     try:

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -137,13 +137,17 @@ def load_guard_daemon_url(guard_home: Path) -> str | None:
         not isinstance(pid, int)
         or pid <= 0
         or not _guard_daemon_pid_is_running(pid)
-        or not _guard_daemon_pid_matches_command(pid, expected_guard_home=guard_home)
     ):
         return None
     url = f"http://127.0.0.1:{port}"
     try:
         with urllib.request.urlopen(f"{url}/healthz", timeout=1) as response:
-            if response.status == 200 and _healthz_payload_is_current(response.read().decode("utf-8")):
+            raw_payload = response.read().decode("utf-8")
+            if response.status != 200 or not _healthz_payload_is_current(raw_payload):
+                return None
+            if _healthz_payload_matches_guard_home(raw_payload, guard_home):
+                return url
+            if _guard_daemon_pid_matches_command(pid, expected_guard_home=guard_home):
                 return url
     except (OSError, ValueError, urllib.error.URLError):
         return None
@@ -827,3 +831,16 @@ def _healthz_payload_is_current(raw_payload: str) -> bool:
         return False
     table_names = {table for table in tables if isinstance(table, str)}
     return REQUIRED_DAEMON_TABLES.issubset(table_names)
+
+
+def _healthz_payload_matches_guard_home(raw_payload: str, guard_home: Path) -> bool:
+    payload = json.loads(raw_payload)
+    if not isinstance(payload, dict):
+        return False
+    payload_guard_home = payload.get("guard_home")
+    if not isinstance(payload_guard_home, str) or not payload_guard_home.strip():
+        return False
+    try:
+        return Path(payload_guard_home).resolve() == guard_home.resolve()
+    except OSError:
+        return Path(payload_guard_home) == guard_home

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -132,6 +132,14 @@ def load_guard_daemon_url(guard_home: Path) -> str | None:
     port = payload.get("port")
     if not isinstance(port, int):
         return None
+    pid = payload.get("pid")
+    if (
+        not isinstance(pid, int)
+        or pid <= 0
+        or not _guard_daemon_pid_is_running(pid)
+        or not _guard_daemon_pid_matches_command(pid, expected_guard_home=guard_home)
+    ):
+        return None
     url = f"http://127.0.0.1:{port}"
     try:
         with urllib.request.urlopen(f"{url}/healthz", timeout=1) as response:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -442,6 +442,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     "tables": store.list_table_names(),
                     "compatibility_version": GUARD_DAEMON_COMPATIBILITY_VERSION,
                     "package_version": __version__,
+                    "guard_home": str(store.guard_home.resolve()),
                 }
             )
             return

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -1155,11 +1155,18 @@ class TestGuardApprovals:
             "_load_state",
             lambda _guard_home: {
                 "port": 5530,
+                "pid": 12345,
                 "auth_token": "token-123",
                 "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
                 "source_root": daemon_manager_module._current_guard_daemon_source_root(),
                 "runtime_fingerprint": daemon_manager_module._current_guard_daemon_runtime_fingerprint(),
             },
+        )
+        monkeypatch.setattr(daemon_manager_module, "_guard_daemon_pid_is_running", lambda _pid: True)
+        monkeypatch.setattr(
+            daemon_manager_module,
+            "_guard_daemon_pid_matches_command",
+            lambda _pid, expected_guard_home=None: True,
         )
         monkeypatch.setattr(
             daemon_manager_module.urllib.request,
@@ -1195,11 +1202,18 @@ class TestGuardApprovals:
             "_load_state",
             lambda _guard_home: {
                 "port": 5530,
+                "pid": 12345,
                 "auth_token": "token-123",
                 "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
                 "source_root": daemon_manager_module._current_guard_daemon_source_root(),
                 "runtime_fingerprint": daemon_manager_module._current_guard_daemon_runtime_fingerprint(),
             },
+        )
+        monkeypatch.setattr(daemon_manager_module, "_guard_daemon_pid_is_running", lambda _pid: True)
+        monkeypatch.setattr(
+            daemon_manager_module,
+            "_guard_daemon_pid_matches_command",
+            lambda _pid, expected_guard_home=None: True,
         )
         monkeypatch.setattr(
             daemon_manager_module.urllib.request,

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -53,6 +53,27 @@ env = { API_BASE = "https://hol.org", FEATURE_FLAG = "1" }
     )
 
 
+def test_guard_codex_hook_command_does_not_pin_custom_guard_home_in_real_global_config(
+    tmp_path,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    stale_guard_home = tmp_path / "pytest-stale-guard-home"
+    monkeypatch.setattr(codex_adapter.Path, "home", lambda: home_dir)
+
+    command = codex_adapter._hook_command(
+        HarnessContext(
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+            guard_home=stale_guard_home,
+        )
+    )
+
+    assert "--guard-home" not in shlex.split(command)
+    assert str(stale_guard_home) not in command
+
+
 def test_guard_install_codex_rewrites_workspace_config_with_proxy_entries(tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_daemon_manager.py
+++ b/tests/test_guard_daemon_manager.py
@@ -41,7 +41,27 @@ def test_clear_guard_daemon_state_preserves_auth_token_file(tmp_path):
 
 def test_load_guard_daemon_url_rejects_live_port_when_state_pid_is_not_guard_daemon(tmp_path, monkeypatch):
     guard_home = tmp_path / "guard-home"
+    other_guard_home = tmp_path / "other-guard-home"
     daemon_manager_module.write_guard_daemon_state(guard_home, 4833, "secret-token")
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self) -> FakeResponse:
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "ok": True,
+                    "tables": ["guard_connect_states"],
+                    "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
+                    "guard_home": str(other_guard_home),
+                }
+            ).encode("utf-8")
 
     monkeypatch.setattr(daemon_manager_module, "_guard_daemon_pid_is_running", lambda _pid: True)
     monkeypatch.setattr(
@@ -52,10 +72,48 @@ def test_load_guard_daemon_url_rejects_live_port_when_state_pid_is_not_guard_dae
     monkeypatch.setattr(
         daemon_manager_module.urllib.request,
         "urlopen",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("stale pid must not be probed")),
+        lambda *_args, **_kwargs: FakeResponse(),
     )
 
     assert daemon_manager_module.load_guard_daemon_url(guard_home) is None
+
+
+def test_load_guard_daemon_url_accepts_matching_healthz_guard_home_for_in_process_daemon(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    daemon_manager_module.write_guard_daemon_state(guard_home, 4833, "secret-token")
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self) -> FakeResponse:
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "ok": True,
+                    "tables": ["guard_connect_states"],
+                    "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
+                    "guard_home": str(guard_home),
+                }
+            ).encode("utf-8")
+
+    monkeypatch.setattr(daemon_manager_module, "_guard_daemon_pid_is_running", lambda _pid: True)
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "_guard_daemon_pid_matches_command",
+        lambda _pid, expected_guard_home=None: False,
+    )
+    monkeypatch.setattr(
+        daemon_manager_module.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: FakeResponse(),
+    )
+
+    assert daemon_manager_module.load_guard_daemon_url(guard_home) == "http://127.0.0.1:4833"
 
 
 def test_write_guard_daemon_state_hardens_permissions_on_open_descriptor(tmp_path, monkeypatch):

--- a/tests/test_guard_daemon_manager.py
+++ b/tests/test_guard_daemon_manager.py
@@ -39,6 +39,25 @@ def test_clear_guard_daemon_state_preserves_auth_token_file(tmp_path):
     assert daemon_manager_module._auth_token_path(guard_home).read_text(encoding="utf-8") == "secret-token"
 
 
+def test_load_guard_daemon_url_rejects_live_port_when_state_pid_is_not_guard_daemon(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    daemon_manager_module.write_guard_daemon_state(guard_home, 4833, "secret-token")
+
+    monkeypatch.setattr(daemon_manager_module, "_guard_daemon_pid_is_running", lambda _pid: True)
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "_guard_daemon_pid_matches_command",
+        lambda _pid, expected_guard_home=None: False,
+    )
+    monkeypatch.setattr(
+        daemon_manager_module.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("stale pid must not be probed")),
+    )
+
+    assert daemon_manager_module.load_guard_daemon_url(guard_home) is None
+
+
 def test_write_guard_daemon_state_hardens_permissions_on_open_descriptor(tmp_path, monkeypatch):
     guard_home = tmp_path / "guard-home"
     fchmod_calls: list[tuple[int, int]] = []

--- a/tests/test_guard_daemon_registry.py
+++ b/tests/test_guard_daemon_registry.py
@@ -119,3 +119,11 @@ class TestHealthzEndpoint:
             assert "tables" in payload
         finally:
             server.stop()
+
+    def test_healthz_includes_guard_home_for_daemon_identity(self, tmp_path: Path) -> None:
+        url, server = self._start_server(tmp_path)
+        try:
+            payload = self._get_healthz(url)
+            assert payload["guard_home"] == str(server.store.guard_home.resolve())
+        finally:
+            server.stop()

--- a/tests/test_guard_daemon_registry.py
+++ b/tests/test_guard_daemon_registry.py
@@ -124,6 +124,6 @@ class TestHealthzEndpoint:
         url, server = self._start_server(tmp_path)
         try:
             payload = self._get_healthz(url)
-            assert payload["guard_home"] == str(server.store.guard_home.resolve())
+            assert payload["guard_home"] == str((tmp_path / "guard-home").resolve())
         finally:
             server.stop()


### PR DESCRIPTION
## Summary
- Stop Codex global hook commands from pinning custom or temporary Guard homes, so approval links resolve against the current default Guard daemon instead of stale pytest/worktree daemon state.
- Harden daemon URL loading so a state file is trusted only when its recorded PID is still a Guard daemon for that Guard home.

## Testing
- Local pytest/ruff commands were blocked by the currently loaded stale Codex hook, which reproduced the bad `127.0.0.1:4833` approval URL before this fix can be installed into the running session.
- Added regression coverage in `tests/test_guard_codex_install.py` and `tests/test_guard_daemon_manager.py`; CI will run the full suite on PR.
