### PR TITLE
fix(audit): bootstrap local daemon token for remediation

### DIFF
--- a/dashboard/src/guard-api.test.ts
+++ b/dashboard/src/guard-api.test.ts
@@ -782,6 +782,49 @@ assert(remediationBody["approval_password"] === "local-password", "L079c: runAud
 assert(remediationBody["approval_totp_code"] === "123456", "L079c: runAuditRemediation sends approval TOTP code");
 assert(remediation.operation === "package_shim_path", "L079c: runAuditRemediation normalizes response");
 
+installGuardWindow("?guardDaemon=http%3A%2F%2F127.0.0.1%3A4781");
+const remediationBootstrapCalls: RecordedFetch[] = [];
+globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  const url = input instanceof Request ? input.url : String(input);
+  remediationBootstrapCalls.push({ url, init });
+  const path = new URL(url, "http://127.0.0.1:4174").pathname;
+  if (path === "/v1/initialize") {
+    return new Response(JSON.stringify({ auth_token: "fresh-remediate-token" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
+  if (path === "/v1/audit/remediations/package_shim_path") {
+    const token = headerValue(init, "X-Guard-Token");
+    if (token !== "fresh-remediate-token") {
+      return new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 });
+    }
+    return new Response(JSON.stringify({
+      entitlement: { allowed: true },
+      operation: "package_shim_path",
+      receipt: null,
+      result: { manager: "pnpm" },
+      status: "completed"
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
+  return new Response(JSON.stringify({ error: "not_found" }), { status: 404 });
+};
+
+const remediationBootstrap = await runAuditRemediation({
+  action: "package_shim_path",
+  manager: "pnpm",
+});
+assert(remediationBootstrapCalls.length === 3, "L079d: remediation bootstraps token after 401 and retries");
+assert(new URL(remediationBootstrapCalls[1].url).pathname === "/v1/initialize", "L079d: remediation calls initialize after unauthorized");
+assert(
+  headerValue(remediationBootstrapCalls[2].init, "X-Guard-Token") === "fresh-remediate-token",
+  "L079d: remediation retries with refreshed Guard token"
+);
+assert(remediationBootstrap.operation === "package_shim_path", "L079d: remediation succeeds after token bootstrap");
+
 installGuardWindow("?guard-token=token-resolve&guardDaemon=http%3A%2F%2F127.0.0.1%3A4781");
 const fetchResolveCalls = installFetchStub({
   "/v1/requests/req-active/approve": {

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -102,7 +102,7 @@ type QueueResolutionPayload = Omit<
 };
 
 async function readJson<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
-  const response = await fetch(guardApiInput(input), withGuardAuth(init));
+  const response = await fetchWithGuardAuth(input, init);
   if (!response.ok) {
     throw new Error(await requestErrorMessage(response, `Request failed with ${response.status}`));
   }
@@ -249,18 +249,35 @@ function guardApiInput(input: RequestInfo): RequestInfo {
 }
 
 function withGuardAuth(init?: RequestInit): RequestInit | undefined {
-  const guardToken = readGuardToken();
+  return withGuardAuthForToken(init, readGuardToken());
+}
+
+function withGuardAuthForToken(
+  init: RequestInit | undefined,
+  guardToken: string | null,
+): RequestInit | undefined {
   if (!guardToken) {
     return init;
   }
   const headers = new Headers(init?.headers);
-  if (!headers.has("X-Guard-Token")) {
-    headers.set("X-Guard-Token", guardToken);
-  }
+  headers.set("X-Guard-Token", guardToken);
   return {
     ...init,
     headers
   };
+}
+
+async function fetchWithGuardAuth(input: RequestInfo, init?: RequestInit): Promise<Response> {
+  const requestInput = guardApiInput(input);
+  let response = await fetch(requestInput, withGuardAuth(init));
+  if (response.status !== 401) {
+    return response;
+  }
+  const refreshedToken = await refreshGuardToken();
+  if (refreshedToken === null) {
+    return response;
+  }
+  return fetch(requestInput, withGuardAuthForToken(init, refreshedToken));
 }
 
 function guardAuthHeaders(): HeadersInit {
@@ -1193,7 +1210,7 @@ export async function fetchDiff(
 }
 
 function fetchGuardApi(input: RequestInfo, init?: RequestInit): Promise<Response> {
-  return fetch(guardApiInput(input), withGuardAuth(init));
+  return fetchWithGuardAuth(input, init);
 }
 
 export async function resolveRequest(input: {
@@ -1356,13 +1373,7 @@ export async function resolveRequestWithQueueResult(input: {
       ...(input.approval_gate_use_cooldown !== undefined ? { approval_gate_use_cooldown: input.approval_gate_use_cooldown } : {})
     })
   });
-  let response = await fetchGuardApi(path, init());
-  if (response.status === 401) {
-    const refreshedToken = await refreshGuardToken();
-    if (refreshedToken !== null) {
-      response = await fetchGuardApi(path, init(refreshedToken));
-    }
-  }
+  const response = await fetchGuardApi(path, init());
   if (!response.ok) {
     throw new Error(await requestErrorMessage(response, `Request failed with ${response.status}`));
   }
@@ -1384,7 +1395,7 @@ export async function exportDiagnostics(): Promise<Blob> {
   if (isGuardDemoMode()) {
     return new Blob([JSON.stringify({ demo: true, generated_at: new Date().toISOString() })], { type: "application/json" });
   }
-  const response = await fetch(guardApiInput("/v1/evidence/export"), withGuardAuth());
+  const response = await fetchWithGuardAuth("/v1/evidence/export");
   if (!response.ok) {
     throw new Error(`Export diagnostics failed with ${response.status}`);
   }
@@ -1395,7 +1406,7 @@ export async function repairApprovalCenter(): Promise<{ repaired: boolean; clear
   if (isGuardDemoMode()) {
     return { repaired: true, cleared: ["locator", "daemon_state"] };
   }
-  const response = await fetch(guardApiInput("/v1/daemon/repair"), withGuardAuth({ method: "POST" }));
+  const response = await fetchWithGuardAuth("/v1/daemon/repair", { method: "POST" });
   if (!response.ok) {
     throw new Error(`Repair failed with ${response.status}`);
   }
@@ -1453,13 +1464,7 @@ export async function retryResume(requestId: string): Promise<GuardCodexResumeRe
     },
     body: JSON.stringify({})
   });
-  let response = await fetchGuardApi(path, init());
-  if (response.status === 401) {
-    const refreshedToken = await refreshGuardToken();
-    if (refreshedToken !== null) {
-      response = await fetchGuardApi(path, init(refreshedToken));
-    }
-  }
+  const response = await fetchGuardApi(path, init());
   if (!response.ok) {
     throw new Error(`Resume retry failed with ${response.status}`);
   }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -12706,7 +12706,7 @@ const GUARD_DAEMON_PARAM = "guardDaemon";
 let guardTokenOverride = null;
 let guardTokenLocationKey = null;
 async function readJson(input, init) {
-  const response = await fetch(guardApiInput(input), withGuardAuth(init));
+  const response = await fetchWithGuardAuth(input, init);
   if (!response.ok) {
     throw new Error(await requestErrorMessage(response, `Request failed with ${response.status}`));
   }
@@ -12840,18 +12840,30 @@ function guardApiInput(input) {
   return `${daemonOrigin}${input}`;
 }
 function withGuardAuth(init) {
-  const guardToken = readGuardToken();
+  return withGuardAuthForToken(init, readGuardToken());
+}
+function withGuardAuthForToken(init, guardToken) {
   if (!guardToken) {
     return init;
   }
   const headers = new Headers(init?.headers);
-  if (!headers.has("X-Guard-Token")) {
-    headers.set("X-Guard-Token", guardToken);
-  }
+  headers.set("X-Guard-Token", guardToken);
   return {
     ...init,
     headers
   };
+}
+async function fetchWithGuardAuth(input, init) {
+  const requestInput = guardApiInput(input);
+  let response = await fetch(requestInput, withGuardAuth(init));
+  if (response.status !== 401) {
+    return response;
+  }
+  const refreshedToken = await refreshGuardToken();
+  if (refreshedToken === null) {
+    return response;
+  }
+  return fetch(requestInput, withGuardAuthForToken(init, refreshedToken));
 }
 function guardAuthHeaders() {
   const guardToken = readGuardToken();
@@ -13579,7 +13591,7 @@ async function fetchDiff(artifactId, harness) {
   return await response.json();
 }
 function fetchGuardApi(input, init) {
-  return fetch(guardApiInput(input), withGuardAuth(init));
+  return fetchWithGuardAuth(input, init);
 }
 async function revokeApprovalGateCooldown(password, totpCode) {
   if (isGuardDemoMode()) {
@@ -13698,13 +13710,7 @@ async function resolveRequestWithQueueResult(input) {
       ...input.approval_gate_use_cooldown !== void 0 ? { approval_gate_use_cooldown: input.approval_gate_use_cooldown } : {}
     })
   });
-  let response = await fetchGuardApi(path, init());
-  if (response.status === 401) {
-    const refreshedToken = await refreshGuardToken();
-    if (refreshedToken !== null) {
-      response = await fetchGuardApi(path, init(refreshedToken));
-    }
-  }
+  const response = await fetchGuardApi(path, init());
   if (!response.ok) {
     throw new Error(await requestErrorMessage(response, `Request failed with ${response.status}`));
   }
@@ -13724,7 +13730,7 @@ async function exportDiagnostics() {
   if (isGuardDemoMode()) {
     return new Blob([JSON.stringify({ demo: true, generated_at: (/* @__PURE__ */ new Date()).toISOString() })], { type: "application/json" });
   }
-  const response = await fetch(guardApiInput("/v1/evidence/export"), withGuardAuth());
+  const response = await fetchWithGuardAuth("/v1/evidence/export");
   if (!response.ok) {
     throw new Error(`Export diagnostics failed with ${response.status}`);
   }
@@ -13734,7 +13740,7 @@ async function repairApprovalCenter() {
   if (isGuardDemoMode()) {
     return { repaired: true, cleared: ["locator", "daemon_state"] };
   }
-  const response = await fetch(guardApiInput("/v1/daemon/repair"), withGuardAuth({ method: "POST" }));
+  const response = await fetchWithGuardAuth("/v1/daemon/repair", { method: "POST" });
   if (!response.ok) {
     throw new Error(`Repair failed with ${response.status}`);
   }
@@ -13772,13 +13778,7 @@ async function retryResume(requestId) {
     },
     body: JSON.stringify({})
   });
-  let response = await fetchGuardApi(path, init());
-  if (response.status === 401) {
-    const refreshedToken = await refreshGuardToken();
-    if (refreshedToken !== null) {
-      response = await fetchGuardApi(path, init(refreshedToken));
-    }
-  }
+  const response = await fetchGuardApi(path, init());
   if (!response.ok) {
     throw new Error(`Resume retry failed with ${response.status}`);
   }


### PR DESCRIPTION
## Summary
- bootstrap local daemon Guard tokens for protected dashboard actions after the first 401 response
- add regression coverage for direct local dashboard remediation without an initial guard token

## Testing
- `pnpm exec tsx src/guard-api.test.ts`
- `pnpm run build`

## Notes
- Verified the `/audit` remediation button end to end against live local daemons in three flows: open, approval password, and password + TOTP.
