### PR TITLE
fix(opencode): resolve pretool hook python outside worktrees

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/hook_python.py
+++ b/src/codex_plugin_scanner/guard/adapters/hook_python.py
@@ -10,12 +10,25 @@ from pathlib import Path
 
 from .base import HarnessContext
 
-_WORKTREE_MARKERS = ("/.worktrees/", "/worktrees/", "-wt-")
+_WORKTREE_MARKERS = ("/.worktrees/", "/worktrees/")
+_WORKTREE_SEGMENT_PREFIXES = ("hol-guard-wt-",)
+_PROBE_ENV_KEYS = (
+    "PATH",
+    "HOME",
+    "VIRTUAL_ENV",
+    "PYTHONPATH",
+    "PYTHONHOME",
+    "UV_PROJECT_ENVIRONMENT",
+    "UV_PYTHON",
+    "CONDA_PREFIX",
+)
 
 
 def _path_looks_like_worktree(path: Path) -> bool:
-    text = str(path.resolve())
-    return any(marker in text for marker in _WORKTREE_MARKERS)
+    text = str(path.resolve()).replace("\\", "/")
+    if any(marker in text for marker in _WORKTREE_MARKERS):
+        return True
+    return any(segment.startswith(prefix) for segment in text.split("/") for prefix in _WORKTREE_SEGMENT_PREFIXES)
 
 
 def filter_worktree_path_entries(entries: list[str]) -> list[str]:
@@ -33,11 +46,6 @@ def filter_worktree_path_entries(entries: list[str]) -> list[str]:
 
 def _guard_hook_python_candidates(context: HarnessContext) -> list[Path]:
     candidates: list[Path] = []
-    if context.workspace_dir is not None:
-        for name in (".venv", "venv"):
-            python_path = context.workspace_dir / name / "bin" / "python"
-            if python_path.is_file() and not _path_looks_like_worktree(python_path):
-                candidates.append(python_path.resolve())
     pipx_python = Path.home() / ".local" / "pipx" / "venvs" / "hol-guard" / "bin" / "python"
     if pipx_python.is_file():
         candidates.append(pipx_python.resolve())
@@ -48,6 +56,11 @@ def _guard_hook_python_candidates(context: HarnessContext) -> list[Path]:
             interpreter = _python_from_launcher_shim(shim)
             if interpreter is not None and interpreter.is_file():
                 candidates.append(interpreter.resolve())
+    if context.workspace_dir is not None:
+        for name in (".venv", "venv"):
+            python_path = context.workspace_dir / name / "bin" / "python"
+            if python_path.is_file() and not _path_looks_like_worktree(python_path):
+                candidates.append(python_path.resolve())
     executable = Path(sys.executable).resolve()
     if executable.is_file() and not _path_looks_like_worktree(executable):
         candidates.append(executable)
@@ -75,7 +88,24 @@ def _python_from_launcher_shim(shim: Path) -> Path | None:
     return interpreter if interpreter.is_file() else None
 
 
+def _hook_python_probe_env() -> dict[str, str]:
+    return {key: os.environ[key] for key in _PROBE_ENV_KEYS if key in os.environ}
+
+
+def _current_interpreter_can_import_guard() -> bool:
+    try:
+        import cryptography  # noqa: F401
+
+        import codex_plugin_scanner  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
 def _python_can_import_guard(python: Path) -> bool:
+    current = Path(sys.executable).resolve()
+    if python == current and _current_interpreter_can_import_guard():
+        return True
     probe = "import codex_plugin_scanner; import cryptography"
     try:
         completed = subprocess.run(
@@ -84,7 +114,7 @@ def _python_can_import_guard(python: Path) -> bool:
             text=True,
             check=False,
             timeout=15,
-            env={key: os.environ[key] for key in ("PATH", "HOME") if key in os.environ},
+            env=_hook_python_probe_env(),
         )
     except (OSError, subprocess.TimeoutExpired):
         return False
@@ -95,6 +125,9 @@ def resolve_guard_hook_python(context: HarnessContext) -> Path:
     for candidate in _guard_hook_python_candidates(context):
         if _python_can_import_guard(candidate):
             return candidate
