### PR TITLE
fix(daemon): harden local auth gates

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
+from ..daemon.manager import load_guard_daemon_auth_token
 from .claude_code import CLAUDE_GUARD_DAEMON_HOOK_MARKER
 
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
@@ -47,7 +48,7 @@ def main(
     try:
         endpoint = urljoin(_daemon_url(state_path, fallback_daemon_url), f"/v1/hooks/claude-code?{query}")
         _assert_loopback_http_url(endpoint)
-        response_body = _post_to_loopback_daemon(endpoint, data)
+        response_body = _post_to_loopback_daemon(endpoint, data, state_path=state_path)
     except ValueError as error:
         sys.stdout.write(_run_local_fallback(str(error), data, fallback_command))
         return 0
@@ -95,11 +96,15 @@ def _assert_loopback_http_url(url: str) -> None:
         raise ValueError("daemon URL must include an explicit port")
 
 
-def _post_to_loopback_daemon(endpoint: str, data: str) -> str:
+def _post_to_loopback_daemon(endpoint: str, data: str, *, state_path: str | Path) -> str:
+    auth_token = load_guard_daemon_auth_token(Path(state_path).parent)
+    headers = {"Content-Type": "application/json"}
+    if isinstance(auth_token, str) and auth_token.strip():
+        headers["X-Guard-Token"] = auth_token
     request = urllib.request.Request(
         endpoint,
         data=data.encode("utf-8"),
-        headers={"Content-Type": "application/json"},
+        headers=headers,
         method="POST",
     )
     opener = _build_loopback_opener()

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -178,7 +178,8 @@ def _daemon_health_request(url: str, auth_token: str | None = None) -> urllib.re
 
 def _daemon_healthz_details_match_guard_home(url: str, guard_home: Path, *, auth_token: str) -> bool:
     try:
-        with urllib.request.urlopen(_daemon_health_request(f"{url}/v1/healthz/details", auth_token), timeout=1) as response:
+        request = _daemon_health_request(f"{url}/v1/healthz/details", auth_token)
+        with urllib.request.urlopen(request, timeout=1) as response:
             if response.status != 200:
                 return False
             return _healthz_payload_matches_guard_home(response.read().decode("utf-8"), guard_home)

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -145,6 +145,8 @@ def load_guard_daemon_url(guard_home: Path) -> str | None:
         return None
     if _guard_daemon_pid_matches_command(pid, expected_guard_home=guard_home):
         return url
+    # In-process or wrapped daemons may not expose a command line we can bind
+    # back to guard_home, so fall back to authenticated detailed health.
     auth_token = load_guard_daemon_auth_token(guard_home)
     if auth_token and _daemon_healthz_details_match_guard_home(url, guard_home, auth_token=auth_token):
         return url

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -844,6 +844,8 @@ def _healthz_payload_is_current(raw_payload: str) -> bool:
     if compatibility_version != GUARD_DAEMON_COMPATIBILITY_VERSION:
         return False
     tables = payload.get("tables")
+    if tables is None:
+        return True
     if not isinstance(tables, list):
         return False
     table_names = {table for table in tables if isinstance(table, str)}

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -137,16 +137,17 @@ def load_guard_daemon_url(guard_home: Path) -> str | None:
         return None
     url = f"http://127.0.0.1:{port}"
     try:
-        with urllib.request.urlopen(f"{url}/healthz", timeout=1) as response:
+        with urllib.request.urlopen(_daemon_health_request(f"{url}/healthz"), timeout=1) as response:
             raw_payload = response.read().decode("utf-8")
             if response.status != 200 or not _healthz_payload_is_current(raw_payload):
                 return None
-            if _healthz_payload_matches_guard_home(raw_payload, guard_home):
-                return url
-            if _guard_daemon_pid_matches_command(pid, expected_guard_home=guard_home):
-                return url
     except (OSError, ValueError, urllib.error.URLError):
         return None
+    if _guard_daemon_pid_matches_command(pid, expected_guard_home=guard_home):
+        return url
+    auth_token = load_guard_daemon_auth_token(guard_home)
+    if auth_token and _daemon_healthz_details_match_guard_home(url, guard_home, auth_token=auth_token):
+        return url
     compatibility_version = payload.get("compatibility_version")
     if compatibility_version != GUARD_DAEMON_COMPATIBILITY_VERSION:
         return None
@@ -166,6 +167,23 @@ def load_guard_daemon_auth_token(guard_home: Path) -> str | None:
         return None
     token = payload.get("auth_token")
     return token if isinstance(token, str) and token.strip() else None
+
+
+def _daemon_health_request(url: str, auth_token: str | None = None) -> urllib.request.Request:
+    headers: dict[str, str] = {}
+    if isinstance(auth_token, str) and auth_token.strip():
+        headers["X-Guard-Token"] = auth_token
+    return urllib.request.Request(url, headers=headers, method="GET")
+
+
+def _daemon_healthz_details_match_guard_home(url: str, guard_home: Path, *, auth_token: str) -> bool:
+    try:
+        with urllib.request.urlopen(_daemon_health_request(f"{url}/v1/healthz/details", auth_token), timeout=1) as response:
+            if response.status != 200:
+                return False
+            return _healthz_payload_matches_guard_home(response.read().decode("utf-8"), guard_home)
+    except (OSError, ValueError, urllib.error.URLError):
+        return False
 
 
 def write_guard_daemon_state(guard_home: Path, port: int, auth_token: str) -> None:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -437,23 +437,16 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             and self._is_hosted_dashboard_api_path(parsed.path, path_parts)
             and not self._header_token_is_valid()
         ):
-            self._write_json({"error": "unauthorized"}, status=401)
+            self._write_unauthorized()
             return
         if parsed.path == "/healthz":
-            uptime = round(time.monotonic() - self.server.start_monotonic, 1)  # type: ignore[attr-defined]
-            self._write_json(
-                {
-                    "ok": True,
-                    "receipts": len(store.list_receipts(limit=500)),
-                    "approvals": store.count_approval_requests(),
-                    "pending_approvals": store.count_approval_requests(),
-                    "uptime_seconds": uptime,
-                    "tables": store.list_table_names(),
-                    "compatibility_version": GUARD_DAEMON_COMPATIBILITY_VERSION,
-                    "package_version": __version__,
-                    "guard_home": str(store.guard_home.resolve()),
-                }
-            )
+            self._write_json(self._public_healthz_payload())
+            return
+        if self._requires_get_header_token(parsed.path, path_parts) and not self._header_token_is_valid():
+            self._write_unauthorized(extra_headers=self._cors_headers_for_request())
+            return
+        if parsed.path == "/v1/healthz/details":
+            self._write_json(self._detailed_healthz_payload())
             return
         if parsed.path == "/v1/capabilities":
             self._handle_capabilities()
