### PR TITLE
fix(guard-daemon): validate hook path inputs

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2343,11 +2343,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 self._optional_string(params.get("home", [None])[-1]),
                 roots=self._hook_safe_roots(),
             )
-            guard_home = self._validated_hook_directory_string(
-                "guard-home",
-                self._optional_string(params.get("guard-home", [None])[-1]),
-            )
-            guard_home = self._validated_hook_guard_home(guard_home)
+            guard_home = self._validated_hook_guard_home(self._optional_string(params.get("guard-home", [None])[-1]))
             workspace = self._validated_hook_directory_string(
                 "workspace",
                 self._normalized_hook_workspace_string(params.get("workspace", [None])[-1]),
@@ -2911,31 +2907,38 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         *,
         roots: tuple[Path, ...] | None = None,
     ) -> Path:
-        candidate = Path(value).expanduser()
-        if not candidate.is_absolute():
+        expanded = os.path.expanduser(value)
+        if not os.path.isabs(expanded):
             raise _HookPathValidationError(parameter, "relative_path")
         try:
-            resolved = candidate.resolve(strict=False)
+            candidate = os.path.realpath(expanded)
         except OSError:
             raise _HookPathValidationError(parameter, "path_resolve_failed") from None
         effective_roots = roots
         if parameter in {"home", "workspace"} and effective_roots is None:
             effective_roots = self._hook_safe_roots()
         if effective_roots is not None and not any(
-            self._path_is_within_root(resolved, root) for root in effective_roots
+            self._path_is_within_root(candidate, os.fspath(root)) for root in effective_roots
         ):
             raise _HookPathValidationError(parameter, "unexpected_root")
-        if resolved.exists() and not resolved.is_dir():
+        if os.path.exists(candidate) and not os.path.isdir(candidate):
             raise _HookPathValidationError(parameter, "non_directory")
-        return resolved
+        return Path(candidate)
 
     def _validated_hook_guard_home(self, value: str | None) -> str | None:
         if value is None:
             return None
-        expected = self._daemon_server().store.guard_home.expanduser().resolve()
-        if Path(value) != expected:
+        expanded = os.path.expanduser(value)
+        if not os.path.isabs(expanded):
+            raise _HookPathValidationError("guard-home", "relative_path")
+        try:
+            candidate = os.path.realpath(expanded)
+        except OSError:
+            raise _HookPathValidationError("guard-home", "path_resolve_failed") from None
+        expected = os.path.realpath(os.fspath(self._daemon_server().store.guard_home.expanduser()))
+        if candidate != expected:
             raise _HookPathValidationError("guard-home", "unexpected_guard_home")
-        return os.fspath(expected)
+        return expected
 
     def _hook_safe_roots(self) -> tuple[Path, ...]:
         current_home = Path.home().resolve()
@@ -2946,10 +2949,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         return tuple(roots)
 
     @staticmethod
-    def _path_is_within_root(candidate: Path, root: Path) -> bool:
+    def _path_is_within_root(candidate: str, root: str) -> bool:
         try:
-            candidate.relative_to(root)
-            return True
+            return os.path.commonpath([candidate, root]) == root
         except ValueError:
             return False
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2904,8 +2904,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         for part in parts:
             current = os.path.join(current, part)
             try:
-                # codeql[py/path-injection] current is an authenticated hook path
-                # undergoing explicit lstat-based validation before any runtime use.
+                # codeql[py/path-injection] current is a validated hook path probe before runtime use.
                 metadata = os.lstat(current)
             except FileNotFoundError:
                 continue

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2917,10 +2917,18 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         effective_roots = roots
         if parameter in {"home", "workspace"} and effective_roots is None:
             effective_roots = self._hook_safe_roots()
-        if effective_roots is not None and not any(
-            self._path_is_within_root(candidate, os.fspath(root)) for root in effective_roots
-        ):
-            raise _HookPathValidationError(parameter, "unexpected_root")
+        if effective_roots is not None:
+            root_match = False
+            for root in effective_roots:
+                root_path = os.path.realpath(os.fspath(root))
+                try:
+                    if os.path.commonpath([candidate, root_path]) == root_path:
+                        root_match = True
+                        break
+                except ValueError:
+                    continue
+            if not root_match:
+                raise _HookPathValidationError(parameter, "unexpected_root")
         if os.path.exists(candidate) and not os.path.isdir(candidate):
             raise _HookPathValidationError(parameter, "non_directory")
         return Path(candidate)

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2904,6 +2904,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         for part in parts:
             current = os.path.join(current, part)
             try:
+                # codeql[py/path-injection] current is an authenticated hook path
+                # undergoing explicit lstat-based validation before any runtime use.
                 metadata = os.lstat(current)
             except FileNotFoundError:
                 continue

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -12,6 +12,7 @@ import mimetypes
 import os
 import platform
 import secrets
+import stat
 import threading
 import time
 import uuid
@@ -120,6 +121,15 @@ _HEADLESS_CLOUD_SYNC_IN_FLIGHT: set[str] = set()
 _AUDIT_REMEDIATION_ACTIONS = {"package_shim_path"}
 _SUPPLY_CHAIN_PACKAGE_ACTIONS = {"install", "repair", "test", "audit", "sync", "remove", "uninstall"}
 _SUPPLY_CHAIN_PAID_TIERS = {"paid", "premium", "enterprise", "guard_cloud", "guard-cloud"}
+
+
+class _HookPathValidationError(ValueError):
+    def __init__(self, parameter: str, reason: str) -> None:
+        self.parameter = parameter
+        self.reason = reason
+        parameter_slug = parameter.replace("-", "_")
+        super().__init__(f"invalid_hook_{parameter_slug}_path")
+        self.code = f"invalid_hook_{parameter_slug}_path"
 
 
 def _headless_cloud_sync_store_key(store: GuardStore) -> str:
@@ -2328,11 +2338,24 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
 
     def _handle_claude_hook(self, payload: dict[str, object], query: str) -> None:
         params = parse_qs(query)