+    current = Path(sys.executable).resolve()
+    if current.is_file() and _python_can_import_guard(current):
+        return current
     raise RuntimeError(
         "Guard could not find a Python interpreter with codex_plugin_scanner and cryptography. "
         "Install hol-guard with pipx and re-run `hol-guard install opencode`."
@@ -102,6 +135,13 @@ def resolve_guard_hook_python(context: HarnessContext) -> Path:
 
 
 def package_root_from_python(python: Path) -> str:
+    current = Path(sys.executable).resolve()
+    if python == current and _current_interpreter_can_import_guard():
+        import pathlib
+
+        import codex_plugin_scanner
+
+        return str(pathlib.Path(codex_plugin_scanner.__file__).resolve().parent.parent)
     probe = (
         "import pathlib;"
         "import codex_plugin_scanner;"
@@ -114,7 +154,7 @@ def package_root_from_python(python: Path) -> str:
             text=True,
             check=False,
             timeout=15,
-            env={key: os.environ[key] for key in ("PATH", "HOME") if key in os.environ},
+            env=_hook_python_probe_env(),
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         raise RuntimeError("Guard could not resolve codex_plugin_scanner from the hook Python.") from exc

--- a/src/codex_plugin_scanner/guard/adapters/hook_python.py
+++ b/src/codex_plugin_scanner/guard/adapters/hook_python.py
@@ -1,0 +1,129 @@
+"""Stable Python interpreter resolution for generated harness hook plugins."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from .base import HarnessContext
+
+_WORKTREE_MARKERS = ("/.worktrees/", "/worktrees/", "-wt-")
+
+
+def _path_looks_like_worktree(path: Path) -> bool:
+    text = str(path.resolve())
+    return any(marker in text for marker in _WORKTREE_MARKERS)
+
+
+def filter_worktree_path_entries(entries: list[str]) -> list[str]:
+    filtered: list[str] = []
+    for entry in entries:
+        trimmed = entry.strip()
+        if not trimmed:
+            continue
+        if _path_looks_like_worktree(Path(trimmed)):
+            continue
+        if trimmed not in filtered:
+            filtered.append(trimmed)
+    return filtered
+
+
+def _guard_hook_python_candidates(context: HarnessContext) -> list[Path]:
+    candidates: list[Path] = []
+    if context.workspace_dir is not None:
+        for name in (".venv", "venv"):
+            python_path = (context.workspace_dir / name / "bin" / "python")
+            if python_path.is_file() and not _path_looks_like_worktree(python_path):
+                candidates.append(python_path.resolve())
+    pipx_python = Path.home() / ".local" / "pipx" / "venvs" / "hol-guard" / "bin" / "python"
+    if pipx_python.is_file():
+        candidates.append(pipx_python.resolve())
+    hol_guard = shutil.which("hol-guard")
+    if hol_guard:
+        shim = Path(hol_guard).resolve()
+        if shim.is_file() and not _path_looks_like_worktree(shim):
+            interpreter = _python_from_launcher_shim(shim)
+            if interpreter is not None and interpreter.is_file():
+                candidates.append(interpreter.resolve())
+    executable = Path(sys.executable).resolve()
+    if executable.is_file() and not _path_looks_like_worktree(executable):
+        candidates.append(executable)
+    deduped: list[Path] = []
+    for candidate in candidates:
+        if candidate not in deduped:
+            deduped.append(candidate)
+    return deduped
+
+
+def _python_from_launcher_shim(shim: Path) -> Path | None:
+    try:
+        first_line = shim.read_text(encoding="utf-8").splitlines()[0]
+    except OSError:
+        return None
+    if not first_line.startswith("#!"):
+        return None
+    interpreter = Path(first_line[2:].strip().split(maxsplit=1)[0])
+    return interpreter if interpreter.is_file() else None
+
+
+def _python_can_import_guard(python: Path) -> bool:
+    probe = "import codex_plugin_scanner; import cryptography"
+    try:
+        completed = subprocess.run(
+            [str(python), "-c", probe],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=15,
+            env={key: os.environ[key] for key in ("PATH", "HOME") if key in os.environ},
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return completed.returncode == 0
+
+
+def resolve_guard_hook_python(context: HarnessContext) -> Path:
+    for candidate in _guard_hook_python_candidates(context):
+        if _python_can_import_guard(candidate):
+            return candidate
+    raise RuntimeError(
+        "Guard could not find a Python interpreter with codex_plugin_scanner and cryptography. "
+        "Install hol-guard with pipx and re-run `hol-guard install opencode`."
+    )
+
+
+def package_root_from_python(python: Path) -> str:
+    probe = (
+        "import pathlib;"
+        "import codex_plugin_scanner;"
+        "print(pathlib.Path(codex_plugin_scanner.__file__).resolve().parent.parent)"
+    )
+    try:
+        completed = subprocess.run(
+            [str(python), "-c", probe],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=15,
+            env={key: os.environ[key] for key in ("PATH", "HOME") if key in os.environ},
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError("Guard could not resolve codex_plugin_scanner from the hook Python.") from exc
+    if completed.returncode != 0:
+        raise RuntimeError(
+            completed.stderr.strip() or "Guard could not resolve codex_plugin_scanner from the hook Python."
+        )
+    root = completed.stdout.strip()
+    if not root:
+        raise RuntimeError("Guard could not resolve codex_plugin_scanner from the hook Python.")
+    return root
+
+
+__all__ = [
+    "filter_worktree_path_entries",
+    "package_root_from_python",
+    "resolve_guard_hook_python",
+]

--- a/src/codex_plugin_scanner/guard/adapters/hook_python.py
+++ b/src/codex_plugin_scanner/guard/adapters/hook_python.py
@@ -64,7 +64,7 @@ def _python_from_launcher_shim(shim: Path) -> Path | None:
         if not lines:
             return None
         first_line = lines[0]
-    except OSError:
+    except (OSError, ValueError):
         return None
     if not first_line.startswith("#!"):
         return None

--- a/src/codex_plugin_scanner/guard/adapters/hook_python.py
+++ b/src/codex_plugin_scanner/guard/adapters/hook_python.py
@@ -35,7 +35,7 @@ def _guard_hook_python_candidates(context: HarnessContext) -> list[Path]:
     candidates: list[Path] = []
     if context.workspace_dir is not None:
         for name in (".venv", "venv"):
-            python_path = (context.workspace_dir / name / "bin" / "python")
+            python_path = context.workspace_dir / name / "bin" / "python"
             if python_path.is_file() and not _path_looks_like_worktree(python_path):
                 candidates.append(python_path.resolve())
     pipx_python = Path.home() / ".local" / "pipx" / "venvs" / "hol-guard" / "bin" / "python"
@@ -60,12 +60,18 @@ def _guard_hook_python_candidates(context: HarnessContext) -> list[Path]:
 
 def _python_from_launcher_shim(shim: Path) -> Path | None:
     try:
-        first_line = shim.read_text(encoding="utf-8").splitlines()[0]
+        lines = shim.read_text(encoding="utf-8").splitlines()
+        if not lines:
+            return None
+        first_line = lines[0]
     except OSError:
         return None
     if not first_line.startswith("#!"):
         return None
-    interpreter = Path(first_line[2:].strip().split(maxsplit=1)[0])
+    parts = first_line[2:].strip().split(maxsplit=1)
+    if not parts:
+        return None
+    interpreter = Path(parts[0])
     return interpreter if interpreter.is_file() else None
 
 

--- a/src/codex_plugin_scanner/guard/adapters/opencode.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode.py
@@ -12,6 +12,7 @@ from ..launcher import merge_guard_launcher_env
 from ..models import HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
 from .base import HarnessAdapter, HarnessContext, _command_available, _run_command_probe
+from .hook_python import resolve_guard_hook_python
 from .mcp_servers import (
     ManagedMcpServer,
     is_guard_proxy_command,
@@ -22,6 +23,7 @@ from .mcp_servers import (
 )
 from .opencode_artifacts import (
     CONFIG_FILENAMES,
+    _command_parts,
     append_config_artifacts,
     append_directory_artifacts,
     append_found_path,
@@ -30,8 +32,6 @@ from .opencode_artifacts import (
     runtime_config_path,
     runtime_overlay,
 )
-from .hook_python import resolve_guard_hook_python
-from .opencode_artifacts import _command_parts
 from .opencode_pretool import install_pretool_plugin, remove_pretool_plugin
 
 

--- a/src/codex_plugin_scanner/guard/adapters/opencode.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-import sys
 from pathlib import Path
 
 from ...ecosystems.opencode import _load_json_or_jsonc
@@ -15,6 +14,7 @@ from ..shims import install_guard_shim, remove_guard_shim
 from .base import HarnessAdapter, HarnessContext, _command_available, _run_command_probe
 from .mcp_servers import (
     ManagedMcpServer,
+    is_guard_proxy_command,
     managed_stdio_servers,
     proxy_cli_args,
     proxy_process_env,
@@ -30,6 +30,8 @@ from .opencode_artifacts import (
     runtime_config_path,
     runtime_overlay,
 )
+from .hook_python import resolve_guard_hook_python
+from .opencode_artifacts import _command_parts
 from .opencode_pretool import install_pretool_plugin, remove_pretool_plugin
 
 
@@ -181,12 +183,7 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
             servers=managed_servers,
             existing_workspace_server_names=existing_workspace_server_names,
         )
-        target_payload["mcp"] = self._managed_mcp_payload(
-            target_payload.get("mcp"),
-            context=context,
-            servers=managed_servers,
-            existing_workspace_server_names=existing_workspace_server_names,
-        )
+        target_payload["mcp"] = _persisted_mcp_payload(target_payload.get("mcp"))
         target_config_path.parent.mkdir(parents=True, exist_ok=True)
         target_config_path.write_text(json.dumps(target_payload, indent=2) + "\n", encoding="utf-8")
         shim_manifest = install_guard_shim(self.harness, context)
@@ -329,7 +326,7 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
             entry: dict[str, object] = {
                 "type": "local",
                 "command": [
-                    sys.executable,
+                    str(resolve_guard_hook_python(context)),
                     *proxy_cli_args(
                         proxy_command="opencode-mcp-proxy",
                         guard_home=str(context.guard_home),
@@ -572,24 +569,6 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
         )
         return permission
 
-    def _managed_mcp_payload(
-        self,
-        current_mcp: object,
-        *,
-        context: HarnessContext,
-        servers: tuple[ManagedMcpServer, ...],
-        existing_workspace_server_names: set[str],
-    ) -> dict[str, object]:
-        payload = _object_dict(current_mcp) or {}
-        payload.update(
-            self._proxy_mcp_overrides(
-                context,
-                servers,
-                existing_workspace_server_names,
-            )
-        )
-        return payload
-
     @staticmethod
     def _coerce_permission_payload(current_permission: object) -> dict[str, object]:
         payload = _object_dict(current_permission)
@@ -601,6 +580,59 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
 
 
 __all__ = ["OpenCodeHarnessAdapter"]
+
+
+def _restore_local_server_from_guard_proxy(server_config: dict[str, object]) -> dict[str, object] | None:
+    """Rebuild the original local MCP entry from a persisted Guard proxy wrapper."""
+
+    command_value = server_config.get("command")
+    if not isinstance(command_value, list):
+        return None
+    tokens = [token for token in command_value if isinstance(token, str)]
+    if "opencode-mcp-proxy" not in tokens:
+        return None
+    underlying_command: str | None = None
+    underlying_args: list[str] = []
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--command" and index + 1 < len(tokens):
+            underlying_command = tokens[index + 1]
+            index += 2
+            continue
+        if token.startswith("--arg="):
+            underlying_args.append(token.split("=", 1)[1])
+        index += 1
+    if underlying_command is None:
+        return None
+    restored: dict[str, object] = {
+        "type": server_config.get("type", "local"),
+        "command": [underlying_command, *underlying_args],
+        "enabled": server_config.get("enabled", True),
+    }
+    environment = server_config.get("environment")
+    if isinstance(environment, dict):
+        restored["environment"] = environment
+    return restored
+
+
+def _persisted_mcp_payload(current_mcp: object) -> dict[str, object]:
+    """Keep user MCP servers on disk; Guard proxies belong in the runtime overlay only."""
+
+    payload = _object_dict(current_mcp) or {}
+    persisted: dict[str, object] = {}
+    for name, entry in payload.items():
+        if not isinstance(name, str) or not isinstance(entry, dict):
+            continue
+        restored = _restore_local_server_from_guard_proxy(entry)
+        if restored is not None:
+            persisted[name] = restored
+            continue
+        command, args = _command_parts(entry)
+        if is_guard_proxy_command(command, args):
+            continue
+        persisted[name] = dict(entry)
+    return persisted
 
 
 def _inline_config(raw_content: str | None) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
@@ -147,7 +147,8 @@ export const HolGuardPretoolPlugin = async ({
 
 
 def _trusted_pythonpath_entries(package_root: str) -> list[str]:
-    return filter_worktree_path_entries([package_root])
+    trimmed = package_root.strip()
+    return [trimmed] if trimmed else []
 
 
 def _pretool_hook_launcher_code(*, package_root: str) -> str:

--- a/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
@@ -7,11 +7,7 @@ import os
 from pathlib import Path
 
 from .base import HarnessContext
-from .hook_python import (
-    filter_worktree_path_entries,
-    package_root_from_python,
-    resolve_guard_hook_python,
-)
+from .hook_python import package_root_from_python, resolve_guard_hook_python
 
 PLUGIN_FILENAME = "hol-guard-pretool.ts"
 _INTERCEPT_TOOLS = ("bash", "shell", "sh", "zsh", "terminal")

--- a/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
@@ -146,14 +146,12 @@ export const HolGuardPretoolPlugin = async ({
 """
 
 
-def _trusted_pythonpath_entries(context: HarnessContext) -> list[str]:
-    python = resolve_guard_hook_python(context)
-    package_root = package_root_from_python(python)
+def _trusted_pythonpath_entries(package_root: str) -> list[str]:
     return filter_worktree_path_entries([package_root])
 
 
-def _pretool_hook_launcher_code(context: HarnessContext) -> str:
-    trusted_entries = _trusted_pythonpath_entries(context)
+def _pretool_hook_launcher_code(*, package_root: str) -> str:
+    trusted_entries = _trusted_pythonpath_entries(package_root)
     return (
         "import json,os,sys;"
         f"sys.path[:0]={json.dumps(trusted_entries)};"
@@ -162,8 +160,8 @@ def _pretool_hook_launcher_code(context: HarnessContext) -> str:
     )
 
 
-def _pretool_hook_env(context: HarnessContext) -> dict[str, str]:
-    entries = _trusted_pythonpath_entries(context)
+def _pretool_hook_env(*, package_root: str) -> dict[str, str]:
+    entries = _trusted_pythonpath_entries(package_root)
     if not entries:
         return {}
     return {"PYTHONPATH": os.pathsep.join(entries)}
@@ -179,12 +177,13 @@ def global_plugin_path(context: HarnessContext) -> Path:
 
 def pretool_plugin_source(context: HarnessContext) -> str:
     guard_python = resolve_guard_hook_python(context)
+    package_root = package_root_from_python(guard_python)
     template = _PLUGIN_TEMPLATE.replace("__HOOK_ARGV_ENV__", _HOOK_ARGV_ENV)
     return (
         template.replace("__GUARD_HOME__", json.dumps(str(context.guard_home.resolve())))
         .replace("__GUARD_PYTHON__", json.dumps(str(guard_python)))
-        .replace("__GUARD_HOOK_LAUNCHER__", json.dumps(_pretool_hook_launcher_code(context)))
-        .replace("__GUARD_HOOK_ENV__", json.dumps(_pretool_hook_env(context)))
+        .replace("__GUARD_HOOK_LAUNCHER__", json.dumps(_pretool_hook_launcher_code(package_root=package_root)))
+        .replace("__GUARD_HOOK_ENV__", json.dumps(_pretool_hook_env(package_root=package_root)))
         .replace("__GUARD_INHERIT_ENV_KEYS__", json.dumps(list(_INHERIT_ENV_KEYS)))
         .replace("__INTERCEPT_TOOLS__", json.dumps(list(_INTERCEPT_TOOLS)))
     )

--- a/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
-import importlib.util
 import json
 import os
-import sys
 from pathlib import Path
 
-from ..launcher import merge_guard_launcher_env
 from .base import HarnessContext
+from .hook_python import (
+    filter_worktree_path_entries,
+    package_root_from_python,
+    resolve_guard_hook_python,
+)
 
 PLUGIN_FILENAME = "hol-guard-pretool.ts"
 _INTERCEPT_TOOLS = ("bash", "shell", "sh", "zsh", "terminal")
@@ -144,31 +146,14 @@ export const HolGuardPretoolPlugin = async ({
 """
 
 
-def _trusted_package_root() -> Path:
-    spec = importlib.util.find_spec("codex_plugin_scanner")
-    if spec is None:
-        raise RuntimeError("Guard could not locate the codex_plugin_scanner package")
-    if spec.submodule_search_locations:
-        locations = tuple(spec.submodule_search_locations)
-        if not locations:
-            raise RuntimeError("Guard could not resolve codex_plugin_scanner package locations")
-        return Path(locations[0]).resolve().parent
-    if spec.origin is None:
-        raise RuntimeError("Guard could not determine the codex_plugin_scanner package root")
-    return Path(spec.origin).resolve().parent.parent
+def _trusted_pythonpath_entries(context: HarnessContext) -> list[str]:
+    python = resolve_guard_hook_python(context)
+    package_root = package_root_from_python(python)
+    return filter_worktree_path_entries([package_root])
 
 
-def _trusted_pythonpath_entries() -> list[str]:
-    launcher_env = merge_guard_launcher_env(pin_package=True)
-    path_entries = [entry for entry in launcher_env.get("PYTHONPATH", "").split(os.pathsep) if entry.strip()]
-    package_root = str(_trusted_package_root())
-    if package_root not in path_entries:
-        path_entries.insert(0, package_root)
-    return path_entries
-
-
-def _pretool_hook_launcher_code() -> str:
-    trusted_entries = _trusted_pythonpath_entries()
+def _pretool_hook_launcher_code(context: HarnessContext) -> str:
+    trusted_entries = _trusted_pythonpath_entries(context)
     return (
         "import json,os,sys;"
         f"sys.path[:0]={json.dumps(trusted_entries)};"
@@ -177,9 +162,11 @@ def _pretool_hook_launcher_code() -> str:
     )
 
 
-def _pretool_hook_env() -> dict[str, str]:
-    env = merge_guard_launcher_env(pin_package=True)
-    return {key: value for key, value in env.items() if key == "PYTHONPATH" and value.strip()}
+def _pretool_hook_env(context: HarnessContext) -> dict[str, str]:
+    entries = _trusted_pythonpath_entries(context)
+    if not entries:
+        return {}
+    return {"PYTHONPATH": os.pathsep.join(entries)}
 
 
 def managed_plugin_path(context: HarnessContext) -> Path:
@@ -191,12 +178,13 @@ def global_plugin_path(context: HarnessContext) -> Path:
 
 
 def pretool_plugin_source(context: HarnessContext) -> str:
+    guard_python = resolve_guard_hook_python(context)
     template = _PLUGIN_TEMPLATE.replace("__HOOK_ARGV_ENV__", _HOOK_ARGV_ENV)
     return (
         template.replace("__GUARD_HOME__", json.dumps(str(context.guard_home.resolve())))
-        .replace("__GUARD_PYTHON__", json.dumps(str(Path(sys.executable).resolve())))
-        .replace("__GUARD_HOOK_LAUNCHER__", json.dumps(_pretool_hook_launcher_code()))
-        .replace("__GUARD_HOOK_ENV__", json.dumps(_pretool_hook_env()))
+        .replace("__GUARD_PYTHON__", json.dumps(str(guard_python)))
+        .replace("__GUARD_HOOK_LAUNCHER__", json.dumps(_pretool_hook_launcher_code(context)))
+        .replace("__GUARD_HOOK_ENV__", json.dumps(_pretool_hook_env(context)))
         .replace("__GUARD_INHERIT_ENV_KEYS__", json.dumps(list(_INHERIT_ENV_KEYS)))
         .replace("__INTERCEPT_TOOLS__", json.dumps(list(_INTERCEPT_TOOLS)))
     )

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -3010,10 +3010,9 @@ args = ["workspace-skill.js", "--changed"]
         assert Path(str(manifest["backup_path"])).is_file()
         assert managed_payload["permission"]["danger_lab_*"] == "ask"
         assert managed_payload["mcp"]["danger_lab"]["type"] == "local"
-        assert managed_payload["mcp"]["danger_lab"]["command"][2] == "codex_plugin_scanner.cli"
-        assert managed_payload["mcp"]["danger_lab"]["command"][3] == "guard"
-        assert managed_payload["mcp"]["danger_lab"]["command"][4] == "opencode-mcp-proxy"
+        assert managed_payload["mcp"]["danger_lab"]["command"] == ["python3", "danger-server.py"]
         assert managed_payload["mcp"]["danger_lab"]["environment"]["API_BASE"] == "https://hol.org"
+        assert "opencode-mcp-proxy" not in json.dumps(managed_payload["mcp"]["danger_lab"])
 
     def test_guard_reinstall_does_not_double_wrap_opencode_mcp_proxies(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -3059,10 +3058,13 @@ args = ["workspace-skill.js", "--changed"]
         second_output = json.loads(capsys.readouterr().out)
         managed_config_path = Path(str(second_output["managed_install"]["manifest"]["managed_config_path"]))
         managed_payload = json.loads(managed_config_path.read_text(encoding="utf-8"))
-        proxy_command = managed_payload["mcp"]["danger_lab"]["command"]
+        runtime_config_path = Path(str(second_output["managed_install"]["manifest"]["runtime_config_path"]))
+        runtime_payload = json.loads(runtime_config_path.read_text(encoding="utf-8"))
+        proxy_command = runtime_payload["mcp"]["danger_lab"]["command"]
 
         assert first_rc == 0
         assert second_rc == 0
+        assert managed_payload["mcp"]["danger_lab"]["command"] == ["python3", "danger-server.py"]
         assert proxy_command.count("opencode-mcp-proxy") == 1
         assert proxy_command[proxy_command.index("--command") + 1] == "python3"
         assert "--arg=danger-server.py" in proxy_command

--- a/tests/test_opencode_adapter.py
+++ b/tests/test_opencode_adapter.py
@@ -315,6 +315,79 @@ class TestOpenCodeInstall:
         result = OpenCodeHarnessAdapter().install(ctx)
         assert result["runtime_env_var"] == "OPENCODE_CONFIG_CONTENT"
 
+    def test_install_keeps_original_mcp_servers_on_disk(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        target = OpenCodeHarnessAdapter._target_config_path(ctx)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        _write_mcp_config(
+            target,
+            {
+                "chrome-devtools": {
+                    "type": "local",
+                    "command": ["npx", "-y", "chrome-devtools-mcp@latest"],
+                    "enabled": True,
+                },
+                "my-remote": {
+                    "type": "remote",
+                    "url": "https://example.com/mcp",
+                    "enabled": True,
+                },
+            },
+        )
+        result = OpenCodeHarnessAdapter().install(ctx)
+        managed_config = json.loads(target.read_text(encoding="utf-8"))
+        chrome = managed_config["mcp"]["chrome-devtools"]
+        assert chrome["command"] == ["npx", "-y", "chrome-devtools-mcp@latest"]
+        assert "opencode-mcp-proxy" not in json.dumps(chrome)
+        assert managed_config["mcp"]["my-remote"]["url"] == "https://example.com/mcp"
+        runtime_config = json.loads(Path(result["runtime_config_path"]).read_text(encoding="utf-8"))
+        runtime_chrome = runtime_config["mcp"]["chrome-devtools"]
+        assert "opencode-mcp-proxy" in json.dumps(runtime_chrome)
+
+    def test_install_restores_prior_persisted_proxy_wrappers(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        target = OpenCodeHarnessAdapter._target_config_path(ctx)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        _write_mcp_config(
+            target,
+            {
+                "chrome-devtools": {
+                    "type": "local",
+                    "command": [
+                        "/usr/bin/python3",
+                        "-m",
+                        "codex_plugin_scanner.cli",
+                        "guard",
+                        "opencode-mcp-proxy",
+                        "--guard-home",
+                        str(ctx.guard_home),
+                        "--server-name",
+                        "chrome-devtools",
+                        "--server-id",
+                        "mcp_server:opencode:global:chrome-devtools:deadbeef",
+                        "--source-scope",
+                        "global",
+                        "--config-path",
+                        str(target),
+                        "--transport",
+                        "local",
+                        "--command",
+                        "npx",
+                        "--arg=-y",
+                        "--arg=chrome-devtools-mcp@latest",
+                    ],
+                    "enabled": True,
+                },
+            },
+        )
+        OpenCodeHarnessAdapter().install(ctx)
+        managed_config = json.loads(target.read_text(encoding="utf-8"))
+        assert managed_config["mcp"]["chrome-devtools"]["command"] == [
+            "npx",
+            "-y",
+            "chrome-devtools-mcp@latest",
+        ]
+
 
 class TestOpenCodeUninstall:
     def test_uninstall_restores_original_content(self, tmp_path: Path) -> None:

--- a/tests/test_opencode_hook_python.py
+++ b/tests/test_opencode_hook_python.py
@@ -25,7 +25,7 @@ def _ctx(tmp_path: Path) -> HarnessContext:
 
 
 def test_filter_worktree_path_entries_drops_worktree_paths() -> None:
-    worktree_src = "/tmp/hol-guard-wt-opencode-trusted-hook/src"
+    worktree_src = "/Users/me/CascadeProjects/hol-guard-wt-opencode-trusted-hook/src"
     stable = "/Users/me/.local/pipx/venvs/hol-guard/lib/python3.12/site-packages"
     filtered = filter_worktree_path_entries(
         [

--- a/tests/test_opencode_hook_python.py
+++ b/tests/test_opencode_hook_python.py
@@ -1,0 +1,75 @@
+"""Tests for stable OpenCode hook Python and PYTHONPATH resolution."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.hook_python import (
+    _guard_hook_python_candidates,
+    filter_worktree_path_entries,
+    resolve_guard_hook_python,
+)
+from codex_plugin_scanner.guard.adapters.opencode_pretool import pretool_plugin_source
+
+
+def _ctx(tmp_path: Path) -> HarnessContext:
+    return HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=None,
+        guard_home=tmp_path / "guard-home",
+    )
+
+
+def test_filter_worktree_path_entries_drops_worktree_paths() -> None:
+    worktree_src = "/tmp/hol-guard-wt-opencode-trusted-hook/src"
+    stable = "/Users/me/.local/pipx/venvs/hol-guard/lib/python3.12/site-packages"
+    filtered = filter_worktree_path_entries(
+        [
+            worktree_src,
+            "/repo/.worktrees/feature/src",
+            "/repo/worktrees/feature/src",
+            stable,
+        ]
+    )
+    assert filtered == [stable]
+
+
+def test_guard_hook_python_candidates_skip_worktree_venv(tmp_path: Path) -> None:
+    workspace = tmp_path / "hol-guard-wt-dev"
+    workspace.mkdir()
+    venv_python = workspace / ".venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text("", encoding="utf-8")
+    ctx = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace,
+        guard_home=tmp_path / "guard-home",
+    )
+    candidates = _guard_hook_python_candidates(ctx)
+    assert venv_python.resolve() not in candidates
+
+
+def test_pretool_plugin_source_omits_worktree_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.opencode_pretool.resolve_guard_hook_python",
+        lambda _context: Path(sys.executable).resolve(),
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.opencode_pretool.package_root_from_python",
+        lambda _python: "/Users/me/.local/pipx/venvs/hol-guard/lib/python3.12/site-packages",
+    )
+    source = pretool_plugin_source(_ctx(tmp_path))
+    assert "hol-guard-wt" not in source
+    assert ".worktrees" not in source
+    assert "/worktrees/" not in source
+
+
+def test_resolve_guard_hook_python_finds_current_interpreter(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    python = resolve_guard_hook_python(ctx)
+    assert python.is_file()
+    assert "hol-guard-wt" not in str(python)

--- a/tests/test_opencode_pretool.py
+++ b/tests/test_opencode_pretool.py
@@ -82,9 +82,9 @@ def test_pretool_hook_launcher_ignores_workspace_package_hijack(
     guard_home = tmp_path / "guard-home"
     guard_home.mkdir()
     ctx = HarnessContext(home_dir=tmp_path / "home", workspace_dir=workspace, guard_home=guard_home)
-    launcher = _pretool_hook_launcher_code()
+    launcher = _pretool_hook_launcher_code(ctx)
     inherit_env = {key: os.environ[key] for key in ("PATH", "HOME") if key in os.environ}
-    env = {**inherit_env, **_pretool_hook_env(), _HOOK_ARGV_ENV: '["guard","hook","--json"]'}
+    env = {**inherit_env, **_pretool_hook_env(ctx), _HOOK_ARGV_ENV: '["guard","hook","--json"]'}
     completed = subprocess.run(
         [sys.executable, "-c", launcher],
         cwd=workspace,

--- a/tests/test_opencode_pretool.py
+++ b/tests/test_opencode_pretool.py
@@ -11,6 +11,7 @@ import pytest
 
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.opencode import OpenCodeHarnessAdapter
+from codex_plugin_scanner.guard.adapters.hook_python import package_root_from_python, resolve_guard_hook_python
 from codex_plugin_scanner.guard.adapters.opencode_pretool import (
     _HOOK_ARGV_ENV,
     _pretool_hook_env,
@@ -82,9 +83,11 @@ def test_pretool_hook_launcher_ignores_workspace_package_hijack(
     guard_home = tmp_path / "guard-home"
     guard_home.mkdir()
     ctx = HarnessContext(home_dir=tmp_path / "home", workspace_dir=workspace, guard_home=guard_home)
-    launcher = _pretool_hook_launcher_code(ctx)
+    guard_python = resolve_guard_hook_python(ctx)
+    package_root = package_root_from_python(guard_python)
+    launcher = _pretool_hook_launcher_code(package_root=package_root)
     inherit_env = {key: os.environ[key] for key in ("PATH", "HOME") if key in os.environ}
-    env = {**inherit_env, **_pretool_hook_env(ctx), _HOOK_ARGV_ENV: '["guard","hook","--json"]'}
+    env = {**inherit_env, **_pretool_hook_env(package_root=package_root), _HOOK_ARGV_ENV: '["guard","hook","--json"]'}
     completed = subprocess.run(
         [sys.executable, "-c", launcher],
         cwd=workspace,

--- a/uv.lock
+++ b/uv.lock
@@ -1077,11 +1077,12 @@ wheels = [
 
 [[package]]
 name = "hol-guard"
-version = "2.0.303"
+version = "2.0.345"
 source = { editable = "." }
 dependencies = [
     { name = "cisco-ai-skill-scanner" },
     { name = "cryptography" },
+    { name = "keyring" },
     { name = "packaging" },
     { name = "rich" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -1110,6 +1111,7 @@ requires-dist = [
     { name = "cisco-ai-skill-scanner", specifier = "~=2.0.9" },
     { name = "cryptography", specifier = ">=47.0.0" },
     { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.26.0" },
+    { name = "keyring", specifier = ">=25.0" },
     { name = "packaging", specifier = ">=24.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },


### PR DESCRIPTION
## Summary
- Resolve OpenCode pretool `GUARD_PYTHON` from pipx/stable installs instead of worktree `sys.executable`, and filter worktree paths from pretool `PYTHONPATH`.
- Keep user MCP server entries in `opencode.json` unchanged; apply hol-guard `opencode-mcp-proxy` wrappers only via the runtime overlay used by `guard-opencode` / `hol-guard run opencode`.
- Restore original local MCP commands from any previously persisted proxy wrappers on reinstall.

## Testing
- `uv run pytest tests/test_opencode_pretool.py tests/test_opencode_hook_python.py tests/test_opencode_adapter.py -q`
