### PR TITLE
fix(guard): fail closed on stale oauth refresh

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -275,8 +275,11 @@ def evaluate_package_request_artifact(
                 now_value,
             )
         return result
-    oauth_local_credentials = store.get_oauth_local_credentials()
-    if bundle_evaluation is not None and bundle_evaluation.refresh_required and oauth_local_credentials is None:
+    if (
+        bundle_evaluation is not None
+        and bundle_evaluation.refresh_required
+        and store.get_oauth_local_credentials() is None
+    ):
         fallback = _finalize_evaluation(
             bundle_evaluation,
             package_intent_hash=package_intent_hash,
@@ -585,7 +588,14 @@ def _evaluate_with_cloud(
 ) -> tuple[PackageRequestEvaluation | None, dict[str, object] | None]:
     if workspace_id is None or workspace_fingerprint is None:
         return None, None
-    fail_closed_decision = _cloud_fail_closed_decision(store=store, workspace_dir=workspace_dir)
+    fail_closed_decision: str | None = None
+
+    def resolve_fail_closed_decision() -> str:
+        nonlocal fail_closed_decision
+        if fail_closed_decision is None:
+            fail_closed_decision = _cloud_fail_closed_decision(store=store, workspace_dir=workspace_dir)
+        return fail_closed_decision
+
     try:
         auth_context = _resolve_guard_sync_auth_context(store)
     except GuardSyncAuthorizationExpiredError:
@@ -598,7 +608,7 @@ def _evaluate_with_cloud(
                 workspace_dir=workspace_dir,
                 workspace_fingerprint=workspace_fingerprint,
                 bundle_meta=bundle_meta,
-                fail_closed_decision=fail_closed_decision,
+                fail_closed_decision=resolve_fail_closed_decision(),
             ),
             None,
         )
@@ -632,7 +642,7 @@ def _evaluate_with_cloud(
             workspace_dir=workspace_dir,
             workspace_fingerprint=workspace_fingerprint,
             bundle_meta=bundle_meta,
-            fail_closed_decision=fail_closed_decision,
+            fail_closed_decision=resolve_fail_closed_decision(),
         )
         if fail_closed is not None:
             return fail_closed, None
@@ -641,7 +651,7 @@ def _evaluate_with_cloud(
             message=(f"Guard cloud evaluation returned HTTP {error.code}, so Guard fell back to local intelligence."),
         )
     except OSError:
-        if fail_closed_decision == "block":
+        if resolve_fail_closed_decision() == "block":
             return (
                 _cloud_fail_closed_evaluation(
                     code="cloud_validation_error",
@@ -651,7 +661,7 @@ def _evaluate_with_cloud(
                     workspace_dir=workspace_dir,
                     workspace_fingerprint=workspace_fingerprint,
                     bundle_meta=bundle_meta,
-                    fail_closed_decision=fail_closed_decision,
+                    fail_closed_decision=resolve_fail_closed_decision(),
                 ),
                 None,
             )
@@ -669,7 +679,7 @@ def _evaluate_with_cloud(
                 workspace_dir=workspace_dir,
                 workspace_fingerprint=workspace_fingerprint,
                 bundle_meta=bundle_meta,
-                fail_closed_decision=fail_closed_decision,
+                fail_closed_decision=resolve_fail_closed_decision(),
             ),
             None,
         )
@@ -683,7 +693,7 @@ def _evaluate_with_cloud(
                 workspace_dir=workspace_dir,
                 workspace_fingerprint=workspace_fingerprint,
                 bundle_meta=bundle_meta,
-                fail_closed_decision=fail_closed_decision,
+                fail_closed_decision=resolve_fail_closed_decision(),
             ),
             None,
         )
