### PR TITLE
fix(sync): reject untrusted cloud origins

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/oauth_client.py
+++ b/src/codex_plugin_scanner/guard/cli/oauth_client.py
@@ -76,7 +76,11 @@ def is_guard_oauth_origin_allowed(issuer: str) -> bool:
 
 def _require_allowlisted_guard_oauth_origin(issuer: str) -> str:
     origin = _issuer_origin(issuer)
-    if is_guard_oauth_origin_allowed(origin):
+    if (
+        origin in _ALLOWED_PRODUCTION_GUARD_ORIGINS
+        or origin in _ALLOWED_STAGING_GUARD_ORIGINS
+        or _is_loopback_guard_origin(origin)
+    ):
         return origin
     raise ValueError("Guard OAuth issuer must use an allowlisted HOL origin or local loopback.")
 

--- a/src/codex_plugin_scanner/guard/cli/oauth_client.py
+++ b/src/codex_plugin_scanner/guard/cli/oauth_client.py
@@ -21,6 +21,10 @@ PRODUCTION_GUARD_ISSUER = "https://hol.org"
 STAGING_GUARD_ISSUER = "https://staging.hol.org"
 LOCAL_GUARD_ISSUER = "http://127.0.0.1:3000"
 
+_ALLOWED_PRODUCTION_GUARD_ORIGINS = frozenset({PRODUCTION_GUARD_ISSUER})
+_ALLOWED_STAGING_GUARD_ORIGINS = frozenset({STAGING_GUARD_ISSUER})
+_LOOPBACK_GUARD_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
 _PKCE_ALLOWED_CHARACTERS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~")
 
 
@@ -50,6 +54,33 @@ def _issuer_origin(issuer: str) -> str:
     return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
 
 
