### PR TITLE
fix(codex): resume approvals after hook timeout

### DIFF
--- a/scripts/codex-auto-resume-smoke.py
+++ b/scripts/codex-auto-resume-smoke.py
@@ -156,7 +156,7 @@ def _run_scenario_in_dir(*, decision: str, args: argparse.Namespace, temp_dir: P
             daemon_port=daemon.port,
             codex_home=args.codex_home,
             socket_path=socket_path,
-            operation_status="approval_wait_timeout",
+            operation_status="waiting_on_approval",
         )
         action_path = "approve" if decision == "allow" else "block"
         approval_payload = _post_json(
@@ -540,7 +540,10 @@ def _queue_pending_request(
             "codex_app_server_socket": str(socket_path),
             "command_text": _proof_command(),
             "tool_name": "Bash",
-            "event": "PreToolUse",
+            "event": "PostToolUse",
+            "hook_event_name": "PostToolUse",
+            "codex_hook_waits_for_browser_approval": True,
+            "codex_browser_wait_deadline_at": "2000-01-01T00:00:00+00:00",
         },
         now=now,
     )

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2732,10 +2732,11 @@ def run_guard_command(
                         "tool_name": str(payload.get("tool_name", "")),
                         "hook_name": "permissionRequest",
                         "hook_event_name": "PermissionRequest",
-                        "codex_hook_waits_for_browser_approval": _codex_hook_waits_for_browser_approval(
+                        **_codex_browser_wait_metadata(
                             args=args,
                             event_name="PermissionRequest",
                             policy_action=policy_action,
+                            config=config,
                         ),
                         "command_text": _hook_command_text(payload),
                         "workspace": str(runtime_workspace) if runtime_workspace else None,
@@ -3206,10 +3207,11 @@ def run_guard_command(
                                 "tool_name": str(payload.get("tool_name", "")),
                                 "event": str(payload.get("event", "")),
                                 "hook_event_name": event_name,
-                                "codex_hook_waits_for_browser_approval": _codex_hook_waits_for_browser_approval(
+                                **_codex_browser_wait_metadata(
                                     args=args,
                                     event_name=event_name,
                                     policy_action=policy_action,
+                                    config=config,
                                 ),
                                 "command_text": _hook_command_text(payload),
                                 "workspace": str(workspace) if workspace else None,
@@ -3670,6 +3672,33 @@ def _codex_hook_waits_for_browser_approval(
         _codex_can_use_browser_approval(args=args, event_name=event_name, policy_action=policy_action)
         and event_name != "PreToolUse"
     )
+
+
+def _codex_browser_wait_metadata(
+    *,
+    args: argparse.Namespace,
+    event_name: str,
+    policy_action: str,
+    config: GuardConfig,
+) -> dict[str, object]:
+    waits_for_browser = _codex_hook_waits_for_browser_approval(
+        args=args,
+        event_name=event_name,
+        policy_action=policy_action,
+    )
+    if not waits_for_browser:
+        return {"codex_hook_waits_for_browser_approval": False}
+    wait_timeout_seconds = max(config.approval_wait_timeout_seconds, 0)
+    if event_name == "UserPromptSubmit":
+        wait_timeout_seconds = min(wait_timeout_seconds, _CODEX_PROMPT_APPROVAL_WAIT_MAX_SECONDS)
+    started_at = datetime.now(timezone.utc)
+    deadline_at = started_at + timedelta(seconds=wait_timeout_seconds)
+    return {
+        "codex_hook_waits_for_browser_approval": True,
+        "codex_browser_wait_started_at": started_at.isoformat(),
+        "codex_browser_wait_deadline_at": deadline_at.isoformat(),
+        "codex_browser_wait_timeout_seconds": wait_timeout_seconds,
+    }
 
 
 def _update_codex_browser_operation_status(

--- a/src/codex_plugin_scanner/guard/codex_resume.py
+++ b/src/codex_plugin_scanner/guard/codex_resume.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import shutil
 from collections.abc import Mapping
+from datetime import datetime, timezone
 
 from .codex_app_server import default_codex_app_server_socket_available, resume_codex_thread_for_request
 from .store import GuardStore
@@ -126,7 +127,7 @@ def defer_request_resume_to_live_hook(
     if str(operation.get("status")) != "waiting_on_approval":
         return None
     metadata = operation.get("metadata")
-    if not isinstance(metadata, Mapping) or metadata.get("codex_hook_waits_for_browser_approval") is not True:
+    if not isinstance(metadata, Mapping) or not _live_hook_wait_is_active(metadata=metadata, now=now):
         return None
     resume = get_request_resume_status(store, request_id=request_id, now=now)
     if resume is None:
@@ -183,6 +184,29 @@ def inspect_codex_resume_capabilities(store: GuardStore) -> dict[str, object]:
         ),
         "latest_attempt": latest_attempt,
     }
+
+
+def _live_hook_wait_is_active(*, metadata: Mapping[str, object], now: str) -> bool:
+    if metadata.get("codex_hook_waits_for_browser_approval") is not True:
+        return False
+    deadline = _first_string(metadata, ("codex_browser_wait_deadline_at", "browser_wait_deadline_at"))
+    if deadline is None:
+        return False
+    deadline_at = _parse_timestamp(deadline)
+    now_at = _parse_timestamp(now)
+    if deadline_at is None or now_at is None:
+        return False
+    return now_at <= deadline_at
+
+
+def _parse_timestamp(value: str) -> datetime | None:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
 
 def _finalize_resume_attempt(

--- a/tests/test_guard_codex_resume_endpoints.py
+++ b/tests/test_guard_codex_resume_endpoints.py
@@ -96,6 +96,7 @@ def _seed_codex_operation(
     command_text: str | None = None,
     hook_event_name: str | None = None,
     waits_for_browser_approval: bool | None = None,
+    browser_wait_deadline_at: str | None = None,
     status: str = "waiting_on_approval",
 ) -> None:
     session = store.upsert_guard_session(
@@ -125,6 +126,8 @@ def _seed_codex_operation(
         metadata["hook_event_name"] = hook_event_name
     if waits_for_browser_approval is not None:
         metadata["codex_hook_waits_for_browser_approval"] = waits_for_browser_approval
+    if browser_wait_deadline_at is not None:
+        metadata["codex_browser_wait_deadline_at"] = browser_wait_deadline_at
     store.upsert_guard_operation(
         operation_id=f"operation-{request_id}",
         session_id=str(session["session_id"]),
@@ -273,6 +276,7 @@ def test_codex_approve_defers_headless_resume_while_live_hook_waits(
         thread_id="live-session-1",
         hook_event_name="PostToolUse",
         waits_for_browser_approval=True,
+        browser_wait_deadline_at="2999-01-01T00:00:00+00:00",
         status="waiting_on_approval",
     )
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
@@ -294,6 +298,66 @@ def test_codex_approve_defers_headless_resume_while_live_hook_waits(
     assert "original Codex action continue" in payload["codex_resume"]["message"]
 
 
+def test_codex_approve_stale_live_hook_wait_starts_headless_resume(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    launched: list[list[str]] = []
+
+    class _FakeProcess:
+        pid = 1031
+
+    def _fake_popen(command, **_kwargs):
+        launched.append(command)
+        return _FakeProcess()
+
+    monkeypatch.setattr(
+        codex_app_server_module.shutil,
+        "which",
+        lambda command: "/usr/bin/codex" if command == "codex" else None,
+    )
+    monkeypatch.setattr(codex_app_server_module.subprocess, "Popen", _fake_popen)
+
+    workspace = tmp_path / "workspace"
+    codex_home = tmp_path / "codex-home"
+    workspace.mkdir()
+    codex_home.mkdir()
+    store = GuardStore(tmp_path / "guard-home")
+    store.add_approval_request(_request("req-stale-live"), "2026-05-19T10:00:00+00:00")
+    _seed_codex_operation(
+        store,
+        request_id="req-stale-live",
+        socket_path=None,
+        thread_id="stale-live-session-1",
+        workspace=str(workspace),
+        codex_home=str(codex_home),
+        command_text="npm install minimist@1.2.8",
+        hook_event_name="PostToolUse",
+        waits_for_browser_approval=True,
+        browser_wait_deadline_at="2000-01-01T00:00:00+00:00",
+        status="waiting_on_approval",
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+
+    try:
+        payload = _post_json(
+            daemon.port,
+            daemon._server.auth_token,
+            "/v1/requests/req-stale-live/approve",
+            {"scope": "artifact", "reason": "reviewed"},
+        )
+    finally:
+        daemon.stop()
+
+    assert payload["resolved"] is True
+    assert payload["codex_resume"]["status"] == "sent"
+    assert payload["codex_resume"]["reason"] == "headless_resume_started"
+    assert payload["codex_resume"]["strategy"] == "codex-headless-exec"
+    assert launched[0][:5] == ["/usr/bin/codex", "exec", "resume", "--json", "--skip-git-repo-check"]
+    assert "stale-live-session-1" in launched[0]
+
+
 def test_codex_block_does_not_defer_to_live_hook_waiting_on_browser_decision(
     tmp_path: Path,
 ) -> None:
@@ -307,6 +371,7 @@ def test_codex_block_does_not_defer_to_live_hook_waiting_on_browser_decision(
         thread_id="live-block-session-1",
         hook_event_name="PostToolUse",
         waits_for_browser_approval=True,
+        browser_wait_deadline_at="2999-01-01T00:00:00+00:00",
         status="waiting_on_approval",
     )
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
@@ -405,6 +470,7 @@ def test_codex_deferred_live_hook_resume_retry_reports_missing_chat_channel(
         thread_id="live-session-retry-1",
         hook_event_name="PostToolUse",
         waits_for_browser_approval=True,
+        browser_wait_deadline_at="2999-01-01T00:00:00+00:00",
         status="waiting_on_approval",
     )
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)


### PR DESCRIPTION
## Summary
- Add browser-wait deadlines to Codex approval metadata so live-hook deferral only happens while the hook can still consume the decision.
- Fall back to Codex app-server/headless continuation when a user approves after the hook wait timed out.
- Extend smoke coverage to prove stale `waiting_on_approval` approvals send Codex `turn/start` instead of staying pending.

## Testing
- `python3 -m pytest tests/test_guard_codex_resume_endpoints.py::test_codex_approve_defers_headless_resume_while_live_hook_waits tests/test_guard_codex_resume_endpoints.py::test_codex_approve_stale_live_hook_wait_starts_headless_resume tests/test_guard_codex_resume_endpoints.py::test_codex_approve_pretooluse_no_wait_starts_headless_resume -q`
- `python3 -m pytest tests/test_guard_codex_resume_endpoints.py tests/test_guard_codex_resume_commands.py tests/test_guard_codex_auto_resume_smoke.py -q`
- `python3 -m pytest tests/test_guard_package_resume_phase14.py -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/codex_resume.py src/codex_plugin_scanner/guard/cli/commands.py scripts/codex-auto-resume-smoke.py tests/test_guard_codex_resume_endpoints.py tests/test_guard_codex_auto_resume_smoke.py`
- `codex exec --json --skip-git-repo-check -C <temp> 'Say exactly HOL_GUARD_LOCAL_CODEX_READY.'`
- `python3 scripts/codex-auto-resume-smoke.py --timeout-seconds 120 --request-timeout-seconds 60`