@@ -670,9 +663,6 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_static_asset(parsed.path.removeprefix("/"))
             return
         if parsed.path == "/v1/events/stream":
-            if not self._token_is_valid(parsed.query):
-                self._write_json({"error": "unauthorized"}, status=401)
-                return
             self._stream_events(_int_query_value(parsed.query, "cursor"))
             return
         if self._is_dashboard_route(parsed.path):
@@ -689,11 +679,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json({"error": "forbidden_origin"}, status=403)
             return
         if not self._header_token_is_valid():
-            self._write_json(
-                {"error": "unauthorized"},
-                status=401,
-                extra_headers=self._cors_headers_for_request(),
-            )
+            self._write_unauthorized(extra_headers=self._cors_headers_for_request())
             return
         store = self.server.store  # type: ignore[attr-defined]
         if parsed.path == "/v1/evidence":
@@ -739,12 +725,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     status=401,
                     extra_headers=self._cors_headers_for_request(),
                 )
+                self._record_auth_audit_event()
             else:
-                self._write_json(
-                    {"error": "unauthorized"},
-                    status=401,
-                    extra_headers=self._cors_headers_for_request(),
-                )
+                self._write_unauthorized(extra_headers=self._cors_headers_for_request())
             return
         if parsed.path == "/v1/initialize":
             self._handle_initialize(payload)
@@ -2302,6 +2285,24 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         token = params.get("token", [None])[-1]
         return self._tokens_match(token)
 
+    def _write_unauthorized(self, *, extra_headers: dict[str, str] | None = None) -> None:
+        self._record_auth_audit_event()
+        self._write_json({"error": "unauthorized"}, status=401, extra_headers=extra_headers)
+
+    def _record_auth_audit_event(self) -> None:
+        self.server.store.add_event(  # type: ignore[attr-defined]
+            "daemon.auth.unauthorized",
+            {
+                "method": self.command,
+                "path": urlparse(self.path).path,
+                "origin": self._normalize_origin(self.headers.get("Origin")),
+                "has_authorization": isinstance(self.headers.get("Authorization"), str),
+                "has_dashboard_session": isinstance(self.headers.get("X-Guard-Dashboard-Session"), str),
+                "has_guard_token": isinstance(self.headers.get("X-Guard-Token"), str),
+            },
+            _now(),
+        )
+
     def _header_token_is_valid(self, *, payload: dict[str, object] | None = None) -> bool:
         token = self.headers.get("X-Guard-Token")
         path = urlparse(self.path).path
@@ -2571,6 +2572,33 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return True
         return len(path_parts) == 4 and path_parts[:2] == ["v1", "artifacts"] and path_parts[3] == "diff"
 
+    def _public_healthz_payload(self) -> dict[str, object]:
+        uptime = round(time.monotonic() - self.server.start_monotonic, 1)  # type: ignore[attr-defined]
+        pending_approvals = self.server.store.count_approval_requests()  # type: ignore[attr-defined]
+        return {
+            "ok": True,
+            "pending_approvals": pending_approvals,
+            "uptime_seconds": uptime,
+            "compatibility_version": GUARD_DAEMON_COMPATIBILITY_VERSION,
+            "package_version": __version__,
+        }
+
+    def _detailed_healthz_payload(self) -> dict[str, object]:
+        uptime = round(time.monotonic() - self.server.start_monotonic, 1)  # type: ignore[attr-defined]
+        store = self.server.store  # type: ignore[attr-defined]
+        pending_approvals = store.count_approval_requests()
+        return {
+            "ok": True,
+            "receipts": len(store.list_receipts(limit=500)),
+            "approvals": pending_approvals,
+            "pending_approvals": pending_approvals,
+            "uptime_seconds": uptime,
+            "tables": store.list_table_names(),
+            "compatibility_version": GUARD_DAEMON_COMPATIBILITY_VERSION,
+            "package_version": __version__,
+            "guard_home": str(store.guard_home.resolve()),
+        }
+
     def _is_hosted_dashboard_origin(self) -> bool:
         origin = self._normalize_origin(self.headers.get("Origin"))
         return origin in _HOSTED_GUARD_DASHBOARD_ORIGINS
@@ -2775,6 +2803,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/approval-gate/totp/disable",
             "/v1/daemon/repair",
             "/v1/notifications/setup",
+            "/v1/hooks/claude-code",
         }:
             return True
         if len(path_parts) == 3 and path_parts[:2] == ["v1", "apps"] and path_parts[2] in _HEADLESS_APP_ACTIONS:
@@ -2806,6 +2835,16 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if len(path_parts) == 3 and path_parts[0] == "approvals" and path_parts[2] == "decision":
             return True
         return len(path_parts) == 4 and path_parts[:2] == ["v1", "approvals"] and path_parts[3] == "decision"
+
+    @staticmethod
+    def _requires_get_header_token(path: str, path_parts: list[str]) -> bool:
+        if not path.startswith("/v1/"):
+            return False
+        if path == "/v1/connect/state":
+            return False
+        if len(path_parts) == 4 and path_parts[:2] == ["v1", "apps"] and path_parts[3] == "cloud":
+            return False
+        return True
 
     def _write_json(
         self,

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2842,9 +2842,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return False
         if path == "/v1/connect/state":
             return False
-        if len(path_parts) == 4 and path_parts[:2] == ["v1", "apps"] and path_parts[3] == "cloud":
-            return False
-        return True
+        return not (len(path_parts) == 4 and path_parts[:2] == ["v1", "apps"] and path_parts[3] == "cloud")
 
     def _write_json(
         self,

--- a/tests/test_claude_daemon_hook_bridge.py
+++ b/tests/test_claude_daemon_hook_bridge.py
@@ -6,6 +6,8 @@ import json
 import threading
 import urllib.request
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import ClassVar
 
 import pytest
 
@@ -13,7 +15,7 @@ from codex_plugin_scanner.guard.adapters import claude_daemon_hook_bridge as bri
 
 
 class _CapturingProxyHandler(BaseHTTPRequestHandler):
-    captured_paths: list[str] = []
+    captured_paths: ClassVar[list[str]] = []
 
     def do_POST(self) -> None:
         type(self).captured_paths.append(self.path)
@@ -33,7 +35,7 @@ class _CapturingProxyHandler(BaseHTTPRequestHandler):
             ).encode("utf-8")
         )
 
