### PR TITLE
fix(guard-daemon): reject query-token streams

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -679,8 +679,12 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_static_asset(parsed.path.removeprefix("/"))
             return
         if parsed.path == "/v1/events/stream":
-            if not self._token_is_valid(parsed.query):
-                self._write_json({"error": "unauthorized"}, status=401)
+            if self._query_has_guard_token(parsed.query):
+                self._record_query_token_rejection()
+                self._write_unauthorized()
+                return
+            if not self._header_token_is_valid():
+                self._write_unauthorized()
                 return
             self._stream_events(_int_query_value(parsed.query, "cursor"))
             return
@@ -2390,10 +2394,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         self._write_json(hook_payload)
 
-    def _token_is_valid(self, query: str) -> bool:
-        params = parse_qs(query)
-        token = params.get("token", [None])[-1]
-        return self._tokens_match(token)
+    def _query_has_guard_token(self, query: str) -> bool:
+        return any(key == "token" for key, _value in parse_qsl(query, keep_blank_values=True))
 
     def _write_unauthorized(self, *, extra_headers: dict[str, str] | None = None) -> None:
         self._record_auth_audit_event()
@@ -2414,6 +2416,17 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 "has_authorization": isinstance(self.headers.get("Authorization"), str),
                 "has_dashboard_session": isinstance(self.headers.get("X-Guard-Dashboard-Session"), str),
                 "has_guard_token": isinstance(self.headers.get("X-Guard-Token"), str),
+            },
+            _now(),
+        )
+
+    def _record_query_token_rejection(self) -> None:
+        self._daemon_server().store.add_event(
+            "daemon.auth.query_token_rejected",
+            {
+                "method": self.command,
+                "path": urlparse(self.path).path,
+                "has_query_token": True,
             },
             _now(),
         )

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -1846,28 +1846,32 @@ class TestGuardApprovals:
         assert status == 401
         assert payload["error"] == "unauthorized"
 
-    def test_guard_daemon_event_stream_rejects_non_ascii_query_token(self, tmp_path):
+    def test_guard_daemon_event_stream_rejects_query_token_and_records_audit(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
         daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
         daemon.start()
 
         try:
             request = urllib.request.Request(
-                f"http://127.0.0.1:{daemon.port}/v1/events/stream?token={urllib.parse.quote('ñ')}",
+                f"http://127.0.0.1:{daemon.port}/v1/events/stream?token={daemon._server.auth_token}",
                 method="GET",
             )
             try:
-                urllib.request.urlopen(request, timeout=5)
+                with urllib.request.urlopen(request, timeout=5):
+                    raise AssertionError("expected HTTPError for query-token event stream auth")
             except urllib.error.HTTPError as error:
                 payload = json.loads(error.read().decode("utf-8"))
                 status = error.code
-            else:
-                raise AssertionError("expected HTTPError for malformed query token")
         finally:
             daemon.stop()
 
         assert status == 401
         assert payload["error"] == "unauthorized"
+        auth_events = store.list_events(event_name="daemon.auth.unauthorized")
+        assert auth_events[-1]["payload"]["path"] == "/v1/events/stream"
+        url_token_events = store.list_events(event_name="daemon.auth.query_token_rejected")
+        assert url_token_events[-1]["payload"]["path"] == "/v1/events/stream"
+        assert url_token_events[-1]["payload"]["has_query_token"] is True
 
     def test_guard_daemon_ignores_invalid_json_body(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -1873,6 +1873,28 @@ class TestGuardApprovals:
         assert url_token_events[-1]["payload"]["path"] == "/v1/events/stream"
         assert url_token_events[-1]["payload"]["has_query_token"] is True
 
+    def test_guard_daemon_event_stream_rejects_non_ascii_query_token(self, tmp_path):
+        store = GuardStore(tmp_path / "guard-home")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/events/stream?token={urllib.parse.quote('ñ')}",
+                method="GET",
+            )
+            try:
+                with urllib.request.urlopen(request, timeout=5):
+                    raise AssertionError("expected HTTPError for non-ASCII query-token event stream auth")
+            except urllib.error.HTTPError as error:
+                payload = json.loads(error.read().decode("utf-8"))
+                status = error.code
+        finally:
+            daemon.stop()
+
+        assert status == 401
+        assert payload["error"] == "unauthorized"
+
     def test_guard_daemon_ignores_invalid_json_body(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
         daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -1216,7 +1216,8 @@ class TestGuardSurfaceServer:
 
         try:
             stream_request = urllib.request.Request(
-                f"http://127.0.0.1:{daemon.port}/v1/events/stream?token={daemon._server.auth_token}",
+                f"http://127.0.0.1:{daemon.port}/v1/events/stream",
+                headers={"X-Guard-Token": daemon._server.auth_token},
                 method="GET",
             )
             response = urllib.request.urlopen(stream_request, timeout=5)


### PR DESCRIPTION
## Summary
- reject durable `?token=` auth on `/v1/events/stream` and require header-based daemon auth instead
- record an explicit audit event when clients attempt query-token stream auth and update daemon regression coverage

## Testing
- `uv run ruff check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_surface_server.py tests/test_guard_approvals.py`
- `uv run ruff format --check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_surface_server.py tests/test_guard_approvals.py`
- `uv run pytest tests/test_guard_surface_server.py tests/test_guard_approvals.py -q`
