### PR TITLE
fix(guard): prefer device-code browser flow

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2350,6 +2350,7 @@ def run_guard_command(
             connect_url=args.connect_url,
             use_browser_oauth=False,
             open_device_browser=True,
+            wait_timeout_seconds=int(getattr(args, "wait_timeout_seconds", 180) or 180),
             announce_copy=None
             if getattr(args, "json", False)
             else _announce_guard_device_connect_copy,
@@ -2381,6 +2382,7 @@ def run_guard_command(
                 connect_url=args.connect_url,
                 use_browser_oauth=False,
                 open_device_browser=True,
+                wait_timeout_seconds=int(getattr(args, "wait_timeout_seconds", 180) or 180),
                 announce_copy=None
                 if getattr(args, "json", False)
                 else _announce_guard_device_connect_copy,
@@ -9002,6 +9004,7 @@ def _run_guard_device_connect_flow(
     *,
     store: GuardStore,
     connect_url: str,
+    wait_timeout_seconds: int = 180,
     announce_copy=None,
     open_browser: Callable[[str], bool] | None = None,
     ci_safe: bool = False,
@@ -9010,6 +9013,7 @@ def _run_guard_device_connect_flow(
     return run_guard_device_connect_command(
         store=store,
         connect_url=connect_url,
+        wait_timeout_seconds=wait_timeout_seconds,
         announce_copy=announce_copy,
         open_browser=open_browser,
         ci_safe=ci_safe,
@@ -9052,6 +9056,7 @@ def _build_guard_device_connect_payload(
             payload = _run_guard_device_connect_flow(
                 store=store,
                 connect_url=connect_url,
+                wait_timeout_seconds=wait_timeout_seconds,
                 announce_copy=announce_copy,
                 open_browser=webbrowser.open,
                 ci_safe=ci_safe,
@@ -9061,6 +9066,7 @@ def _build_guard_device_connect_payload(
             payload = _run_guard_device_connect_flow(
                 store=store,
                 connect_url=connect_url,
+                wait_timeout_seconds=wait_timeout_seconds,
                 announce_copy=announce_copy,
                 ci_safe=ci_safe,
                 machine_label=machine_label,
@@ -9084,10 +9090,10 @@ def _announce_guard_device_connect_copy(payload: dict[str, object]) -> None:
     )
     if target is None:
         return
-    print("HOL Guard headless approval")
-    print(f"1. Open {target}")
-    print(f"2. Enter code {user_code}")
-    print("3. Keep this terminal open while HOL Guard waits for approval.")
+    print("HOL Guard headless approval", file=sys.stderr)
+    print(f"1. Open {target}", file=sys.stderr)
+    print(f"2. Enter code {user_code}", file=sys.stderr)
+    print("3. Keep this terminal open while HOL Guard waits for approval.", file=sys.stderr)
 
 
 def _guard_ci_safe_connect_options(args: argparse.Namespace) -> tuple[bool, str | None]:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2348,8 +2348,11 @@ def run_guard_command(
         payload, exit_code = _build_guard_device_connect_payload(
             store=store,
             connect_url=args.connect_url,
-            use_browser_oauth=True,
-            wait_timeout_seconds=int(getattr(args, "wait_timeout_seconds", 180) or 180),
+            use_browser_oauth=False,
+            open_device_browser=True,
+            announce_copy=None
+            if getattr(args, "json", False)
+            else _announce_guard_device_connect_copy,
         )
         if payload is None:
             return exit_code
@@ -2376,8 +2379,11 @@ def run_guard_command(
             payload, exit_code = _build_guard_device_connect_payload(
                 store=store,
                 connect_url=args.connect_url,
-                use_browser_oauth=True,
-                wait_timeout_seconds=int(getattr(args, "wait_timeout_seconds", 180) or 180),
+                use_browser_oauth=False,
+                open_device_browser=True,
+                announce_copy=None
+                if getattr(args, "json", False)
+                else _announce_guard_device_connect_copy,
             )
             if payload is None:
                 return exit_code

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -446,11 +446,15 @@ def exchange_guard_device_code(
     dpop_key_material: GuardDpopKeyMaterial,
     interval_seconds: int,
     expires_in_seconds: int,
+    wait_timeout_seconds: float | None = None,
     urlopen=urllib.request.urlopen,
     sleep=time.sleep,
     now: datetime | None = None,
 ) -> GuardOAuthTokenExchangeResult:
-    deadline = time.monotonic() + max(expires_in_seconds, 1)
+    wait_window_seconds = max(expires_in_seconds, 1)
+    if wait_timeout_seconds is not None:
+        wait_window_seconds = min(wait_window_seconds, max(wait_timeout_seconds, 0))
+    deadline = time.monotonic() + wait_window_seconds
     current_interval = max(interval_seconds, 1)
     while True:
         request = urllib.request.Request(
@@ -556,6 +560,7 @@ def run_guard_device_connect_command(
     token_urlopen=urllib.request.urlopen,
     sleep=time.sleep,
     now: str | None = None,
+    wait_timeout_seconds: float | None = None,
     announce_copy=None,
     open_browser=None,
     ci_safe: bool = False,
@@ -599,6 +604,7 @@ def run_guard_device_connect_command(
         dpop_key_material=dpop_key_material,
         interval_seconds=int(response.get("interval") or 5),
         expires_in_seconds=int(response.get("expires_in") or 0),
+        wait_timeout_seconds=wait_timeout_seconds,
         urlopen=token_urlopen,
         sleep=sleep,
         now=datetime.fromisoformat(now) if now else None,

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6319,34 +6319,41 @@ url = http://127.0.0.1:8787/guard-canary
         assert "artifactHash" in first_receipt
         assert "recommendation" in first_receipt
 
-    def test_guard_connect_opens_browser_oauth_without_pairing(self, tmp_path, capsys, monkeypatch):
+    def test_guard_connect_opens_device_code_browser_flow_without_pairing(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         _build_guard_fixture(home_dir, workspace_dir)
         _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\n')
         store = GuardStore(home_dir)
-        authorize_url = "https://hol.org/api/guard/oauth/authorize?client_id=guard-local-daemon"
+        opened: list[str] = []
 
-        def fake_browser_flow(
+        def fake_device_flow(
             *,
             store: GuardStore,
             connect_url: str,
-            wait_timeout_seconds: int,
+            announce_copy=None,
+            open_browser=None,
+            ci_safe: bool = False,
+            machine_label: str | None = None,
         ) -> dict[str, object]:
+            del store, announce_copy, ci_safe, machine_label
             assert connect_url == "https://hol.org/guard/connect"
-            assert wait_timeout_seconds == 180
+            assert open_browser is not None
+            browser_opened = bool(open_browser("https://hol.org/guard/oauth/device?user_code=ABCD-EFGH"))
             return {
                 "status": "connected",
-                "connect_mode": "browser_oauth",
-                "browser_opened": True,
-                "authorize_url": authorize_url,
-                "redirect_uri": "http://127.0.0.1:61234/oauth/callback",
+                "connect_mode": "device_code",
+                "browser_opened": browser_opened,
+                "user_code": "ABCD-EFGH",
+                "verification_uri": "https://hol.org/guard/oauth/device",
+                "verification_uri_complete": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
                 "grant_id": "grant-123",
                 "machine_id": "machine-123",
                 "workspace_id": "workspace-123",
             }
 
-        monkeypatch.setattr(guard_commands_module, "_run_guard_browser_connect_flow", fake_browser_flow)
+        monkeypatch.setattr(guard_commands_module, "_run_guard_device_connect_flow", fake_device_flow)
+        monkeypatch.setattr(guard_commands_module.webbrowser, "open", lambda target: opened.append(target) or True)
         run_rc = main(
             [
                 "guard",
@@ -6378,11 +6385,13 @@ url = http://127.0.0.1:8787/guard-canary
 
         assert run_rc == 0
         assert connect_rc == 0
+        assert opened == ["https://hol.org/guard/oauth/device?user_code=ABCD-EFGH"]
         assert connect_output["status"] == "connected"
-        assert connect_output["connect_mode"] == "browser_oauth"
+        assert connect_output["connect_mode"] == "device_code"
         assert connect_output["browser_opened"] is True
-        assert connect_output["authorize_url"] == "*****"
-        assert connect_output["redirect_uri"] == "http://127.0.0.1:61234/oauth/callback"
+        assert connect_output["user_code"] == "ABCD-EFGH"
+        assert connect_output["verification_uri"] == "https://hol.org/guard/oauth/device"
+        assert connect_output["verification_uri_complete"] == "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH"
         assert connect_output["grant_id"] == "grant-123"
         assert connect_output["machine_id"] == "machine-123"
         assert connect_output["workspace_id"] == "workspace-123"
@@ -6432,31 +6441,38 @@ url = http://127.0.0.1:8787/guard-canary
             "workspace_id": "workspace-123",
         }
 
-    def test_guard_login_without_manual_credentials_uses_browser_oauth(self, tmp_path, capsys, monkeypatch):
+    def test_guard_login_without_manual_credentials_uses_device_code_browser_flow(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)
-        authorize_url = "https://hol.org/api/guard/oauth/authorize?client_id=guard-local-daemon"
+        opened: list[str] = []
 
-        def fake_browser_flow(
+        def fake_device_flow(
             *,
             store: GuardStore,
             connect_url: str,
-            wait_timeout_seconds: int,
+            announce_copy=None,
+            open_browser=None,
+            ci_safe: bool = False,
+            machine_label: str | None = None,
         ) -> dict[str, object]:
+            del store, announce_copy, ci_safe, machine_label
             assert connect_url == "https://hol.org/guard/connect"
-            assert wait_timeout_seconds == 180
+            assert open_browser is not None
+            browser_opened = bool(open_browser("https://hol.org/guard/oauth/device?user_code=ZXCV-BNMQ"))
             return {
                 "status": "connected",
-                "connect_mode": "browser_oauth",
-                "browser_opened": True,
-                "authorize_url": authorize_url,
-                "redirect_uri": "http://127.0.0.1:61234/oauth/callback",
+                "connect_mode": "device_code",
+                "browser_opened": browser_opened,
+                "user_code": "ZXCV-BNMQ",
+                "verification_uri": "https://hol.org/guard/oauth/device",
+                "verification_uri_complete": "https://hol.org/guard/oauth/device?user_code=ZXCV-BNMQ",
                 "grant_id": "grant-456",
                 "machine_id": "machine-456",
                 "workspace_id": "workspace-456",
             }
 
-        monkeypatch.setattr(guard_commands_module, "_run_guard_browser_connect_flow", fake_browser_flow)
+        monkeypatch.setattr(guard_commands_module, "_run_guard_device_connect_flow", fake_device_flow)
+        monkeypatch.setattr(guard_commands_module.webbrowser, "open", lambda target: opened.append(target) or True)
         login_rc = main(
             [
                 "guard",
@@ -6471,11 +6487,13 @@ url = http://127.0.0.1:8787/guard-canary
         login_output = json.loads(capsys.readouterr().out)
 
         assert login_rc == 0
+        assert opened == ["https://hol.org/guard/oauth/device?user_code=ZXCV-BNMQ"]
         assert login_output["status"] == "connected"
-        assert login_output["connect_mode"] == "browser_oauth"
+        assert login_output["connect_mode"] == "device_code"
         assert login_output["browser_opened"] is True
-        assert login_output["authorize_url"] == "*****"
-        assert login_output["redirect_uri"] == "http://127.0.0.1:61234/oauth/callback"
+        assert login_output["user_code"] == "ZXCV-BNMQ"
+        assert login_output["verification_uri"] == "https://hol.org/guard/oauth/device"
+        assert login_output["verification_uri_complete"] == "https://hol.org/guard/oauth/device?user_code=ZXCV-BNMQ"
         assert login_output["grant_id"] == "grant-456"
         assert login_output["machine_id"] == "machine-456"
         assert login_output["workspace_id"] == "workspace-456"
@@ -6841,19 +6859,23 @@ url = http://127.0.0.1:8787/guard-canary
             "sync_url": None,
         }
 
-    def test_guard_connect_reports_browser_authorization_errors_cleanly(self, tmp_path, capsys, monkeypatch):
+    def test_guard_connect_reports_device_authorization_errors_cleanly(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)
 
-        def failing_browser_flow(
+        def failing_device_flow(
             *,
             store: GuardStore,
             connect_url: str,
-            wait_timeout_seconds: int,
+            announce_copy=None,
+            open_browser=None,
+            ci_safe: bool = False,
+            machine_label: str | None = None,
         ) -> dict[str, object]:
-            raise RuntimeError("browser_oauth_unreachable")
+            raise RuntimeError("device_code_unreachable")
 
-        monkeypatch.setattr(guard_commands_module, "_run_guard_browser_connect_flow", failing_browser_flow)
+        monkeypatch.setattr(guard_commands_module, "_run_guard_device_connect_flow", failing_device_flow)
+        monkeypatch.setattr(guard_commands_module.webbrowser, "open", lambda _target: True)
         connect_rc = main(
             [
                 "guard",
@@ -6868,29 +6890,34 @@ url = http://127.0.0.1:8787/guard-canary
         captured = capsys.readouterr()
 
         assert connect_rc == 1
-        assert "Guard authorization failed: browser_oauth_unreachable" in captured.err
+        assert "Guard authorization failed: device_code_unreachable" in captured.err
         assert "Traceback" not in captured.err
         assert store.get_sync_credentials() is None
 
-    def test_guard_connect_never_opens_legacy_pairing_url(self, tmp_path, capsys, monkeypatch):
+    def test_guard_connect_never_exposes_legacy_pairing_fields(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
-        authorize_url = "https://hol.org/api/guard/oauth/authorize?client_id=guard-local-daemon"
 
-        def fake_browser_flow(
+        def fake_device_flow(
             *,
             store: GuardStore,
             connect_url: str,
-            wait_timeout_seconds: int,
+            announce_copy=None,
+            open_browser=None,
+            ci_safe: bool = False,
+            machine_label: str | None = None,
         ) -> dict[str, object]:
+            del store, announce_copy, open_browser, ci_safe, machine_label
             return {
                 "status": "connected",
-                "connect_mode": "browser_oauth",
+                "connect_mode": "device_code",
                 "browser_opened": True,
-                "authorize_url": authorize_url,
-                "redirect_uri": "http://127.0.0.1:61234/oauth/callback",
+                "user_code": "ABCD-EFGH",
+                "verification_uri": "https://hol.org/guard/oauth/device",
+                "verification_uri_complete": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
             }
 
-        monkeypatch.setattr(guard_commands_module, "_run_guard_browser_connect_flow", fake_browser_flow)
+        monkeypatch.setattr(guard_commands_module, "_run_guard_device_connect_flow", fake_device_flow)
+        monkeypatch.setattr(guard_commands_module.webbrowser, "open", lambda _target: True)
         connect_rc = main(
             [
                 "guard",
@@ -6906,8 +6933,7 @@ url = http://127.0.0.1:8787/guard-canary
         rendered = json.dumps(connect_output, sort_keys=True)
 
         assert connect_rc == 0
-        assert connect_output["connect_mode"] == "browser_oauth"
-        assert connect_output["authorize_url"] == "*****"
+        assert connect_output["connect_mode"] == "device_code"
         assert "guardPairSecret" not in rendered
         assert "guardPairRequest" not in rendered
         assert "guardDaemon" not in rendered

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6331,12 +6331,14 @@ url = http://127.0.0.1:8787/guard-canary
             *,
             store: GuardStore,
             connect_url: str,
+            wait_timeout_seconds: int = 180,
             announce_copy=None,
             open_browser=None,
             ci_safe: bool = False,
             machine_label: str | None = None,
         ) -> dict[str, object]:
             del store, announce_copy, ci_safe, machine_label
+            assert wait_timeout_seconds == 180
             assert connect_url == "https://hol.org/guard/connect"
             assert open_browser is not None
             browser_opened = bool(open_browser("https://hol.org/guard/oauth/device?user_code=ABCD-EFGH"))
@@ -6450,12 +6452,14 @@ url = http://127.0.0.1:8787/guard-canary
             *,
             store: GuardStore,
             connect_url: str,
+            wait_timeout_seconds: int = 180,
             announce_copy=None,
             open_browser=None,
             ci_safe: bool = False,
             machine_label: str | None = None,
         ) -> dict[str, object]:
             del store, announce_copy, ci_safe, machine_label
+            assert wait_timeout_seconds == 180
             assert connect_url == "https://hol.org/guard/connect"
             assert open_browser is not None
             browser_opened = bool(open_browser("https://hol.org/guard/oauth/device?user_code=ZXCV-BNMQ"))
@@ -6867,11 +6871,13 @@ url = http://127.0.0.1:8787/guard-canary
             *,
             store: GuardStore,
             connect_url: str,
+            wait_timeout_seconds: int = 180,
             announce_copy=None,
             open_browser=None,
             ci_safe: bool = False,
             machine_label: str | None = None,
         ) -> dict[str, object]:
+            del store, connect_url, wait_timeout_seconds, announce_copy, open_browser, ci_safe, machine_label
             raise RuntimeError("device_code_unreachable")
 
         monkeypatch.setattr(guard_commands_module, "_run_guard_device_connect_flow", failing_device_flow)
@@ -6901,12 +6907,14 @@ url = http://127.0.0.1:8787/guard-canary
             *,
             store: GuardStore,
             connect_url: str,
+            wait_timeout_seconds: int = 180,
             announce_copy=None,
             open_browser=None,
             ci_safe: bool = False,
             machine_label: str | None = None,
         ) -> dict[str, object]:
             del store, announce_copy, open_browser, ci_safe, machine_label
+            assert wait_timeout_seconds == 180
             return {
                 "status": "connected",
                 "connect_mode": "device_code",

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -407,6 +407,57 @@ def test_headless_connect_polls_until_success_and_persists_oauth_credentials(tmp
     assert credentials["runtime_label"] == "HOL Guard CLI"
 
 
+def test_headless_connect_respects_client_wait_timeout(tmp_path: Path, monkeypatch) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    sleeps: list[float] = []
+    clock = {"value": 0.0}
+
+    def fake_request(_url: str, _body: str) -> dict[str, object]:
+        return {
+            "device_code": "device-secret-value",
+            "user_code": "ABCD-EFGH",
+            "verification_uri": "https://hol.org/guard/oauth/device",
+            "verification_uri_complete": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
+            "expires_in": 600,
+            "interval": 5,
+        }
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int):
+        del timeout
+        raise urllib.error.HTTPError(
+            request.full_url,
+            400,
+            "authorization_pending",
+            hdrs={"Content-Type": "application/json"},
+            fp=io.BytesIO(json.dumps({"error": "authorization_pending"}).encode("utf-8")),
+        )
+
+    def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+        clock["value"] += seconds
+
+    monkeypatch.setattr(connect_flow.time, "monotonic", lambda: clock["value"])
+
+    try:
+        connect_flow.run_guard_device_connect_command(
+            store=store,
+            connect_url="https://hol.org/guard/connect",
+            request_device_authorization=fake_request,
+            token_urlopen=fake_urlopen,
+            sleep=fake_sleep,
+            now="2026-06-01T12:00:00+00:00",
+            wait_timeout_seconds=2,
+        )
+    except RuntimeError as error:
+        message = str(error)
+    else:
+        raise AssertionError("client wait timeout must stop device-code polling")
+
+    assert "timed out" in message
+    assert sleeps == [5]
+
+
 def test_headless_connect_slows_down_polling_when_server_requests_it(tmp_path: Path) -> None:
     guard_home = tmp_path / "guard-home"
     store = GuardStore(guard_home)
@@ -576,6 +627,7 @@ def test_connect_headless_emits_device_code_payload_without_pairing_secret(tmp_p
         *,
         store: GuardStore,
         connect_url: str,
+        wait_timeout_seconds: int = 180,
         announce_copy=None,
         ci_safe: bool = False,
         machine_label: str | None = None,
@@ -720,6 +772,7 @@ def test_connect_headless_open_browser_opens_device_approval_before_polling(
         *,
         store: GuardStore,
         connect_url: str,
+        wait_timeout_seconds: int = 180,
         announce_copy=None,
         open_browser=None,
         ci_safe: bool = False,
@@ -781,6 +834,7 @@ def test_connect_default_uses_device_code_flow_with_browser_open(tmp_path: Path,
         *,
         store: GuardStore,
         connect_url: str,
+        wait_timeout_seconds: int = 180,
         announce_copy=None,
         open_browser=None,
         ci_safe: bool = False,
@@ -788,6 +842,7 @@ def test_connect_default_uses_device_code_flow_with_browser_open(tmp_path: Path,
     ) -> dict[str, object]:
         del store, ci_safe, machine_label
         assert connect_url == "https://hol.org/guard/connect"
+        assert wait_timeout_seconds == 5
         assert open_browser is not None
         if announce_copy is not None:
             announce_copy(
@@ -826,6 +881,87 @@ def test_connect_default_uses_device_code_flow_with_browser_open(tmp_path: Path,
     assert "guardPairSecret" not in captured.out
     assert "guardPairRequest" not in captured.out
     assert not hasattr(guard_commands, "_run_guard_connect_flow")
+
+
+def test_connect_default_device_flow_respects_wait_timeout_seconds(tmp_path: Path, capsys, monkeypatch) -> None:
+    guard_home = tmp_path / "guard-home"
+    args = _ConnectArgs()
+    args.guard_home = str(guard_home)
+    args.wait_timeout_seconds = 7
+
+    def fake_device_flow(
+        *,
+        store: GuardStore,
+        connect_url: str,
+        wait_timeout_seconds: int = 180,
+        announce_copy=None,
+        open_browser=None,
+        ci_safe: bool = False,
+        machine_label: str | None = None,
+    ) -> dict[str, object]:
+        del store, announce_copy, open_browser, ci_safe, machine_label
+        assert connect_url == "https://hol.org/guard/connect"
+        assert wait_timeout_seconds == 7
+        return {
+            "status": "connected",
+            "connect_mode": "device_code",
+            "browser_opened": False,
+            "user_code": "ABCD-EFGH",
+            "verification_uri": "https://hol.org/guard/oauth/device",
+        }
+
+    monkeypatch.setattr(guard_commands, "_run_guard_device_connect_flow", fake_device_flow)
+    monkeypatch.setattr(guard_commands.webbrowser, "open", lambda _target: True)
+
+    exit_code = run_guard_command(args)
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "device_code" in captured.out
+
+
+def test_connect_default_non_json_announces_device_copy_on_stderr(tmp_path: Path, capsys, monkeypatch) -> None:
+    guard_home = tmp_path / "guard-home"
+    args = _ConnectArgs()
+    args.guard_home = str(guard_home)
+    args.json = False
+
+    def fake_device_flow(
+        *,
+        store: GuardStore,
+        connect_url: str,
+        wait_timeout_seconds: int = 180,
+        announce_copy=None,
+        open_browser=None,
+        ci_safe: bool = False,
+        machine_label: str | None = None,
+    ) -> dict[str, object]:
+        del store, connect_url, open_browser, ci_safe, machine_label
+        assert announce_copy is not None
+        announce_copy(
+            {
+                "user_code": "ABCD-EFGH",
+                "verification_uri": "https://hol.org/guard/oauth/device",
+                "verification_uri_complete": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
+            }
+        )
+        return {
+            "status": "connected",
+            "connect_mode": "device_code",
+            "browser_opened": False,
+            "user_code": "ABCD-EFGH",
+            "verification_uri": "https://hol.org/guard/oauth/device",
+        }
+
+    monkeypatch.setattr(guard_commands, "_run_guard_device_connect_flow", fake_device_flow)
+    monkeypatch.setattr(guard_commands.webbrowser, "open", lambda _target: True)
+
+    exit_code = run_guard_command(args)
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "HOL Guard headless approval" in captured.err
+    assert "HOL Guard headless approval" not in captured.out
 
 
 def test_loopback_callback_listener_uses_random_high_port_and_loopback_path() -> None:
@@ -1097,6 +1233,7 @@ def test_connect_headless_reports_device_authorization_network_error(tmp_path: P
         *,
         store: GuardStore,
         connect_url: str,
+        wait_timeout_seconds: int = 180,
         announce_copy=None,
         ci_safe: bool = False,
         machine_label: str | None = None,
@@ -1124,6 +1261,7 @@ def test_connect_headless_reports_malformed_device_authorization_response(tmp_pa
         *,
         store: GuardStore,
         connect_url: str,
+        wait_timeout_seconds: int = 180,
         announce_copy=None,
         ci_safe: bool = False,
         machine_label: str | None = None,

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -767,31 +767,62 @@ def test_connect_headless_open_browser_opens_device_approval_before_polling(
     assert "browser_opened" in captured.out
 
 
-def test_connect_default_uses_browser_oauth_without_pairing_secret(tmp_path: Path, capsys, monkeypatch) -> None:
+def test_connect_default_uses_device_code_flow_with_browser_open(tmp_path: Path, capsys, monkeypatch) -> None:
     guard_home = tmp_path / "guard-home"
     args = _ConnectArgs()
     args.guard_home = str(guard_home)
     args.wait_timeout_seconds = 5
+    opened: list[str] = []
 
-    def fake_browser_flow(*, store: GuardStore, connect_url: str, wait_timeout_seconds: int) -> dict[str, object]:
-        assert wait_timeout_seconds == 5
+    def fail_browser_flow(*, store: GuardStore, connect_url: str, wait_timeout_seconds: int) -> dict[str, object]:
+        raise AssertionError("default connect should not use browser oauth")
+
+    def fake_device_flow(
+        *,
+        store: GuardStore,
+        connect_url: str,
+        announce_copy=None,
+        open_browser=None,
+        ci_safe: bool = False,
+        machine_label: str | None = None,
+    ) -> dict[str, object]:
+        del store, ci_safe, machine_label
+        assert connect_url == "https://hol.org/guard/connect"
+        assert open_browser is not None
+        if announce_copy is not None:
+            announce_copy(
+                {
+                    "user_code": "ABCD-EFGH",
+                    "verification_uri": "https://hol.org/guard/oauth/device",
+                    "verification_uri_complete": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
+                }
+            )
+        browser_opened = bool(open_browser("https://hol.org/guard/oauth/device?user_code=ABCD-EFGH"))
         return {
             "status": "connected",
-            "connect_mode": "browser_oauth",
-            "authorize_url": "https://hol.org/api/guard/oauth/authorize?client_id=guard-local-daemon",
-            "redirect_uri": "http://127.0.0.1:61234/oauth/callback",
+            "connect_mode": "device_code",
+            "browser_opened": browser_opened,
+            "user_code": "ABCD-EFGH",
+            "verification_uri": "https://hol.org/guard/oauth/device",
+            "next_action": {
+                "command": "open",
+                "target": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
+            },
         }
 
-    monkeypatch.setattr(guard_commands, "_run_guard_browser_connect_flow", fake_browser_flow)
+    monkeypatch.setattr(guard_commands, "_run_guard_browser_connect_flow", fail_browser_flow)
+    monkeypatch.setattr(guard_commands, "_run_guard_device_connect_flow", fake_device_flow)
+    monkeypatch.setattr(guard_commands.webbrowser, "open", lambda target: opened.append(target) or True)
 
     exit_code = run_guard_command(args)
     captured = capsys.readouterr()
 
     assert exit_code == 0
-    assert "browser_oauth" in captured.out
-    assert '"authorize_url": "*****"' in captured.out
-    assert "ABCD-EFGH" not in captured.out
-    assert "verification_uri" not in captured.out
+    assert opened == ["https://hol.org/guard/oauth/device?user_code=ABCD-EFGH"]
+    assert "device_code" in captured.out
+    assert "browser_opened" in captured.out
+    assert "ABCD-EFGH" in captured.out
+    assert "verification_uri" in captured.out
     assert "guardPairSecret" not in captured.out
     assert "guardPairRequest" not in captured.out
     assert not hasattr(guard_commands, "_run_guard_connect_flow")


### PR DESCRIPTION
## Summary
- switch default `hol-guard connect` and `hol-guard login` to the device-code flow while still auto-opening the browser
- keep the interactive one-command setup UX, but avoid the browser loopback OAuth path that is surfacing `invalid_client` failures in production

## Testing
- `uv run pytest tests/test_guard_oauth_device_connect.py tests/test_guard_cli.py`
- `uv run ruff check src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_oauth_device_connect.py tests/test_guard_cli.py`

## Notes
- reproduced the live production device-authorization request from `hol.org` and confirmed it issues codes successfully for the default Guard scopes; the fix routes default interactive connect through that working path
