### PR TITLE
fix(guard): harden oauth-safe local surfaces

### DIFF
--- a/docs/guard/release-checklist.md
+++ b/docs/guard/release-checklist.md
@@ -4,5 +4,7 @@ Before each Guard harness release:
 
 - Run the automated CI suite for the release branch.
 - Update smoke evidence from `tests/fixtures/smoke-evidence-template.json` with current manual results.
-- Confirm browser-assisted Guard Cloud connect flows still open the hosted pairing page and can reach the local daemon.
+- Confirm browser-assisted Guard Cloud connect flows still open the hosted OAuth connect page and can reach the local daemon.
+- In release notes, call out that `hol-guard connect` is the canonical Guard Cloud sign-in flow and `hol-guard connect --headless` is the canonical SSH/CI flow.
+- In release notes, call out that pasted `--token` login and legacy bearer setup are retired.
 - Attach smoke evidence to the release notes or pull request before publishing.

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -712,8 +712,8 @@ def _runtime_proof_status_label(state: str) -> str:
         "sync_unavailable": "Local connected, cloud sync gated",
         "failed": "First proof needs retry",
         "pending": "First proof pending",
-        "expired": "Pairing expired",
-        "waiting": "Waiting for browser pairing",
+        "expired": "Sign-in expired",
+        "waiting": "Waiting for browser sign-in",
         "not_connected": "Cloud proof not started",
     }
     return labels.get(state, "Cloud proof not started")
@@ -724,9 +724,9 @@ def _runtime_proof_status_detail(state: str) -> str:
         "synced": "This device completed its first Guard Cloud proof sync.",
         "sync_unavailable": "Local Guard is connected. Shared cloud sync needs a paid Guard plan.",
         "failed": "Run hol-guard connect again to finish first proof sync.",
-        "pending": "Browser pairing finished. First proof sync has not completed yet.",
-        "expired": "The pairing link expired. Run hol-guard connect again.",
-        "waiting": "Open the pairing link to register this local Guard device.",
+        "pending": "Browser sign-in finished. First proof sync has not completed yet.",
+        "expired": "The sign-in link expired. Run hol-guard connect again.",
+        "waiting": "Open the sign-in link to register this local Guard device.",
         "not_connected": "Connect Guard Cloud to sync this device proof.",
     }
     return details.get(state, "Connect Guard Cloud to sync this device proof.")

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -338,21 +338,34 @@ def build_device_authorization_request_body(
     *,
     machine_id: str,
     machine_label: str,
+    machine_location_label: str | None = None,
     runtime_id: str,
     runtime_label: str,
     client_id: str,
     scopes: tuple[str, ...] = DEFAULT_GUARD_DEVICE_SCOPES,
 ) -> str:
-    return urllib.parse.urlencode(
-        {
-            "client_id": client_id,
-            "scope": " ".join(scopes),
-            "requested_machine_id": machine_id,
-            "requested_machine_label": machine_label,
-            "requested_runtime_id": runtime_id,
-            "requested_runtime_label": runtime_label,
-        }
-    )
+    payload = {
+        "client_id": client_id,
+        "scope": " ".join(scopes),
+        "requested_machine_id": machine_id,
+        "requested_machine_label": machine_label,
+        "requested_runtime_id": runtime_id,
+        "requested_runtime_label": runtime_label,
+    }
+    if isinstance(machine_location_label, str) and machine_location_label.strip():
+        payload["requested_machine_location_label"] = machine_location_label.strip()
+    return urllib.parse.urlencode(payload)
+
+
+def resolve_machine_location_label() -> str | None:
+    tzinfo = datetime.now().astimezone().tzinfo
+    timezone_key = getattr(tzinfo, "key", None)
+    if isinstance(timezone_key, str) and timezone_key.strip():
+        return timezone_key.strip()
+    timezone_name = datetime.now().astimezone().tzname()
+    if isinstance(timezone_name, str) and timezone_name.strip():
+        return timezone_name.strip()
+    return None
 
 
 def _resolve_guard_device_scopes(*, ci_safe: bool) -> tuple[str, ...]:
