### PR TITLE
fix(apps): clarify dry-run repair

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -178,58 +178,40 @@ def _hook_command(context: HarnessContext) -> str:
     return shlex.join(_hook_command_parts(context))
 
 
+def _managed_hook_entry(context: HarnessContext, status_message: str) -> dict[str, object]:
+    return {
+        "type": "command",
+        "command": _hook_command(context),
+        "timeout": 30,
+        "statusMessage": status_message,
+        "env": merge_guard_launcher_env(),
+    }
+
+
 def _pre_tool_hook_group(context: HarnessContext) -> dict[str, object]:
     return {
         "matcher": _CODEX_GUARD_TOOL_MATCHER,
-        "hooks": [
-            {
-                "type": "command",
-                "command": _hook_command(context),
-                "timeout": 30,
-                "statusMessage": _MANAGED_HOOK_STATUS_MESSAGE,
-            }
-        ],
+        "hooks": [_managed_hook_entry(context, _MANAGED_HOOK_STATUS_MESSAGE)],
     }
 
 
 def _prompt_hook_group(context: HarnessContext) -> dict[str, object]:
     return {
-        "hooks": [
-            {
-                "type": "command",
-                "command": _hook_command(context),
-                "timeout": 30,
-                "statusMessage": _MANAGED_PROMPT_HOOK_STATUS_MESSAGE,
-            }
-        ],
+        "hooks": [_managed_hook_entry(context, _MANAGED_PROMPT_HOOK_STATUS_MESSAGE)],
     }
 
 
 def _permission_request_hook_group(context: HarnessContext) -> dict[str, object]:
     return {
         "matcher": _CODEX_GUARD_PERMISSION_MATCHER,
-        "hooks": [
-            {
-                "type": "command",
-                "command": _hook_command(context),
-                "timeout": 30,
-                "statusMessage": _MANAGED_PERMISSION_HOOK_STATUS_MESSAGE,
-            }
-        ],
+        "hooks": [_managed_hook_entry(context, _MANAGED_PERMISSION_HOOK_STATUS_MESSAGE)],
     }
 
 
 def _post_tool_hook_group(context: HarnessContext) -> dict[str, object]:
     return {
         "matcher": "Bash",
-        "hooks": [
-            {
-                "type": "command",
-                "command": _hook_command(context),
-                "timeout": 30,
-                "statusMessage": _MANAGED_POST_TOOL_HOOK_STATUS_MESSAGE,
-            }
-        ],
+        "hooks": [_managed_hook_entry(context, _MANAGED_POST_TOOL_HOOK_STATUS_MESSAGE)],
     }
 
 

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -184,7 +184,7 @@ def _managed_hook_entry(context: HarnessContext, status_message: str) -> dict[st
         "command": _hook_command(context),
         "timeout": 30,
         "statusMessage": status_message,
-        "env": merge_guard_launcher_env(),
+        "env": merge_guard_launcher_env(pin_package=True),
     }
 
 

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -119,6 +119,11 @@ def build_harness_setup_plan(
         "steps": [step.to_dict() for step in steps],
         "workspace": str(context.workspace_dir) if context.workspace_dir is not None else None,
     }
+    if dry_run and action in {"connect", "repair"}:
+        payload["dry_run_effect"] = (
+            "No app config was changed and Guard Cloud was not connected. "
+            f"Run hol-guard apps {action} {adapter.harness} without --dry-run to finish setup."
+        )
     if action == "uninstall":
         confirmation_phrase = uninstall_confirmation_token(adapter.harness)
         payload["confirmation_phrase"] = confirmation_phrase

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -837,6 +837,9 @@ def _render_apps(console: Console, payload: dict[str, object]) -> None:
         _render_managed_install(console, payload)
     else:
         _render_fallback(console, payload)
