### PR TITLE
fix(guard): fail scans without manifests

### DIFF
--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -304,7 +304,7 @@ def build_workspace_audit_payload(
                 "message": "No supported manifests or lockfiles found in this workspace.",
                 "supply_chain": posture,
             },
-            0,
+            1,
         )
     evaluation: dict[str, object]
     source = "local"

--- a/tests/test_guard_local_supply_chain_phase15.py
+++ b/tests/test_guard_local_supply_chain_phase15.py
@@ -426,7 +426,7 @@ def test_guard_supply_chain_scan_uses_manifest_and_lockfile_context(tmp_path: Pa
     assert output["evaluation"]["packages"][0]["name"] == "minimist"
 
 
-def test_guard_supply_chain_scan_without_supported_manifests_returns_zero(tmp_path: Path, capsys) -> None:
+def test_guard_supply_chain_scan_without_supported_manifests_returns_nonzero(tmp_path: Path, capsys) -> None:
     home_dir = tmp_path / "guard-home"
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir()
@@ -451,7 +451,7 @@ def test_guard_supply_chain_scan_without_supported_manifests_returns_zero(tmp_pa
     )
     output = json.loads(capsys.readouterr().out)
 
-    assert rc == 0
+    assert rc == 1
     assert output["manifest_paths"] == []
     assert output["lockfile_paths"] == []
     assert output["message"] == "No supported manifests or lockfiles found in this workspace."


### PR DESCRIPTION
## Summary
- make `hol-guard supply-chain scan` return a nonzero exit when no supported manifest or lockfile is present
- keep the existing JSON payload and friendly message so interactive output stays unchanged while CI no longer passes on an empty scan

## Testing
- `cd /Users/michaelkantor/CascadeProjects/hashgraph-online/hol-guard/.worktrees/fix-sa055-scan-no-manifests-fails && pytest -q tests/test_guard_local_supply_chain_phase15.py -k 'supply_chain_scan_without_supported_manifests_returns_nonzero or guard_supply_chain_scan_uses_manifest_and_lockfile_context'`