@@ -581,6 +594,7 @@ def run_guard_device_connect_command(
     request_body = build_device_authorization_request_body(
         machine_id=str(device["installation_id"]),
         machine_label=resolved_machine_label or str(device["device_label"]),
+        machine_location_label=resolve_machine_location_label(),
         runtime_id=HEADLESS_RUNTIME_ID,
         runtime_label=HEADLESS_RUNTIME_LABEL,
         client_id=oauth_client.client_id,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/feed-health-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/feed-health-workspace.js
@@ -85,7 +85,7 @@ function FeedHealthWorkspace({ snapshot, onOpenSettings }) {
         /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "mt-0.5 h-4 w-4 shrink-0 text-brand-blue", "aria-hidden": "true" }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: "Full feed syncing" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-600 mt-0.5", children: "Cloud pairing is complete. Feed sync is in progress. First proof will arrive shortly." })
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-600 mt-0.5", children: "Cloud connection is complete. Feed sync is in progress. First proof will arrive shortly." })
         ] })
       ] }),
       sourceMode === "live" && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-2 rounded-xl border border-brand-green/20 bg-brand-green/[0.04] px-3 py-2.5", children: [

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/runtime-overview.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/runtime-overview.js
@@ -19,7 +19,7 @@ function resolveCloudIntelCopy(state) {
     return { label: "Offline, free", detail: "Running locally with no cloud sync. Your choices stay on this machine." };
   }
   if (state === "paired_waiting") {
-    return { label: "Pairing…", detail: "Connected to Guard Cloud, waiting for sync to start." };
+    return { label: "Sync pending", detail: "Connected to Guard Cloud, waiting for sync to start." };
   }
   return { label: "Synced, pro", detail: "Guard Cloud is active and syncing choices across your devices." };
 }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13323,7 +13323,7 @@ function buildDemoRuntimeSnapshot() {
     proof_status: {
       state: "pending",
       label: "First proof pending",
-      detail: "Browser pairing finished. First proof sync has not completed yet.",
+      detail: "Browser sign-in finished. First proof sync has not completed yet.",
       request_id: "demo-connect-request",
       pairing_completed_at: now2,
       first_synced_at: null,
@@ -15062,7 +15062,7 @@ function WelcomeState(props) {
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-border bg-card p-6 shadow-[0_4px_20px_rgba(85,153,254,0.04)]", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-[0.18em] text-brand-blue mb-4", children: "Sync decisions" }),
         props.connectUrl ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap gap-3", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: props.connectUrl, children: "Open pairing flow" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: props.connectUrl, children: "Open Guard connect" }),
           props.dashboardUrl ? /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: props.dashboardUrl, variant: "outline", children: "Open Home" }) : null,
           props.inboxUrl ? /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: props.inboxUrl, variant: "outline", children: "Review Queue" }) : null,
           props.fleetUrl ? /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: props.fleetUrl, variant: "outline", children: "Protect" }) : null

--- a/src/codex_plugin_scanner/guard/redaction.py
+++ b/src/codex_plugin_scanner/guard/redaction.py
@@ -90,13 +90,13 @@ _REDACTION_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...] = (
     ),
 )
 
-_SENSITIVE_INLINE_PATTERNS: tuple[re.Pattern[str], ...] = (
+_SENSITIVE_INLINE_PREFIX_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(
-        r'(?i)"?sync_state\.credentials"?\s*[:=]\s*(?:\{[^{}]*\}|".*?"|\'[^\']*\'|[^,\s;}\]]+)',
+        r'(?i)"?sync_state\.credentials"?\s*[:=]\s*',
     ),
     re.compile(
         r'(?i)"?(?:access[_-]?token|refresh[_-]?token|authorization[_-]?code|user[_-]?code|'
-        r'dpop[_-]?private[_-]?key(?:[_-]?(?:pem|ref))?)"?\s*[:=]\s*(?:".*?"|\'[^\']*\'|[^,\s;}\]]+)',
+        r'dpop[_-]?private[_-]?key(?:[_-]?(?:pem|ref))?)"?\s*[:=]\s*',
     ),
 )
 _SENSITIVE_TEXT_PATTERN = re.compile(r"(?i)(sk-[a-z0-9_-]+|(?:token|secret|api[_-]?key)(?:\s*[:=]\s*|\s+)[^\s,;]+)")
