### PR TITLE
feat(guard-auth): add loopback oauth browser flow

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -192,6 +192,7 @@ from .connect_flow import (
     DEFAULT_GUARD_CONNECT_URL,
     DEFAULT_GUARD_SYNC_URL,
     build_connect_status_payload,
+    run_guard_browser_connect_command,
     run_guard_device_connect_command,
 )
 from .docs import build_install_connect_docs_payload
@@ -2319,6 +2320,7 @@ def run_guard_command(
             store=store,
             connect_url=args.connect_url,
             open_browser=True,
+            wait_timeout_seconds=int(getattr(args, "wait_timeout_seconds", 180) or 180),
         )
         if payload is None:
             return exit_code
@@ -2341,6 +2343,7 @@ def run_guard_command(
                 store=store,
                 connect_url=args.connect_url,
                 open_browser=True,
+                wait_timeout_seconds=int(getattr(args, "wait_timeout_seconds", 180) or 180),
             )
             if payload is None:
                 return exit_code
@@ -2351,6 +2354,7 @@ def run_guard_command(
                 store=store,
                 connect_url=args.connect_url,
                 open_browser=False,
+                wait_timeout_seconds=int(getattr(args, "wait_timeout_seconds", 180) or 180),
             )
             if payload is None:
                 return exit_code