@@ -699,7 +709,7 @@ def _evaluate_with_cloud(
                 workspace_dir=workspace_dir,
                 workspace_fingerprint=workspace_fingerprint,
                 bundle_meta=bundle_meta,
-                fail_closed_decision=fail_closed_decision,
+                fail_closed_decision=resolve_fail_closed_decision(),
             ),
             None,
         )

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -37,6 +37,7 @@ from .package_manifest_diff import (
     parse_manifest_dependencies,
 )
 from .runner import (
+    GuardSyncAuthorizationExpiredError,
     GuardSyncNotConfiguredError,
     _guard_sync_headers,
     _normalized_receipts_sync_url,
@@ -274,7 +275,8 @@ def evaluate_package_request_artifact(
                 now_value,
             )
         return result
-    if bundle_evaluation is not None and bundle_evaluation.refresh_required:
+    oauth_local_credentials = store.get_oauth_local_credentials()
+    if bundle_evaluation is not None and bundle_evaluation.refresh_required and oauth_local_credentials is None:
         fallback = _finalize_evaluation(
             bundle_evaluation,
             package_intent_hash=package_intent_hash,
@@ -583,8 +585,23 @@ def _evaluate_with_cloud(
 ) -> tuple[PackageRequestEvaluation | None, dict[str, object] | None]:
     if workspace_id is None or workspace_fingerprint is None:
         return None, None
+    fail_closed_decision = _cloud_fail_closed_decision(store=store, workspace_dir=workspace_dir)
     try:
         auth_context = _resolve_guard_sync_auth_context(store)
+    except GuardSyncAuthorizationExpiredError:
+        return (
+            _cloud_fail_closed_evaluation(
+                code="cloud_auth_error",
+                message="Guard cloud evaluation was not authorized, so this package request needs review.",
+                artifact=artifact,
+                targets=targets,
+                workspace_dir=workspace_dir,
+                workspace_fingerprint=workspace_fingerprint,
+                bundle_meta=bundle_meta,
+                fail_closed_decision=fail_closed_decision,
+            ),
+            None,
+        )
     except GuardSyncNotConfiguredError:
         return None, None
     evaluate_url = _normalized_supply_chain_evaluate_url(auth_context["sync_url"], workspace_id)
@@ -601,7 +618,6 @@ def _evaluate_with_cloud(
         headers=_guard_sync_headers(auth_context, request_url=evaluate_url, method="POST"),
         method="POST",
     )
-    fail_closed_decision = _cloud_fail_closed_decision(store=store, workspace_dir=workspace_dir)
     try:
         response_payload = _urlopen_json_with_timeout_retry(
             request=request,

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -594,7 +594,8 @@ def _evaluate_with_cloud(
         nonlocal fail_closed_decision
         if fail_closed_decision is None:
             fail_closed_decision = _cloud_fail_closed_decision(store=store, workspace_dir=workspace_dir)
-        return fail_closed_decision
+        result: str = fail_closed_decision
+        return result
 
     try:
         auth_context = _resolve_guard_sync_auth_context(store)

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -20,6 +20,8 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generate_private_key
 
+from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+from codex_plugin_scanner.guard.runtime.runner import GuardSyncAuthorizationExpiredError
 import codex_plugin_scanner.guard.runtime.supply_chain_package_eval as evaluator_module
 from codex_plugin_scanner.guard.runtime.package_intent_common import (
     PackageIntent,
@@ -1775,6 +1777,62 @@ def test_evaluate_package_request_artifact_stale_bundle_requests_refresh_and_rec
     evidence = store.list_evidence()
     assert evidence
     assert evidence[0]["category"] == "supply-chain"
+
+
+def test_evaluate_package_request_artifact_fails_closed_when_stale_bundle_needs_cloud_refresh_but_auth_expired(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token-1",
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=WORKSPACE_ID,
+        now="2026-05-19T00:00:00Z",
+    )
+    stale_response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="left-pad",
+                version="1.0.0",
+                default_action="monitor",
+                normalized_severity="low",
+                exploit_level="none",
+                known_exploited=False,
+                malware_state="none",
+                risk_score=220,
+            )
+        ],
+        generated_at=datetime(2026, 5, 18, tzinfo=timezone.utc),
+        expires_at=datetime(2026, 5, 18, 1, tzinfo=timezone.utc),
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, stale_response, "2026-05-18T01:00:00Z")
+
+    def raise_auth_expired(_store: GuardStore) -> dict[str, object]:
+        raise GuardSyncAuthorizationExpiredError(
+            "Guard authorization expired. Run `hol-guard connect` to sign in again."
+        )
+
+    monkeypatch.setattr(evaluator_module, "_resolve_guard_sync_auth_context", raise_auth_expired)
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("left-pad@1.0.0"),
+        store=store,
+        workspace_dir=tmp_path / "workspace",
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "ask"
+    assert result.policy_action == "require-reapproval"
+    assert result.enforcement == "premium_cloud"
+    assert any(reason["code"] == "cloud_auth_error" for reason in result.reasons)
 
 
 def test_with_additional_reason_updates_all_packages() -> None:


### PR DESCRIPTION
## Summary
- fail closed when stale bundle evaluation needs Guard Cloud refresh but OAuth local auth is expired
- preserve legacy sync-credential stale-bundle monitor behavior while adding an OAuth-expiry regression

## Testing
- `uv run pytest tests/test_guard_supply_chain_evaluator.py -q -k 'stale_bundle_needs_cloud_refresh_but_auth_expired or blocks_from_cached_bundle_without_cloud_reachability or stale_bundle_requests_refresh_and_records_monitor or fails_closed_on_untrusted_cloud_http_error or strict_mode_blocks_on_cloud_unreachable'
- `uv run pytest tests/test_guard_supply_chain_evaluator.py -q`
- `uv run pytest tests/test_guard_supply_chain_daemon.py -q`
- `git diff --check`
