### PR TITLE
test(hol-guard): lock Apache license metadata in docs

### DIFF
--- a/tests/test_guard_docs.py
+++ b/tests/test_guard_docs.py
@@ -3,7 +3,13 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.cli.docs import install_connect_command_catalog
@@ -151,8 +157,11 @@ def test_project_metadata_declares_apache_license() -> None:
     readme_text = _read_repo_file("README.md")
 
     assert "SPDX-License-Identifier: Apache-2.0" in license_text
-    assert 'license = "Apache-2.0"' in pyproject_text
-    assert "Apache-2.0" in readme_text.split("## License", 1)[-1]
+    pyproject_data = tomllib.loads(pyproject_text)
+    assert pyproject_data.get("project", {}).get("license") == "Apache-2.0"
+    readme_parts = readme_text.split("## License", 1)
+    assert len(readme_parts) == 2, "README.md is missing a '## License' section"
+    assert "Apache-2.0" in readme_parts[1]
 
 
 def test_static_docs_do_not_claim_mit_license_for_hol_guard() -> None:

--- a/tests/test_guard_docs.py
+++ b/tests/test_guard_docs.py
@@ -145,6 +145,38 @@ def test_release_checklist_mentions_oauth_only_connect_and_token_retirement() ->
     assert "retired" in release_checklist
 
 
+def test_project_metadata_declares_apache_license() -> None:
+    license_text = _read_repo_file("LICENSE")
+    pyproject_text = _read_repo_file("pyproject.toml")
+    readme_text = _read_repo_file("README.md")
+
+    assert "SPDX-License-Identifier: Apache-2.0" in license_text
+    assert 'license = "Apache-2.0"' in pyproject_text
+    assert "Apache-2.0" in readme_text.split("## License", 1)[-1]
+
+
+def test_static_docs_do_not_claim_mit_license_for_hol_guard() -> None:
+    docs_text = "\n".join(
+        [
+            _read_repo_file("README.md"),
+            _read_repo_file("docs/guard/get-started.md"),
+            _read_repo_file("docs/guard/local-vs-cloud.md"),
+            _read_repo_file("docs/guard/architecture.md"),
+            _read_repo_file("docs/guard/SKILL.md"),
+        ]
+    )
+
+    forbidden_claims = (
+        "published under MIT",
+        "MIT licensed",
+        "licensed under MIT",
+        "hol-guard is MIT",
+        "HOL Guard is MIT",
+    )
+    for claim in forbidden_claims:
+        assert claim.lower() not in docs_text.lower()
+
+
 def test_static_docs_cover_false_positive_remediation_and_incident_response() -> None:
     docs_text = "\n".join(
         [


### PR DESCRIPTION
## Summary
- Add doc/metadata regression tests that hol-guard is Apache-2.0 licensed.
- Block public docs from claiming hol-guard is MIT licensed.

## Testing
- `uv run pytest tests/test_guard_docs.py -q -k "apache_license or mit_license_for_hol_guard"`