+def _issuer_host(origin: str) -> str:
+    return (urllib.parse.urlparse(origin).hostname or "").lower()
+
+
+def _is_loopback_guard_origin(origin: str) -> bool:
+    return _issuer_host(origin) in _LOOPBACK_GUARD_HOSTS
+
+
+def is_guard_oauth_origin_allowed(issuer: str) -> bool:
+    try:
+        origin = _issuer_origin(issuer)
+    except ValueError:
+        return False
+    return (
+        origin in _ALLOWED_PRODUCTION_GUARD_ORIGINS
+        or origin in _ALLOWED_STAGING_GUARD_ORIGINS
+        or _is_loopback_guard_origin(origin)
+    )
+
+
+def _require_allowlisted_guard_oauth_origin(issuer: str) -> str:
+    origin = _issuer_origin(issuer)
+    if is_guard_oauth_origin_allowed(origin):
+        return origin
+    raise ValueError("Guard OAuth issuer must use an allowlisted HOL origin or local loopback.")
+
+
 def _oauth_endpoints(origin: str) -> GuardOAuthClientConfig:
     environment = detect_guard_oauth_environment(origin)
     client_id = {
@@ -68,17 +99,16 @@ def _oauth_endpoints(origin: str) -> GuardOAuthClientConfig:
 
 
 def detect_guard_oauth_environment(issuer: str) -> str:
-    origin = _issuer_origin(issuer).lower()
-    host = urllib.parse.urlparse(origin).hostname or ""
-    if host in {"127.0.0.1", "localhost", "::1"}:
+    origin = _require_allowlisted_guard_oauth_origin(issuer).lower()
+    if _is_loopback_guard_origin(origin):
         return "local"
-    if host.startswith("staging."):
+    if origin in _ALLOWED_STAGING_GUARD_ORIGINS:
         return "staging"
     return "production"
 
 
 def resolve_guard_oauth_client_config(issuer: str) -> GuardOAuthClientConfig:
-    return _oauth_endpoints(_issuer_origin(issuer))
+    return _oauth_endpoints(_require_allowlisted_guard_oauth_origin(issuer))
 
 
 def _base64url_encode(data: bytes) -> str:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -28,7 +28,12 @@ from ...version import __version__
 from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
 from ..approval_gate import ApprovalGateError
-from ..cli.oauth_client import GuardDpopKeyMaterial, resolve_guard_oauth_client_config
+from ..cli.oauth_client import (
+    GuardDpopKeyMaterial,
+    detect_guard_oauth_environment,
+    is_guard_oauth_origin_allowed,
+    resolve_guard_oauth_client_config,
+)
 from ..config import GuardConfig
 from ..consumer import detect_harness, evaluate_detection
 from ..edge_events import build_runtime_session_event
@@ -1732,6 +1737,54 @@ def _guard_oauth_reauthorization_message() -> str:
     return "Guard authorization expired. Run `hol-guard connect` to sign in again."
 
 
+def _guard_sync_reconnect_message() -> str:
+    return "Guard Cloud sync endpoint is not trusted. Run `hol-guard connect` to restore Cloud sync."
+
+
+def _guard_sync_origin(sync_url: str) -> str:
+    parsed = urllib.parse.urlsplit(sync_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise GuardSyncNotConfiguredError(
+            f"{_guard_sync_reconnect_message()} Sync URL must be an absolute http(s) URL."
+        )
+    if parsed.username is not None or parsed.password is not None:
+        raise GuardSyncNotConfiguredError(
+            f"{_guard_sync_reconnect_message()} Sync URL userinfo is not allowed."
+        )
+    if parsed.fragment:
+        raise GuardSyncNotConfiguredError(
+            f"{_guard_sync_reconnect_message()} Sync URL fragments are not allowed."
+        )
+    return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
+
+
+def _validate_guard_sync_url(sync_url: str, *, issuer: str | None = None) -> str:
+    origin = _guard_sync_origin(sync_url)
+    if issuer is not None:
+        try:
+            oauth_client = resolve_guard_oauth_client_config(issuer)
+        except ValueError as error:
+            raise GuardSyncAuthorizationExpiredError(
+                f"{_guard_oauth_reauthorization_message()} {error}"
+            ) from error
+        if origin != oauth_client.issuer:
+            raise GuardSyncAuthorizationExpiredError(
+                f"{_guard_oauth_reauthorization_message()} "
+                "Guard Cloud sync origin no longer matches the configured issuer."
+            )
+        return sync_url
+    if not is_guard_oauth_origin_allowed(origin):
+        raise GuardSyncNotConfiguredError(
+            f"{_guard_sync_reconnect_message()} Sync URL origin is not allowlisted."
+        )
+    environment = detect_guard_oauth_environment(origin)
+    if environment != "local" and urllib.parse.urlsplit(origin).scheme != "https":
+        raise GuardSyncNotConfiguredError(
+            f"{_guard_sync_reconnect_message()} Sync URL must use https outside local loopback."
+        )
+    return sync_url
+
+
 def _refresh_guard_oauth_access_token(
     *,
     token_endpoint: str,
@@ -1845,8 +1898,14 @@ def _resolve_guard_sync_auth_context(store: GuardStore) -> dict[str, object]:
         if issuer is None or client_id is None or refresh_token is None:
             raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
         dpop_key_material = _oauth_dpop_key_material(oauth_credentials)
+        try:
+            oauth_client = resolve_guard_oauth_client_config(issuer)
+        except ValueError as error:
+            raise GuardSyncAuthorizationExpiredError(
+                f"{_guard_oauth_reauthorization_message()} {error}"
+            ) from error
         refreshed = _refresh_guard_oauth_access_token(
-            token_endpoint=resolve_guard_oauth_client_config(issuer).token_endpoint,
+            token_endpoint=oauth_client.token_endpoint,
             client_id=client_id,
             refresh_token=refresh_token,
             dpop_key_material=dpop_key_material,
@@ -1858,8 +1917,12 @@ def _resolve_guard_sync_auth_context(store: GuardStore) -> dict[str, object]:
                 credentials=oauth_credentials,
                 refresh_token=rotated_refresh_token,
             )
+        sync_url = _validate_guard_sync_url(
+            _oauth_sync_url_from_issuer(oauth_client.issuer),
+            issuer=oauth_client.issuer,
+        )
         return {
-            "sync_url": _oauth_sync_url_from_issuer(issuer),
+            "sync_url": sync_url,
             "access_token": str(refreshed["access_token"]),
             "dpop_key_material": dpop_key_material,
         }
@@ -1867,7 +1930,7 @@ def _resolve_guard_sync_auth_context(store: GuardStore) -> dict[str, object]:
     if credentials is None:
         raise GuardSyncNotConfiguredError("Guard is not logged in.")
     return {
-        "sync_url": str(credentials["sync_url"]),
+        "sync_url": _validate_guard_sync_url(str(credentials["sync_url"])),
         "access_token": str(credentials["token"]),
         "dpop_key_material": None,
     }

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1748,13 +1748,9 @@ def _guard_sync_origin(sync_url: str) -> str:
             f"{_guard_sync_reconnect_message()} Sync URL must be an absolute http(s) URL."
         )
     if parsed.username is not None or parsed.password is not None:
-        raise GuardSyncNotConfiguredError(
-            f"{_guard_sync_reconnect_message()} Sync URL userinfo is not allowed."
-        )
+        raise GuardSyncNotConfiguredError(f"{_guard_sync_reconnect_message()} Sync URL userinfo is not allowed.")
     if parsed.fragment:
-        raise GuardSyncNotConfiguredError(
-            f"{_guard_sync_reconnect_message()} Sync URL fragments are not allowed."
-        )
+        raise GuardSyncNotConfiguredError(f"{_guard_sync_reconnect_message()} Sync URL fragments are not allowed.")
     return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
 
 
@@ -1764,9 +1760,7 @@ def _validate_guard_sync_url(sync_url: str, *, issuer: str | None = None) -> str
         try:
             oauth_client = resolve_guard_oauth_client_config(issuer)
         except ValueError as error:
-            raise GuardSyncAuthorizationExpiredError(
-                f"{_guard_oauth_reauthorization_message()} {error}"
-            ) from error
+            raise GuardSyncAuthorizationExpiredError(f"{_guard_oauth_reauthorization_message()} {error}") from error
         if origin != oauth_client.issuer:
             raise GuardSyncAuthorizationExpiredError(
                 f"{_guard_oauth_reauthorization_message()} "
@@ -1774,9 +1768,7 @@ def _validate_guard_sync_url(sync_url: str, *, issuer: str | None = None) -> str
             )
         return sync_url
     if not is_guard_oauth_origin_allowed(origin):
-        raise GuardSyncNotConfiguredError(
-            f"{_guard_sync_reconnect_message()} Sync URL origin is not allowlisted."
-        )
+        raise GuardSyncNotConfiguredError(f"{_guard_sync_reconnect_message()} Sync URL origin is not allowlisted.")
     environment = detect_guard_oauth_environment(origin)
     if environment != "local" and urllib.parse.urlsplit(origin).scheme != "https":
         raise GuardSyncNotConfiguredError(
@@ -1901,9 +1893,7 @@ def _resolve_guard_sync_auth_context(store: GuardStore) -> dict[str, object]:
         try:
             oauth_client = resolve_guard_oauth_client_config(issuer)
         except ValueError as error:
-            raise GuardSyncAuthorizationExpiredError(
-                f"{_guard_oauth_reauthorization_message()} {error}"
-            ) from error
+            raise GuardSyncAuthorizationExpiredError(f"{_guard_oauth_reauthorization_message()} {error}") from error
         refreshed = _refresh_guard_oauth_access_token(
             token_endpoint=oauth_client.token_endpoint,
             client_id=client_id,

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -30,7 +30,6 @@ from ..adapters.base import HarnessContext
 from ..approval_gate import ApprovalGateError
 from ..cli.oauth_client import (
     GuardDpopKeyMaterial,
-    detect_guard_oauth_environment,
     is_guard_oauth_origin_allowed,
     resolve_guard_oauth_client_config,
 )
@@ -1769,11 +1768,6 @@ def _validate_guard_sync_url(sync_url: str, *, issuer: str | None = None) -> str
         return sync_url
     if not is_guard_oauth_origin_allowed(origin):
         raise GuardSyncNotConfiguredError(f"{_guard_sync_reconnect_message()} Sync URL origin is not allowlisted.")
-    environment = detect_guard_oauth_environment(origin)
-    if environment != "local" and urllib.parse.urlsplit(origin).scheme != "https":
-        raise GuardSyncNotConfiguredError(
-            f"{_guard_sync_reconnect_message()} Sync URL must use https outside local loopback."
-        )
     return sync_url
 
 

--- a/tests/test_guard_oauth_client.py
+++ b/tests/test_guard_oauth_client.py
@@ -1,3 +1,5 @@
+import pytest
+
 from codex_plugin_scanner.guard.cli.oauth_client import (
     LOCAL_GUARD_OAUTH_CLIENT_ID,
     PRODUCTION_GUARD_OAUTH_CLIENT_ID,
@@ -36,6 +38,11 @@ def test_resolve_guard_oauth_client_config_for_local_loopback() -> None:
     assert config.client_id == LOCAL_GUARD_OAUTH_CLIENT_ID
     assert config.authorize_endpoint == "http://127.0.0.1:3000/api/guard/oauth/authorize"
     assert detect_guard_oauth_environment(config.issuer) == "local"
+
+
+def test_resolve_guard_oauth_client_config_rejects_unallowlisted_host() -> None:
+    with pytest.raises(ValueError, match="allowlisted"):
+        resolve_guard_oauth_client_config("https://evil.example")
 
 
 def test_generate_pkce_verifier_uses_rfc7636_charset() -> None:

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -15352,6 +15352,28 @@ def test_sync_receipts_retries_once_after_timeout(tmp_path, monkeypatch):
     assert payload["synced_at"] == "2026-04-19T00:00:10+00:00"
 
 
+def test_sync_receipts_rejects_untrusted_sync_host_before_network(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://evil.example/api/guard/receipts/sync",
+        "guard-live-token",
+        "2026-04-19T00:00:00+00:00",
+    )
+    attempted_request = False
+
+    def _fake_urlopen(request, timeout):
+        nonlocal attempted_request
+        attempted_request = True
+        raise AssertionError("network call should be blocked before urlopen")
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+
+    with pytest.raises(guard_runner_module.GuardSyncNotConfiguredError, match="hol-guard connect"):
+        guard_runner_module.sync_receipts(store)
+
+    assert attempted_request is False
+
+
 def test_sync_receipts_batches_large_local_history(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
     store.set_sync_credentials(
@@ -15967,6 +15989,52 @@ def test_sync_runtime_session_retries_once_after_read_timeout(tmp_path, monkeypa
 
     assert timeouts == [10, 90]
     assert payload["runtime_session_id"] == "session-read-timeout"
+
+
+def test_sync_runtime_session_rejects_untrusted_oauth_issuer_before_network(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://evil.example",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token-1",
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id="workspace-1",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    attempted_request = False
+
+    def _fake_urlopen(request, timeout):
+        nonlocal attempted_request
+        attempted_request = True
+        raise AssertionError("network call should be blocked before urlopen")
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+
+    with pytest.raises(guard_runner_module.GuardSyncAuthorizationExpiredError, match="hol-guard connect"):
+        guard_runner_module.sync_runtime_session(
+            store,
+            session={
+                "session_id": "session-oauth",
+                "harness": "codex",
+                "surface": "cli",
+                "status": "active",
+                "client_name": "Codex",
+                "client_title": "Codex CLI",
+                "client_version": "1.0.0",
+                "workspace": "prod",
+                "capabilities": ["chat"],
+                "started_at": "2026-06-01T00:00:00+00:00",
+                "updated_at": "2026-06-01T00:00:00+00:00",
+                "operations": [],
+            },
+        )
+
+    assert attempted_request is False
 
 
 def test_sync_runtime_session_refreshes_oauth_access_token_and_rotates_refresh_token(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- reject unallowlisted Guard OAuth issuers and only allow HOL production, staging, or local loopback origins
- validate sync endpoints before any network call for both OAuth-derived and legacy static sync contexts
- add regression coverage proving untrusted sync hosts and untrusted OAuth issuers are blocked before `urlopen`

## Verification
- `source /Users/michaelkantor/CascadeProjects/hashgraph-online/hol-guard/.worktrees/guard-server-auth-p0-followup/.venv/bin/activate && python -m ruff check src/codex_plugin_scanner/guard/cli/oauth_client.py src/codex_plugin_scanner/guard/runtime/runner.py tests/test_guard_oauth_client.py tests/test_guard_runtime.py`
- `source /Users/michaelkantor/CascadeProjects/hashgraph-online/hol-guard/.worktrees/guard-server-auth-p0-followup/.venv/bin/activate && python -m pytest tests/test_guard_oauth_client.py tests/test_guard_runtime.py -q -k 'unallowlisted_host or untrusted_sync_host_before_network or untrusted_oauth_issuer_before_network'`
- `source /Users/michaelkantor/CascadeProjects/hashgraph-online/hol-guard/.worktrees/guard-server-auth-p0-followup/.venv/bin/activate && python -m pytest tests/test_guard_runtime.py tests/test_guard_connect_flow.py tests/test_guard_oauth_device_connect.py tests/test_guard_oauth_client.py -q`
- `git diff --check`
