### PR TITLE
fix(codex): extend hook timeout

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -16,7 +16,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10
     import tomli as tomllib  # type: ignore[no-redef]
 
 from ..codex_config import dump_toml, read_toml_payload, write_toml_payload
-from ..config import MAX_APPROVAL_WAIT_TIMEOUT_SECONDS
+from ..config import MAX_APPROVAL_WAIT_TIMEOUT_SECONDS, load_guard_config
 from ..launcher import merge_guard_launcher_env
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
@@ -122,7 +122,6 @@ _MANAGED_PERMISSION_HOOK_STATUS_MESSAGE = "HOL Guard checking Codex approval req
 _MANAGED_POST_TOOL_HOOK_STATUS_MESSAGE = "HOL Guard checking tool result"
 _MANAGED_HOOK_TIMEOUT_SECONDS = 30
 _MANAGED_HOOK_TIMEOUT_GRACE_SECONDS = 5
-_MANAGED_POST_TOOL_HOOK_TIMEOUT_SECONDS = MAX_APPROVAL_WAIT_TIMEOUT_SECONDS + _MANAGED_HOOK_TIMEOUT_GRACE_SECONDS
 _CODEX_GUARD_TOOL_MATCHER = "Bash|Read|Write|Edit|MultiEdit|^apply_patch$|mcp__.*"
 _CODEX_GUARD_PERMISSION_MATCHER = "Bash|Read|Write|Edit|MultiEdit|^apply_patch$|mcp__.*"
 _LEGACY_MANAGED_HOOK_STATUS_MESSAGES = {
@@ -217,6 +216,20 @@ def _permission_request_hook_group(context: HarnessContext) -> dict[str, object]
     }
 
 
+def _post_tool_hook_timeout_seconds(context: HarnessContext) -> int:
+    configured_wait_timeout = load_guard_config(
+        context.guard_home,
+        context.workspace_dir,
+    ).approval_wait_timeout_seconds
+    return (
+        min(
+            max(configured_wait_timeout, 0),
+            MAX_APPROVAL_WAIT_TIMEOUT_SECONDS,
+        )
+        + _MANAGED_HOOK_TIMEOUT_GRACE_SECONDS
+    )
+
+
 def _post_tool_hook_group(context: HarnessContext) -> dict[str, object]:
     return {
         "matcher": "Bash",
@@ -224,7 +237,7 @@ def _post_tool_hook_group(context: HarnessContext) -> dict[str, object]:
             _managed_hook_entry(
                 context,
                 _MANAGED_POST_TOOL_HOOK_STATUS_MESSAGE,
-                timeout_seconds=_MANAGED_POST_TOOL_HOOK_TIMEOUT_SECONDS,
+                timeout_seconds=_post_tool_hook_timeout_seconds(context),
             )
         ],
     }

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -16,6 +16,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10
     import tomli as tomllib  # type: ignore[no-redef]
 
 from ..codex_config import dump_toml, read_toml_payload, write_toml_payload
+from ..config import MAX_APPROVAL_WAIT_TIMEOUT_SECONDS
 from ..launcher import merge_guard_launcher_env
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
@@ -119,6 +120,9 @@ _MANAGED_HOOK_STATUS_MESSAGE = "HOL Guard checking tool action"
 _MANAGED_PROMPT_HOOK_STATUS_MESSAGE = "HOL Guard checking prompt"
 _MANAGED_PERMISSION_HOOK_STATUS_MESSAGE = "HOL Guard checking Codex approval request"
 _MANAGED_POST_TOOL_HOOK_STATUS_MESSAGE = "HOL Guard checking tool result"
