### PR TITLE
fix(guard): bound codex websocket frames

### DIFF
--- a/src/codex_plugin_scanner/guard/codex_app_server.py
+++ b/src/codex_plugin_scanner/guard/codex_app_server.py
@@ -25,6 +25,7 @@ class _OperationStore(Protocol):
 _DEFAULT_PROXY_TIMEOUT_SECONDS = 5.0
 _DEFAULT_COMPLETION_TIMEOUT_SECONDS = 90.0
 _DEFAULT_SOCKET_PATH = Path.home() / ".codex" / "app-server-control" / "app-server-control.sock"
+_MAX_WEBSOCKET_FRAME_BYTES = 1_000_000
 _WEBSOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 _THREAD_ID_KEYS = (
     "codex_thread_id",
@@ -480,6 +481,8 @@ def _read_websocket_frame(client: socket.socket, pending: bytearray) -> tuple[in
         length = struct.unpack("!H", _recv_exact(client, 2, pending))[0]
     elif length == 127:
         length = struct.unpack("!Q", _recv_exact(client, 8, pending))[0]
+    if length > _MAX_WEBSOCKET_FRAME_BYTES:
+        raise ValueError("websocket_frame_too_large")
     mask = _recv_exact(client, 4, pending) if second & 0x80 else None
     payload = _recv_exact(client, length, pending) if length else b""
     if mask is not None:

--- a/tests/test_guard_codex_app_server.py
+++ b/tests/test_guard_codex_app_server.py
@@ -1,0 +1,21 @@
+"""Focused tests for Codex app-server websocket frame handling."""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from codex_plugin_scanner.guard import codex_app_server as codex_app_server_module
+
+
+class _UnexpectedRecvSocket:
+    def recv(self, _size: int) -> bytes:
+        raise AssertionError("oversized websocket frame should be rejected before payload read")
+
+
+def test_read_websocket_frame_rejects_oversized_payload_before_reading() -> None:
+    pending = bytearray(bytes([0x81, 0x7F]) + struct.pack("!Q", codex_app_server_module._MAX_WEBSOCKET_FRAME_BYTES + 1))
+
+    with pytest.raises(ValueError, match="websocket_frame_too_large"):
+        codex_app_server_module._read_websocket_frame(_UnexpectedRecvSocket(), pending)


### PR DESCRIPTION
## Summary
- bound Codex app-server websocket frame reads before payload consumption
- add a regression that rejects oversized websocket frame headers before any payload read

## Testing
- `uv run pytest tests/test_guard_codex_app_server.py tests/test_guard_queue_api_contract.py -q`
- `uv run ruff check src/codex_plugin_scanner/guard/codex_app_server.py tests/test_guard_codex_app_server.py`
- `uv run ruff format --check src/codex_plugin_scanner/guard/codex_app_server.py tests/test_guard_codex_app_server.py`
