### PR TITLE
feat(guard-auth): finish headless device code connect

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -852,6 +852,12 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     connect_parser.add_argument("--connect-url", default=DEFAULT_GUARD_CONNECT_URL, type=_guard_http_url)
     connect_parser.add_argument("--wait-timeout-seconds", type=int, default=180)
     connect_parser.add_argument("--headless", action="store_true")
+    connect_parser.add_argument(
+        "--no-browser",
+        action="store_true",
+        dest="headless",
+        help="Alias for --headless. Start Device Code approval without opening a browser.",
+    )
     connect_parser.add_argument("--json", action="store_true")
 
     sync_parser = guard_subparsers.add_parser("sync", help="Sync receipts to the configured Guard endpoint")
@@ -2361,6 +2367,9 @@ def run_guard_command(
                 connect_url=args.connect_url,
                 open_browser=False,
                 wait_timeout_seconds=int(getattr(args, "wait_timeout_seconds", 180) or 180),
+                announce_copy=None
+                if getattr(args, "json", False)
+                else _announce_guard_device_connect_copy,
             )
             if payload is None:
                 return exit_code
@@ -8760,8 +8769,13 @@ def _run_guard_device_connect_flow(
     *,
     store: GuardStore,
     connect_url: str,
+    announce_copy=None,
 ) -> dict[str, object]:
