### PR TITLE
fix(guard): add oauth disconnect revoke

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -194,6 +194,7 @@ from .connect_flow import (
     DEFAULT_GUARD_SYNC_URL,
     build_connect_status_payload,
     run_guard_browser_connect_command,
+    run_guard_disconnect_command,
     run_guard_device_connect_command,
 )
 from .docs import build_install_connect_docs_payload
@@ -244,6 +245,7 @@ _GUARD_HELP_GROUPS = (
     "\n"
     "Team and cloud coordination:\n"
     "  connect      Pair this machine to Guard Cloud\n"
+    "  disconnect   Revoke local Guard Cloud auth and optionally revoke cloud grant state\n"
     "  login        Compatibility alias for browser pairing\n"
     "  sync         Send local decisions, receipts, and policy memory to Guard Cloud\n"
     "  service      Manage hosted-runtime Guard Cloud login and sync\n"
@@ -386,6 +388,7 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
         metavar=(
             "{start,status,dashboard,init,apps,bootstrap,detect,install,update,uninstall,package-shims,run,protect,preflight,scan,diff,"
             "receipts,inventory,abom,approvals,explain,allow,deny,policies,exceptions,advisories,events,doctor,connect,"
+            "disconnect,"
             "login,sync,device,bridge}"
         ),
     )
@@ -876,6 +879,18 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
         help="Alias for --headless. Start Device Code approval without opening a browser.",
     )
     connect_parser.add_argument("--json", action="store_true")
+
+    disconnect_parser = guard_subparsers.add_parser(
+        "disconnect",
+        help="Revoke local Guard Cloud OAuth credentials and optionally revoke the cloud grant",
+    )
+    _add_guard_common_args(disconnect_parser)
+    disconnect_parser.add_argument(
+        "--revoke-cloud-grant",
+        action="store_true",
+        help="Also revoke the machine and runtime grant state in Guard Cloud.",
+    )
+    disconnect_parser.add_argument("--json", action="store_true")
 
     sync_parser = guard_subparsers.add_parser("sync", help="Sync receipts to the configured Guard endpoint")
     sync_parser.add_argument("--home")
