### PR TITLE
fix(claude-code): show HOL Guard branding in terminal during PermissionRequest

### DIFF
--- a/.github/pr-bodies/claude-permission-request-visible.md
+++ b/.github/pr-bodies/claude-permission-request-visible.md
@@ -1,0 +1,9 @@
+## Summary
+
+- Emit a short HOL Guard stderr line during Claude `PermissionRequest` hooks (non-`--json`) so terminal users see branding while approvals are reviewed.
+- Set Claude hook `statusMessage` on `PreToolUse` and `PermissionRequest` installs so Claude shows HOL Guard progress during hook execution.
+
+## Test plan
+
+- [x] `pytest tests/test_guard_runtime.py -k "claude_permission_request" -q`
+- [x] `pytest tests/test_guard_claude_adapter.py::test_claude_install_writes_session_start_and_command_hook_schema_and_is_idempotent -q`

--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -42,6 +42,10 @@ def _guard_command_handler(
     return handler
 
 
+def _claude_managed_settings_path(context: HarnessContext) -> Path:
+    return context.home_dir / ".claude" / "settings.json"
+
+
 def _shell_command(command: tuple[str, ...], *, windows: bool | None = None) -> str:
     is_windows = os.name == "nt" if windows is None else windows
     if is_windows:
@@ -557,7 +561,8 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
             "from codex_plugin_scanner.guard.adapters.claude_code import ClaudeCodeHarnessAdapter;"
             f"ensure_guard_daemon(Path({str(context.guard_home)!r}));"
             f"ClaudeCodeHarnessAdapter.refresh_installed_hook_urls(home_dir=Path({str(context.home_dir)!r}), "
-            f"workspace_dir=Path({str(context.workspace_dir)!r}), guard_home=Path({str(context.guard_home)!r}));"
+            f"workspace_dir={f'Path({str(context.workspace_dir)!r})' if context.workspace_dir is not None else 'None'}, "
+            f"guard_home=Path({str(context.guard_home)!r}));"
             "print(json.dumps({'hookSpecificOutput': {'hookEventName': 'SessionStart', "
             "'additionalContext': 'HOL Guard protection is active for this workspace.'}}, "
             "separators=(',', ':')))"
@@ -571,9 +576,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
         )
 
     def refresh_runtime_hook_urls(self, context: HarnessContext) -> None:
-        if context.workspace_dir is None:
-            return
-        settings_path = context.workspace_dir / ".claude" / "settings.local.json"
+        settings_path = _claude_managed_settings_path(context)
         payload = _json_payload(settings_path)
         hooks = payload.get("hooks")
         if not isinstance(hooks, dict):
@@ -596,15 +599,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
             launcher_name="claude",
             display_name="claude",
         )
-        if context.workspace_dir is None:
-            return {
-                "harness": self.harness,
-                "active": True,
-                "config_path": shim_manifest["shim_path"],
-                **shim_manifest,
-            }
-        settings_path = context.workspace_dir / ".claude" / "settings.local.json"
-        _ensure_path_within_root(context.workspace_dir, settings_path, label="Claude Code")
+        settings_path = _claude_managed_settings_path(context)
         payload = _json_payload(settings_path)
         session_start_command = self._session_start_command(context)
         hook_command = self._daemon_hook_command(context)
@@ -632,7 +627,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
             "config_path": str(settings_path),
             **shim_manifest,
             "notes": [
-                "Guard hook entries added to .claude/settings.local.json",
+                "Guard hook entries added to ~/.claude/settings.json",
                 *[str(note) for note in shim_manifest.get("notes", [])],
             ],
         }
@@ -645,15 +640,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
             display_name="claude",
             legacy_launcher_names=("claude-code",),
         )
-        if context.workspace_dir is None:
-            return {
-                "harness": self.harness,
-                "active": False,
-                "config_path": shim_manifest["shim_path"],
-                **shim_manifest,
-            }
-        settings_path = context.workspace_dir / ".claude" / "settings.local.json"
-        _ensure_path_within_root(context.workspace_dir, settings_path, label="Claude Code")
+        settings_path = _claude_managed_settings_path(context)
         payload = _json_payload(settings_path)
         hooks = payload.get("hooks")
         if isinstance(hooks, dict):