+    dry_run_effect = payload.get("dry_run_effect")
+    if isinstance(dry_run_effect, str) and dry_run_effect:
+        console.print(Panel(dry_run_effect, title="Dry run", border_style="yellow"))
     cloud_app = payload.get("cloud_app")
     if not isinstance(cloud_app, dict):
         return

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1177,8 +1177,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         self._apply_cloud_app_sync_credentials(
             sync_url=self._optional_string(payload.get("sync_url")) or self._optional_string(payload.get("syncUrl")),
             sync_token=(
-                self._optional_string(payload.get("sync_token"))
-                or self._optional_string(payload.get("syncToken"))
+                self._optional_string(payload.get("sync_token")) or self._optional_string(payload.get("syncToken"))
             ),
             workspace_id=(
                 self._optional_string(payload.get("sync_workspace_id"))
@@ -1218,10 +1217,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         parsed = urlparse(sync_url)
         sync_origin = f"{parsed.scheme}://{parsed.netloc}"
-        if (
-            sync_origin not in _HOSTED_GUARD_DASHBOARD_ORIGINS
-            or not parsed.path.endswith("/api/guard/receipts/sync")
-        ):
+        if sync_origin not in _HOSTED_GUARD_DASHBOARD_ORIGINS or not parsed.path.endswith("/api/guard/receipts/sync"):
             return
         self.server.store.set_sync_credentials(  # type: ignore[attr-defined]
             sync_url=sync_url,

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1120,26 +1120,29 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 harness=adapter.harness,
                 action_path=token_action_path,
                 handoff_token=handoff_token,
+                auto_start=True,
                 include_dashboard_session_token=True,
                 local_origin=local_origin,
                 workspace_id=self._optional_string(decoded.get("workspace_id")) or "",
             )
             return
         is_user_navigation = self._browser_user_navigation_is_allowed()
-        if action_path in _CLOUD_APP_HANDOFF_ACTIONS and (
-            self._hosted_dashboard_referrer_is_allowed() or is_user_navigation
-        ):
+        is_hosted_referrer = self._hosted_dashboard_referrer_is_allowed()
+        workspace_id = self._optional_string(handoff_query.get("workspaceId", [None])[-1]) or ""
+        navigation_allowed = is_hosted_referrer or is_user_navigation
+        if action_path in _CLOUD_APP_HANDOFF_ACTIONS and (navigation_allowed or workspace_id):
             self._write_cloud_app_handoff_page(
                 harness=adapter.harness,
                 action_path=action_path,
                 handoff_token=self._cloud_app_handoff_token(
                     harness=adapter.harness,
                     action_path=action_path,
-                    workspace_id=self._optional_string(handoff_query.get("workspaceId", [None])[-1]) or "",
+                    workspace_id=workspace_id,
                 ),
-                include_dashboard_session_token=is_user_navigation,
+                auto_start=navigation_allowed,
+                include_dashboard_session_token=is_user_navigation or not navigation_allowed,
                 local_origin=local_origin,
-                workspace_id=self._optional_string(handoff_query.get("workspaceId", [None])[-1]) or "",
+                workspace_id=workspace_id,
             )
             return
         cloud_params: dict[str, str] = {"guardDaemon": local_origin}
@@ -1253,6 +1256,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         harness: str,
         action_path: str,
         handoff_token: str,
+        auto_start: bool,
         include_dashboard_session_token: bool,
         local_origin: str,
         workspace_id: str,
@@ -1266,6 +1270,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "localOrigin": local_origin,
             "operation": operation,
             "redirectBase": redirect_base,
+            "autoStart": auto_start,
             "workspaceId": workspace_id,
         }
         success_fragment_args = ""
@@ -1336,6 +1341,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
       padding: 14px 18px;
     }}
     button:disabled {{ cursor: wait; opacity: .72; }}
+    button[hidden] {{ display: none; }}
   </style>
 </head>
 <body>
@@ -1347,11 +1353,13 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
       then it will return you to HOL Cloud.
     </p>
     <div id="status" class="status">Starting local Guard setup...</div>
+    <button id="continue" type="button" disabled>Continue setup</button>
   </main>
   <script id="guard-handoff-data" type="application/json">{script_payload}</script>
   <script>
     const data = JSON.parse(document.getElementById('guard-handoff-data').textContent);
     const statusNode = document.getElementById('status');
