### PR TITLE
fix(publish): pin hatchling metadata version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling<1.28"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
## Summary
- Pin the isolated Hatchling build backend below the release that emits Core Metadata 2.5.
- Restore compatibility with the current `twine check` verifier used by the publish workflow.

## Testing
- `python3 - <<'PY' ... assert 'hatchling<1.28' in pyproject.toml build-system requires ... PY`
- `git diff --check`

## Notes
- Follow-up for the post-merge publish failure from PR #541: `twine check` rejected `Metadata-Version: 2.5`.
