### PR TITLE
fix(guard-cli): open generic device approval url

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -9085,8 +9085,8 @@ def _build_guard_device_connect_payload(
 
 def _announce_guard_device_connect_copy(payload: dict[str, object]) -> None:
     user_code = _optional_string(payload.get("user_code")) or "unknown"
-    target = _optional_string(payload.get("verification_uri_complete")) or _optional_string(
-        payload.get("verification_uri")
+    target = _optional_string(payload.get("verification_uri")) or _optional_string(
+        payload.get("verification_uri_complete")
     )
     if target is None:
         return

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -390,7 +390,6 @@ def build_device_authorization_copy_payload(response: dict[str, object]) -> dict
     verification_uri_complete = str(response.get("verification_uri_complete") or "").strip()
     if not user_code or not verification_uri:
         raise ValueError("Device authorization response is missing approval instructions.")
-    next_target = verification_uri_complete or verification_uri
     return {
         "status": "waiting_for_approval",
         "user_code": user_code,
@@ -400,8 +399,8 @@ def build_device_authorization_copy_payload(response: dict[str, object]) -> dict
         "interval": int(response.get("interval") or 5),
         "next_action": {
             "command": "open",
-            "target": next_target,
-            "message": f"Open {next_target} and enter code {user_code}.",
+            "target": verification_uri,
+            "message": f"Open {verification_uri} and enter code {user_code}.",
         },
     }
 

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6341,7 +6341,7 @@ url = http://127.0.0.1:8787/guard-canary
             assert wait_timeout_seconds == 180
             assert connect_url == "https://hol.org/guard/connect"
             assert open_browser is not None
-            browser_opened = bool(open_browser("https://hol.org/guard/oauth/device?user_code=ABCD-EFGH"))
+            browser_opened = bool(open_browser("https://hol.org/guard/oauth/device"))
             return {
                 "status": "connected",
                 "connect_mode": "device_code",
@@ -6387,7 +6387,7 @@ url = http://127.0.0.1:8787/guard-canary
 
         assert run_rc == 0
         assert connect_rc == 0
-        assert opened == ["https://hol.org/guard/oauth/device?user_code=ABCD-EFGH"]
+        assert opened == ["https://hol.org/guard/oauth/device"]
         assert connect_output["status"] == "connected"
         assert connect_output["connect_mode"] == "device_code"
         assert connect_output["browser_opened"] is True
@@ -6462,7 +6462,7 @@ url = http://127.0.0.1:8787/guard-canary
             assert wait_timeout_seconds == 180
             assert connect_url == "https://hol.org/guard/connect"
             assert open_browser is not None
-            browser_opened = bool(open_browser("https://hol.org/guard/oauth/device?user_code=ZXCV-BNMQ"))
+            browser_opened = bool(open_browser("https://hol.org/guard/oauth/device"))
             return {
                 "status": "connected",
                 "connect_mode": "device_code",
@@ -6491,7 +6491,7 @@ url = http://127.0.0.1:8787/guard-canary
         login_output = json.loads(capsys.readouterr().out)
 
         assert login_rc == 0
-        assert opened == ["https://hol.org/guard/oauth/device?user_code=ZXCV-BNMQ"]
+        assert opened == ["https://hol.org/guard/oauth/device"]
         assert login_output["status"] == "connected"
         assert login_output["connect_mode"] == "device_code"
         assert login_output["browser_opened"] is True

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -182,7 +182,7 @@ def test_device_authorization_copy_payload_hides_device_code_secret() -> None:
     assert payload["status"] == "waiting_for_approval"
     assert payload["user_code"] == "ABCD-EFGH"
     assert payload["verification_uri"] == "https://hol.org/guard/oauth/device"
-    assert payload["next_action"]["target"] == "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH"
+    assert payload["next_action"]["target"] == "https://hol.org/guard/oauth/device"
     assert "device-secret-value" not in rendered
     assert "device_code" not in rendered
 
@@ -207,7 +207,7 @@ def test_headless_connect_requests_device_code_without_persisting_secrets(tmp_pa
 
     class _Response:
         def __enter__(self):
-            assert opened == ["https://hol.org/guard/oauth/device?user_code=ABCD-EFGH"]
+            assert opened == ["https://hol.org/guard/oauth/device"]
             return self
 
         def __exit__(self, exc_type, exc, tb):
@@ -690,7 +690,7 @@ def test_connect_headless_emits_device_code_payload_without_pairing_secret(tmp_p
             "verification_uri": "https://hol.org/guard/oauth/device",
             "next_action": {
                 "command": "open",
-                "target": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
+                "target": "https://hol.org/guard/oauth/device",
             },
         }
 
@@ -832,7 +832,7 @@ def test_connect_headless_open_browser_opens_device_approval_before_polling(
                 }
             )
         opened.append("before-poll")
-        browser_opened = bool(open_browser("https://hol.org/guard/oauth/device?user_code=ABCD-EFGH"))
+        browser_opened = bool(open_browser("https://hol.org/guard/oauth/device"))
         opened.append("after-open")
         return {
             "status": "connected",
@@ -842,7 +842,7 @@ def test_connect_headless_open_browser_opens_device_approval_before_polling(
             "verification_uri": "https://hol.org/guard/oauth/device",
             "next_action": {
                 "command": "open",
-                "target": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
+                "target": "https://hol.org/guard/oauth/device",
             },
         }
 
@@ -855,7 +855,7 @@ def test_connect_headless_open_browser_opens_device_approval_before_polling(
     assert exit_code == 0
     assert opened == [
         "before-poll",
-        "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
+        "https://hol.org/guard/oauth/device",
         "after-open",
     ]
     assert "device_code" in captured.out
@@ -894,7 +894,7 @@ def test_connect_default_uses_device_code_flow_with_browser_open(tmp_path: Path,
                     "verification_uri_complete": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
                 }
             )
-        browser_opened = bool(open_browser("https://hol.org/guard/oauth/device?user_code=ABCD-EFGH"))
+        browser_opened = bool(open_browser("https://hol.org/guard/oauth/device"))
         return {
             "status": "connected",
             "connect_mode": "device_code",
@@ -903,7 +903,7 @@ def test_connect_default_uses_device_code_flow_with_browser_open(tmp_path: Path,
             "verification_uri": "https://hol.org/guard/oauth/device",
             "next_action": {
                 "command": "open",
-                "target": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
+                "target": "https://hol.org/guard/oauth/device",
             },
         }
 
@@ -915,7 +915,7 @@ def test_connect_default_uses_device_code_flow_with_browser_open(tmp_path: Path,
     captured = capsys.readouterr()
 
     assert exit_code == 0
-    assert opened == ["https://hol.org/guard/oauth/device?user_code=ABCD-EFGH"]
+    assert opened == ["https://hol.org/guard/oauth/device"]
     assert "device_code" in captured.out
     assert "browser_opened" in captured.out
     assert "ABCD-EFGH" in captured.out


### PR DESCRIPTION
## Summary
- launch and announce the generic OAuth device verification URI instead of the `verification_uri_complete` URL with the user code embedded in the query string
- keep the device-code payload shape compatible while updating tests to prove browser open and CLI copy now use the safer approval URL

## Testing
- `uv run pytest tests/test_guard_oauth_device_connect.py tests/test_guard_cli.py`
- `uv run ruff check src/codex_plugin_scanner/guard/cli/connect_flow.py src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_oauth_device_connect.py tests/test_guard_cli.py`
