### PR TITLE
fix(guard-auth): retire legacy CLI sync upgrades

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -8963,6 +8963,11 @@ def _guard_service_login_payload(
                 "Hosted runtime token login is retired. "
                 f"Run `{headless_command}` or `{browser_command}` instead."
             ),
+            "service": {
+                "runtime": runtime,
+                "label": label,
+                "workspace": workspace or None,
+            },
         }, 2
     return {
         "logged_in": False,

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -8950,18 +8950,13 @@ def _guard_service_login_payload(
 ) -> tuple[dict[str, object], int]:
     runtime = str(args.runtime)
     label = str(args.label).strip()
-    workspace = _optional_string(args.workspace) or ""
+    workspace = _optional_string(getattr(args, "workspace", None)) or ""
     if getattr(args, "token", None) is not None:
-        headless_command = "hol-guard connect --headless"
-        browser_command = "hol-guard connect"
-        if workspace:
-            headless_command = f"{headless_command} --workspace {workspace}"
-            browser_command = f"{browser_command} --workspace {workspace}"
         return {
             "logged_in": False,
             "error": (
                 "Hosted runtime token login is retired. "
-                f"Run `{headless_command}` or `{browser_command}` instead."
+                "Run `hol-guard connect --headless` or `hol-guard connect` instead."
             ),
             "service": {
                 "runtime": runtime,

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -939,7 +939,7 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
 
     service_login_parser = service_subparsers.add_parser(
         "login",
-        help="Save a hosted-runtime Guard Cloud token and runtime profile",
+        help="Redirect to `hol-guard connect`; pasted hosted-runtime tokens are retired",
     )
     _add_guard_common_args(service_login_parser)
     service_login_parser.add_argument("--runtime", choices=_SERVICE_RUNTIME_CHOICES, required=True)
@@ -8905,7 +8905,7 @@ def _manual_guard_login_payload(
     if manual_token is None:
         return None
     print(
-        "Raw Guard tokens are no longer accepted. Run `hol-guard connect` to sign in with OAuth Device Code.",
+        "Manual token login is retired. Run `hol-guard connect` to sign in with OAuth Device Code.",
         file=sys.stderr,
     )
     return None, 2
@@ -8952,18 +8952,17 @@ def _guard_service_login_payload(
     label = str(args.label).strip()
     workspace = _optional_string(args.workspace) or ""
     if getattr(args, "token", None) is not None:
+        headless_command = "hol-guard connect --headless"
+        browser_command = "hol-guard connect"
+        if workspace:
+            headless_command = f"{headless_command} --workspace {workspace}"
+            browser_command = f"{browser_command} --workspace {workspace}"
         return {
             "logged_in": False,
-            "error": "Raw hosted-runtime Guard tokens are no longer accepted.",
-            "next_action": {
-                "command": "hol-guard connect --headless",
-                "message": "Use OAuth Device Code to connect headless or hosted runtimes.",
-            },
-            "service": {
-                "runtime": runtime,
-                "label": label,
-                "workspace": workspace or None,
-            },
+            "error": (
+                "Hosted runtime token login is retired. "
+                f"Run `{headless_command}` or `{browser_command}` instead."
+            ),
         }, 2
     return {
         "logged_in": False,
@@ -8980,10 +8979,7 @@ def _guard_service_login_payload(
 
 
 def _guard_service_sync_prerequisite_message() -> str:
-    return (
-        "Hosted Guard runtime is not configured yet. Run `hol-guard connect --headless` "
-        "to approve this runtime with OAuth Device Code first."
-    )
+    return "Hosted Guard runtime is not configured yet. Run `hol-guard connect` first."
 
 
 def _guard_service_sync_failure_message(error: GuardSyncNotConfiguredError) -> str:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -2863,47 +2863,19 @@ class GuardStore:
         sync_url = payload.get("sync_url")
         if not isinstance(sync_url, str):
             return None
-        workspace_id = payload.get("workspace_id")
-        normalized_workspace_id = workspace_id if isinstance(workspace_id, str) and workspace_id.strip() else None
         token_reference = payload.get("token_ref")
         if isinstance(token_reference, str) and token_reference:
+            if token_reference != self._sync_token_ref:
+                return None
             expected_hash = payload.get(_SYNC_TOKEN_HASH_KEY)
             expected_hash_value = expected_hash if isinstance(expected_hash, str) and expected_hash else None
 
-            reference_candidates = [self._sync_token_ref]
-            if token_reference != self._sync_token_ref:
-                reference_candidates.append(token_reference)
-
-            for secret_ref in reference_candidates:
-                for token in self._get_secret_candidates(self._secret_store, secret_ref, expected_hash_value):
-                    if expected_hash_value is not None and _token_sha256(token) != expected_hash_value:
-                        continue
-                    if token_reference != self._sync_token_ref:
-                        now = _now()
-                        with self._connect() as connection:
-                            self._set_sync_credentials_in_connection(
-                                connection,
-                                sync_url,
-                                token,
-                                now,
-                                workspace_id=normalized_workspace_id,
-                            )
-                    else:
-                        self._promote_secret_to_primary(self._secret_store, secret_ref, token)
-                    return {"sync_url": sync_url, "token": token}
+            for token in self._get_secret_candidates(self._secret_store, self._sync_token_ref, expected_hash_value):
+                if expected_hash_value is not None and _token_sha256(token) != expected_hash_value:
+                    continue
+                self._promote_secret_to_primary(self._secret_store, self._sync_token_ref, token)
+                return {"sync_url": sync_url, "token": token}
             return None
-        legacy_token = payload.get("token")
-        if isinstance(legacy_token, str) and legacy_token:
-            now = _now()
-            with self._connect() as connection:
-                self._set_sync_credentials_in_connection(
-                    connection,
-                    sync_url,
-                    legacy_token,
-                    now,
-                    workspace_id=normalized_workspace_id,
-                )
-            return {"sync_url": sync_url, "token": legacy_token}
         return None
 
     def set_oauth_local_credentials(

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6791,6 +6791,42 @@ url = http://127.0.0.1:8787/guard-canary
         assert payload["receipts"]["receipts_stored"] == 2
         assert payload["connection"]["sync_url"] == "https://hol.org/api/guard/receipts/sync"
 
+    def test_guard_service_status_ignores_inline_legacy_sync_token(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        store = GuardStore(home_dir)
+        now = "2026-05-01T00:00:00Z"
+        store.set_sync_payload(
+            "credentials",
+            {
+                "sync_url": "https://hol.org/api/guard/receipts/sync",
+                "token": "guard_live_secretvalue",
+            },
+            now,
+        )
+        store.set_sync_payload(
+            "service_runtime_profile",
+            {
+                "runtime": "hermes",
+                "label": "Hermes Telegram agent",
+                "workspace": "workspace_ops",
+                "surface": "agent-sdk",
+                "client_name": "hol-guard",
+                "client_title": "Hermes Telegram agent",
+                "client_version": "2.0.0",
+            },
+            now,
+        )
+
+        status_rc = main(["guard", "service", "status", "--home", str(home_dir), "--json"])
+        payload = json.loads(capsys.readouterr().out)
+
+        assert status_rc == 0
+        assert payload["configured"] is False
+        assert payload["connection"] == {
+            "configured": False,
+            "sync_url": None,
+        }
+
     def test_guard_connect_reports_browser_authorization_errors_cleanly(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6537,6 +6537,11 @@ url = http://127.0.0.1:8787/guard-canary
                 "Run `hol-guard connect --headless --workspace workspace_ops` "
                 "or `hol-guard connect --workspace workspace_ops` instead."
             ),
+            "service": {
+                "runtime": "hermes",
+                "label": "Hermes Telegram agent",
+                "workspace": "workspace_ops",
+            },
         }
         assert store.get_sync_credentials() is None
         assert store.get_sync_payload("service_runtime_profile") is None
@@ -6602,6 +6607,11 @@ url = http://127.0.0.1:8787/guard-canary
                 "Run `hol-guard connect --headless --workspace workspace_ops` "
                 "or `hol-guard connect --workspace workspace_ops` instead."
             ),
+            "service": {
+                "runtime": "hermes",
+                "label": "Hermes Telegram agent",
+                "workspace": "workspace_ops",
+            },
         }
         assert store.get_sync_credentials() is None
 

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6478,8 +6478,9 @@ url = http://127.0.0.1:8787/guard-canary
         assert login_output["workspace_id"] == "workspace-456"
         assert store.get_sync_credentials() is None
 
-    def test_guard_login_manual_mode_requires_sync_url_and_token(self, tmp_path, capsys):
+    def test_guard_login_rejects_manual_token_mode_and_redirects_to_connect(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
+        store = GuardStore(home_dir)
 
         login_rc = main(
             [
@@ -6487,16 +6488,24 @@ url = http://127.0.0.1:8787/guard-canary
                 "login",
                 "--home",
                 str(home_dir),
+                "--sync-url",
+                "https://hol.org/api/guard/receipts/sync",
                 "--token",
                 "demo-token",
             ]
         )
+        stderr = capsys.readouterr().err
 
         assert login_rc == 2
-        assert "Raw Guard tokens are no longer accepted" in capsys.readouterr().err
+        assert "Manual token login is retired." in stderr
+        assert "Run `hol-guard connect`" in stderr
+        assert store.get_sync_credentials() is None
+        assert store.list_events(event_name="sign_in") == []
 
-    def test_guard_service_login_rejects_hosted_runtime_token(self, tmp_path, capsys):
+    def test_guard_service_login_rejects_pasted_token_and_redirects_to_connect(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
+        store = GuardStore(home_dir)
+        original_device_metadata = store.get_device_metadata()
 
         login_rc = main(
             [
@@ -6514,24 +6523,24 @@ url = http://127.0.0.1:8787/guard-canary
                 "--sync-url",
                 "https://hol.org/api/guard/receipts/sync",
                 "--token",
-                "legacy-bearer-secretvalue",
+                "guard_live_secretvalue",
                 "--json",
             ]
         )
         payload = json.loads(capsys.readouterr().out)
-        store = GuardStore(home_dir)
 
         assert login_rc == 2
-        assert payload["logged_in"] is False
-        assert payload["next_action"]["command"] == "hol-guard connect --headless"
-        assert "legacy-bearer-secretvalue" not in json.dumps(payload)
-        assert payload["service"] == {
-            "runtime": "hermes",
-            "label": "Hermes Telegram agent",
-            "workspace": "workspace_ops",
+        assert payload == {
+            "logged_in": False,
+            "error": (
+                "Hosted runtime token login is retired. "
+                "Run `hol-guard connect --headless --workspace workspace_ops` "
+                "or `hol-guard connect --workspace workspace_ops` instead."
+            ),
         }
         assert store.get_sync_credentials() is None
         assert store.get_sync_payload("service_runtime_profile") is None
+        assert store.get_device_metadata() == original_device_metadata
 
     def test_guard_service_login_without_token_points_to_headless_connect(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -6586,10 +6595,36 @@ url = http://127.0.0.1:8787/guard-canary
         store = GuardStore(home_dir)
 
         assert login_rc == 2
-        assert payload["logged_in"] is False
-        assert payload["error"] == "Raw hosted-runtime Guard tokens are no longer accepted."
-        assert payload["next_action"]["command"] == "hol-guard connect --headless"
+        assert payload == {
+            "logged_in": False,
+            "error": (
+                "Hosted runtime token login is retired. "
+                "Run `hol-guard connect --headless --workspace workspace_ops` "
+                "or `hol-guard connect --workspace workspace_ops` instead."
+            ),
+        }
         assert store.get_sync_credentials() is None
+
+    def test_guard_service_sync_prerequisite_points_to_guard_connect(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+
+        sync_rc = main(
+            [
+                "guard",
+                "service",
+                "sync",
+                "--home",
+                str(home_dir),
+                "--json",
+            ]
+        )
+        payload = json.loads(capsys.readouterr().out)
+
+        assert sync_rc == 1
+        assert payload == {
+            "synced": False,
+            "error": "Hosted Guard runtime is not configured yet. Run `hol-guard connect` first.",
+        }
 
     def test_guard_service_sync_publishes_runtime_session_before_receipts(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6534,8 +6534,7 @@ url = http://127.0.0.1:8787/guard-canary
             "logged_in": False,
             "error": (
                 "Hosted runtime token login is retired. "
-                "Run `hol-guard connect --headless --workspace workspace_ops` "
-                "or `hol-guard connect --workspace workspace_ops` instead."
+                "Run `hol-guard connect --headless` or `hol-guard connect` instead."
             ),
             "service": {
                 "runtime": "hermes",
@@ -6604,8 +6603,7 @@ url = http://127.0.0.1:8787/guard-canary
             "logged_in": False,
             "error": (
                 "Hosted runtime token login is retired. "
-                "Run `hol-guard connect --headless --workspace workspace_ops` "
-                "or `hol-guard connect --workspace workspace_ops` instead."
+                "Run `hol-guard connect --headless` or `hol-guard connect` instead."
             ),
             "service": {
                 "runtime": "hermes",

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -42,7 +42,7 @@ def test_sync_credentials_are_not_persisted_in_plaintext_sqlite(tmp_path):
     }
 
 
-def test_legacy_plaintext_sync_payload_is_migrated_on_read(tmp_path):
+def test_legacy_plaintext_sync_payload_is_rejected_on_read(tmp_path):
     store = GuardStore(tmp_path / "guard-home")
     with sqlite3.connect(store.path) as connection:
         connection.execute(
@@ -63,19 +63,18 @@ def test_legacy_plaintext_sync_payload_is_migrated_on_read(tmp_path):
         )
 
     credentials = store.get_sync_credentials()
-    assert credentials == {
-        "sync_url": "https://hol.org/api/guard/receipts/sync",
-        "token": "legacy-token",
-    }
+    assert credentials is None
 
     with sqlite3.connect(store.path) as connection:
         row = connection.execute("select payload_json from sync_state where state_key = 'credentials'").fetchone()
 
     payload = json.loads(str(row[0])) if row is not None else {}
-    assert "token" not in payload
-    assert isinstance(payload.get("token_ref"), str)
-    assert str(payload["token_ref"]).startswith("guard-cloud-token:")
-    assert isinstance(payload.get("token_sha256"), str)
+    assert payload == {
+        "sync_url": "https://hol.org/api/guard/receipts/sync",
+        "token": "legacy-token",
+    }
+    assert "token_ref" not in payload
+    assert "token_sha256" not in payload
 
 
 def test_sync_credentials_are_scoped_per_guard_home(tmp_path):
@@ -105,7 +104,7 @@ def test_sync_credentials_are_scoped_per_guard_home(tmp_path):
     }
 
 
-def test_legacy_token_reference_is_migrated_to_scoped_reference(tmp_path):
+def test_legacy_token_reference_is_rejected_on_read(tmp_path):
     store = GuardStore(tmp_path / "guard-home")
     legacy_token = "legacy-token-ref"
     legacy_ref = "guard-cloud-token"
@@ -130,16 +129,13 @@ def test_legacy_token_reference_is_migrated_to_scoped_reference(tmp_path):
         )
 
     credentials = store.get_sync_credentials()
-    assert credentials == {
-        "sync_url": "https://hol.org/api/guard/receipts/sync",
-        "token": legacy_token,
-    }
-    assert store._secret_store.get_secret(store._sync_token_ref) == legacy_token
+    assert credentials is None
+    assert store._secret_store.get_secret(store._sync_token_ref) is None
 
     with sqlite3.connect(store.path) as connection:
         row = connection.execute("select payload_json from sync_state where state_key = 'credentials'").fetchone()
     payload = json.loads(str(row[0])) if row is not None else {}
-    assert payload["token_ref"] == store._sync_token_ref
+    assert payload["token_ref"] == legacy_ref
 
 
 def test_sync_token_rotation_with_same_url_clears_cloud_sync_payloads(tmp_path):


### PR DESCRIPTION
## Summary
- retire the remaining legacy CLI sync-credential upgrade paths so `hol-guard connect` is the only reauth path
- collapse pasted-token login and hosted-runtime login responses to redirect-only guidance and fail closed on legacy inline sync credential state
- update CLI and store regressions for the retired legacy bearer paths

## Testing
- `python3 -m pytest tests/test_guard_store_migrations.py -q`
- `python3 -m pytest tests/test_guard_cli.py -k 'login_rejects_manual_token_mode or service_login_rejects_pasted_token or service_login_rejects_blank_token or service_login_without_token_points_to_headless_connect or service_sync_prerequisite_points_to_guard_connect or service_sync_publishes_runtime_session_before_receipts or service_sync_preserves_empty_workspace or service_status_reports_hosted_runtime_state' -q`
- `ruff check src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/store.py tests/test_guard_cli.py tests/test_guard_store_migrations.py`
- `ruff format --check src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/store.py tests/test_guard_cli.py tests/test_guard_store_migrations.py`
- `git diff --check`
