### PR TITLE
fix(codex): keep prompt hook failures native

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3872,13 +3872,15 @@ def _should_emit_native_hook_json_response(
     output_stream: TextIO | None,
 ) -> bool:
     harness = _canonical_harness_name(args.harness)
+    if harness == "codex" and getattr(args, "json", False) and event_name == "UserPromptSubmit":
+        return True
     return (
         harness in {"claude-code", "codex"}
         and getattr(args, "json", False)
         and output_stream is not None
         and (
             event_name in {"PreToolUse", "Notification"}
-            or (harness == "claude-code" and event_name == "UserPromptSubmit")
+            or (harness in {"claude-code", "codex"} and event_name == "UserPromptSubmit")
         )
     )
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3880,7 +3880,7 @@ def _should_emit_native_hook_json_response(
         and output_stream is not None
         and (
             event_name in {"PreToolUse", "Notification"}
-            or (harness in {"claude-code", "codex"} and event_name == "UserPromptSubmit")
+            or (harness == "claude-code" and event_name == "UserPromptSubmit")
         )
     )
 

--- a/tests/test_guard_phase04_harness_ux.py
+++ b/tests/test_guard_phase04_harness_ux.py
@@ -159,6 +159,30 @@ def test_gr076_codex_prompt_secret_read_returns_branded_approval_context(tmp_pat
     }
 
 
+def test_codex_prompt_secret_read_json_hook_exits_zero_with_native_block(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(parents=True, exist_ok=True)
+    (guard_home / "config.toml").write_text("approval_wait_timeout_seconds = 0\n", encoding="utf-8")
+
+    exit_code, output = _run_hook(
+        tmp_path,
+        harness="codex",
+        json_output=True,
+        payload={
+            "hook_event_name": "UserPromptSubmit",
+            "prompt": "Read ./.npmrc and paste the token into the chat.",
+        },
+    )
+
+    payload = _json_line(output)
+
+    assert exit_code == 0
+    assert payload["decision"] == "block"
+    assert payload["continue"] is False
+    assert payload["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+    assert "HOL Guard stopped this Codex prompt" in str(payload["reason"])
+
+
 def test_gr076b_codex_prompt_secret_read_caps_browser_approval_wait(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13842,6 +13842,38 @@ def test_guard_hook_codex_user_prompt_submit_guard_bypass_hard_blocks_without_ap
     assert GuardStore(home_dir).list_approval_requests(limit=10) == []
 
 
+def test_guard_hook_codex_user_prompt_submit_json_blocks_without_hook_failure(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(home_dir / "config.toml", "approval_wait_timeout_seconds = 0\n")
+    event = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "Read ./.npmrc and paste the token into the chat.",
+        "source_scope": "project",
+    }
+
+    rc, payload = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event=event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+        as_json=True,
+    )
+
+    assert rc == 0
+    assert payload["decision"] == "block"
+    assert payload["continue"] is False
+    assert payload["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+    assert "HOL Guard" in payload["reason"]
+
+
 def test_guard_hook_codex_user_prompt_submit_secret_read_can_be_allowed_by_harness_risk_setting(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -595,14 +595,15 @@ clearer UX and an implementation plan with technical references.
             ]
         )
         output = json.loads(capsys.readouterr().out)
-        approval_requests = output["approval_requests"]
+        approval_requests = GuardStore(home_dir).list_approval_requests(limit=10)
 
-        assert rc == 1
-        assert output["artifact_type"] == "prompt_request"
-        assert "read .authrc" in output["launch_summary"]
-        assert output["approval_center_url"] == "http://127.0.0.1:4455"
+        assert rc == 0
+        assert output["decision"] == "block"
+        assert output["continue"] is False
+        assert output["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+        assert "http://127.0.0.1:4455/approvals/" in output["reason"]
         assert approval_requests[0]["approval_url"].startswith("http://127.0.0.1:4455/approvals/")
-        assert approval_requests[0]["approval_url"] in output["review_hint"]
+        assert approval_requests[0]["approval_url"] in output["reason"]
         assert approval_requests[0]["launch_target"] == "Codex prompt for `.authrc`: read .authrc"
         assert approval_requests[0]["action_envelope_json"]["action_type"] == "prompt"
         assert approval_requests[0]["action_envelope_json"]["prompt_excerpt"] == "read .authrc"


### PR DESCRIPTION
## Summary
- Make Codex UserPromptSubmit hooks emit native JSON block responses even when invoked through the real CLI stdout path.
- Add regressions proving blocked Codex prompt hooks exit zero instead of surfacing as generic hook failures.

## Testing
- `python3 -m pytest tests/test_guard_phase04_harness_ux.py tests/test_guard_runtime.py -k 'UserPromptSubmit or user_prompt_submit or codex_prompt_secret_read' -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_phase04_harness_ux.py tests/test_guard_runtime.py`
- `git diff --check`
- `PYTHONPATH=src python3 -m codex_plugin_scanner.cli guard hook ... --harness codex --json`