@@ -677,7 +664,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
             "config_path": str(settings_path),
             **shim_manifest,
             "notes": [
-                "Guard hook entries removed from .claude/settings.local.json",
+                "Guard hook entries removed from ~/.claude/settings.json",
                 *[str(note) for note in shim_manifest.get("notes", [])],
             ],
         }

--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -552,6 +552,11 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
     @staticmethod
     def _session_start_command_parts(context: HarnessContext) -> tuple[str, ...]:
         package_root = Path(__file__).resolve().parents[3]
+        workspace_dir_literal = (
+            f"Path({str(context.workspace_dir)!r})"
+            if context.workspace_dir is not None
+            else "None"
+        )
         code = (
             "import sys;"
             f"sys.path.insert(0, {str(package_root)!r});"
@@ -561,11 +566,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
             "from codex_plugin_scanner.guard.adapters.claude_code import ClaudeCodeHarnessAdapter;"
             f"ensure_guard_daemon(Path({str(context.guard_home)!r}));"
             f"ClaudeCodeHarnessAdapter.refresh_installed_hook_urls(home_dir=Path({str(context.home_dir)!r}), "
-            f"workspace_dir={(
-                f"Path({str(context.workspace_dir)!r})"
-                if context.workspace_dir is not None
-                else "None"
-            )}, "
+            f"workspace_dir={workspace_dir_literal}, "
             f"guard_home=Path({str(context.guard_home)!r}));"
             "print(json.dumps({'hookSpecificOutput': {'hookEventName': 'SessionStart', "
             "'additionalContext': 'HOL Guard protection is active for this workspace.'}}, "

--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -30,8 +30,16 @@ CLAUDE_SETTINGS_FILES = ("settings.json", "settings.local.json")
 CLAUDE_GUARD_DAEMON_HOOK_MARKER = "HOL_GUARD_CLAUDE_DAEMON_HOOK"
 
 
-def _guard_command_handler(command: str, *, timeout: int) -> dict[str, object]:
-    return {"type": "command", "command": command, "timeout": timeout}
+def _guard_command_handler(
+    command: str,
+    *,
+    timeout: int,
+    status_message: str | None = None,
+) -> dict[str, object]:
+    handler: dict[str, object] = {"type": "command", "command": command, "timeout": timeout}
+    if status_message is not None:
+        handler["statusMessage"] = status_message
+    return handler
 
 
 def _shell_command(command: tuple[str, ...], *, windows: bool | None = None) -> str:
@@ -42,18 +50,28 @@ def _shell_command(command: tuple[str, ...], *, windows: bool | None = None) -> 
 
 
 def _sync_runtime_hook_groups(hooks: dict[str, object], hook_command: str) -> None:
-    for key, matcher, timeout in (
-        ("PreToolUse", CLAUDE_GUARD_TOOL_MATCHER, CLAUDE_GUARD_TOOL_TIMEOUT_SECONDS),
-        ("PermissionRequest", CLAUDE_GUARD_TOOL_MATCHER, CLAUDE_GUARD_NOTIFICATION_TIMEOUT_SECONDS),
-        ("PostToolUse", CLAUDE_GUARD_POST_TOOL_MATCHER, CLAUDE_GUARD_TOOL_TIMEOUT_SECONDS),
-        ("Notification", CLAUDE_GUARD_NOTIFICATION_MATCHER, CLAUDE_GUARD_NOTIFICATION_TIMEOUT_SECONDS),
-        ("Stop", None, CLAUDE_GUARD_STOP_TIMEOUT_SECONDS),
+    for key, matcher, timeout, status_message in (
+        (
+            "PreToolUse",
+            CLAUDE_GUARD_TOOL_MATCHER,
+            CLAUDE_GUARD_TOOL_TIMEOUT_SECONDS,
+            "HOL Guard is checking this tool use",
+        ),
+        (
+            "PermissionRequest",
+            CLAUDE_GUARD_TOOL_MATCHER,
+            CLAUDE_GUARD_NOTIFICATION_TIMEOUT_SECONDS,
+            "HOL Guard is reviewing this approval prompt",
+        ),
+        ("PostToolUse", CLAUDE_GUARD_POST_TOOL_MATCHER, CLAUDE_GUARD_TOOL_TIMEOUT_SECONDS, None),
+        ("Notification", CLAUDE_GUARD_NOTIFICATION_MATCHER, CLAUDE_GUARD_NOTIFICATION_TIMEOUT_SECONDS, None),
+        ("Stop", None, CLAUDE_GUARD_STOP_TIMEOUT_SECONDS, None),
     ):
         existing_entries = hooks.get(key)
         hooks[key] = _merge_hook_group(
             _prune_guard_hook_entries(existing_entries if isinstance(existing_entries, list) else []),
             matcher,
-            _guard_command_handler(hook_command, timeout=timeout),
+            _guard_command_handler(hook_command, timeout=timeout, status_message=status_message),
         )
 
 

--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -552,11 +552,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
     @staticmethod
     def _session_start_command_parts(context: HarnessContext) -> tuple[str, ...]:
         package_root = Path(__file__).resolve().parents[3]
-        workspace_dir_literal = (
-            f"Path({str(context.workspace_dir)!r})"
-            if context.workspace_dir is not None
-            else "None"
-        )
+        workspace_dir_literal = f"Path({str(context.workspace_dir)!r})" if context.workspace_dir is not None else "None"
         code = (
             "import sys;"
             f"sys.path.insert(0, {str(package_root)!r});"

--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -561,7 +561,11 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
             "from codex_plugin_scanner.guard.adapters.claude_code import ClaudeCodeHarnessAdapter;"
             f"ensure_guard_daemon(Path({str(context.guard_home)!r}));"
             f"ClaudeCodeHarnessAdapter.refresh_installed_hook_urls(home_dir=Path({str(context.home_dir)!r}), "
-            f"workspace_dir={f'Path({str(context.workspace_dir)!r})' if context.workspace_dir is not None else 'None'}, "
+            f"workspace_dir={(
+                f"Path({str(context.workspace_dir)!r})"
+                if context.workspace_dir is not None
+                else "None"
+            )}, "
             f"guard_home=Path({str(context.guard_home)!r}));"
             "print(json.dumps({'hookSpecificOutput': {'hookEventName': 'SessionStart', "
             "'additionalContext': 'HOL Guard protection is active for this workspace.'}}, "
@@ -600,6 +604,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
             display_name="claude",
         )
         settings_path = _claude_managed_settings_path(context)
+        _ensure_path_within_root(context.home_dir, settings_path, label="Claude Code")
         payload = _json_payload(settings_path)
         session_start_command = self._session_start_command(context)
         hook_command = self._daemon_hook_command(context)
@@ -641,6 +646,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
             legacy_launcher_names=("claude-code",),
         )
         settings_path = _claude_managed_settings_path(context)
