### PR TITLE
fix(copilot): parse JSONC config for install and uninstall

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/copilot.py
+++ b/src/codex_plugin_scanner/guard/adapters/copilot.py
@@ -48,14 +48,14 @@ _INLINE_GUARD_ARGS_PATTERN = re.compile(r"json\.loads\((?P<payload>'(?:[^'\\]|\\
 
 
 def _parse_copilot_json_text(raw_text: str) -> dict[str, object] | None:
-    for candidate in (raw_text, _strip_jsonc(raw_text)):
+    try:
+        payload = json.loads(raw_text)
+    except json.JSONDecodeError:
         try:
-            payload = json.loads(candidate)
+            payload = json.loads(_strip_jsonc(raw_text))
         except json.JSONDecodeError:
-            continue
-        if isinstance(payload, dict):
-            return payload
-    return None
+            return None
+    return payload if isinstance(payload, dict) else None
 
 
 def _copilot_json_payload(path: Path) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/adapters/copilot.py
+++ b/src/codex_plugin_scanner/guard/adapters/copilot.py
@@ -13,6 +13,7 @@ import sys
 from hashlib import sha256
 from pathlib import Path
 
+from ...ecosystems.opencode import _strip_jsonc
 from ..launcher import merge_guard_launcher_env
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
@@ -44,6 +45,27 @@ _LEGACY_MANAGED_HOOK_PATTERNS = (
     re.compile(r'--harness(?:["\s=]+)copilot(["\s]|$)'),
 )
 _INLINE_GUARD_ARGS_PATTERN = re.compile(r"json\.loads\((?P<payload>'(?:[^'\\]|\\.)*'|\"(?:[^\"\\]|\\.)*\")\)")
+
+
+def _parse_copilot_json_text(raw_text: str) -> dict[str, object] | None:
+    for candidate in (raw_text, _strip_jsonc(raw_text)):
+        try:
+            payload = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            return payload
+    return None
+
+
+def _copilot_json_payload(path: Path) -> dict[str, object]:
+    if not path.is_file():
+        return {}
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    return _parse_copilot_json_text(raw_text) or {}
 
 
 def _hook_command_parts(context: HarnessContext, *, include_workspace: bool) -> tuple[str, ...]:
@@ -363,14 +385,11 @@ class CopilotHarnessAdapter(HarnessAdapter):
             raw_text = path.read_text(encoding="utf-8")
         except OSError as exc:
             raise RuntimeError(f"Guard refused to overwrite unreadable {label} at {path}") from exc
-        try:
-            payload = json.loads(raw_text)
-        except json.JSONDecodeError as exc:
+        payload = _parse_copilot_json_text(raw_text)
+        if payload is None:
             if recover_malformed:
                 return {}
-            raise RuntimeError(f"Guard refused to overwrite unreadable {label} at {path}") from exc
-        if not isinstance(payload, dict):
-            raise RuntimeError(f"Guard refused to overwrite non-object {label} at {path}")
+            raise RuntimeError(f"Guard refused to overwrite unreadable {label} at {path}")
         return payload
 
     def detect(self, context: HarnessContext) -> HarnessDetection:
@@ -382,7 +401,7 @@ class CopilotHarnessAdapter(HarnessAdapter):
         artifacts: list[GuardArtifact] = []
         found_paths: list[str] = []
         for config_path in config_candidates:
-            payload = _json_payload(config_path)
+            payload = _copilot_json_payload(config_path)
             if not payload:
                 continue
             found_paths.append(str(config_path))
@@ -396,7 +415,7 @@ class CopilotHarnessAdapter(HarnessAdapter):
             hooks_dir = context.workspace_dir / ".github" / "hooks"
             if hooks_dir.is_dir():
                 for hook_path in sorted(path for path in hooks_dir.glob("*.json") if path.is_file()):
-                    payload = _json_payload(hook_path)
+                    payload = _copilot_json_payload(hook_path)
                     if not payload:
                         continue
                     hook_artifacts = self._hook_artifacts(hook_path, payload, "project")
@@ -446,7 +465,7 @@ class CopilotHarnessAdapter(HarnessAdapter):
                 + "\n",
                 encoding="utf-8",
             )
-            mcp_payload = _json_payload(target_mcp_path)
+            mcp_payload = _copilot_json_payload(target_mcp_path)
             existing_servers = _mcp_servers_payload(target_mcp_path, mcp_payload)
             normalized_servers = dict(existing_servers) if isinstance(existing_servers, dict) else {}
             for name, server_config in tuple(normalized_servers.items()):

--- a/tests/test_guard_copilot_adapter.py
+++ b/tests/test_guard_copilot_adapter.py
@@ -351,6 +351,39 @@ def test_copilot_install_and_uninstall_preserve_existing_inline_hook_content(tmp
     }
 
 
+def test_copilot_install_and_uninstall_parse_jsonc_config_comments(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = CopilotHarnessAdapter()
+    config_path = context.home_dir / ".copilot" / "config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        "// User settings belong in settings.json.\n"
+        "// This file is managed automatically.\n"
+        '{\n  "trusted_repositories": ["demo"],\n'
+        '  "hooks": {\n'
+        '    "preToolUse": [{"command": "python existing-pre.py"}]\n'
+        "  }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    adapter.install(context)
+    managed_payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert managed_payload["trusted_repositories"] == ["demo"]
+    assert len(managed_payload["hooks"]["preToolUse"]) == 2
+
+    uninstall_payload = adapter.uninstall(context)
+    remaining_payload = json.loads(config_path.read_text(encoding="utf-8"))
+
+    assert uninstall_payload["active"] is False
+    assert remaining_payload == {
+        "trusted_repositories": ["demo"],
+        "hooks": {
+            "preToolUse": [{"command": "python existing-pre.py"}],
+        },
+    }
+
+
 def test_copilot_install_and_uninstall_match_inline_hooks_after_path_changes(tmp_path):
     context = _build_context(tmp_path)
     adapter = CopilotHarnessAdapter()


### PR DESCRIPTION
## Summary
- Parse Copilot `~/.copilot/config.json` as JSONC (strip `//` and `/* */` comments) before install/uninstall mutate it.
- Fixes `hol-guard uninstall copilot` failing with "Guard refused to overwrite unreadable Copilot config" on real Copilot-managed configs.

## Testing
- `python3 -m pytest tests/test_guard_copilot_adapter.py::test_copilot_install_and_uninstall_parse_jsonc_config_comments -q`
- `python3 -m pytest tests/test_guard_copilot_adapter.py -q`
- `PYTHONPATH=src hol-guard uninstall copilot` against a JSONC `~/.copilot/config.json`
