### PR TITLE
fix(guard): route package approvals to local links

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -4902,23 +4902,45 @@ def _localize_decision_v2_review_copy(decision_v2: dict[str, object], review_con
 
 
 def _approval_center_routed_message(message: str, review_context: str) -> str:
-    normalized = re.sub(r"https?://[^\s]+/guard/inbox/?\.?", "", message).strip()
+    normalized = _strip_cloud_inbox_urls(message)
     normalized = normalized.replace("Review this request in HOL Guard, then retry.", "").strip()
-    normalized = re.sub(
-        (
-            r"Open HOL Guard to approve or keep this blocked: https?://\S+\.\s+"
-            r"After you choose, retry the same [^.]+ action\."
-        ),
-        "",
-        normalized,
-        flags=re.IGNORECASE,
-    ).strip()
+    normalized = _strip_legacy_approval_center_sentence(normalized)
     normalized = re.sub(r"\s{2,}", " ", normalized).strip()
-    if normalized.endswith("Review evidence:"):
-        normalized = normalized[: -len("Review evidence:")].rstrip()
+    normalized = re.sub(r"\bReview evidence:\s*\.?\s*$", "", normalized).strip()
     if not normalized:
         return review_context
     return f"{_ensure_terminal_punctuation(normalized)} {review_context}"
+
+
+def _strip_legacy_approval_center_sentence(message: str) -> str:
+    lower_message = message.lower()
+    start = lower_message.find("open hol guard to approve or keep this blocked:")
+    if start == -1:
+        return message.strip()
+    retry_start = lower_message.find("after you choose, retry the same ", start)
+    if retry_start == -1:
+        return message[:start].strip()
+    end = lower_message.find(" action.", retry_start)
+    if end == -1:
+        return message[:start].strip()
+    end += len(" action.")
+    return f"{message[:start]} {message[end:]}".strip()
+
+
+def _strip_cloud_inbox_urls(message: str) -> str:
+    kept_tokens: list[str] = []
+    for token in message.split():
+        candidate = token.strip("([{<'\"")
+        candidate = candidate.rstrip(")]}>'\".,;:!?")
+        if _is_cloud_inbox_url(candidate):
+            continue
+        kept_tokens.append(token)
+    return " ".join(kept_tokens).strip()
+
+
+def _is_cloud_inbox_url(value: str) -> bool:
+    parsed = urllib.parse.urlparse(value)
+    return parsed.scheme in {"http", "https"} and parsed.path.rstrip("/") == "/guard/inbox"
 
 
 def _runtime_stored_policy_action(

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2859,6 +2859,7 @@ def run_guard_command(
                 queued=queued,
                 managed_install=managed_install,
             )
+            _localize_pending_approval_copy(response_payload, harness=args.harness)
             _record_harness_usage_for_hook(
                 store=store,
                 action_envelope=action_envelope,
@@ -3399,6 +3400,7 @@ def run_guard_command(
                         args.harness,
                         managed_install=managed_install,
                     )
+                    _localize_pending_approval_copy(response_payload, harness=args.harness)
             if _should_emit_copilot_hook_response(args):
                 _record_harness_usage_for_hook(
                     store=store,
@@ -4859,6 +4861,66 @@ def _native_approval_center_context(response_payload: dict[str, object], *, harn
     )
 
 
+def _localize_pending_approval_copy(response_payload: dict[str, object], *, harness: str) -> None:
+    review_context = _native_approval_center_context(response_payload, harness=harness)
+    if review_context is None:
+        return
+    queued = response_payload.get("approval_requests")
+    review_url = first_approval_url(queued) if isinstance(queued, list) else None
+    approval_center_url = response_payload.get("approval_center_url")
+    if review_url is None and isinstance(approval_center_url, str) and approval_center_url.strip():
+        review_url = approval_center_url.strip()
+    if review_url is None:
+        return
+    decision_v2 = response_payload.get("decision_v2_json")
+    if isinstance(decision_v2, dict):
+        _localize_decision_v2_review_copy(decision_v2, review_context)
+    supply_chain_evaluation = response_payload.get("supply_chain_evaluation")
+    if isinstance(supply_chain_evaluation, dict):
+        user_copy = supply_chain_evaluation.get("user_copy")
+        if isinstance(user_copy, dict):
+            harness_message = _optional_string(user_copy.get("harness_message"))
+            if harness_message is not None:
+                user_copy["harness_message"] = _approval_center_routed_message(harness_message, review_context)
+            user_copy["dashboard_url"] = review_url
+    if isinstance(queued, list):
+        for item in queued:
+            if not isinstance(item, dict):
+                continue
+            decision_v2 = item.get("decision_v2_json")
+            if isinstance(decision_v2, dict):
+                _localize_decision_v2_review_copy(decision_v2, review_context)
+
+
+def _localize_decision_v2_review_copy(decision_v2: dict[str, object], review_context: str) -> None:
+    harness_message = _optional_string(decision_v2.get("harness_message"))
+    if harness_message is not None:
+        decision_v2["harness_message"] = _approval_center_routed_message(harness_message, review_context)
+    action = _optional_string(decision_v2.get("action"))
+    if action in {"ask", "block"}:
+        decision_v2["retry_instruction"] = review_context
+
+
+def _approval_center_routed_message(message: str, review_context: str) -> str:
+    normalized = re.sub(r"https?://[^\s]+/guard/inbox/?\.?", "", message).strip()
+    normalized = normalized.replace("Review this request in HOL Guard, then retry.", "").strip()
+    normalized = re.sub(
+        (
+            r"Open HOL Guard to approve or keep this blocked: https?://\S+\.\s+"
+            r"After you choose, retry the same [^.]+ action\."
+        ),
+        "",
+        normalized,
+        flags=re.IGNORECASE,
+    ).strip()
+    normalized = re.sub(r"\s{2,}", " ", normalized).strip()
+    if normalized.endswith("Review evidence:"):
+        normalized = normalized[: -len("Review evidence:")].rstrip()
+    if not normalized:
+        return review_context
+    return f"{_ensure_terminal_punctuation(normalized)} {review_context}"
+
+
 def _runtime_stored_policy_action(
     *,
     store: GuardStore,
@@ -5771,6 +5833,7 @@ def _headless_approval_resolver(
                 queued=queued,
             )
             payload["approval_delivery"] = _approval_delivery_payload(args.harness, managed_install=managed_install)
+            _localize_pending_approval_copy(payload, harness=args.harness)
             if str(approval_flow["tier"]) != "native-or-center" or not should_wait_for_approvals:
                 payload["approval_wait"] = {
                     "resolved": False,
@@ -5837,6 +5900,7 @@ def _headless_approval_resolver(
             managed_install=managed_install,
         )
         payload["approval_delivery"] = _approval_delivery_payload(args.harness, managed_install=managed_install)
+        _localize_pending_approval_copy(payload, harness=args.harness)
         if str(approval_flow["tier"]) != "native-or-center" or not should_wait_for_approvals:
             payload["approval_wait"] = {
                 "resolved": False,

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -4905,11 +4905,20 @@ def _approval_center_routed_message(message: str, review_context: str) -> str:
     normalized = _strip_cloud_inbox_urls(message)
     normalized = normalized.replace("Review this request in HOL Guard, then retry.", "").strip()
     normalized = _strip_legacy_approval_center_sentence(normalized)
-    normalized = re.sub(r"\s{2,}", " ", normalized).strip()
-    normalized = re.sub(r"\bReview evidence:\s*\.?\s*$", "", normalized).strip()
+    normalized = " ".join(normalized.split())
+    normalized = _strip_review_evidence_tail(normalized)
     if not normalized:
         return review_context
     return f"{_ensure_terminal_punctuation(normalized)} {review_context}"
+
+
+def _strip_review_evidence_tail(message: str) -> str:
+    stripped = message.strip()
+    lower_stripped = stripped.lower()
+    for suffix in ("Review evidence: .", "Review evidence:.", "Review evidence:"):
+        if lower_stripped.endswith(suffix.lower()):
+            return stripped[: -len(suffix)].rstrip()
+    return stripped
 
 
 def _strip_legacy_approval_center_sentence(message: str) -> str:

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -745,8 +745,7 @@ def _normalize_package_user_copy(user_copy: SupplyChainUserCopy, *, policy_actio
         dashboard_url = None
     harness_message = _CLOUD_INBOX_URL_RE.sub("", user_copy.harness_message or "").strip()
     harness_message = re.sub(r"\s{2,}", " ", harness_message).strip()
-    if harness_message.endswith("Review evidence:"):
-        harness_message = harness_message[: -len("Review evidence:")].rstrip()
+    harness_message = re.sub(r"\bReview evidence:\s*\.?\s*$", "", harness_message).strip()
     needs_local_review = policy_action in {"require-reapproval", "block"}
     if needs_local_review and _LOCAL_REVIEW_INSTRUCTION.lower() not in harness_message.lower():
         harness_message = f"{harness_message} {_LOCAL_REVIEW_INSTRUCTION}".strip()

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -744,12 +744,21 @@ def _normalize_package_user_copy(user_copy: SupplyChainUserCopy, *, policy_actio
     if _looks_like_cloud_inbox_url(dashboard_url):
         dashboard_url = None
     harness_message = _CLOUD_INBOX_URL_RE.sub("", user_copy.harness_message or "").strip()
-    harness_message = re.sub(r"\s{2,}", " ", harness_message).strip()
-    harness_message = re.sub(r"\bReview evidence:\s*\.?\s*$", "", harness_message).strip()
+    harness_message = " ".join(harness_message.split())
+    harness_message = _strip_review_evidence_tail(harness_message)
     needs_local_review = policy_action in {"require-reapproval", "block"}
     if needs_local_review and _LOCAL_REVIEW_INSTRUCTION.lower() not in harness_message.lower():
         harness_message = f"{harness_message} {_LOCAL_REVIEW_INSTRUCTION}".strip()
     return replace(user_copy, dashboard_url=dashboard_url, harness_message=harness_message)
+
+
+def _strip_review_evidence_tail(message: str) -> str:
+    stripped = message.strip()
+    lower_stripped = stripped.lower()
+    for suffix in ("Review evidence: .", "Review evidence:.", "Review evidence:"):
+        if lower_stripped.endswith(suffix.lower()):
+            return stripped[: -len(suffix)].rstrip()
+    return stripped
 
 
 def _looks_like_cloud_inbox_url(url: str | None) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -63,7 +63,8 @@ _DECISION_RANK = {"allow": 0, "monitor": 1, "warn": 2, "ask": 3, "block": 4}
 _SEVERITY_RANK = {"unknown": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
 _TIMEOUT_SECONDS = 1
 _RETRY_TIMEOUT_SECONDS = 1
-_CLOUD_DASHBOARD_URL = "https://hol.org/guard/inbox"
+_CLOUD_INBOX_URL_RE = re.compile(r"https?://[^\s]+/guard/inbox/?", re.IGNORECASE)
+_LOCAL_REVIEW_INSTRUCTION = "Review this request in HOL Guard, then retry."
 _LOCKFILE_PARSE_BUDGET_SECONDS = 0.2
 _TRANSITIVE_BLOCK_CONFIDENCE_THRESHOLD = 900
 _NPM_REGISTRY_METADATA_BASE_URL = "https://registry.npmjs.org"
@@ -155,9 +156,20 @@ class PackageRequestEvaluation:
         cached_packages = tuple(
             _with_support_metadata(item) for item in payload.get("packages", []) if isinstance(item, dict)
         )
+        policy_action = str(payload.get("policy_action") or "allow")
+        normalized_user_copy = _normalize_package_user_copy(
+            SupplyChainUserCopy(
+                title=str(user_copy_map.get("title") or "Monitoring this package"),
+                summary=str(user_copy_map.get("summary") or "HOL Guard recorded this package request."),
+                next_step=_optional_string(user_copy_map.get("next_step")),
+                dashboard_url=_optional_string(user_copy_map.get("dashboard_url")),
+                harness_message=str(user_copy_map.get("harness_message") or payload.get("risk_summary") or ""),
+            ),
+            policy_action=policy_action,
+        )
         return cls(
             decision=str(payload.get("decision") or "monitor"),
-            policy_action=str(payload.get("policy_action") or "allow"),
+            policy_action=policy_action,
             enforcement=str(payload.get("enforcement") or "offline_cached"),
             entitlement_state=str(payload.get("entitlement_state") or "premium"),
             cache_status=str(payload.get("cache_status") or "hit"),
@@ -168,13 +180,7 @@ class PackageRequestEvaluation:
             reasons=tuple(item for item in payload.get("reasons", []) if isinstance(item, dict)),
             packages=cached_packages,
             risk_summary=str(payload.get("risk_summary") or "HOL Guard recorded this package request."),
-            user_copy=SupplyChainUserCopy(
-                title=str(user_copy_map.get("title") or "Monitoring this package"),
-                summary=str(user_copy_map.get("summary") or "HOL Guard recorded this package request."),
-                next_step=_optional_string(user_copy_map.get("next_step")),
-                dashboard_url=_optional_string(user_copy_map.get("dashboard_url")),
-                harness_message=str(user_copy_map.get("harness_message") or payload.get("risk_summary") or ""),
-            ),
+            user_copy=normalized_user_copy,
             matched_rule_id=_optional_string(payload.get("matched_rule_id")),
             exception_id=_optional_string(payload.get("exception_id")),
             refresh_required=bool(payload.get("refresh_required")),
@@ -517,13 +523,21 @@ def _finalize_evaluation(
         harness_parts.append(f"Reason: {reason_message}.")
     if fix_command:
         harness_parts.append(f"Fix: install `{fix_command}` or choose a team exception.")
-    harness_parts.append(f"Review evidence: {_CLOUD_DASHBOARD_URL}.")
-    user_copy = SupplyChainUserCopy(
-        title=title,
-        summary=summary,
-        next_step=fix_command,
-        dashboard_url=_CLOUD_DASHBOARD_URL,
-        harness_message=" ".join(part.strip() for part in harness_parts if part.strip()),
+    user_copy = _normalize_package_user_copy(
+        SupplyChainUserCopy(
+            title=title,
+            summary=summary,
+            next_step=fix_command,
+            dashboard_url=None,
+            harness_message=" ".join(part.strip() for part in harness_parts if part.strip()),
+        ),
+        policy_action={
+            "allow": "allow",
+            "monitor": "allow",
+            "warn": "warn",
+            "ask": "require-reapproval",
+            "block": "block",
+        }[draft.decision],
     )
     return PackageRequestEvaluation(
         decision=draft.decision,
@@ -709,18 +723,41 @@ def _evaluate_with_cloud(
             harness_parts = [evaluation.risk_summary, updated_summary]
             if evaluation.user_copy.next_step:
                 harness_parts.append(f"Fix: run `{evaluation.user_copy.next_step}`.")
-            harness_parts.append(f"Review evidence: {_CLOUD_DASHBOARD_URL}.")
             evaluation = replace(
                 evaluation,
-                user_copy=SupplyChainUserCopy(
-                    title=title or evaluation.user_copy.title,
-                    summary=updated_summary,
-                    next_step=evaluation.user_copy.next_step,
-                    dashboard_url=evaluation.user_copy.dashboard_url,
-                    harness_message=" ".join(harness_parts),
+                user_copy=_normalize_package_user_copy(
+                    SupplyChainUserCopy(
+                        title=title or evaluation.user_copy.title,
+                        summary=updated_summary,
+                        next_step=evaluation.user_copy.next_step,
+                        dashboard_url=evaluation.user_copy.dashboard_url,
+                        harness_message=" ".join(harness_parts),
+                    ),
+                    policy_action=evaluation.policy_action,
                 ),
             )
     return evaluation, None
+
+
+def _normalize_package_user_copy(user_copy: SupplyChainUserCopy, *, policy_action: str) -> SupplyChainUserCopy:
+    dashboard_url = user_copy.dashboard_url
+    if _looks_like_cloud_inbox_url(dashboard_url):
+        dashboard_url = None
+    harness_message = _CLOUD_INBOX_URL_RE.sub("", user_copy.harness_message or "").strip()
+    harness_message = re.sub(r"\s{2,}", " ", harness_message).strip()
+    if harness_message.endswith("Review evidence:"):
+        harness_message = harness_message[: -len("Review evidence:")].rstrip()
+    needs_local_review = policy_action in {"require-reapproval", "block"}
+    if needs_local_review and _LOCAL_REVIEW_INSTRUCTION.lower() not in harness_message.lower():
+        harness_message = f"{harness_message} {_LOCAL_REVIEW_INSTRUCTION}".strip()
+    return replace(user_copy, dashboard_url=dashboard_url, harness_message=harness_message)
+
+
+def _looks_like_cloud_inbox_url(url: str | None) -> bool:
+    if url is None or not url.strip():
+        return False
+    parsed = urllib.parse.urlparse(url.strip())
+    return parsed.path.rstrip("/") == "/guard/inbox"
 
 
 def _cloud_http_fail_closed_evaluation(

--- a/tests/test_guard_package_hook_phase14.py
+++ b/tests/test_guard_package_hook_phase14.py
@@ -399,7 +399,9 @@ def test_phase14_package_hook_block_copy_stays_consistent_across_harnesses(
     assert decision["harness_message"].startswith("HOL Guard blocked")
     assert "Reason:" in decision["harness_message"]
     assert "Fix: install `npm install minimist@1.2.9` or choose a team exception." in decision["harness_message"]
-    assert "Review this request in HOL Guard, then retry." in decision["harness_message"]
+    assert "Open HOL Guard to approve or keep this blocked: http://127.0.0.1:5474/approvals/" in decision[
+        "harness_message"
+    ]
     assert "guard/inbox" not in decision["harness_message"]
 
 

--- a/tests/test_guard_package_hook_phase14.py
+++ b/tests/test_guard_package_hook_phase14.py
@@ -399,7 +399,8 @@ def test_phase14_package_hook_block_copy_stays_consistent_across_harnesses(
     assert decision["harness_message"].startswith("HOL Guard blocked")
     assert "Reason:" in decision["harness_message"]
     assert "Fix: install `npm install minimist@1.2.9` or choose a team exception." in decision["harness_message"]
-    assert "Review evidence: https://hol.org/guard/inbox." in decision["harness_message"]
+    assert "Review this request in HOL Guard, then retry." in decision["harness_message"]
+    assert "guard/inbox" not in decision["harness_message"]
 
 
 def test_phase14_claude_daemon_hook_bridge_queues_package_install_without_node(tmp_path: Path) -> None:

--- a/tests/test_guard_render.py
+++ b/tests/test_guard_render.py
@@ -174,12 +174,12 @@ def test_guard_protect_render_uses_supply_chain_user_copy(capsys) -> None:
                     "title": "HOL Guard blocked `minimist@1.2.5` before install.",
                     "summary": "Known exploited package.",
                     "next_step": "Install `minimist@1.2.9` instead.",
-                    "dashboard_url": "https://hol.org/guard/inbox",
+                    "dashboard_url": None,
                     "harness_message": (
                         "HOL Guard blocked `minimist@1.2.5` before install.\n"
                         "Reason: Known exploited package.\n"
                         "Fix: Install `minimist@1.2.9` instead.\n"
-                        "Review evidence: https://hol.org/guard/inbox"
+                        "Review this request in HOL Guard, then retry."
                     ),
                 },
             },
@@ -191,7 +191,7 @@ def test_guard_protect_render_uses_supply_chain_user_copy(capsys) -> None:
 
     assert "HOL Guard blocked" in output
     assert "Install `minimist@1.2.9` instead." in output
-    assert "Review evidence:" in output
+    assert "Review this request in HOL Guard, then retry." in output
 
 
 def test_guard_protect_render_uses_supply_chain_review_copy(capsys) -> None:

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -9669,6 +9669,7 @@ def test_guard_hook_emits_claude_permission_request_terminal_notice_stderr(
 ):
     import io
     import sys
+
     from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import (
         PackageRequestEvaluation,
         SupplyChainUserCopy,
@@ -9750,6 +9751,177 @@ def test_guard_hook_emits_claude_permission_request_terminal_notice_stderr(
     assert permission_rc == 0
     assert "HOL Guard" in permission_capture.err
     assert "Bash" in permission_capture.err
+
+
+def test_guard_hook_localizes_package_review_copy_with_local_approval_url(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import (
+        PackageRequestEvaluation,
+        SupplyChainUserCopy,
+    )
+
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(
+        home_dir / "config.toml",
+        '[risk_actions]\npackage_script = "require-reapproval"\napproval_wait_timeout_seconds = 0\n',
+    )
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(
+        guard_commands_module,
+        "load_guard_surface_daemon_client",
+        lambda _guard_home: (_ for _ in ()).throw(RuntimeError("no daemon client")),
+    )
+
+    def _package_requires_review(**_kwargs: object) -> PackageRequestEvaluation:
+        return PackageRequestEvaluation(
+            decision="review",
+            policy_action="require-reapproval",
+            enforcement="policy",
+            entitlement_state="offline",
+            cache_status="miss",
+            package_intent_hash="intent-hash",
+            policy_version="policy-v1",
+            bundle_version="bundle-v1",
+            workspace_fingerprint="workspace-fingerprint",
+            reasons=({"code": "package_review", "message": "Review npm install react@18.3.0"},),
+            packages=({"name": "react", "decision": "review", "reasons": ()},),
+            risk_summary="HOL Guard is reviewing npm install react@18.3.0.",
+            user_copy=SupplyChainUserCopy(
+                title="Review package install",
+                summary="react@18.3.0 needs review before install.",
+                next_step="Confirm the exact version in Claude's approval prompt.",
+                dashboard_url="https://hol.org/guard/inbox",
+                harness_message=(
+                    "HOL Guard is reviewing npm install react@18.3.0. "
+                    "Review evidence: https://hol.org/guard/inbox."
+                ),
+            ),
+        )
+
+    monkeypatch.setattr(
+        guard_commands_module,
+        "evaluate_package_request_artifact",
+        _package_requires_review,
+    )
+
+    rc, output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event={
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "npm install react@18.3.0"},
+            "source_scope": "project",
+        },
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+        as_json=True,
+    )
+
+    review_url = output["approval_requests"][0]["approval_url"]
+    retry_instruction = (
+        f"Open HOL Guard to approve or keep this blocked: {review_url}. "
+        "After you choose, retry the same Codex action."
+    )
+
+    assert rc == 1
+    assert review_url.startswith("http://127.0.0.1:4455/approvals/")
+    assert review_url in output["review_hint"]
+    assert output["decision_v2_json"]["retry_instruction"] == retry_instruction
+    assert review_url in output["decision_v2_json"]["harness_message"]
+    assert "guard/inbox" not in output["decision_v2_json"]["harness_message"]
+    assert output["supply_chain_evaluation"]["user_copy"]["dashboard_url"] == review_url
+    assert review_url in output["supply_chain_evaluation"]["user_copy"]["harness_message"]
+    assert output["approval_requests"][0]["decision_v2_json"]["retry_instruction"] == retry_instruction
+    assert review_url in output["approval_requests"][0]["decision_v2_json"]["harness_message"]
+
+
+def test_guard_hook_localizes_package_review_copy_with_daemon_client_approval_url(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import (
+        PackageRequestEvaluation,
+        SupplyChainUserCopy,
+    )
+
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(
+        home_dir / "config.toml",
+        '[risk_actions]\npackage_script = "require-reapproval"\napproval_wait_timeout_seconds = 0\n',
+    )
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    store = GuardStore(home_dir)
+    _install_fake_guard_surface_daemon(monkeypatch, store)
+
+    def _package_requires_review(**_kwargs: object) -> PackageRequestEvaluation:
+        return PackageRequestEvaluation(
+            decision="review",
+            policy_action="require-reapproval",
+            enforcement="policy",
+            entitlement_state="offline",
+            cache_status="miss",
+            package_intent_hash="intent-hash",
+            policy_version="policy-v1",
+            bundle_version="bundle-v1",
+            workspace_fingerprint="workspace-fingerprint",
+            reasons=({"code": "package_review", "message": "Review npm install react@18.3.0"},),
+            packages=({"name": "react", "decision": "review", "reasons": ()},),
+            risk_summary="HOL Guard is reviewing npm install react@18.3.0.",
+            user_copy=SupplyChainUserCopy(
+                title="Review package install",
+                summary="react@18.3.0 needs review before install.",
+                next_step="Confirm the exact version in Claude's approval prompt.",
+                dashboard_url="https://hol.org/guard/inbox",
+                harness_message="HOL Guard is reviewing npm install react@18.3.0.",
+            ),
+        )
+
+    monkeypatch.setattr(
+        guard_commands_module,
+        "evaluate_package_request_artifact",
+        _package_requires_review,
+    )
+
+    rc, output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event={
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "npm install react@18.3.0"},
+            "source_scope": "project",
+        },
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+        as_json=True,
+    )
+
+    review_url = output["approval_requests"][0]["approval_url"]
+    retry_instruction = (
+        f"Open HOL Guard to approve or keep this blocked: {review_url}. "
+        "After you choose, retry the same Codex action."
+    )
+
+    assert rc == 1
+    assert review_url == "http://127.0.0.1:4455/approvals/request-1"
+    assert review_url in output["review_hint"]
+    assert output["decision_v2_json"]["retry_instruction"] == retry_instruction
+    assert review_url in output["decision_v2_json"]["harness_message"]
+    assert output["supply_chain_evaluation"]["user_copy"]["dashboard_url"] == review_url
+    assert review_url in output["supply_chain_evaluation"]["user_copy"]["harness_message"]
 
 
 def test_guard_hook_emits_claude_native_ask_for_sensitive_file_reads(

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -427,6 +427,7 @@ def test_evaluate_package_request_artifact_uses_cached_eval_before_network(
     assert result.user_copy.next_step == "npm install minimist@1.2.9"
     assert result.user_copy.dashboard_url is None
     assert "guard/inbox" not in result.user_copy.harness_message
+    assert "Review evidence:" not in result.user_copy.harness_message
     assert "Review this request in HOL Guard, then retry." in result.user_copy.harness_message
 
 

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -343,9 +343,10 @@ def test_evaluate_package_request_artifact_posts_cloud_request_and_maps_block_re
     assert result.user_copy.title == "Critical install blocked"
     assert result.user_copy.summary == "minimist needs a safer version before you continue."
     assert result.user_copy.next_step == "npm install minimist@1.2.9"
-    assert result.user_copy.dashboard_url == "https://hol.org/guard/inbox"
+    assert result.user_copy.dashboard_url is None
     assert "minimist@1.2.8" in result.user_copy.harness_message
     assert "npm install minimist@1.2.9" in result.user_copy.harness_message
+    assert "Review this request in HOL Guard, then retry." in result.user_copy.harness_message
 
 
 def test_evaluate_package_request_artifact_uses_cached_eval_before_network(
@@ -401,7 +402,9 @@ def test_evaluate_package_request_artifact_uses_cached_eval_before_network(
                 "next_step": "npm install minimist@1.2.9",
                 "dashboard_url": "https://hol.org/guard/inbox",
                 "harness_message": (
-                    "HOL Guard blocked `minimist@1.2.8` before install. Fix: install `npm install minimist@1.2.9`."
+                    "HOL Guard blocked `minimist@1.2.8` before install. "
+                    "Fix: install `npm install minimist@1.2.9`. "
+                    "Review evidence: https://hol.org/guard/inbox."
                 ),
             },
         },
@@ -422,6 +425,9 @@ def test_evaluate_package_request_artifact_uses_cached_eval_before_network(
     assert result.decision == "block"
     assert result.cache_status == "hit"
     assert result.user_copy.next_step == "npm install minimist@1.2.9"
+    assert result.user_copy.dashboard_url is None
+    assert "guard/inbox" not in result.user_copy.harness_message
+    assert "Review this request in HOL Guard, then retry." in result.user_copy.harness_message
 
 
 def test_evaluate_package_request_artifact_skips_cached_eval_when_workspace_fingerprint_changes(


### PR DESCRIPTION
## Summary
- Route package-review payloads to the live local HOL Guard approval URL after requests are queued so agents send users to the correct `/approvals/<id>` link
- Keep stale cloud inbox copy out of supply-chain package review messaging and cached evaluations

## Testing
- `python3 -m pytest tests/test_guard_supply_chain_evaluator.py::test_evaluate_package_request_artifact_posts_cloud_request_and_maps_block_response tests/test_guard_supply_chain_evaluator.py::test_evaluate_package_request_artifact_uses_cached_eval_before_network tests/test_guard_package_hook_phase14.py::test_phase14_package_hook_block_copy_stays_consistent_across_harnesses tests/test_guard_render.py::test_guard_protect_render_uses_supply_chain_review_copy tests/test_guard_runtime.py::test_guard_hook_localizes_package_review_copy_with_local_approval_url tests/test_guard_runtime.py::test_guard_hook_localizes_package_review_copy_with_daemon_client_approval_url -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_supply_chain_evaluator.py tests/test_guard_package_hook_phase14.py tests/test_guard_render.py tests/test_guard_runtime.py`