@@ -131,9 +131,86 @@ def redact_text(value: str) -> RedactedText:
 
 def redact_sensitive_text(value: str) -> str:
     redacted = value
-    for pattern in _SENSITIVE_INLINE_PATTERNS:
-        redacted = pattern.sub("[redacted]", redacted)
+    for pattern in _SENSITIVE_INLINE_PREFIX_PATTERNS:
+        redacted = _redact_inline_secret_assignments(redacted, pattern)
     return _SENSITIVE_TEXT_PATTERN.sub("[redacted]", redacted)
+
+
+def _redact_inline_secret_assignments(value: str, pattern: re.Pattern[str]) -> str:
+    redacted: list[str] = []
+    search_start = 0
+    while True:
+        match = pattern.search(value, search_start)
+        if match is None:
+            redacted.append(value[search_start:])
+            return "".join(redacted)
+        redacted.append(value[search_start:match.start()])
+        redacted.append("[redacted]")
+        search_start = _consume_inline_secret_value(value, match.end())
+
+
+def _consume_inline_secret_value(value: str, start: int) -> int:
+    if start >= len(value):
+        return start
+
+    opening = value[start]
+    if opening in {'"', "'"}:
+        return _consume_quoted_secret_value(value, start, opening)
+    if opening in {"{", "["}:
+        return _consume_balanced_secret_value(value, start)
+
+    end = start
+    while end < len(value) and value[end] not in ", \t\r\n;}]":
+        end += 1
+    return end
+
+
+def _consume_quoted_secret_value(value: str, start: int, quote: str) -> int:
+    index = start + 1
+    while index < len(value):
+        character = value[index]
+        if character == "\\":
+            index += 2
+            continue
+        index += 1
+        if character == quote:
+            return index
+    return len(value)
+
+
+def _consume_balanced_secret_value(value: str, start: int) -> int:
+    closing_for_opening = {"{": "}", "[": "]"}
+    stack = [closing_for_opening[value[start]]]
+    index = start + 1
+    active_quote: str | None = None
+
+    while index < len(value):
+        character = value[index]
+        if active_quote is not None:
+            if character == "\\":
+                index += 2
+                continue
+            index += 1
+            if character == active_quote:
+                active_quote = None
+            continue
+
+        if character in {'"', "'"}:
+            active_quote = character
+            index += 1
+            continue
+        if character in closing_for_opening:
+            stack.append(closing_for_opening[character])
+            index += 1
+            continue
+
+        index += 1
+        if character == stack[-1]:
+            stack.pop()
+            if not stack:
+                return index
+
+    return len(value)
 
 
 def redact_local_path(value: str, *, home_dir: Path | None = None) -> str:

--- a/src/codex_plugin_scanner/guard/redaction.py
+++ b/src/codex_plugin_scanner/guard/redaction.py
@@ -90,6 +90,15 @@ _REDACTION_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...] = (
     ),
 )
 
+_SENSITIVE_INLINE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        r'(?i)"?sync_state\.credentials"?\s*[:=]\s*(?:\{[^{}]*\}|".*?"|\'[^\']*\'|[^,\s;}\]]+)',
+    ),
+    re.compile(
+        r'(?i)"?(?:access[_-]?token|refresh[_-]?token|authorization[_-]?code|user[_-]?code|'
+        r'dpop[_-]?private[_-]?key(?:[_-]?(?:pem|ref))?)"?\s*[:=]\s*(?:".*?"|\'[^\']*\'|[^,\s;}\]]+)',
+    ),
+)
 _SENSITIVE_TEXT_PATTERN = re.compile(r"(?i)(sk-[a-z0-9_-]+|(?:token|secret|api[_-]?key)(?:\s*[:=]\s*|\s+)[^\s,;]+)")
 _POSIX_USER_PATH_PATTERN = re.compile(
     r"(?P<prefix>^|[\s\"'=({\[])(?P<root>/(?:Users|home)/[^/\s\"'`,;:)}\]]+)(?P<rest>(?:/[^\s\"'`,;:)}\]]*)?)"
@@ -121,7 +130,10 @@ def redact_text(value: str) -> RedactedText:
 
 
 def redact_sensitive_text(value: str) -> str:
-    return _SENSITIVE_TEXT_PATTERN.sub("[redacted]", value)
+    redacted = value
+    for pattern in _SENSITIVE_INLINE_PATTERNS:
+        redacted = pattern.sub("[redacted]", redacted)
+    return _SENSITIVE_TEXT_PATTERN.sub("[redacted]", redacted)
 
 
 def redact_local_path(value: str, *, home_dir: Path | None = None) -> str:

--- a/src/codex_plugin_scanner/guard/redaction.py
+++ b/src/codex_plugin_scanner/guard/redaction.py
@@ -144,7 +144,7 @@ def _redact_inline_secret_assignments(value: str, pattern: re.Pattern[str]) -> s
         if match is None:
             redacted.append(value[search_start:])
             return "".join(redacted)
-        redacted.append(value[search_start:match.start()])
+        redacted.append(value[search_start : match.start()])
         redacted.append("[redacted]")
         search_start = _consume_inline_secret_value(value, match.end())
 

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -4409,6 +4409,112 @@ args = ["-lc", "echo hi"]
             "disabled_detector_ids": ["secret.local"],
         }
 