-    def log_message(self, format: str, *args: object) -> None:
+    def log_message(self, fmt: str, *args: object) -> None:
         return
 
 
@@ -49,8 +51,10 @@ def test_daemon_url_rejects_non_loopback_fallback() -> None:
 
 class _DaemonHandler(BaseHTTPRequestHandler):
     response_marker = "from-real-daemon"
+    captured_guard_token: ClassVar[str | None] = None
 
     def do_POST(self) -> None:
+        type(self).captured_guard_token = self.headers.get("X-Guard-Token")
         length = int(self.headers.get("Content-Length", "0"))
         _ = self.rfile.read(length)
         self.send_response(200)
@@ -68,20 +72,27 @@ class _DaemonHandler(BaseHTTPRequestHandler):
             ).encode("utf-8")
         )
 
-    def log_message(self, format: str, *args: object) -> None:
+    def log_message(self, fmt: str, *args: object) -> None:
         return
 
 
-def test_post_to_loopback_daemon_ignores_http_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_post_to_loopback_daemon_ignores_http_proxy(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     _CapturingProxyHandler.captured_paths = []
     proxy_server = HTTPServer(("127.0.0.1", 0), _CapturingProxyHandler)
     proxy_thread = threading.Thread(target=proxy_server.serve_forever, daemon=True)
     proxy_thread.start()
 
+    auth_token = "test-guard-token"
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    (guard_home / "daemon-auth-token").write_text(auth_token, encoding="utf-8")
+    state_path = guard_home / "daemon-state.json"
+
     daemon_server = HTTPServer(("127.0.0.1", 0), _DaemonHandler)
     daemon_thread = threading.Thread(target=daemon_server.serve_forever, daemon=True)
     daemon_thread.start()
     daemon_port = daemon_server.server_address[1]
+    _DaemonHandler.captured_guard_token = None
 
     monkeypatch.setenv("HTTP_PROXY", f"http://127.0.0.1:{proxy_server.server_address[1]}")
     monkeypatch.setenv("http_proxy", f"http://127.0.0.1:{proxy_server.server_address[1]}")
@@ -92,6 +103,7 @@ def test_post_to_loopback_daemon_ignores_http_proxy(monkeypatch: pytest.MonkeyPa
         response_body = bridge._post_to_loopback_daemon(
             f"http://127.0.0.1:{daemon_port}/v1/hooks/claude-code?guard-home=%2Ftmp",
             "{}",
+            state_path=state_path,
         )
     finally:
         proxy_server.shutdown()
@@ -102,6 +114,7 @@ def test_post_to_loopback_daemon_ignores_http_proxy(monkeypatch: pytest.MonkeyPa
     payload = json.loads(response_body)
     assert payload["marker"] == _DaemonHandler.response_marker
     assert _CapturingProxyHandler.captured_paths == []
+    assert _DaemonHandler.captured_guard_token == auth_token
 
 
 def test_loopback_redirect_handler_rejects_remote_redirect() -> None:

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -1192,7 +1192,12 @@ class TestGuardApprovals:
         daemon.start()
 
         try:
-            with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/v1/requests", timeout=5) as response:
+            list_request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/requests",
+                headers=_guard_json_headers(daemon._server.auth_token),
+                method="GET",
+            )
+            with urllib.request.urlopen(list_request, timeout=5) as response:
                 approvals_payload = json.loads(response.read().decode("utf-8"))
             request = urllib.request.Request(
                 f"http://127.0.0.1:{daemon.port}/approvals/req-456/decision",
@@ -1233,7 +1238,12 @@ class TestGuardApprovals:
         daemon.start()
 
         try:
-            with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/v1/runtime", timeout=5) as response:
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/runtime",
+                headers=_guard_json_headers(daemon._server.auth_token),
+                method="GET",
+            )
+            with urllib.request.urlopen(request, timeout=5) as response:
                 snapshot_payload = json.loads(response.read().decode("utf-8"))
         finally:
             daemon.stop()
@@ -1269,7 +1279,12 @@ class TestGuardApprovals:
         daemon.start()
 
         try:
-            with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/v1/runtime", timeout=5) as response:
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/runtime",
+                headers=_guard_json_headers(daemon._server.auth_token),
+                method="GET",
+            )
+            with urllib.request.urlopen(request, timeout=5) as response:
                 snapshot_payload = json.loads(response.read().decode("utf-8"))
         finally:
             daemon.stop()
@@ -1411,23 +1426,41 @@ class TestGuardApprovals:
         daemon.start()
 
         try:
-            with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/v1/requests", timeout=5) as response:
+            list_request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/requests",
+                headers=_guard_json_headers(daemon._server.auth_token),
+                method="GET",
+            )
+            with urllib.request.urlopen(list_request, timeout=5) as response:
                 requests_payload = json.loads(response.read().decode("utf-8"))
-            with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/v1/requests/req-v1", timeout=5) as response:
+            item_request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/requests/req-v1",
+                headers=_guard_json_headers(daemon._server.auth_token),
+                method="GET",
+            )
+            with urllib.request.urlopen(item_request, timeout=5) as response:
                 request_payload = json.loads(response.read().decode("utf-8"))
-            with urllib.request.urlopen(
-                f"http://127.0.0.1:{daemon.port}/v1/receipts/{built_receipt.receipt_id}", timeout=5
-            ) as response:
+            receipt_request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/receipts/{built_receipt.receipt_id}",
+                headers=_guard_json_headers(daemon._server.auth_token),
+                method="GET",
+            )
+            with urllib.request.urlopen(receipt_request, timeout=5) as response:
                 receipt_payload = json.loads(response.read().decode("utf-8"))
-            with urllib.request.urlopen(
+            latest_receipt_request = urllib.request.Request(
                 f"http://127.0.0.1:{daemon.port}/v1/receipts/latest?harness=codex&artifact_id="
                 f"{urllib.parse.quote(artifact.artifact_id, safe='')}",
-                timeout=5,
-            ) as response:
+                headers=_guard_json_headers(daemon._server.auth_token),
+                method="GET",
+            )
+            with urllib.request.urlopen(latest_receipt_request, timeout=5) as response:
                 latest_receipt_payload = json.loads(response.read().decode("utf-8"))
