### PR TITLE
fix(sync): reject untrusted credential writes

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/oauth_client.py
+++ b/src/codex_plugin_scanner/guard/cli/oauth_client.py
@@ -115,6 +115,25 @@ def resolve_guard_oauth_client_config(issuer: str) -> GuardOAuthClientConfig:
     return _oauth_endpoints(_require_allowlisted_guard_oauth_origin(issuer))
 
 
+def validate_guard_sync_endpoint(sync_url: str, *, issuer: str | None = None) -> str:
+    parsed = urllib.parse.urlsplit(sync_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("Guard Cloud sync URL must be an absolute http(s) URL.")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("Guard Cloud sync URL userinfo is not allowed.")
+    if parsed.fragment:
+        raise ValueError("Guard Cloud sync URL fragments are not allowed.")
+    origin = urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
+    if issuer is not None:
+        oauth_client = resolve_guard_oauth_client_config(issuer)
+        if origin != oauth_client.issuer:
+            raise ValueError("Guard Cloud sync origin no longer matches the configured issuer.")
+        return sync_url
+    if not is_guard_oauth_origin_allowed(origin):
+        raise ValueError("Guard Cloud sync URL must use an allowlisted HOL origin or local loopback.")
+    return sync_url
+
+
 def _base64url_encode(data: bytes) -> str:
     return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
 

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -30,8 +30,8 @@ from ..adapters.base import HarnessContext
 from ..approval_gate import ApprovalGateError
 from ..cli.oauth_client import (
     GuardDpopKeyMaterial,
-    is_guard_oauth_origin_allowed,
     resolve_guard_oauth_client_config,
+    validate_guard_sync_endpoint,
 )
 from ..config import GuardConfig
 from ..consumer import detect_harness, evaluate_detection
@@ -1739,36 +1739,15 @@ def _guard_oauth_reauthorization_message() -> str:
 def _guard_sync_reconnect_message() -> str:
     return "Guard Cloud sync endpoint is not trusted. Run `hol-guard connect` to restore Cloud sync."
 
-
-def _guard_sync_origin(sync_url: str) -> str:
-    parsed = urllib.parse.urlsplit(sync_url)
-    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-        raise GuardSyncNotConfiguredError(
-            f"{_guard_sync_reconnect_message()} Sync URL must be an absolute http(s) URL."
-        )
-    if parsed.username is not None or parsed.password is not None:
-        raise GuardSyncNotConfiguredError(f"{_guard_sync_reconnect_message()} Sync URL userinfo is not allowed.")
-    if parsed.fragment:
-        raise GuardSyncNotConfiguredError(f"{_guard_sync_reconnect_message()} Sync URL fragments are not allowed.")
-    return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, "", "", ""))
-
-
 def _validate_guard_sync_url(sync_url: str, *, issuer: str | None = None) -> str:
-    origin = _guard_sync_origin(sync_url)
-    if issuer is not None:
-        try:
-            oauth_client = resolve_guard_oauth_client_config(issuer)
-        except ValueError as error:
-            raise GuardSyncAuthorizationExpiredError(f"{_guard_oauth_reauthorization_message()} {error}") from error
-        if origin != oauth_client.issuer:
+    try:
+        return validate_guard_sync_endpoint(sync_url, issuer=issuer)
+    except ValueError as error:
+        if issuer is not None:
             raise GuardSyncAuthorizationExpiredError(
-                f"{_guard_oauth_reauthorization_message()} "
-                "Guard Cloud sync origin no longer matches the configured issuer."
-            )
-        return sync_url
-    if not is_guard_oauth_origin_allowed(origin):
-        raise GuardSyncNotConfiguredError(f"{_guard_sync_reconnect_message()} Sync URL origin is not allowlisted.")
-    return sync_url
+                f"{_guard_oauth_reauthorization_message()} {error}"
+            ) from error
+        raise GuardSyncNotConfiguredError(f"{_guard_sync_reconnect_message()} {error}") from error
 
 
 def _refresh_guard_oauth_access_token(

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1739,14 +1739,13 @@ def _guard_oauth_reauthorization_message() -> str:
 def _guard_sync_reconnect_message() -> str:
     return "Guard Cloud sync endpoint is not trusted. Run `hol-guard connect` to restore Cloud sync."
 
+
 def _validate_guard_sync_url(sync_url: str, *, issuer: str | None = None) -> str:
     try:
         return validate_guard_sync_endpoint(sync_url, issuer=issuer)
     except ValueError as error:
         if issuer is not None:
-            raise GuardSyncAuthorizationExpiredError(
-                f"{_guard_oauth_reauthorization_message()} {error}"
-            ) from error
+            raise GuardSyncAuthorizationExpiredError(f"{_guard_oauth_reauthorization_message()} {error}") from error
         raise GuardSyncNotConfiguredError(f"{_guard_sync_reconnect_message()} {error}") from error
 
 

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -21,6 +21,7 @@ from uuid import uuid4
 from cryptography.fernet import Fernet, InvalidToken
 
 from .approval_gate import ApprovalGateGrant, require_policy_clear, require_policy_write, require_request_resolution
+from .cli.oauth_client import resolve_guard_oauth_client_config, validate_guard_sync_endpoint
 from .edge_events import build_receipt_event
 from .models import GuardApprovalRequest, GuardArtifact, GuardReceipt, GuardRuntimeState, PolicyDecision
 from .runtime.scanner_cache import scanner_cache_key
@@ -2999,6 +3000,7 @@ class GuardStore:
         runtime_id: str | None = None,
         runtime_label: str | None = None,
     ) -> None:
