### PR TITLE
fix(guard): add OpenCode pretool plugin for runtime blocking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ output/playwright/
 # IDE
 .idea/
 .vscode/
+.codex/
 *.swp
 *.swo
 

--- a/docs/guard/cursor-local-cloud-contract.md
+++ b/docs/guard/cursor-local-cloud-contract.md
@@ -1,0 +1,13 @@
+# Cursor Local Cloud Contract
+
+Cursor support is split by surface so the dashboard does not imply protection that the local harness cannot provide.
+
+## Unsupported State
+
+If a Cursor surface is unavailable or unsupported, Guard must say so directly and must not offer a no-op repair.
+
+Unsupported Cursor states should:
+
+- Explain which surface is unavailable.
+- Keep any repair action disabled when Guard cannot change the local state.
+- Direct the user to a supported Cursor editor or Cursor CLI setup path.

--- a/docs/guard/harness-support.md
+++ b/docs/guard/harness-support.md
@@ -61,6 +61,8 @@ Current Guard support in this repo:
 - `opencode`
   - detects global and project config, MCP servers, config-defined commands, markdown commands, npm plugins, local
     plugin files, and OpenCode-compatible skill directories
+  - installs a Guard-owned pretool plugin in `~/.config/opencode/plugins/` that calls `hol-guard hook --harness opencode`
+    before bash and shell tools run, so package installs and secret-read commands are evaluated during the session
   - supports wrapper-mode management state plus a Guard-owned runtime overlay for native skill approval prompts
   - supports wrapper-mode `guard run opencode`
   - wrapper prompt screening is covered for benign debug prompts and risky secret-read prompts

--- a/src/codex_plugin_scanner/guard/adapters/contracts.py
+++ b/src/codex_plugin_scanner/guard/adapters/contracts.py
@@ -176,7 +176,8 @@ HARNESS_CONTRACTS: tuple[HarnessProtectionContract, ...] = (
         browser_fallback=True,
         resume_support=False,
         known_blind_spots=(
-            "Prompt content is not currently surfaced through hooks. File read/write events bypass Guard."
+            "Prompt content is not currently surfaced through hooks. File read/write events bypass Guard "
+            "unless OpenCode permission rules block them."
         ),
         smoke_command="hol-guard install opencode --dry-run",
     ),

--- a/src/codex_plugin_scanner/guard/adapters/opencode.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode.py
@@ -30,6 +30,7 @@ from .opencode_artifacts import (
     runtime_config_path,
     runtime_overlay,
 )
+from .opencode_pretool import install_pretool_plugin, remove_pretool_plugin
 
 
 class OpenCodeHarnessAdapter(HarnessAdapter):
@@ -189,6 +190,7 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
         target_config_path.parent.mkdir(parents=True, exist_ok=True)
         target_config_path.write_text(json.dumps(target_payload, indent=2) + "\n", encoding="utf-8")
         shim_manifest = install_guard_shim(self.harness, context)
