### PR TITLE
feat(cursor): add editor and cli local hooks

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/cursor.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor.py
@@ -2,10 +2,23 @@
 
 from __future__ import annotations
 
+import json
+import sys
+from hashlib import sha256
 from pathlib import Path
 
+from ..launcher import merge_guard_launcher_env
 from ..models import GuardArtifact, HarnessDetection
+from ..shims import install_guard_shim, remove_guard_shim
 from .base import HarnessAdapter, HarnessContext, _command_available, _json_payload, _run_command_probe
+from .mcp_servers import (
+    ManagedMcpServer,
+    is_guard_proxy_command,
+    managed_stdio_servers,
+    proxy_cli_args,
+    proxy_process_env,
+    skipped_stdio_server_names,
+)
 
 
 class CursorHarnessAdapter(HarnessAdapter):
@@ -32,13 +45,24 @@ class CursorHarnessAdapter(HarnessAdapter):
             return context.workspace_dir / ".cursor" / "mcp.json"
         return context.home_dir / ".cursor" / "mcp.json"
 
-    def detect(self, context: HarnessContext) -> HarnessDetection:
-        config_paths = [context.home_dir / ".cursor" / "mcp.json"]
+    @staticmethod
+    def _editor_config_paths(context: HarnessContext) -> tuple[Path, ...]:
+        paths: list[Path] = []
         if context.workspace_dir is not None:
-            config_paths.append(context.workspace_dir / ".cursor" / "mcp.json")
+            paths.append(context.workspace_dir / ".cursor" / "mcp.json")
+        paths.append(context.home_dir / ".cursor" / "mcp.json")
+        return tuple(paths)
+
+    @staticmethod
+    def _target_editor_config_path(context: HarnessContext) -> Path:
+        if context.workspace_dir is not None:
+            return context.workspace_dir / ".cursor" / "mcp.json"
+        return context.home_dir / ".cursor" / "mcp.json"
+
+    def detect(self, context: HarnessContext) -> HarnessDetection:
         artifacts: list[GuardArtifact] = []
         found_paths: list[str] = []
-        for config_path in config_paths:
+        for config_path in self._editor_config_paths(context):
             payload = _json_payload(config_path)
             if not payload:
                 continue
@@ -52,6 +76,9 @@ class CursorHarnessAdapter(HarnessAdapter):
                     continue
                 args = tuple(str(value) for value in server_config.get("args", []) if isinstance(value, str))
                 command = server_config.get("command")
+                env_payload = server_config.get("env")
+                environment_payload = server_config.get("environment")
+                environment = env_payload if isinstance(env_payload, dict) else environment_payload
                 artifacts.append(
                     GuardArtifact(
                         artifact_id=f"cursor:{scope}:{name}",
@@ -64,6 +91,19 @@ class CursorHarnessAdapter(HarnessAdapter):
                         args=args,
                         url=server_config.get("url") if isinstance(server_config.get("url"), str) else None,
                         transport="http" if isinstance(server_config.get("url"), str) else "stdio",
+                        metadata={
+                            "env": {
+                                str(key): str(value)
+                                for key, value in environment.items()
+                                if isinstance(key, str) and isinstance(value, str)
+                            }
+                            if isinstance(environment, dict)
+                            else {},
+                            "guard_managed_proxy": is_guard_proxy_command(
+                                command if isinstance(command, str) else None,
+                                args,
+                            ),
+                        },
                     )
                 )
         return HarnessDetection(
@@ -74,6 +114,136 @@ class CursorHarnessAdapter(HarnessAdapter):
             artifacts=tuple(artifacts),
             warnings=(),
         )
