### PR TITLE
feat(guard): add cursor local surface actions

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -437,6 +437,7 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
         app_parser.add_argument("harness")
         _add_guard_common_args(app_parser, suppress_defaults=True)
         app_parser.add_argument("--json", action="store_true", default=argparse.SUPPRESS)
+        app_parser.add_argument("--surface", choices=("editor", "cli"))
         if app_command in {"connect", "repair"}:
             app_parser.add_argument("--dry-run", action="store_true")
         if app_command == "disconnect":
@@ -1400,7 +1401,7 @@ def _run_apps_command(
         return 2
     if apps_command == "test":
         try:
-            payload = build_harness_verification(harness, context, store)
+            payload = build_harness_verification(harness, context, store, surface=getattr(args, "surface", None))
         except ValueError as error:
             print(str(error), file=sys.stderr)
             return 2
@@ -1409,7 +1410,13 @@ def _run_apps_command(
 
     if apps_command in {"connect", "repair"} and bool(getattr(args, "dry_run", False)):
         try:
-            payload = build_harness_setup_plan(apps_command, harness, context, dry_run=True)
+            payload = build_harness_setup_plan(
+                apps_command,
+                harness,
+                context,
+                dry_run=True,
+                surface=getattr(args, "surface", None),
+            )
         except ValueError as error:
             print(str(error), file=sys.stderr)
             return 2

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -49,6 +49,13 @@ def apply_managed_install(
         skill_scan = scan_workspace_skills(context.workspace_dir, store, now)
         if skill_scan:
             payload["skill_scan"] = skill_scan
+    if requested_harness == "cursor" and len(managed_installs) == 1:
+        payload["cursor_action"] = cursor_local_action_payload(
+            action=command,
+            surface=None,
+            context=context,
+            protected=active,
+        )
     return payload
 
 
@@ -102,6 +109,7 @@ def build_harness_setup_plan(
     context: HarnessContext,
     *,
     dry_run: bool,
+    surface: str | None = None,
 ) -> dict[str, object]:
     adapter = get_adapter(requested_harness)
     contract = adapter.setup_contract()
@@ -138,6 +146,13 @@ def build_harness_setup_plan(
                 "requires_confirmation": True,
             }
         ]
+    if adapter.harness == "cursor":
+        payload["cursor_action"] = cursor_local_action_payload(
+            action=action,
+            surface=surface,
+            context=context,
+            protected=False,
+        )
     return payload
 
 
@@ -145,10 +160,11 @@ def build_harness_verification(
     requested_harness: str,
     context: HarnessContext,
     store: GuardStore | None = None,
+    surface: str | None = None,
 ) -> dict[str, object]:
     adapter = get_adapter(requested_harness)
     detection = _safe_setup_detection(adapter, context, store)
-    return {
+    payload: dict[str, object] = {
         "harness": adapter.harness,
         "safe": True,
         "contract": adapter.setup_contract().to_dict(),
@@ -163,6 +179,90 @@ def build_harness_verification(
             "steps": [step.to_dict() for step in adapter.verify_steps()],
         },
     }
+    if adapter.harness == "cursor":
+        payload["cursor_action"] = cursor_local_action_payload(
+            action="test",
+            surface=surface,
+            context=context,
+            protected=bool(detection["installed"]),
+        )
+    return payload
+
+
+def cursor_local_action_payload(
+    *,
+    action: str,
+    surface: str | None,
+    context: HarnessContext,
+    protected: bool,
+) -> dict[str, object]:
+    selected_surface = _cursor_surface(surface)
+    statuses = _cursor_surface_statuses(context, protected=protected)
+    selected_status = next(item["status"] for item in statuses if item["surface"] == selected_surface)
+    action_scope = f"cursor:{selected_surface}:{action}"
+    return {
+        "app_id": "cursor",
+        "action": action,
+        "surface": selected_surface,
+        "status": selected_status,
+        "surface_statuses": statuses,
+        "sync": {
+            "surface": selected_surface,
+            "status": selected_status,
+            "lastSeenAt": None,
+            "lastReceiptSyncedAt": None,
+            "daemonReachability": "local",
+            "protectedLocationId": None,
+        },
+        "evidence": {
+            "receiptId": None,
+            "artifactId": action_scope,
+            "actionScope": action_scope,
+            "surface": selected_surface,
+            "redactedPath": _cursor_redacted_path(context, selected_surface),
+            "policyDecision": "monitor",
+        },
+    }
+
+
+def _cursor_surface(surface: str | None) -> str:
+    if surface is None:
+        return "editor"
+    if surface in {"editor", "cli"}:
+        return surface
+    raise ValueError(f"Unsupported Cursor surface: {surface}")
+
+
+def _cursor_surface_statuses(context: HarnessContext, *, protected: bool) -> list[dict[str, str]]:
+    editor_path = context.workspace_dir / ".cursor" / "mcp.json" if context.workspace_dir is not None else None
+    editor_detected = editor_path is not None and editor_path.exists()
+    cli_detected = get_adapter("cursor").resolved_executable(context) is not None
+    return [
+        {
+            "surface": "editor",
+            "status": _cursor_status(editor_detected, protected=protected),
+        },
+        {
+            "surface": "cli",
+            "status": _cursor_status(cli_detected, protected=protected),
+        },
+    ]
+
+
+def _cursor_status(detected: bool, *, protected: bool) -> str:
+    if protected and detected:
+        return "protected"
+    if detected:
+        return "detected_unprotected"
+    return "not_detected"
+
+
+def _cursor_redacted_path(context: HarnessContext, surface: str) -> str:
+    if surface == "cli":
+        return "PATH:cursor-agent"
+    if context.workspace_dir is not None:
+        return "$WORKSPACE/.cursor/mcp.json"
+    return "$HOME/.cursor/mcp.json"
 
 
 def uninstall_confirmation_token(harness: str) -> str:

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -49,9 +49,7 @@ def apply_managed_install(
         skill_scan = scan_workspace_skills(context.workspace_dir, store, now)
         if skill_scan:
             payload["skill_scan"] = skill_scan
-    if len(managed_installs) == 1 and (
-        requested_harness == "cursor" or managed_installs[0].get("harness") == "cursor"
-    ):
+    if len(managed_installs) == 1 and (requested_harness == "cursor" or managed_installs[0].get("harness") == "cursor"):
         payload["cursor_action"] = cursor_local_action_payload(
             action=command,
             surface=None,

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -49,7 +49,9 @@ def apply_managed_install(
         skill_scan = scan_workspace_skills(context.workspace_dir, store, now)
         if skill_scan:
             payload["skill_scan"] = skill_scan
-    if requested_harness == "cursor" and len(managed_installs) == 1:
+    if len(managed_installs) == 1 and (
+        requested_harness == "cursor" or managed_installs[0].get("harness") == "cursor"
+    ):
         payload["cursor_action"] = cursor_local_action_payload(
             action=command,
             surface=None,
@@ -234,8 +236,7 @@ def _cursor_surface(surface: str | None) -> str:
 
 
 def _cursor_surface_statuses(context: HarnessContext, *, protected: bool) -> list[dict[str, str]]:
-    editor_path = context.workspace_dir / ".cursor" / "mcp.json" if context.workspace_dir is not None else None
-    editor_detected = editor_path is not None and editor_path.exists()
+    editor_detected = any(path.exists() for path in _cursor_editor_config_paths(context))
     cli_detected = get_adapter("cursor").resolved_executable(context) is not None
     return [
         {
@@ -260,9 +261,18 @@ def _cursor_status(detected: bool, *, protected: bool) -> str:
 def _cursor_redacted_path(context: HarnessContext, surface: str) -> str:
     if surface == "cli":
         return "PATH:cursor-agent"
-    if context.workspace_dir is not None:
+    workspace_path = context.workspace_dir / ".cursor" / "mcp.json" if context.workspace_dir is not None else None
+    if workspace_path is not None and workspace_path.exists():
         return "$WORKSPACE/.cursor/mcp.json"
     return "$HOME/.cursor/mcp.json"
+
+
+def _cursor_editor_config_paths(context: HarnessContext) -> tuple[Path, ...]:
+    paths: list[Path] = []
+    if context.workspace_dir is not None:
+        paths.append(context.workspace_dir / ".cursor" / "mcp.json")
+    paths.append(context.home_dir / ".cursor" / "mcp.json")
+    return tuple(paths)
 
 
 def uninstall_confirmation_token(harness: str) -> str:

--- a/tests/test_cursor_local_actions.py
+++ b/tests/test_cursor_local_actions.py
@@ -1,0 +1,71 @@
+"""Cursor local setup, status, repair, and remove action tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.cli.install_commands import (
+    apply_managed_install,
+    build_harness_setup_plan,
+    build_harness_verification,
+    cursor_local_action_payload,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _context(tmp_path: Path) -> HarnessContext:
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    guard_home = tmp_path / "guard-home"
+    home.mkdir()
+    workspace.mkdir()
+    guard_home.mkdir()
+    cursor_dir = workspace / ".cursor"
+    cursor_dir.mkdir()
+    (cursor_dir / "mcp.json").write_text('{"mcpServers":{}}', encoding="utf-8")
+    return HarnessContext(home_dir=home, workspace_dir=workspace, guard_home=guard_home)
+
+
+def test_cursor_local_actions_preserve_editor_and_cli_surfaces(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PATH", str(tmp_path / "empty-bin"))
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    now = "2026-05-29T12:00:00Z"
+
+    connect = apply_managed_install("install", "cursor", False, context, store, str(context.workspace_dir), now)
+    repair = build_harness_setup_plan("repair", "cursor", context, dry_run=True, surface="editor")
+    status = build_harness_verification("cursor", context, store, surface="cli")
+    remove = build_harness_setup_plan("uninstall", "cursor", context, dry_run=True, surface="editor")
+
+    assert connect["cursor_action"]["surface_statuses"] == [
+        {"surface": "editor", "status": "protected"},
+        {"surface": "cli", "status": "not_detected"},
+    ]
+    assert repair["cursor_action"] == cursor_local_action_payload(
+        action="repair",
+        surface="editor",
+        context=context,
+        protected=False,
+    )
+    assert status["cursor_action"]["surface"] == "cli"
+    assert status["cursor_action"]["sync"]["surface"] == "cli"
+    assert status["cursor_action"]["evidence"]["surface"] == "cli"
+    assert remove["cursor_action"]["action"] == "uninstall"
+    assert remove["cursor_action"]["surface"] == "editor"
+
+
+def test_cursor_local_actions_reject_unknown_surfaces(tmp_path: Path) -> None:
+    context = _context(tmp_path)
+
+    try:
+        build_harness_setup_plan("repair", "cursor", context, dry_run=True, surface="browser")
+    except ValueError as error:
+        assert "Unsupported Cursor surface" in str(error)
+    else:
+        raise AssertionError("Expected unsupported Cursor surface to fail")

--- a/tests/test_cursor_local_actions.py
+++ b/tests/test_cursor_local_actions.py
@@ -13,19 +13,21 @@ from codex_plugin_scanner.guard.cli.install_commands import (
     build_harness_verification,
     cursor_local_action_payload,
 )
+from codex_plugin_scanner.guard.models import HarnessDetection
 from codex_plugin_scanner.guard.store import GuardStore
 
 
-def _context(tmp_path: Path) -> HarnessContext:
+def _context(tmp_path: Path, *, workspace_cursor: bool = True) -> HarnessContext:
     home = tmp_path / "home"
     workspace = tmp_path / "workspace"
     guard_home = tmp_path / "guard-home"
     home.mkdir()
     workspace.mkdir()
     guard_home.mkdir()
-    cursor_dir = workspace / ".cursor"
-    cursor_dir.mkdir()
-    (cursor_dir / "mcp.json").write_text('{"mcpServers":{}}', encoding="utf-8")
+    if workspace_cursor:
+        cursor_dir = workspace / ".cursor"
+        cursor_dir.mkdir()
+        (cursor_dir / "mcp.json").write_text('{"mcpServers":{}}', encoding="utf-8")
     return HarnessContext(home_dir=home, workspace_dir=workspace, guard_home=guard_home)
 
 
@@ -69,3 +71,62 @@ def test_cursor_local_actions_reject_unknown_surfaces(tmp_path: Path) -> None:
         assert "Unsupported Cursor surface" in str(error)
     else:
         raise AssertionError("Expected unsupported Cursor surface to fail")
+
+
+def test_cursor_install_all_reports_auto_detected_cursor_action(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PATH", str(tmp_path / "empty-bin"))
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.install_commands.detect_all",
+        lambda _: [
+            HarnessDetection(
+                harness="cursor",
+                installed=False,
+                command_available=False,
+                config_paths=(str(context.workspace_dir / ".cursor" / "mcp.json"),),
+                artifacts=(),
+            )
+        ],
+    )
+
+    payload = apply_managed_install(
+        "install",
+        None,
+        True,
+        context,
+        store,
+        str(context.workspace_dir),
+        "2026-05-29T12:00:00Z",
+    )
+
+    assert payload["managed_install"]["harness"] == "cursor"
+    assert payload["cursor_action"]["app_id"] == "cursor"
+    assert payload["cursor_action"]["status"] == "protected"
+
+
+def test_cursor_editor_detection_uses_global_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PATH", str(tmp_path / "empty-bin"))
+    context = _context(tmp_path, workspace_cursor=False)
+    cursor_dir = context.home_dir / ".cursor"
+    cursor_dir.mkdir()
+    (cursor_dir / "mcp.json").write_text('{"mcpServers":{}}', encoding="utf-8")
+
+    payload = cursor_local_action_payload(
+        action="test",
+        surface="editor",
+        context=context,
+        protected=False,
+    )
+
+    assert payload["surface_statuses"] == [
+        {"surface": "editor", "status": "detected_unprotected"},
+        {"surface": "cli", "status": "not_detected"},
+    ]
+    assert payload["evidence"]["redactedPath"] == "$HOME/.cursor/mcp.json"


### PR DESCRIPTION
## Summary
- Add Cursor editor/CLI surface-aware local action payloads for setup, repair, test, and remove flows.
- Add deterministic tests proving editor and CLI statuses, sync fields, evidence fields, redacted paths, and invalid-surface handling.

## Testing
- `pytest -q tests/test_cursor_local_actions.py tests/test_guard_harness_setup.py tests/test_cursor_adapter.py`
- `ruff check src tests/test_cursor_local_actions.py tests/test_guard_harness_setup.py tests/test_cursor_adapter.py`
