### PR TITLE
feat(guard-auth): add oauth secret storage primitives

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/oauth_client.py
+++ b/src/codex_plugin_scanner/guard/cli/oauth_client.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import json
 import secrets
 import urllib.parse
 from dataclasses import dataclass
 from functools import lru_cache
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
 
 PRODUCTION_GUARD_OAUTH_CLIENT_ID = "guard-local-daemon"
 STAGING_GUARD_OAUTH_CLIENT_ID = "guard-local-daemon-staging"
@@ -28,6 +32,14 @@ class GuardOAuthClientConfig:
     device_authorization_endpoint: str
     jwks_endpoint: str
     client_id: str
+
+
+@dataclass(frozen=True)
+class GuardDpopKeyMaterial:
+    algorithm: str
+    private_key_pem: str
+    public_jwk: dict[str, str]
+    public_jwk_thumbprint: str
 
 
 @lru_cache(maxsize=64)
@@ -86,3 +98,38 @@ def build_pkce_s256_challenge(verifier: str) -> str:
     if not set(verifier).issubset(_PKCE_ALLOWED_CHARACTERS):
         raise ValueError("PKCE verifier contains unsupported characters.")
     return _base64url_encode(hashlib.sha256(verifier.encode("ascii")).digest())
+
+
+def generate_dpop_key_pair() -> GuardDpopKeyMaterial:
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    private_numbers = private_key.private_numbers()
+    public_numbers = private_numbers.public_numbers
+    public_jwk = {
+        "alg": "ES256",
+        "crv": "P-256",
+        "kty": "EC",
+        "use": "sig",
+        "x": _base64url_encode(public_numbers.x.to_bytes(32, byteorder="big")),
+        "y": _base64url_encode(public_numbers.y.to_bytes(32, byteorder="big")),
+    }
+    thumbprint_payload = {
+        "crv": public_jwk["crv"],
+        "kty": public_jwk["kty"],
+        "x": public_jwk["x"],
+        "y": public_jwk["y"],
+    }
+    private_key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("ascii")
+    return GuardDpopKeyMaterial(
+        algorithm="ES256",
+        private_key_pem=private_key_pem,
+        public_jwk=public_jwk,
+        public_jwk_thumbprint=_base64url_encode(
+            hashlib.sha256(
+                json.dumps(thumbprint_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+            ).digest()
+        ),
+    )

--- a/src/codex_plugin_scanner/guard/cli/oauth_client.py
+++ b/src/codex_plugin_scanner/guard/cli/oauth_client.py
@@ -105,10 +105,8 @@ def generate_dpop_key_pair() -> GuardDpopKeyMaterial:
     private_numbers = private_key.private_numbers()
     public_numbers = private_numbers.public_numbers
     public_jwk = {
-        "alg": "ES256",
         "crv": "P-256",
         "kty": "EC",
-        "use": "sig",
         "x": _base64url_encode(public_numbers.x.to_bytes(32, byteorder="big")),
         "y": _base64url_encode(public_numbers.y.to_bytes(32, byteorder="big")),
     }

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -445,6 +445,10 @@ class GuardStore:
         scoped_hash = sha256(scoped_home.encode("utf-8")).hexdigest()[:16]
         return f"{prefix}:{scoped_hash}"
 
+    @staticmethod
+    def _versioned_secret_ref(base_ref: str, value_hash: str) -> str:
+        return f"{base_ref}:{value_hash[:16]}"
+
     def _promote_secret_to_primary(self, secret_store: SecretStore, secret_id: str, value: str) -> None:
         if isinstance(secret_store, FallbackSecretStore):
             secret_store.promote_secret(secret_id, value)
@@ -2902,12 +2906,14 @@ class GuardStore:
     ) -> None:
         refresh_token_hash = _token_sha256(refresh_token)
         dpop_private_key_hash = _token_sha256(dpop_private_key_pem)
