### PR TITLE
feat(cursor): install native IDE hooks for shell and MCP

### DIFF
--- a/docs/guard/cursor-local-cloud-contract.md
+++ b/docs/guard/cursor-local-cloud-contract.md
@@ -1,8 +1,33 @@
 # Cursor Local Cloud Contract
 
-Cursor support is split by surface so the dashboard does not imply protection that the local harness cannot provide.
+Cursor support is split by surface so the dashboard does not imply protection the local harness cannot provide.
 
-## Unsupported State
+## Surfaces
+
+| Surface | What Guard installs | What is intercepted |
+| ------- | ------------------- | ----------------- |
+| **Editor (IDE)** | MCP proxies in `.cursor/mcp.json` and native hooks in `.cursor/hooks.json` | Agent `beforeShellExecution`, `beforeMCPExecution`, `preToolUse` (Shell/MCP/Read), and `beforeReadFile` |
+| **CLI** | `guard-cursor-agent` shim on `PATH` | Launches routed through `hol-guard run cursor` before `cursor-agent` starts |
+
+Run `hol-guard install cursor --surface all` to enable both editor hooks and the CLI shim.
+
+## Native Cursor hooks
+
+Guard installs command hooks documented by Cursor:
+
+- `beforeShellExecution` and `beforeMCPExecution` with `failClosed: true` so hook failures block risky actions
+- `preToolUse` with matchers for Shell, MCP, Bash, and Read tools
+- `beforeReadFile` for sensitive file reads before they reach the model
+
+Hooks call a managed bridge script (`.cursor/hooks/hol-guard-cursor-hook.py`) that forwards stdin JSON to `hol-guard hook --harness cursor --json` and maps Guard policy results to Cursor `permission` responses (`allow`, `deny`, `ask`).
+
+Restart Cursor after install so hook config reloads.
+
+## Claude-compatible hooks inside Cursor
+
+When Cursor loads Claude Code hooks (`.claude/settings.json` daemon URLs), Guard re-labels those events as harness `cursor` when `CURSOR_*` environment markers are present. Prefer `hol-guard install cursor` for first-class Cursor hook coverage; keep `hol-guard install claude-code` refreshed so daemon URLs include `runtime-harness=cursor` when both are used.
+
+## Unsupported state
 
 If a Cursor surface is unavailable or unsupported, Guard must say so directly and must not offer a no-op repair.
 
@@ -11,3 +36,9 @@ Unsupported Cursor states should:
 - Explain which surface is unavailable.
 - Keep any repair action disabled when Guard cannot change the local state.
 - Direct the user to a supported Cursor editor or Cursor CLI setup path.
+
+## Known blind spots
+
+- Commands run in Cursor's **built-in terminal** outside the agent loop are not seen by agent hooks.
+- `beforeTabFileRead` / Tab-only operations use a separate hook surface and are not installed by Guard today.
+- Cloud agents load project `.cursor/hooks.json` but not user `~/.cursor/hooks.json`; use project-level install for cloud agent repos.

--- a/docs/guard/harness-support.md
+++ b/docs/guard/harness-support.md
@@ -31,9 +31,10 @@ Current Guard support in this repo:
   - package-manager shell tool calls now persist package intent, consistent block copy, and pre-execution Guard state before Copilot retries
 - `cursor`
   - detects global and project `mcp.json`
-  - supports wrapper-mode management state
+  - installs native Cursor hooks in `.cursor/hooks.json` for `beforeShellExecution`, `beforeMCPExecution`, `preToolUse`, and `beforeReadFile`
+  - supports wrapper-mode management state and the `guard-cursor-agent` CLI shim
   - wrapper prompt screening is covered for benign debug prompts and risky secret-read prompts
-  - leaves native Cursor tool approval in place and focuses Guard on artifact trust
+  - leaves native Cursor tool approval in place for `ask` decisions and focuses Guard on artifact trust plus runtime interception
   - managed MCP package-manager tool calls are routed through the supply-chain decision engine before Cursor receives the tool result
   - uses the Cursor local/cloud contract in [cursor-local-cloud-contract.md](cursor-local-cloud-contract.md) to keep editor and CLI status, repair, receipts, and Cloud sync distinct under one Cursor app
 - `antigravity`
@@ -123,7 +124,7 @@ Generated from `src/codex_plugin_scanner/guard/adapters/contracts.py`.
 | `claude-code` | `claude-code`, `claude` | ✅ | ✅ | ✅ | shell, prompt, mcp_tool, file_read |
 | `opencode` | `opencode` | ❌ | ✅ | ❌ | shell, mcp_tool |
 | `copilot` | `copilot` | ✅ | ✅ | ✅ | shell, prompt |
-| `cursor` | `cursor` | ❌ | ✅ | ❌ | mcp_tool |
+| `cursor` | `cursor` | ❌ | ✅ | ❌ | shell, mcp_tool, file_read |
 | `gemini` | `gemini` | ❌ | ✅ | ❌ | shell, mcp_tool |
 | `hermes` | `hermes` | ❌ | ✅ | ❌ | shell, mcp_tool, prompt |
 | `openclaw` | `openclaw` | ❌ | ✅ | ❌ | mcp_tool |