-    return run_guard_device_connect_command(store=store, connect_url=connect_url)
+    return run_guard_device_connect_command(
+        store=store,
+        connect_url=connect_url,
+        announce_copy=announce_copy,
+    )
 
 
 def _run_guard_browser_connect_flow(
@@ -8783,6 +8797,7 @@ def _build_guard_device_connect_payload(
     connect_url: str,
     open_browser: bool,
     wait_timeout_seconds: int = 180,
+    announce_copy=None,
 ) -> tuple[dict[str, object] | None, int]:
     try:
         payload = (
@@ -8792,7 +8807,11 @@ def _build_guard_device_connect_payload(
                 wait_timeout_seconds=wait_timeout_seconds,
             )
             if open_browser
-            else _run_guard_device_connect_flow(store=store, connect_url=connect_url)
+            else _run_guard_device_connect_flow(
+                store=store,
+                connect_url=connect_url,
+                announce_copy=announce_copy,
+            )
         )
     except json.JSONDecodeError as error:
         print(f"Guard authorization failed: {error}", file=sys.stderr)
@@ -8815,6 +8834,19 @@ def _open_guard_device_next_action(payload: dict[str, object]) -> None:
     target = _optional_string(next_action.get("target"))
     if target is not None:
         payload["browser_opened"] = bool(webbrowser.open(target))
+
+
+def _announce_guard_device_connect_copy(payload: dict[str, object]) -> None:
+    user_code = _optional_string(payload.get("user_code")) or "unknown"
+    target = _optional_string(payload.get("verification_uri_complete")) or _optional_string(
+        payload.get("verification_uri")
+    )
+    if target is None:
+        return
+    print("HOL Guard headless approval")
+    print(f"1. Open {target}")
+    print(f"2. Enter code {user_code}")
+    print("3. Keep this terminal open while HOL Guard waits for approval.")
 
 
 def _manual_guard_login_payload(

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -7,6 +7,7 @@ import http.server
 import json
 import secrets
 import threading
+import time
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass
@@ -37,6 +38,11 @@ DEFAULT_GUARD_DEVICE_SCOPES = (
 CONNECT_COMMAND = "hol-guard connect"
 CONNECT_STATUS_COMMAND = "hol-guard connect status"
 CONNECT_REPAIR_COMMAND = "hol-guard connect repair"
+HEADLESS_CONNECT_COMMAND = "hol-guard connect --headless"
+DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
+DEVICE_CODE_SLOW_DOWN_SECONDS = 5
+HEADLESS_RUNTIME_ID = "hol-guard"
+HEADLESS_RUNTIME_LABEL = "HOL Guard CLI"
 _LOOPBACK_REDIRECT_PATH = "/oauth/callback"
 _LOOPBACK_HOSTS = ("127.0.0.1", "::1")
 _LOOPBACK_PORT_MIN = 49152
@@ -330,6 +336,31 @@ def build_device_authorization_request_body(
     )
 
 
+def _require_string(payload: dict[str, object], key: str) -> str:
+    value = str(payload.get(key) or "").strip()
+    if not value:
+        raise RuntimeError(f"Guard OAuth token exchange failed: missing {key}.")
+    return value
+
+
+def _parse_guard_token_exchange_payload(payload: dict[str, object]) -> GuardOAuthTokenExchangeResult:
+    access_token = _require_string(payload, "access_token")
+    token_type = _require_string(payload, "token_type")
+    if token_type.lower() != "bearer":
+        raise RuntimeError("Guard OAuth token exchange failed: missing access token.")
+    claims = _decode_access_token_claims(access_token)
+    return GuardOAuthTokenExchangeResult(
+        access_token=access_token,
+        refresh_token=str(payload.get("refresh_token") or "").strip() or None,
+        expires_in=int(payload.get("expires_in") or 0),
+        scope=str(payload.get("scope") or "").strip(),
+        token_type=token_type,
+        grant_id=_read_nested_string(claims, "grant", "grantId"),
+        machine_id=_read_nested_string(claims, "machine", "machineId"),
+        workspace_id=_read_nested_string(claims, "workspace", "workspaceId"),
+    )
+
+
 def build_device_authorization_copy_payload(response: dict[str, object]) -> dict[str, object]:
     user_code = str(response.get("user_code") or "").strip()
     verification_uri = str(response.get("verification_uri") or "").strip()
@@ -350,6 +381,30 @@ def build_device_authorization_copy_payload(response: dict[str, object]) -> dict
             "message": f"Open {next_target} and enter code {user_code}.",
         },
     }
+
+
+def _device_token_request_body(*, client_id: str, device_code: str) -> bytes:
+    return urllib.parse.urlencode(
+        {
+            "grant_type": DEVICE_CODE_GRANT_TYPE,
+            "client_id": client_id,
+            "device_code": device_code,
+        }
+    ).encode("utf-8")
+
+
+def _load_error_payload(error: urllib.error.HTTPError) -> dict[str, object] | None:
+    try:
+        raw_body = error.read().decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+    if not raw_body.strip():
+        return None
+    try:
+        payload = json.loads(raw_body)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
 
 
 def device_authorization_endpoint_from_connect_url(connect_url: str) -> str:
@@ -373,6 +428,75 @@ def request_device_authorization(url: str, body: str) -> dict[str, object]:
     if not isinstance(payload, dict):
         raise RuntimeError("Guard Device Code authorization failed: invalid response.")
     return payload
+
+
+def exchange_guard_device_code(
+    *,
+    token_endpoint: str,
+    client_id: str,
+    device_code: str,
+    dpop_key_material: GuardDpopKeyMaterial,
+    interval_seconds: int,
+    expires_in_seconds: int,
+    urlopen=urllib.request.urlopen,
+    sleep=time.sleep,
+    now: datetime | None = None,
+) -> GuardOAuthTokenExchangeResult:
+    deadline = time.monotonic() + max(expires_in_seconds, 1)
+    current_interval = max(interval_seconds, 1)
+    while True:
+        request = urllib.request.Request(
+            token_endpoint,
+            data=_device_token_request_body(client_id=client_id, device_code=device_code),
+            method="POST",
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Accept": "application/json",
+                "DPoP": _sign_dpop_proof(
+                    token_endpoint=token_endpoint,
+                    dpop_key_material=dpop_key_material,
+                    now=now or datetime.now(timezone.utc),
+                ),
+            },
+        )
+        try:
+            with urlopen(request, timeout=20) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as error:
+            payload = _load_error_payload(error)
+            oauth_error = str(payload.get("error") or "").strip() if isinstance(payload, dict) else ""
+            if oauth_error == "authorization_pending":
+                if time.monotonic() >= deadline:
+                    raise RuntimeError(
+                        "Guard OAuth approval timed out. Retry `hol-guard connect --headless` to request a new code."
+                    ) from error
+                sleep(float(current_interval))
+                continue
+            if oauth_error == "slow_down":
+                current_interval = max(current_interval + DEVICE_CODE_SLOW_DOWN_SECONDS, 1)
+                if time.monotonic() >= deadline:
+                    raise RuntimeError(
+                        "Guard OAuth approval timed out. Retry `hol-guard connect --headless` to request a new code."
+                    ) from error
+                sleep(float(current_interval))
+                continue
+            if oauth_error == "expired_token":
+                raise RuntimeError(
+                    "Guard OAuth device approval expired. Retry `hol-guard connect --headless` to request a new code."
+                ) from error
+            if oauth_error in {"access_denied", "authorization_declined"}:
+                raise RuntimeError(
+                    "Guard OAuth approval was denied. Retry `hol-guard connect --headless` to request a new code."
+                ) from error
+            message = (
+                str(payload.get("error_description") or oauth_error or error.reason)
+                if isinstance(payload, dict)
+                else str(error.reason)
+            )
+            raise RuntimeError(f"Guard OAuth token exchange failed: {message}") from error
+        if not isinstance(payload, dict):
+            raise RuntimeError("Guard OAuth token exchange failed: invalid response.")
+        return _parse_guard_token_exchange_payload(payload)
 
 
 def exchange_guard_authorization_code(
@@ -413,21 +537,7 @@ def exchange_guard_authorization_code(
         payload = json.loads(response.read().decode("utf-8"))
     if not isinstance(payload, dict):
         raise RuntimeError("Guard OAuth token exchange failed: invalid response.")
-    access_token = str(payload.get("access_token") or "").strip()
-    token_type = str(payload.get("token_type") or "").strip()
-    if not access_token or token_type.lower() != "bearer":
-        raise RuntimeError("Guard OAuth token exchange failed: missing access token.")
-    claims = _decode_access_token_claims(access_token)
-    return GuardOAuthTokenExchangeResult(
-        access_token=access_token,
-        refresh_token=str(payload.get("refresh_token") or "").strip() or None,
-        expires_in=int(payload.get("expires_in") or 0),
-        scope=str(payload.get("scope") or "").strip(),
-        token_type=token_type,
-        grant_id=_read_nested_string(claims, "grant", "grantId"),
-        machine_id=_read_nested_string(claims, "machine", "machineId"),
-        workspace_id=_read_nested_string(claims, "workspace", "workspaceId"),
-    )
+    return _parse_guard_token_exchange_payload(payload)
 
 
 def run_guard_device_connect_command(
@@ -435,15 +545,20 @@ def run_guard_device_connect_command(
     store: GuardStore,
     connect_url: str,
     request_device_authorization=request_device_authorization,
+    token_urlopen=urllib.request.urlopen,
+    sleep=time.sleep,
+    now: str | None = None,
+    announce_copy=None,
 ) -> dict[str, object]:
     device = store.get_device_metadata()
     _, allowed_origin = resolve_connect_url(connect_url)
     oauth_client = resolve_guard_oauth_client_config(allowed_origin)
+    dpop_key_material = generate_dpop_key_pair()
     request_body = build_device_authorization_request_body(
         machine_id=str(device["installation_id"]),
         machine_label=str(device["device_label"]),
-        runtime_id="hol-guard",
-        runtime_label="HOL Guard CLI",
+        runtime_id=HEADLESS_RUNTIME_ID,
+        runtime_label=HEADLESS_RUNTIME_LABEL,
         client_id=oauth_client.client_id,
     )
     response = request_device_authorization(
@@ -452,6 +567,50 @@ def run_guard_device_connect_command(
     )
     payload = build_device_authorization_copy_payload(response)
     payload["connect_mode"] = "device_code"
+    if announce_copy is not None:
+        announce_copy(payload)
+    device_code = str(response.get("device_code") or "").strip()
+    if not device_code:
+        raise ValueError("Device authorization response is missing device_code.")
+    token_result = exchange_guard_device_code(
+        token_endpoint=oauth_client.token_endpoint,
+        client_id=oauth_client.client_id,
+        device_code=device_code,
+        dpop_key_material=dpop_key_material,
+        interval_seconds=int(response.get("interval") or 5),
+        expires_in_seconds=int(response.get("expires_in") or 0),
+        urlopen=token_urlopen,
+        sleep=sleep,
+        now=datetime.fromisoformat(now) if now else None,
+    )
+    if token_result.refresh_token is None:
+        raise RuntimeError("Guard OAuth token exchange failed: missing refresh token.")
+    timestamp = now or datetime.now(timezone.utc).isoformat()
+    store.set_oauth_local_credentials(
+        issuer=oauth_client.issuer,
+        client_id=oauth_client.client_id,
+        refresh_token=token_result.refresh_token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id=token_result.grant_id,
+        machine_id=token_result.machine_id,
+        workspace_id=token_result.workspace_id,
+        runtime_id=HEADLESS_RUNTIME_ID,
+        runtime_label=HEADLESS_RUNTIME_LABEL,
+        now=timestamp,
+    )
+    payload.update(
+        {
+            "status": "connected",
+            "grant_id": token_result.grant_id,
+            "machine_id": token_result.machine_id,
+            "workspace_id": token_result.workspace_id,
+            "connect_command": CONNECT_COMMAND,
+            "connect_status_command": CONNECT_STATUS_COMMAND,
+            "connect_repair_command": CONNECT_REPAIR_COMMAND,
+        }
+    )
     return payload
 
 
@@ -500,6 +659,8 @@ def run_guard_browser_connect_command(
         grant_id=token_result.grant_id,
         machine_id=token_result.machine_id,
         workspace_id=token_result.workspace_id,
+        runtime_id=HEADLESS_RUNTIME_ID,
+        runtime_label=HEADLESS_RUNTIME_LABEL,
         now=timestamp,
     )
     return {

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -2919,6 +2919,8 @@ class GuardStore:
         grant_id: str | None = None,
         machine_id: str | None = None,
         workspace_id: str | None = None,
+        runtime_id: str | None = None,
+        runtime_label: str | None = None,
     ) -> None:
         refresh_token_hash = _token_sha256(refresh_token)
         dpop_private_key_hash = _token_sha256(dpop_private_key_pem)
@@ -2940,6 +2942,10 @@ class GuardStore:
             payload["machine_id"] = machine_id
         if workspace_id:
             payload["workspace_id"] = workspace_id
+        if runtime_id:
+            payload["runtime_id"] = runtime_id
+        if runtime_label:
+            payload["runtime_label"] = runtime_label
         self._oauth_secret_store.set_secret(refresh_token_ref, refresh_token)
         self._oauth_secret_store.set_secret(dpop_private_key_ref, dpop_private_key_pem)
         self.set_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY, payload, now)
@@ -3009,12 +3015,18 @@ class GuardStore:
         grant_id = payload.get("grant_id")
         machine_id = payload.get("machine_id")
         workspace_id = payload.get("workspace_id")
+        runtime_id = payload.get("runtime_id")
+        runtime_label = payload.get("runtime_label")
         if isinstance(grant_id, str) and grant_id:
             result["grant_id"] = grant_id
         if isinstance(machine_id, str) and machine_id:
             result["machine_id"] = machine_id
         if isinstance(workspace_id, str) and workspace_id:
             result["workspace_id"] = workspace_id
+        if isinstance(runtime_id, str) and runtime_id:
+            result["runtime_id"] = runtime_id
+        if isinstance(runtime_label, str) and runtime_label:
+            result["runtime_label"] = runtime_label
         return result
 
     def get_oauth_local_credential_health(self) -> dict[str, object]:

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -1,4 +1,5 @@
 import base64
+import io
 import json
 import urllib.error
 import urllib.parse
@@ -6,6 +7,7 @@ import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
+from codex_plugin_scanner.cli import _build_parser
 from codex_plugin_scanner.guard.cli import commands as guard_commands
 from codex_plugin_scanner.guard.cli import connect_flow
 from codex_plugin_scanner.guard.cli.commands import run_guard_command
@@ -143,19 +145,47 @@ def test_headless_connect_requests_device_code_without_persisting_secrets(tmp_pa
             "interval": 5,
         }
 
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "access_token": _fake_access_token(
+                        grant_id="grant-123",
+                        machine_id="machine-123",
+                        workspace_id="workspace-123",
+                    ),
+                    "refresh_token": "refresh-123",
+                    "expires_in": 3600,
+                    "scope": "guard:runtime.sync guard:offline_access",
+                    "token_type": "Bearer",
+                }
+            ).encode("utf-8")
+
     payload = connect_flow.run_guard_device_connect_command(
         store=store,
         connect_url="https://hol.org/guard/connect",
         request_device_authorization=fake_request,
+        token_urlopen=lambda request, timeout: _Response(),
+        now="2026-06-01T12:00:00+00:00",
     )
     rendered = json.dumps(payload, sort_keys=True)
+    credentials = store.get_oauth_local_credentials()
 
     assert requests
     assert requests[0][0] == "https://hol.org/api/guard/oauth/device/authorize"
     assert "requested_machine_label=CI+Runner" in requests[0][1]
+    assert payload["status"] == "connected"
     assert payload["user_code"] == "ABCD-EFGH"
     assert "device-secret-value" not in rendered
-    assert store.get_sync_credentials() is None
+    assert credentials is not None
+    assert credentials["refresh_token"] == "refresh-123"
+    assert credentials["runtime_label"] == "HOL Guard CLI"
 
 
 def test_headless_connect_uses_staging_client_defaults(tmp_path: Path) -> None:
@@ -175,15 +205,238 @@ def test_headless_connect_uses_staging_client_defaults(tmp_path: Path) -> None:
             "interval": 5,
         }
 
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "access_token": _fake_access_token(
+                        grant_id="grant-123",
+                        machine_id="machine-123",
+                        workspace_id="workspace-123",
+                    ),
+                    "refresh_token": "refresh-123",
+                    "expires_in": 3600,
+                    "scope": "guard:runtime.sync guard:offline_access",
+                    "token_type": "Bearer",
+                }
+            ).encode("utf-8")
+
     connect_flow.run_guard_device_connect_command(
         store=store,
         connect_url="https://staging.hol.org/guard/connect",
         request_device_authorization=fake_request,
+        token_urlopen=lambda request, timeout: _Response(),
+        now="2026-06-01T12:00:00+00:00",
     )
     parsed = urllib.parse.parse_qs(requests[0][1])
 
     assert requests[0][0] == "https://staging.hol.org/api/guard/oauth/device/authorize"
     assert parsed["client_id"] == ["guard-local-daemon-staging"]
