### PR TITLE
fix(cursor): install hooks into cwd package inside monorepos

### DIFF
--- a/scripts/e2e-cursor-hook-smoke.py
+++ b/scripts/e2e-cursor-hook-smoke.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Smoke-test the project Cursor hook script (used by CI/agents)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK_SCRIPT = REPO_ROOT / ".cursor" / "hooks" / "hol-guard-cursor-hook.py"
+
+
+def main() -> int:
+    if not HOOK_SCRIPT.is_file():
+        print(f"missing hook script: {HOOK_SCRIPT}", file=sys.stderr)
+        return 1
+    payload = json.dumps({"hook_event_name": "beforeShellExecution", "command": "echo hol-guard-e2e"})
+    completed = subprocess.run(
+        [sys.executable, str(HOOK_SCRIPT)],
+        input=payload,
+        text=True,
+        capture_output=True,
+        cwd=REPO_ROOT,
+        timeout=60,
+        check=False,
+    )
+    if completed.returncode != 0:
+        print(completed.stderr or completed.stdout, file=sys.stderr)
+        return completed.returncode or 1
+    response = json.loads(completed.stdout)
+    permission = response.get("permission")
+    print(json.dumps({"permission": permission, "hook": str(HOOK_SCRIPT)}))
+    return 0 if permission == "allow" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1492,6 +1492,9 @@ def _resolve_default_install_workspace(
     if cursor_project_dir is not None and (harness is None or harness == "cursor"):
         return cursor_project_dir
 
+    if _workspace_has_project_markers(cwd):
+        return cwd
+
     git_root = _git_repo_root(cwd)
     if git_root is not None:
         return git_root
@@ -1500,9 +1503,6 @@ def _resolve_default_install_workspace(
         detected = _workspace_from_harness_detection(harness, cwd=cwd, guard_home=guard_home)
         if detected is not None:
             return detected
-
-    if _workspace_has_project_markers(cwd):
-        return cwd
     return None
 
 

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -992,6 +992,17 @@ def _managed_install_workspace_label(workspace: object) -> str:
     return "global (~/.cursor)"
 
 
+def _managed_install_config_label(manifest: dict[str, object]) -> str:
+    for key in ("config_path", "managed_config_path"):
+        value = manifest.get(key)
+        if isinstance(value, str) and value.strip():
+            return _short_path(value.strip())
+    hooks_path = manifest.get("managed_hooks_path")
+    if isinstance(hooks_path, str) and hooks_path.strip():
+        return f"hooks updated ({_short_path(hooks_path.strip())})"
+    return "no config changed"
+
+
 def _render_single_managed_install(console: Console, managed_install: dict[str, object]) -> None:
     manifest = managed_install.get("manifest")
     notes = _managed_install_notes(managed_install, manifest)
@@ -1003,7 +1014,7 @@ def _render_single_managed_install(console: Console, managed_install: dict[str, 
         mode = _managed_install_mode_text(manifest.get("mode"))
         if mode is not None:
             body.add_row("Mode", mode)
-        body.add_row("Config", str(manifest.get("config_path") or "no config changed"))
+        body.add_row("Config", _managed_install_config_label(manifest))
         managed_servers = _coerce_string_list(manifest.get("managed_servers"))
         if managed_servers:
             body.add_row("Managed servers", str(len(managed_servers)))

--- a/tests/test_guard_install_workspace.py
+++ b/tests/test_guard_install_workspace.py
@@ -28,6 +28,23 @@ def _install_args(*, harness: str = "cursor", workspace: str | None = None) -> a
     )
 
 
+def test_resolve_default_install_workspace_prefers_cwd_markers_over_git_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monorepo = tmp_path / "monorepo"
+    monorepo.mkdir()
+    package = monorepo / "hol-guard"
+    package.mkdir()
+    (package / "pyproject.toml").write_text("[project]\nname='hol-guard'\n", encoding="utf-8")
+    subprocess.run(["git", "init"], cwd=monorepo, check=True, capture_output=True)
+    monkeypatch.chdir(package)
+    monkeypatch.delenv("CURSOR_PROJECT_DIR", raising=False)
+    guard_home = resolve_guard_home(None)
+    resolved = _resolve_default_install_workspace(_install_args(), guard_home=guard_home)
+    assert resolved == package.resolve()
+
+
 def test_resolve_default_install_workspace_uses_git_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     repo = tmp_path / "repo"
     nested = repo / "src" / "pkg"


### PR DESCRIPTION
## Summary
- Prefer the current directory (when it has project markers like pyproject.toml) over the git monorepo root for hol-guard install cursor, so hooks land in hol-guard/.cursor instead of the parent hashgraph-online/.cursor.
- Show hooks updated in install output when MCP config is unchanged but native hooks were refreshed.

## Testing
- uv run pytest tests/test_guard_install_workspace.py -q
- python3 scripts/e2e-cursor-hook-smoke.py
- cd hol-guard && hol-guard install cursor