@@ -8754,14 +8758,36 @@ def _run_guard_device_connect_flow(
     return run_guard_device_connect_command(store=store, connect_url=connect_url)
 
 
+def _run_guard_browser_connect_flow(
+    *,
+    store: GuardStore,
+    connect_url: str,
+    wait_timeout_seconds: int,
+) -> dict[str, object]:
+    return run_guard_browser_connect_command(
+        store=store,
+        connect_url=connect_url,
+        wait_timeout_seconds=wait_timeout_seconds,
+    )
+
+
 def _build_guard_device_connect_payload(
     *,
     store: GuardStore,
     connect_url: str,
     open_browser: bool,
+    wait_timeout_seconds: int = 180,
 ) -> tuple[dict[str, object] | None, int]:
     try:
-        payload = _run_guard_device_connect_flow(store=store, connect_url=connect_url)
+        payload = (
+            _run_guard_browser_connect_flow(
+                store=store,
+                connect_url=connect_url,
+                wait_timeout_seconds=wait_timeout_seconds,
+            )
+            if open_browser
+            else _run_guard_device_connect_flow(store=store, connect_url=connect_url)
+        )
     except json.JSONDecodeError as error:
         print(f"Guard Device Code authorization failed: {error}", file=sys.stderr)
         return None, 1
@@ -8771,7 +8797,7 @@ def _build_guard_device_connect_payload(
     except (RuntimeError, urllib.error.URLError, http.client.HTTPException) as error:
         print(f"Guard Device Code authorization failed: {error}", file=sys.stderr)
         return None, 1
-    if open_browser:
+    if open_browser and str(payload.get("connect_mode") or "") == "device_code":
         _open_guard_device_next_action(payload)
     return payload, 0
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -8794,7 +8794,7 @@ def _build_guard_device_connect_payload(
     except ValueError as error:
         print(str(error), file=sys.stderr)
         return None, 2
-    except (RuntimeError, urllib.error.URLError, http.client.HTTPException) as error:
+    except (RuntimeError, TimeoutError, urllib.error.URLError, http.client.HTTPException) as error:
         print(f"Guard authorization failed: {error}", file=sys.stderr)
         return None, 1
     if open_browser and str(payload.get("connect_mode") or "") == "device_code":

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -8789,13 +8789,13 @@ def _build_guard_device_connect_payload(
             else _run_guard_device_connect_flow(store=store, connect_url=connect_url)
         )
     except json.JSONDecodeError as error:
-        print(f"Guard Device Code authorization failed: {error}", file=sys.stderr)
+        print(f"Guard authorization failed: {error}", file=sys.stderr)
         return None, 1
     except ValueError as error:
         print(str(error), file=sys.stderr)
         return None, 2
     except (RuntimeError, urllib.error.URLError, http.client.HTTPException) as error:
-        print(f"Guard Device Code authorization failed: {error}", file=sys.stderr)
+        print(f"Guard authorization failed: {error}", file=sys.stderr)
         return None, 1
     if open_browser and str(payload.get("connect_mode") or "") == "device_code":
         _open_guard_device_next_action(payload)

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -2,13 +2,29 @@
 
 from __future__ import annotations
 
+import base64
+import http.server
 import json
+import secrets
+import threading
 import urllib.parse
 import urllib.request
+from dataclasses import dataclass
 from datetime import datetime, timezone
+from uuid import uuid4
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
 
 from ..store import GuardStore
-from .oauth_client import resolve_guard_oauth_client_config
+from .oauth_client import (
+    GuardDpopKeyMaterial,
+    build_pkce_s256_challenge,
+    generate_dpop_key_pair,
+    generate_pkce_verifier,
+    resolve_guard_oauth_client_config,
+)
 
 DEFAULT_GUARD_SYNC_URL = "https://hol.org/api/guard/receipts/sync"
 DEFAULT_GUARD_CONNECT_URL = "https://hol.org/guard/connect"
@@ -21,6 +37,239 @@ DEFAULT_GUARD_DEVICE_SCOPES = (
 CONNECT_COMMAND = "hol-guard connect"
 CONNECT_STATUS_COMMAND = "hol-guard connect status"
 CONNECT_REPAIR_COMMAND = "hol-guard connect repair"
+_LOOPBACK_REDIRECT_PATH = "/oauth/callback"
+_LOOPBACK_HOSTS = ("127.0.0.1", "::1")
+_LOOPBACK_PORT_MIN = 49152
+_LOOPBACK_PORT_MAX = 65535
+
+
+@dataclass(frozen=True)
+class GuardOAuthLoopbackCallback:
+    code: str
+    state: str
+
+
+@dataclass(frozen=True)
+class GuardOAuthTokenExchangeResult:
+    access_token: str
+    refresh_token: str | None
+    expires_in: int
+    scope: str
+    token_type: str
+    grant_id: str | None
+    machine_id: str | None
+    workspace_id: str | None
+
+
+@dataclass
+class GuardOAuthBrowserSession:
+    authorize_url: str
+    redirect_uri: str
+    pkce_verifier: str
+    state: str
+    dpop_key_material: GuardDpopKeyMaterial
+    _server: http.server.ThreadingHTTPServer
+    _thread: threading.Thread
+    _callback_ready: threading.Event
+    _callback: GuardOAuthLoopbackCallback | None = None
+
+    def wait_for_callback(self, timeout_seconds: float) -> GuardOAuthLoopbackCallback:
+        if timeout_seconds <= 0:
+            raise TimeoutError("Guard OAuth browser callback timed out.")
+        if not self._callback_ready.wait(timeout_seconds):
+            raise TimeoutError("Guard OAuth browser callback timed out.")
+        if self._callback is None:
+            raise TimeoutError("Guard OAuth browser callback timed out.")
+        return self._callback
+
+    def close(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=2)
+
+
+def _base64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def _base64url_decode(data: str) -> bytes:
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(f"{data}{padding}")
+
+
+def _decode_access_token_claims(access_token: str) -> dict[str, object]:
+    parts = access_token.split(".")
+    if len(parts) != 3:
+        return {}
+    try:
+        payload = json.loads(_base64url_decode(parts[1]).decode("utf-8"))
+    except (ValueError, json.JSONDecodeError, UnicodeDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _read_nested_string(payload: dict[str, object], *path: str) -> str | None:
+    current: object = payload
+    for segment in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(segment)
+    return current if isinstance(current, str) and current else None
+
+
+def _encode_jwt_segment(payload: dict[str, object]) -> str:
+    return _base64url_encode(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+
+
+def _sign_dpop_proof(*, token_endpoint: str, dpop_key_material: GuardDpopKeyMaterial, now: datetime) -> str:
+    issued_at = int(now.timestamp())
+    header = {
+        "alg": dpop_key_material.algorithm,
+        "jwk": dpop_key_material.public_jwk,
+        "typ": "dpop+jwt",
+    }
+    claims = {
+        "htu": token_endpoint,
+        "htm": "POST",
+        "iat": issued_at,
+        "jti": str(uuid4()),
+    }
+    signing_input = f"{_encode_jwt_segment(header)}.{_encode_jwt_segment(claims)}".encode("ascii")
+    private_key = serialization.load_pem_private_key(
+        dpop_key_material.private_key_pem.encode("ascii"),
+        password=None,
+    )
+    if not isinstance(private_key, ec.EllipticCurvePrivateKey):
+        raise RuntimeError("Guard DPoP key must be an EC private key.")
+    der_signature = private_key.sign(signing_input, ec.ECDSA(hashes.SHA256()))
+    r_value, s_value = decode_dss_signature(der_signature)
+    jose_signature = _base64url_encode(r_value.to_bytes(32, byteorder="big") + s_value.to_bytes(32, byteorder="big"))
+    return f"{signing_input.decode('ascii')}.{jose_signature}"
+
+
+def _build_browser_authorize_url(
+    *,
+    authorize_endpoint: str,
+    client_id: str,
+    redirect_uri: str,
+    state: str,
+    code_challenge: str,
+    machine_id: str,
+    machine_label: str,
+) -> str:
+    query = urllib.parse.urlencode(
+        {
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "state": state,
+            "scope": " ".join(DEFAULT_GUARD_DEVICE_SCOPES),
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+            "requested_machine_id": machine_id,
+            "requested_machine_label": machine_label,
+            "requested_runtime_id": "hol-guard",
+            "requested_runtime_label": "HOL Guard CLI",
+        }
+    )
+    return f"{authorize_endpoint}?{query}"
+
+
+def start_guard_loopback_callback_listener(
+    *,
+    expected_state: str,
+    authorize_url: str | None = None,
+    client_id: str | None = None,
+    machine_id: str | None = None,
+    machine_label: str | None = None,
+    dpop_key_material: GuardDpopKeyMaterial | None = None,
+    pkce_verifier: str | None = None,
+) -> GuardOAuthBrowserSession:
+    callback_ready = threading.Event()
+
+    class _CallbackServer(http.server.ThreadingHTTPServer):
+        allow_reuse_address = False
+
+    class _CallbackHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            parsed = urllib.parse.urlparse(self.path)
+            if parsed.path != _LOOPBACK_REDIRECT_PATH:
+                self.send_error(404)
+                return
+            params = urllib.parse.parse_qs(parsed.query)
+            state = str(params.get("state", [""])[0] or "")
+            code = str(params.get("code", [""])[0] or "")
+            if state != expected_state or not code:
+                self.send_response(400)
+                self.send_header("Content-Type", "text/plain; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(b"Guard OAuth state mismatch.")
+                return
+            self.server.guard_callback = GuardOAuthLoopbackCallback(code=code, state=state)  # type: ignore[attr-defined]
+            callback_ready.set()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(b"HOL Guard connected. Return to your terminal.")
+
+        def log_message(self, _message: str, *args: object) -> None:
+            return
+
+    for host in _LOOPBACK_HOSTS:
+        for _ in range(20):
+            port = secrets.randbelow(_LOOPBACK_PORT_MAX - _LOOPBACK_PORT_MIN + 1) + _LOOPBACK_PORT_MIN
+            try:
+                server = _CallbackServer((host, port), _CallbackHandler)
+            except OSError:
+                continue
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            formatted_host = f"[{host}]" if ":" in host else host
+            redirect_uri = f"http://{formatted_host}:{port}{_LOOPBACK_REDIRECT_PATH}"
+            return GuardOAuthBrowserSession(
+                authorize_url=authorize_url or "",
+                redirect_uri=redirect_uri,
+                pkce_verifier=pkce_verifier or "",
+                state=expected_state,
+                dpop_key_material=dpop_key_material or generate_dpop_key_pair(),
+                _server=server,
+                _thread=thread,
+                _callback_ready=callback_ready,
+            )
+    raise RuntimeError("Guard OAuth loopback callback listener could not bind a random high port.")
+
+
+def start_guard_browser_session(
+    *,
+    connect_url: str,
+    machine_id: str,
+    machine_label: str,
+) -> GuardOAuthBrowserSession:
+    _, allowed_origin = resolve_connect_url(connect_url)
+    client = resolve_guard_oauth_client_config(allowed_origin)
+    pkce_verifier = generate_pkce_verifier()
+    state = secrets.token_urlsafe(32)
+    dpop_key_material = generate_dpop_key_pair()
+    session = start_guard_loopback_callback_listener(
+        expected_state=state,
+        client_id=client.client_id,
+        machine_id=machine_id,
+        machine_label=machine_label,
+        dpop_key_material=dpop_key_material,
+        pkce_verifier=pkce_verifier,
+    )
+    authorize_url = _build_browser_authorize_url(
+        authorize_endpoint=client.authorize_endpoint,
+        client_id=client.client_id,
+        redirect_uri=session.redirect_uri,
+        state=state,
+        code_challenge=build_pkce_s256_challenge(pkce_verifier),
+        machine_id=machine_id,
+        machine_label=machine_label,
+    )
+    session.authorize_url = authorize_url
+    session.pkce_verifier = pkce_verifier
+    return session
 
 
 def resolve_connect_url(connect_url: str) -> tuple[str, str]:
@@ -99,6 +348,61 @@ def request_device_authorization(url: str, body: str) -> dict[str, object]:
     return payload
 
 
+def exchange_guard_authorization_code(
+    *,
+    token_endpoint: str,
+    client_id: str,
+    code: str,
+    redirect_uri: str,
+    code_verifier: str,
+    dpop_key_material: GuardDpopKeyMaterial,
+    urlopen=urllib.request.urlopen,
+    now: datetime | None = None,
+) -> GuardOAuthTokenExchangeResult:
+    request_body = urllib.parse.urlencode(
+        {
+            "grant_type": "authorization_code",
+            "client_id": client_id,
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "code_verifier": code_verifier,
+        }
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        token_endpoint,
+        data=request_body,
+        method="POST",
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
+            "DPoP": _sign_dpop_proof(
+                token_endpoint=token_endpoint,
+                dpop_key_material=dpop_key_material,
+                now=now or datetime.now(timezone.utc),
+            ),
+        },
+    )
+    with urlopen(request, timeout=20) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise RuntimeError("Guard OAuth token exchange failed: invalid response.")
+    access_token = str(payload.get("access_token") or "").strip()
+    token_type = str(payload.get("token_type") or "").strip()
+    if not access_token or token_type.lower() != "bearer":
+        raise RuntimeError("Guard OAuth token exchange failed: missing access token.")
+    claims = _decode_access_token_claims(access_token)
+    return GuardOAuthTokenExchangeResult(
+        access_token=access_token,
+        refresh_token=str(payload.get("refresh_token") or "").strip() or None,
+        expires_in=int(payload.get("expires_in") or 0),
+        scope=str(payload.get("scope") or "").strip(),
+        token_type=token_type,
+        grant_id=_read_nested_string(claims, "grant", "grantId"),
+        machine_id=_read_nested_string(claims, "machine", "machineId"),
+        workspace_id=_read_nested_string(claims, "workspace", "workspaceId"),
+    )
+
+
 def run_guard_device_connect_command(
     *,
     store: GuardStore,
@@ -122,6 +426,68 @@ def run_guard_device_connect_command(
     payload = build_device_authorization_copy_payload(response)
     payload["connect_mode"] = "device_code"
     return payload
+
+
+def run_guard_browser_connect_command(
+    *,
+    store: GuardStore,
+    connect_url: str,
+    start_browser_session=start_guard_browser_session,
+    open_browser=None,
+    exchange_authorization_code=exchange_guard_authorization_code,
+    now: str | None = None,
+    wait_timeout_seconds: float = 180,
+) -> dict[str, object]:
+    device = store.get_device_metadata()
+    _, allowed_origin = resolve_connect_url(connect_url)
+    oauth_client = resolve_guard_oauth_client_config(allowed_origin)
+    browser_opener = open_browser if open_browser is not None else __import__("webbrowser").open
+    session = start_browser_session(
+        connect_url=connect_url,
+        machine_id=str(device["installation_id"]),
+        machine_label=str(device["device_label"]),
+    )
+    try:
+        browser_opened = bool(browser_opener(session.authorize_url))
+        callback = session.wait_for_callback(wait_timeout_seconds)
+        token_result = exchange_authorization_code(
+            token_endpoint=oauth_client.token_endpoint,
+            client_id=oauth_client.client_id,
+            code=callback.code,
+            redirect_uri=session.redirect_uri,
+            code_verifier=session.pkce_verifier,
+            dpop_key_material=session.dpop_key_material,
+        )
+    finally:
+        session.close()
+    if token_result.refresh_token is None:
+        raise RuntimeError("Guard OAuth token exchange failed: missing refresh token.")
+    timestamp = now or datetime.now(timezone.utc).isoformat()
+    store.set_oauth_local_credentials(
+        issuer=oauth_client.issuer,
+        client_id=oauth_client.client_id,
+        refresh_token=token_result.refresh_token,
+        dpop_private_key_pem=session.dpop_key_material.private_key_pem,
+        dpop_public_jwk=session.dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=session.dpop_key_material.public_jwk_thumbprint,
+        grant_id=token_result.grant_id,
+        machine_id=token_result.machine_id,
+        workspace_id=token_result.workspace_id,
+        now=timestamp,
+    )
+    return {
+        "status": "connected",
+        "connect_mode": "browser_oauth",
+        "browser_opened": browser_opened,
+        "authorize_url": session.authorize_url,
+        "redirect_uri": session.redirect_uri,
+        "grant_id": token_result.grant_id,
+        "machine_id": token_result.machine_id,
+        "workspace_id": token_result.workspace_id,
+        "connect_command": CONNECT_COMMAND,
+        "connect_status_command": CONNECT_STATUS_COMMAND,
+        "connect_repair_command": CONNECT_REPAIR_COMMAND,
+    }
 
 
 def build_connect_status_payload(

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -78,9 +78,10 @@ class GuardOAuthBrowserSession:
             raise TimeoutError("Guard OAuth browser callback timed out.")
         if not self._callback_ready.wait(timeout_seconds):
             raise TimeoutError("Guard OAuth browser callback timed out.")
-        if self._callback is None:
+        callback = self._callback or getattr(self._server, "guard_callback", None)
+        if callback is None:
             raise TimeoutError("Guard OAuth browser callback timed out.")
-        return self._callback
+        return callback
 
     def close(self) -> None:
         self._server.shutdown()

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -45,8 +45,10 @@ _LOOPBACK_PORT_MAX = 65535
 
 @dataclass(frozen=True)
 class GuardOAuthLoopbackCallback:
-    code: str
+    code: str | None
     state: str
+    error: str | None = None
+    error_description: str | None = None
 
 
 @dataclass(frozen=True)
@@ -81,6 +83,9 @@ class GuardOAuthBrowserSession:
         callback = self._callback or getattr(self._server, "guard_callback", None)
         if callback is None:
             raise TimeoutError("Guard OAuth browser callback timed out.")
+        if callback.error is not None:
+            description = callback.error_description or callback.error
+            raise RuntimeError(f"Guard OAuth authorization was denied: {description}")
         return callback
 
     def close(self) -> None:
@@ -200,11 +205,32 @@ def start_guard_loopback_callback_listener(
             params = urllib.parse.parse_qs(parsed.query)
             state = str(params.get("state", [""])[0] or "")
             code = str(params.get("code", [""])[0] or "")
-            if state != expected_state or not code:
+            error = str(params.get("error", [""])[0] or "")
+            error_description = str(params.get("error_description", [""])[0] or "")
+            if state != expected_state:
                 self.send_response(400)
                 self.send_header("Content-Type", "text/plain; charset=utf-8")
                 self.end_headers()
                 self.wfile.write(b"Guard OAuth state mismatch.")
+                return
+            if error:
+                self.server.guard_callback = GuardOAuthLoopbackCallback(  # type: ignore[attr-defined]
+                    code=None,
+                    state=state,
+                    error=error,
+                    error_description=error_description or None,
+                )
+                callback_ready.set()
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(b"HOL Guard authorization was denied. Return to your terminal.")
+                return
+            if not code:
+                self.send_response(400)
+                self.send_header("Content-Type", "text/plain; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(b"Guard OAuth callback is missing the authorization code.")
                 return
             self.server.guard_callback = GuardOAuthLoopbackCallback(code=code, state=state)  # type: ignore[attr-defined]
             callback_ready.set()

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6316,33 +6316,34 @@ url = http://127.0.0.1:8787/guard-canary
         assert "artifactHash" in first_receipt
         assert "recommendation" in first_receipt
 
-    def test_guard_connect_opens_device_code_approval_without_pairing(self, tmp_path, capsys, monkeypatch):
+    def test_guard_connect_opens_browser_oauth_without_pairing(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         _build_guard_fixture(home_dir, workspace_dir)
         _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\n')
         store = GuardStore(home_dir)
-        opened_urls: list[str] = []
+        authorize_url = "https://hol.org/api/guard/oauth/authorize?client_id=guard-local-daemon"
 
-        def open_browser(url: str) -> bool:
-            opened_urls.append(url)
-            return True
-
-        def fake_device_flow(*, store: GuardStore, connect_url: str) -> dict[str, object]:
+        def fake_browser_flow(
+            *,
+            store: GuardStore,
+            connect_url: str,
+            wait_timeout_seconds: int,
+        ) -> dict[str, object]:
             assert connect_url == "https://hol.org/guard/connect"
+            assert wait_timeout_seconds == 180
             return {
-                "status": "waiting_for_approval",
-                "connect_mode": "device_code",
-                "user_code": "ABCD-EFGH",
-                "verification_uri": "https://hol.org/guard/oauth/device",
-                "next_action": {
-                    "command": "open",
-                    "target": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
-                },
+                "status": "connected",
+                "connect_mode": "browser_oauth",
+                "browser_opened": True,
+                "authorize_url": authorize_url,
+                "redirect_uri": "http://127.0.0.1:61234/oauth/callback",
+                "grant_id": "grant-123",
+                "machine_id": "machine-123",
+                "workspace_id": "workspace-123",
             }
 
-        monkeypatch.setattr(guard_commands_module.webbrowser, "open", open_browser)
-        monkeypatch.setattr(guard_commands_module, "_run_guard_device_connect_flow", fake_device_flow)
+        monkeypatch.setattr(guard_commands_module, "_run_guard_browser_connect_flow", fake_browser_flow)
         run_rc = main(
             [
                 "guard",
@@ -6374,38 +6375,43 @@ url = http://127.0.0.1:8787/guard-canary
 
         assert run_rc == 0
         assert connect_rc == 0
-        assert connect_output["status"] == "waiting_for_approval"
-        assert connect_output["connect_mode"] == "device_code"
-        assert connect_output["user_code"] == "ABCD-EFGH"
+        assert connect_output["status"] == "connected"
+        assert connect_output["connect_mode"] == "browser_oauth"
         assert connect_output["browser_opened"] is True
-        assert opened_urls == ["https://hol.org/guard/oauth/device?user_code=ABCD-EFGH"]
+        assert connect_output["authorize_url"] == "*****"
+        assert connect_output["redirect_uri"] == "http://127.0.0.1:61234/oauth/callback"
+        assert connect_output["grant_id"] == "grant-123"
+        assert connect_output["machine_id"] == "machine-123"
+        assert connect_output["workspace_id"] == "workspace-123"
         assert "guardPairSecret" not in json.dumps(connect_output)
         assert "guardPairRequest" not in json.dumps(connect_output)
         assert store.get_sync_credentials() is None
 
-    def test_guard_login_without_manual_credentials_redirects_to_device_code(self, tmp_path, capsys, monkeypatch):
+    def test_guard_login_without_manual_credentials_uses_browser_oauth(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)
-        opened_urls: list[str] = []
+        authorize_url = "https://hol.org/api/guard/oauth/authorize?client_id=guard-local-daemon"
 
-        def open_browser(url: str) -> bool:
-            opened_urls.append(url)
-            return True
-
-        def fake_device_flow(*, store: GuardStore, connect_url: str) -> dict[str, object]:
+        def fake_browser_flow(
+            *,
+            store: GuardStore,
+            connect_url: str,
+            wait_timeout_seconds: int,
+        ) -> dict[str, object]:
+            assert connect_url == "https://hol.org/guard/connect"
+            assert wait_timeout_seconds == 180
             return {
-                "status": "waiting_for_approval",
-                "connect_mode": "device_code",
-                "user_code": "ABCD-EFGH",
-                "verification_uri": "https://hol.org/guard/oauth/device",
-                "next_action": {
-                    "command": "open",
-                    "target": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
-                },
+                "status": "connected",
+                "connect_mode": "browser_oauth",
+                "browser_opened": True,
+                "authorize_url": authorize_url,
+                "redirect_uri": "http://127.0.0.1:61234/oauth/callback",
+                "grant_id": "grant-456",
+                "machine_id": "machine-456",
+                "workspace_id": "workspace-456",
             }
 
-        monkeypatch.setattr(guard_commands_module.webbrowser, "open", open_browser)
-        monkeypatch.setattr(guard_commands_module, "_run_guard_device_connect_flow", fake_device_flow)
+        monkeypatch.setattr(guard_commands_module, "_run_guard_browser_connect_flow", fake_browser_flow)
         login_rc = main(
             [
                 "guard",
@@ -6420,9 +6426,14 @@ url = http://127.0.0.1:8787/guard-canary
         login_output = json.loads(capsys.readouterr().out)
 
         assert login_rc == 0
-        assert login_output["status"] == "waiting_for_approval"
-        assert login_output["connect_mode"] == "device_code"
-        assert opened_urls == ["https://hol.org/guard/oauth/device?user_code=ABCD-EFGH"]
+        assert login_output["status"] == "connected"
+        assert login_output["connect_mode"] == "browser_oauth"
+        assert login_output["browser_opened"] is True
+        assert login_output["authorize_url"] == "*****"
+        assert login_output["redirect_uri"] == "http://127.0.0.1:61234/oauth/callback"
+        assert login_output["grant_id"] == "grant-456"
+        assert login_output["machine_id"] == "machine-456"
+        assert login_output["workspace_id"] == "workspace-456"
         assert store.get_sync_credentials() is None
 
     def test_guard_login_manual_mode_requires_sync_url_and_token(self, tmp_path, capsys):
@@ -6703,14 +6714,19 @@ url = http://127.0.0.1:8787/guard-canary
         assert payload["receipts"]["receipts_stored"] == 2
         assert payload["connection"]["sync_url"] == "https://hol.org/api/guard/receipts/sync"
 
-    def test_guard_connect_reports_device_authorization_errors_cleanly(self, tmp_path, capsys, monkeypatch):
+    def test_guard_connect_reports_browser_authorization_errors_cleanly(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)
 
-        def failing_device_flow(*, store: GuardStore, connect_url: str) -> dict[str, object]:
-            raise RuntimeError("device_authorization_unreachable")
+        def failing_browser_flow(
+            *,
+            store: GuardStore,
+            connect_url: str,
+            wait_timeout_seconds: int,
+        ) -> dict[str, object]:
+            raise RuntimeError("browser_oauth_unreachable")
 
-        monkeypatch.setattr(guard_commands_module, "_run_guard_device_connect_flow", failing_device_flow)
+        monkeypatch.setattr(guard_commands_module, "_run_guard_browser_connect_flow", failing_browser_flow)
         connect_rc = main(
             [
                 "guard",
@@ -6725,32 +6741,29 @@ url = http://127.0.0.1:8787/guard-canary
         captured = capsys.readouterr()
 
         assert connect_rc == 1
-        assert "Guard Device Code authorization failed: device_authorization_unreachable" in captured.err
+        assert "Guard authorization failed: browser_oauth_unreachable" in captured.err
         assert "Traceback" not in captured.err
         assert store.get_sync_credentials() is None
 
     def test_guard_connect_never_opens_legacy_pairing_url(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
-        opened_urls: list[str] = []
+        authorize_url = "https://hol.org/api/guard/oauth/authorize?client_id=guard-local-daemon"
 
-        def open_browser(url: str) -> bool:
-            opened_urls.append(url)
-            return True
-
-        def fake_device_flow(*, store: GuardStore, connect_url: str) -> dict[str, object]:
+        def fake_browser_flow(
+            *,
+            store: GuardStore,
+            connect_url: str,
+            wait_timeout_seconds: int,
+        ) -> dict[str, object]:
             return {
-                "status": "waiting_for_approval",
-                "connect_mode": "device_code",
-                "user_code": "ABCD-EFGH",
-                "verification_uri": "https://hol.org/guard/oauth/device",
-                "next_action": {
-                    "command": "open",
-                    "target": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
-                },
+                "status": "connected",
+                "connect_mode": "browser_oauth",
+                "browser_opened": True,
+                "authorize_url": authorize_url,
+                "redirect_uri": "http://127.0.0.1:61234/oauth/callback",
             }
 
-        monkeypatch.setattr(guard_commands_module, "_run_guard_device_connect_flow", fake_device_flow)
-        monkeypatch.setattr(guard_commands_module.webbrowser, "open", open_browser)
+        monkeypatch.setattr(guard_commands_module, "_run_guard_browser_connect_flow", fake_browser_flow)
         connect_rc = main(
             [
                 "guard",
@@ -6766,7 +6779,8 @@ url = http://127.0.0.1:8787/guard-canary
         rendered = json.dumps(connect_output, sort_keys=True)
 
         assert connect_rc == 0
-        assert opened_urls == ["https://hol.org/guard/oauth/device?user_code=ABCD-EFGH"]
+        assert connect_output["connect_mode"] == "browser_oauth"
+        assert connect_output["authorize_url"] == "*****"
         assert "guardPairSecret" not in rendered
         assert "guardPairRequest" not in rendered
         assert "guardDaemon" not in rendered

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -311,6 +311,23 @@ def test_loopback_callback_listener_rejects_state_mismatch() -> None:
         listener.close()
 
 
+def test_loopback_callback_listener_surfaces_oauth_denial_without_timeout() -> None:
+    listener = connect_flow.start_guard_loopback_callback_listener(expected_state="state-123")
+    try:
+        denied_url = f"{listener.redirect_uri}?state=state-123&error=access_denied&error_description=User+denied+access"
+        with urllib.request.urlopen(denied_url, timeout=5) as response:
+            assert response.status == 200
+
+        try:
+            listener.wait_for_callback(timeout_seconds=0.05)
+        except RuntimeError as error:
+            assert "User denied access" in str(error)
+        else:
+            raise AssertionError("denied callback must surface a runtime error")
+    finally:
+        listener.close()
+
+
 def test_exchange_authorization_code_posts_pkce_and_dpop_binding() -> None:
     assert hasattr(connect_flow, "exchange_guard_authorization_code")
 

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -1,11 +1,15 @@
+import base64
 import json
 import urllib.error
 import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
 from pathlib import Path
 
 from codex_plugin_scanner.guard.cli import commands as guard_commands
 from codex_plugin_scanner.guard.cli import connect_flow
 from codex_plugin_scanner.guard.cli.commands import run_guard_command
+from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -59,6 +63,22 @@ class _ConnectArgs:
     home = None
     guard_home = None
     workspace = None
+
+
+def _fake_access_token(*, grant_id: str, machine_id: str, workspace_id: str) -> str:
+    def encode_part(payload: dict[str, object]) -> str:
+        encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        return base64.urlsafe_b64encode(encoded).decode("ascii").rstrip("=")
+
+    header = encode_part({"alg": "none", "typ": "JWT"})
+    claims = encode_part(
+        {
+            "grant": {"grantId": grant_id},
+            "machine": {"machineId": machine_id},
+            "workspace": {"workspaceId": workspace_id},
+        }
+    )
+    return f"{header}.{claims}.signature"
 
 
 def test_device_authorization_request_uses_oauth_scopes_without_token_material() -> None:
@@ -226,40 +246,207 @@ def test_connect_headless_emits_device_code_payload_without_pairing_secret(tmp_p
     assert "guard_live_" not in captured.out
 
 
-def test_connect_default_uses_device_code_without_pairing_secret(tmp_path: Path, capsys, monkeypatch) -> None:
+def test_connect_default_uses_browser_oauth_without_pairing_secret(tmp_path: Path, capsys, monkeypatch) -> None:
     guard_home = tmp_path / "guard-home"
     args = _ConnectArgs()
     args.guard_home = str(guard_home)
-    opened_urls: list[str] = []
+    args.wait_timeout_seconds = 5
 
-    def fake_headless_flow(*, store: GuardStore, connect_url: str) -> dict[str, object]:
+    def fake_browser_flow(*, store: GuardStore, connect_url: str, wait_timeout_seconds: int) -> dict[str, object]:
+        assert wait_timeout_seconds == 5
         return {
-            "status": "waiting_for_approval",
-            "connect_mode": "device_code",
-            "user_code": "ABCD-EFGH",
-            "verification_uri": "https://hol.org/guard/oauth/device",
-            "next_action": {
-                "command": "open",
-                "target": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
-            },
+            "status": "connected",
+            "connect_mode": "browser_oauth",
+            "authorize_url": "https://hol.org/api/guard/oauth/authorize?client_id=guard-local-daemon",
+            "redirect_uri": "http://127.0.0.1:61234/oauth/callback",
         }
 
-    def fake_open(url: str) -> bool:
-        opened_urls.append(url)
-        return True
-
-    monkeypatch.setattr(guard_commands, "_run_guard_device_connect_flow", fake_headless_flow)
-    monkeypatch.setattr(guard_commands.webbrowser, "open", fake_open)
+    monkeypatch.setattr(guard_commands, "_run_guard_browser_connect_flow", fake_browser_flow)
 
     exit_code = run_guard_command(args)
     captured = capsys.readouterr()
 
     assert exit_code == 0
-    assert opened_urls == ["https://hol.org/guard/oauth/device?user_code=ABCD-EFGH"]
-    assert "ABCD-EFGH" in captured.out
+    assert "browser_oauth" in captured.out
+    assert '"authorize_url": "*****"' in captured.out
+    assert "ABCD-EFGH" not in captured.out
+    assert "verification_uri" not in captured.out
     assert "guardPairSecret" not in captured.out
     assert "guardPairRequest" not in captured.out
     assert not hasattr(guard_commands, "_run_guard_connect_flow")
+
+
+def test_loopback_callback_listener_uses_random_high_port_and_loopback_path() -> None:
+    assert hasattr(connect_flow, "start_guard_loopback_callback_listener")
+
+    listener = connect_flow.start_guard_loopback_callback_listener(expected_state="state-123")
+    try:
+        parsed = urllib.parse.urlparse(listener.redirect_uri)
+        assert parsed.hostname in {"127.0.0.1", "::1"}
+        assert parsed.path == "/oauth/callback"
+        assert parsed.port is not None
+        assert 49152 <= parsed.port <= 65535
+    finally:
+        listener.close()
+
+
+def test_loopback_callback_listener_rejects_state_mismatch() -> None:
+    listener = connect_flow.start_guard_loopback_callback_listener(expected_state="state-123")
+    try:
+        wrong_state_url = f"{listener.redirect_uri}?code=code-123&state=wrong-state"
+        try:
+            urllib.request.urlopen(wrong_state_url, timeout=5)
+        except urllib.error.HTTPError as error:
+            assert error.code == 400
+        else:
+            raise AssertionError("state mismatch must be rejected")
+
+        try:
+            listener.wait_for_callback(timeout_seconds=0.05)
+        except TimeoutError as error:
+            assert "timed out" in str(error)
+        else:
+            raise AssertionError("mismatched callback must not be accepted")
+    finally:
+        listener.close()
+
+    def test_exchange_authorization_code_posts_pkce_and_dpop_binding() -> None:
+        assert hasattr(connect_flow, "exchange_guard_authorization_code")
+
+    dpop = generate_dpop_key_pair()
+    captured: dict[str, object] = {}
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            token = _fake_access_token(
+                grant_id="grant-123",
+                machine_id="machine-123",
+                workspace_id="workspace-123",
+            )
+            return json.dumps(
+                {
+                    "access_token": token,
+                    "refresh_token": "refresh-123",
+                    "expires_in": 3600,
+                    "scope": "guard:runtime.sync guard:offline_access",
+                    "token_type": "Bearer",
+                }
+            ).encode("utf-8")
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int):
+        captured["url"] = request.full_url
+        captured["timeout"] = timeout
+        captured["headers"] = dict(request.header_items())
+        captured["body"] = request.data.decode("utf-8") if request.data else ""
+        return _Response()
+
+    result = connect_flow.exchange_guard_authorization_code(
+        token_endpoint="https://hol.org/api/guard/oauth/token",
+        client_id="guard-local-daemon",
+        code="auth-code-123",
+        redirect_uri="http://127.0.0.1:61234/oauth/callback",
+        code_verifier="verifier-123",
+        dpop_key_material=dpop,
+        urlopen=fake_urlopen,
+        now=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+
+    parsed = urllib.parse.parse_qs(str(captured["body"]))
+    headers = {str(key).lower(): str(value) for key, value in dict(captured["headers"]).items()}
+
+    assert captured["url"] == "https://hol.org/api/guard/oauth/token"
+    assert captured["timeout"] == 20
+    assert parsed["grant_type"] == ["authorization_code"]
+    assert parsed["client_id"] == ["guard-local-daemon"]
+    assert parsed["code"] == ["auth-code-123"]
+    assert parsed["redirect_uri"] == ["http://127.0.0.1:61234/oauth/callback"]
+    assert parsed["code_verifier"] == ["verifier-123"]
+    assert "dpop" in headers
+    assert result.refresh_token == "refresh-123"
+    assert result.grant_id == "grant-123"
+    assert result.machine_id == "machine-123"
+    assert result.workspace_id == "workspace-123"
+
+
+def test_browser_connect_persists_local_oauth_credentials(tmp_path: Path) -> None:
+    assert hasattr(connect_flow, "run_guard_browser_connect_command")
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    store.set_device_label("Desk Mac", "2026-06-01T00:00:00+00:00")
+    opened: list[str] = []
+    dpop = generate_dpop_key_pair()
+
+    class _FakeSession:
+        authorize_url = "https://hol.org/api/guard/oauth/authorize?client_id=guard-local-daemon"
+        redirect_uri = "http://127.0.0.1:61234/oauth/callback"
+        pkce_verifier = "verifier-123"
+        state = "state-123"
+        dpop_key_material = dpop
+        closed = False
+
+        def wait_for_callback(self, timeout_seconds: float):
+            assert timeout_seconds == 30
+            return connect_flow.GuardOAuthLoopbackCallback(code="auth-code-123", state="state-123")
+
+        def close(self) -> None:
+            self.closed = True
+
+    session = _FakeSession()
+
+    def fake_open(url: str) -> bool:
+        opened.append(url)
+        return True
+
+    def fake_exchange(**kwargs):
+        assert kwargs["token_endpoint"] == "https://hol.org/api/guard/oauth/token"
+        assert kwargs["client_id"] == "guard-local-daemon"
+        assert kwargs["code"] == "auth-code-123"
+        assert kwargs["redirect_uri"] == "http://127.0.0.1:61234/oauth/callback"
+        assert kwargs["code_verifier"] == "verifier-123"
+        return connect_flow.GuardOAuthTokenExchangeResult(
+            access_token=_fake_access_token(
+                grant_id="grant-123",
+                machine_id="machine-123",
+                workspace_id="workspace-123",
+            ),
+            refresh_token="refresh-123",
+            expires_in=3600,
+            scope="guard:runtime.sync guard:offline_access",
+            token_type="Bearer",
+            grant_id="grant-123",
+            machine_id="machine-123",
+            workspace_id="workspace-123",
+        )
+
+    payload = connect_flow.run_guard_browser_connect_command(
+        store=store,
+        connect_url="https://hol.org/guard/connect",
+        start_browser_session=lambda **_: session,
+        open_browser=fake_open,
+        exchange_authorization_code=fake_exchange,
+        now="2026-06-01T12:00:00+00:00",
+        wait_timeout_seconds=30,
+    )
+
+    credentials = store.get_oauth_local_credentials()
+
+    assert opened == ["https://hol.org/api/guard/oauth/authorize?client_id=guard-local-daemon"]
+    assert session.closed is True
+    assert payload["status"] == "connected"
+    assert payload["connect_mode"] == "browser_oauth"
+    assert payload["grant_id"] == "grant-123"
+    assert payload["machine_id"] == "machine-123"
+    assert credentials is not None
+    assert credentials["grant_id"] == "grant-123"
+    assert credentials["machine_id"] == "machine-123"
+    assert credentials["workspace_id"] == "workspace-123"
+    assert credentials["refresh_token"] == "refresh-123"
 
 
 def test_legacy_pairing_helpers_are_not_exported() -> None:

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -310,8 +310,9 @@ def test_loopback_callback_listener_rejects_state_mismatch() -> None:
     finally:
         listener.close()
 
-    def test_exchange_authorization_code_posts_pkce_and_dpop_binding() -> None:
-        assert hasattr(connect_flow, "exchange_guard_authorization_code")
+
+def test_exchange_authorization_code_posts_pkce_and_dpop_binding() -> None:
+    assert hasattr(connect_flow, "exchange_guard_authorization_code")
 
     dpop = generate_dpop_key_pair()
     captured: dict[str, object] = {}
@@ -532,7 +533,7 @@ def test_connect_headless_reports_device_authorization_network_error(tmp_path: P
     captured = capsys.readouterr()
 
     assert exit_code == 1
-    assert "Guard Device Code authorization failed" in captured.err
+    assert "Guard authorization failed" in captured.err
     assert "Traceback" not in captured.err
 
 
@@ -550,5 +551,5 @@ def test_connect_headless_reports_malformed_device_authorization_response(tmp_pa
     captured = capsys.readouterr()
 
     assert exit_code == 1
-    assert "Guard Device Code authorization failed" in captured.err
+    assert "Guard authorization failed" in captured.err
     assert "Traceback" not in captured.err

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -570,3 +570,36 @@ def test_connect_headless_reports_malformed_device_authorization_response(tmp_pa
     assert exit_code == 1
     assert "Guard authorization failed" in captured.err
     assert "Traceback" not in captured.err
+
+
+def test_connect_browser_reports_loopback_timeout_without_traceback(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+
+    def failing_browser_flow(
+        *,
+        store: GuardStore,
+        connect_url: str,
+        wait_timeout_seconds: float,
+    ) -> dict[str, object]:
+        raise TimeoutError("Guard OAuth browser callback timed out.")
+
+    monkeypatch.setattr(guard_commands, "_run_guard_browser_connect_flow", failing_browser_flow)
+
+    payload, exit_code = guard_commands._build_guard_device_connect_payload(
+        store=store,
+        connect_url="https://hol.org/guard/connect",
+        open_browser=True,
+        wait_timeout_seconds=30,
+    )
+    captured = capsys.readouterr()
+
+    assert payload is None
+    assert exit_code == 1
+    assert "Guard authorization failed" in captured.err
+    assert "timed out" in captured.err
+    assert "Traceback" not in captured.err


### PR DESCRIPTION
## Summary
- add a browser-based OAuth loopback flow for interactive `hol-guard connect` with PKCE, random high-port loopback callbacks, and token exchange DPoP binding
- persist local OAuth refresh-token metadata after successful browser auth while keeping headless Device Code coverage intact

## Testing
- `cd /Users/michaelkantor/CascadeProjects/hashgraph-online/hol-guard/.worktrees/guard-auth-phase-m-loopback && python3 -m pytest tests/test_guard_oauth_client.py tests/test_guard_oauth_device_connect.py -q`
- `cd /Users/michaelkantor/CascadeProjects/hashgraph-online/hol-guard/.worktrees/guard-auth-phase-m-loopback && ruff check src/codex_plugin_scanner/guard/cli/connect_flow.py src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_oauth_device_connect.py`
- `cd /Users/michaelkantor/CascadeProjects/hashgraph-online/hol-guard/.worktrees/guard-auth-phase-m-loopback && ruff format --check src/codex_plugin_scanner/guard/cli/connect_flow.py src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_oauth_device_connect.py`
