### PR TITLE
fix(daemon): require auth for cloud handoff start

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -3114,6 +3114,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             }
         ):
             return True
+        if len(path_parts) == 5 and path_parts[:2] == ["v1", "apps"] and path_parts[3:] == ["cloud", "start"]:
+            return True
         if len(path_parts) == 3 and path_parts[0] == "approvals" and path_parts[2] == "decision":
             return True
         return len(path_parts) == 4 and path_parts[:2] == ["v1", "approvals"] and path_parts[3] == "decision"

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -474,6 +474,26 @@ def test_cloud_app_handoff_start_mints_handoff_url_for_hosted_dashboard(tmp_path
     assert "dashboardSessionToken" in body
 
 
+def test_cloud_app_handoff_start_requires_dashboard_session(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/apps/codex/cloud/start",
+                payload={"action": "connect"},
+                origin="https://hol.org",
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 401
+    assert payload["error"] == "unauthorized"
+
+
 def test_cloud_app_handoff_start_response_is_not_cacheable(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)


### PR DESCRIPTION
## Summary
- require daemon dashboard-session authentication for hosted cloud handoff start minting (`/v1/apps/{harness}/cloud/start`)
- add a regression that proves unauthenticated hosted-origin requests are rejected with `401 unauthorized`

## Testing
- `uv run pytest tests/test_guard_headless_daemon_api.py -k "cloud_app_handoff_start_requires_dashboard_session or cloud_app_handoff_start_mints_handoff_url_for_hosted_dashboard or cloud_app_handoff_start_response_is_not_cacheable" -q`
- `uv run pytest tests/test_guard_headless_daemon_api.py -k "cloud_app_handoff or headless_api_rejects_forged_dashboard_session_token" -q`
- `uv run ruff check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_headless_daemon_api.py`
- `uv run ruff format --check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_headless_daemon_api.py`