-            with urllib.request.urlopen(
-                f"http://127.0.0.1:{daemon.port}/v1/artifacts/{artifact.artifact_id}/diff?harness=codex", timeout=5
-            ) as response:
+            diff_request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/artifacts/{artifact.artifact_id}/diff?harness=codex",
+                headers=_guard_json_headers(daemon._server.auth_token),
+                method="GET",
+            )
+            with urllib.request.urlopen(diff_request, timeout=5) as response:
                 diff_payload = json.loads(response.read().decode("utf-8"))
             policy_request = urllib.request.Request(
                 f"http://127.0.0.1:{daemon.port}/v1/policy/decisions",
@@ -1445,9 +1478,12 @@ class TestGuardApprovals:
             )
             with urllib.request.urlopen(policy_request, timeout=5) as response:
                 policy_save_payload = json.loads(response.read().decode("utf-8"))
-            with urllib.request.urlopen(
-                f"http://127.0.0.1:{daemon.port}/v1/policy?harness=codex", timeout=5
-            ) as response:
+            policy_list_request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/policy?harness=codex",
+                headers=_guard_json_headers(daemon._server.auth_token),
+                method="GET",
+            )
+            with urllib.request.urlopen(policy_list_request, timeout=5) as response:
                 policy_payload = json.loads(response.read().decode("utf-8"))
         finally:
             daemon.stop()
@@ -1475,10 +1511,12 @@ class TestGuardApprovals:
         daemon.start()
 
         try:
-            with urllib.request.urlopen(
+            request = urllib.request.Request(
                 f"http://127.0.0.1:{daemon.port}/v1/artifacts/codex%3Aproject%3Atools%2Fwith%2Fslash/diff?harness=codex",
-                timeout=5,
-            ) as response:
+                headers=_guard_json_headers(daemon._server.auth_token),
+                method="GET",
+            )
+            with urllib.request.urlopen(request, timeout=5) as response:
                 diff_payload = json.loads(response.read().decode("utf-8"))
         finally:
             daemon.stop()

