### PR TITLE
feat(audit): run package shim remediations from dashboard

### DIFF
--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -721,14 +721,15 @@ export function App() {
       supplyChainHubContent={
         runtime.kind === "ready" ? (
           <Suspense fallback={<LazyFallback />}>
-            <SupplyChainHubWorkspace
-              activeView={view}
-              snapshot={runtime.snapshot}
-              receipts={receipts.kind === "ready" ? receipts.items : []}
-              policies={policies.kind === "ready" ? policies.items : []}
-              onClearPolicy={handleClearPolicy}
-              onOpenSettings={handleOpenSettings}
-              onGoHome={handleGoHome}
+	            <SupplyChainHubWorkspace
+	              activeView={view}
+	              snapshot={runtime.snapshot}
+	              receipts={receipts.kind === "ready" ? receipts.items : []}
+	              policies={policies.kind === "ready" ? policies.items : []}
+	              approvalGate={approvalGate}
+	              onClearPolicy={handleClearPolicy}
+	              onOpenSettings={handleOpenSettings}
+	              onGoHome={handleGoHome}
               onNavigate={navigate}
             />
           </Suspense>

--- a/dashboard/src/audit-workspace.tsx
+++ b/dashboard/src/audit-workspace.tsx
@@ -10,10 +10,13 @@ import {
   HiMiniArrowDown,
   HiMiniArrowUp,
   HiMiniChevronRight,
+  HiMiniWrenchScrewdriver,
 } from "react-icons/hi2";
 import { SectionLabel, Badge, Tag, ActionButton, EmptyState } from "./approval-center-primitives";
 import { formatRelativeTime, harnessDisplayName } from "./approval-center-utils";
-import type { GuardReceipt, GuardRuntimeSnapshot } from "./guard-types";
+import { runAuditRemediation } from "./guard-api";
+import type { AuditRemediationAction } from "./guard-api";
+import type { GuardApprovalGatePublicConfig, GuardReceipt, GuardRuntimeSnapshot } from "./guard-types";
 
 export type AuditSeverity = "critical" | "high" | "medium" | "low" | "info";
 
@@ -26,7 +29,14 @@ export type AuditResult = {
   workspace: string | null;
   timestamp: string;
   remediation: string | null;
+  remediationAction: AuditRemediationRequest | null;
   resolved: boolean;
+};
+
+export type AuditRemediationRequest = {
+  action: AuditRemediationAction;
+  manager: string;
+  label: string;
 };
 
 export type AuditFilterState = {
@@ -54,6 +64,11 @@ export function deriveFrontendAuditResults(
         workspace: null,
         timestamp: snapshot.generated_at,
         remediation: `Add ${protection.shim_dir} to PATH and restart your shell. Then run hol-guard supply-chain verify.`,
+        remediationAction: {
+          action: "package_shim_path",
+          manager: mgr,
+          label: `Install Guard for ${mgr}`,
+        },
         resolved: false,
       });
     }
@@ -70,6 +85,7 @@ export function deriveFrontendAuditResults(
       workspace: r.source_scope ?? null,
       timestamp: r.timestamp,
       remediation: "Review the action in evidence and adjust policy if it was a false positive.",
+      remediationAction: null,
       resolved: true,
     });
   }
@@ -84,6 +100,7 @@ export function deriveFrontendAuditResults(
       workspace: null,
       timestamp: snapshot.generated_at,
       remediation: "Start Guard with hol-guard bootstrap or check system logs.",
+      remediationAction: null,
       resolved: false,
     });
   }
