### PR TITLE
fix(cursor): enable failClosed on preToolUse hook

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -475,7 +475,8 @@ def _managed_hook_entry(
     entry: dict[str, object] = {
         "command": str(script_path.resolve()),
         "timeout": _MANAGED_HOOK_TIMEOUT_SECONDS,
-        "failClosed": event_name in {"beforeShellExecution", "beforeMCPExecution", "beforeReadFile"},
+        "failClosed": event_name
+        in {"beforeShellExecution", "beforeMCPExecution", "beforeReadFile", "preToolUse"},
     }
     if event_name == "preToolUse":
         entry["matcher"] = _PRETOOL_MATCHER

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -475,8 +475,7 @@ def _managed_hook_entry(
     entry: dict[str, object] = {
         "command": str(script_path.resolve()),
         "timeout": _MANAGED_HOOK_TIMEOUT_SECONDS,
-        "failClosed": event_name
-        in {"beforeShellExecution", "beforeMCPExecution", "beforeReadFile", "preToolUse"},
+        "failClosed": event_name in _MANAGED_HOOK_EVENTS,
     }
     if event_name == "preToolUse":
         entry["matcher"] = _PRETOOL_MATCHER

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -121,6 +121,7 @@ def test_install_cursor_hooks_writes_hooks_json_and_script(tmp_path: Path) -> No
     assert "preToolUse" in hooks
     assert "beforeReadFile" in hooks
     assert hooks["beforeShellExecution"][0]["failClosed"] is True
+    assert hooks["preToolUse"][0]["failClosed"] is True
     assert hooks["preToolUse"][0]["matcher"]
 
 

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -121,6 +121,8 @@ def test_install_cursor_hooks_writes_hooks_json_and_script(tmp_path: Path) -> No
     assert "preToolUse" in hooks
     assert "beforeReadFile" in hooks
     assert hooks["beforeShellExecution"][0]["failClosed"] is True
+    assert hooks["beforeMCPExecution"][0]["failClosed"] is True
+    assert hooks["beforeReadFile"][0]["failClosed"] is True
     assert hooks["preToolUse"][0]["failClosed"] is True
     assert hooks["preToolUse"][0]["matcher"]
 


### PR DESCRIPTION
## Summary
- Enable `failClosed: true` on the Cursor `preToolUse` managed hook entry so hook failures block tool use (addresses Greptile P1 from #580).
- Add regression assertion in `test_install_cursor_hooks_writes_hooks_json_and_script`.

## Testing
- `uv run pytest tests/test_cursor_hooks.py -q`
- `uv run ruff check src/codex_plugin_scanner/guard/adapters/cursor_hooks.py tests/test_cursor_hooks.py`

