### PR TITLE
feat(guard-auth): add oauth client groundwork

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -8,10 +8,10 @@ import urllib.request
 from datetime import datetime, timezone
 
 from ..store import GuardStore
+from .oauth_client import resolve_guard_oauth_client_config
 
 DEFAULT_GUARD_SYNC_URL = "https://hol.org/api/guard/receipts/sync"
 DEFAULT_GUARD_CONNECT_URL = "https://hol.org/guard/connect"
-DEFAULT_GUARD_DEVICE_CLIENT_ID = "guard-local-daemon"
 DEFAULT_GUARD_DEVICE_SCOPES = (
     "guard:runtime.sync",
     "guard:receipt.write",
@@ -39,7 +39,7 @@ def build_device_authorization_request_body(
     machine_label: str,
     runtime_id: str,
     runtime_label: str,
-    client_id: str = DEFAULT_GUARD_DEVICE_CLIENT_ID,
+    client_id: str,
     scopes: tuple[str, ...] = DEFAULT_GUARD_DEVICE_SCOPES,
 ) -> str:
     return urllib.parse.urlencode(
@@ -78,7 +78,7 @@ def build_device_authorization_copy_payload(response: dict[str, object]) -> dict
 
 def device_authorization_endpoint_from_connect_url(connect_url: str) -> str:
     _, allowed_origin = resolve_connect_url(connect_url)
-    return f"{allowed_origin}/api/guard/oauth/device/authorize"
+    return resolve_guard_oauth_client_config(allowed_origin).device_authorization_endpoint
 
 
 def request_device_authorization(url: str, body: str) -> dict[str, object]:
@@ -106,11 +106,14 @@ def run_guard_device_connect_command(
     request_device_authorization=request_device_authorization,
 ) -> dict[str, object]:
     device = store.get_device_metadata()
+    _, allowed_origin = resolve_connect_url(connect_url)
+    oauth_client = resolve_guard_oauth_client_config(allowed_origin)
     request_body = build_device_authorization_request_body(
         machine_id=str(device["installation_id"]),
         machine_label=str(device["device_label"]),
         runtime_id="hol-guard",
         runtime_label="HOL Guard CLI",
+        client_id=oauth_client.client_id,
     )
     response = request_device_authorization(
         device_authorization_endpoint_from_connect_url(connect_url),

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -116,7 +116,7 @@ def run_guard_device_connect_command(
         client_id=oauth_client.client_id,
     )
     response = request_device_authorization(
-        device_authorization_endpoint_from_connect_url(connect_url),
+        oauth_client.device_authorization_endpoint,
         request_body,
     )
     payload = build_device_authorization_copy_payload(response)

--- a/src/codex_plugin_scanner/guard/cli/oauth_client.py
+++ b/src/codex_plugin_scanner/guard/cli/oauth_client.py
@@ -17,9 +17,7 @@ PRODUCTION_GUARD_ISSUER = "https://hol.org"
 STAGING_GUARD_ISSUER = "https://staging.hol.org"
 LOCAL_GUARD_ISSUER = "http://127.0.0.1:3000"
 
-_PKCE_ALLOWED_CHARACTERS = frozenset(
-    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~"
-)
+_PKCE_ALLOWED_CHARACTERS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~")
 
 
 @dataclass(frozen=True)

--- a/src/codex_plugin_scanner/guard/cli/oauth_client.py
+++ b/src/codex_plugin_scanner/guard/cli/oauth_client.py
@@ -7,6 +7,7 @@ import hashlib
 import secrets
 import urllib.parse
 from dataclasses import dataclass
+from functools import lru_cache
 
 PRODUCTION_GUARD_OAUTH_CLIENT_ID = "guard-local-daemon"
 STAGING_GUARD_OAUTH_CLIENT_ID = "guard-local-daemon-staging"
@@ -31,6 +32,7 @@ class GuardOAuthClientConfig:
     client_id: str
 
 
+@lru_cache(maxsize=64)
 def _issuer_origin(issuer: str) -> str:
     parsed = urllib.parse.urlparse(issuer)
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
@@ -76,13 +78,7 @@ def _base64url_encode(data: bytes) -> str:
 def generate_pkce_verifier(length: int = 64) -> str:
     if length < 43 or length > 128:
         raise ValueError("PKCE verifier length must be between 43 and 128 characters.")
-    chunks: list[str] = []
-    while len("".join(chunks)) < length:
-        token = _base64url_encode(secrets.token_bytes(length))
-        chunks.append(token)
-    verifier = "".join(chunks)[:length]
-    if not set(verifier).issubset(_PKCE_ALLOWED_CHARACTERS):
-        raise RuntimeError("Generated PKCE verifier contains unsupported characters.")
+    verifier = _base64url_encode(secrets.token_bytes(length))[:length]
     return verifier
 
 

--- a/src/codex_plugin_scanner/guard/cli/oauth_client.py
+++ b/src/codex_plugin_scanner/guard/cli/oauth_client.py
@@ -1,0 +1,94 @@
+"""OAuth client configuration helpers for HOL Guard runtimes."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+import urllib.parse
+from dataclasses import dataclass
+
+PRODUCTION_GUARD_OAUTH_CLIENT_ID = "guard-local-daemon"
+STAGING_GUARD_OAUTH_CLIENT_ID = "guard-local-daemon-staging"
+LOCAL_GUARD_OAUTH_CLIENT_ID = "guard-local-daemon-local"
+
+PRODUCTION_GUARD_ISSUER = "https://hol.org"
+STAGING_GUARD_ISSUER = "https://staging.hol.org"
+LOCAL_GUARD_ISSUER = "http://127.0.0.1:3000"
+
+_PKCE_ALLOWED_CHARACTERS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~"
+)
+
+
+@dataclass(frozen=True)
+class GuardOAuthClientConfig:
+    issuer: str
+    authorize_endpoint: str
+    token_endpoint: str
+    device_authorization_endpoint: str
+    jwks_endpoint: str
+    client_id: str
+
+
+def _issuer_origin(issuer: str) -> str:
+    parsed = urllib.parse.urlparse(issuer)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("Guard OAuth issuer must be an absolute http(s) URL.")
+    return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
+
+
+def _oauth_endpoints(origin: str) -> GuardOAuthClientConfig:
+    environment = detect_guard_oauth_environment(origin)
+    client_id = {
+        "production": PRODUCTION_GUARD_OAUTH_CLIENT_ID,
+        "staging": STAGING_GUARD_OAUTH_CLIENT_ID,
+        "local": LOCAL_GUARD_OAUTH_CLIENT_ID,
+    }[environment]
+    return GuardOAuthClientConfig(
+        issuer=origin,
+        authorize_endpoint=f"{origin}/api/guard/oauth/authorize",
+        token_endpoint=f"{origin}/api/guard/oauth/token",
+        device_authorization_endpoint=f"{origin}/api/guard/oauth/device/authorize",
+        jwks_endpoint=f"{origin}/api/guard/oauth/jwks",
+        client_id=client_id,
+    )
+
+
+def detect_guard_oauth_environment(issuer: str) -> str:
+    origin = _issuer_origin(issuer).lower()
+    host = urllib.parse.urlparse(origin).hostname or ""
+    if host in {"127.0.0.1", "localhost", "::1"}:
+        return "local"
+    if host.startswith("staging."):
+        return "staging"
+    return "production"
+
+
+def resolve_guard_oauth_client_config(issuer: str) -> GuardOAuthClientConfig:
+    return _oauth_endpoints(_issuer_origin(issuer))
+
+
+def _base64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def generate_pkce_verifier(length: int = 64) -> str:
+    if length < 43 or length > 128:
+        raise ValueError("PKCE verifier length must be between 43 and 128 characters.")
+    chunks: list[str] = []
+    while len("".join(chunks)) < length:
+        token = _base64url_encode(secrets.token_bytes(length))
+        chunks.append(token)
+    verifier = "".join(chunks)[:length]
+    if not set(verifier).issubset(_PKCE_ALLOWED_CHARACTERS):
+        raise RuntimeError("Generated PKCE verifier contains unsupported characters.")
+    return verifier
+
+
+def build_pkce_s256_challenge(verifier: str) -> str:
+    if not verifier:
+        raise ValueError("PKCE verifier is required.")
+    if not set(verifier).issubset(_PKCE_ALLOWED_CHARACTERS):
+        raise ValueError("PKCE verifier contains unsupported characters.")
+    return _base64url_encode(hashlib.sha256(verifier.encode("ascii")).digest())

--- a/tests/test_guard_oauth_client.py
+++ b/tests/test_guard_oauth_client.py
@@ -1,0 +1,60 @@
+from codex_plugin_scanner.guard.cli.oauth_client import (
+    LOCAL_GUARD_OAUTH_CLIENT_ID,
+    PRODUCTION_GUARD_OAUTH_CLIENT_ID,
+    STAGING_GUARD_OAUTH_CLIENT_ID,
+    build_pkce_s256_challenge,
+    detect_guard_oauth_environment,
+    generate_pkce_verifier,
+    resolve_guard_oauth_client_config,
+)
+
+
+def test_resolve_guard_oauth_client_config_for_production() -> None:
+    config = resolve_guard_oauth_client_config("https://hol.org")
+
+    assert config.issuer == "https://hol.org"
+    assert config.authorize_endpoint == "https://hol.org/api/guard/oauth/authorize"
+    assert config.token_endpoint == "https://hol.org/api/guard/oauth/token"
+    assert config.device_authorization_endpoint == "https://hol.org/api/guard/oauth/device/authorize"
+    assert config.jwks_endpoint == "https://hol.org/api/guard/oauth/jwks"
+    assert config.client_id == PRODUCTION_GUARD_OAUTH_CLIENT_ID
+
+
+def test_resolve_guard_oauth_client_config_for_staging() -> None:
+    config = resolve_guard_oauth_client_config("https://staging.hol.org")
+
+    assert config.client_id == STAGING_GUARD_OAUTH_CLIENT_ID
+    assert config.token_endpoint == "https://staging.hol.org/api/guard/oauth/token"
+    assert detect_guard_oauth_environment(config.issuer) == "staging"
+
+
+def test_resolve_guard_oauth_client_config_for_local_loopback() -> None:
+    config = resolve_guard_oauth_client_config("http://127.0.0.1:3000")
+
+    assert config.client_id == LOCAL_GUARD_OAUTH_CLIENT_ID
+    assert config.authorize_endpoint == "http://127.0.0.1:3000/api/guard/oauth/authorize"
+    assert detect_guard_oauth_environment(config.issuer) == "local"
+
+
+def test_generate_pkce_verifier_uses_rfc7636_charset() -> None:
+    verifier = generate_pkce_verifier(64)
+
+    assert len(verifier) == 64
+    assert all(character.isalnum() or character in "-._~" for character in verifier)
+
+
+def test_generate_pkce_verifier_rejects_out_of_range_length() -> None:
+    try:
+        generate_pkce_verifier(42)
+    except ValueError as error:
+        assert "between 43 and 128" in str(error)
+    else:
+        raise AssertionError("PKCE verifier length below RFC minimum must fail")
+
+
+def test_build_pkce_s256_challenge_matches_known_vector() -> None:
+    verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+
+    challenge = build_pkce_s256_challenge(verifier)
+
+    assert challenge == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -68,6 +68,7 @@ def test_device_authorization_request_uses_oauth_scopes_without_token_material()
         machine_label="Michaels MacBook",
         runtime_id="hol-guard",
         runtime_label="HOL Guard CLI",
+        client_id="guard-local-daemon",
     )
     parsed = urllib.parse.parse_qs(encoded)
 
@@ -135,6 +136,34 @@ def test_headless_connect_requests_device_code_without_persisting_secrets(tmp_pa
     assert payload["user_code"] == "ABCD-EFGH"
     assert "device-secret-value" not in rendered
     assert store.get_sync_credentials() is None
+
+
+def test_headless_connect_uses_staging_client_defaults(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    store.set_device_label("CI Runner", "2026-05-31T00:00:00Z")
+    requests: list[tuple[str, str]] = []
+
+    def fake_request(url: str, body: str) -> dict[str, object]:
+        requests.append((url, body))
+        return {
+            "device_code": "device-secret-value",
+            "user_code": "ABCD-EFGH",
+            "verification_uri": "https://staging.hol.org/guard/oauth/device",
+            "verification_uri_complete": "https://staging.hol.org/guard/oauth/device?user_code=ABCD-EFGH",
+            "expires_in": 600,
+            "interval": 5,
+        }
+
+    connect_flow.run_guard_device_connect_command(
+        store=store,
+        connect_url="https://staging.hol.org/guard/connect",
+        request_device_authorization=fake_request,
+    )
+    parsed = urllib.parse.parse_qs(requests[0][1])
+
+    assert requests[0][0] == "https://staging.hol.org/api/guard/oauth/device/authorize"
+    assert parsed["client_id"] == ["guard-local-daemon-staging"]
 
 
 def test_login_token_alias_rejects_raw_token_without_persisting_credentials(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- add a dedicated HOL Guard OAuth client config module with issuer, authorize, token, device, and JWKS endpoint defaults for production, staging, and local environments
- add RFC 7636 PKCE verifier/challenge helpers and route Device Code connect through the shared OAuth client config

## Testing
- `python3 -m pytest tests/test_guard_oauth_client.py tests/test_guard_oauth_device_connect.py -q`
- `ruff check src/codex_plugin_scanner/guard/cli/oauth_client.py src/codex_plugin_scanner/guard/cli/connect_flow.py tests/test_guard_oauth_client.py tests/test_guard_oauth_device_connect.py`
