### PR TITLE
fix(guard): send hol-guard User-Agent on OAuth requests

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -61,6 +61,8 @@ def _guard_oauth_request_headers(*, dpop: str | None = None) -> dict[str, str]:
     if dpop is not None:
         headers["DPoP"] = dpop
     return headers
+
+
 _LOOPBACK_HOSTS = ("127.0.0.1", "::1")
 _LOOPBACK_PORT_MIN = 49152
 _LOOPBACK_PORT_MAX = 65535

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -18,6 +18,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
 
+from ...version import __version__
 from ..store import GuardStore
 from .oauth_client import (
     GuardDpopKeyMaterial,
@@ -47,7 +48,19 @@ DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
 DEVICE_CODE_SLOW_DOWN_SECONDS = 5
 HEADLESS_RUNTIME_ID = "hol-guard"
 HEADLESS_RUNTIME_LABEL = "HOL Guard CLI"
+_GUARD_OAUTH_USER_AGENT = f"hol-guard/{__version__}"
 _LOOPBACK_REDIRECT_PATH = "/oauth/callback"
+
+
+def _guard_oauth_request_headers(*, dpop: str | None = None) -> dict[str, str]:
+    headers = {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Accept": "application/json",
+        "User-Agent": _GUARD_OAUTH_USER_AGENT,
+    }
+    if dpop is not None:
+        headers["DPoP"] = dpop
+    return headers
 _LOOPBACK_HOSTS = ("127.0.0.1", "::1")
 _LOOPBACK_PORT_MIN = 49152
 _LOOPBACK_PORT_MAX = 65535
@@ -426,10 +439,7 @@ def request_device_authorization(url: str, body: str) -> dict[str, object]:
         url,
         data=encoded_body,
         method="POST",
-        headers={
-            "Content-Type": "application/x-www-form-urlencoded",
-            "Accept": "application/json",
-        },
+        headers=_guard_oauth_request_headers(),
     )
     with urllib.request.urlopen(request, timeout=20) as response:
         payload = json.loads(response.read().decode("utf-8"))
@@ -461,15 +471,13 @@ def exchange_guard_device_code(
             token_endpoint,
             data=_device_token_request_body(client_id=client_id, device_code=device_code),
             method="POST",
-            headers={
-                "Content-Type": "application/x-www-form-urlencoded",
-                "Accept": "application/json",
-                "DPoP": _sign_dpop_proof(
+            headers=_guard_oauth_request_headers(
+                dpop=_sign_dpop_proof(
                     token_endpoint=token_endpoint,
                     dpop_key_material=dpop_key_material,
                     now=now or datetime.now(timezone.utc),
                 ),
-            },
+            ),
         )
         try:
             with urlopen(request, timeout=20) as response:
@@ -535,15 +543,13 @@ def exchange_guard_authorization_code(
         token_endpoint,
         data=request_body,
         method="POST",
-        headers={
-            "Content-Type": "application/x-www-form-urlencoded",
-            "Accept": "application/json",
-            "DPoP": _sign_dpop_proof(
+        headers=_guard_oauth_request_headers(
+            dpop=_sign_dpop_proof(
                 token_endpoint=token_endpoint,
                 dpop_key_material=dpop_key_material,
                 now=now or datetime.now(timezone.utc),
             ),
-        },
+        ),
     )
     with urlopen(request, timeout=20) as response:
         payload = json.loads(response.read().decode("utf-8"))

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -84,6 +84,48 @@ def _fake_access_token(*, grant_id: str, machine_id: str, workspace_id: str) -> 
     return f"{header}.{claims}.signature"
 
 
+def test_request_device_authorization_sets_hol_guard_user_agent(monkeypatch) -> None:
+    captured: dict[str, str] = {}
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "device_code": "device-secret-value",
+                    "user_code": "ABCD-EFGH",
+                    "verification_uri": "https://hol.org/guard/oauth/device",
+                    "expires_in": 600,
+                    "interval": 5,
+                }
+            ).encode("utf-8")
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int):
+        del timeout
+        captured["user_agent"] = request.get_header("User-agent") or ""
+        return _Response()
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    connect_flow.request_device_authorization(
+        "https://hol.org/api/guard/oauth/device/authorize",
+        connect_flow.build_device_authorization_request_body(
+            machine_id="machine-123",
+            machine_label="Test Machine",
+            runtime_id=connect_flow.HEADLESS_RUNTIME_ID,
+            runtime_label=connect_flow.HEADLESS_RUNTIME_LABEL,
+            client_id="guard-local-daemon",
+        ),
+    )
+
+    assert captured["user_agent"].startswith("hol-guard/")
+
+
 def test_device_authorization_request_uses_oauth_scopes_without_token_material() -> None:
     assert hasattr(connect_flow, "build_device_authorization_request_body")
     encoded = connect_flow.build_device_authorization_request_body(


### PR DESCRIPTION
## Summary
- Send `User-Agent: hol-guard/<version>` on Guard OAuth HTTP requests (device authorize, token exchange, authorization code exchange).

## Testing
- `uv run pytest tests/test_guard_oauth_device_connect.py::test_request_device_authorization_sets_hol_guard_user_agent -q`
- `uv run ruff check src/codex_plugin_scanner/guard/cli/connect_flow.py tests/test_guard_oauth_device_connect.py`
- `uv run hol-guard connect --home <tmp> --connect-url https://hol.org/guard/connect --wait-timeout-seconds 12 --json` (reaches approval wait; no 403)

## Notes
- Path-based Cloudflare skip rules alone do not fix signature bans on `/api/guard/oauth/*`.