+        normalized_issuer = resolve_guard_oauth_client_config(issuer).issuer
         secret_payload = {
             "refresh_token": refresh_token,
             "dpop_private_key_pem": dpop_private_key_pem,
@@ -3008,7 +3010,7 @@ class GuardStore:
         secret_json = json.dumps(secret_payload, sort_keys=True, separators=(",", ":"))
         secret_hash = _secret_fingerprint(secret_json)
         payload: dict[str, object] = {
-            "issuer": issuer,
+            "issuer": normalized_issuer,
             "client_id": client_id,
             _OAUTH_LOCAL_CREDENTIALS_REF_KEY: self._oauth_local_credentials_ref,
             _OAUTH_LOCAL_CREDENTIALS_HASH_KEY: secret_hash,
@@ -3211,6 +3213,7 @@ class GuardStore:
         *,
         workspace_id: str | None = None,
     ) -> None:
+        validated_sync_url = validate_guard_sync_endpoint(sync_url)
         token_hash = _secret_fingerprint(token)
         normalized_workspace_id = (
             workspace_id.strip() if isinstance(workspace_id, str) and workspace_id.strip() else None
@@ -3235,7 +3238,7 @@ class GuardStore:
         )
         effective_workspace_id = normalized_workspace_id
         can_preserve_workspace = (
-            previous_sync_url == sync_url
+            previous_sync_url == validated_sync_url
             and previous_token_hash is not None
             and previous_token_hash == token_hash
             and isinstance(previous_workspace_id, str)
@@ -3249,7 +3252,7 @@ class GuardStore:
             and previous_workspace != effective_workspace_id
         )
         payload = {
-            "sync_url": sync_url,
+            "sync_url": validated_sync_url,
             "token_ref": self._sync_token_ref,
             _SYNC_TOKEN_HASH_KEY: token_hash,
         }
@@ -3259,7 +3262,7 @@ class GuardStore:
             credentials_changed = True
         else:
             credentials_changed = (
-                previous_sync_url != sync_url
+                previous_sync_url != validated_sync_url
                 or previous_token_hash is None
                 or previous_token_hash != token_hash
                 or workspace_changed

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -15355,10 +15355,14 @@ def test_sync_receipts_retries_once_after_timeout(tmp_path, monkeypatch):
 def test_sync_receipts_rejects_untrusted_sync_host_before_network(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
     store.set_sync_credentials(
-        "https://evil.example/api/guard/receipts/sync",
+        "https://hol.org/api/guard/receipts/sync",
         "guard-live-token",
         "2026-04-19T00:00:00+00:00",
     )
+    credentials_payload = store.get_sync_payload("credentials")
+    assert isinstance(credentials_payload, dict)
+    credentials_payload["sync_url"] = "https://evil.example/api/guard/receipts/sync"
+    store.set_sync_payload("credentials", credentials_payload, "2026-04-19T00:00:01+00:00")
     attempted_request = False
 
     def _fake_urlopen(request, timeout):
@@ -15995,7 +15999,7 @@ def test_sync_runtime_session_rejects_untrusted_oauth_issuer_before_network(tmp_
     store = GuardStore(tmp_path / "guard-home")
     dpop_key_material = generate_dpop_key_pair()
     store.set_oauth_local_credentials(
-        issuer="https://evil.example",
+        issuer="https://hol.org",
         client_id="guard-local-daemon",
         refresh_token="refresh-token-1",
         dpop_private_key_pem=dpop_key_material.private_key_pem,
@@ -16006,6 +16010,10 @@ def test_sync_runtime_session_rejects_untrusted_oauth_issuer_before_network(tmp_
         workspace_id="workspace-1",
         now="2026-06-01T00:00:00+00:00",
     )
+    oauth_payload = store.get_sync_payload("oauth_local_credentials")
+    assert isinstance(oauth_payload, dict)
+    oauth_payload["issuer"] = "https://evil.example"
+    store.set_sync_payload("oauth_local_credentials", oauth_payload, "2026-06-01T00:00:01+00:00")
     attempted_request = False
 
     def _fake_urlopen(request, timeout):

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -9,6 +9,8 @@ import os
 import sqlite3
 import subprocess
 
+import pytest
+
 from codex_plugin_scanner.guard.models import GuardReceipt
 from codex_plugin_scanner.guard.store import (
     EncryptedFileSecretStore,
@@ -135,6 +137,32 @@ def test_sync_credentials_are_scoped_per_guard_home(tmp_path):
         "sync_url": "https://hol.org/api/guard/receipts/sync",
         "token": "token-b",
     }
+
+
+def test_set_sync_credentials_rejects_unallowlisted_sync_host(tmp_path):
+    store = GuardStore(tmp_path / "guard-home")
+
+    with pytest.raises(ValueError, match="allowlisted HOL origin"):
+        store.set_sync_credentials(
+            "https://evil.example/api/guard/receipts/sync",
+            "secret-token-value",
+            "2026-04-19T00:00:00+00:00",
+        )
+
+
+def test_set_oauth_local_credentials_rejects_unallowlisted_issuer(tmp_path):
+    store = GuardStore(tmp_path / "guard-home")
+
+    with pytest.raises(ValueError, match="allowlisted HOL origin"):
+        store.set_oauth_local_credentials(
+            issuer="https://evil.example",
+            client_id="guard-local-daemon",
+            refresh_token="refresh-token",
+            dpop_private_key_pem="private-key",
+            dpop_public_jwk={"kty": "EC"},
+            dpop_public_jwk_thumbprint="thumbprint",
+            now="2026-04-19T00:00:00+00:00",
+        )
 
 
 def test_legacy_token_reference_is_rejected_on_read(tmp_path):

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -763,7 +763,7 @@ class TestGuardSurfaceServer:
     def test_guard_daemon_runtime_snapshot_derives_cloud_urls_from_sync_origin(self, tmp_path) -> None:
         store = GuardStore(tmp_path / "guard-home")
         store.set_sync_credentials(
-            "https://guard.example.com/api/guard/receipts/sync",
+            "https://hol.org/api/guard/receipts/sync",
             "guard-token",
             "2026-04-22T00:00:00Z",
         )
@@ -784,10 +784,10 @@ class TestGuardSurfaceServer:
         assert payload["cloud_state"] == "paired_waiting"
         assert payload["cloud_pairing_state"]["state"] == "paired_waiting"
         assert payload["cloud_pairing_state"]["sync_configured"] is True
-        assert payload["dashboard_url"] == "https://guard.example.com/guard"
-        assert payload["inbox_url"] == "https://guard.example.com/guard/inbox"
-        assert payload["fleet_url"] == "https://guard.example.com/guard/fleet"
-        assert payload["connect_url"] == "https://guard.example.com/guard/connect"
+        assert payload["dashboard_url"] == "https://hol.org/guard"
+        assert payload["inbox_url"] == "https://hol.org/guard/inbox"
+        assert payload["fleet_url"] == "https://hol.org/guard/fleet"
+        assert payload["connect_url"] == "https://hol.org/guard/connect"
 
     def test_guard_daemon_claude_hook_endpoint_accepts_empty_allow_response(self, tmp_path) -> None:
         home_dir = tmp_path / "home"


### PR DESCRIPTION
## Summary
- reject untrusted sync endpoint writes before Guard persists static sync credentials
- canonicalize and reject untrusted OAuth issuer writes while preserving read-time rejection for legacy bad state

## Notes
- local full suite still hits pre-existing machine-specific backend selection failure in `test_oauth_local_credential_health_reports_backend_and_metadata` on hosts where secure storage uses `system-keyring` instead of `encrypted-file`
