### PR TITLE
feat(guard-auth): expose oauth storage health

### DIFF
--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -389,6 +389,7 @@ def build_runtime_snapshot(
         "generated_at": snapshot_now,
         "approval_center_url": approval_center_url,
         "runtime_state": store.get_runtime_state(),
+        "oauth_storage_health": store.get_oauth_local_credential_health(),
         "device": _build_runtime_device_context(store),
         "latest_connect_state": latest_connect_state,
         "proof_status": _build_runtime_proof_status(latest_connect_state),

--- a/src/codex_plugin_scanner/guard/cli/product.py
+++ b/src/codex_plugin_scanner/guard/cli/product.py
@@ -88,6 +88,7 @@ def _build_guard_product_payload(
         "guard_home": _redacted_path(context.guard_home, context.home_dir),
         "workspace": _redacted_path(context.workspace_dir, context.home_dir),
         "sync_configured": store.get_sync_credentials() is not None,
+        "oauth_storage_health": store.get_oauth_local_credential_health(),
         "receipt_count": receipt_count,
         "pending_approvals": store.count_approval_requests(),
         "approval_center_url": approval_center_url,

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -121,11 +121,13 @@ def emit_guard_payload(command: str, payload: dict[str, object], as_json: bool) 
 
 
 def _redact_payload(value: object, *, key: str | None = None) -> object:
-    if key in _NON_SECRET_STRUCTURED_KEYS:
-        if isinstance(value, dict):
-            return {item_key: _redact_payload(item_value, key=item_key) for item_key, item_value in value.items()}
-        return value
-    if key is not None and any(token in key.lower() for token in _SENSITIVE_KEY_TOKENS):
+    if key in _NON_SECRET_STRUCTURED_KEYS and isinstance(value, dict):
+        return {item_key: _redact_payload(item_value, key=item_key) for item_key, item_value in value.items()}
+    if (
+        key is not None
+        and key not in _NON_SECRET_STRUCTURED_KEYS
+        and any(token in key.lower() for token in _SENSITIVE_KEY_TOKENS)
+    ):
         if isinstance(value, str) and value.lower() in _SAFE_POLICY_LITERALS:
             return value
         return "*****"

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -78,6 +78,7 @@ _KNOWN_MANAGED_INSTALL_MODES = {
     "codex-mcp-proxy": "Codex MCP proxy",
 }
 _SENSITIVE_KEY_TOKENS = ("key", "token", "auth", "secret", "password", "credential")
+_NON_SECRET_STRUCTURED_KEYS = frozenset({"oauth_storage_health"})
 _SAFE_POLICY_LITERALS = frozenset(
     {"allow", "warn", "review", "block", "require-reapproval", "sandbox-required", "strict", "balanced", "custom"}
 )
@@ -120,6 +121,10 @@ def emit_guard_payload(command: str, payload: dict[str, object], as_json: bool) 
 
 
 def _redact_payload(value: object, *, key: str | None = None) -> object:
+    if key in _NON_SECRET_STRUCTURED_KEYS:
+        if isinstance(value, dict):
+            return {item_key: _redact_payload(item_value, key=item_key) for item_key, item_value in value.items()}
+        return value
     if key is not None and any(token in key.lower() for token in _SENSITIVE_KEY_TOKENS):
         if isinstance(value, str) and value.lower() in _SAFE_POLICY_LITERALS:
             return value

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -421,6 +421,22 @@ def _build_oauth_secret_store(guard_home: Path) -> SecretStore:
     return fallback_store
 
 
+def _secret_store_backend_name(secret_store: SecretStore) -> str:
+    if isinstance(secret_store, KeychainSecretStore):
+        return "keychain"
+    if isinstance(secret_store, EncryptedFileSecretStore):
+        return "encrypted-file"
+    if isinstance(secret_store, FallbackSecretStore):
+        return _secret_store_backend_name(secret_store.primary)
+    return "unknown"
+
+
+def _secret_store_fallback_backend_name(secret_store: SecretStore) -> str | None:
+    if isinstance(secret_store, FallbackSecretStore):
+        return _secret_store_backend_name(secret_store.fallback)
+    return None
+
+
 _SLOW_QUERY_THRESHOLD_MS: int = 200
 _store_logger = logging.getLogger(__name__)
 
@@ -3000,6 +3016,29 @@ class GuardStore:
         if isinstance(workspace_id, str) and workspace_id:
             result["workspace_id"] = workspace_id
         return result
+
+    def get_oauth_local_credential_health(self) -> dict[str, object]:
+        payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
+        health: dict[str, object] = {
+            "configured": isinstance(payload, dict),
+            "state": "not_configured",
+            "backend": _secret_store_backend_name(self._oauth_secret_store),
+            "fallback_backend": _secret_store_fallback_backend_name(self._oauth_secret_store),
+        }
+        if not isinstance(payload, dict):
+            return health
+
+        credentials = self.get_oauth_local_credentials()
+        if credentials is None:
+            health["state"] = "degraded"
+            return health
+
+        health["state"] = "healthy"
+        for key in ("issuer", "client_id", "grant_id", "machine_id", "workspace_id"):
+            value = credentials.get(key)
+            if isinstance(value, str) and value:
+                health[key] = value
+        return health
 
     def get_latest_guard_connect_state(self, *, now: str) -> dict[str, object] | None:
         with self._connect() as connection:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -3028,14 +3028,46 @@ class GuardStore:
         if not isinstance(payload, dict):
             return health
 
-        credentials = self.get_oauth_local_credentials()
-        if credentials is None:
+        refresh_token_ref = payload.get("refresh_token_ref")
+        refresh_token_hash = payload.get("refresh_token_sha256")
+        dpop_private_key_ref = payload.get("dpop_private_key_ref")
+        dpop_private_key_hash = payload.get("dpop_private_key_sha256")
+        if not isinstance(refresh_token_ref, str) or not refresh_token_ref:
+            health["state"] = "degraded"
+            return health
+        if not isinstance(refresh_token_hash, str) or not refresh_token_hash:
+            health["state"] = "degraded"
+            return health
+        if not isinstance(dpop_private_key_ref, str) or not dpop_private_key_ref:
+            health["state"] = "degraded"
+            return health
+        if not isinstance(dpop_private_key_hash, str) or not dpop_private_key_hash:
+            health["state"] = "degraded"
+            return health
+
+        refresh_token_present = any(
+            _token_sha256(candidate) == refresh_token_hash
+            for candidate in self._get_secret_candidates(
+                self._oauth_secret_store,
+                refresh_token_ref,
+                refresh_token_hash,
+            )
+        )
+        dpop_private_key_present = any(
+            _token_sha256(candidate) == dpop_private_key_hash
+            for candidate in self._get_secret_candidates(
+                self._oauth_secret_store,
+                dpop_private_key_ref,
+                dpop_private_key_hash,
+            )
+        )
+        if not refresh_token_present or not dpop_private_key_present:
             health["state"] = "degraded"
             return health
 
         health["state"] = "healthy"
         for key in ("issuer", "client_id", "grant_id", "machine_id", "workspace_id"):
-            value = credentials.get(key)
+            value = payload.get(key)
             if isinstance(value, str) and value:
                 health[key] = value
         return health

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -34,7 +34,7 @@ from codex_plugin_scanner.guard.cli import update_commands as guard_update_comma
 from codex_plugin_scanner.guard.cli.render import emit_guard_payload
 from codex_plugin_scanner.guard.config import GuardConfig, load_guard_config, resolve_risk_action
 from codex_plugin_scanner.guard.desktop_notifications import DesktopNotificationSetupResult
-from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.guard.store import GuardStore, KeychainSecretStore
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -6382,6 +6382,48 @@ url = http://127.0.0.1:8787/guard-canary
         assert "guardPairSecret" not in json.dumps(connect_output)
         assert "guardPairRequest" not in json.dumps(connect_output)
         assert store.get_sync_credentials() is None
+
+    def test_guard_status_reports_oauth_key_storage_health(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: False))
+        store = GuardStore(home_dir)
+        store.set_oauth_local_credentials(
+            issuer="https://hol.org",
+            client_id="guard-local-daemon",
+            refresh_token="refresh-secret-value",
+            dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+            dpop_public_jwk={
+                "kty": "EC",
+                "crv": "P-256",
+                "x": "x-value",
+                "y": "y-value",
+                "alg": "ES256",
+                "use": "sig",
+            },
+            dpop_public_jwk_thumbprint="thumbprint-123",
+            grant_id="grant-123",
+            machine_id="machine-123",
+            workspace_id="workspace-123",
+            now="2026-06-01T00:00:00+00:00",
+        )
+
+        status_rc = main(["guard", "status", "--home", str(home_dir), "--workspace", str(workspace_dir), "--json"])
+        status_output = json.loads(capsys.readouterr().out)
+
+        assert status_rc == 0
+        assert status_output["oauth_storage_health"] == {
+            "configured": True,
+            "state": "healthy",
+            "backend": "encrypted-file",
+            "fallback_backend": None,
+            "issuer": "https://hol.org",
+            "client_id": "guard-local-daemon",
+            "grant_id": "grant-123",
+            "machine_id": "machine-123",
+            "workspace_id": "workspace-123",
+        }
 
     def test_guard_login_without_manual_credentials_redirects_to_device_code(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_render.py
+++ b/tests/test_guard_render.py
@@ -833,6 +833,28 @@ def test_emit_guard_payload_preserves_policy_literals_for_risk_action_keys(capsy
     assert '"local_secret_read": "allow"' in output
 
 
+def test_guard_render_redacts_non_dict_oauth_storage_health_values(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_renderer(_console, payload: dict[str, object]) -> None:
+        captured["payload"] = payload
+
+    monkeypatch.setitem(render._RENDERERS, "status", fake_renderer)
+    monkeypatch.setattr(render, "_RICH_AVAILABLE", True)
+
+    emit_guard_payload(
+        "status",
+        {
+            "oauth_storage_health": "Authorization: Bearer super-secret /Users/example/private",
+        },
+        False,
+    )
+
+    payload = captured["payload"]
+    assert isinstance(payload, dict)
+    assert payload["oauth_storage_health"] == "Authorization: ***** ~/private"
+
+
 def test_emit_guard_payload_renders_supply_chain_risks_table(capsys, monkeypatch) -> None:
     monkeypatch.setattr(render, "_RICH_AVAILABLE", True)
     emit_guard_payload(

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -360,6 +360,44 @@ def test_oauth_local_credentials_use_encrypted_file_fallback_when_keychain_write
     assert store.get_oauth_local_credentials() is not None
 
 
+def test_oauth_local_credential_health_reports_backend_and_metadata(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: False))
+    store = GuardStore(guard_home)
+
+    assert store.get_oauth_local_credential_health() == {
+        "configured": False,
+        "state": "not_configured",
+        "backend": "encrypted-file",
+        "fallback_backend": None,
+    }
+
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+
+    assert store.get_oauth_local_credential_health() == {
+        "configured": True,
+        "state": "healthy",
+        "backend": "encrypted-file",
+        "fallback_backend": None,
+        "issuer": "https://hol.org",
+        "client_id": "guard-local-daemon",
+        "grant_id": "grant-123",
+        "machine_id": "machine-123",
+        "workspace_id": "workspace-123",
+    }
+
+
 def test_oauth_local_credentials_preserve_previous_material_on_partial_secret_write_failure(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
     store.set_oauth_local_credentials(

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -397,6 +397,13 @@ def test_oauth_local_credential_health_reports_backend_and_metadata(tmp_path, mo
         "workspace_id": "workspace-123",
     }
 
+    monkeypatch.setattr(
+        store,
+        "_promote_secret_to_primary",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("health check must not promote secrets")),
+    )
+    assert store.get_oauth_local_credential_health()["state"] == "healthy"
+
 
 def test_oauth_local_credentials_preserve_previous_material_on_partial_secret_write_failure(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")


### PR DESCRIPTION
## Summary
- add local OAuth key-storage health details to `hol-guard status` and Guard runtime snapshots
- preserve structured `oauth_storage_health` rendering while keeping other auth material redacted
- add regression coverage for store metadata and CLI status output

## Testing
- `python3 -m pytest tests/test_guard_store_migrations.py tests/test_guard_cli.py -k 'oauth_local_credential_health_reports_backend_and_metadata or guard_status_reports_oauth_key_storage_health' -q`
- `ruff check src/codex_plugin_scanner/guard/store.py src/codex_plugin_scanner/guard/approvals.py src/codex_plugin_scanner/guard/cli/product.py src/codex_plugin_scanner/guard/cli/render.py tests/test_guard_store_migrations.py tests/test_guard_cli.py`
- `ruff format --check src/codex_plugin_scanner/guard/store.py src/codex_plugin_scanner/guard/approvals.py src/codex_plugin_scanner/guard/cli/product.py src/codex_plugin_scanner/guard/cli/render.py tests/test_guard_store_migrations.py tests/test_guard_cli.py`