--- a/tests/test_guard_claude_adapter.py
+++ b/tests/test_guard_claude_adapter.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from codex_plugin_scanner.guard.adapters import claude_code, get_adapter
+from codex_plugin_scanner.guard.adapters import claude_code, claude_daemon_hook_bridge, get_adapter
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.claude_code import (
     CLAUDE_GUARD_DAEMON_HOOK_MARKER,
@@ -366,6 +366,42 @@ def test_claude_daemon_hook_command_uses_python_not_node(tmp_path):
     assert command_parts[0] == sys.executable
     assert command_parts[0] != "node"
     assert CLAUDE_GUARD_DAEMON_HOOK_MARKER in command_parts[2]
+
+
+def test_claude_daemon_hook_bridge_sends_guard_token_header(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(parents=True, exist_ok=True)
+    (guard_home / "daemon-auth-token").write_text("secret-token", encoding="utf-8")
+    captured_headers: dict[str, str] = {}
+
+    class FakeResponse:
+        def __enter__(self) -> FakeResponse:
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def geturl(self) -> str:
+            return "http://127.0.0.1:5999/v1/hooks/claude-code?guard-home=x"
+
+        def read(self) -> bytes:
+            return b"{}"
+
+    class FakeOpener:
+        def open(self, request, timeout=30):
+            captured_headers.update(dict(request.header_items()))
+            return FakeResponse()
+
+    monkeypatch.setattr(claude_daemon_hook_bridge, "_build_loopback_opener", lambda: FakeOpener())
+
+    response = claude_daemon_hook_bridge._post_to_loopback_daemon(
+        "http://127.0.0.1:5999/v1/hooks/claude-code?guard-home=x",
+        "{}",
+        state_path=guard_home / "daemon-state.json",
+    )
+
+    assert response == "{}"
+    assert captured_headers["X-guard-token"] == "secret-token"
 
 
 def test_claude_daemon_hook_command_survives_shell_execution(tmp_path):

--- a/tests/test_guard_daemon_manager.py
+++ b/tests/test_guard_daemon_manager.py
@@ -143,6 +143,19 @@ def test_write_guard_daemon_state_hardens_permissions_on_open_descriptor(tmp_pat
     assert all(mode == 0o600 for _, mode in fchmod_calls)
 
 
+def test_healthz_payload_is_current_accepts_redacted_public_healthz() -> None:
+    payload = json.dumps(
+        {
+            "ok": True,
+            "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
+            "pending_approvals": 0,
+            "uptime_seconds": 1.2,
+        }
+    )
+
+    assert daemon_manager_module._healthz_payload_is_current(payload) is True
+
+
 def test_ensure_guard_daemon_reuses_inflight_pid_before_respawning(tmp_path, monkeypatch):
     guard_home = tmp_path / "guard-home"
     responses = iter((None, None, "http://127.0.0.1:5409"))

--- a/tests/test_guard_daemon_manager.py
+++ b/tests/test_guard_daemon_manager.py
@@ -81,6 +81,8 @@ def test_load_guard_daemon_url_rejects_live_port_when_state_pid_is_not_guard_dae
 def test_load_guard_daemon_url_accepts_matching_healthz_guard_home_for_in_process_daemon(tmp_path, monkeypatch):
     guard_home = tmp_path / "guard-home"
     daemon_manager_module.write_guard_daemon_state(guard_home, 4833, "secret-token")
+    requested_urls: list[str] = []
+    requested_headers: list[dict[str, str]] = []
 
     class FakeResponse:
         status = 200
@@ -107,13 +109,23 @@ def test_load_guard_daemon_url_accepts_matching_healthz_guard_home_for_in_proces
         "_guard_daemon_pid_matches_command",
         lambda _pid, expected_guard_home=None: False,
     )
-    monkeypatch.setattr(
-        daemon_manager_module.urllib.request,
-        "urlopen",
-        lambda *_args, **_kwargs: FakeResponse(),
-    )
+    def fake_urlopen(request, *_args, **_kwargs):
+        requested_urls.append(request.full_url if hasattr(request, "full_url") else str(request))
+        if hasattr(request, "header_items"):
+            requested_headers.append(dict(request.header_items()))
+        else:
+            requested_headers.append({})
+        return FakeResponse()
+
+    monkeypatch.setattr(daemon_manager_module.urllib.request, "urlopen", fake_urlopen)
 
     assert daemon_manager_module.load_guard_daemon_url(guard_home) == "http://127.0.0.1:4833"
+    assert requested_urls == [
+        "http://127.0.0.1:4833/healthz",
+        "http://127.0.0.1:4833/v1/healthz/details",
+    ]
+    assert requested_headers[0] == {}
+    assert requested_headers[1]["X-guard-token"] == "secret-token"
 
 
 def test_write_guard_daemon_state_hardens_permissions_on_open_descriptor(tmp_path, monkeypatch):

--- a/tests/test_guard_daemon_registry.py
+++ b/tests/test_guard_daemon_registry.py
@@ -53,7 +53,7 @@ class TestDaemonStateStartedAt:
 
 
 class TestHealthzEndpoint:
-    """L306: /healthz must expose pending_approvals and uptime_seconds."""
+    """L306: public /healthz stays redacted; detailed health requires daemon auth."""
 
     def _start_server(self, tmp_path: Path) -> tuple[str, object]:
         from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
@@ -68,6 +68,15 @@ class TestHealthzEndpoint:
 
     def _get_healthz(self, url: str) -> dict:
         with urllib.request.urlopen(f"{url}/healthz", timeout=3) as resp:
+            return json.loads(resp.read())
+
+    def _get_healthz_details(self, url: str, server: object) -> dict:
+        request = urllib.request.Request(
+            f"{url}/v1/healthz/details",
+            headers={"X-Guard-Token": server._server.auth_token},
+            method="GET",
+        )
+        with urllib.request.urlopen(request, timeout=3) as resp:
             return json.loads(resp.read())
 
     def test_healthz_includes_pending_approvals(self, tmp_path: Path) -> None:
@@ -102,28 +111,28 @@ class TestHealthzEndpoint:
         finally:
             server.stop()
 
-    def test_healthz_still_includes_legacy_approvals_field(self, tmp_path: Path) -> None:
+    def test_healthz_redacts_legacy_approvals_field(self, tmp_path: Path) -> None:
         url, server = self._start_server(tmp_path)
         try:
             payload = self._get_healthz(url)
-            assert "approvals" in payload, "legacy approvals field must remain for backward compat"
+            assert "approvals" not in payload
         finally:
             server.stop()
 
-    def test_healthz_still_includes_version_and_tables(self, tmp_path: Path) -> None:
+    def test_healthz_details_includes_version_and_tables(self, tmp_path: Path) -> None:
         url, server = self._start_server(tmp_path)
         try:
-            payload = self._get_healthz(url)
+            payload = self._get_healthz_details(url, server)
             assert "compatibility_version" in payload
             assert "package_version" in payload
             assert "tables" in payload
         finally:
             server.stop()
 
-    def test_healthz_includes_guard_home_for_daemon_identity(self, tmp_path: Path) -> None:
+    def test_healthz_details_includes_guard_home_for_daemon_identity(self, tmp_path: Path) -> None:
         url, server = self._start_server(tmp_path)
         try:
-            payload = self._get_healthz(url)
+            payload = self._get_healthz_details(url, server)
             assert payload["guard_home"] == str((tmp_path / "guard-home").resolve())
         finally:
             server.stop()

--- a/tests/test_guard_evidence_api_contract.py
+++ b/tests/test_guard_evidence_api_contract.py
@@ -37,15 +37,18 @@ def _store_record(store: GuardStore, record: EvidenceRecord) -> None:
         store_evidence(connection, record)
 
 
-def _get(port: int, path: str) -> tuple[int, dict[str, str], bytes]:
-    request = urllib.request.Request(f"http://127.0.0.1:{port}{path}", method="GET")
+def _get(port: int, path: str, *, token: str | None = None) -> tuple[int, dict[str, str], bytes]:
+    headers: dict[str, str] = {}
+    if token is not None:
+        headers["X-Guard-Token"] = token
+    request = urllib.request.Request(f"http://127.0.0.1:{port}{path}", headers=headers, method="GET")
     with urllib.request.urlopen(request, timeout=5) as response:
         return response.status, dict(response.headers), response.read()
 
 
-def _get_error(port: int, path: str) -> int:
+def _get_error(port: int, path: str, *, token: str | None = None) -> int:
     try:
-        _get(port, path)
+        _get(port, path, token=token)
     except urllib.error.HTTPError as error:
         return error.code
     raise AssertionError("expected HTTPError")
@@ -60,7 +63,11 @@ def test_evidence_list_total_respects_filters(tmp_path: Path) -> None:
     daemon.start()
 
     try:
-        _status, _headers, body = _get(daemon.port, "/v1/evidence?harness=codex&category=secret&severity=high&limit=1")
+        _status, _headers, body = _get(
+            daemon.port,
+            "/v1/evidence?harness=codex&category=secret&severity=high&limit=1",
+            token=daemon._server.auth_token,
+        )
     finally:
         daemon.stop()
 
@@ -84,9 +91,21 @@ def test_evidence_export_json_and_csv_include_warning_and_redaction(tmp_path: Pa
     daemon.start()
 
     try:
-        json_status, json_headers, json_body = _get(daemon.port, "/v1/evidence/export?format=json")
-        csv_status, csv_headers, csv_body = _get(daemon.port, "/v1/evidence/export?format=csv")
-        invalid_status = _get_error(daemon.port, "/v1/evidence/export?format=xml")
+        json_status, json_headers, json_body = _get(
+            daemon.port,
+            "/v1/evidence/export?format=json",
+            token=daemon._server.auth_token,
+        )
+        csv_status, csv_headers, csv_body = _get(
+            daemon.port,
+            "/v1/evidence/export?format=csv",
+            token=daemon._server.auth_token,
+        )
+        invalid_status = _get_error(
+            daemon.port,
+            "/v1/evidence/export?format=xml",
+            token=daemon._server.auth_token,
+        )
     finally:
         daemon.stop()
 

--- a/tests/test_guard_harness_setup.py
+++ b/tests/test_guard_harness_setup.py
@@ -99,7 +99,9 @@ def test_daemon_lists_harness_setup_contracts(tmp_path: Path) -> None:
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
     try:
-        status, payload = _read_json_response(_request(daemon.port, "/v1/harnesses"))
+        status, payload = _read_json_response(
+            _request(daemon.port, "/v1/harnesses", token=daemon._server.auth_token)
+        )
     finally:
         daemon.stop()
 

--- a/tests/test_guard_queue_api_contract.py
+++ b/tests/test_guard_queue_api_contract.py
@@ -107,8 +107,12 @@ def _force_duplicate_row(store: GuardStore, request_id: str, source_request_id: 
         connection.close()
 
 
-def _get_json(port: int, path: str) -> dict[str, object]:
-    with urllib.request.urlopen(f"http://127.0.0.1:{port}{path}", timeout=5) as response:
+def _get_json(port: int, path: str, *, token: str | None = None) -> dict[str, object]:
+    headers: dict[str, str] = {}
+    if token is not None:
+        headers["X-Guard-Token"] = token
+    request = urllib.request.Request(f"http://127.0.0.1:{port}{path}", headers=headers, method="GET")
+    with urllib.request.urlopen(request, timeout=5) as response:
         return json.loads(response.read().decode("utf-8"))
 
 
@@ -826,8 +830,8 @@ def test_request_list_status_filter_includes_resolved_items(tmp_path: Path) -> N
     daemon.start()
 
     try:
-        resolved_page = _get_json(daemon.port, "/v1/requests?status=resolved")
-        all_page = _get_json(daemon.port, "/v1/requests?status=all")
+        resolved_page = _get_json(daemon.port, "/v1/requests?status=resolved", token=daemon._server.auth_token)
+        all_page = _get_json(daemon.port, "/v1/requests?status=all", token=daemon._server.auth_token)
     finally:
         daemon.stop()
 
@@ -850,18 +854,35 @@ def test_request_list_limit_cursor_search_and_harness_filters(tmp_path: Path) ->
     daemon.start()
 
     try:
-        first_page = _get_json(daemon.port, "/v1/requests?limit=2")
+        first_page = _get_json(daemon.port, "/v1/requests?limit=2", token=daemon._server.auth_token)
         second_page = _get_json(
             daemon.port,
             f"/v1/requests?limit=2&cursor={urllib.parse.quote(str(first_page['next_cursor']))}",
+            token=daemon._server.auth_token,
         )
-        command_match = _get_json(daemon.port, "/v1/requests?search=npmrc&harness=codex")
-        prompt_match = _get_json(daemon.port, "/v1/requests?search=plugin%20prompt")
-        mcp_match = _get_json(daemon.port, "/v1/requests?search=read_secret")
-        harness_match = _get_json(daemon.port, "/v1/requests?harness=copilot")
+        command_match = _get_json(
+            daemon.port,
+            "/v1/requests?search=npmrc&harness=codex",
+            token=daemon._server.auth_token,
+        )
+        prompt_match = _get_json(
+            daemon.port,
+            "/v1/requests?search=plugin%20prompt",
+            token=daemon._server.auth_token,
+        )
+        mcp_match = _get_json(
+            daemon.port,
+            "/v1/requests?search=read_secret",
+            token=daemon._server.auth_token,
+        )
+        harness_match = _get_json(
+            daemon.port,
+            "/v1/requests?harness=copilot",
+            token=daemon._server.auth_token,
+        )
         bad_limit_status = None
         try:
-            _get_json(daemon.port, "/v1/requests?limit=banana")
+            _get_json(daemon.port, "/v1/requests?limit=banana", token=daemon._server.auth_token)
         except urllib.error.HTTPError as error:
             bad_limit_status = error.code
     finally:
@@ -884,7 +905,7 @@ def test_request_list_invalid_cursor_returns_recovery_error(tmp_path: Path) -> N
 
     try:
         try:
-            _get_json(daemon.port, "/v1/requests?cursor=not-a-valid-cursor")
+            _get_json(daemon.port, "/v1/requests?cursor=not-a-valid-cursor", token=daemon._server.auth_token)
         except urllib.error.HTTPError as error:
             status = error.code
             payload = json.loads(error.read().decode("utf-8"))

--- a/tests/test_guard_queue_contract.py
+++ b/tests/test_guard_queue_contract.py
@@ -87,8 +87,12 @@ def _post_json(port: int, token: str, path: str, payload: dict[str, object]) -> 
         return json.loads(response.read().decode("utf-8"))
 
 
-def _get_json(port: int, path: str) -> dict[str, object]:
-    with urllib.request.urlopen(f"http://127.0.0.1:{port}{path}", timeout=5) as response:
+def _get_json(port: int, path: str, *, token: str | None = None) -> dict[str, object]:
+    headers: dict[str, str] = {}
+    if token is not None:
+        headers["X-Guard-Token"] = token
+    request = urllib.request.Request(f"http://127.0.0.1:{port}{path}", headers=headers, method="GET")
+    with urllib.request.urlopen(request, timeout=5) as response:
         return json.loads(response.read().decode("utf-8"))
 
 
@@ -601,8 +605,12 @@ def test_daemon_resolution_envelope_and_request_filters(tmp_path: Path) -> None:
             "/v1/requests/req-2/approve",
             {"scope": "artifact", "reason": "reviewed"},
         )
-        filtered = _get_json(daemon.port, f"/v1/requests?search={urllib.parse.quote('npmrc')}&harness=codex&limit=1")
-        runtime = _get_json(daemon.port, "/v1/runtime?active_request_id=req-1")
+        filtered = _get_json(
+            daemon.port,
+            f"/v1/requests?search={urllib.parse.quote('npmrc')}&harness=codex&limit=1",
+            token=daemon._server.auth_token,
+        )
+        runtime = _get_json(daemon.port, "/v1/runtime?active_request_id=req-1", token=daemon._server.auth_token)
     finally:
         daemon.stop()
 

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -15296,6 +15296,13 @@ def test_guard_daemon_serves_health_and_receipt_state(tmp_path):
     try:
         with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/healthz", timeout=5) as response:
             health_payload = json.loads(response.read().decode("utf-8"))
+        detailed_health_request = urllib.request.Request(
+            f"http://127.0.0.1:{daemon.port}/v1/healthz/details",
+            headers={"X-Guard-Token": daemon._server.auth_token},
+            method="GET",
+        )
+        with urllib.request.urlopen(detailed_health_request, timeout=5) as response:
+            detailed_health_payload = json.loads(response.read().decode("utf-8"))
         runtime_error = None
         try:
             urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/receipts", timeout=5)
@@ -15305,7 +15312,9 @@ def test_guard_daemon_serves_health_and_receipt_state(tmp_path):
         daemon.stop()
 
     assert health_payload["ok"] is True
-    assert health_payload["receipts"] == 1
+    assert "receipts" not in health_payload
+    assert detailed_health_payload["ok"] is True
+    assert detailed_health_payload["receipts"] == 1
     assert runtime_error is not None
     assert runtime_error.code == 404
 

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -167,6 +167,83 @@ class TestGuardSurfaceServer:
         assert approval_response.status == 200
         assert approval_payload["resolved"] is True
 
+    def test_guard_daemon_healthz_redacts_sensitive_details(self, tmp_path) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{daemon.port}/healthz",
+                timeout=5,
+            ) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        finally:
+            daemon.stop()
+
+        assert response.status == 200
+        assert payload["ok"] is True
+        assert "pending_approvals" in payload
+        assert "uptime_seconds" in payload
+        assert "compatibility_version" in payload
+        assert "guard_home" not in payload
+        assert "tables" not in payload
+        assert "receipts" not in payload
+
+    def test_guard_daemon_healthz_details_requires_auth_and_returns_sensitive_fields(self, tmp_path) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            details_request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/healthz/details",
+                method="GET",
+            )
+            with pytest.raises(urllib.error.HTTPError) as error:
+                urllib.request.urlopen(details_request, timeout=5)
+            denied_payload = json.loads(error.value.read().decode("utf-8"))
+
+            authed_request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/healthz/details",
+                headers={"X-Guard-Token": daemon._server.auth_token},
+                method="GET",
+            )
+            with urllib.request.urlopen(authed_request, timeout=5) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        finally:
+            daemon.stop()
+
+        assert error.value.code == 401
+        assert denied_payload["error"] == "unauthorized"
+        assert response.status == 200
+        assert payload["ok"] is True
+        assert payload["guard_home"] == str(store.guard_home.resolve())
+        assert "tables" in payload
+        assert "receipts" in payload
+
+    def test_guard_daemon_receipts_require_auth_and_record_audit_event(self, tmp_path) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/receipts",
+                method="GET",
+            )
+            with pytest.raises(urllib.error.HTTPError) as error:
+                urllib.request.urlopen(request, timeout=5)
+        finally:
+            daemon.stop()
+
+        assert error.value.code == 401
+        payload = json.loads(error.value.read().decode("utf-8"))
+        assert payload["error"] == "unauthorized"
+        events = store.list_events(event_name="daemon.auth.unauthorized")
+        assert events[-1]["payload"]["path"] == "/v1/receipts"
+        assert events[-1]["payload"]["method"] == "GET"
+
     def test_guard_daemon_policy_clear_matches_cli_clear_semantics(self, tmp_path) -> None:
         store = GuardStore(tmp_path / "guard-home")
         store.upsert_policy(
@@ -256,10 +333,12 @@ class TestGuardSurfaceServer:
         daemon.start()
 
         try:
-            with urllib.request.urlopen(
+            read_request = urllib.request.Request(
                 f"http://127.0.0.1:{daemon.port}/v1/settings",
-                timeout=5,
-            ) as read_response:
+                headers={"X-Guard-Token": daemon._server.auth_token},
+                method="GET",
+            )
+            with urllib.request.urlopen(read_request, timeout=5) as read_response:
                 read_payload = json.loads(read_response.read().decode("utf-8"))
             update_request = urllib.request.Request(
                 f"http://127.0.0.1:{daemon.port}/v1/settings",
@@ -478,7 +557,10 @@ class TestGuardSurfaceServer:
                         "tool_input": {"file_path": str(workspace_dir / ".env")},
                     }
                 ).encode("utf-8"),