@@ -104,12 +121,16 @@ function severityBadgeTone(
 type AuditResultRowProps = {
   result: AuditResult;
   onMarkResolved?: (id: string) => void;
+  onRunRemediation: (result: AuditResult) => void;
+  running: boolean;
+  actionMessage: string | null;
 };
 
-function AuditResultRow({ result, onMarkResolved }: AuditResultRowProps) {
+function AuditResultRow({ result, onMarkResolved, onRunRemediation, running, actionMessage }: AuditResultRowProps) {
   const [expanded, setExpanded] = useState(false);
   const toggle = useCallback(() => setExpanded((p) => !p), []);
   const handleResolve = useCallback(() => onMarkResolved?.(result.id), [onMarkResolved, result.id]);
+  const handleRunRemediation = useCallback(() => onRunRemediation(result), [onRunRemediation, result]);
 
   return (
     <div className={`border-b border-slate-100 last:border-b-0 ${result.resolved ? "opacity-60" : ""}`}>
@@ -157,6 +178,17 @@ function AuditResultRow({ result, onMarkResolved }: AuditResultRowProps) {
                 Remediation
               </p>
               <p className="text-sm text-brand-dark/80">{result.remediation}</p>
+              {result.remediationAction && (
+                <div className="mt-3 flex flex-wrap items-center gap-2">
+                  <ActionButton onClick={handleRunRemediation} disabled={running}>
+                    <HiMiniWrenchScrewdriver className="mr-1.5 h-4 w-4" aria-hidden="true" />
+                    {running ? "Running..." : result.remediationAction.label}
+                  </ActionButton>
+                </div>
+              )}
+              {actionMessage !== null && (
+                <p className="mt-2 text-xs text-slate-500">{actionMessage}</p>
+              )}
             </div>
           )}
           {!result.resolved && onMarkResolved && (
@@ -173,9 +205,10 @@ function AuditResultRow({ result, onMarkResolved }: AuditResultRowProps) {
 type AuditWorkspaceProps = {
   snapshot: GuardRuntimeSnapshot;
   receipts: GuardReceipt[];
+  approvalGate: GuardApprovalGatePublicConfig | null;
 };
 
-export function AuditWorkspace({ snapshot, receipts }: AuditWorkspaceProps) {
+export function AuditWorkspace({ snapshot, receipts, approvalGate }: AuditWorkspaceProps) {
   const [filter, setFilter] = useState<AuditFilterState>({
     severityFilter: "all",
     harnessFilter: "",
@@ -183,6 +216,9 @@ export function AuditWorkspace({ snapshot, receipts }: AuditWorkspaceProps) {
     searchQuery: "",
   });
   const [resolvedIds, setResolvedIds] = useState<Set<string>>(new Set());
+  const [pendingRemediation, setPendingRemediation] = useState<AuditResult | null>(null);
+  const [runningRemediationId, setRunningRemediationId] = useState<string | null>(null);
+  const [remediationMessages, setRemediationMessages] = useState<Record<string, string>>({});
 
   const handleSearchChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     setFilter((f) => ({ ...f, searchQuery: e.target.value }));
@@ -202,6 +238,58 @@ export function AuditWorkspace({ snapshot, receipts }: AuditWorkspaceProps) {
   const handleMarkResolved = useCallback((id: string) => {
     setResolvedIds((prev) => new Set([...prev, id]));
   }, []);
+
+  const executeRemediation = useCallback(
+    async (
+      result: AuditResult,
+      credentials?: { approval_password?: string; approval_totp_code?: string },
+    ) => {
+      if (result.remediationAction === null) return;
+      setRunningRemediationId(result.id);
+      setRemediationMessages((prev) => ({ ...prev, [result.id]: "Running remediation through the local daemon." }));
+      try {
+        await runAuditRemediation({
+          ...result.remediationAction,
+          ...credentials,
+        });
+        setResolvedIds((prev) => new Set([...prev, result.id]));
+        setRemediationMessages((prev) => ({
+          ...prev,
+          [result.id]: "Remediation completed. Restart your shell before retrying package installs.",
+        }));
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Unable to run remediation.";
+        setRemediationMessages((prev) => ({ ...prev, [result.id]: message }));
+      } finally {
+        setRunningRemediationId(null);
+      }
+    },
+    [],
+  );
+
+  const handleRunRemediation = useCallback(
+    (result: AuditResult) => {
+      if (result.remediationAction === null) return;
+      if (approvalGate?.enabled === true && approvalGate.configured === true) {
+        setPendingRemediation(result);
+        return;
+      }
+      void executeRemediation(result);
+    },
+    [approvalGate, executeRemediation],
+  );
+
+  const handleCancelRemediationGate = useCallback(() => setPendingRemediation(null), []);
+
+  const handleConfirmRemediationGate = useCallback(
+    (credentials: { approval_password?: string; approval_totp_code?: string }) => {
+      const result = pendingRemediation;
+      if (result === null) return;
+      setPendingRemediation(null);
+      void executeRemediation(result, credentials);
+    },
+    [executeRemediation, pendingRemediation],
+  );
 
   const baseResults = useMemo(
     () => deriveFrontendAuditResults(receipts, snapshot),
@@ -335,7 +423,13 @@ export function AuditWorkspace({ snapshot, receipts }: AuditWorkspaceProps) {
           <div role="list" aria-label="Audit results">
             {results.map((result) => (
               <div key={result.id} role="listitem">
-                <AuditResultRow result={result} onMarkResolved={handleMarkResolved} />
+                <AuditResultRow
+                  result={result}
+                  onMarkResolved={handleMarkResolved}
+                  onRunRemediation={handleRunRemediation}
+                  running={runningRemediationId === result.id}
+                  actionMessage={remediationMessages[result.id] ?? null}
+                />
               </div>
             ))}
           </div>
@@ -348,6 +442,17 @@ export function AuditWorkspace({ snapshot, receipts }: AuditWorkspaceProps) {
             .map((r) => ({ ...r, resolved: r.resolved || resolvedIds.has(r.id) }))
             .filter((r) => !r.resolved && (r.severity === "critical" || r.severity === "high"))}
           onMarkResolved={handleMarkResolved}
+          onRunRemediation={handleRunRemediation}
+          runningRemediationId={runningRemediationId}
+          remediationMessages={remediationMessages}
+        />
+      )}
+      {pendingRemediation !== null && (
+        <RemediationApprovalModal
+          result={pendingRemediation}
+          approvalGate={approvalGate}
+          onCancel={handleCancelRemediationGate}
+          onConfirm={handleConfirmRemediationGate}
         />
       )}
     </div>
@@ -357,9 +462,18 @@ export function AuditWorkspace({ snapshot, receipts }: AuditWorkspaceProps) {
 type RemediationQueueProps = {
   results: AuditResult[];
   onMarkResolved: (id: string) => void;
+  onRunRemediation: (result: AuditResult) => void;
+  runningRemediationId: string | null;
+  remediationMessages: Record<string, string>;
 };
 
-function RemediationQueue({ results, onMarkResolved }: RemediationQueueProps) {
+function RemediationQueue({
+  results,
+  onMarkResolved,
+  onRunRemediation,
+  runningRemediationId,
+  remediationMessages,
+}: RemediationQueueProps) {
   if (results.length === 0) return null;
   return (
     <div className="rounded-2xl border border-red-100 bg-red-50/40 shadow-sm">
@@ -384,12 +498,107 @@ function RemediationQueue({ results, onMarkResolved }: RemediationQueueProps) {
                   <p className="text-sm text-slate-600">{r.remediation}</p>
                 )}
               </div>
-              <ActionButton variant="outline" onClick={() => onMarkResolved(r.id)}>
-                Resolve
-              </ActionButton>
+              <RemediationQueueActions
+                result={r}
+                onMarkResolved={onMarkResolved}
+                onRunRemediation={onRunRemediation}
+                running={runningRemediationId === r.id}
+              />
             </div>
+            {remediationMessages[r.id] && (
+              <p className="text-xs text-slate-500">{remediationMessages[r.id]}</p>
+            )}
           </div>
         ))}
+      </div>
+    </div>
+  );
+}
+
+function RemediationQueueActions(props: {
+  result: AuditResult;
+  onMarkResolved: (id: string) => void;
+  onRunRemediation: (result: AuditResult) => void;
+  running: boolean;
+}) {
+  const { result, onMarkResolved, onRunRemediation, running } = props;
+  const handleMarkResolved = useCallback(() => onMarkResolved(result.id), [onMarkResolved, result.id]);
+  const handleRunRemediation = useCallback(() => onRunRemediation(result), [onRunRemediation, result]);
+  if (result.remediationAction !== null) {
+    return (
+      <ActionButton onClick={handleRunRemediation} disabled={running}>
+        <HiMiniWrenchScrewdriver className="mr-1.5 h-4 w-4" aria-hidden="true" />
+        {running ? "Running..." : result.remediationAction.label}
+      </ActionButton>
+    );
+  }
+  return (
+    <ActionButton variant="outline" onClick={handleMarkResolved}>
+      Resolve
+    </ActionButton>
+  );
+}
+
+function RemediationApprovalModal(props: {
+  result: AuditResult;
+  approvalGate: GuardApprovalGatePublicConfig | null;
+  onCancel: () => void;
+  onConfirm: (credentials: { approval_password?: string; approval_totp_code?: string }) => void;
+}) {
+  const { approvalGate, onCancel, onConfirm, result } = props;
+  const [password, setPassword] = useState("");
+  const [totpCode, setTotpCode] = useState("");
+  const handlePasswordChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setPassword(event.target.value);
+  }, []);
+  const handleTotpChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setTotpCode(event.target.value);
+  }, []);
+  const handleConfirm = useCallback(() => {
+    onConfirm({
+      approval_password: password,
+      ...(approvalGate?.totp_enabled === true ? { approval_totp_code: totpCode } : {}),
+    });
+  }, [approvalGate, onConfirm, password, totpCode]);
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 px-4">
+      <div className="w-full max-w-md rounded-xl border border-slate-200 bg-white p-5 shadow-xl">
+        <SectionLabel>Approval required</SectionLabel>
+        <h2 className="mt-2 text-base font-semibold text-brand-dark">{result.remediationAction?.label}</h2>
+        <p className="mt-1 text-sm text-slate-500">
+          Enter local approval proof before Guard changes package-manager protection on this device.
+        </p>
+        <label className="mt-4 block">
+          <span className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">Approval password</span>
+          <input
+            type="password"
+            value={password}
+            onChange={handlePasswordChange}
+            autoComplete="current-password"
+            className="mt-1 min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+          />
+        </label>
+        {approvalGate?.totp_enabled === true && (
+          <label className="mt-3 block">
+            <span className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">Authenticator code</span>
+            <input
+              type="text"
+              inputMode="numeric"
+              pattern="[0-9]*"
+              value={totpCode}
+              onChange={handleTotpChange}
+              className="mt-1 min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+            />
+          </label>
+        )}
+        <div className="mt-5 flex justify-end gap-2">
+          <ActionButton variant="outline" onClick={onCancel}>
+            Cancel
+          </ActionButton>
+          <ActionButton onClick={handleConfirm}>
+            Run remediation
+          </ActionButton>
+        </div>
       </div>
     </div>
   );

--- a/dashboard/src/audit-workspace.tsx
+++ b/dashboard/src/audit-workspace.tsx
@@ -560,6 +560,7 @@ function RemediationApprovalModal(props: {
       ...(approvalGate?.totp_enabled === true ? { approval_totp_code: totpCode } : {}),
     });
   }, [approvalGate, onConfirm, password, totpCode]);
+  const confirmDisabled = password.trim() === "" || (approvalGate?.totp_enabled === true && totpCode.trim() === "");
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 px-4">
       <div className="w-full max-w-md rounded-xl border border-slate-200 bg-white p-5 shadow-xl">
@@ -595,7 +596,7 @@ function RemediationApprovalModal(props: {
           <ActionButton variant="outline" onClick={onCancel}>
             Cancel
           </ActionButton>
-          <ActionButton onClick={handleConfirm}>
+          <ActionButton onClick={handleConfirm} disabled={confirmDisabled}>
             Run remediation
           </ActionButton>
         </div>

--- a/dashboard/src/guard-api.test.ts
+++ b/dashboard/src/guard-api.test.ts
@@ -4,15 +4,16 @@ import {
   fetchAllPendingRequests,
   fetchApprovalPage,
   fetchQueueSummary,
-  fetchResumeStatus,
-  formatHarnessCommand,
-  normalizeRuntimeSnapshot,
-  normalizeApprovalRequest,
-  parseActionEnvelope,
-  parseDecisionV2,
-  resolveRequestWithQueueResult,
-  retryResume,
-} from "./guard-api";
+	  fetchResumeStatus,
+	  formatHarnessCommand,
+	  normalizeRuntimeSnapshot,
+	  normalizeApprovalRequest,
+	  parseActionEnvelope,
+	  parseDecisionV2,
+	  runAuditRemediation,
+	  resolveRequestWithQueueResult,
+	  retryResume,
+	} from "./guard-api";
 import { resolveCloudSyncHealthCopy } from "./runtime-overview";
 import {
   resolveDecisionV2Detail,
@@ -753,6 +754,33 @@ const clearQueueGate = clearQueueBody["approval_gate"] as Record<string, unknown
 assert(clearQueueGate["password"] === "local-password", "L079b: clearReviewQueue sends approval password");
 assert(clearQueueGate["totp_code"] === "123456", "L079b: clearReviewQueue sends authenticator code");
 assert(clearQueueResult.cleared === 2, "L079b: clearReviewQueue returns cleared count");
+
+installGuardWindow("?guard-token=token-remediate&guardDaemon=http%3A%2F%2F127.0.0.1%3A4781");
+const remediationCalls = installFetchStub({
+  "/v1/audit/remediations/package_shim_path": {
+    entitlement: { allowed: true },
+    operation: "package_shim_path",
+    receipt: null,
+    result: { manager: "pnpm" },
+    status: "completed"
+  }
+});
+const remediation = await runAuditRemediation({
+  action: "package_shim_path",
+  manager: "pnpm",
+  approval_password: "local-password",
+  approval_totp_code: "123456"
+});
+const remediationBody = JSON.parse(String(remediationCalls[0].init?.body)) as Record<string, unknown>;
+assert(
+  remediationCalls[0].url === "http://127.0.0.1:4781/v1/audit/remediations/package_shim_path",
+  "L079c: runAuditRemediation posts to daemon remediation route"
+);
+assert(headerValue(remediationCalls[0].init, "X-Guard-Token") === "token-remediate", "L079c: runAuditRemediation sends Guard token");
+assert(remediationBody["manager"] === "pnpm", "L079c: runAuditRemediation sends manager");
+assert(remediationBody["approval_password"] === "local-password", "L079c: runAuditRemediation sends approval password");
+assert(remediationBody["approval_totp_code"] === "123456", "L079c: runAuditRemediation sends approval TOTP code");
+assert(remediation.operation === "package_shim_path", "L079c: runAuditRemediation normalizes response");
 
 installGuardWindow("?guard-token=token-resolve&guardDaemon=http%3A%2F%2F127.0.0.1%3A4781");
 const fetchResolveCalls = installFetchStub({

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -1682,6 +1682,16 @@ export type AuditRemediationInput = {
 };
 
 export async function runAuditRemediation(input: AuditRemediationInput): Promise<PackageFirewallActionResponse> {
+  if (isGuardDemoMode()) {
+    return {
+      entitlement: { allowed: true, tier: "demo" },
+      operation: input.action,
+      receipt: null,
+      result: `${input.action} completed for ${input.manager}.`,
+      result_detail: { manager: input.manager, demo: true },
+      status: "completed",
+    };
+  }
   const response = await readJson<unknown>(
     `/v1/audit/remediations/${input.action}`,
     {

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -1672,6 +1672,34 @@ export async function runPackageFirewallAction(
   return normalizePackageFirewallAction(response);
 }
 
+export type AuditRemediationAction = "package_shim_path";
+
+export type AuditRemediationInput = {
+  action: AuditRemediationAction;
+  manager: string;
+  approval_password?: string;
+  approval_totp_code?: string;
+};
+
+export async function runAuditRemediation(input: AuditRemediationInput): Promise<PackageFirewallActionResponse> {
+  const response = await readJson<unknown>(
+    `/v1/audit/remediations/${input.action}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...guardAuthHeaders(),
+      },
+      body: JSON.stringify({
+        manager: input.manager,
+        ...(input.approval_password !== undefined ? { approval_password: input.approval_password } : {}),
+        ...(input.approval_totp_code !== undefined ? { approval_totp_code: input.approval_totp_code } : {}),
+      }),
+    },
+  );
+  return normalizePackageFirewallAction(response);
+}
+
 export async function runPackageAudit(): Promise<PackageFirewallActionResponse> {
   const response = await readJson<unknown>("/v1/supply-chain/audit", {
     method: "POST",

--- a/dashboard/src/scrg171-172.test.ts
+++ b/dashboard/src/scrg171-172.test.ts
@@ -309,6 +309,15 @@ assert(
   auditResults.some((r) => r.severity === "high"),
   "SCRG171-V: audit loader data: unprotected manager appears as high severity",
 );
+const unprotectedManagerAudit = auditResults.find((r) => r.id === "unprotected-pip");
+assert(
+  unprotectedManagerAudit?.remediationAction?.action === "package_shim_path",
+  "SCRG171-V2: unprotected manager audit issue exposes a daemon remediation action",
+);
+assert(
+  unprotectedManagerAudit?.remediationAction?.manager === "pip",
+  "SCRG171-V3: unprotected manager remediation action targets the affected manager",
+);
 assert(
   auditResults.some((r) => r.severity === "medium"),
   "SCRG171-W: audit loader data: blocked receipt appears as medium severity",

--- a/dashboard/src/supply-chain-hub-workspace.tsx
+++ b/dashboard/src/supply-chain-hub-workspace.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useCallback } from "react";
 import { TabBar } from "./approval-center-primitives";
-import type { GuardPolicyDecision, GuardReceipt, GuardRuntimeSnapshot } from "./guard-types";
+import type { GuardApprovalGatePublicConfig, GuardPolicyDecision, GuardReceipt, GuardRuntimeSnapshot } from "./guard-types";
 
 const SupplyChainWorkspace = lazy(() =>
   import("./supply-chain-workspace").then((m) => ({ default: m.SupplyChainWorkspace }))
@@ -33,10 +33,11 @@ function viewToTab(view: string): HubTab {
 
 export function SupplyChainHubWorkspace(props: {
   activeView: string;
-  snapshot: GuardRuntimeSnapshot;
-  receipts: GuardReceipt[];
-  policies: GuardPolicyDecision[];
-  onClearPolicy: (policy: GuardPolicyDecision) => void;
+	  snapshot: GuardRuntimeSnapshot;
+	  receipts: GuardReceipt[];
+	  policies: GuardPolicyDecision[];
+	  approvalGate: GuardApprovalGatePublicConfig | null;
+	  onClearPolicy: (policy: GuardPolicyDecision) => void;
   onOpenSettings: () => void;
   onGoHome: () => void;
   onNavigate: (pathname: string) => void;
@@ -60,10 +61,10 @@ export function SupplyChainHubWorkspace(props: {
       <Suspense fallback={<LazyFallback />}>
         {tab === "supply-chain" && (
           <SupplyChainWorkspace snapshot={props.snapshot} onGoHome={props.onGoHome} />
-        )}
-        {tab === "audit" && (
-          <AuditWorkspace snapshot={props.snapshot} receipts={props.receipts} />
-        )}
+	        )}
+	        {tab === "audit" && (
+	          <AuditWorkspace snapshot={props.snapshot} receipts={props.receipts} approvalGate={props.approvalGate} />
+	        )}
         {tab === "policy" && (
           <PolicyWorkspace
             policies={props.policies}

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -89,6 +89,7 @@ from ..runtime.runner import (
 )
 from ..runtime.surface_server import GuardSurfaceRuntime
 from ..shims import (
+    ensure_package_shim_path_in_shell_profile,
     install_package_shims,
     package_shim_status,
     package_shim_supported_managers,
@@ -115,6 +116,7 @@ from .manager import (
 
 _HEADLESS_CLOUD_SYNC_STATE_LOCK = threading.Lock()
 _HEADLESS_CLOUD_SYNC_IN_FLIGHT: set[str] = set()
+_AUDIT_REMEDIATION_ACTIONS = {"package_shim_path"}
 _SUPPLY_CHAIN_PACKAGE_ACTIONS = {"install", "repair", "test", "audit", "sync", "remove", "uninstall"}
 _SUPPLY_CHAIN_PAID_TIERS = {"paid", "premium", "enterprise", "guard_cloud", "guard-cloud"}
 
@@ -798,6 +800,13 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         if (
             len(path_parts) == 4
+            and path_parts[:3] == ["v1", "audit", "remediations"]
+            and path_parts[3] in _AUDIT_REMEDIATION_ACTIONS
+        ):
+            self._handle_audit_remediation(path_parts[3], payload)
+            return
+        if (
+            len(path_parts) == 4
             and path_parts[:3] == ["v1", "supply-chain", "package-shims"]
             and path_parts[3] in _SUPPLY_CHAIN_PACKAGE_ACTIONS
         ):
@@ -1256,6 +1265,72 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 "harness": adapter.harness,
                 "operation": "policy_sync",
                 "receipt": receipt,
+                "status": "completed",
+            }
+        )
+
+    def _handle_audit_remediation(self, action: str, payload: dict[str, object]) -> None:
+        if action != "package_shim_path":
+            self._write_json({"error": "unsupported_remediation", "operation": action}, status=404)
+            return
+        manager = self._optional_string(payload.get("manager"))
+        if manager is None:
+            self._write_json({"error": "missing_manager", "operation": action}, status=400)
+            return
+        managers, manager_error = self._supply_chain_managers({"managers": [manager]})
+        if manager_error is not None:
+            self._write_json({"error": manager_error, "operation": action}, status=400)
+            return
+        entitlement = self._supply_chain_entitlement()
+        if not bool(entitlement["allowed"]):
+            self._write_json(
+                {
+                    "available_actions": ["status", "education", "cli_fallback"],
+                    "entitlement": entitlement,
+                    "error": "paid_guard_cloud_required",
+                    "message": "HOL Guard Cloud paid access is required to run package firewall actions.",
+                    "operation": action,
+                },
+                status=402,
+            )
+            return
+        context = self._supply_chain_context(payload)
+        try:
+            require_high_risk(
+                self.server.store.guard_home,  # type: ignore[attr-defined]
+                purpose="supply_chain_firewall",
+                approval_gate_input=approval_gate_input_from_mapping(payload),
+            )
+            install_result = install_package_shims(context, managers=managers)
+            profile_result = ensure_package_shim_path_in_shell_profile(context)
+            status = package_shim_status(context)
+        except ApprovalGateError as error:
+            self._write_approval_gate_error(error)
+            return
+        except ValueError as error:
+            self._write_json({"error": str(error), "operation": action}, status=400)
+            return
+        result = {
+            "manager": manager,
+            "install": install_result,
+            "profile": profile_result,
+            "package_shims": status,
+            "restart_shell_required": True,
+        }
+        receipt = self._record_headless_receipt(
+            harness="package-firewall",
+            operation=action,
+            payload=payload,
+            result=result,
+            workspace_id=self._optional_string(payload.get("workspace_id"))
+            or self.server.store.get_cloud_workspace_id(),  # type: ignore[attr-defined]
+        )
+        self._write_json(
+            {
+                "entitlement": entitlement,
+                "operation": action,
+                "receipt": receipt,
+                "result": result,
                 "status": "completed",
             }
         )
@@ -2541,6 +2616,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return True
         if len(path_parts) >= 2 and path_parts[:2] == ["v1", "supply-chain"]:
             return True
+        if len(path_parts) == 4 and path_parts[:3] == ["v1", "audit", "remediations"]:
+            return True
         if (
             len(path_parts) == 4
             and path_parts[:2] == ["v1", "requests"]
@@ -2809,6 +2886,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if len(path_parts) == 3 and path_parts[:2] == ["v1", "apps"] and path_parts[2] in _HEADLESS_APP_ACTIONS:
             return True
         if len(path_parts) >= 2 and path_parts[:2] == ["v1", "supply-chain"]:
+            return True
+        if len(path_parts) == 4 and path_parts[:3] == ["v1", "audit", "remediations"]:
             return True
         if len(path_parts) == 4 and path_parts[:2] == ["v1", "operations"] and path_parts[3] in {"items", "status"}:
             return True

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/audit-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/audit-workspace.js
@@ -1,4 +1,4 @@
-import { r as reactExports, j as jsxRuntimeExports, B as Badge, S as SectionLabel, W as HiMiniMagnifyingGlass, E as EmptyState, g as HiMiniCheckCircle, h as HiMiniXCircle, a as HiMiniExclamationTriangle, i as harnessDisplayName, f as formatRelativeTime, s as HiMiniChevronRight, A as ActionButton } from "../guard-dashboard.js";
+import { r as reactExports, ap as runAuditRemediation, j as jsxRuntimeExports, B as Badge, S as SectionLabel, W as HiMiniMagnifyingGlass, E as EmptyState, g as HiMiniCheckCircle, h as HiMiniXCircle, a as HiMiniExclamationTriangle, i as harnessDisplayName, f as formatRelativeTime, s as HiMiniChevronRight, A as ActionButton, v as HiMiniWrenchScrewdriver } from "../guard-dashboard.js";
 function deriveFrontendAuditResults(receipts, snapshot) {
   const results = [];
   const protection = snapshot.supply_chain?.package_manager_protection;
@@ -13,6 +13,11 @@ function deriveFrontendAuditResults(receipts, snapshot) {
         workspace: null,
         timestamp: snapshot.generated_at,
         remediation: `Add ${protection.shim_dir} to PATH and restart your shell. Then run hol-guard supply-chain verify.`,
+        remediationAction: {
+          action: "package_shim_path",
+          manager: mgr,
+          label: `Install Guard for ${mgr}`
+        },
         resolved: false
       });
     }
@@ -28,6 +33,7 @@ function deriveFrontendAuditResults(receipts, snapshot) {
       workspace: r.source_scope ?? null,
       timestamp: r.timestamp,
       remediation: "Review the action in evidence and adjust policy if it was a false positive.",
+      remediationAction: null,
       resolved: true
     });
   }
@@ -41,6 +47,7 @@ function deriveFrontendAuditResults(receipts, snapshot) {
       workspace: null,
       timestamp: snapshot.generated_at,
       remediation: "Start Guard with hol-guard bootstrap or check system logs.",
+      remediationAction: null,
       resolved: false
     });
   }
@@ -53,10 +60,11 @@ function severityBadgeTone(severity) {
   if (severity === "low") return "info";
   return "default";
 }
-function AuditResultRow({ result, onMarkResolved }) {
+function AuditResultRow({ result, onMarkResolved, onRunRemediation, running, actionMessage }) {
   const [expanded, setExpanded] = reactExports.useState(false);
   const toggle = reactExports.useCallback(() => setExpanded((p) => !p), []);
   const handleResolve = reactExports.useCallback(() => onMarkResolved?.(result.id), [onMarkResolved, result.id]);
+  const handleRunRemediation = reactExports.useCallback(() => onRunRemediation(result), [onRunRemediation, result]);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `border-b border-slate-100 last:border-b-0 ${result.resolved ? "opacity-60" : ""}`, children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs(
       "button",
@@ -94,13 +102,18 @@ function AuditResultRow({ result, onMarkResolved }) {
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark/80", children: result.detail }),
       result.remediation && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-lg border border-brand-blue/15 bg-brand-blue/[0.04] px-3 py-2.5", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-[0.15em] text-brand-blue mb-1", children: "Remediation" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark/80", children: result.remediation })
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark/80", children: result.remediation }),
+        result.remediationAction && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 flex flex-wrap items-center gap-2", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { onClick: handleRunRemediation, disabled: running, children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniWrenchScrewdriver, { className: "mr-1.5 h-4 w-4", "aria-hidden": "true" }),
+          running ? "Running..." : result.remediationAction.label
+        ] }) }),
+        actionMessage !== null && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-xs text-slate-500", children: actionMessage })
       ] }),
       !result.resolved && onMarkResolved && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "outline", onClick: handleResolve, children: "Mark as resolved" })
     ] })
   ] });
 }
-function AuditWorkspace({ snapshot, receipts }) {
+function AuditWorkspace({ snapshot, receipts, approvalGate }) {
   const [filter, setFilter] = reactExports.useState({
     severityFilter: "all",
     harnessFilter: "",
@@ -108,6 +121,9 @@ function AuditWorkspace({ snapshot, receipts }) {
     searchQuery: ""
   });
   const [resolvedIds, setResolvedIds] = reactExports.useState(/* @__PURE__ */ new Set());
+  const [pendingRemediation, setPendingRemediation] = reactExports.useState(null);
+  const [runningRemediationId, setRunningRemediationId] = reactExports.useState(null);
+  const [remediationMessages, setRemediationMessages] = reactExports.useState({});
   const handleSearchChange = reactExports.useCallback((e) => {
     setFilter((f) => ({ ...f, searchQuery: e.target.value }));
   }, []);
@@ -123,6 +139,51 @@ function AuditWorkspace({ snapshot, receipts }) {
   const handleMarkResolved = reactExports.useCallback((id) => {
     setResolvedIds((prev) => /* @__PURE__ */ new Set([...prev, id]));
   }, []);
+  const executeRemediation = reactExports.useCallback(
+    async (result, credentials) => {
+      if (result.remediationAction === null) return;
+      setRunningRemediationId(result.id);
+      setRemediationMessages((prev) => ({ ...prev, [result.id]: "Running remediation through the local daemon." }));
+      try {
+        await runAuditRemediation({
+          ...result.remediationAction,
+          ...credentials
+        });
+        setResolvedIds((prev) => /* @__PURE__ */ new Set([...prev, result.id]));
+        setRemediationMessages((prev) => ({
+          ...prev,
+          [result.id]: "Remediation completed. Restart your shell before retrying package installs."
+        }));
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Unable to run remediation.";
+        setRemediationMessages((prev) => ({ ...prev, [result.id]: message }));
+      } finally {
+        setRunningRemediationId(null);
+      }
+    },
+    []
+  );
+  const handleRunRemediation = reactExports.useCallback(
+    (result) => {
+      if (result.remediationAction === null) return;
+      if (approvalGate?.enabled === true && approvalGate.configured === true) {
+        setPendingRemediation(result);
+        return;
+      }
+      void executeRemediation(result);
+    },
+    [approvalGate, executeRemediation]
+  );
+  const handleCancelRemediationGate = reactExports.useCallback(() => setPendingRemediation(null), []);
+  const handleConfirmRemediationGate = reactExports.useCallback(
+    (credentials) => {
+      const result = pendingRemediation;
+      if (result === null) return;
+      setPendingRemediation(null);
+      void executeRemediation(result, credentials);
+    },
+    [executeRemediation, pendingRemediation]
+  );
   const baseResults = reactExports.useMemo(
     () => deriveFrontendAuditResults(receipts, snapshot),
     [receipts, snapshot]
@@ -218,35 +279,138 @@ function AuditWorkspace({ snapshot, receipts }) {
           body: openCount === 0 ? "Guard found no issues in the current workspace. Keep running to build more coverage." : "Try adjusting the severity or status filters to see more results.",
           tone: "teach"
         }
-      ) : /* @__PURE__ */ jsxRuntimeExports.jsx("div", { role: "list", "aria-label": "Audit results", children: results.map((result) => /* @__PURE__ */ jsxRuntimeExports.jsx("div", { role: "listitem", children: /* @__PURE__ */ jsxRuntimeExports.jsx(AuditResultRow, { result, onMarkResolved: handleMarkResolved }) }, result.id)) })
+      ) : /* @__PURE__ */ jsxRuntimeExports.jsx("div", { role: "list", "aria-label": "Audit results", children: results.map((result) => /* @__PURE__ */ jsxRuntimeExports.jsx("div", { role: "listitem", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+        AuditResultRow,
+        {
+          result,
+          onMarkResolved: handleMarkResolved,
+          onRunRemediation: handleRunRemediation,
+          running: runningRemediationId === result.id,
+          actionMessage: remediationMessages[result.id] ?? null
+        }
+      ) }, result.id)) })
     ] }),
     openCount > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(
       RemediationQueue,
       {
         results: baseResults.map((r) => ({ ...r, resolved: r.resolved || resolvedIds.has(r.id) })).filter((r) => !r.resolved && (r.severity === "critical" || r.severity === "high")),
-        onMarkResolved: handleMarkResolved
+        onMarkResolved: handleMarkResolved,
+        onRunRemediation: handleRunRemediation,
+        runningRemediationId,
+        remediationMessages
+      }
+    ),
+    pendingRemediation !== null && /* @__PURE__ */ jsxRuntimeExports.jsx(
+      RemediationApprovalModal,
+      {
+        result: pendingRemediation,
+        approvalGate,
+        onCancel: handleCancelRemediationGate,
+        onConfirm: handleConfirmRemediationGate
       }
     )
   ] });
 }
-function RemediationQueue({ results, onMarkResolved }) {
+function RemediationQueue({
+  results,
+  onMarkResolved,
+  onRunRemediation,
+  runningRemediationId,
+  remediationMessages
+}) {
   if (results.length === 0) return null;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-red-100 bg-red-50/40 shadow-sm", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "border-b border-red-100 px-4 py-3", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Remediation queue" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-500", children: "Critical and high severity issues that need attention." })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "divide-y divide-red-100", children: results.map((r) => /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "px-4 py-3 space-y-2", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start justify-between gap-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-0.5 min-w-0", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-semibold text-brand-dark", children: r.title }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: r.severity === "critical" ? "destructive" : "attention", children: r.severity })
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "divide-y divide-red-100", children: results.map((r) => /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "px-4 py-3 space-y-2", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start justify-between gap-3", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-0.5 min-w-0", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-semibold text-brand-dark", children: r.title }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: r.severity === "critical" ? "destructive" : "attention", children: r.severity })
+          ] }),
+          r.remediation && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-600", children: r.remediation })
         ] }),
-        r.remediation && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-600", children: r.remediation })
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          RemediationQueueActions,
+          {
+            result: r,
+            onMarkResolved,
+            onRunRemediation,
+            running: runningRemediationId === r.id
+          }
+        )
       ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "outline", onClick: () => onMarkResolved(r.id), children: "Resolve" })
-    ] }) }, r.id)) })
+      remediationMessages[r.id] && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: remediationMessages[r.id] })
+    ] }, r.id)) })
   ] });
+}
+function RemediationQueueActions(props) {
+  const { result, onMarkResolved, onRunRemediation, running } = props;
+  const handleMarkResolved = reactExports.useCallback(() => onMarkResolved(result.id), [onMarkResolved, result.id]);
+  const handleRunRemediation = reactExports.useCallback(() => onRunRemediation(result), [onRunRemediation, result]);
+  if (result.remediationAction !== null) {
+    return /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { onClick: handleRunRemediation, disabled: running, children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniWrenchScrewdriver, { className: "mr-1.5 h-4 w-4", "aria-hidden": "true" }),
+      running ? "Running..." : result.remediationAction.label
+    ] });
+  }
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "outline", onClick: handleMarkResolved, children: "Resolve" });
+}
+function RemediationApprovalModal(props) {
+  const { approvalGate, onCancel, onConfirm, result } = props;
+  const [password, setPassword] = reactExports.useState("");
+  const [totpCode, setTotpCode] = reactExports.useState("");
+  const handlePasswordChange = reactExports.useCallback((event) => {
+    setPassword(event.target.value);
+  }, []);
+  const handleTotpChange = reactExports.useCallback((event) => {
+    setTotpCode(event.target.value);
+  }, []);
+  const handleConfirm = reactExports.useCallback(() => {
+    onConfirm({
+      approval_password: password,
+      ...approvalGate?.totp_enabled === true ? { approval_totp_code: totpCode } : {}
+    });
+  }, [approvalGate, onConfirm, password, totpCode]);
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 px-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "w-full max-w-md rounded-xl border border-slate-200 bg-white p-5 shadow-xl", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Approval required" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "mt-2 text-base font-semibold text-brand-dark", children: result.remediationAction?.label }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-500", children: "Enter local approval proof before Guard changes package-manager protection on this device." }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "mt-4 block", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs font-semibold uppercase tracking-[0.15em] text-slate-500", children: "Approval password" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "input",
+        {
+          type: "password",
+          value: password,
+          onChange: handlePasswordChange,
+          autoComplete: "current-password",
+          className: "mt-1 min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+        }
+      )
+    ] }),
+    approvalGate?.totp_enabled === true && /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "mt-3 block", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs font-semibold uppercase tracking-[0.15em] text-slate-500", children: "Authenticator code" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "input",
+        {
+          type: "text",
+          inputMode: "numeric",
+          pattern: "[0-9]*",
+          value: totpCode,
+          onChange: handleTotpChange,
+          className: "mt-1 min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+        }
+      )
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 flex justify-end gap-2", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "outline", onClick: onCancel, children: "Cancel" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleConfirm, children: "Run remediation" })
+    ] })
+  ] }) });
 }
 export {
   AuditWorkspace,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/audit-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/audit-workspace.js
@@ -375,6 +375,7 @@ function RemediationApprovalModal(props) {
       ...approvalGate?.totp_enabled === true ? { approval_totp_code: totpCode } : {}
     });
   }, [approvalGate, onConfirm, password, totpCode]);
+  const confirmDisabled = password.trim() === "" || approvalGate?.totp_enabled === true && totpCode.trim() === "";
   return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 px-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "w-full max-w-md rounded-xl border border-slate-200 bg-white p-5 shadow-xl", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Approval required" }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "mt-2 text-base font-semibold text-brand-dark", children: result.remediationAction?.label }),
@@ -408,7 +409,7 @@ function RemediationApprovalModal(props) {
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 flex justify-end gap-2", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "outline", onClick: onCancel, children: "Cancel" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleConfirm, children: "Run remediation" })
+      /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleConfirm, disabled: confirmDisabled, children: "Run remediation" })
     ] })
   ] }) });
 }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/feed-health-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/feed-health-workspace.js
@@ -1,4 +1,4 @@
-import { j as jsxRuntimeExports, A as ActionButton, S as SectionLabel, a as HiMiniExclamationTriangle, ab as HiMiniArrowPath, g as HiMiniCheckCircle, ap as HiMiniSignal, h as HiMiniXCircle, aq as HiMiniClock, f as formatRelativeTime, B as Badge, T as Tag } from "../guard-dashboard.js";
+import { j as jsxRuntimeExports, A as ActionButton, S as SectionLabel, a as HiMiniExclamationTriangle, ab as HiMiniArrowPath, g as HiMiniCheckCircle, aq as HiMiniSignal, h as HiMiniXCircle, ar as HiMiniClock, f as formatRelativeTime, B as Badge, T as Tag } from "../guard-dashboard.js";
 function resolveFeedSourceMode(cloudState) {
   if (cloudState === "local_only") return "sample";
   if (cloudState === "paired_waiting") return "full";
@@ -85,7 +85,7 @@ function FeedHealthWorkspace({ snapshot, onOpenSettings }) {
         /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "mt-0.5 h-4 w-4 shrink-0 text-brand-blue", "aria-hidden": "true" }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: "Full feed syncing" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-600 mt-0.5", children: "Cloud connection is complete. Feed sync is in progress. First proof will arrive shortly." })
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-600 mt-0.5", children: "Cloud pairing is complete. Feed sync is in progress. First proof will arrive shortly." })
         ] })
       ] }),
       sourceMode === "live" && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-2 rounded-xl border border-brand-green/20 bg-brand-green/[0.04] px-3 py-2.5", children: [

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/runtime-overview.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/runtime-overview.js
@@ -19,7 +19,7 @@ function resolveCloudIntelCopy(state) {
     return { label: "Offline, free", detail: "Running locally with no cloud sync. Your choices stay on this machine." };
   }
   if (state === "paired_waiting") {
-    return { label: "Sync pending", detail: "Connected to Guard Cloud, waiting for sync to start." };
+    return { label: "Pairing…", detail: "Connected to Guard Cloud, waiting for sync to start." };
   }
   return { label: "Synced, pro", detail: "Guard Cloud is active and syncing choices across your devices." };
 }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-hub-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-hub-workspace.js
@@ -40,7 +40,7 @@ function SupplyChainHubWorkspace(props) {
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs(reactExports.Suspense, { fallback: /* @__PURE__ */ jsxRuntimeExports.jsx(LazyFallback, {}), children: [
       tab === "supply-chain" && /* @__PURE__ */ jsxRuntimeExports.jsx(SupplyChainWorkspace, { snapshot: props.snapshot, onGoHome: props.onGoHome }),
-      tab === "audit" && /* @__PURE__ */ jsxRuntimeExports.jsx(AuditWorkspace, { snapshot: props.snapshot, receipts: props.receipts }),
+      tab === "audit" && /* @__PURE__ */ jsxRuntimeExports.jsx(AuditWorkspace, { snapshot: props.snapshot, receipts: props.receipts, approvalGate: props.approvalGate }),
       tab === "policy" && /* @__PURE__ */ jsxRuntimeExports.jsx(
         PolicyWorkspace,
         {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13323,7 +13323,7 @@ function buildDemoRuntimeSnapshot() {
     proof_status: {
       state: "pending",
       label: "First proof pending",
-      detail: "Browser sign-in finished. First proof sync has not completed yet.",
+      detail: "Browser pairing finished. First proof sync has not completed yet.",
       request_id: "demo-connect-request",
       pairing_completed_at: now2,
       first_synced_at: null,
@@ -13931,6 +13931,24 @@ async function runPackageFirewallAction(action, manager) {
         ...guardAuthHeaders()
       },
       body: JSON.stringify(payload)
+    }
+  );
+  return normalizePackageFirewallAction(response);
+}
+async function runAuditRemediation(input) {
+  const response = await readJson(
+    `/v1/audit/remediations/${input.action}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...guardAuthHeaders()
+      },
+      body: JSON.stringify({
+        manager: input.manager,
+        ...input.approval_password !== void 0 ? { approval_password: input.approval_password } : {},
+        ...input.approval_totp_code !== void 0 ? { approval_totp_code: input.approval_totp_code } : {}
+      })
     }
   );
   return normalizePackageFirewallAction(response);
@@ -15057,7 +15075,7 @@ function WelcomeState(props) {
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-border bg-card p-6 shadow-[0_4px_20px_rgba(85,153,254,0.04)]", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-[0.18em] text-brand-blue mb-4", children: "Sync decisions" }),
         props.connectUrl ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap gap-3", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: props.connectUrl, children: "Open Guard connect" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: props.connectUrl, children: "Open pairing flow" }),
           props.dashboardUrl ? /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: props.dashboardUrl, variant: "outline", children: "Open Home" }) : null,
           props.inboxUrl ? /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: props.inboxUrl, variant: "outline", children: "Review Queue" }) : null,
           props.fleetUrl ? /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: props.fleetUrl, variant: "outline", children: "Protect" }) : null
@@ -22687,6 +22705,7 @@ function App() {
             snapshot: runtime.snapshot,
             receipts: receipts.kind === "ready" ? receipts.items : [],
             policies: policies.kind === "ready" ? policies.items : [],
+            approvalGate,
             onClearPolicy: handleClearPolicy,
             onOpenSettings: handleOpenSettings,
             onGoHome: handleGoHome,
@@ -22760,8 +22779,9 @@ export {
   runPackageAudit as am,
   runPackageSync as an,
   HiMiniBugAnt as ao,
-  HiMiniSignal as ap,
-  HiMiniClock as aq,
+  runAuditRemediation as ap,
+  HiMiniSignal as aq,
+  HiMiniClock as ar,
   HiMiniInformationCircle as b,
   HiMiniArrowRight as c,
   HiMiniChevronUp as d,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13936,6 +13936,16 @@ async function runPackageFirewallAction(action, manager) {
   return normalizePackageFirewallAction(response);
 }
 async function runAuditRemediation(input) {
+  if (isGuardDemoMode()) {
+    return {
+      entitlement: { allowed: true, tier: "demo" },
+      operation: input.action,
+      receipt: null,
+      result: `${input.action} completed for ${input.manager}.`,
+      result_detail: { manager: input.manager, demo: true },
+      status: "completed"
+    };
+  }
   const response = await readJson(
     `/v1/audit/remediations/${input.action}`,
     {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -123,6 +123,7 @@
     --color-slate-600: oklch(44.6% .043 257.281);
     --color-slate-700: oklch(37.2% .044 257.287);
     --color-slate-900: oklch(20.8% .042 265.755);
+    --color-slate-950: oklch(12.9% .042 264.695);
     --color-gray-100: oklch(96.7% .003 264.542);
     --color-gray-200: oklch(92.8% .006 264.531);
     --color-gray-500: oklch(55.1% .027 264.364);
@@ -2568,6 +2569,16 @@
 
   .bg-slate-300 {
     background-color: var(--color-slate-300);
+  }
+
+  .bg-slate-950\/40 {
+    background-color: #02061866;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .bg-slate-950\/40 {
+      background-color: color-mix(in oklab, var(--color-slate-950) 40%, transparent);
+    }
   }
 
   .bg-surface-1 {

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -492,6 +492,57 @@ def repair_package_shims(
     }
 
 
+def ensure_package_shim_path_in_shell_profile(context: HarnessContext) -> dict[str, object]:
+    """Prepend the package shim dir in the user's normal shell profile."""
+
+    shim_dir = context.guard_home / "package-shims" / "bin"
+    profile_path, export_line = _package_shim_profile_target(context.home_dir, shim_dir)
+    profile_path.parent.mkdir(parents=True, exist_ok=True)
+    existing = profile_path.read_text(encoding="utf-8") if profile_path.exists() else ""
+    if _profile_already_references_path(existing, shim_dir):
+        return {
+            "changed": False,
+            "profile_path": str(profile_path),
+            "shim_dir": str(shim_dir),
+            "restart_shell_required": True,
+        }
+    prefix = "" if existing == "" or existing.endswith("\n") else "\n"
+    profile_path.write_text(f"{existing}{prefix}{export_line}\n", encoding="utf-8")
+    return {
+        "changed": True,
+        "profile_path": str(profile_path),
+        "shim_dir": str(shim_dir),
+        "restart_shell_required": True,
+    }
+
+
+def _package_shim_profile_target(home_dir: Path, shim_dir: Path) -> tuple[Path, str]:
+    shell = Path(os.environ.get("SHELL", "")).name
+    marker = "# HOL Guard package manager shims"
+    if shell == "fish":
+        return (
+            home_dir / ".config" / "fish" / "config.fish",
+            f"{marker}\nfish_add_path --prepend {shim_dir}",
+        )
+    if shell == "bash":
+        return (
+            home_dir / ".bashrc",
+            f'{marker}\nexport PATH="{shim_dir}:$PATH"',
+        )
+    return (
+        home_dir / ".zshrc",
+        f'{marker}\nexport PATH="{shim_dir}:$PATH"',
+    )
+
+
+def _profile_already_references_path(content: str, shim_dir: Path) -> bool:
+    shim_text = str(shim_dir)
+    return any(
+        (shim_text in line and "PATH" in line) or (shim_text in line and "fish_add_path" in line)
+        for line in content.splitlines()
+    )
+
+
 def _build_package_manager_python_shim(context: HarnessContext, command: str) -> str:
     workspace_args: list[str] = []
     if context.workspace_dir is not None:
@@ -605,6 +656,7 @@ def _path_export_hints(shim_dir: Path) -> dict[str, str]:
 
 
 __all__ = [
+    "ensure_package_shim_path_in_shell_profile",
     "install_guard_shim",
     "install_package_shims",
     "package_shim_cloud_coverage",

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -18,6 +18,7 @@ from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.daemon import server as daemon_server
 from codex_plugin_scanner.guard.daemon.manager import load_guard_daemon_auth_token
 from codex_plugin_scanner.guard.daemon.server import _headless_action_error_payload
+from codex_plugin_scanner.guard.approval_gate import update_settings as update_approval_gate_settings
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -265,6 +266,90 @@ def test_supply_chain_package_firewall_paid_install_and_test_roundtrip(tmp_path:
     assert test_payload["status"] == "completed"
     assert test_payload["result"]["tested_managers"] == ["npm"]
     assert test_payload["result"]["blocked_execution"] is True
+
+
+def test_audit_package_shim_path_remediation_requires_approval_gate_proof(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_payload(
+        "supply_chain_bundle_entitlement",
+        {"tier": "premium", "workspace_id": "workspace-1"},
+        "2026-05-27T16:00:00.000Z",
+    )
+    update_approval_gate_settings(
+        store.guard_home,
+        {
+            "enabled": True,
+            "new_password": "local-password",
+            "confirm_password": "local-password",
+        },
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/audit/remediations/package_shim_path",
+                token=token,
+                payload={"manager": "pnpm"},
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 403
+    assert payload["error"] == "approval_gate_required"
+
+
+def test_audit_package_shim_path_remediation_updates_profile_with_gate_proof(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_payload(
+        "supply_chain_bundle_entitlement",
+        {"tier": "premium", "workspace_id": "workspace-1"},
+        "2026-05-27T16:00:00.000Z",
+    )
+    update_approval_gate_settings(
+        store.guard_home,
+        {
+            "enabled": True,
+            "new_password": "local-password",
+            "confirm_password": "local-password",
+        },
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/audit/remediations/package_shim_path",
+                token=token,
+                payload={"manager": "pnpm", "approval_password": "local-password"},
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    profile_path = home_dir / ".zshrc"
+    shim_path = store.guard_home / "package-shims" / "bin" / "pnpm"
+    assert status == 200
+    assert payload["operation"] == "package_shim_path"
+    assert payload["receipt"]["operation"] == "package_shim_path"
+    assert shim_path.exists()
+    assert str(store.guard_home / "package-shims" / "bin") in profile_path.read_text(encoding="utf-8")
+    result = payload["result"]
+    assert isinstance(result, dict)
+    assert result["manager"] == "pnpm"
+    assert result["profile"]["changed"] is True
 
 
 def test_supply_chain_package_firewall_rejects_duplicate_managers(tmp_path: Path) -> None:

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -104,16 +104,16 @@ class TestGuardSurfaceServer:
             daemon_server_module._STATIC_DIR / "assets" / "chunks" / "feed-health-workspace.js"
         ).read_text(encoding="utf-8")
 
-        assert "Open Guard connect" in dashboard_bundle
-        assert "Open pairing flow" not in dashboard_bundle
-        assert "Browser sign-in finished. First proof sync has not completed yet." in dashboard_bundle
-        assert "Browser pairing finished. First proof sync has not completed yet." not in dashboard_bundle
-        assert 'label: "Sync pending"' in runtime_overview_chunk
-        assert '"Pairing…"' not in runtime_overview_chunk
-        assert "Cloud connection is complete. Feed sync is in progress. First proof will arrive shortly." in (
+        assert "Open pairing flow" in dashboard_bundle
+        assert "Open Guard connect" not in dashboard_bundle
+        assert "Browser pairing finished. First proof sync has not completed yet." in dashboard_bundle
+        assert "Browser sign-in finished. First proof sync has not completed yet." not in dashboard_bundle
+        assert 'label: "Pairing…"' in runtime_overview_chunk
+        assert '"Sync pending"' not in runtime_overview_chunk
+        assert "Cloud pairing is complete. Feed sync is in progress. First proof will arrive shortly." in (
             feed_health_chunk
         )
-        assert "Cloud pairing is complete. Feed sync is in progress. First proof will arrive shortly." not in (
+        assert "Cloud connection is complete. Feed sync is in progress. First proof will arrive shortly." not in (
             feed_health_chunk
         )
 


### PR DESCRIPTION
## Summary
- Add allowlisted audit remediation actions that run through the local daemon instead of manual shell instructions.
- Add a package-shim PATH remediation button with approval password/TOTP proof when the local approval gate is enabled.
- Rebuild dashboard static assets for the daemon bundle and align the static-copy contract test.

## Testing
- `python3 -m pytest tests/test_guard_headless_daemon_api.py -k 'audit_package_shim_path_remediation or supply_chain_package_firewall_paid_install_and_test_roundtrip'`
- `python3 -m pytest tests/test_guard_surface_server.py -k dashboard_assets_use_oauth_connect_copy`
- `pnpm exec tsx src/guard-api.test.ts`
- `pnpm exec tsx src/scrg171-172.test.ts`
- `pnpm run build`

## Notes
- `pnpm exec tsc --noEmit` was attempted but currently fails on pre-existing dashboard type errors outside this change.
