### PR TITLE
feat(guard-auth): make connect default to device code

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -192,7 +192,6 @@ from .connect_flow import (
     DEFAULT_GUARD_CONNECT_URL,
     DEFAULT_GUARD_SYNC_URL,
     build_connect_status_payload,
-    run_guard_connect_command,
     run_guard_device_connect_command,
 )
 from .docs import build_install_connect_docs_payload
@@ -2316,24 +2315,15 @@ def run_guard_command(
             if payload is not None:
                 _emit("login", payload, getattr(args, "json", False))
             return exit_code
-        try:
-            payload = _run_guard_device_connect_flow(store=store, connect_url=args.connect_url)
-        except json.JSONDecodeError as error:
-            print(f"Guard Device Code authorization failed: {error}", file=sys.stderr)
-            return 1
-        except ValueError as error:
-            print(str(error), file=sys.stderr)
-            return 2
-        except (RuntimeError, urllib.error.URLError, http.client.HTTPException) as error:
-            print(f"Guard Device Code authorization failed: {error}", file=sys.stderr)
-            return 1
-        next_action = payload.get("next_action")
-        if isinstance(next_action, dict):
-            target = _optional_string(next_action.get("target"))
-            if target is not None:
-                payload["browser_opened"] = bool(webbrowser.open(target))
+        payload, exit_code = _build_guard_device_connect_payload(
+            store=store,
+            connect_url=args.connect_url,
+            open_browser=True,
+        )
+        if payload is None:
+            return exit_code
         _emit("connect", payload, getattr(args, "json", False))
-        return 0
+        return exit_code
 
     if args.guard_command == "connect":
         connect_subcommand = getattr(args, "connect_command", None)
@@ -2347,38 +2337,25 @@ def run_guard_command(
             _emit("connect", payload, getattr(args, "json", False))
             return 0
         if not bool(getattr(args, "headless", False)):
-            try:
-                payload = _run_guard_device_connect_flow(store=store, connect_url=args.connect_url)
-            except json.JSONDecodeError as error:
-                print(f"Guard Device Code authorization failed: {error}", file=sys.stderr)
-                return 1
-            except ValueError as error:
-                print(str(error), file=sys.stderr)
-                return 2
-            except (RuntimeError, urllib.error.URLError, http.client.HTTPException) as error:
-                print(f"Guard Device Code authorization failed: {error}", file=sys.stderr)
-                return 1
-            next_action = payload.get("next_action")
-            if isinstance(next_action, dict):
-                target = _optional_string(next_action.get("target"))
-                if target is not None:
-                    payload["browser_opened"] = bool(webbrowser.open(target))
+            payload, exit_code = _build_guard_device_connect_payload(
+                store=store,
+                connect_url=args.connect_url,
+                open_browser=True,
+            )
+            if payload is None:
+                return exit_code
             _emit("connect", payload, getattr(args, "json", False))
-            return 0
+            return exit_code
         if bool(getattr(args, "headless", False)):
-            try:
-                payload = _run_guard_device_connect_flow(store=store, connect_url=args.connect_url)
-            except json.JSONDecodeError as error:
-                print(f"Guard Device Code authorization failed: {error}", file=sys.stderr)
-                return 1
-            except ValueError as error:
-                print(str(error), file=sys.stderr)
-                return 2
-            except (RuntimeError, urllib.error.URLError, http.client.HTTPException) as error:
-                print(f"Guard Device Code authorization failed: {error}", file=sys.stderr)
-                return 1
+            payload, exit_code = _build_guard_device_connect_payload(
+                store=store,
+                connect_url=args.connect_url,
+                open_browser=False,
+            )
+            if payload is None:
+                return exit_code
             _emit("connect", payload, getattr(args, "json", False))
-            return 0
+            return exit_code
 
     if args.guard_command == "bridge":
         poll_interval = getattr(args, "poll_interval", 10) or 10
@@ -8748,30 +8725,43 @@ def _filter_policy_items(items: list[dict[str, object]], *, active_only: bool) -
     return filtered
 
 
-def _run_guard_connect_flow(
-    *,
-    guard_home: Path,
-    store: GuardStore,
-    sync_url: str,
-    connect_url: str,
-    wait_timeout_seconds: int,
-) -> dict[str, object]:
-    return run_guard_connect_command(
-        guard_home=guard_home,
-        store=store,
-        sync_url=sync_url,
-        connect_url=connect_url,
-        opener=webbrowser.open,
-        wait_timeout_seconds=wait_timeout_seconds,
-    )
-
-
 def _run_guard_device_connect_flow(
     *,
     store: GuardStore,
     connect_url: str,
 ) -> dict[str, object]:
     return run_guard_device_connect_command(store=store, connect_url=connect_url)
+
+
+def _build_guard_device_connect_payload(
+    *,
+    store: GuardStore,
+    connect_url: str,
+    open_browser: bool,
+) -> tuple[dict[str, object] | None, int]:
+    try:
+        payload = _run_guard_device_connect_flow(store=store, connect_url=connect_url)
+    except json.JSONDecodeError as error:
+        print(f"Guard Device Code authorization failed: {error}", file=sys.stderr)
+        return None, 1
+    except ValueError as error:
+        print(str(error), file=sys.stderr)
+        return None, 2
+    except (RuntimeError, urllib.error.URLError, http.client.HTTPException) as error:
+        print(f"Guard Device Code authorization failed: {error}", file=sys.stderr)
+        return None, 1
+    if open_browser:
+        _open_guard_device_next_action(payload)
+    return payload, 0
+
+
+def _open_guard_device_next_action(payload: dict[str, object]) -> None:
+    next_action = payload.get("next_action")
+    if not isinstance(next_action, dict):
+        return
+    target = _optional_string(next_action.get("target"))
+    if target is not None:
+        payload["browser_opened"] = bool(webbrowser.open(target))
 
 
 def _manual_guard_login_payload(

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1285,12 +1285,9 @@ def _run_init_command(
                     step_payload = {"skipped": False, "error": str(error), "managed_installs": []}
             elif step_id == "cloud":
                 try:
-                    step_payload = _run_guard_connect_flow(
-                        guard_home=context.guard_home,
+                    step_payload = _run_guard_device_connect_flow(
                         store=store,
-                        sync_url=args.sync_url,
                         connect_url=args.connect_url,
-                        wait_timeout_seconds=int(getattr(args, "wait_timeout_seconds", 0)),
                     )
                     step_payload["skipped"] = False
                 except Exception as error:
@@ -2320,21 +2317,23 @@ def run_guard_command(
                 _emit("login", payload, getattr(args, "json", False))
             return exit_code
         try:
-            payload = _run_guard_connect_flow(
-                guard_home=guard_home,
-                store=store,
-                sync_url=getattr(args, "sync_url", None) or DEFAULT_GUARD_SYNC_URL,
-                connect_url=args.connect_url,
-                wait_timeout_seconds=args.wait_timeout_seconds,
-            )
+            payload = _run_guard_device_connect_flow(store=store, connect_url=args.connect_url)
+        except json.JSONDecodeError as error:
+            print(f"Guard Device Code authorization failed: {error}", file=sys.stderr)
+            return 1
         except ValueError as error:
             print(str(error), file=sys.stderr)
             return 2
-        except RuntimeError as error:
-            print(str(error), file=sys.stderr)
+        except (RuntimeError, urllib.error.URLError, http.client.HTTPException) as error:
+            print(f"Guard Device Code authorization failed: {error}", file=sys.stderr)
             return 1
+        next_action = payload.get("next_action")
+        if isinstance(next_action, dict):
+            target = _optional_string(next_action.get("target"))
+            if target is not None:
+                payload["browser_opened"] = bool(webbrowser.open(target))
         _emit("connect", payload, getattr(args, "json", False))
-        return 0 if bool(payload.get("connected")) else 1
+        return 0
 
     if args.guard_command == "connect":
         connect_subcommand = getattr(args, "connect_command", None)
@@ -2345,6 +2344,25 @@ def run_guard_command(
                 connect_url=args.connect_url,
                 action=str(connect_subcommand),
             )
+            _emit("connect", payload, getattr(args, "json", False))
+            return 0
+        if not bool(getattr(args, "headless", False)):
+            try:
+                payload = _run_guard_device_connect_flow(store=store, connect_url=args.connect_url)
+            except json.JSONDecodeError as error:
+                print(f"Guard Device Code authorization failed: {error}", file=sys.stderr)
+                return 1
+            except ValueError as error:
+                print(str(error), file=sys.stderr)
+                return 2
+            except (RuntimeError, urllib.error.URLError, http.client.HTTPException) as error:
+                print(f"Guard Device Code authorization failed: {error}", file=sys.stderr)
+                return 1
+            next_action = payload.get("next_action")
+            if isinstance(next_action, dict):
+                target = _optional_string(next_action.get("target"))
+                if target is not None:
+                    payload["browser_opened"] = bool(webbrowser.open(target))
             _emit("connect", payload, getattr(args, "json", False))
             return 0
         if bool(getattr(args, "headless", False)):
@@ -2361,22 +2379,6 @@ def run_guard_command(
                 return 1
             _emit("connect", payload, getattr(args, "json", False))
             return 0
-        try:
-            payload = _run_guard_connect_flow(
-                guard_home=guard_home,
-                store=store,
-                sync_url=args.sync_url,
-                connect_url=args.connect_url,
-                wait_timeout_seconds=args.wait_timeout_seconds,
-            )
-        except ValueError as error:
-            print(str(error), file=sys.stderr)
-            return 2
-        except RuntimeError as error:
-            print(str(error), file=sys.stderr)
-            return 1
-        _emit("connect", payload, getattr(args, "json", False))
-        return 0 if bool(payload.get("connected")) else 1
 
     if args.guard_command == "bridge":
         poll_interval = getattr(args, "poll_interval", 10) or 10

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -34,7 +34,6 @@ from codex_plugin_scanner.guard.cli import prompt as guard_prompt_module
 from codex_plugin_scanner.guard.cli import update_commands as guard_update_commands_module
 from codex_plugin_scanner.guard.cli.render import emit_guard_payload
 from codex_plugin_scanner.guard.config import GuardConfig, load_guard_config, resolve_risk_action
-from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.desktop_notifications import DesktopNotificationSetupResult
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -6318,243 +6317,114 @@ url = http://127.0.0.1:8787/guard-canary
         assert "artifactHash" in first_receipt
         assert "recommendation" in first_receipt
 
-    def test_guard_connect_pairs_browser_session_and_syncs(self, tmp_path, capsys, monkeypatch):
+    def test_guard_connect_opens_device_code_approval_without_pairing(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         _build_guard_fixture(home_dir, workspace_dir)
         _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\n')
-        _SyncRequestHandler.response_payload = {
-            "syncedAt": "2026-04-09T00:00:00Z",
-            "receiptsStored": 1,
-            "advisories": [
-                {
-                    "id": "adv-001",
-                    "publisher": "hashgraph-online",
-                    "severity": "high",
-                    "headline": "Publisher rotated to a new remote domain.",
-                }
-            ],
-            "policy": {
-                "mode": "enforce",
-                "defaultAction": "warn",
-                "unknownPublisherAction": "review",
-                "changedHashAction": "allow",
-                "newNetworkDomainAction": "warn",
-                "subprocessAction": "block",
-                "telemetryEnabled": False,
-                "syncEnabled": True,
-                "updatedAt": "2026-04-09T00:00:00Z",
-            },
-            "alertPreferences": {
-                "emailEnabled": True,
-                "digestMode": "daily",
-                "watchlistEnabled": True,
-                "advisoriesEnabled": True,
-                "repeatedWarningsEnabled": True,
-                "teamAlertsEnabled": True,
-                "updatedAt": "2026-04-09T00:00:00Z",
-            },
-            "teamPolicyPack": {
-                "name": "Security team default",
-                "sharedHarnessDefaults": {"codex": "enforce"},
-                "allowedPublishers": ["hashgraph-online"],
-                "blockedArtifacts": [],
-                "alertChannel": "email",
-                "updatedAt": "2026-04-09T00:00:00Z",
-                "auditTrail": [],
-            },
-        }
-
-        server = HTTPServer(("127.0.0.1", 0), _SyncRequestHandler)
-        thread = threading.Thread(target=server.serve_forever, daemon=True)
-        thread.start()
-
         store = GuardStore(home_dir)
-        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
-        daemon.start()
-        monkeypatch.setattr(
-            guard_commands_module,
-            "ensure_guard_daemon",
-            lambda guard_home: f"http://127.0.0.1:{daemon.port}",
-        )
-
         opened_urls: list[str] = []
 
         def open_browser(url: str) -> bool:
             opened_urls.append(url)
-            parsed = urllib.parse.urlparse(url)
-            query = urllib.parse.parse_qs(parsed.query)
-            fragment = urllib.parse.parse_qs(parsed.fragment)
-            request_id = query["guardPairRequest"][-1]
-            daemon_url = query["guardDaemon"][-1]
-            pairing_secret = fragment["guardPairSecret"][-1]
-
-            def complete_pairing() -> None:
-                request = urllib.request.Request(
-                    f"{daemon_url}/v1/connect/complete",
-                    data=urllib.parse.urlencode(
-                        {
-                            "request_id": request_id,
-                            "pairing_secret": pairing_secret,
-                            "token": "session-token-123",
-                        }
-                    ).encode("utf-8"),
-                    headers={
-                        "Content-Type": "application/x-www-form-urlencoded",
-                        "Origin": "https://hol.org",
-                    },
-                    method="POST",
-                )
-                with urllib.request.urlopen(request, timeout=5):
-                    pass
-
-            threading.Thread(target=complete_pairing, daemon=True).start()
             return True
 
-        monkeypatch.setattr(guard_commands_module.webbrowser, "open", open_browser)
-        try:
-            run_rc = main(
-                [
-                    "guard",
-                    "run",
-                    "codex",
-                    "--home",
-                    str(home_dir),
-                    "--workspace",
-                    str(workspace_dir),
-                    "--dry-run",
-                    "--default-action",
-                    "allow",
-                    "--json",
-                ]
-            )
-            json.loads(capsys.readouterr().out)
+        def fake_device_flow(*, store: GuardStore, connect_url: str) -> dict[str, object]:
+            assert connect_url == "https://hol.org/guard/connect"
+            return {
+                "status": "waiting_for_approval",
+                "connect_mode": "device_code",
+                "user_code": "ABCD-EFGH",
+                "verification_uri": "https://hol.org/guard/oauth/device",
+                "next_action": {
+                    "command": "open",
+                    "target": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
+                },
+            }
 
-            connect_rc = main(
-                [
-                    "guard",
-                    "connect",
-                    "--home",
-                    str(home_dir),
-                    "--sync-url",
-                    f"http://127.0.0.1:{server.server_port}/receipts",
-                    "--connect-url",
-                    "https://hol.org/guard/connect",
-                    "--json",
-                ]
-            )
-            connect_output = json.loads(capsys.readouterr().out)
-        finally:
-            daemon.stop()
-            server.shutdown()
-            thread.join(timeout=5)
+        monkeypatch.setattr(guard_commands_module.webbrowser, "open", open_browser)
+        monkeypatch.setattr(guard_commands_module, "_run_guard_device_connect_flow", fake_device_flow)
+        run_rc = main(
+            [
+                "guard",
+                "run",
+                "codex",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--dry-run",
+                "--default-action",
+                "allow",
+                "--json",
+            ]
+        )
+        json.loads(capsys.readouterr().out)
+        connect_rc = main(
+            [
+                "guard",
+                "connect",
+                "--home",
+                str(home_dir),
+                "--connect-url",
+                "https://hol.org/guard/connect",
+                "--json",
+            ]
+        )
+        connect_output = json.loads(capsys.readouterr().out)
 
         assert run_rc == 0
         assert connect_rc == 0
-        assert connect_output["connected"] is True
-        assert connect_output["status"] == "connected"
-        assert connect_output["milestone"] == "first_sync_succeeded"
-        assert connect_output["sync"]["receipts_stored"] == 1
-        assert connect_output["sync"]["inventory_tracked"] >= 1
+        assert connect_output["status"] == "waiting_for_approval"
+        assert connect_output["connect_mode"] == "device_code"
+        assert connect_output["user_code"] == "ABCD-EFGH"
         assert connect_output["browser_opened"] is True
-        assert opened_urls and opened_urls[0].startswith("https://hol.org/guard/connect?")
-        assert _SyncRequestHandler.captured_headers["authorization"] == "Bearer session-token-123"
-        assert _SyncRequestHandler.captured_headers["user-agent"].startswith("hol-guard/")
-        assert store.get_sync_credentials() == {
-            "sync_url": f"http://127.0.0.1:{server.server_port}/receipts",
-            "token": "session-token-123",
-        }
+        assert opened_urls == ["https://hol.org/guard/oauth/device?user_code=ABCD-EFGH"]
+        assert "guardPairSecret" not in json.dumps(connect_output)
+        assert "guardPairRequest" not in json.dumps(connect_output)
+        assert store.get_sync_credentials() is None
 
-    def test_guard_login_without_manual_credentials_runs_browser_pairing(self, tmp_path, capsys, monkeypatch):
+    def test_guard_login_without_manual_credentials_redirects_to_device_code(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
-        workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
-        _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\n')
-        _SyncRequestHandler.response_payload = {
-            "syncedAt": "2026-04-09T00:00:00Z",
-            "receiptsStored": 1,
-        }
-
-        server = HTTPServer(("127.0.0.1", 0), _SyncRequestHandler)
-        thread = threading.Thread(target=server.serve_forever, daemon=True)
-        thread.start()
-
         store = GuardStore(home_dir)
-        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
-        daemon.start()
-        monkeypatch.setattr(
-            guard_commands_module,
-            "ensure_guard_daemon",
-            lambda guard_home: f"http://127.0.0.1:{daemon.port}",
-        )
-
         opened_urls: list[str] = []
 
         def open_browser(url: str) -> bool:
             opened_urls.append(url)
-            parsed = urllib.parse.urlparse(url)
-            query = urllib.parse.parse_qs(parsed.query)
-            fragment = urllib.parse.parse_qs(parsed.fragment)
-            request_id = query["guardPairRequest"][-1]
-            daemon_url = query["guardDaemon"][-1]
-            pairing_secret = fragment["guardPairSecret"][-1]
-
-            def complete_pairing() -> None:
-                request = urllib.request.Request(
-                    f"{daemon_url}/v1/connect/complete",
-                    data=urllib.parse.urlencode(
-                        {
-                            "request_id": request_id,
-                            "pairing_secret": pairing_secret,
-                            "token": "session-token-compat",
-                        }
-                    ).encode("utf-8"),
-                    headers={
-                        "Content-Type": "application/x-www-form-urlencoded",
-                        "Origin": "https://hol.org",
-                    },
-                    method="POST",
-                )
-                with urllib.request.urlopen(request, timeout=5):
-                    pass
-
-            threading.Thread(target=complete_pairing, daemon=True).start()
             return True
 
+        def fake_device_flow(*, store: GuardStore, connect_url: str) -> dict[str, object]:
+            return {
+                "status": "waiting_for_approval",
+                "connect_mode": "device_code",
+                "user_code": "ABCD-EFGH",
+                "verification_uri": "https://hol.org/guard/oauth/device",
+                "next_action": {
+                    "command": "open",
+                    "target": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
+                },
+            }
+
         monkeypatch.setattr(guard_commands_module.webbrowser, "open", open_browser)
-        try:
-            login_rc = main(
-                [
-                    "guard",
-                    "login",
-                    "--home",
-                    str(home_dir),
-                    "--sync-url",
-                    f"http://127.0.0.1:{server.server_port}/receipts",
-                    "--connect-url",
-                    "https://hol.org/guard/connect",
-                    "--json",
-                ]
-            )
-            login_output = json.loads(capsys.readouterr().out)
-            sync_rc = main(["guard", "sync", "--home", str(home_dir), "--json"])
-            sync_output = json.loads(capsys.readouterr().out)
-        finally:
-            daemon.stop()
-            server.shutdown()
-            thread.join(timeout=5)
+        monkeypatch.setattr(guard_commands_module, "_run_guard_device_connect_flow", fake_device_flow)
+        login_rc = main(
+            [
+                "guard",
+                "login",
+                "--home",
+                str(home_dir),
+                "--connect-url",
+                "https://hol.org/guard/connect",
+                "--json",
+            ]
+        )
+        login_output = json.loads(capsys.readouterr().out)
 
         assert login_rc == 0
-        assert login_output["connected"] is True
-        assert login_output["status"] == "connected"
-        assert opened_urls and opened_urls[0].startswith("https://hol.org/guard/connect?")
-        assert sync_rc == 0
-        assert sync_output["receipts_stored"] == 1
-        assert _SyncRequestHandler.captured_headers["authorization"] == "Bearer session-token-compat"
-        assert store.get_sync_credentials() == {
-            "sync_url": f"http://127.0.0.1:{server.server_port}/receipts",
-            "token": "session-token-compat",
-        }
+        assert login_output["status"] == "waiting_for_approval"
+        assert login_output["connect_mode"] == "device_code"
+        assert opened_urls == ["https://hol.org/guard/oauth/device?user_code=ABCD-EFGH"]
+        assert store.get_sync_credentials() is None
 
     def test_guard_login_manual_mode_requires_sync_url_and_token(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -6834,182 +6704,73 @@ url = http://127.0.0.1:8787/guard-canary
         assert payload["receipts"]["receipts_stored"] == 2
         assert payload["connection"]["sync_url"] == "https://hol.org/api/guard/receipts/sync"
 
-    def test_guard_connect_preserves_pairing_when_first_sync_fails(self, tmp_path, capsys, monkeypatch):
+    def test_guard_connect_reports_device_authorization_errors_cleanly(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
-        workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
-
         store = GuardStore(home_dir)
-        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
-        daemon.start()
-        monkeypatch.setattr(
-            guard_commands_module,
-            "ensure_guard_daemon",
-            lambda guard_home: f"http://127.0.0.1:{daemon.port}",
+
+        def failing_device_flow(*, store: GuardStore, connect_url: str) -> dict[str, object]:
+            raise RuntimeError("device_authorization_unreachable")
+
+        monkeypatch.setattr(guard_commands_module, "_run_guard_device_connect_flow", failing_device_flow)
+        connect_rc = main(
+            [
+                "guard",
+                "connect",
+                "--home",
+                str(home_dir),
+                "--connect-url",
+                "https://hol.org/guard/connect",
+                "--json",
+            ]
         )
-        monkeypatch.setattr(
-            "codex_plugin_scanner.guard.cli.connect_flow.sync_receipts",
-            lambda current_store: (_ for _ in ()).throw(RuntimeError("sync_unreachable")),
-        )
-        monkeypatch.setattr(
-            "codex_plugin_scanner.guard.cli.connect_flow.sync_runtime_session",
-            lambda current_store, *, session: {
-                "runtime_session_id": str(session.get("session_id") or session.get("sessionId")),
-                "runtime_session_synced_at": "2026-04-15T00:00:01Z",
-                "runtime_sessions_visible": 1,
-            },
-        )
-
-        def open_browser(url: str) -> bool:
-            parsed = urllib.parse.urlparse(url)
-            query = urllib.parse.parse_qs(parsed.query)
-            fragment = urllib.parse.parse_qs(parsed.fragment)
-            request_id = query["guardPairRequest"][-1]
-            daemon_url = query["guardDaemon"][-1]
-            pairing_secret = fragment["guardPairSecret"][-1]
-
-            def complete_pairing() -> None:
-                request = urllib.request.Request(
-                    f"{daemon_url}/v1/connect/complete",
-                    data=urllib.parse.urlencode(
-                        {
-                            "request_id": request_id,
-                            "pairing_secret": pairing_secret,
-                            "token": "session-token-123",
-                        }
-                    ).encode("utf-8"),
-                    headers={
-                        "Content-Type": "application/x-www-form-urlencoded",
-                        "Origin": "https://hol.org",
-                    },
-                    method="POST",
-                )
-                with urllib.request.urlopen(request, timeout=5):
-                    pass
-
-            threading.Thread(target=complete_pairing, daemon=True).start()
-            return True
-
-        monkeypatch.setattr(guard_commands_module.webbrowser, "open", open_browser)
-        try:
-            connect_rc = main(
-                [
-                    "guard",
-                    "connect",
-                    "--home",
-                    str(home_dir),
-                    "--sync-url",
-                    "https://hol.org/registry/api/v1",
-                    "--connect-url",
-                    "https://hol.org/guard/connect",
-                    "--json",
-                ]
-            )
-            connect_output = json.loads(capsys.readouterr().out)
-        finally:
-            daemon.stop()
+        captured = capsys.readouterr()
 
         assert connect_rc == 1
-        assert connect_output["connected"] is False
-        assert connect_output["status"] == "retry_required"
-        assert connect_output["milestone"] == "first_sync_failed"
-        assert connect_output["reason"] == "sync_unreachable"
-        assert connect_output["sync_message"] == "sync_unreachable"
+        assert "Guard Device Code authorization failed: device_authorization_unreachable" in captured.err
+        assert "Traceback" not in captured.err
+        assert store.get_sync_credentials() is None
 
-    def test_guard_connect_surfaces_remote_sync_errors_cleanly(self, tmp_path, capsys, monkeypatch):
+    def test_guard_connect_never_opens_legacy_pairing_url(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
-        workspace_dir = tmp_path / "workspace"
-        _build_guard_fixture(home_dir, workspace_dir)
-        _SyncRequestHandler.response_code = 403
-        _SyncRequestHandler.response_payload = {
-            "error": "Guard sync requires a Pro or Team plan.",
-        }
-
-        server = HTTPServer(("127.0.0.1", 0), _SyncRequestHandler)
-        thread = threading.Thread(target=server.serve_forever, daemon=True)
-        thread.start()
-
-        store = GuardStore(home_dir)
-        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
-        daemon.start()
-        monkeypatch.setattr(
-            guard_commands_module,
-            "ensure_guard_daemon",
-            lambda guard_home: f"http://127.0.0.1:{daemon.port}",
-        )
-        monkeypatch.setattr(
-            "codex_plugin_scanner.guard.cli.connect_flow.sync_runtime_session",
-            lambda current_store, *, session: {
-                "runtime_session_id": str(session.get("session_id") or session.get("sessionId")),
-                "runtime_session_synced_at": "2026-04-15T00:00:01Z",
-                "runtime_sessions_visible": 1,
-            },
-        )
+        opened_urls: list[str] = []
 
         def open_browser(url: str) -> bool:
-            parsed = urllib.parse.urlparse(url)
-            query = urllib.parse.parse_qs(parsed.query)
-            fragment = urllib.parse.parse_qs(parsed.fragment)
-            request_id = query["guardPairRequest"][-1]
-            daemon_url = query["guardDaemon"][-1]
-            pairing_secret = fragment["guardPairSecret"][-1]
-
-            def complete_pairing() -> None:
-                request = urllib.request.Request(
-                    f"{daemon_url}/v1/connect/complete",
-                    data=urllib.parse.urlencode(
-                        {
-                            "request_id": request_id,
-                            "pairing_secret": pairing_secret,
-                            "token": "session-token-123",
-                        }
-                    ).encode("utf-8"),
-                    headers={
-                        "Content-Type": "application/x-www-form-urlencoded",
-                        "Origin": "https://hol.org",
-                    },
-                    method="POST",
-                )
-                with urllib.request.urlopen(request, timeout=5):
-                    pass
-
-            threading.Thread(target=complete_pairing, daemon=True).start()
+            opened_urls.append(url)
             return True
 
-        monkeypatch.setattr(guard_commands_module.webbrowser, "open", open_browser)
-        try:
-            connect_rc = main(
-                [
-                    "guard",
-                    "connect",
-                    "--home",
-                    str(home_dir),
-                    "--sync-url",
-                    f"http://127.0.0.1:{server.server_port}/receipts",
-                    "--connect-url",
-                    "https://hol.org/guard/connect",
-                    "--json",
-                ]
-            )
-            connect_output = json.loads(capsys.readouterr().out)
-        finally:
-            daemon.stop()
-            server.shutdown()
-            thread.join(timeout=5)
-            _SyncRequestHandler.response_code = 200
-            _SyncRequestHandler.response_payload = {
-                "syncedAt": "2026-04-09T00:00:00Z",
-                "receiptsStored": 1,
+        def fake_device_flow(*, store: GuardStore, connect_url: str) -> dict[str, object]:
+            return {
+                "status": "waiting_for_approval",
+                "connect_mode": "device_code",
+                "user_code": "ABCD-EFGH",
+                "verification_uri": "https://hol.org/guard/oauth/device",
+                "next_action": {
+                    "command": "open",
+                    "target": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
+                },
             }
 
+        monkeypatch.setattr(guard_commands_module, "_run_guard_device_connect_flow", fake_device_flow)
+        monkeypatch.setattr(guard_commands_module.webbrowser, "open", open_browser)
+        connect_rc = main(
+            [
+                "guard",
+                "connect",
+                "--home",
+                str(home_dir),
+                "--connect-url",
+                "https://hol.org/guard/connect",
+                "--json",
+            ]
+        )
+        connect_output = json.loads(capsys.readouterr().out)
+        rendered = json.dumps(connect_output, sort_keys=True)
+
         assert connect_rc == 0
-        assert connect_output["connected"] is True
-        assert connect_output["sync_available"] is False
-        assert connect_output["status"] == "connected"
-        assert connect_output["milestone"] == "sync_not_available"
-        assert connect_output["reason"] == "Local Guard is connected. Shared cloud sync needs a paid Guard plan."
-        assert connect_output["sync_message"] == "Local Guard is connected. Shared cloud sync needs a paid Guard plan."
-        assert connect_output["sync"]["sync_not_available_reason"] == "Guard sync requires a Pro or Team plan."
+        assert opened_urls == ["https://hol.org/guard/oauth/device?user_code=ABCD-EFGH"]
+        assert "guardPairSecret" not in rendered
+        assert "guardPairRequest" not in rendered
+        assert "guardDaemon" not in rendered
 
     def test_guard_dashboard_opens_local_approval_center(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
@@ -7063,7 +6824,7 @@ url = http://127.0.0.1:8787/guard-canary
         )
         monkeypatch.setattr(
             guard_commands_module,
-            "_run_guard_connect_flow",
+            "_run_guard_device_connect_flow",
             lambda **_kwargs: pytest.fail("cloud connect should wait for approval"),
         )
         monkeypatch.setattr(
@@ -7138,7 +6899,7 @@ url = http://127.0.0.1:8787/guard-canary
         monkeypatch.setattr(guard_commands_module, "apply_managed_install", fake_install)
         monkeypatch.setattr(
             guard_commands_module,
-            "_run_guard_connect_flow",
+            "_run_guard_device_connect_flow",
             lambda **_kwargs: {
                 "connected": False,
                 "status": "waiting_for_browser",
@@ -7206,7 +6967,7 @@ url = http://127.0.0.1:8787/guard-canary
         )
         monkeypatch.setattr(
             guard_commands_module,
-            "_run_guard_connect_flow",
+            "_run_guard_device_connect_flow",
             lambda **_kwargs: {"connected": False, "status": "waiting_for_browser"},
         )
         monkeypatch.setattr(
@@ -7272,7 +7033,7 @@ url = http://127.0.0.1:8787/guard-canary
         monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", fake_daemon)
         monkeypatch.setattr(guard_commands_module, "_open_approval_center", fake_open)
         monkeypatch.setattr(guard_commands_module, "apply_managed_install", fake_install)
-        monkeypatch.setattr(guard_commands_module, "_run_guard_connect_flow", fake_connect)
+        monkeypatch.setattr(guard_commands_module, "_run_guard_device_connect_flow", fake_connect)
         monkeypatch.setattr(
             guard_commands_module,
             "ensure_desktop_notification_setup",
@@ -7319,7 +7080,7 @@ url = http://127.0.0.1:8787/guard-canary
         )
         monkeypatch.setattr(
             guard_commands_module,
-            "_run_guard_connect_flow",
+            "_run_guard_device_connect_flow",
             lambda **_kwargs: {"connected": False, "status": "waiting_for_browser"},
         )
         monkeypatch.setattr(
@@ -7369,7 +7130,7 @@ url = http://127.0.0.1:8787/guard-canary
         )
         monkeypatch.setattr(
             guard_commands_module,
-            "_run_guard_connect_flow",
+            "_run_guard_device_connect_flow",
             lambda **_kwargs: pytest.fail("cloud connect should be skipped"),
         )
 
@@ -7439,7 +7200,7 @@ url = http://127.0.0.1:8787/guard-canary
         )
         monkeypatch.setattr(
             guard_commands_module,
-            "_run_guard_connect_flow",
+            "_run_guard_device_connect_flow",
             lambda **_kwargs: events.append("run:cloud") or {"connected": True, "status": "connected"},
         )
 
@@ -7503,7 +7264,7 @@ url = http://127.0.0.1:8787/guard-canary
         )
         monkeypatch.setattr(
             guard_commands_module,
-            "_run_guard_connect_flow",
+            "_run_guard_device_connect_flow",
             lambda **_kwargs: pytest.fail("cloud connect should be skipped"),
         )
         monkeypatch.setattr(

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -47,6 +47,19 @@ class _HeadlessConnectArgs:
     workspace = None
 
 
+class _ConnectArgs:
+    guard_command = "connect"
+    connect_command = None
+    headless = False
+    sync_url = "https://hol.org/api/guard/receipts/sync"
+    connect_url = "https://hol.org/guard/connect"
+    wait_timeout_seconds = 180
+    json = True
+    home = None
+    guard_home = None
+    workspace = None
+
+
 def test_device_authorization_request_uses_oauth_scopes_without_token_material() -> None:
     assert hasattr(connect_flow, "build_device_authorization_request_body")
     encoded = connect_flow.build_device_authorization_request_body(
@@ -180,6 +193,47 @@ def test_connect_headless_emits_device_code_payload_without_pairing_secret(tmp_p
     assert "ABCD-EFGH" in captured.out
     assert "guardPairSecret" not in captured.out
     assert "guardPairRequest" not in captured.out
+    assert "guard_live_" not in captured.out
+
+
+def test_connect_default_uses_device_code_without_pairing_secret(tmp_path: Path, capsys, monkeypatch) -> None:
+    guard_home = tmp_path / "guard-home"
+    args = _ConnectArgs()
+    args.guard_home = str(guard_home)
+    opened_urls: list[str] = []
+
+    def fake_headless_flow(*, store: GuardStore, connect_url: str) -> dict[str, object]:
+        return {
+            "status": "waiting_for_approval",
+            "connect_mode": "device_code",
+            "user_code": "ABCD-EFGH",
+            "verification_uri": "https://hol.org/guard/oauth/device",
+            "next_action": {
+                "command": "open",
+                "target": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
+            },
+        }
+
+    def fake_open(url: str) -> bool:
+        opened_urls.append(url)
+        return True
+
+    def legacy_pairing_flow(**kwargs: object) -> dict[str, object]:
+        raise AssertionError("default connect must not use legacy pairing flow")
+
+    monkeypatch.setattr(guard_commands, "_run_guard_device_connect_flow", fake_headless_flow)
+    monkeypatch.setattr(guard_commands, "_run_guard_connect_flow", legacy_pairing_flow)
+    monkeypatch.setattr(guard_commands.webbrowser, "open", fake_open)
+
+    exit_code = run_guard_command(args)
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert opened_urls == ["https://hol.org/guard/oauth/device?user_code=ABCD-EFGH"]
+    assert "ABCD-EFGH" in captured.out
+    assert "guardPairSecret" not in captured.out
+    assert "guardPairRequest" not in captured.out
+    assert "guardDaemon" not in captured.out
     assert "guard_live_" not in captured.out
 
 

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -218,11 +218,7 @@ def test_connect_default_uses_device_code_without_pairing_secret(tmp_path: Path,
         opened_urls.append(url)
         return True
 
-    def legacy_pairing_flow(**kwargs: object) -> dict[str, object]:
-        raise AssertionError("default connect must not use legacy pairing flow")
-
     monkeypatch.setattr(guard_commands, "_run_guard_device_connect_flow", fake_headless_flow)
-    monkeypatch.setattr(guard_commands, "_run_guard_connect_flow", legacy_pairing_flow)
     monkeypatch.setattr(guard_commands.webbrowser, "open", fake_open)
 
     exit_code = run_guard_command(args)
@@ -233,6 +229,7 @@ def test_connect_default_uses_device_code_without_pairing_secret(tmp_path: Path,
     assert "ABCD-EFGH" in captured.out
     assert "guardPairSecret" not in captured.out
     assert "guardPairRequest" not in captured.out
+    assert not hasattr(guard_commands, "_run_guard_connect_flow")
     assert "guardDaemon" not in captured.out
     assert "guard_live_" not in captured.out
 


### PR DESCRIPTION
## Summary
- Make `hol-guard connect` default to the OAuth Device Code approval flow instead of legacy browser pairing.
- Route `hol-guard login` without a raw token and `hol-guard init --yes` Cloud setup through the same Device Code path.
- Replace legacy pairing CLI tests with regressions that prove no `guardPairSecret`, `guardPairRequest`, device code, or token material is emitted.

## Testing
- `python3 -m pytest tests/test_guard_oauth_device_connect.py tests/test_guard_cli.py tests/test_guard_connect_flow.py tests/test_guard_events.py tests/test_guard_protect.py::TestGuardProtect::test_guard_protect_auto_syncs_cloud_advisories`
- `python3 -m ruff check src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_oauth_device_connect.py tests/test_guard_cli.py`
