### PR TITLE
fix(claude-code): harden hook bridge and brand PermissionRequest

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
@@ -9,10 +9,11 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Any
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 from .claude_code import CLAUDE_GUARD_DAEMON_HOOK_MARKER
 
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 _DEGRADED_DAEMON_MESSAGE = (
     "HOL Guard could not reach the local daemon ({reason}), so it is using Claude's native "
     "approval prompt as a temporary safety fallback."
@@ -45,18 +46,11 @@ def main(
     data = body.strip() or "{}"
     try:
         endpoint = urljoin(_daemon_url(state_path, fallback_daemon_url), f"/v1/hooks/claude-code?{query}")
+        _assert_loopback_http_url(endpoint)
+        response_body = _post_to_loopback_daemon(endpoint, data)
     except ValueError as error:
         sys.stdout.write(_run_local_fallback(str(error), data, fallback_command))
         return 0
-    request = urllib.request.Request(
-        endpoint,
-        data=data.encode("utf-8"),
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
-    try:
-        with urllib.request.urlopen(request, timeout=30) as response:
-            response_body = response.read().decode("utf-8", errors="replace")
     except urllib.error.HTTPError as error:
         detail = error.read().decode("utf-8", errors="replace")
         reason = f"daemon returned HTTP {error.code}"
@@ -77,6 +71,45 @@ def main(
     return 0
 
 
+def _build_loopback_opener() -> urllib.request.OpenerDirector:
+    return urllib.request.build_opener(
+        urllib.request.ProxyHandler({}),
+        _LoopbackOnlyRedirectHandler(),
+    )
+
+
+class _LoopbackOnlyRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        _assert_loopback_http_url(newurl)
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def _assert_loopback_http_url(url: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme != "http":
+        raise ValueError(f"daemon URL must use http, not {parsed.scheme!r}")
+    host = (parsed.hostname or "").lower()
+    if host not in _LOOPBACK_HOSTS:
+        raise ValueError(f"daemon URL must target loopback, not {host!r}")
+    if parsed.port is None:
+        raise ValueError("daemon URL must include an explicit port")
+
+
+def _post_to_loopback_daemon(endpoint: str, data: str) -> str:
+    request = urllib.request.Request(
+        endpoint,
+        data=data.encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    opener = _build_loopback_opener()
+    with opener.open(request, timeout=30) as response:
+        final_url = response.geturl()
+        if final_url:
+            _assert_loopback_http_url(final_url)
+        return response.read().decode("utf-8", errors="replace")
+
+
 def _daemon_url(state_path: str | Path, fallback_daemon_url: str) -> str:
     path = Path(state_path)
     try:
@@ -87,7 +120,9 @@ def _daemon_url(state_path: str | Path, fallback_daemon_url: str) -> str:
                 return f"http://127.0.0.1:{port}/"
     except (OSError, ValueError):
         pass
-    return fallback_daemon_url.rstrip("/") + "/"
+    normalized = fallback_daemon_url.rstrip("/") + "/"
+    _assert_loopback_http_url(normalized)
+    return normalized
 
 
 def _event_name(data: str) -> str:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2883,17 +2883,64 @@ def run_guard_command(
         )
         if _is_claude_permission_request(args, payload):
             notice = _peek_claude_permission_notice(store, payload)
-            if notice is None:
+            if notice is not None and _claude_permission_notice_prefers_ask_user_question(notice):
+                _mark_claude_pending_permission_prompt_seen(store=store, payload=payload, notice=notice)
+                _emit_native_hook_response(
+                    harness=args.harness,
+                    policy_action="block",
+                    event_name="PermissionRequest",
+                    reason="HOL Guard is routing this approval through AskUserQuestion.",
+                    system_message=_claude_permission_prompt_system_message(payload=payload, notice=notice),
+                    additional_context=_claude_guard_approval_question_message(notice),
+                    output_stream=output_stream,
+                )
+                return 0
+            native_reason: str | None = None
+            policy_action: str | None = None
+            if notice is not None:
+                policy_action = "require-reapproval"
+                native_reason = _optional_string(notice.get("reason"))
+            elif runtime_artifact is not None:
+                policy_action, reason_stub = _resolve_claude_permission_request_policy_action(
+                    config=config,
+                    store=store,
+                    args=args,
+                    runtime_artifact=runtime_artifact,
+                    runtime_workspace=runtime_workspace,
+                )
+                if policy_action not in {"block", "sandbox-required", "require-reapproval"}:
+                    _emit_claude_permission_request_passthrough(output_stream=output_stream)
+                    return 0
+                native_reason = _runtime_artifact_native_reason(runtime_artifact, reason_stub)
+            else:
                 _emit_claude_permission_request_passthrough(output_stream=output_stream)
                 return 0
-            _mark_claude_pending_permission_prompt_seen(store=store, payload=payload, notice=notice)
+            if native_reason is None or not native_reason.strip():
+                native_reason = "HOL Guard is reviewing this Claude approval prompt."
+            if policy_action in {"block", "sandbox-required"}:
+                _emit_native_hook_response(
+                    harness=args.harness,
+                    policy_action=policy_action,
+                    event_name="PermissionRequest",
+                    reason=native_reason,
+                    system_message=_claude_permission_request_system_message(
+                        payload=payload,
+                        native_reason=native_reason,
+                    ),
+                    additional_context=_claude_permission_request_additional_context(native_reason),
+                    output_stream=output_stream,
+                )
+                return 0
             _emit_native_hook_response(
                 harness=args.harness,
-                policy_action="block",
+                policy_action="require-reapproval",
                 event_name="PermissionRequest",
-                reason="HOL Guard is routing this approval through AskUserQuestion.",
-                system_message=_claude_permission_prompt_system_message(payload=payload, notice=notice),
-                additional_context=_claude_guard_approval_question_message(notice),
+                reason=native_reason,
+                system_message=_claude_permission_request_system_message(
+                    payload=payload,
+                    native_reason=native_reason,
+                ),
+                additional_context=_claude_permission_request_additional_context(native_reason),
                 output_stream=output_stream,
             )
             return 0
@@ -4552,6 +4599,72 @@ def _is_claude_permission_request(args: argparse.Namespace, payload: dict[str, o
     return _canonical_harness_name(args.harness) == "claude-code" and _hook_event_name(payload) == "PermissionRequest"
 
 
+def _claude_permission_notice_prefers_ask_user_question(notice: dict[str, object]) -> bool:
+    artifact_type = _optional_string(notice.get("artifact_type"))
+    return artifact_type != "package_request"
+
+
+def _resolve_claude_permission_request_policy_action(
+    *,
+    config: GuardConfig,
+    store: GuardStore,
+    args: argparse.Namespace,
+    runtime_artifact: GuardArtifact,
+    runtime_workspace: Path | None,
+) -> tuple[str, dict[str, object]]:
+    policy_action = _runtime_artifact_policy_action(config, runtime_artifact, args.harness)
+    package_evaluation = None
+    if runtime_artifact.artifact_type == "package_request":
+        package_evaluation = evaluate_package_request_artifact(
+            artifact=runtime_artifact,
+            store=store,
+            workspace_dir=runtime_workspace,
+        )
+        if guard_action_severity(package_evaluation.policy_action) > guard_action_severity(policy_action):
+            policy_action = package_evaluation.policy_action
+    stub: dict[str, object] = {
+        "harness": _canonical_harness_name(args.harness),
+        "policy_action": policy_action,
+        "risk_summary": (
+            package_evaluation.risk_summary
+            if package_evaluation is not None
+            else artifact_risk_summary(runtime_artifact)
+        ),
+    }
+    if package_evaluation is not None:
+        stub["decision_v2_json"] = {
+            "harness_message": package_evaluation.user_copy.harness_message,
+        }
+    return policy_action, stub
+
+
+def _claude_permission_request_system_message(
+    *,
+    payload: dict[str, object],
+    native_reason: str,
+) -> str:
+    tool_name = _claude_notification_tool_name(payload)
+    if tool_name is not None:
+        return (
+            f"HOL Guard is reviewing Claude's approval prompt for {tool_name}. "
+            "Claude's risk warnings above are separate from HOL Guard. "
+            f"{_ensure_terminal_punctuation(native_reason)}"
+        )
+    return (
+        "HOL Guard is reviewing this Claude approval prompt. "
+        "Claude's risk warnings above are separate from HOL Guard. "
+        f"{_ensure_terminal_punctuation(native_reason)}"
+    )
+
+
+def _claude_permission_request_additional_context(native_reason: str) -> str:
+    return (
+        "This review came from HOL Guard, not from Claude alone. "
+        f"{_ensure_terminal_punctuation(native_reason)} "
+        "Use Claude's normal Allow / deny controls unless HOL Guard opened a separate approval question."
+    )
+
+
 def _claude_permission_prompt_system_message(
     *,
     payload: dict[str, object],
@@ -5520,6 +5633,20 @@ def _emit_native_hook_response(
                     "HOL Guard is reviewing this Codex approval request. Codex will show its normal approval prompt; "
                     "choose allow only if you trust the exact tool action."
                 )
+            if payload:
+                _write_json_line(payload, output_stream=output_stream)
+            return
+        if event_name == "PermissionRequest" and _canonical_harness_name(harness) == "claude-code":
+            message = system_message or reason
+            if message:
+                payload["systemMessage"] = message
+            if additional_context:
+                payload["hookSpecificOutput"] = {
+                    "hookEventName": event_name,
+                    "additionalContext": additional_context,
+                }
+            elif message:
+                payload["hookSpecificOutput"] = {"hookEventName": event_name}
             if payload:
                 _write_json_line(payload, output_stream=output_stream)
             return

--- a/tests/test_claude_daemon_hook_bridge.py
+++ b/tests/test_claude_daemon_hook_bridge.py
@@ -1,0 +1,117 @@
+"""Security and transport tests for the Claude daemon hook bridge."""
+
+from __future__ import annotations
+
+import json
+import threading
+import urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters import claude_daemon_hook_bridge as bridge
+
+
+class _CapturingProxyHandler(BaseHTTPRequestHandler):
+    captured_paths: list[str] = []
+
+    def do_POST(self) -> None:
+        type(self).captured_paths.append(self.path)
+        length = int(self.headers.get("Content-Length", "0"))
+        _ = self.rfile.read(length)
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "permissionDecision": "allow",
+                    }
+                }
+            ).encode("utf-8")
+        )
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+
+def test_assert_loopback_http_url_rejects_remote_host() -> None:
+    with pytest.raises(ValueError, match="loopback"):
+        bridge._assert_loopback_http_url("http://evil.example:5474/v1/hooks/claude-code")
+
+
+def test_daemon_url_rejects_non_loopback_fallback() -> None:
+    with pytest.raises(ValueError, match="loopback"):
+        bridge._daemon_url("/nonexistent/daemon-state.json", "http://proxy.internal:5474/")
+
+
+class _DaemonHandler(BaseHTTPRequestHandler):
+    response_marker = "from-real-daemon"
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        _ = self.rfile.read(length)
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(
+            json.dumps(
+                {
+                    "marker": type(self).response_marker,
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "permissionDecision": "deny",
+                    },
+                }
+            ).encode("utf-8")
+        )
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+
+def test_post_to_loopback_daemon_ignores_http_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    _CapturingProxyHandler.captured_paths = []
+    proxy_server = HTTPServer(("127.0.0.1", 0), _CapturingProxyHandler)
+    proxy_thread = threading.Thread(target=proxy_server.serve_forever, daemon=True)
+    proxy_thread.start()
+
+    daemon_server = HTTPServer(("127.0.0.1", 0), _DaemonHandler)
+    daemon_thread = threading.Thread(target=daemon_server.serve_forever, daemon=True)
+    daemon_thread.start()
+    daemon_port = daemon_server.server_address[1]
+
+    monkeypatch.setenv("HTTP_PROXY", f"http://127.0.0.1:{proxy_server.server_address[1]}")
+    monkeypatch.setenv("http_proxy", f"http://127.0.0.1:{proxy_server.server_address[1]}")
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.delenv("no_proxy", raising=False)
+
+    try:
+        response_body = bridge._post_to_loopback_daemon(
+            f"http://127.0.0.1:{daemon_port}/v1/hooks/claude-code?guard-home=%2Ftmp",
+            "{}",
+        )
+    finally:
+        proxy_server.shutdown()
+        daemon_server.shutdown()
+        proxy_thread.join(timeout=5)
+        daemon_thread.join(timeout=5)
+
+    payload = json.loads(response_body)
+    assert payload["marker"] == _DaemonHandler.response_marker
+    assert _CapturingProxyHandler.captured_paths == []
+
+
+def test_loopback_redirect_handler_rejects_remote_redirect() -> None:
+    handler = bridge._LoopbackOnlyRedirectHandler()
+    with pytest.raises(ValueError, match="loopback"):
+        handler.redirect_request(
+            urllib.request.Request("http://127.0.0.1:5474/"),
+            None,
+            302,
+            "Found",
+            {},
+            "http://evil.example/allow",
+        )

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -9582,6 +9582,86 @@ def test_guard_hook_ignores_unattributed_claude_permission_request(
     assert output == ""
 
 
+def test_guard_hook_emits_claude_native_permission_request_for_package_notice(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import (
+        PackageRequestEvaluation,
+        SupplyChainUserCopy,
+    )
+
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(
+        home_dir / "config.toml",
+        '[risk_actions]\npackage_script = "require-reapproval"\napproval_wait_timeout_seconds = 0\n',
+    )
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+
+    def _package_requires_review(**_kwargs: object) -> PackageRequestEvaluation:
+        return PackageRequestEvaluation(
+            decision="review",
+            policy_action="require-reapproval",
+            enforcement="policy",
+            entitlement_state="offline",
+            cache_status="miss",
+            package_intent_hash="intent-hash",
+            policy_version="policy-v1",
+            bundle_version="bundle-v1",
+            workspace_fingerprint="workspace-fingerprint",
+            reasons=({"code": "package_review", "message": "Review npm install react@18.3.0"},),
+            packages=({"name": "react", "decision": "review", "reasons": ()},),
+            risk_summary="HOL Guard is reviewing npm install react@18.3.0.",
+            user_copy=SupplyChainUserCopy(
+                title="Review package install",
+                summary="react@18.3.0 needs review before install.",
+                next_step="Confirm the exact version in Claude's approval prompt.",
+                dashboard_url="https://hol.org/guard/inbox",
+                harness_message="HOL Guard is reviewing npm install react@18.3.0.",
+            ),
+        )
+
+    monkeypatch.setattr(
+        guard_commands_module,
+        "evaluate_package_request_artifact",
+        _package_requires_review,
+    )
+    pre_tool_event = {
+        "session_id": "session-claude-package-permission-request",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "npm install react@18.3.0"},
+        "source_scope": "project",
+    }
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    pre_tool_rc, pre_tool_output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="claude-code",
+        event=pre_tool_event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    permission_rc, permission_output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="claude-code",
+        event={**pre_tool_event, "hook_event_name": "PermissionRequest"},
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    permission_payload = json.loads(permission_output)
+
+    assert pre_tool_rc == 0
+    assert json.loads(pre_tool_output)["hookSpecificOutput"]["permissionDecision"] in {"ask", "deny"}
+    assert permission_rc == 0
+    assert "HOL Guard is reviewing Claude's approval prompt for Bash" in permission_payload["systemMessage"]
+    assert "AskUserQuestion" not in json.dumps(permission_payload["hookSpecificOutput"])
+
+
 def test_guard_hook_emits_claude_native_ask_for_sensitive_file_reads(
     tmp_path,
     capsys,


### PR DESCRIPTION
## Summary
- Harden Claude daemon hook bridge: loopback-only URLs, no HTTP_PROXY, redirect validation
- Brand Claude PermissionRequest with HOL Guard systemMessage for package/supply-chain review; keep AskUserQuestion for secret-read notices

## Testing
- `python3 -m pytest tests/test_claude_daemon_hook_bridge.py tests/test_guard_runtime.py::test_guard_hook_emits_claude_native_permission_request_for_package_notice tests/test_guard_runtime.py::test_guard_hook_emits_claude_permission_request_attribution_without_decision tests/test_guard_phase04_harness_ux.py::test_gr083_claude_permission_request_routes_to_ask_user_question -q`
