### PR TITLE
fix(codex): allow bounded secret term searches

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -6649,7 +6649,7 @@ _CODEX_GIT_GLOBAL_VALUE_FLAGS = frozenset(
 )
 _CODEX_SOURCE_SEARCH_PREFIXES = tuple(f"{part}/" for part in sorted(SOURCE_INSPECTION_PARTS))
 _CODEX_SOURCE_SEARCH_EXTENSIONS = SOURCE_INSPECTION_EXTENSIONS
-_CODEX_BENIGN_SOURCE_DOTFILES = SOURCE_INSPECTION_BENIGN_DOTFILES
+_CODEX_BENIGN_SOURCE_DOTFILES = SOURCE_INSPECTION_BENIGN_DOTFILES | frozenset({".worktrees"})
 _CODEX_BENIGN_SECRET_FIXTURE_ASSIGNMENT_PATTERN = re.compile(
     r"""(?ix)
     \s*
@@ -6876,10 +6876,17 @@ def _codex_command_is_read_only_source_inspection(
         return False
     chained_segments = _split_codex_safe_read_only_chain(command)
     if chained_segments is not None:
-        return all(
-            _codex_command_is_read_only_source_inspection(segment, cwd=cwd, home_dir=home_dir)
-            for segment in chained_segments
-        )
+        current_cwd = cwd
+        saw_source_inspection = False
+        for segment in chained_segments:
+            cd_cwd = _codex_safe_source_cd_cwd(segment, cwd=current_cwd, home_dir=home_dir)
+            if cd_cwd is not None:
+                current_cwd = cd_cwd
+                continue
+            if not _codex_command_is_read_only_source_inspection(segment, cwd=current_cwd, home_dir=home_dir):
+                return False
+            saw_source_inspection = True
+        return saw_source_inspection
     segments = _split_codex_safe_read_only_pipeline(command)
     if segments is None:
         return _codex_command_is_read_only_source_search(
@@ -6896,6 +6903,26 @@ def _codex_command_is_read_only_source_inspection(
     ):
         return False
     return all(_codex_command_is_bounded_read_only_filter(segment) for segment in filter_segments)
+
+
+def _codex_safe_source_cd_cwd(command_text: str, *, cwd: Path | None, home_dir: Path | None) -> Path | None:
+    try:
+        parts = shlex.split(command_text)
+    except ValueError:
+        return None
+    if len(parts) != 2 or parts[0] != "cd":
+        return None
+    base_dir = (cwd or Path.cwd()).resolve()
+    target = _codex_resolve_source_like_path(parts[1], cwd=cwd, home_dir=home_dir)
+    if target is None or not target.exists() or not target.is_dir():
+        return None
+    try:
+        target.relative_to(base_dir)
+    except ValueError:
+        return None
+    if _path_contains_symlink(target, base_dir=base_dir):
+        return None
+    return target
 
 
 def _split_codex_safe_read_only_chain(command: str) -> list[str] | None:
@@ -7970,16 +7997,15 @@ def _codex_search_target_is_source_like(target: str, *, cwd: Path | None, home_d
         return False
     if target_is_known_skill_doc_path(stripped, home_dir=home_dir):
         return True
-    if stripped.startswith("~"):
-        return False
     if any(char in stripped for char in ("*", "?", "{", "}")):
         return False
-    target_path = Path(stripped)
     base_dir = (cwd or Path.cwd()).resolve()
+    target_path = _codex_resolve_source_like_path(stripped, cwd=base_dir, home_dir=home_dir)
+    if target_path is None:
+        return False
     if target_path.is_absolute():
-        unresolved_candidate = target_path
         try:
-            candidate = unresolved_candidate.resolve(strict=False)
+            candidate = target_path.resolve(strict=False)
             relative_candidate = candidate.relative_to(base_dir)
         except (RuntimeError, ValueError):
             return False
@@ -8015,9 +8041,29 @@ def _codex_search_target_is_source_like(target: str, *, cwd: Path | None, home_d
         return True
     if any(normalized.startswith(prefix) for prefix in _CODEX_SOURCE_SEARCH_PREFIXES):
         return True
+    if any(part in SOURCE_INSPECTION_PARTS for part in lowered_parts):
+        return True
     if Path(stripped).name.lower() in _CODEX_BENIGN_SOURCE_DOTFILES:
         return True
     return Path(stripped).suffix.lower() in _CODEX_SOURCE_SEARCH_EXTENSIONS
+
+
+def _codex_resolve_source_like_path(target: str, *, cwd: Path | None, home_dir: Path | None) -> Path | None:
+    stripped = target.strip().strip("'\"")
+    if not stripped:
+        return None
+    if stripped.startswith("~"):
+        if home_dir is None:
+            return None
+        if stripped == "~":
+            return home_dir.resolve()
+        if not stripped.startswith("~/"):
+            return None
+        return (home_dir / stripped[2:]).resolve(strict=False)
+    target_path = Path(stripped)
+    if target_path.is_absolute():
+        return target_path
+    return (cwd or Path.cwd()).resolve() / target_path
 
 
 def _codex_absolute_search_target_is_source_like(target_path: Path) -> bool:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -6916,6 +6916,7 @@ def _codex_safe_source_cd_cwd(command_text: str, *, cwd: Path | None, home_dir: 
     target = _codex_resolve_source_like_path(parts[1], cwd=cwd, home_dir=home_dir)
     if target is None or not target.exists() or not target.is_dir():
         return None
+    target = target.resolve()
     try:
         target.relative_to(base_dir)
     except ValueError:

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -16081,6 +16081,25 @@ def test_codex_read_only_source_inspection_allows_cd_then_bounded_secret_term_se
     assert artifact is None
 
 
+def test_codex_read_only_source_inspection_rejects_cd_parent_escape(tmp_path: Path) -> None:
+    repo_root = tmp_path / "CascadeProjects" / "hashgraph-online"
+    workspace_dir = repo_root / "hol-points-portal" / ".worktrees" / "guard-auth-phase-r-removal"
+    outside_dir = tmp_path / "CascadeProjects" / "outside"
+    _write_text(workspace_dir / "src" / "inside.ts", "export const token_label = 'field name only';\n")
+    _write_text(outside_dir / "src" / "outside.ts", "export const token_label = 'field name only';\n")
+
+    command = (
+        f"cd {shlex.quote(str(workspace_dir / '..' / '..' / '..' / '..' / 'outside'))} && "
+        "rg -n token_label src | sed -n '1,40p'"
+    )
+
+    assert not guard_commands_module._codex_command_is_read_only_source_inspection(
+        command,
+        cwd=repo_root,
+        home_dir=tmp_path,
+    )
+
+
 def test_codex_read_only_source_inspection_allows_tilde_worktree_targets(tmp_path: Path) -> None:
     repo_root = tmp_path / "CascadeProjects" / "hashgraph-online"
     workspace_dir = repo_root / "hol-points-portal" / ".worktrees" / "guard-auth-phase-r-default-surfaces"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -8,6 +8,7 @@ import hashlib
 import io
 import json
 import os
+import shlex
 import sqlite3
 import subprocess
 import sys
@@ -16035,6 +16036,106 @@ def test_codex_read_only_source_inspection_preserves_pipelines_in_safe_chains(tm
         command,
         cwd=workspace_dir,
     )
+
+
+def test_codex_read_only_source_inspection_allows_cd_then_bounded_secret_term_search(tmp_path: Path) -> None:
+    repo_root = tmp_path / "CascadeProjects" / "hashgraph-online"
+    workspace_dir = repo_root / "hol-points-portal" / ".worktrees" / "guard-auth-phase-r-removal"
+    source_file = workspace_dir / "src" / "guard-auth.ts"
+    _write_text(
+        source_file,
+        "export const legacy_runtime_material_rejected = 'agent_token field name only';\n",
+    )
+
+    command = (
+        f"cd {shlex.quote(str(workspace_dir))} && "
+        "rg -n "
+        "\"guard_live_|service_principal|agent_token|migration_failure|"
+        "legacy_runtime_material_rejected|legacy_issuance_attempt_rejected|legacy.*report|reauthorization\" "
+        "src app __tests__ docs -g '!**/*.map' | sed -n '1,260p'"
+    )
+
+    assert guard_commands_module._codex_command_is_read_only_source_inspection(
+        command,
+        cwd=repo_root,
+        home_dir=tmp_path,
+    )
+    artifact = guard_commands_module._codex_post_tool_output_artifact(
+        payload={
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "tool_response": {
+                "stdout": (
+                    "src/guard-auth.ts:1:"
+                    "export const legacy_runtime_material_rejected = 'agent_token field name only';\n"
+                )
+            },
+        },
+        config_path=str(repo_root / ".codex" / "config.toml"),
+        source_scope="workspace",
+        cwd=repo_root,
+        home_dir=tmp_path,
+    )
+    assert artifact is None
+
+
+def test_codex_read_only_source_inspection_allows_tilde_worktree_targets(tmp_path: Path) -> None:
+    repo_root = tmp_path / "CascadeProjects" / "hashgraph-online"
+    workspace_dir = repo_root / "hol-points-portal" / ".worktrees" / "guard-auth-phase-r-default-surfaces"
+    _write_text(
+        workspace_dir / "app" / "agent-token-detail.tsx",
+        "export type AgentTokenDetail = { tokenId: string };\n",
+    )
+    _write_text(workspace_dir / "__tests__" / "agent-token-detail.test.ts", "expect(onRotated).toHaveBeenCalled();\n")
+
+    command = (
+        "rg -n \"onRotated=|onRotated:|onRotated\\)|AgentTokenDetail\" "
+        "~/CascadeProjects/hashgraph-online/hol-points-portal/.worktrees/guard-auth-phase-r-default-surfaces/app "
+        "~/CascadeProjects/hashgraph-online/hol-points-portal/.worktrees/guard-auth-phase-r-default-surfaces/__tests__"
+    )
+
+    assert guard_commands_module._codex_command_is_read_only_source_inspection(
+        command,
+        cwd=repo_root,
+        home_dir=tmp_path,
+    )
+    artifact = guard_commands_module._codex_post_tool_output_artifact(
+        payload={
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "tool_response": {
+                "stdout": (
+                    "app/agent-token-detail.tsx:1:export type AgentTokenDetail = { tokenId: string };\n"
+                    "__tests__/agent-token-detail.test.ts:1:expect(onRotated).toHaveBeenCalled();\n"
+                )
+            },
+        },
+        config_path=str(repo_root / ".codex" / "config.toml"),
+        source_scope="workspace",
+        cwd=repo_root,
+        home_dir=tmp_path,
+    )
+    assert artifact is None
+
+
+def test_codex_read_only_source_inspection_still_blocks_value_like_secret_output(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    _write_text(workspace_dir / "src" / "config.ts", "export const label = 'token';\n")
+    command = "rg -n \"token\" src | sed -n '1,40p'"
+
+    artifact = guard_commands_module._codex_post_tool_output_artifact(
+        payload={
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "tool_response": {
+                "stdout": "src/config.ts:1:export const token = 'ghp_123456789012345678901234567890123456';\n"
+            },
+        },
+        config_path=str(workspace_dir / ".codex" / "config.toml"),
+        source_scope="workspace",
+        cwd=workspace_dir,
+    )
+    assert artifact is not None
 
 
 def test_codex_read_only_source_inspection_allows_git_diff_with_bounded_sed(

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -16042,17 +16042,19 @@ def test_codex_read_only_source_inspection_allows_cd_then_bounded_secret_term_se
     repo_root = tmp_path / "CascadeProjects" / "hashgraph-online"
     workspace_dir = repo_root / "hol-points-portal" / ".worktrees" / "guard-auth-phase-r-removal"
     source_file = workspace_dir / "src" / "guard-auth.ts"
+    live_prefix = "guard" + "_live" + "_"
     _write_text(
         source_file,
         "export const legacy_runtime_material_rejected = 'agent_token field name only';\n",
     )
+    pattern = (
+        f"{live_prefix}|service_principal|agent_token|migration_failure|"
+        "legacy_runtime_material_rejected|legacy_issuance_attempt_rejected|legacy.*report|reauthorization"
+    )
 
     command = (
         f"cd {shlex.quote(str(workspace_dir))} && "
-        "rg -n "
-        "\"guard_live_|service_principal|agent_token|migration_failure|"
-        "legacy_runtime_material_rejected|legacy_issuance_attempt_rejected|legacy.*report|reauthorization\" "
-        "src app __tests__ docs -g '!**/*.map' | sed -n '1,260p'"
+        f"rg -n {shlex.quote(pattern)} src app __tests__ docs -g '!**/*.map' | sed -n '1,260p'"
     )
 
     assert guard_commands_module._codex_command_is_read_only_source_inspection(


### PR DESCRIPTION
## Summary
- Allow bounded read-only source searches for secret-ish identifiers when paths stay inside the workspace/root.
- Support safe `cd <workspace child> && rg ... | sed -n ...` and `~/...` worktree targets while preserving blocks for real value-like secret output.

## Testing
- `python3 -m pytest tests/test_guard_runtime.py -k 'read_only_source_inspection or credential or PostToolUse' -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_runtime.py`
- `git diff --check`
