### PR TITLE
feat: enrich guard runtime local identity payload

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2253,6 +2253,11 @@ def _cloud_runtime_session_payload(store: GuardStore, session: dict[str, object]
         workspace=workspace,
         generated_at=updated_at,
     )
+    local_identity = _cloud_local_identity_payload(
+        device_id,
+        daemon_version=_optional_string(session.get("client_version") or session.get("clientVersion")) or __version__,
+        observed_at=updated_at,
+    )
     return {
         "sessionId": session_id,
         "harness": _optional_string(session.get("harness")) or "hol-guard",
@@ -2264,7 +2269,8 @@ def _cloud_runtime_session_payload(store: GuardStore, session: dict[str, object]
         "clientVersion": _optional_string(session.get("client_version") or session.get("clientVersion")) or __version__,
         "deviceId": device_id,
         "deviceName": device_name,
-        "localIdentity": _cloud_local_identity_payload(device_id),
+        "localIdentity": local_identity,
+        "localIdentitySource": _cloud_local_identity_source_payload(local_identity),
         "packageManagerCoverage": package_manager_coverage,
         "workspace": workspace,
         "capabilities": capabilities,
@@ -2274,13 +2280,22 @@ def _cloud_runtime_session_payload(store: GuardStore, session: dict[str, object]
     }
 
 
-def _cloud_local_identity_payload(device_id: str) -> dict[str, object]:
+def _cloud_local_identity_payload(
+    device_id: str,
+    *,
+    daemon_version: str,
+    observed_at: str,
+) -> dict[str, object]:
     hostname = _safe_hostname()
     private_ip = _safe_private_ip()
+    if private_ip is None:
+        private_ip = _safe_private_ipv6()
     payload: dict[str, object] = {
         "daemonId": device_id,
+        "daemonVersion": daemon_version,
         "daemonStatus": "healthy",
         "relayState": "online",
+        "lastSyncedAt": observed_at,
     }
     if hostname is not None:
         payload["hostname"] = hostname
@@ -2288,6 +2303,24 @@ def _cloud_local_identity_payload(device_id: str) -> dict[str, object]:
         payload["ipAddress"] = private_ip
         payload["privateIpAddress"] = private_ip
     return payload
+
+
+def _cloud_local_identity_source_payload(local_identity: dict[str, object]) -> dict[str, str]:
+    source: dict[str, str] = {
+        "daemonId": "local-guard",
+        "daemonVersion": "local-guard",
+        "daemonStatus": "local-guard",
+        "relayState": "local-guard",
+    }
+    if "hostname" in local_identity:
+        source["hostname"] = "local-guard"
+    if "ipAddress" in local_identity:
+        source["ipAddress"] = "local-guard"
+    if "privateIpAddress" in local_identity:
+        source["privateIpAddress"] = "local-guard"
+    if "publicIpAddress" in local_identity:
+        source["publicIpAddress"] = "local-guard"
+    return source
 
 
 def _safe_hostname() -> str | None:
@@ -2308,6 +2341,16 @@ def _safe_private_ip() -> str | None:
         address = socket.gethostbyname(socket.gethostname())
         if address and not address.startswith("127."):
             return address[:128]
+    return None
+
+
+def _safe_private_ipv6() -> str | None:
+    with suppress(OSError):
+        addresses = socket.getaddrinfo(socket.gethostname(), None, socket.AF_INET6)
+        for entry in addresses:
+            candidate = entry[4][0]
+            if isinstance(candidate, str) and candidate and candidate != "::1":
+                return candidate[:128]
     return None
 
 

--- a/tests/test_guard_cloud_local_sync.py
+++ b/tests/test_guard_cloud_local_sync.py
@@ -679,8 +679,14 @@ def test_sync_runtime_session_emits_package_manager_coverage_payload(
     assert session_payload["deviceId"] == store.get_or_create_installation_id()
     assert session_payload["deviceName"] == store.get_device_metadata()["device_label"]
     assert session_payload["localIdentity"]["daemonId"] == store.get_or_create_installation_id()
+    assert session_payload["localIdentity"]["daemonVersion"] == guard_runner_module.__version__
     assert session_payload["localIdentity"]["daemonStatus"] == "healthy"
     assert session_payload["localIdentity"]["relayState"] == "online"
+    assert session_payload["localIdentity"]["lastSyncedAt"] == "2026-04-24T00:01:00+00:00"
+    assert session_payload["localIdentitySource"]["daemonId"] == "local-guard"
+    assert session_payload["localIdentitySource"]["daemonVersion"] == "local-guard"
+    assert session_payload["localIdentitySource"]["daemonStatus"] == "local-guard"
+    assert session_payload["localIdentitySource"]["relayState"] == "local-guard"
     assert session_payload["packageManagerCoverage"] == {
         "generatedAt": "2026-04-24T00:01:00+00:00",
         "configuredManagers": ["npm"],
@@ -694,3 +700,105 @@ def test_sync_runtime_session_emits_package_manager_coverage_payload(
             "nextRefreshAt": "2026-04-24T00:15:00+00:00",
         },
     }
+
+
+def test_sync_runtime_session_prefers_ipv6_private_identity_when_ipv4_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "token-ipv6",
+        "2026-04-24T00:00:00+00:00",
+        workspace_id="workspace-alpha",
+    )
+    monkeypatch.setattr(guard_runner_module, "_safe_private_ip", lambda: None)
+    monkeypatch.setattr(guard_runner_module, "_safe_private_ipv6", lambda: "fd00::42")
+    captured_body: dict[str, object] = {}
+
+    def _runtime_sync_response(**kwargs):
+        request = kwargs["request"]
+        captured_body.update(json.loads(request.data.decode("utf-8")))
+        return {"syncedAt": "2026-04-24T00:01:00+00:00", "items": []}
+
+    monkeypatch.setattr(
+        guard_runner_module,
+        "_urlopen_json_with_timeout_retry",
+        _runtime_sync_response,
+    )
+
+    guard_runner_module.sync_runtime_session(
+        store,
+        session={
+            "harness": "codex",
+            "surface": "cli",
+            "status": "active",
+            "updatedAt": "2026-04-24T00:01:00+00:00",
+            "workspace": str(tmp_path / "workspace"),
+        },
+    )
+
+    session_payload = captured_body["session"]
+    assert isinstance(session_payload, dict)
+    assert session_payload["localIdentity"]["ipAddress"] == "fd00::42"
+    assert session_payload["localIdentity"]["privateIpAddress"] == "fd00::42"
+    assert session_payload["localIdentitySource"]["privateIpAddress"] == "local-guard"
+
+
+def test_sync_runtime_session_keeps_local_identity_when_package_coverage_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "token-no-coverage",
+        "2026-04-24T00:00:00+00:00",
+        workspace_id="workspace-alpha",
+    )
+    monkeypatch.setattr(
+        guard_runner_module,
+        "package_shim_cloud_coverage",
+        lambda *_args, **_kwargs: {
+            "generatedAt": "2026-04-24T00:01:00+00:00",
+            "configuredManagers": [],
+            "protectedManagers": [],
+            "missingManagers": [],
+            "pathActive": False,
+            "bypasses": [],
+            "staleIntel": {
+                "status": "unknown",
+                "lastSyncedAt": None,
+                "nextRefreshAt": None,
+            },
+        },
+    )
+    captured_body: dict[str, object] = {}
+
+    def _runtime_sync_response(**kwargs):
+        request = kwargs["request"]
+        captured_body.update(json.loads(request.data.decode("utf-8")))
+        return {"syncedAt": "2026-04-24T00:01:00+00:00", "items": []}
+
+    monkeypatch.setattr(
+        guard_runner_module,
+        "_urlopen_json_with_timeout_retry",
+        _runtime_sync_response,
+    )
+
+    guard_runner_module.sync_runtime_session(
+        store,
+        session={
+            "harness": "codex",
+            "surface": "cli",
+            "status": "active",
+            "updatedAt": "2026-04-24T00:01:00+00:00",
+            "workspace": str(tmp_path / "workspace"),
+        },
+    )
+
+    session_payload = captured_body["session"]
+    assert isinstance(session_payload, dict)
+    assert session_payload["localIdentity"]["daemonId"] == store.get_or_create_installation_id()
+    assert session_payload["localIdentitySource"]["daemonId"] == "local-guard"


### PR DESCRIPTION
## Summary
- include daemon version, last-synced timestamp, and local identity source metadata in cloud runtime session payloads
- add IPv6-safe private identity fallback when IPv4 private identity is unavailable
- add regressions for deterministic local identity payload and runtime identity emission without package coverage

## Validation
- python3 -m pytest tests/test_guard_cloud_local_sync.py -q