+        refresh_token_ref = self._versioned_secret_ref(self._oauth_refresh_token_ref, refresh_token_hash)
+        dpop_private_key_ref = self._versioned_secret_ref(self._oauth_dpop_private_key_ref, dpop_private_key_hash)
         payload: dict[str, object] = {
             "issuer": issuer,
             "client_id": client_id,
-            "refresh_token_ref": self._oauth_refresh_token_ref,
+            "refresh_token_ref": refresh_token_ref,
             "refresh_token_sha256": refresh_token_hash,
-            "dpop_private_key_ref": self._oauth_dpop_private_key_ref,
+            "dpop_private_key_ref": dpop_private_key_ref,
             "dpop_private_key_sha256": dpop_private_key_hash,
             "dpop_public_jwk": dpop_public_jwk,
             "dpop_public_jwk_thumbprint": dpop_public_jwk_thumbprint,
@@ -2918,8 +2924,8 @@ class GuardStore:
             payload["machine_id"] = machine_id
         if workspace_id:
             payload["workspace_id"] = workspace_id
-        self._oauth_secret_store.set_secret(self._oauth_refresh_token_ref, refresh_token)
-        self._oauth_secret_store.set_secret(self._oauth_dpop_private_key_ref, dpop_private_key_pem)
+        self._oauth_secret_store.set_secret(refresh_token_ref, refresh_token)
+        self._oauth_secret_store.set_secret(dpop_private_key_ref, dpop_private_key_pem)
         self.set_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY, payload, now)
 
     def get_oauth_local_credentials(self) -> dict[str, object] | None:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -131,7 +131,10 @@ from .store_threat_intel import (
 from .types import CapabilitySet
 
 _SYNC_TOKEN_REF = "guard-cloud-token"
+_OAUTH_REFRESH_TOKEN_REF = "guard-oauth-refresh-token"
+_OAUTH_DPOP_PRIVATE_KEY_REF = "guard-oauth-dpop-private-key"
 _SYNC_TOKEN_HASH_KEY = "token_sha256"
+_OAUTH_LOCAL_CREDENTIALS_STATE_KEY = "oauth_local_credentials"
 _DEVICE_ROW_KEY = "local-device"
 _MAX_RESOLVED_SCOPE_IDS = 200
 _SQLITE_ID_BATCH_SIZE = 500
@@ -408,6 +411,16 @@ def _build_secret_store(guard_home: Path) -> SecretStore:
     return fallback_store
 
 
+def _build_oauth_secret_store(guard_home: Path) -> SecretStore:
+    fallback_store = EncryptedFileSecretStore(guard_home)
+    if KeychainSecretStore._is_available():
+        return FallbackSecretStore(
+            KeychainSecretStore(service_name="hol-guard.oauth"),
+            fallback_store,
+        )
+    return fallback_store
+
+
 _SLOW_QUERY_THRESHOLD_MS: int = 200
 _store_logger = logging.getLogger(__name__)
 
@@ -419,19 +432,22 @@ class GuardStore:
         self.guard_home = guard_home
         self.guard_home.mkdir(parents=True, exist_ok=True)
         self._secret_store = _build_secret_store(self.guard_home)
-        self._sync_token_ref = self._build_sync_token_ref()
+        self._oauth_secret_store = _build_oauth_secret_store(self.guard_home)
+        self._sync_token_ref = self._build_scoped_secret_ref(_SYNC_TOKEN_REF)
+        self._oauth_refresh_token_ref = self._build_scoped_secret_ref(_OAUTH_REFRESH_TOKEN_REF)
+        self._oauth_dpop_private_key_ref = self._build_scoped_secret_ref(_OAUTH_DPOP_PRIVATE_KEY_REF)
         self._guard_event_queue_limit = max(1, guard_event_queue_limit)
         self.path = self.guard_home / "guard.db"
         self._initialize()
 
-    def _build_sync_token_ref(self) -> str:
+    def _build_scoped_secret_ref(self, prefix: str) -> str:
         scoped_home = str(self.guard_home.expanduser().resolve())
         scoped_hash = sha256(scoped_home.encode("utf-8")).hexdigest()[:16]
-        return f"{_SYNC_TOKEN_REF}:{scoped_hash}"
+        return f"{prefix}:{scoped_hash}"
 
-    def _promote_secret_to_primary(self, secret_id: str, value: str) -> None:
-        if isinstance(self._secret_store, FallbackSecretStore):
-            self._secret_store.promote_secret(secret_id, value)
+    def _promote_secret_to_primary(self, secret_store: SecretStore, secret_id: str, value: str) -> None:
+        if isinstance(secret_store, FallbackSecretStore):
+            secret_store.promote_secret(secret_id, value)
 
     def _get_secret_from_store(self, store: SecretStore, secret_id: str) -> str | None:
         try:
@@ -439,21 +455,26 @@ class GuardStore:
         except Exception:
             return None
 
-    def _get_secret_candidates(self, secret_id: str, expected_hash_value: str | None) -> list[str]:
-        if isinstance(self._secret_store, FallbackSecretStore):
-            primary_token = self._get_secret_from_store(self._secret_store.primary, secret_id)
+    def _get_secret_candidates(
+        self,
+        secret_store: SecretStore,
+        secret_id: str,
+        expected_hash_value: str | None,
+    ) -> list[str]:
+        if isinstance(secret_store, FallbackSecretStore):
+            primary_token = self._get_secret_from_store(secret_store.primary, secret_id)
             if primary_token is not None:
                 if expected_hash_value is None or _token_sha256(primary_token) == expected_hash_value:
                     return [primary_token]
-                fallback_token = self._get_secret_from_store(self._secret_store.fallback, secret_id)
+                fallback_token = self._get_secret_from_store(secret_store.fallback, secret_id)
                 if fallback_token is None or fallback_token == primary_token:
                     return [primary_token]
                 return [primary_token, fallback_token]
-            fallback_token = self._get_secret_from_store(self._secret_store.fallback, secret_id)
+            fallback_token = self._get_secret_from_store(secret_store.fallback, secret_id)
             if fallback_token is None:
                 return []
             return [fallback_token]
-        token = self._secret_store.get_secret(secret_id)
+        token = secret_store.get_secret(secret_id)
         if token is None:
             return []
         return [token]
@@ -2834,7 +2855,7 @@ class GuardStore:
                 reference_candidates.append(token_reference)
 
             for secret_ref in reference_candidates:
-                for token in self._get_secret_candidates(secret_ref, expected_hash_value):
+                for token in self._get_secret_candidates(self._secret_store, secret_ref, expected_hash_value):
                     if expected_hash_value is not None and _token_sha256(token) != expected_hash_value:
                         continue
                     if token_reference != self._sync_token_ref:
@@ -2848,7 +2869,7 @@ class GuardStore:
                                 workspace_id=normalized_workspace_id,
                             )
                     else:
-                        self._promote_secret_to_primary(secret_ref, token)
+                        self._promote_secret_to_primary(self._secret_store, secret_ref, token)
                     return {"sync_url": sync_url, "token": token}
             return None
         legacy_token = payload.get("token")
@@ -2864,6 +2885,115 @@ class GuardStore:
                 )
             return {"sync_url": sync_url, "token": legacy_token}
         return None
+
+    def set_oauth_local_credentials(
+        self,
+        *,
+        issuer: str,
+        client_id: str,
+        refresh_token: str,
+        dpop_private_key_pem: str,
+        dpop_public_jwk: dict[str, str],
+        dpop_public_jwk_thumbprint: str,
+        now: str,
+        grant_id: str | None = None,
+        machine_id: str | None = None,
+        workspace_id: str | None = None,
+    ) -> None:
+        refresh_token_hash = _token_sha256(refresh_token)
+        dpop_private_key_hash = _token_sha256(dpop_private_key_pem)
+        payload: dict[str, object] = {
+            "issuer": issuer,
+            "client_id": client_id,
+            "refresh_token_ref": self._oauth_refresh_token_ref,
+            "refresh_token_sha256": refresh_token_hash,
+            "dpop_private_key_ref": self._oauth_dpop_private_key_ref,
+            "dpop_private_key_sha256": dpop_private_key_hash,
+            "dpop_public_jwk": dpop_public_jwk,
+            "dpop_public_jwk_thumbprint": dpop_public_jwk_thumbprint,
+        }
+        if grant_id:
+            payload["grant_id"] = grant_id
+        if machine_id:
+            payload["machine_id"] = machine_id
+        if workspace_id:
+            payload["workspace_id"] = workspace_id
+        self._oauth_secret_store.set_secret(self._oauth_refresh_token_ref, refresh_token)
+        self._oauth_secret_store.set_secret(self._oauth_dpop_private_key_ref, dpop_private_key_pem)
+        self.set_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY, payload, now)
+
+    def get_oauth_local_credentials(self) -> dict[str, object] | None:
+        payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
+        if not isinstance(payload, dict):
+            return None
+        issuer = payload.get("issuer")
+        client_id = payload.get("client_id")
+        refresh_token_ref = payload.get("refresh_token_ref")
+        refresh_token_hash = payload.get("refresh_token_sha256")
+        dpop_private_key_ref = payload.get("dpop_private_key_ref")
+        dpop_private_key_hash = payload.get("dpop_private_key_sha256")
+        dpop_public_jwk = payload.get("dpop_public_jwk")
+        dpop_public_jwk_thumbprint = payload.get("dpop_public_jwk_thumbprint")
+        if not isinstance(issuer, str) or not issuer:
+            return None
+        if not isinstance(client_id, str) or not client_id:
+            return None
+        if not isinstance(refresh_token_ref, str) or not refresh_token_ref:
+            return None
+        if not isinstance(dpop_private_key_ref, str) or not dpop_private_key_ref:
+            return None
+        if not isinstance(refresh_token_hash, str) or not refresh_token_hash:
+            return None
+        if not isinstance(dpop_private_key_hash, str) or not dpop_private_key_hash:
+            return None
+        if not isinstance(dpop_public_jwk, dict):
+            return None
+        if not isinstance(dpop_public_jwk_thumbprint, str) or not dpop_public_jwk_thumbprint:
+            return None
+        refresh_token: str | None = None
+        for candidate in self._get_secret_candidates(
+            self._oauth_secret_store,
+            refresh_token_ref,
+            refresh_token_hash,
+        ):
+            if _token_sha256(candidate) != refresh_token_hash:
+                continue
+            refresh_token = candidate
+            self._promote_secret_to_primary(self._oauth_secret_store, refresh_token_ref, candidate)
+            break
+        if refresh_token is None:
+            return None
+        dpop_private_key_pem: str | None = None
+        for candidate in self._get_secret_candidates(
+            self._oauth_secret_store,
+            dpop_private_key_ref,
+            dpop_private_key_hash,
+        ):
+            if _token_sha256(candidate) != dpop_private_key_hash:
+                continue
+            dpop_private_key_pem = candidate
+            self._promote_secret_to_primary(self._oauth_secret_store, dpop_private_key_ref, candidate)
+            break
+        if dpop_private_key_pem is None:
+            return None
+        result: dict[str, object] = {
+            "issuer": issuer,
+            "client_id": client_id,
+            "refresh_token": refresh_token,
+            "dpop_private_key_pem": dpop_private_key_pem,
+            "dpop_public_jwk": dpop_public_jwk,
+            "dpop_public_jwk_thumbprint": dpop_public_jwk_thumbprint,
+        }
+        grant_id = payload.get("grant_id")
+        machine_id = payload.get("machine_id")
+        workspace_id = payload.get("workspace_id")
+        if isinstance(grant_id, str) and grant_id:
+            result["grant_id"] = grant_id
+        if isinstance(machine_id, str) and machine_id:
+            result["machine_id"] = machine_id
+        if isinstance(workspace_id, str) and workspace_id:
+            result["workspace_id"] = workspace_id
+        return result
 
     def get_latest_guard_connect_state(self, *, now: str) -> dict[str, object] | None:
         with self._connect() as connection:

--- a/tests/test_guard_oauth_client.py
+++ b/tests/test_guard_oauth_client.py
@@ -70,8 +70,6 @@ def test_generate_dpop_key_pair_returns_es256_material() -> None:
     assert material.private_key_pem.startswith("-----BEGIN PRIVATE KEY-----")
     assert material.public_jwk["kty"] == "EC"
     assert material.public_jwk["crv"] == "P-256"
-    assert material.public_jwk["alg"] == "ES256"
-    assert material.public_jwk["use"] == "sig"
     assert isinstance(material.public_jwk["x"], str) and material.public_jwk["x"]
     assert isinstance(material.public_jwk["y"], str) and material.public_jwk["y"]
     assert isinstance(material.public_jwk_thumbprint, str) and material.public_jwk_thumbprint

--- a/tests/test_guard_oauth_client.py
+++ b/tests/test_guard_oauth_client.py
@@ -2,8 +2,10 @@ from codex_plugin_scanner.guard.cli.oauth_client import (
     LOCAL_GUARD_OAUTH_CLIENT_ID,
     PRODUCTION_GUARD_OAUTH_CLIENT_ID,
     STAGING_GUARD_OAUTH_CLIENT_ID,
+    GuardDpopKeyMaterial,
     build_pkce_s256_challenge,
     detect_guard_oauth_environment,
+    generate_dpop_key_pair,
     generate_pkce_verifier,
     resolve_guard_oauth_client_config,
 )
