### PR TITLE
feat(guard): add doctor auth diagnostics

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -9062,12 +9062,22 @@ def _resolve_policy_expiry(args: argparse.Namespace) -> str | None:
 def _guard_doctor_connect_health_payload(store: GuardStore) -> dict[str, object]:
     latest_state = store.get_latest_guard_connect_state(now=_now())
     payload: dict[str, object] = {
-        "oauth_storage_health": store.get_oauth_local_credential_health(),
+        "oauth_storage_health": _guard_doctor_oauth_storage_health_payload(store),
         "connect_recovery_command": connect_recovery_command(latest_state),
     }
     if isinstance(latest_state, dict):
         payload["latest_connect_state"] = _guard_doctor_latest_connect_state_payload(latest_state)
     return payload
+
+
+def _guard_doctor_oauth_storage_health_payload(store: GuardStore) -> dict[str, str]:
+    oauth_storage_health = store.get_oauth_local_credential_health()
+    state = "unknown"
+    if isinstance(oauth_storage_health, dict):
+        raw_state = oauth_storage_health.get("state")
+        if isinstance(raw_state, str) and raw_state.strip():
+            state = raw_state
+    return {"state": state}
 
 
 def _guard_doctor_latest_connect_state_payload(latest_state: dict[str, object]) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -193,6 +193,7 @@ from .connect_flow import (
     DEFAULT_GUARD_CONNECT_URL,
     DEFAULT_GUARD_SYNC_URL,
     build_connect_status_payload,
+    connect_recovery_command,
     run_guard_browser_connect_command,
     run_guard_device_connect_command,
 )
@@ -2324,6 +2325,7 @@ def run_guard_command(
             adapter = get_adapter(args.harness)
             payload = adapter.diagnostics(context)
             payload["runtime_detector_registry"] = _runtime_detector_registry_payload(config)
+            payload["connect_health"] = _guard_doctor_connect_health_payload(store)
             if args.harness == "codex":
                 payload["codex_resume"] = inspect_codex_resume_capabilities(store)
         else:
@@ -9055,6 +9057,39 @@ def _resolve_policy_expiry(args: argparse.Namespace) -> str | None:
         print("--expires-in-hours must be greater than 0.", file=sys.stderr)
         raise SystemExit(2)
     return (datetime.now(timezone.utc) + timedelta(hours=float(hours))).isoformat()
+
+
+def _guard_doctor_connect_health_payload(store: GuardStore) -> dict[str, object]:
+    latest_state = store.get_latest_guard_connect_state(now=_now())
+    payload: dict[str, object] = {
+        "oauth_storage_health": store.get_oauth_local_credential_health(),
+        "connect_recovery_command": connect_recovery_command(latest_state),
+    }
+    if isinstance(latest_state, dict):
+        payload["latest_connect_state"] = _guard_doctor_latest_connect_state_payload(latest_state)
+    return payload
+
+
+def _guard_doctor_latest_connect_state_payload(latest_state: dict[str, object]) -> dict[str, object]:
+    payload: dict[str, object] = {}
+    for key in (
+        "request_id",
+        "status",
+        "milestone",
+        "reason",
+        "created_at",
+        "updated_at",
+        "expires_at",
+        "completed_at",
+        "version",
+    ):
+        value = latest_state.get(key)
+        if isinstance(value, str) and value.strip():
+            payload[key] = value
+    poll_after_ms = latest_state.get("poll_after_ms")
+    if isinstance(poll_after_ms, int):
+        payload["poll_after_ms"] = poll_after_ms
+    return payload
 
 
 def _synced_policy_payload(store: GuardStore) -> dict[str, object] | None:

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -494,6 +494,19 @@ def _render_doctor(console: Console, payload: dict[str, object]) -> None:
             registry_state = "enabled" if bool(registry.get("enabled")) else "disabled"
             timeout_ms = registry.get("timeout_ms")
             summary.add_row("Detector registry", f"{registry_state}, {timeout_ms} ms")
+        connect_health = payload.get("connect_health")
+        if isinstance(connect_health, dict):
+            oauth_storage_health = connect_health.get("oauth_storage_health")
+            if isinstance(oauth_storage_health, dict):
+                summary.add_row("OAuth storage", str(oauth_storage_health.get("state") or "unknown"))
+            latest_connect_state = connect_health.get("latest_connect_state")
+            if isinstance(latest_connect_state, dict):
+                connect_status = str(latest_connect_state.get("status") or "unknown")
+                milestone = str(latest_connect_state.get("milestone") or "unknown")
+                summary.add_row("Connect state", f"{connect_status}, {milestone}")
+            recovery_command = connect_health.get("connect_recovery_command")
+            if isinstance(recovery_command, str) and recovery_command.strip():
+                summary.add_row("Recovery", recovery_command)
         summary.add_row("Warnings", str(len(warnings)))
         console.print(Panel(summary, title="Guard doctor", border_style="cyan"))
         if warnings:

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -4504,7 +4504,9 @@ args = ["-lc", "echo hi"]
         json_payload = json.loads(json_output)
         assert json_payload["harness"] == "codex"
         assert json_payload["connect_health"]["connect_recovery_command"] == "hol-guard connect"
+        assert json_payload["connect_health"]["oauth_storage_health"] == {"state": "healthy"}
         assert json_payload["connect_health"]["latest_connect_state"]["status"] == "retry_required"
+        assert set(json_payload["connect_health"]["oauth_storage_health"]) == {"state"}
         for value in forbidden_values:
             assert value not in json_output
         lowered_json_output = json_output.lower()

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -4429,6 +4429,19 @@ args = ["-lc", "echo hi"]
             + "\n",
         )
         monkeypatch.setattr("codex_plugin_scanner.guard.adapters.codex._command_available", lambda command: True)