+        plugin_manifest = install_pretool_plugin(context)
         overlay_path = runtime_config_path(context)
         overlay_path.parent.mkdir(parents=True, exist_ok=True)
         overlay_path.write_text(
@@ -212,14 +214,19 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
         )
         notes = [
             *list(shim_manifest.get("notes", [])),
+            "Guard installed an OpenCode pretool plugin that reviews bash and shell commands through "
+            "hol-guard hook before execution.",
             "Guard added an OpenCode runtime overlay that keeps managed MCP tools on native ask and routes "
             "managed local MCP servers through Guard runtime interception when you launch through Guard.",
+            "Launch OpenCode through guard-opencode or hol-guard run opencode when you also want "
+            "pre-launch artifact checks and the runtime skill overlay.",
         ]
         return {
             "harness": self.harness,
             "active": True,
             "config_path": str(target_config_path),
             **shim_manifest,
+            **plugin_manifest,
             "managed_config_path": str(target_config_path),
             "backup_path": str(backup_path),
             "state_path": str(state_path),
@@ -257,8 +264,10 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
         if state_cleanup_complete and state_path.is_file():
             state_path.unlink()
         shim_manifest = remove_guard_shim(self.harness, context)
+        plugin_manifest = remove_pretool_plugin(context)
         notes = [
             *list(shim_manifest.get("notes", [])),
+            "Guard removed the OpenCode pretool plugin from the global plugin directory.",
             "Guard leaves the OpenCode runtime overlay on disk for auditability, but it is ignored unless you "
             "launch through Guard.",
         ]
@@ -267,6 +276,7 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
             "active": False,
             "config_path": str(target_config_path),
             **shim_manifest,
+            **plugin_manifest,
             "managed_config_path": str(target_config_path),
             "backup_path": str(backup_path),
             "state_path": str(state_path),

--- a/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
@@ -84,14 +84,24 @@ export const HolGuardPretoolPlugin = async ({
       if (typeof command !== "string" || !command.trim()) {
         return;
       }
-      const result = await runGuardHook(directory, {
-        hook_event_name: "PreToolUse",
-        event: "PreToolUse",
-        tool_name: input.tool,
-        tool_input: { command },
-        cwd: directory,
-        source_scope: "project",
-      });
+      const workspace = directory?.trim() || process.cwd();
+      let result;
+      try {
+        result = await runGuardHook(directory, {
+          hook_event_name: "PreToolUse",
+          event: "PreToolUse",
+          tool_name: input.tool,
+          tool_input: { command },
+          cwd: workspace,
+          source_scope: workspace ? "project" : "global",
+        });
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new Error(
+          `HOL Guard could not review this ${input.tool} command (${detail}). ` +
+            "Re-run `hol-guard install opencode` and ensure the Guard CLI is available.",
+        );
+      }
       if (result.exitCode === 0) {
         return;
       }

--- a/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
@@ -1,0 +1,181 @@
+"""OpenCode pretool plugin generation for HOL Guard runtime interception."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from .base import HarnessContext
+
+PLUGIN_FILENAME = "hol-guard-pretool.ts"
+_INTERCEPT_TOOLS = ("bash", "shell", "sh", "zsh", "terminal")
+
+_PLUGIN_TEMPLATE = """// Managed by HOL Guard. Re-run `hol-guard install opencode` after moving Guard home.
+const GUARD_HOME = __GUARD_HOME__;
+const GUARD_PYTHON = __GUARD_PYTHON__;
+const INTERCEPT_TOOLS = new Set(__INTERCEPT_TOOLS__);
+
+async function runGuardHook(directory: string, payload: Record<string, unknown>) {
+  const workspace = directory?.trim() || process.cwd();
+  const proc = Bun.spawn(
+    [
+      GUARD_PYTHON,
+      "-m",
+      "codex_plugin_scanner.cli",
+      "guard",
+      "hook",
+      "--guard-home",
+      GUARD_HOME,
+      "--harness",
+      "opencode",
+      "--workspace",
+      workspace,
+      "--json",
+    ],
+    {
+      cwd: workspace,
+      stdin: JSON.stringify(payload),
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
+  const exitCode = await proc.exited;
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  return { exitCode, stdout, stderr };
+}
+
+function guardBlockMessage(stdout: string, stderr: string): string {
+  try {
+    const payload = JSON.parse(stdout) as {
+      review_hint?: string;
+      decision_v2_json?: { harness_message?: string; retry_instruction?: string };
+    };
+    const decision = payload.decision_v2_json;
+    return (
+      payload.review_hint ||
+      decision?.retry_instruction ||
+      decision?.harness_message ||
+      stderr.trim() ||
+      "HOL Guard blocked this OpenCode action."
+    );
+  } catch {
+    return stderr.trim() || "HOL Guard blocked this OpenCode action.";
+  }
+}
+
+export const HolGuardPretoolPlugin = async ({
+  directory,
+}: {
+  directory: string;
+}) => {
+  return {
+    "tool.execute.before": async (
+      input: { tool: string },
+      output: { args: Record<string, unknown> },
+    ) => {
+      if (!INTERCEPT_TOOLS.has(input.tool)) {
+        return;
+      }
+      const command = output.args?.command;
+      if (typeof command !== "string" || !command.trim()) {
+        return;
+      }
+      const result = await runGuardHook(directory, {
+        hook_event_name: "PreToolUse",
+        event: "PreToolUse",
+        tool_name: input.tool,
+        tool_input: { command },
+        cwd: directory,
+        source_scope: "project",
+      });
+      if (result.exitCode === 0) {
+        return;
+      }
+      if (result.exitCode === 1) {
+        throw new Error(guardBlockMessage(result.stdout, result.stderr));
+      }
+      throw new Error(
+        result.stderr.trim() ||
+          `HOL Guard hook failed while reviewing this ${input.tool} command.`,
+      );
+    },
+  };
+};
+"""
+
+
+def managed_plugin_path(context: HarnessContext) -> Path:
+    return context.guard_home / "opencode" / "plugins" / PLUGIN_FILENAME
+
+
+def global_plugin_path(context: HarnessContext) -> Path:
+    return context.home_dir / ".config" / "opencode" / "plugins" / PLUGIN_FILENAME
+
+
+def pretool_plugin_source(context: HarnessContext) -> str:
+    return (
+        _PLUGIN_TEMPLATE.replace("__GUARD_HOME__", json.dumps(str(context.guard_home.resolve())))
+        .replace("__GUARD_PYTHON__", json.dumps(str(Path(sys.executable).resolve())))
+        .replace("__INTERCEPT_TOOLS__", json.dumps(list(_INTERCEPT_TOOLS)))
+    )
+
+
+def install_pretool_plugin(context: HarnessContext) -> dict[str, object]:
+    source = pretool_plugin_source(context)
+    managed_path = managed_plugin_path(context)
+    global_path = global_plugin_path(context)
+    managed_path.parent.mkdir(parents=True, exist_ok=True)
+    global_path.parent.mkdir(parents=True, exist_ok=True)
+    managed_path.write_text(source, encoding="utf-8")
+    global_path.write_text(source, encoding="utf-8")
+    return {
+        "managed_plugin_path": str(managed_path),
+        "global_plugin_path": str(global_path),
+    }
+
+
+def remove_pretool_plugin(context: HarnessContext) -> dict[str, object]:
+    managed_path = managed_plugin_path(context)
+    global_path = global_plugin_path(context)
+    removed_paths: list[str] = []
+    for path in (global_path, managed_path):
+        if path.is_file():
+            path.unlink()
+            removed_paths.append(str(path))
+    return {"removed_plugin_paths": removed_paths}
+
+
+def opencode_config_uses_guard_proxy(config_path: Path) -> bool:
+    if not config_path.is_file():
+        return False
+    try:
+        payload = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    mcp = payload.get("mcp")
+    if not isinstance(mcp, dict):
+        return False
+    for server in mcp.values():
+        if not isinstance(server, dict):
+            continue
+        command = server.get("command")
+        if isinstance(command, list) and any("opencode-mcp-proxy" in str(part) for part in command):
+            return True
+        if isinstance(command, str) and "opencode-mcp-proxy" in command:
+            return True
+    return False
+
+
+__all__ = [
+    "PLUGIN_FILENAME",
+    "global_plugin_path",
+    "install_pretool_plugin",
+    "managed_plugin_path",
+    "opencode_config_uses_guard_proxy",
+    "pretool_plugin_source",
+    "remove_pretool_plugin",
+]

--- a/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
@@ -35,14 +35,16 @@ async function runGuardHook(directory: string, payload: Record<string, unknown>)
     ],
     {
       cwd: workspace,
-      stdin: JSON.stringify(payload),
+      stdin: new TextEncoder().encode(JSON.stringify(payload)),
       stdout: "pipe",
       stderr: "pipe",
     },
   );
+  const stdoutPromise = new Response(proc.stdout).text();
+  const stderrPromise = new Response(proc.stderr).text();
   const exitCode = await proc.exited;
-  const stdout = await new Response(proc.stdout).text();
-  const stderr = await new Response(proc.stderr).text();
+  const stdout = await stdoutPromise;
+  const stderr = await stderrPromise;
   return { exitCode, stdout, stderr };
 }
 
@@ -148,13 +150,12 @@ def remove_pretool_plugin(context: HarnessContext) -> dict[str, object]:
 
 
 def opencode_config_uses_guard_proxy(config_path: Path) -> bool:
+    from ...ecosystems.opencode import _load_json_or_jsonc
+
     if not config_path.is_file():
         return False
-    try:
-        payload = json.loads(config_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return False
-    if not isinstance(payload, dict):
+    payload, parse_error, _ = _load_json_or_jsonc(config_path)
+    if parse_error or not isinstance(payload, dict):
         return False
     mcp = payload.get("mcp")
     if not isinstance(mcp, dict):

--- a/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
@@ -35,7 +35,7 @@ async function runGuardHook(directory: string, payload: Record<string, unknown>)
     ],
     {
       cwd: workspace,
-      stdin: new TextEncoder().encode(JSON.stringify(payload)),
+      stdin: new Blob([JSON.stringify(payload)]).stream(),
       stdout: "pipe",
       stderr: "pipe",
     },
@@ -93,7 +93,7 @@ export const HolGuardPretoolPlugin = async ({
           tool_name: input.tool,
           tool_input: { command },
           cwd: workspace,
-          source_scope: workspace ? "project" : "global",
+          source_scope: directory?.trim() ? "project" : "global",
         });
       } catch (error) {
         const detail = error instanceof Error ? error.message : String(error);

--- a/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
@@ -159,6 +159,18 @@ def remove_pretool_plugin(context: HarnessContext) -> dict[str, object]:
     return {"removed_plugin_paths": removed_paths}
 
 
+def opencode_config_has_mcp_servers(config_path: Path) -> bool:
+    from ...ecosystems.opencode import _load_json_or_jsonc
+
+    if not config_path.is_file():
+        return False
+    payload, parse_error, _ = _load_json_or_jsonc(config_path)
+    if parse_error or not isinstance(payload, dict):
+        return False
+    mcp = payload.get("mcp")
+    return isinstance(mcp, dict) and bool(mcp)
+
+
 def opencode_config_uses_guard_proxy(config_path: Path) -> bool:
     from ...ecosystems.opencode import _load_json_or_jsonc
 
@@ -186,6 +198,7 @@ __all__ = [
     "global_plugin_path",
     "install_pretool_plugin",
     "managed_plugin_path",
+    "opencode_config_has_mcp_servers",
     "opencode_config_uses_guard_proxy",
     "pretool_plugin_source",
     "remove_pretool_plugin",

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -220,7 +220,11 @@ def uninstall_confirmation_token(harness: str) -> str:
 
 def _opencode_protection_checks(context: HarnessContext, store: GuardStore | None) -> dict[str, object]:
     from ..adapters.opencode import OpenCodeHarnessAdapter
-    from ..adapters.opencode_pretool import global_plugin_path, opencode_config_uses_guard_proxy
+    from ..adapters.opencode_pretool import (
+        global_plugin_path,
+        opencode_config_has_mcp_servers,
+        opencode_config_uses_guard_proxy,
+    )
 
     managed = store.get_managed_install("opencode") if store is not None else None
     config_path = OpenCodeHarnessAdapter()._target_config_path(context)
@@ -234,7 +238,7 @@ def _opencode_protection_checks(context: HarnessContext, store: GuardStore | Non
         warnings.append(
             "OpenCode pretool plugin is missing from ~/.config/opencode/plugins/. Re-run `hol-guard install opencode`."
         )
-    if not mcp_proxy_configured:
+    if opencode_config_has_mcp_servers(config_path) and not mcp_proxy_configured:
         warnings.append("OpenCode MCP servers are not routed through hol-guard. Re-run `hol-guard install opencode`.")
     if not shim_path.is_file():
         warnings.append(

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -226,6 +226,7 @@ def _opencode_protection_checks(context: HarnessContext, store: GuardStore | Non
     config_path = OpenCodeHarnessAdapter()._target_config_path(context)
     shim_path = context.guard_home / "bin" / "guard-opencode"
     plugin_path = global_plugin_path(context)
+    mcp_proxy_configured = opencode_config_uses_guard_proxy(config_path)
     warnings: list[str] = []
     if not (managed and managed.get("active")):
         warnings.append("Run `hol-guard install opencode` to activate Guard-managed OpenCode protection.")
@@ -233,7 +234,7 @@ def _opencode_protection_checks(context: HarnessContext, store: GuardStore | Non
         warnings.append(
             "OpenCode pretool plugin is missing from ~/.config/opencode/plugins/. Re-run `hol-guard install opencode`."
         )
-    if not opencode_config_uses_guard_proxy(config_path):
+    if not mcp_proxy_configured:
         warnings.append("OpenCode MCP servers are not routed through hol-guard. Re-run `hol-guard install opencode`.")
     if not shim_path.is_file():
         warnings.append(
@@ -242,7 +243,7 @@ def _opencode_protection_checks(context: HarnessContext, store: GuardStore | Non
         )
     return {
         "pretool_plugin_installed": plugin_path.is_file(),
-        "mcp_proxy_configured": opencode_config_uses_guard_proxy(config_path),
+        "mcp_proxy_configured": mcp_proxy_configured,
         "launch_shim_installed": shim_path.is_file(),
         "managed_install_active": bool(managed and managed.get("active")),
         "warnings": warnings,

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -231,13 +231,10 @@ def _opencode_protection_checks(context: HarnessContext, store: GuardStore | Non
         warnings.append("Run `hol-guard install opencode` to activate Guard-managed OpenCode protection.")
     if not plugin_path.is_file():
         warnings.append(
-            "OpenCode pretool plugin is missing from ~/.config/opencode/plugins/. "
-            "Re-run `hol-guard install opencode`."
+            "OpenCode pretool plugin is missing from ~/.config/opencode/plugins/. Re-run `hol-guard install opencode`."
         )
     if not opencode_config_uses_guard_proxy(config_path):
-        warnings.append(
-            "OpenCode MCP servers are not routed through hol-guard. Re-run `hol-guard install opencode`."
-        )
+        warnings.append("OpenCode MCP servers are not routed through hol-guard. Re-run `hol-guard install opencode`.")
     if not shim_path.is_file():
         warnings.append(
             "guard-opencode launcher shim is missing. Add ~/.hol-guard/bin to PATH or launch with "

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -182,20 +182,23 @@ def build_harness_verification(
 ) -> dict[str, object]:
     adapter = get_adapter(requested_harness)
     detection = _safe_setup_detection(adapter, context, store)
+    verification: dict[str, object] = {
+        "checked": True,
+        "writes_config": False,
+        "installed": detection["installed"],
+        "command_available": detection["command_available"],
+        "config_paths": detection["config_paths"],
+        "artifact_count": 0,
+        "warnings": [],
+        "steps": [step.to_dict() for step in adapter.verify_steps()],
+    }
+    if adapter.harness == "opencode":
+        verification.update(_opencode_protection_checks(context, store))
     payload: dict[str, object] = {
         "harness": adapter.harness,
         "safe": True,
         "contract": adapter.setup_contract().to_dict(),
-        "verification": {
-            "checked": True,
-            "writes_config": False,
-            "installed": detection["installed"],
-            "command_available": detection["command_available"],
-            "config_paths": detection["config_paths"],
-            "artifact_count": 0,
-            "warnings": [],
-            "steps": [step.to_dict() for step in adapter.verify_steps()],
-        },
+        "verification": verification,
     }
     if adapter.harness == "cursor":
         payload["cursor_action"] = cursor_local_action_payload(
@@ -213,6 +216,41 @@ def build_harness_verification(
 
 def uninstall_confirmation_token(harness: str) -> str:
     return f"disconnect-{harness}"
+
+
+def _opencode_protection_checks(context: HarnessContext, store: GuardStore | None) -> dict[str, object]:
+    from ..adapters.opencode import OpenCodeHarnessAdapter
+    from ..adapters.opencode_pretool import global_plugin_path, opencode_config_uses_guard_proxy
+
+    managed = store.get_managed_install("opencode") if store is not None else None
+    config_path = OpenCodeHarnessAdapter()._target_config_path(context)
+    shim_path = context.guard_home / "bin" / "guard-opencode"
+    plugin_path = global_plugin_path(context)
+    warnings: list[str] = []
+    if not (managed and managed.get("active")):
+        warnings.append("Run `hol-guard install opencode` to activate Guard-managed OpenCode protection.")
+    if not plugin_path.is_file():
+        warnings.append(
+            "OpenCode pretool plugin is missing from ~/.config/opencode/plugins/. "
+            "Re-run `hol-guard install opencode`."
+        )
+    if not opencode_config_uses_guard_proxy(config_path):
+        warnings.append(
+            "OpenCode MCP servers are not routed through hol-guard. Re-run `hol-guard install opencode`."
+        )
+    if not shim_path.is_file():
+        warnings.append(
+            "guard-opencode launcher shim is missing. Add ~/.hol-guard/bin to PATH or launch with "
+            "`hol-guard run opencode` for pre-launch checks."
+        )
+    return {
+        "pretool_plugin_installed": plugin_path.is_file(),
+        "mcp_proxy_configured": opencode_config_uses_guard_proxy(config_path),
+        "launch_shim_installed": shim_path.is_file(),
+        "managed_install_active": bool(managed and managed.get("active")),
+        "warnings": warnings,
+        "ready": not warnings,
+    }
 
 
 def _safe_setup_detection(

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -242,7 +242,7 @@ def _opencode_protection_checks(context: HarnessContext, store: GuardStore | Non
         warnings.append("OpenCode MCP servers are not routed through hol-guard. Re-run `hol-guard install opencode`.")
     if not shim_path.is_file():
         warnings.append(
-            "guard-opencode launcher shim is missing. Add ~/.hol-guard/bin to PATH or launch with "
+            f"guard-opencode launcher shim is missing. Add {context.guard_home / 'bin'} to PATH or launch with "
             "`hol-guard run opencode` for pre-launch checks."
         )
     return {

--- a/tests/test_opencode_pretool.py
+++ b/tests/test_opencode_pretool.py
@@ -11,6 +11,7 @@ from codex_plugin_scanner.guard.adapters.opencode_pretool import (
     global_plugin_path,
     install_pretool_plugin,
     managed_plugin_path,
+    opencode_config_has_mcp_servers,
     opencode_config_uses_guard_proxy,
     pretool_plugin_source,
     remove_pretool_plugin,
@@ -106,6 +107,27 @@ def test_opencode_config_uses_guard_proxy_detects_managed_command(tmp_path: Path
         encoding="utf-8",
     )
     assert opencode_config_uses_guard_proxy(config) is True
+
+
+def test_opencode_verification_ready_without_mcp_servers(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.store import GuardStore
+
+    ctx = _ctx(tmp_path)
+    config = ctx.home_dir / ".config" / "opencode" / "opencode.json"
+    config.parent.mkdir(parents=True, exist_ok=True)
+    config.write_text('{"mcp": {}}', encoding="utf-8")
+    install_pretool_plugin(ctx)
+    (ctx.guard_home / "bin").mkdir(parents=True, exist_ok=True)
+    (ctx.guard_home / "bin" / "guard-opencode").write_text("#!/bin/sh\n", encoding="utf-8")
+    store = GuardStore(ctx.guard_home)
+    store.set_managed_install("opencode", True, None, {}, "2026-06-04T00:00:00+00:00")
+    payload = install_commands_module.build_harness_verification("opencode", ctx, store=store)
+    verification = payload["verification"]
+    assert verification["pretool_plugin_installed"] is True
+    assert verification["mcp_proxy_configured"] is False
+    assert opencode_config_has_mcp_servers(config) is False
+    assert verification["ready"] is True
+    assert not verification["warnings"]
 
 
 def test_opencode_verification_reports_missing_plugin(tmp_path: Path) -> None:

--- a/tests/test_opencode_pretool.py
+++ b/tests/test_opencode_pretool.py
@@ -35,6 +35,8 @@ def test_pretool_plugin_source_embeds_guard_paths(tmp_path: Path) -> None:
     source = pretool_plugin_source(ctx)
     assert str(ctx.guard_home.resolve()) in source
     assert "tool.execute.before" in source
+    assert "TextEncoder().encode" in source
+    assert "stdoutPromise" in source
     assert "codex_plugin_scanner.cli" in source
     assert "guard" in source
 
@@ -66,6 +68,24 @@ def test_opencode_install_includes_pretool_plugin_paths(tmp_path: Path) -> None:
     result = OpenCodeHarnessAdapter().install(ctx)
     assert Path(result["managed_plugin_path"]).is_file()
     assert Path(result["global_plugin_path"]).is_file()
+
+
+def test_opencode_config_uses_guard_proxy_parses_jsonc_comments(tmp_path: Path) -> None:
+    config = tmp_path / "opencode.jsonc"
+    config.write_text(
+        """
+        {
+          // Guard-managed MCP proxy
+          "mcp": {
+            "playwright": {
+              "command": ["hol-guard", "guard", "opencode-mcp-proxy"]
+            }
+          }
+        }
+        """,
+        encoding="utf-8",
+    )
+    assert opencode_config_uses_guard_proxy(config) is True
 
 
 def test_opencode_config_uses_guard_proxy_detects_managed_command(tmp_path: Path) -> None:

--- a/tests/test_opencode_pretool.py
+++ b/tests/test_opencode_pretool.py
@@ -36,10 +36,10 @@ def test_pretool_plugin_source_embeds_guard_paths(tmp_path: Path) -> None:
     source = pretool_plugin_source(ctx)
     assert str(ctx.guard_home.resolve()) in source
     assert "tool.execute.before" in source
-    assert "TextEncoder().encode" in source
+    assert "Blob([JSON.stringify(payload)]).stream()" in source
     assert "stdoutPromise" in source
     assert "try {" in source
-    assert 'source_scope: workspace ? "project" : "global"' in source
+    assert 'source_scope: directory?.trim() ? "project" : "global"' in source
     assert "codex_plugin_scanner.cli" in source
     assert "guard" in source
 

--- a/tests/test_opencode_pretool.py
+++ b/tests/test_opencode_pretool.py
@@ -37,6 +37,8 @@ def test_pretool_plugin_source_embeds_guard_paths(tmp_path: Path) -> None:
     assert "tool.execute.before" in source
     assert "TextEncoder().encode" in source
     assert "stdoutPromise" in source
+    assert "try {" in source
+    assert 'source_scope: workspace ? "project" : "global"' in source
     assert "codex_plugin_scanner.cli" in source
     assert "guard" in source
 

--- a/tests/test_opencode_pretool.py
+++ b/tests/test_opencode_pretool.py
@@ -1,0 +1,100 @@
+"""Tests for the OpenCode pretool plugin installer."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.opencode import OpenCodeHarnessAdapter
+from codex_plugin_scanner.guard.adapters.opencode_pretool import (
+    global_plugin_path,
+    install_pretool_plugin,
+    managed_plugin_path,
+    opencode_config_uses_guard_proxy,
+    pretool_plugin_source,
+    remove_pretool_plugin,
+)
+from codex_plugin_scanner.guard.cli import install_commands as install_commands_module
+
+
+def _ctx(tmp_path: Path, *, workspace: bool = False) -> HarnessContext:
+    home = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace" if workspace else None
+    if workspace_dir is not None:
+        workspace_dir.mkdir(parents=True, exist_ok=True)
+    return HarnessContext(
+        home_dir=home,
+        workspace_dir=workspace_dir,
+        guard_home=tmp_path / "guard-home",
+    )
+
+
+def test_pretool_plugin_source_embeds_guard_paths(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    source = pretool_plugin_source(ctx)
+    assert str(ctx.guard_home.resolve()) in source
+    assert "tool.execute.before" in source
+    assert "codex_plugin_scanner.cli" in source
+    assert "guard" in source
+
+
+def test_install_pretool_plugin_writes_managed_and_global_copies(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    manifest = install_pretool_plugin(ctx)
+    assert Path(manifest["managed_plugin_path"]).is_file()
+    assert Path(manifest["global_plugin_path"]).is_file()
+    assert managed_plugin_path(ctx).read_text(encoding="utf-8") == global_plugin_path(ctx).read_text(
+        encoding="utf-8"
+    )
+
+
+def test_remove_pretool_plugin_deletes_installed_files(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    install_pretool_plugin(ctx)
+    removed = remove_pretool_plugin(ctx)
+    assert removed["removed_plugin_paths"]
+    assert not global_plugin_path(ctx).exists()
+    assert not managed_plugin_path(ctx).exists()
+
+
+def test_opencode_install_includes_pretool_plugin_paths(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    config = ctx.home_dir / ".config" / "opencode" / "opencode.json"
+    config.parent.mkdir(parents=True, exist_ok=True)
+    config.write_text('{"mcp": {}}', encoding="utf-8")
+    result = OpenCodeHarnessAdapter().install(ctx)
+    assert Path(result["managed_plugin_path"]).is_file()
+    assert Path(result["global_plugin_path"]).is_file()
+
+
+def test_opencode_config_uses_guard_proxy_detects_managed_command(tmp_path: Path) -> None:
+    config = tmp_path / "opencode.json"
+    config.write_text(
+        json.dumps(
+            {
+                "mcp": {
+                    "playwright": {
+                        "type": "local",
+                        "command": ["python", "-m", "codex_plugin_scanner.cli", "guard", "opencode-mcp-proxy"],
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert opencode_config_uses_guard_proxy(config) is True
+
+
+def test_opencode_verification_reports_missing_plugin(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.store import GuardStore
+
+    ctx = _ctx(tmp_path)
+    store = GuardStore(ctx.guard_home)
+    store.set_managed_install("opencode", True, None, {}, "2026-06-04T00:00:00+00:00")
+    payload = install_commands_module.build_harness_verification("opencode", ctx, store=store)
+    verification = payload["verification"]
+    assert verification["managed_install_active"] is True
+    assert verification["pretool_plugin_installed"] is False
+    assert verification["ready"] is False
+    assert verification["warnings"]


### PR DESCRIPTION
## Summary
- Install a Guard-owned OpenCode pretool plugin in `~/.config/opencode/plugins/` that calls `hol-guard hook --harness opencode` before bash and shell tools run
- Extend OpenCode install/uninstall and harness verification so missing pretool plugin, MCP proxy wiring, or launch shim are reported clearly

## Testing
- `python3 -m pytest tests/test_opencode_pretool.py tests/test_opencode_adapter.py::TestOpenCodeInstall -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/adapters/opencode.py src/codex_plugin_scanner/guard/adapters/opencode_pretool.py src/codex_plugin_scanner/guard/cli/install_commands.py tests/test_opencode_pretool.py`
- `PYTHONPATH=src python3 -m codex_plugin_scanner.cli guard install opencode --guard-home ~/.hol-guard`
- `echo '{"hook_event_name":"PreToolUse","tool_name":"bash","tool_input":{"command":"npm install minimist@1.2.8"},"source_scope":"project"}' | python3 -m codex_plugin_scanner.cli guard hook --guard-home ~/.hol-guard --harness opencode --workspace . --json` (exit 1, local approval URL in payload)