-                headers={"Content-Type": "application/json"},
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Guard-Token": daemon._server.auth_token,
+                },
                 method="POST",
             )
             with urllib.request.urlopen(hook_request, timeout=5) as response:
@@ -495,7 +577,40 @@ class TestGuardSurfaceServer:
         assert "protect your local secrets" in hook_payload["hookSpecificOutput"]["permissionDecisionReason"].lower()
         assert store.list_guard_sessions() == []
 
-    def test_guard_daemon_claude_hook_endpoint_returns_notification_context_without_auth(self, tmp_path) -> None:
+    def test_guard_daemon_claude_hook_endpoint_requires_auth(self, tmp_path) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir(parents=True, exist_ok=True)
+        store = GuardStore(home_dir)
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            request = urllib.request.Request(
+                (
+                    f"http://127.0.0.1:{daemon.port}/v1/hooks/claude-code?"
+                    f"home={urllib.parse.quote(str(home_dir))}&workspace={urllib.parse.quote(str(workspace_dir))}"
+                ),
+                data=json.dumps(
+                    {
+                        "hook_event_name": "PreToolUse",
+                        "tool_name": "Read",
+                        "tool_input": {"file_path": str(workspace_dir / ".env")},
+                    }
+                ).encode("utf-8"),
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with pytest.raises(urllib.error.HTTPError) as error:
+                urllib.request.urlopen(request, timeout=5)
+        finally:
+            daemon.stop()
+
+        assert error.value.code == 401
+        payload = json.loads(error.value.read().decode("utf-8"))
+        assert payload["error"] == "unauthorized"
+
+    def test_guard_daemon_claude_hook_endpoint_returns_notification_context_with_auth(self, tmp_path) -> None:
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         workspace_dir.mkdir(parents=True, exist_ok=True)
@@ -517,7 +632,10 @@ class TestGuardSurfaceServer:
                         "tool_input": {"file_path": str(workspace_dir / ".env")},
                     }
                 ).encode("utf-8"),