@@ -58,3 +60,18 @@ def test_build_pkce_s256_challenge_matches_known_vector() -> None:
     challenge = build_pkce_s256_challenge(verifier)
 
     assert challenge == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+
+def test_generate_dpop_key_pair_returns_es256_material() -> None:
+    material = generate_dpop_key_pair()
+
+    assert isinstance(material, GuardDpopKeyMaterial)
+    assert material.algorithm == "ES256"
+    assert material.private_key_pem.startswith("-----BEGIN PRIVATE KEY-----")
+    assert material.public_jwk["kty"] == "EC"
+    assert material.public_jwk["crv"] == "P-256"
+    assert material.public_jwk["alg"] == "ES256"
+    assert material.public_jwk["use"] == "sig"
+    assert isinstance(material.public_jwk["x"], str) and material.public_jwk["x"]
+    assert isinstance(material.public_jwk["y"], str) and material.public_jwk["y"]
+    assert isinstance(material.public_jwk_thumbprint, str) and material.public_jwk_thumbprint

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -13,6 +13,7 @@ from codex_plugin_scanner.guard.store import (
     FallbackSecretStore,
     GuardStore,
     KeychainSecretStore,
+    _build_oauth_secret_store,
     _build_secret_store,
 )
 
@@ -222,6 +223,17 @@ def test_secret_store_prefers_encrypted_file_backend_when_keychain_is_available(
     assert isinstance(secret_store.fallback, KeychainSecretStore)
 
 
+def test_oauth_secret_store_prefers_keychain_when_available(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
+
+    secret_store = _build_oauth_secret_store(guard_home)
+
+    assert isinstance(secret_store, FallbackSecretStore)
+    assert isinstance(secret_store.primary, KeychainSecretStore)
+    assert isinstance(secret_store.fallback, EncryptedFileSecretStore)
+
+
 def test_encrypted_file_secret_store_secures_secret_directory_permissions(tmp_path):
     secret_store = EncryptedFileSecretStore(tmp_path / "guard-home")
 
@@ -257,7 +269,95 @@ def test_sync_credentials_do_not_shell_out_to_keychain_when_file_store_is_availa
         raise AssertionError("keychain should not be used for sync credential writes")
 
     monkeypatch.setattr(subprocess, "run", fail_on_keychain)
+    GuardStore(guard_home)
+
+
+def test_oauth_local_credentials_are_not_persisted_in_plaintext_sqlite(tmp_path):
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={
+            "kty": "EC",
+            "crv": "P-256",
+            "x": "x-value",
+            "y": "y-value",
+            "alg": "ES256",
+            "use": "sig",
+        },
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+
+    with sqlite3.connect(store.path) as connection:
+        row = connection.execute(
+            "select payload_json from sync_state where state_key = 'oauth_local_credentials'"
+        ).fetchone()
+
+    assert row is not None
+    payload = json.loads(str(row[0]))
+    assert payload["issuer"] == "https://hol.org"
+    assert payload["client_id"] == "guard-local-daemon"
+    assert payload["grant_id"] == "grant-123"
+    assert payload["machine_id"] == "machine-123"
+    assert payload["workspace_id"] == "workspace-123"
+    assert isinstance(payload.get("refresh_token_ref"), str)
+    assert isinstance(payload.get("refresh_token_sha256"), str)
+    assert isinstance(payload.get("dpop_private_key_ref"), str)
+    assert isinstance(payload.get("dpop_private_key_sha256"), str)
+    assert payload["dpop_public_jwk"]["kty"] == "EC"
+    assert payload["dpop_public_jwk_thumbprint"] == "thumbprint-123"
+    assert "refresh_token" not in payload
+    assert "dpop_private_key_pem" not in payload
+
+    assert store.get_oauth_local_credentials() == {
+        "issuer": "https://hol.org",
+        "client_id": "guard-local-daemon",
+        "refresh_token": "refresh-secret-value",
+        "dpop_private_key_pem": "-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+        "dpop_public_jwk": {
+            "kty": "EC",
+            "crv": "P-256",
+            "x": "x-value",
+            "y": "y-value",
+            "alg": "ES256",
+            "use": "sig",
+        },
+        "dpop_public_jwk_thumbprint": "thumbprint-123",
+        "grant_id": "grant-123",
+        "machine_id": "machine-123",
+        "workspace_id": "workspace-123",
+    }
+
+
+def test_oauth_local_credentials_use_encrypted_file_fallback_when_keychain_write_fails(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
+
+    def fail_on_keychain(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(returncode=1, cmd=["security"], stderr="keychain unavailable")
+
+    monkeypatch.setattr(subprocess, "run", fail_on_keychain)
     store = GuardStore(guard_home)
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+
+    secrets_dir = guard_home / "secrets"
+    assert secrets_dir.exists()
+    assert any(path.name.endswith(".enc") for path in secrets_dir.iterdir())
+    assert store.get_oauth_local_credentials() is not None
 
     store.set_sync_credentials(
         "https://hol.org/api/guard/receipts/sync",

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -359,17 +359,61 @@ def test_oauth_local_credentials_use_encrypted_file_fallback_when_keychain_write
     assert any(path.name.endswith(".enc") for path in secrets_dir.iterdir())
     assert store.get_oauth_local_credentials() is not None
 
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "secret-token-value",
-        "2026-04-19T00:00:00+00:00",
-    )
 
-    assert store.get_sync_credentials() == {
-        "sync_url": "https://hol.org/api/guard/receipts/sync",
-        "token": "secret-token-value",
+def test_oauth_local_credentials_preserve_previous_material_on_partial_secret_write_failure(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="old-refresh-token",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nold-key-material\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "old-x", "y": "old-y"},
+        dpop_public_jwk_thumbprint="old-thumbprint",
+        grant_id="grant-old",
+        machine_id="machine-old",
+        workspace_id="workspace-old",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    original_set_secret = store._oauth_secret_store.set_secret
+    write_calls: list[str] = []
+
+    def fail_on_second_write(secret_id: str, value: str) -> None:
+        write_calls.append(secret_id)
+        if len(write_calls) == 2:
+            raise RuntimeError("second write failed")
+        original_set_secret(secret_id, value)
+
+    monkeypatch.setattr(store._oauth_secret_store, "set_secret", fail_on_second_write)
+
+    try:
+        store.set_oauth_local_credentials(
+            issuer="https://hol.org",
+            client_id="guard-local-daemon",
+            refresh_token="new-refresh-token",
+            dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nnew-key-material\n-----END PRIVATE KEY-----\n",
+            dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "new-x", "y": "new-y"},
+            dpop_public_jwk_thumbprint="new-thumbprint",
+            grant_id="grant-new",
+            machine_id="machine-new",
+            workspace_id="workspace-new",
+            now="2026-06-01T00:05:00+00:00",
+        )
+    except RuntimeError as error:
+        assert str(error) == "second write failed"
+    else:
+        raise AssertionError("second OAuth secret write should fail in this regression test")
+
+    assert store.get_oauth_local_credentials() == {
+        "issuer": "https://hol.org",
+        "client_id": "guard-local-daemon",
+        "refresh_token": "old-refresh-token",
+        "dpop_private_key_pem": "-----BEGIN PRIVATE KEY-----\nold-key-material\n-----END PRIVATE KEY-----\n",
+        "dpop_public_jwk": {"kty": "EC", "crv": "P-256", "x": "old-x", "y": "old-y"},
+        "dpop_public_jwk_thumbprint": "old-thumbprint",
+        "grant_id": "grant-old",
+        "machine_id": "machine-old",
+        "workspace_id": "workspace-old",
     }
-    assert any((guard_home / "secrets").glob("*.enc"))
 
 
 def test_validated_keychain_fallback_reads_are_migrated_into_encrypted_file_store(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add ES256 DPoP key generation helpers for the local daemon OAuth client
- add dedicated OAuth refresh-token and DPoP private-key persistence that prefers OS credential storage and falls back to encrypted files
- cover the new storage path with focused Guard store and OAuth client tests

## Testing
- `python3 -m pytest tests/test_guard_oauth_client.py tests/test_guard_store_migrations.py tests/test_guard_oauth_device_connect.py -q`
- `ruff check src/codex_plugin_scanner/guard/cli/oauth_client.py src/codex_plugin_scanner/guard/store.py tests/test_guard_oauth_client.py tests/test_guard_store_migrations.py`
- `ruff format --check src/codex_plugin_scanner/guard/cli/oauth_client.py src/codex_plugin_scanner/guard/store.py tests/test_guard_oauth_client.py tests/test_guard_store_migrations.py`
