### PR TITLE
fix(guard): cap websocket handshake headers

### DIFF
--- a/src/codex_plugin_scanner/guard/codex_app_server.py
+++ b/src/codex_plugin_scanner/guard/codex_app_server.py
@@ -25,6 +25,7 @@ class _OperationStore(Protocol):
 _DEFAULT_PROXY_TIMEOUT_SECONDS = 5.0
 _DEFAULT_COMPLETION_TIMEOUT_SECONDS = 90.0
 _DEFAULT_SOCKET_PATH = Path.home() / ".codex" / "app-server-control" / "app-server-control.sock"
+_MAX_WEBSOCKET_HEADER_BYTES = 16_384
 _MAX_WEBSOCKET_FRAME_BYTES = 1_000_000
 _WEBSOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 _THREAD_ID_KEYS = (
@@ -444,7 +445,11 @@ def _send_websocket_handshake(client: socket.socket) -> bytes:
         "\r\n"
     )
     client.sendall(request.encode("ascii"))
-    response, leftover = _recv_until(client, b"\r\n\r\n")
+    response, leftover = _recv_until(
+        client,
+        b"\r\n\r\n",
+        max_bytes=_MAX_WEBSOCKET_HEADER_BYTES,
+    )
     header_text = response.decode("iso-8859-1", errors="replace")
     if not header_text.startswith("HTTP/1.1 101"):
         raise ValueError("websocket_upgrade_failed")
@@ -490,12 +495,19 @@ def _read_websocket_frame(client: socket.socket, pending: bytearray) -> tuple[in
     return opcode, payload
 
 
-def _recv_until(client: socket.socket, marker: bytes) -> tuple[bytes, bytes]:
+def _recv_until(
+    client: socket.socket,
+    marker: bytes,
+    *,
+    max_bytes: int | None = None,
+) -> tuple[bytes, bytes]:
     data = b""
     while marker not in data:
         chunk = client.recv(4096)
         if not chunk:
             raise _WebSocketClosedError("socket_closed")
+        if max_bytes is not None and len(data) + len(chunk) > max_bytes:
+            raise ValueError("websocket_headers_too_large")
         data += chunk
     boundary = data.index(marker) + len(marker)
     return data[:boundary], data[boundary:]

--- a/tests/test_guard_codex_app_server.py
+++ b/tests/test_guard_codex_app_server.py
@@ -14,8 +14,32 @@ class _UnexpectedRecvSocket:
         raise AssertionError("oversized websocket frame should be rejected before payload read")
 
 
+class _OversizedHandshakeSocket:
+    def __init__(self, chunk: bytes) -> None:
+        self._chunk = chunk
+        self.sent = b""
+
+    def sendall(self, payload: bytes) -> None:
+        self.sent += payload
+
+    def recv(self, _size: int) -> bytes:
+        chunk, self._chunk = self._chunk, b""
+        return chunk
+
+
 def test_read_websocket_frame_rejects_oversized_payload_before_reading() -> None:
     pending = bytearray(bytes([0x81, 0x7F]) + struct.pack("!Q", codex_app_server_module._MAX_WEBSOCKET_FRAME_BYTES + 1))
 
     with pytest.raises(ValueError, match="websocket_frame_too_large"):
         codex_app_server_module._read_websocket_frame(_UnexpectedRecvSocket(), pending)
+
+
+def test_send_websocket_handshake_rejects_oversized_headers_before_marker() -> None:
+    oversized_header_bytes = 128_000
+    socket = _OversizedHandshakeSocket(
+        b"HTTP/1.1 101 Switching Protocols\r\n"
+        + (b"A" * oversized_header_bytes)
+    )
+
+    with pytest.raises(ValueError, match="websocket_headers_too_large"):
+        codex_app_server_module._send_websocket_handshake(socket)

--- a/tests/test_guard_codex_app_server.py
+++ b/tests/test_guard_codex_app_server.py
@@ -36,10 +36,10 @@ def test_read_websocket_frame_rejects_oversized_payload_before_reading() -> None
 
 def test_send_websocket_handshake_rejects_oversized_headers_before_marker() -> None:
     oversized_header_bytes = 128_000
-    socket = _OversizedHandshakeSocket(
+    mock_socket = _OversizedHandshakeSocket(
         b"HTTP/1.1 101 Switching Protocols\r\n"
         + (b"A" * oversized_header_bytes)
     )
 
     with pytest.raises(ValueError, match="websocket_headers_too_large"):
-        codex_app_server_module._send_websocket_handshake(socket)
+        codex_app_server_module._send_websocket_handshake(mock_socket)


### PR DESCRIPTION
## Summary
- cap Codex app-server websocket handshake headers before the CRLF terminator to prevent unbounded local buffering
- add a focused regression test for oversized handshake responses while preserving the existing frame-size bound

## Testing
- `python3 -m pytest tests/test_guard_codex_app_server.py`
- `python3 -m pytest tests/test_guard_codex_app_server.py tests/test_guard_queue_api_contract.py`
