### PR TITLE
fix(codex): surface live approval links

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3678,6 +3678,10 @@ def _codex_browser_approval_decision(
     wait_timeout_seconds = max(config.approval_wait_timeout_seconds, 0)
     if event_name == "UserPromptSubmit":
         wait_timeout_seconds = min(wait_timeout_seconds, _CODEX_PROMPT_APPROVAL_WAIT_MAX_SECONDS)
+    if wait_timeout_seconds <= 0:
+        return None
+    if event_name == "PreToolUse":
+        _open_codex_live_approval(response_payload)
     wait_result = wait_for_approval_requests(
         store=store,
         request_ids=request_ids,
@@ -3783,6 +3787,23 @@ def _codex_pretooluse_live_wait_candidate(payload: Mapping[str, object] | None) 
         or "package install request" in lowered
         or "before install" in lowered
     )
+
+
+def _open_codex_live_approval(response_payload: Mapping[str, object]) -> None:
+    queued = response_payload.get("approval_requests")
+    review_url = first_approval_url(queued) if isinstance(queued, list) else None
+    if not review_url:
+        approval_center_url = response_payload.get("approval_center_url")
+        review_url = approval_center_url.strip() if isinstance(approval_center_url, str) else None
+    if not review_url:
+        return
+    print(
+        f"HOL Guard is waiting for approval in your browser: {review_url}",
+        file=sys.stderr,
+        flush=True,
+    )
+    with suppress(Exception):
+        webbrowser.open(review_url)
 
 
 def _update_codex_browser_operation_status(

--- a/tests/test_guard_package_hook.py
+++ b/tests/test_guard_package_hook.py
@@ -318,6 +318,83 @@ def test_guard_hook_ask_queues_package_approval_with_advisory_context(
     assert "minimist" in pending[0]["risk_summary"].lower()
 
 
+def test_guard_hook_ask_package_live_wait_surfaces_approval_url(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    payload_path = workspace_dir / "hook-event.json"
+    _write_codex_pre_tool_payload(payload_path, workspace_dir, "npm install minimist@1.2.8")
+    store = GuardStore(home_dir)
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
+    )
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(
+            action="block",
+            policy_rules=[
+                {
+                    "action": "review",
+                    "ruleId": "policy-review-1",
+                    "ecosystemSelector": "npm",
+                    "enabled": True,
+                    "expiresAt": "2099-01-01T00:00:00Z",
+                    "harnessSelector": "codex",
+                    "packageSelector": "minimist",
+                    "priority": 1,
+                    "severityThreshold": "low",
+                    "versionRangeSelector": "1.2.8",
+                }
+            ],
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+    (home_dir / "config.toml").write_text("approval_wait_timeout_seconds = 10\n", encoding="utf-8")
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+
+    def fail_daemon(_home: Path) -> object:
+        raise RuntimeError("no daemon")
+
+    monkeypatch.setattr(guard_commands_module, "load_guard_surface_daemon_client", fail_daemon)
+    opened_urls: list[str] = []
+    monkeypatch.setattr(guard_commands_module.webbrowser, "open", opened_urls.append)
+    monkeypatch.setattr(
+        guard_commands_module,
+        "wait_for_approval_requests",
+        lambda **_kwargs: {
+            "resolved": True,
+            "pending_request_ids": [],
+            "items": [{"request_id": "req-1", "resolution_action": "allow"}],
+        },
+    )
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--harness",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--event-file",
+            str(payload_path),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 0
+    assert captured.out == ""
+    assert opened_urls
+    assert "/approvals/" in opened_urls[0]
+    assert opened_urls[0] in captured.err
+
+
 def test_guard_hook_warns_for_package_request_without_blocking(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/tests/test_guard_phase04_harness_ux.py
+++ b/tests/test_guard_phase04_harness_ux.py
@@ -333,6 +333,28 @@ def test_gr081b_codex_package_install_pretooluse_is_live_wait_candidate() -> Non
     )
 
 
+def test_gr081c_codex_live_wait_opens_and_prints_approval_url(monkeypatch, capsys) -> None:
+    opened_urls: list[str] = []
+
+    monkeypatch.setattr(guard_commands_module.webbrowser, "open", opened_urls.append)
+
+    guard_commands_module._open_codex_live_approval(
+        {
+            "approval_requests": [
+                {
+                    "request_id": "req-1",
+                    "approval_url": "http://127.0.0.1:5475/approvals/req-1",
+                }
+            ]
+        }
+    )
+
+    captured = capsys.readouterr()
+
+    assert opened_urls == ["http://127.0.0.1:5475/approvals/req-1"]
+    assert "http://127.0.0.1:5475/approvals/req-1" in captured.err
+
+
 def test_gr082_claude_pretooluse_brands_native_prompt(tmp_path: Path) -> None:
     exit_code, output = _run_hook(
         tmp_path,


### PR DESCRIPTION
## Summary
- Print and open the HOL Guard approval URL before Codex package-install PreToolUse hooks enter live wait.
- Keep zero-timeout package blocks from entering live wait while preserving approved same-tool-call continuation.

## Testing
- `python3 -m pytest tests/test_guard_phase04_harness_ux.py tests/test_guard_package_hook.py tests/test_guard_codex_install.py -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_phase04_harness_ux.py tests/test_guard_package_hook.py`