+
+
+def test_headless_connect_polls_until_success_and_persists_oauth_credentials(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    store.set_device_label("CI Runner", "2026-05-31T00:00:00Z")
+    sleeps: list[float] = []
+    token_bodies: list[str] = []
+
+    def fake_request(url: str, body: str) -> dict[str, object]:
+        assert url == "https://hol.org/api/guard/oauth/device/authorize"
+        assert "requested_machine_label=CI+Runner" in body
+        return {
+            "device_code": "device-secret-value",
+            "user_code": "ABCD-EFGH",
+            "verification_uri": "https://hol.org/guard/oauth/device",
+            "verification_uri_complete": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
+            "expires_in": 600,
+            "interval": 3,
+        }
+
+    class _Response:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(self._payload).encode("utf-8")
+
+    attempt = {"count": 0}
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int):
+        token_bodies.append(request.data.decode("utf-8") if request.data else "")
+        attempt["count"] += 1
+        if attempt["count"] == 1:
+            raise urllib.error.HTTPError(
+                request.full_url,
+                400,
+                "authorization_pending",
+                hdrs={"Content-Type": "application/json"},
+                fp=io.BytesIO(json.dumps({"error": "authorization_pending"}).encode("utf-8")),
+            )
+        return _Response(
+            {
+                "access_token": _fake_access_token(
+                    grant_id="grant-123",
+                    machine_id="machine-123",
+                    workspace_id="workspace-123",
+                ),
+                "refresh_token": "refresh-123",
+                "expires_in": 3600,
+                "scope": "guard:runtime.sync guard:offline_access",
+                "token_type": "Bearer",
+            }
+        )
+
+    payload = connect_flow.run_guard_device_connect_command(
+        store=store,
+        connect_url="https://hol.org/guard/connect",
+        request_device_authorization=fake_request,
+        token_urlopen=fake_urlopen,
+        sleep=sleeps.append,
+        now="2026-06-01T12:00:00+00:00",
+    )
+    credentials = store.get_oauth_local_credentials()
+    rendered = json.dumps(payload, sort_keys=True)
+
+    assert payload["status"] == "connected"
+    assert payload["connect_mode"] == "device_code"
+    assert payload["grant_id"] == "grant-123"
+    assert payload["machine_id"] == "machine-123"
+    assert payload["workspace_id"] == "workspace-123"
+    assert payload["user_code"] == "ABCD-EFGH"
+    assert payload["verification_uri"] == "https://hol.org/guard/oauth/device"
+    assert "device-secret-value" not in rendered
+    assert "refresh-123" not in rendered
+    assert "access_token" not in rendered
+    assert sleeps == [3]
+    assert len(token_bodies) == 2
+    assert urllib.parse.parse_qs(token_bodies[0])["grant_type"] == ["urn:ietf:params:oauth:grant-type:device_code"]
+    assert credentials is not None
+    assert credentials["grant_id"] == "grant-123"
+    assert credentials["machine_id"] == "machine-123"
+    assert credentials["workspace_id"] == "workspace-123"
+    assert credentials["refresh_token"] == "refresh-123"
+    assert credentials["runtime_label"] == "HOL Guard CLI"
+
+
+def test_headless_connect_slows_down_polling_when_server_requests_it(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    sleeps: list[float] = []
+
+    def fake_request(_url: str, _body: str) -> dict[str, object]:
+        return {
+            "device_code": "device-secret-value",
+            "user_code": "ABCD-EFGH",
+            "verification_uri": "https://hol.org/guard/oauth/device",
+            "expires_in": 600,
+            "interval": 2,
+        }
+
+    class _Response:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(self._payload).encode("utf-8")
+
+    attempt = {"count": 0}
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int):
+        del timeout
+        attempt["count"] += 1
+        if attempt["count"] == 1:
+            raise urllib.error.HTTPError(
+                request.full_url,
+                400,
+                "slow_down",
+                hdrs={"Content-Type": "application/json"},
+                fp=io.BytesIO(json.dumps({"error": "slow_down"}).encode("utf-8")),
+            )
+        return _Response(
+            {
+                "access_token": _fake_access_token(
+                    grant_id="grant-123",
+                    machine_id="machine-123",
+                    workspace_id="workspace-123",
+                ),
+                "refresh_token": "refresh-123",
+                "expires_in": 3600,
+                "scope": "guard:runtime.sync guard:offline_access",
+                "token_type": "Bearer",
+            }
+        )
+
+    payload = connect_flow.run_guard_device_connect_command(
+        store=store,
+        connect_url="https://hol.org/guard/connect",
+        request_device_authorization=fake_request,
+        token_urlopen=fake_urlopen,
+        sleep=sleeps.append,
+        now="2026-06-01T12:00:00+00:00",
+    )
+
+    assert payload["status"] == "connected"
+    assert sleeps == [7]
+
+
+def test_headless_connect_expired_code_surfaces_retry_command(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+
+    def fake_request(_url: str, _body: str) -> dict[str, object]:
+        return {
+            "device_code": "device-secret-value",
+            "user_code": "ABCD-EFGH",
+            "verification_uri": "https://hol.org/guard/oauth/device",
+            "expires_in": 600,
+            "interval": 2,
+        }
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int):
+        del timeout
+        raise urllib.error.HTTPError(
+            request.full_url,
+            400,
+            "expired_token",
+            hdrs={"Content-Type": "application/json"},
+            fp=io.BytesIO(json.dumps({"error": "expired_token"}).encode("utf-8")),
+        )
+
+    try:
+        connect_flow.run_guard_device_connect_command(
+            store=store,
+            connect_url="https://hol.org/guard/connect",
+            request_device_authorization=fake_request,
+            token_urlopen=fake_urlopen,
+            now="2026-06-01T12:00:00+00:00",
+        )
+    except RuntimeError as error:
+        message = str(error)
+    else:
+        raise AssertionError("expired device code must raise a retry-safe runtime error")
+
+    assert "hol-guard connect --headless" in message
+    assert "device-secret-value" not in message
+    assert store.get_oauth_local_credentials() is None
 
 
 def test_login_token_alias_rejects_raw_token_without_persisting_credentials(tmp_path: Path, capsys) -> None:
