### PR TITLE
fix(guard): prevent OpenCode pretool workspace CLI hijack

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -15,6 +15,7 @@ from urllib.parse import urlencode
 from ...path_support import iter_safe_matching_files, resolves_within_root
 from ..daemon import guard_daemon_url_for_home, load_guard_daemon_url
 from ..models import GuardArtifact, HarnessDetection
+from ..runtime.harness_attribution import cursor_hook_query_extras
 from ..shims import install_guard_shim, remove_guard_shim
 from .base import HarnessAdapter, HarnessContext, _ensure_path_within_root, _json_payload, _run_command_probe
 
@@ -504,6 +505,8 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
             query["home"] = str(context.home_dir)
         if context.workspace_dir is not None:
             query["workspace"] = str(context.workspace_dir)
+        for key, value in cursor_hook_query_extras().items():
+            query[key] = value
         return f"{daemon_url}/v1/hooks/claude-code?{urlencode(query)}"
 
     @staticmethod
@@ -516,6 +519,8 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
             query["home"] = str(context.home_dir)
         if context.workspace_dir is not None:
             query["workspace"] = str(context.workspace_dir)
+        for key, value in cursor_hook_query_extras().items():
+            query[key] = value
         package_root = Path(__file__).resolve().parents[3]
         code = (
             f"_HOL_GUARD_CLAUDE_DAEMON_HOOK_MARKER = {CLAUDE_GUARD_DAEMON_HOOK_MARKER!r};"

--- a/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
@@ -2,44 +2,46 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
+import os
 import sys
 from pathlib import Path
 
+from ..launcher import merge_guard_launcher_env
 from .base import HarnessContext
 
 PLUGIN_FILENAME = "hol-guard-pretool.ts"
 _INTERCEPT_TOOLS = ("bash", "shell", "sh", "zsh", "terminal")
+_HOOK_ARGV_ENV = "HOL_GUARD_HOOK_ARGV"
 
 _PLUGIN_TEMPLATE = """// Managed by HOL Guard. Re-run `hol-guard install opencode` after moving Guard home.
 const GUARD_HOME = __GUARD_HOME__;
 const GUARD_PYTHON = __GUARD_PYTHON__;
+const GUARD_HOOK_LAUNCHER = __GUARD_HOOK_LAUNCHER__;
+const GUARD_HOOK_ENV = __GUARD_HOOK_ENV__;
 const INTERCEPT_TOOLS = new Set(__INTERCEPT_TOOLS__);
 
 async function runGuardHook(directory: string, payload: Record<string, unknown>) {
   const workspace = directory?.trim() || process.cwd();
-  const proc = Bun.spawn(
-    [
-      GUARD_PYTHON,
-      "-m",
-      "codex_plugin_scanner.cli",
-      "guard",
-      "hook",
-      "--guard-home",
-      GUARD_HOME,
-      "--harness",
-      "opencode",
-      "--workspace",
-      workspace,
-      "--json",
-    ],
-    {
-      cwd: workspace,
-      stdin: new Blob([JSON.stringify(payload)]).stream(),
-      stdout: "pipe",
-      stderr: "pipe",
-    },
-  );
+  const guardArgv = [
+    "guard",
+    "hook",
+    "--guard-home",
+    GUARD_HOME,
+    "--harness",
+    "opencode",
+    "--workspace",
+    workspace,
+    "--json",
+  ];
+  const proc = Bun.spawn([GUARD_PYTHON, "-c", GUARD_HOOK_LAUNCHER], {
+    cwd: GUARD_HOME,
+    env: { ...GUARD_HOOK_ENV, __HOOK_ARGV_ENV__: JSON.stringify(guardArgv) },
+    stdin: new Blob([JSON.stringify(payload)]).stream(),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
   const stdoutPromise = new Response(proc.stdout).text();
   const stderrPromise = new Response(proc.stderr).text();
   const exitCode = await proc.exited;
@@ -118,6 +120,41 @@ export const HolGuardPretoolPlugin = async ({
 """
 
 
+def _trusted_package_root() -> Path:
+    spec = importlib.util.find_spec("codex_plugin_scanner")
+    if spec is None:
+        raise RuntimeError("Guard could not locate the codex_plugin_scanner package")
+    if spec.submodule_search_locations:
+        return Path(next(iter(spec.submodule_search_locations))).resolve().parent
+    if spec.origin is None:
+        raise RuntimeError("Guard could not determine the codex_plugin_scanner package root")
+    return Path(spec.origin).resolve().parent.parent
+
+
+def _trusted_pythonpath_entries() -> list[str]:
+    launcher_env = merge_guard_launcher_env(pin_package=True)
+    path_entries = [entry for entry in launcher_env.get("PYTHONPATH", "").split(os.pathsep) if entry.strip()]
+    package_root = str(_trusted_package_root())
+    if package_root not in path_entries:
+        path_entries.insert(0, package_root)
+    return path_entries
+
+
+def _pretool_hook_launcher_code() -> str:
+    trusted_entries = _trusted_pythonpath_entries()
+    return (
+        "import json,os,sys;"
+        f"sys.path[:0]={json.dumps(trusted_entries)};"
+        "from codex_plugin_scanner.cli import main;"
+        f"raise SystemExit(main(json.loads(os.environ[{_HOOK_ARGV_ENV!r}])))"
+    )
+
+
+def _pretool_hook_env() -> dict[str, str]:
+    env = merge_guard_launcher_env(pin_package=True)
+    return {key: value for key, value in env.items() if key == "PYTHONPATH" and value.strip()}
+
+
 def managed_plugin_path(context: HarnessContext) -> Path:
     return context.guard_home / "opencode" / "plugins" / PLUGIN_FILENAME
 
@@ -127,9 +164,12 @@ def global_plugin_path(context: HarnessContext) -> Path:
 
 
 def pretool_plugin_source(context: HarnessContext) -> str:
+    template = _PLUGIN_TEMPLATE.replace("__HOOK_ARGV_ENV__", _HOOK_ARGV_ENV)
     return (
-        _PLUGIN_TEMPLATE.replace("__GUARD_HOME__", json.dumps(str(context.guard_home.resolve())))
+        template.replace("__GUARD_HOME__", json.dumps(str(context.guard_home.resolve())))
         .replace("__GUARD_PYTHON__", json.dumps(str(Path(sys.executable).resolve())))
+        .replace("__GUARD_HOOK_LAUNCHER__", json.dumps(_pretool_hook_launcher_code()))
+        .replace("__GUARD_HOOK_ENV__", json.dumps(_pretool_hook_env()))
         .replace("__INTERCEPT_TOOLS__", json.dumps(list(_INTERCEPT_TOOLS)))
     )
 

--- a/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
@@ -14,13 +14,27 @@ from .base import HarnessContext
 PLUGIN_FILENAME = "hol-guard-pretool.ts"
 _INTERCEPT_TOOLS = ("bash", "shell", "sh", "zsh", "terminal")
 _HOOK_ARGV_ENV = "HOL_GUARD_HOOK_ARGV"
+_INHERIT_ENV_KEYS = ("PATH", "HOME", "USER", "TMPDIR", "TEMP", "TMP", "LANG", "LC_ALL", "SYSTEMROOT")
 
 _PLUGIN_TEMPLATE = """// Managed by HOL Guard. Re-run `hol-guard install opencode` after moving Guard home.
 const GUARD_HOME = __GUARD_HOME__;
 const GUARD_PYTHON = __GUARD_PYTHON__;
 const GUARD_HOOK_LAUNCHER = __GUARD_HOOK_LAUNCHER__;
 const GUARD_HOOK_ENV = __GUARD_HOOK_ENV__;
+const GUARD_INHERIT_ENV_KEYS = __GUARD_INHERIT_ENV_KEYS__;
 const INTERCEPT_TOOLS = new Set(__INTERCEPT_TOOLS__);
+
+function hookProcessEnv(guardArgv: string[]) {
+  const env: Record<string, string> = { ...GUARD_HOOK_ENV };
+  for (const key of GUARD_INHERIT_ENV_KEYS) {
+    const value = process.env[key];
+    if (typeof value === "string" && value.length > 0) {
+      env[key] = value;
+    }
+  }
+  env.__HOOK_ARGV_ENV__ = JSON.stringify(guardArgv);
+  return env;
+}
 
 async function runGuardHook(directory: string, payload: Record<string, unknown>) {
   const workspace = directory?.trim() || process.cwd();
@@ -37,7 +51,7 @@ async function runGuardHook(directory: string, payload: Record<string, unknown>)
   ];
   const proc = Bun.spawn([GUARD_PYTHON, "-c", GUARD_HOOK_LAUNCHER], {
     cwd: GUARD_HOME,
-    env: { ...GUARD_HOOK_ENV, __HOOK_ARGV_ENV__: JSON.stringify(guardArgv) },
+    env: hookProcessEnv(guardArgv),
     stdin: new Blob([JSON.stringify(payload)]).stream(),
     stdout: "pipe",
     stderr: "pipe",
@@ -125,7 +139,10 @@ def _trusted_package_root() -> Path:
     if spec is None:
         raise RuntimeError("Guard could not locate the codex_plugin_scanner package")
     if spec.submodule_search_locations:
-        return Path(next(iter(spec.submodule_search_locations))).resolve().parent
+        locations = tuple(spec.submodule_search_locations)
+        if not locations:
+            raise RuntimeError("Guard could not resolve codex_plugin_scanner package locations")
+        return Path(locations[0]).resolve().parent
     if spec.origin is None:
         raise RuntimeError("Guard could not determine the codex_plugin_scanner package root")
     return Path(spec.origin).resolve().parent.parent
@@ -170,6 +187,7 @@ def pretool_plugin_source(context: HarnessContext) -> str:
         .replace("__GUARD_PYTHON__", json.dumps(str(Path(sys.executable).resolve())))
         .replace("__GUARD_HOOK_LAUNCHER__", json.dumps(_pretool_hook_launcher_code()))
         .replace("__GUARD_HOOK_ENV__", json.dumps(_pretool_hook_env()))
+        .replace("__GUARD_INHERIT_ENV_KEYS__", json.dumps(list(_INHERIT_ENV_KEYS)))
         .replace("__INTERCEPT_TOOLS__", json.dumps(list(_INTERCEPT_TOOLS)))
     )
 

--- a/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
@@ -36,6 +36,16 @@ function hookProcessEnv(guardArgv: string[]) {
   return env;
 }
 
+function normalizeCommand(command: unknown): string | null {
+  if (typeof command === "string" && command.trim()) {
+    return command.trim();
+  }
+  if (Array.isArray(command) && command.length > 0 && command.every((part) => typeof part === "string")) {
+    return command.join(" ");
+  }
+  return null;
+}
+
 async function runGuardHook(directory: string, payload: Record<string, unknown>) {
   const workspace = directory?.trim() || process.cwd();
   const guardArgv = [
@@ -52,7 +62,7 @@ async function runGuardHook(directory: string, payload: Record<string, unknown>)
   const proc = Bun.spawn([GUARD_PYTHON, "-c", GUARD_HOOK_LAUNCHER], {
     cwd: GUARD_HOME,
     env: hookProcessEnv(guardArgv),
-    stdin: new Blob([JSON.stringify(payload)]).stream(),
+    stdin: new Blob([JSON.stringify(payload)]),
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -96,8 +106,8 @@ export const HolGuardPretoolPlugin = async ({
       if (!INTERCEPT_TOOLS.has(input.tool)) {
         return;
       }
-      const command = output.args?.command;
-      if (typeof command !== "string" || !command.trim()) {
+      const command = normalizeCommand(output.args?.command);
+      if (command === null) {
         return;
       }
       const workspace = directory?.trim() || process.cwd();

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -149,6 +149,7 @@ from ..runtime.false_positive_rules import (
     split_fd_args_and_exec,
     target_is_known_skill_doc_path,
 )
+from ..runtime.harness_attribution import resolve_runtime_hook_harness
 from ..runtime.package_intent import build_package_request_artifact, extract_package_intent_request
 from ..runtime.runner import (
     GuardSyncAuthorizationExpiredError,
@@ -176,7 +177,6 @@ from ..runtime.secret_sensitivity import (
 )
 from ..runtime.sed_scripts import sed_script_is_bounded_print
 from ..runtime.signals import RiskSignalV2
-from ..runtime.harness_attribution import resolve_runtime_hook_harness
 from ..runtime.supply_chain_package_eval import evaluate_package_request_artifact
 from ..runtime.surface_server import GuardSurfaceRuntime
 from ..shims import install_package_shims, package_shim_status, repair_package_shims, uninstall_package_shims

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -176,6 +176,7 @@ from ..runtime.secret_sensitivity import (
 )
 from ..runtime.sed_scripts import sed_script_is_bounded_print
 from ..runtime.signals import RiskSignalV2
+from ..runtime.harness_attribution import resolve_runtime_hook_harness
 from ..runtime.supply_chain_package_eval import evaluate_package_request_artifact
 from ..runtime.surface_server import GuardSurfaceRuntime
 from ..shims import install_package_shims, package_shim_status, repair_package_shims, uninstall_package_shims
@@ -1397,6 +1398,25 @@ def _run_init_command(
     return 1 if init_failed else 0
 
 
+def _normalize_explicit_workspace_path(value: str | None) -> Path | None:
+    """Drop sentinel workspace strings and trailing `/None` path segments."""
+
+    if value is None:
+        return None
+    stripped = value.strip()
+    if not stripped or stripped.lower() in {"none", "null"}:
+        return None
+    path = Path(stripped).expanduser()
+    if path.name == "None":
+        path = path.parent
+        if not str(path).strip():
+            return None
+    try:
+        return path.resolve()
+    except OSError:
+        return path
+
+
 def _resolve_guard_workspace(
     args: argparse.Namespace,
     *,
@@ -1404,7 +1424,7 @@ def _resolve_guard_workspace(
 ) -> Path | None:
     explicit_workspace = getattr(args, "workspace", None)
     if explicit_workspace:
-        return Path(explicit_workspace).resolve()
+        return _normalize_explicit_workspace_path(str(explicit_workspace))
     if getattr(args, "guard_command", None) != "apps":
         return None
     if getattr(args, "apps_command", None) not in {"connect", "disconnect", "repair", "test"}:
@@ -2639,6 +2659,11 @@ def run_guard_command(
         return 0
 
     if args.guard_command == "hook":
+        runtime_harness = getattr(args, "runtime_harness", None)
+        if isinstance(runtime_harness, str) and runtime_harness.strip():
+            args.harness = runtime_harness.strip()
+        else:
+            args.harness = resolve_runtime_hook_harness(args.harness)
         payload = _load_hook_payload(getattr(args, "event_file", None), input_text=input_text)
         managed_install = _managed_install_for(store, args.harness)
         workspace_was_explicit = workspace is not None
@@ -8839,6 +8864,10 @@ def _copilot_mcp_tool_token(value: str) -> str:
 def _runtime_policy_path(harness: str, home_dir: Path, workspace: Path | None) -> Path:
     if harness == "hermes":
         return home_dir / ".hermes" / "config.yaml"
+    if harness == "cursor":
+        if workspace is not None:
+            return workspace / ".cursor" / "mcp.json"
+        return home_dir / ".cursor" / "mcp.json"
     if harness == "claude-code":
         if workspace is not None:
             return workspace / ".claude" / "settings.local.json"

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2257,13 +2257,18 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         params = parse_qs(query)
         home_dir = self._optional_string(params.get("home", [None])[-1])
         guard_home = self._optional_string(params.get("guard-home", [None])[-1])
-        workspace = self._optional_string(params.get("workspace", [None])[-1])
+        from ..cli.commands import _normalize_explicit_workspace_path
+
+        workspace = _normalize_explicit_workspace_path(self._optional_string(params.get("workspace", [None])[-1]))
+        runtime_harness = self._optional_string(params.get("runtime-harness", [None])[-1])
+        harness = runtime_harness or "claude-code"
         args = argparse.Namespace(
             guard_command="hook",
             home=home_dir,
             guard_home=guard_home,
-            workspace=workspace,
-            harness="claude-code",
+            workspace=str(workspace) if workspace is not None else None,
+            runtime_harness=runtime_harness,
+            harness=harness,
             artifact_id=None,
             artifact_name=None,
             policy_action=None,

--- a/src/codex_plugin_scanner/guard/runtime/harness_attribution.py
+++ b/src/codex_plugin_scanner/guard/runtime/harness_attribution.py
@@ -20,9 +20,7 @@ def cursor_runtime_detected(env: Mapping[str, str] | None = None) -> bool:
     """Return True when hook subprocess env indicates Cursor IDE/agent."""
 
     source = os.environ if env is None else env
-    return any(
-        isinstance(source.get(key), str) and source[key].strip() for key in _CURSOR_ENV_MARKERS
-    )
+    return any(isinstance(source.get(key), str) and source[key].strip() for key in _CURSOR_ENV_MARKERS)
 
 
 def resolve_runtime_hook_harness(

--- a/src/codex_plugin_scanner/guard/runtime/harness_attribution.py
+++ b/src/codex_plugin_scanner/guard/runtime/harness_attribution.py
@@ -1,0 +1,58 @@
+"""Resolve which harness initiated a runtime hook invocation."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+_CURSOR_ENV_MARKERS = frozenset(
+    {
+        "CURSOR_VERSION",
+        "CURSOR_PROJECT_DIR",
+        "CURSOR_TRACE_ID",
+        "CURSOR_SESSION_ID",
+        "CURSOR_TRANSCRIPT_PATH",
+    }
+)
+
+
+def cursor_runtime_detected(env: Mapping[str, str] | None = None) -> bool:
+    """Return True when hook subprocess env indicates Cursor IDE/agent."""
+
+    source = os.environ if env is None else env
+    return any(
+        isinstance(source.get(key), str) and source[key].strip() for key in _CURSOR_ENV_MARKERS
+    )
+
+
+def resolve_runtime_hook_harness(
+    requested_harness: str,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> str:
+    """Re-attribute Claude-compatible hooks to Cursor when they run inside Cursor."""
+
+    normalized = requested_harness.strip().lower().replace("_", "-")
+    if normalized in {"claude", "claude-code"} and cursor_runtime_detected(env):
+        return "cursor"
+    return requested_harness
+
+
+def cursor_hook_query_extras(env: Mapping[str, str] | None = None) -> dict[str, str]:
+    """Query parameters for the Claude daemon hook bridge when invoked from Cursor."""
+
+    source = os.environ if env is None else env
+    if not cursor_runtime_detected(source):
+        return {}
+    extras: dict[str, str] = {"runtime-harness": "cursor"}
+    project_dir = source.get("CURSOR_PROJECT_DIR")
+    if isinstance(project_dir, str) and project_dir.strip():
+        extras["workspace"] = project_dir.strip()
+    return extras
+
+
+__all__ = [
+    "cursor_hook_query_extras",
+    "cursor_runtime_detected",
+    "resolve_runtime_hook_harness",
+]

--- a/tests/test_harness_attribution.py
+++ b/tests/test_harness_attribution.py
@@ -1,0 +1,81 @@
+"""Tests for runtime harness attribution (Cursor vs Claude Code hooks)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.claude_code import ClaudeCodeHarnessAdapter
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+from codex_plugin_scanner.guard.runtime.harness_attribution import (
+    cursor_hook_query_extras,
+    cursor_runtime_detected,
+    resolve_runtime_hook_harness,
+)
+
+
+def test_cursor_runtime_detected_from_cursor_env() -> None:
+    assert cursor_runtime_detected({"CURSOR_VERSION": "2.0.0"}) is True
+    assert cursor_runtime_detected({}) is False
+
+
+def test_resolve_runtime_hook_harness_maps_claude_to_cursor_in_cursor() -> None:
+    env = {"CURSOR_VERSION": "2.0.0", "CURSOR_PROJECT_DIR": "/tmp/project"}
+    assert resolve_runtime_hook_harness("claude-code", env=env) == "cursor"
+    assert resolve_runtime_hook_harness("opencode", env=env) == "opencode"
+
+
+def test_cursor_hook_query_extras_includes_runtime_harness_and_workspace() -> None:
+    extras = cursor_hook_query_extras(
+        {"CURSOR_VERSION": "1.2.3", "CURSOR_PROJECT_DIR": "/Users/me/repo"},
+    )
+    assert extras == {"runtime-harness": "cursor", "workspace": "/Users/me/repo"}
+
+
+def test_claude_hook_http_url_includes_cursor_runtime_harness(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("CURSOR_VERSION", "9.9.9")
+    monkeypatch.setenv("CURSOR_PROJECT_DIR", str(tmp_path / "workspace"))
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=tmp_path / "ignored",
+        guard_home=tmp_path / "guard",
+    )
+    url = ClaudeCodeHarnessAdapter._hook_http_url(context)
+    assert "runtime-harness=cursor" in url
+    assert f"workspace={tmp_path / 'workspace'}" in url.replace("%2F", "/")
+
+
+def test_guard_hook_records_cursor_harness_for_cursor_env(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tests.test_guard_runtime import _build_guard_fixture, _run_guard_hook
+
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    monkeypatch.setenv("CURSOR_VERSION", "2.0.0")
+    monkeypatch.setenv("CURSOR_PROJECT_DIR", str(workspace_dir))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc, payload = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="claude-code",
+        event={
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Shell",
+            "tool_input": {"command": "rm -rf /tmp/hol-guard-cursor-attribution-test"},
+            "source_scope": "project",
+        },
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+        as_json=True,
+    )
+
+    assert rc == 1
+    assert isinstance(payload, dict)
+    assert payload["harness"] == "cursor"

--- a/tests/test_opencode_pretool.py
+++ b/tests/test_opencode_pretool.py
@@ -3,11 +3,18 @@
 from __future__ import annotations
 
 import json
+import os
+import sys
 from pathlib import Path
+
+import pytest
 
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.opencode import OpenCodeHarnessAdapter
 from codex_plugin_scanner.guard.adapters.opencode_pretool import (
+    _HOOK_ARGV_ENV,
+    _pretool_hook_env,
+    _pretool_hook_launcher_code,
     global_plugin_path,
     install_pretool_plugin,
     managed_plugin_path,
@@ -40,8 +47,45 @@ def test_pretool_plugin_source_embeds_guard_paths(tmp_path: Path) -> None:
     assert "stdoutPromise" in source
     assert "try {" in source
     assert 'source_scope: directory?.trim() ? "project" : "global"' in source
-    assert "codex_plugin_scanner.cli" in source
-    assert "guard" in source
+    assert "GUARD_HOOK_LAUNCHER" in source
+    assert "HOL_GUARD_HOOK_ARGV" in source
+    assert "cwd: GUARD_HOME" in source
+    spawn_block = source.split("Bun.spawn(", 1)[1].split("});", 1)[0]
+    assert "cwd: workspace" not in spawn_block
+    assert '"-m",' not in source
+    assert '-m",' not in source
+
+
+def test_pretool_hook_launcher_ignores_workspace_package_hijack(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: workspace must not precede trusted Guard on sys.path."""
+    import subprocess
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    fake_pkg = workspace / "codex_plugin_scanner"
+    fake_pkg.mkdir()
+    (fake_pkg / "__init__.py").write_text("", encoding="utf-8")
+    (fake_pkg / "cli.py").write_text("import sys\nsys.stderr.write('hijacked')\nraise SystemExit(99)\n", encoding="utf-8")
+
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    ctx = HarnessContext(home_dir=tmp_path / "home", workspace_dir=workspace, guard_home=guard_home)
+    launcher = _pretool_hook_launcher_code()
+    env = {**_pretool_hook_env(), _HOOK_ARGV_ENV: '["guard","hook","--json"]'}
+    completed = subprocess.run(
+        [sys.executable, "-c", launcher],
+        cwd=workspace,
+        env={**os.environ, **env},
+        input="{}",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert "hijacked" not in completed.stderr
+    assert completed.returncode != 99
 
 
 def test_install_pretool_plugin_writes_managed_and_global_copies(tmp_path: Path) -> None:

--- a/tests/test_opencode_pretool.py
+++ b/tests/test_opencode_pretool.py
@@ -43,7 +43,9 @@ def test_pretool_plugin_source_embeds_guard_paths(tmp_path: Path) -> None:
     source = pretool_plugin_source(ctx)
     assert str(ctx.guard_home.resolve()) in source
     assert "tool.execute.before" in source
-    assert "Blob([JSON.stringify(payload)]).stream()" in source
+    assert "stdin: new Blob([JSON.stringify(payload)])" in source
+    assert "normalizeCommand" in source
+    assert '.stream()' not in source.split("Bun.spawn", 1)[1].split("});", 1)[0]
     assert "stdoutPromise" in source
     assert "try {" in source
     assert 'source_scope: directory?.trim() ? "project" : "global"' in source
@@ -56,6 +58,11 @@ def test_pretool_plugin_source_embeds_guard_paths(tmp_path: Path) -> None:
     assert "cwd: workspace" not in spawn_block
     assert '"-m",' not in source
     assert '-m",' not in source
+
+
+def test_pretool_plugin_source_normalizes_argv_array_commands(tmp_path: Path) -> None:
+    source = pretool_plugin_source(_ctx(tmp_path))
+    assert "Array.isArray(command)" in source
 
 
 def test_pretool_hook_launcher_ignores_workspace_package_hijack(

--- a/tests/test_opencode_pretool.py
+++ b/tests/test_opencode_pretool.py
@@ -48,6 +48,8 @@ def test_pretool_plugin_source_embeds_guard_paths(tmp_path: Path) -> None:
     assert "try {" in source
     assert 'source_scope: directory?.trim() ? "project" : "global"' in source
     assert "GUARD_HOOK_LAUNCHER" in source
+    assert "hookProcessEnv" in source
+    assert "GUARD_INHERIT_ENV_KEYS" in source
     assert "HOL_GUARD_HOOK_ARGV" in source
     assert "cwd: GUARD_HOME" in source
     spawn_block = source.split("Bun.spawn(", 1)[1].split("});", 1)[0]
@@ -74,11 +76,12 @@ def test_pretool_hook_launcher_ignores_workspace_package_hijack(
     guard_home.mkdir()
     ctx = HarnessContext(home_dir=tmp_path / "home", workspace_dir=workspace, guard_home=guard_home)
     launcher = _pretool_hook_launcher_code()
-    env = {**_pretool_hook_env(), _HOOK_ARGV_ENV: '["guard","hook","--json"]'}
+    inherit_env = {key: os.environ[key] for key in ("PATH", "HOME") if key in os.environ}
+    env = {**inherit_env, **_pretool_hook_env(), _HOOK_ARGV_ENV: '["guard","hook","--json"]'}
     completed = subprocess.run(
         [sys.executable, "-c", launcher],
         cwd=workspace,
-        env={**os.environ, **env},
+        env=env,
         input="{}",
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Summary
- Spawn the OpenCode pretool Guard hook from `guard_home` with a trusted `-c` launcher instead of `python -m` from the workspace cwd (prevents workspace CLI hijack).
- Fix OpenCode pretool Bun stdin (`Blob` not raw JSON string) and normalize argv-array shell commands.
- Whitelist PATH/HOME/TMPDIR (and related) for the hook subprocess while keeping PYTHONPATH pinned to the trusted Guard install.
- Attribute Claude-compatible daemon hooks to **Cursor** when `CURSOR_*` env is present, so Cursor agent approvals show the correct harness.
- Sanitize bogus workspace paths ending in `/None`.

## Testing
- `uv run pytest tests/test_opencode_pretool.py tests/test_harness_attribution.py -q`
- `uv run ruff check src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/adapters/opencode_pretool.py src/codex_plugin_scanner/guard/runtime/harness_attribution.py`

## Notes
- After merge, run `hol-guard install opencode` and refresh Claude hooks (`hol-guard install claude-code` or open a Cursor session) so installed hook URLs pick up `runtime-harness=cursor`.