+_MANAGED_HOOK_TIMEOUT_SECONDS = 30
+_MANAGED_HOOK_TIMEOUT_GRACE_SECONDS = 5
+_MANAGED_POST_TOOL_HOOK_TIMEOUT_SECONDS = MAX_APPROVAL_WAIT_TIMEOUT_SECONDS + _MANAGED_HOOK_TIMEOUT_GRACE_SECONDS
 _CODEX_GUARD_TOOL_MATCHER = "Bash|Read|Write|Edit|MultiEdit|^apply_patch$|mcp__.*"
 _CODEX_GUARD_PERMISSION_MATCHER = "Bash|Read|Write|Edit|MultiEdit|^apply_patch$|mcp__.*"
 _LEGACY_MANAGED_HOOK_STATUS_MESSAGES = {
@@ -178,11 +182,16 @@ def _hook_command(context: HarnessContext) -> str:
     return shlex.join(_hook_command_parts(context))
 
 
-def _managed_hook_entry(context: HarnessContext, status_message: str) -> dict[str, object]:
+def _managed_hook_entry(
+    context: HarnessContext,
+    status_message: str,
+    *,
+    timeout_seconds: int = _MANAGED_HOOK_TIMEOUT_SECONDS,
+) -> dict[str, object]:
     return {
         "type": "command",
         "command": _hook_command(context),
-        "timeout": 30,
+        "timeout": timeout_seconds,
         "statusMessage": status_message,
         "env": merge_guard_launcher_env(pin_package=True),
     }
@@ -211,7 +220,13 @@ def _permission_request_hook_group(context: HarnessContext) -> dict[str, object]
 def _post_tool_hook_group(context: HarnessContext) -> dict[str, object]:
     return {
         "matcher": "Bash",
-        "hooks": [_managed_hook_entry(context, _MANAGED_POST_TOOL_HOOK_STATUS_MESSAGE)],
+        "hooks": [
+            _managed_hook_entry(
+                context,
+                _MANAGED_POST_TOOL_HOOK_STATUS_MESSAGE,
+                timeout_seconds=_MANAGED_POST_TOOL_HOOK_TIMEOUT_SECONDS,
+            )
+        ],
     }
 
 

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -32,6 +32,7 @@ NON_MIGRATED_GUARD_RUNTIME_FILES = frozenset(
 GUARD_DB_BACKUP_TIMEOUT_SECONDS = 5.0
 GUARD_DB_BACKUP_SLEEP_SECONDS = 0.05
 WORKSPACE_CONFIG_FILENAMES = (".ai-plugin-scanner-guard.toml", ".hol-guard.toml")
+MAX_APPROVAL_WAIT_TIMEOUT_SECONDS = 600
 VALID_GUARD_ACTIONS = {"allow", "warn", "review", "block", "sandbox-required", "require-reapproval"}
 VALID_GUARD_MODES = {"observe", "prompt", "enforce"}
 VALID_SECURITY_LEVELS = {"relaxed", "gentle", "balanced", "strict", "paranoid", "custom"}
@@ -447,9 +448,9 @@ def _coerce_editable_setting(key: str, value: object) -> object:
             return value
         raise ValueError("Invalid approval surface policy.")
     if key == "approval_wait_timeout_seconds":
-        if isinstance(value, int) and not isinstance(value, bool) and 0 <= value <= 600:
+        if isinstance(value, int) and not isinstance(value, bool) and 0 <= value <= MAX_APPROVAL_WAIT_TIMEOUT_SECONDS:
             return value
-        raise ValueError("Approval wait timeout must be between 0 and 600 seconds.")
+        raise ValueError(f"Approval wait timeout must be between 0 and {MAX_APPROVAL_WAIT_TIMEOUT_SECONDS} seconds.")
     if key in {"desktop_notifications", "telemetry", "sync", "billing"}:
         if isinstance(value, bool):
             return value

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -19,7 +19,7 @@ from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.codex import CodexHarnessAdapter
 from codex_plugin_scanner.guard.adapters.mcp_servers import managed_stdio_servers
 from codex_plugin_scanner.guard.codex_config import dump_toml
-from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.config import MAX_APPROVAL_WAIT_TIMEOUT_SECONDS
 
 
 def _write_text(path: Path, text: str) -> None:
@@ -749,10 +749,12 @@ def test_guard_install_codex_migrates_legacy_bash_only_managed_hook(tmp_path, ca
     assert len(config_payload["hooks"]["UserPromptSubmit"]) == 1
 
 
-def test_guard_install_codex_post_tool_use_hook_timeout_covers_default_browser_wait(tmp_path, capsys):
+def test_guard_install_codex_post_tool_use_hook_timeout_tracks_configured_browser_wait(tmp_path, capsys):
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
+    guard_home = home_dir / ".hol-guard"
     _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(guard_home / "config.toml", "approval_wait_timeout_seconds = 45\n")
 
     install_rc = main(
         [
@@ -763,19 +765,49 @@ def test_guard_install_codex_post_tool_use_hook_timeout_covers_default_browser_w
             str(home_dir),
             "--workspace",
             str(workspace_dir),
+            "--guard-home",
+            str(guard_home),
             "--json",
         ]
     )
     json.loads(capsys.readouterr().out)
     config_payload = tomllib.loads((home_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
     hook_timeout = config_payload["hooks"]["PostToolUse"][0]["hooks"][0]["timeout"]
-    default_wait_timeout = GuardConfig(
-        guard_home=home_dir / ".hol-guard",
-        workspace=workspace_dir,
-    ).approval_wait_timeout_seconds
 
     assert install_rc == 0
-    assert hook_timeout >= default_wait_timeout
+    assert hook_timeout == 45 + codex_adapter._MANAGED_HOOK_TIMEOUT_GRACE_SECONDS
+
+
+def test_guard_install_codex_post_tool_use_hook_timeout_covers_max_browser_wait(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    guard_home = home_dir / ".hol-guard"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(
+        guard_home / "config.toml",
+        f"approval_wait_timeout_seconds = {MAX_APPROVAL_WAIT_TIMEOUT_SECONDS}\n",
+    )
+
+    install_rc = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--guard-home",
+            str(guard_home),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+    config_payload = tomllib.loads((home_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
+    hook_timeout = config_payload["hooks"]["PostToolUse"][0]["hooks"][0]["timeout"]
+
+    assert install_rc == 0
+    assert hook_timeout == MAX_APPROVAL_WAIT_TIMEOUT_SECONDS + codex_adapter._MANAGED_HOOK_TIMEOUT_GRACE_SECONDS
 
 
 def test_guard_install_codex_migrates_stale_python_c_managed_hooks(tmp_path, capsys):

--- a/tests/test_guard_codex_install.py
+++ b/tests/test_guard_codex_install.py
@@ -19,6 +19,7 @@ from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.codex import CodexHarnessAdapter
 from codex_plugin_scanner.guard.adapters.mcp_servers import managed_stdio_servers
 from codex_plugin_scanner.guard.codex_config import dump_toml
+from codex_plugin_scanner.guard.config import GuardConfig
 
 
 def _write_text(path: Path, text: str) -> None:
@@ -746,6 +747,35 @@ def test_guard_install_codex_migrates_legacy_bash_only_managed_hook(tmp_path, ca
     assert config_payload["hooks"]["PreToolUse"][0]["matcher"] == codex_adapter._CODEX_GUARD_TOOL_MATCHER
     assert config_payload["hooks"]["PreToolUse"][0]["hooks"][0]["statusMessage"] == "HOL Guard checking tool action"
     assert len(config_payload["hooks"]["UserPromptSubmit"]) == 1
+
+
+def test_guard_install_codex_post_tool_use_hook_timeout_covers_default_browser_wait(tmp_path, capsys):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+
+    install_rc = main(
+        [
+            "guard",
+            "install",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    json.loads(capsys.readouterr().out)
+    config_payload = tomllib.loads((home_dir / ".codex" / "config.toml").read_text(encoding="utf-8"))
+    hook_timeout = config_payload["hooks"]["PostToolUse"][0]["hooks"][0]["timeout"]
+    default_wait_timeout = GuardConfig(
+        guard_home=home_dir / ".hol-guard",
+        workspace=workspace_dir,
+    ).approval_wait_timeout_seconds
+
+    assert install_rc == 0
+    assert hook_timeout >= default_wait_timeout
 
 
 def test_guard_install_codex_migrates_stale_python_c_managed_hooks(tmp_path, capsys):


### PR DESCRIPTION
## Summary
- align the installed Codex `PostToolUse` hook timeout with the configured browser approval window plus Guard grace time
- add regressions that prove the generated Codex hook timeout tracks configured waits and still covers the max supported browser approval window

## Testing
- `uv run pytest tests/test_guard_codex_install.py -q`
- `uv run pytest tests/test_guard_runtime.py -k "codex_browser_approval or post_tool_use_browser_approval_resumes_result" -q`
- `uv run ruff check src/codex_plugin_scanner/guard/adapters/codex.py src/codex_plugin_scanner/guard/config.py tests/test_guard_codex_install.py`
- `uv run ruff format --check src/codex_plugin_scanner/guard/adapters/codex.py src/codex_plugin_scanner/guard/config.py tests/test_guard_codex_install.py`