--- a/src/codex_plugin_scanner/guard/adapters/contracts.py
+++ b/src/codex_plugin_scanner/guard/adapters/contracts.py
@@ -197,13 +197,14 @@ HARNESS_CONTRACTS: tuple[HarnessProtectionContract, ...] = (
     HarnessProtectionContract(
         harness="cursor",
         install_aliases=("cursor",),
-        config_paths=("~/.cursor/mcp.json",),
-        event_surfaces=("mcp_tool",),
+        config_paths=("~/.cursor/mcp.json", "~/.cursor/hooks.json", ".cursor/hooks.json"),
+        event_surfaces=("shell", "mcp_tool", "file_read"),
         native_approval=False,
         browser_fallback=True,
         resume_support=False,
         known_blind_spots=(
-            "Shell commands issued through Cursor's built-in terminal bypass Guard. Prompt content is not surfaced."
+            "Shell commands issued through Cursor's built-in terminal bypass Guard unless the terminal runs inside "
+            "an agent session. Prompt submission is not surfaced through native Cursor hooks."
         ),
         smoke_command="hol-guard install cursor --dry-run",
         surface_capabilities=("editor", "cli"),

--- a/src/codex_plugin_scanner/guard/adapters/cursor.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor.py
@@ -11,6 +11,7 @@ from ..launcher import merge_guard_launcher_env
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
 from .base import HarnessAdapter, HarnessContext, _command_available, _json_payload, _run_command_probe
+from .cursor_hooks import install_cursor_hooks, uninstall_cursor_hooks
 from .mcp_servers import (
     ManagedMcpServer,
     is_guard_proxy_command,
@@ -215,6 +216,7 @@ class CursorHarnessAdapter(HarnessAdapter):
         payload["mcpServers"] = normalized_servers
         target_path.parent.mkdir(parents=True, exist_ok=True)
         target_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        hooks_manifest = install_cursor_hooks(context)
         return {
             "harness": self.harness,
             "active": True,
@@ -224,7 +226,12 @@ class CursorHarnessAdapter(HarnessAdapter):
             "state_path": str(state_path),
             "managed_servers": [server.name for server in managed_servers],
             "skipped_servers": list(skipped_servers),
-            "notes": ["Guard Cursor editor MCP proxies added to the selected Cursor mcp.json config."],
+            "managed_hooks_path": hooks_manifest.get("managed_hooks_path"),
+            "managed_hook_script_path": hooks_manifest.get("managed_hook_script_path"),
+            "notes": [
+                "Guard Cursor editor MCP proxies added to the selected Cursor mcp.json config.",
+                "Guard native Cursor hooks installed for shell, MCP, and file-read interception.",
+            ],
         }
 
     def _uninstall_editor(self, context: HarnessContext) -> dict[str, object]:
@@ -247,6 +254,7 @@ class CursorHarnessAdapter(HarnessAdapter):
             backup_path.unlink()
         if restored and state_path.is_file():
             state_path.unlink()
+        hooks_manifest = uninstall_cursor_hooks(context)
         return {
             "harness": self.harness,
             "active": False,
@@ -255,7 +263,11 @@ class CursorHarnessAdapter(HarnessAdapter):
             "backup_path": str(backup_path),
             "state_path": str(state_path),
             "restored": restored,
-            "notes": ["Removed Guard Cursor editor MCP proxies and restored the prior Cursor config."],
+            "managed_hooks_path": hooks_manifest.get("managed_hooks_path"),
+            "notes": [
+                "Removed Guard Cursor editor MCP proxies and restored the prior Cursor config.",
+                "Removed Guard native Cursor hooks when a managed hooks backup was available.",
+            ],
         }
 
     def _install_cli(self, context: HarnessContext) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -243,6 +243,10 @@ def cursor_hook_script_source(context: HarnessContext) -> str:
             "__GUARD_INHERIT_ENV_KEYS__",
             json.dumps(list(_INHERIT_ENV_KEYS)),
         )
+        .replace(
+            "__GUARD_HOOK_TIMEOUT_SECONDS__",
+            str(max(_MANAGED_HOOK_TIMEOUT_SECONDS - 5, 1)),
+        )
     )
 
 
@@ -311,15 +315,16 @@ GUARD_PYTHON = __GUARD_PYTHON__
 GUARD_HOOK_LAUNCHER = __GUARD_HOOK_LAUNCHER__
 GUARD_HOOK_ARGV = __GUARD_HOOK_ARGV__
 GUARD_INHERIT_ENV_KEYS = __GUARD_INHERIT_ENV_KEYS__
+GUARD_HOOK_TIMEOUT_SECONDS = __GUARD_HOOK_TIMEOUT_SECONDS__
 
 
-def _hook_process_env() -> dict[str, str]:
+def _hook_process_env(guard_argv: list[str]) -> dict[str, str]:
     env: dict[str, str] = {}
     for key in GUARD_INHERIT_ENV_KEYS:
         value = os.environ.get(key)
         if isinstance(value, str) and value:
             env[key] = value
-    env["HOL_GUARD_HOOK_ARGV"] = json.dumps(GUARD_HOOK_ARGV)
+    env["HOL_GUARD_HOOK_ARGV"] = json.dumps(guard_argv)
     return env
 
 
@@ -327,7 +332,7 @@ def _workspace_from_cursor_input(payload: dict[str, object]) -> str | None:
     project_dir = os.environ.get("CURSOR_PROJECT_DIR")
     if isinstance(project_dir, str) and project_dir.strip():
         return project_dir.strip()
-    roots = payload.get("workspace_roots")
+    roots = payload.get("workspace_roots") or payload.get("workspaceRoots")
     if isinstance(roots, list):
         for item in roots:
             if isinstance(item, str) and item.strip():
@@ -398,16 +403,33 @@ def main() -> int:
         return 2
     workspace = _workspace_from_cursor_input(payload)
     guard_argv = list(GUARD_HOOK_ARGV)
-    if workspace and "--workspace" not in guard_argv:
-        guard_argv.extend(["--workspace", workspace])
-    proc = subprocess.run(
-        [GUARD_PYTHON, "-c", GUARD_HOOK_LAUNCHER],
-        input=json.dumps(payload),
-        capture_output=True,
-        text=True,
-        cwd=GUARD_HOME,
-        env=_hook_process_env(),
-    )
+    if workspace:
+        if "--workspace" in guard_argv:
+            workspace_index = guard_argv.index("--workspace")
+            if workspace_index + 1 < len(guard_argv):
+                guard_argv[workspace_index + 1] = workspace
+        else:
+            guard_argv.extend(["--workspace", workspace])
+    try:
+        proc = subprocess.run(
+            [GUARD_PYTHON, "-c", GUARD_HOOK_LAUNCHER],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            cwd=GUARD_HOME,
+            env=_hook_process_env(guard_argv),
+            timeout=GUARD_HOOK_TIMEOUT_SECONDS,
+        )
+    except Exception as exc:
+        print(
+            json.dumps(
+                {
+                    "permission": "deny",
+                    "user_message": f"HOL Guard hook execution failed: {exc}",
+                }
+            )
+        )
+        return 2
     guard_payload: dict[str, object] = {}
     if proc.stdout.strip():
         try:
@@ -418,7 +440,7 @@ def main() -> int:
             guard_payload = {}
     policy_action = str(guard_payload.get("policy_action") or "allow")
     hook_event_name = str(payload.get("hook_event_name") or payload.get("hookEventName") or "preToolUse")
-    if proc.returncode not in {0, 1} and not guard_payload:
+    if proc.returncode != 0 and not guard_payload:
         print(
             json.dumps(
                 {
@@ -461,11 +483,10 @@ def _managed_hook_entry(
 
 
 def _merge_hook_entries(entries: object, hook_entry: dict[str, object], *, event_name: str) -> list[object]:
+    del event_name
     normalized = list(entries) if isinstance(entries, list) else []
     command = str(hook_entry.get("command", ""))
     preserved = [entry for entry in normalized if not _is_managed_hook_entry(entry, command=command)]
-    if event_name == "preToolUse" and "matcher" in hook_entry:
-        hook_entry = dict(hook_entry)
     return [*preserved, hook_entry]
 
 
@@ -545,6 +566,8 @@ def _raw_hook_event_name(payload: Mapping[str, object]) -> str:
 def _tool_input_dict(value: object) -> dict[str, object]:
     if isinstance(value, dict):
         return dict(value)
+    if isinstance(value, list):
+        return {"arguments": list(value)}
     if isinstance(value, str) and value.strip():
         try:
             parsed = json.loads(value)
@@ -552,6 +575,8 @@ def _tool_input_dict(value: object) -> dict[str, object]:
             return {"raw": value.strip()}
         if isinstance(parsed, dict):
             return dict(parsed)
+        if isinstance(parsed, list):
+            return {"arguments": list(parsed)}
     return {}
 
 

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -1,0 +1,628 @@
+"""Cursor IDE native hooks (.cursor/hooks.json) for HOL Guard."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import shlex
+import stat
+import sys
+from collections.abc import Mapping
+from hashlib import sha256
+from pathlib import Path
+
+from ..launcher import merge_guard_launcher_env
+from .base import HarnessContext
+
+HOOK_SCRIPT_NAME = "hol-guard-cursor-hook.py"
+_MANAGED_HOOK_EVENTS = (
+    "beforeShellExecution",
+    "beforeMCPExecution",
+    "preToolUse",
+    "beforeReadFile",
+)
+_PRETOOL_MATCHER = r"Shell|MCP|mcp__.*|Bash|Read"
+_HOOK_ARGV_ENV = "HOL_GUARD_HOOK_ARGV"
+_MANAGED_HOOK_TIMEOUT_SECONDS = 35
+_LEGACY_MANAGED_COMMAND_MARKERS = (
+    "hol-guard-cursor-hook.py",
+    "HOL_GUARD_HOOK_ARGV",
+    "--harness",
+    "cursor",
+)
+
+
+def prepare_cursor_hook_payload(payload: Mapping[str, object]) -> dict[str, object]:
+    """Map Cursor hook stdin JSON into Guard hook normalization shape."""
+
+    normalized = dict(payload)
+    raw_event = _raw_hook_event_name(normalized)
+    if raw_event == "beforeshellexecution":
+        normalized["hook_event_name"] = "PreToolUse"
+        normalized.setdefault("tool_name", "Shell")
+        tool_input = _tool_input_dict(normalized.get("tool_input"))
+        command = normalized.get("command")
+        if isinstance(command, str) and command.strip():
+            tool_input.setdefault("command", command.strip())
+        cwd = normalized.get("cwd")
+        if isinstance(cwd, str) and cwd.strip():
+            tool_input.setdefault("working_directory", cwd.strip())
+        normalized["tool_input"] = tool_input
+        return normalized
+    if raw_event == "beforemcpexecution":
+        normalized["hook_event_name"] = "PreToolUse"
+        tool_name = normalized.get("tool_name")
+        if isinstance(tool_name, str) and tool_name.strip():
+            normalized["tool_name"] = tool_name.strip()
+        else:
+            normalized.setdefault("tool_name", "MCP")
+        tool_input = _tool_input_dict(normalized.get("tool_input"))
+        for key in ("url", "command"):
+            value = normalized.get(key)
+            if isinstance(value, str) and value.strip():
+                tool_input.setdefault(key, value.strip())
+        normalized["tool_input"] = tool_input
+        return normalized
+    if raw_event == "beforereadfile":
+        normalized["hook_event_name"] = "PreToolUse"
+        normalized.setdefault("tool_name", "Read")
+        tool_input = _tool_input_dict(normalized.get("tool_input"))
+        file_path = normalized.get("file_path")
+        if isinstance(file_path, str) and file_path.strip():
+            tool_input.setdefault("file_path", file_path.strip())
+            tool_input.setdefault("path", file_path.strip())
+        normalized["tool_input"] = tool_input
+        return normalized
+    if raw_event == "pretooluse":
+        normalized["hook_event_name"] = "PreToolUse"
+    return normalized
+
+
+def cursor_hook_response_from_guard(
+    *,
+    policy_action: str,
+    guard_payload: Mapping[str, object],
+    hook_event_name: str,
+) -> dict[str, object]:
+    """Translate Guard hook JSON into Cursor hook stdout JSON."""
+
+    permission = _cursor_permission_for_policy(policy_action)
+    reason = _cursor_block_reason(guard_payload)
+    raw_event = hook_event_name.strip().lower()
+    if raw_event == "beforereadfile":
+        return {
+            "permission": "deny" if permission == "deny" else "allow",
+            "user_message": reason if permission == "deny" else None,
+        }
+    response: dict[str, object] = {"permission": permission}
+    if permission != "allow":
+        response["user_message"] = reason
+        response["agent_message"] = reason
+    return {key: value for key, value in response.items() if value is not None}
+
+
+def cursor_hook_should_block(*, policy_action: str) -> bool:
+    return policy_action in {"block", "sandbox-required"}
+
+
+def cursor_hooks_path(context: HarnessContext) -> Path:
+    if context.workspace_dir is not None:
+        return context.workspace_dir / ".cursor" / "hooks.json"
+    return context.home_dir / ".cursor" / "hooks.json"
+
+
+def cursor_hook_script_path(context: HarnessContext) -> Path:
+    hooks_path = cursor_hooks_path(context)
+    if context.workspace_dir is not None and hooks_path.is_relative_to(context.workspace_dir):
+        return context.workspace_dir / ".cursor" / "hooks" / HOOK_SCRIPT_NAME
+    return context.home_dir / ".cursor" / "hooks" / HOOK_SCRIPT_NAME
+
+
+def managed_hook_script_path(context: HarnessContext) -> Path:
+    return context.guard_home / "managed" / "cursor" / HOOK_SCRIPT_NAME
+
+
+def install_cursor_hooks(context: HarnessContext) -> dict[str, object]:
+    """Install Guard-managed Cursor hooks and bridge script."""
+
+    hooks_path = cursor_hooks_path(context)
+    script_path = cursor_hook_script_path(context)
+    managed_script_path = managed_hook_script_path(context)
+    managed_script_path.parent.mkdir(parents=True, exist_ok=True)
+    script_source = cursor_hook_script_source(context)
+    managed_script_path.write_text(script_source, encoding="utf-8")
+    _make_executable(managed_script_path)
+    script_path.parent.mkdir(parents=True, exist_ok=True)
+    script_path.write_text(script_source, encoding="utf-8")
+    _make_executable(script_path)
+
+    original_text = hooks_path.read_text(encoding="utf-8") if hooks_path.is_file() else None
+    backup_path = _hooks_backup_path(hooks_path, context)
+    if not backup_path.exists():
+        backup_path.parent.mkdir(parents=True, exist_ok=True)
+        backup_path.write_text(
+            json.dumps({"existed": original_text is not None, "content": original_text}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+    state_path = _hooks_state_path(hooks_path, context)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    workspace_dir = str(context.workspace_dir.resolve()) if context.workspace_dir is not None else None
+    state_path.write_text(
+        json.dumps(
+            {
+                "managed_hooks_path": str(hooks_path),
+                "managed_hook_script_path": str(script_path),
+                "backup_path": str(backup_path),
+                "workspace_dir": workspace_dir,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    payload = _managed_hooks_payload(_json_object(hooks_path, recover_missing=True))
+    hooks = _inline_hooks(payload)
+    for event_name in _MANAGED_HOOK_EVENTS:
+        entry = _managed_hook_entry(context, script_path=script_path, event_name=event_name)
+        hooks[event_name] = _merge_hook_entries(hooks.get(event_name), entry, event_name=event_name)
+    payload["hooks"] = hooks
+    hooks_path.parent.mkdir(parents=True, exist_ok=True)
+    hooks_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return {
+        "managed_hooks_path": str(hooks_path),
+        "managed_hook_script_path": str(script_path),
+        "managed_hook_events": list(_MANAGED_HOOK_EVENTS),
+        "backup_path": str(backup_path),
+        "state_path": str(state_path),
+    }
+
+
+def uninstall_cursor_hooks(context: HarnessContext) -> dict[str, object]:
+    """Remove Guard-managed Cursor hooks and restore prior hooks.json."""
+
+    hooks_path = cursor_hooks_path(context)
+    backup_path = _hooks_backup_path(hooks_path, context)
+    state_path = _hooks_state_path(hooks_path, context)
+    script_path = cursor_hook_script_path(context)
+    backup_payload = _backup_payload(backup_path)
+    restored = False
+    if backup_payload["readable"] is True:
+        if backup_payload["existed"] and isinstance(backup_payload["content"], str):
+            hooks_path.parent.mkdir(parents=True, exist_ok=True)
+            hooks_path.write_text(str(backup_payload["content"]), encoding="utf-8")
+            restored = True
+        elif backup_payload["existed"] is not True and hooks_path.is_file():
+            hooks_path.unlink()
+            restored = True
+        elif backup_payload["existed"] is not True:
+            restored = True
+    if restored and backup_path.is_file():
+        backup_path.unlink()
+    if restored and state_path.is_file():
+        state_path.unlink()
+    if script_path.is_file() and _is_managed_hook_script(script_path.read_text(encoding="utf-8")):
+        script_path.unlink()
+    managed_script_path = managed_hook_script_path(context)
+    if managed_script_path.is_file():
+        managed_script_path.unlink()
+    return {
+        "managed_hooks_path": str(hooks_path),
+        "restored": restored,
+        "removed_hook_script": not script_path.is_file(),
+    }
+
+
+def cursor_hook_script_source(context: HarnessContext) -> str:
+    guard_argv = [
+        "guard",
+        "hook",
+        "--guard-home",
+        str(context.guard_home),
+        "--harness",
+        "cursor",
+        "--json",
+    ]
+    if context.home_dir.resolve() != Path.home().resolve():
+        guard_argv.extend(["--home", str(context.home_dir)])
+    if context.workspace_dir is not None:
+        guard_argv.extend(["--workspace", str(context.workspace_dir)])
+    return (
+        _HOOK_SCRIPT_TEMPLATE.replace("__GUARD_HOME__", json.dumps(str(context.guard_home.resolve())))
+        .replace(
+            "__GUARD_PYTHON__",
+            json.dumps(str(Path(sys.executable).resolve())),
+        )
+        .replace("__GUARD_HOOK_LAUNCHER__", json.dumps(_hook_launcher_code()))
+        .replace(
+            "__GUARD_HOOK_ARGV__",
+            json.dumps(guard_argv),
+        )
+        .replace(
+            "__GUARD_INHERIT_ENV_KEYS__",
+            json.dumps(list(_INHERIT_ENV_KEYS)),
+        )
+    )
+
+
+def _hook_launcher_code() -> str:
+    trusted_entries = _trusted_pythonpath_entries()
+    return (
+        "import json,os,sys;"
+        f"sys.path[:0]={json.dumps(trusted_entries)};"
+        "from codex_plugin_scanner.cli import main;"
+        f"raise SystemExit(main(json.loads(os.environ[{_HOOK_ARGV_ENV!r}])))"
+    )
+
+
+def _trusted_package_root() -> Path:
+    spec = importlib.util.find_spec("codex_plugin_scanner")
+    if spec is None:
+        raise RuntimeError("Guard could not locate the codex_plugin_scanner package")
+    if spec.submodule_search_locations:
+        locations = tuple(spec.submodule_search_locations)
+        if not locations:
+            raise RuntimeError("Guard could not resolve codex_plugin_scanner package locations")
+        return Path(locations[0]).resolve().parent
+    if spec.origin is None:
+        raise RuntimeError("Guard could not determine the codex_plugin_scanner package root")
+    return Path(spec.origin).resolve().parent.parent
+
+
+def _trusted_pythonpath_entries() -> list[str]:
+    launcher_env = merge_guard_launcher_env(pin_package=True)
+    path_entries = [entry for entry in launcher_env.get("PYTHONPATH", "").split(os.pathsep) if entry.strip()]
+    package_root = str(_trusted_package_root())
+    if package_root not in path_entries:
+        path_entries.insert(0, package_root)
+    return path_entries
+
+
+_INHERIT_ENV_KEYS = (
+    "PATH",
+    "HOME",
+    "USER",
+    "TMPDIR",
+    "TEMP",
+    "TMP",
+    "LANG",
+    "LC_ALL",
+    "SYSTEMROOT",
+    "CURSOR_PROJECT_DIR",
+    "CURSOR_VERSION",
+    "CURSOR_TRACE_ID",
+    "CURSOR_SESSION_ID",
+    "CURSOR_TRANSCRIPT_PATH",
+)
+
+_HOOK_SCRIPT_TEMPLATE = '''#!/usr/bin/env python3
+"""Managed by HOL Guard. Re-run `hol-guard install cursor` after moving Guard home."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+GUARD_HOME = __GUARD_HOME__
+GUARD_PYTHON = __GUARD_PYTHON__
+GUARD_HOOK_LAUNCHER = __GUARD_HOOK_LAUNCHER__
+GUARD_HOOK_ARGV = __GUARD_HOOK_ARGV__
+GUARD_INHERIT_ENV_KEYS = __GUARD_INHERIT_ENV_KEYS__
+
+
+def _hook_process_env() -> dict[str, str]:
+    env: dict[str, str] = {}
+    for key in GUARD_INHERIT_ENV_KEYS:
+        value = os.environ.get(key)
+        if isinstance(value, str) and value:
+            env[key] = value
+    env["HOL_GUARD_HOOK_ARGV"] = json.dumps(GUARD_HOOK_ARGV)
+    return env
+
+
+def _workspace_from_cursor_input(payload: dict[str, object]) -> str | None:
+    project_dir = os.environ.get("CURSOR_PROJECT_DIR")
+    if isinstance(project_dir, str) and project_dir.strip():
+        return project_dir.strip()
+    roots = payload.get("workspace_roots")
+    if isinstance(roots, list):
+        for item in roots:
+            if isinstance(item, str) and item.strip():
+                return item.strip()
+    cwd = payload.get("cwd")
+    if isinstance(cwd, str) and cwd.strip():
+        return cwd.strip()
+    return None
+
+
+def _cursor_permission(policy_action: str) -> str:
+    if policy_action in {"block", "sandbox-required"}:
+        return "deny"
+    if policy_action in {"require-reapproval", "review"}:
+        return "ask"
+    return "allow"
+
+
+def _cursor_reason(guard_payload: dict[str, object]) -> str:
+    for key in ("review_hint", "risk_summary", "why_now", "risk_headline"):
+        value = guard_payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    decision = guard_payload.get("decision_v2_json")
+    if isinstance(decision, dict):
+        for key in ("harness_message", "retry_instruction", "user_body", "user_title"):
+            value = decision.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return "HOL Guard blocked this Cursor action."
+
+
+def _emit_cursor_response(
+    *,
+    hook_event_name: str,
+    policy_action: str,
+    guard_payload: dict[str, object],
+) -> tuple[dict[str, object], int]:
+    permission = _cursor_permission(policy_action)
+    reason = _cursor_reason(guard_payload)
+    if hook_event_name.strip().lower() == "beforereadfile":
+        response = {
+            "permission": "deny" if permission == "deny" else "allow",
+        }
+        if permission == "deny":
+            response["user_message"] = reason
+        return response, 2 if permission == "deny" else 0
+    response: dict[str, object] = {"permission": permission}
+    if permission != "allow":
+        response["user_message"] = reason
+        response["agent_message"] = reason
+    exit_code = 2 if permission == "deny" else 0
+    return response, exit_code
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        print(json.dumps({"permission": "allow"}))
+        return 0
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        print(json.dumps({"permission": "deny", "user_message": "HOL Guard could not parse Cursor hook input."}))
+        return 2
+    if not isinstance(payload, dict):
+        print(json.dumps({"permission": "deny", "user_message": "HOL Guard received invalid Cursor hook input."}))
+        return 2
+    workspace = _workspace_from_cursor_input(payload)
+    guard_argv = list(GUARD_HOOK_ARGV)
+    if workspace and "--workspace" not in guard_argv:
+        guard_argv.extend(["--workspace", workspace])
+    proc = subprocess.run(
+        [GUARD_PYTHON, "-c", GUARD_HOOK_LAUNCHER],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        cwd=GUARD_HOME,
+        env=_hook_process_env(),
+    )
+    guard_payload: dict[str, object] = {}
+    if proc.stdout.strip():
+        try:
+            parsed = json.loads(proc.stdout)
+            if isinstance(parsed, dict):
+                guard_payload = parsed
+        except json.JSONDecodeError:
+            guard_payload = {}
+    policy_action = str(guard_payload.get("policy_action") or "allow")
+    hook_event_name = str(payload.get("hook_event_name") or payload.get("hookEventName") or "preToolUse")
+    if proc.returncode not in {0, 1} and not guard_payload:
+        print(
+            json.dumps(
+                {
+                    "permission": "deny",
+                    "user_message": (proc.stderr or "HOL Guard hook failed.").strip()
+                    or "HOL Guard hook failed.",
+                }
+            )
+        )
+        return 2
+    response, exit_code = _emit_cursor_response(
+        hook_event_name=hook_event_name,
+        policy_action=policy_action,
+        guard_payload=guard_payload,
+    )
+    print(json.dumps(response))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+'''
+
+
+def _managed_hook_entry(
+    context: HarnessContext,
+    *,
+    script_path: Path,
+    event_name: str,
+) -> dict[str, object]:
+    del context
+    entry: dict[str, object] = {
+        "command": str(script_path.resolve()),
+        "timeout": _MANAGED_HOOK_TIMEOUT_SECONDS,
+        "failClosed": event_name in {"beforeShellExecution", "beforeMCPExecution", "beforeReadFile"},
+    }
+    if event_name == "preToolUse":
+        entry["matcher"] = _PRETOOL_MATCHER
+    return entry
+
+
+def _merge_hook_entries(entries: object, hook_entry: dict[str, object], *, event_name: str) -> list[object]:
+    normalized = list(entries) if isinstance(entries, list) else []
+    command = str(hook_entry.get("command", ""))
+    preserved = [entry for entry in normalized if not _is_managed_hook_entry(entry, command=command)]
+    if event_name == "preToolUse" and "matcher" in hook_entry:
+        hook_entry = dict(hook_entry)
+    return [*preserved, hook_entry]
+
+
+def _is_managed_hook_entry(entry: object, *, command: str) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    entry_command = entry.get("command")
+    if isinstance(entry_command, str) and entry_command == command:
+        return True
+    return _is_managed_hook_command(entry_command)
+
+
+def _is_managed_hook_command(command: object) -> bool:
+    if not isinstance(command, str):
+        return False
+    lowered = command.lower()
+    if HOOK_SCRIPT_NAME.lower() in lowered:
+        return True
+    if "hol_guard_hook_argv" not in lowered.replace("-", "_"):
+        return False
+    if "--harness" not in lowered or "cursor" not in lowered:
+        return False
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+    if tokens and Path(tokens[0]).name == HOOK_SCRIPT_NAME:
+        return True
+    return Path(tokens[0]).name.lower().startswith("python") if tokens else False
+
+
+def _is_managed_hook_script(source: str) -> bool:
+    return "Managed by HOL Guard" in source and HOOK_SCRIPT_NAME in source
+
+
+def _managed_hooks_payload(payload: dict[str, object]) -> dict[str, object]:
+    normalized: dict[str, object] = {"version": 1, "hooks": {}}
+    version = payload.get("version")
+    if isinstance(version, int):
+        normalized["version"] = version
+    hooks = payload.get("hooks")
+    if isinstance(hooks, dict):
+        normalized["hooks"] = {
+            str(name): list(entries) if isinstance(entries, list) else entries for name, entries in hooks.items()
+        }
+        return normalized
+    normalized["hooks"] = {
+        str(name): list(entries)
+        for name, entries in payload.items()
+        if name != "version" and name not in _MANAGED_HOOK_EVENTS and isinstance(entries, list)
+    }
+    return normalized
+
+
+def _inline_hooks(payload: dict[str, object]) -> dict[str, object]:
+    hooks = payload.get("hooks")
+    if isinstance(hooks, dict):
+        normalized = {
+            str(hook_name): list(entries) if isinstance(entries, list) else entries
+            for hook_name, entries in hooks.items()
+        }
+        payload["hooks"] = normalized
+        return normalized
+    normalized: dict[str, object] = {}
+    payload["hooks"] = normalized
+    return normalized
+
+
+def _raw_hook_event_name(payload: Mapping[str, object]) -> str:
+    for key in ("hook_event_name", "hookEventName", "hook_name", "hookName", "event", "eventName"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip().lower()
+    return ""
+
+
+def _tool_input_dict(value: object) -> dict[str, object]:
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {"raw": value.strip()}
+        if isinstance(parsed, dict):
+            return dict(parsed)
+    return {}
+
+
+def _cursor_permission_for_policy(policy_action: str) -> str:
+    if policy_action in {"block", "sandbox-required"}:
+        return "deny"
+    if policy_action in {"require-reapproval", "review"}:
+        return "ask"
+    return "allow"
+
+
+def _cursor_block_reason(guard_payload: Mapping[str, object]) -> str:
+    for key in ("review_hint", "risk_summary", "why_now", "risk_headline"):
+        value = guard_payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    decision = guard_payload.get("decision_v2_json")
+    if isinstance(decision, Mapping):
+        for key in ("harness_message", "retry_instruction", "user_body", "user_title"):
+            value = decision.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return "HOL Guard blocked this Cursor action."
+
+
+def _json_object(path: Path, *, recover_missing: bool) -> dict[str, object]:
+    if not path.is_file():
+        if recover_missing:
+            return {}
+        raise RuntimeError(f"Guard refused to overwrite missing Cursor hooks config at {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"Guard refused to overwrite unreadable Cursor hooks config at {path}") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Guard refused to overwrite non-object Cursor hooks config at {path}")
+    return payload
+
+
+def _hooks_backup_path(target_path: Path, context: HarnessContext) -> Path:
+    digest = sha256(str(target_path.resolve()).encode("utf-8")).hexdigest()[:12]
+    return context.guard_home / "managed" / "cursor" / f"hooks-{digest}.backup.json"
+
+
+def _hooks_state_path(target_path: Path, context: HarnessContext) -> Path:
+    digest = sha256(str(target_path.resolve()).encode("utf-8")).hexdigest()[:12]
+    return context.guard_home / "managed" / "cursor" / f"hooks-{digest}.state.json"
+
+
+def _backup_payload(backup_path: Path) -> dict[str, str | bool | None]:
+    try:
+        payload = json.loads(backup_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"readable": False, "existed": False, "content": None}
+    if not isinstance(payload, dict):
+        return {"readable": False, "existed": False, "content": None}
+    existed = payload.get("existed") is True
+    content = payload.get("content")
+    return {"readable": True, "existed": existed, "content": content if isinstance(content, str) else None}
+
+
+def _make_executable(path: Path) -> None:
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+__all__ = [
+    "HOOK_SCRIPT_NAME",
+    "cursor_hook_response_from_guard",
+    "cursor_hook_should_block",
+    "cursor_hooks_path",
+    "install_cursor_hooks",
+    "prepare_cursor_hook_payload",
+    "uninstall_cursor_hooks",
+]

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -6114,7 +6114,9 @@ def _load_hook_payload(event_file: str | None, *, input_text: str | None = None)
     return _normalize_hook_payload(payload) if isinstance(payload, dict) else {}
 
 
-_ACTION_ENVELOPE_HARNESSES = frozenset({"codex", "claude-code", "opencode", "copilot", "gemini", "hermes", "openclaw"})
+_ACTION_ENVELOPE_HARNESSES = frozenset(
+    {"codex", "claude-code", "opencode", "copilot", "gemini", "hermes", "openclaw", "cursor"}
+)
 
 
 def _hook_action_envelope(

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -376,6 +376,25 @@ def normalize_openclaw_payload(
     )
 
 
+def normalize_cursor_hook_payload(
+    payload: Mapping[str, object],
+    *,
+    workspace: Path | str | None = None,
+    home_dir: Path | str | None = None,
+) -> GuardActionEnvelope:
+    """Normalize a Cursor IDE hook payload into a typed action envelope."""
+
+    from ..adapters.cursor_hooks import prepare_cursor_hook_payload
+
+    return _normalize_action_payload(
+        prepare_cursor_hook_payload(payload),
+        harness="cursor",
+        default_event_name=None,
+        workspace=workspace,
+        home_dir=home_dir,
+    )
+
+
 def normalize_harness_payload(
     harness: str,
     event_name: str,
@@ -396,6 +415,7 @@ def normalize_harness_payload(
         "gemini": normalize_gemini_payload,
         "hermes": normalize_hermes_payload,
         "openclaw": normalize_openclaw_payload,
+        "cursor": normalize_cursor_hook_payload,
     }
     normalizer = normalizers.get(normalized_harness)
     if normalizer is None:

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -1,0 +1,146 @@
+"""Tests for Cursor native hooks installation and payload mapping."""
+
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.cursor import CursorHarnessAdapter
+from codex_plugin_scanner.guard.adapters.cursor_hooks import (
+    HOOK_SCRIPT_NAME,
+    cursor_hook_response_from_guard,
+    cursor_hook_should_block,
+    cursor_hooks_path,
+    install_cursor_hooks,
+    prepare_cursor_hook_payload,
+    uninstall_cursor_hooks,
+)
+from codex_plugin_scanner.guard.runtime.actions import normalize_cursor_hook_payload
+
+
+def _ctx(tmp_path: Path, *, workspace: bool = True) -> HarnessContext:
+    workspace_dir = tmp_path / "workspace" if workspace else None
+    if workspace_dir is not None:
+        workspace_dir.mkdir(parents=True, exist_ok=True)
+    return HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace_dir,
+        guard_home=tmp_path / "guard-home",
+    )
+
+
+def test_prepare_cursor_payload_maps_before_shell_execution() -> None:
+    prepared = prepare_cursor_hook_payload(
+        {
+            "hook_event_name": "beforeShellExecution",
+            "command": "curl https://example.com",
+            "cwd": "/tmp/project",
+        }
+    )
+    assert prepared["hook_event_name"] == "PreToolUse"
+    assert prepared["tool_name"] == "Shell"
+    assert prepared["tool_input"] == {
+        "command": "curl https://example.com",
+        "working_directory": "/tmp/project",
+    }
+
+
+def test_prepare_cursor_payload_maps_before_mcp_execution() -> None:
+    prepared = prepare_cursor_hook_payload(
+        {
+            "hook_event_name": "beforeMCPExecution",
+            "tool_name": "fetch",
+            "tool_input": '{"id": 1}',
+            "url": "http://127.0.0.1:3000/mcp",
+        }
+    )
+    assert prepared["hook_event_name"] == "PreToolUse"
+    assert prepared["tool_name"] == "fetch"
+    assert prepared["tool_input"]["url"] == "http://127.0.0.1:3000/mcp"
+
+
+def test_prepare_cursor_payload_maps_before_read_file() -> None:
+    prepared = prepare_cursor_hook_payload(
+        {
+            "hook_event_name": "beforeReadFile",
+            "file_path": "/tmp/project/.env",
+        }
+    )
+    assert prepared["tool_name"] == "Read"
+    assert prepared["tool_input"]["file_path"] == "/tmp/project/.env"
+
+
+def test_normalize_cursor_hook_payload_builds_envelope() -> None:
+    envelope = normalize_cursor_hook_payload(
+        {
+            "hook_event_name": "beforeShellExecution",
+            "command": "npm install left-pad",
+            "cwd": "/repo",
+        },
+        workspace="/repo",
+    )
+    assert envelope.harness == "cursor"
+    assert envelope.tool_name == "Shell"
+    assert envelope.command == "npm install left-pad"
+
+
+def test_cursor_hook_response_maps_policy_actions() -> None:
+    deny = cursor_hook_response_from_guard(
+        policy_action="block",
+        guard_payload={"review_hint": "Blocked by policy"},
+        hook_event_name="beforeShellExecution",
+    )
+    assert deny["permission"] == "deny"
+    assert deny["user_message"] == "Blocked by policy"
+    ask = cursor_hook_response_from_guard(
+        policy_action="require-reapproval",
+        guard_payload={"decision_v2_json": {"harness_message": "Approve in Guard"}},
+        hook_event_name="preToolUse",
+    )
+    assert ask["permission"] == "ask"
+    assert cursor_hook_should_block(policy_action="block") is True
+    assert cursor_hook_should_block(policy_action="require-reapproval") is False
+
+
+def test_install_cursor_hooks_writes_hooks_json_and_script(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    assert context.workspace_dir is not None
+    manifest = install_cursor_hooks(context)
+    hooks_path = Path(str(manifest["managed_hooks_path"]))
+    script_path = Path(str(manifest["managed_hook_script_path"]))
+    assert hooks_path == context.workspace_dir / ".cursor" / "hooks.json"
+    assert script_path.name == HOOK_SCRIPT_NAME
+    assert script_path.is_file()
+    assert script_path.stat().st_mode & stat.S_IXUSR
+    payload = json.loads(hooks_path.read_text(encoding="utf-8"))
+    hooks = payload["hooks"]
+    assert "beforeShellExecution" in hooks
+    assert "beforeMCPExecution" in hooks
+    assert "preToolUse" in hooks
+    assert "beforeReadFile" in hooks
+    assert hooks["beforeShellExecution"][0]["failClosed"] is True
+    assert hooks["preToolUse"][0]["matcher"]
+
+
+def test_uninstall_cursor_hooks_restores_backup(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    assert context.workspace_dir is not None
+    hooks_path = cursor_hooks_path(context)
+    hooks_path.parent.mkdir(parents=True, exist_ok=True)
+    original = json.dumps({"version": 1, "hooks": {"afterFileEdit": [{"command": "./fmt.sh"}]}}) + "\n"
+    hooks_path.write_text(original, encoding="utf-8")
+    install_cursor_hooks(context)
+    assert "beforeShellExecution" in json.loads(hooks_path.read_text(encoding="utf-8"))["hooks"]
+    uninstall_cursor_hooks(context)
+    assert hooks_path.read_text(encoding="utf-8") == original
+
+
+def test_cursor_editor_install_includes_native_hooks(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    assert context.workspace_dir is not None
+    manifest = CursorHarnessAdapter()._install_editor(context)
+    hooks_path = Path(str(manifest["managed_hooks_path"]))
+    assert hooks_path.is_file()
+    assert manifest["managed_hook_script_path"]


### PR DESCRIPTION
## Summary
- Install native Cursor `.cursor/hooks.json` entries for shell, MCP, preToolUse, and file-read interception via a managed bridge script.
- Map Cursor hook payloads into Guard action envelopes and document editor vs CLI coverage in the Cursor contract.

## Testing
- `uv run pytest tests/test_cursor_hooks.py tests/test_harness_attribution.py tests/test_cursor_adapter.py tests/test_guard_phase04_harness_contracts.py -q`
- `uv run ruff check src/codex_plugin_scanner/guard/adapters/cursor_hooks.py src/codex_plugin_scanner/guard/adapters/cursor.py src/codex_plugin_scanner/guard/runtime/actions.py tests/test_cursor_hooks.py`