@@ -222,9 +475,17 @@ def test_connect_headless_emits_device_code_payload_without_pairing_secret(tmp_p
     args = _HeadlessConnectArgs()
     args.guard_home = str(guard_home)
 
-    def fake_headless_flow(*, store: GuardStore, connect_url: str) -> dict[str, object]:
+    def fake_headless_flow(*, store: GuardStore, connect_url: str, announce_copy=None) -> dict[str, object]:
+        if announce_copy is not None:
+            announce_copy(
+                {
+                    "user_code": "ABCD-EFGH",
+                    "verification_uri": "https://hol.org/guard/oauth/device",
+                    "verification_uri_complete": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
+                }
+            )
         return {
-            "status": "waiting_for_approval",
+            "status": "connected",
             "connect_mode": "device_code",
             "user_code": "ABCD-EFGH",
             "verification_uri": "https://hol.org/guard/oauth/device",
@@ -244,6 +505,16 @@ def test_connect_headless_emits_device_code_payload_without_pairing_secret(tmp_p
     assert "guardPairSecret" not in captured.out
     assert "guardPairRequest" not in captured.out
     assert "guard_live_" not in captured.out
+
+
+def test_connect_no_browser_alias_uses_headless_device_code_flow(tmp_path: Path, capsys, monkeypatch) -> None:
+    guard_home = tmp_path / "guard-home"
+
+    parser = _build_parser("hol-guard", program_mode="guard")
+    args = parser.parse_args(["connect", "--no-browser", "--home", str(guard_home), "--json"])
+
+    assert args.guard_command == "connect"
+    assert args.headless is True
 
 
 def test_connect_default_uses_browser_oauth_without_pairing_secret(tmp_path: Path, capsys, monkeypatch) -> None:
@@ -541,7 +812,8 @@ def test_connect_headless_reports_device_authorization_network_error(tmp_path: P
     args = _HeadlessConnectArgs()
     args.guard_home = str(guard_home)
 
-    def failing_headless_flow(*, store: GuardStore, connect_url: str) -> dict[str, object]:
+    def failing_headless_flow(*, store: GuardStore, connect_url: str, announce_copy=None) -> dict[str, object]:
+        del announce_copy
         raise urllib.error.URLError("network unavailable")
 
     monkeypatch.setattr(guard_commands, "_run_guard_device_connect_flow", failing_headless_flow)
@@ -559,7 +831,8 @@ def test_connect_headless_reports_malformed_device_authorization_response(tmp_pa
     args = _HeadlessConnectArgs()
     args.guard_home = str(guard_home)
 
-    def failing_headless_flow(*, store: GuardStore, connect_url: str) -> dict[str, object]:
+    def failing_headless_flow(*, store: GuardStore, connect_url: str, announce_copy=None) -> dict[str, object]:
+        del announce_copy
         raise json.JSONDecodeError("invalid json", "not-json", 0)
 
     monkeypatch.setattr(guard_commands, "_run_guard_device_connect_flow", failing_headless_flow)


### PR DESCRIPTION
## Summary
- complete `hol-guard connect --headless` so Device Code approval polls to token success, persists OAuth credentials, and handles pending/slow_down/expired/denied states safely
- add the `--no-browser` alias plus safe headless approval copy, and persist runtime metadata alongside the stored OAuth grant
- expand Guard OAuth device-connect regression coverage for success, polling backoff, expiry, redaction, and CLI parsing

## Testing
- `python3 -m pytest tests/test_guard_oauth_client.py tests/test_guard_oauth_device_connect.py tests/test_guard_connect_flow.py -q`
- `ruff check src/codex_plugin_scanner/guard/cli/connect_flow.py src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/store.py tests/test_guard_oauth_device_connect.py`
- `ruff format --check src/codex_plugin_scanner/guard/cli/connect_flow.py src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/store.py tests/test_guard_oauth_device_connect.py`
- `git diff --check`

## Notes
- This slice covers the headless Device Code connect path in `hol-guard`; the portal auth ledger/evidence sync will follow after merge.
