### PR TITLE
feat(cursor): add scoped local action receipts

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/cursor_actions.py
+++ b/src/codex_plugin_scanner/guard/cli/cursor_actions.py
@@ -1,0 +1,181 @@
+"""Cursor local action payload helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ..adapters import get_adapter
+from ..adapters.base import HarnessContext
+from ..adapters.mcp_servers import is_guard_proxy_command
+from ..store import GuardStore
+
+
+def cursor_local_action_payload(
+    *,
+    action: str,
+    surface: str | None,
+    context: HarnessContext,
+    protected: bool | None = None,
+    protected_surfaces: tuple[str, ...] = (),
+) -> dict[str, object]:
+    selected_surface = _cursor_surface(surface)
+    selected_protected_surfaces = protected_surfaces
+    if protected is not None and protected:
+        selected_protected_surfaces = ("editor", "cli")
+    statuses = _cursor_surface_statuses(context, protected_surfaces=selected_protected_surfaces)
+    selected_status = next(item["status"] for item in statuses if item["surface"] == selected_surface)
+    action_scope = f"cursor:{selected_surface}:{action}"
+    return {
+        "app_id": "cursor",
+        "action": action,
+        "surface": selected_surface,
+        "status": selected_status,
+        "surface_statuses": statuses,
+        "sync": {
+            "surface": selected_surface,
+            "status": selected_status,
+            "lastSeenAt": None,
+            "lastReceiptSyncedAt": None,
+            "daemonReachability": "local",
+            "protectedLocationId": None,
+        },
+        "evidence": {
+            "receiptId": None,
+            "artifactId": action_scope,
+            "actionScope": action_scope,
+            "surface": selected_surface,
+            "redactedPath": _cursor_redacted_path(context, selected_surface),
+            "policyDecision": "monitor",
+        },
+    }
+
+
+def cursor_install_surface(surface: str | None) -> str:
+    if surface is None:
+        return "all"
+    return _cursor_surface(surface)
+
+
+def cursor_protected_surfaces(managed_installs: list[dict[str, object]]) -> tuple[str, ...]:
+    surfaces: list[str] = []
+    for managed_install in managed_installs:
+        surface = managed_install.get("surface")
+        if surface in {"editor", "cli"} and surface not in surfaces:
+            surfaces.append(surface)
+            continue
+        manifest = managed_install.get("manifest")
+        if not isinstance(manifest, dict):
+            continue
+        manifest_surfaces = manifest.get("surfaces")
+        if isinstance(manifest_surfaces, list):
+            for value in manifest_surfaces:
+                if value in {"editor", "cli"} and value not in surfaces:
+                    surfaces.append(value)
+        manifest_surface = manifest.get("surface")
+        if manifest_surface in {"editor", "cli"} and manifest_surface not in surfaces:
+            surfaces.append(manifest_surface)
+        elif manifest_surface == "all":
+            for value in ("editor", "cli"):
+                if value not in surfaces:
+                    surfaces.append(value)
+    return tuple(surfaces)
+
+
+def cursor_protected_surfaces_from_store(
+    harness: str,
+    store: GuardStore | None,
+    detection: dict[str, object],
+) -> tuple[str, ...]:
+    if not bool(detection["installed"]):
+        return ()
+    managed = store.get_managed_install(harness) if store is not None else None
+    if not isinstance(managed, dict):
+        return ("editor", "cli")
+    return cursor_protected_surfaces([managed])
+
+
+def _cursor_surface(surface: str | None) -> str:
+    if surface is None:
+        return "editor"
+    if surface in {"editor", "cli"}:
+        return surface
+    raise ValueError(f"Unsupported Cursor surface: {surface}")
+
+
+def _cursor_surface_statuses(
+    context: HarnessContext,
+    *,
+    protected_surfaces: tuple[str, ...],
+) -> list[dict[str, str]]:
+    editor_detected = any(path.exists() for path in _cursor_editor_config_paths(context))
+    cli_detected = _cursor_cli_detected(context)
+    protected = set(protected_surfaces)
+    editor_protected = "editor" in protected or _cursor_editor_protected(context)
+    cli_protected = "cli" in protected or _cursor_cli_protected(context)
+    return [
+        {
+            "surface": "editor",
+            "status": _cursor_status(editor_detected, protected=editor_protected),
+        },
+        {
+            "surface": "cli",
+            "status": _cursor_status(cli_detected, protected=cli_protected),
+        },
+    ]
+
+
+def _cursor_status(detected: bool, *, protected: bool) -> str:
+    if protected and detected:
+        return "protected"
+    if detected:
+        return "detected_unprotected"
+    return "not_detected"
+
+
+def _cursor_redacted_path(context: HarnessContext, surface: str) -> str:
+    if surface == "cli":
+        return "PATH:cursor-agent"
+    workspace_path = context.workspace_dir / ".cursor" / "mcp.json" if context.workspace_dir is not None else None
+    if workspace_path is not None and workspace_path.exists():
+        return "$WORKSPACE/.cursor/mcp.json"
+    return "$HOME/.cursor/mcp.json"
+
+
+def _cursor_editor_config_paths(context: HarnessContext) -> tuple[Path, ...]:
+    paths: list[Path] = []
+    if context.workspace_dir is not None:
+        paths.append(context.workspace_dir / ".cursor" / "mcp.json")
+    paths.append(context.home_dir / ".cursor" / "mcp.json")
+    return tuple(paths)
+
+
+def _cursor_cli_detected(context: HarnessContext) -> bool:
+    if get_adapter("cursor").resolved_executable(context) is not None:
+        return True
+    return (context.guard_home / "bin" / "guard-cursor-agent").exists()
+
+
+def _cursor_editor_protected(context: HarnessContext) -> bool:
+    for config_path in _cursor_editor_config_paths(context):
+        try:
+            payload = json.loads(config_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        mcp_servers = payload.get("mcpServers")
+        if not isinstance(mcp_servers, dict):
+            continue
+        for server_config in mcp_servers.values():
+            if not isinstance(server_config, dict):
+                continue
+            command = server_config.get("command")
+            args = tuple(str(value) for value in server_config.get("args", []) if isinstance(value, str))
+            if is_guard_proxy_command(command if isinstance(command, str) else None, args):
+                return True
+    return False
+
+
+def _cursor_cli_protected(context: HarnessContext) -> bool:
+    return (context.guard_home / "bin" / "guard-cursor-agent").exists()

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -3,17 +3,21 @@
 from __future__ import annotations
 
 import glob as globlib
-import json
 from pathlib import Path
 
 from ..adapters import get_adapter, list_adapters
 from ..adapters.base import HarnessAdapter, HarnessContext
 from ..adapters.contracts import contract_for
 from ..adapters.cursor import CursorHarnessAdapter
-from ..adapters.mcp_servers import is_guard_proxy_command
 from ..consumer import detect_all
 from ..runtime.skill_protection import build_skill_identity, detect_skill_content_risk
 from ..store import GuardStore
+from .cursor_actions import (
+    cursor_install_surface,
+    cursor_local_action_payload,
+    cursor_protected_surfaces,
+    cursor_protected_surfaces_from_store,
+)
 
 _HARNESS_OBSERVED_COPY = {
     "protected": "Active Guard protection is installed.",
@@ -40,7 +44,7 @@ def apply_managed_install(
         adapter = get_adapter(harness)
         canonical_harness = adapter.harness
         if isinstance(adapter, CursorHarnessAdapter):
-            selected_surface = _cursor_install_surface(surface)
+            selected_surface = cursor_install_surface(surface)
             manifest = (
                 adapter.install(context, surface=selected_surface)
                 if active
@@ -67,7 +71,7 @@ def apply_managed_install(
             action=command,
             surface=surface,
             context=context,
-            protected_surfaces=_cursor_protected_surfaces(managed_installs) if active else (),
+            protected_surfaces=cursor_protected_surfaces(managed_installs) if active else (),
         )
     return payload
 
@@ -174,6 +178,7 @@ def build_harness_verification(
     context: HarnessContext,
     store: GuardStore | None = None,
     surface: str | None = None,
+    action: str = "test",
 ) -> dict[str, object]:
     adapter = get_adapter(requested_harness)
     detection = _safe_setup_detection(adapter, context, store)
@@ -194,182 +199,16 @@ def build_harness_verification(
     }
     if adapter.harness == "cursor":
         payload["cursor_action"] = cursor_local_action_payload(
-            action="test",
+            action=action,
             surface=surface,
             context=context,
-            protected_surfaces=_cursor_protected_surfaces_from_store(adapter.harness, store, detection),
+            protected_surfaces=cursor_protected_surfaces_from_store(
+                adapter.harness,
+                store,
+                detection,
+            ),
         )
     return payload
-
-
-def cursor_local_action_payload(
-    *,
-    action: str,
-    surface: str | None,
-    context: HarnessContext,
-    protected: bool | None = None,
-    protected_surfaces: tuple[str, ...] = (),
-) -> dict[str, object]:
-    selected_surface = _cursor_surface(surface)
-    selected_protected_surfaces = protected_surfaces
-    if protected is not None and protected:
-        selected_protected_surfaces = ("editor", "cli")
-    statuses = _cursor_surface_statuses(context, protected_surfaces=selected_protected_surfaces)
-    selected_status = next(item["status"] for item in statuses if item["surface"] == selected_surface)
-    action_scope = f"cursor:{selected_surface}:{action}"
-    return {
-        "app_id": "cursor",
-        "action": action,
-        "surface": selected_surface,
-        "status": selected_status,
-        "surface_statuses": statuses,
-        "sync": {
-            "surface": selected_surface,
-            "status": selected_status,
-            "lastSeenAt": None,
-            "lastReceiptSyncedAt": None,
-            "daemonReachability": "local",
-            "protectedLocationId": None,
-        },
-        "evidence": {
-            "receiptId": None,
-            "artifactId": action_scope,
-            "actionScope": action_scope,
-            "surface": selected_surface,
-            "redactedPath": _cursor_redacted_path(context, selected_surface),
-            "policyDecision": "monitor",
-        },
-    }
-
-
-def _cursor_surface(surface: str | None) -> str:
-    if surface is None:
-        return "editor"
-    if surface in {"editor", "cli"}:
-        return surface
-    raise ValueError(f"Unsupported Cursor surface: {surface}")
-
-
-def _cursor_install_surface(surface: str | None) -> str:
-    if surface is None:
-        return "all"
-    return _cursor_surface(surface)
-
-
-def _cursor_surface_statuses(
-    context: HarnessContext,
-    *,
-    protected_surfaces: tuple[str, ...],
-) -> list[dict[str, str]]:
-    editor_detected = any(path.exists() for path in _cursor_editor_config_paths(context))
-    cli_detected = _cursor_cli_detected(context)
-    protected = set(protected_surfaces)
-    editor_protected = "editor" in protected or _cursor_editor_protected(context)
-    cli_protected = "cli" in protected or _cursor_cli_protected(context)
-    return [
-        {
-            "surface": "editor",
-            "status": _cursor_status(editor_detected, protected=editor_protected),
-        },
-        {
-            "surface": "cli",
-            "status": _cursor_status(cli_detected, protected=cli_protected),
-        },
-    ]
-
-
-def _cursor_status(detected: bool, *, protected: bool) -> str:
-    if protected and detected:
-        return "protected"
-    if detected:
-        return "detected_unprotected"
-    return "not_detected"
-
-
-def _cursor_redacted_path(context: HarnessContext, surface: str) -> str:
-    if surface == "cli":
-        return "PATH:cursor-agent"
-    workspace_path = context.workspace_dir / ".cursor" / "mcp.json" if context.workspace_dir is not None else None
-    if workspace_path is not None and workspace_path.exists():
-        return "$WORKSPACE/.cursor/mcp.json"
-    return "$HOME/.cursor/mcp.json"
-
-
-def _cursor_editor_config_paths(context: HarnessContext) -> tuple[Path, ...]:
-    paths: list[Path] = []
-    if context.workspace_dir is not None:
-        paths.append(context.workspace_dir / ".cursor" / "mcp.json")
-    paths.append(context.home_dir / ".cursor" / "mcp.json")
-    return tuple(paths)
-
-
-def _cursor_cli_detected(context: HarnessContext) -> bool:
-    if get_adapter("cursor").resolved_executable(context) is not None:
-        return True
-    return (context.guard_home / "bin" / "guard-cursor-agent").exists()
-
-
-def _cursor_editor_protected(context: HarnessContext) -> bool:
-    for config_path in _cursor_editor_config_paths(context):
-        try:
-            payload = json.loads(config_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            continue
-        if not isinstance(payload, dict):
-            continue
-        mcp_servers = payload.get("mcpServers")
-        if not isinstance(mcp_servers, dict):
-            continue
-        for server_config in mcp_servers.values():
-            if not isinstance(server_config, dict):
-                continue
-            command = server_config.get("command")
-            args = tuple(str(value) for value in server_config.get("args", []) if isinstance(value, str))
-            if is_guard_proxy_command(command if isinstance(command, str) else None, args):
-                return True
-    return False
-
-
-def _cursor_cli_protected(context: HarnessContext) -> bool:
-    return (context.guard_home / "bin" / "guard-cursor-agent").exists()
-
-
-def _cursor_protected_surfaces(managed_installs: list[dict[str, object]]) -> tuple[str, ...]:
-    surfaces: list[str] = []
-    for managed_install in managed_installs:
-        surface = managed_install.get("surface")
-        if surface in {"editor", "cli"} and surface not in surfaces:
-            surfaces.append(surface)
-            continue
-        manifest = managed_install.get("manifest")
-        if not isinstance(manifest, dict):
-            continue
-        manifest_surfaces = manifest.get("surfaces")
-        if isinstance(manifest_surfaces, list):
-            for value in manifest_surfaces:
-                if value in {"editor", "cli"} and value not in surfaces:
-                    surfaces.append(value)
-        manifest_surface = manifest.get("surface")
-        if manifest_surface in {"editor", "cli"} and manifest_surface not in surfaces:
-            surfaces.append(manifest_surface)
-        elif manifest_surface == "all":
-            for value in ("editor", "cli"):
-                if value not in surfaces:
-                    surfaces.append(value)
-    return tuple(surfaces)
-
-
-def _cursor_protected_surfaces_from_store(
-    harness: str,
-    store: GuardStore | None,
-    detection: dict[str, object],
-) -> tuple[str, ...]:
-    if not bool(detection["installed"]):
-        return ()
-    managed = store.get_managed_install(harness) if store is not None else None
-    if not isinstance(managed, dict):
-        return ("editor", "cli")
-    return _cursor_protected_surfaces([_managed_install_payload(managed)])
 
 
 def uninstall_confirmation_token(harness: str) -> str:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1103,10 +1103,30 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 operation=operation,
                 error_code="unknown_harness",
             )
+        try:
+            surface = self._cursor_headless_surface(payload) if adapter.harness == "cursor" else None
+        except ValueError:
+            error_payload = _headless_error_payload(
+                code="invalid_cursor_surface",
+                message="Choose Cursor editor or CLI before retrying this local action.",
+                retryable=False,
+            )
+            error = error_payload["error"]
+            if isinstance(error, dict):
+                error["app_id"] = "cursor"
+                error["surface"] = self._optional_string(payload.get("surface")) or ""
+            return 400, error_payload
         context = self._harness_context(payload)
         try:
             if harness_action == "verify":
-                result = build_harness_verification(adapter.harness, context, self.server.store)  # type: ignore[attr-defined]
+                verification_action = "status" if action_path == "status" else "test"
+                result = build_harness_verification(
+                    adapter.harness,
+                    context,
+                    self.server.store,  # type: ignore[attr-defined]
+                    surface=surface,
+                    action=verification_action,
+                )
             else:
                 result = self._run_headless_managed_action(adapter.harness, harness_action, payload, context)
         except ValueError as error:
@@ -1124,8 +1144,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             result=result,
             location_id=location_id,
             workspace_id=self._optional_string(payload.get("workspace_id")),
+            cloud_sync={"status": "pending"},
         )
         cloud_sync = _queue_headless_cloud_sync(store=self.server.store)  # type: ignore[attr-defined]
+        receipt["cloud_sync"] = cloud_sync
         return 200, {
             "cloud_sync": cloud_sync,
             "harness": adapter.harness,
@@ -1638,6 +1660,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         payload: dict[str, object],
         context: HarnessContext,
     ) -> dict[str, object]:
+        surface = self._cursor_headless_surface(payload) if harness == "cursor" else None
         if action == "uninstall":
             expected_confirmation = uninstall_confirmation_token(harness)
             confirmation = self._optional_string(payload.get("confirmation_phrase")) or self._optional_string(
@@ -1654,6 +1677,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self.server.store,  # type: ignore[attr-defined]
             self._optional_string(payload.get("workspace_id")),
             _now(),
+            surface=surface,
         )
 
     def _handle_headless_policy_sync(self, payload: dict[str, object]) -> None:
@@ -1911,45 +1935,123 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         payload: dict[str, object],
         result: dict[str, object],
         workspace_id: str | None,
+        cloud_sync: dict[str, object] | None = None,
     ) -> dict[str, object]:
+        cursor_receipt_context = self._cursor_receipt_context(
+            harness=harness,
+            operation=operation,
+            payload=payload,
+            result=result,
+            cloud_sync=cloud_sync,
+        )
         material = json.dumps(
             {
                 "harness": harness,
                 "location_id": location_id,
                 "operation": operation,
                 "result_keys": sorted(result.keys()),
+                "cursor": cursor_receipt_context,
                 "workspace_id": workspace_id,
             },
             sort_keys=True,
         )
         artifact_hash = hashlib.sha256(material.encode("utf-8")).hexdigest()
         changed_capabilities = [] if operation in {"status", "scan"} else [operation]
+        artifact_id = f"headless:{harness}:{operation}"
+        artifact_name = f"Headless {operation}"
+        capabilities_summary = f"Guard local daemon completed headless {operation}."
+        source_scope = "local-daemon"
+        scanner_evidence: dict[str, object] = {
+            "operation": operation,
+            "location_id": location_id,
+            "workspace_id": workspace_id,
+            "status": "completed",
+        }
+        if cursor_receipt_context is not None:
+            artifact_id = str(cursor_receipt_context["action_scope"])
+            artifact_name = str(cursor_receipt_context["artifact_name"])
+            capabilities_summary = str(cursor_receipt_context["capabilities_summary"])
+            source_scope = str(cursor_receipt_context["source_scope"])
+            changed_capabilities = [str(cursor_receipt_context["changed_capability"])]
+            scanner_evidence.update(cursor_receipt_context["scanner_evidence"])
         receipt = build_receipt(
             harness=harness,
-            artifact_id=f"headless:{harness}:{operation}",
+            artifact_id=artifact_id,
             artifact_hash=artifact_hash,
             policy_decision="allow",
-            capabilities_summary=f"Guard local daemon completed headless {operation}.",
+            capabilities_summary=capabilities_summary,
             changed_capabilities=changed_capabilities,
             provenance_summary="Guard Cloud local daemon API",
-            artifact_name=f"Headless {operation}",
-            source_scope="local-daemon",
-            scanner_evidence=(
-                {
-                    "operation": operation,
-                    "location_id": location_id,
-                    "workspace_id": workspace_id,
-                    "status": "completed",
-                },
-            ),
+            artifact_name=artifact_name,
+            source_scope=source_scope,
+            scanner_evidence=(scanner_evidence,),
             approval_source="guard-cloud-headless",
         )
         self.server.store.add_receipt(receipt)  # type: ignore[attr-defined]
-        return {
+        summary = {
             "id": receipt.receipt_id,
             "operation": operation,
             "status": "completed",
             "timestamp": receipt.timestamp,
+        }
+        if cursor_receipt_context is not None:
+            summary.update(cursor_receipt_context["summary"])
+        return summary
+
+    def _cursor_headless_surface(self, payload: dict[str, object]) -> str | None:
+        surface = self._optional_string(payload.get("surface")) or self._optional_string(payload.get("editor_or_cli"))
+        if surface is None:
+            return None
+        if surface not in {"editor", "cli"}:
+            raise ValueError("invalid_cursor_surface")
+        return surface
+
+    def _cursor_receipt_context(
+        self,
+        *,
+        harness: str,
+        operation: str,
+        payload: dict[str, object],
+        result: dict[str, object],
+        cloud_sync: dict[str, object] | None,
+    ) -> dict[str, object] | None:
+        if harness != "cursor":
+            return None
+        action_payload = result.get("cursor_action")
+        action_dict = action_payload if isinstance(action_payload, dict) else {}
+        surface = (
+            self._optional_string(action_dict.get("surface"))
+            or self._optional_string(payload.get("surface"))
+            or self._optional_string(payload.get("editor_or_cli"))
+            or "editor"
+        )
+        action = self._optional_string(action_dict.get("action")) or operation
+        evidence = action_dict.get("evidence")
+        evidence_dict = evidence if isinstance(evidence, dict) else {}
+        action_scope = self._optional_string(evidence_dict.get("actionScope")) or f"cursor:{surface}:{action}"
+        cloud_sync_status = "pending"
+        if isinstance(cloud_sync, dict):
+            cloud_sync_status = self._optional_string(cloud_sync.get("status")) or cloud_sync_status
+        surface_label = "CLI" if surface == "cli" else "editor"
+        scanner_evidence = {
+            "action_scope": action_scope,
+            "cloud_sync_status": cloud_sync_status,
+            "cursor_status": self._optional_string(action_dict.get("status")) or "unknown",
+            "editor_or_cli": surface,
+            "error_reason": self._optional_string(payload.get("error_reason")),
+        }
+        return {
+            "action_scope": action_scope,
+            "artifact_name": f"Cursor {surface_label} {action}",
+            "capabilities_summary": f"Guard local daemon completed Cursor {surface_label} {action}.",
+            "changed_capability": f"{surface}:{action}",
+            "scanner_evidence": scanner_evidence,
+            "source_scope": f"cursor:{surface}",
+            "summary": {
+                "action_scope": action_scope,
+                "cloud_sync": dict(cloud_sync) if isinstance(cloud_sync, dict) else {"status": cloud_sync_status},
+                "editor_or_cli": surface,
+            },
         }
 
     def _handle_policy_clear(self, payload: dict[str, object]) -> None:

--- a/tests/test_cursor_local_actions.py
+++ b/tests/test_cursor_local_actions.py
@@ -15,6 +15,7 @@ from codex_plugin_scanner.guard.cli.install_commands import (
     build_harness_verification,
     cursor_local_action_payload,
 )
+from codex_plugin_scanner.guard.daemon.server import _GuardDaemonHandler
 from codex_plugin_scanner.guard.models import HarnessDetection
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -231,3 +232,75 @@ def test_cursor_cli_install_uses_cursor_agent_shim_without_editor_config(
 
     assert remove_payload["managed_install"]["surface"] == "cli"
     assert not Path(managed_install["shim_path"]).exists()
+
+
+def test_cursor_local_action_receipts_include_surface_scope_and_sync_summary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PATH", str(tmp_path / "empty-bin"))
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    handler = object.__new__(_GuardDaemonHandler)
+    handler.server = type("Server", (), {"store": store})()
+    action_payload = cursor_local_action_payload(
+        action="repair",
+        surface="cli",
+        context=context,
+        protected=True,
+    )
+
+    receipt_summary = _GuardDaemonHandler._record_headless_receipt(
+        handler,
+        harness="cursor",
+        operation="repair",
+        payload={"surface": "cli", "workspace_id": "workspace-123"},
+        result={"cursor_action": action_payload},
+        workspace_id="workspace-123",
+        cloud_sync={"status": "not_configured"},
+    )
+    receipt = store.get_receipt(str(receipt_summary["id"]))
+
+    assert receipt is not None
+    assert receipt["artifact_id"] == "cursor:cli:repair"
+    assert receipt["artifact_name"] == "Cursor CLI repair"
+    assert receipt_summary["action_scope"] == "cursor:cli:repair"
+    assert receipt_summary["editor_or_cli"] == "cli"
+    assert receipt_summary["cloud_sync"]["status"] == "not_configured"
+    evidence = receipt["scanner_evidence"][0]
+    assert evidence["action_scope"] == "cursor:cli:repair"
+    assert evidence["editor_or_cli"] == "cli"
+    assert evidence["cloud_sync_status"] == "not_configured"
+    assert evidence["workspace_id"] == "workspace-123"
+
+
+def test_cursor_status_and_test_actions_keep_distinct_receipt_scopes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PATH", str(tmp_path / "empty-bin"))
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+
+    status_payload = build_harness_verification("cursor", context, store, surface="editor", action="status")
+    test_payload = build_harness_verification("cursor", context, store, surface="editor", action="test")
+
+    assert status_payload["cursor_action"]["evidence"]["actionScope"] == "cursor:editor:status"
+    assert test_payload["cursor_action"]["evidence"]["actionScope"] == "cursor:editor:test"
+
+
+def test_cursor_headless_action_error_includes_surface_scope(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    handler = object.__new__(_GuardDaemonHandler)
+    handler.server = type("Server", (), {"store": store})()
+
+    status, payload = _GuardDaemonHandler._headless_app_action_payload(
+        handler,
+        action_path="connect",
+        payload={"harness": "cursor", "surface": "browser"},
+    )
+
+    assert status == 400
+    assert payload["error"]["code"] == "invalid_cursor_surface"
+    assert payload["error"]["surface"] == "browser"
+    assert payload["error"]["app_id"] == "cursor"


### PR DESCRIPTION
## Summary
- add Cursor editor/CLI scope to local daemon app-action receipts
- preserve distinct Cursor status/test receipt scopes and cloud-sync summaries
- return actionable invalid Cursor surface errors for local app actions

## Testing
- `pytest -q tests/test_cursor_local_actions.py tests/test_guard_runtime.py tests/test_cursor_adapter.py tests/test_guard_harness_setup.py`
- `ruff check src tests/test_cursor_local_actions.py tests/test_guard_runtime.py tests/test_cursor_adapter.py tests/test_guard_harness_setup.py`
- `ruff format --check src tests/test_cursor_local_actions.py tests/test_guard_runtime.py tests/test_cursor_adapter.py tests/test_guard_harness_setup.py`