+        monkeypatch.setattr(
+            GuardStore,
+            "get_latest_guard_connect_state",
+            lambda self, *, now: {
+                "status": "retry_required",
+                "milestone": "first_sync_failed",
+                "reason": "Guard authorization expired. Run `hol-guard connect` to sign in again.",
+                "authorization_code": "auth-code-secret",
+                "user_code": "ZXCV-BNMQ",
+                "pairing_secret": "pairing-secret-value",
+                "verification_uri_complete": "https://hol.org/guard/oauth/device?user_code=ZXCV-BNMQ",
+            },
+        )
         store = GuardStore(guard_home)
         store.set_sync_credentials(
             "https://hol.org/api/guard/receipts/sync",
@@ -4488,7 +4501,10 @@ args = ["-lc", "echo hi"]
         json_output = capsys.readouterr().out
 
         assert rc == 0
-        assert json.loads(json_output)["harness"] == "codex"
+        json_payload = json.loads(json_output)
+        assert json_payload["harness"] == "codex"
+        assert json_payload["connect_health"]["connect_recovery_command"] == "hol-guard connect"
+        assert json_payload["connect_health"]["latest_connect_state"]["status"] == "retry_required"
         for value in forbidden_values:
             assert value not in json_output
         lowered_json_output = json_output.lower()
@@ -4509,6 +4525,9 @@ args = ["-lc", "echo hi"]
         human_output = capsys.readouterr().out
 
         assert rc == 0
+        assert "OAuth storage" in human_output
+        assert "Connect state" in human_output
+        assert "hol-guard connect" in human_output
         for value in forbidden_values:
             assert value not in human_output
         lowered_human_output = human_output.lower()


### PR DESCRIPTION
## Summary
- add a safe connect-health section to hol-guard doctor for harness diagnostics
- surface oauth storage state, latest connect status, and recovery command without forwarding raw connect secrets
- prove seeded token, auth-code, user-code, and pairing-secret values never print in JSON or human doctor output

## Verification
- uv run pytest tests/test_guard_cli.py -q -k 'doctor_does_not_print_oauth_or_legacy_secret_material'
- uv run pytest tests/test_guard_cli.py -q -k 'doctor_reports_runtime_detector_registry_state or doctor_warns_when_codex_native_hooks_are_missing or doctor_does_not_print_oauth_or_legacy_secret_material'
- git diff --check