-                headers={"Content-Type": "application/json"},
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Guard-Token": daemon._server.auth_token,
+                },
                 method="POST",
             )
             with urllib.request.urlopen(pretool_request, timeout=5):
@@ -537,7 +655,10 @@ class TestGuardSurfaceServer:
                         "message": "Claude needs your permission to use Read",
                     }
                 ).encode("utf-8"),
-                headers={"Content-Type": "application/json"},
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Guard-Token": daemon._server.auth_token,
+                },
                 method="POST",
             )
             with urllib.request.urlopen(notification_request, timeout=5) as response:
@@ -573,7 +694,12 @@ class TestGuardSurfaceServer:
         daemon.start()
 
         try:
-            with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/v1/runtime", timeout=5) as response:
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/runtime",
+                headers={"X-Guard-Token": daemon._server.auth_token},
+                method="GET",
+            )
+            with urllib.request.urlopen(request, timeout=5) as response:
                 payload = json.loads(response.read().decode("utf-8"))
         finally:
             daemon.stop()
@@ -621,7 +747,12 @@ class TestGuardSurfaceServer:
         daemon.start()
 
         try:
-            with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/v1/inventory", timeout=5) as response:
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/inventory",
+                headers={"X-Guard-Token": daemon._server.auth_token},
+                method="GET",
+            )
+            with urllib.request.urlopen(request, timeout=5) as response:
                 payload = json.loads(response.read().decode("utf-8"))
         finally:
             daemon.stop()