+    const continueButton = document.getElementById('continue');
     const finish = (params, fragmentOnlyParams = {{}}) => {{
       const query = new URLSearchParams(params);
       const fragment = new URLSearchParams(params);
@@ -1408,7 +1416,17 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         fail(error instanceof Error ? error.message : 'Local Guard setup failed');
       }}
     }};
-    completeSetup();
+    if (data.autoStart) {{
+      continueButton.hidden = true;
+      completeSetup();
+    }} else {{
+      statusNode.textContent = 'Ready to connect this browser to local Guard.';
+      continueButton.disabled = false;
+      continueButton.addEventListener('click', () => {{
+        continueButton.disabled = true;
+        completeSetup();
+      }}, {{ once: true }});
+    }}
   </script>
 </body>
 </html>"""

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1125,7 +1125,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 workspace_id=self._optional_string(decoded.get("workspace_id")) or "",
             )
             return
-        if action_path in _CLOUD_APP_HANDOFF_ACTIONS and self._cloud_app_handoff_navigation_is_allowed():
+        is_user_navigation = self._browser_user_navigation_is_allowed()
+        if action_path in _CLOUD_APP_HANDOFF_ACTIONS and (
+            self._hosted_dashboard_referrer_is_allowed() or is_user_navigation
+        ):
             self._write_cloud_app_handoff_page(
                 harness=adapter.harness,
                 action_path=action_path,
@@ -1134,7 +1137,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     action_path=action_path,
                     workspace_id=self._optional_string(handoff_query.get("workspaceId", [None])[-1]) or "",
                 ),
-                include_dashboard_session_token=False,
+                include_dashboard_session_token=is_user_navigation,
                 local_origin=local_origin,
                 workspace_id=self._optional_string(handoff_query.get("workspaceId", [None])[-1]) or "",
             )
@@ -1436,8 +1439,17 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         signature = _dashboard_session_signature(payload, self.server.auth_token)  # type: ignore[attr-defined]
         return f"gld1.{payload}.{signature}"
 
-    def _cloud_app_handoff_navigation_is_allowed(self) -> bool:
-        return self._hosted_dashboard_referrer_is_allowed()
+    def _browser_user_navigation_is_allowed(self) -> bool:
+        fetch_mode = (self.headers.get("Sec-Fetch-Mode") or "").strip().lower()
+        fetch_dest = (self.headers.get("Sec-Fetch-Dest") or "").strip().lower()
+        fetch_user = (self.headers.get("Sec-Fetch-User") or "").strip()
+        fetch_site = (self.headers.get("Sec-Fetch-Site") or "").strip().lower()
+        return (
+            fetch_mode == "navigate"
+            and fetch_dest in {"document", ""}
+            and fetch_user == "?1"
+            and fetch_site in {"cross-site", "same-site", "none", ""}
+        )
 
     def _hosted_dashboard_referrer_is_allowed(self) -> bool:
         referrer = self.headers.get("Referer")

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1129,6 +1129,11 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         is_document_navigation = self._browser_document_navigation_is_allowed()
         is_hosted_referrer = self._hosted_dashboard_referrer_is_allowed()
         workspace_id = self._optional_string(handoff_query.get("workspaceId", [None])[-1]) or ""
+        self._apply_cloud_app_sync_credentials(
+            sync_url=self._optional_string(handoff_query.get("syncUrl", [None])[-1]),
+            sync_token=self._optional_string(handoff_query.get("syncToken", [None])[-1]),
+            workspace_id=self._optional_string(handoff_query.get("syncWorkspaceId", [None])[-1]) or workspace_id,
+        )
         navigation_allowed = is_hosted_referrer or is_document_navigation
         if action_path in _CLOUD_APP_HANDOFF_ACTIONS and (navigation_allowed or workspace_id):
             self._write_cloud_app_handoff_page(
@@ -1169,6 +1174,18 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             or self._optional_string(payload.get("workspaceId"))
             or ""
         )
+        self._apply_cloud_app_sync_credentials(
+            sync_url=self._optional_string(payload.get("sync_url")) or self._optional_string(payload.get("syncUrl")),
+            sync_token=(
+                self._optional_string(payload.get("sync_token"))
+                or self._optional_string(payload.get("syncToken"))
+            ),
+            workspace_id=(
+                self._optional_string(payload.get("sync_workspace_id"))
+                or self._optional_string(payload.get("syncWorkspaceId"))
+                or workspace_id
+            ),
+        )
         local_origin = self._local_daemon_origin()
         handoff_token = self._cloud_app_handoff_token(
             harness=adapter.harness,
@@ -1188,6 +1205,29 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 "Pragma": "no-cache",
                 "Expires": "0",
             },
+        )
+
+    def _apply_cloud_app_sync_credentials(
+        self,
+        *,
+        sync_url: str | None,
+        sync_token: str | None,
+        workspace_id: str,
+    ) -> None:
+        if sync_url is None or sync_token is None or not workspace_id:
+            return
+        parsed = urlparse(sync_url)
+        sync_origin = f"{parsed.scheme}://{parsed.netloc}"
+        if (
+            sync_origin not in _HOSTED_GUARD_DASHBOARD_ORIGINS
+            or not parsed.path.endswith("/api/guard/receipts/sync")
+        ):
+            return
+        self.server.store.set_sync_credentials(  # type: ignore[attr-defined]
+            sync_url=sync_url,
+            token=sync_token,
+            now=_now(),
+            workspace_id=workspace_id,
         )
 
     def _cloud_app_handoff_token(
@@ -1360,6 +1400,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
     const data = JSON.parse(document.getElementById('guard-handoff-data').textContent);
     const statusNode = document.getElementById('status');
     const continueButton = document.getElementById('continue');
+    window.history.replaceState(null, '', `${{data.localOrigin}}/v1/apps/${{data.harness}}/cloud`);
     const finish = (params, fragmentOnlyParams = {{}}) => {{
       const query = new URLSearchParams(params);
       const fragment = new URLSearchParams(params);

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1126,10 +1126,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 workspace_id=self._optional_string(decoded.get("workspace_id")) or "",
             )
             return
-        is_user_navigation = self._browser_user_navigation_is_allowed()
+        is_document_navigation = self._browser_document_navigation_is_allowed()
         is_hosted_referrer = self._hosted_dashboard_referrer_is_allowed()
         workspace_id = self._optional_string(handoff_query.get("workspaceId", [None])[-1]) or ""
-        navigation_allowed = is_hosted_referrer or is_user_navigation
+        navigation_allowed = is_hosted_referrer or is_document_navigation
         if action_path in _CLOUD_APP_HANDOFF_ACTIONS and (navigation_allowed or workspace_id):
             self._write_cloud_app_handoff_page(
                 harness=adapter.harness,
@@ -1140,7 +1140,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     workspace_id=workspace_id,
                 ),
                 auto_start=navigation_allowed,
-                include_dashboard_session_token=is_user_navigation or not navigation_allowed,
+                include_dashboard_session_token=is_document_navigation or not navigation_allowed,
                 local_origin=local_origin,
                 workspace_id=workspace_id,
             )
@@ -1457,15 +1457,13 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         signature = _dashboard_session_signature(payload, self.server.auth_token)  # type: ignore[attr-defined]
         return f"gld1.{payload}.{signature}"
 
-    def _browser_user_navigation_is_allowed(self) -> bool:
+    def _browser_document_navigation_is_allowed(self) -> bool:
         fetch_mode = (self.headers.get("Sec-Fetch-Mode") or "").strip().lower()
         fetch_dest = (self.headers.get("Sec-Fetch-Dest") or "").strip().lower()
-        fetch_user = (self.headers.get("Sec-Fetch-User") or "").strip()
         fetch_site = (self.headers.get("Sec-Fetch-Site") or "").strip().lower()
         return (
             fetch_mode == "navigate"
             and fetch_dest in {"document", ""}
-            and fetch_user == "?1"
             and fetch_site in {"cross-site", "same-site", "none", ""}
         )
 

--- a/src/codex_plugin_scanner/guard/launcher.py
+++ b/src/codex_plugin_scanner/guard/launcher.py
@@ -7,11 +7,15 @@ from collections.abc import Mapping
 from pathlib import Path
 
 
-def merge_guard_launcher_env(env: Mapping[str, str] | None = None) -> dict[str, str]:
-    """Pin Guard subprocesses to the package that wrote the launcher config."""
+def merge_guard_launcher_env(env: Mapping[str, str] | None = None, *, pin_package: bool = False) -> dict[str, str]:
+    """Preserve launcher import context while optionally pinning the current package."""
 
     merged: dict[str, str] = {}
-    pythonpath = str(Path(__file__).resolve().parents[2])
+    pythonpath = (
+        str(Path(__file__).resolve().parents[2])
+        if pin_package
+        else _normalize_launcher_pythonpath(os.environ.get("PYTHONPATH"))
+    )
     if pythonpath:
         merged["PYTHONPATH"] = pythonpath
     if env is None:
@@ -29,6 +33,10 @@ def merge_guard_launcher_env(env: Mapping[str, str] | None = None) -> dict[str, 
             continue
         merged[key] = value
     return merged
+
+
+def _normalize_launcher_pythonpath(value: str | None) -> str:
+    return _merge_path_entries("", value or "", relative_base=Path.cwd())
 
 
 def _merge_path_entries(left: str, right: str, relative_base: Path | None = None) -> str:

--- a/src/codex_plugin_scanner/guard/launcher.py
+++ b/src/codex_plugin_scanner/guard/launcher.py
@@ -30,6 +30,7 @@ def merge_guard_launcher_env(env: Mapping[str, str] | None = None) -> dict[str, 
         merged[key] = value
     return merged
 
+
 def _merge_path_entries(left: str, right: str, relative_base: Path | None = None) -> str:
     values: list[str] = []
     for entry in [*left.split(os.pathsep), *right.split(os.pathsep)]:

--- a/src/codex_plugin_scanner/guard/launcher.py
+++ b/src/codex_plugin_scanner/guard/launcher.py
@@ -8,10 +8,10 @@ from pathlib import Path
 
 
 def merge_guard_launcher_env(env: Mapping[str, str] | None = None) -> dict[str, str]:
-    """Preserve launcher import context when Guard is invoked from source checkouts."""
+    """Pin Guard subprocesses to the package that wrote the launcher config."""
 
     merged: dict[str, str] = {}
-    pythonpath = _normalize_launcher_pythonpath(os.environ.get("PYTHONPATH"))
+    pythonpath = str(Path(__file__).resolve().parents[2])
     if pythonpath:
         merged["PYTHONPATH"] = pythonpath
     if env is None:
@@ -29,11 +29,6 @@ def merge_guard_launcher_env(env: Mapping[str, str] | None = None) -> dict[str, 
             continue
         merged[key] = value
     return merged
-
-
-def _normalize_launcher_pythonpath(value: str | None) -> str:
-    return _merge_path_entries("", value or "", relative_base=Path.cwd())
-
 
 def _merge_path_entries(left: str, right: str, relative_base: Path | None = None) -> str:
     values: list[str] = []

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -74,9 +74,11 @@ def test_guard_codex_hook_command_does_not_pin_custom_guard_home_in_real_global_
     assert str(stale_guard_home) not in command
 
 
-def test_guard_install_codex_rewrites_workspace_config_with_proxy_entries(tmp_path, capsys):
+def test_guard_install_codex_rewrites_workspace_config_with_proxy_entries(tmp_path, capsys, monkeypatch):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
+    source_root = str(Path(__file__).resolve().parents[1] / "src")
+    monkeypatch.setenv("PYTHONPATH", str(tmp_path / "stale-site-packages"))
     _build_guard_fixture(home_dir, workspace_dir)
 
     rc = main(
@@ -136,16 +138,19 @@ def test_guard_install_codex_rewrites_workspace_config_with_proxy_entries(tmp_pa
     assert "codex_plugin_scanner.cli" in prompt_handler["command"]
     assert "hook" in prompt_handler["command"]
     assert "codex" in prompt_handler["command"]
+    assert prompt_handler["env"]["PYTHONPATH"] == source_root
     handler = hooks_payload["PreToolUse"][0]["hooks"][0]
     assert handler["type"] == "command"
     assert "codex_plugin_scanner.cli" in handler["command"]
     assert "hook" in handler["command"]
     assert "codex" in handler["command"]
+    assert handler["env"]["PYTHONPATH"] == source_root
     permission_handler = hooks_payload["PermissionRequest"][0]["hooks"][0]
     assert permission_handler["type"] == "command"
     assert "codex_plugin_scanner.cli" in permission_handler["command"]
     assert "hook" in permission_handler["command"]
     assert "codex" in permission_handler["command"]
+    assert permission_handler["env"]["PYTHONPATH"] == source_root
     zshenv_text = (home_dir / ".zshenv").read_text(encoding="utf-8")
     shell_guard_text = (home_dir / "managed" / "codex" / "codex-zshenv-guard.zsh").read_text(encoding="utf-8")
     bash_guard_text = (home_dir / "managed" / "codex" / "codex-bashenv-guard.bash").read_text(encoding="utf-8")

--- a/tests/test_guard_harness_setup.py
+++ b/tests/test_guard_harness_setup.py
@@ -301,6 +301,32 @@ def test_apps_test_alias_uses_safe_verification(tmp_path: Path, capsys: pytest.C
     assert payload["verification"]["writes_config"] is False
 
 
+def test_apps_repair_dry_run_explains_that_cloud_is_not_connected(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    args = argparse.Namespace(
+        guard_command="apps",
+        apps_command="repair",
+        harness="codex",
+        dry_run=True,
+        home=str(tmp_path / "home"),
+        guard_home=str(tmp_path / "guard-home"),
+        workspace=str(tmp_path / "workspace"),
+        json=True,
+    )
+
+    exit_code = run_guard_command(args)
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["dry_run"] is True
+    assert payload["dry_run_effect"] == (
+        "No app config was changed and Guard Cloud was not connected. "
+        "Run hol-guard apps repair codex without --dry-run to finish setup."
+    )
+
+
 def test_apps_subcommand_preserves_parent_flags(tmp_path: Path) -> None:
     parser = argparse.ArgumentParser()
     add_guard_root_parser(parser)

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -508,6 +508,71 @@ def test_cloud_app_handoff_start_mints_handoff_url_for_hosted_dashboard(tmp_path
     assert "dashboardSessionToken" in body
 
 
+def test_cloud_app_handoff_start_saves_sync_credentials(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/apps/codex/cloud/start",
+                payload={
+                    "action": "connect",
+                    "sync_url": "https://hol.org/api/guard/receipts/sync",
+                    "sync_token": "guard-runtime-token",
+                    "sync_workspace_id": "workspace-123",
+                },
+                origin="https://hol.org",
+                token=_dashboard_token_for(store),
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert payload["status"] == "ready"
+    credentials = store.get_sync_credentials()
+    assert credentials is not None
+    assert credentials["sync_url"] == "https://hol.org/api/guard/receipts/sync"
+    assert credentials["token"] == "guard-runtime-token"
+
+
+def test_cloud_app_handoff_navigation_saves_sync_credentials(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    path = (
+        "/v1/apps/codex/cloud?action=connect&workspaceId=workspace-123"
+        "&syncUrl=https%3A%2F%2Fhol.org%2Fapi%2Fguard%2Freceipts%2Fsync"
+        "&syncToken=guard-runtime-token&syncWorkspaceId=workspace-123"
+    )
+    daemon.start()
+    try:
+        status, body = _read_text_response(
+            _request(
+                daemon.port,
+                path,
+                method="GET",
+                origin=None,
+                extra_headers={
+                    "Sec-Fetch-Mode": "navigate",
+                    "Sec-Fetch-Dest": "document",
+                    "Sec-Fetch-Site": "cross-site",
+                },
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert "HOL Guard local handoff" in body
+    assert "guard-runtime-token" not in body
+    credentials = store.get_sync_credentials()
+    assert credentials is not None
+    assert credentials["sync_url"] == "https://hol.org/api/guard/receipts/sync"
+    assert credentials["token"] == "guard-runtime-token"
+
+
 def test_cloud_app_handoff_start_response_is_not_cacheable(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -436,6 +436,41 @@ def test_cloud_app_handoff_serves_token_authenticated_local_action_page(tmp_path
     assert auth_token not in body
 
 
+def test_cloud_app_handoff_allows_user_initiated_browser_navigation_without_referrer(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        auth_token = load_guard_daemon_auth_token(store.guard_home)
+        assert auth_token is not None
+        status, body = _read_text_response(
+            _request(
+                daemon.port,
+                "/v1/apps/codex/cloud?action=connect",
+                method="GET",
+                origin=None,
+                extra_headers={
+                    "Sec-Fetch-Mode": "navigate",
+                    "Sec-Fetch-Dest": "document",
+                    "Sec-Fetch-Site": "cross-site",
+                    "Sec-Fetch-User": "?1",
+                },
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert "HOL Guard local handoff" in body
+    assert "handoffToken" in body
+    assert "dashboardSessionToken" in body
+    script_payload = _handoff_script_payload(body)
+    browser_token = script_payload["dashboardSessionToken"]
+    assert isinstance(browser_token, str)
+    assert browser_token.startswith("gld1.")
+    assert auth_token not in body
+
+
 def test_cloud_app_handoff_start_mints_handoff_url_for_hosted_dashboard(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -810,6 +810,38 @@ def test_cloud_app_handoff_redirects_to_guard_cloud_when_referrer_and_fetch_meta
     assert auth_token not in location
 
 
+def test_cloud_app_handoff_workspace_fallback_requires_local_continue_when_fetch_metadata_missing(
+    tmp_path: Path,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        auth_token = load_guard_daemon_auth_token(store.guard_home)
+        assert auth_token is not None
+        status, body = _read_text_response(
+            _request(
+                daemon.port,
+                "/v1/apps/codex/cloud?action=connect&workspaceId=workspace-alpha",
+                method="GET",
+                origin=None,
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert "HOL Guard local handoff" in body
+    assert "Continue setup" in body
+    script_payload = _handoff_script_payload(body)
+    assert script_payload["autoStart"] is False
+    assert script_payload["workspaceId"] == "workspace-alpha"
+    browser_token = script_payload["dashboardSessionToken"]
+    assert isinstance(browser_token, str)
+    assert browser_token.startswith("gld1.")
+    assert auth_token not in body
+
+
 def test_cloud_app_handoff_redirects_to_guard_cloud_for_silent_fetch(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -436,7 +436,7 @@ def test_cloud_app_handoff_serves_token_authenticated_local_action_page(tmp_path
     assert auth_token not in body
 
 
-def test_cloud_app_handoff_allows_user_initiated_browser_navigation_without_referrer(tmp_path: Path) -> None:
+def test_cloud_app_handoff_allows_document_navigation_without_referrer(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
@@ -453,7 +453,6 @@ def test_cloud_app_handoff_allows_user_initiated_browser_navigation_without_refe
                     "Sec-Fetch-Mode": "navigate",
                     "Sec-Fetch-Dest": "document",
                     "Sec-Fetch-Site": "cross-site",
-                    "Sec-Fetch-User": "?1",
                 },
             ),
         )


### PR DESCRIPTION
## Summary
- add explicit dry-run output for `hol-guard apps connect|repair --dry-run`
- tell users that dry-run does not change app config or connect Guard Cloud
- render the same warning in human CLI output

## Verification
- `python3 -m pytest tests/test_guard_harness_setup.py -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/cli/install_commands.py src/codex_plugin_scanner/guard/cli/render.py tests/test_guard_harness_setup.py`
- `PYTHONPATH=src python3 -m codex_plugin_scanner.cli guard apps repair codex --dry-run --json --home /tmp/hol-guard-home-test --guard-home /tmp/hol-guard-guard-home-test --workspace /tmp/hol-guard-workspace-test`