+    def test_guard_doctor_does_not_print_oauth_or_legacy_secret_material(
+        self,
+        tmp_path,
+        monkeypatch,
+        capsys,
+    ):
+        home_dir = tmp_path / "home"
+        guard_home = tmp_path / "guard-home"
+        _write_text(
+            home_dir / ".codex" / "config.toml",
+            """
+approval_policy = "never"
+
+[mcp_servers.test-stdio]
+command = "/bin/sh"
+args = ["-lc", "echo hi"]
+""".strip()
+            + "\n",
+        )
+        monkeypatch.setattr("codex_plugin_scanner.guard.adapters.codex._command_available", lambda command: True)
+        store = GuardStore(guard_home)
+        store.set_sync_credentials(
+            "https://hol.org/api/guard/receipts/sync",
+            "access-secret-value",
+            "2026-06-01T00:00:00+00:00",
+        )
+        store.set_oauth_local_credentials(
+            issuer="https://hol.org",
+            client_id="guard-local-daemon",
+            refresh_token="refresh-secret-value",
+            dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+            dpop_public_jwk={
+                "kty": "EC",
+                "crv": "P-256",
+                "x": "x-value",
+                "y": "y-value",
+                "alg": "ES256",
+                "use": "sig",
+            },
+            dpop_public_jwk_thumbprint="thumbprint-123",
+            grant_id="grant-123",
+            machine_id="machine-123",
+            workspace_id="workspace-123",
+            now="2026-06-01T00:00:00+00:00",
+        )
+
+        forbidden_values = (
+            "access-secret-value",
+            "refresh-secret-value",
+            "secret-key-material",
+            "auth-code-secret",
+            "ZXCV-BNMQ",
+            "pairing-secret-value",
+        )
+        forbidden_labels = (
+            "access_token",
+            "refresh_token",
+            "dpop_private_key",
+            "authorization_code",
+            "user_code",
+            "pairing_secret",
+            "guardpairsecret",
+        )
+
+        rc = main(
+            [
+                "guard",
+                "doctor",
+                "codex",
+                "--home",
+                str(home_dir),
+                "--guard-home",
+                str(guard_home),
+                "--json",
+            ]
+        )
+        json_output = capsys.readouterr().out
+
+        assert rc == 0
+        assert json.loads(json_output)["harness"] == "codex"
+        for value in forbidden_values:
+            assert value not in json_output
+        lowered_json_output = json_output.lower()
+        for label in forbidden_labels:
+            assert label not in lowered_json_output
+
+        rc = main(
+            [
+                "guard",
+                "doctor",
+                "codex",
+                "--home",
+                str(home_dir),
+                "--guard-home",
+                str(guard_home),
+            ]
+        )
+        human_output = capsys.readouterr().out
+
+        assert rc == 0
+        for value in forbidden_values:
+            assert value not in human_output
+        lowered_human_output = human_output.lower()
+        for label in forbidden_labels:
+            assert label not in lowered_human_output
+
     def test_guard_doctor_notifications_opens_system_settings(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"
         guard_home = tmp_path / "guard-home"

--- a/tests/test_guard_cloud_local_sync.py
+++ b/tests/test_guard_cloud_local_sync.py
@@ -555,6 +555,89 @@ def test_runtime_snapshot_exposes_latest_connect_proof_without_pairing_secrets(t
     }
 
 
+@pytest.mark.parametrize(
+    ("status", "milestone", "expected_state", "expected_label", "expected_detail"),
+    [
+        (
+            "connected",
+            "first_sync_pending",
+            "pending",
+            "First proof pending",
+            "Browser sign-in finished. First proof sync has not completed yet.",
+        ),
+        (
+            "waiting",
+            "waiting_for_browser",
+            "waiting",
+            "Waiting for browser sign-in",
+            "Open the sign-in link to register this local Guard device.",
+        ),
+        (
+            "expired",
+            "expired",
+            "expired",
+            "Sign-in expired",
+            "The sign-in link expired. Run hol-guard connect again.",
+        ),
+    ],
+)
+def test_runtime_snapshot_uses_oauth_connect_copy_for_proof_statuses(
+    tmp_path: Path,
+    status: str,
+    milestone: str,
+    expected_state: str,
+    expected_label: str,
+    expected_detail: str,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    request_id = f"connect-{expected_state}"
+    with store._connect() as connection:
+        connection.execute(
+            """
+            insert into guard_connect_states (
+              request_id,
+              sync_url,
+              allowed_origin,
+              status,
+              milestone,
+              reason,
+              created_at,
+              updated_at,
+              expires_at,
+              completed_at,
+              proof_json
+            )
+            values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                request_id,
+                "https://hol.org/api/guard/receipts/sync",
+                "https://hol.org",
+                status,
+                milestone,
+                None,
+                "2026-04-24T00:00:00+00:00",
+                "2026-04-24T00:00:30+00:00",
+                "2026-04-24T00:05:00+00:00",
+                None,
+                json.dumps({}),
+            ),
+        )
+
+    snapshot = build_runtime_snapshot(
+        store=store,
+        approval_center_url=None,
+        now="2026-04-24T00:01:00+00:00",
+    )
+    proof_status = snapshot["proof_status"]
+
+    assert proof_status["state"] == expected_state
+    assert proof_status["label"] == expected_label
+    assert proof_status["detail"] == expected_detail
+    assert "pairing" not in expected_label.lower()
+    assert "pairing" not in expected_detail.lower()
+
+
 def test_runtime_snapshot_counts_large_history_without_shipping_every_receipt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_guard_docs.py
+++ b/tests/test_guard_docs.py
@@ -136,6 +136,15 @@ def test_static_docs_include_skill_guidance_for_package_install_workflows() -> N
     assert "hol-guard supply-chain audit --json" in docs_text
 
 
+def test_release_checklist_mentions_oauth_only_connect_and_token_retirement() -> None:
+    release_checklist = _read_repo_file("docs/guard/release-checklist.md").lower()
+
+    assert "hol-guard connect" in release_checklist
+    assert "oauth" in release_checklist
+    assert "token" in release_checklist
+    assert "retired" in release_checklist
+
+
 def test_static_docs_cover_false_positive_remediation_and_incident_response() -> None:
     docs_text = "\n".join(
         [

--- a/tests/test_guard_evidence_store.py
+++ b/tests/test_guard_evidence_store.py
@@ -474,3 +474,31 @@ class TestExportRedaction:
         assert "auth-code-secret" not in encoded
         assert "ABCD-EFGH" not in encoded
         assert "dpop-private-key-secret" not in encoded
+
+    def test_export_redacts_nested_oauth_secret_fields_from_evidence_strings(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        oauth_blob = (
+            'sync_state.credentials={"access_token":"eyJtest.payload.signature",'
+            '"metadata":{"refresh_token":"refresh-secret-value",'
+            '"nested":{"authorization_code":"auth-code-secret",'
+            '"dpop_private_key_pem":"dpop-private-key-secret"}},'
+            '"user_code":"ABCD-EFGH"}'
+        )
+        store_evidence(
+            conn,
+            _rec(
+                evidence_id="ex-oauth-redaction-nested",
+                summary=f"nested oauth debug dump {oauth_blob}",
+                details={"oauth_blob": oauth_blob},
+            ),
+        )
+
+        exported = json.loads(export_evidence_json(conn, redact_fields=()))
+        encoded = json.dumps(exported)
+
+        assert "sync_state.credentials" not in encoded
+        assert "eyJtest.payload.signature" not in encoded
+        assert "refresh-secret-value" not in encoded
+        assert "auth-code-secret" not in encoded
+        assert "ABCD-EFGH" not in encoded
+        assert "dpop-private-key-secret" not in encoded

--- a/tests/test_guard_evidence_store.py
+++ b/tests/test_guard_evidence_store.py
@@ -446,3 +446,31 @@ class TestExportRedaction:
         assert "/Users/alice" not in encoded
         assert "secret-value" not in encoded
         assert "sk-test-secret-value" not in encoded
+
+    def test_export_redacts_oauth_secret_fields_from_evidence_strings(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        oauth_blob = (
+            'sync_state.credentials={"access_token":"eyJtest.payload.signature",'
+            '"refresh_token":"refresh-secret-value",'
+            '"authorization_code":"auth-code-secret",'
+            '"user_code":"ABCD-EFGH",'
+            '"dpop_private_key_pem":"dpop-private-key-secret"}'
+        )
+        store_evidence(
+            conn,
+            _rec(
+                evidence_id="ex-oauth-redaction",
+                summary=f"oauth debug dump {oauth_blob}",
+                details={"oauth_blob": oauth_blob},
+            ),
+        )
+
+        exported = json.loads(export_evidence_json(conn, redact_fields=()))
+        encoded = json.dumps(exported)
+
+        assert "sync_state.credentials" not in encoded
+        assert "eyJtest.payload.signature" not in encoded
+        assert "refresh-secret-value" not in encoded
+        assert "auth-code-secret" not in encoded
+        assert "ABCD-EFGH" not in encoded
+        assert "dpop-private-key-secret" not in encoded

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -1050,6 +1050,7 @@ def test_loopback_callback_listener_rejects_raw_runtime_credentials_without_code
             "&pairing_secret=pair-secret"
             "&sync_token=sync-secret"
         )
+        response_body = ""
         try:
             urllib.request.urlopen(legacy_query_url, timeout=5)
         except urllib.error.HTTPError as error:

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -131,6 +131,7 @@ def test_device_authorization_request_uses_oauth_scopes_without_token_material()
     encoded = connect_flow.build_device_authorization_request_body(
         machine_id="machine-123",
         machine_label="Michaels MacBook",
+        machine_location_label="America/New_York",
         runtime_id="hol-guard",
         runtime_label="HOL Guard CLI",
         client_id="guard-local-daemon",
@@ -143,6 +144,7 @@ def test_device_authorization_request_uses_oauth_scopes_without_token_material()
     ]
     assert parsed["requested_machine_id"] == ["machine-123"]
     assert parsed["requested_machine_label"] == ["Michaels MacBook"]
+    assert parsed["requested_machine_location_label"] == ["America/New_York"]
     assert parsed["requested_runtime_id"] == ["hol-guard"]
     assert parsed["requested_runtime_label"] == ["HOL Guard CLI"]
     assert "token" not in encoded
@@ -153,6 +155,7 @@ def test_ci_safe_device_authorization_request_uses_restricted_scopes() -> None:
     encoded = connect_flow.build_device_authorization_request_body(
         machine_id="machine-123",
         machine_label="CI Runner",
+        machine_location_label=None,
         runtime_id="hol-guard",
         runtime_label="HOL Guard CLI",
         client_id="guard-local-daemon",
@@ -163,6 +166,7 @@ def test_ci_safe_device_authorization_request_uses_restricted_scopes() -> None:
     assert parsed["scope"] == ["guard:runtime.sync guard:offline_access"]
     assert "guard:receipt.write" not in encoded
     assert "guard:runtime.session.write" not in encoded
+    assert "requested_machine_location_label" not in parsed
 
 
 def test_device_authorization_copy_payload_hides_device_code_secret() -> None:

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -1041,6 +1041,38 @@ def test_loopback_callback_listener_rejects_state_mismatch() -> None:
         listener.close()
 
 
+def test_loopback_callback_listener_rejects_raw_runtime_credentials_without_code() -> None:
+    listener = connect_flow.start_guard_loopback_callback_listener(expected_state="state-123")
+    try:
+        legacy_query_url = (
+            f"{listener.redirect_uri}?state=state-123"
+            "&token=guard_live_secret"
+            "&pairing_secret=pair-secret"
+            "&sync_token=sync-secret"
+        )
+        try:
+            urllib.request.urlopen(legacy_query_url, timeout=5)
+        except urllib.error.HTTPError as error:
+            assert error.code == 400
+            response_body = error.read().decode("utf-8")
+        else:
+            raise AssertionError("raw runtime credentials must not satisfy OAuth callback")
+
+        assert "authorization code" in response_body
+        assert "guard_live_secret" not in response_body
+        assert "pair-secret" not in response_body
+        assert "sync-secret" not in response_body
+
+        try:
+            listener.wait_for_callback(timeout_seconds=0.05)
+        except TimeoutError as error:
+            assert "timed out" in str(error)
+        else:
+            raise AssertionError("legacy runtime credentials must not be accepted as callback state")
+    finally:
+        listener.close()
+
+
 def test_loopback_callback_listener_surfaces_oauth_denial_without_timeout() -> None:
     listener = connect_flow.start_guard_loopback_callback_listener(expected_state="state-123")
     try:
@@ -1353,3 +1385,5 @@ def test_connect_browser_reports_loopback_timeout_without_traceback(
     assert "Guard authorization failed" in captured.err
     assert "timed out" in captured.err
     assert "Traceback" not in captured.err
+    assert store.get_sync_credentials() is None
+    assert store.get_oauth_local_credentials() is None

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -83,6 +83,40 @@ class TestGuardSurfaceServer:
         assert favicon_response.status == 200
         assert favicon_response.headers.get("Cache-Control") == "no-store, max-age=0"
 
+    def test_guard_daemon_dashboard_assets_use_oauth_connect_copy(self, tmp_path) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{daemon.port}/assets/guard-dashboard.js",
+                timeout=5,
+            ) as response:
+                dashboard_bundle = response.read().decode("utf-8")
+        finally:
+            daemon.stop()
+
+        runtime_overview_chunk = (
+            daemon_server_module._STATIC_DIR / "assets" / "chunks" / "runtime-overview.js"
+        ).read_text(encoding="utf-8")
+        feed_health_chunk = (
+            daemon_server_module._STATIC_DIR / "assets" / "chunks" / "feed-health-workspace.js"
+        ).read_text(encoding="utf-8")
+
+        assert "Open Guard connect" in dashboard_bundle
+        assert "Open pairing flow" not in dashboard_bundle
+        assert "Browser sign-in finished. First proof sync has not completed yet." in dashboard_bundle
+        assert "Browser pairing finished. First proof sync has not completed yet." not in dashboard_bundle
+        assert 'label: "Sync pending"' in runtime_overview_chunk
+        assert '"Pairing…"' not in runtime_overview_chunk
+        assert "Cloud connection is complete. Feed sync is in progress. First proof will arrive shortly." in (
+            feed_health_chunk
+        )
+        assert "Cloud pairing is complete. Feed sync is in progress. First proof will arrive shortly." not in (
+            feed_health_chunk
+        )
+
     def test_guard_daemon_dashboard_shell_omits_local_auth_token(self, tmp_path) -> None:
         store = GuardStore(tmp_path / "guard-home")
         store.add_approval_request(


### PR DESCRIPTION
## Summary
- refresh local daemon and release-note copy to match OAuth-only Guard connect flows
- harden evidence and loopback tests against raw OAuth secret leakage and legacy runtime credential callbacks
- include optional approximate device location labels in Device Code request bodies while keeping helper callers backward-compatible

## Testing
- `uv run pytest tests/test_guard_cloud_local_sync.py tests/test_guard_surface_server.py tests/test_guard_evidence_store.py tests/test_guard_oauth_device_connect.py tests/test_guard_docs.py -q`
- `uv run pytest tests/test_guard_runtime.py -q -k sign_guard_dpop_proof_sets_access_token_hash_claim`
