### PR TITLE
test(guard-auth): purge legacy bearer fixtures

### DIFF
--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6461,7 +6461,7 @@ url = http://127.0.0.1:8787/guard-canary
                 "--sync-url",
                 "https://hol.org/api/guard/receipts/sync",
                 "--token",
-                "guard_live_secretvalue",
+                "legacy-bearer-secretvalue",
                 "--json",
             ]
         )
@@ -6471,7 +6471,7 @@ url = http://127.0.0.1:8787/guard-canary
         assert login_rc == 2
         assert payload["logged_in"] is False
         assert payload["next_action"]["command"] == "hol-guard connect --headless"
-        assert "guard_live_secretvalue" not in json.dumps(payload)
+        assert "legacy-bearer-secretvalue" not in json.dumps(payload)
         assert payload["service"] == {
             "runtime": "hermes",
             "label": "Hermes Telegram agent",
@@ -6542,7 +6542,7 @@ url = http://127.0.0.1:8787/guard-canary
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)
         now = "2026-05-01T00:00:00Z"
-        store.set_sync_credentials("https://hol.org/api/guard/receipts/sync", "guard_live_secretvalue", now)
+        store.set_sync_credentials("https://hol.org/api/guard/receipts/sync", "oauth_access_token_fixture", now)
         store.set_sync_payload(
             "service_runtime_profile",
             {
@@ -6603,7 +6603,7 @@ url = http://127.0.0.1:8787/guard-canary
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)
         now = "2026-05-01T00:00:00Z"
-        store.set_sync_credentials("https://hol.org/api/guard/receipts/sync", "guard_live_secretvalue", now)
+        store.set_sync_credentials("https://hol.org/api/guard/receipts/sync", "oauth_access_token_fixture", now)
         store.set_sync_payload(
             "service_runtime_profile",
             {
@@ -6653,7 +6653,7 @@ url = http://127.0.0.1:8787/guard-canary
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)
         now = "2026-05-01T00:00:00Z"
-        store.set_sync_credentials("https://hol.org/api/guard/receipts/sync", "guard_live_secretvalue", now)
+        store.set_sync_credentials("https://hol.org/api/guard/receipts/sync", "oauth_access_token_fixture", now)
         store.set_sync_payload(
             "service_runtime_profile",
             {

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -45,7 +45,7 @@ def _post_legacy_connect_endpoint(
                 "pairing_secret": "pairing-secret",
                 "request_id": "connect-123",
                 "sync_url": "https://hol.org/api/guard/receipts/sync",
-                "token": "guard_live_secret",
+                "token": "legacy-sync-secret",
             }
         ).encode("utf-8"),
         headers={
@@ -94,7 +94,7 @@ def test_daemon_rejects_legacy_connect_pairing_endpoints(tmp_path: Path) -> None
     assert complete_payload["error"] == "legacy_pairing_disabled"
     assert result_status == 410
     assert result_payload["error"] == "legacy_pairing_disabled"
-    assert "guard_live_secret" not in json.dumps([request_payload, complete_payload, result_payload])
+    assert "legacy-sync-secret" not in json.dumps([request_payload, complete_payload, result_payload])
 
 
 def test_connect_repair_copy_points_to_device_code(tmp_path: Path) -> None:

--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -435,8 +435,8 @@ def test_inventory_snapshot_maps_cisco_findings_to_redacted_inventory_evidence(t
         rule_id="CISCO-SKILL-PROMPT-INJECTION",
         severity=Severity.HIGH,
         category="skill-security",
-        title="Prompt injection guard_live_secret",
-        description=f"Unsafe instruction in {skill_path} with token=guard_live_secret",
+        title="Prompt injection ghp_secretvalue",
+        description=f"Unsafe instruction in {skill_path} with token=ghp_secretvalue",
         file_path=str(skill_path),
         line_number=7,
         source="cisco-skill-scanner",
@@ -444,7 +444,7 @@ def test_inventory_snapshot_maps_cisco_findings_to_redacted_inventory_evidence(t
     cisco_run = CiscoInventoryRun(
         source="cisco-skill-scanner",
         status="enabled",
-        message="Cisco skill scanner found guard_live_secret",
+        message="Cisco skill scanner found ghp_secretvalue",
         findings=(finding, finding),
         duration_ms=42,
         metadata={"totalFindings": 2},
@@ -467,5 +467,5 @@ def test_inventory_snapshot_maps_cisco_findings_to_redacted_inventory_evidence(t
     assert payload["findings"][0]["evidence"]["durationMs"] == 42
     assert payload["findings"][0]["evidence"]["riskComponent"]["scoreDelta"] == -25
     assert payload["sources"][-1]["source_type"] == "scanner"
-    assert "guard_live_secret" not in encoded
+    assert "ghp_secretvalue" not in encoded
     assert str(tmp_path) not in encoded

--- a/tests/test_guard_legacy_token_fixtures.py
+++ b/tests/test_guard_legacy_token_fixtures.py
@@ -1,0 +1,21 @@
+"""Legacy Guard bearer-token fixture boundaries."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_guard_live_fixtures_are_rejection_only() -> None:
+    legacy_prefix = "guard" + "_live" + "_"
+    tests_root = Path(__file__).resolve().parent
+    allowed_files = {
+        "test_guard_oauth_device_connect.py",
+        Path(__file__).name,
+    }
+    offenders = sorted(
+        str(path.relative_to(tests_root))
+        for path in tests_root.rglob("test_*.py")
+        if path.name not in allowed_files and legacy_prefix in path.read_text(encoding="utf-8")
+    )
+
+    assert offenders == []

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -48,7 +48,7 @@ def _seed_cloud_profile(context: HarnessContext, runtime: str = "hermes") -> Non
             "agent_id": "agent_123",
             "principal_id": "principal_123",
             "sync_url": "https://hol.org/api/guard/receipts/sync",
-            "token": "guard_live_secret",
+            "token": "oauth_access_token_fixture",
         },
         "2026-05-05T00:00:00.000Z",
     )
@@ -99,12 +99,12 @@ def test_inventory_snapshot_redacts_hermes_skills_and_mcp_config(tmp_path: Path)
         (
             "mcp_servers:\n"
             "  docs:\n"
-            '    command: "/usr/bin/node --token guard_live_secret '
-            'HTTPS://user:pass@example.com/mcp?auth=guard_live_secret '
+            '    command: "/usr/bin/node --token ghp_secretvalue '
+            'HTTPS://user:pass@example.com/mcp?auth=ghp_secretvalue '
             'ws://user:pass@example.com/socket"\n'
-            '    url: "https://user:pass@example.com/mcp?token=guard_live_secret&mode=safe"\n'
+            '    url: "https://user:pass@example.com/mcp?token=ghp_secretvalue&mode=safe"\n'
             "    headers:\n"
-            '      Authorization: "Bearer guard_live_secret"\n'
+            '      Authorization: "Bearer ghp_secretvalue"\n'
         ),
     )
     context = _ctx(tmp_path)
@@ -118,9 +118,9 @@ def test_inventory_snapshot_redacts_hermes_skills_and_mcp_config(tmp_path: Path)
     assert {item["item_kind"] for item in payload["items"]} >= {"skill", "mcp_server"}
     assert all(item["metadata"]["has_env_secrets"] is False for item in mcp_items)
     assert all(item["metadata"]["has_auth_headers"] is True for item in mcp_items)
-    assert "guard_live_secret" not in encoded
-    assert "Bearer guard_live_secret" not in encoded
-    assert "--token guard_live_secret" not in encoded
+    assert "ghp_secretvalue" not in encoded
+    assert "Bearer ghp_secretvalue" not in encoded
+    assert "--token ghp_secretvalue" not in encoded
     assert "user:pass" not in encoded
     assert str(tmp_path) not in encoded
 

--- a/tests/test_openclaw_adapter.py
+++ b/tests/test_openclaw_adapter.py
@@ -45,7 +45,7 @@ def _seed_cloud_profile(context: HarnessContext, runtime: str = "openclaw") -> N
             "client_version": "2.0.95",
             "agent_id": "agent_456",
             "principal_id": "principal_456",
-            "token": "guard_live_secret",
+            "token": "oauth_access_token_fixture",
             "sync_url": "https://hol.org/api/guard/receipts/sync",
         },
         "2026-05-05T00:00:00.000Z",
@@ -135,8 +135,8 @@ def test_inventory_snapshot_redacts_openclaw_channels_mcp_and_skills(tmp_path: P
                 "mcp": {
                     "servers": {
                         "docs": {
-                            "url": "https://user:pass@example.com/mcp?token=guard_live_secret",
-                            "headers": {"Authorization": "Bearer guard_live_secret"},
+                            "url": "https://user:pass@example.com/mcp?token=ghp_secretvalue",
+                            "headers": {"Authorization": "Bearer ghp_secretvalue"},
                         }
                     }
                 },
@@ -151,7 +151,7 @@ def test_inventory_snapshot_redacts_openclaw_channels_mcp_and_skills(tmp_path: P
 
     assert payload["agent_type"] == "openclaw"
     assert {item["item_kind"] for item in payload["items"]} >= {"channel", "mcp_server", "skill"}
-    assert "guard_live_secret" not in encoded
+    assert "ghp_secretvalue" not in encoded
     assert str(context.home_dir) not in encoded
     assert str(context.workspace_dir) not in encoded
 


### PR DESCRIPTION
## Summary
- Add a regression boundary that permits `guard_live_` fixtures only in explicit raw-token rejection tests.
- Replace stale success-path and generic redaction fixtures with OAuth-neutral or non-Guard secret examples.

## Testing
- `python3 -m pytest tests/test_guard_legacy_token_fixtures.py`
- `python3 -m pytest tests/test_guard_legacy_token_fixtures.py tests/test_guard_oauth_device_connect.py tests/test_guard_connect_flow.py tests/test_guard_cli.py tests/test_hermes_adapter.py tests/test_openclaw_adapter.py tests/test_guard_inventory_contract.py`
- `python3 -m ruff check tests/test_guard_legacy_token_fixtures.py tests/test_guard_oauth_device_connect.py tests/test_guard_connect_flow.py tests/test_guard_cli.py tests/test_hermes_adapter.py tests/test_openclaw_adapter.py tests/test_guard_inventory_contract.py`
