### PR TITLE
feat(guard): refresh oauth sync requests

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -151,6 +151,7 @@ from ..runtime.false_positive_rules import (
 )
 from ..runtime.package_intent import build_package_request_artifact, extract_package_intent_request
 from ..runtime.runner import (
+    GuardSyncAuthorizationExpiredError,
     GuardSyncNotConfiguredError,
     extract_prompt_requests,
     guard_run,
@@ -2141,10 +2142,15 @@ def run_guard_command(
         if adv_sub == "sync":
             try:
                 payload = _validated_supply_chain_sync_payload(sync_supply_chain_bundle(store))
-            except GuardSyncNotConfiguredError:
+            except GuardSyncNotConfiguredError as error:
+                status = (
+                    "auth_expired"
+                    if isinstance(error, GuardSyncAuthorizationExpiredError)
+                    else "no_cloud_sync_configured"
+                )
                 _emit(
                     "advisories_sync",
-                    {"generated_at": _now(), "status": "no_cloud_sync_configured"},
+                    {"generated_at": _now(), "status": status, "error": _guard_sync_failure_message(error)},
                     getattr(args, "json", False),
                 )
             except RuntimeError as error:
@@ -2387,8 +2393,8 @@ def run_guard_command(
     if args.guard_command == "sync":
         try:
             payload = sync_receipts(store)
-        except GuardSyncNotConfiguredError:
-            message = _guard_sync_prerequisite_message()
+        except GuardSyncNotConfiguredError as error:
+            message = _guard_sync_failure_message(error)
             if getattr(args, "json", False):
                 _emit("sync", {"synced": False, "error": message}, True)
             else:
@@ -2408,8 +2414,8 @@ def run_guard_command(
         if cloud_command == "sync-intel":
             try:
                 payload = _validated_supply_chain_sync_payload(sync_supply_chain_bundle(store))
-            except GuardSyncNotConfiguredError:
-                message = _guard_sync_prerequisite_message()
+            except GuardSyncNotConfiguredError as error:
+                message = _guard_sync_failure_message(error)
                 if getattr(args, "json", False):
                     _emit("cloud-sync-intel", {"synced": False, "error": message}, True)
                 else:
@@ -2461,8 +2467,8 @@ def run_guard_command(
         if supply_chain_command == "sync":
             try:
                 payload = _validated_supply_chain_sync_payload(sync_supply_chain_bundle(store))
-            except GuardSyncNotConfiguredError:
-                message = _guard_sync_prerequisite_message()
+            except GuardSyncNotConfiguredError as error:
+                message = _guard_sync_failure_message(error)
                 if getattr(args, "json", False):
                     _emit("supply-chain-sync", {"synced": False, "error": message}, True)
                 else:
@@ -2500,7 +2506,7 @@ def run_guard_command(
                 payload = _guard_service_sync_payload(store)
             except (GuardSyncNotConfiguredError, RuntimeError) as error:
                 message = (
-                    _guard_service_sync_prerequisite_message()
+                    _guard_service_sync_failure_message(error)
                     if isinstance(error, GuardSyncNotConfiguredError)
                     else str(error)
                 )
@@ -8901,6 +8907,12 @@ def _guard_service_sync_prerequisite_message() -> str:
     )
 
 
+def _guard_service_sync_failure_message(error: GuardSyncNotConfiguredError) -> str:
+    if isinstance(error, GuardSyncAuthorizationExpiredError):
+        return str(error)
+    return _guard_service_sync_prerequisite_message()
+
+
 def _guard_service_status_payload(store: GuardStore) -> dict[str, object]:
     credentials = store.get_sync_credentials()
     service_profile = _guard_service_runtime_profile(store)
@@ -8963,6 +8975,12 @@ def _guard_sync_prerequisite_message() -> str:
         "Guard Cloud is not connected yet. Run `hol-guard connect` to sign in and pair this machine, "
         "or use `hol-guard login` as a compatibility alias for the same browser flow."
     )
+
+
+def _guard_sync_failure_message(error: GuardSyncNotConfiguredError) -> str:
+    if isinstance(error, GuardSyncAuthorizationExpiredError):
+        return str(error)
+    return _guard_sync_prerequisite_message()
 
 
 def _build_abom_payload(store: GuardStore) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -81,6 +81,7 @@ from ..local_supply_chain import build_local_supply_chain_posture
 from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES, PolicyDecision
 from ..receipts.manager import build_receipt
 from ..runtime.runner import (
+    GuardSyncAuthorizationExpiredError,
     GuardSyncNotAvailableError,
     GuardSyncNotConfiguredError,
     sync_receipts,
@@ -346,6 +347,11 @@ def _run_headless_cloud_sync(
             "status": "synced",
             "synced_at": sync_payload.get("synced_at"),
             "receipts_stored": sync_payload.get("receipts_stored", 0),
+        }
+    except GuardSyncAuthorizationExpiredError as error:
+        summary = {
+            "status": "auth_expired",
+            "message": str(error),
         }
     except GuardSyncNotConfiguredError as error:
         summary = {
@@ -1032,6 +1038,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         cloud_sync_status = self._optional_string(cloud_sync.get("status")) or "unknown"
         if cloud_sync_status in {"queued", "in_progress"}:
             reconciliation_status = cloud_sync_status
+        elif cloud_sync_status == "auth_expired":
+            reconciliation_status = "auth_expired"
         elif cloud_sync_status == "not_configured":
             reconciliation_status = "not_configured"
         elif cloud_sync_status == "synced":
@@ -3049,6 +3057,17 @@ class GuardDaemonServer:
                     refreshed_at,
                 )
                 wait_seconds = interval_seconds
+            except GuardSyncAuthorizationExpiredError as error:
+                self._server.store.set_sync_payload(
+                    "supply_chain_bundle_daemon",
+                    {
+                        "status": "auth_expired",
+                        "refreshed_at": refreshed_at,
+                        "message": str(error),
+                    },
+                    refreshed_at,
+                )
+                wait_seconds = backoff_seconds
             except GuardSyncNotConfiguredError:
                 self._server.store.set_sync_payload(
                     "supply_chain_bundle_daemon",

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -12,7 +12,7 @@ import threading
 import urllib.error
 import urllib.parse
 import urllib.request
-from base64 import urlsafe_b64decode, urlsafe_b64encode
+from base64 import urlsafe_b64encode
 from collections.abc import Callable
 from contextlib import suppress
 from datetime import datetime, timedelta, timezone
@@ -961,7 +961,7 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
         exceptions=deduped_exceptions,
         now=now,
     )
-    pain_signals_uploaded = sync_pain_signals(store)
+    pain_signals_uploaded = sync_pain_signals(store, auth_context=auth_context)
     value_metrics = _build_value_metrics(store)
     weekly_digest = _build_weekly_firewall_digest(metrics=value_metrics, now=now)
     summary = {
@@ -988,7 +988,7 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
     }
     if remote_policy_sync_blocked:
         summary["remote_policy_sync_blocked"] = True
-    summary["guard_events_v1"] = sync_guard_events(store)
+    summary["guard_events_v1"] = sync_guard_events(store, auth_context=auth_context)
     store.set_sync_payload("sync_summary", summary, now)
     store.record_latest_guard_connect_sync_success(sync_payload=summary, now=now)
     return summary
@@ -1285,11 +1285,15 @@ def sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
     return summary
 
 
-def sync_guard_events(store: GuardStore) -> dict[str, object]:
+def sync_guard_events(
+    store: GuardStore,
+    *,
+    auth_context: dict[str, object] | None = None,
+) -> dict[str, object]:
     """Push pending GuardEventV1 envelopes to Guard Cloud."""
 
-    auth_context = _resolve_guard_sync_auth_context(store)
-    sync_url = _guard_events_sync_url(auth_context["sync_url"])
+    resolved_auth_context = auth_context or _resolve_guard_sync_auth_context(store)
+    sync_url = _guard_events_sync_url(resolved_auth_context["sync_url"])
     previous_summary = store.get_sync_payload("guard_events_v1_summary")
     total_events = 0
     total_accepted = 0
@@ -1310,7 +1314,7 @@ def sync_guard_events(store: GuardStore) -> dict[str, object]:
             sync_url,
             data=body,
             method="POST",
-            headers=_guard_sync_headers(auth_context, request_url=sync_url, method="POST"),
+            headers=_guard_sync_headers(resolved_auth_context, request_url=sync_url, method="POST"),
         )
         try:
             payload = _urlopen_json_with_timeout_retry(
@@ -1507,12 +1511,18 @@ def sync_runtime_session(
     return summary
 
 
-def sync_pain_signals(store: GuardStore) -> int:
+def sync_pain_signals(
+    store: GuardStore,
+    *,
+    auth_context: dict[str, object] | None = None,
+) -> int:
     try:
-        auth_context = _resolve_guard_sync_auth_context(store)
+        resolved_auth_context = auth_context or _resolve_guard_sync_auth_context(store)
+    except GuardSyncAuthorizationExpiredError:
+        raise
     except GuardSyncNotConfiguredError:
         return 0
-    normalized_sync_url = _normalized_receipts_sync_url(auth_context["sync_url"])
+    normalized_sync_url = _normalized_receipts_sync_url(resolved_auth_context["sync_url"])
     cursor_payload = store.get_sync_payload("pain_signal_cursor")
     last_event_id = _last_uploaded_event_id(cursor_payload)
     uploaded_count = 0
@@ -1544,7 +1554,7 @@ def sync_pain_signals(store: GuardStore) -> int:
                 data=json.dumps({"items": signal_items}).encode("utf-8"),
                 method="POST",
                 headers=_guard_sync_headers(
-                    auth_context,
+                    resolved_auth_context,
                     request_url=_pain_signal_sync_url(normalized_sync_url),
                     method="POST",
                 ),
@@ -1649,11 +1659,6 @@ def _base64url_encode(data: bytes) -> str:
     return urlsafe_b64encode(data).decode("ascii").rstrip("=")
 
 
-def _base64url_decode(data: str) -> bytes:
-    padding = "=" * (-len(data) % 4)
-    return urlsafe_b64decode(f"{data}{padding}")
-
-
 def _encode_jwt_segment(payload: dict[str, object]) -> str:
     return _base64url_encode(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8"))
 
@@ -1685,8 +1690,8 @@ def _sign_guard_dpop_proof(
         dpop_key_material.private_key_pem.encode("ascii"),
         password=None,
     )
-    if not isinstance(private_key, ec.EllipticCurvePrivateKey):
-        raise RuntimeError("Guard DPoP key must be an EC private key.")
+    if not isinstance(private_key, ec.EllipticCurvePrivateKey) or not isinstance(private_key.curve, ec.SECP256R1):
+        raise RuntimeError("Guard DPoP key must be a P-256 (SECP256R1) EC private key.")
     der_signature = private_key.sign(signing_input, ec.ECDSA(hashes.SHA256()))
     r_value, s_value = decode_dss_signature(der_signature)
     jose_signature = _base64url_encode(r_value.to_bytes(32, byteorder="big") + s_value.to_bytes(32, byteorder="big"))
@@ -1709,7 +1714,10 @@ def _oauth_refresh_error_message(error: urllib.error.HTTPError) -> str:
         error_code = _optional_string(payload.get("error"))
         if error_code is not None:
             return error_code
-    return _sync_http_error_message(error)
+    normalized_body = raw_body.strip()
+    if normalized_body:
+        return normalized_body
+    return f"HTTP Error {error.code}: {error.reason}"
 
 
 def _guard_oauth_reauthorization_message() -> str:
@@ -1757,7 +1765,7 @@ def _refresh_guard_oauth_access_token(
         raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
     access_token = _optional_string(payload.get("access_token"))
     token_type = _optional_string(payload.get("token_type"))
-    if access_token is None or token_type is None or token_type.lower() != "bearer":
+    if access_token is None or token_type is None or token_type.lower() not in {"bearer", "dpop"}:
         raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
     return {
         "access_token": access_token,

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1663,6 +1663,14 @@ def _encode_jwt_segment(payload: dict[str, object]) -> str:
     return _base64url_encode(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8"))
 
 
+def _dpop_access_token_confirmation_claim(access_token: str) -> str:
+    # RFC 9449 requires the DPoP `ath` claim to be the SHA-256 hash of the access token.
+    # codeql[py/weak-sensitive-data-hashing]
+    digest = hashes.Hash(hashes.SHA256())
+    digest.update(access_token.encode("ascii"))
+    return _base64url_encode(digest.finalize())
+
+
 def _sign_guard_dpop_proof(
     *,
     request_url: str,
@@ -1684,7 +1692,7 @@ def _sign_guard_dpop_proof(
         "jti": str(uuid4()),
     }
     if isinstance(access_token, str) and access_token:
-        claims["ath"] = _base64url_encode(hashlib.sha256(access_token.encode("ascii")).digest())
+        claims["ath"] = _dpop_access_token_confirmation_claim(access_token)
     signing_input = f"{_encode_jwt_segment(header)}.{_encode_jwt_segment(claims)}".encode("ascii")
     private_key = serialization.load_pem_private_key(
         dpop_key_material.private_key_pem.encode("ascii"),
@@ -1756,9 +1764,12 @@ def _refresh_guard_oauth_access_token(
         with urllib.request.urlopen(request, timeout=_SYNC_HTTP_TIMEOUT_SECONDS) as response:
             payload = json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as error:
-        raise GuardSyncAuthorizationExpiredError(
-            f"{_guard_oauth_reauthorization_message()} {_oauth_refresh_error_message(error)}"
-        ) from error
+        refresh_error_message = _oauth_refresh_error_message(error)
+        if error.code in {400, 401, 403}:
+            raise GuardSyncAuthorizationExpiredError(
+                f"{_guard_oauth_reauthorization_message()} {refresh_error_message}"
+            ) from error
+        raise RuntimeError(f"Guard OAuth token refresh failed: {refresh_error_message}") from error
     except OSError as error:
         raise RuntimeError(_sync_url_error_message(error)) from error
     if not isinstance(payload, dict):

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -12,16 +12,23 @@ import threading
 import urllib.error
 import urllib.parse
 import urllib.request
+from base64 import urlsafe_b64decode, urlsafe_b64encode
 from collections.abc import Callable
 from contextlib import suppress
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
 
 from ...version import __version__
 from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
 from ..approval_gate import ApprovalGateError
+from ..cli.oauth_client import GuardDpopKeyMaterial, resolve_guard_oauth_client_config
 from ..config import GuardConfig
 from ..consumer import detect_harness, evaluate_detection
 from ..edge_events import build_runtime_session_event
@@ -219,6 +226,10 @@ class GuardSyncNotConfiguredError(RuntimeError):
 
 class GuardSyncNotAvailableError(RuntimeError):
     """Raised when the sync endpoint returns 403 (free-plan restriction)."""
+
+
+class GuardSyncAuthorizationExpiredError(GuardSyncNotConfiguredError):
+    """Raised when local OAuth material can no longer mint a runtime access token."""
 
 
 def _prompt_sentence_start(text: str, index: int) -> int:
@@ -825,10 +836,8 @@ def _prompt_config_candidates(detection: HarnessDetection, context: HarnessConte
 def sync_receipts(store: GuardStore) -> dict[str, object]:
     """Push local receipts to the configured sync endpoint."""
 
-    credentials = store.get_sync_credentials()
-    if credentials is None:
-        raise GuardSyncNotConfiguredError("Guard is not logged in.")
-    sync_url = _normalized_receipts_sync_url(str(credentials["sync_url"]))
+    auth_context = _resolve_guard_sync_auth_context(store)
+    sync_url = _normalized_receipts_sync_url(auth_context["sync_url"])
     prior_receipt_cursor = _receipt_sync_cursor_rowid(store)
     receipts = _receipt_sync_rows_for_upload(store, cursor_rowid=prior_receipt_cursor)
     inventory = store.list_inventory()
@@ -859,7 +868,7 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
             sync_url,
             data=body,
             method="POST",
-            headers=_guard_sync_headers(str(credentials["token"])),
+            headers=_guard_sync_headers(auth_context, request_url=sync_url, method="POST"),
         )
         try:
             payload = _urlopen_json_with_timeout_retry(
@@ -1039,7 +1048,7 @@ def _sync_supply_chain_bundle_incremental(
     *,
     bundle_url: str,
     cached_bundle_version: str | None,
-    headers: dict[str, str],
+    auth_context: dict[str, object],
     store: GuardStore,
     trusted_keys: tuple[object, ...],
     workspace_id: str,
@@ -1047,7 +1056,12 @@ def _sync_supply_chain_bundle_incremental(
     index_request = urllib.request.Request(
         _normalized_supply_chain_bundle_index_url(bundle_url),
         method="GET",
-        headers=headers,
+        headers=_guard_sync_headers(
+            auth_context,
+            request_url=_normalized_supply_chain_bundle_index_url(bundle_url),
+            method="GET",
+            extra_headers={"Accept-Encoding": "identity"},
+        ),
     )
     try:
         index_payload = _fetch_supply_chain_bundle_payload(index_request)
@@ -1098,7 +1112,16 @@ def _sync_supply_chain_bundle_incremental(
                         partition=partition,
                     ),
                     method="GET",
-                    headers=headers,
+                    headers=_guard_sync_headers(
+                        auth_context,
+                        request_url=_supply_chain_partition_bundle_url(
+                            bundle_url,
+                            ecosystem=ecosystem,
+                            partition=partition,
+                        ),
+                        method="GET",
+                        extra_headers={"Accept-Encoding": "identity"},
+                    ),
                 )
                 partition_payload = _fetch_supply_chain_bundle_payload(partition_request)
                 response = load_supply_chain_bundle_response(partition_payload)
@@ -1134,15 +1157,11 @@ def _sync_supply_chain_bundle_incremental(
 def sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
     """Fetch, verify, and persist the active supply-chain bundle for the cloud workspace."""
 
-    credentials = store.get_sync_credentials()
-    if credentials is None:
-        raise GuardSyncNotConfiguredError("Guard is not logged in.")
+    auth_context = _resolve_guard_sync_auth_context(store)
     workspace_id = store.get_cloud_workspace_id()
     if workspace_id is None:
         raise GuardSyncNotConfiguredError("Guard Cloud workspace is not connected.")
-    bundle_url = _normalized_supply_chain_bundle_url(str(credentials["sync_url"]), workspace_id)
-    headers = _guard_sync_headers(str(credentials["token"]))
-    headers["Accept-Encoding"] = "identity"
+    bundle_url = _normalized_supply_chain_bundle_url(str(auth_context["sync_url"]), workspace_id)
     cached_bundle = store.get_cached_supply_chain_bundle(workspace_id)
     cached_bundle_version = None
     if isinstance(cached_bundle, dict):
@@ -1156,7 +1175,7 @@ def sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
         partition_sync: dict[str, object] | None = _sync_supply_chain_bundle_incremental(
             bundle_url=bundle_url,
             cached_bundle_version=cached_bundle_version,
-            headers=headers,
+            auth_context=auth_context,
             store=store,
             trusted_keys=trusted_keys,
             workspace_id=workspace_id,
@@ -1177,7 +1196,16 @@ def sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
             )
         except SupplyChainBundleError:
             try:
-                request = urllib.request.Request(bundle_url, method="GET", headers=headers)
+                request = urllib.request.Request(
+                    bundle_url,
+                    method="GET",
+                    headers=_guard_sync_headers(
+                        auth_context,
+                        request_url=bundle_url,
+                        method="GET",
+                        extra_headers={"Accept-Encoding": "identity"},
+                    ),
+                )
                 payload = _fetch_supply_chain_bundle_payload(request)
                 response = load_supply_chain_bundle_response(payload)
                 verify_supply_chain_bundle_response(
@@ -1188,7 +1216,16 @@ def sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
             except (RuntimeError, SupplyChainBundleError) as error:
                 raise RuntimeError(f"Guard supply-chain bundle sync failed: {error}") from error
     else:
-        request = urllib.request.Request(bundle_url, method="GET", headers=headers)
+        request = urllib.request.Request(
+            bundle_url,
+            method="GET",
+            headers=_guard_sync_headers(
+                auth_context,
+                request_url=bundle_url,
+                method="GET",
+                extra_headers={"Accept-Encoding": "identity"},
+            ),
+        )
         payload = _fetch_supply_chain_bundle_payload(request)
         try:
             response = load_supply_chain_bundle_response(payload)
@@ -1251,10 +1288,8 @@ def sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
 def sync_guard_events(store: GuardStore) -> dict[str, object]:
     """Push pending GuardEventV1 envelopes to Guard Cloud."""
 
-    credentials = store.get_sync_credentials()
-    if credentials is None:
-        raise GuardSyncNotConfiguredError("Guard is not logged in.")
-    sync_url = _guard_events_sync_url(str(credentials["sync_url"]))
+    auth_context = _resolve_guard_sync_auth_context(store)
+    sync_url = _guard_events_sync_url(auth_context["sync_url"])
     previous_summary = store.get_sync_payload("guard_events_v1_summary")
     total_events = 0
     total_accepted = 0
@@ -1275,7 +1310,7 @@ def sync_guard_events(store: GuardStore) -> dict[str, object]:
             sync_url,
             data=body,
             method="POST",
-            headers=_guard_sync_headers(str(credentials["token"])),
+            headers=_guard_sync_headers(auth_context, request_url=sync_url, method="POST"),
         )
         try:
             payload = _urlopen_json_with_timeout_retry(
@@ -1405,17 +1440,15 @@ def sync_runtime_session(
 ) -> dict[str, object]:
     """Publish the active Guard runtime session so the dashboard can show the machine immediately."""
 
-    credentials = store.get_sync_credentials()
-    if credentials is None:
-        raise GuardSyncNotConfiguredError("Guard is not logged in.")
-    sync_url = _normalized_runtime_sessions_sync_url(str(credentials["sync_url"]))
+    auth_context = _resolve_guard_sync_auth_context(store)
+    sync_url = _normalized_runtime_sessions_sync_url(auth_context["sync_url"])
     session_payload = _cloud_runtime_session_payload(store, session)
     body = json.dumps({"session": session_payload}).encode("utf-8")
     request = urllib.request.Request(
         sync_url,
         data=body,
         method="POST",
-        headers=_guard_sync_headers(str(credentials["token"])),
+        headers=_guard_sync_headers(auth_context, request_url=sync_url, method="POST"),
     )
     try:
         payload = _urlopen_json_with_timeout_retry(
@@ -1475,10 +1508,11 @@ def sync_runtime_session(
 
 
 def sync_pain_signals(store: GuardStore) -> int:
-    credentials = store.get_sync_credentials()
-    if credentials is None:
+    try:
+        auth_context = _resolve_guard_sync_auth_context(store)
+    except GuardSyncNotConfiguredError:
         return 0
-    normalized_sync_url = _normalized_receipts_sync_url(str(credentials["sync_url"]))
+    normalized_sync_url = _normalized_receipts_sync_url(auth_context["sync_url"])
     cursor_payload = store.get_sync_payload("pain_signal_cursor")
     last_event_id = _last_uploaded_event_id(cursor_payload)
     uploaded_count = 0
@@ -1509,7 +1543,11 @@ def sync_pain_signals(store: GuardStore) -> int:
                 _pain_signal_sync_url(normalized_sync_url),
                 data=json.dumps({"items": signal_items}).encode("utf-8"),
                 method="POST",
-                headers=_guard_sync_headers(str(credentials["token"])),
+                headers=_guard_sync_headers(
+                    auth_context,
+                    request_url=_pain_signal_sync_url(normalized_sync_url),
+                    method="POST",
+                ),
             )
             try:
                 _urlopen_with_timeout_retry(
@@ -1607,13 +1645,240 @@ def _build_remote_policy_decisions(payload: dict[str, object]) -> list[PolicyDec
     return decisions
 
 
-def _guard_sync_headers(token: str) -> dict[str, str]:
+def _base64url_encode(data: bytes) -> str:
+    return urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def _base64url_decode(data: str) -> bytes:
+    padding = "=" * (-len(data) % 4)
+    return urlsafe_b64decode(f"{data}{padding}")
+
+
+def _encode_jwt_segment(payload: dict[str, object]) -> str:
+    return _base64url_encode(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+
+
+def _sign_guard_dpop_proof(
+    *,
+    request_url: str,
+    method: str,
+    dpop_key_material: GuardDpopKeyMaterial,
+    access_token: str | None = None,
+    now: datetime | None = None,
+) -> str:
+    issued_at = int((now or datetime.now(timezone.utc)).timestamp())
+    header = {
+        "alg": dpop_key_material.algorithm,
+        "jwk": dpop_key_material.public_jwk,
+        "typ": "dpop+jwt",
+    }
+    claims: dict[str, object] = {
+        "htu": request_url,
+        "htm": method.upper(),
+        "iat": issued_at,
+        "jti": str(uuid4()),
+    }
+    if isinstance(access_token, str) and access_token:
+        claims["ath"] = _base64url_encode(hashlib.sha256(access_token.encode("ascii")).digest())
+    signing_input = f"{_encode_jwt_segment(header)}.{_encode_jwt_segment(claims)}".encode("ascii")
+    private_key = serialization.load_pem_private_key(
+        dpop_key_material.private_key_pem.encode("ascii"),
+        password=None,
+    )
+    if not isinstance(private_key, ec.EllipticCurvePrivateKey):
+        raise RuntimeError("Guard DPoP key must be an EC private key.")
+    der_signature = private_key.sign(signing_input, ec.ECDSA(hashes.SHA256()))
+    r_value, s_value = decode_dss_signature(der_signature)
+    jose_signature = _base64url_encode(r_value.to_bytes(32, byteorder="big") + s_value.to_bytes(32, byteorder="big"))
+    return f"{signing_input.decode('ascii')}.{jose_signature}"
+
+
+def _oauth_refresh_error_message(error: urllib.error.HTTPError) -> str:
+    try:
+        raw_body = error.read().decode("utf-8")
+    except OSError:
+        raw_body = ""
+    try:
+        payload = json.loads(raw_body) if raw_body else None
+    except json.JSONDecodeError:
+        payload = None
+    if isinstance(payload, dict):
+        description = _optional_string(payload.get("error_description"))
+        if description is not None:
+            return description
+        error_code = _optional_string(payload.get("error"))
+        if error_code is not None:
+            return error_code
+    return _sync_http_error_message(error)
+
+
+def _guard_oauth_reauthorization_message() -> str:
+    return "Guard authorization expired. Run `hol-guard connect` to sign in again."
+
+
+def _refresh_guard_oauth_access_token(
+    *,
+    token_endpoint: str,
+    client_id: str,
+    refresh_token: str,
+    dpop_key_material: GuardDpopKeyMaterial,
+) -> dict[str, object]:
+    request_body = urllib.parse.urlencode(
+        {
+            "grant_type": "refresh_token",
+            "client_id": client_id,
+            "refresh_token": refresh_token,
+        }
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        token_endpoint,
+        data=request_body,
+        method="POST",
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
+            "DPoP": _sign_guard_dpop_proof(
+                request_url=token_endpoint,
+                method="POST",
+                dpop_key_material=dpop_key_material,
+            ),
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=_SYNC_HTTP_TIMEOUT_SECONDS) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        raise GuardSyncAuthorizationExpiredError(
+            f"{_guard_oauth_reauthorization_message()} {_oauth_refresh_error_message(error)}"
+        ) from error
+    except OSError as error:
+        raise RuntimeError(_sync_url_error_message(error)) from error
+    if not isinstance(payload, dict):
+        raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
+    access_token = _optional_string(payload.get("access_token"))
+    token_type = _optional_string(payload.get("token_type"))
+    if access_token is None or token_type is None or token_type.lower() != "bearer":
+        raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
     return {
-        "Authorization": f"Bearer {token}",
+        "access_token": access_token,
+        "refresh_token": _optional_string(payload.get("refresh_token")) or refresh_token,
+    }
+
+
+def _oauth_sync_url_from_issuer(issuer: str) -> str:
+    oauth_client = resolve_guard_oauth_client_config(issuer)
+    return f"{oauth_client.issuer}/api/guard/receipts/sync"
+
+
+def _oauth_dpop_key_material(credentials: dict[str, object]) -> GuardDpopKeyMaterial:
+    dpop_private_key_pem = _optional_string(credentials.get("dpop_private_key_pem"))
+    dpop_public_jwk = credentials.get("dpop_public_jwk")
+    dpop_public_jwk_thumbprint = _optional_string(credentials.get("dpop_public_jwk_thumbprint"))
+    if dpop_private_key_pem is None or not isinstance(dpop_public_jwk, dict) or dpop_public_jwk_thumbprint is None:
+        raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
+    return GuardDpopKeyMaterial(
+        algorithm="ES256",
+        private_key_pem=dpop_private_key_pem,
+        public_jwk={str(key): str(value) for key, value in dpop_public_jwk.items()},
+        public_jwk_thumbprint=dpop_public_jwk_thumbprint,
+    )
+
+
+def _persist_rotated_oauth_refresh_token(
+    *,
+    store: GuardStore,
+    credentials: dict[str, object],
+    refresh_token: str,
+) -> None:
+    issuer = _optional_string(credentials.get("issuer"))
+    client_id = _optional_string(credentials.get("client_id"))
+    dpop_private_key_pem = _optional_string(credentials.get("dpop_private_key_pem"))
+    dpop_public_jwk = credentials.get("dpop_public_jwk")
+    dpop_public_jwk_thumbprint = _optional_string(credentials.get("dpop_public_jwk_thumbprint"))
+    if (
+        issuer is None
+        or client_id is None
+        or dpop_private_key_pem is None
+        or not isinstance(dpop_public_jwk, dict)
+        or dpop_public_jwk_thumbprint is None
+    ):
+        raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
+    store.set_oauth_local_credentials(
+        issuer=issuer,
+        client_id=client_id,
+        refresh_token=refresh_token,
+        dpop_private_key_pem=dpop_private_key_pem,
+        dpop_public_jwk={str(key): str(value) for key, value in dpop_public_jwk.items()},
+        dpop_public_jwk_thumbprint=dpop_public_jwk_thumbprint,
+        grant_id=_optional_string(credentials.get("grant_id")),
+        machine_id=_optional_string(credentials.get("machine_id")),
+        workspace_id=_optional_string(credentials.get("workspace_id")),
+        now=_now(),
+    )
+
+
+def _resolve_guard_sync_auth_context(store: GuardStore) -> dict[str, object]:
+    oauth_credentials = store.get_oauth_local_credentials()
+    if oauth_credentials is not None:
+        issuer = _optional_string(oauth_credentials.get("issuer"))
+        client_id = _optional_string(oauth_credentials.get("client_id"))
+        refresh_token = _optional_string(oauth_credentials.get("refresh_token"))
+        if issuer is None or client_id is None or refresh_token is None:
+            raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
+        dpop_key_material = _oauth_dpop_key_material(oauth_credentials)
+        refreshed = _refresh_guard_oauth_access_token(
+            token_endpoint=resolve_guard_oauth_client_config(issuer).token_endpoint,
+            client_id=client_id,
+            refresh_token=refresh_token,
+            dpop_key_material=dpop_key_material,
+        )
+        rotated_refresh_token = str(refreshed["refresh_token"])
+        if rotated_refresh_token != refresh_token:
+            _persist_rotated_oauth_refresh_token(
+                store=store,
+                credentials=oauth_credentials,
+                refresh_token=rotated_refresh_token,
+            )
+        return {
+            "sync_url": _oauth_sync_url_from_issuer(issuer),
+            "access_token": str(refreshed["access_token"]),
+            "dpop_key_material": dpop_key_material,
+        }
+    credentials = store.get_sync_credentials()
+    if credentials is None:
+        raise GuardSyncNotConfiguredError("Guard is not logged in.")
+    return {
+        "sync_url": str(credentials["sync_url"]),
+        "access_token": str(credentials["token"]),
+        "dpop_key_material": None,
+    }
+
+
+def _guard_sync_headers(
+    auth_context: dict[str, object],
+    *,
+    request_url: str,
+    method: str,
+    extra_headers: dict[str, str] | None = None,
+) -> dict[str, str]:
+    access_token = str(auth_context["access_token"])
+    headers = {
+        "Authorization": f"Bearer {access_token}",
         "Content-Type": "application/json",
         "Accept": "application/json",
         "User-Agent": _GUARD_SYNC_USER_AGENT,
     }
+    dpop_key_material = auth_context.get("dpop_key_material")
+    if isinstance(dpop_key_material, GuardDpopKeyMaterial):
+        headers["DPoP"] = _sign_guard_dpop_proof(
+            request_url=request_url,
+            method=method,
+            dpop_key_material=dpop_key_material,
+            access_token=access_token,
+        )
+    if isinstance(extra_headers, dict):
+        headers.update(extra_headers)
+    return headers
 
 
 def _sync_http_error_message(error: urllib.error.HTTPError) -> str:

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -37,8 +37,10 @@ from .package_manifest_diff import (
     parse_manifest_dependencies,
 )
 from .runner import (
+    GuardSyncNotConfiguredError,
     _guard_sync_headers,
     _normalized_receipts_sync_url,
+    _resolve_guard_sync_auth_context,
     _urlopen_json_with_timeout_retry,
 )
 from .supply_chain import detect_supply_chain_risk
@@ -567,9 +569,11 @@ def _evaluate_with_cloud(
 ) -> tuple[PackageRequestEvaluation | None, dict[str, object] | None]:
     if workspace_id is None or workspace_fingerprint is None:
         return None, None
-    sync_credentials = store.get_sync_credentials()
-    if sync_credentials is None:
+    try:
+        auth_context = _resolve_guard_sync_auth_context(store)
+    except GuardSyncNotConfiguredError:
         return None, None
+    evaluate_url = _normalized_supply_chain_evaluate_url(auth_context["sync_url"], workspace_id)
     request_payload = _build_request_payload(
         artifact=artifact,
         targets=targets,
@@ -578,9 +582,9 @@ def _evaluate_with_cloud(
         policy_version=bundle_meta["policy_hash"] if bundle_meta is not None else "local:none",
     )
     request = urllib.request.Request(
-        _normalized_supply_chain_evaluate_url(sync_credentials["sync_url"], workspace_id),
+        evaluate_url,
         data=json.dumps(request_payload).encode("utf-8"),
-        headers=_guard_sync_headers(sync_credentials["token"]),
+        headers=_guard_sync_headers(auth_context, request_url=evaluate_url, method="POST"),
         method="POST",
     )
     fail_closed_decision = _cloud_fail_closed_decision(store=store, workspace_dir=workspace_dir)

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -3207,12 +3207,21 @@ class GuardStore:
     @staticmethod
     def _cloud_workspace_id_from_connection(connection: sqlite3.Connection) -> str | None:
         row = connection.execute("select payload_json from sync_state where state_key = 'credentials'").fetchone()
-        if row is None:
+        if row is not None:
+            payload = json.loads(str(row["payload_json"]))
+            if isinstance(payload, dict):
+                workspace_id = payload.get("workspace_id")
+                if isinstance(workspace_id, str) and workspace_id.strip():
+                    return workspace_id
+        oauth_row = connection.execute(
+            "select payload_json from sync_state where state_key = 'oauth_local_credentials'"
+        ).fetchone()
+        if oauth_row is None:
             return None
-        payload = json.loads(str(row["payload_json"]))
-        if not isinstance(payload, dict):
+        oauth_payload = json.loads(str(oauth_row["payload_json"]))
+        if not isinstance(oauth_payload, dict):
             return None
-        workspace_id = payload.get("workspace_id")
+        workspace_id = oauth_payload.get("workspace_id")
         if isinstance(workspace_id, str) and workspace_id.strip():
             return workspace_id
         return None

--- a/tests/test_guard_approval_gate.py
+++ b/tests/test_guard_approval_gate.py
@@ -1244,8 +1244,8 @@ def test_approval_gate_background_remote_policy_sync_fails_closed_without_crashi
         "_guard_device_metadata",
         lambda _store: ("device-1", "MacBook Pro"),
     )
-    monkeypatch.setattr(guard_runner_module, "sync_pain_signals", lambda _store: 0)
-    monkeypatch.setattr(guard_runner_module, "sync_guard_events", lambda _store: 0)
+    monkeypatch.setattr(guard_runner_module, "sync_pain_signals", lambda _store, auth_context=None: 0)
+    monkeypatch.setattr(guard_runner_module, "sync_guard_events", lambda _store, auth_context=None: 0)
 
     class _Response:
         def __enter__(self):

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -7904,6 +7904,25 @@ url = http://127.0.0.1:8787/guard-canary
         assert "Guard Cloud is not connected yet." in stderr
         assert "Run `hol-guard connect`" in stderr
 
+    def test_guard_sync_surfaces_auth_expired_reauth_message(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+
+        def _fail_sync(_store: GuardStore) -> dict[str, object]:
+            raise guard_commands_module.GuardSyncAuthorizationExpiredError(
+                "Guard authorization expired. Run `hol-guard connect` to sign in again."
+            )
+
+        monkeypatch.setattr(guard_commands_module, "sync_receipts", _fail_sync)
+
+        rc = main(["guard", "sync", "--home", str(home_dir), "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 1
+        assert output == {
+            "synced": False,
+            "error": "Guard authorization expired. Run `hol-guard connect` to sign in again.",
+        }
+
     def test_guard_sync_reports_remote_sync_errors_in_json_mode(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         _SyncRequestHandler.response_code = 403

--- a/tests/test_guard_oauth_client.py
+++ b/tests/test_guard_oauth_client.py
@@ -62,6 +62,15 @@ def test_build_pkce_s256_challenge_matches_known_vector() -> None:
     assert challenge == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
 
 
+def test_build_pkce_s256_challenge_rejects_invalid_characters() -> None:
+    try:
+        build_pkce_s256_challenge("invalid verifier with spaces")
+    except ValueError as error:
+        assert "unsupported characters" in str(error)
+    else:
+        raise AssertionError("PKCE challenge builder must reject invalid verifier characters")
+
+
 def test_generate_dpop_key_pair_returns_es256_material() -> None:
     material = generate_dpop_key_pair()
 

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -15385,7 +15385,7 @@ def test_sync_receipts_preserves_batch_metadata_and_reuses_device_metadata(tmp_p
         "_guard_device_metadata",
         lambda _store: metadata_calls.append(True) or ("device-1", "MacBook Pro"),
     )
-    monkeypatch.setattr(guard_runner_module, "sync_pain_signals", lambda _store: 0)
+    monkeypatch.setattr(guard_runner_module, "sync_pain_signals", lambda _store, auth_context=None: 0)
 
     sync_payloads = iter(
         [
@@ -15651,7 +15651,7 @@ def test_sync_runtime_session_refreshes_oauth_access_token_and_rotates_refresh_t
                 {
                     "access_token": "oauth-access-token-1",
                     "refresh_token": "refresh-token-2",
-                    "token_type": "Bearer",
+                    "token_type": "DPoP",
                     "expires_in": 3600,
                 }
             )
@@ -15783,10 +15783,55 @@ def test_sync_receipts_uses_distinct_dpop_proofs_per_batch(tmp_path, monkeypatch
 
     payload = guard_runner_module.sync_receipts(store)
 
-    assert len(token_requests) >= 1
+    assert len(token_requests) == 1
     assert len(receipt_dpop_headers) >= 2
     assert receipt_dpop_headers[0] != receipt_dpop_headers[1]
     assert payload["receipts_stored"] == 51
+
+
+def test_sync_pain_signals_raises_when_oauth_refresh_is_revoked(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token-1",
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id="workspace-1",
+        now="2026-06-01T00:00:00+00:00",
+    )
+
+    class _ErrorResponse:
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "error": "invalid_grant",
+                    "error_description": "refresh token revoked",
+                }
+            ).encode("utf-8")
+
+        def close(self) -> None:
+            return None
+
+    def _fake_urlopen(request, timeout):
+        raise urllib.error.HTTPError(
+            request.full_url,
+            400,
+            "Bad Request",
+            hdrs=None,
+            fp=_ErrorResponse(),
+        )
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+
+    with pytest.raises(guard_runner_module.GuardSyncAuthorizationExpiredError) as error:
+        guard_runner_module.sync_pain_signals(store)
+
+    assert "hol-guard connect" in str(error.value)
 
 
 def test_codex_read_only_source_inspection_rejects_globbed_targets(tmp_path: Path) -> None:

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -24,6 +24,7 @@ from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.approvals import apply_approval_resolution
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
 from codex_plugin_scanner.guard.cli import render as guard_render_module
+from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
 from codex_plugin_scanner.guard.cli.render import emit_guard_payload
 from codex_plugin_scanner.guard.config import GuardConfig, load_guard_config
 from codex_plugin_scanner.guard.consumer import artifact_hash, evaluate_detection
@@ -59,6 +60,14 @@ def _write_json(path: Path, payload: dict[str, object]) -> None:
 def _write_text(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
+
+
+def _request_header(request: urllib.request.Request, name: str) -> str | None:
+    expected = name.lower()
+    for header_name, header_value in request.headers.items():
+        if header_name.lower() == expected:
+            return header_value
+    return None
 
 
 def _isolate_git_config(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -15597,6 +15606,187 @@ def test_sync_runtime_session_retries_once_after_read_timeout(tmp_path, monkeypa
 
     assert timeouts == [10, 90]
     assert payload["runtime_session_id"] == "session-read-timeout"
+
+
+def test_sync_runtime_session_refreshes_oauth_access_token_and_rotates_refresh_token(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token-1",
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id="workspace-1",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    captured_requests: list[urllib.request.Request] = []
+
+    class _Response:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(self._payload).encode("utf-8")
+
+    def _fake_urlopen(request, timeout):
+        captured_requests.append(request)
+        if request.full_url == "https://hol.org/api/guard/oauth/token":
+            assert request.get_method() == "POST"
+            body = urllib.parse.parse_qs(request.data.decode("utf-8"))
+            assert body["grant_type"] == ["refresh_token"]
+            assert body["client_id"] == ["guard-local-daemon"]
+            assert body["refresh_token"] == ["refresh-token-1"]
+            assert isinstance(_request_header(request, "DPoP"), str) and _request_header(request, "DPoP")
+            return _Response(
+                {
+                    "access_token": "oauth-access-token-1",
+                    "refresh_token": "refresh-token-2",
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                }
+            )
+        assert request.full_url == "https://hol.org/api/guard/runtime/sessions/sync"
+        assert _request_header(request, "Authorization") == "Bearer oauth-access-token-1"
+        assert isinstance(_request_header(request, "DPoP"), str) and _request_header(request, "DPoP")
+        return _Response(
+            {
+                "generatedAt": "2026-06-01T00:00:10+00:00",
+                "items": [{"sessionId": "session-oauth"}],
+            }
+        )
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+
+    payload = guard_runner_module.sync_runtime_session(
+        store,
+        session={
+            "session_id": "session-oauth",
+            "harness": "codex",
+            "surface": "cli",
+            "status": "active",
+            "client_name": "Codex",
+            "client_title": "Codex CLI",
+            "client_version": "1.0.0",
+            "workspace": "prod",
+            "capabilities": ["chat"],
+            "started_at": "2026-06-01T00:00:00+00:00",
+            "updated_at": "2026-06-01T00:00:00+00:00",
+            "operations": [],
+        },
+    )
+
+    credentials = store.get_oauth_local_credentials()
+
+    assert [request.full_url for request in captured_requests] == [
+        "https://hol.org/api/guard/oauth/token",
+        "https://hol.org/api/guard/runtime/sessions/sync",
+    ]
+    assert payload["runtime_session_id"] == "session-oauth"
+    assert credentials is not None
+    assert credentials["refresh_token"] == "refresh-token-2"
+
+
+def test_sync_receipts_uses_distinct_dpop_proofs_per_batch(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token-1",
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id="workspace-1",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    for index in range(51):
+        store.add_receipt(
+            GuardReceipt(
+                receipt_id=f"receipt-{index}",
+                timestamp="2026-06-01T00:00:00+00:00",
+                harness="codex",
+                artifact_id=f"artifact-{index}",
+                artifact_hash=f"sha256:{index:064x}",
+                policy_decision="review",
+                capabilities_summary="requests file write",
+                changed_capabilities=("fs_write",),
+                provenance_summary="local codex workspace",
+                artifact_name=f"artifact-{index}",
+                source_scope="workspace",
+            )
+        )
+    token_requests: list[urllib.request.Request] = []
+    receipt_dpop_headers: list[str] = []
+
+    class _Response:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(self._payload).encode("utf-8")
+
+    def _fake_urlopen(request, timeout):
+        if request.full_url == "https://hol.org/api/guard/oauth/token":
+            token_requests.append(request)
+            return _Response(
+                {
+                    "access_token": "oauth-access-token-1",
+                    "refresh_token": "refresh-token-1",
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                }
+            )
+        dpop_header = _request_header(request, "DPoP")
+        assert isinstance(dpop_header, str) and dpop_header
+        receipt_dpop_headers.append(dpop_header)
+        assert _request_header(request, "Authorization") == "Bearer oauth-access-token-1"
+        payload = json.loads(request.data.decode("utf-8"))
+        if "receipts" not in payload:
+            return _Response(
+                {
+                    "syncedAt": "2026-06-01T00:00:10+00:00",
+                    "accepted": len(payload.get("events", [])),
+                    "events": len(payload.get("events", [])),
+                }
+            )
+        return _Response(
+            {
+                "syncedAt": "2026-06-01T00:00:10+00:00",
+                "receiptsStored": len(payload["receipts"]),
+                "advisories": [],
+                "policy": {},
+                "alertPreferences": {},
+                "teamPolicyPack": {},
+                "exceptions": [],
+            }
+        )
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+
+    payload = guard_runner_module.sync_receipts(store)
+
+    assert len(token_requests) >= 1
+    assert len(receipt_dpop_headers) >= 2
+    assert receipt_dpop_headers[0] != receipt_dpop_headers[1]
+    assert payload["receipts_stored"] == 51
 
 
 def test_codex_read_only_source_inspection_rejects_globbed_targets(tmp_path: Path) -> None:

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import builtins
+import hashlib
 import io
 import json
 import os
@@ -13,6 +14,8 @@ import sys
 import threading
 import urllib.error
 import urllib.request
+from base64 import urlsafe_b64decode
+from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import ClassVar
@@ -68,6 +71,12 @@ def _request_header(request: urllib.request.Request, name: str) -> str | None:
         if header_name.lower() == expected:
             return header_value
     return None
+
+
+def _decode_jwt_segment(segment: str) -> dict[str, object]:
+    padding = "=" * (-len(segment) % 4)
+    decoded = urlsafe_b64decode(f"{segment}{padding}".encode("ascii"))
+    return json.loads(decoded.decode("utf-8"))
 
 
 def _isolate_git_config(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -15696,6 +15705,25 @@ def test_sync_runtime_session_refreshes_oauth_access_token_and_rotates_refresh_t
     assert credentials["refresh_token"] == "refresh-token-2"
 
 
+def test_sign_guard_dpop_proof_sets_access_token_hash_claim() -> None:
+    dpop_key_material = generate_dpop_key_pair()
+    access_token = "oauth-access-token-1"
+
+    proof = guard_runner_module._sign_guard_dpop_proof(
+        request_url="https://hol.org/api/guard/runtime/sessions/sync",
+        method="POST",
+        dpop_key_material=dpop_key_material,
+        access_token=access_token,
+        now=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+
+    claims = _decode_jwt_segment(proof.split(".")[1])
+
+    expected_ath = guard_runner_module._base64url_encode(hashlib.sha256(access_token.encode("ascii")).digest())
+
+    assert claims["ath"] == expected_ath
+
+
 def test_sync_receipts_uses_distinct_dpop_proofs_per_batch(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
     dpop_key_material = generate_dpop_key_pair()
@@ -15832,6 +15860,67 @@ def test_sync_pain_signals_raises_when_oauth_refresh_is_revoked(tmp_path, monkey
         guard_runner_module.sync_pain_signals(store)
 
     assert "hol-guard connect" in str(error.value)
+
+
+def test_sync_runtime_session_treats_token_endpoint_503_as_retryable_error(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token-1",
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id="workspace-1",
+        now="2026-06-01T00:00:00+00:00",
+    )
+
+    class _ErrorResponse:
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "error": "temporarily_unavailable",
+                    "error_description": "oauth upstream down",
+                }
+            ).encode("utf-8")
+
+        def close(self) -> None:
+            return None
+
+    def _fake_urlopen(request, timeout):
+        raise urllib.error.HTTPError(
+            request.full_url,
+            503,
+            "Service Unavailable",
+            hdrs=None,
+            fp=_ErrorResponse(),
+        )
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+
+    with pytest.raises(RuntimeError, match="oauth upstream down") as error:
+        guard_runner_module.sync_runtime_session(
+            store,
+            session={
+                "session_id": "session-oauth",
+                "harness": "codex",
+                "surface": "cli",
+                "status": "active",
+                "client_name": "Codex",
+                "client_title": "Codex CLI",
+                "client_version": "1.0.0",
+                "workspace": "prod",
+                "capabilities": ["chat"],
+                "started_at": "2026-06-01T00:00:00+00:00",
+                "updated_at": "2026-06-01T00:00:00+00:00",
+                "operations": [],
+            },
+        )
+
+    assert not isinstance(error.value, guard_runner_module.GuardSyncAuthorizationExpiredError)
 
 
 def test_codex_read_only_source_inspection_rejects_globbed_targets(tmp_path: Path) -> None:

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -333,6 +333,7 @@ def test_oauth_local_credentials_are_not_persisted_in_plaintext_sqlite(tmp_path)
         "machine_id": "machine-123",
         "workspace_id": "workspace-123",
     }
+    assert store.get_cloud_workspace_id() == "workspace-123"
 
 
 def test_oauth_local_credentials_use_encrypted_file_fallback_when_keychain_write_fails(tmp_path, monkeypatch):

--- a/tests/test_guard_supply_chain_daemon.py
+++ b/tests/test_guard_supply_chain_daemon.py
@@ -6,7 +6,7 @@ import time
 from pathlib import Path
 
 from codex_plugin_scanner.guard.daemon import server as guard_daemon_module
-from codex_plugin_scanner.guard.runtime.runner import GuardSyncNotConfiguredError
+from codex_plugin_scanner.guard.runtime.runner import GuardSyncAuthorizationExpiredError, GuardSyncNotConfiguredError
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -84,3 +84,35 @@ def test_daemon_bundle_refresh_stays_quiet_when_not_configured(
     assert summary["status"] == "not_configured"
     assert store.list_approval_requests() == []
     assert store.list_events(limit=5) == []
+
+
+def test_daemon_bundle_refresh_reports_auth_expired(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+
+    def _fail_sync(_store: GuardStore) -> dict[str, object]:
+        raise GuardSyncAuthorizationExpiredError(
+            "Guard authorization expired. Run `hol-guard connect` to sign in again."
+        )
+
+    monkeypatch.setattr(guard_daemon_module, "sync_supply_chain_bundle", _fail_sync)
+    daemon = guard_daemon_module.GuardDaemonServer(
+        store,
+        host="127.0.0.1",
+        port=0,
+        idle_timeout_seconds=60,
+        bundle_refresh_interval_seconds=0.05,
+        bundle_refresh_backoff_seconds=0.05,
+    )
+    daemon.start()
+    try:
+        time.sleep(0.12)
+    finally:
+        daemon.stop()
+
+    summary = store.get_sync_payload("supply_chain_bundle_daemon")
+    assert isinstance(summary, dict)
+    assert summary["status"] == "auth_expired"
+    assert "hol-guard connect" in str(summary["message"])

--- a/tests/test_guard_supply_chain_daemon.py
+++ b/tests/test_guard_supply_chain_daemon.py
@@ -116,3 +116,33 @@ def test_daemon_bundle_refresh_reports_auth_expired(
     assert isinstance(summary, dict)
     assert summary["status"] == "auth_expired"
     assert "hol-guard connect" in str(summary["message"])
+
+
+def test_daemon_bundle_refresh_reports_retryable_error(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+
+    def _fail_sync(_store: GuardStore) -> dict[str, object]:
+        raise RuntimeError("Guard OAuth token refresh failed: oauth upstream down")
+
+    monkeypatch.setattr(guard_daemon_module, "sync_supply_chain_bundle", _fail_sync)
+    daemon = guard_daemon_module.GuardDaemonServer(
+        store,
+        host="127.0.0.1",
+        port=0,
+        idle_timeout_seconds=60,
+        bundle_refresh_interval_seconds=0.05,
+        bundle_refresh_backoff_seconds=0.05,
+    )
+    daemon.start()
+    try:
+        time.sleep(0.12)
+    finally:
+        daemon.stop()
+
+    summary = store.get_sync_payload("supply_chain_bundle_daemon")
+    assert isinstance(summary, dict)
+    assert summary["status"] == "error"
+    assert "oauth upstream down" in str(summary["error"])


### PR DESCRIPTION
## Summary
- refresh HOL Guard runtime sync calls with OAuth access-token refresh and per-request DPoP proofs when local OAuth credentials are configured
- rotate refreshed OAuth material back into secure local storage, fall back to OAuth workspace metadata, and add regression coverage for runtime sync plus PKCE validation

## Testing
- `python3 -m pytest tests/test_guard_runtime.py tests/test_guard_oauth_client.py tests/test_guard_store_migrations.py -q`
- `ruff check src/codex_plugin_scanner/guard/runtime/runner.py src/codex_plugin_scanner/guard/store.py tests/test_guard_runtime.py tests/test_guard_oauth_client.py tests/test_guard_store_migrations.py`
- `ruff format --check src/codex_plugin_scanner/guard/runtime/runner.py src/codex_plugin_scanner/guard/store.py tests/test_guard_runtime.py tests/test_guard_oauth_client.py tests/test_guard_store_migrations.py`
- `git diff --check`