@@ -2408,6 +2423,22 @@ def run_guard_command(
                 return exit_code
             _emit("connect", payload, getattr(args, "json", False))
             return exit_code
+
+    if args.guard_command == "disconnect":
+        try:
+            payload = run_guard_disconnect_command(
+                store=store,
+                revoke_cloud_grant=bool(getattr(args, "revoke_cloud_grant", False)),
+                now=_now(),
+            )
+        except RuntimeError as error:
+            if getattr(args, "json", False):
+                _emit("disconnect", {"status": "error", "error": str(error)}, True)
+            else:
+                print(str(error), file=sys.stderr)
+            return 1
+        _emit("disconnect", payload, getattr(args, "json", False))
+        return 0
 
     if args.guard_command == "bridge":
         poll_interval = getattr(args, "poll_interval", 10) or 10

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -194,8 +194,8 @@ from .connect_flow import (
     DEFAULT_GUARD_SYNC_URL,
     build_connect_status_payload,
     run_guard_browser_connect_command,
-    run_guard_disconnect_command,
     run_guard_device_connect_command,
+    run_guard_disconnect_command,
 )
 from .docs import build_install_connect_docs_payload
 from .install_commands import (
@@ -2431,7 +2431,7 @@ def run_guard_command(
                 revoke_cloud_grant=bool(getattr(args, "revoke_cloud_grant", False)),
                 now=_now(),
             )
-        except RuntimeError as error:
+        except (RuntimeError, TimeoutError, urllib.error.URLError, http.client.HTTPException) as error:
             if getattr(args, "json", False):
                 _emit("disconnect", {"status": "error", "error": str(error)}, True)
             else:

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -43,6 +43,7 @@ CI_SAFE_GUARD_DEVICE_SCOPES = (
 CONNECT_COMMAND = "hol-guard connect"
 CONNECT_STATUS_COMMAND = "hol-guard connect status"
 CONNECT_REPAIR_COMMAND = "hol-guard connect repair"
+DISCONNECT_COMMAND = "hol-guard disconnect"
 HEADLESS_CONNECT_COMMAND = "hol-guard connect --headless"
 DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
 DEVICE_CODE_SLOW_DOWN_SECONDS = 5
@@ -50,6 +51,7 @@ HEADLESS_RUNTIME_ID = "hol-guard"
 HEADLESS_RUNTIME_LABEL = "HOL Guard CLI"
 _GUARD_OAUTH_USER_AGENT = f"hol-guard/{__version__}"
 _LOOPBACK_REDIRECT_PATH = "/oauth/callback"
+_SELF_REVOKE_PATH = "/api/guard/oauth/revoke/self"
 
 
 def _guard_oauth_request_headers(*, dpop: str | None = None) -> dict[str, str]:
@@ -428,6 +430,31 @@ def _device_token_request_body(*, client_id: str, device_code: str) -> bytes:
     ).encode("utf-8")
 
 
+def _refresh_token_request_body(*, client_id: str, refresh_token: str) -> bytes:
+    return urllib.parse.urlencode(
+        {
+            "grant_type": "refresh_token",
+            "client_id": client_id,
+            "refresh_token": refresh_token,
+        }
+    ).encode("utf-8")
+
+
+def _self_revoke_request_body(
+    *,
+    workspace_id: str,
+    revoke_cloud_grant: bool,
+) -> bytes:
+    return urllib.parse.urlencode(
+        {
+            "workspace_id": workspace_id,
+            "reason": "user_disconnect",
+            "revoke_machine_grant": "true" if revoke_cloud_grant else "false",
+            "revoke_runtime_grant": "true" if revoke_cloud_grant else "false",
+        }
+    ).encode("utf-8")
+
+
 def _load_error_payload(error: urllib.error.HTTPError) -> dict[str, object] | None:
     try:
         raw_body = error.read().decode("utf-8")
@@ -570,6 +597,175 @@ def exchange_guard_authorization_code(
     if not isinstance(payload, dict):
         raise RuntimeError("Guard OAuth token exchange failed: invalid response.")
     return _parse_guard_token_exchange_payload(payload)
+
+
+def refresh_guard_access_token(
+    *,
+    token_endpoint: str,
+    client_id: str,
+    refresh_token: str,
+    dpop_key_material: GuardDpopKeyMaterial,
+    urlopen=urllib.request.urlopen,
+    now: datetime | None = None,
+) -> GuardOAuthTokenExchangeResult:
+    request = urllib.request.Request(
+        token_endpoint,
+        data=_refresh_token_request_body(
+            client_id=client_id,
+            refresh_token=refresh_token,
+        ),
+        method="POST",
+        headers=_guard_oauth_request_headers(
+            dpop=_sign_dpop_proof(
+                token_endpoint=token_endpoint,
+                dpop_key_material=dpop_key_material,
+                now=now or datetime.now(timezone.utc),
+            ),
+        ),
+    )
+    try:
+        with urlopen(request, timeout=20) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        payload = _load_error_payload(error)
+        message = (
+            str(payload.get("error_description") or payload.get("error") or error.reason)
+            if isinstance(payload, dict)
+            else str(error.reason)
+        )
+        raise RuntimeError(f"Guard OAuth token exchange failed: {message}") from error
+    if not isinstance(payload, dict):
+        raise RuntimeError("Guard OAuth token exchange failed: invalid response.")
+    return _parse_guard_token_exchange_payload(payload)
+
+
+def revoke_guard_self_oauth_grant(
+    *,
+    issuer: str,
+    access_token: str,
+    workspace_id: str,
+    revoke_cloud_grant: bool,
+    dpop_key_material: GuardDpopKeyMaterial,
+    urlopen=urllib.request.urlopen,
+    now: datetime | None = None,
+) -> None:
+    revoke_url = f"{resolve_guard_oauth_client_config(issuer).issuer}{_SELF_REVOKE_PATH}"
+    request = urllib.request.Request(
+        revoke_url,
+        data=_self_revoke_request_body(
+            workspace_id=workspace_id,
+            revoke_cloud_grant=revoke_cloud_grant,
+        ),
+        method="POST",
+        headers={
+            **_guard_oauth_request_headers(
+                dpop=_sign_dpop_proof(
+                    token_endpoint=revoke_url,
+                    dpop_key_material=dpop_key_material,
+                    now=now or datetime.now(timezone.utc),
+                ),
+            ),
+            "Authorization": f"Bearer {access_token}",
+        },
+    )
+    try:
+        with urlopen(request, timeout=20):
+            return
+    except urllib.error.HTTPError as error:
+        payload = _load_error_payload(error)
+        message = (
+            str(payload.get("error_description") or payload.get("error") or error.reason)
+            if isinstance(payload, dict)
+            else str(error.reason)
+        )
+        raise RuntimeError(f"Guard OAuth disconnect failed: {message}") from error
+
+
+def _require_oauth_credential_string(credentials: dict[str, object], key: str) -> str:
+    value = credentials.get(key)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    raise RuntimeError("Guard Cloud is not connected yet. Run `hol-guard connect`.")
+
+
+def _oauth_dpop_key_material_from_credentials(
+    credentials: dict[str, object],
+) -> GuardDpopKeyMaterial:
+    dpop_private_key_pem = _require_oauth_credential_string(credentials, "dpop_private_key_pem")
+    dpop_public_jwk = credentials.get("dpop_public_jwk")
+    if not isinstance(dpop_public_jwk, dict):
+        raise RuntimeError("Guard Cloud is not connected yet. Run `hol-guard connect`.")
+    return GuardDpopKeyMaterial(
+        algorithm="ES256",
+        private_key_pem=dpop_private_key_pem,
+        public_jwk={str(key): str(value) for key, value in dpop_public_jwk.items()},
+        public_jwk_thumbprint=_require_oauth_credential_string(
+            credentials,
+            "dpop_public_jwk_thumbprint",
+        ),
+    )
+
+
+def run_guard_disconnect_command(
+    *,
+    store: GuardStore,
+    revoke_cloud_grant: bool,
+    now: str | None = None,
+    urlopen=urllib.request.urlopen,
+) -> dict[str, object]:
+    credentials = store.get_oauth_local_credentials()
+    if credentials is None:
+        return {
+            "status": "not_connected",
+            "cloud_grant_revoked": False,
+            "reconnect_command": CONNECT_COMMAND,
+        }
+
+    issuer = _require_oauth_credential_string(credentials, "issuer")
+    client_id = _require_oauth_credential_string(credentials, "client_id")
+    refresh_token = _require_oauth_credential_string(credentials, "refresh_token")
+    workspace_id = _require_oauth_credential_string(credentials, "workspace_id")
+    dpop_key_material = _oauth_dpop_key_material_from_credentials(credentials)
+    exchange_now = datetime.fromisoformat(now) if isinstance(now, str) else datetime.now(timezone.utc)
+    token_result = refresh_guard_access_token(
+        token_endpoint=resolve_guard_oauth_client_config(issuer).token_endpoint,
+        client_id=client_id,
+        refresh_token=refresh_token,
+        dpop_key_material=dpop_key_material,
+        urlopen=urlopen,
+        now=exchange_now,
+    )
+    rotated_refresh_token = token_result.refresh_token
+    if rotated_refresh_token and rotated_refresh_token != refresh_token:
+        store.set_oauth_local_credentials(
+            issuer=issuer,
+            client_id=client_id,
+            refresh_token=rotated_refresh_token,
+            dpop_private_key_pem=dpop_key_material.private_key_pem,
+            dpop_public_jwk=dpop_key_material.public_jwk,
+            dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+            grant_id=_read_nested_string(credentials, "grant_id"),
+            machine_id=_read_nested_string(credentials, "machine_id"),
+            workspace_id=workspace_id,
+            runtime_id=_read_nested_string(credentials, "runtime_id"),
+            runtime_label=_read_nested_string(credentials, "runtime_label"),
+            now=now or datetime.now(timezone.utc).isoformat(),
+        )
+    revoke_guard_self_oauth_grant(
+        issuer=issuer,
+        access_token=token_result.access_token,
+        workspace_id=workspace_id,
+        revoke_cloud_grant=revoke_cloud_grant,
+        dpop_key_material=dpop_key_material,
+        urlopen=urlopen,
+        now=exchange_now,
+    )
+    store.clear_oauth_local_credentials()
+    return {
+        "status": "disconnected",
+        "cloud_grant_revoked": revoke_cloud_grant,
+        "reconnect_command": CONNECT_COMMAND,
+    }
 
 
 def run_guard_device_connect_command(

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -22,6 +22,7 @@ from ...version import __version__
 from ..store import GuardStore
 from .oauth_client import (
     GuardDpopKeyMaterial,
+    GuardOAuthClientConfig,
     build_pkce_s256_challenge,
     generate_dpop_key_pair,
     generate_pkce_verifier,
@@ -641,7 +642,7 @@ def refresh_guard_access_token(
 
 def revoke_guard_self_oauth_grant(
     *,
-    issuer: str,
+    oauth_client: GuardOAuthClientConfig,
     access_token: str,
     workspace_id: str,
     revoke_cloud_grant: bool,
@@ -649,7 +650,7 @@ def revoke_guard_self_oauth_grant(
     urlopen=urllib.request.urlopen,
     now: datetime | None = None,
 ) -> None:
-    revoke_url = f"{resolve_guard_oauth_client_config(issuer).issuer}{_SELF_REVOKE_PATH}"
+    revoke_url = f"{oauth_client.issuer}{_SELF_REVOKE_PATH}"
     request = urllib.request.Request(
         revoke_url,
         data=_self_revoke_request_body(
@@ -706,6 +707,36 @@ def _oauth_dpop_key_material_from_credentials(
     )
 
 
+def _persist_oauth_local_credentials(
+    *,
+    store: GuardStore,
+    issuer: str,
+    client_id: str,
+    refresh_token: str,
+    dpop_key_material: GuardDpopKeyMaterial,
+    now: str,
+    grant_id: str | None = None,
+    machine_id: str | None = None,
+    workspace_id: str | None = None,
+    runtime_id: str | None = None,
+    runtime_label: str | None = None,
+) -> None:
+    store.set_oauth_local_credentials(
+        issuer=issuer,
+        client_id=client_id,
+        refresh_token=refresh_token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id=grant_id,
+        machine_id=machine_id,
+        workspace_id=workspace_id,
+        runtime_id=runtime_id,
+        runtime_label=runtime_label,
+        now=now,
+    )
+
+
 def run_guard_disconnect_command(
     *,
     store: GuardStore,
@@ -726,9 +757,11 @@ def run_guard_disconnect_command(
     refresh_token = _require_oauth_credential_string(credentials, "refresh_token")
     workspace_id = _require_oauth_credential_string(credentials, "workspace_id")
     dpop_key_material = _oauth_dpop_key_material_from_credentials(credentials)
+    oauth_client = resolve_guard_oauth_client_config(issuer)
     exchange_now = datetime.fromisoformat(now) if isinstance(now, str) else datetime.now(timezone.utc)
+    timestamp = now or exchange_now.isoformat()
     token_result = refresh_guard_access_token(
-        token_endpoint=resolve_guard_oauth_client_config(issuer).token_endpoint,
+        token_endpoint=oauth_client.token_endpoint,
         client_id=client_id,
         refresh_token=refresh_token,
         dpop_key_material=dpop_key_material,
@@ -737,22 +770,21 @@ def run_guard_disconnect_command(
     )
     rotated_refresh_token = token_result.refresh_token
     if rotated_refresh_token and rotated_refresh_token != refresh_token:
-        store.set_oauth_local_credentials(
-            issuer=issuer,
+        _persist_oauth_local_credentials(
+            store=store,
+            issuer=oauth_client.issuer,
             client_id=client_id,
             refresh_token=rotated_refresh_token,
-            dpop_private_key_pem=dpop_key_material.private_key_pem,
-            dpop_public_jwk=dpop_key_material.public_jwk,
-            dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+            dpop_key_material=dpop_key_material,
             grant_id=_read_nested_string(credentials, "grant_id"),
             machine_id=_read_nested_string(credentials, "machine_id"),
             workspace_id=workspace_id,
             runtime_id=_read_nested_string(credentials, "runtime_id"),
             runtime_label=_read_nested_string(credentials, "runtime_label"),
-            now=now or datetime.now(timezone.utc).isoformat(),
+            now=timestamp,
         )
     revoke_guard_self_oauth_grant(
-        issuer=issuer,
+        oauth_client=oauth_client,
         access_token=token_result.access_token,
         workspace_id=workspace_id,
         revoke_cloud_grant=revoke_cloud_grant,
@@ -829,13 +861,12 @@ def run_guard_device_connect_command(
     if token_result.refresh_token is None:
         raise RuntimeError("Guard OAuth token exchange failed: missing refresh token.")
     timestamp = now or datetime.now(timezone.utc).isoformat()
-    store.set_oauth_local_credentials(
+    _persist_oauth_local_credentials(
+        store=store,
         issuer=oauth_client.issuer,
         client_id=oauth_client.client_id,
         refresh_token=token_result.refresh_token,
-        dpop_private_key_pem=dpop_key_material.private_key_pem,
-        dpop_public_jwk=dpop_key_material.public_jwk,
-        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        dpop_key_material=dpop_key_material,
         grant_id=token_result.grant_id,
         machine_id=token_result.machine_id,
         workspace_id=token_result.workspace_id,
@@ -892,13 +923,12 @@ def run_guard_browser_connect_command(
     if token_result.refresh_token is None:
         raise RuntimeError("Guard OAuth token exchange failed: missing refresh token.")
     timestamp = now or datetime.now(timezone.utc).isoformat()
-    store.set_oauth_local_credentials(
+    _persist_oauth_local_credentials(
+        store=store,
         issuer=oauth_client.issuer,
         client_id=oauth_client.client_id,
         refresh_token=token_result.refresh_token,
-        dpop_private_key_pem=session.dpop_key_material.private_key_pem,
-        dpop_public_jwk=session.dpop_key_material.public_jwk,
-        dpop_public_jwk_thumbprint=session.dpop_key_material.public_jwk_thumbprint,
+        dpop_key_material=session.dpop_key_material,
         grant_id=token_result.grant_id,
         machine_id=token_result.machine_id,
         workspace_id=token_result.workspace_id,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -421,10 +421,11 @@ class FallbackSecretStore:
             try:
                 store.delete_secret(secret_id)
             except Exception:
+                secret_id_fingerprint = sha256(secret_id.encode("utf-8")).hexdigest()[:12]
                 _store_logger.exception(
-                    "Failed to delete Guard secret from %s for secret_id=%s",
+                    "Failed to delete Guard secret from %s for secret_ref_hash=%s",
                     type(store).__name__,
-                    secret_id,
+                    secret_id_fingerprint,
                 )
                 continue
 

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -421,6 +421,11 @@ class FallbackSecretStore:
             try:
                 store.delete_secret(secret_id)
             except Exception:
+                _store_logger.exception(
+                    "Failed to delete Guard secret from %s for secret_id=%s",
+                    type(store).__name__,
+                    secret_id,
+                )
                 continue
 
 

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -421,11 +421,9 @@ class FallbackSecretStore:
             try:
                 store.delete_secret(secret_id)
             except Exception:
-                secret_id_fingerprint = sha256(secret_id.encode("utf-8")).hexdigest()[:12]
-                _store_logger.exception(
-                    "Failed to delete Guard secret from %s for secret_ref_hash=%s",
+                _store_logger.warning(
+                    "Failed to delete Guard secret from %s",
                     type(store).__name__,
-                    secret_id_fingerprint,
                 )
                 continue
 

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -158,6 +158,9 @@ class SecretStore(Protocol):
     def get_secret(self, secret_id: str) -> str | None:
         """Fetch a secret value."""
 
+    def delete_secret(self, secret_id: str) -> None:
+        """Delete a secret value if it exists."""
+
 
 class KeychainSecretStore:
     """macOS keychain-backed secret store."""
@@ -212,6 +215,23 @@ class KeychainSecretStore:
         value = result.stdout.rstrip("\r\n")
         return value if value else None
 
+    def delete_secret(self, secret_id: str) -> None:
+        if not self._is_available():
+            return
+        subprocess.run(
+            [
+                "/usr/bin/security",
+                "delete-generic-password",
+                "-a",
+                secret_id,
+                "-s",
+                self.service_name,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
 
 class EncryptedFileSecretStore:
     """Encrypted file-based secret store for predictable cross-platform Guard credentials.
@@ -261,6 +281,12 @@ class EncryptedFileSecretStore:
             return None
         self.set_secret(secret_id, legacy_value)
         return legacy_value
+
+    def delete_secret(self, secret_id: str) -> None:
+        self._ensure_ready()
+        path = self._path_for(secret_id)
+        if path.exists():
+            path.unlink()
 
     def _path_for(self, secret_id: str) -> Path:
         normalized = secret_id.replace("/", "_").replace(":", "_")
@@ -389,6 +415,13 @@ class FallbackSecretStore:
             self.primary.set_secret(secret_id, value)
         except Exception:
             return
+
+    def delete_secret(self, secret_id: str) -> None:
+        for store in (self.primary, self.fallback):
+            try:
+                store.delete_secret(secret_id)
+            except Exception:
+                continue
 
 
 def _expand_keystream(*, key: bytes, nonce: bytes, length: int) -> bytes:
@@ -3000,6 +3033,15 @@ class GuardStore:
         if isinstance(runtime_label, str) and runtime_label:
             result["runtime_label"] = runtime_label
         return result
+
+    def clear_oauth_local_credentials(self) -> None:
+        payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
+        if isinstance(payload, dict):
+            for key in ("refresh_token_ref", "dpop_private_key_ref"):
+                secret_ref = payload.get(key)
+                if isinstance(secret_ref, str) and secret_ref:
+                    self._oauth_secret_store.delete_secret(secret_ref)
+        self.delete_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
 
     def get_oauth_local_credential_health(self) -> dict[str, object]:
         payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6549,6 +6549,52 @@ url = http://127.0.0.1:8787/guard-canary
             "workspace_id": "workspace-123",
         }
 
+    def test_guard_disconnect_revokes_cloud_grant_through_oauth_disconnect_helper(
+        self,
+        tmp_path,
+        capsys,
+        monkeypatch,
+    ):
+        home_dir = tmp_path / "home"
+        calls: list[dict[str, object]] = []
+
+        def fake_disconnect(
+            *,
+            store: GuardStore,
+            revoke_cloud_grant: bool,
+            now: str | None = None,
+            urlopen=None,
+        ) -> dict[str, object]:
+            del store, now, urlopen
+            calls.append({"revoke_cloud_grant": revoke_cloud_grant})
+            return {
+                "status": "disconnected",
+                "cloud_grant_revoked": revoke_cloud_grant,
+                "reconnect_command": "hol-guard connect",
+            }
+
+        monkeypatch.setattr(guard_commands_module, "run_guard_disconnect_command", fake_disconnect)
+
+        rc = main(
+            [
+                "guard",
+                "disconnect",
+                "--home",
+                str(home_dir),
+                "--revoke-cloud-grant",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output == {
+            "status": "disconnected",
+            "cloud_grant_revoked": True,
+            "reconnect_command": "hol-guard connect",
+        }
+        assert calls == [{"revoke_cloud_grant": True}]
+
     def test_guard_login_without_manual_credentials_uses_device_code_browser_flow(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6595,6 +6595,43 @@ url = http://127.0.0.1:8787/guard-canary
         }
         assert calls == [{"revoke_cloud_grant": True}]
 
+    def test_guard_disconnect_reports_network_layer_errors_in_json_mode(
+        self,
+        tmp_path,
+        capsys,
+        monkeypatch,
+    ):
+        home_dir = tmp_path / "home"
+
+        def fake_disconnect(
+            *,
+            store: GuardStore,
+            revoke_cloud_grant: bool,
+            now: str | None = None,
+            urlopen=None,
+        ) -> dict[str, object]:
+            del store, revoke_cloud_grant, now, urlopen
+            raise urllib.error.URLError("loopback refused")
+
+        monkeypatch.setattr(guard_commands_module, "run_guard_disconnect_command", fake_disconnect)
+
+        rc = main(
+            [
+                "guard",
+                "disconnect",
+                "--home",
+                str(home_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 1
+        assert output == {
+            "status": "error",
+            "error": "<urlopen error loopback refused>",
+        }
+
     def test_guard_login_without_manual_credentials_uses_device_code_browser_flow(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -362,6 +362,181 @@ def test_headless_connect_ci_safe_uses_explicit_label_and_restricted_scopes(tmp_
     assert parsed["scope"] == ["guard:runtime.sync guard:offline_access"]
 
 
+def test_disconnect_revokes_cloud_grant_with_runtime_access_token_and_clears_local_oauth_credentials(
+    tmp_path: Path,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-123",
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        runtime_id="hol-guard",
+        runtime_label="HOL Guard CLI",
+        now="2026-06-01T12:00:00+00:00",
+    )
+    access_token = _fake_access_token(
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+    )
+    requests: list[dict[str, object]] = []
+
+    class _Response:
+        def __init__(self, payload: dict[str, object] | None = None) -> None:
+            self._payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            if self._payload is None:
+                return b""
+            return json.dumps(self._payload).encode("utf-8")
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int):
+        del timeout
+        body = request.data.decode("utf-8") if request.data else ""
+        requests.append(
+            {
+                "authorization": request.get_header("Authorization"),
+                "body": body,
+                "headers": dict(request.header_items()),
+                "url": request.full_url,
+            }
+        )
+        if request.full_url == "https://hol.org/api/guard/oauth/token":
+            return _Response(
+                {
+                    "access_token": access_token,
+                    "refresh_token": "refresh-123",
+                    "expires_in": 3600,
+                    "scope": "guard:runtime.sync guard:offline_access",
+                    "token_type": "Bearer",
+                }
+            )
+        if request.full_url == "https://hol.org/api/guard/oauth/revoke/self":
+            return _Response()
+        raise AssertionError(f"Unexpected request URL: {request.full_url}")
+
+    payload = connect_flow.run_guard_disconnect_command(
+        store=store,
+        revoke_cloud_grant=True,
+        urlopen=fake_urlopen,
+        now="2026-06-01T12:05:00+00:00",
+    )
+
+    assert payload["status"] == "disconnected"
+    assert payload["cloud_grant_revoked"] is True
+    assert payload["reconnect_command"] == "hol-guard connect"
+    assert store.get_oauth_local_credentials() is None
+    assert [request["url"] for request in requests] == [
+        "https://hol.org/api/guard/oauth/token",
+        "https://hol.org/api/guard/oauth/revoke/self",
+    ]
+
+    token_body = urllib.parse.parse_qs(str(requests[0]["body"]))
+    revoke_body = urllib.parse.parse_qs(str(requests[1]["body"]))
+    assert token_body["grant_type"] == ["refresh_token"]
+    assert token_body["client_id"] == ["guard-local-daemon"]
+    assert token_body["refresh_token"] == ["refresh-123"]
+    assert revoke_body == {
+        "reason": ["user_disconnect"],
+        "revoke_machine_grant": ["true"],
+        "revoke_runtime_grant": ["true"],
+        "workspace_id": ["workspace-123"],
+    }
+    assert requests[1]["authorization"] == f"Bearer {access_token}"
+    assert isinstance(requests[1]["headers"], dict)
+    assert requests[1]["headers"].get("Dpop")
+    assert "refresh-123" not in str(requests[1]["body"])
+
+
+def test_disconnect_keeps_local_oauth_credentials_when_self_revoke_fails(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-123",
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        runtime_id="hol-guard",
+        runtime_label="HOL Guard CLI",
+        now="2026-06-01T12:00:00+00:00",
+    )
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "access_token": _fake_access_token(
+                        grant_id="grant-123",
+                        machine_id="machine-123",
+                        workspace_id="workspace-123",
+                    ),
+                    "refresh_token": "refresh-123",
+                    "expires_in": 3600,
+                    "scope": "guard:runtime.sync guard:offline_access",
+                    "token_type": "Bearer",
+                }
+            ).encode("utf-8")
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int):
+        del timeout
+        if request.full_url == "https://hol.org/api/guard/oauth/token":
+            return _Response()
+        raise urllib.error.HTTPError(
+            request.full_url,
+            500,
+            "server_error",
+            hdrs={"Content-Type": "application/json"},
+            fp=io.BytesIO(
+                json.dumps(
+                    {
+                        "error": "server_error",
+                        "error_description": "temporary failure",
+                    }
+                ).encode("utf-8")
+            ),
+        )
+
+    try:
+        connect_flow.run_guard_disconnect_command(
+            store=store,
+            revoke_cloud_grant=True,
+            urlopen=fake_urlopen,
+            now="2026-06-01T12:05:00+00:00",
+        )
+    except RuntimeError as error:
+        assert str(error) == "Guard OAuth disconnect failed: temporary failure"
+    else:
+        raise AssertionError("disconnect should fail when self-revocation fails")
+
+    assert store.get_oauth_local_credentials() is not None
+
+
 def test_headless_connect_polls_until_success_and_persists_oauth_credentials(tmp_path: Path) -> None:
     guard_home = tmp_path / "guard-home"
     store = GuardStore(guard_home)

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -225,7 +225,7 @@ def test_headless_connect_requests_device_code_without_persisting_secrets(tmp_pa
                         machine_id="machine-123",
                         workspace_id="workspace-123",
                     ),
-                    "refresh_token": "refresh-rotated",
+                    "refresh_token": "refresh-123",
                     "expires_in": 3600,
                     "scope": "guard:runtime.sync guard:offline_access",
                     "token_type": "Bearer",

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -225,7 +225,7 @@ def test_headless_connect_requests_device_code_without_persisting_secrets(tmp_pa
                         machine_id="machine-123",
                         workspace_id="workspace-123",
                     ),
-                    "refresh_token": "refresh-123",
+                    "refresh_token": "refresh-rotated",
                     "expires_in": 3600,
                     "scope": "guard:runtime.sync guard:offline_access",
                     "token_type": "Bearer",
@@ -287,7 +287,7 @@ def test_headless_connect_uses_staging_client_defaults(tmp_path: Path) -> None:
                         machine_id="machine-123",
                         workspace_id="workspace-123",
                     ),
-                    "refresh_token": "refresh-123",
+                    "refresh_token": "refresh-rotated",
                     "expires_in": 3600,
                     "scope": "guard:runtime.sync guard:offline_access",
                     "token_type": "Bearer",
@@ -339,7 +339,7 @@ def test_headless_connect_ci_safe_uses_explicit_label_and_restricted_scopes(tmp_
                         machine_id="machine-123",
                         workspace_id="workspace-123",
                     ),
-                    "refresh_token": "refresh-123",
+                    "refresh_token": "refresh-rotated",
                     "expires_in": 3600,
                     "scope": "guard:runtime.sync guard:offline_access",
                     "token_type": "Bearer",
@@ -496,7 +496,7 @@ def test_disconnect_keeps_local_oauth_credentials_when_self_revoke_fails(tmp_pat
                         machine_id="machine-123",
                         workspace_id="workspace-123",
                     ),
-                    "refresh_token": "refresh-123",
+                    "refresh_token": "refresh-rotated",
                     "expires_in": 3600,
                     "scope": "guard:runtime.sync guard:offline_access",
                     "token_type": "Bearer",
@@ -534,7 +534,9 @@ def test_disconnect_keeps_local_oauth_credentials_when_self_revoke_fails(tmp_pat
     else:
         raise AssertionError("disconnect should fail when self-revocation fails")
 
-    assert store.get_oauth_local_credentials() is not None
+    credentials = store.get_oauth_local_credentials()
+    assert credentials is not None
+    assert credentials["refresh_token"] == "refresh-rotated"
 
 
 def test_headless_connect_polls_until_success_and_persists_oauth_credentials(tmp_path: Path) -> None:

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -229,7 +229,7 @@ def test_fallback_secret_store_logs_delete_failures(caplog):
     store.delete_secret("guard-token")
 
     assert fallback.deleted == ["guard-token"]
-    assert "guard-token" in caplog.text
+    assert "secret_ref_hash=75922f38f3f5" in caplog.text
     assert "Failed to delete Guard secret from FailingStore" in caplog.text
 
 

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -8,6 +8,7 @@ import os
 import sqlite3
 import subprocess
 
+from codex_plugin_scanner.guard.models import GuardReceipt
 from codex_plugin_scanner.guard.store import (
     EncryptedFileSecretStore,
     FallbackSecretStore,
@@ -330,6 +331,61 @@ def test_oauth_local_credentials_are_not_persisted_in_plaintext_sqlite(tmp_path)
         "workspace_id": "workspace-123",
     }
     assert store.get_cloud_workspace_id() == "workspace-123"
+
+
+def test_clear_oauth_local_credentials_preserves_local_receipt_history(tmp_path, monkeypatch):
+    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: False))
+
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={
+            "kty": "EC",
+            "crv": "P-256",
+            "x": "x-value",
+            "y": "y-value",
+            "alg": "ES256",
+            "use": "sig",
+        },
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        runtime_id="hol-guard",
+        runtime_label="HOL Guard CLI",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    store.add_receipt(
+        GuardReceipt(
+            receipt_id="receipt-1",
+            timestamp="2026-06-01T00:05:00+00:00",
+            harness="codex",
+            artifact_id="artifact-1",
+            artifact_hash="sha256:artifact",
+            policy_decision="allow",
+            capabilities_summary="safe",
+            changed_capabilities=("stdio",),
+            provenance_summary="known-good",
+        )
+    )
+
+    store.clear_oauth_local_credentials()
+
+    assert store.get_oauth_local_credentials() is None
+    assert store.count_receipts() == 1
+    assert store.get_receipt("receipt-1") is not None
+
+    with sqlite3.connect(store.path) as connection:
+        row = connection.execute(
+            "select payload_json from sync_state where state_key = 'oauth_local_credentials'"
+        ).fetchone()
+
+    assert row is None
+    assert list((guard_home / "secrets").glob("guard-oauth-*.enc")) == []
 
 
 def test_oauth_local_credentials_use_encrypted_file_fallback_when_keychain_write_fails(tmp_path, monkeypatch):

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -225,12 +225,12 @@ def test_fallback_secret_store_logs_delete_failures(caplog):
     fallback = MemoryStore()
     store = FallbackSecretStore(FailingStore(), fallback)
 
-    caplog.set_level(logging.ERROR, logger="codex_plugin_scanner.guard.store")
+    caplog.set_level(logging.WARNING, logger="codex_plugin_scanner.guard.store")
     store.delete_secret("guard-token")
 
     assert fallback.deleted == ["guard-token"]
-    assert "secret_ref_hash=75922f38f3f5" in caplog.text
     assert "Failed to delete Guard secret from FailingStore" in caplog.text
+    assert "guard-token" not in caplog.text
 
 
 def test_secret_store_prefers_encrypted_file_backend_when_keychain_is_available(tmp_path, monkeypatch):

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import sqlite3
 import subprocess
@@ -207,6 +208,29 @@ def test_fallback_secret_store_promotes_secret_to_primary():
     store.promote_secret("guard-token", "value-123")
 
     assert primary.get_secret("guard-token") == "value-123"
+
+
+def test_fallback_secret_store_logs_delete_failures(caplog):
+    class FailingStore:
+        def delete_secret(self, secret_id: str) -> None:
+            raise RuntimeError(f"cannot delete {secret_id}")
+
+    class MemoryStore:
+        def __init__(self) -> None:
+            self.deleted: list[str] = []
+
+        def delete_secret(self, secret_id: str) -> None:
+            self.deleted.append(secret_id)
+
+    fallback = MemoryStore()
+    store = FallbackSecretStore(FailingStore(), fallback)
+
+    caplog.set_level(logging.ERROR, logger="codex_plugin_scanner.guard.store")
+    store.delete_secret("guard-token")
+
+    assert fallback.deleted == ["guard-token"]
+    assert "guard-token" in caplog.text
+    assert "Failed to delete Guard secret from FailingStore" in caplog.text
 
 
 def test_secret_store_prefers_encrypted_file_backend_when_keychain_is_available(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add `hol-guard disconnect` OAuth self-revoke flow for local daemon credentials
- clear only local OAuth credential material after successful revoke while preserving local receipt history

## Testing
- `uv run pytest tests/test_guard_store_migrations.py -q -k "clear_oauth_local_credentials_preserves_local_receipt_history or oauth_local_credentials_are_not_persisted_in_plaintext_sqlite"`
- `uv run pytest tests/test_guard_oauth_device_connect.py -q -k "disconnect_revokes_cloud_grant_with_runtime_access_token_and_clears_local_oauth_credentials or disconnect_keeps_local_oauth_credentials_when_self_revoke_fails"`
- `uv run pytest tests/test_guard_cli.py -q -k guard_disconnect_revokes_cloud_grant_through_oauth_disconnect_helper`

## Notes
- Companion portal PR carries the runtime-authenticated `/api/guard/oauth/revoke/self` route.
- Unrelated dirty `uv.lock` was preserved separately and intentionally excluded from this slice.
