### PR TITLE
feat(guard): add ci-safe headless connect

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2367,6 +2367,11 @@ def run_guard_command(
             )
             _emit("connect", payload, getattr(args, "json", False))
             return 0
+        try:
+            ci_safe, machine_label = _guard_ci_safe_connect_options(args)
+        except ValueError as error:
+            print(str(error), file=sys.stderr)
+            return 2
         if not bool(getattr(args, "headless", False)):
             payload, exit_code = _build_guard_device_connect_payload(
                 store=store,
@@ -2379,11 +2384,6 @@ def run_guard_command(
             _emit("connect", payload, getattr(args, "json", False))
             return exit_code
         if bool(getattr(args, "headless", False)):
-            try:
-                ci_safe, machine_label = _guard_ci_safe_connect_options(args)
-            except ValueError as error:
-                print(str(error), file=sys.stderr)
-                return 2
             payload, exit_code = _build_guard_device_connect_payload(
                 store=store,
                 connect_url=args.connect_url,
@@ -8888,26 +8888,22 @@ def _build_guard_device_connect_payload(
                 wait_timeout_seconds=wait_timeout_seconds,
             )
         elif open_device_browser:
-            headless_kwargs: dict[str, object] = {
-                "store": store,
-                "connect_url": connect_url,
-                "announce_copy": announce_copy,
-                "open_browser": webbrowser.open,
-            }
-            if ci_safe or machine_label is not None:
-                headless_kwargs["ci_safe"] = ci_safe
-                headless_kwargs["machine_label"] = machine_label
-            payload = _run_guard_device_connect_flow(**headless_kwargs)
+            payload = _run_guard_device_connect_flow(
+                store=store,
+                connect_url=connect_url,
+                announce_copy=announce_copy,
+                open_browser=webbrowser.open,
+                ci_safe=ci_safe,
+                machine_label=machine_label,
+            )
         else:
-            headless_kwargs = {
-                "store": store,
-                "connect_url": connect_url,
-                "announce_copy": announce_copy,
-            }
-            if ci_safe or machine_label is not None:
-                headless_kwargs["ci_safe"] = ci_safe
-                headless_kwargs["machine_label"] = machine_label
-            payload = _run_guard_device_connect_flow(**headless_kwargs)
+            payload = _run_guard_device_connect_flow(
+                store=store,
+                connect_url=connect_url,
+                announce_copy=announce_copy,
+                ci_safe=ci_safe,
+                machine_label=machine_label,
+            )
     except json.JSONDecodeError as error:
         print(f"Guard authorization failed: {error}", file=sys.stderr)
         return None, 1

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -853,6 +853,18 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     connect_parser.add_argument("--wait-timeout-seconds", type=int, default=180)
     connect_parser.add_argument("--headless", action="store_true")
     connect_parser.add_argument(
+        "--ci-safe",
+        action="store_true",
+        help=(
+            "Use restricted headless OAuth scopes and require explicit workspace metadata "
+            "for CI or hosted automation."
+        ),
+    )
+    connect_parser.add_argument(
+        "--label",
+        help="With --ci-safe, require an explicit label for the CI or hosted runtime being connected.",
+    )
+    connect_parser.add_argument(
         "--open-browser",
         action="store_true",
         help="With --headless, open the Device Code approval page before waiting for approval.",
@@ -2367,6 +2379,11 @@ def run_guard_command(
             _emit("connect", payload, getattr(args, "json", False))
             return exit_code
         if bool(getattr(args, "headless", False)):
+            try:
+                ci_safe, machine_label = _guard_ci_safe_connect_options(args)
+            except ValueError as error:
+                print(str(error), file=sys.stderr)
+                return 2
             payload, exit_code = _build_guard_device_connect_payload(
                 store=store,
                 connect_url=args.connect_url,
@@ -2376,6 +2393,8 @@ def run_guard_command(
                 announce_copy=None
                 if getattr(args, "json", False)
                 else _announce_guard_device_connect_copy,
+                ci_safe=ci_safe,
+                machine_label=machine_label,
             )
             if payload is None:
                 return exit_code
@@ -8824,12 +8843,16 @@ def _run_guard_device_connect_flow(
     connect_url: str,
     announce_copy=None,
     open_browser: Callable[[str], bool] | None = None,
+    ci_safe: bool = False,
+    machine_label: str | None = None,
 ) -> dict[str, object]:
     return run_guard_device_connect_command(
         store=store,
         connect_url=connect_url,
         announce_copy=announce_copy,
         open_browser=open_browser,
+        ci_safe=ci_safe,
+        machine_label=machine_label,
     )
 
 
@@ -8854,6 +8877,8 @@ def _build_guard_device_connect_payload(
     open_device_browser: bool = False,
     wait_timeout_seconds: int = 180,
     announce_copy=None,
+    ci_safe: bool = False,
+    machine_label: str | None = None,
 ) -> tuple[dict[str, object] | None, int]:
     try:
         if use_browser_oauth:
@@ -8863,18 +8888,26 @@ def _build_guard_device_connect_payload(
                 wait_timeout_seconds=wait_timeout_seconds,
             )
         elif open_device_browser:
-            payload = _run_guard_device_connect_flow(
-                store=store,
-                connect_url=connect_url,
-                announce_copy=announce_copy,
-                open_browser=webbrowser.open,
-            )
+            headless_kwargs: dict[str, object] = {
+                "store": store,
+                "connect_url": connect_url,
+                "announce_copy": announce_copy,
+                "open_browser": webbrowser.open,
+            }
+            if ci_safe or machine_label is not None:
+                headless_kwargs["ci_safe"] = ci_safe
+                headless_kwargs["machine_label"] = machine_label
+            payload = _run_guard_device_connect_flow(**headless_kwargs)
         else:
-            payload = _run_guard_device_connect_flow(
-                store=store,
-                connect_url=connect_url,
-                announce_copy=announce_copy,
-            )
+            headless_kwargs = {
+                "store": store,
+                "connect_url": connect_url,
+                "announce_copy": announce_copy,
+            }
+            if ci_safe or machine_label is not None:
+                headless_kwargs["ci_safe"] = ci_safe
+                headless_kwargs["machine_label"] = machine_label
+            payload = _run_guard_device_connect_flow(**headless_kwargs)
     except json.JSONDecodeError as error:
         print(f"Guard authorization failed: {error}", file=sys.stderr)
         return None, 1
@@ -8898,6 +8931,21 @@ def _announce_guard_device_connect_copy(payload: dict[str, object]) -> None:
     print(f"1. Open {target}")
     print(f"2. Enter code {user_code}")
     print("3. Keep this terminal open while HOL Guard waits for approval.")
+
+
+def _guard_ci_safe_connect_options(args: argparse.Namespace) -> tuple[bool, str | None]:
+    ci_safe = bool(getattr(args, "ci_safe", False))
+    if not ci_safe:
+        return False, None
+    if not bool(getattr(args, "headless", False)):
+        raise ValueError("Guard CI-safe connect requires --headless.")
+    workspace = _optional_string(getattr(args, "workspace", None))
+    if workspace is None:
+        raise ValueError("Guard CI-safe headless connect requires --workspace.")
+    label = _optional_string(getattr(args, "label", None))
+    if label is None:
+        raise ValueError("Guard CI-safe headless connect requires --label.")
+    return True, label
 
 
 def _manual_guard_login_payload(
@@ -8968,11 +9016,19 @@ def _guard_service_login_payload(
                 "workspace": workspace or None,
             },
         }, 2
+    next_command = "hol-guard connect --headless"
+    next_message = "Use OAuth Device Code to connect headless or hosted runtimes."
+    if workspace:
+        next_command = (
+            "hol-guard connect --headless --ci-safe "
+            f"--workspace {shlex.quote(workspace)} --label {shlex.quote(label)}"
+        )
+        next_message = "Use CI-safe OAuth Device Code to connect a hosted runtime with explicit workspace metadata."
     return {
         "logged_in": False,
         "next_action": {
-            "command": "hol-guard connect --headless",
-            "message": "Use OAuth Device Code to connect headless or hosted runtimes.",
+            "command": next_command,
+            "message": next_message,
         },
         "service": {
             "runtime": runtime,

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -35,6 +35,10 @@ DEFAULT_GUARD_DEVICE_SCOPES = (
     "guard:runtime.session.write",
     "guard:offline_access",
 )
+CI_SAFE_GUARD_DEVICE_SCOPES = (
+    "guard:runtime.sync",
+    "guard:offline_access",
+)
 CONNECT_COMMAND = "hol-guard connect"
 CONNECT_STATUS_COMMAND = "hol-guard connect status"
 CONNECT_REPAIR_COMMAND = "hol-guard connect repair"
@@ -336,6 +340,10 @@ def build_device_authorization_request_body(
     )
 
 
+def _resolve_guard_device_scopes(*, ci_safe: bool) -> tuple[str, ...]:
+    return CI_SAFE_GUARD_DEVICE_SCOPES if ci_safe else DEFAULT_GUARD_DEVICE_SCOPES
+
+
 def _require_string(payload: dict[str, object], key: str) -> str:
     value = str(payload.get(key) or "").strip()
     if not value:
@@ -550,17 +558,21 @@ def run_guard_device_connect_command(
     now: str | None = None,
     announce_copy=None,
     open_browser=None,
+    ci_safe: bool = False,
+    machine_label: str | None = None,
 ) -> dict[str, object]:
     device = store.get_device_metadata()
     _, allowed_origin = resolve_connect_url(connect_url)
     oauth_client = resolve_guard_oauth_client_config(allowed_origin)
     dpop_key_material = generate_dpop_key_pair()
+    resolved_machine_label = machine_label.strip() if isinstance(machine_label, str) else ""
     request_body = build_device_authorization_request_body(
         machine_id=str(device["installation_id"]),
-        machine_label=str(device["device_label"]),
+        machine_label=resolved_machine_label or str(device["device_label"]),
         runtime_id=HEADLESS_RUNTIME_ID,
         runtime_label=HEADLESS_RUNTIME_LABEL,
         client_id=oauth_client.client_id,
+        scopes=_resolve_guard_device_scopes(ci_safe=ci_safe),
     )
     response = request_device_authorization(
         oauth_client.device_authorization_endpoint,

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6546,7 +6546,7 @@ url = http://127.0.0.1:8787/guard-canary
         assert store.get_sync_payload("service_runtime_profile") is None
         assert store.get_device_metadata() == original_device_metadata
 
-    def test_guard_service_login_without_token_points_to_headless_connect(self, tmp_path, capsys):
+    def test_guard_service_login_without_token_points_to_ci_safe_headless_connect(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
 
         login_rc = main(
@@ -6569,7 +6569,10 @@ url = http://127.0.0.1:8787/guard-canary
         store = GuardStore(home_dir)
 
         assert login_rc == 2
-        assert payload["next_action"]["command"] == "hol-guard connect --headless"
+        assert (
+            payload["next_action"]["command"]
+            == "hol-guard connect --headless --ci-safe --workspace workspace_ops --label 'Hermes Telegram agent'"
+        )
         assert store.get_sync_credentials() is None
 
     def test_guard_service_login_rejects_blank_token(self, tmp_path, capsys):

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -107,6 +107,22 @@ def test_device_authorization_request_uses_oauth_scopes_without_token_material()
     assert "secret" not in encoded
 
 
+def test_ci_safe_device_authorization_request_uses_restricted_scopes() -> None:
+    encoded = connect_flow.build_device_authorization_request_body(
+        machine_id="machine-123",
+        machine_label="CI Runner",
+        runtime_id="hol-guard",
+        runtime_label="HOL Guard CLI",
+        client_id="guard-local-daemon",
+        scopes=connect_flow.CI_SAFE_GUARD_DEVICE_SCOPES,
+    )
+    parsed = urllib.parse.parse_qs(encoded)
+
+    assert parsed["scope"] == ["guard:runtime.sync guard:offline_access"]
+    assert "guard:receipt.write" not in encoded
+    assert "guard:runtime.session.write" not in encoded
+
+
 def test_device_authorization_copy_payload_hides_device_code_secret() -> None:
     assert hasattr(connect_flow, "build_device_authorization_copy_payload")
     payload = connect_flow.build_device_authorization_copy_payload(
@@ -243,6 +259,61 @@ def test_headless_connect_uses_staging_client_defaults(tmp_path: Path) -> None:
 
     assert requests[0][0] == "https://staging.hol.org/api/guard/oauth/device/authorize"
     assert parsed["client_id"] == ["guard-local-daemon-staging"]
+
+
+def test_headless_connect_ci_safe_uses_explicit_label_and_restricted_scopes(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    store.set_device_label("Local Laptop", "2026-05-31T00:00:00Z")
+    requests: list[tuple[str, str]] = []
+
+    def fake_request(url: str, body: str) -> dict[str, object]:
+        requests.append((url, body))
+        return {
+            "device_code": "device-secret-value",
+            "user_code": "ABCD-EFGH",
+            "verification_uri": "https://hol.org/guard/oauth/device",
+            "verification_uri_complete": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
+            "expires_in": 600,
+            "interval": 5,
+        }
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "access_token": _fake_access_token(
+                        grant_id="grant-123",
+                        machine_id="machine-123",
+                        workspace_id="workspace-123",
+                    ),
+                    "refresh_token": "refresh-123",
+                    "expires_in": 3600,
+                    "scope": "guard:runtime.sync guard:offline_access",
+                    "token_type": "Bearer",
+                }
+            ).encode("utf-8")
+
+    payload = connect_flow.run_guard_device_connect_command(
+        store=store,
+        connect_url="https://hol.org/guard/connect",
+        request_device_authorization=fake_request,
+        token_urlopen=lambda request, timeout: _Response(),
+        now="2026-06-01T12:00:00+00:00",
+        ci_safe=True,
+        machine_label="CI Runner",
+    )
+    parsed = urllib.parse.parse_qs(requests[0][1])
+
+    assert payload["status"] == "connected"
+    assert parsed["requested_machine_label"] == ["CI Runner"]
+    assert parsed["scope"] == ["guard:runtime.sync guard:offline_access"]
 
 
 def test_headless_connect_polls_until_success_and_persists_oauth_credentials(tmp_path: Path) -> None:
@@ -475,6 +546,27 @@ def test_service_login_rejects_raw_token_without_persisting_credentials(tmp_path
     assert store.get_sync_credentials() is None
 
 
+def test_service_login_without_token_points_to_ci_safe_connect(tmp_path: Path, capsys) -> None:
+    guard_home = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    args = _ServiceLoginArgs()
+    args.guard_home = str(guard_home)
+    args.token = None
+    args.workspace = str(workspace)
+
+    exit_code = run_guard_command(args)
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert exit_code == 2
+    assert "hol-guard connect --headless --ci-safe" in payload["next_action"]["command"]
+    assert "--workspace" in payload["next_action"]["command"]
+    assert str(workspace) in payload["next_action"]["command"]
+    assert "--label" in payload["next_action"]["command"]
+    assert "Hosted Codex" in payload["next_action"]["command"]
+
+
 def test_connect_headless_emits_device_code_payload_without_pairing_secret(tmp_path: Path, capsys, monkeypatch) -> None:
     guard_home = tmp_path / "guard-home"
     args = _HeadlessConnectArgs()
@@ -520,6 +612,54 @@ def test_connect_no_browser_alias_uses_headless_device_code_flow(tmp_path: Path,
 
     assert args.guard_command == "connect"
     assert args.headless is True
+
+
+def test_connect_ci_safe_requires_explicit_workspace(tmp_path: Path, capsys) -> None:
+    guard_home = tmp_path / "guard-home"
+    parser = _build_parser("hol-guard", program_mode="guard")
+    args = parser.parse_args(
+        [
+            "connect",
+            "--headless",
+            "--ci-safe",
+            "--label",
+            "CI Runner",
+            "--home",
+            str(guard_home),
+            "--json",
+        ]
+    )
+
+    exit_code = run_guard_command(args)
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "--workspace" in captured.err
+
+
+def test_connect_ci_safe_requires_explicit_label(tmp_path: Path, capsys) -> None:
+    guard_home = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    parser = _build_parser("hol-guard", program_mode="guard")
+    args = parser.parse_args(
+        [
+            "connect",
+            "--headless",
+            "--ci-safe",
+            "--workspace",
+            str(workspace),
+            "--home",
+            str(guard_home),
+            "--json",
+        ]
+    )
+
+    exit_code = run_guard_command(args)
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "--label" in captured.err
 
 
 def test_connect_headless_open_browser_opens_device_approval_before_polling(

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -572,7 +572,15 @@ def test_connect_headless_emits_device_code_payload_without_pairing_secret(tmp_p
     args = _HeadlessConnectArgs()
     args.guard_home = str(guard_home)
 
-    def fake_headless_flow(*, store: GuardStore, connect_url: str, announce_copy=None) -> dict[str, object]:
+    def fake_headless_flow(
+        *,
+        store: GuardStore,
+        connect_url: str,
+        announce_copy=None,
+        ci_safe: bool = False,
+        machine_label: str | None = None,
+    ) -> dict[str, object]:
+        del ci_safe, machine_label
         if announce_copy is not None:
             announce_copy(
                 {
@@ -637,6 +645,41 @@ def test_connect_ci_safe_requires_explicit_workspace(tmp_path: Path, capsys) -> 
     assert "--workspace" in captured.err
 
 
+def test_connect_ci_safe_requires_headless_mode(tmp_path: Path, capsys, monkeypatch) -> None:
+    guard_home = tmp_path / "guard-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    parser = _build_parser("hol-guard", program_mode="guard")
+    args = parser.parse_args(
+        [
+            "connect",
+            "--ci-safe",
+            "--workspace",
+            str(workspace),
+            "--label",
+            "CI Runner",
+            "--home",
+            str(guard_home),
+            "--json",
+        ]
+    )
+    browser_called = {"value": False}
+
+    def fake_browser_flow(*, store: GuardStore, connect_url: str, wait_timeout_seconds: int) -> dict[str, object]:
+        del store, connect_url, wait_timeout_seconds
+        browser_called["value"] = True
+        return {"status": "connected", "connect_mode": "browser_oauth"}
+
+    monkeypatch.setattr(guard_commands, "_run_guard_browser_connect_flow", fake_browser_flow)
+
+    exit_code = run_guard_command(args)
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "--headless" in captured.err
+    assert browser_called["value"] is False
+
+
 def test_connect_ci_safe_requires_explicit_label(tmp_path: Path, capsys) -> None:
     guard_home = tmp_path / "guard-home"
     workspace = tmp_path / "workspace"
@@ -679,7 +722,10 @@ def test_connect_headless_open_browser_opens_device_approval_before_polling(
         connect_url: str,
         announce_copy=None,
         open_browser=None,
+        ci_safe: bool = False,
+        machine_label: str | None = None,
     ) -> dict[str, object]:
+        del ci_safe, machine_label
         assert connect_url == "https://hol.org/guard/connect"
         assert open_browser is not None
         if announce_copy is not None:
@@ -1016,7 +1062,15 @@ def test_connect_headless_reports_device_authorization_network_error(tmp_path: P
     args = _HeadlessConnectArgs()
     args.guard_home = str(guard_home)
 
-    def failing_headless_flow(*, store: GuardStore, connect_url: str, announce_copy=None) -> dict[str, object]:
+    def failing_headless_flow(
+        *,
+        store: GuardStore,
+        connect_url: str,
+        announce_copy=None,
+        ci_safe: bool = False,
+        machine_label: str | None = None,
+    ) -> dict[str, object]:
+        del ci_safe, machine_label
         del announce_copy
         raise urllib.error.URLError("network unavailable")
 
@@ -1035,7 +1089,15 @@ def test_connect_headless_reports_malformed_device_authorization_response(tmp_pa
     args = _HeadlessConnectArgs()
     args.guard_home = str(guard_home)
 
-    def failing_headless_flow(*, store: GuardStore, connect_url: str, announce_copy=None) -> dict[str, object]:
+    def failing_headless_flow(
+        *,
+        store: GuardStore,
+        connect_url: str,
+        announce_copy=None,
+        ci_safe: bool = False,
+        machine_label: str | None = None,
+    ) -> dict[str, object]:
+        del ci_safe, machine_label
         del announce_copy
         raise json.JSONDecodeError("invalid json", "not-json", 0)
 


### PR DESCRIPTION
## Summary
- add a CI-safe `hol-guard connect --headless` mode that requires explicit `--workspace` and `--label`
- restrict CI-safe device-code requests to non-delegated runtime scopes and point hosted `service login` guidance at the new command
- add regression coverage for CI-safe scope selection, validation, and hosted-runtime guidance

## Testing
- `python3 -m pytest tests/test_guard_oauth_client.py tests/test_guard_oauth_device_connect.py -q`
- `python3 -m pytest tests/test_guard_oauth_device_connect.py tests/test_guard_connect_flow.py -q`
- `ruff check src/codex_plugin_scanner/guard/cli/connect_flow.py src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_oauth_device_connect.py`
- `ruff format --check src/codex_plugin_scanner/guard/cli/connect_flow.py src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_oauth_device_connect.py`
- `git diff --check`