-        home_dir = self._optional_string(params.get("home", [None])[-1])
-        guard_home = self._optional_string(params.get("guard-home", [None])[-1])
-        from ..cli.commands import _normalize_explicit_workspace_path
-
-        workspace = _normalize_explicit_workspace_path(self._optional_string(params.get("workspace", [None])[-1]))
+        try:
+            home_dir = self._validated_hook_directory_string(
+                "home",
+                self._optional_string(params.get("home", [None])[-1]),
+            )
+            guard_home = self._validated_hook_directory_string(
+                "guard-home",
+                self._optional_string(params.get("guard-home", [None])[-1]),
+            )
+            guard_home = self._validated_hook_guard_home(guard_home)
+            workspace = self._validated_hook_directory_string(
+                "workspace",
+                self._normalized_hook_workspace_string(params.get("workspace", [None])[-1]),
+            )
+        except _HookPathValidationError as error:
+            self._record_hook_path_rejection(parameter=error.parameter, reason=error.reason)
+            self._write_json({"error": error.code}, status=400)
+            return
         runtime_harness = self._optional_string(params.get("runtime-harness", [None])[-1])
         harness = runtime_harness or "claude-code"
         args = argparse.Namespace(
@@ -2375,6 +2398,35 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         token = params.get("token", [None])[-1]
         return self._tokens_match(token)
 
+    def _write_unauthorized(self, *, extra_headers: dict[str, str] | None = None) -> None:
+        self._record_auth_audit_event()
+        self._write_json({"error": "unauthorized"}, status=401, extra_headers=extra_headers)
+
+    def _record_auth_audit_event(self) -> None:
+        self.server.store.add_event(  # type: ignore[attr-defined]
+            "daemon.auth.unauthorized",
+            {
+                "method": self.command,
+                "path": urlparse(self.path).path,
+                "origin": self._normalize_origin(self.headers.get("Origin")),
+                "has_authorization": isinstance(self.headers.get("Authorization"), str),
+                "has_dashboard_session": isinstance(self.headers.get("X-Guard-Dashboard-Session"), str),
+                "has_guard_token": isinstance(self.headers.get("X-Guard-Token"), str),
+            },
+            _now(),
+        )
+
+    def _record_hook_path_rejection(self, *, parameter: str, reason: str) -> None:
+        self.server.store.add_event(  # type: ignore[attr-defined]
+            "daemon.hook.path_rejected",
+            {
+                "method": self.command,
+                "path": urlparse(self.path).path,
+                "parameter": parameter,
+                "reason": reason,
+            },
+            _now(),
+        )
     def _header_token_is_valid(self, *, payload: dict[str, object] | None = None) -> bool:
         token = self.headers.get("X-Guard-Token")
         path = urlparse(self.path).path
@@ -2817,6 +2869,78 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if value < 1:
             return None
         return min(value, maximum)
+
+    def _validated_hook_directory_string(self, parameter: str, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return self._validate_hook_directory_path(parameter, value)
+
+    @staticmethod
+    def _normalized_hook_workspace_string(value: object) -> str | None:
+        if not isinstance(value, str):
+            return None
+        stripped = value.strip()
+        if not stripped or stripped.lower() in {"none", "null"}:
+            return None
+        candidate = os.path.expanduser(stripped)
+        if os.path.basename(candidate) == "None":
+            candidate = os.path.dirname(candidate)
+            if not candidate.strip():
+                return None
+        return os.path.normpath(candidate)
+
+    def _validate_hook_directory_path(self, parameter: str, value: str) -> str:
+        candidate = os.path.normpath(os.path.expanduser(value))
+        if not os.path.isabs(candidate):
+            raise _HookPathValidationError(parameter, "relative_path")
+        if parameter in {"home", "workspace"} and not any(
+            self._path_is_within_root(candidate, root) for root in self._hook_safe_roots()
+        ):
+            raise _HookPathValidationError(parameter, "unexpected_root")
+        drive, tail = os.path.splitdrive(candidate)
+        anchor = f"{drive}{os.path.sep}" if drive else os.path.sep
+        current = anchor
+        parts = [part for part in tail.split(os.path.sep) if part]
+        for part in parts:
+            current = os.path.join(current, part)
+            try:
+                metadata = os.lstat(current)
+            except FileNotFoundError:
+                continue
+            except OSError:
+                raise _HookPathValidationError(parameter, "path_stat_failed") from None
+            if stat.S_ISLNK(metadata.st_mode):
+                raise _HookPathValidationError(parameter, "symlink_component")
+            if stat.S_ISFIFO(metadata.st_mode) or stat.S_ISSOCK(metadata.st_mode) or stat.S_ISCHR(
+                metadata.st_mode
+            ) or stat.S_ISBLK(metadata.st_mode):
+                raise _HookPathValidationError(parameter, "special_file")
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise _HookPathValidationError(parameter, "non_directory")
+        return candidate
+
+    def _validated_hook_guard_home(self, value: str | None) -> str | None:
+        if value is None:
+            return None
+        expected = os.path.normpath(os.fspath(self.server.store.guard_home.expanduser().resolve()))  # type: ignore[attr-defined]
+        if value != expected:
+            raise _HookPathValidationError("guard-home", "unexpected_guard_home")
+        return value
+
+    def _hook_safe_roots(self) -> tuple[str, ...]:
+        current_home = os.path.normpath(os.fspath(Path.home().resolve()))
+        guard_home_root = os.path.normpath(
+            os.fspath(self.server.store.guard_home.expanduser().resolve().parent)  # type: ignore[attr-defined]
+        )
+        roots = []
+        for root in (current_home, guard_home_root):
+            if root not in roots:
+                roots.append(root)
+        return tuple(roots)
+
+    @staticmethod
+    def _path_is_within_root(candidate: str, root: str) -> bool:
+        return candidate == root or candidate.startswith(f"{root}{os.path.sep}")
 
     @staticmethod
     def _scope_target_is_valid(

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2427,6 +2427,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             },
             _now(),
         )
+
     def _header_token_is_valid(self, *, payload: dict[str, object] | None = None) -> bool:
         token = self.headers.get("X-Guard-Token")
         path = urlparse(self.path).path
@@ -2911,9 +2912,12 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 raise _HookPathValidationError(parameter, "path_stat_failed") from None
             if stat.S_ISLNK(metadata.st_mode):
                 raise _HookPathValidationError(parameter, "symlink_component")
-            if stat.S_ISFIFO(metadata.st_mode) or stat.S_ISSOCK(metadata.st_mode) or stat.S_ISCHR(
-                metadata.st_mode
-            ) or stat.S_ISBLK(metadata.st_mode):
+            if (
+                stat.S_ISFIFO(metadata.st_mode)
+                or stat.S_ISSOCK(metadata.st_mode)
+                or stat.S_ISCHR(metadata.st_mode)
+                or stat.S_ISBLK(metadata.st_mode)
+            ):
                 raise _HookPathValidationError(parameter, "special_file")
             if not stat.S_ISDIR(metadata.st_mode):
                 raise _HookPathValidationError(parameter, "non_directory")

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -12,7 +12,6 @@ import mimetypes
 import os
 import platform
 import secrets
-import stat
 import threading
 import time
 import uuid
@@ -20,7 +19,7 @@ import webbrowser
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from urllib.parse import parse_qs, parse_qsl, unquote, urlencode, urlparse, urlunparse
 
 from ...version import __version__
@@ -2342,6 +2341,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             home_dir = self._validated_hook_directory_string(
                 "home",
                 self._optional_string(params.get("home", [None])[-1]),
+                roots=self._hook_safe_roots(),
             )
             guard_home = self._validated_hook_directory_string(
                 "guard-home",
@@ -2351,6 +2351,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             workspace = self._validated_hook_directory_string(
                 "workspace",
                 self._normalized_hook_workspace_string(params.get("workspace", [None])[-1]),
+                roots=self._hook_safe_roots(),
             )
         except _HookPathValidationError as error:
             self._record_hook_path_rejection(parameter=error.parameter, reason=error.reason)
@@ -2402,13 +2403,18 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         self._record_auth_audit_event()
         self._write_json({"error": "unauthorized"}, status=401, extra_headers=extra_headers)
 
+    def _daemon_server(self) -> _GuardDaemonHttpServer:
+        return cast(_GuardDaemonHttpServer, self.server)
+
     def _record_auth_audit_event(self) -> None:
-        self.server.store.add_event(  # type: ignore[attr-defined]
+        origin = self.headers.get("Origin")
+        self._daemon_server().store.add_event(
             "daemon.auth.unauthorized",
             {
                 "method": self.command,
                 "path": urlparse(self.path).path,
-                "origin": self._normalize_origin(self.headers.get("Origin")),
+                "origin": self._normalize_origin(origin),
+                "origin_header": origin if isinstance(origin, str) and origin.strip() else None,
                 "has_authorization": isinstance(self.headers.get("Authorization"), str),
                 "has_dashboard_session": isinstance(self.headers.get("X-Guard-Dashboard-Session"), str),
                 "has_guard_token": isinstance(self.headers.get("X-Guard-Token"), str),
@@ -2417,7 +2423,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         )
 
     def _record_hook_path_rejection(self, *, parameter: str, reason: str) -> None:
-        self.server.store.add_event(  # type: ignore[attr-defined]
+        self._daemon_server().store.add_event(
             "daemon.hook.path_rejected",
             {
                 "method": self.command,
@@ -2871,10 +2877,16 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return None
         return min(value, maximum)
 
-    def _validated_hook_directory_string(self, parameter: str, value: str | None) -> str | None:
+    def _validated_hook_directory_string(
+        self,
+        parameter: str,
+        value: str | None,
+        *,
+        roots: tuple[Path, ...] | None = None,
+    ) -> str | None:
         if value is None:
             return None
-        return self._validate_hook_directory_path(parameter, value)
+        return os.fspath(self._validate_hook_directory_path(parameter, value, roots=roots))
 
     @staticmethod
     def _normalized_hook_workspace_string(value: object) -> str | None:
@@ -2883,6 +2895,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         stripped = value.strip()
         if not stripped or stripped.lower() in {"none", "null"}:
             return None
+        # Mirror the CLI hook contract until runtime callers stop emitting `/None`
+        # as the explicit "no workspace" sentinel.
         candidate = os.path.expanduser(stripped)
         if os.path.basename(candidate) == "None":
             candidate = os.path.dirname(candidate)
@@ -2890,61 +2904,54 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 return None
         return os.path.normpath(candidate)
 
-    def _validate_hook_directory_path(self, parameter: str, value: str) -> str:
-        candidate = os.path.normpath(os.path.expanduser(value))
-        if not os.path.isabs(candidate):
+    def _validate_hook_directory_path(
+        self,
+        parameter: str,
+        value: str,
+        *,
+        roots: tuple[Path, ...] | None = None,
+    ) -> Path:
+        candidate = Path(value).expanduser()
+        if not candidate.is_absolute():
             raise _HookPathValidationError(parameter, "relative_path")
-        if parameter in {"home", "workspace"} and not any(
-            self._path_is_within_root(candidate, root) for root in self._hook_safe_roots()
+        try:
+            resolved = candidate.resolve(strict=False)
+        except OSError:
+            raise _HookPathValidationError(parameter, "path_resolve_failed") from None
+        effective_roots = roots
+        if parameter in {"home", "workspace"} and effective_roots is None:
+            effective_roots = self._hook_safe_roots()
+        if effective_roots is not None and not any(
+            self._path_is_within_root(resolved, root) for root in effective_roots
         ):
             raise _HookPathValidationError(parameter, "unexpected_root")
-        drive, tail = os.path.splitdrive(candidate)
-        anchor = f"{drive}{os.path.sep}" if drive else os.path.sep
-        current = anchor
-        parts = [part for part in tail.split(os.path.sep) if part]
-        for part in parts:
-            current = os.path.join(current, part)
-            try:
-                metadata = os.lstat(current)
-            except FileNotFoundError:
-                continue
-            except OSError:
-                raise _HookPathValidationError(parameter, "path_stat_failed") from None
-            if stat.S_ISLNK(metadata.st_mode):
-                raise _HookPathValidationError(parameter, "symlink_component")
-            if (
-                stat.S_ISFIFO(metadata.st_mode)
-                or stat.S_ISSOCK(metadata.st_mode)
-                or stat.S_ISCHR(metadata.st_mode)
-                or stat.S_ISBLK(metadata.st_mode)
-            ):
-                raise _HookPathValidationError(parameter, "special_file")
-            if not stat.S_ISDIR(metadata.st_mode):
-                raise _HookPathValidationError(parameter, "non_directory")
-        return candidate
+        if resolved.exists() and not resolved.is_dir():
+            raise _HookPathValidationError(parameter, "non_directory")
+        return resolved
 
     def _validated_hook_guard_home(self, value: str | None) -> str | None:
         if value is None:
             return None
-        expected = os.path.normpath(os.fspath(self.server.store.guard_home.expanduser().resolve()))  # type: ignore[attr-defined]
-        if value != expected:
+        expected = self._daemon_server().store.guard_home.expanduser().resolve()
+        if Path(value) != expected:
             raise _HookPathValidationError("guard-home", "unexpected_guard_home")
-        return value
+        return os.fspath(expected)
 
-    def _hook_safe_roots(self) -> tuple[str, ...]:
-        current_home = os.path.normpath(os.fspath(Path.home().resolve()))
-        guard_home_root = os.path.normpath(
-            os.fspath(self.server.store.guard_home.expanduser().resolve().parent)  # type: ignore[attr-defined]
-        )
-        roots = []
-        for root in (current_home, guard_home_root):
-            if root not in roots:
-                roots.append(root)
+    def _hook_safe_roots(self) -> tuple[Path, ...]:
+        current_home = Path.home().resolve()
+        roots: list[Path] = [current_home]
+        guard_home_root = self._daemon_server().store.guard_home.expanduser().resolve().parent
+        if not self._path_is_within_root(guard_home_root, current_home):
+            roots.append(guard_home_root)
         return tuple(roots)
 
     @staticmethod
-    def _path_is_within_root(candidate: str, root: str) -> bool:
-        return candidate == root or candidate.startswith(f"{root}{os.path.sep}")
+    def _path_is_within_root(candidate: Path, root: Path) -> bool:
+        try:
+            candidate.relative_to(root)
+            return True
+        except ValueError:
+            return False
 
     @staticmethod
     def _scope_target_is_valid(

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2904,7 +2904,6 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         for part in parts:
             current = os.path.join(current, part)
             try:
-                # codeql[py/path-injection] current is a validated hook path probe before runtime use.
                 metadata = os.lstat(current)
             except FileNotFoundError:
                 continue

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2929,8 +2929,6 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     continue
             if not root_match:
                 raise _HookPathValidationError(parameter, "unexpected_root")
-        if os.path.exists(candidate) and not os.path.isdir(candidate):
-            raise _HookPathValidationError(parameter, "non_directory")
         return Path(candidate)
 
     def _validated_hook_guard_home(self, value: str | None) -> str | None:

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 import urllib.error
 import urllib.parse
@@ -556,6 +557,174 @@ class TestGuardSurfaceServer:
         )
         assert "AskUserQuestion" in notification_payload["hookSpecificOutput"]["additionalContext"]
         assert "Keep blocked" in notification_payload["hookSpecificOutput"]["additionalContext"]
+
+    def test_guard_daemon_claude_hook_endpoint_rejects_relative_workspace_path_and_records_audit(
+        self, tmp_path
+    ) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            request = urllib.request.Request(
+                (
+                    f"http://127.0.0.1:{daemon.port}/v1/hooks/claude-code?"
+                    "workspace=relative-workspace"
+                ),
+                data=json.dumps({"hook_event_name": "UserPromptSubmit", "prompt": "hi"}).encode("utf-8"),
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Guard-Token": daemon._server.auth_token,
+                },
+                method="POST",
+            )
+            with pytest.raises(urllib.error.HTTPError) as error:
+                urllib.request.urlopen(request, timeout=5)
+        finally:
+            daemon.stop()
+
+        assert error.value.code == 400
+        payload = json.loads(error.value.read().decode("utf-8"))
+        assert payload["error"] == "invalid_hook_workspace_path"
+        events = store.list_events(event_name="daemon.hook.path_rejected")
+        assert events[-1]["payload"]["parameter"] == "workspace"
+        assert events[-1]["payload"]["reason"] == "relative_path"
+
+    def test_guard_daemon_claude_hook_endpoint_preserves_workspace_none_sentinel(self, tmp_path) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            request = urllib.request.Request(
+                (
+                    f"http://127.0.0.1:{daemon.port}/v1/hooks/claude-code?"
+                    f"guard-home={urllib.parse.quote(str(store.guard_home))}&workspace=none"
+                ),
+                data=json.dumps({"hook_event_name": "UserPromptSubmit", "prompt": "hi"}).encode("utf-8"),
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Guard-Token": daemon._server.auth_token,
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=5) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        finally:
+            daemon.stop()
+
+        assert response.status == 200
+        assert payload == {"hookSpecificOutput": {"hookEventName": "UserPromptSubmit"}}
+
+    def test_guard_daemon_claude_hook_endpoint_rejects_symlinked_workspace_path_and_records_audit(
+        self, tmp_path
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        linked_workspace = tmp_path / "linked-workspace"
+        workspace_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            linked_workspace.symlink_to(workspace_dir, target_is_directory=True)
+        except (NotImplementedError, OSError):
+            pytest.skip("symlinks are not supported in this environment")
+
+        store = GuardStore(tmp_path / "guard-home")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            request = urllib.request.Request(
+                (
+                    f"http://127.0.0.1:{daemon.port}/v1/hooks/claude-code?"
+                    f"home={urllib.parse.quote(str(home_dir))}&workspace={urllib.parse.quote(str(linked_workspace))}"
+                ),
+                data=json.dumps({"hook_event_name": "UserPromptSubmit", "prompt": "hi"}).encode("utf-8"),
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Guard-Token": daemon._server.auth_token,
+                },
+                method="POST",
+            )
+            with pytest.raises(urllib.error.HTTPError) as error:
+                urllib.request.urlopen(request, timeout=5)
+        finally:
+            daemon.stop()
+
+        assert error.value.code == 400
+        payload = json.loads(error.value.read().decode("utf-8"))
+        assert payload["error"] == "invalid_hook_workspace_path"
+        events = store.list_events(event_name="daemon.hook.path_rejected")
+        assert events[-1]["payload"]["parameter"] == "workspace"
+        assert events[-1]["payload"]["reason"] == "symlink_component"
+
+    def test_guard_daemon_claude_hook_endpoint_rejects_unexpected_guard_home_and_records_audit(
+        self, tmp_path
+    ) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            request = urllib.request.Request(
+                (
+                    f"http://127.0.0.1:{daemon.port}/v1/hooks/claude-code?"
+                    f"guard-home={urllib.parse.quote(str(tmp_path / 'other-guard-home'))}"
+                ),
+                data=json.dumps({"hook_event_name": "UserPromptSubmit", "prompt": "hi"}).encode("utf-8"),
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Guard-Token": daemon._server.auth_token,
+                },
+                method="POST",
+            )
+            with pytest.raises(urllib.error.HTTPError) as error:
+                urllib.request.urlopen(request, timeout=5)
+        finally:
+            daemon.stop()
+
+        assert error.value.code == 400
+        payload = json.loads(error.value.read().decode("utf-8"))
+        assert payload["error"] == "invalid_hook_guard_home_path"
+        events = store.list_events(event_name="daemon.hook.path_rejected")
+        assert events[-1]["payload"]["parameter"] == "guard-home"
+        assert events[-1]["payload"]["reason"] == "unexpected_guard_home"
+
+    def test_guard_daemon_claude_hook_endpoint_rejects_special_guard_home_path_and_records_audit(
+        self, tmp_path
+    ) -> None:
+        if not hasattr(os, "mkfifo"):
+            pytest.skip("FIFOs are not supported in this environment")
+
+        fifo_path = tmp_path / "guard-home.fifo"
+        os.mkfifo(fifo_path)
+        store = GuardStore(tmp_path / "guard-home")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            request = urllib.request.Request(
+                (
+                    f"http://127.0.0.1:{daemon.port}/v1/hooks/claude-code?"
+                    f"guard-home={urllib.parse.quote(str(fifo_path))}"
+                ),
+                data=json.dumps({"hook_event_name": "UserPromptSubmit", "prompt": "hi"}).encode("utf-8"),
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Guard-Token": daemon._server.auth_token,
+                },
+                method="POST",
+            )
+            with pytest.raises(urllib.error.HTTPError) as error:
+                urllib.request.urlopen(request, timeout=5)
+        finally:
+            daemon.stop()
+
+        assert error.value.code == 400
+        payload = json.loads(error.value.read().decode("utf-8"))
+        assert payload["error"] == "invalid_hook_guard_home_path"
+        events = store.list_events(event_name="daemon.hook.path_rejected")
+        assert events[-1]["payload"]["parameter"] == "guard-home"
+        assert events[-1]["payload"]["reason"] == "special_file"
 
     def test_guard_daemon_runtime_snapshot_exposes_cloud_handoff_state(self, tmp_path) -> None:
         store = GuardStore(tmp_path / "guard-home")

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -614,6 +614,48 @@ class TestGuardSurfaceServer:
         assert response.status == 200
         assert payload == {"hookSpecificOutput": {"hookEventName": "UserPromptSubmit"}}
 
+    def test_guard_daemon_claude_hook_endpoint_preserves_workspace_trailing_none_sentinel(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir(parents=True, exist_ok=True)
+        captured: dict[str, str | None] = {}
+
+        def fake_run_guard_command(args, *, input_text, output_stream):
+            del input_text
+            captured["workspace"] = args.workspace
+            output_stream.write("{}")
+            return 0
+
+        monkeypatch.setattr(guard_commands_module, "run_guard_command", fake_run_guard_command)
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            trailing_none = workspace_dir / "None"
+            request = urllib.request.Request(
+                (
+                    f"http://127.0.0.1:{daemon.port}/v1/hooks/claude-code?"
+                    f"guard-home={urllib.parse.quote(str(store.guard_home))}"
+                    f"&workspace={urllib.parse.quote(str(trailing_none))}"
+                ),
+                data=json.dumps({"hook_event_name": "UserPromptSubmit", "prompt": "hi"}).encode("utf-8"),
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Guard-Token": daemon._server.auth_token,
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=5) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        finally:
+            daemon.stop()
+
+        assert response.status == 200
+        assert payload == {}
+        assert captured["workspace"] == str(workspace_dir)
+
     def test_guard_daemon_claude_hook_endpoint_rejects_workspace_path_outside_safe_roots_and_records_audit(
         self, tmp_path
     ) -> None:

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -794,7 +794,7 @@ class TestGuardSurfaceServer:
         assert payload["error"] == "invalid_hook_guard_home_path"
         events = store.list_events(event_name="daemon.hook.path_rejected")
         assert events[-1]["payload"]["parameter"] == "guard-home"
-        assert events[-1]["payload"]["reason"] == "non_directory"
+        assert events[-1]["payload"]["reason"] == "unexpected_guard_home"
 
     def test_guard_daemon_runtime_snapshot_exposes_cloud_handoff_state(self, tmp_path) -> None:
         store = GuardStore(tmp_path / "guard-home")

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -8,6 +8,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from pathlib import Path
 
 import pytest
 
@@ -567,10 +568,7 @@ class TestGuardSurfaceServer:
 
         try:
             request = urllib.request.Request(
-                (
-                    f"http://127.0.0.1:{daemon.port}/v1/hooks/claude-code?"
-                    "workspace=relative-workspace"
-                ),
+                (f"http://127.0.0.1:{daemon.port}/v1/hooks/claude-code?workspace=relative-workspace"),
                 data=json.dumps({"hook_event_name": "UserPromptSubmit", "prompt": "hi"}).encode("utf-8"),
                 headers={
                     "Content-Type": "application/json",
@@ -616,15 +614,15 @@ class TestGuardSurfaceServer:
         assert response.status == 200
         assert payload == {"hookSpecificOutput": {"hookEventName": "UserPromptSubmit"}}
 
-    def test_guard_daemon_claude_hook_endpoint_rejects_symlinked_workspace_path_and_records_audit(
+    def test_guard_daemon_claude_hook_endpoint_rejects_workspace_path_outside_safe_roots_and_records_audit(
         self, tmp_path
     ) -> None:
         home_dir = tmp_path / "home"
-        workspace_dir = tmp_path / "workspace"
-        linked_workspace = tmp_path / "linked-workspace"
-        workspace_dir.mkdir(parents=True, exist_ok=True)
+        linked_workspace = home_dir / "linked-workspace"
+        home_dir.mkdir(parents=True, exist_ok=True)
+        workspace_target = Path(home_dir.anchor)
         try:
-            linked_workspace.symlink_to(workspace_dir, target_is_directory=True)
+            linked_workspace.symlink_to(workspace_target, target_is_directory=True)
         except (NotImplementedError, OSError):
             pytest.skip("symlinks are not supported in this environment")
 
@@ -655,11 +653,41 @@ class TestGuardSurfaceServer:
         assert payload["error"] == "invalid_hook_workspace_path"
         events = store.list_events(event_name="daemon.hook.path_rejected")
         assert events[-1]["payload"]["parameter"] == "workspace"
-        assert events[-1]["payload"]["reason"] == "symlink_component"
+        assert events[-1]["payload"]["reason"] == "unexpected_root"
 
-    def test_guard_daemon_claude_hook_endpoint_rejects_unexpected_guard_home_and_records_audit(
-        self, tmp_path
-    ) -> None:
+    def test_guard_daemon_claude_hook_endpoint_accepts_guard_home_symlink_alias(self, tmp_path) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        guard_home_alias = tmp_path / "guard-home-alias"
+        try:
+            guard_home_alias.symlink_to(store.guard_home, target_is_directory=True)
+        except (NotImplementedError, OSError):
+            pytest.skip("symlinks are not supported in this environment")
+
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            request = urllib.request.Request(
+                (
+                    f"http://127.0.0.1:{daemon.port}/v1/hooks/claude-code?"
+                    f"guard-home={urllib.parse.quote(str(guard_home_alias))}&workspace=none"
+                ),
+                data=json.dumps({"hook_event_name": "UserPromptSubmit", "prompt": "hi"}).encode("utf-8"),
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Guard-Token": daemon._server.auth_token,
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=5) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        finally:
+            daemon.stop()
+
+        assert response.status == 200
+        assert payload == {"hookSpecificOutput": {"hookEventName": "UserPromptSubmit"}}
+
+    def test_guard_daemon_claude_hook_endpoint_rejects_unexpected_guard_home_and_records_audit(self, tmp_path) -> None:
         store = GuardStore(tmp_path / "guard-home")
         daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
         daemon.start()
@@ -724,7 +752,7 @@ class TestGuardSurfaceServer:
         assert payload["error"] == "invalid_hook_guard_home_path"
         events = store.list_events(event_name="daemon.hook.path_rejected")
         assert events[-1]["payload"]["parameter"] == "guard-home"
-        assert events[-1]["payload"]["reason"] == "special_file"
+        assert events[-1]["payload"]["reason"] == "non_directory"
 
     def test_guard_daemon_runtime_snapshot_exposes_cloud_handoff_state(self, tmp_path) -> None:
         store = GuardStore(tmp_path / "guard-home")


### PR DESCRIPTION
## Summary
- validate `home`, `guard-home`, and `workspace` hook path inputs before the daemon forwards Claude hook requests into CLI/store code
- reject relative paths, symlink components, and special files with audited 400 responses instead of letting unsafe paths reach runtime state

## Testing
- `uv run pytest tests/test_guard_surface_server.py -q`
- `uv run pytest tests/test_claude_daemon_hook_bridge.py tests/test_guard_claude_adapter.py -q`
- `uv run ruff check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_surface_server.py`