+        _ensure_path_within_root(context.home_dir, settings_path, label="Claude Code")
         payload = _json_payload(settings_path)
         hooks = payload.get("hooks")
         if isinstance(hooks, dict):

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2917,6 +2917,13 @@ def run_guard_command(
                 return 0
             if native_reason is None or not native_reason.strip():
                 native_reason = "HOL Guard is reviewing this Claude approval prompt."
+            if not getattr(args, "json", False):
+                _emit_native_hook_notification_stderr(
+                    _claude_permission_request_terminal_notice(
+                        payload=payload,
+                        native_reason=native_reason,
+                    )
+                )
             if policy_action in {"block", "sandbox-required"}:
                 _emit_native_hook_response(
                     harness=args.harness,
@@ -4636,6 +4643,20 @@ def _resolve_claude_permission_request_policy_action(
             "harness_message": package_evaluation.user_copy.harness_message,
         }
     return policy_action, stub
+
+
+def _claude_permission_request_terminal_notice(
+    *,
+    payload: dict[str, object],
+    native_reason: str,
+) -> str:
+    tool_name = _claude_notification_tool_name(payload)
+    if tool_name is not None:
+        return (
+            f"HOL Guard: reviewing Claude approval for {tool_name}. "
+            f"{_ensure_terminal_punctuation(native_reason)}"
+        )
+    return f"HOL Guard: reviewing this Claude approval prompt. {_ensure_terminal_punctuation(native_reason)}"
 
 
 def _claude_permission_request_system_message(

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -4650,7 +4650,7 @@ def _claude_permission_request_terminal_notice(
     payload: dict[str, object],
     native_reason: str,
 ) -> str:
-    tool_name = _claude_notification_tool_name(payload)
+    tool_name = _claude_notification_tool_display_name(payload)
     if tool_name is not None:
         return (
             f"HOL Guard: reviewing Claude approval for {tool_name}. "
@@ -4664,7 +4664,7 @@ def _claude_permission_request_system_message(
     payload: dict[str, object],
     native_reason: str,
 ) -> str:
-    tool_name = _claude_notification_tool_name(payload)
+    tool_name = _claude_notification_tool_display_name(payload)
     if tool_name is not None:
         return (
             f"HOL Guard is reviewing Claude's approval prompt for {tool_name}. "
@@ -4784,6 +4784,13 @@ def _claude_notification_tool_name(payload: dict[str, object]) -> str | None:
         match = re.search(r"\buse\s+([A-Za-z][A-Za-z0-9_]*)\b", value)
         if match is not None:
             return match.group(1)
+    return None
+
+
+def _claude_notification_tool_display_name(payload: dict[str, object]) -> str | None:
+    tool_name = _claude_notification_tool_name(payload)
+    if tool_name and tool_name.strip():
+        return tool_name.strip()
     return None
 
 

--- a/tests/test_guard_claude_adapter.py
+++ b/tests/test_guard_claude_adapter.py
@@ -119,7 +119,7 @@ def test_claude_install_bakes_current_source_root_into_session_start_command(tmp
 
     install_output = adapter.install(context)
 
-    settings_path = context.workspace_dir / ".claude" / "settings.local.json"
+    settings_path = context.home_dir / ".claude" / "settings.json"
     payload = json.loads(settings_path.read_text(encoding="utf-8"))
     hook_command = str(payload["hooks"]["SessionStart"][0]["hooks"][0]["command"])
     expected_source_root = str(Path(__file__).resolve().parents[1] / "src")
@@ -141,7 +141,7 @@ def test_claude_install_writes_session_start_and_command_hook_schema_and_is_idem
     adapter.install(context)
     adapter.install(context)
 
-    settings_path = context.workspace_dir / ".claude" / "settings.local.json"
+    settings_path = context.home_dir / ".claude" / "settings.json"
     payload = json.loads(settings_path.read_text(encoding="utf-8"))
     session_start = payload["hooks"]["SessionStart"]
     pre_tool_use = payload["hooks"]["PreToolUse"]
@@ -188,7 +188,7 @@ def test_get_adapter_accepts_claude_alias():
 def test_claude_install_replaces_legacy_http_guard_hooks(tmp_path):
     context = _build_context(tmp_path)
     adapter = ClaudeCodeHarnessAdapter()
-    settings_path = context.workspace_dir / ".claude" / "settings.local.json"
+    settings_path = context.home_dir / ".claude" / "settings.json"
     _write_json(
         settings_path,
         {
@@ -264,7 +264,7 @@ def test_claude_install_replaces_legacy_http_guard_hooks(tmp_path):
 def test_claude_refresh_runtime_hook_urls_rewrites_stale_daemon_port(tmp_path):
     context = _build_context(tmp_path)
     adapter = ClaudeCodeHarnessAdapter()
-    settings_path = context.workspace_dir / ".claude" / "settings.local.json"
+    settings_path = context.home_dir / ".claude" / "settings.json"
     _write_json(
         settings_path,
         {
@@ -312,7 +312,7 @@ def test_claude_install_rejects_symlinked_settings_file(tmp_path):
     adapter = ClaudeCodeHarnessAdapter()
     outside_settings = tmp_path / "outside-settings.json"
     outside_settings.write_text("{}", encoding="utf-8")
-    settings_path = context.workspace_dir / ".claude" / "settings.local.json"
+    settings_path = context.home_dir / ".claude" / "settings.json"
     _symlink_or_skip(settings_path, outside_settings)
 
     with pytest.raises(ValueError, match="settings path"):
@@ -455,7 +455,7 @@ def test_claude_install_replaces_prior_session_start_guard_handlers_when_context
     adapter.install(initial_context)
     adapter.install(changed_context)
 
-    settings_path = initial_context.workspace_dir / ".claude" / "settings.local.json"
+    settings_path = initial_context.home_dir / ".claude" / "settings.json"
     payload = json.loads(settings_path.read_text(encoding="utf-8"))
     session_start = payload["hooks"]["SessionStart"]
     hook_commands = [entry["hooks"][0]["command"] for entry in session_start]
@@ -475,7 +475,7 @@ def test_claude_install_replaces_prior_session_start_guard_handlers_when_context
 def test_claude_install_and_uninstall_preserve_unrelated_nested_hooks(tmp_path):
     context = _build_context(tmp_path)
     adapter = ClaudeCodeHarnessAdapter()
-    settings_path = context.workspace_dir / ".claude" / "settings.local.json"
+    settings_path = context.home_dir / ".claude" / "settings.json"
     _write_json(
         settings_path,
         {
@@ -512,7 +512,7 @@ def test_claude_install_and_uninstall_preserve_unrelated_nested_hooks(tmp_path):
 def test_claude_install_migrates_legacy_flat_guard_hook_entries(tmp_path):
     context = _build_context(tmp_path)
     adapter = ClaudeCodeHarnessAdapter()
-    settings_path = context.workspace_dir / ".claude" / "settings.local.json"
+    settings_path = context.home_dir / ".claude" / "settings.json"
     legacy_command = adapter._hook_command(context)
     _write_json(
         settings_path,

--- a/tests/test_guard_claude_adapter.py
+++ b/tests/test_guard_claude_adapter.py
@@ -446,7 +446,7 @@ def test_claude_daemon_hook_command_falls_back_to_native_ask_on_daemon_miss(tmp_
 def test_claude_install_replaces_prior_session_start_guard_handlers_when_context_changes(tmp_path):
     initial_context = _build_context(tmp_path)
     changed_context = HarnessContext(
-        home_dir=tmp_path / "different-home",
+        home_dir=initial_context.home_dir,
         workspace_dir=initial_context.workspace_dir,
         guard_home=tmp_path / "different-guard-home",
     )

--- a/tests/test_guard_claude_adapter.py
+++ b/tests/test_guard_claude_adapter.py
@@ -158,10 +158,12 @@ def test_claude_install_writes_session_start_and_command_hook_schema_and_is_idem
     assert CLAUDE_GUARD_DAEMON_HOOK_MARKER in pre_tool_use[0]["hooks"][0]["command"]
     assert "url" not in pre_tool_use[0]["hooks"][0]
     assert pre_tool_use[0]["hooks"][0]["timeout"] == 30
+    assert pre_tool_use[0]["hooks"][0]["statusMessage"] == "HOL Guard is checking this tool use"
     assert len(permission_request) == 1
     assert permission_request[0]["matcher"] == "Bash|Read|Write|Edit|MultiEdit|WebFetch|WebSearch|mcp__.*"
     assert permission_request[0]["hooks"][0]["type"] == "command"
     assert permission_request[0]["hooks"][0]["timeout"] == 10
+    assert permission_request[0]["hooks"][0]["statusMessage"] == "HOL Guard is reviewing this approval prompt"
     assert len(post_tool_use) == 1
     assert post_tool_use[0]["matcher"] == "Bash|Read|Write|Edit|MultiEdit|WebFetch|WebSearch|mcp__.*|AskUserQuestion"
     assert post_tool_use[0]["hooks"][0]["type"] == "command"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -2657,7 +2657,10 @@ args = ["workspace-skill.js", "--changed"]
         assert install_output["managed_install"]["manifest"]["shim_command"] == "guard-claude"
         assert settings_path.exists()
         assert len(install_settings_payload["hooks"]["SessionStart"]) == 4
-        assert len(install_settings_payload["hooks"]["PreToolUse"]) == 1
+        pretool_entries = install_settings_payload["hooks"]["PreToolUse"]
+        assert len(pretool_entries) == 2
+        assert pretool_entries[0] == {"command": "python guard-pre.py"}
+        guard_pretool_entry = pretool_entries[1]
         assert install_output["managed_install"]["manifest"]["notes"][0]
         expected_session_start_command = ClaudeCodeHarnessAdapter._session_start_command(
             HarnessContext(
@@ -2667,7 +2670,7 @@ args = ["workspace-skill.js", "--changed"]
             )
         )
         assert (
-            install_settings_payload["hooks"]["PreToolUse"][0]["matcher"]
+            guard_pretool_entry["matcher"]
             == "Bash|Read|Write|Edit|MultiEdit|WebFetch|WebSearch|mcp__.*"
         )
         assert (
@@ -2681,9 +2684,9 @@ args = ["workspace-skill.js", "--changed"]
                 guard_home=home_dir,
             )
         )
-        assert install_settings_payload["hooks"]["PreToolUse"][0]["hooks"][0]["type"] == "command"
-        assert install_settings_payload["hooks"]["PreToolUse"][0]["hooks"][0]["command"] == expected_hook_command
-        assert "url" not in install_settings_payload["hooks"]["PreToolUse"][0]["hooks"][0]
+        assert guard_pretool_entry["hooks"][0]["type"] == "command"
+        assert guard_pretool_entry["hooks"][0]["command"] == expected_hook_command
+        assert "url" not in guard_pretool_entry["hooks"][0]
         assert install_settings_payload["hooks"].get("UserPromptSubmit", []) == []
         assert install_settings_payload["hooks"]["Notification"][0]["matcher"] == "permission_prompt"
         assert install_settings_payload["hooks"]["Notification"][0]["hooks"][0]["type"] == "command"
@@ -2693,7 +2696,7 @@ args = ["workspace-skill.js", "--changed"]
         assert uninstall_rc == 0
         assert uninstall_output["managed_install"]["active"] is False
         assert settings_payload["hooks"]["SessionStart"] == []
-        assert settings_payload["hooks"]["PreToolUse"] == []
+        assert settings_payload["hooks"]["PreToolUse"] == [{"command": "python guard-pre.py"}]
         assert settings_payload["hooks"]["Notification"] == []
         assert settings_payload["hooks"]["Stop"] == []
 
@@ -2848,7 +2851,7 @@ args = ["workspace-skill.js", "--changed"]
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         _build_guard_fixture(home_dir, workspace_dir)
-        settings_local = workspace_dir / ".claude" / "settings.local.json"
+        settings_path = home_dir / ".claude" / "settings.json"
         legacy_command = ClaudeCodeHarnessAdapter._hook_command(
             HarnessContext(
                 home_dir=home_dir,
@@ -2857,7 +2860,7 @@ args = ["workspace-skill.js", "--changed"]
             )
         )
         _write_json(
-            settings_local,
+            settings_path,
             {
                 "hooks": {
                     "SessionStart": [
@@ -2906,7 +2909,7 @@ args = ["workspace-skill.js", "--changed"]
             ]
         )
         output = json.loads(capsys.readouterr().out)
-        payload = json.loads(settings_local.read_text(encoding="utf-8"))
+        payload = json.loads(settings_path.read_text(encoding="utf-8"))
 
         assert rc == 0
         assert output["managed_install"]["active"] is True

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -2634,8 +2634,8 @@ args = ["workspace-skill.js", "--changed"]
             ]
         )
         install_output = json.loads(capsys.readouterr().out)
-        settings_local = workspace_dir / ".claude" / "settings.local.json"
-        install_settings_payload = json.loads(settings_local.read_text(encoding="utf-8"))
+        settings_path = home_dir / ".claude" / "settings.json"
+        install_settings_payload = json.loads(settings_path.read_text(encoding="utf-8"))
 
         uninstall_rc = main(
             [
@@ -2650,12 +2650,12 @@ args = ["workspace-skill.js", "--changed"]
             ]
         )
         uninstall_output = json.loads(capsys.readouterr().out)
-        settings_payload = json.loads(settings_local.read_text(encoding="utf-8"))
+        settings_payload = json.loads(settings_path.read_text(encoding="utf-8"))
 
         assert install_rc == 0
         assert install_output["managed_install"]["active"] is True
         assert install_output["managed_install"]["manifest"]["shim_command"] == "guard-claude"
-        assert settings_local.exists()
+        assert settings_path.exists()
         assert len(install_settings_payload["hooks"]["SessionStart"]) == 4
         assert len(install_settings_payload["hooks"]["PreToolUse"]) == 1
         assert install_output["managed_install"]["manifest"]["notes"][0]
@@ -2701,7 +2701,7 @@ args = ["workspace-skill.js", "--changed"]
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         _build_guard_fixture(home_dir, workspace_dir)
-        settings_local = workspace_dir / ".claude" / "settings.local.json"
+        settings_path = home_dir / ".claude" / "settings.json"
         expected_hook_command = ClaudeCodeHarnessAdapter._hook_command(
             HarnessContext(
                 home_dir=home_dir,
@@ -2710,7 +2710,7 @@ args = ["workspace-skill.js", "--changed"]
             )
         )
         _write_json(
-            settings_local,
+            settings_path,
             {
                 "hooks": {
                     "PreToolUse": ["unexpected-entry", {"command": expected_hook_command}],
@@ -2732,7 +2732,7 @@ args = ["workspace-skill.js", "--changed"]
             ]
         )
         output = json.loads(capsys.readouterr().out)
-        payload = json.loads(settings_local.read_text(encoding="utf-8"))
+        payload = json.loads(settings_path.read_text(encoding="utf-8"))
 
         assert rc == 0
         assert output["managed_install"]["active"] is False
@@ -2742,7 +2742,7 @@ args = ["workspace-skill.js", "--changed"]
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         _build_guard_fixture(home_dir, workspace_dir)
-        settings_local = workspace_dir / ".claude" / "settings.local.json"
+        settings_path = home_dir / ".claude" / "settings.json"
 
         install_rc = main(
             [
@@ -2776,12 +2776,12 @@ args = ["workspace-skill.js", "--changed"]
             ]
         )
         output = json.loads(capsys.readouterr().out)
-        payload = json.loads(settings_local.read_text(encoding="utf-8"))
+        payload = json.loads(settings_path.read_text(encoding="utf-8"))
 
         assert install_rc == 0
         assert uninstall_rc == 0
         assert output["managed_install"]["active"] is False
-        assert payload["hooks"]["PreToolUse"] == []
+        assert payload["hooks"]["PreToolUse"] == [{"command": "python guard-pre.py"}]
         assert payload["hooks"].get("UserPromptSubmit", []) == []
         assert payload["hooks"]["Notification"] == []
         assert payload["hooks"]["Stop"] == []

--- a/tests/test_guard_phase04_harness_contracts.py
+++ b/tests/test_guard_phase04_harness_contracts.py
@@ -139,9 +139,7 @@ def test_gr096_managed_hook_json_matches_each_harness_schema(tmp_path: Path) -> 
     CopilotHarnessAdapter().install(context)
 
     codex_hooks = _read_codex_hooks(Path(str(codex_manifest["managed_hook_config_path"])))
-    claude_hooks = json.loads((context.workspace_dir / ".claude" / "settings.local.json").read_text(encoding="utf-8"))[
-        "hooks"
-    ]
+    claude_hooks = json.loads((context.home_dir / ".claude" / "settings.json").read_text(encoding="utf-8"))["hooks"]
     opencode_runtime = json.loads(Path(str(opencode_manifest["runtime_config_path"])).read_text(encoding="utf-8"))
     copilot_hooks = json.loads((context.workspace_dir / ".github" / "hooks" / "hol-guard-copilot.json").read_text())
 
@@ -160,9 +158,7 @@ def test_gr099_managed_hooks_use_lightweight_cli_entrypoints(tmp_path: Path) -> 
     CopilotHarnessAdapter().install(context)
 
     codex_hooks = _read_codex_hooks(Path(str(codex_manifest["managed_hook_config_path"])))
-    claude_hooks = json.loads((context.workspace_dir / ".claude" / "settings.local.json").read_text(encoding="utf-8"))[
-        "hooks"
-    ]
+    claude_hooks = json.loads((context.home_dir / ".claude" / "settings.json").read_text(encoding="utf-8"))["hooks"]
     copilot_hooks = json.loads(
         (context.workspace_dir / ".github" / "hooks" / "hol-guard-copilot.json").read_text(encoding="utf-8")
     )["hooks"]

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -9662,6 +9662,94 @@ def test_guard_hook_emits_claude_native_permission_request_for_package_notice(
     assert "AskUserQuestion" not in json.dumps(permission_payload["hookSpecificOutput"])
 
 
+def test_guard_hook_emits_claude_permission_request_terminal_notice_stderr(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import (
+        PackageRequestEvaluation,
+        SupplyChainUserCopy,
+    )
+
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(
+        home_dir / "config.toml",
+        '[risk_actions]\npackage_script = "require-reapproval"\napproval_wait_timeout_seconds = 0\n',
+    )
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+
+    def _package_requires_review(**_kwargs: object) -> PackageRequestEvaluation:
+        return PackageRequestEvaluation(
+            decision="review",
+            policy_action="require-reapproval",
+            enforcement="policy",
+            entitlement_state="offline",
+            cache_status="miss",
+            package_intent_hash="intent-hash",
+            policy_version="policy-v1",
+            bundle_version="bundle-v1",
+            workspace_fingerprint="workspace-fingerprint",
+            reasons=({"code": "package_review", "message": "Review npm install react@18.3.0"},),
+            packages=({"name": "react", "decision": "review", "reasons": ()},),
+            risk_summary="HOL Guard is reviewing npm install react@18.3.0.",
+            user_copy=SupplyChainUserCopy(
+                title="Review package install",
+                summary="react@18.3.0 needs review before install.",
+                next_step="Confirm the exact version in Claude's approval prompt.",
+                dashboard_url="https://hol.org/guard/inbox",
+                harness_message="HOL Guard is reviewing npm install react@18.3.0.",
+            ),
+        )
+
+    monkeypatch.setattr(
+        guard_commands_module,
+        "evaluate_package_request_artifact",
+        _package_requires_review,
+    )
+    pre_tool_event = {
+        "session_id": "session-claude-package-permission-request-stderr",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "npm install react@18.3.0"},
+        "source_scope": "project",
+    }
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    pre_tool_rc, _ = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="claude-code",
+        event=pre_tool_event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(json.dumps({**pre_tool_event, "hook_event_name": "PermissionRequest"})),
+    )
+    permission_rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "claude-code",
+        ]
+    )
+    permission_capture = capsys.readouterr()
+
+    assert pre_tool_rc == 0
+    assert permission_rc == 0
+    assert "HOL Guard" in permission_capture.err
+    assert "Bash" in permission_capture.err
+
+
 def test_guard_hook_emits_claude_native_ask_for_sensitive_file_reads(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -9667,6 +9667,8 @@ def test_guard_hook_emits_claude_permission_request_terminal_notice_stderr(
     capsys,
     monkeypatch,
 ):
+    import io
+    import sys
     from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import (
         PackageRequestEvaluation,
         SupplyChainUserCopy,


### PR DESCRIPTION
## Summary
- Install Claude Guard hooks into ~/.claude/settings.json (global), merging with existing hooks
- Emit HOL Guard stderr + statusMessage during PermissionRequest and PreToolUse

## Testing
- `python3 -m pytest tests/test_guard_claude_adapter.py tests/test_guard_runtime.py -k "claude_permission_request or claude_install" -q`
- `python3 -m pytest tests/test_guard_cli.py -k "claude_writes_hooks or uninstall_claude" -q`