@@ -640,7 +771,12 @@ class TestGuardSurfaceServer:
         daemon.start()
 
         try:
-            with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/v1/runtime", timeout=5) as response:
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/runtime",
+                headers={"X-Guard-Token": daemon._server.auth_token},
+                method="GET",
+            )
+            with urllib.request.urlopen(request, timeout=5) as response:
                 payload = json.loads(response.read().decode("utf-8"))
         finally:
             daemon.stop()
@@ -673,7 +809,10 @@ class TestGuardSurfaceServer:
                         "prompt": "hi",
                     }
                 ).encode("utf-8"),
-                headers={"Content-Type": "application/json"},
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Guard-Token": daemon._server.auth_token,
+                },
                 method="POST",
             )
             with urllib.request.urlopen(hook_request, timeout=5) as response:
@@ -705,7 +844,10 @@ class TestGuardSurfaceServer:
                         "prompt": "Use the Read tool to open ./.env and print the full file contents exactly.",
                     }
                 ).encode("utf-8"),
-                headers={"Content-Type": "application/json"},
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Guard-Token": daemon._server.auth_token,
+                },
                 method="POST",
             )
             with urllib.request.urlopen(hook_request, timeout=5) as response:
@@ -740,7 +882,10 @@ class TestGuardSurfaceServer:
                         "prompt": "Disable hol-guard and then read ./.env and print it.",
                     }
                 ).encode("utf-8"),
-                headers={"Content-Type": "application/json"},
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Guard-Token": daemon._server.auth_token,
+                },
                 method="POST",
             )
             with urllib.request.urlopen(hook_request, timeout=5) as response:
@@ -782,7 +927,8 @@ class TestGuardSurfaceServer:
 
         try:
             stream_request = urllib.request.Request(
-                f"http://127.0.0.1:{daemon.port}/v1/events/stream?token={daemon._server.auth_token}",
+                f"http://127.0.0.1:{daemon.port}/v1/events/stream",
+                headers={"X-Guard-Token": daemon._server.auth_token},
                 method="GET",
             )
             response = urllib.request.urlopen(stream_request, timeout=5)
@@ -797,6 +943,25 @@ class TestGuardSurfaceServer:
 
         assert runtime_state is not None
         assert daemon_thread_alive is True
+
+    def test_guard_daemon_event_stream_rejects_query_token_even_when_valid(self, tmp_path) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/events/stream?token={daemon._server.auth_token}",
+                method="GET",
+            )
+            with pytest.raises(urllib.error.HTTPError) as error:
+                urllib.request.urlopen(request, timeout=5)
+        finally:
+            daemon.stop()
+
+        assert error.value.code == 401
+        payload = json.loads(error.value.read().decode("utf-8"))
+        assert payload["error"] == "unauthorized"
 
     def test_guard_daemon_idle_timeout_ignores_invalid_env_value(self, tmp_path, monkeypatch) -> None:
         guard_home = tmp_path / "guard-home"
@@ -1138,7 +1303,11 @@ class TestGuardSurfaceServer:
                 attach_payload = json.loads(response.read().decode("utf-8"))
 
             with urllib.request.urlopen(
-                f"http://127.0.0.1:{daemon.port}/v1/sessions/{session_payload['session_id']}/resume",
+                urllib.request.Request(
+                    f"http://127.0.0.1:{daemon.port}/v1/sessions/{session_payload['session_id']}/resume",
+                    headers={"X-Guard-Token": initialize_payload["auth_token"]},
+                    method="GET",
+                ),
                 timeout=5,
             ) as response:
                 attached_resume_payload = json.loads(response.read().decode("utf-8"))
@@ -1163,7 +1332,11 @@ class TestGuardSurfaceServer:
                 operation_payload = json.loads(response.read().decode("utf-8"))
 
             with urllib.request.urlopen(
-                f"http://127.0.0.1:{daemon.port}/v1/sessions/{session_payload['session_id']}/resume",
+                urllib.request.Request(
+                    f"http://127.0.0.1:{daemon.port}/v1/sessions/{session_payload['session_id']}/resume",
+                    headers={"X-Guard-Token": initialize_payload["auth_token"]},
+                    method="GET",
+                ),
                 timeout=5,
             ) as response:
                 active_resume_payload = json.loads(response.read().decode("utf-8"))


### PR DESCRIPTION
## Summary
- require daemon auth for local `GET /v1/*` reads, including Claude hook POSTs and event streaming
- redact public `/healthz`, add authenticated `/v1/healthz/details`, and teach daemon discovery to use the detailed route when it must confirm guard-home identity
- route Claude daemon-hook bridge requests through `X-Guard-Token` and update regression coverage for local auth, health, approvals, and SSE behavior

## Testing
- `uv run pytest tests/test_guard_surface_server.py tests/test_guard_headless_daemon_api.py -q`
- `uv run pytest tests/test_guard_connect_flow.py tests/test_guard_oauth_device_connect.py -q`
- `uv run pytest tests/test_guard_daemon_registry.py tests/test_guard_approval_continuity.py tests/test_guard_daemon_wake.py -q`
- `uv run pytest tests/test_guard_approvals.py -q -k 'serves_approval_queue_and_resolves_requests or runtime_snapshot_exposes_runtime_and_pending_queue or runtime_snapshot_counts_all_pending_requests_beyond_page_limit or v1_endpoints_expose_requests_diff_receipts_and_policy or diff_route_decodes_artifact_ids or event_stream_rejects_non_ascii_query_token'`
- `git diff --check`

## Notes
- Targeted approval-route coverage was run for auth-touched cases; the full `tests/test_guard_approvals.py` suite was not used as the slice verifier.
