### PR TITLE
fix(guard): use system keyring for connect

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 dependencies = [
     "rich>=13.0",
     "cryptography>=47.0.0",
+    "keyring>=25.0",
     "packaging>=24.0",
     "tomli>=2.0; python_version < '3.11'",
     "cisco-ai-skill-scanner~=2.0.9",

--- a/src/codex_plugin_scanner/guard/cli/product.py
+++ b/src/codex_plugin_scanner/guard/cli/product.py
@@ -9,9 +9,10 @@ from urllib.parse import urlparse
 from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
 from ..config import GuardConfig
-from ..consumer import detect_all, evaluate_detection
+from ..consumer import detect_all
+from ..consumer.service import diff_artifact
 from ..daemon import load_guard_daemon_url
-from ..models import HarnessDetection
+from ..models import GuardArtifact, HarnessDetection
 from ..redaction import redact_local_path
 from ..store import GuardStore
 from .connect_flow import CONNECT_COMMAND, CONNECT_REPAIR_COMMAND, CONNECT_STATUS_COMMAND, connect_recovery_command
@@ -110,10 +111,9 @@ def _summarize_harness(
     config: GuardConfig,
     home_dir: Path,
 ) -> dict[str, object]:
-    evaluation = evaluate_detection(detection, store, config, default_action="allow", persist=False)
     managed_install = store.get_managed_install(detection.harness)
     approval_flow = get_adapter(detection.harness).approval_flow(managed_install=managed_install)
-    review_count = sum(1 for artifact in evaluation["artifacts"] if bool(artifact["changed"]))
+    review_count = _count_review_artifacts(store, detection.artifacts, detection.harness)
     managed = bool(managed_install and managed_install.get("active"))
     shim_path = None
     if managed_install is not None:
@@ -138,6 +138,15 @@ def _summarize_harness(
         "receipts_command": f"{GUARD_COMMAND} receipts",
         "approval_flow": approval_flow,
     }
+
+
+def _count_review_artifacts(store: GuardStore, artifacts: tuple[GuardArtifact, ...], harness: str) -> int:
+    previous_snapshots = store.list_snapshots(harness)
+    return sum(
+        1
+        for artifact in artifacts
+        if bool(diff_artifact(previous_snapshots.get(artifact.artifact_id), artifact)["changed"])
+    )
 
 
 def _redacted_path(path: str | Path | None, home_dir: Path) -> str | None:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -451,9 +451,13 @@ def _build_secret_store(guard_home: Path) -> SecretStore:
 def _build_oauth_secret_store(guard_home: Path) -> SecretStore:
     fallback_store = EncryptedFileSecretStore(guard_home)
     if KeychainSecretStore._is_available():
+        # Device connect persists a refresh token plus multiline DPoP key material.
+        # Keep writes on the encrypted file backend so normal CLI pairing never drops
+        # the user into repeated macOS keychain password prompts, while still reading
+        # legacy keychain-backed installs through the fallback path and migrating them forward.
         return FallbackSecretStore(
-            KeychainSecretStore(service_name="hol-guard.oauth"),
             fallback_store,
+            KeychainSecretStore(service_name="hol-guard.oauth"),
         )
     return fallback_store
 

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import importlib
 import json
 import logging
 import os
@@ -131,10 +132,11 @@ from .store_threat_intel import (
 from .types import CapabilitySet
 
 _SYNC_TOKEN_REF = "guard-cloud-token"
-_OAUTH_REFRESH_TOKEN_REF = "guard-oauth-refresh-token"
-_OAUTH_DPOP_PRIVATE_KEY_REF = "guard-oauth-dpop-private-key"
+_OAUTH_LOCAL_CREDENTIALS_REF = "guard-oauth-local-credentials"
 _SYNC_TOKEN_HASH_KEY = "token_sha256"
 _OAUTH_LOCAL_CREDENTIALS_STATE_KEY = "oauth_local_credentials"
+_OAUTH_LOCAL_CREDENTIALS_HASH_KEY = "credentials_sha256"
+_OAUTH_LOCAL_CREDENTIALS_REF_KEY = "credentials_ref"
 _DEVICE_ROW_KEY = "local-device"
 _MAX_RESOLVED_SCOPE_IDS = 200
 _SQLITE_ID_BATCH_SIZE = 500
@@ -143,6 +145,7 @@ _SCOPED_HARNESS_FAMILIES = frozenset(
     {"file-read", "mcp-tool", "prompt", "prompt-env-read", "prompt-file", "tool-action"}
 )
 _POLICY_SCOPES = frozenset({"artifact", "workspace", "publisher", "harness", "global"})
+_SLOW_STORE_WARNING_ENV = "HOL_GUARD_WARN_SLOW_STORE"
 
 
 def _token_sha256(value: str) -> str:
@@ -233,13 +236,52 @@ class KeychainSecretStore:
         )
 
 
-class EncryptedFileSecretStore:
-    """Encrypted file-based secret store for predictable cross-platform Guard credentials.
+class SystemKeyringSecretStore:
+    """Cross-platform OS credential store backed by the Python keyring library."""
 
-    This keeps sync tokens out of plaintext SQLite and avoids OS-specific keychain prompts
-    during CLI flows. The Fernet key and encrypted payloads both live inside the same
-    per-user Guard directory, so this is a portability and encrypted-at-rest improvement,
-    not stronger isolation than an OS keychain against same-user local compromise.
+    def __init__(self, service_name: str) -> None:
+        self.service_name = service_name
+
+    @staticmethod
+    def _load_keyring_module():
+        return importlib.import_module("keyring")
+
+    @classmethod
+    def _is_available(cls) -> bool:
+        try:
+            keyring_module = cls._load_keyring_module()
+            backend = keyring_module.get_keyring()
+        except Exception:
+            return False
+        backend_name = type(backend).__name__.lower()
+        if backend_name == "failkeyring":
+            return False
+        priority = getattr(backend, "priority", None)
+        return not (isinstance(priority, (int, float)) and priority <= 0)
+
+    def set_secret(self, secret_id: str, value: str) -> None:
+        keyring_module = self._load_keyring_module()
+        keyring_module.set_password(self.service_name, secret_id, value)
+
+    def get_secret(self, secret_id: str) -> str | None:
+        keyring_module = self._load_keyring_module()
+        value = keyring_module.get_password(self.service_name, secret_id)
+        return value if isinstance(value, str) and value else None
+
+    def delete_secret(self, secret_id: str) -> None:
+        keyring_module = self._load_keyring_module()
+        try:
+            keyring_module.delete_password(self.service_name, secret_id)
+        except Exception:
+            return
+
+
+class EncryptedFileSecretStore:
+    """Encrypted file-based secret store for Guard credentials.
+
+    The Fernet key and encrypted payloads both live inside the same per-user Guard
+    directory, so this is encrypted-at-rest fallback storage rather than a substitute
+    for an OS credential manager.
     """
 
     def __init__(self, guard_home: Path) -> None:
@@ -450,19 +492,17 @@ def _build_secret_store(guard_home: Path) -> SecretStore:
 
 def _build_oauth_secret_store(guard_home: Path) -> SecretStore:
     fallback_store = EncryptedFileSecretStore(guard_home)
-    if KeychainSecretStore._is_available():
-        # Device connect persists a refresh token plus multiline DPoP key material.
-        # Keep writes on the encrypted file backend so normal CLI pairing never drops
-        # the user into repeated macOS keychain password prompts, while still reading
-        # legacy keychain-backed installs through the fallback path and migrating them forward.
+    if SystemKeyringSecretStore._is_available():
         return FallbackSecretStore(
+            SystemKeyringSecretStore(service_name="hol-guard.oauth"),
             fallback_store,
-            KeychainSecretStore(service_name="hol-guard.oauth"),
         )
     return fallback_store
 
 
 def _secret_store_backend_name(secret_store: SecretStore) -> str:
+    if isinstance(secret_store, SystemKeyringSecretStore):
+        return "system-keyring"
     if isinstance(secret_store, KeychainSecretStore):
         return "keychain"
     if isinstance(secret_store, EncryptedFileSecretStore):
@@ -478,6 +518,11 @@ def _secret_store_fallback_backend_name(secret_store: SecretStore) -> str | None
     return None
 
 
+def _should_warn_on_slow_store_transactions() -> bool:
+    value = os.environ.get(_SLOW_STORE_WARNING_ENV, "").strip().lower()
+    return value in {"1", "true", "yes", "on"}
+
+
 _SLOW_QUERY_THRESHOLD_MS: int = 200
 _store_logger = logging.getLogger(__name__)
 
@@ -491,8 +536,7 @@ class GuardStore:
         self._secret_store = _build_secret_store(self.guard_home)
         self._oauth_secret_store = _build_oauth_secret_store(self.guard_home)
         self._sync_token_ref = self._build_scoped_secret_ref(_SYNC_TOKEN_REF)
-        self._oauth_refresh_token_ref = self._build_scoped_secret_ref(_OAUTH_REFRESH_TOKEN_REF)
-        self._oauth_dpop_private_key_ref = self._build_scoped_secret_ref(_OAUTH_DPOP_PRIVATE_KEY_REF)
+        self._oauth_local_credentials_ref = self._build_scoped_secret_ref(_OAUTH_LOCAL_CREDENTIALS_REF)
         self._guard_event_queue_limit = max(1, guard_event_queue_limit)
         self.path = self.guard_home / "guard.db"
         self._initialize()
@@ -552,7 +596,8 @@ class GuardStore:
             connection.close()
             elapsed_ms = (time.monotonic() - start) * 1000
             if elapsed_ms >= _SLOW_QUERY_THRESHOLD_MS:
-                _store_logger.warning(
+                log = _store_logger.warning if _should_warn_on_slow_store_transactions() else _store_logger.debug
+                log(
                     "Guard store slow transaction (%.0fms); consider indexing hot query paths.",
                     elapsed_ms,
                 )
@@ -2935,19 +2980,19 @@ class GuardStore:
         runtime_id: str | None = None,
         runtime_label: str | None = None,
     ) -> None:
-        refresh_token_hash = _token_sha256(refresh_token)
-        dpop_private_key_hash = _token_sha256(dpop_private_key_pem)
-        refresh_token_ref = self._versioned_secret_ref(self._oauth_refresh_token_ref, refresh_token_hash)
-        dpop_private_key_ref = self._versioned_secret_ref(self._oauth_dpop_private_key_ref, dpop_private_key_hash)
+        secret_payload = {
+            "refresh_token": refresh_token,
+            "dpop_private_key_pem": dpop_private_key_pem,
+            "dpop_public_jwk": dpop_public_jwk,
+            "dpop_public_jwk_thumbprint": dpop_public_jwk_thumbprint,
+        }
+        secret_json = json.dumps(secret_payload, sort_keys=True, separators=(",", ":"))
+        secret_hash = _token_sha256(secret_json)
         payload: dict[str, object] = {
             "issuer": issuer,
             "client_id": client_id,
-            "refresh_token_ref": refresh_token_ref,
-            "refresh_token_sha256": refresh_token_hash,
-            "dpop_private_key_ref": dpop_private_key_ref,
-            "dpop_private_key_sha256": dpop_private_key_hash,
-            "dpop_public_jwk": dpop_public_jwk,
-            "dpop_public_jwk_thumbprint": dpop_public_jwk_thumbprint,
+            _OAUTH_LOCAL_CREDENTIALS_REF_KEY: self._oauth_local_credentials_ref,
+            _OAUTH_LOCAL_CREDENTIALS_HASH_KEY: secret_hash,
         }
         if grant_id:
             payload["grant_id"] = grant_id
@@ -2959,96 +3004,27 @@ class GuardStore:
             payload["runtime_id"] = runtime_id
         if runtime_label:
             payload["runtime_label"] = runtime_label
-        self._oauth_secret_store.set_secret(refresh_token_ref, refresh_token)
-        self._oauth_secret_store.set_secret(dpop_private_key_ref, dpop_private_key_pem)
+        self._oauth_secret_store.set_secret(self._oauth_local_credentials_ref, secret_json)
         self.set_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY, payload, now)
 
     def get_oauth_local_credentials(self) -> dict[str, object] | None:
         payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
         if not isinstance(payload, dict):
             return None
-        issuer = payload.get("issuer")
-        client_id = payload.get("client_id")
-        refresh_token_ref = payload.get("refresh_token_ref")
-        refresh_token_hash = payload.get("refresh_token_sha256")
-        dpop_private_key_ref = payload.get("dpop_private_key_ref")
-        dpop_private_key_hash = payload.get("dpop_private_key_sha256")
-        dpop_public_jwk = payload.get("dpop_public_jwk")
-        dpop_public_jwk_thumbprint = payload.get("dpop_public_jwk_thumbprint")
-        if not isinstance(issuer, str) or not issuer:
+        metadata = self._oauth_local_credentials_metadata(payload)
+        if metadata is None:
             return None
-        if not isinstance(client_id, str) or not client_id:
+        secret_payload = self._load_oauth_secret_payload(payload)
+        if secret_payload is None:
             return None
-        if not isinstance(refresh_token_ref, str) or not refresh_token_ref:
-            return None
-        if not isinstance(dpop_private_key_ref, str) or not dpop_private_key_ref:
-            return None
-        if not isinstance(refresh_token_hash, str) or not refresh_token_hash:
-            return None
-        if not isinstance(dpop_private_key_hash, str) or not dpop_private_key_hash:
-            return None
-        if not isinstance(dpop_public_jwk, dict):
-            return None
-        if not isinstance(dpop_public_jwk_thumbprint, str) or not dpop_public_jwk_thumbprint:
-            return None
-        refresh_token: str | None = None
-        for candidate in self._get_secret_candidates(
-            self._oauth_secret_store,
-            refresh_token_ref,
-            refresh_token_hash,
-        ):
-            if _token_sha256(candidate) != refresh_token_hash:
-                continue
-            refresh_token = candidate
-            self._promote_secret_to_primary(self._oauth_secret_store, refresh_token_ref, candidate)
-            break
-        if refresh_token is None:
-            return None
-        dpop_private_key_pem: str | None = None
-        for candidate in self._get_secret_candidates(
-            self._oauth_secret_store,
-            dpop_private_key_ref,
-            dpop_private_key_hash,
-        ):
-            if _token_sha256(candidate) != dpop_private_key_hash:
-                continue
-            dpop_private_key_pem = candidate
-            self._promote_secret_to_primary(self._oauth_secret_store, dpop_private_key_ref, candidate)
-            break
-        if dpop_private_key_pem is None:
-            return None
-        result: dict[str, object] = {
-            "issuer": issuer,
-            "client_id": client_id,
-            "refresh_token": refresh_token,
-            "dpop_private_key_pem": dpop_private_key_pem,
-            "dpop_public_jwk": dpop_public_jwk,
-            "dpop_public_jwk_thumbprint": dpop_public_jwk_thumbprint,
-        }
-        grant_id = payload.get("grant_id")
-        machine_id = payload.get("machine_id")
-        workspace_id = payload.get("workspace_id")
-        runtime_id = payload.get("runtime_id")
-        runtime_label = payload.get("runtime_label")
-        if isinstance(grant_id, str) and grant_id:
-            result["grant_id"] = grant_id
-        if isinstance(machine_id, str) and machine_id:
-            result["machine_id"] = machine_id
-        if isinstance(workspace_id, str) and workspace_id:
-            result["workspace_id"] = workspace_id
-        if isinstance(runtime_id, str) and runtime_id:
-            result["runtime_id"] = runtime_id
-        if isinstance(runtime_label, str) and runtime_label:
-            result["runtime_label"] = runtime_label
-        return result
+        return self._build_oauth_local_credentials_result(metadata=metadata, secret_payload=secret_payload)
 
     def clear_oauth_local_credentials(self) -> None:
         payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
         if isinstance(payload, dict):
-            for key in ("refresh_token_ref", "dpop_private_key_ref"):
-                secret_ref = payload.get(key)
-                if isinstance(secret_ref, str) and secret_ref:
-                    self._oauth_secret_store.delete_secret(secret_ref)
+            secret_ref = payload.get(_OAUTH_LOCAL_CREDENTIALS_REF_KEY)
+            if isinstance(secret_ref, str) and secret_ref:
+                self._oauth_secret_store.delete_secret(secret_ref)
         self.delete_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
 
     def get_oauth_local_credential_health(self) -> dict[str, object]:
@@ -3061,50 +3037,99 @@ class GuardStore:
         }
         if not isinstance(payload, dict):
             return health
-
-        refresh_token_ref = payload.get("refresh_token_ref")
-        refresh_token_hash = payload.get("refresh_token_sha256")
-        dpop_private_key_ref = payload.get("dpop_private_key_ref")
-        dpop_private_key_hash = payload.get("dpop_private_key_sha256")
-        if not isinstance(refresh_token_ref, str) or not refresh_token_ref:
+        metadata = self._oauth_local_credentials_metadata(payload)
+        if metadata is None:
             health["state"] = "degraded"
             return health
-        if not isinstance(refresh_token_hash, str) or not refresh_token_hash:
+        secret_payload = self._load_oauth_secret_payload(payload, promote=False)
+        if secret_payload is None:
             health["state"] = "degraded"
             return health
-        if not isinstance(dpop_private_key_ref, str) or not dpop_private_key_ref:
+        if self._build_oauth_local_credentials_result(metadata=metadata, secret_payload=secret_payload) is None:
             health["state"] = "degraded"
             return health
-        if not isinstance(dpop_private_key_hash, str) or not dpop_private_key_hash:
-            health["state"] = "degraded"
-            return health
-
-        refresh_token_present = any(
-            _token_sha256(candidate) == refresh_token_hash
-            for candidate in self._get_secret_candidates(
-                self._oauth_secret_store,
-                refresh_token_ref,
-                refresh_token_hash,
-            )
-        )
-        dpop_private_key_present = any(
-            _token_sha256(candidate) == dpop_private_key_hash
-            for candidate in self._get_secret_candidates(
-                self._oauth_secret_store,
-                dpop_private_key_ref,
-                dpop_private_key_hash,
-            )
-        )
-        if not refresh_token_present or not dpop_private_key_present:
-            health["state"] = "degraded"
-            return health
-
         health["state"] = "healthy"
         for key in ("issuer", "client_id", "grant_id", "machine_id", "workspace_id"):
             value = payload.get(key)
             if isinstance(value, str) and value:
                 health[key] = value
         return health
+
+    @staticmethod
+    def _oauth_local_credentials_metadata(payload: dict[str, object]) -> dict[str, object] | None:
+        issuer = payload.get("issuer")
+        client_id = payload.get("client_id")
+        if not isinstance(issuer, str) or not issuer:
+            return None
+        if not isinstance(client_id, str) or not client_id:
+            return None
+        result: dict[str, object] = {
+            "issuer": issuer,
+            "client_id": client_id,
+        }
+        for key in ("grant_id", "machine_id", "workspace_id", "runtime_id", "runtime_label"):
+            value = payload.get(key)
+            if isinstance(value, str) and value:
+                result[key] = value
+        return result
+
+    def _load_oauth_secret_payload(
+        self,
+        payload: dict[str, object],
+        *,
+        promote: bool = True,
+    ) -> dict[str, object] | None:
+        secret_ref = payload.get(_OAUTH_LOCAL_CREDENTIALS_REF_KEY)
+        secret_hash = payload.get(_OAUTH_LOCAL_CREDENTIALS_HASH_KEY)
+        if not isinstance(secret_ref, str) or not secret_ref:
+            return None
+        if not isinstance(secret_hash, str) or not secret_hash:
+            return None
+        for candidate in self._get_secret_candidates(self._oauth_secret_store, secret_ref, secret_hash):
+            if _token_sha256(candidate) != secret_hash:
+                continue
+            try:
+                secret_payload = json.loads(candidate)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(secret_payload, dict):
+                continue
+            if promote:
+                self._promote_secret_to_primary(self._oauth_secret_store, secret_ref, candidate)
+            return secret_payload
+        return None
+
+    @staticmethod
+    def _build_oauth_local_credentials_result(
+        *,
+        metadata: dict[str, object],
+        secret_payload: dict[str, object],
+    ) -> dict[str, object] | None:
+        refresh_token = secret_payload.get("refresh_token")
+        dpop_private_key_pem = secret_payload.get("dpop_private_key_pem")
+        dpop_public_jwk = secret_payload.get("dpop_public_jwk")
+        dpop_public_jwk_thumbprint = secret_payload.get("dpop_public_jwk_thumbprint")
+        if not isinstance(refresh_token, str) or not refresh_token:
+            return None
+        if not isinstance(dpop_private_key_pem, str) or not dpop_private_key_pem:
+            return None
+        if not isinstance(dpop_public_jwk, dict):
+            return None
+        if not isinstance(dpop_public_jwk_thumbprint, str) or not dpop_public_jwk_thumbprint:
+            return None
+        result: dict[str, object] = {
+            "issuer": metadata["issuer"],
+            "client_id": metadata["client_id"],
+            "refresh_token": refresh_token,
+            "dpop_private_key_pem": dpop_private_key_pem,
+            "dpop_public_jwk": {str(key): str(value) for key, value in dpop_public_jwk.items()},
+            "dpop_public_jwk_thumbprint": dpop_public_jwk_thumbprint,
+        }
+        for key in ("grant_id", "machine_id", "workspace_id", "runtime_id", "runtime_label"):
+            value = metadata.get(key)
+            if isinstance(value, str) and value:
+                result[key] = value
+        return result
 
     def get_latest_guard_connect_state(self, *, now: str) -> dict[str, object] | None:
         with self._connect() as connection:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -149,9 +149,8 @@ _SLOW_STORE_WARNING_ENV = "HOL_GUARD_WARN_SLOW_STORE"
 
 
 def _token_sha256(value: str) -> str:
-    # codeql[py/weak-sensitive-data-hashing]: Guard stores high-entropy local token fingerprints for integrity checks,
-    # not password verifiers.
-    return sha256(value.encode("utf-8")).hexdigest()
+    # Guard stores high-entropy local token fingerprints for integrity checks, not password verifiers.
+    return sha256(value.encode("utf-8")).hexdigest()  # codeql[py/weak-sensitive-data-hashing]
 
 
 class SecretStore(Protocol):

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -149,6 +149,8 @@ _SLOW_STORE_WARNING_ENV = "HOL_GUARD_WARN_SLOW_STORE"
 
 
 def _token_sha256(value: str) -> str:
+    # codeql[py/weak-sensitive-data-hashing]: Guard stores high-entropy local token fingerprints for integrity checks,
+    # not password verifiers.
     return sha256(value.encode("utf-8")).hexdigest()
 
 

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -13,7 +13,7 @@ import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
-from hashlib import sha256
+from hashlib import pbkdf2_hmac, sha256
 from pathlib import Path
 from typing import Protocol
 from uuid import uuid4
@@ -146,11 +146,29 @@ _SCOPED_HARNESS_FAMILIES = frozenset(
 )
 _POLICY_SCOPES = frozenset({"artifact", "workspace", "publisher", "harness", "global"})
 _SLOW_STORE_WARNING_ENV = "HOL_GUARD_WARN_SLOW_STORE"
+_SECRET_FINGERPRINT_PREFIX = "pbkdf2-sha256$"
+_SECRET_FINGERPRINT_SALT = b"hol-guard-secret-fingerprint:v1"
+_SECRET_FINGERPRINT_ITERATIONS = 200_000
 
 
-def _token_sha256(value: str) -> str:
-    # Guard stores high-entropy local token fingerprints for integrity checks, not password verifiers.
+def _secret_fingerprint(value: str) -> str:
+    digest = pbkdf2_hmac(
+        "sha256",
+        value.encode("utf-8"),
+        _SECRET_FINGERPRINT_SALT,
+        _SECRET_FINGERPRINT_ITERATIONS,
+    ).hex()
+    return f"{_SECRET_FINGERPRINT_PREFIX}{digest}"
+
+
+def _legacy_secret_sha256(value: str) -> str:
     return sha256(value.encode("utf-8")).hexdigest()  # codeql[py/weak-sensitive-data-hashing]
+
+
+def _secret_matches_hash(value: str, expected_hash: str) -> bool:
+    if expected_hash.startswith(_SECRET_FINGERPRINT_PREFIX):
+        return _secret_fingerprint(value) == expected_hash
+    return _legacy_secret_sha256(value) == expected_hash
 
 
 class SecretStore(Protocol):
@@ -570,7 +588,7 @@ class GuardStore:
         if isinstance(secret_store, FallbackSecretStore):
             primary_token = self._get_secret_from_store(secret_store.primary, secret_id)
             if primary_token is not None:
-                if expected_hash_value is None or _token_sha256(primary_token) == expected_hash_value:
+                if expected_hash_value is None or _secret_matches_hash(primary_token, expected_hash_value):
                     return [primary_token]
                 fallback_token = self._get_secret_from_store(secret_store.fallback, secret_id)
                 if fallback_token is None or fallback_token == primary_token:
@@ -2958,7 +2976,7 @@ class GuardStore:
             expected_hash_value = expected_hash if isinstance(expected_hash, str) and expected_hash else None
 
             for token in self._get_secret_candidates(self._secret_store, self._sync_token_ref, expected_hash_value):
-                if expected_hash_value is not None and _token_sha256(token) != expected_hash_value:
+                if expected_hash_value is not None and not _secret_matches_hash(token, expected_hash_value):
                     continue
                 self._promote_secret_to_primary(self._secret_store, self._sync_token_ref, token)
                 return {"sync_url": sync_url, "token": token}
@@ -2988,7 +3006,7 @@ class GuardStore:
             "dpop_public_jwk_thumbprint": dpop_public_jwk_thumbprint,
         }
         secret_json = json.dumps(secret_payload, sort_keys=True, separators=(",", ":"))
-        secret_hash = _token_sha256(secret_json)
+        secret_hash = _secret_fingerprint(secret_json)
         payload: dict[str, object] = {
             "issuer": issuer,
             "client_id": client_id,
@@ -3087,7 +3105,7 @@ class GuardStore:
         if not isinstance(secret_hash, str) or not secret_hash:
             return None
         for candidate in self._get_secret_candidates(self._oauth_secret_store, secret_ref, secret_hash):
-            if _token_sha256(candidate) != secret_hash:
+            if not _secret_matches_hash(candidate, secret_hash):
                 continue
             try:
                 secret_payload = json.loads(candidate)
@@ -3176,12 +3194,12 @@ class GuardStore:
             return token_hash
         legacy_token = payload.get("token")
         if isinstance(legacy_token, str) and legacy_token:
-            return _token_sha256(legacy_token)
+            return _secret_fingerprint(legacy_token)
         token_reference = payload.get("token_ref")
         if isinstance(token_reference, str) and token_reference:
             token = self._secret_store.get_secret(token_reference)
             if isinstance(token, str) and token:
-                return _token_sha256(token)
+                return _secret_fingerprint(token)
         return None
 
     def _set_sync_credentials_in_connection(
@@ -3193,7 +3211,7 @@ class GuardStore:
         *,
         workspace_id: str | None = None,
     ) -> None:
-        token_hash = _token_sha256(token)
+        token_hash = _secret_fingerprint(token)
         normalized_workspace_id = (
             workspace_id.strip() if isinstance(workspace_id, str) and workspace_id.strip() else None
         )

--- a/tests/test_guard_daemon_perf.py
+++ b/tests/test_guard_daemon_perf.py
@@ -272,7 +272,7 @@ class TestSlowSQLiteTelemetry:
         slow_warnings = [r for r in caplog.records if "slow transaction" in r.getMessage().lower()]
         assert len(slow_warnings) == 0, "Fast transaction must not emit slow transaction warning"
 
-    def test_slow_transaction_emits_warning(
+    def test_slow_transaction_does_not_warn_by_default(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         import logging
@@ -285,7 +285,23 @@ class TestSlowSQLiteTelemetry:
         with caplog.at_level(logging.WARNING, logger="codex_plugin_scanner.guard.store"):
             _ = store.list_approval_requests()
         slow_warnings = [r for r in caplog.records if "slow transaction" in r.getMessage().lower()]
-        assert len(slow_warnings) > 0, "Slow transaction (threshold=0ms) must emit a slow transaction warning"
+        assert len(slow_warnings) == 0, "Slow transaction warnings must stay out of normal CLI output"
+
+    def test_slow_transaction_warns_when_env_opt_in_is_enabled(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import logging
+
+        import codex_plugin_scanner.guard.store as store_module
+        from codex_plugin_scanner.guard.store import GuardStore
+
+        monkeypatch.setattr(store_module, "_SLOW_QUERY_THRESHOLD_MS", 0)
+        monkeypatch.setenv("HOL_GUARD_WARN_SLOW_STORE", "1")
+        store = GuardStore(guard_home=tmp_path / "guard-home")
+        with caplog.at_level(logging.WARNING, logger="codex_plugin_scanner.guard.store"):
+            _ = store.list_approval_requests()
+        slow_warnings = [r for r in caplog.records if "slow transaction" in r.getMessage().lower()]
+        assert len(slow_warnings) > 0, "Slow transaction warning must remain available for explicit diagnostics"
 
     def test_store_has_slow_query_threshold_constant(self) -> None:
         from codex_plugin_scanner.guard.store import _SLOW_QUERY_THRESHOLD_MS

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -1,6 +1,7 @@
 import base64
 import io
 import json
+import subprocess
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -13,7 +14,7 @@ from codex_plugin_scanner.guard.cli import connect_flow
 from codex_plugin_scanner.guard.cli.commands import run_guard_command
 from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
-from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.guard.store import GuardStore, KeychainSecretStore
 
 
 class _Args:
@@ -746,6 +747,69 @@ def test_headless_connect_slows_down_polling_when_server_requests_it(tmp_path: P
 
     assert payload["status"] == "connected"
     assert sleeps == [7]
+
+
+def test_headless_connect_avoids_keychain_password_prompts_when_file_store_is_available(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
+
+    def fail_on_keychain(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise AssertionError("device connect should not shell out to macOS keychain prompts")
+
+    monkeypatch.setattr(subprocess, "run", fail_on_keychain)
+    store = GuardStore(guard_home)
+
+    def fake_request(_url: str, _body: str) -> dict[str, object]:
+        return {
+            "device_code": "device-secret-value",
+            "user_code": "ABCD-EFGH",
+            "verification_uri": "https://hol.org/guard/oauth/device",
+            "verification_uri_complete": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
+            "expires_in": 600,
+            "interval": 2,
+        }
+
+    class _Response:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(self._payload).encode("utf-8")
+
+    payload = connect_flow.run_guard_device_connect_command(
+        store=store,
+        connect_url="https://hol.org/guard/connect",
+        request_device_authorization=fake_request,
+        token_urlopen=lambda request, timeout: _Response(
+            {
+                "access_token": _fake_access_token(
+                    grant_id="grant-123",
+                    machine_id="machine-123",
+                    workspace_id="workspace-123",
+                ),
+                "refresh_token": "refresh-123",
+                "expires_in": 3600,
+                "scope": "guard:runtime.sync guard:offline_access",
+                "token_type": "Bearer",
+            }
+        ),
+        now="2026-06-01T12:00:00+00:00",
+    )
+
+    assert payload["status"] == "connected"
+    credentials = store.get_oauth_local_credentials()
+    assert credentials is not None
+    assert credentials["refresh_token"] == "refresh-123"
+    assert credentials["grant_id"] == "grant-123"
 
 
 def test_headless_connect_expired_code_surfaces_retry_command(tmp_path: Path) -> None:

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -14,7 +14,34 @@ from codex_plugin_scanner.guard.cli import connect_flow
 from codex_plugin_scanner.guard.cli.commands import run_guard_command
 from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
-from codex_plugin_scanner.guard.store import GuardStore, KeychainSecretStore
+from codex_plugin_scanner.guard.store import GuardStore, SystemKeyringSecretStore
+
+
+class _FakeSystemKeyringModule:
+    def __init__(self) -> None:
+        self._secrets: dict[tuple[str, str], str] = {}
+
+    @staticmethod
+    def get_keyring():
+        class _Backend:
+            priority = 1
+
+        return _Backend()
+
+    def set_password(self, service_name: str, secret_id: str, value: str) -> None:
+        self._secrets[(service_name, secret_id)] = value
+
+    def get_password(self, service_name: str, secret_id: str) -> str | None:
+        return self._secrets.get((service_name, secret_id))
+
+    def delete_password(self, service_name: str, secret_id: str) -> None:
+        self._secrets.pop((service_name, secret_id), None)
+
+
+def _install_fake_system_keyring(monkeypatch) -> _FakeSystemKeyringModule:
+    module = _FakeSystemKeyringModule()
+    monkeypatch.setattr(SystemKeyringSecretStore, "_load_keyring_module", staticmethod(lambda: module))
+    return module
 
 
 class _Args:
@@ -749,12 +776,12 @@ def test_headless_connect_slows_down_polling_when_server_requests_it(tmp_path: P
     assert sleeps == [7]
 
 
-def test_headless_connect_avoids_keychain_password_prompts_when_file_store_is_available(
+def test_headless_connect_avoids_keychain_password_prompts_when_system_keyring_is_available(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     guard_home = tmp_path / "guard-home"
-    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
+    _install_fake_system_keyring(monkeypatch)
 
     def fail_on_keychain(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
         raise AssertionError("device connect should not shell out to macOS keychain prompts")

--- a/tests/test_guard_product_flow.py
+++ b/tests/test_guard_product_flow.py
@@ -11,6 +11,11 @@ from pathlib import Path
 import pytest
 
 from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.cli.product import build_guard_status_payload
+from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.consumer import detect_all
+from codex_plugin_scanner.guard.consumer.service import artifact_hash
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -118,6 +123,48 @@ class TestGuardProductFlow:
         assert "same-chat approvals" in codex_summary["approval_flow"]["summary"]
         assert output["next_steps"][0]["command"] == "hol-guard install codex"
         assert output["next_steps"][1]["command"] == "hol-guard run codex --dry-run"
+
+    def test_guard_status_review_count_does_not_resolve_policy(self, tmp_path, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        guard_home = tmp_path / "guard-home"
+        _build_guard_fixture(home_dir, workspace_dir)
+        context = HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=guard_home)
+        config = GuardConfig(guard_home=guard_home, workspace=workspace_dir)
+        store = GuardStore(guard_home)
+        detections = detect_all(context)
+        codex_detection = next(item for item in detections if item.harness == "codex")
+
+        assert codex_detection.artifacts
+
+        for artifact in codex_detection.artifacts:
+            store.save_snapshot(
+                codex_detection.harness,
+                artifact.artifact_id,
+                artifact.to_dict(),
+                artifact_hash(artifact),
+                "2026-06-04T12:00:00+00:00",
+            )
+
+        _write_text(
+            workspace_dir / ".codex" / "config.toml",
+            """
+[mcp_servers.workspace_skill]
+command = "node"
+args = ["workspace-skill.js", "--changed"]
+""".strip()
+            + "\n",
+        )
+        monkeypatch.setattr(
+            store,
+            "resolve_policy",
+            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("status should not resolve policy")),
+        )
+
+        payload = build_guard_status_payload(context, store, config)
+        codex_summary = next(item for item in payload["harnesses"] if item["harness"] == "codex")
+
+        assert codex_summary["review_count"] >= 1
 
     def test_guard_bootstrap_stays_local_when_cloud_is_unreachable(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -15,9 +15,40 @@ from codex_plugin_scanner.guard.store import (
     FallbackSecretStore,
     GuardStore,
     KeychainSecretStore,
+    SystemKeyringSecretStore,
     _build_oauth_secret_store,
     _build_secret_store,
 )
+
+
+class _FakeSystemKeyringModule:
+    def __init__(self) -> None:
+        self._secrets: dict[tuple[str, str], str] = {}
+        self.fail_on_set = False
+
+    @staticmethod
+    def get_keyring():
+        class _Backend:
+            priority = 1
+
+        return _Backend()
+
+    def set_password(self, service_name: str, secret_id: str, value: str) -> None:
+        if self.fail_on_set:
+            raise RuntimeError("system keyring unavailable")
+        self._secrets[(service_name, secret_id)] = value
+
+    def get_password(self, service_name: str, secret_id: str) -> str | None:
+        return self._secrets.get((service_name, secret_id))
+
+    def delete_password(self, service_name: str, secret_id: str) -> None:
+        self._secrets.pop((service_name, secret_id), None)
+
+
+def _install_fake_system_keyring(monkeypatch) -> _FakeSystemKeyringModule:
+    module = _FakeSystemKeyringModule()
+    monkeypatch.setattr(SystemKeyringSecretStore, "_load_keyring_module", staticmethod(lambda: module))
+    return module
 
 
 def test_sync_credentials_are_not_persisted_in_plaintext_sqlite(tmp_path):
@@ -244,15 +275,15 @@ def test_secret_store_prefers_encrypted_file_backend_when_keychain_is_available(
     assert isinstance(secret_store.fallback, KeychainSecretStore)
 
 
-def test_oauth_secret_store_prefers_encrypted_file_backend_when_keychain_is_available(tmp_path, monkeypatch):
+def test_oauth_secret_store_prefers_system_keyring_backend_when_available(tmp_path, monkeypatch):
     guard_home = tmp_path / "guard-home"
-    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
+    _install_fake_system_keyring(monkeypatch)
 
     secret_store = _build_oauth_secret_store(guard_home)
 
     assert isinstance(secret_store, FallbackSecretStore)
-    assert isinstance(secret_store.primary, EncryptedFileSecretStore)
-    assert isinstance(secret_store.fallback, KeychainSecretStore)
+    assert isinstance(secret_store.primary, SystemKeyringSecretStore)
+    assert isinstance(secret_store.fallback, EncryptedFileSecretStore)
 
 
 def test_encrypted_file_secret_store_secures_secret_directory_permissions(tmp_path):
@@ -293,9 +324,9 @@ def test_sync_credentials_do_not_shell_out_to_keychain_when_file_store_is_availa
     GuardStore(guard_home)
 
 
-def test_oauth_local_credentials_do_not_shell_out_to_keychain_when_file_store_is_available(tmp_path, monkeypatch):
+def test_oauth_local_credentials_do_not_shell_out_to_keychain_when_system_keyring_is_available(tmp_path, monkeypatch):
     guard_home = tmp_path / "guard-home"
-    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
+    _install_fake_system_keyring(monkeypatch)
 
     def fail_on_keychain(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
         raise AssertionError("keychain should not be used for OAuth credential writes")
@@ -349,14 +380,12 @@ def test_oauth_local_credentials_are_not_persisted_in_plaintext_sqlite(tmp_path)
     assert payload["grant_id"] == "grant-123"
     assert payload["machine_id"] == "machine-123"
     assert payload["workspace_id"] == "workspace-123"
-    assert isinstance(payload.get("refresh_token_ref"), str)
-    assert isinstance(payload.get("refresh_token_sha256"), str)
-    assert isinstance(payload.get("dpop_private_key_ref"), str)
-    assert isinstance(payload.get("dpop_private_key_sha256"), str)
-    assert payload["dpop_public_jwk"]["kty"] == "EC"
-    assert payload["dpop_public_jwk_thumbprint"] == "thumbprint-123"
+    assert payload["credentials_ref"].startswith("guard-oauth-local-credentials:")
+    assert isinstance(payload.get("credentials_sha256"), str)
     assert "refresh_token" not in payload
     assert "dpop_private_key_pem" not in payload
+    assert "dpop_public_jwk" not in payload
+    assert "dpop_public_jwk_thumbprint" not in payload
 
     assert store.get_oauth_local_credentials() == {
         "issuer": "https://hol.org",
@@ -434,14 +463,10 @@ def test_clear_oauth_local_credentials_preserves_local_receipt_history(tmp_path,
     assert list((guard_home / "secrets").glob("guard-oauth-*.enc")) == []
 
 
-def test_oauth_local_credentials_use_encrypted_file_fallback_when_keychain_write_fails(tmp_path, monkeypatch):
+def test_oauth_local_credentials_use_encrypted_file_fallback_when_system_keyring_write_fails(tmp_path, monkeypatch):
     guard_home = tmp_path / "guard-home"
-    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
-
-    def fail_on_keychain(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
-        raise subprocess.CalledProcessError(returncode=1, cmd=["security"], stderr="keychain unavailable")
-
-    monkeypatch.setattr(subprocess, "run", fail_on_keychain)
+    fake_keyring = _install_fake_system_keyring(monkeypatch)
+    fake_keyring.fail_on_set = True
     store = GuardStore(guard_home)
     store.set_oauth_local_credentials(
         issuer="https://hol.org",
@@ -461,7 +486,6 @@ def test_oauth_local_credentials_use_encrypted_file_fallback_when_keychain_write
 
 def test_oauth_local_credential_health_reports_backend_and_metadata(tmp_path, monkeypatch):
     guard_home = tmp_path / "guard-home"
-    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: False))
     store = GuardStore(guard_home)
 
     assert store.get_oauth_local_credential_health() == {
@@ -504,6 +528,36 @@ def test_oauth_local_credential_health_reports_backend_and_metadata(tmp_path, mo
     assert store.get_oauth_local_credential_health()["state"] == "healthy"
 
 
+def test_oauth_local_credential_health_reports_system_keyring_backend(tmp_path, monkeypatch):
+    _install_fake_system_keyring(monkeypatch)
+    store = GuardStore(tmp_path / "guard-home")
+
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+
+    assert store.get_oauth_local_credential_health() == {
+        "configured": True,
+        "state": "healthy",
+        "backend": "system-keyring",
+        "fallback_backend": "encrypted-file",
+        "issuer": "https://hol.org",
+        "client_id": "guard-local-daemon",
+        "grant_id": "grant-123",
+        "machine_id": "machine-123",
+        "workspace_id": "workspace-123",
+    }
+
+
 def test_oauth_local_credentials_preserve_previous_material_on_partial_secret_write_failure(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
     store.set_oauth_local_credentials(
@@ -521,13 +575,13 @@ def test_oauth_local_credentials_preserve_previous_material_on_partial_secret_wr
     original_set_secret = store._oauth_secret_store.set_secret
     write_calls: list[str] = []
 
-    def fail_on_second_write(secret_id: str, value: str) -> None:
+    def fail_on_first_write(secret_id: str, value: str) -> None:
         write_calls.append(secret_id)
-        if len(write_calls) == 2:
-            raise RuntimeError("second write failed")
+        if len(write_calls) == 1:
+            raise RuntimeError("secret write failed")
         original_set_secret(secret_id, value)
 
-    monkeypatch.setattr(store._oauth_secret_store, "set_secret", fail_on_second_write)
+    monkeypatch.setattr(store._oauth_secret_store, "set_secret", fail_on_first_write)
 
     try:
         store.set_oauth_local_credentials(
@@ -543,9 +597,9 @@ def test_oauth_local_credentials_preserve_previous_material_on_partial_secret_wr
             now="2026-06-01T00:05:00+00:00",
         )
     except RuntimeError as error:
-        assert str(error) == "second write failed"
+        assert str(error) == "secret write failed"
     else:
-        raise AssertionError("second OAuth secret write should fail in this regression test")
+        raise AssertionError("OAuth secret write should fail in this regression test")
 
     assert store.get_oauth_local_credentials() == {
         "issuer": "https://hol.org",
@@ -559,110 +613,6 @@ def test_oauth_local_credentials_preserve_previous_material_on_partial_secret_wr
         "workspace_id": "workspace-old",
     }
 
-
-def test_validated_keychain_fallback_oauth_reads_are_migrated_into_encrypted_file_store(tmp_path, monkeypatch):
-    guard_home = tmp_path / "guard-home"
-    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
-
-    refresh_token = "legacy-refresh-token"
-    dpop_private_key_pem = "-----BEGIN PRIVATE KEY-----\nlegacy-key-material\n-----END PRIVATE KEY-----"
-    refresh_token_hash = hashlib.sha256(refresh_token.encode("utf-8")).hexdigest()
-    dpop_private_key_hash = hashlib.sha256(dpop_private_key_pem.encode("utf-8")).hexdigest()
-    keychain_reads: list[str] = []
-
-    def keychain_lookup(args: list[str], *other_args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
-        del other_args, kwargs
-        secret_id = str(args[args.index("-a") + 1])
-        keychain_reads.append(secret_id)
-        if secret_id.endswith(refresh_token_hash[:16]):
-            return subprocess.CompletedProcess(args=args, returncode=0, stdout=f"{refresh_token}\n", stderr="")
-        if secret_id.endswith(dpop_private_key_hash[:16]):
-            return subprocess.CompletedProcess(args=args, returncode=0, stdout=dpop_private_key_pem, stderr="")
-        return subprocess.CompletedProcess(args=args, returncode=44, stdout="", stderr="not found")
-
-    monkeypatch.setattr(subprocess, "run", keychain_lookup)
-    store = GuardStore(guard_home)
-    refresh_token_ref = store._versioned_secret_ref(store._oauth_refresh_token_ref, refresh_token_hash)
-    dpop_private_key_ref = store._versioned_secret_ref(store._oauth_dpop_private_key_ref, dpop_private_key_hash)
-
-    with sqlite3.connect(store.path) as connection:
-        connection.execute(
-            """
-            insert into sync_state (state_key, payload_json, updated_at)
-            values ('oauth_local_credentials', ?, ?)
-            on conflict(state_key) do update set payload_json = excluded.payload_json, updated_at = excluded.updated_at
-            """,
-            (
-                json.dumps(
-                    {
-                        "issuer": "https://hol.org",
-                        "client_id": "guard-local-daemon",
-                        "refresh_token_ref": refresh_token_ref,
-                        "refresh_token_sha256": refresh_token_hash,
-                        "dpop_private_key_ref": dpop_private_key_ref,
-                        "dpop_private_key_sha256": dpop_private_key_hash,
-                        "dpop_public_jwk": {
-                            "kty": "EC",
-                            "crv": "P-256",
-                            "x": "x-value",
-                            "y": "y-value",
-                            "alg": "ES256",
-                            "use": "sig",
-                        },
-                        "dpop_public_jwk_thumbprint": "thumbprint-123",
-                        "grant_id": "grant-123",
-                        "machine_id": "machine-123",
-                        "workspace_id": "workspace-123",
-                    }
-                ),
-                "2026-06-01T00:00:00+00:00",
-            ),
-        )
-
-    assert store.get_oauth_local_credentials() == {
-        "issuer": "https://hol.org",
-        "client_id": "guard-local-daemon",
-        "refresh_token": refresh_token,
-        "dpop_private_key_pem": dpop_private_key_pem,
-        "dpop_public_jwk": {
-            "kty": "EC",
-            "crv": "P-256",
-            "x": "x-value",
-            "y": "y-value",
-            "alg": "ES256",
-            "use": "sig",
-        },
-        "dpop_public_jwk_thumbprint": "thumbprint-123",
-        "grant_id": "grant-123",
-        "machine_id": "machine-123",
-        "workspace_id": "workspace-123",
-    }
-    assert len(keychain_reads) == 2
-    assert any((guard_home / "secrets").glob("*.enc"))
-
-    def fail_on_keychain(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
-        raise AssertionError("OAuth keychain fallback should not run after migration")
-
-    monkeypatch.setattr(subprocess, "run", fail_on_keychain)
-
-    assert store.get_oauth_local_credentials() == {
-        "issuer": "https://hol.org",
-        "client_id": "guard-local-daemon",
-        "refresh_token": refresh_token,
-        "dpop_private_key_pem": dpop_private_key_pem,
-        "dpop_public_jwk": {
-            "kty": "EC",
-            "crv": "P-256",
-            "x": "x-value",
-            "y": "y-value",
-            "alg": "ES256",
-            "use": "sig",
-        },
-        "dpop_public_jwk_thumbprint": "thumbprint-123",
-        "grant_id": "grant-123",
-        "machine_id": "machine-123",
-        "workspace_id": "workspace-123",
-    }
 
 
 def test_validated_keychain_fallback_reads_are_migrated_into_encrypted_file_store(tmp_path, monkeypatch):

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -244,15 +244,15 @@ def test_secret_store_prefers_encrypted_file_backend_when_keychain_is_available(
     assert isinstance(secret_store.fallback, KeychainSecretStore)
 
 
-def test_oauth_secret_store_prefers_keychain_when_available(tmp_path, monkeypatch):
+def test_oauth_secret_store_prefers_encrypted_file_backend_when_keychain_is_available(tmp_path, monkeypatch):
     guard_home = tmp_path / "guard-home"
     monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
 
     secret_store = _build_oauth_secret_store(guard_home)
 
     assert isinstance(secret_store, FallbackSecretStore)
-    assert isinstance(secret_store.primary, KeychainSecretStore)
-    assert isinstance(secret_store.fallback, EncryptedFileSecretStore)
+    assert isinstance(secret_store.primary, EncryptedFileSecretStore)
+    assert isinstance(secret_store.fallback, KeychainSecretStore)
 
 
 def test_encrypted_file_secret_store_secures_secret_directory_permissions(tmp_path):
@@ -291,6 +291,28 @@ def test_sync_credentials_do_not_shell_out_to_keychain_when_file_store_is_availa
 
     monkeypatch.setattr(subprocess, "run", fail_on_keychain)
     GuardStore(guard_home)
+
+
+def test_oauth_local_credentials_do_not_shell_out_to_keychain_when_file_store_is_available(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
+
+    def fail_on_keychain(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise AssertionError("keychain should not be used for OAuth credential writes")
+
+    monkeypatch.setattr(subprocess, "run", fail_on_keychain)
+    store = GuardStore(guard_home)
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+
+    assert store.get_oauth_local_credentials() is not None
 
 
 def test_oauth_local_credentials_are_not_persisted_in_plaintext_sqlite(tmp_path):
@@ -535,6 +557,111 @@ def test_oauth_local_credentials_preserve_previous_material_on_partial_secret_wr
         "grant_id": "grant-old",
         "machine_id": "machine-old",
         "workspace_id": "workspace-old",
+    }
+
+
+def test_validated_keychain_fallback_oauth_reads_are_migrated_into_encrypted_file_store(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
+
+    refresh_token = "legacy-refresh-token"
+    dpop_private_key_pem = "-----BEGIN PRIVATE KEY-----\nlegacy-key-material\n-----END PRIVATE KEY-----"
+    refresh_token_hash = hashlib.sha256(refresh_token.encode("utf-8")).hexdigest()
+    dpop_private_key_hash = hashlib.sha256(dpop_private_key_pem.encode("utf-8")).hexdigest()
+    keychain_reads: list[str] = []
+
+    def keychain_lookup(args: list[str], *other_args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        del other_args, kwargs
+        secret_id = str(args[args.index("-a") + 1])
+        keychain_reads.append(secret_id)
+        if secret_id.endswith(refresh_token_hash[:16]):
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=f"{refresh_token}\n", stderr="")
+        if secret_id.endswith(dpop_private_key_hash[:16]):
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=dpop_private_key_pem, stderr="")
+        return subprocess.CompletedProcess(args=args, returncode=44, stdout="", stderr="not found")
+
+    monkeypatch.setattr(subprocess, "run", keychain_lookup)
+    store = GuardStore(guard_home)
+    refresh_token_ref = store._versioned_secret_ref(store._oauth_refresh_token_ref, refresh_token_hash)
+    dpop_private_key_ref = store._versioned_secret_ref(store._oauth_dpop_private_key_ref, dpop_private_key_hash)
+
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            """
+            insert into sync_state (state_key, payload_json, updated_at)
+            values ('oauth_local_credentials', ?, ?)
+            on conflict(state_key) do update set payload_json = excluded.payload_json, updated_at = excluded.updated_at
+            """,
+            (
+                json.dumps(
+                    {
+                        "issuer": "https://hol.org",
+                        "client_id": "guard-local-daemon",
+                        "refresh_token_ref": refresh_token_ref,
+                        "refresh_token_sha256": refresh_token_hash,
+                        "dpop_private_key_ref": dpop_private_key_ref,
+                        "dpop_private_key_sha256": dpop_private_key_hash,
+                        "dpop_public_jwk": {
+                            "kty": "EC",
+                            "crv": "P-256",
+                            "x": "x-value",
+                            "y": "y-value",
+                            "alg": "ES256",
+                            "use": "sig",
+                        },
+                        "dpop_public_jwk_thumbprint": "thumbprint-123",
+                        "grant_id": "grant-123",
+                        "machine_id": "machine-123",
+                        "workspace_id": "workspace-123",
+                    }
+                ),
+                "2026-06-01T00:00:00+00:00",
+            ),
+        )
+
+    assert store.get_oauth_local_credentials() == {
+        "issuer": "https://hol.org",
+        "client_id": "guard-local-daemon",
+        "refresh_token": refresh_token,
+        "dpop_private_key_pem": dpop_private_key_pem,
+        "dpop_public_jwk": {
+            "kty": "EC",
+            "crv": "P-256",
+            "x": "x-value",
+            "y": "y-value",
+            "alg": "ES256",
+            "use": "sig",
+        },
+        "dpop_public_jwk_thumbprint": "thumbprint-123",
+        "grant_id": "grant-123",
+        "machine_id": "machine-123",
+        "workspace_id": "workspace-123",
+    }
+    assert len(keychain_reads) == 2
+    assert any((guard_home / "secrets").glob("*.enc"))
+
+    def fail_on_keychain(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise AssertionError("OAuth keychain fallback should not run after migration")
+
+    monkeypatch.setattr(subprocess, "run", fail_on_keychain)
+
+    assert store.get_oauth_local_credentials() == {
+        "issuer": "https://hol.org",
+        "client_id": "guard-local-daemon",
+        "refresh_token": refresh_token,
+        "dpop_private_key_pem": dpop_private_key_pem,
+        "dpop_public_jwk": {
+            "kty": "EC",
+            "crv": "P-256",
+            "x": "x-value",
+            "y": "y-value",
+            "alg": "ES256",
+            "use": "sig",
+        },
+        "dpop_public_jwk_thumbprint": "thumbprint-123",
+        "grant_id": "grant-123",
+        "machine_id": "machine-123",
+        "workspace_id": "workspace-123",
     }
 
 


### PR DESCRIPTION
## Summary
- store OAuth device-connect material as one secret blob in the OS credential store when available, with encrypted-file fallback only when no system keyring is usable
- stop `hol-guard status` from surfacing internal slow-store warnings in normal CLI output and compute review counts from snapshots instead of full policy evaluation
- remove OAuth legacy keychain migration coverage and lock the new behavior with connect, status, and storage regression tests

## Testing
- `python3 -m pytest tests/test_guard_store_migrations.py tests/test_guard_oauth_device_connect.py tests/test_guard_daemon_perf.py tests/test_guard_product_flow.py -q`
- `python3 -m ruff check pyproject.toml src/codex_plugin_scanner/guard/store.py src/codex_plugin_scanner/guard/cli/product.py tests/test_guard_store_migrations.py tests/test_guard_oauth_device_connect.py tests/test_guard_daemon_perf.py tests/test_guard_product_flow.py`
- `pipx install --force .`
- `hol-guard connect` (verified the device flow prints only the approval steps, without repeated keychain password prompts)
- `hol-guard status`

## Notes
- Pre-single-blob experimental OAuth state is not migrated forward. Those installs must reconnect with `hol-guard connect`.
