### PR TITLE
fix(codex): remove headless resume fallback

### DIFF
--- a/src/codex_plugin_scanner/guard/codex_app_server.py
+++ b/src/codex_plugin_scanner/guard/codex_app_server.py
@@ -6,10 +6,8 @@ import base64
 import hashlib
 import json
 import os
-import shutil
 import socket
 import struct
-import subprocess
 import tempfile
 import threading
 import time
@@ -132,6 +130,14 @@ def resume_codex_thread_for_request(
     thread_id = _first_string(metadata, ("codex_thread_id", "thread_id", "threadId", "session_id", "sessionId"))
     if thread_id is None:
         return None
+    if not _is_safe_codex_thread_id(thread_id):
+        return {
+            "status": "skipped",
+            "reason": "unsafe_thread_id",
+            "thread_id": thread_id,
+            "strategy": "codex-app-server-thread",
+            "supported": False,
+        }
     codex_home = _first_string(metadata, _CODEX_HOME_KEYS)
     socket_path = _first_string(metadata, _SOCKET_KEYS) or str(
         default_codex_app_server_socket_path(environ={"CODEX_HOME": codex_home or ""})
@@ -145,11 +151,17 @@ def resume_codex_thread_for_request(
     command_text = _first_string(metadata, _COMMAND_TEXT_KEYS)
     prompt = build_codex_continuation_prompt(action, request_id=request_id, command_text=command_text)
     if not Path(socket_path).expanduser().exists():
-        return _resume_codex_thread_with_cli(
-            metadata=metadata,
-            thread_id=thread_id,
-            prompt=prompt,
-        )
+        return {
+            "status": "failed",
+            "reason": "socket_not_available",
+            "thread_id": thread_id,
+            "strategy": "codex-app-server-thread",
+            "supported": True,
+            "message": (
+                "Codex App remote-control socket is unavailable. HOL Guard will not start `codex exec resume` "
+                "because that creates a separate background run instead of continuing the visible Codex chat."
+            ),
+        }
     request_payloads = [
         {
             "jsonrpc": "2.0",
@@ -282,102 +294,6 @@ def _send_codex_resume_worker(
         result["error"] = error
     finally:
         ready.set()
-
-
-def _resume_codex_thread_with_cli(
-    *,
-    metadata: Mapping[str, object],
-    thread_id: str,
-    prompt: str,
-) -> dict[str, object]:
-    """Resume a saved Codex exec thread when the live app-server socket is gone."""
-
-    if not _is_safe_codex_thread_id(thread_id):
-        return {
-            "status": "skipped",
-            "reason": "unsafe_thread_id",
-            "thread_id": thread_id,
-            "strategy": "codex-headless-exec",
-            "supported": False,
-        }
-    workspace = _first_string(metadata, _WORKSPACE_KEYS)
-    if workspace is None:
-        return {
-            "status": "skipped",
-            "reason": "workspace_not_available",
-            "thread_id": thread_id,
-            "strategy": "codex-headless-exec",
-            "supported": False,
-        }
-    workspace_path = Path(workspace).expanduser()
-    if not workspace_path.is_dir():
-        return {
-            "status": "skipped",
-            "reason": "workspace_not_available",
-            "thread_id": thread_id,
-            "strategy": "codex-headless-exec",
-            "supported": False,
-        }
-    codex_home = _first_string(metadata, _CODEX_HOME_KEYS)
-    if codex_home is not None and not Path(codex_home).expanduser().is_dir():
-        return {
-            "status": "skipped",
-            "reason": "codex_home_not_available",
-            "thread_id": thread_id,
-            "strategy": "codex-headless-exec",
-            "supported": False,
-        }
-    codex_binary = shutil.which("codex")
-    if codex_binary is None:
-        return {
-            "status": "skipped",
-            "reason": "codex_binary_not_found",
-            "thread_id": thread_id,
-            "strategy": "codex-headless-exec",
-            "supported": False,
-        }
-    command = [
-        codex_binary,
-        "exec",
-        "resume",
-        "--json",
-        "--skip-git-repo-check",
-    ]
-    model = _first_string(metadata, _MODEL_KEYS)
-    if model is not None and _is_safe_codex_model(model):
-        command.extend(["--model", model])
-    command.append("--")
-    command.extend([thread_id, prompt])
-    env = os.environ.copy()
-    if codex_home is not None:
-        env["CODEX_HOME"] = str(Path(codex_home).expanduser())
-    try:
-        process = subprocess.Popen(
-            command,
-            cwd=workspace_path,
-            env=env,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            start_new_session=True,
-        )
-    except OSError as error:
-        return {
-            "status": "failed",
-            "reason": "headless_resume_launch_failed",
-            "last_error": str(error),
-            "thread_id": thread_id,
-            "strategy": "codex-headless-exec",
-            "supported": True,
-        }
-    return {
-        "status": "sent",
-        "reason": "headless_resume_started",
-        "thread_id": thread_id,
-        "strategy": "codex-headless-exec",
-        "supported": True,
-        "pid": process.pid,
-    }
 
 
 def _find_codex_operation_for_request(store: _OperationStore, request_id: str) -> dict[str, object] | None:
@@ -629,15 +545,6 @@ def _is_safe_codex_thread_id(thread_id: str) -> bool:
         0 < len(thread_id) <= 256
         and not thread_id.startswith("-")
         and all(char.isalnum() or char in "-_" for char in thread_id)
-    )
-
-
-def _is_safe_codex_model(model: str) -> bool:
-    return (
-        0 < len(model) <= 128
-        and not model.startswith("-")
-        and bool(model.strip())
-        and all(char.isalnum() or char in "-_.:" for char in model)
     )
 
 

--- a/src/codex_plugin_scanner/guard/codex_resume.py
+++ b/src/codex_plugin_scanner/guard/codex_resume.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import shutil
 from collections.abc import Mapping
 from datetime import datetime, timezone
 
@@ -163,24 +162,20 @@ def defer_request_resume_to_live_hook(
 
 
 def inspect_codex_resume_capabilities(store: GuardStore) -> dict[str, object]:
-    binary_path = shutil.which("codex")
     socket_available = default_codex_app_server_socket_available()
     latest_attempt = store.get_latest_request_resume(harness="codex")
     return {
-        "codex_binary_found": binary_path is not None,
+        "codex_binary_found": False,
         "app_server_support": socket_available,
         "app_server_support_reason": (
             "Same-chat continuation requires the Codex app-server remote-control socket. "
             "When the socket is missing, HOL Guard cannot visibly continue the open Codex App chat."
         ),
         "app_server_socket_available": socket_available,
-        "headless_resume_support": binary_path is not None,
+        "headless_resume_support": False,
         "headless_resume_support_reason": (
-            "When the live app-server socket is gone, HOL Guard resumes saved Codex exec threads with "
-            "`codex exec resume` from the original workspace. This is a background retry, not a visible "
-            "message in the open Codex App chat."
-            if binary_path is not None
-            else "`codex` was not found on PATH, so HOL Guard can only save the approval for manual retry."
+            "Disabled by design. `codex exec resume` starts a separate background run and does not continue "
+            "the visible Codex App chat. HOL Guard only auto-continues Codex through the app-server socket."
         ),
         "latest_attempt": latest_attempt,
     }
@@ -352,15 +347,7 @@ def _normalize_dispatch_result(
     raw_supported = raw_result.get("supported")
     supported = raw_supported if isinstance(raw_supported, bool) else raw_status != "skipped"
     if raw_status == "sent":
-        message = (
-            "HOL Guard sent Codex a continuation message in the original chat."
-            if effective_strategy != "codex-headless-exec"
-            else (
-                "HOL Guard started a background `codex exec resume` retry for this saved thread. "
-                "The command can complete in Codex history, but this open Codex App chat will not visibly "
-                "continue unless the Codex app-server remote-control socket is enabled."
-            )
-        )
+        message = "HOL Guard sent Codex a continuation message in the original chat."
         return {
             "status": "sent",
             "reason": raw_reason,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -14681,13 +14681,6 @@ function buildCodexResumeUx(resume) {
     };
   }
   if (resume.status === "sent" || resume.status === "already_sent") {
-    if (resume.strategy === "codex-headless-exec" || resume.reason === "headless_resume_started") {
-      return {
-        headline: "Codex resumed in background.",
-        body: resume.message ?? "HOL Guard started a background Codex resume. This open Codex App chat may not visibly continue until Codex remote control is enabled.",
-        showRetry: false
-      };
-    }
     return {
       headline: "Codex chat notified.",
       body: resume.message ?? "HOL Guard sent Codex a continuation message in the original chat.",

--- a/tests/test_guard_codex_resume_commands.py
+++ b/tests/test_guard_codex_resume_commands.py
@@ -9,15 +9,8 @@ import pytest
 
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard import codex_app_server as codex_app_server_module
-from codex_plugin_scanner.guard import codex_resume as codex_resume_module
 from codex_plugin_scanner.guard.models import GuardApprovalRequest
 from codex_plugin_scanner.guard.store import GuardStore
-
-
-def _stub_codex_binary(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        codex_resume_module.shutil, "which", lambda command: "/usr/bin/codex" if command == "codex" else None
-    )
 
 
 def _request(request_id: str) -> GuardApprovalRequest:
@@ -231,37 +224,33 @@ def test_guard_doctor_codex_reports_resume_diagnostics(
     output = json.loads(capsys.readouterr().out)
 
     assert rc == 0
-    assert output["codex_resume"]["codex_binary_found"] in {True, False}
+    assert output["codex_resume"]["codex_binary_found"] is False
     assert output["codex_resume"]["app_server_support"] in {True, False}
     assert "remote-control socket" in output["codex_resume"]["app_server_support_reason"]
     assert output["codex_resume"]["app_server_socket_available"] in {True, False}
-    assert output["codex_resume"]["headless_resume_support"] in {True, False}
-    assert "codex exec resume" in output["codex_resume"]["headless_resume_support_reason"] or (
-        "codex` was not found" in output["codex_resume"]["headless_resume_support_reason"]
-    )
+    assert output["codex_resume"]["headless_resume_support"] is False
+    assert "Disabled by design" in output["codex_resume"]["headless_resume_support_reason"]
     assert output["codex_resume"]["latest_attempt"] is None
 
 
-def test_guard_doctor_codex_reports_app_server_support_from_codex_binary(
+def test_guard_doctor_codex_reports_headless_resume_disabled(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     home_dir = tmp_path / "home"
     guard_home = tmp_path / "guard-home"
     GuardStore(guard_home)
-    _stub_codex_binary(monkeypatch)
 
     rc = main(["guard", "doctor", "codex", "--home", str(home_dir), "--guard-home", str(guard_home), "--json"])
     output = json.loads(capsys.readouterr().out)
 
     assert rc == 0
-    assert output["codex_resume"]["codex_binary_found"] is True
+    assert output["codex_resume"]["codex_binary_found"] is False
     assert output["codex_resume"]["app_server_support"] in {True, False}
     assert "remote-control socket" in output["codex_resume"]["app_server_support_reason"]
     assert output["codex_resume"]["app_server_socket_available"] in {True, False}
-    assert output["codex_resume"]["headless_resume_support"] is True
-    assert "codex exec resume" in output["codex_resume"]["headless_resume_support_reason"]
+    assert output["codex_resume"]["headless_resume_support"] is False
+    assert "does not continue the visible Codex App chat" in output["codex_resume"]["headless_resume_support_reason"]
     assert "remote_control_support" not in output["codex_resume"]
 
 
@@ -296,31 +285,14 @@ def test_guard_approvals_resume_rejects_unsafe_headless_thread_id(
     assert rc == 0
     assert output["status"] == "skipped"
     assert output["reason"] == "unsafe_thread_id"
-    assert output["strategy"] == "codex-headless-exec"
+    assert output["strategy"] == "codex-app-server-thread"
     assert "retry the same request" in output["message"]
 
 
-def test_guard_approvals_resume_starts_headless_codex_when_app_server_unavailable(
+def test_guard_approvals_resume_requires_app_server_when_socket_unavailable(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    launched: list[dict[str, object]] = []
-
-    class _FakeProcess:
-        pid = 4455
-
-    def _fake_popen(command, **kwargs):
-        launched.append({"command": command, **kwargs})
-        return _FakeProcess()
-
-    monkeypatch.setattr(
-        codex_app_server_module.shutil,
-        "which",
-        lambda command: "/usr/local/bin/codex" if command == "codex" else None,
-    )
-    monkeypatch.setattr(codex_app_server_module.subprocess, "Popen", _fake_popen)
-
     home_dir = tmp_path / "guard-home"
     workspace = tmp_path / "workspace"
     codex_home = tmp_path / "codex-home"
@@ -347,35 +319,16 @@ def test_guard_approvals_resume_starts_headless_codex_when_app_server_unavailabl
     output = json.loads(capsys.readouterr().out)
 
     assert rc == 0
-    assert output["status"] == "sent"
-    assert output["reason"] == "headless_resume_started"
-    assert output["strategy"] == "codex-headless-exec"
-    assert "background" in output["message"]
-    assert "open Codex App chat" in output["message"]
-    assert len(launched) == 1
-    assert launched[0]["cwd"] == workspace
-    assert launched[0]["command"][:5] == ["/usr/local/bin/codex", "exec", "resume", "--json", "--skip-git-repo-check"]
-    assert "--" in launched[0]["command"]
-    assert "thread-1" in launched[0]["command"]
-    assert launched[0]["env"]["CODEX_HOME"] == str(codex_home)
+    assert output["status"] == "failed"
+    assert output["reason"] == "socket_not_available"
+    assert output["strategy"] == "codex-app-server-thread"
+    assert "original chat" in output["message"]
 
 
 def test_guard_approvals_resume_does_not_start_headless_codex_for_blocked_request(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(
-        codex_app_server_module.shutil,
-        "which",
-        lambda command: "/usr/local/bin/codex" if command == "codex" else None,
-    )
-    monkeypatch.setattr(
-        codex_app_server_module.subprocess,
-        "Popen",
-        lambda *_args, **_kwargs: pytest.fail("blocked requests must not start codex exec resume"),
-    )
-
     home_dir = tmp_path / "guard-home"
     workspace = tmp_path / "workspace"
     codex_home = tmp_path / "codex-home"
@@ -408,13 +361,10 @@ def test_guard_approvals_resume_does_not_start_headless_codex_for_blocked_reques
     assert "blocked this Codex request" in output["message"]
 
 
-def test_guard_approvals_resume_reports_missing_codex_home_without_spawning(
+def test_guard_approvals_resume_reports_missing_app_server_without_spawning(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(codex_app_server_module.subprocess, "Popen", lambda *_args, **_kwargs: pytest.fail("no spawn"))
-
     home_dir = tmp_path / "guard-home"
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -439,6 +389,6 @@ def test_guard_approvals_resume_reports_missing_codex_home_without_spawning(
     output = json.loads(capsys.readouterr().out)
 
     assert rc == 0
-    assert output["status"] == "skipped"
-    assert output["reason"] == "codex_home_not_available"
-    assert output["strategy"] == "codex-headless-exec"
+    assert output["status"] == "failed"
+    assert output["reason"] == "socket_not_available"
+    assert output["strategy"] == "codex-app-server-thread"

--- a/tests/test_guard_codex_resume_endpoints.py
+++ b/tests/test_guard_codex_resume_endpoints.py
@@ -209,19 +209,7 @@ def test_codex_block_does_not_resume_codex_thread(
 
 def test_codex_block_with_missing_socket_does_not_start_headless_resume(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(
-        codex_app_server_module.shutil,
-        "which",
-        lambda command: "/usr/bin/codex" if command == "codex" else None,
-    )
-    monkeypatch.setattr(
-        codex_app_server_module.subprocess,
-        "Popen",
-        lambda *_args, **_kwargs: pytest.fail("blocked requests must not start codex exec resume"),
-    )
-
     workspace = tmp_path / "workspace"
     codex_home = tmp_path / "codex-home"
     workspace.mkdir()
@@ -298,26 +286,9 @@ def test_codex_approve_defers_headless_resume_while_live_hook_waits(
     assert "original Codex action continue" in payload["codex_resume"]["message"]
 
 
-def test_codex_approve_stale_live_hook_wait_starts_headless_resume(
+def test_codex_approve_stale_live_hook_wait_requires_app_server_socket(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    launched: list[list[str]] = []
-
-    class _FakeProcess:
-        pid = 1031
-
-    def _fake_popen(command, **_kwargs):
-        launched.append(command)
-        return _FakeProcess()
-
-    monkeypatch.setattr(
-        codex_app_server_module.shutil,
-        "which",
-        lambda command: "/usr/bin/codex" if command == "codex" else None,
-    )
-    monkeypatch.setattr(codex_app_server_module.subprocess, "Popen", _fake_popen)
-
     workspace = tmp_path / "workspace"
     codex_home = tmp_path / "codex-home"
     workspace.mkdir()
@@ -351,11 +322,10 @@ def test_codex_approve_stale_live_hook_wait_starts_headless_resume(
         daemon.stop()
 
     assert payload["resolved"] is True
-    assert payload["codex_resume"]["status"] == "sent"
-    assert payload["codex_resume"]["reason"] == "headless_resume_started"
-    assert payload["codex_resume"]["strategy"] == "codex-headless-exec"
-    assert launched[0][:5] == ["/usr/bin/codex", "exec", "resume", "--json", "--skip-git-repo-check"]
-    assert "stale-live-session-1" in launched[0]
+    assert payload["codex_resume"]["status"] == "failed"
+    assert payload["codex_resume"]["reason"] == "socket_not_available"
+    assert payload["codex_resume"]["strategy"] == "codex-app-server-thread"
+    assert "original chat" in payload["codex_resume"]["message"]
 
 
 def test_codex_block_does_not_defer_to_live_hook_waiting_on_browser_decision(
@@ -393,26 +363,9 @@ def test_codex_block_does_not_defer_to_live_hook_waiting_on_browser_decision(
     assert payload["codex_resume"]["supported"] is False
 
 
-def test_codex_approve_pretooluse_no_wait_starts_headless_resume(
+def test_codex_approve_pretooluse_no_wait_requires_app_server_socket(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    launched: list[dict[str, object]] = []
-
-    class _FakeProcess:
-        pid = 1007
-
-    def _fake_popen(command, **kwargs):
-        launched.append({"command": command, **kwargs})
-        return _FakeProcess()
-
-    monkeypatch.setattr(
-        codex_app_server_module.shutil,
-        "which",
-        lambda command: "/usr/bin/codex" if command == "codex" else None,
-    )
-    monkeypatch.setattr(codex_app_server_module.subprocess, "Popen", _fake_popen)
-
     workspace = tmp_path / "workspace"
     codex_home = tmp_path / "codex-home"
     workspace.mkdir()
@@ -445,21 +398,14 @@ def test_codex_approve_pretooluse_no_wait_starts_headless_resume(
         daemon.stop()
 
     assert payload["resolved"] is True
-    assert payload["codex_resume"]["status"] == "sent"
-    assert payload["codex_resume"]["reason"] == "headless_resume_started"
-    assert payload["codex_resume"]["strategy"] == "codex-headless-exec"
-    assert len(launched) == 1
-    assert launched[0]["cwd"] == workspace
-    assert launched[0]["command"][:5] == ["/usr/bin/codex", "exec", "resume", "--json", "--skip-git-repo-check"]
-    assert "pretool-session-1" in launched[0]["command"]
+    assert payload["codex_resume"]["status"] == "failed"
+    assert payload["codex_resume"]["reason"] == "socket_not_available"
+    assert payload["codex_resume"]["strategy"] == "codex-app-server-thread"
 
 
 def test_codex_deferred_live_hook_resume_retry_reports_missing_chat_channel(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(codex_app_server_module.shutil, "which", lambda _command: None)
-
     store = GuardStore(tmp_path / "guard-home")
     store.add_approval_request(_request("req-live-retry"), "2026-05-19T10:00:00+00:00")
     missing_socket = tmp_path / "missing-codex.sock"
@@ -493,10 +439,10 @@ def test_codex_deferred_live_hook_resume_retry_reports_missing_chat_channel(
         daemon.stop()
 
     assert approved["codex_resume"]["status"] == "pending"
-    assert retried["status"] == "skipped"
-    assert retried["reason"] == "workspace_not_available"
-    assert retried["strategy"] == "codex-headless-exec"
-    assert "Codex chat" in retried["message"]
+    assert retried["status"] == "failed"
+    assert retried["reason"] == "socket_not_available"
+    assert retried["strategy"] == "codex-app-server-thread"
+    assert "original chat" in retried["message"]
 
 
 def test_request_resume_status_endpoint_returns_persisted_result(tmp_path: Path) -> None:
@@ -629,7 +575,7 @@ def test_request_resume_retry_endpoint_keeps_same_thread_failure_after_socket_mi
             "/v1/requests/req-retry/approve",
             {"scope": "artifact", "reason": "reviewed"},
         )
-        assert initial["codex_resume"]["reason"] == "codex_home_not_available"
+        assert initial["codex_resume"]["reason"] == "socket_not_available"
 
         retried = _post_json(
             daemon.port,
@@ -645,11 +591,11 @@ def test_request_resume_retry_endpoint_keeps_same_thread_failure_after_socket_mi
     finally:
         daemon.stop()
 
-    assert retried["status"] == "skipped"
-    assert retried["strategy"] == "codex-headless-exec"
+    assert retried["status"] == "failed"
+    assert retried["strategy"] == "codex-app-server-thread"
     assert retried["attempt_count"] == 2
     assert status_code == 200
-    assert current["status"] == "skipped"
+    assert current["status"] == "failed"
 
 
 def test_request_resume_retry_is_idempotent_after_success(
@@ -698,26 +644,9 @@ def test_request_resume_retry_is_idempotent_after_success(
     assert send_calls == 1
 
 
-def test_codex_approve_falls_back_to_exec_resume_when_socket_binding_is_missing(
+def test_codex_approve_fails_without_app_server_socket_and_never_starts_exec_resume(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    launched: list[list[str]] = []
-
-    class _FakeProcess:
-        pid = 6789
-
-    def _fake_popen(command, **_kwargs):
-        launched.append(command)
-        return _FakeProcess()
-
-    monkeypatch.setattr(
-        codex_app_server_module.shutil,
-        "which",
-        lambda command: "/usr/local/bin/codex" if command == "codex" else None,
-    )
-    monkeypatch.setattr(codex_app_server_module.subprocess, "Popen", _fake_popen)
-
     store = GuardStore(tmp_path / "guard-home")
     store.add_approval_request(_request("req-exec"), "2026-05-19T10:00:00+00:00")
     missing_socket = tmp_path / "missing-codex.sock"
@@ -747,13 +676,10 @@ def test_codex_approve_falls_back_to_exec_resume_when_socket_binding_is_missing(
     finally:
         daemon.stop()
 
-    assert payload["codex_resume"]["status"] == "sent"
-    assert payload["codex_resume"]["reason"] == "headless_resume_started"
-    assert payload["codex_resume"]["strategy"] == "codex-headless-exec"
-    assert "background" in payload["codex_resume"]["message"]
-    assert "open Codex App chat" in payload["codex_resume"]["message"]
-    assert launched[0][:5] == ["/usr/local/bin/codex", "exec", "resume", "--json", "--skip-git-repo-check"]
-    assert "--" in launched[0]
+    assert payload["codex_resume"]["status"] == "failed"
+    assert payload["codex_resume"]["reason"] == "socket_not_available"
+    assert payload["codex_resume"]["strategy"] == "codex-app-server-thread"
+    assert "original chat" in payload["codex_resume"]["message"]
 
 
 def test_codex_approve_uses_default_app_server_when_hook_omits_socket(
@@ -807,18 +733,7 @@ def test_codex_approve_uses_default_app_server_when_hook_omits_socket(
 
 def test_codex_approve_returns_failed_resume_when_app_server_socket_missing(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def _fake_popen(*_args, **_kwargs):
-        raise OSError("spawn failed")
-
-    monkeypatch.setattr(
-        codex_app_server_module.shutil,
-        "which",
-        lambda command: "/usr/local/bin/codex" if command == "codex" else None,
-    )
-    monkeypatch.setattr(codex_app_server_module.subprocess, "Popen", _fake_popen)
-
     store = GuardStore(tmp_path / "guard-home")
     store.add_approval_request(_request("req-oserror"), "2026-05-19T10:00:00+00:00")
     missing_socket = tmp_path / "missing-codex.sock"
@@ -847,8 +762,8 @@ def test_codex_approve_returns_failed_resume_when_app_server_socket_missing(
 
     assert payload["resolved"] is True
     assert payload["codex_resume"]["status"] == "failed"
-    assert payload["codex_resume"]["reason"] == "headless_resume_launch_failed"
-    assert "spawn failed" in payload["codex_resume"]["last_error"]
+    assert payload["codex_resume"]["reason"] == "socket_not_available"
+    assert payload["codex_resume"]["strategy"] == "codex-app-server-thread"
 
 
 def test_codex_approve_returns_app_server_failure_after_transport_error_reason(


### PR DESCRIPTION
## Summary
- Remove the `codex exec resume` fallback from Codex approval auto-resume.
- Require the Codex app-server socket for automatic same-chat continuation; missing socket is now a failed same-chat resume, not a background thread.
- Update diagnostics, local dashboard copy, and regression tests so headless resume is disabled by design.

## Testing
- `python3 -m pytest tests/test_guard_codex_resume_endpoints.py tests/test_guard_codex_resume_commands.py tests/test_guard_codex_auto_resume_smoke.py -q`
- `python3 -m pytest tests/test_guard_package_resume_phase14.py -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/codex_app_server.py src/codex_plugin_scanner/guard/codex_resume.py tests/test_guard_codex_resume_endpoints.py tests/test_guard_codex_resume_commands.py scripts/codex-auto-resume-smoke.py`
- `python3 scripts/codex-auto-resume-smoke.py --timeout-seconds 120 --request-timeout-seconds 60`
