### PR TITLE
test(guard-auth): purge legacy bearer fixtures

### DIFF
--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -435,7 +435,7 @@ def test_inventory_snapshot_maps_cisco_findings_to_redacted_inventory_evidence(t
         rule_id="CISCO-SKILL-PROMPT-INJECTION",
         severity=Severity.HIGH,
         category="skill-security",
-        title="Prompt injection finding",
+        title="Prompt injection token=fixture_secretvalue",
         description=f"Unsafe instruction in {skill_path} with token=fixture_secretvalue",
         file_path=str(skill_path),
         line_number=7,
@@ -444,7 +444,7 @@ def test_inventory_snapshot_maps_cisco_findings_to_redacted_inventory_evidence(t
     cisco_run = CiscoInventoryRun(
         source="cisco-skill-scanner",
         status="enabled",
-        message="Cisco skill scanner found unsafe instruction",
+        message="Cisco skill scanner found token=fixture_secretvalue",
         findings=(finding, finding),
         duration_ms=42,
         metadata={"totalFindings": 2},

--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -435,8 +435,8 @@ def test_inventory_snapshot_maps_cisco_findings_to_redacted_inventory_evidence(t
         rule_id="CISCO-SKILL-PROMPT-INJECTION",
         severity=Severity.HIGH,
         category="skill-security",
-        title="Prompt injection ghp_secretvalue",
-        description=f"Unsafe instruction in {skill_path} with token=ghp_secretvalue",
+        title="Prompt injection finding",
+        description=f"Unsafe instruction in {skill_path} with token=fixture_secretvalue",
         file_path=str(skill_path),
         line_number=7,
         source="cisco-skill-scanner",
@@ -444,7 +444,7 @@ def test_inventory_snapshot_maps_cisco_findings_to_redacted_inventory_evidence(t
     cisco_run = CiscoInventoryRun(
         source="cisco-skill-scanner",
         status="enabled",
-        message="Cisco skill scanner found ghp_secretvalue",
+        message="Cisco skill scanner found unsafe instruction",
         findings=(finding, finding),
         duration_ms=42,
         metadata={"totalFindings": 2},
@@ -467,5 +467,5 @@ def test_inventory_snapshot_maps_cisco_findings_to_redacted_inventory_evidence(t
     assert payload["findings"][0]["evidence"]["durationMs"] == 42
     assert payload["findings"][0]["evidence"]["riskComponent"]["scoreDelta"] == -25
     assert payload["sources"][-1]["source_type"] == "scanner"
-    assert "ghp_secretvalue" not in encoded
+    assert "fixture_secretvalue" not in encoded
     assert str(tmp_path) not in encoded

--- a/tests/test_guard_legacy_token_fixtures.py
+++ b/tests/test_guard_legacy_token_fixtures.py
@@ -15,7 +15,8 @@ def test_guard_live_fixtures_are_rejection_only() -> None:
     offenders = sorted(
         str(path.relative_to(tests_root))
         for path in tests_root.rglob("test_*.py")
-        if path.name not in allowed_files and legacy_prefix in path.read_text(encoding="utf-8")
+        if str(path.relative_to(tests_root)) not in allowed_files
+        and legacy_prefix in path.read_text(encoding="utf-8")
     )
 
     assert offenders == []


### PR DESCRIPTION
## Summary
- purge `guard_live_` happy-path fixtures from hol-guard runtime and adapter tests so legacy bearer examples only remain in explicit rejection coverage
- add a regression test that fails if new non-rejection test files reintroduce `guard_live_` fixtures

## Testing
- `python3 -m pytest tests/test_guard_cli.py tests/test_guard_connect_flow.py tests/test_guard_inventory_contract.py tests/test_hermes_adapter.py tests/test_openclaw_adapter.py tests/test_guard_legacy_token_fixtures.py -q`