+
+    def install(self, context: HarnessContext, *, surface: str = "editor") -> dict[str, object]:
+        if surface == "cli":
+            return self._install_cli(context)
+        if surface != "editor":
+            raise ValueError(f"Unsupported Cursor surface: {surface}")
+        return self._install_editor(context)
+
+    def uninstall(self, context: HarnessContext, *, surface: str = "editor") -> dict[str, object]:
+        if surface == "cli":
+            return self._uninstall_cli(context)
+        if surface != "editor":
+            raise ValueError(f"Unsupported Cursor surface: {surface}")
+        return self._uninstall_editor(context)
+
+    def _install_editor(self, context: HarnessContext) -> dict[str, object]:
+        detection = self.detect(context)
+        managed_servers = managed_stdio_servers(detection)
+        skipped_servers = skipped_stdio_server_names(detection)
+        target_path = self._target_editor_config_path(context)
+        original_text = target_path.read_text(encoding="utf-8") if target_path.is_file() else None
+        backup_path = self._backup_path(target_path, context)
+        if not backup_path.exists():
+            backup_path.parent.mkdir(parents=True, exist_ok=True)
+            backup_path.write_text(
+                json.dumps({"existed": original_text is not None, "content": original_text}, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        state_path = self._state_path(target_path, context)
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        workspace_dir = str(context.workspace_dir.resolve()) if context.workspace_dir is not None else None
+        state_path.write_text(
+            json.dumps(
+                {
+                    "managed_config_path": str(target_path),
+                    "backup_path": str(backup_path),
+                    "surface": "editor",
+                    "workspace_dir": workspace_dir,
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        payload = self._strict_json_object(target_path, label="Cursor editor config", recover_missing=True)
+        servers_payload = payload.get("mcpServers")
+        normalized_servers = dict(servers_payload) if isinstance(servers_payload, dict) else {}
+        for name, server_config in tuple(normalized_servers.items()):
+            if not isinstance(name, str) or not isinstance(server_config, dict):
+                continue
+            command = server_config.get("command")
+            args = tuple(str(value) for value in server_config.get("args", []) if isinstance(value, str))
+            if not is_guard_proxy_command(command if isinstance(command, str) else None, args):
+                continue
+            normalized_servers[name] = self._refresh_guard_proxy_entry(server_config)
+        for server in managed_servers:
+            normalized_servers[server.name] = self._proxy_server_entry(context, server)
+        payload["mcpServers"] = normalized_servers
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        return {
+            "harness": self.harness,
+            "active": True,
+            "surface": "editor",
+            "managed_config_path": str(target_path),
+            "backup_path": str(backup_path),
+            "state_path": str(state_path),
+            "managed_servers": [server.name for server in managed_servers],
+            "skipped_servers": list(skipped_servers),
+            "notes": ["Guard Cursor editor MCP proxies added to the selected Cursor mcp.json config."],
+        }
+
+    def _uninstall_editor(self, context: HarnessContext) -> dict[str, object]:
+        target_path = self._target_editor_config_path(context)
+        backup_path = self._backup_path(target_path, context)
+        state_path = self._state_path(target_path, context)
+        backup_payload = self._backup_payload(backup_path)
+        restored = False
+        if backup_payload["readable"] is True:
+            if backup_payload["existed"] and isinstance(backup_payload["content"], str):
+                target_path.parent.mkdir(parents=True, exist_ok=True)
+                target_path.write_text(str(backup_payload["content"]), encoding="utf-8")
+                restored = True
+            elif backup_payload["existed"] is not True and target_path.is_file():
+                target_path.unlink()
+                restored = True
+            elif backup_payload["existed"] is not True:
+                restored = True
+        if restored and backup_path.is_file():
+            backup_path.unlink()
+        if restored and state_path.is_file():
+            state_path.unlink()
+        return {
+            "harness": self.harness,
+            "active": False,
+            "surface": "editor",
+            "managed_config_path": str(target_path),
+            "backup_path": str(backup_path),
+            "state_path": str(state_path),
+            "restored": restored,
+            "notes": ["Removed Guard Cursor editor MCP proxies and restored the prior Cursor config."],
+        }
+
+    def _install_cli(self, context: HarnessContext) -> dict[str, object]:
+        shim_manifest = install_guard_shim(
+            self.harness,
+            context,
+            launcher_name="cursor-agent",
+            display_name="Cursor CLI",
+        )
+        return {
+            "harness": self.harness,
+            "active": True,
+            "surface": "cli",
+            **shim_manifest,
+        }
+
+    def _uninstall_cli(self, context: HarnessContext) -> dict[str, object]:
+        shim_manifest = remove_guard_shim(
+            self.harness,
+            context,
+            launcher_name="cursor-agent",
+            display_name="Cursor CLI",
+        )
+        return {
+            "harness": self.harness,
+            "active": False,
+            "surface": "cli",
+            **shim_manifest,
+        }
 
     def runtime_probe(self, context: HarnessContext) -> dict[str, object] | None:
         if not _command_available(self.executable):
@@ -106,3 +276,67 @@ class CursorHarnessAdapter(HarnessAdapter):
                 "Cursor may be using a different config root than Guard."
             )
         return warnings
+
+    def _proxy_server_entry(self, context: HarnessContext, server: ManagedMcpServer) -> dict[str, object]:
+        args = proxy_cli_args(
+            proxy_command="cursor-mcp-proxy",
+            guard_home=str(context.guard_home),
+            server=server,
+            home=str(context.home_dir) if context.home_dir.resolve() != Path.home().resolve() else None,
+            workspace=str(context.workspace_dir) if context.workspace_dir is not None else None,
+        )
+        entry: dict[str, object] = {
+            "command": sys.executable,
+            "args": args,
+            "type": "stdio",
+        }
+        env = merge_guard_launcher_env(proxy_process_env(getattr(server, "env", {})))
+        if env:
+            entry["env"] = env
+        return entry
+
+    @staticmethod
+    def _refresh_guard_proxy_entry(server_config: dict[str, object]) -> dict[str, object]:
+        refreshed = dict(server_config)
+        args = tuple(str(value) for value in server_config.get("args", []) if isinstance(value, str))
+        refreshed["command"] = sys.executable
+        refreshed["args"] = list(args)
+        return refreshed
+
+    @staticmethod
+    def _strict_json_object(path: Path, *, label: str, recover_missing: bool = False) -> dict[str, object]:
+        if not path.is_file():
+            if recover_missing:
+                return {}
+            raise RuntimeError(f"Guard refused to overwrite missing {label} at {path}")
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RuntimeError(f"Guard refused to overwrite unreadable {label} at {path}") from exc
+        if not isinstance(payload, dict):
+            raise RuntimeError(f"Guard refused to overwrite non-object {label} at {path}")
+        return payload
+
+    @staticmethod
+    def _backup_path(target_path: Path, context: HarnessContext) -> Path:
+        target = str(target_path.resolve())
+        digest = sha256(target.encode("utf-8")).hexdigest()[:12]
+        return context.guard_home / "managed" / "cursor" / f"{digest}.backup.json"
+
+    @staticmethod
+    def _state_path(target_path: Path, context: HarnessContext) -> Path:
+        target = str(target_path.resolve())
+        digest = sha256(target.encode("utf-8")).hexdigest()[:12]
+        return context.guard_home / "managed" / "cursor" / f"{digest}.state.json"
+
+    @staticmethod
+    def _backup_payload(backup_path: Path) -> dict[str, str | bool | None]:
+        try:
+            payload = json.loads(backup_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {"readable": False, "existed": False, "content": None}
+        if not isinstance(payload, dict):
+            return {"readable": False, "existed": False, "content": None}
+        existed = payload.get("existed") is True
+        content = payload.get("content")
+        return {"readable": True, "existed": existed, "content": content if isinstance(content, str) else None}

--- a/src/codex_plugin_scanner/guard/adapters/cursor.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor.py
@@ -26,6 +26,8 @@ class CursorHarnessAdapter(HarnessAdapter):
 
     harness = "cursor"
     executable = "cursor-agent"
+    launcher_name = "cursor-agent"
+    legacy_launcher_names = ("cursor",)
     approval_tier = "native-harness"
     approval_summary = (
         "Cursor already owns tool approval, so Guard focuses on artifact trust, provenance, and preflight review."
@@ -48,9 +50,9 @@ class CursorHarnessAdapter(HarnessAdapter):
     @staticmethod
     def _editor_config_paths(context: HarnessContext) -> tuple[Path, ...]:
         paths: list[Path] = []
+        paths.append(context.home_dir / ".cursor" / "mcp.json")
         if context.workspace_dir is not None:
             paths.append(context.workspace_dir / ".cursor" / "mcp.json")
-        paths.append(context.home_dir / ".cursor" / "mcp.json")
         return tuple(paths)
 
     @staticmethod
@@ -118,6 +120,8 @@ class CursorHarnessAdapter(HarnessAdapter):
     def install(self, context: HarnessContext, *, surface: str = "editor") -> dict[str, object]:
         if surface == "cli":
             return self._install_cli(context)
+        if surface == "all":
+            return self._install_all(context)
         if surface != "editor":
             raise ValueError(f"Unsupported Cursor surface: {surface}")
         return self._install_editor(context)
@@ -125,9 +129,46 @@ class CursorHarnessAdapter(HarnessAdapter):
     def uninstall(self, context: HarnessContext, *, surface: str = "editor") -> dict[str, object]:
         if surface == "cli":
             return self._uninstall_cli(context)
+        if surface == "all":
+            return self._uninstall_all(context)
         if surface != "editor":
             raise ValueError(f"Unsupported Cursor surface: {surface}")
         return self._uninstall_editor(context)
+
+    def _install_all(self, context: HarnessContext) -> dict[str, object]:
+        editor_manifest = self._install_editor(context)
+        cli_manifest = self._install_cli(context)
+        return {
+            "harness": self.harness,
+            "active": True,
+            "surface": "all",
+            "surfaces": ["editor", "cli"],
+            "editor": editor_manifest,
+            "cli": cli_manifest,
+            "managed_config_path": editor_manifest.get("managed_config_path"),
+            "backup_path": editor_manifest.get("backup_path"),
+            "state_path": editor_manifest.get("state_path"),
+            "shim_path": cli_manifest.get("shim_path"),
+            "shim_command": cli_manifest.get("shim_command"),
+        }
+
+    def _uninstall_all(self, context: HarnessContext) -> dict[str, object]:
+        cli_manifest = self._uninstall_cli(context)
+        editor_manifest = self._uninstall_editor(context)
+        return {
+            "harness": self.harness,
+            "active": False,
+            "surface": "all",
+            "surfaces": ["editor", "cli"],
+            "editor": editor_manifest,
+            "cli": cli_manifest,
+            "managed_config_path": editor_manifest.get("managed_config_path"),
+            "backup_path": editor_manifest.get("backup_path"),
+            "state_path": editor_manifest.get("state_path"),
+            "shim_path": cli_manifest.get("shim_path"),
+            "removed": cli_manifest.get("removed"),
+            "restored": editor_manifest.get("restored"),
+        }
 
     def _install_editor(self, context: HarnessContext) -> dict[str, object]:
         detection = self.detect(context)

--- a/src/codex_plugin_scanner/guard/adapters/mcp_servers.py
+++ b/src/codex_plugin_scanner/guard/adapters/mcp_servers.py
@@ -32,6 +32,7 @@ _GUARD_PROXY_COMMANDS = frozenset(
         "codex-mcp-proxy",
         "opencode-mcp-proxy",
         "copilot-mcp-proxy",
+        "cursor-mcp-proxy",
         "mcp-proxy",
     }
 )

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -121,6 +121,7 @@ from ..protect import build_protect_payload
 from ..proxy import (
     CodexMcpGuardProxy,
     CopilotMcpGuardProxy,
+    CursorMcpGuardProxy,
     OpenCodeMcpGuardProxy,
     RemoteGuardProxy,
     StdioGuardProxy,
@@ -1050,6 +1051,17 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     copilot_proxy_parser.add_argument("--arg", dest="server_args", action="append", default=[])
     copilot_proxy_parser.add_argument("--server-env-key", dest="server_env_keys", action="append", default=[])
 
+    cursor_proxy_parser = guard_subparsers.add_parser("cursor-mcp-proxy", help=argparse.SUPPRESS)
+    _add_guard_common_args(cursor_proxy_parser)
+    cursor_proxy_parser.add_argument("--server-name", required=True)
+    cursor_proxy_parser.add_argument("--server-id")
+    cursor_proxy_parser.add_argument("--source-scope", default="project")
+    cursor_proxy_parser.add_argument("--config-path", required=True)
+    cursor_proxy_parser.add_argument("--transport", default="stdio")
+    cursor_proxy_parser.add_argument("--command", dest="server_command", required=True)
+    cursor_proxy_parser.add_argument("--arg", dest="server_args", action="append", default=[])
+    cursor_proxy_parser.add_argument("--server-env-key", dest="server_env_keys", action="append", default=[])
+
     hermes_mcp_proxy_parser = guard_subparsers.add_parser("hermes-mcp-proxy", help=argparse.SUPPRESS)
     _add_guard_common_args(hermes_mcp_proxy_parser)
     hermes_mcp_proxy_parser.add_argument("--server", required=True)
@@ -1061,6 +1073,7 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
         "codex-mcp-proxy",
         "opencode-mcp-proxy",
         "copilot-mcp-proxy",
+        "cursor-mcp-proxy",
         "hermes-mcp-proxy",
     }
     guard_subparsers._choices_actions = [
@@ -1435,7 +1448,11 @@ def _run_apps_command(
                 "error": "confirmation_required",
                 "harness": canonical_harness,
                 "confirmation_phrase": expected_confirmation,
-                "confirm_command": f"hol-guard apps disconnect {canonical_harness} --confirm {expected_confirmation}",
+                "confirm_command": _apps_disconnect_confirm_command(
+                    canonical_harness,
+                    expected_confirmation,
+                    surface=getattr(args, "surface", None),
+                ),
             }
             _emit("apps", payload, getattr(args, "json", False))
             return 2
@@ -1450,6 +1467,7 @@ def _run_apps_command(
             store,
             workspace,
             _now(),
+            surface=getattr(args, "surface", None),
         )
     except ValueError as error:
         print(str(error), file=sys.stderr)
@@ -1475,6 +1493,11 @@ def _run_apps_command(
             )
     _emit("apps", payload, getattr(args, "json", False))
     return 0
+
+
+def _apps_disconnect_confirm_command(harness: str, confirmation_phrase: str, *, surface: str | None) -> str:
+    surface_args = f" --surface {surface}" if surface in {"editor", "cli"} else ""
+    return f"hol-guard apps disconnect {harness}{surface_args} --confirm {confirmation_phrase}"
 
 
 def _open_guard_cloud_app(
@@ -1789,6 +1812,21 @@ def run_guard_command(
 
     if args.guard_command == "codex-mcp-proxy":
         proxy = CodexMcpGuardProxy(
+            server_name=args.server_name,
+            command=[args.server_command, *list(args.server_args)],
+            context=context,
+            store=store,
+            config=config,
+            source_scope=args.source_scope,
+            config_path=args.config_path,
+            transport=args.transport,
+            server_id=args.server_id,
+            server_env_keys=tuple(args.server_env_keys),
+        )
+        return proxy.serve()
+
+    if args.guard_command == "cursor-mcp-proxy":
+        proxy = CursorMcpGuardProxy(
             server_name=args.server_name,
             command=[args.server_command, *list(args.server_args)],
             context=context,

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import glob as globlib
+import json
 from pathlib import Path
 
 from ..adapters import get_adapter, list_adapters
 from ..adapters.base import HarnessAdapter, HarnessContext
 from ..adapters.contracts import contract_for
+from ..adapters.cursor import CursorHarnessAdapter
+from ..adapters.mcp_servers import is_guard_proxy_command
 from ..consumer import detect_all
 from ..runtime.skill_protection import build_skill_identity, detect_skill_content_risk
 from ..store import GuardStore
@@ -27,6 +30,8 @@ def apply_managed_install(
     store: GuardStore,
     workspace: str | None,
     now: str,
+    *,
+    surface: str | None = None,
 ) -> dict[str, object]:
     targets = _resolve_targets(command, requested_harness, install_all, context, store)
     active = command == "install"
@@ -34,7 +39,15 @@ def apply_managed_install(
     for harness in targets:
         adapter = get_adapter(harness)
         canonical_harness = adapter.harness
-        manifest = adapter.install(context) if active else adapter.uninstall(context)
+        if isinstance(adapter, CursorHarnessAdapter):
+            selected_surface = _cursor_surface(surface)
+            manifest = (
+                adapter.install(context, surface=selected_surface)
+                if active
+                else adapter.uninstall(context, surface=selected_surface)
+            )
+        else:
+            manifest = adapter.install(context) if active else adapter.uninstall(context)
         store.set_managed_install(canonical_harness, active, workspace, manifest, now)
         managed_install = store.get_managed_install(canonical_harness)
         if managed_install is not None:
@@ -52,9 +65,9 @@ def apply_managed_install(
     if len(managed_installs) == 1 and (requested_harness == "cursor" or managed_installs[0].get("harness") == "cursor"):
         payload["cursor_action"] = cursor_local_action_payload(
             action=command,
-            surface=None,
+            surface=surface,
             context=context,
-            protected=active,
+            protected_surfaces=_cursor_protected_surfaces(managed_installs) if active else (),
         )
     return payload
 
@@ -69,7 +82,7 @@ def _managed_install_payload(managed_install: dict[str, object]) -> dict[str, ob
         payload["primary_integration"] = "native_hooks" if protection_contract.native_approval else "browser_fallback"
     manifest = payload.get("manifest")
     if isinstance(manifest, dict):
-        for key in ("config_path", "managed_config_path", "shim_path", "mode"):
+        for key in ("config_path", "managed_config_path", "shim_path", "shim_command", "mode", "surface"):
             value = manifest.get(key)
             if value is not None:
                 payload[key] = value
@@ -151,7 +164,7 @@ def build_harness_setup_plan(
             action=action,
             surface=surface,
             context=context,
-            protected=False,
+            protected_surfaces=(),
         )
     return payload
 
@@ -184,7 +197,7 @@ def build_harness_verification(
             action="test",
             surface=surface,
             context=context,
-            protected=bool(detection["installed"]),
+            protected_surfaces=_cursor_protected_surfaces_from_store(adapter.harness, store, detection),
         )
     return payload
 
@@ -194,10 +207,14 @@ def cursor_local_action_payload(
     action: str,
     surface: str | None,
     context: HarnessContext,
-    protected: bool,
+    protected: bool | None = None,
+    protected_surfaces: tuple[str, ...] = (),
 ) -> dict[str, object]:
     selected_surface = _cursor_surface(surface)
-    statuses = _cursor_surface_statuses(context, protected=protected)
+    selected_protected_surfaces = protected_surfaces
+    if protected is not None and protected:
+        selected_protected_surfaces = ("editor", "cli")
+    statuses = _cursor_surface_statuses(context, protected_surfaces=selected_protected_surfaces)
     selected_status = next(item["status"] for item in statuses if item["surface"] == selected_surface)
     action_scope = f"cursor:{selected_surface}:{action}"
     return {
@@ -233,17 +250,24 @@ def _cursor_surface(surface: str | None) -> str:
     raise ValueError(f"Unsupported Cursor surface: {surface}")
 
 
-def _cursor_surface_statuses(context: HarnessContext, *, protected: bool) -> list[dict[str, str]]:
+def _cursor_surface_statuses(
+    context: HarnessContext,
+    *,
+    protected_surfaces: tuple[str, ...],
+) -> list[dict[str, str]]:
     editor_detected = any(path.exists() for path in _cursor_editor_config_paths(context))
-    cli_detected = get_adapter("cursor").resolved_executable(context) is not None
+    cli_detected = _cursor_cli_detected(context)
+    protected = set(protected_surfaces)
+    editor_protected = "editor" in protected or _cursor_editor_protected(context)
+    cli_protected = "cli" in protected or _cursor_cli_protected(context)
     return [
         {
             "surface": "editor",
-            "status": _cursor_status(editor_detected, protected=protected),
+            "status": _cursor_status(editor_detected, protected=editor_protected),
         },
         {
             "surface": "cli",
-            "status": _cursor_status(cli_detected, protected=protected),
+            "status": _cursor_status(cli_detected, protected=cli_protected),
         },
     ]
 
@@ -271,6 +295,66 @@ def _cursor_editor_config_paths(context: HarnessContext) -> tuple[Path, ...]:
         paths.append(context.workspace_dir / ".cursor" / "mcp.json")
     paths.append(context.home_dir / ".cursor" / "mcp.json")
     return tuple(paths)
+
+
+def _cursor_cli_detected(context: HarnessContext) -> bool:
+    if get_adapter("cursor").resolved_executable(context) is not None:
+        return True
+    return (context.guard_home / "bin" / "guard-cursor-agent").exists()
+
+
+def _cursor_editor_protected(context: HarnessContext) -> bool:
+    for config_path in _cursor_editor_config_paths(context):
+        try:
+            payload = json.loads(config_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        mcp_servers = payload.get("mcpServers")
+        if not isinstance(mcp_servers, dict):
+            continue
+        for server_config in mcp_servers.values():
+            if not isinstance(server_config, dict):
+                continue
+            command = server_config.get("command")
+            args = tuple(str(value) for value in server_config.get("args", []) if isinstance(value, str))
+            if is_guard_proxy_command(command if isinstance(command, str) else None, args):
+                return True
+    return False
+
+
+def _cursor_cli_protected(context: HarnessContext) -> bool:
+    return (context.guard_home / "bin" / "guard-cursor-agent").exists()
+
+
+def _cursor_protected_surfaces(managed_installs: list[dict[str, object]]) -> tuple[str, ...]:
+    surfaces: list[str] = []
+    for managed_install in managed_installs:
+        surface = managed_install.get("surface")
+        if surface in {"editor", "cli"} and surface not in surfaces:
+            surfaces.append(surface)
+            continue
+        manifest = managed_install.get("manifest")
+        if not isinstance(manifest, dict):
+            continue
+        manifest_surface = manifest.get("surface")
+        if manifest_surface in {"editor", "cli"} and manifest_surface not in surfaces:
+            surfaces.append(manifest_surface)
+    return tuple(surfaces)
+
+
+def _cursor_protected_surfaces_from_store(
+    harness: str,
+    store: GuardStore | None,
+    detection: dict[str, object],
+) -> tuple[str, ...]:
+    if not bool(detection["installed"]):
+        return ()
+    managed = store.get_managed_install(harness) if store is not None else None
+    if not isinstance(managed, dict):
+        return ("editor", "cli")
+    return _cursor_protected_surfaces([_managed_install_payload(managed)])
 
 
 def uninstall_confirmation_token(harness: str) -> str:

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -40,7 +40,7 @@ def apply_managed_install(
         adapter = get_adapter(harness)
         canonical_harness = adapter.harness
         if isinstance(adapter, CursorHarnessAdapter):
-            selected_surface = _cursor_surface(surface)
+            selected_surface = _cursor_install_surface(surface)
             manifest = (
                 adapter.install(context, surface=selected_surface)
                 if active
@@ -82,7 +82,7 @@ def _managed_install_payload(managed_install: dict[str, object]) -> dict[str, ob
         payload["primary_integration"] = "native_hooks" if protection_contract.native_approval else "browser_fallback"
     manifest = payload.get("manifest")
     if isinstance(manifest, dict):
-        for key in ("config_path", "managed_config_path", "shim_path", "shim_command", "mode", "surface"):
+        for key in ("config_path", "managed_config_path", "shim_path", "shim_command", "mode", "surface", "surfaces"):
             value = manifest.get(key)
             if value is not None:
                 payload[key] = value
@@ -250,6 +250,12 @@ def _cursor_surface(surface: str | None) -> str:
     raise ValueError(f"Unsupported Cursor surface: {surface}")
 
 
+def _cursor_install_surface(surface: str | None) -> str:
+    if surface is None:
+        return "all"
+    return _cursor_surface(surface)
+
+
 def _cursor_surface_statuses(
     context: HarnessContext,
     *,
@@ -338,9 +344,18 @@ def _cursor_protected_surfaces(managed_installs: list[dict[str, object]]) -> tup
         manifest = managed_install.get("manifest")
         if not isinstance(manifest, dict):
             continue
+        manifest_surfaces = manifest.get("surfaces")
+        if isinstance(manifest_surfaces, list):
+            for value in manifest_surfaces:
+                if value in {"editor", "cli"} and value not in surfaces:
+                    surfaces.append(value)
         manifest_surface = manifest.get("surface")
         if manifest_surface in {"editor", "cli"} and manifest_surface not in surfaces:
             surfaces.append(manifest_surface)
+        elif manifest_surface == "all":
+            for value in ("editor", "cli"):
+                if value not in surfaces:
+                    surfaces.append(value)
     return tuple(surfaces)
 
 

--- a/src/codex_plugin_scanner/guard/proxy/__init__.py
+++ b/src/codex_plugin_scanner/guard/proxy/__init__.py
@@ -4,6 +4,7 @@ from .remote import RemoteGuardProxy
 from .runtime_mcp import (
     CodexMcpGuardProxy,
     CopilotMcpGuardProxy,
+    CursorMcpGuardProxy,
     ElicitationMcpGuardProxy,
     OpenCodeMcpGuardProxy,
     RuntimeMcpGuardProxy,
@@ -13,6 +14,7 @@ from .stdio import StdioGuardProxy
 __all__ = [
     "CodexMcpGuardProxy",
     "CopilotMcpGuardProxy",
+    "CursorMcpGuardProxy",
     "ElicitationMcpGuardProxy",
     "OpenCodeMcpGuardProxy",
     "RemoteGuardProxy",

--- a/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
+++ b/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
@@ -1049,6 +1049,13 @@ class CopilotMcpGuardProxy(ElicitationMcpGuardProxy):
         super().__init__(harness="copilot", **kwargs)
 
 
+class CursorMcpGuardProxy(ElicitationMcpGuardProxy):
+    """Guard-managed runtime MCP proxy for Cursor editor MCP clients."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(harness="cursor", **kwargs)
+
+
 class OpenCodeMcpGuardProxy(RuntimeMcpGuardProxy):
     """Guard-managed runtime MCP proxy for OpenCode."""
 
@@ -1177,6 +1184,7 @@ def _now() -> str:
 __all__ = [
     "CodexMcpGuardProxy",
     "CopilotMcpGuardProxy",
+    "CursorMcpGuardProxy",
     "ElicitationMcpGuardProxy",
     "OpenCodeMcpGuardProxy",
     "RuntimeMcpGuardProxy",

--- a/tests/test_cursor_local_actions.py
+++ b/tests/test_cursor_local_actions.py
@@ -49,7 +49,7 @@ def test_cursor_local_actions_preserve_editor_and_cli_surfaces(
 
     assert connect["cursor_action"]["surface_statuses"] == [
         {"surface": "editor", "status": "protected"},
-        {"surface": "cli", "status": "not_detected"},
+        {"surface": "cli", "status": "protected"},
     ]
     assert repair["cursor_action"] == cursor_local_action_payload(
         action="repair",

--- a/tests/test_cursor_local_actions.py
+++ b/tests/test_cursor_local_actions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -130,3 +132,102 @@ def test_cursor_editor_detection_uses_global_config(
         {"surface": "cli", "status": "not_detected"},
     ]
     assert payload["evidence"]["redactedPath"] == "$HOME/.cursor/mcp.json"
+
+
+def test_cursor_editor_install_wraps_workspace_config_and_remove_restores(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PATH", str(tmp_path / "empty-bin"))
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    config_path = context.workspace_dir / ".cursor" / "mcp.json"
+    original_payload = {
+        "mcpServers": {
+            "filesystem": {
+                "command": "node",
+                "args": ["server.js"],
+                "env": {"SAFE_FLAG": "1"},
+            }
+        }
+    }
+    config_path.write_text(json.dumps(original_payload, indent=2) + "\n", encoding="utf-8")
+
+    install_payload = apply_managed_install(
+        "install",
+        "cursor",
+        False,
+        context,
+        store,
+        str(context.workspace_dir),
+        "2026-05-29T12:00:00Z",
+        surface="editor",
+    )
+    managed_install = install_payload["managed_install"]
+    assert managed_install["surface"] == "editor"
+    assert install_payload["cursor_action"]["surface"] == "editor"
+    assert install_payload["cursor_action"]["status"] == "protected"
+
+    protected_payload = json.loads(config_path.read_text(encoding="utf-8"))
+    server = protected_payload["mcpServers"]["filesystem"]
+    assert server["command"] == sys.executable
+    assert "cursor-mcp-proxy" in server["args"]
+    assert "--command" in server["args"]
+    assert "node" in server["args"]
+    assert "--arg=server.js" in server["args"]
+    assert server["env"]["SAFE_FLAG"] == "1"
+
+    remove_payload = apply_managed_install(
+        "uninstall",
+        "cursor",
+        False,
+        context,
+        store,
+        str(context.workspace_dir),
+        "2026-05-29T12:01:00Z",
+        surface="editor",
+    )
+
+    assert remove_payload["cursor_action"]["surface"] == "editor"
+    assert json.loads(config_path.read_text(encoding="utf-8")) == original_payload
+
+
+def test_cursor_cli_install_uses_cursor_agent_shim_without_editor_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PATH", str(tmp_path / "empty-bin"))
+    context = _context(tmp_path, workspace_cursor=False)
+    store = GuardStore(context.guard_home)
+
+    install_payload = apply_managed_install(
+        "install",
+        "cursor",
+        False,
+        context,
+        store,
+        str(context.workspace_dir),
+        "2026-05-29T12:00:00Z",
+        surface="cli",
+    )
+
+    managed_install = install_payload["managed_install"]
+    assert managed_install["surface"] == "cli"
+    assert managed_install["shim_command"] == "guard-cursor-agent"
+    assert Path(managed_install["shim_path"]).exists()
+    assert install_payload["cursor_action"]["surface"] == "cli"
+    assert not (context.workspace_dir / ".cursor" / "mcp.json").exists()
+
+    remove_payload = apply_managed_install(
+        "uninstall",
+        "cursor",
+        False,
+        context,
+        store,
+        str(context.workspace_dir),
+        "2026-05-29T12:01:00Z",
+        surface="cli",
+    )
+
+    assert remove_payload["managed_install"]["surface"] == "cli"
+    assert not Path(managed_install["shim_path"]).exists()


### PR DESCRIPTION
## Summary
- add surface-aware Cursor editor MCP proxy install/remove support
- add Cursor CLI shim install/remove support with guarded action payloads
- add hidden Cursor MCP runtime proxy command and local regression coverage

## Testing
- `pytest -q tests/test_cursor_local_actions.py tests/test_cursor_adapter.py tests/test_guard_harness_setup.py`
- `ruff check src tests/test_cursor_local_actions.py tests/test_cursor_adapter.py tests/test_guard_harness_setup.py`
- `ruff format --check src tests/test_cursor_local_actions.py tests/test_cursor_adapter.py tests/test_guard_harness_setup.py`
